### PR TITLE
fix(#4364): reyn config validate now checks all 3 real hooks: input paths

### DIFF
--- a/docs/reference/cli/config.md
+++ b/docs/reference/cli/config.md
@@ -47,7 +47,8 @@ reyn config migrate-mcp [--dry-run]
 `reyn config validate` always exits `0`, even when it reports findings — it REPORTS, it
 never gates (owner ruling: warn, never hard-fail, anywhere). It checks four things,
 each printed as its own labeled section (never merged into one list — the fix differs
-per section, and merging would lose "which one do I fix, and how"):
+per section, and merging would lose "which one do I fix, and how"). Note the last
+check (hook entries) covers three separate config *files* under one section, not one:
 
 - **Unrecognized/renamed/removed keys, policy tier** (`reyn.yaml` / `reyn.local.yaml` /
   `~/.reyn/config.yaml`) — the same check `load_config`'s own startup warning runs.
@@ -66,13 +67,19 @@ per section, and merging would lose "which one do I fix, and how"):
   applies on the next turn automatically, no restart and no `reyn config migrate`
   support for this tier (a different remedy than the policy tier above, which is
   exactly why this is its own section).
-- **Hook entry validation, the IN-set's `hooks:` list** (#4501) — the IN-set's own
-  unknown-key check above only walks the TOP-LEVEL config schema, so `hooks:` itself
-  being a recognized key says nothing about what each list *entry* contains. This
-  section feeds `.reyn/config/hooks.yaml`'s `hooks:` list through the real
-  `load_hooks` parser and reports any `HookConfigError` (e.g. an unrecognized
-  per-hook key). Fix: edit the offending hook entry directly in
-  `.reyn/config/hooks.yaml`.
+- **Hook entry validation, all three real `hooks:` input paths** (#4501 / #4364
+  PR-1) — the top-level unknown-key checks above only confirm `hooks:` itself is a
+  recognized key; they never recurse into what each list *entry* contains. This
+  section feeds every real hooks source through the real `load_hooks` parser
+  (the SAME parser hook-loading itself uses) and reports any `HookConfigError`
+  (e.g. an unrecognized or wrong-scope per-hook key), labeled by source:
+    - **`reyn.yaml`'s own top-level `hooks:`** — the startup layer, and the one
+      [the hooks guide](../../concepts/runtime/hooks.md) tells operators to write
+      in. #4501 did not cover this source.
+    - **`.reyn/config/hooks.yaml`** — the runtime IN-set (#4501's own original fix).
+    - **every `.reyn/agents/<name>/hooks.yaml`** — the per-agent layer, one
+      finding per agent directory that has a malformed entry.
+  Fix: edit the offending hook entry in whichever labeled file the finding names.
 
 `reyn config migrate` only rewrites an entry whose registered rename has an automatic
 destination (a plain rename, no value transform); a rename that also transforms the

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -305,13 +305,20 @@ def _validate() -> None:
     walker sees). That gap is exactly what let an operator's
     ``allow_write_paths`` (the agent-level sandbox.policy field name,
     written at the wrong per-hook site) pass ``validate`` silently while
-    doing nothing — architect's own real incident. Closes it by feeding
-    the IN-set's own ``hooks:`` list through ``load_hooks`` (the SAME
-    parser hook-loading itself uses, per this function's own
-    "check exactly what startup checks" discipline) and reporting any
-    ``HookConfigError`` as a fourth labeled section — never raising it:
-    this command REPORTS, per the docstring above, so a malformed hook
-    entry is caught here rather than only at the next actual hook-load.
+    doing nothing — architect's own real incident. #4501 closed it for
+    ONE of hooks' three real input paths: the ``.reyn/config/hooks.yaml``
+    runtime IN-set. #4364 PR-1 found the other two the same night —
+    ``_build_hook_registry``'s own 3-layer COMBINE (startup / runtime /
+    per-agent) names them: reyn.yaml's own top-level ``hooks:`` (the
+    layer ``docs/concepts/runtime/hooks.md`` actually tells operators to
+    write in, and architect's own real incident lived there, not in the
+    IN-set #4501 fixed) and every ``.reyn/agents/<name>/hooks.yaml``. All
+    three now feed through ``load_hooks`` (the SAME parser hook-loading
+    itself uses, per this function's own "check exactly what startup
+    checks" discipline) and any ``HookConfigError`` per source is
+    reported as a fourth labeled section — never raised: this command
+    REPORTS, per the docstring above, so a malformed hook entry is caught
+    here rather than only at the next actual hook-load.
 
     Uses ``build_policy_tier_config`` — the SAME construction
     ``load_config``'s own startup warning uses (architect's explicit
@@ -330,7 +337,11 @@ def _validate() -> None:
     decision.
     """
     from reyn.config.config_schema import disabled_config_keys, unknown_config_keys
-    from reyn.config.loader import build_policy_tier_config, load_hot_reload_config
+    from reyn.config.loader import (
+        build_policy_tier_config,
+        load_hot_reload_config,
+        load_per_agent_hooks,
+    )
     from reyn.hooks.loader import load_hooks
     from reyn.hooks.schema import HookConfigError
 
@@ -340,18 +351,51 @@ def _validate() -> None:
     in_set_merged = load_hot_reload_config()
     in_set_unknown = unknown_config_keys(in_set_merged)
 
-    # #4501: hooks[] entries are a free-form list the top-level schema walk
-    # above never opens — feed them through the real parser to catch a
-    # malformed/wrong-scope key inside one, same as an actual hook-load would.
-    hooks_raw = in_set_merged.get("hooks")
-    hook_entry_error: str | None = None
-    if hooks_raw is not None:
-        try:
-            load_hooks(hooks_raw)
-        except HookConfigError as exc:
-            hook_entry_error = str(exc)
+    # #4501/#4364 PR-1: hooks[] entries are a free-form list the top-level
+    # schema walk above never opens — feed EVERY real input path through the
+    # real parser to catch a malformed/wrong-scope key inside one, same as an
+    # actual hook-load would. Three sources, mirroring
+    # Session._build_hook_registry's own startup/runtime/per-agent layers:
+    hook_entry_errors: dict[str, str] = {}
 
-    if not policy_unknown and not disabled and not in_set_unknown and not hook_entry_error:
+    # (1) reyn.yaml top-level `hooks:` (the startup layer — the one
+    # docs/concepts/runtime/hooks.md tells operators to write in; #4501 did
+    # NOT cover this source, only (2) below).
+    policy_hooks_raw = policy_merged.get("hooks")
+    if policy_hooks_raw:
+        try:
+            load_hooks(policy_hooks_raw)
+        except HookConfigError as exc:
+            hook_entry_errors["reyn.yaml"] = str(exc)
+
+    # (2) .reyn/config/hooks.yaml (the runtime IN-set — #4501's own fix).
+    in_set_hooks_raw = in_set_merged.get("hooks")
+    if in_set_hooks_raw:
+        try:
+            load_hooks(in_set_hooks_raw)
+        except HookConfigError as exc:
+            hook_entry_errors[".reyn/config/hooks.yaml"] = str(exc)
+
+    # (3) every .reyn/agents/<name>/hooks.yaml (the per-agent layer).
+    # load_per_agent_hooks mirrors Session._read_per_agent_hooks exactly —
+    # same defensive "not a list -> []" degrade the real runtime uses, so a
+    # non-list `hooks:` here is silently skipped just like it would be at an
+    # actual hook-load, not a validate-only gap.
+    project_root = Path.cwd()
+    agents_dir = project_root / ".reyn" / "agents"
+    if agents_dir.is_dir():
+        for agent_dir in sorted(agents_dir.iterdir()):
+            if not agent_dir.is_dir():
+                continue
+            agent_hooks_raw = load_per_agent_hooks(project_root, agent_dir.name)
+            if not agent_hooks_raw:
+                continue
+            try:
+                load_hooks(agent_hooks_raw)
+            except HookConfigError as exc:
+                hook_entry_errors[f".reyn/agents/{agent_dir.name}/hooks.yaml"] = str(exc)
+
+    if not policy_unknown and not disabled and not in_set_unknown and not hook_entry_errors:
         print("No unknown, renamed, or disabled-by-dependency config keys found.")
         return
 
@@ -401,14 +445,20 @@ def _validate() -> None:
             ".reyn/*.yaml file directly)."
         )
 
-    if hook_entry_error:
+    if hook_entry_errors:
         if policy_unknown or disabled or in_set_unknown:
             print()
-        print("Hook entry validation — .reyn/config/hooks.yaml's hooks: list:\n")
-        print(f"  {hook_entry_error}")
         print(
-            "\nThis entry will fail to load the next time hooks are (re)loaded "
-            "(hot-reload or restart) — fix the key above."
+            f"Hook entry validation — checked reyn.yaml, .reyn/config/hooks.yaml, "
+            f"and every .reyn/agents/<name>/hooks.yaml — "
+            f"{len(hook_entry_errors)} source(s) with a malformed entry:\n"
+        )
+        for label, err in sorted(hook_entry_errors.items()):
+            print(f"  [{label}]")
+            print(f"    {err}")
+        print(
+            "\nEach flagged entry will fail to load the next time hooks are "
+            "(re)loaded (hot-reload or restart) — fix the key(s) above."
         )
 
 

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -338,6 +338,7 @@ def _validate() -> None:
     """
     from reyn.config.config_schema import disabled_config_keys, unknown_config_keys
     from reyn.config.loader import (
+        _find_project_root,
         build_policy_tier_config,
         load_hot_reload_config,
         load_per_agent_hooks,
@@ -345,10 +346,17 @@ def _validate() -> None:
     from reyn.hooks.loader import load_hooks
     from reyn.hooks.schema import HookConfigError
 
+    # lead-coder review (#4555): root resolution must be consistent across
+    # all 3 sources this command reads, or `cd subdir && reyn config
+    # validate` checks reyn.yaml (build_policy_tier_config walks up to the
+    # real root via _find_project_root) while silently skipping the other 2
+    # (a bare Path.cwd() does not walk up). Resolve once, thread everywhere.
+    project_root = _find_project_root(Path.cwd()) or Path.cwd()
+
     policy_merged = build_policy_tier_config()
     policy_unknown = unknown_config_keys(policy_merged)
     disabled = disabled_config_keys(policy_merged)
-    in_set_merged = load_hot_reload_config()
+    in_set_merged = load_hot_reload_config(project_root)
     in_set_unknown = unknown_config_keys(in_set_merged)
 
     # #4501/#4364 PR-1: hooks[] entries are a free-form list the top-level
@@ -380,8 +388,8 @@ def _validate() -> None:
     # load_per_agent_hooks mirrors Session._read_per_agent_hooks exactly —
     # same defensive "not a list -> []" degrade the real runtime uses, so a
     # non-list `hooks:` here is silently skipped just like it would be at an
-    # actual hook-load, not a validate-only gap.
-    project_root = Path.cwd()
+    # actual hook-load, not a validate-only gap. Uses the SAME resolved
+    # project_root as (1)/(2) above (lead-coder review, #4555).
     agents_dir = project_root / ".reyn" / "agents"
     if agents_dir.is_dir():
         for agent_dir in sorted(agents_dir.iterdir()):

--- a/tests/interfaces/test_4501_validate_hook_entries.py
+++ b/tests/interfaces/test_4501_validate_hook_entries.py
@@ -231,6 +231,67 @@ def test_an_agent_dir_with_no_hooks_file_is_silently_skipped(project, capsys):
     assert "Hook entry validation" not in out
 
 
+# ── #4555 review (lead-coder): root resolution must be consistent ─────────
+#
+# The `project` fixture above monkeypatches `_find_project_root` to always
+# return `tmp_path` regardless of the path it's called with — it can never
+# witness a root-resolution bug where one call site walks up from cwd and
+# another does not. This fixture uses the REAL `_find_project_root` (only
+# `Path.home` is faked) so a genuine subdirectory run exercises the actual
+# filesystem walk each of the 3 call sites in `_validate()` must agree on.
+
+
+@pytest.fixture()
+def real_project_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    root = tmp_path / "project"
+    root.mkdir()
+    return root
+
+
+def test_findings_from_all_3_sources_survive_running_from_a_subdirectory(
+    real_project_root, capsys, monkeypatch,
+):
+    """Tier 2: #4555 review — build_policy_tier_config walks up to the real
+    project root via _find_project_root, but load_hot_reload_config and the
+    per-agent scan used a bare Path.cwd() before this fix, which does NOT
+    walk up. Running from a subdirectory used to silently drop the IN-set
+    and per-agent findings while still reporting the reyn.yaml one — this
+    pins that all 3 sources are found identically regardless of which
+    subdirectory `reyn config validate` is invoked from."""
+    _write_yaml(real_project_root / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        real_project_root / ".reyn" / "config" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    allow_write_paths: [\"/tmp\"]\n",
+    )
+    _write_yaml(
+        real_project_root / ".reyn" / "agents" / "planner" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    nam: typo\n",
+    )
+    subdir = real_project_root / "src" / "nested"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert ".reyn/config/hooks.yaml" in out, (
+        f"IN-set finding missing when run from a subdirectory: {out!r}"
+    )
+    assert ".reyn/agents/planner/hooks.yaml" in out, (
+        f"per-agent finding missing when run from a subdirectory: {out!r}"
+    )
+
+
 def test_multiple_hook_sources_each_report_their_own_labeled_finding(project, capsys):
     """Tier 2: a malformed entry in BOTH reyn.yaml and a per-agent file at
     once produces two distinct labeled findings, not one that shadows the

--- a/tests/interfaces/test_4501_validate_hook_entries.py
+++ b/tests/interfaces/test_4501_validate_hook_entries.py
@@ -1,8 +1,8 @@
-"""Tier 2: #4501 — ``reyn config validate`` widened to also open each
-``hooks:`` list entry (the IN-set's own free-form nested structure the
-top-level schema walk in #4235 never recurses into) via the real
-``load_hooks`` parser, catching a malformed/wrong-scope per-hook key —
-not just an unrecognized TOP-LEVEL config key.
+"""Tier 2: #4501 / #4364 PR-1 — ``reyn config validate`` widened to open
+each ``hooks:`` list entry (the free-form nested structure the top-level
+schema walk in #4235 never recurses into) via the real ``load_hooks``
+parser, catching a malformed/wrong-scope per-hook key — not just an
+unrecognized TOP-LEVEL config key.
 
 Companion to ``test_4235_validate_in_set.py`` (that PR's own top-level
 IN-set coverage, unchanged by this one — its accept/reject tests still
@@ -11,6 +11,15 @@ incident): ``allow_write_paths`` (the agent-level ``sandbox.policy``
 field name) written inside a ``hooks:`` entry instead of the per-hook
 key (``write_paths``) — ``validate`` passed ("No unknown ... keys
 found") while the hook silently did nothing.
+
+#4501 covered exactly ONE of hooks' three real input paths (the
+``.reyn/config/hooks.yaml`` runtime IN-set). #4364 PR-1 found the other
+two the same night, mirroring ``Session._build_hook_registry``'s own
+3-layer COMBINE: reyn.yaml's own top-level ``hooks:`` (the layer
+``docs/concepts/runtime/hooks.md`` actually tells operators to write in —
+and where architect's real incident lived, NOT the IN-set #4501 fixed)
+and every ``.reyn/agents/<name>/hooks.yaml``. The tests below cover those
+two additions; the IN-set tests above are unchanged.
 """
 from __future__ import annotations
 
@@ -115,3 +124,136 @@ def test_an_absent_hooks_key_is_not_treated_as_a_hook_entry_error(project, capsy
     _validate()
     out = capsys.readouterr().out
     assert "Hook entry validation" not in out
+
+
+# ── #4364 PR-1: reyn.yaml top-level hooks: (the startup layer) ─────────────
+
+
+def test_a_malformed_entry_in_reyn_yamls_own_hooks_block_is_now_caught(project, capsys):
+    """Tier 2: #4364 PR-1 ② — the layer #4501 did NOT cover. This is the
+    layer docs/concepts/runtime/hooks.md tells operators to write in, and
+    the one architect's own real incident actually lived in (they had no
+    .reyn/config/hooks.yaml at all that night — every hook was in
+    reyn.yaml's own top-level hooks: block)."""
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML
+        + "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    allow_write_paths: [\"/tmp\"]\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" in out
+    assert "[reyn.yaml]" in out
+    assert "allow_write_paths" in out
+    assert "write_paths" in out
+
+
+def test_a_well_formed_reyn_yaml_hooks_block_produces_no_finding(project, capsys):
+    """Tier 2: accept-side for the reyn.yaml source — a valid top-level
+    hooks: block must not trip the new section."""
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML
+        + "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    write_paths: [\"/tmp\"]\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" not in out
+    assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
+
+
+# ── #4364 PR-1: .reyn/agents/<name>/hooks.yaml (the per-agent layer) ───────
+
+
+def test_a_malformed_entry_in_a_per_agent_hooks_file_is_now_caught(project, capsys):
+    """Tier 2: #4364 PR-1 ③ — the third real input path, previously
+    invisible to validate entirely (no prior test covered it, IN-set or
+    otherwise). The finding is labeled with the specific agent+path so an
+    operator with multiple agents knows exactly which file to fix."""
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "agents" / "planner" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    allow_write_paths: [\"/tmp\"]\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" in out
+    assert ".reyn/agents/planner/hooks.yaml" in out
+    assert "allow_write_paths" in out
+    assert "write_paths" in out
+
+
+def test_a_well_formed_per_agent_hooks_file_produces_no_finding(project, capsys):
+    """Tier 2: accept-side for the per-agent source — a valid
+    .reyn/agents/<name>/hooks.yaml must not trip the new section."""
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "agents" / "planner" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    write_paths: [\"/tmp\"]\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" not in out
+    assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
+
+
+def test_an_agent_dir_with_no_hooks_file_is_silently_skipped(project, capsys):
+    """Tier 2: accept-side — an agent directory that exists (e.g. it has
+    state/ from a prior run) but no hooks.yaml at all must not be treated
+    as a malformed source; load_per_agent_hooks's own [] default covers
+    this, this test pins that validate's new loop respects it."""
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    (project / ".reyn" / "agents" / "planner" / "state").mkdir(parents=True)
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" not in out
+
+
+def test_multiple_hook_sources_each_report_their_own_labeled_finding(project, capsys):
+    """Tier 2: a malformed entry in BOTH reyn.yaml and a per-agent file at
+    once produces two distinct labeled findings, not one that shadows the
+    other — an operator fixing only the first-listed one must still see
+    the second remains."""
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML
+        + "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    allow_write_paths: [\"/tmp\"]\n",
+    )
+    _write_yaml(
+        project / ".reyn" / "agents" / "planner" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    nam: typo\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "[reyn.yaml]" in out
+    assert ".reyn/agents/planner/hooks.yaml" in out


### PR DESCRIPTION
**[docs-maintainer]** — #4364 PR-1, corrected scope per lead-coder's dispatch. I wrote #4526/#4501's original hooks-entry-validation fix, which turned out to close exactly ONE of hooks' three real input paths.

## The gap #4501 left

`Session._build_hook_registry`'s own docstring names the real 3-layer COMBINE: **startup** (reyn.yaml's own top-level `hooks:`), **runtime** (`.reyn/config/hooks.yaml`, the hot-reload IN-set), and **per-agent** (`.reyn/agents/<name>/hooks.yaml`). #4501 fed only the IN-set through `load_hooks`. Architect's own real 3-hour incident (the motivating case for #4501 itself) lived in reyn.yaml's top-level block — `docs/concepts/runtime/hooks.md` is what actually tells operators to write hooks there — so #4501 closed the gap for the layer that *wasn't* the one hit.

## The fix

`_validate()` now feeds all three sources through `load_hooks` (same parser hook-loading itself uses):
- `policy_merged.get("hooks")` — reyn.yaml's top-level block.
- `in_set_merged.get("hooks")` — unchanged from #4501.
- every `.reyn/agents/<name>/hooks.yaml` — enumerated the same way `chat.py`'s own snapshot-cleanup code walks `.reyn/agents/`, read via `load_per_agent_hooks` (the same function `Session._read_per_agent_hooks` uses, including its defensive "not a list → []" degrade for a malformed `hooks:` shape — matches what an actual hook-load does, not a validate-only gap).

Each malformed source gets its own labeled finding (`dict[str, str]` keyed by source label) instead of the prior single `Optional[str]`, so two sources failing at once don't shadow each other.

## Doc sync (same PR)

`docs/reference/cli/config.md`'s "Hook entry validation" bullet described only the IN-set path — updated to name all three sources and link to the hooks guide for where operators actually write hooks.

## Tests

6 new tests in `test_4501_validate_hook_entries.py`: malformed + accept-side for each of the two new sources, an agent directory that exists but has no `hooks.yaml` (must not be a spurious finding), and two sources failing simultaneously (each gets its own labeled finding). The 4 pre-existing IN-set tests are unchanged.

## Falsify-verify

Stashed just the src fix and reran: the 3 tests exercising the two new sources genuinely failed for the right reason (`"No unknown..."` instead of `"Hook entry validation"` in output); the pre-existing IN-set tests stayed green (untouched path). Restored, reconfirmed all 10 green.

## Verification

- `pytest tests/interfaces/test_4501_validate_hook_entries.py tests/hooks/` — 344 passed
- `ruff check src tests` — clean
- `test_tier_audit.py --strict` on the changed test file — 10/10 OK
- `verify_module_docstrings.py` — OK
- `mypy_ratchet.py` — OK, all baselined
- `check_tests_path_literal_reference.py` — OK, all baselined (re-run fresh on this branch, per its own staleness caveat)
- `mkdocs build --strict` — clean, no Aborted/error line

part of #4364

## Test plan

- [x] `pytest tests/interfaces/test_4501_validate_hook_entries.py tests/hooks/` — 344 passed
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` on the changed test file — 10/10 OK
- [x] `verify_module_docstrings.py` — OK
- [x] `mypy_ratchet.py` — OK
- [x] `check_tests_path_literal_reference.py` — OK
- [x] `mkdocs build --strict` — clean
- [x] Falsify-verify: 3 new tests genuinely RED without the fix, GREEN with it
- [x] (skipped — no Visual item, CLI-output change with no UI surface)


---

**[lead-coder]** — ✅ **TESTS-READ 済。★中身は 良いです。🔴 ★ブロック 1 点 ── ★サブディレクトリから
実行すると ★3 面のうち 1 面しか 検査しません。**

- [x] 🔴 **★root の 解決が ★3 面で 揃っていません（★実測）** — fixed in commit `1507d9cf8`: resolved `project_root` once via `_find_project_root(Path.cwd())`, threaded into `load_hot_reload_config()` and the per-agent scan. Added `test_findings_from_all_3_sources_survive_running_from_a_subdirectory` (a new fixture that leaves `_find_project_root` real, unlike the existing fixture which monkeypatches it and could never have caught this) — falsify-verified genuinely RED without the fix.
      ```
      ★(1) build_policy_tier_config()  loader.py:160 ★_find_project_root(cwd) ── ★遡る ✅
      🔴 ★(2) load_hot_reload_config()  loader.py:931 root = (project_root or ★Path.cwd())
                                        ── ★遡らない（★引数なしで 呼ばれています）
      🔴 ★(3) 本 PR      project_root = ★Path.cwd() ── ★遡らない
      ∴ ★`cd subdir && reyn config validate` で
         ★reyn.yaml は 見る が ★.reyn/config/hooks.yaml と ★per-agent は ★黙って 素通り
      ```
      ⚠️ **★(2) は ★#4501 からの 既存**（★私が 通しました）—— **★本 PR が (3) を 同じ形で
      足した ので、★「3 面 検査する」という ★この PR 自身の 約束が ★場所依存に なります。**
      ✅ **★直し ── ★root を 1 度 解決して ★両方に 渡す**
      （`_find_project_root(Path.cwd())` → `load_hot_reload_config(root)` ＋ per-agent scan）。
      ⚠️ **★テストが 気づけないのは ★fixture が `monkeypatch.chdir(tmp_path)` ＋
      `_find_project_root` の patch を 両方 している から**です —— **★サブディレクトリから
      走る ケースが ★1 本も ありません。★足して ください。**

## ✅ 六問

```
① Tier ── ★2（★CLI が ★startup が 拒む ものを 報告する）── ★妥当
② 転記 ── ★無し
③ 誰が困る ── 🔴 ★doc が「ここに書け」と 教えている 面（reyn.yaml）の 利用者
             ── ★architect が ★3 時間 失った 当の 面
④ 走らず緑 ── ⚠️ ★上記（★場所依存で ★静かに 素通り）
⑤ 累積 ── ★無し
⑥ 宣言＝実体 ── ★一致
```

## ✅ ★良い 点

```
✅ ★`load_per_agent_hooks` を ★そのまま 使う ── ★抽出ロジックを ★二重に 書いていない
✅ ★source ごとに ★別の finding（dict）── ★2 つ壊れた 時に ★片方が 隠れない
✅ ★#4526 の 形（実 parser ／ 捕まえる ／ exit 0）を ★そのまま ── ★足したのは 入力経路だけ
✅ ★docs/reference/cli/config.md も ★同 PR
```

