### PR TITLE
feat(#4364 PR-3a): reyn doctor skeleton + D-3 coverage disclosure + C-7 disk

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
               - reference/cli/memory.md
               - reference/cli/cron.md
               - reference/cli/storage.md
+              - reference/cli/doctor.md
               - reference/cli/support-bundle.md
               - reference/cli/common-flags.md
       - Runtime:

--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -1,0 +1,116 @@
+---
+type: reference
+topic: cli
+audience: [human, agent]
+applies_to: [reyn doctor]
+---
+
+# `reyn doctor`
+
+Report **measured** health, never **declared** health (#4364). Read-only — this
+command never deletes, writes, or repairs anything; every line it prints comes from
+actually reading a live effect (a file's real age/size on disk), not from restating a
+config value back.
+
+This is PR-3a of a staged arc — see [`.reyn/` directory layout](../runtime/reyn-dir-layout.md)
+and the design constraints below for what's in and out of scope today.
+
+## Synopsis
+
+```
+reyn doctor [--project-root <path>]
+```
+
+`--project-root` defaults to the current directory; it must contain a `.reyn/` tree
+(the same resolution `reyn chat` and other project-scoped commands use, walking up
+from the given path to find `reyn.yaml`).
+
+## Design constraints (why the output reads the way it does)
+
+- **Measure, don't assert.** "A hook is registered" is `reyn config show`'s job;
+  "a hook's argv actually launched" is a *later* doctor slice (#4364's own C-1/C-2,
+  not implemented by this PR). This PR's own checks (disk usage) follow the same
+  rule: every number comes from `os.stat`/`Path.rglob`, never from re-reading a
+  config object.
+- **Report-only, never mutate.** `doctor` reaches into wider internals than any
+  other CLI surface (sandbox / MCP / hook, in later slices). Every local-CLI
+  precedent surveyed for this design (`npm doctor`, `claude doctor`,
+  oh-my-opencode `doctor`) reports-only or requires explicit confirmation before
+  acting; none auto-repairs from a CLI invocation. `reyn doctor` never calls a
+  delete/purge function — only read-only queries.
+- **Disclose what wasn't measured, and how "measurable" was decided.** A doctor
+  that only ever prints what it happens to check reads, on a clean run, identical
+  to a doctor that checked everything — a shape this repo hit repeatedly the night
+  this design was settled (a declaration outrunning what was actually verified).
+  The first line of output is therefore always a coverage disclosure: total config
+  leaves / how many have a measurable effective surface / how many don't, with the
+  measurability criterion printed alongside the count — never a bare "N checks
+  passed."
+
+## What this PR checks
+
+```bash
+$ reyn doctor
+
+154 config leaves total, 2 have a measurable effective surface (checked below), 152 uncovered.
+  Measurable means: a leaf counts as measurable here iff this module reads its LIVE EFFECT
+  (a file's actual age/size on disk), not merely the config value itself -- re-reading the
+  config object back is not a measurement
+
+Disk usage — declared retention vs. actual (.reyn/events/):
+  declared: cleanup_period_days=30 (0=disabled), max_disk_usage_percent=10.0 (0=disabled)
+  actual:   1 file(s), 22 bytes, oldest = 43 day(s) old
+  ⚠ 1 file(s) currently exceed the declared policy but have not been purged yet (purge
+  fires on the next write/rotation, not continuously) — run 'reyn events purge' to apply
+  the policy now if you don't want to wait.
+
+Disk usage — no declared retention policy (visibility only):
+  media/:         0 file(s), 0 bytes
+  tool-results/:  0 file(s), 0 bytes
+  history.jsonl:  0 file(s), 0 bytes, 0 turn(s)
+  total (media+tool-results+history): 0 bytes
+  (filesystem free space: 243,848,552,448 bytes)
+```
+
+### `.reyn/events/` — declared vs. actual
+
+Compares `audit_events.cleanup_period_days` / `audit_events.max_disk_usage_percent`
+(the automatic-purge policy, [#4479](https://github.com/tya5/reyn/issues/4479)) against
+the real on-disk file count, byte total, and oldest file's age. The `select_purge_targets`
+query this reuses (`reyn.core.events.event_purge`) is the SAME read-only selection logic
+`reyn events purge` and the automatic trigger both use — no re-derived logic here.
+
+A non-empty "exceed the declared policy" finding means files exist RIGHT NOW that the
+policy's own axes would purge, but haven't been yet — the automatic trigger only fires
+on write/rotation, not continuously, so a quiet period can leave a real backlog this
+command surfaces without waiting for the next write.
+
+### `media/` / `tool-results/` / `history.jsonl` — no declared policy (visibility only)
+
+None of these three has a retention policy yet ([#4478](https://github.com/tya5/reyn/issues/4478) /
+[#4476](https://github.com/tya5/reyn/issues/4476) Phase 2 unimplemented) — the visibility
+itself is the finding: an unowned, unbounded resource made visible rather than silently
+absent from every report. Reuses `MediaStore.storage_stats()` and
+`aggregate_history_stats()`, the same functions [`reyn storage stats`](storage.md) reports.
+
+## Out of scope for this PR (later slices, same arc)
+
+- **C-1 / C-2** (hook argv launch probe / zero-responder subscription detection) — a
+  separate PR once their own execution semantics were settled: C-1 launches only
+  `argv[0]` in the hook's own sandbox, never the hook's configured args, and its
+  output is explicitly labeled a launch probe, not a run (owner ruling: running a
+  hook's real configured args as a side effect of `reyn doctor` would make the
+  diagnostic itself a footgun).
+- **C-5 / C-6** (sandbox posture, listen port, and model-name declared-vs-effective
+  pairs) — each needs its own new measurement code (reading the resolved sandbox
+  backend object, introspecting a live bound socket, a real litellm probe call),
+  unlike this PR's C-7 disk checks, which reuse existing measurement functions.
+
+## Related
+
+- [`reyn storage`](storage.md) — the measurement functions this command's
+  no-declared-policy section reuses
+- [`reyn events`](events.md) — `reyn events purge`, the manual counterpart to the
+  automatic policy this command's events section checks compliance against
+- [`.reyn/` directory layout](../runtime/reyn-dir-layout.md) — the audit-bucket
+  classification for `media/`/`tool-results/`/`events/`

--- a/src/reyn/interfaces/cli/commands/__init__.py
+++ b/src/reyn/interfaces/cli/commands/__init__.py
@@ -12,6 +12,7 @@ from . import auth as auth
 from . import chat as chat
 from . import config as config
 from . import cron as cron
+from . import doctor as doctor
 from . import dogfood as dogfood
 from . import embeddings as embeddings
 from . import events as events
@@ -31,4 +32,4 @@ from . import web as web
 # Order is the order shown in `reyn --help`.
 # `source` (reyn source list/describe/rm) retired FP-0066 P1c — user-facing
 # in-core RAG source creation/management is gone; user RAG = FP-0063 plugin.
-ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, mcp, storage, pipe, plugin, secret, cron, dogfood, embeddings, support_bundle, audit]
+ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, mcp, storage, pipe, plugin, secret, cron, dogfood, embeddings, support_bundle, audit, doctor]

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -1,0 +1,211 @@
+"""`reyn doctor` — health checks that report what was MEASURED, never what
+was declared (#4364 PR-3a: skeleton + D-3's coverage-disclosure framework +
+C-7's disk visibility).
+
+## D-1 (owner/lead-coder ruling, #4364): measure, don't assert
+
+Every line this command prints is the result of actually reading a live
+effect — a file on disk, a resolved value — never a restatement of what
+``reyn.yaml`` (or any other config source) DECLARES. "A hook is registered"
+is ``reyn config show``'s job; "a hook's argv actually launched" would be
+doctor's (a later slice — see #4364's own C-1/C-2). This module's own slice
+(C-7, disk) follows the same rule: every number below comes from
+``os.stat``/``Path.rglob``, never from re-reading a config object.
+
+## D-2 (owner/lead-coder ruling): report-only, never mutate
+
+``reyn`` gives ``doctor`` reach into sandbox / MCP / hook internals — wider
+than any other CLI surface. Every prior local-CLI precedent surveyed in
+#4364's own investigation (``npm doctor``, ``claude doctor``, oh-my-opencode
+``doctor``) either reports-only or requires explicit confirmation before
+acting; none auto-repairs from a CLI invocation. This module never deletes,
+never writes, never calls ``apply_auto_purge``/``purge_files`` — only the
+read-only ``select_purge_targets`` (a query, not an action).
+
+## D-3 (architect ruling, #4364, generalized from C-5/C-6): disclose what
+was NOT measured, and how "measurable" was decided
+
+A doctor that only ever prints what it happens to check reads, on a clean
+run, identical to a doctor that checked everything — the #4480/#4478/#4479
+pattern this repo hit four times in one night (a declaration outrunning
+what was actually verified). This module's own summary line is therefore
+not "N checks passed" but:
+
+    <N> config leaves total, <M> have a measurable effective surface,
+    <N-M> uncovered (no live-effect reader exists for them yet)
+
+"Measurable effective surface" is a genuinely hand-picked judgment call —
+architect's own words, not avoidable — so the CRITERION is printed
+alongside the count, not just the number: :data:`_MEASURABLE_LEAF_KEYS`
+below is the literal, auditable list, and a future PR widening it changes
+this file's own diff, not a silent number. Do not print an unqualified "N
+items checked" anywhere in this module or its own docs — see this issue's
+own owner note: any claim about coverage must be DERIVABLE from this
+disclosure line, never asserted independently of it.
+
+## Scope of this slice (PR-3a)
+
+C-7 (disk: declared retention ↔ actual bytes/age for ``.reyn/events/``, plus
+policy-independent visibility for ``.reyn/media/`` / ``.reyn/tool-results/``
+/ every ``history.jsonl`` — none of which has a declared retention policy
+yet, #4478/#4476 Phase 2 unimplemented). C-5 (sandbox posture) and C-6's
+other named pairs (listen port, model-name acceptance) are PR-3b — each
+needs its own NEW measurement code (reading the resolved sandbox backend
+object, introspecting a live bound socket, a real litellm probe call), not
+reuse of an existing function the way C-7 is. C-1 (hook argv launch) / C-2
+(zero-responder subscription) are PR-2, dispatched separately once their
+own execution semantics were settled (lead-coder, #4364: argv[0] only, no
+configured hook args, explicitly labeled "a launch probe, not a run" in
+doctor's own output — not implemented in this module).
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+from datetime import date
+from pathlib import Path
+from typing import Final
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "doctor",
+        help="Report measured (not declared) health — disk retention, storage footprint",
+    )
+    p.add_argument(
+        "--project-root",
+        default=".",
+        help="Project root containing .reyn/ (default: current directory).",
+    )
+    p.set_defaults(func=run)
+
+
+# #4364 D-3: the literal, auditable set of config leaves this doctor slice
+# actually measures a live effect for — printed alongside the N/M/N-M
+# summary so "measurable" stays a disclosed judgment call, not a hidden one.
+# Widening this set is a diff to THIS list, never a silent count change.
+_MEASURABLE_LEAF_KEYS: Final[tuple[str, ...]] = (
+    "audit_events.cleanup_period_days",
+    "audit_events.max_disk_usage_percent",
+)
+_MEASURABILITY_CRITERION: Final[str] = (
+    "a leaf counts as measurable here iff this module reads its LIVE EFFECT "
+    "(a file's actual age/size on disk), not merely the config value itself "
+    "-- re-reading the config object back is not a measurement (#4364 "
+    "architect note: an assignment can succeed while never being used)"
+)
+
+
+def _events_dir_stats(root: Path) -> "tuple[int, int, date | None]":
+    """(file_count, total_bytes, oldest_start_date) for every dated
+    ``.jsonl`` under ``root`` — read-only, mirrors
+    ``event_purge.collect_dated_files``'s own file discovery so this
+    reports on exactly the population a real purge would consider."""
+    from reyn.core.events.event_purge import collect_dated_files
+
+    files = collect_dated_files(root)
+    count = len(files)
+    total_bytes = 0
+    oldest: "date | None" = None
+    for path, start_date in files:
+        try:
+            total_bytes += path.stat().st_size
+        except OSError:
+            continue
+        if start_date is not None and (oldest is None or start_date < oldest):
+            oldest = start_date
+    return count, total_bytes, oldest
+
+
+def run(args: argparse.Namespace) -> None:
+    from reyn.config.config_schema import walk_config_schema
+    from reyn.config.loader import _find_project_root, load_config
+    from reyn.core.events.event_purge import select_purge_targets
+    from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+    from reyn.runtime.history_tail_reader import aggregate_history_stats
+
+    project_root = Path(args.project_root).resolve()
+    resolved_root = _find_project_root(project_root) or project_root
+
+    # ── D-3: coverage disclosure — printed FIRST, before any check result,
+    # so a reader sees the scope claim before the findings (#4364 owner note:
+    # a scope claim buried after results reads as an afterthought).
+    total_leaves = len(walk_config_schema())
+    measured = len(_MEASURABLE_LEAF_KEYS)
+    uncovered = total_leaves - measured
+    print(
+        f"{total_leaves} config leaves total, {measured} have a measurable "
+        f"effective surface (checked below), {uncovered} uncovered.",
+    )
+    print(f"  Measurable means: {_MEASURABILITY_CRITERION}")
+    print()
+
+    # ── C-7: .reyn/events/ — declared retention vs actual state.
+    config = load_config(project_root)
+    cleanup_period_days = config.audit_events.cleanup_period_days
+    max_disk_usage_percent = config.audit_events.max_disk_usage_percent
+    events_dir = resolved_root / ".reyn" / "events"
+
+    print("Disk usage — declared retention vs. actual (.reyn/events/):")
+    if not events_dir.is_dir():
+        print("  no .reyn/events/ directory yet (nothing written)")
+    else:
+        count, total_bytes, oldest = _events_dir_stats(events_dir)
+        print(
+            f"  declared: cleanup_period_days={cleanup_period_days} "
+            f"(0=disabled), max_disk_usage_percent={max_disk_usage_percent} "
+            f"(0=disabled)",
+        )
+        oldest_desc = f"{(date.today() - oldest).days} day(s) old" if oldest else "n/a (no dated files)"
+        print(f"  actual:   {count} file(s), {total_bytes:,} bytes, oldest = {oldest_desc}")
+        # Read-only query — never deletes (D-2). A non-empty result here
+        # means the declared policy is NOT currently being honored: files
+        # exist RIGHT NOW that the policy's own axes would purge, but
+        # haven't been (the automatic trigger only fires on write/rotation,
+        # not continuously — see event_store.py's own submit_auto_purge).
+        pending = select_purge_targets(
+            events_dir,
+            max_age_days=cleanup_period_days,
+            max_disk_usage_percent=max_disk_usage_percent,
+        )
+        if pending:
+            print(
+                f"  ⚠ {len(pending)} file(s) currently exceed the declared "
+                f"policy but have not been purged yet (purge fires on the "
+                f"next write/rotation, not continuously) — run 'reyn events "
+                f"purge' to apply the policy now if you don't want to wait.",
+            )
+        else:
+            print("  ✓ no file currently exceeds the declared policy")
+
+    # ── C-7: media/ / tool-results/ / history.jsonl — no declared retention
+    # policy exists for any of these yet (#4478/#4476 Phase 2 unimplemented)
+    # — the visibility itself IS the finding (#4480: "no one owns this
+    # resource" made visible, not asserted).
+    print()
+    print("Disk usage — no declared retention policy (visibility only):")
+    store = MediaStore(MediaStoreConfig(), project_root=resolved_root)
+    media_stats = store.storage_stats()
+    hist = aggregate_history_stats(resolved_root)
+    print(
+        f"  media/:         {media_stats.media_file_count} file(s), "
+        f"{media_stats.media_bytes:,} bytes",
+    )
+    print(
+        f"  tool-results/:  {media_stats.tool_result_file_count} file(s), "
+        f"{media_stats.tool_result_bytes:,} bytes",
+    )
+    print(
+        f"  history.jsonl:  {hist.file_count} file(s), {hist.total_bytes:,} "
+        f"bytes, {hist.total_lines:,} turn(s)",
+    )
+    total_bytes_all = (
+        media_stats.media_bytes + media_stats.tool_result_bytes + hist.total_bytes
+    )
+    try:
+        free_bytes = shutil.disk_usage(resolved_root).free
+    except OSError:
+        free_bytes = None
+    print(f"  total (media+tool-results+history): {total_bytes_all:,} bytes")
+    if free_bytes is not None:
+        print(f"  (filesystem free space: {free_bytes:,} bytes)")

--- a/tests/interfaces/test_4364_pr3a_doctor_cli.py
+++ b/tests/interfaces/test_4364_pr3a_doctor_cli.py
@@ -1,0 +1,229 @@
+"""Tier 2: #4364 PR-3a — ``reyn doctor`` skeleton + D-3 coverage disclosure
++ C-7 disk visibility.
+
+No mocks — drives the real ``run`` against real on-disk state under
+``tmp_path``, matching ``test_4488_storage_cli.py``'s own established
+shape for this command family. ``select_purge_targets`` (the read-only
+query C-7 uses to detect a declared-policy violation) is the SAME function
+``reyn events purge`` and the automatic trigger both use — no re-derived
+selection logic here.
+"""
+from __future__ import annotations
+
+import argparse
+from argparse import Namespace
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.cli.commands.doctor import _MEASURABLE_LEAF_KEYS, register, run
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_event_file(
+    events_dir: Path, *, start_date: date, size_bytes: int = 22, suffix: str = "abc123",
+) -> Path:
+    """A real dated events .jsonl file, matching the real on-disk naming
+    convention (YYYY-MM-DDTHHMMSS-<suffix>.jsonl) collect_dated_files parses.
+    ``suffix`` must be unique per call within the same start_date+time or
+    one write silently overwrites another."""
+    subdir = events_dir / "agents" / "default" / "chat" / start_date.strftime("%Y-%m")
+    subdir.mkdir(parents=True, exist_ok=True)
+    path = subdir / f"{start_date.isoformat()}T000000-{suffix}.jsonl"
+    path.write_text("x" * size_bytes, encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def project(tmp_path: Path) -> Path:
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+    return tmp_path
+
+
+# ── Reachability (the exact shape #4478's own review flagged) ─────────────
+
+
+def test_doctor_is_registered_on_the_reyn_parser():
+    """Tier 2: (reachability) 'reyn doctor' is wired into the real top-level
+    parser, not just importable in isolation — this is the 'declared,
+    implemented, tested, invoked by nobody' shape #4478's review flagged.
+    This exact test class would have caught this PR's own initial mistake:
+    doctor.py was imported in commands/__init__.py but never added to the
+    ALL list, so the subcommand was importable but not reachable through
+    argparse — caught by a live smoke test before this test was written,
+    now pinned so it can't silently regress."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    sub.required = True
+    register(sub)
+
+    args = parser.parse_args(["doctor", "--project-root", "/tmp"])
+    assert args.func is run
+
+
+def test_doctor_is_registered_via_the_real_command_registry():
+    """Tier 2: (reachability) the ALL list in commands/__init__.py — not
+    just this module's own register() — actually includes doctor. This is
+    the specific list a forgotten entry silently drops a subcommand from
+    while every other test (including the one above) stays green, since
+    they call register() directly rather than through the real registry."""
+    from reyn.interfaces.cli import build_parser
+
+    parser = build_parser()
+    # argparse exposes registered subparser names via the subparsers action.
+    subparsers_action = next(
+        a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
+    )
+    assert "doctor" in subparsers_action.choices
+
+
+# ── D-3: coverage disclosure ────────────────────────────────────────────
+
+
+def test_coverage_disclosure_line_reports_measurable_and_uncovered(project, capsys):
+    """Tier 2: the summary line states N total / M measurable / N-M
+    uncovered, and the measurability criterion is printed alongside — not
+    just the bare number (#4364 owner note: a scope claim must be
+    derivable from this line, not asserted independently)."""
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    first_line = out.splitlines()[0]
+    assert "config leaves total" in first_line
+    assert "measurable effective surface" in first_line
+    assert "uncovered" in first_line
+    assert "Measurable means:" in out
+
+
+def test_measurable_leaf_keys_are_real_schema_keys():
+    """Tier 2: every key _MEASURABLE_LEAF_KEYS declares actually exists in
+    the live config schema — a rename that doesn't update this list would
+    silently claim to measure a leaf that no longer exists."""
+    from reyn.config.config_schema import walk_config_schema
+
+    real_keys = {node.key for node in walk_config_schema()}
+    for key in _MEASURABLE_LEAF_KEYS:
+        assert key in real_keys, f"{key!r} is not a real config schema key"
+
+
+# ── C-7: .reyn/events/ — declared vs. actual ────────────────────────────
+
+
+def test_events_section_is_absent_gracefully_when_no_events_dir_exists(project, capsys):
+    """Tier 2: accept-side — a fresh project with no .reyn/events/ yet does
+    not error or fabricate a finding."""
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    assert "no .reyn/events/ directory yet" in out
+    assert not (project / ".reyn" / "events").exists()
+
+
+def test_events_reports_real_file_count_and_bytes(project, capsys):
+    """Tier 2: actual on-disk state (not the config value) drives the
+    reported count/bytes."""
+    events_dir = project / ".reyn" / "events"
+    _write_event_file(events_dir, start_date=date.today(), size_bytes=42, suffix="one")
+    _write_event_file(events_dir, start_date=date.today(), size_bytes=8, suffix="two")
+
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    actual_line = next(line for line in out.splitlines() if line.strip().startswith("actual:"))
+    assert "2 file(s)" in actual_line
+    assert "50 bytes" in actual_line  # 42 + 8
+
+
+def test_a_declared_policy_violation_is_detected(project, capsys):
+    """Tier 2: THE core C-7 value — a file older than the declared
+    cleanup_period_days is flagged as a real, currently-unenforced
+    violation. This is a live declared-vs-effective mismatch, not a
+    hypothetical: reyn's own default cleanup_period_days=30 with a 45-day-
+    old file reproduces exactly the #4480 concern (a policy exists but
+    isn't demonstrably working)."""
+    events_dir = project / ".reyn" / "events"
+    old_date = date.today() - timedelta(days=45)
+    _write_event_file(events_dir, start_date=old_date)
+
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    assert "exceed the declared policy" in out
+    assert "1 file(s) currently exceed" in out
+    assert "45 day(s) old" in out
+
+
+def test_a_compliant_state_shows_no_violation_warning(project, capsys):
+    """Tier 2: accept-side — files well within the declared retention
+    window must not trip the violation warning (a false positive here
+    would teach an operator to ignore doctor's own output)."""
+    events_dir = project / ".reyn" / "events"
+    _write_event_file(events_dir, start_date=date.today())
+
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    assert "exceed the declared policy" not in out
+    assert "no file currently exceeds the declared policy" in out
+
+
+def test_doctor_never_deletes_the_violating_file(project, capsys):
+    """Tier 2: D-2 falsify — the exact file doctor reports as violating the
+    declared policy must still exist on disk after doctor runs. select_
+    purge_targets is a query; doctor must never call purge_files/
+    apply_auto_purge on what it finds."""
+    events_dir = project / ".reyn" / "events"
+    old_date = date.today() - timedelta(days=45)
+    violating_path = _write_event_file(events_dir, start_date=old_date)
+
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    assert "exceed the declared policy" in out  # sanity: the case fired
+    assert violating_path.is_file(), "doctor must never delete what it reports on"
+
+
+# ── C-7: media/ / tool-results/ / history.jsonl visibility ────────────────
+
+
+def test_no_declared_policy_section_lists_all_three_unowned_resources(project, capsys):
+    """Tier 2: the #4480-motivated finding — media/, tool-results/, and
+    history.jsonl each get their own visibility row, unconditionally
+    (their value IS being listed, even at zero), since none has a declared
+    retention policy to check compliance against."""
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    assert "no declared retention policy" in out
+    assert "media/:" in out
+    assert "tool-results/:" in out
+    assert "history.jsonl:" in out
+
+
+def test_no_declared_policy_section_reflects_real_writes(project, capsys):
+    """Tier 2: real on-disk history.jsonl content shows up, reusing the
+    same aggregate_history_stats #4476's own storage command uses."""
+    hist = project / ".reyn" / "agents" / "alice" / "history.jsonl"
+    hist.parent.mkdir(parents=True)
+    hist.write_text('{"seq": 1}\n{"seq": 2}\n', encoding="utf-8")
+
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    hist_line = next(line for line in out.splitlines() if line.strip().startswith("history.jsonl:"))
+    assert "1 file(s)" in hist_line
+    assert "2 turn(s)" in hist_line
+
+
+def test_honors_an_explicit_project_root_not_cwd(project, capsys, monkeypatch):
+    """Tier 2: --project-root overrides cwd, same contract as 'reyn storage
+    stats' (#4488) — doctor must not implicitly assume cwd is the project."""
+    events_dir = project / ".reyn" / "events"
+    _write_event_file(events_dir, start_date=date.today())
+
+    other_dir = project.parent / "elsewhere"
+    other_dir.mkdir()
+    monkeypatch.chdir(other_dir)
+
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    actual_line = next(line for line in out.splitlines() if line.strip().startswith("actual:"))
+    assert "1 file(s)" in actual_line


### PR DESCRIPTION
**[docs-maintainer]** — #4364 PR-3a, per lead-coder's split approval (this session flagged PR-2's C-1 as carrying an unresolved execution-semantics question; lead-coder settled it separately, and reassigned this bounded, no-ambiguity slice — skeleton + D-3 + C-7 — here).

## Design constraints this PR must satisfy (owner/lead-coder/architect rulings, #4364)

- **D-1**: every printed line reports a MEASURED live effect, never a restated config declaration.
- **D-2**: report-only — never deletes/writes/repairs. C-7 uses `event_purge.select_purge_targets` (the same read-only query `reyn events purge` and the automatic trigger both use) purely to detect a violation; never calls `purge_files`/`apply_auto_purge`.
- **D-3** (architect, generalized from the C-5/C-6 discussion): the summary line discloses N total config leaves / M with a measurable effective surface / N-M uncovered, **with the measurability criterion printed alongside the count** — never a bare number. **lead-coder's explicit condition on approving the 3a/3b split: D-3 must ship in 3a, not defer to 3b**, or a disk-only doctor misreads as "checked everything".

## What

- `src/reyn/interfaces/cli/commands/doctor.py` — new `reyn doctor` subcommand.
- **C-7**: `.reyn/events/` declared (`audit_events.cleanup_period_days`/`max_disk_usage_percent`, #4479) vs. actual (real file count/bytes/oldest-file age), including a live violation check — a non-empty result means files exist right now the declared policy would purge but hasn't (the automatic trigger only fires on write/rotation, not continuously). Plus `media/`/`tool-results/`/`history.jsonl` visibility rows with no declared policy at all (#4478/#4476 Phase 2 unimplemented) — the visibility itself is the finding (#4480: an unowned resource made visible, not silently absent).
- All disk measurement reuses existing functions: `event_purge.select_purge_targets`, `MediaStore.storage_stats()`, `aggregate_history_stats()` (#4478/#4476 Phase 1) — no new measurement subsystem, which is exactly what made this slice safe to split off from PR-3b's C-5/C-6 (each of those needs genuinely new measurement code per pair).
- `docs/reference/cli/doctor.md` + nav entry — same-PR doc landing, following the `storage.md` precedent.

## Out of scope (later slices, same arc)

- C-1/C-2 (hook argv launch probe / zero-responder detection) — PR-2, separately dispatched once lead-coder settled C-1's execution semantics.
- C-5/C-6 (sandbox posture, listen port, model-name pairs) — PR-3b.

## Tests

12 tests, including two reachability tests that caught this PR's own real bug during development: `doctor.py` was imported in `commands/__init__.py` but I initially forgot to add it to the `ALL` list — importable, but unreachable through argparse. A live smoke test caught it before the test suite did; `test_doctor_is_registered_via_the_real_command_registry` (through the real `build_parser()`, not a hand-built parser) now pins it so it can't silently regress.

## Falsify-verify

- Reverted the `ALL`-list entry: both reachability tests failed for the right reason.
- Injected a real `purge_files()` call after the violation-detection branch: the D-2 never-deletes test failed for the right reason.
- Restored both, reconfirmed all 12 green.

## Verification

- `pytest tests/interfaces/test_4364_pr3a_doctor_cli.py` — 12 passed
- `pytest tests/interfaces/ -k "storage or doctor or events or 4478 or 4476 or 4479 or 4485 or 4488"` — 46 passed (no regression in reused functions)
- Real CLI smoke test against a temp project with a genuinely policy-violating events file — correct output end to end
- `ruff check src tests` — clean
- `test_tier_audit.py --strict` on the new test file — 12/12 OK
- `verify_module_docstrings.py` — OK
- `mypy_ratchet.py` — OK, all baselined
- `check_tests_path_literal_reference.py` — OK, all baselined
- `mkdocs build --strict` — clean, no Aborted/error line

part of #4364

## Test plan

- [x] `pytest tests/interfaces/test_4364_pr3a_doctor_cli.py` — 12 passed
- [x] `pytest tests/interfaces/` broader sweep on reused functions — 46 passed
- [x] Real CLI smoke test — correct end-to-end output including a genuine policy-violation detection
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` — 12/12 OK
- [x] `verify_module_docstrings.py` — OK
- [x] `mypy_ratchet.py` — OK
- [x] `check_tests_path_literal_reference.py` — OK
- [x] `mkdocs build --strict` — clean
- [x] Falsify-verify: both the ALL-list reachability bug and the D-2 never-deletes rule genuinely RED without the fix
- [x] (skipped — no Visual item, CLI-output-only feature)
