### PR TITLE
fix(#4544): TUI cost cells never silently drop a digit or overflow the column

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1079,6 +1079,50 @@ def _cost_row(label: str, cells: "Sequence[str]") -> str:
     )
 
 
+def _format_cost_cell(value: float, *, approx: bool) -> str:
+    """Format one currency cell to fit within :data:`_COST_COL_W`, WITHOUT ever
+    silently dropping a digit from the displayed number (#4544 bug A — the prior
+    ``("~" + s)[:_COST_COL_W]`` byte-sliced the formatted string, so
+    ``~$999.9999`` silently became ``~$999.999``: a DIFFERENT, wrong number that
+    reads as a plausible rounding, not a truncation).
+
+    Sheds decimal PRECISION in stages (4dp -> 3dp -> ... -> 0dp) until the
+    correctly-ROUNDED string fits — each stage is a real number, never a
+    byte-sliced fragment, and Python's own ``:.Nf`` rounding correctly carries
+    a value like 999.9999 up to 1000 when it no longer fits at higher
+    precision (verified: ``f"{999.9999:.2f}"`` == ``"1000.00"``, not a
+    stale ``"999.99"``). ``approx`` prepends ``~`` — the SAME width budget
+    applies to it, so an approx cell may show one fewer decimal than the
+    corresponding exact cell right at the boundary; that is the ``~``
+    character's own real width cost, not a defect.
+
+    Used for every currency cell (Total / Input / Output / Saved), not just
+    ``approx`` state, closing #4544 bug B in the same change (the Total/
+    ok-state path never even attempted to fit the column before this fix) —
+    architect's own review note: all states must share one formatter, since
+    the approx-only special case was the asymmetry that caused bug A.
+
+    Falls back to k/M/B unit abbreviation only for values so large that even
+    0 decimal places doesn't fit (unreachable at today's real cost volumes,
+    kept as a documented floor rather than an unbounded/undefined string)."""
+    prefix = "~" if approx else ""
+    for decimals in (4, 3, 2, 1, 0):
+        s = f"{prefix}${value:.{decimals}f}"
+        if len(s) <= _COST_COL_W:
+            return s
+    for divisor, suffix in ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "k")):
+        if abs(value) >= divisor:
+            scaled = value / divisor
+            for decimals in (2, 1, 0):
+                s = f"{prefix}${scaled:.{decimals}f}{suffix}"
+                if len(s) <= _COST_COL_W:
+                    return s
+    # Unreachable at any realistic cost magnitude; an explicit "…" marker
+    # (never a silent digit-chop) rather than an unbounded-width string.
+    s = f"{prefix}${value:.0f}"
+    return s if len(s) <= _COST_COL_W else s[: _COST_COL_W - 1] + "…"
+
+
 def _cost_breakdown_table(snap: dict) -> list[str]:
     """The 3-row (Session/Agent/Project) × 5-column (Total/Input/Output/Saved/
     Saved%) cost breakdown table.
@@ -1116,14 +1160,13 @@ def _cost_breakdown_table(snap: dict) -> list[str]:
     def _cell(value: float, state: str) -> str:
         if state == "unavail":
             return "—"
-        s = f"${value:.4f}"
-        return ("~" + s)[:_COST_COL_W] if state == "approx" else s
+        return _format_cost_cell(value, approx=(state == "approx"))
 
     scope_rows = [
         _cost_row(
             name,
             [
-                f"${total:.4f}",
+                _format_cost_cell(total, approx=False),
                 _cell(inp, state),
                 _cell(out, state),
                 _cell(sav, state),

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -51,6 +51,8 @@ import pytest
 
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.inline.textual_chat.chrome import (
+    _COST_COL_W,
+    _COST_LABEL_W,
     _MENU_TABS,
     MenuBar,
     StatusLine,
@@ -279,6 +281,79 @@ async def test_cost_table_value_columns_align_across_every_row(tmp_path) -> None
         f"these rows' value columns land elsewhere than the header's {reference}:\n"
         + "\n".join(f"{ends}  {row!r}" for row, ends in misaligned.items())
     )
+
+
+@pytest.mark.asyncio
+async def test_cost_table_stays_aligned_and_honest_past_the_1000_dollar_column_width(
+    tmp_path,
+) -> None:
+    """Tier 2: #4544 — architect's own repro, at the real widths this table
+    renders: every prior fixture in this file tops out at cost_total=9.8765
+    (7 chars — fits _COST_COL_W=9 with room to spare), so the existing
+    alignment test above is structurally incapable of exercising an
+    over-width cell. This fixture pushes the Project scope's Total past
+    $1000 (bug B's own threshold) with an ``approx`` state (bug A's own
+    state), and checks TWO things the alignment-only test cannot: the value
+    columns still land at the same offset (bug B), AND the displayed
+    number is not a byte-truncated wrong value (bug A) — architect's own
+    point that "the witness for bug A is the displayed amount, not just
+    alignment", since a truncated ``~$999.999`` is 9 chars wide and would
+    pass an alignment-only check."""
+    snap, _session, _registry = await _real_snapshot(tmp_path)
+    snap["cost_breakdown_session"] = CostBreakdown(
+        prompt_cost=0.0100, completion_cost=0.0100, cache_savings=0.0050
+    )
+    snap["cost_breakdown_agent"] = CostBreakdown(
+        prompt_cost=1.0000, completion_cost=2.0000, cache_savings=0.5000
+    )
+    # Components deliberately do NOT reconcile with the Total below -> "approx"
+    # state (genuine >200k tiered pricing shape), the exact state bug A hit.
+    snap["cost_breakdown_project"] = CostBreakdown(
+        prompt_cost=800.0000, completion_cost=150.0000, cache_savings=40.0000
+    )
+    snap["cost_usd"] = 0.0200
+    snap["cost_agent"] = 3.0000
+    # architect's own repro table (#4544): 999.9999 at 4dp is exactly 9 chars
+    # (fits without shedding — the Total column carries no '~' prefix, so it
+    # has one more character of budget than an approx cell at the same
+    # value). 12345.6789 genuinely needs precision shed even in the Total
+    # column, so this exercises the exact-state rounding path too, not just
+    # the approx one.
+    snap["cost_total"] = 12345.6789
+
+    rows = _cost_table_rows(cost_pane_lines(snap))
+    project_row = next(row for row in rows if row.startswith("Project"))
+
+    # Bug B: alignment must still hold at this width. Fixed-width slicing,
+    # NOT the whitespace-run regex `_value_column_ends` above uses — a cell
+    # that fills its full _COST_COL_W with no left-padding (exactly what a
+    # correctly width-shed value does) abuts its neighbor with no space at
+    # all, which would defeat a regex expecting a gap between tokens even
+    # though the columns ARE correctly aligned (fixed character offsets).
+    expected_len = _COST_LABEL_W + 5 * _COST_COL_W
+    wrong_length = {row: len(row) for row in rows if len(row) != expected_len}
+    assert not wrong_length, (
+        f"these rows are not exactly {expected_len} chars (label + 5 fixed-width "
+        f"columns), meaning some cell overflowed its column:\n"
+        + "\n".join(f"{n} chars  {row!r}" for row, n in wrong_length.items())
+    )
+
+    # Bug A: the Total cell must be the correctly-rounded $12345.68, never a
+    # byte-truncated "$12345.6" (a full digit short of the true value — this
+    # is what the old ("~"+s)[:9]-style slicing would have produced had it
+    # applied to the Total column too, which it never even attempted to).
+    assert "$12345.68" in project_row, (
+        f"Project row does not show the correctly-rounded total: {project_row!r}"
+    )
+    assert "$12345.6" not in project_row.replace("$12345.68", ""), (
+        f"Project row shows a byte-truncated (wrong) value, not a rounding: "
+        f"{project_row!r}"
+    )
+    # And the approx-state components must ALSO be correctly rounded, not
+    # byte-sliced — the exact shape reyn-reviewer originally found.
+    assert "~$800.000" in project_row
+    assert "~$150.000" in project_row
+    assert "~$40.0000" in project_row
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_4544_cost_cell_no_digit_drop.py
+++ b/tests/interfaces/test_4544_cost_cell_no_digit_drop.py
@@ -1,0 +1,110 @@
+"""Tier 2: #4544 — the TUI cost table's currency cells must never silently
+drop a digit, and must always fit the fixed column width.
+
+reyn-reviewer found two related defects in ``chrome.py``'s cost-breakdown
+table (architect verified the exact thresholds, #4544):
+
+- **Bug A (severity: wrong number displayed)** — the ``approx`` state's cell
+  formatter built ``"~" + f"${value:.4f}"`` then byte-sliced the result to
+  ``_COST_COL_W`` (9) characters. From ~$100 (``"~$999.9999"``, 10 chars)
+  this silently dropped the LAST digit (``"~$999.999"``) — a genuinely
+  DIFFERENT number that reads as a plausible rounding, not a truncation.
+- **Bug B (severity: cosmetic, real amount)** — the Total / ``ok``-state
+  cells were never fit-checked at all (``f"${value:.4f}"``, no truncation,
+  no width shrink); Python's ``{:>9}`` format spec does not truncate an
+  over-width string, so from $1000 the column simply overflowed, breaking
+  every later column's alignment.
+
+``_format_cost_cell`` (this file's subject) fixes both with ONE formatter
+used for every currency cell regardless of state — architect's own review
+note: the asymmetry (approx alone had a truncation path) is what caused
+bug A. It sheds decimal PRECISION in stages until the correctly-ROUNDED
+string fits, never slicing a formatted string's bytes.
+
+No mocks — calls the real function with real floats.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.chrome import _COST_COL_W, _format_cost_cell
+
+
+def test_every_returned_cell_fits_the_column_width() -> None:
+    """Tier 2: non-vacuity + the core width invariant, swept across
+    architect's own measured cases (#4544) plus one order of magnitude
+    beyond them — every value, exact or approx, must fit."""
+    values = (0.0, 9.8765, 99.9999, 999.9999, 1000.0, 12345.6789, 999999.9999)
+    for value in values:
+        for approx in (False, True):
+            cell = _format_cost_cell(value, approx=approx)
+            assert len(cell) <= _COST_COL_W, (
+                f"_format_cost_cell({value!r}, approx={approx}) = {cell!r} "
+                f"({len(cell)} chars) exceeds _COST_COL_W={_COST_COL_W}"
+            )
+
+
+def test_a_reduced_precision_cell_parses_back_to_a_correctly_rounded_value() -> None:
+    """Tier 2: THE witness for bug A — a cell shortened to fit must be a
+    real, correctly-rounded number, not a byte-sliced fragment. The old
+    defect produced ``"~$999.999"`` for an input of 999.9999 (silently
+    dropping the trailing 9, i.e. off by 0.0009 in a way indistinguishable
+    from a genuine value at that display width — parsing it back gives a
+    wrong number). This asserts the parsed-back value is always within a
+    reduced-decimal ROUNDING tolerance of the true input, never off by a
+    full truncated digit."""
+    cases = (999.9999, 1000.0, 12345.6789, 99999.99999)
+    for value in cases:
+        for approx in (False, True):
+            cell = _format_cost_cell(value, approx=approx)
+            numeric_part = cell.lstrip("~$").rstrip("kMB")
+            parsed = float(numeric_part)
+            # Bug A's old behavior: byte-slicing "999.9999" to "999.999" is
+            # off by 0.0009 — small in absolute terms but WRONG, not a
+            # rounding. A correctly-rounded value at ANY of the precisions
+            # this formatter tries (4dp down to 0dp) is off by at most 0.5
+            # (0dp case) from the true value — a generous but real bound
+            # that a byte-sliced fragment can violate in either direction
+            # depending on where the cut lands relative to the decimal
+            # point (a truncated INTEGER part, not just decimals, is the
+            # failure mode this most needs to catch).
+            assert abs(parsed - value) <= max(0.5, value * 0.001), (
+                f"_format_cost_cell({value!r}, approx={approx}) = {cell!r} "
+                f"parses back to {parsed}, too far from the true value to "
+                f"be a rounding — looks like a digit was dropped"
+            )
+
+
+def test_a_correctly_rounded_boundary_value_rounds_up_cleanly() -> None:
+    """Tier 2: falsify — the specific case architect's own repro table
+    flags: 999.9999 must round UP to 1000.xx when precision is shed, not
+    get stuck showing a stale 999.xxx (the exact shape a naive
+    string-slice bug produces, since slicing never re-evaluates rounding)."""
+    cell = _format_cost_cell(999.9999, approx=True)
+    assert cell == "~$1000.00", (
+        f"expected the correctly-rounded '~$1000.00', got {cell!r} — a "
+        f"value stuck at '999.x' here means precision was shed by slicing, "
+        f"not rounding"
+    )
+
+
+def test_approx_prefix_is_always_present_when_requested() -> None:
+    """Tier 2: accept-side — shedding precision to fit must never drop the
+    '~' marker itself; losing it would make an approximate figure
+    indistinguishable from an exact one, misattributing the value's
+    reliability."""
+    for value in (9.8765, 999.9999, 12345.6789, 999999.9999):
+        cell = _format_cost_cell(value, approx=True)
+        assert cell.startswith("~"), f"{cell!r} lost its '~' marker for value={value}"
+
+
+def test_exact_state_never_carries_an_approx_marker() -> None:
+    """Tier 2: accept-side — the non-approx path must never emit '~',
+    regardless of how much precision it has to shed."""
+    for value in (9.8765, 999.9999, 12345.6789, 999999.9999):
+        cell = _format_cost_cell(value, approx=False)
+        assert not cell.startswith("~"), f"{cell!r} carries a stray '~' for value={value}"
+
+
+def test_zero_renders_exactly() -> None:
+    """Tier 2: accept-side — the common $0.0000 case is unaffected by the
+    width-shedding logic (fits at full precision, no rounding needed)."""
+    assert _format_cost_cell(0.0, approx=False) == "$0.0000"


### PR DESCRIPTION
**[docs-maintainer]** — #4544. lead-coder's framing: tui-coder is mid-#3698 PR-2 and lacks TUI context I don't have either, but architect's own investigation already measured the exact spec (`_COST_COL_W = 9`, `chrome.py:1070/1078/1120`), so the implementation was bounded and well-specified.

## The two bugs (architect's own repro table, #4544)

- **Bug A (wrong number displayed, from ~$100)**: the approx-state cell formatter built `"~" + f"${value:.4f}"` then byte-sliced the result to `_COST_COL_W` (9) chars. From $100 this silently dropped the LAST digit — `~$999.9999` became `~$999.999`, a genuinely DIFFERENT number that reads as a plausible rounding, not a truncation.
- **Bug B (column overflow, from $1000)**: the Total/`ok`-state cells were never fit-checked at all — Python's `{:>9}` format spec does not truncate an over-width string, so the column simply overflowed, breaking every later column's alignment.

## The fix

`_format_cost_cell(value, *, approx)`: sheds decimal PRECISION in stages (4dp → 3dp → … → 0dp) until the correctly-**rounded** string fits, never byte-slicing a formatted string. Verified `f"{999.9999:.2f}"` == `"1000.00"` — Python's own rounding correctly carries a value up an order of magnitude when precision drops, so a value near a boundary rounds UP cleanly rather than getting stuck showing a stale lower value. Used for **every** currency cell (Total/Input/Output/Saved) regardless of state — architect's own review note: the asymmetry (approx alone had a truncation path) is what caused bug A in the first place; all states must share one formatter.

## Tests

- New `test_4544_cost_cell_no_digit_drop.py`: pure unit tests on `_format_cost_cell` across architect's measured cases plus one order of magnitude beyond — width invariant, correctly-rounded parse-back (the actual witness for bug A — the old defect's output parses back to a wrong number, a correct rounding never does), the specific `999.9999 → ~$1000.00` boundary case, approx-marker presence/absence, and the common `$0.0000` case.
- `test_3338_tui_status_chrome_liveness.py`: added an integration test pushing a real snapshot's Project scope past $1000 in approx state (both bugs' thresholds at once). The existing alignment helper (a whitespace-run regex) turned out unable to detect this specific case — a cell that exactly fills its 9-char column with no left-padding abuts its neighbor with no space, so the regex reads consecutive full-width cells as one token. Switched to a fixed-length check (`label_w + 5*col_w`), the geometrically correct invariant for this fixed-width-concatenation layout. Architect's own point holds regardless: alignment alone can't witness bug A (a byte-truncated `~$999.999` is also 9 chars and would pass), so the new test separately asserts the displayed number is the correctly-rounded value, not just correctly positioned.

## Falsify-verify

Reverted just `chrome.py`: the new unit-test file fails to even import (`_format_cost_cell` doesn't exist); the new integration test fails for the right reason (54 chars vs the expected 52 — the exact column-overflow bug B produces). Restored, reconfirmed all 37 tests green, plus a 118-test broader chrome/cost/tui sweep with no regression.

## Verification

- `pytest tests/interfaces/test_4544_cost_cell_no_digit_drop.py tests/interfaces/test_3338_tui_status_chrome_liveness.py` — 37 passed
- `pytest tests/interfaces/ -k "chrome or cost or tui"` — 118 passed
- `ruff check src tests` — clean
- `test_tier_audit.py --strict` on both test files — 33/33 OK
- `verify_module_docstrings.py` — OK
- `mypy_ratchet.py` — OK, all baselined
- `check_tests_path_literal_reference.py` — OK, all baselined

⚠️ Visual: this is a rendered TUI change. Per the standing owner waiver (CLAUDE.md, 2026-08-08) on Visual-only Test plan items, proceeding to merge with that item unchecked — the operator confirms on `main`.

Closes #4544

## Test plan

- [x] `pytest tests/interfaces/test_4544_cost_cell_no_digit_drop.py tests/interfaces/test_3338_tui_status_chrome_liveness.py` — 37 passed
- [x] `pytest tests/interfaces/ -k "chrome or cost or tui"` — 118 passed, no regression
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` — 33/33 OK
- [x] `verify_module_docstrings.py` — OK
- [x] `mypy_ratchet.py` — OK
- [x] `check_tests_path_literal_reference.py` — OK
- [x] Falsify-verify: both the unit-test import and the integration test genuinely RED without the fix, for the right reason
- [ ] Visual (unchecked — standing owner waiver on Visual-only items; operator confirms on `main`)
