### PR TITLE
fix(#4554): drawer Static panes share the tab row's 2-cell left edge

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -951,8 +951,23 @@ class TextualChatApp(App):
     /* #3699: deliberately NO max-height here — the pane must be allowed to be
        its full content height so the scroll container above has something to
        scroll to. Capping the Static instead clamps its virtual size and the
-       content past the cap stops existing rather than moving off screen. */
-    #drawer Static { height: auto; padding: 1 0; }
+       content past the cap stops existing rather than moving off screen.
+       Horizontal padding unrelated to this rule's own concern (height) —
+       touched by #4554, see that rule change's own comment just below for
+       why 0 became 2. */
+    /* #4554: the tab label sits 2 cells in from the drawer's left edge
+       (MenuBar's own `padding: 0 1` + Tab's own `padding: 0 1`, above), but
+       a Static pane's content started at column 0 — no shared left edge
+       between a tab and the pane it opens, most visible on the Cost tab's
+       column-aligned table (reyn-reviewer, #4544's own investigation).
+       Fixes ALL 5 Static panes (cost/ctx/pipe/cron/help) from this ONE
+       rule — `_MENU_TABS` (chrome.py) has 14 entries, `_LIST_PANES` has 9;
+       the other 9 are OptionList, explicitly excluded (architect's own
+       measurement, #4554): OptionList already has `padding: 0` above by
+       design (full-width row highlight on selection — adding padding here
+       would shrink that highlight), so this rule intentionally targets
+       Static only, never OptionList. */
+    #drawer Static { height: auto; padding: 1 2; }
     """)
 
     #: Per-entry BODY animation rate (Hz) for the live RUNNING-tool indicator

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -357,6 +357,59 @@ async def test_cost_table_stays_aligned_and_honest_past_the_1000_dollar_column_w
 
 
 @pytest.mark.asyncio
+async def test_every_static_drawer_pane_shares_the_tabs_left_edge(tmp_path) -> None:
+    """Tier 2: #4554 — the drawer's tab label sits 2 cells in from the left
+    edge (MenuBar's own `padding: 0 1` + Tab's own `padding: 0 1`), but a
+    Static pane's content used to start at column 0 with no shared left
+    edge. Reads the REAL RESOLVED CSS via ``.styles.padding`` on a real
+    mounted widget — not a string grep of the stylesheet source, which
+    would only confirm the rule was EDITED, not that Textual actually
+    applies it (a selector typo/specificity miss would still show the
+    edited text in the source).
+
+    Derives the pane-id set from `_MENU_TABS` minus `pane_is_list()`
+    (the real registries #4554's own investigation used to enumerate all
+    5 Static panes), rather than hand-listing cost/ctx/pipe/cron/help — a
+    hand list would silently stop covering a 6th Static pane added later."""
+    from textual.geometry import Spacing
+    from textual.widgets import OptionList, Static
+
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+    from reyn.interfaces.inline.textual_chat.chrome import _MENU_TABS, pane_is_list
+
+    static_pane_ids = [tab_id for tab_id, _label in _MENU_TABS if not pane_is_list(tab_id)]
+    list_pane_ids = [tab_id for tab_id, _label in _MENU_TABS if pane_is_list(tab_id)]
+    assert static_pane_ids and list_pane_ids, "pane registries are empty — fixture is stale"
+
+    snap, _session, _registry = await _real_snapshot(tmp_path)
+    transport = _EventOnlyTransport()
+    app = TextualChatApp(transport=transport, read_model=_MutableSnapshotReadModel(snap))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        wrong: dict[str, Spacing] = {}
+        for tab_id in static_pane_ids:
+            app._open_drawer(tab_id)
+            await pilot.pause()
+            padding = app.query_one(f"#{tab_id}", Static).styles.padding
+            if padding != Spacing(top=1, right=2, bottom=1, left=2):
+                wrong[tab_id] = padding
+        assert not wrong, (
+            f"these Static panes do not share the tab row's 2-cell left edge: {wrong}"
+        )
+
+        # OptionList panes must be UNCHANGED (architect's own exclusion,
+        # #4554) — adding padding here would shrink the full-width row
+        # highlight that selecting a row relies on.
+        for tab_id in list_pane_ids:
+            app._open_drawer(tab_id)
+            await pilot.pause()
+            padding = app.query_one(f"#{tab_id}", OptionList).styles.padding
+            assert padding == Spacing(0, 0, 0, 0), (
+                f"OptionList pane {tab_id!r} gained padding it must not have: {padding}"
+            )
+
+
+@pytest.mark.asyncio
 async def test_cost_pane_surfaces_all_three_scope_breakdowns(tmp_path) -> None:
     """Tier 2: a value carried in EACH of the three ``cost_breakdown_*`` keys
     surfaces in the Cost pane — the regression was that the pane read none of


### PR DESCRIPTION
**[docs-maintainer]** — #4554, owner-directed. lead-coder's explicit condition: fix the ONE root cause (a single CSS rule mismatch), never patch the 5 panes individually.

## The bug (reyn-reviewer's finding, architect's measurement)

The tab label sits 2 cells in from the drawer's left edge (`MenuBar { padding: 0 1; }` + `MenuBar Tab { padding: 0 1; }`), but `#drawer Static { padding: 1 0; }` starts pane content at column 0 — no shared left edge between a tab and the pane it opens. Most visible on the Cost tab's column-aligned table (#4544's own investigation).

## The fix

One rule: `#drawer Static { padding: 1 0; }` → `padding: 1 2;`. Fixes all 5 Static panes (cost/ctx/pipe/cron/help) from this one change — `_MENU_TABS` has 14 entries, `pane_is_list()` returns True for 9 (OptionList, explicitly excluded by architect's own measurement: OptionList already has `padding: 0` by design, for the full-width row-selection highlight; adding padding here would shrink it). `#3699`'s own "deliberately NO max-height" comment on the same rule line is unaffected — horizontal padding doesn't touch height.

## Tests

Extended `test_3338_tui_status_chrome_liveness.py` with a test that mounts the REAL app, opens each of the 5 Static panes plus example OptionList panes, and reads `.styles.padding` on the REAL RESOLVED widget through Textual's own CSS engine — not a string grep of the stylesheet source (which would only confirm the rule text was edited, not that Textual actually applies it; a selector typo or specificity miss would still show the edited text in source). Derives the pane-id set from `_MENU_TABS` minus `pane_is_list()` rather than hand-listing the 5 panes, so a 6th Static pane added later stays covered.

## Falsify-verify

Reverted just the CSS line: the new test failed for the right reason, showing the real resolved padding for all 5 panes as `Spacing(top=1, right=0, bottom=1, left=0)` — exactly the bug. Restored, reconfirmed all 32 tests green plus a 149-test broader sweep with no regression.

## What this PR does NOT close

The issue's own acceptance criteria require a real-TTY screencapture witness ("CSS を変えた is not a witness") and owner confirmation that "2" is visually correct — architect's own note: neither they nor reyn-reviewer measured the real terminal rendering, only read the CSS arithmetic, and "Textual の描画と端末でずれ得る". Per the standing owner waiver (CLAUDE.md, 2026-08-08) on Visual-only Test plan items, proceeding to merge with that item unchecked; the operator confirms on `main`. Marked `part of #4554`, not `Closes`, since the issue's own completion bar is genuinely unmet until that confirmation happens — this isn't the #4544 shape (a formatting bug with an unambiguous right answer); here the value itself could turn out wrong on real rendering.

## Verification

- `pytest tests/interfaces/test_3338_tui_status_chrome_liveness.py` — 32 passed
- `pytest tests/interfaces/ -k "chrome or drawer or tui or menu or cost"` — 149 passed
- `ruff check src tests` — clean
- `test_tier_audit.py --strict` — 0 errors
- `verify_module_docstrings.py` — OK
- `mypy_ratchet.py` — OK, all baselined
- `check_tests_path_literal_reference.py` — OK, all baselined

part of #4554

## Test plan

- [x] `pytest tests/interfaces/test_3338_tui_status_chrome_liveness.py` — 32 passed
- [x] `pytest tests/interfaces/` broader sweep — 149 passed
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` — 0 errors
- [x] `verify_module_docstrings.py` — OK
- [x] `mypy_ratchet.py` — OK
- [x] `check_tests_path_literal_reference.py` — OK
- [x] Falsify-verify: the real-CSS-resolution test genuinely RED without the fix
- [ ] Visual (unchecked — standing owner waiver; real-TTY confirmation of the "2" value and visual alignment is the issue's own explicit remaining acceptance bar)
