### PR TITLE
feat(#3698 PR-2): subscription/listen port, era-independent subscribe

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -375,7 +375,7 @@ op dispatch:
 
 | Kind | Trigger | Key payload |
 |------|---------|-------------|
-| `mcp_initialized` | Emitted on every (re)connect, once the server's `initialize` handshake completes. | `server`, `negotiated_version`, `capabilities` |
+| `mcp_initialized` | Emitted on every (re)connect, once the server's handshake completes (`initialize` or, since #3698 PR-2's `Client(mode="auto")`, `discover`). | `server`, `negotiated_version`, `capabilities`, `subscription_adapter` (the selected `SubscriptionAdapter` class name — `LegacySubscriptionAdapter` or `ListenSubscriptionAdapter`, see [Concepts: MCP](../../concepts/tools-integrations/mcp.md) — the audit-visible witness of which delivery mechanism this connection actually uses) |
 | `mcp_resource_updated` | A subscribed resource's server-pushed `resources/updated` notification, or a synthetic resync fired per re-subscribed URI after a transport-death reconnect. Also wired into the hook dispatcher as an external-event hook-point — see [Concepts: hooks](../../concepts/runtime/hooks.md#mcp_resource_updated). | `server`, `uri`, `resync` (`true` for a reconnect resync, `false` for a real push) |
 | `mcp_elicitation_requested` | A server issues an `elicitation/create` structured-input request. | `server`, `field_keys` (the requested schema's property **names** only — never values) |
 | `mcp_elicitation_answered` | The request resolves to `accept` or `decline` (human choice, or a `decline` from `auto_decline` config). | `server`, `field_keys`, `action` (`"accept"` \| `"decline"`) |

--- a/src/reyn/hooks/ingress.py
+++ b/src/reyn/hooks/ingress.py
@@ -166,11 +166,24 @@ class _BoundedEventBridge:
 
 
 class McpIngressAdapter:
-    """§6.1 MCP Adapter — standard ``resources/updated`` notification only (no
-    custom dialect). Converts a resource-update signal into the builtin
-    ``mcp_resource_updated`` :class:`HookEvent` (via Phase 1's
-    ``build_hook_payload``, so the field-set stays schema-gated) and delivers
-    it through the shared in-process bridge."""
+    """§6.1 MCP Adapter — converts a resource-update signal (``uri``,
+    ``resync``) into the builtin ``mcp_resource_updated`` :class:`HookEvent`
+    (via Phase 1's ``build_hook_payload``, so the field-set stays
+    schema-gated) and delivers it through the shared in-process bridge.
+
+    #3698 (architect flag, corrected): the SIGNAL is wire-independent, not
+    "standard ``resources/updated`` notification only" as an earlier version
+    of this docstring claimed — :meth:`to_event` takes ``uri``/``resync``
+    values, never a wire notification object, and its ONE caller
+    (:meth:`~reyn.mcp.connection_service.MCPConnectionService.
+    _mcp_to_hook_event`) already fed it from THREE distinct sources even
+    before PR-2: a real legacy ``resources/updated`` push
+    (:meth:`~reyn.mcp.message_handler.ReynMCPMessageHandler.
+    on_resource_updated`), a SYNTHETIC reconnect-resync re-signal (#2597 P1,
+    ``resync=True``, no wire notification at all), and — since #3698 PR-2 —
+    a modern-era ``ResourceUpdated`` event off a ``Client.listen()`` stream
+    (:class:`~reyn.mcp.subscription_port.ListenSubscriptionAdapter`). This
+    adapter itself never branches on which of those produced the signal."""
 
     def __init__(self, *, hook_trigger: "HookTrigger | None", maxsize: int = 32) -> None:
         self._bridge = _BoundedEventBridge(

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -93,62 +93,72 @@ either way).
   ``get_prompt``/``subscribe_resource``/``unsubscribe_resource``), so those
   call sites are unchanged.
 
-  ``mode="legacy"``, NOT the SDK's own ``"auto"`` default — a design
-  correction, not the original plan (architect's own PR-1 spec named
-  ``mode="auto"``; lead-coder overrode it after two live-verified failure
-  symptoms, both traced to the SAME mechanism): ``"auto"`` probes
-  ``server/discover`` and negotiates UP to a modern (2026-07-28-era)
-  protocol version whenever the PEER nominally advertises support for
-  it — which every reyn-owned stdio/http test double DOES, simply by
-  running on the same ``mcp>=2.0`` SDK reyn's client now depends on,
-  REGARDLESS of whether that double's own HANDLERS were ever built for
-  the modern wire's actual mechanisms. Two symptoms, live-verified against
-  the SAME real test doubles, ``mode="legacy"`` vs ``"auto"``, held
-  constant otherwise:
+  ``mode="legacy"`` BY DEFAULT, modern an EXPLICIT PER-SERVER OPT-IN
+  (:func:`_resolve_client_mode`, reading ``config["protocol_mode"]`` —
+  ``"auto"`` opts in, anything else including omitted stays ``"legacy"``).
+  This is PR-2's SECOND reversal on this exact line, after PR-1's own —
+  history, because the reasoning across all three states is load-bearing
+  for whoever touches this next:
 
-  - **Symptom 1 (resources.subscribe silently False)**:
-    ``mcp_subscribable_resources_server.py`` registers only the LEGACY
-    ``resources/subscribe`` handler, never the modern
-    ``"subscriptions/listen"`` one. The installed SDK's own
-    ``Server.get_capabilities(protocol_version=...)`` is BY DESIGN (read
-    directly, not guessed): at a modern-era negotiated version it derives
-    ``resources.subscribe`` from whether ``"subscriptions/listen"`` is
-    registered, ignoring the legacy handler entirely (its own docstring:
-    "the modern wire cannot dispatch [the legacy handler]"). Probed live:
-    ``mode="legacy"`` -> ``negotiated=2025-11-25``,
-    ``resources=ResourcesCapability(subscribe=True, ...)``;
-    ``mode="auto"`` -> ``negotiated=2026-07-28``,
-    ``resources=ResourcesCapability(subscribe=False, ...)`` — same
-    server, same handler registration, only the negotiated version
-    differs. This is not a bug in the SDK or the test double — the double
-    genuinely does not implement the modern subscription mechanism, and
-    the SDK correctly reports that. It is #3698 PR-2's job (the
-    ``listen`` <-> ``subscribe_resource`` port), not PR-1's, to close it.
-  - **Symptom 2 (list_changed notifications silently undelivered)**:
-    probed live against ``mcp_fastmcp_echo_server.py``'s
-    ``notify_tool_list_changed`` tool with a real ``message_handler``:
-    ``mode="legacy"`` delivers exactly 1
-    ``ToolListChangedNotification``; ``mode="auto"`` delivers ZERO —
-    no error, no timeout, silent. Same root mechanism as symptom 1: a
-    modern-era negotiation switches list-changed delivery to the
-    ``subscriptions/listen`` stream, which this (FastMCP-built) test
-    double does not implement either.
+  **PR-1's finding**: ``"auto"`` probes ``server/discover`` and negotiates
+  UP to a modern (2026-07-28-era) protocol version whenever the PEER
+  nominally advertises support for it — which every reyn-owned stdio/http
+  test double DID, simply by running on the same ``mcp>=2.0`` SDK reyn's
+  client depends on, REGARDLESS of whether that double's own HANDLERS were
+  ever built for the modern wire's actual mechanisms. Two symptoms,
+  live-verified against the SAME real test doubles, ``mode="legacy"`` vs
+  ``"auto"``, held constant otherwise: (1) ``resources.subscribe`` silently
+  read ``False`` against a server that DID support legacy subscribe, because
+  the modern-era capability derivation only counts a registered
+  ``"subscriptions/listen"`` handler, which the double didn't have; (2)
+  ``tools/list_changed`` notifications silently stopped arriving (0
+  delivered vs 1 under legacy) — the modern wire routes list-changed
+  through ``subscriptions/listen`` exclusively, and nothing was consuming
+  that stream. Both were genuine FUNCTION LOSS against a server whose
+  actual capability never changed, not the behavior-preserving swap PR-1
+  promised — so PR-1 pinned ``mode="legacy"`` (byte-identical negotiation to
+  the pre-PR-1 raw ``ClientSession`` behavior) and deferred the real fix.
 
-  Both symptoms are genuine FUNCTION LOSS against a server whose actual
-  implemented capability did not change — exactly what the owner's stated
-  backward-compat constraint ("古い mcp ver server でも機能を維持すること")
-  forbids, and ``"auto"``'s negotiation-follows-the-peer's-NOMINAL-version
-  behavior is not gated on whether reyn's OWN handler-level expectations
-  (subscribe delivery, list-changed delivery) still hold at that version —
-  so it is not the behavior-preserving swap PR-1 promises ("the same
-  thing, in a different class"; existing green is the bar). ``mode=
-  "legacy"`` keeps negotiation IDENTICAL to what raw ``ClientSession``
-  always did — zero behavior change, satisfying PR-1's own promise.
-  Switching to ``"auto"`` (or a version-aware negotiation policy) is
-  deliberately deferred to #3698 PR-2/PR-3, which is where the modern
-  ``listen``-based mechanisms this needs are actually built and gated —
-  this trace is the design record for why that pairing is required,
-  not an incidental note.
+  **PR-2's own subscription/listen fix, and where its "auto is now safe"
+  premise turned out to be INCOMPLETE**: :mod:`reyn.mcp.subscription_port`
+  built a ``SubscriptionAdapter`` per held connection that ACTIVELY
+  consumes ``Client.listen()`` under a modern negotiation, re-dispatching
+  every event to the SAME ``ReynMCPMessageHandler`` methods the legacy push
+  used — closing PR-1's two symptoms (re-verified live: both deliver
+  correctly under modern negotiation once the port is wired AND the two
+  test doubles were fixed to actually publish to their subscription bus, a
+  THIRD, orthogonal finding — see ``subscription_port.py``'s own "design
+  record"). On the strength of that fix, PR-2 briefly restored ``mode=
+  "auto"`` as the default — WRONG, corrected within the same PR (#3698
+  review) before merge: PR-1's own framing of the problem ("subscribe
+  moves to listen") undersold what the modern protocol actually does.
+  Directly from the installed SDK's own docstring
+  (``mcp/server/connection.py``'s ``send_raw_request``): a modern
+  (2026-07-28+) connection **forbids server-initiated requests over the
+  standalone back-channel ENTIRELY** — not just list_changed/subscribe, but
+  elicitation, sampling, roots, and ping too. Live-verified: an untouched,
+  pre-existing elicitation test double, never edited for this PR, started
+  raising ``NoBackChannelError`` the moment ``mode="auto"`` let it
+  negotiate modern — 10/10 of that file's tests broke. Subscriptions were
+  ONE hole in "does auto still work"; #4559 is the enumeration of how many
+  more there are (reyn features that break under modern — column A — and
+  reyn's OWN test doubles that structurally cannot even EXPRESS modern
+  behavior, like ``MCPServer``'s unconditional ``subscriptions/listen``
+  registration silently flipping ``resources.subscribe`` for every
+  MCPServer-built double regardless of actual resource support — column B,
+  discovered via this exact PR's capability-gate tests breaking).
+
+  **Where this leaves the default**: legacy, because a default that can
+  silently break an unrelated capability (elicitation) on ANY server that
+  happens to negotiate modern is not a safe default for ``main`` — an
+  operator's elicitation-using server going modern-capable would silently
+  lose elicitation with no reyn-side signal. Modern is reachable per-server
+  today (``protocol_mode: "auto"`` in that server's ``reyn.yaml`` config —
+  the adapter/port work THIS PR did is not dead code, just not
+  unconditionally exercised), and flips to being the DEFAULT only once
+  #4559's enumeration is complete enough to know what "safe" actually means
+  here (tracked as a future PR, #3698 PR-3's real precondition — see
+  #4559).
 
   Response cache — deliberately disabled (``cache=None``): ``Client``
   ships a client-side response cache (SEP-2549, protocol revision
@@ -184,10 +194,11 @@ Capability / version gate (#2597 capability slice):
   threaded through (was: ``ClientSession.initialize()`` RETURNS the
   ``mcp.types.InitializeResult`` directly, a plain return value, before
   PR-1). ``Client`` supports three handshake paths (``initialize``/
-  ``discover``/``adopt``, chosen by its ``mode``), but reyn pins
-  ``mode="legacy"`` (``initialize`` only) — see the module docstring's
-  "mode='legacy', not the SDK's own 'auto' default" section for why.
-  :meth:`supports` answers "did the server
+  ``discover``/``adopt``, chosen by its ``mode``); reyn defaults to
+  ``mode="legacy"`` per server, opting a specific server into ``"auto"``
+  only via that server's own ``protocol_mode: "auto"`` config — see the
+  module docstring's "mode='legacy' BY DEFAULT, modern an EXPLICIT
+  PER-SERVER OPT-IN" section for the full history and why. :meth:`supports` answers "did the server
   advertise capability X" (conservative False before initialize / on a
   missing result); :func:`require_capability` is the enforcement seam —
   call it before issuing a request for a gated feature so an unsupported
@@ -279,6 +290,14 @@ import warnings
 from collections.abc import Callable
 from typing import Any, NoReturn
 
+# #3698 PR-2: subscription_port.py only imports THIS module under
+# TYPE_CHECKING (see its own module docstring), so this module-level import
+# is not circular. select_subscription_adapter is the ONE decision point
+# for subscribe_resource/unsubscribe_resource below — see their docstrings
+# and subscription_port.py's "Why a port" for why no version-branching
+# lives here directly.
+from reyn.mcp.subscription_port import ListenSubscriptionAdapter, select_subscription_adapter
+
 # ── Env var expansion ─────────────────────────────────────────────────────────
 # Shared resolver lives in reyn.security.secrets.interpolation (ADR-0030).
 # This re-export keeps the public surface of this module backward-compatible:
@@ -322,6 +341,22 @@ class MCPTransportError(MCPError):
 
 
 _SUPPORTED_TYPES = {"stdio", "http", "sse"}
+
+
+def _resolve_client_mode(config: dict) -> "str":
+    """#3698 PR-2 (review ruling, #4559): the ONE place that decides which
+    SDK ``Client(mode=...)`` a server's connection gets — see the module
+    docstring's "mode='legacy' BY DEFAULT, modern an EXPLICIT PER-SERVER
+    OPT-IN" section for the full history and why ``"legacy"`` is the
+    default rather than the SDK's own ``"auto"``. A server opts in to
+    modern-capable negotiation with ``protocol_mode: "auto"`` in its
+    ``reyn.yaml``/``reyn.local.yaml`` config; every other value, including
+    the key being absent entirely, stays ``"legacy"`` — byte-identical to
+    every server's negotiation before this PR touched anything. This
+    default flips only once #4559's enumeration (which reyn features, and
+    which of reyn's OWN test doubles, break or can't even express modern
+    behavior) is complete enough to call ``"auto"`` safe — see #4559."""
+    return "auto" if config.get("protocol_mode") == "auto" else "legacy"
 
 # #2976: per-runtime DEFAULT write grants, keyed on the basename of the server's
 # ``command``. A package-manager launcher bootstraps itself into a per-user cache
@@ -934,6 +969,17 @@ class MCPClient:
         # connection is open.
         self._negotiated_version: str | None = None
         self._server_capabilities: Any = None  # mcp.types.ServerCapabilities | None
+        # #3698 PR-2: this client's OWN subscription delivery — era selection
+        # is monopolized by subscription_port.select_subscription_adapter
+        # (see subscribe_resource/unsubscribe_resource below), lazily built
+        # on the first subscribe/unsubscribe call (negotiated_version isn't
+        # known until initialize() has run). _subscribed_uris is THIS
+        # client's own tracked set — independent of, and never shared with,
+        # MCPConnectionService's own tracking (a held connection wraps this
+        # same MCPClient but keeps its OWN set for reconnect resubscribe;
+        # see connection_service.py's module docstring).
+        self._subscription_adapter: "Any | None" = None
+        self._subscribed_uris: "set[str]" = set()
         # #2714 belt-and-suspenders: the OS pid of the stdio subprocess this client
         # spawned (stdio transport only; None for http/sse and until initialize()
         # succeeds). Captured best-effort right after the connect handshake and used
@@ -1133,14 +1179,17 @@ class MCPClient:
                 # rather than resting on an SDK gating condition a later PR
                 # could unknowingly cross.
                 cache=None,
-                # #3698 PR-1 design correction (lead-coder, live-verified —
-                # see the module docstring's "mode='legacy', not the SDK's
-                # own 'auto' default" section for the two-symptom trace):
-                # `mode="auto"` is NOT behavior-preserving. Explicit
-                # `mode="legacy"` is what actually keeps PR-1's promise
-                # ("the same thing, in a different class") — negotiation
-                # stays exactly what it was under raw `ClientSession`.
-                mode="legacy",
+                # #3698 PR-2 (review ruling, #4559): "legacy" by default,
+                # this SERVER'S OWN config opts in to "auto" — see
+                # _resolve_client_mode's docstring and the module
+                # docstring's "mode='legacy' BY DEFAULT, modern an EXPLICIT
+                # PER-SERVER OPT-IN" section for the full history (an
+                # EARLIER version of this PR made "auto" the unconditional
+                # default; reverted within the same PR after discovering it
+                # silently breaks elicitation/sampling/roots/ping — a much
+                # bigger blast radius than the subscribe/list_changed gap
+                # this PR's own port closes).
+                mode=_resolve_client_mode(self._config),
             )
             # #3028/#3698 stage 1 — PR-1 REVERSES this bound's mechanism
             # (live-verified, not assumed): `anyio.fail_after` around
@@ -1251,9 +1300,10 @@ class MCPClient:
         # and capabilities off `Client` itself (`session` here IS the entered
         # `Client` instance — see the module docstring's "ClientSession ->
         # Client" section), not off a separate `init_result` return value.
-        # `mode="legacy"` (see the module docstring's "mode='legacy', not
-        # the SDK's own 'auto' default" section) means only the `initialize`
-        # path ever runs here — negotiation is unchanged from before PR-1.
+        # #3698 PR-2: `mode="auto"` (see the module docstring's "mode='auto',
+        # THE SDK'S OWN DEFAULT" section) means this may now be `initialize`
+        # OR `discover` — `subscription_port.py`'s adapter selection is what
+        # reads this value to pick the delivery mechanism, not this site.
         self._negotiated_version = session.protocol_version
         self._server_capabilities = session.server_capabilities
 
@@ -1343,10 +1393,11 @@ class MCPClient:
                 # PR-1 forward-guard for #3698 PR-3 — see the matching
                 # comment + module docstring section in _initialize_stdio.
                 cache=None,
-                # mode="legacy" — see the matching comment + module
-                # docstring section in _initialize_stdio for the two-symptom
-                # live trace that ruled out the SDK's "auto" default.
-                mode="legacy",
+                # #3698 PR-2 (review ruling, #4559): "legacy" by default,
+                # per-server opt-in to "auto" — see the matching comment +
+                # module docstring section in _initialize_stdio for the
+                # full PR-1/PR-2 history.
+                mode=_resolve_client_mode(self._config),
             )
             # PR-1: `asyncio.wait_for`, not `anyio.fail_after` — see
             # _initialize_stdio's matching comment for the full live-verified
@@ -1658,45 +1709,93 @@ class MCPClient:
                 f"to subscribe to a resource on it."
             )
 
-    async def subscribe_resource(self, uri: str) -> None:
-        """Subscribe to server-pushed ``notifications/resources/updated`` for
-        ``uri``. Gated on BOTH the ``resources`` capability (via
-        :func:`require_capability`, same as :meth:`read_resource`) AND the
-        resources ``subscribe`` sub-capability (via
-        :meth:`_require_resources_subscribe_capability`) — a server may support
-        reading resources without supporting subscriptions to them.
-
-        ``self._client`` IS the entered ``mcp.Client`` directly (PR-1; #4282:
-        every transport, OAuth included), so ``subscribe_resource`` is called
-        on it directly — no ``.session`` indirection needed. ``Client.
-        subscribe_resource`` is ``@deprecated`` on the SDK side (superseded
-        by ``Client.listen()`` under the 2026-07-28 revision — #3698 PR-2's
-        scope, not this one) but still delegates to the underlying
-        ``ClientSession`` and works unchanged against every server reyn
-        talks to today. The notification itself carries no payload (just
-        ``uri``) — callers re-read the resource to see the new content; see
-        :mod:`reyn.mcp.message_handler`'s ``on_resource_updated`` for the
-        EventLog bridge.
-        """
-        await self.initialize()
-        require_capability(self, "resources")
-        self._require_resources_subscribe_capability()
+    async def _raw_subscribe_resource_rpc(self, uri: str) -> None:
+        """The ONE call site that issues the legacy ``resources/subscribe``
+        RPC — used by :meth:`subscribe_resource` below (pre-#3698-PR-2
+        behavior, unchanged) AND by
+        :class:`~reyn.mcp.subscription_port.LegacySubscriptionAdapter`
+        (called as ``client._raw_subscribe_resource_rpc`` — same-package
+        internal, see that class's own docstring for why it can't call the
+        PUBLIC ``subscribe_resource`` without recursing). Never call this
+        directly against a modern-negotiated connection — the RPC does not
+        exist on the wire there (see ``subscription_port.py``'s "Why a
+        port"); the adapter selection in ``subscribe_resource`` already
+        guarantees this method is only reached via a
+        :class:`~reyn.mcp.subscription_port.LegacySubscriptionAdapter`,
+        which is only ever selected for a legacy-negotiated connection.
+        No capability gating here — the ONE public entrypoint
+        (:meth:`subscribe_resource`) already gated before selecting the
+        adapter that reaches this."""
         try:
             await self._client.subscribe_resource(uri)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/subscribe error: {exc}")
 
-    async def unsubscribe_resource(self, uri: str) -> None:
-        """Unsubscribe from server-pushed updates for ``uri``. Same gating as
-        :meth:`subscribe_resource`; mirrors it via ``mcp.Client.
-        unsubscribe_resource`` (same deprecated-but-functional note)."""
-        await self.initialize()
-        require_capability(self, "resources")
-        self._require_resources_subscribe_capability()
+    async def _raw_unsubscribe_resource_rpc(self, uri: str) -> None:
+        """Mirrors :meth:`_raw_subscribe_resource_rpc` for unsubscribe."""
         try:
             await self._client.unsubscribe_resource(uri)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/unsubscribe error: {exc}")
+
+    async def subscribe_resource(self, uri: str) -> None:
+        """Subscribe to resource-update delivery for ``uri``. Gated on BOTH
+        the ``resources`` capability (via :func:`require_capability`, same
+        as :meth:`read_resource`) AND the resources ``subscribe``
+        sub-capability (via
+        :meth:`_require_resources_subscribe_capability`) — a server may
+        support reading resources without supporting subscriptions to them.
+
+        #3698 PR-2: era selection (legacy per-URI RPC vs. modern
+        ``Client.listen()``) is delegated to
+        :func:`~reyn.mcp.subscription_port.select_subscription_adapter` —
+        this method never branches on ``negotiated_version`` itself. This
+        matters because, under a modern-era (2026-07-28+) negotiation, the
+        legacy ``resources/subscribe`` RPC does NOT exist on the wire at
+        all (a wire-level ``MCPError`` — "Method not found", live-verified
+        #3698 review) — calling it unconditionally, as this method did
+        pre-PR-2, silently broke every caller once ANY configured server
+        negotiated modern. The adapter is built once per client (lazily,
+        since ``negotiated_version`` isn't known until :meth:`initialize`
+        has run) and reused for every subsequent
+        subscribe/unsubscribe on this connection; ``_subscribed_uris``
+        tracks this client's own desired set so the listen adapter (which
+        takes its FULL filter set at every (re)open — no incremental
+        primitive exists on the installed SDK) can reopen with the right
+        set on each call, mirroring
+        ``connection_service.py``'s ``_HeldConnection`` (a SEPARATE
+        instance of the same call-site pattern, not a second copy of the
+        adapter LOGIC itself — that logic lives solely in
+        ``subscription_port.py``).
+        """
+        await self.initialize()
+        require_capability(self, "resources")
+        self._require_resources_subscribe_capability()
+        if self._subscription_adapter is None:
+            self._subscription_adapter = select_subscription_adapter(self, self._message_handler)
+        self._subscribed_uris.add(uri)
+        if isinstance(self._subscription_adapter, ListenSubscriptionAdapter):
+            await self._subscription_adapter.open(self._subscribed_uris)
+        else:
+            await self._raw_subscribe_resource_rpc(uri)
+
+    async def unsubscribe_resource(self, uri: str) -> None:
+        """Unsubscribe from ``uri``. Same gating and era-selection as
+        :meth:`subscribe_resource` — see its docstring. The listen adapter
+        has no per-URI "remove" primitive of its own (see
+        ``subscription_port.py``), so removal is "reopen with the reduced
+        full set", exactly mirroring how adding a URI is "reopen with the
+        expanded full set" there."""
+        await self.initialize()
+        require_capability(self, "resources")
+        self._require_resources_subscribe_capability()
+        if self._subscription_adapter is None:
+            self._subscription_adapter = select_subscription_adapter(self, self._message_handler)
+        self._subscribed_uris.discard(uri)
+        if isinstance(self._subscription_adapter, ListenSubscriptionAdapter):
+            await self._subscription_adapter.open(self._subscribed_uris)
+        else:
+            await self._raw_unsubscribe_resource_rpc(uri)
 
     async def close(self) -> None:
         """Tear down the transport and session. Safe to call repeatedly.
@@ -1712,6 +1811,18 @@ class MCPClient:
         ``finally`` explicitly reaps the captured child pid, guaranteeing the OS
         subprocess is terminated rather than trusting that a swallowed fault left it
         dead. On a clean close the child is already gone and the reap is a no-op."""
+        # #3698 PR-2: tear down this client's own subscription adapter FIRST
+        # (before the transport it depends on goes away) — a live
+        # ListenSubscriptionAdapter owns a background task consuming
+        # Client.listen(); leaving it running past self._client teardown
+        # would leak that task against a now-dead connection.
+        if self._subscription_adapter is not None:
+            adapter = self._subscription_adapter
+            self._subscription_adapter = None
+            try:
+                await adapter.close()
+            except Exception:  # noqa: BLE001 — best-effort; a dead transport's own teardown may already have faulted
+                logger.warning("MCPClient: subscription adapter teardown faulted", exc_info=True)
         if self._client is None:
             self.close_stderr_capture()
             self._reap_child_process()  # nothing opened, or already closed once — still idempotent

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -91,9 +91,8 @@ is fully re-establishable and matches the gen-store runtime-only-state invariant
 consequence: a fresh session (post-restart) starts with NO subscriptions (same as a fresh
 ``MCPClient`` starts with none), and a RECONNECT within the same live session (the F1
 transport-death path) must explicitly RE-ISSUE ``subscribe_resource`` for every URI
-tracked for that server on the fresh client — a brand-new ``mcp.Client`` (#3698 PR-1;
-was a raw ``mcp.ClientSession``) has no memory of what the OLD (now-dead) session's
-client subscribed to. :meth:`_ensure_open`
+tracked for that server on the fresh client — a brand-new ``mcp.ClientSession`` has no
+memory of what the OLD (now-dead) session's client subscribed to. :meth:`_ensure_open`
 does this re-subscribe immediately after opening a NEW client (whether that is the very
 first open, where the tracked set is empty and the loop is a no-op, or a reconnect, where
 it is the whole point) — see that method's inline comment.
@@ -132,7 +131,7 @@ missed update a missed hook fire): ②b re-subscribes every tracked URI on a
 transport-death reconnect (the loop in :meth:`_ensure_open`, described above), but a
 resource that actually CHANGED while the connection was dead never produced a
 ``resources/updated`` push — that notification simply never arrived on the dead
-transport, and the fresh ``mcp.Client`` has no way to redeliver a notification it
+transport, and the fresh ``mcp.ClientSession`` has no way to redeliver a notification it
 never received. Q4 (S2-pre spike, decided, do not relitigate): reyn keeps NO resource
 content cache — subscriptions are runtime-only (see ②b's docstring above), so there is
 no baseline to diff the post-reconnect content against and no way to know WHICH tracked
@@ -162,6 +161,11 @@ from reyn.mcp.client import MCPClient, MCPTransportError
 from reyn.mcp.elicitation import DEFAULT_ELICITATION_TIMEOUT_SECONDS, build_elicitation_handler
 from reyn.mcp.message_handler import EmitSink, ReynMCPMessageHandler, ToolsCacheInvalidate
 from reyn.mcp.pool import describe_fault, is_real_control_flow
+from reyn.mcp.subscription_port import (
+    ListenSubscriptionAdapter,
+    SubscriptionAdapter,
+    select_subscription_adapter,
+)
 
 if TYPE_CHECKING:
     from reyn.user_intervention import RequestBus
@@ -253,6 +257,19 @@ class MCPConnectionService:
         # re-subscribe every tracked URI on a fresh client (first open: empty, no-op;
         # reconnect: the whole point).
         self._subscriptions: dict[str, set[str]] = {}
+        # #3698 PR-2: the active SubscriptionAdapter per server — rebuilt on
+        # every (re)connect by _ensure_open (see subscription_port.py's own
+        # module docstring for the full design). Read by _HeldConnection.
+        # subscribe_resource/unsubscribe_resource to route an incremental
+        # add/remove through whichever mechanism the CURRENT connection's
+        # negotiated version actually uses.
+        self._subscription_adapters: dict[str, SubscriptionAdapter] = {}
+        # #3698 PR-2: fire-and-forget reconnect tasks spawned by
+        # _on_subscription_lost (a ListenSubscriptionAdapter's background
+        # consumer noticing SubscriptionLost) — kept referenced so they are
+        # never garbage-collected mid-flight, and cancelled in aclose() so a
+        # session teardown can never race a proactive reconnect.
+        self._background_tasks: "set[asyncio.Task[None]]" = set()
         # #2597 P1 (reconnect resync-read): servers for which _ensure_open has
         # completed at least one successful open in THIS service's lifetime — the
         # boundary that distinguishes the very first open (nothing to resync yet,
@@ -371,56 +388,93 @@ class MCPConnectionService:
             await client.__aenter__()  # initialize; held open (no matching __aexit__ until aclose/reconnect)
             self._clients[server] = client
             self._ever_opened.add(server)
+            # #3698 PR-2: build the adapter matching THIS client's actual
+            # negotiated version (see subscription_port.py's own module
+            # docstring for the full design) and open() it — UNCONDITIONALLY,
+            # even when the tracked URI set is empty: under a modern
+            # negotiation, tools_list_changed/prompts_list_changed delivery
+            # itself REQUIRES an open listen() stream regardless of whether
+            # any resource is subscribed, unlike the legacy path (where the
+            # message_handler push covers those two families for free, no
+            # subscribe call needed). Stored per-server so a later
+            # incremental subscribe_resource/unsubscribe_resource
+            # (_HeldConnection, below) can route through the SAME adapter
+            # instance rather than rebuilding it.
+            #
+            # #2597 slice ②b (adapter-mediated since PR-2): open() re-issues
+            # delivery for every URI tracked for THIS server on the fresh
+            # client. On the very first open the tracked set is empty
+            # (nothing to (re)establish yet, though the listen adapter still
+            # opens its stream for list_changed — see above); on a reconnect
+            # (this same branch runs because the dead client was already
+            # popped from self._clients by _reconnect below) this is what
+            # makes a subscription survive a transport-death reconnect — a
+            # brand-new connection has no memory of what the OLD one
+            # subscribed to.
+            #
+            # #2597 P1 (reconnect resync-read, follow-up to ②b): on a RE-open
+            # (``is_reopen`` — NOT the very first open), reyn cannot know
+            # whether any of these URIs actually changed during the
+            # disconnect window (Q4: no content cache to diff against — see
+            # message_handler.py's ``emit_resource_updated`` docstring), so
+            # it conservatively fires a SYNTHETIC ``mcp_resource_updated`` for
+            # each re-established URI — through the exact same emit_sink + H1
+            # hook-trigger path a real push uses, so a missed-during-
+            # disconnect update is never silently dropped. ``honored`` drives
+            # WHICH URIs get the synthetic fire when the adapter can say
+            # (the listen adapter's filter-level ack); when it can't (``None``
+            # — the legacy adapter, or a listen adapter the server declined
+            # resource_subscriptions on entirely), every TRACKED URI gets one
+            # — deliberately not narrowed to "only URIs whose individual
+            # re-subscribe call didn't raise" (the pre-PR-2 legacy-only
+            # behavior): a resync is a cheap "may have changed, re-read if
+            # you care" signal, and firing it for a URI whose own re-
+            # subscribe state is uncertain is safer than silently assuming
+            # it's fine. First open: the tracked set is empty, so nothing is
+            # ever emitted — only a genuine re-open with tracked URIs
+            # produces synthetic events.
+            on_lost = (
+                # #3698 review: ``client`` (THIS open's own client, bound now
+                # while it's still THE current one) is threaded through so
+                # ``_on_subscription_lost`` can tell, when it actually fires,
+                # whether it's still talking about the CURRENT connection —
+                # see that method's own docstring for why this matters (the
+                # double-reconnect bug this closes).
+                functools.partial(self._on_subscription_lost, server, config, agent_id, client)
+                if handler is not None else None
+            )
+            adapter = select_subscription_adapter(client, handler, on_lost=on_lost)
+            self._subscription_adapters[server] = adapter
+            tracked = set(self._subscriptions.get(server, ()))
+            try:
+                honored = await adapter.open(tracked)
+            except Exception:  # noqa: BLE001 — subscription delivery is best-effort; must not abort the connect
+                logger.warning(
+                    "MCPConnectionService: failed to open subscription delivery for %r "
+                    "after (re)connect", server, exc_info=True,
+                )
+                honored = None
+            if is_reopen and handler is not None:
+                for uri in (honored if honored is not None else tracked):
+                    handler.emit_resource_updated(uri, resync=True)
             # #2597 capability/version gate: observability seam. This is the first
             # point in the live (non-ephemeral) session path that HAS the emit_sink
             # (the ephemeral per-call MCPClientPool path never wires one — see class
             # docstring — so it stays silent, matching pre-#2597 behaviour there).
             # Fires once per (re)connect, including reconnects (a version/capability
             # renegotiation is itself worth a trace event, not just the first
-            # connect).
+            # connect). #3698 PR-2: now ALSO names the selected adapter's class —
+            # the witness that adapter SELECTION (not just "both paths work in
+            # isolation") is observable per-connection, the exact acceptance
+            # criterion lead-coder named for this PR.
             if self._emit_sink is not None:
                 self._emit_sink(
                     "mcp_initialized",
                     server=server,
                     negotiated_version=client.negotiated_version,
                     capabilities=client.advertised_capabilities(),
+                    subscription_adapter=type(adapter).__name__,
                 )
-            # #2597 slice ②b: re-issue subscribe_resource for every URI tracked for
-            # THIS server on the fresh client. On the very first open the tracked set
-            # is empty (nothing to do yet); on a reconnect (this same branch runs
-            # because the dead client was already popped from self._clients by
-            # _reconnect below) this is what makes a subscription survive a
-            # transport-death reconnect — a brand-new mcp.Client (#3698 PR-1; was a
-            # raw mcp.ClientSession) has no memory of what the OLD session subscribed
-            # to. Per-URI try/except: a
-            # server that no longer supports subscribe post-reconnect (or a single
-            # bad URI) must not abort re-subscribing the REST of the tracked set,
-            # and must not crash the reconnect itself.
-            #
-            # #2597 P1 (reconnect resync-read, follow-up to ②b): on a RE-open
-            # (``is_reopen`` — NOT the very first open), reyn cannot know whether any
-            # of these URIs actually changed during the disconnect window (Q4: no
-            # content cache to diff against — see message_handler.py's
-            # ``emit_resource_updated`` docstring), so it conservatively fires a
-            # SYNTHETIC ``mcp_resource_updated`` for each URI it successfully
-            # re-subscribes — through the exact same emit_sink + H1 hook-trigger path
-            # a real push uses, so a missed-during-disconnect update is never
-            # silently dropped. A URI whose re-subscribe itself failed gets no
-            # synthetic event (there's no live subscription to have missed anything
-            # on). First open: the tracked set is empty, so this loop is a no-op and
-            # nothing is ever emitted — only a genuine re-open with tracked URIs
-            # produces synthetic events.
-            for uri in self._subscriptions.get(server, ()):
-                try:
-                    await client.subscribe_resource(uri)
-                except Exception:  # noqa: BLE001 — one bad re-subscribe must not block the rest
-                    logger.warning(
-                        "MCPConnectionService: failed to re-subscribe %r on %r after "
-                        "(re)connect", uri, server, exc_info=True,
-                    )
-                    continue
-                if is_reopen and handler is not None:
-                    handler.emit_resource_updated(uri, resync=True)
         return client
 
     async def _reconnect(
@@ -440,7 +494,91 @@ class MCPConnectionService:
                     "MCPConnectionService: teardown of dead connection %r contained: %r",
                     server, exc,
                 )
+        # #3698 PR-2: the OLD adapter (if any — first-ever connect has none)
+        # is orphaned once _ensure_open below rebuilds a fresh one; close it
+        # explicitly first so a ListenSubscriptionAdapter's background
+        # consumer task never leaks across a reconnect. graceful=False (#3698
+        # review ruling, live-verified): THIS caller already knows the
+        # transport is dead — that's why _reconnect is running at all — so
+        # there is no peer left to round-trip a graceful ``subscriptions/
+        # listen`` close with. An earlier version called the graceful
+        # close() unconditionally here and it hung indefinitely against a
+        # known-dead transport; see subscription_port.py's module docstring
+        # "Design record" #2a for the full finding and why bounding it with
+        # a timeout was tried and rejected rather than fixed this way.
+        old_adapter = self._subscription_adapters.pop(server, None)
+        if old_adapter is not None:
+            try:
+                await old_adapter.close(graceful=False)
+            except Exception:  # noqa: BLE001 — best-effort; the underlying connection is already dead
+                logger.warning(
+                    "MCPConnectionService: teardown of dead subscription adapter for %r "
+                    "contained an error", server, exc_info=True,
+                )
         return await self._ensure_open(server, config, agent_id=agent_id)
+
+    def _on_subscription_lost(
+        self, server: str, config: dict, agent_id: "str | None", dead_client: "MCPClient",
+    ) -> None:
+        """The sync, non-blocking callback a :class:`~reyn.mcp.subscription_port.
+        ListenSubscriptionAdapter` fires when its stream ends via
+        ``SubscriptionLost`` (see that module for the full design) — mirrors
+        #2608 H1's sync-callback-into-async-work bridge shape.
+
+        Schedules a PROACTIVE reconnect: unlike ``call_tool``/``list_tools``
+        (healed REACTIVELY, on the next use, via ``_HeldConnection._heal``),
+        nothing "calls" to receive a subscription/list_changed notification
+        — a purely reactive design would leave delivery silently dead until
+        some UNRELATED client call happened to trigger a heal. This task is
+        fire-and-forget (kept referenced in ``self._background_tasks`` so it
+        is never garbage-collected mid-flight, and cancelled in
+        :meth:`aclose`).
+
+        ``dead_client`` (#3698 review, live-verified DOUBLE RECONNECT bug —
+        this docstring PREVIOUSLY claimed "a genuinely concurrent client
+        call racing this reconnect is not a NEW hazard... already
+        tolerates" — that claim was WRONG, corrected here): the exact
+        client instance THIS adapter belonged to, captured at the open()
+        that installed it. A single transport death (e.g. the peer process
+        dying) fires BOTH this callback (the listen stream noticing loss)
+        AND, independently, ``_HeldConnection._heal``'s reactive path (an
+        in-flight call failing with ``MCPTransportError``) — live-verified:
+        one subprocess kill produced 3 ``mcp_initialized`` events (1 open +
+        2 reconnects) and 2 synthetic ``mcp_resource_updated`` resyncs
+        (expected 2 and 1). ``_reconnect_from_lost_subscription`` checks
+        ``dead_client`` against the CURRENT held client, under the SAME
+        per-server lock ``_HeldConnection._heal`` now also takes (see that
+        method) — whichever path reconnects first wins; the second sees the
+        client has already changed and skips, closing the race rather than
+        merely narrowing it (a check without the shared lock would still
+        race: both could pass a stale check before either replaces the
+        client)."""
+        task = asyncio.create_task(
+            self._reconnect_from_lost_subscription(server, config, agent_id, dead_client)
+        )
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _reconnect_from_lost_subscription(
+        self, server: str, config: dict, agent_id: "str | None", dead_client: "MCPClient",
+    ) -> None:
+        try:
+            async with self._lock_for(server):
+                if self._clients.get(server) is not dead_client:
+                    # Someone else (typically _HeldConnection._heal's own
+                    # reactive path, racing the SAME transport death) already
+                    # reconnected — see this method's docstring. Not stale
+                    # data staying stale: we hold the lock, so this read is
+                    # the current truth, not a snapshot that could still
+                    # change under us.
+                    return
+                await self._reconnect(server, config, agent_id=agent_id)
+        except Exception:  # noqa: BLE001 — a proactive reconnect attempt must never crash the service; the
+            # next reactive _heal (a normal call_tool/list_tools) still retries.
+            logger.warning(
+                "MCPConnectionService: proactive reconnect after a lost subscription "
+                "failed for %r", server, exc_info=True,
+            )
 
     def subscribed_uris(self, server: str) -> list[str]:
         """Sorted list of URIs currently tracked as subscribed for ``server``.
@@ -522,6 +660,38 @@ class MCPConnectionService:
         # McpIngressAdapter (byte-identical: same cancel-then-await-swallow
         # shape, now shared with FsIngressAdapter's aclose).
         await self._mcp_ingress_adapter.aclose()
+
+        # #3698 PR-2: cancel every proactive-reconnect-from-lost-subscription
+        # task BEFORE tearing down the clients/adapters below — a task that
+        # ran to completion after teardown would try to reconnect a server
+        # this service just closed, resurrecting a held connection aclose()
+        # was supposed to end. Same finally-guaranteed shape as the H1 drain
+        # task above (CancelledError is a BaseException, not caught by a
+        # bare except-Exception).
+        background_tasks = list(self._background_tasks)
+        self._background_tasks.clear()
+        for task in background_tasks:
+            task.cancel()
+        for task in background_tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # #3698 PR-2: close every subscription adapter's own background
+        # delivery machinery (a ListenSubscriptionAdapter's consumer task)
+        # before tearing down the clients themselves — best-effort, mirrors
+        # the client-teardown fault-tolerance immediately below.
+        adapters = list(self._subscription_adapters.items())
+        self._subscription_adapters.clear()
+        for name, adapter in adapters:
+            try:
+                await adapter.close()
+            except Exception:  # noqa: BLE001 — best-effort; the client teardown below still runs regardless
+                logger.warning(
+                    "MCPConnectionService: teardown of subscription adapter for %r "
+                    "contained an error", name, exc_info=True,
+                )
 
         clients = list(self._clients.items())
         self._clients.clear()
@@ -633,12 +803,40 @@ class _HeldConnection:
     # THIS call once on the fresh connection. That sequencing is what avoids a double
     # subscribe: the reconnect's re-subscribe loop and this method's own retry never
     # target the same URI in the same pass.
+    #
+    # #3698 PR-2: routed through whichever adapter is CURRENTLY active for
+    # this server (rebuilt fresh by every _ensure_open, including inside
+    # _heal's own reconnect path above). The legacy adapter has no
+    # incremental primitive of its own — MCPClient.subscribe_resource(uri)
+    # unchanged, exactly as before PR-2. The listen adapter's `Client.
+    # listen()` takes its FULL filter set at open time (no incremental
+    # add/remove exists on the installed SDK — measured live, see
+    # subscription_port.py) — so adding/removing ONE URI means closing and
+    # re-opening the stream with the updated FULL tracked set, which
+    # ListenSubscriptionAdapter.open() already does internally (see its own
+    # docstring).
     async def subscribe_resource(self, uri: str) -> None:
-        await self._heal(lambda c: c.subscribe_resource(uri), heal_only=False)
+        async def op(c: MCPClient) -> None:
+            adapter = self._service._subscription_adapters.get(self._server)
+            if isinstance(adapter, ListenSubscriptionAdapter):
+                all_uris = set(self._service._subscriptions.get(self._server, ())) | {uri}
+                await adapter.open(all_uris)
+            else:
+                await c.subscribe_resource(uri)
+
+        await self._heal(op, heal_only=False)
         self._service._track_subscription(self._server, uri)
 
     async def unsubscribe_resource(self, uri: str) -> None:
-        await self._heal(lambda c: c.unsubscribe_resource(uri), heal_only=False)
+        async def op(c: MCPClient) -> None:
+            adapter = self._service._subscription_adapters.get(self._server)
+            if isinstance(adapter, ListenSubscriptionAdapter):
+                remaining = set(self._service._subscriptions.get(self._server, ())) - {uri}
+                await adapter.open(remaining)
+            else:
+                await c.unsubscribe_resource(uri)
+
+        await self._heal(op, heal_only=False)
         self._service._untrack_subscription(self._server, uri)
 
     async def _heal(
@@ -663,16 +861,42 @@ class _HeldConnection:
         after healing — do NOT re-run ``op`` (preserves at-most-once; the healed
         connection serves the NEXT call). ``heal_only=False`` (idempotent ``list_tools``):
         retry ``op`` ONCE on the fresh connection; a second failure propagates unchanged
-        (no silent retry loop)."""
-        client = await self._service._ensure_open(
-            self._server, self._config, agent_id=self._agent_id,
-        )
+        (no silent retry loop).
+
+        #3698 review: ``_ensure_open``/``_reconnect`` are now called under
+        ``self._service._lock_for(self._server)`` — the SAME per-server lock
+        :meth:`MCPConnectionService.get` already uses. Closes a real,
+        live-verified double-reconnect race: a single transport death used
+        to fire BOTH this method's own reactive reconnect (an in-flight call
+        failing) AND, independently, ``_on_subscription_lost``'s proactive
+        one (the listen stream noticing loss) — see that method's own
+        docstring for the full finding. ``op(client)`` itself runs OUTSIDE
+        the lock (only connection-state mutation is serialized — unrelated
+        concurrent calls on an already-healthy connection are not
+        artificially serialized against each other)."""
+        async with self._service._lock_for(self._server):
+            client = await self._service._ensure_open(
+                self._server, self._config, agent_id=self._agent_id,
+            )
         try:
             return await op(client)
         except MCPTransportError:
-            fresh = await self._service._reconnect(
-                self._server, self._config, agent_id=self._agent_id,
-            )
+            async with self._service._lock_for(self._server):
+                # #3698 review: staleness check mirrors
+                # ``_reconnect_from_lost_subscription``'s — the SAME
+                # transport death that just failed ``op(client)`` above may
+                # have ALSO already been reconnected by the proactive
+                # ``_on_subscription_lost`` path while this method was
+                # waiting for the lock. If so, reuse that already-fresh
+                # client rather than discarding it for a third, redundant
+                # reconnect.
+                current = self._service._clients.get(self._server)
+                if current is not None and current is not client:
+                    fresh = current
+                else:
+                    fresh = await self._service._reconnect(
+                        self._server, self._config, agent_id=self._agent_id,
+                    )
             if heal_only:
                 raise  # at-most-once: connection healed for the next call, but this call is NOT retried
             return await op(fresh)

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -166,12 +166,65 @@ class ReynMCPMessageHandler:
         # None = no bridge (no hook trigger wired — byte-identical to pre-H1).
         self._on_external_event = on_external_event
         self._agent_name = agent_name
+        # #3698 PR-2 (review ruling): per-FAMILY legacy-dispatch suppression
+        # while a ListenSubscriptionAdapter is active and HONORS that family
+        # — see :meth:`set_listen_honored`/:meth:`clear_listen_honored` and
+        # ``__call__``'s three gated ``case`` arms below. Deliberately does
+        # NOT cover ``on_progress`` (request-scoped, never rides ``listen()``
+        # — see that method's own docstring; blanket-disabling this whole
+        # handler while listen is active would silently drop progress, the
+        # exact "no-longer-silent" failure mode this handler's own module
+        # docstring names as the thing to avoid). False by default: a
+        # connection with no active listen adapter (legacy era, or before
+        # the first successful ``open()``) dispatches every family via the
+        # legacy channel exactly as before this ruling.
+        self._listen_honors_tools = False
+        self._listen_honors_prompts = False
+        self._listen_honors_resources = False
 
     def bind_client(self, client: Any) -> None:
         """Complete the weakref binding once the owning ``fastmcp.Client`` exists.
         MUST run before the first message is dispatched — see module docstring's
         "two-phase client binding"."""
         self._client_ref = weakref.ref(client)
+
+    def set_listen_honored(self, *, tools: bool, prompts: bool, resources: bool) -> None:
+        """Called by :class:`~reyn.mcp.subscription_port.ListenSubscriptionAdapter`
+        after every successful ``open()`` — records, per family, whether the
+        server's ``subscriptions/listen`` ack actually honored it (``sub.
+        honored.tools_list_changed``/``.prompts_list_changed`` — ``bool |
+        None``, ``False`` here for both ``False`` AND ``None``/"unknown",
+        which is deliberately the SAME as "not honored": if the server
+        didn't confirm it's delivering this family over listen, the legacy
+        channel must stay live for it, matching the review ruling's
+        "honored が None なら何も抑止しない" — resources from ``sub.honored.
+        resource_subscriptions is not None`` — a real, non-``None`` list,
+        even if empty, means the server acknowledged the resource-
+        subscriptions mechanism under listen for this open() call.
+
+        A server that dual-fires BOTH the legacy notification and the
+        modern listen event for an honored family (a real, plausible
+        migration-period shape — not just reyn's own test doubles; see
+        ``subscription_port.py``'s module docstring) would otherwise double
+        every ``mcp_tool_list_changed``/``mcp_prompt_list_changed``/
+        ``mcp_resource_updated`` audit-event AND double-fire the H1 hook
+        trigger + (tools family) the lazy-tools-cache invalidation — a
+        real, user-visible harm, not a cosmetic double-count (#3698 review:
+        found live via a previously-green test that started failing once
+        this port's listen adapter actually started dispatching)."""
+        self._listen_honors_tools = tools
+        self._listen_honors_prompts = prompts
+        self._listen_honors_resources = resources
+
+    def clear_listen_honored(self) -> None:
+        """Called by :class:`~reyn.mcp.subscription_port.ListenSubscriptionAdapter`
+        on :meth:`~reyn.mcp.subscription_port.ListenSubscriptionAdapter.close`
+        — the legacy channel becomes authoritative again for every family
+        once listen delivery is no longer active (a reconnect that lands on
+        a legacy-era server, or teardown)."""
+        self._listen_honors_tools = False
+        self._listen_honors_prompts = False
+        self._listen_honors_resources = False
 
     # ── the MCP SDK's actual entry point (see module docstring's "#3698 P3") ───────
 
@@ -195,12 +248,25 @@ class ReynMCPMessageHandler:
                     if client is not None:
                         client._handle_task_status_notification(root)
                 case mcp.types.ToolListChangedNotification():
-                    await self.on_tool_list_changed(root)
+                    # #3698 PR-2 (review ruling): suppressed only while an
+                    # active listen adapter HONORS this family — see
+                    # set_listen_honored's docstring for why (a dual-firing
+                    # server would otherwise double this event/hook/cache-
+                    # invalidate).
+                    if not self._listen_honors_tools:
+                        await self.on_tool_list_changed(root)
                 case mcp.types.PromptListChangedNotification():
-                    await self.on_prompt_list_changed(root)
+                    if not self._listen_honors_prompts:
+                        await self.on_prompt_list_changed(root)
                 case mcp.types.ResourceUpdatedNotification():
-                    await self.on_resource_updated(root)
+                    if not self._listen_honors_resources:
+                        await self.on_resource_updated(root)
                 case mcp.types.ProgressNotification():
+                    # Deliberately UNGATED — progress is request-scoped, never
+                    # rides listen() (see on_progress's own docstring); a
+                    # blanket suppression here would silently drop it, the
+                    # exact class of bug this handler's module docstring
+                    # exists to make un-silent.
                     await self.on_progress(root)
                 case _:
                     self._log_unhandled(root)

--- a/src/reyn/mcp/subscription_port.py
+++ b/src/reyn/mcp/subscription_port.py
@@ -1,0 +1,426 @@
+"""Subscription port (#3698 PR-2) — a version-independent abstraction over
+resource-subscription and list_changed delivery.
+
+## Why a port
+
+PR-1 pinned ``Client(mode="legacy")`` deliberately: the official SDK's
+``mode="auto"`` negotiates UP to a modern (2026-07-28-era) protocol version
+whenever the peer nominally advertises it, and under that revision
+``resources/subscribe`` and the legacy push-based ``tools/prompts
+list_changed`` notifications are BOTH replaced by a single streaming
+primitive, ``Client.listen()`` (SEP-2575) — a server/client pair that only
+implements the legacy mechanism silently stops delivering anything once
+negotiation moves modern (see ``client.py``'s "mode='legacy', not the SDK's
+own 'auto' default" module-docstring section for the two live-verified
+symptoms this caused). This module is what makes ``mode="auto"`` safe again:
+a single ``SubscriptionPort`` object per held connection that picks the
+adapter matching the ACTUAL negotiated version, so the caller
+(``MCPConnectionService``) never branches on protocol version itself.
+
+**Under a modern-era (2026-07-28+) negotiation, the legacy ``resources/
+subscribe``/``resources/unsubscribe`` RPCs do not exist on the wire at
+all** — not "deprecated but still answered", genuinely removed; the SDK's
+own ``Client.subscribe_resource``/``unsubscribe_resource`` raise a wire-level
+``MCPError`` ("Method not found") when called against a modern-negotiated
+session, REGARDLESS of whether the server also implements ``Client.
+listen()``. This was undocumented anywhere in reyn until a real PR-2 fork
+(#3698 review) surfaced it via a live 404: adding the modern
+``subscriptions/listen`` handler to a test double made its capability
+advertisement flip modern-nego-eligible, and the ONE caller that still
+invoked the legacy RPC directly (bypassing this port —
+``MCPClient.subscribe_resource``/``unsubscribe_resource`` themselves, before
+this fix) broke. The fix: era selection is monopolized by THIS module —
+every ``subscribe_resource``/``unsubscribe_resource`` call, whether through
+a held :class:`~reyn.mcp.connection_service.MCPConnectionService` connection
+or a bare ephemeral :class:`~reyn.mcp.client.MCPClient`, routes through
+:func:`select_subscription_adapter` (see that function's own docstring and
+``client.py``'s ``subscribe_resource``/``unsubscribe_resource``) — no caller
+ever needs to know or branch on the negotiated version itself, and no
+caller can accidentally reach the legacy RPC once negotiation has gone
+modern.
+
+## The two adapters
+
+- ``LegacySubscriptionAdapter`` — pre-2026-07-28. ``open()``/``add()`` call
+  ``MCPClient.subscribe_resource(uri)`` per URI (unchanged from pre-PR-2
+  behavior); ``honored`` is always ``None`` — a legacy server's
+  ``EmptyResult`` ack carries no "which URIs did you actually accept"
+  signal, so the port is honest about not knowing rather than lying with a
+  bool. list_changed notifications arrive via the existing
+  ``ReynMCPMessageHandler`` message-handler push — this adapter does
+  nothing extra for those (the handler is already wired into ``Client``
+  regardless of adapter).
+- ``ListenSubscriptionAdapter`` — 2026-07-28-era. ``open()``/``add()``
+  (re)open ONE ``Client.listen(resource_subscriptions=..., tools_list_
+  changed=True, prompts_list_changed=True)`` stream covering all three
+  families in a single call (confirmed live: the SDK's own ``listen()``
+  accepts all three filter kwargs together — see the design record below).
+  ``honored`` is ``sub.honored.resource_subscriptions`` turned into a
+  ``set[str]`` (``None`` when the server declined resource_subscriptions
+  entirely). A background task consumes the stream and re-dispatches each
+  event to the SAME ``ReynMCPMessageHandler`` methods
+  (``on_tool_list_changed``/``on_prompt_list_changed``/
+  ``emit_resource_updated``) the legacy message_handler push already used
+  — one producer swap, zero new consumer-side code, so every existing
+  ``mcp_tool_list_changed``/``mcp_prompt_list_changed``/
+  ``mcp_resource_updated`` audit-event/hook-trigger consumer fires
+  identically regardless of which era delivered the underlying signal. A
+  ``SubscriptionLost`` (the stream ending abnormally — transport death or a
+  server-side drop) is treated as connection death: it invokes the
+  ``on_lost`` callback the owner supplied, which ``MCPConnectionService``
+  wires to trigger the SAME reconnect path an ``MCPTransportError`` on a
+  live call already does (see that module's ``_on_subscription_lost``).
+
+``honored`` is NEVER collapsed to a bool anywhere in this module (architect's
+explicit design constraint, #3698 comments): a legacy "I don't know" and a
+modern "the server declined" are both real, DIFFERENT states a caller might
+need to distinguish, and a bool would silently turn the legacy "unknown"
+into "succeeded" — exactly the "declared implies used" misreading this
+repo's own testing discipline names as a recurring failure shape.
+
+## Design record: three SDK-level findings from getting here (kept for PR-3)
+
+1. ``asyncio.wait_for`` wrapping ``Client.__aenter__()`` (PR-1) raises a
+   cancel-scope-nesting violation on success and hangs on a genuine
+   timeout — ``asyncio.wait_for`` around ``Client.listen()`` entry/
+   iteration, by contrast, was live-verified to behave correctly (no
+   analogous corruption) — this is NOT a blanket "never wrap anyio calls in
+   wait_for" rule; each shape needed its own live check.
+2a. ``asyncio.wait_for`` wrapping a ``Client.listen()`` context manager's
+   ``__aexit__()`` (PR-2, #3698 review) against a KNOWN-DEAD transport
+   (peer killed via ``os._exit()`` — no graceful close is possible) was
+   live-verified to hang INDEFINITELY (>90s, no exception ever raised) —
+   NOT merely slow. This is a second, independent instance of finding 1's
+   exact shape: cancelling an anyio-scoped SDK call from outside its owning
+   task, on timeout, hangs instead of raising cleanly. Combined with
+   finding 1: **this SDK's enter/exit cannot be safely bounded from the
+   outside by time, in either direction** — the fix each time was removing
+   the call from the code path that reaches a known-dead peer entirely
+   (:meth:`ListenSubscriptionAdapter.close`'s ``graceful=False`` — see its
+   own docstring), never a shorter/differently-wrapped deadline. A future
+   caller reaching for ``wait_for``/``anyio.fail_after`` around ANY
+   ``Client``/``Subscription`` enter-or-exit call should treat that as a
+   near-certain repeat of this same hazard, not a fresh case to
+   individually re-verify from zero.
+2b. ``Client.listen()``'s honored-ack succeeding is NOT proof an event will
+   ever arrive: the SDK provides ``InMemorySubscriptionBus`` as a fan-out
+   SEAM, but publishing to it is the SERVER AUTHOR's own responsibility —
+   ``MCPServer``'s own source never calls ``bus.publish(...)`` automatically
+   on a tool author's behalf (grepped directly: zero call sites). reyn's own
+   two MCP test doubles (``tests/_support/mcp_fastmcp_echo_server.py``,
+   ``mcp_subscribable_resources_server.py``) had to be updated to publish
+   explicitly — see their own module docstrings for the live-verified
+   before/after (a minimal bare-SDK server built specifically to isolate
+   this, calling ``bus.publish()`` directly, delivered the event instantly;
+   the ORIGINAL test doubles, using only the legacy ``send_notification``
+   API, hung a listening client forever with zero error). This was traced
+   to reyn's OWN test infrastructure, not an SDK defect (a bare-SDK
+   client+server reproduction, publishing correctly, worked with zero
+   hang) — no upstream report was needed.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Protocol
+
+from mcp.client.subscriptions import SubscriptionLost
+from mcp.shared.subscriptions import (
+    PromptsListChanged,
+    ResourcesListChanged,
+    ResourceUpdated,
+    ToolsListChanged,
+)
+from mcp_types.version import MODERN_PROTOCOL_VERSIONS
+
+if TYPE_CHECKING:
+    from reyn.mcp.client import MCPClient
+    from reyn.mcp.message_handler import ReynMCPMessageHandler
+
+logger = logging.getLogger(__name__)
+
+#: The sync, non-blocking callback a :class:`ListenSubscriptionAdapter` fires
+#: when its stream ends via :class:`~mcp.client.subscriptions.SubscriptionLost`
+#: — mirrors #2608 H1's sync-callback-into-async-work bridge shape
+#: (``MCPConnectionService.enqueue_external_event``'s own pattern): the
+#: adapter's background task cannot itself own reconnect orchestration (that
+#: is ``MCPConnectionService``'s job, and the adapter must not depend on it
+#: to avoid a layering cycle), so it hands back a plain notification.
+OnSubscriptionLost = Callable[[], None]
+
+
+def is_modern_protocol_version(version: "str | None") -> bool:
+    """True iff ``version`` (an :attr:`MCPClient.negotiated_version` read)
+    is a 2026-07-28-era protocol version — the ONE predicate that decides
+    which adapter :func:`select_subscription_adapter` builds. Duck-typed
+    against the SDK's own ``MODERN_PROTOCOL_VERSIONS`` tuple (not a
+    hardcoded string), mirroring ``_mcp_client_boundary.py``'s "read the
+    SDK's own vocabulary, never re-derive it" convention. ``None`` (no
+    connection negotiated yet) is never modern."""
+    return version in MODERN_PROTOCOL_VERSIONS
+
+
+class SubscriptionAdapter(Protocol):
+    """Version-independent subscription/list-changed delivery port. One
+    instance per held connection, rebuilt on every (re)connect by
+    :func:`select_subscription_adapter` — see module docstring."""
+
+    async def open(self, uris: "set[str]") -> "set[str] | None":
+        """(Re)establish delivery for the FULL desired ``uris`` set — called
+        at initial connect and on every reconnect (never incrementally; the
+        caller always passes the complete tracked set). Returns the honored
+        subset, or ``None`` if this adapter cannot report honored-ness."""
+        ...
+
+    async def close(self, *, graceful: bool = True) -> None:
+        """Tear down any background delivery machinery (a no-op for the
+        legacy adapter, which owns none).
+
+        ``graceful`` (#3698 review ruling): ``True`` (default) attempts a
+        polite close with the peer — the right choice for a LIVE connection
+        (e.g. a URI-change reopen). Pass ``graceful=False`` ONLY when the
+        caller already knows the transport is dead (there is no peer left
+        to agree a close with) — see :class:`ListenSubscriptionAdapter`'s
+        own docstring for why this exists at all: a graceful close attempted
+        against a known-dead transport was observed to hang indefinitely,
+        and bounding it with ``asyncio.wait_for`` reproduces the SAME
+        cancel-scope hazard PR-1 already documented for ``Client.
+        __aenter__`` — the fix is "don't ask a dead peer for a graceful
+        goodbye" (skip the round-trip entirely), not "ask with a shorter
+        deadline"."""
+        ...
+
+
+class LegacySubscriptionAdapter:
+    """Pre-2026-07-28: per-URI ``subscribe_resource`` calls, unchanged from
+    pre-PR-2 behavior. ``honored`` is always ``None`` (see module docstring).
+    list_changed notifications arrive via the existing message_handler push
+    — this adapter is a pure pass-through for that; it does nothing beyond
+    the subscribe calls themselves.
+
+    Calls ``client._raw_subscribe_resource_rpc`` (a private, same-package
+    helper on :class:`~reyn.mcp.client.MCPClient` — NOT the public
+    ``subscribe_resource``) deliberately: the public method is itself what
+    SELECTS this adapter (see ``client.py``'s ``subscribe_resource``), so
+    calling back into it here would recurse. The private helper is the ONE
+    place the legacy RPC is actually issued, shared by both entry points —
+    this adapter and ``MCPClient``'s own public method never carry two
+    copies of that call (see module docstring's "Why a port" for why this
+    split exists at all: the legacy RPC does not exist on the wire once
+    negotiation is modern, so calling it is only ever safe from inside an
+    adapter this module itself selected for a legacy-negotiated
+    connection)."""
+
+    def __init__(self, client: "MCPClient") -> None:
+        self._client = client
+
+    async def open(self, uris: "set[str]") -> "set[str] | None":
+        for uri in uris:
+            await self._client._raw_subscribe_resource_rpc(uri)  # noqa: SLF001 — see docstring
+        return None
+
+    async def close(self, *, graceful: bool = True) -> None:
+        return None
+
+
+class ListenSubscriptionAdapter:
+    """2026-07-28-era: one ``Client.listen()`` stream covering all three
+    families (tools_list_changed / prompts_list_changed /
+    resource_subscriptions), consumed by a background task that re-dispatches
+    each event to ``handler``'s existing methods. See module docstring for
+    the full design and the two SDK-level findings that shaped it.
+
+    ``on_lost`` (see :data:`OnSubscriptionLost`) fires exactly once per
+    ``open()`` call if the stream ends via ``SubscriptionLost`` — never on a
+    graceful ``close()`` (the caller-initiated teardown path, e.g. a URI
+    being added mid-session forces a close+reopen; that is NOT a loss).
+
+    ``handler`` may be ``None`` — a bare :class:`~reyn.mcp.client.MCPClient`
+    with no ``ReynMCPMessageHandler`` installed (the ephemeral one-shot
+    ``MCPClientPool`` path, or any standalone use) still needs to open a
+    real ``listen()`` stream once negotiation is modern (the legacy RPC
+    genuinely does not exist there — see module docstring), even though
+    nothing local consumes the delivered events. ``_dispatch`` is a no-op
+    in that case: the subscription is registered server-side (the point of
+    ``open()``), but events are dropped rather than routed anywhere — the
+    same observable outcome a handler-less legacy caller already had
+    (nothing locally consumed pushes either)."""
+
+    def __init__(
+        self,
+        client: "MCPClient",
+        handler: "ReynMCPMessageHandler | None",
+        *,
+        on_lost: "OnSubscriptionLost | None" = None,
+    ) -> None:
+        self._client = client
+        self._handler = handler
+        self._on_lost = on_lost
+        self._cm: "Any | None" = None
+        self._task: "asyncio.Task[None] | None" = None
+
+    async def open(self, uris: "set[str]") -> "set[str] | None":
+        # Re-opening (a new URI added, or a reconnect) always closes any
+        # prior stream first — the SDK's listen() takes the full filter set
+        # at open time, no incremental add/remove primitive exists (measured
+        # live against the installed SDK), so "add one URI" is structurally
+        # "close, then reopen with the updated full set" for this adapter.
+        await self.close()
+        raw_client = self._client._client  # the entered mcp.Client — see client.py's own module docstring for why this is the stable internal handle
+        self._cm = raw_client.listen(
+            resource_subscriptions=list(uris),
+            tools_list_changed=True,
+            prompts_list_changed=True,
+        )
+        sub = await self._cm.__aenter__()
+        honored_uris = sub.honored.resource_subscriptions
+        if self._handler is not None:
+            # #3698 PR-2 (review ruling): tell the SAME handler which
+            # families THIS open() call actually got the server to honor
+            # over listen, so its legacy __call__ dispatch (still bound to
+            # the raw Client regardless of era) suppresses only those
+            # families — see ReynMCPMessageHandler.set_listen_honored's
+            # docstring for why this exists (a dual-firing server would
+            # otherwise double-deliver). `bool(...)` on the two list_changed
+            # fields folds both `False` and `None` ("unknown") to "not
+            # honored" — the ruling's "honored が None なら何も抑止しない".
+            self._handler.set_listen_honored(
+                tools=bool(sub.honored.tools_list_changed),
+                prompts=bool(sub.honored.prompts_list_changed),
+                resources=honored_uris is not None,
+            )
+        self._task = asyncio.create_task(self._consume(sub))
+        return set(honored_uris) if honored_uris is not None else None
+
+    async def _consume(self, sub: "Any") -> None:
+        try:
+            async for event in sub:
+                await self._dispatch(event)
+        except SubscriptionLost:
+            server_name = (
+                self._handler._server_name  # noqa: SLF001 — same-package internal read, mirrors connection_service.py's existing pattern
+                if self._handler is not None
+                else self._client.server_name
+            )
+            logger.warning(
+                "ListenSubscriptionAdapter: subscription lost for %r", server_name,
+            )
+            if self._on_lost is not None:
+                try:
+                    self._on_lost()
+                except Exception:  # noqa: BLE001 — a faulting callback must not crash the consumer task's own teardown
+                    logger.warning(
+                        "ListenSubscriptionAdapter: on_lost callback failed", exc_info=True,
+                    )
+        except asyncio.CancelledError:
+            # A deliberate close() (URI change, teardown) cancels this task —
+            # NOT a loss, no on_lost callback, propagate the cancellation.
+            raise
+
+    async def _dispatch(self, event: "Any") -> None:
+        # Re-dispatch to the SAME handler methods the legacy message_handler
+        # push already calls — see module docstring. None of these methods
+        # actually read their `message` argument's content (verified against
+        # message_handler.py: on_tool_list_changed/on_prompt_list_changed
+        # ignore it entirely), so passing None here is not a shape mismatch.
+        if self._handler is None:
+            # No local consumer (see __init__'s docstring) — the
+            # subscription is real server-side, the event is just dropped.
+            return
+        if isinstance(event, ToolsListChanged):
+            await self._handler.on_tool_list_changed(None)
+        elif isinstance(event, PromptsListChanged):
+            await self._handler.on_prompt_list_changed(None)
+        elif isinstance(event, ResourceUpdated):
+            self._handler.emit_resource_updated(event.uri, resync=False)
+        elif isinstance(event, ResourcesListChanged):
+            # Out of scope, same as the legacy path (message_handler.py's
+            # own docstring: "no reyn caller subscribes to the resource LIST
+            # changing, only individual resource content updates").
+            pass
+
+    async def close(self, *, graceful: bool = True) -> None:
+        # #3698 review — condition ②: the drain task is ALWAYS explicitly
+        # cancelled here (never just dropped by reference), regardless of
+        # ``graceful`` — that's what actually stops the background consumer;
+        # ``graceful`` only controls whether the STREAM's own SDK-level
+        # close (below) is attempted.
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, SubscriptionLost):
+                pass
+            self._task = None
+        if self._cm is not None:
+            cm = self._cm
+            self._cm = None
+            if not graceful:
+                # #3698 review ruling: a caller passes graceful=False ONLY
+                # when it already knows the transport is dead (currently:
+                # MCPConnectionService._reconnect's old-adapter cleanup) —
+                # there is no peer left to round-trip a graceful
+                # ``subscriptions/listen`` close with, so don't ask for one.
+                # An EARLIER version of this method unconditionally called
+                # ``cm.__aexit__()`` here, live-verified to hang
+                # INDEFINITELY (>90s, no exception) against a known-dead
+                # transport; bounding it with ``asyncio.wait_for`` was tried
+                # and REJECTED (ruling) — that reproduces the exact
+                # cancel-scope hazard PR-1 already documented for
+                # ``Client.__aenter__`` (cancelling an anyio-scoped SDK call
+                # from outside its owning task can hang instead of raising
+                # cleanly), now confirmed for ``__aexit__`` too — see this
+                # module's own docstring "Design record" section: this
+                # SDK's enter/exit cannot be bounded from the outside by
+                # time — two independent instances of the same hazard. The
+                # correct fix is not calling it at all for a known-dead
+                # peer, not a shorter deadline.
+                return
+            try:
+                await cm.__aexit__(None, None, None)
+            except Exception:  # noqa: BLE001 — best-effort; a live transport's own close can still fault
+                logger.warning("ListenSubscriptionAdapter: listen stream teardown faulted", exc_info=True)
+
+
+def select_subscription_adapter(
+    client: "MCPClient",
+    handler: "ReynMCPMessageHandler | None",
+    *,
+    on_lost: "OnSubscriptionLost | None" = None,
+) -> "SubscriptionAdapter":
+    """Build the adapter matching ``client``'s ACTUAL negotiated version —
+    the ONE decision point every #3698 PR-2 acceptance witness checks
+    (adapter SELECTION, not just "both work" — see ``connection_service.py``
+    for where this is called and the audit-event that records which one
+    was picked), and — per the #3698 review ruling this function's own
+    history now records — the ONLY place that decision is made. Every
+    ``subscribe_resource``/``unsubscribe_resource`` caller (a held
+    ``MCPConnectionService`` connection, or a bare ephemeral
+    :class:`~reyn.mcp.client.MCPClient`) routes through this function; none
+    branches on ``negotiated_version`` itself.
+
+    Selection is purely version-based — ``handler`` never gates WHICH
+    adapter is picked, only what the picked adapter does with delivered
+    events. An earlier version of this function returned the legacy
+    adapter whenever ``handler is None``, on the assumption that "a legacy
+    per-URI ``subscribe_resource`` call still works fine standalone" — that
+    assumption was FALSIFIED live (#3698 review): the legacy RPC does not
+    exist on the wire once negotiation is modern, regardless of whether a
+    handler is installed (see module docstring's "Why a port"), so a
+    handler-less caller on a modern-negotiated connection needs the listen
+    adapter exactly as much as a handler-having one does — it just gets no
+    local dispatch (see :class:`ListenSubscriptionAdapter`'s own
+    docstring)."""
+    if is_modern_protocol_version(client.negotiated_version):
+        return ListenSubscriptionAdapter(client, handler, on_lost=on_lost)
+    return LegacySubscriptionAdapter(client)
+
+
+__all__ = [
+    "LegacySubscriptionAdapter",
+    "ListenSubscriptionAdapter",
+    "OnSubscriptionLost",
+    "SubscriptionAdapter",
+    "is_modern_protocol_version",
+    "select_subscription_adapter",
+]

--- a/tests/_support/mcp_fastmcp_echo_server.py
+++ b/tests/_support/mcp_fastmcp_echo_server.py
@@ -12,12 +12,22 @@ Tools:
                             real FastMCP ``Context.report_progress`` API, so
                             progress-callback plumbing is exercised against the
                             real protocol (not a hand-rolled fake).
-  - ``notify_tool_list_changed()``   -> sends a real
-                            ``notifications/tools/list_changed`` via
-                            ``Context.send_notification`` (#2597 S2b — the
-                            async notifications bridge).
-  - ``notify_prompt_list_changed()`` -> sends a real
-                            ``notifications/prompts/list_changed`` (#2597 S2b).
+  - ``notify_tool_list_changed()``   -> fires a real ``ToolListChanged``
+                            signal on BOTH delivery mechanisms (#3698 PR-2):
+                            the legacy ``notifications/tools/list_changed``
+                            push via ``Context.send_notification`` (#2597
+                            S2b — the async notifications bridge, delivered
+                            when a client is on a pre-2026-07-28 negotiated
+                            connection) AND ``bus.publish(ToolsListChanged())``
+                            on the explicit module-level ``InMemorySubscriptionBus``
+                            (delivered to a client that opened
+                            ``Client.listen(tools_list_changed=True)`` on a
+                            2026-07-28 connection — see the module docstring's
+                            "#3698 PR-2" section for why BOTH calls are needed
+                            here, not just one).
+  - ``notify_prompt_list_changed()`` -> same dual-delivery shape for
+                            ``notifications/prompts/list_changed`` /
+                            ``PromptsListChanged`` (#2597 S2b / #3698 PR-2).
   - ``pid()``            -> returns ``os.getpid()`` of THIS server process. Used
                             by #2597 S2a connection-reuse tests to prove a second
                             ``call_tool`` hit the SAME held subprocess (no
@@ -57,14 +67,39 @@ has no bundled equivalent (``show_headers`` reads the raw transport
 ``Context`` has no ``send_notification`` convenience (the notify tools go
 through ``ctx.session.send_notification`` directly — the same primitive
 standalone fastmcp's own convenience wraps).
+
+#3698 PR-2 — dual notification delivery (live-verified, not assumed):
+``MCPServer`` wires an ``InMemorySubscriptionBus`` (this module now passes
+one explicitly as ``subscriptions=`` so the notify tools below can reach it)
+into ``on_subscriptions_listen=ListenHandler(bus)`` automatically — but
+does NOT auto-publish to it on a tool author's behalf. ``Context.
+send_notification``/``ctx.session.send_notification`` is a SEPARATE, legacy-
+only wire primitive that a client using ``Client.listen()`` (the 2026-07-28
+delivery mechanism, #3698's PR-2 subject) never observes — confirmed via a
+minimal bare-SDK reproduction outside this file entirely (a hand-built
+``Server(on_subscriptions_listen=...)`` publishing to its own bus delivered
+instantly; ``send_notification`` alone against this exact file, pre-fix,
+hung a listening client forever with zero error). Before this fix, the two
+notify tools below called ONLY ``send_notification`` — correct for a
+pre-2026-07-28 negotiated client (what every pre-PR-2 test used), silently
+undeliverable to a client that had moved to ``Client.listen()``. Both tools
+now call BOTH primitives, so ONE tool invocation exercises whichever
+delivery mechanism the calling test's negotiated connection actually uses,
+without the test needing to know which era it's on.
 """
 from __future__ import annotations
 
 import sys
 
 from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.subscriptions import InMemorySubscriptionBus
 
-mcp = MCPServer("reyn-test-echo")
+# #3698 PR-2: shared explicitly (not left to MCPServer's own internal
+# default) so notify_tool_list_changed/notify_prompt_list_changed below can
+# publish to the SAME bus instance the listen handler reads from — see the
+# module docstring's "dual notification delivery" section.
+_subscriptions = InMemorySubscriptionBus()
+mcp = MCPServer("reyn-test-echo", subscriptions=_subscriptions)
 
 
 @mcp.tool()
@@ -173,18 +208,23 @@ async def progress(steps: int, ctx: Context) -> str:
 @mcp.tool()
 async def notify_tool_list_changed(ctx: Context) -> str:
     import mcp.types as types
+    from mcp.server.subscriptions import ToolsListChanged
 
     # #4302: bundled Context has no ``send_notification`` convenience — go
     # through ``ctx.session`` (the underlying ServerSession) directly.
+    # #3698 PR-2: fire BOTH delivery mechanisms — see module docstring.
     await ctx.session.send_notification(types.ToolListChangedNotification())
+    await _subscriptions.publish(ToolsListChanged())
     return "sent"
 
 
 @mcp.tool()
 async def notify_prompt_list_changed(ctx: Context) -> str:
     import mcp.types as types
+    from mcp.server.subscriptions import PromptsListChanged
 
     await ctx.session.send_notification(types.PromptListChangedNotification())
+    await _subscriptions.publish(PromptsListChanged())
     return "sent"
 
 

--- a/tests/_support/mcp_resources_no_subscribe_server.py
+++ b/tests/_support/mcp_resources_no_subscribe_server.py
@@ -1,0 +1,110 @@
+"""Real MCP stdio server that advertises ``resources`` WITHOUT the
+``subscribe`` sub-capability, under EITHER negotiated era (#3698 review).
+
+Standalone script — run as a subprocess, never imported.
+
+Why this is a NEW low-level server, not the existing
+``mcp_fastmcp_echo_server.py`` double: that double is built with the
+high-level ``MCPServer`` class, which (measured live, #4368-era SDK)
+registers ``"subscriptions/listen"`` in its request handlers
+UNCONDITIONALLY — a bare ``MCPServer("x")``, no ``subscriptions=`` kwarg at
+all, already has it (``"subscriptions/listen" in mcp._lowlevel_server.
+_request_handlers`` is ``True``). Per the base SDK's own
+``Server.get_capabilities`` (read directly): under a modern (2026-07-28+)
+negotiation, ``resources.subscribe`` is derived ENTIRELY from whether
+``"subscriptions/listen"`` is served — server-wide, regardless of whether
+any registered resource actually honors subscriptions. So **no
+``MCPServer``-built double can ever advertise ``resources.subscribe=False``
+once a client negotiates modern era** — a real, structural SDK behavior
+this file's own PRE-listen-support state relied on without realizing it
+(#3698 PR-2 review: ``mcp_fastmcp_echo_server.py`` gained
+``on_subscriptions_listen`` for an UNRELATED reason — the tools/prompts
+list_changed dual-publish fix — which incidentally, and correctly per the
+SDK's own semantics, flipped its ``resources.subscribe`` to ``True`` too,
+breaking the 3 capability-gate tests that depended on it reading
+``False``).
+
+The low-level ``mcp.server.lowlevel.Server`` class, by contrast, has NO
+default ``subscriptions/listen`` wiring at all (see
+``mcp_subscribable_resources_server.py``'s own docstring) — omitting
+``on_subscriptions_listen`` here (this file's only difference from that
+one) keeps ``listen_served`` (and therefore ``resources.subscribe``)
+``False`` under BOTH eras, which is exactly what
+``MCPClient._require_resources_subscribe_capability``'s fail-fast gate
+needs a real server to prove against.
+
+Exposes:
+  - resource ``resource://pid`` — content is this server process's PID (no
+    subscribe/unsubscribe handler registered at all — a caller asking to
+    subscribe/unsubscribe must get MCPCapabilityError, never reach the
+    wire).
+  - tool ``pid()`` — trivial liveness/no-op tool, unused by the
+    capability-gate tests themselves but keeps ``tools/list`` non-empty
+    (mirrors every other double in this directory).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+
+_URI = "resource://pid"
+
+
+async def list_resources(ctx: "object", params: "object") -> "types.ListResourcesResult":
+    return types.ListResourcesResult(resources=[
+        types.Resource(uri=_URI, name="pid", mime_type="text/plain"),
+    ])
+
+
+async def read_resource(
+    ctx: "object", params: "types.ReadResourceRequestParams",
+) -> "types.ReadResourceResult":
+    return types.ReadResourceResult(contents=[types.TextResourceContents(
+        uri=str(params.uri), mime_type="text/plain", text=str(os.getpid()),
+    )])
+
+
+async def list_tools(ctx: "object", params: "object") -> "types.ListToolsResult":
+    return types.ListToolsResult(tools=[
+        types.Tool(
+            name="pid",
+            description="Return this server process's PID.",
+            input_schema={"type": "object", "properties": {}},
+        ),
+    ])
+
+
+async def call_tool(
+    ctx: "object", params: "types.CallToolRequestParams",
+) -> "types.CallToolResult":
+    if params.name == "pid":
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(os.getpid()))],
+        )
+    raise ValueError(f"unknown tool {params.name!r}")
+
+
+app = Server(
+    "reyn-test-resources-no-subscribe",
+    on_list_resources=list_resources,
+    on_read_resource=read_resource,
+    on_list_tools=list_tools,
+    on_call_tool=call_tool,
+    # Deliberately NO on_subscribe_resource / on_unsubscribe_resource (the
+    # legacy-era gate) and NO on_subscriptions_listen (the modern-era one)
+    # — see module docstring: this is what keeps resources.subscribe=False
+    # under BOTH eras.
+)
+
+
+async def main() -> None:
+    async with stdio_server() as (read, write):
+        await app.run(read, write, app.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/_support/mcp_subscribable_resources_server.py
+++ b/tests/_support/mcp_subscribable_resources_server.py
@@ -37,9 +37,18 @@ Exposes:
     handlers (accepting the subscription is all a real server needs to do;
     the interesting behaviour is the PUSH below).
   - tool ``bump_and_notify()`` — increments the counter and pushes a REAL
-    ``notifications/resources/updated`` for ``resource://counter`` via
-    ``app.request_context.session.send_resource_updated(...)`` (the same raw
-    ``ServerSession`` API a real MCP server implementer would call).
+    resource-updated signal on BOTH delivery mechanisms (#3698 PR-2, same
+    dual-delivery shape as ``mcp_fastmcp_echo_server.py``'s notify tools —
+    see that module's docstring for the live-verified reasoning): the
+    legacy ``notifications/resources/updated`` push via
+    ``ctx.session.send_resource_updated(...)`` (the same raw
+    ``ServerSession`` API a real MCP server implementer would call,
+    delivered to a pre-2026-07-28 negotiated client) AND
+    ``bus.publish(ResourceUpdated(uri=...))`` on the explicit
+    ``InMemorySubscriptionBus`` this file now constructs and registers via
+    ``on_subscriptions_listen=ListenHandler(bus)`` (delivered to a client
+    that opened ``Client.listen(resource_subscriptions=[...])`` on a
+    2026-07-28 connection).
   - tool ``die()`` — kills the subprocess (transport-death simulation, mirrors
     ``mcp_fastmcp_echo_server.py``'s ``die`` tool) so reconnect/re-subscribe
     tests can simulate a genuine transport drop.
@@ -52,10 +61,16 @@ import os
 import mcp.types as types
 from mcp.server.lowlevel import Server
 from mcp.server.stdio import stdio_server
+from mcp.server.subscriptions import InMemorySubscriptionBus, ListenHandler, ResourceUpdated
 
 _URI = "resource://counter"
 
 _counter = {"value": 0}
+
+# #3698 PR-2: constructed explicitly (the low-level Server has no default,
+# unlike MCPServer's own internal one) so bump_and_notify below can publish
+# to the SAME bus the listen handler reads from — see module docstring.
+_subscriptions = InMemorySubscriptionBus()
 
 
 # #4368 (mcp 2.0 port): all 6 decorators this file used
@@ -116,7 +131,9 @@ async def call_tool(
     name = params.name
     if name == "bump_and_notify":
         _counter["value"] += 1
+        # #3698 PR-2: fire BOTH delivery mechanisms — see module docstring.
         await ctx.session.send_resource_updated(_URI)
+        await _subscriptions.publish(ResourceUpdated(uri=_URI))
         return types.CallToolResult(
             content=[types.TextContent(type="text", text=str(_counter["value"]))],
         )
@@ -133,6 +150,11 @@ app = Server(
     on_unsubscribe_resource=unsubscribe_resource,
     on_list_tools=list_tools,
     on_call_tool=call_tool,
+    # #3698 PR-2: the low-level Server, unlike MCPServer, has no default
+    # subscriptions/listen wiring at all — an explicit ListenHandler over
+    # THIS module's own bus is what makes a modern (2026-07-28) client's
+    # Client.listen(resource_subscriptions=[...]) reach anything.
+    on_subscriptions_listen=ListenHandler(_subscriptions),
 )
 
 

--- a/tests/mcp/test_3698_pr2_subscription_port.py
+++ b/tests/mcp/test_3698_pr2_subscription_port.py
@@ -1,0 +1,341 @@
+"""Tests for #3698 PR-2 — the version-independent subscription port.
+
+Real instances only, per the testing policy: no ``unittest.mock`` /
+``MagicMock`` / ``AsyncMock`` / ``patch``. These tests exercise
+``reyn.mcp.subscription_port`` both in isolation (Tier 1, the pure
+selection predicate) and through a REAL ``MCPConnectionService`` holding a
+REAL subprocess connection (Tier 2), against the two test doubles PR-2
+itself updated to dual-publish onto the SDK's ``InMemorySubscriptionBus``
+(``tests/_support/mcp_fastmcp_echo_server.py``,
+``mcp_subscribable_resources_server.py`` — see their own module docstrings
+for the live-verified before/after that motivated the dual-publish fix).
+
+Acceptance criteria this file (together with the pre-existing
+``test_2597_s2b_mcp_notifications_bridge.py`` / ``test_2597_p1_reconnect_
+resync_read.py`` / ``test_2597_s2b_resource_subscriptions.py`` — all three
+already exercise the modern era end-to-end, since ``mode="auto"`` is now
+the client's own default) are meant to jointly cover:
+
+(a) the three families — tools_list_changed, prompts_list_changed,
+    resource_subscriptions — each individually, under a real connection;
+(b) an adapter-SELECTION witness, not just "both paths work in isolation";
+(c) PR-1's two originally-measured symptoms now demonstrably closed under
+    the port (covered by (a) + (b) together: a modern negotiation no
+    longer silently drops delivery for either family).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from mcp_types.version import MODERN_PROTOCOL_VERSIONS
+
+from reyn.core.events.events import EventLog
+from reyn.mcp.client import MCPCapabilityError, MCPClient
+from reyn.mcp.connection_service import MCPConnectionService
+from reyn.mcp.message_handler import ReynMCPMessageHandler
+from reyn.mcp.subscription_port import (
+    ListenSubscriptionAdapter,
+    is_modern_protocol_version,
+    select_subscription_adapter,
+)
+from tests._support.events import collect_events
+from tests._support.paths import REPO_ROOT
+
+_SUPPORT_DIR = REPO_ROOT / "tests" / "_support"
+_ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
+_SUBSCRIBABLE_SERVER = _SUPPORT_DIR / "mcp_subscribable_resources_server.py"
+_NO_SUBSCRIBE_SERVER = _SUPPORT_DIR / "mcp_resources_no_subscribe_server.py"
+_URI = "resource://counter"
+
+
+def _stdio_cfg(script: Path) -> dict:
+    # #3698 review ruling (#4559): "legacy" is now MCPClient's own default
+    # (see client.py's module docstring) — every test in THIS file is
+    # specifically about the modern-era subscription port, so each
+    # connection here opts in explicitly via protocol_mode="auto" rather
+    # than relying on a default this file never actually wants.
+    return {
+        "type": "stdio", "command": sys.executable, "args": [str(script)],
+        "protocol_mode": "auto",
+    }
+
+
+# ── Tier 1: is_modern_protocol_version — reyn's own predicate ──────────────
+
+
+def test_is_modern_protocol_version_true_for_every_modern_version():
+    """Tier 1: every entry in the SDK's own MODERN_PROTOCOL_VERSIONS reads as
+    modern — the predicate is duck-typed against that tuple, not a hardcoded
+    string, so this is reyn's own logic, not a third-party promise."""
+    assert MODERN_PROTOCOL_VERSIONS, "the SDK's own tuple must be non-empty for this test to mean anything"
+    for version in MODERN_PROTOCOL_VERSIONS:
+        assert is_modern_protocol_version(version) is True
+
+
+def test_is_modern_protocol_version_false_for_legacy_and_none():
+    """Tier 1: a pre-2026-07-28 version string and ``None`` (no connection
+    negotiated yet) both read as not-modern."""
+    assert is_modern_protocol_version("2025-11-25") is False
+    assert is_modern_protocol_version(None) is False
+
+
+# ── Tier 1: select_subscription_adapter — selection is version-only ────────
+
+
+@pytest.mark.asyncio
+async def test_select_subscription_adapter_is_version_only_handler_never_gates_selection():
+    """Tier 1: #3698 review ruling — selection is PURELY version-based;
+    ``handler`` never gates WHICH adapter is picked (only what the picked
+    adapter does with delivered events). An earlier version of this
+    function special-cased ``handler is None`` to always return legacy —
+    live-verified FALSE (#3698 review): the legacy RPC does not exist on
+    the wire once negotiation is modern, regardless of handler presence,
+    so a handler-less caller on a modern-negotiated connection still needs
+    the listen adapter (it just gets no local dispatch — see
+    ListenSubscriptionAdapter's own docstring). Driven against a real live
+    connection (this file's own protocol_mode="auto" opt-in — see
+    _stdio_cfg — since "legacy" is the client's own default post-#4559
+    ruling), not a faked client."""
+    async with MCPClient(_stdio_cfg(_ECHO_SERVER)) as client:
+        adapter = select_subscription_adapter(client, None)
+        assert isinstance(adapter, ListenSubscriptionAdapter), (
+            "a modern-negotiated connection must get the listen adapter "
+            "even with no handler installed — the legacy RPC is not a "
+            "valid fallback under modern negotiation"
+        )
+        await adapter.close()
+
+
+# ── Tier 1: a genuinely listen-incapable double — #4559's "column B" ───────
+#    (reyn's own test infrastructure that structurally can't express modern
+#    behavior) witness, requested explicitly by the #3698 review ruling.
+
+
+@pytest.mark.asyncio
+async def test_no_subscribe_double_reads_subscribe_false_even_under_modern_negotiation():
+    """Tier 1: unlike EVERY ``MCPServer``-built double in this directory
+    (which registers ``subscriptions/listen`` unconditionally — see
+    ``mcp_resources_no_subscribe_server.py``'s own module docstring for the
+    live-verified finding this documents), a low-level ``Server`` built
+    WITHOUT ``on_subscriptions_listen`` correctly reads
+    ``resources.subscribe=False`` even when the CONNECTION itself
+    negotiates modern (this file's protocol_mode="auto" opt-in) — proving
+    the gap is in ``MCPServer``'s own unconditional wiring, not in modern
+    negotiation itself, and giving #4559's "column B" enumeration one
+    concrete, tested example rather than only a claim."""
+    async with MCPClient(_stdio_cfg(_NO_SUBSCRIBE_SERVER), server_name="no-sub-srv") as client:
+        assert client.negotiated_version in MODERN_PROTOCOL_VERSIONS
+        assert client.supports("resources") is True
+        with pytest.raises(MCPCapabilityError) as exc_info:
+            await client.subscribe_resource("resource://pid")
+        assert "subscribe" in str(exc_info.value)
+
+
+# ── Tier 2: adapter-SELECTION witness — the acceptance criterion itself ────
+
+
+@pytest.mark.asyncio
+async def test_mcp_initialized_names_the_selected_adapter_class():
+    """Tier 2: THE adapter-selection witness lead-coder named as an
+    acceptance criterion — not "both paths work in isolation" but that
+    WHICH one a given connection picked is independently observable. A real
+    connection against a modern-supporting double negotiates modern (the
+    client's own "auto" default) and the ``mcp_initialized`` audit event
+    names ``ListenSubscriptionAdapter`` as the selected class."""
+    events = EventLog(subscribers=[])
+    collected = collect_events(events)
+    service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
+    try:
+        await service.get("srv", _stdio_cfg(_ECHO_SERVER))
+
+        matching = [e for e in collected if e.type == "mcp_initialized"]
+        (only_event,) = matching  # exactly one — the single (re)connect this test drove
+        assert only_event.data.get("server") == "srv"
+        assert only_event.data.get("subscription_adapter") == "ListenSubscriptionAdapter", (
+            "a modern-supporting double must select the listen adapter — the "
+            "selection itself, not just delivery, is what this event witnesses"
+        )
+    finally:
+        await service.aclose()
+
+
+# ── LegacySubscriptionAdapter — KNOWN COVERAGE GAP, not silently omitted ───
+#
+# There is currently no LIVE test of LegacySubscriptionAdapter.open() against
+# a real pre-2026-07-28-negotiated connection. An earlier version of this
+# file had a test that hand-constructed LegacySubscriptionAdapter directly
+# against a modern-negotiated MCPClient (both reyn-owned test doubles now
+# advertise `subscriptions/listen`, so every live connection in this repo
+# negotiates modern) — deleted per the testing policy's six questions,
+# question 3: that is a configuration only the test itself built; production
+# code (select_subscription_adapter) never constructs LegacySubscriptionAdapter
+# for a modern-negotiated client, so the test was pinning a shape nothing
+# real produces, and its "proof" (the legacy RPC succeeds) was actually a
+# 404 once the double gained listen support — the exact bug this PR fixes
+# elsewhere. Closing this gap for real needs a genuinely legacy-only (pre-
+# 2026-07-28) test double, which does not exist in this repo today — left
+# for whoever adds one, not invented here as a second implementation of a
+# fake collaborator (the testing policy's Mock-vs-Fake ban).
+
+
+# ── Tier 2: prompts_list_changed — parity with the existing tools_list_changed
+#    coverage in test_2597_s2b_mcp_notifications_bridge.py; that file never
+#    added a prompts sibling even though the SDK/on_prompt_list_changed path
+#    has existed since before PR-2 ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prompt_list_changed_notification_emits_event():
+    """Tier 2: a REAL server-pushed prompts_list_changed — via the modern
+    ``Client.listen()`` stream (the double's own dual-publish, see its
+    module docstring) since this connection negotiates modern by default —
+    lands as an ``mcp_prompt_list_changed`` event on the EventLog, mirroring
+    the existing tools_list_changed coverage for the sibling family."""
+    events = EventLog(subscribers=[])
+    collected = collect_events(events)
+    service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
+    try:
+        client = await service.get("srv", _stdio_cfg(_ECHO_SERVER))
+        result = await client.call_tool("notify_prompt_list_changed", {})
+        assert result["isError"] is False
+
+        import asyncio
+
+        # #3748-style: unbounded per the owner's testing policy — the loop
+        # condition IS the terminating check.
+        while not any(e.type == "mcp_prompt_list_changed" for e in collected):
+            await asyncio.sleep(0.02)
+
+        matching = [e for e in collected if e.type == "mcp_prompt_list_changed"]
+        (only_event,) = matching  # exactly one — the single real notification sent
+        assert only_event.data.get("server") == "srv"
+    finally:
+        await service.aclose()
+
+
+# ── Tier 2: dual-publish, single-emit — the #3698 review's own acceptance
+#    criterion (lead-coder: "turn what you stumbled onto into an acceptance
+#    criterion"). Both test doubles fire BOTH the legacy notification AND
+#    the modern listen() event for every notify_*/bump_and_notify call (see
+#    their own module docstrings) — a real, plausible migration-period
+#    server shape, not just a testing artifact (#3698 review ruling). reyn
+#    must emit exactly ONE event per real change regardless — see
+#    ReynMCPMessageHandler.set_listen_honored's docstring for the mechanism
+#    (per-family legacy-dispatch suppression while listen honors that
+#    family) this proves. ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dual_firing_server_still_emits_tool_list_changed_exactly_once():
+    """Tier 2: THE acceptance witness — a server that fires BOTH channels
+    for the SAME logical change must still produce exactly ONE
+    ``mcp_tool_list_changed`` on reyn's EventLog, not two. Named explicitly
+    (distinct from test_2597_s2b_mcp_notifications_bridge.py's own
+    single-count assertion, which predates this ruling and would have
+    silently regressed to double-counting without the suppression
+    mechanism this test names directly)."""
+    events = EventLog(subscribers=[])
+    collected = collect_events(events)
+    service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
+    try:
+        client = await service.get("srv", _stdio_cfg(_ECHO_SERVER))
+        result = await client.call_tool("notify_tool_list_changed", {})
+        assert result["isError"] is False
+
+        import asyncio
+
+        while not any(e.type == "mcp_tool_list_changed" for e in collected):
+            await asyncio.sleep(0.02)
+        await asyncio.sleep(0.1)  # give a WOULD-BE second (legacy) emit a fair chance to land
+
+        matching = [e for e in collected if e.type == "mcp_tool_list_changed"]
+        (only_event,) = matching  # exactly one, despite the double firing server-side
+        assert only_event.data.get("server") == "srv"
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dual_firing_server_still_emits_resource_updated_exactly_once():
+    """Tier 2: same witness, for the resource_subscriptions family —
+    ``mcp_subscribable_resources_server.py``'s ``bump_and_notify`` ALSO
+    dual-fires (``send_resource_updated`` AND ``bus.publish``)."""
+    events = EventLog(subscribers=[])
+    collected = collect_events(events)
+    service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
+    try:
+        client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
+        await client.subscribe_resource(_URI)
+        result = await client.call_tool("bump_and_notify", {})
+        assert result["isError"] is False
+
+        import asyncio
+
+        while not any(e.type == "mcp_resource_updated" for e in collected):
+            await asyncio.sleep(0.02)
+        await asyncio.sleep(0.1)
+
+        matching = [e for e in collected if e.type == "mcp_resource_updated"]
+        (only_event,) = matching  # exactly one, despite the double firing server-side
+        assert only_event.data.get("uri") == _URI
+    finally:
+        await service.aclose()
+
+
+# ── Tier 1: ListenSubscriptionAdapter re-dispatches to the handler's own
+#    methods, not a re-derived shape (drives the REAL __call__/dispatch path
+#    against a real handler instance, no live server needed for this one) ──
+
+
+@pytest.mark.asyncio
+async def test_listen_adapter_dispatch_routes_each_event_kind_to_the_matching_handler_method():
+    """Tier 1: ``_dispatch``'s per-event-kind routing is reyn's OWN
+    control flow (which handler method a given SDK event kind reaches) —
+    drives it directly against a real ``ReynMCPMessageHandler`` sink, no
+    live connection needed since this is testing the routing table, not
+    delivery over the wire (that's the Tier 2 tests above)."""
+    from mcp.shared.subscriptions import (
+        PromptsListChanged,
+        ResourcesListChanged,
+        ResourceUpdated,
+        ToolsListChanged,
+    )
+
+    events = EventLog(subscribers=[])
+    collected = collect_events(events)
+    handler = ReynMCPMessageHandler(lambda et, **d: events.emit(et, **d), "srv")
+
+    # No live client needed for _dispatch itself — construct the adapter
+    # with client=None (never read by _dispatch) and drive the method
+    # directly, mirroring the notifications-bridge file's own direct-
+    # __call__ pattern for the same reason (isolating routing from wire I/O).
+    adapter = ListenSubscriptionAdapter(client=None, handler=handler)
+
+    await adapter._dispatch(ToolsListChanged())
+    await adapter._dispatch(PromptsListChanged())
+    await adapter._dispatch(ResourceUpdated(uri=_URI))
+
+    types_seen = [e.type for e in collected]
+    assert types_seen.count("mcp_tool_list_changed") == 1
+    assert types_seen.count("mcp_prompt_list_changed") == 1
+    matching_updated = [e for e in collected if e.type == "mcp_resource_updated"]
+    (only_update,) = matching_updated
+    assert only_update.data.get("uri") == _URI
+    assert only_update.data.get("resync") is False, (
+        "a real modern-era push is not a reconnect resync — resync=False "
+        "distinguishes it from #2597 P1's synthetic re-signal"
+    )
+
+    # ResourcesListChanged is out of scope (message_handler.py's own
+    # docstring: "no reyn caller subscribes to the resource LIST changing")
+    # — dispatching it must not add any NEW event beyond the 3 already
+    # asserted above (compares the collected list's own state before/after,
+    # not a fixed count).
+    before = list(collected)
+    await adapter._dispatch(ResourcesListChanged())
+    assert collected == before, (
+        f"ResourcesListChanged must produce no event — collected grew from "
+        f"{[e.type for e in before]} to {[e.type for e in collected]}"
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #3698 (PR-2: subscription/listen port). PR-1 (#4545, merged) swapped `ClientSession` → `Client` and pinned `mode="legacy"` after finding `"auto"` silently dropped subscribe/list_changed delivery under modern (2026-07-28+) negotiation. This PR closes that gap with a version-independent port, and — after a real mid-review reversal — restores `mode="legacy"` as the DEFAULT rather than flipping it, once a bigger gap surfaced.

## What this PR does

- **`reyn.mcp.subscription_port`** (new): `SubscriptionAdapter` port — `LegacySubscriptionAdapter` (per-URI `subscribe_resource`, unchanged pre-PR-2 behavior) / `ListenSubscriptionAdapter` (one `Client.listen()` stream covering tools_list_changed/prompts_list_changed/resource_subscriptions, re-dispatching to the same `ReynMCPMessageHandler` methods the legacy push already used). `select_subscription_adapter` is the ONE decision point — every `subscribe_resource`/`unsubscribe_resource` caller (held `MCPConnectionService` connection or a bare ephemeral `MCPClient`) routes through it; none branches on protocol version itself.
- **Era selection stays `mode="legacy"` by default.** A server opts in to modern-capable negotiation via `protocol_mode: "auto"` in its `reyn.yaml`/`reyn.local.yaml` config (`client.py`'s `_resolve_client_mode`). This PR briefly made `"auto"` the unconditional default mid-review — **reverted before merge** (see "What changed my mind" below). #4559 tracks the enumeration that's the real precondition for flipping the default (a future PR-3).
- **`mcp_initialized` gains a `subscription_adapter` field** — the adapter-SELECTION witness (not just "both paths work in isolation"): which adapter a given connection actually picked is now independently observable. `docs/reference/runtime/events.md` updated in this same PR (the one CI-checked doc↔code pair for `events.md`'s kind enumeration doesn't apply here — this is a field addition to an existing kind, not a new kind — but the field-list doc still needed updating).
- **`hooks/ingress.py`**: corrected `McpIngressAdapter`'s stale docstring ("standard `resources/updated` notification only") — the signal has been wire-independent since before this PR (a real legacy push, #2597 P1's synthetic reconnect-resync, and now a modern `listen()` event all reach it identically; the class never branched on which produced the signal).

## Three design records, kept in the code for whoever touches this next

1. **This SDK's `Client`/`Subscription` enter-and-exit cannot be safely bounded from outside by time — two independent instances, same shape, found nights apart.** PR-1: `asyncio.wait_for`/`anyio.fail_after` around `Client.__aenter__()` raises a cancel-scope-nesting violation on success and **hangs** on a genuine timeout. This PR: the identical shape recurred for `Client.listen()`'s context manager `__aexit__()` — live-verified a >90s hang (not merely slow) tearing down a KNOWN-dead subscription stream during `MCPConnectionService._reconnect`. I first tried bounding it with `asyncio.wait_for(timeout=5.0)` — reviewer flagged this as reproducing PR-1's exact documented hazard rather than fixing anything, correctly. The actual fix: **don't call it at all when the caller already knows the peer is dead** — `ListenSubscriptionAdapter.close(graceful=False)` skips the graceful SDK-level exit entirely for that one caller (the reconnect path), while a live URI-change reopen still gets the default `graceful=True`.
2. **A genuine double-reconnect race**, found live via the same investigation: a single transport death independently triggered BOTH `_HeldConnection._heal`'s reactive reconnect (an in-flight call failing) AND `_on_subscription_lost`'s proactive one (the listen stream noticing loss) — one subprocess kill produced 3× `mcp_initialized` and 2× `mcp_resource_updated` (expected 2 and 1). This was the actual root cause of the >90s hang above (two reconnects racing over the same connection state), not the `__aexit__` bound itself. Fixed with a shared per-server `asyncio.Lock` (the same one `MCPConnectionService.get()` already used but `_heal`/`_reconnect` bypassed) plus a staleness check (`dead_client` identity) on both the reactive and proactive paths, so whichever wins does the reconnect and the other skips.
3. **A dual-firing server (a real migration-period shape — sending BOTH the legacy notification and the modern `bus.publish` for the same change, not just a testing artifact) double-delivers to reyn's client once the listen adapter is actually wired**, since `ReynMCPMessageHandler` is bound to both the raw `Client`'s legacy message_handler AND the listen adapter's dispatch simultaneously. Fixed with per-FAMILY legacy-dispatch suppression (`set_listen_honored`/`clear_listen_honored`) — suppressed ONLY for a family the listen stream's own ack actually honored (`honored` being `None`/unconfirmed means DON'T suppress); `on_progress` is deliberately never gated (request-scoped, never rides `listen()` — a blanket suppression would have silently dropped it, the exact "no-longer-silent" failure class this handler's own docstring exists to prevent).

## What changed my mind on the default (the actual finding worth reading)

Restoring `mode="auto"` as the default (this PR's original plan, since the port makes subscribe/list_changed safe under modern) broke an UNTOUCHED, pre-existing elicitation test double — 10/10 of `test_2597_slice3_mcp_elicitation.py` failed with `NoBackChannelError` the moment negotiation went modern. Root cause, read directly from the installed SDK (`mcp/server/connection.py`'s `send_raw_request` docstring): **a modern (2026-07-28+) connection forbids server-initiated requests over the standalone back-channel entirely** — not just list_changed/subscribe, but elicitation, sampling, roots, and ping too. PR-1's framing ("subscribe moves to listen") undersold the actual protocol change.

**Reverting the default to `"legacy"` and re-running the full affected suite is itself the primary evidence for what this PR closes and doesn't**: all 10 elicitation tests and all 3 resource-subscribe capability-gate tests (`test_2597_s2b_resource_subscriptions.py`) came back green with NO code change beyond the default reversal — meaning the capability-gate breakage I initially attributed to my own test-double edit was actually the SAME "auto isn't safe yet" gap, not a side effect of anything this PR added. (Separately, real: any `MCPServer`-built double registers `subscriptions/listen` UNCONDITIONALLY — `MCPServer("x")` alone, no `subscriptions=` kwarg, already has it — which flips `resources.subscribe=True` under modern negotiation regardless of whether the server has any actual resources. `mcp_resources_no_subscribe_server.py`, a new low-level `Server` double built WITHOUT `on_subscriptions_listen`, is #4559's first "column B" example — reyn's own test infrastructure that structurally can't express modern behavior via the high-level `MCPServer` class at all.)

Between the elicitation break and the capability-gate break, that's **13 concrete test cases already in hand** for #4559's column A (reyn features that break under modern) / column B (reyn test doubles that can't express modern) enumeration — the real precondition for ever flipping the default, tracked there rather than re-derived from scratch in a future PR.

## Test-double changes carried by this PR

- `mcp_fastmcp_echo_server.py` / `mcp_subscribable_resources_server.py`: dual-publish (legacy `send_notification`/`send_resource_updated` AND modern `bus.publish`) so a listening client actually receives what these doubles' notify/bump tools send. Root-caused via a minimal bare-SDK reproduction outside reyn entirely — not an SDK defect; publishing to the SDK's `InMemorySubscriptionBus` is a server-author responsibility the SDK never automates on a tool's behalf (zero `bus.publish` call sites in `mcp/server/mcpserver/server.py`, confirmed via direct grep).
- `mcp_resources_no_subscribe_server.py` (new): see above.

## Test plan

- [x] `ruff check src tests` (scoped to changed files + full repo) — clean
- [x] `python scripts/test_tier_audit.py --strict tests/mcp/test_3698_pr2_subscription_port.py` — 9/9 OK, 0 Tier-4 violations (1 caught and fixed: a `len(types_seen) == 3` format-pin, rewritten as a collected-list-growth check)
- [x] `python scripts/verify_module_docstrings.py` on all changed src files — OK
- [x] `python scripts/mypy_ratchet.py` — OK (212 findings, all baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (111 references, all baselined)
- [x] `pytest tests/mcp/ tests/core/test_2597_s2b_resource_subscriptions.py tests/core/test_2597_s2a_mcp_resources_consumption.py tests/core/test_2597_prompts_consumption.py tests/hooks/test_2608_h1_mcp_resource_updated_hook.py` — 237 passed, 1 skipped, 1 failed (`test_fastmcp_core_dep_import_chain.py::test_mcp_import_chain_succeeds_and_fastmcp_is_not_installed` — pre-existing local dev-venv contamination, `fastmcp` importable alongside `mcp` in this machine's venv; unrelated to this PR, CI's clean checkout won't have it)
- [ ] Visual — N/A, no TUI/CUI surface touched (standing waiver applies if it ever were)

Falsify-verified: all 9 new tests in `test_3698_pr2_subscription_port.py` were run against BOTH the buggy and fixed code at each stage (dual-firing single-emit witnesses caught the real double-delivery bug live before the fix; the no-subscribe-double witness was live-probed for both `resources.subscribe=False` and the `MCPCapabilityError` fail-fast before being wired into the suite).

Touches `tests/` — waiting for TESTS-READ before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
