### PR TITLE
feat(#4552): PR-2 — remove `action_retrieval.mode`

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -566,7 +566,6 @@ sandbox:
 ```yaml
 action_retrieval:
   universal_wrappers_enabled: true    # デフォルト; false でオプトアウト
-  mode: default                       # default | minimal | performance
 embedding:
   enabled: false                      # デフォルト（無効）; opt-in するには true
   # default_class: standard           # enabled 時に使う embedding class
@@ -577,7 +576,6 @@ embedding:
 | フィールド | 型 | デフォルト | 説明 |
 |-----|------|---------|-------------|
 | `universal_wrappers_enabled` | bool | `true` | `tool_use` scheme が `universal-category` に解決される layer について、`true`(デフォルト)の時、その layer の `tools=` は 4 universal wrappers (`list_actions` / `search_actions` / `describe_action` / `invoke_action`) のみ。 legacy per-kind tool (`invoke_skill` / `call_mcp_tool` 等) はその layer で LLM に surface されず、 wrapper の backing handler として残存。 `search_actions` は `embedding.enabled` で別途ゲート（下記参照）。 `false` 設定でその layer の wrapper surface 自体を無効化 (= legacy のみが addressing path)。 scheme が `enumerate-all`(`chat` layer 自身のデフォルト)である layer には影響しない — その scheme はこのフラグを一切参照しない。 |
-| `mode` | string | `"default"` | 運用モードラベル: `"minimal"` / `"default"` / `"performance"`。 自由文字列で、現在どの呼び出し元も参照していない。 |
 
 > **#4552（2026-08）— hot list 撤去。** 従来の `hot_list_n` / `hot_list_seed`
 > フィールド（top-N freq+recency の direct-alias 投影）は**削除、alias なし**
@@ -585,6 +583,12 @@ embedding:
 > discovery path として代替済み。 これらのキーを持つ `reyn.yaml` は通常の
 > unknown-key 許容（無視されるだけで parse エラーにはならない）を受ける —
 > 移行先が無いので移行パスも無い。
+
+> **#4552 PR-2（2026-08）— `mode` 撤去。** `mode` フィールド
+> （`"minimal"`/`"default"`/`"performance"`、§D24）は実際の消費者が 0 だった
+> — どの呼び出し元も参照しておらず、将来の仮想的な消費者のためだけに存在
+> していた accessor（`get_action_retrieval_config()`）も同じ PR で削除。
+> 上記と同じ unknown-key 許容がこのキーを持つ `reyn.yaml` にも適用される。
 
 ### クイックスタート — semantic `search_actions` を opt-in
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1222,7 +1222,6 @@ Universal catalog visibility + retrieval settings.  Scheme *selection* is genera
 ```yaml
 action_retrieval:
   universal_wrappers_enabled: true    # default; set false to opt out
-  mode: default                       # default | minimal | performance
 embedding:
   enabled: false                      # default (off); set true to opt in to search_actions
   # default_class: standard           # which embedding class to use when enabled
@@ -1233,7 +1232,6 @@ embedding:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `universal_wrappers_enabled` | bool | `true` | For a layer whose `tool_use` scheme resolves to `universal-category`, `true` (default) exposes only the 4 universal wrappers (`list_actions`, `search_actions`, `describe_action`, `invoke_action`) in that layer's `tools=`.  Legacy per-kind tools (`invoke_skill`, `call_mcp_tool`, etc.) are no longer surfaced to the LLM on that layer but remain available as wrapper backing handlers.  `search_actions` is gated separately by [`embedding.enabled`](#embedding-block).  Set `false` to disable the wrapper surface entirely for that layer (= legacy tools become the only addressing path again).  Does not affect a layer whose scheme is `enumerate-all` (the `chat` layer's own default) — that scheme never consults this flag. |
-| `mode` | string | `"default"` | Operational mode label: `"minimal"` / `"default"` / `"performance"`.  Free-form string; currently unread — no caller layers semantics on it yet. |
 
 > **#4552 (2026-08) — hot-list retired.** The prior `hot_list_n` / `hot_list_seed`
 > fields (a top-N freq+recency direct-alias projection) are **removed, no
@@ -1242,6 +1240,13 @@ embedding:
 > carrying either key gets the standard unknown-key tolerance (ignored, not
 > a parse error) rather than a migration path — there is nothing left to
 > migrate TO.
+
+> **#4552 PR-2 (2026-08) — `mode` retired.** The `mode` field
+> (`"minimal"`/`"default"`/`"performance"`, §D24) had 0 real consumers — no
+> caller ever read it, and the accessor method that existed solely to
+> expose it to a hypothetical future consumer (`get_action_retrieval_config()`)
+> is removed in the same PR. Same unknown-key tolerance as above applies to
+> a `reyn.yaml` still carrying it.
 
 > **FP-0066 §7 (2026-07) — config clean-break.** The prior fragmented gate
 > `action_retrieval.embedding_class` (which conflated the on/off decision with

--- a/src/reyn/config/embedding.py
+++ b/src/reyn/config/embedding.py
@@ -347,16 +347,15 @@ class ActionRetrievalConfig:
             in-process local-model embedding backend; reyn depends on
             litellm exclusively for embeddings).
 
-        mode:
-            Operational mode label (§D24): ``"minimal"`` /
-            ``"default"`` / ``"performance"``. Stored as a free-form
-            string so callers can layer interpretations on top
-            without further config breaking changes. Default
-            ``"default"`` is the §D24 balanced setting.
+    #4552 PR-2: ``mode`` (§D24 operational-mode label — "minimal" /
+    "default" / "performance") is removed — a census (both the literal
+    field and the ``get_action_retrieval_config()`` symbol that existed
+    solely to expose it to a future consumer) found 0 real consumers;
+    the "future PR reading .mode" PR-1 anticipated never happened and
+    PR-2 retires the intent instead.
     """
 
     universal_wrappers_enabled: bool = True
-    mode: str = "default"
 
 
 def _build_action_retrieval_config(raw: object) -> ActionRetrievalConfig:
@@ -388,13 +387,5 @@ def _build_action_retrieval_config(raw: object) -> ActionRetrievalConfig:
                 f"got {type(val).__name__}"
             )
         cfg.universal_wrappers_enabled = val
-
-    if "mode" in raw:
-        val = raw["mode"]
-        if not isinstance(val, str):
-            raise ValueError(
-                f"action_retrieval.mode must be a string, got {type(val).__name__}"
-            )
-        cfg.mode = val
 
     return cfg

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -367,11 +367,6 @@ class RouterHostAdapter:
         # dispatch built a host-cwd Workspace (the #187 wrong-FS defect: file
         # ops on the reyn repo, not /testbed).
         environment_backend: Any = None,
-        # #4552: ActionRetrievalConfig — currently unused pending a future
-        # PR reading ``.mode`` (this param used to also feed the hot-list
-        # feature's ``hot_list_n``/``hot_list_seed``, discarded — owner
-        # directive). Session passes its config; None → default.
-        action_retrieval_config: Any = None,
         # #2548 PR-A: enabled skill registry snapshot (list[SkillEntry]).
         # Session builds it via build_skill_registry(config.skills) and passes
         # it in; RouterLoop reads it via get_available_skills() to render the
@@ -587,7 +582,6 @@ class RouterHostAdapter:
         # FP-0034 Phase 2
         self._sandbox_backend = sandbox_backend
         self._environment_backend = environment_backend
-        self._action_retrieval_config = action_retrieval_config
         # FP-0022 fix (#53): intervention-bus factory used by
         # make_router_op_context to populate ``ctx.intervention_bus`` so
         # web_fetch / mcp install / mcp drop handlers can run their
@@ -1135,18 +1129,6 @@ class RouterHostAdapter:
         empty list) → no Skills section.
         """
         return self._available_skills
-
-    def get_action_retrieval_config(self) -> Any:
-        """Return the ActionRetrievalConfig.
-
-        #4552: currently unused pending a future PR reading ``.mode`` — this
-        accessor's sole caller used to be ``router_loop.py``'s hot-list alias
-        builder (determining ``hot_list_n`` aliases to generate and which
-        seed to apply), removed with the hot-list feature (owner directive:
-        discarded). Returns None when not set; callers fall back to a
-        default-constructed ActionRetrievalConfig.
-        """
-        return self._action_retrieval_config
 
     # --- Web ops ---
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4403,7 +4403,6 @@ class Session:
             action_embedding_index=self._action_embedding_index,
             embedding_provider=self._embedding_provider,
             embedding_model_class=self._embedding_model_class,
-            action_retrieval_config=self._action_retrieval,
             available_skills=self._available_skills,  # #2548 PR-A
             # Read the injected sandbox_backend INSTANCE's .name, not the
             # config string — a mismatch silently HIDES a working exec

--- a/tests/config/test_action_retrieval_config.py
+++ b/tests/config/test_action_retrieval_config.py
@@ -1,7 +1,7 @@
 """Tier 2: FP-0034 PR-3b-ii ActionRetrievalConfig + parser contract.
 
 Tests for the ``action_retrieval:`` config block:
-  - Default config has the safe defaults (= wrappers enabled, mode='default').
+  - Default config has the safe defaults (= wrappers enabled).
   - Parser accepts each field independently, validates types, and
     raises on bad values.
   - ReynConfig.action_retrieval is populated by load_config from the
@@ -18,7 +18,12 @@ The on/off decision now lives at ``embedding.enabled: bool`` (default
 False); the model-class field is the (pre-existing) ``embedding.default_class``
 (default "standard"). Its tests live in ``tests/config/test_embedding_config.py``;
 this file keeps only the ``action_retrieval:`` block's own fields
-(``universal_wrappers_enabled`` / ``mode``).
+(``universal_wrappers_enabled``).
+
+#4552 PR-2: ``mode`` (§D24 operational-mode label) is removed — 0 real
+consumers, 3-shape census (literal field / ``get_action_retrieval_config()``
+symbol / the orphaned ``action_retrieval_config=`` call site it fed) found
+in the PR body. Its dedicated tests here are deleted.
 
 No mocks; uses real load_config with a yaml file written to tmp_path.
 """
@@ -48,7 +53,6 @@ def test_default_action_retrieval_config_is_on() -> None:
     """
     cfg = ActionRetrievalConfig()
     assert cfg.universal_wrappers_enabled is True
-    assert cfg.mode == "default"
 
 
 def test_reyn_config_carries_action_retrieval_default() -> None:
@@ -82,26 +86,12 @@ def test_parser_universal_wrappers_enabled_true() -> None:
     assert cfg.universal_wrappers_enabled is True
 
 
-def test_parser_mode_minimal() -> None:
-    """Tier 2: mode='minimal' (§D24) flows through."""
-    cfg = _build_action_retrieval_config({"mode": "minimal"})
-    assert cfg.mode == "minimal"
-
-
-def test_parser_mode_performance() -> None:
-    """Tier 2: mode='performance' (§D24) flows through."""
-    cfg = _build_action_retrieval_config({"mode": "performance"})
-    assert cfg.mode == "performance"
-
-
 def test_parser_all_fields_at_once() -> None:
     """Tier 2: all supported fields can be set together."""
     cfg = _build_action_retrieval_config({
         "universal_wrappers_enabled": True,
-        "mode": "performance",
     })
     assert cfg.universal_wrappers_enabled is True
-    assert cfg.mode == "performance"
 
 
 # ── 3. Parser — validation errors ─────────────────────────────────────────
@@ -117,12 +107,6 @@ def test_parser_rejects_non_bool_wrappers_enabled() -> None:
     """Tier 2: universal_wrappers_enabled with non-bool raises."""
     with pytest.raises(ValueError, match="universal_wrappers_enabled"):
         _build_action_retrieval_config({"universal_wrappers_enabled": "yes"})
-
-
-def test_parser_rejects_non_string_mode() -> None:
-    """Tier 2: mode with non-string raises."""
-    with pytest.raises(ValueError, match="mode"):
-        _build_action_retrieval_config({"mode": 42})
 
 
 def test_parser_ignores_unknown_keys() -> None:
@@ -151,14 +135,12 @@ def test_load_config_picks_up_action_retrieval_yaml(tmp_path: Path) -> None:
         """
 action_retrieval:
   universal_wrappers_enabled: true
-  mode: performance
 """,
         encoding="utf-8",
     )
 
     cfg = load_config(cwd=tmp_path)
     assert cfg.action_retrieval.universal_wrappers_enabled is True
-    assert cfg.action_retrieval.mode == "performance"
 
 
 def test_load_config_without_action_retrieval_uses_defaults(tmp_path: Path) -> None:
@@ -175,7 +157,6 @@ def test_load_config_without_action_retrieval_uses_defaults(tmp_path: Path) -> N
 
     cfg = load_config(cwd=tmp_path)
     assert cfg.action_retrieval.universal_wrappers_enabled is True
-    assert cfg.action_retrieval.mode == "default"
 
 
 def test_load_config_with_explicit_opt_out(tmp_path: Path) -> None:

--- a/tests/core/test_2575_pipeline_disk_registration.py
+++ b/tests/core/test_2575_pipeline_disk_registration.py
@@ -441,7 +441,6 @@ class _FakeHost:
     def get_action_embedding_index(self): return None
     def get_embedding_provider(self): return None
     def get_embedding_model_class(self): return None
-    def get_action_retrieval_config(self): return None
     def list_available_skills(self) -> list[dict]: return []
     def list_available_agents(self) -> list[dict]: return []
     def get_memory_index(self) -> dict: return {"status": "not_found", "content": ""}

--- a/tests/dev/test_chat_turn_completed_inline.py
+++ b/tests/dev/test_chat_turn_completed_inline.py
@@ -113,9 +113,6 @@ class _FakeRouterHost:
     def get_universal_wrappers_enabled(self) -> bool:
         return self._universal_wrappers_enabled
 
-    def get_action_usage_tracker(self):  # type: ignore[return]
-        return None
-
     def get_action_embedding_index(self):  # type: ignore[return]
         return None
 
@@ -123,9 +120,6 @@ class _FakeRouterHost:
         return None
 
     def get_embedding_model_class(self):  # type: ignore[return]
-        return None
-
-    def get_action_retrieval_config(self):  # type: ignore[return]
         return None
 
     def list_available_skills(self) -> list[dict]:

--- a/tests/llm/test_codeact_coexistence_1593.py
+++ b/tests/llm/test_codeact_coexistence_1593.py
@@ -78,9 +78,6 @@ class _FakeHost:
     def get_universal_wrappers_enabled(self) -> bool:
         return False
 
-    def get_action_usage_tracker(self):
-        return None
-
     def get_action_embedding_index(self):
         return None
 
@@ -89,10 +86,6 @@ class _FakeHost:
 
     def get_embedding_model_class(self):
         return None
-
-    def get_action_retrieval_config(self):
-        from reyn.config import ActionRetrievalConfig
-        return ActionRetrievalConfig(hot_list_n=0)
 
     def resolve_model(self, name: str) -> str:
         return "fake-model"

--- a/tests/llm/test_router_loop_non_interactive_live_1443.py
+++ b/tests/llm/test_router_loop_non_interactive_live_1443.py
@@ -79,8 +79,6 @@ class _FakeRouterHost:
     def get_embedding_model_class(self):  # type: ignore[return]
         return None
 
-    def get_action_retrieval_config(self):  # type: ignore[return]
-        return None
 
     def list_available_skills(self) -> list[dict]:
         return []

--- a/tests/runtime/test_pipeline_driver_resource_caller_state_2567.py
+++ b/tests/runtime/test_pipeline_driver_resource_caller_state_2567.py
@@ -94,7 +94,6 @@ class _FakeHost:
     def get_action_embedding_index(self): return self._embedding_index
     def get_embedding_provider(self): return self._embedding_provider
     def get_embedding_model_class(self): return "EmbedCls"
-    def get_action_retrieval_config(self): return None
     def get_sandbox_backend(self): return "sandboxed"
     def get_mcp_servers(self) -> list[dict]: return self._mcp_servers
     def get_available_skills(self): return self._skills

--- a/tests/runtime/test_router_caller_state_mcp_servers.py
+++ b/tests/runtime/test_router_caller_state_mcp_servers.py
@@ -43,11 +43,9 @@ class _FakeHost:
     def events(self): return self._events
 
     def get_universal_wrappers_enabled(self) -> bool: return True
-    def get_action_usage_tracker(self): return None
     def get_action_embedding_index(self): return None
     def get_embedding_provider(self): return None
     def get_embedding_model_class(self): return None
-    def get_action_retrieval_config(self): return None
     def list_available_skills(self) -> list[dict]: return []
     def list_available_agents(self) -> list[dict]: return []
     def get_memory_index(self) -> dict: return {"status": "not_found", "content": ""}
@@ -112,11 +110,9 @@ def test_mcp_servers_missing_method_falls_back_to_none() -> None:
             subscribers: list = []
         events = _E()
         def get_universal_wrappers_enabled(self): return True
-        def get_action_usage_tracker(self): return None
         def get_action_embedding_index(self): return None
         def get_embedding_provider(self): return None
         def get_embedding_model_class(self): return None
-        def get_action_retrieval_config(self): return None
         def list_available_skills(self): return []
         def list_available_agents(self): return []
         def get_memory_index(self): return {"status": "not_found", "content": ""}

--- a/tests/tools/test_pipeline_is5_surfacing.py
+++ b/tests/tools/test_pipeline_is5_surfacing.py
@@ -122,7 +122,6 @@ class _FakeHost:
     def get_action_embedding_index(self): return None
     def get_embedding_provider(self): return None
     def get_embedding_model_class(self): return None
-    def get_action_retrieval_config(self): return None
     def list_available_skills(self) -> list[dict]: return []
     def list_available_agents(self) -> list[dict]: return []
     def get_memory_index(self) -> dict: return {"status": "not_found", "content": ""}


### PR DESCRIPTION
**[e2e-coder]** — PR-2 of the #4552 arc: remove `action_retrieval.mode` (0 real consumers, independently confirmed via orthogonal census before starting).

Part of #4552 (PR-3: `universal_wrappers_enabled` → `tool_use`, unblocked now that #3896 landed; PR-4: delete the `action_retrieval:` section — both not started).

## Same 3-shape census PR-1 needed (per lead-coder's instruction)

**① literal `.mode`**: removed the field + parsing block from `embedding.py`; deleted 3 mode-dedicated tests from `test_action_retrieval_config.py`, stripped mode-specific lines from 4 mixed-purpose tests; updated `reyn-yaml.md`(.ja) field table + example.

**② the symbol that existed solely to expose it**: `get_action_retrieval_config()` had **0 callers anywhere** (confirmed via grep) — its only purpose, per PR-1's own docstring, was "pending a future PR reading `.mode`". Deleted the method + its ctor param + attribute from `RouterHostAdapter`, and the matching stub from 8 test fake-hosts (never part of the actual `RouterLoopHost` Protocol — defensive mirroring only).

🔴 **Bonus find**: `test_codeact_coexistence_1593.py`'s stub called `ActionRetrievalConfig(hot_list_n=0)` — a **latent PR-1 defect** (would `TypeError` if ever invoked; stayed green only because nothing calls it). Also cleaned a same-shape `get_action_usage_tracker` stub residue in this file + 2 others.

**③ orphan cascade**: removed the `action_retrieval_config=self._action_retrieval,` call site in `session.py` feeding the now-gone param. `self._action_retrieval` itself **survives** — still the source of `universal_wrappers_enabled`, confirmed by reading both real consumers (`_build_retrieval_bundle`, `RouterHistoryBuffer`) — neither reads `.mode`.

## Explicitly out of scope (unaffected)

- `universal_wrappers_enabled` and everything downstream of it (PR-3).
- `Session.__init__`'s own `action_retrieval_config` param/`self._action_retrieval` — a different object than RouterHostAdapter's now-deleted copy.
- `tests/runtime/test_action_retrieval_wiring.py` — confirmed via full read to test `universal_wrappers_enabled` exclusively.
- `tests/security/test_sandbox_factory.py`'s `cfg.mode` — a different, unrelated `.mode` (sandbox policy mode), confirmed via the same orthogonal-census method used in PR-1.

## Verification

- `ruff check src tests`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py` (3 changed src files): clean.
- `scripts/test_tier_audit.py --strict` (8 changed test files): 60 tests inspected, 0 Tier-4 violations.
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined.
- Regression sweep (`tests/config`+`core`+`dev`+`llm`+`runtime`+`tools`): **6370 passed, 6 skipped**. 6 failures present, all confirmed pre-existing in PR-1's own verification (PIL-dependent image-decode tests, not installed in this env — unrelated).

## Test plan

- [x] Confirmed `get_action_retrieval_config()` had 0 real callers before deleting it.
- [x] Confirmed `self._action_retrieval` (Session's own attribute) survives — traced both real consumers.
- [x] Ran the full 5 local gates — all clean.
- [x] Ran a regression sweep across all affected test directories — all failures confirmed pre-existing.
- [x] Confirmed `tests/security/test_sandbox_factory.py`'s `.mode` is an unrelated field (sandbox policy mode).
- [ ] (Visual) — n/a, no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
