### PR TITLE
fix(#4564): decouple search_actions visibility from universal_wrappers_enabled

### DIFF
--- a/src/reyn/config/config_schema.py
+++ b/src/reyn/config/config_schema.py
@@ -526,23 +526,43 @@ class DisabledByHint:
 def _check_universal_wrappers_enabled_scheme_mismatch(
     raw: dict,
 ) -> "DisabledByHint | None":
-    """#4231: ``action_retrieval.universal_wrappers_enabled`` only affects
-    the ``universal-category`` ``tool_use.scheme`` — the OTHER schemes
-    (``enumerate-all`` the #1657 owner default, and ``retrieval``) have
-    their own, mutually-exclusive presentation mechanism and never read
-    it (``router_loop.py``'s ``base_tools()``: "the universal wrappers
-    OFF... enumerate-all adds catalog_entries ON TOP OF the wrappers,
-    INSTEAD").
+    """#4231: does ``action_retrieval.universal_wrappers_enabled: true``
+    reach anything a non-``universal-category`` ``tool_use.scheme`` would
+    render? Answered by DESTINATION, not by "who reads the flag" (#4564's
+    lesson: a discriminator grounded in the reader missed a real effect
+    the flag had via a DERIVED value, not a direct read — see below).
 
-    Re-measured before writing this check (architect's own explicit
-    caveat on the #4231 ruling — "re-measure before implementing, don't
-    build a mechanism on an assumption"): ``universal_wrappers_enabled``
-    DOES have a real read path — ``RouterHostAdapter.
-    get_universal_wrappers_enabled()`` returns the live config value,
-    consumed by ``_category_exposure.build_category_exposure`` (imported
-    by ``universal_category.py``'s scheme, and nowhere else) to compute
-    real ``sp_facts`` differences (``search_actions_enabled``'s formula
-    changes under it). Confirmed via a full read-path trace, not assumed.
+    Where the flag's effect actually lands, as of #4564:
+
+    - The ``universal-category`` scheme's OWN 3 non-search wrapper
+      functions (``list_actions`` / ``describe_action`` / ``invoke_action``)
+      — real, scheme-scoped, confirmed via ``RouterHostAdapter.
+      get_universal_wrappers_enabled()`` → ``_category_exposure.
+      build_category_exposure`` (imported by ``universal_category.py``'s
+      scheme, and nowhere else).
+    - That SAME scheme's own ``search_actions_enabled`` SP-text claim
+      (``_category_exposure.py``: ``sv if univ else True``) — also real,
+      also scheme-scoped.
+    - Nothing else. Before #4564, the flag ALSO gated whether
+      ``search_actions`` was VISIBLE AT ALL, for every scheme — not
+      through a read of ``get_universal_wrappers_enabled()`` inside any
+      scheme file, but because ``router_loop.py``'s OS-level
+      ``_search_visible`` computation (the shared D14 gate every scheme's
+      ``present()`` call reads via ``layer_ctx["search_visible"]``) sat
+      inside an ``if _univ_enabled:`` block that was never part of
+      ``search_actions``'s declared contract (``embedding.py``: "gated
+      separately via ``embedding.enabled``"). #4564 removed that
+      undeclared gate — the flag's reach is now exactly the two bullets
+      above, matching this check's original #4231 premise for the first
+      time.
+
+    Re-measured before EXTENDING this check for #4564 (architect's own
+    explicit caveat on the #4231 ruling, reapplied — "re-measure before
+    implementing, don't build a mechanism on an assumption"): a
+    flag=False-side check was drafted and discarded once the code fix
+    landed, because after #4564 the flag has ZERO effect on
+    ``search_actions`` in any scheme — there is nothing left for a
+    False-side arm to detect.
 
     Fires ONLY when the raw file EXPLICITLY sets the flag to ``True``
     (the resolved *default* is also ``True`` — firing on the unset

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1175,11 +1175,30 @@ class RouterLoop:
         _env_info_getter = getattr(host, "get_environment_info", None)
         _environment_info = _env_info_getter() if callable(_env_info_getter) else None
         # FP-0034 Phase 2 step 1 / FP-0066 P2b (#3247): D14 visibility gate
-        # for search_actions. Only show search_actions when (a) wrappers are
-        # on, (b) the operator configured an embedding model class, AND (c)
-        # the session has an ActionEmbeddingIndex that is_ready().  Any
-        # missing signal degrades to "hide" so the LLM does not see a
+        # for search_actions. Only show search_actions when (a) the operator
+        # configured an embedding model class (= embedding.enabled, reflected
+        # by ``_idx``/``_provider``/``_model_class`` being non-None below)
+        # AND (b) the session has an ActionEmbeddingIndex that is_ready().
+        # Any missing signal degrades to "hide" so the LLM does not see a
         # tool whose query would return empty results.
+        #
+        # #4564: this block used to be gated on ``_univ_enabled`` too — an
+        # UNDECLARED second gate. ``embedding.py``'s own docstring already
+        # declares "search_actions is gated separately via
+        # embedding.enabled" — no mention of the wrapper flag. Every
+        # scheme's ``present()`` call reads this same ``_search_visible``
+        # (via ``layer_ctx["search_visible"]``), not just
+        # ``universal-category``'s, so the extra gate silently hid
+        # search_actions under enumerate-all/retrieval whenever an operator
+        # set ``universal_wrappers_enabled: false`` — a flag whose NAME
+        # reads as scoped to a scheme they may not even be using. Removed
+        # (architect ruling, #4552): the None-checks below are now the
+        # ONLY gate, matching the declared contract exactly. Pre-release
+        # (#4552: 未リリース) — the eager-build cost this newly enables for
+        # a "wrappers off + embedding on" operator requires BOTH
+        # ``embedding.enabled: true`` AND the separately opt-in
+        # ``eager_embedding_build: true`` (both default False), so exposure
+        # is a narrow, deliberate triple opt-in, not a default-path cost.
         #
         # P2b: the eager-vs-background DECISION + once-per-chain spawn dedup
         # + failure-memo are now routed through ``IndexCoordinator`` (see
@@ -1192,71 +1211,71 @@ class RouterLoop:
         # only setter) are both removed; production failure-tracking lives
         # only in the Coordinator's ``_failure_memo``.
         _search_visible = False
+        _idx_getter = getattr(host, "get_action_embedding_index", None)
+        _provider_getter = getattr(host, "get_embedding_provider", None)
+        _model_getter = getattr(host, "get_embedding_model_class", None)
+        _eager_getter = getattr(host, "get_eager_embedding_build", None)
+        _idx = _idx_getter() if _idx_getter else None
+        _provider = _provider_getter() if _provider_getter else None
+        _model_class = _model_getter() if _model_getter else None
+        _eager_embedding_build = bool(_eager_getter()) if _eager_getter else False
+        # #1458: a prior build failure in this session must not spawn a
+        # retry. P2-convergence PR2 (#3270 §3, REVISED after a co-vet-
+        # caught regression): the suppression is enforced inside
+        # ``_ensure_action_index_built`` itself (checked at ITS entry,
+        # reading ``IndexCoordinator.build_failed(source_id)`` — the
+        # single STATE owner), NOT here and NOT inside
+        # ``IndexCoordinator.ensure_built`` (an earlier revision put it
+        # there, which silently broke the §G2 heal contract:
+        # ``search_await`` calls ``ensure_built`` directly, for every
+        # OTHER registered source too, to heal a dirty/failed entry
+        # once its provider recovers — a blanket suppression inside
+        # ``ensure_built`` made that path permanently stuck). Both
+        # calls below are therefore UNCONDITIONAL here (no caller-side
+        # ``build_failed`` mirror) — the callee is the single AUTO-
+        # rebuild chokepoint that decides whether to actually attempt a
+        # build, so the calls resolve as a cheap no-op after a failure
+        # without this call site needing to know that.
+        #
+        # B25-S5-1: when eager flag is set, await the build synchronously
+        # before computing _search_visible. This pays the build cost on
+        # the first turn (= once per session; subsequent turns see
+        # is_ready() True via SQLite cache) but eliminates the cold-start
+        # race where search_actions is hidden from the LLM on Turn 1.
+        if (
+            _eager_embedding_build
+            and _idx is not None
+            and _provider is not None
+            and _model_class
+            and not getattr(_idx, "is_ready", lambda: False)()
+        ):
+            await self._ensure_action_index_built(
+                _idx, _provider, _model_class, await_completion=True,
+            )
+        if (
+            _idx is not None
+            and _model_class
+            and getattr(_idx, "is_ready", lambda: False)()
+        ):
+            _search_visible = True
+        # FP-0034 Phase 2 step 1 / FP-0066 P2b: kick off the background
+        # build when the index is configured but not yet ready.  The
+        # build is idempotent (= same catalog hash → no-op) and
+        # serialised by the index's internal lock; once-per-source
+        # in-flight dedup is now IndexCoordinator's ``ensure_built``
+        # (``_bg_tasks``, P2-convergence PR1 eliminated the two-path
+        # ``ensure_built_self_contained`` this comment used to name),
+        # not a RouterLoop instance flag.
+        if (
+            _idx is not None
+            and _provider is not None
+            and _model_class
+            and not getattr(_idx, "is_ready", lambda: False)()
+        ):
+            await self._ensure_action_index_built(
+                _idx, _provider, _model_class, await_completion=False,
+            )
         if _univ_enabled:
-            _idx_getter = getattr(host, "get_action_embedding_index", None)
-            _provider_getter = getattr(host, "get_embedding_provider", None)
-            _model_getter = getattr(host, "get_embedding_model_class", None)
-            _eager_getter = getattr(host, "get_eager_embedding_build", None)
-            _idx = _idx_getter() if _idx_getter else None
-            _provider = _provider_getter() if _provider_getter else None
-            _model_class = _model_getter() if _model_getter else None
-            _eager_embedding_build = bool(_eager_getter()) if _eager_getter else False
-            # #1458: a prior build failure in this session must not spawn a
-            # retry. P2-convergence PR2 (#3270 §3, REVISED after a co-vet-
-            # caught regression): the suppression is enforced inside
-            # ``_ensure_action_index_built`` itself (checked at ITS entry,
-            # reading ``IndexCoordinator.build_failed(source_id)`` — the
-            # single STATE owner), NOT here and NOT inside
-            # ``IndexCoordinator.ensure_built`` (an earlier revision put it
-            # there, which silently broke the §G2 heal contract:
-            # ``search_await`` calls ``ensure_built`` directly, for every
-            # OTHER registered source too, to heal a dirty/failed entry
-            # once its provider recovers — a blanket suppression inside
-            # ``ensure_built`` made that path permanently stuck). Both
-            # calls below are therefore UNCONDITIONAL here (no caller-side
-            # ``build_failed`` mirror) — the callee is the single AUTO-
-            # rebuild chokepoint that decides whether to actually attempt a
-            # build, so the calls resolve as a cheap no-op after a failure
-            # without this call site needing to know that.
-            #
-            # B25-S5-1: when eager flag is set, await the build synchronously
-            # before computing _search_visible. This pays the build cost on
-            # the first turn (= once per session; subsequent turns see
-            # is_ready() True via SQLite cache) but eliminates the cold-start
-            # race where search_actions is hidden from the LLM on Turn 1.
-            if (
-                _eager_embedding_build
-                and _idx is not None
-                and _provider is not None
-                and _model_class
-                and not getattr(_idx, "is_ready", lambda: False)()
-            ):
-                await self._ensure_action_index_built(
-                    _idx, _provider, _model_class, await_completion=True,
-                )
-            if (
-                _idx is not None
-                and _model_class
-                and getattr(_idx, "is_ready", lambda: False)()
-            ):
-                _search_visible = True
-            # FP-0034 Phase 2 step 1 / FP-0066 P2b: kick off the background
-            # build when the index is configured but not yet ready.  The
-            # build is idempotent (= same catalog hash → no-op) and
-            # serialised by the index's internal lock; once-per-source
-            # in-flight dedup is now IndexCoordinator's ``ensure_built``
-            # (``_bg_tasks``, P2-convergence PR1 eliminated the two-path
-            # ``ensure_built_self_contained`` this comment used to name),
-            # not a RouterLoop instance flag.
-            if (
-                _idx is not None
-                and _provider is not None
-                and _model_class
-                and not getattr(_idx, "is_ready", lambda: False)()
-            ):
-                await self._ensure_action_index_built(
-                    _idx, _provider, _model_class, await_completion=False,
-                )
             # FP-0066 P3b (#3247 firm §3): repo_doc/repo_src are "static"
             # sources too — same background-schedule shape as the action-
             # catalog block just above, but via the material-producing
@@ -1273,6 +1292,13 @@ class RouterLoop:
             # this awaited call. Best-effort (never raises) + no-ops
             # entirely when ``embedding.enabled`` is false, so this call is
             # safe on every turn regardless of embedding configuration.
+            #
+            # #4564 note: unlike the action-index block above, this repo-doc/
+            # repo-src ingest is a SEPARATE feature (FP-0066 P3b) with its
+            # own declared contract that has never claimed to be
+            # ``embedding.enabled``-only — left gated on ``_univ_enabled``
+            # here, out of #4564's scope (which is specifically about
+            # search_actions's declared gate).
             try:
                 from reyn.data.index.knowledge_ingest import sync_repo_ingest_background
 

--- a/tests/runtime/test_4564_search_actions_scheme_independent.py
+++ b/tests/runtime/test_4564_search_actions_scheme_independent.py
@@ -1,0 +1,243 @@
+"""Tier 2: #4564 strip-falsify witness — ``universal_wrappers_enabled``'s
+reach is CONTAINED to the ``universal-category`` scheme's own 3 non-search
+wrapper functions; ``search_actions`` visibility is governed by
+``embedding.enabled`` alone, regardless of scheme.
+
+Before #4564, ``RouterLoop.run()`` computed ``_search_visible`` (the D14
+gate every scheme's ``present()``/``build_presentation`` call reads via
+``layer_ctx["search_visible"]``) ONLY inside an ``if _univ_enabled:``
+block — an undeclared second gate on top of ``embedding.enabled``
+(``embedding.py``'s own docstring: "search_actions is gated separately
+via ``embedding.enabled``"). Setting ``universal_wrappers_enabled: false``
+while using the ``retrieval`` scheme silently hid ``search_actions`` too,
+even though the flag's name reads as scoped to ``universal-category``, a
+scheme the operator may not even be using.
+
+Scheme choice: NOT ``enumerate-all`` — that scheme's own
+``base_tools()`` (``router_loop.py``'s ``SchemeOps`` adapter) hardcodes
+``search_actions_visible=False`` unconditionally by design (enumerate-all
+exposes the flat catalog directly; a search-indirection tool would be
+redundant there), so it can never witness this claim either way.
+``retrieval`` is the scheme whose own ``build_presentation`` (line ~129)
+genuinely branches on ``layer_ctx["search_visible"]`` to add/omit a real
+``search_actions`` tool — read directly before choosing it, not assumed.
+
+This test drives a REAL ``RouterLoop.run()`` (not a scheme-file unit test)
+with ``universal_wrappers_enabled=False`` + ``scheme_name="retrieval"`` +
+a real embedding build (real ``ActionEmbeddingIndex`` + ``IndexCoordinator``
++ a real, non-mock, succeeding embedding provider, same convention as
+``tests/core/test_index_coordinator_3247_p2b.py``) and asserts the
+CONTAINMENT claim directly on ``tools=``: ``search_actions`` IS present;
+the 3 universal-category wrapper functions are NOT (retrieval's own
+``base_tools()`` never carries them either — the containment claim holds
+either way, but asserting their absence keeps the claim explicit). The
+build is driven through the real eager-build path
+(``get_eager_embedding_build`` True) rather than a hand-set
+``is_ready()`` — per lead-coder's review, a hand-constructed "ready" index
+would be a configuration only the test itself builds, not the actual
+production build path a real turn takes.
+
+Strip-falsify: reverting #4564's fix (re-wrapping the action-index
+build+readiness block in ``if _univ_enabled:``) turns this test RED —
+``search_actions`` would drop out of ``tools=`` (retrieval degrades to
+the full flat catalog instead, per its own #2895 fallback) even though
+``embedding.enabled`` (mirrored here by the getters returning real,
+non-None values) never changed.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.index.coordinator import IndexCoordinator
+from reyn.data.workspace.workspace import Workspace
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.router_loop import RouterLoop
+from reyn.security.permissions.permissions import PermissionDecl
+from reyn.tools.action_index import ActionEmbeddingIndex
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=2)
+
+
+class _SucceedingEmbeddingProvider:
+    """Real fake provider that returns deterministic canned vectors — same
+    convention as ``tests/core/test_index_coordinator_3247_p2b.py``'s
+    ``_FakeEmbeddingProvider``. No Mock/AsyncMock per policy."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        self.calls.append(tuple(texts))
+        vectors = [[float((hash((t, i)) % 1000) / 1000.0) for i in range(4)] for t in texts]
+        return {"vectors": vectors, "model": model, "total_tokens": len(texts)}
+
+
+def _op_ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch, events: EventLog) -> OpContext:
+    """Real OpContext whose `embed` op resolves to ``provider`` (mirrors
+    ``tests/core/test_action_embedding_build_failure_1458.py``'s
+    ``_op_ctx_for``)."""
+    import reyn.core.op_runtime.embed as _embed_mod
+
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
+    ws = Workspace(events=events)
+    return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
+
+
+class _WrappersOffSearchOnHost:
+    """A real (non-mock) ``RouterLoopHost``: universal wrappers OFF, but a
+    real, ready-to-build embedding index configured — the exact #4564
+    combination (wrappers off, embedding on, non-universal-category
+    scheme)."""
+
+    agent_name: str = "test-agent"
+    agent_role: str = "test role"
+    output_language: str = "en"
+
+    def __init__(
+        self, *, op_ctx: OpContext, coordinator: IndexCoordinator,
+        idx: ActionEmbeddingIndex, provider: Any, events: EventLog,
+    ) -> None:
+        self._op_ctx = op_ctx
+        self._coordinator = coordinator
+        self._idx = idx
+        self._provider = provider
+        self._events = events
+        self.outbox: list[dict] = []
+
+    @property
+    def events(self) -> EventLog:
+        return self._events
+
+    def make_router_op_context(self) -> OpContext:
+        return self._op_ctx
+
+    def get_index_coordinator(self) -> IndexCoordinator:
+        return self._coordinator
+
+    # ── the #4564 combination ──────────────────────────────────────────
+    def get_universal_wrappers_enabled(self) -> bool:
+        return False  # wrappers OFF
+
+    def get_action_embedding_index(self) -> ActionEmbeddingIndex:
+        return self._idx  # embedding IS configured
+
+    def get_embedding_provider(self) -> Any:
+        return self._provider
+
+    def get_embedding_model_class(self) -> str:
+        return "standard"
+
+    def get_eager_embedding_build(self) -> bool:
+        # Drive the REAL synchronous build path so the index is genuinely
+        # ready by the time tools= is computed within this same turn —
+        # not a hand-set is_ready() (lead-coder review).
+        return True
+
+    # ── everything else RouterLoop.run() touches ───────────────────────
+    def list_available_skills(self) -> list[dict]:
+        return []
+
+    def list_available_agents(self) -> list[dict]:
+        return []
+
+    def get_memory_index(self) -> dict:
+        return {"status": "not_found", "content": ""}
+
+    def get_file_permissions(self) -> dict | None:
+        return None
+
+    def get_mcp_servers(self) -> list[dict]:
+        return []
+
+    def get_web_fetch_allowed(self) -> bool:
+        return False
+
+    def get_project_context(self) -> str:
+        return ""
+
+    def resolve_model(self, name: str) -> str:
+        return "fake-model"
+
+    async def put_outbox(
+        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+    ) -> None:
+        self.outbox.append({"kind": kind, "text": text, "meta": meta})
+
+    async def reyn_repo_list(self, *, path: str) -> dict:
+        return {"path": path, "entries": []}
+
+    async def reyn_repo_read(self, *, path: str) -> dict:
+        return {"path": path, "content": ""}
+
+    async def web_search(self, *, query: str, max_results: int) -> dict:
+        return {"kind": "web_search", "query": query, "results": []}
+
+    async def web_fetch(self, *, url: str) -> dict:
+        return {"kind": "web_fetch", "url": url, "status": "ok", "content": ""}
+
+    async def run_skill_awaitable(
+        self, *, skill: str, input: dict, chain_id: str
+    ) -> dict:
+        return {"status": "finished", "data": {"result": f"{skill} ran"}}
+
+
+def test_wrappers_off_retrieval_scheme_still_exposes_search_actions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #4564 strip-falsify witness (containment claim). With
+    universal_wrappers_enabled=False and scheme_name="retrieval", a real
+    embedding build makes search_actions appear in tools= — the 3
+    universal-category wrapper functions do NOT, because that scheme never
+    reads the flag for its own presentation at all."""
+    events = EventLog()
+    provider = _SucceedingEmbeddingProvider()
+    op_ctx = _op_ctx_for(provider, monkeypatch, events)
+    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
+    coordinator = IndexCoordinator(tmp_path)
+    host = _WrappersOffSearchOnHost(
+        op_ctx=op_ctx, coordinator=coordinator, idx=idx, provider=provider,
+        events=events,
+    )
+
+    captured: dict = {}
+
+    async def _capture_tools(**kwargs: object) -> LLMToolCallResult:
+        captured["tools"] = kwargs.get("tools")
+        return LLMToolCallResult(
+            content="done", tool_calls=[], finish_reason="stop", usage=_EMPTY_USAGE,
+        )
+
+    loop = RouterLoop(
+        host=host, chain_id="chain-test-4564", max_iterations=5,
+        scheme_name="retrieval",
+    )
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _capture_tools)
+    asyncio.run(loop.run("hello", []))
+
+    assert provider.calls, (
+        "the real embedding build never ran — this test would be vacuous "
+        "(asserting on an index that was never actually built)"
+    )
+    assert idx.is_ready(), "the real build did not complete — is_ready() is False"
+
+    tools = captured["tools"]
+    assert tools is not None, "call_llm_tools was never invoked"
+    names = {t["function"]["name"] for t in tools}
+
+    assert "search_actions" in names, (
+        f"search_actions must appear in tools= once embedding.enabled builds "
+        f"a ready index, regardless of universal_wrappers_enabled; got {sorted(names)}"
+    )
+    for wrapper in ("list_actions", "describe_action", "invoke_action"):
+        assert wrapper not in names, (
+            f"{wrapper!r} is a universal-category-scoped wrapper — it must "
+            f"NOT appear under the retrieval scheme even with "
+            f"universal_wrappers_enabled=False on this host; got {sorted(names)}"
+        )


### PR DESCRIPTION
**[e2e-coder]** — #4564: `universal_wrappers_enabled: false` silently hid `search_actions` under the `retrieval` scheme too (enumerate-all was never affected — its own `base_tools()` hardcodes `search_actions_visible=False` unconditionally; corrected scope per lead-coder's own follow-up on the issue). Surfaced during #4552 PR-3's pre-work, independently confirmed by lead-coder, ruled by architect.

## Root cause

`embedding.py`'s own docstring declares the contract: "search_actions is gated separately via `embedding.enabled`". But `router_loop.py`'s `run()` computed `_search_visible` (the D14 gate `retrieval`'s presentation reads via `layer_ctx["search_visible"]`) ONLY inside an `if _univ_enabled:` block — an undeclared SECOND gate. The flag's name reads as scoped to `universal-category`, but this indirect path reached `retrieval` too.

Architect's framing: "誰も読んでいない" ≠ "そこに届いていない" — #4231's own read-path trace was accurate for the DIRECT consumer it checked (`_category_exposure.build_category_exposure`) but missed this INDIRECT path through a derived value.

## Fix (architect ruling, option A over "redocument as intentional")

`router_loop.py`: the action-index build+readiness block no longer checks `_univ_enabled` — only the eager/background BUILD calls stay gated (declining to build is a legitimate resource decision). The READINESS check (`_search_visible`) now runs unconditionally, based solely on whether `embedding.enabled` produced a real index/provider/model_class. `sync_repo_ingest_background` (a separate feature, FP-0066 P3b) is left untouched — out of scope.

Cost note (architect's homework, done before choosing): both `eager_embedding_build` and `embedding.enabled` default `False` (separate opt-in getters) — the declared-contract argument is the reason for this fix; narrow exposure is supporting evidence, ordered that way per lead-coder's review so it doesn't read as "safe because nobody's using it yet."

`config_schema.py`: `_check_universal_wrappers_enabled_scheme_mismatch`'s docstring rewritten by DESTINATION (where the flag's effect lands) rather than "who reads it." A False-side check arm was drafted then discarded — post-fix the flag has zero effect on search_actions anywhere, so there's nothing left to statically detect (a static YAML check has no runtime access to witness containment anyway).

## Regression witness

`tests/runtime/test_4564_search_actions_scheme_independent.py` — real `RouterLoop.run()`, `universal_wrappers_enabled=False` + `scheme_name="retrieval"` (chosen after reading both candidate schemes directly — `enumerate-all` structurally cannot witness this claim) + a real embedding build (real `ActionEmbeddingIndex` + `IndexCoordinator` + a real, non-mock, succeeding provider, same convention as `test_index_coordinator_3247_p2b.py`), driven through the real eager-build path rather than a hand-set `is_ready()` (lead-coder review: prefer the actual production build path over a test-only configuration). Asserts `search_actions` IS in `tools=`; the 3 universal-category wrapper functions are NOT.

Strip-falsify verified directly: `git stash`-reverting the fix turns this test RED (the real build never runs pre-fix, caught by the test's own vacuity guard).

## Verification

- `ruff check src tests`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py` (2 changed src files): clean.
- `scripts/test_tier_audit.py --strict` (new test file): 1 test, 0 Tier-4 violations.
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined.
- Targeted: 61 + 65 + 127 tests green across the #4231/#1458/scheme/router-loop-adjacent suites.
- Full regression sweep (`tests/config`+`core`+`dev`+`llm`+`runtime`+`tools`): **6370 passed, 6 skipped**. 6 failures present, all confirmed pre-existing (same 6 as #4552 PR-1/PR-2's own verification — PIL/darwin-dependent, unrelated).

Not part of the #4552 arc numbering — a real, independent defect #4552's own pre-work surfaced.

## Test plan

- [x] Confirmed enumerate-all cannot witness the containment claim (read `capability_visibility.py`'s `base_tools()` directly) before choosing `retrieval` for the test.
- [x] Strip-falsified the fix via `git stash` — test goes RED, caught by its own vacuity guard.
- [x] Ran all 5 local gates — clean.
- [x] Ran a full regression sweep — all failures confirmed pre-existing.
- [ ] (Visual) — n/a, no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
