### PR TITLE
feat(#4542): status bar redesign — Navigation / Telemetry, no │ separators

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -98,6 +98,7 @@ aren't.
 | `skills` | map | both (`.reyn/config/skills.yaml` side is **hot-reloaded**) | Skill declarations. Merged across config tiers by name (an explicit entry wins a collision). |
 | `pipelines` | map | both (`.reyn/config/pipelines.yaml` side is **hot-reloaded**) | Pipeline declarations. Same union-merge shape as `skills`. |
 | `presentations` | map | both (`.reyn/config/presentations.yaml` side is **hot-reloaded**) | Presentation-template declarations. Same union-merge shape as `skills` / `pipelines`. |
+| `tui` | map | PRJ only · **restart** | Operator-tunable inline-TUI presentation thresholds — today just the status bar's context-usage-percent warn threshold. See below. |
 
 > **Project context file (`project_context_path`).** Left unset, Reyn reads
 > `AGENTS.md` — the cross-tool convention that Claude Code, Codex, opencode and
@@ -1222,6 +1223,7 @@ Universal catalog visibility + retrieval settings.  Scheme *selection* is genera
 ```yaml
 action_retrieval:
   universal_wrappers_enabled: true    # default; set false to opt out
+  mode: default                       # default | minimal | performance
 embedding:
   enabled: false                      # default (off); set true to opt in to search_actions
   # default_class: standard           # which embedding class to use when enabled
@@ -1232,6 +1234,7 @@ embedding:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `universal_wrappers_enabled` | bool | `true` | For a layer whose `tool_use` scheme resolves to `universal-category`, `true` (default) exposes only the 4 universal wrappers (`list_actions`, `search_actions`, `describe_action`, `invoke_action`) in that layer's `tools=`.  Legacy per-kind tools (`invoke_skill`, `call_mcp_tool`, etc.) are no longer surfaced to the LLM on that layer but remain available as wrapper backing handlers.  `search_actions` is gated separately by [`embedding.enabled`](#embedding-block).  Set `false` to disable the wrapper surface entirely for that layer (= legacy tools become the only addressing path again).  Does not affect a layer whose scheme is `enumerate-all` (the `chat` layer's own default) — that scheme never consults this flag. |
+| `mode` | string | `"default"` | Operational mode label: `"minimal"` / `"default"` / `"performance"`.  Free-form string; currently unread — no caller layers semantics on it yet. |
 
 > **#4552 (2026-08) — hot-list retired.** The prior `hot_list_n` / `hot_list_seed`
 > fields (a top-N freq+recency direct-alias projection) are **removed, no
@@ -1240,13 +1243,6 @@ embedding:
 > carrying either key gets the standard unknown-key tolerance (ignored, not
 > a parse error) rather than a migration path — there is nothing left to
 > migrate TO.
-
-> **#4552 PR-2 (2026-08) — `mode` retired.** The `mode` field
-> (`"minimal"`/`"default"`/`"performance"`, §D24) had 0 real consumers — no
-> caller ever read it, and the accessor method that existed solely to
-> expose it to a hypothetical future consumer (`get_action_retrieval_config()`)
-> is removed in the same PR. Same unknown-key tolerance as above applies to
-> a `reyn.yaml` still carrying it.
 
 > **FP-0066 §7 (2026-07) — config clean-break.** The prior fragmented gate
 > `action_retrieval.embedding_class` (which conflated the on/off decision with
@@ -1803,6 +1799,21 @@ image:
 | `row_height_cells` | int | `20` | Fixed height, in terminal rows, for every inline image `present` renders. A non-positive or non-numeric value falls back to the default. |
 
 **Why this is operator-configurable**: the "right" row count is a function of your own terminal height and how much scrollback a photo should occupy — not something reyn can decide for every environment. 20 is a shipped default (tall enough for real photo detail, short enough not to dominate a typical terminal), not a measured "correct" number. Omitting the block keeps this default (behaviour unchanged).
+
+## `tui` block
+
+Operator-tunable inline-TUI presentation thresholds (#4542). Today just the status bar's Telemetry segment (model / agent / cost / context%): the percent at which context-window usage escalates from a bare number (`16%`) to a labelled one (`ctx 82%`).
+
+```yaml
+tui:
+  context_usage_warn_percent: 80   # ctx% at/above this gets the "ctx" label
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `context_usage_warn_percent` | int | `80` | Context-window usage percent at which the status bar labels the figure (`ctx NN%`) instead of showing it bare. A non-numeric value or one outside `0`–`100` falls back to the default. |
+
+**Why this is operator-configurable**: 80 is a shipped default (a plain, unsurprising round number), not a measured "correct" threshold for every operator's own risk tolerance or model/context window — same discipline as `image.row_height_cells` above. Omitting the block keeps this default (behaviour unchanged).
 
 ## MCP servers
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -703,6 +703,23 @@
 
 
 # -----------------------------------------------------------------------------
+# tui: operator-tunable inline-TUI presentation thresholds (#4542). Today
+# just the status bar's Telemetry segment (model / agent / cost / context%):
+# the percent at which context-window usage escalates from a bare number
+# (16%) to a labelled one (ctx 82%). Omit the block to keep the 80 default
+# below; a non-numeric value or one outside 0-100 falls back to that default
+# too.
+#
+# Why this is operator-configurable rather than a bare constant: 80 is a
+# shipped default (a plain, unsurprising round number), not a measured
+# "correct" threshold for every operator's own risk tolerance or model/
+# context window — same discipline as image.row_height_cells above.
+# -----------------------------------------------------------------------------
+# tui:
+#   context_usage_warn_percent: 80   # ctx% at/above this gets the "ctx" label
+
+
+# -----------------------------------------------------------------------------
 # tool_use: the chat-layer tool-use scheme x transport selector (#1593;
 # FP-0066 P4b, #3247). ``scheme`` is the PRESENTATION axis (category /
 # enumerate-all / retrieval — how capabilities are shown/discovered);

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -594,6 +594,51 @@ def _build_image_config(raw: object) -> "ImageConfig":
 
 
 @dataclass
+class TuiConfig:
+    """`tui:` — operator-tunable inline-TUI presentation thresholds (#4542).
+
+    ``context_usage_warn_percent`` — the context-window usage percent at
+    which the status bar's Telemetry segment escalates from a bare number
+    (``16%``) to a labelled one (``ctx 82%``).
+
+    **Why this is operator-configurable, not a bare constant** (owner's
+    standing rule — no unjustified number embedded without either a
+    reasoning comment or a user-facing override, same discipline as
+    :class:`ImageConfig`'s ``row_height_cells``): 80 is a shipped default
+    (a plain, unsurprising round number), not a measured "correct"
+    threshold for every operator's own risk tolerance or model/context
+    window — the config key exists specifically so an operator who wants
+    an earlier or later warning can change it without a code edit.
+    """
+    context_usage_warn_percent: int = 80
+
+
+def _build_tui_config(raw: object) -> "TuiConfig":
+    """Parse the `tui:` section (#4542).
+
+    Missing or malformed -> default (80). A non-numeric or out-of-[0,100]
+    value falls back to the default — same discipline as
+    ``_build_image_config``: an operator typo must not silently produce a
+    threshold that never fires (e.g. a negative number) or fires
+    immediately (e.g. 0), either of which would be a confusing, silent
+    change to what the status bar shows.
+    """
+    if not isinstance(raw, dict):
+        return TuiConfig()
+    defaults = TuiConfig()
+    warn_percent = raw.get(
+        "context_usage_warn_percent", defaults.context_usage_warn_percent,
+    )
+    try:
+        warn_percent = int(warn_percent)
+        if not (0 <= warn_percent <= 100):
+            warn_percent = defaults.context_usage_warn_percent
+    except (TypeError, ValueError):
+        warn_percent = defaults.context_usage_warn_percent
+    return TuiConfig(context_usage_warn_percent=warn_percent)
+
+
+@dataclass
 class SpawnConfig:
     """`safety.spawn:` — operator bounds on the LLM spawn tree (#2103 C3).
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -17,6 +17,7 @@ from reyn.config.chat import (  # #1682 #3 cross-section
     _build_read_cap_config,
     _build_render_template_config,
     _build_safety_config,
+    _build_tui_config,
 )
 from reyn.config.embedding import (  # #1682 #3 cross-section
     _build_action_retrieval_config,
@@ -824,6 +825,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     read_cap = _build_read_cap_config(merged.get("read_cap"))
     history_resident = _build_history_resident_config(merged.get("history_resident"))
     image = _build_image_config(merged.get("image"))
+    tui = _build_tui_config(merged.get("tui"))
     # #4174 T3: model / models / model_class_by_purpose / api_base /
     # prompt_cache_enabled moved from top-level ReynConfig fields into
     # ``llm:`` — _build_llm_config parses all of it (router/retry AND the
@@ -857,6 +859,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         read_cap=read_cap,
         history_resident=history_resident,
         image=image,
+        tui=tui,
         web_fetch=_build_web_fetch_config(merged.get("web_fetch")),
         gateway=_build_gateway_config(merged.get("gateway")),
         multimodal=_build_multimodal_config(merged.get("multimodal")),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -40,6 +40,7 @@ from reyn.config.chat import (
     RenderTemplateConfig,
     SafetyConfig,
     TimeoutConfig,
+    TuiConfig,
 )
 from reyn.config.embedding import (
     ActionRetrievalConfig,
@@ -229,6 +230,10 @@ class ReynConfig:
     # can be derived to preserve the image's real aspect ratio (see
     # ImageConfig's own docstring). Default 20.
     image: ImageConfig = field(default_factory=ImageConfig)
+    # #4542: operator-tunable inline-TUI presentation thresholds — today
+    # just the status bar's context-usage-percent warn threshold (see
+    # TuiConfig's own docstring). Default 80.
+    tui: TuiConfig = field(default_factory=TuiConfig)
     # FP-0022 follow-up: declarative SSL config for web_fetch + MCP registry.
     # Priority: web_fetch.ca_bundle → web_fetch.verify_ssl → SSL_VERIFY env →
     # litellm.ssl_verify → SSL_CERT_FILE → True (default).

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -74,6 +74,7 @@ from ._meta_keys import PIPELINE_RUN_KEY as _PIPELINE_RUN_KEY
 from .activity_row import ActivityRow
 from .chrome import (
     _MENU_TABS,
+    CTX_WARN_PERCENT,
     Composer,
     ConfigWarningLine,
     MenuBar,
@@ -848,9 +849,14 @@ class TextualChatApp(App):
     Composer > .text-area--placeholder {
         text-style: dim;
     }
+    /* #4542: text-style, not color — same "$text-muted is inert under the
+       ansi-* themes" reasoning MenuBar's own comment below already states
+       (#3522/#3528/#3505's ansi-dark measurement). @telemetry@ (dim) is a
+       DEDICATED token (palette.py), separate from @recede@ despite sharing
+       today's underlying value — see that token's own docstring. */
     StatusLine {
         height: 1;
-        color: @quiet@;
+        text-style: @telemetry@;
         padding: 0 1;
     }
     /* #4194: bold, not a colour — palette.py's own rule (@attention@ is the
@@ -908,15 +914,22 @@ class TextualChatApp(App):
        near-white block; a single tab is the size the idiom is built for. */
     MenuBar:focus-within Tab.-active { text-style: reverse bold; }
     MenuBar Tab { padding: 0 1; }
-    /* #3326: tone down. Tab's own DEFAULT_CSS gives ``.-active`` full-brightness
-       ``$foreground`` against every other tab's muted 50%-opacity foreground —
-       a stark contrast jump that reads as loud emphasis (no literal underline
-       is drawn anywhere; MenuBar doesn't use Textual's Tabs/Underline widget).
-       Matched to the status line's own quiet ``$text-muted`` tone instead,
-       kept bold so the active tab stays identifiable without the brightness
-       jump. */
+    /* #4542 (owner ruling, REVERSES #3326's own "tone down" rule below —
+       kept as history, not repaired quietly): the redesign's own words are
+       "選択中の項目のみ...強調表示を行う" (ONLY the selected item gets
+       emphasis) — the opposite instruction from #3326's "match it to the
+       muted status line so it doesn't jump out". #3326 solved a real
+       problem (Tab's own DEFAULT_CSS ``.-active`` at full-brightness
+       ``$foreground`` against every other tab's 50%-muted one read as loud)
+       by TONING DOWN toward Telemetry's own tone — but #4542 gives
+       Telemetry its OWN dedicated, permanently-dim style (``@telemetry@``,
+       see StatusLine's rule above and palette.py), so "match the active tab
+       to it" now means "make the active tab look like the OBSERVATION half
+       of the row" — backwards from what emphasis should read as. No
+       ``color`` override here anymore: the active tab keeps the terminal's
+       own normal foreground (never toned down), ``bold`` alone is the
+       emphasis. */
     MenuBar Tab.-active {
-        color: @quiet@;
         text-style: bold;
     }
     /* No separator rule between the menu row and its drawer — they read as one
@@ -1689,15 +1702,31 @@ class TextualChatApp(App):
         return "failed" if self._transport.attach_failed() else "connecting"
 
     def _status_text(self, snap: "dict | None | object" = _UNSET) -> str:
-        """The status-values line (``model │ agent │ cost │ ctx``), from the live
-        status snapshot (F5b: running cost + context percent are visible even with
-        the drawer closed). Falls back to the threaded ``agent_name`` pre-session.
-        Pass ``snap`` to reuse an already-read snapshot (one read per frame)."""
+        """The Telemetry segment (#4542: ``model · agent    $cost  ctx%``),
+        from the live status snapshot (F5b: running cost + context percent are
+        visible even with the drawer closed). Falls back to the threaded
+        ``agent_name`` pre-session. Pass ``snap`` to reuse an already-read
+        snapshot (one read per frame).
+
+        #4542: ``warn_percent`` reads ``self._config.tui.
+        context_usage_warn_percent`` via ``getattr`` (same "config may be
+        None, or a caller-supplied stand-in missing this section entirely"
+        tolerance as every other ``self._config.X`` read in this class —
+        see ``_configured_gutter_visibility``'s own docstring for the
+        pattern) — falls back to ``status_line_text``'s own module-default
+        (:data:`~reyn.interfaces.inline.textual_chat.chrome.
+        CTX_WARN_PERCENT`) when unset."""
         snapshot = self._snapshot() if snap is _UNSET else snap
+        warn_percent = getattr(
+            getattr(self._config, "tui", None),
+            "context_usage_warn_percent",
+            CTX_WARN_PERCENT,
+        )
         return status_line_text(
             snapshot,
             self._agent_name,
             attach_state=self._attach_state(),
+            warn_percent=warn_percent,
         )  # type: ignore[arg-type]
 
     async def _watch_loop_responsiveness(self) -> None:

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -86,6 +86,8 @@ from textual.widgets import (
     TextArea,
 )
 
+from reyn.config.chat import TuiConfig
+
 from .completion import CompletionPopup
 from .intervention_panel import InterventionPanel
 from .presenter import option_content_rows
@@ -1414,17 +1416,27 @@ def cost_figure(snap: "dict | None") -> str:
 #:
 #: #4542 review (owner's standing rule — no unjustified number embedded
 #: without either a reasoning comment or a user-facing override, same
-#: discipline as ``ImageConfig.row_height_cells``): this constant is the
-#: DEFAULT for the ``tui.context_usage_warn_percent`` config key
-#: (:class:`reyn.config.chat.TuiConfig`) — 80 is a plain, unsurprising
-#: round number, not a measured "correct" threshold for every operator's
-#: own risk tolerance. It stays defined HERE (not only in the config
-#: module) so this function has a real value to fall back to when called
-#: without a threaded config (e.g. every pre-#4542 caller, and most direct
-#: unit tests) — see :meth:`~reyn.interfaces.inline.textual_chat.app.
-#: TextualChatApp._status_text` for where the config value is actually
-#: read and passed as ``warn_percent`` below.
-CTX_WARN_PERCENT = 80
+#: discipline as ``ImageConfig.row_height_cells``): 80 is a plain,
+#: unsurprising round number, not a measured "correct" threshold for
+#: every operator's own risk tolerance — see ``tui.context_usage_warn_
+#: percent`` in ``reyn.yaml``.
+#:
+#: **The CANONICAL value is :class:`reyn.config.chat.TuiConfig`'s own
+#: default, not this constant** — this constant just READS it, so there
+#: is exactly one number to keep in sync, not two hand-written literals
+#: (#4542 review: an earlier version defined ``80`` here too, a real
+#: drift risk the review caught — "the same contract hand-written in two
+#: places"). Importing ``TuiConfig`` (not the reverse — ``config/chat.py``
+#: is a foundational, TTY-independent module nearly every reyn code path
+#: loads, including headless ones; ``chrome.py`` imports ``textual`` at
+#: module level and genuinely cannot be imported without it — verified
+#: live, and exactly what ``test_phase3_chrome_imports_stay_tty_only``
+#: guards) is the only safe direction. If you're tempted to flip this
+#: back because "chrome should own its own UI constant" — don't; that
+#: direction breaks ``load_config()`` in any textual-less environment.
+#: The name ``CTX_WARN_PERCENT`` is kept (existing references stay
+#: valid) even though the value now lives elsewhere.
+CTX_WARN_PERCENT = TuiConfig().context_usage_warn_percent
 
 
 def status_line_text(

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -403,8 +403,14 @@ _MENU_TABS: "list[tuple[str, str]]" = [
     ("pipe", "Pipe"),
     ("hook", "Hook"),
     ("cron", "Cron"),
-    ("menu", "Menu"),
-    ("help", "Help"),
+    # #4542 (owner ruling): compact glyphs, not "Menu"/"Help" full words —
+    # same flat arrow-navigable tab, same Enter-opens-drawer mechanism as
+    # every other entry above; only the visible label shrinks. Distinct
+    # single characters (not the SAME "…" twice) so #3338's on-screen
+    # geometry test (every tab id maps 1:1 to a real, distinguishable Tab
+    # widget) has something to distinguish rather than two identical labels.
+    ("menu", "…"),
+    ("help", "?"),
 ]
 
 #: Menu items whose pane is an interactive :class:`OptionList` picker (keyboard
@@ -1401,15 +1407,50 @@ def cost_figure(snap: "dict | None") -> str:
     return f"{figure}{UNPRICED_MARK}" if snap.get("cost_agent_unpriced_calls") else figure
 
 
+#: #4542: the context-usage percent at which the Telemetry segment escalates
+#: from the bare number to a labelled one (``16%`` -> ``ctx 82%``) — the
+#: owner's proposal names the BEHAVIOR ("通常時は簡潔... 閾値を超えた場合の
+#: み情報量を増やしてよい") but not a specific number.
+#:
+#: #4542 review (owner's standing rule — no unjustified number embedded
+#: without either a reasoning comment or a user-facing override, same
+#: discipline as ``ImageConfig.row_height_cells``): this constant is the
+#: DEFAULT for the ``tui.context_usage_warn_percent`` config key
+#: (:class:`reyn.config.chat.TuiConfig`) — 80 is a plain, unsurprising
+#: round number, not a measured "correct" threshold for every operator's
+#: own risk tolerance. It stays defined HERE (not only in the config
+#: module) so this function has a real value to fall back to when called
+#: without a threaded config (e.g. every pre-#4542 caller, and most direct
+#: unit tests) — see :meth:`~reyn.interfaces.inline.textual_chat.app.
+#: TextualChatApp._status_text` for where the config value is actually
+#: read and passed as ``warn_percent`` below.
+CTX_WARN_PERCENT = 80
+
+
 def status_line_text(
     snap: "dict | None",
     agent_name: str,
     *,
     attach_state: "str | None" = None,
+    warn_percent: int = CTX_WARN_PERCENT,
 ) -> str:
-    """The slim ``model │ agent │ cost │ ctx`` status-values line, from the live
-    status snapshot (F5b: the running cost + context percent are visible here even
-    when the drawer is closed).
+    """The Telemetry segment (#4542: ``model · agent    $cost  ctx%``, no
+    ``│``/``|`` separators — position and text-style carry the grouping
+    instead) — from the live status snapshot (F5b: the running cost +
+    context percent are visible here even when the drawer is closed).
+
+    #4542 (owner ruling, superseding #4540's ``│``-separator direction):
+    the labelled ``model X │ agent Y │ cost Z │ ctx W`` format is replaced
+    by an UNLABELLED one — ``model · agent`` (a ``·`` groups the two
+    identity fields, distinct from the ``│`` this redesign explicitly
+    rejects) followed by the cost figure and context percent, separated by
+    plain whitespace. Labels are dropped deliberately: this line's own
+    styling (``@quiet@`` / dim, see app.py's ``StatusLine`` CSS) already
+    marks it as the "observation" half of the row, so the meaning is
+    conveyed by POSITION, not text. ``ctx`` escalates to a labelled ``ctx
+    NN%`` only at/past ``warn_percent`` (default :data:`CTX_WARN_PERCENT`,
+    operator-overridable via ``tui.context_usage_warn_percent`` — below it,
+    the bare percent is unambiguous next to the cost figure).
 
     ``attach_state`` (#3671 P3): ``"connecting"`` / ``"failed"`` / ``None``
     (attached — the ordinary case). Owner ruling: "not yet attached" and
@@ -1424,20 +1465,20 @@ def status_line_text(
 
     #3671 P3 review (lead-coder): deliberately plain text, no decorative
     glyph — ``⏳`` measures East-Asian-Width ``W`` (2 terminal cells) while
-    every other character on this ONE always-visible, ``│``-delimited row is
-    ``N``/``Na`` (1 cell); glyph width also varies by terminal/font, and this
-    line has zero such glyphs today, so it would be the first. A 1-cell
-    misjudgement on the narrowest-terminal case (owner's own environment)
-    breaks the whole row, not just this segment. Visual decoration is
-    explicitly a separate, still-open owner decision (#3642) — this PR lands
-    the MECHANISM only; a glyph can be added later without touching the
-    mechanism, but a broken row on a still-forming feature would cast doubt
-    on the mechanism itself.
+    every other character on this ONE always-visible row is ``N``/``Na`` (1
+    cell); glyph width also varies by terminal/font, and this line has zero
+    such glyphs today, so it would be the first. A 1-cell misjudgement on
+    the narrowest-terminal case (owner's own environment) breaks the whole
+    row, not just this segment. Visual decoration is explicitly a separate,
+    still-open owner decision (#3642) — this PR lands the MECHANISM only; a
+    glyph can be added later without touching the mechanism, but a broken
+    row on a still-forming feature would cast doubt on the mechanism
+    itself.
     """
     if attach_state == "connecting":
-        return f"connecting… │ agent {agent_name}"
+        return f"connecting… · agent {agent_name}"
     if attach_state == "failed":
-        return f"attach failed (see log) │ agent {agent_name}"
+        return f"attach failed (see log) · agent {agent_name}"
 
     # #2280: when ``snap["halted_reason"]`` is set (the session fail-stopped on
     # a persistent durability failure — ``Session.halted_reason``), a
@@ -1452,14 +1493,18 @@ def status_line_text(
     snap = snap or {}
     model = snap.get("model_active_class") or snap.get("model") or "—"
     agent = snap.get("attached_name") or agent_name
-    cost = snap.get("cost_agent", 0.0)
-    base = (
-        f"model {model} │ agent {agent} │ cost {cost_figure(snap)} "
-        f"│ ctx {_ctx_pct(snap)}"
-    )
+    ctx_pct = _ctx_pct(snap)
+    ctx_segment = ctx_pct
+    if ctx_pct.endswith("%"):
+        try:
+            if int(ctx_pct[:-1]) >= warn_percent:
+                ctx_segment = f"ctx {ctx_pct}"
+        except ValueError:
+            pass  # "—" (no completed call yet) — bare, never escalated
+    base = f"{model} · {agent}    {cost_figure(snap)}  {ctx_segment}"
     halted_reason = snap.get("halted_reason")
     if halted_reason:
-        return f"⚠ HALTED — {halted_reason} — agent stopped accepting ops │ {base}"
+        return f"⚠ HALTED — {halted_reason} — agent stopped accepting ops · {base}"
     return base
 
 

--- a/src/reyn/interfaces/inline/textual_chat/palette.py
+++ b/src/reyn/interfaces/inline/textual_chat/palette.py
@@ -61,6 +61,21 @@ TOKENS: "dict[str, str]" = {
     #: leaves the hue to the terminal, which is the operator's to choose, and
     #: actually changes what is drawn.
     "@recede@": "dim",
+    #: #4542: the status bar's Telemetry segment (model/agent/cost/context%) —
+    #: "one step weaker than Navigation's own normal intensity" (owner's
+    #: proposal), so the row reads as two visually distinct halves without a
+    #: literal separator. A DEDICATED token, not a reuse of ``@recede@``
+    #: (same underlying SGR value today, but a distinct semantic role — a
+    #: heading/count receding and the Telemetry segment's own steady-state
+    #: tone are different concepts that happen to share a mechanism; keeping
+    #: them separate here means changing one's value later can't silently
+    #: move the other). ``dim``, not ``@quiet@``/``$text-muted``, for the
+    #: same reason ``@recede@`` isn't a colour either: under the ``ansi-*``
+    #: themes ``$text-muted`` resolves to the same ``ansi_default`` marker as
+    #: ordinary text (#3522/#3528's own measurement) — using it here would
+    #: make Telemetry read IDENTICAL to Navigation under exactly the themes
+    #: this redesign's "visually distinct halves" goal most needs to survive.
+    "@telemetry@": "dim",
     #: The selected row in a list the operator navigates (the sent-queue).
     #: ``bold`` rather than a background: a filled block is what
     #: ``$accent 30%`` produced once alpha was dropped — a solid ANSI-green bar

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -1097,20 +1097,22 @@ async def test_inline_code_style_toned_down_from_the_loud_default(tmp_path) -> N
 
 
 @pytest.mark.asyncio
-async def test_menubar_active_tab_toned_down_to_status_line_muted_tone(
+async def test_menubar_active_tab_is_not_toned_down_to_telemetry_dimness(
     tmp_path,
 ) -> None:
-    """Tier 2: #3326 — MenuBar's active-tab color is toned down to match
-    StatusLine's own quiet ``$text-muted`` tone, rather than Tab's default
-    full-brightness ``$foreground`` jump against every other tab's 50%-muted
-    foreground (measured: no literal underline is drawn anywhere — MenuBar
-    doesn't use Textual's ``Tabs``/``Underline`` widget — the "underline" the
-    issue named was this brightness contrast read as loud emphasis).
-
-    Falsification: pre-fix, the active tab's resolved color is the full
-    ``$foreground`` (distinctly brighter than an inactive tab's 50%-muted
-    one); this asserts the active tab's color instead matches the SAME muted
-    tone StatusLine itself uses."""
+    """Tier 2: #4542 (owner ruling, REVERSES #3326's own relationship —
+    see app.py's ``MenuBar Tab.-active`` rule for the full history). #3326
+    matched the active tab's color to the status line's own muted tone so it
+    would not read as a loud, distinct highlight; #4542's redesign explicitly
+    wants the OPPOSITE — "選択中の項目のみ...強調表示を行う" (only the
+    selected item gets emphasis) — and gives the status line (now Telemetry)
+    its own dedicated, permanently-dim style instead. Keeping #3326's own
+    test green under the new CSS would have meant asserting a relationship
+    the owner deliberately reversed; this replaces it with the relationship
+    #4542 actually specifies: the active tab's text-style includes ``bold``
+    (emphasis) and stays UNDIMMED, while Telemetry's own style is ``dim``
+    — the two segments read as distinctly different tones, active tab the
+    brighter of the two, not matched to it."""
     from textual.widgets import Tab
 
     from reyn.interfaces.inline.textual_chat import TextualChatApp
@@ -1131,11 +1133,15 @@ async def test_menubar_active_tab_toned_down_to_status_line_muted_tone(
         await pilot.pause()
         line = app.query_one(StatusLine)
         active_tab = next(tab for tab in app.query(Tab) if tab.has_class("-active"))
-        status_color = line.styles.color
-        active_color = active_tab.styles.color
-        assert active_color == status_color, (
-            f"active tab color {active_color!r} does not match StatusLine's "
-            f"muted tone {status_color!r} — still reads as a loud, distinct highlight"
+        assert active_tab.styles.text_style.bold, (
+            f"active tab lost its bold emphasis: {active_tab.styles.text_style!r}"
+        )
+        assert not active_tab.styles.text_style.dim, (
+            "active tab is toned down (dim) — #4542 reserves dim for "
+            f"Telemetry only, active tab must stay undimmed: {active_tab.styles.text_style!r}"
+        )
+        assert line.styles.text_style.dim, (
+            f"StatusLine (Telemetry) lost its dim style: {line.styles.text_style!r}"
         )
 
 

--- a/tests/interfaces/test_textual_chat_phase4_3273.py
+++ b/tests/interfaces/test_textual_chat_phase4_3273.py
@@ -160,11 +160,27 @@ def test_no_placeholder_residue_pickers_empty_readouts_zero() -> None:
 
 def test_f5b_cost_and_ctx_surface_on_status_line() -> None:
     """Tier 1: the status-values line reflects the live cost + context percent
-    from the snapshot (F5b: cost is legible in the Textual TTY, drawer closed)."""
+    from the snapshot (F5b: cost is legible in the Textual TTY, drawer closed).
+
+    #4542: 90k/200k = 45%, below CTX_WARN_PERCENT (80) — the bare percent
+    renders WITHOUT the "ctx" label at this level (labelling is reserved for
+    the over-threshold case; see test_ctx_percent_gains_ctx_label_past_warn_threshold)."""
     line = status_line_text(_SNAP, "default")
     assert "$0.0123" in line, "running cost missing from the status line"
-    assert "ctx 45%" in line, "context percent (90k/200k) missing from the status line"
+    assert "45%" in line, "context percent (90k/200k) missing from the status line"
+    assert "ctx 45%" not in line, "below CTX_WARN_PERCENT must stay unlabelled"
     assert "opus" in line and "default" in line, "model/agent missing from the status line"
+
+
+def test_ctx_percent_gains_ctx_label_past_warn_threshold() -> None:
+    """Tier 1: #4542 — context percent gains the "ctx" label ONLY at/past
+    CTX_WARN_PERCENT; below it, the bare percent is unambiguous next to the
+    cost figure (see the test above for the below-threshold case)."""
+    from reyn.interfaces.inline.textual_chat.chrome import CTX_WARN_PERCENT
+
+    hot_snap = {**_SNAP, "ctx_used": 180000, "ctx_window": 200000}  # 90%
+    line = status_line_text(hot_snap, "default")
+    assert "ctx 90%" in line, f"90% is past CTX_WARN_PERCENT ({CTX_WARN_PERCENT}) and must be labelled"
 
 
 def test_f5b_cost_and_ctx_panes_reflect_usage() -> None:
@@ -327,7 +343,11 @@ async def test_menu_drawer_equals_full_slash_registry() -> None:
 async def test_status_line_and_cost_pane_show_live_cost_f5b() -> None:
     """Tier 2: F5b end-to-end — the mounted status line and the Cost drawer pane
     both reflect the snapshot's live cost/ctx (previously the Textual path showed
-    no cost at all)."""
+    no cost at all).
+
+    #4542: 90k/200k = 45%, below CTX_WARN_PERCENT — asserts the bare percent
+    (see test_ctx_percent_gains_ctx_label_past_warn_threshold for the
+    labelled, over-threshold case)."""
     from textual.widgets import Static
 
     from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
@@ -338,7 +358,7 @@ async def test_status_line_and_cost_pane_show_live_cost_f5b() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         status = str(app.query_one(StatusLine).render())
-        assert "$0.0123" in status and "ctx 45%" in status, f"status line lacks cost/ctx: {status}"
+        assert "$0.0123" in status and "45%" in status, f"status line lacks cost/ctx: {status}"
         app._open_drawer("cost")
         await pilot.pause()
         cost_text = str(app.query_one("#cost", Static).render())


### PR DESCRIPTION
**[tui-coder]** — part of #4542 (status bar redesign: left=Navigation / right=Telemetry, no `│`/`|` separators). This is the text-format + CSS-styling increment; left/right layout mechanics (a stretching spacer, a dedicated two-region layout) are a follow-up — see Scope note below.

## Owner's 3 architectural decisions (taken directly, this conversation — recorded verbatim in the [#4542 issue comment thread](https://github.com/tya5/reyn/issues/4542#issuecomment-5279633444) since conversation is not a durable surface)

Premise-measurement against the current code (chrome.py, #3338) surfaced that 3 parts of the original relayed proposal conflict with existing guarantees or require new mechanisms not yet built:

1. **Narrow-width model**: keep #3338's wrap-to-2nd-row behavior — nothing dropped from Navigation. The proposal's "drop low-priority items" would have been a genuinely new, unguarded behavior (no drop/priority mechanism exists anywhere in chrome.py today).
2. **Cost/Ctx**: stay as Navigation tabs, unlike the proposal's "excluded from Navigation" — their detail-breakdown drawer pane currently has no other entry point, and the owner's direct answer keeps them where that entry point already exists.
3. **Menu/Help**: compact glyphs (`…`/`?`), not a command palette — no palette surface exists anywhere in this codebase (confirmed repo-wide), and building one is separate scope from a status-bar layout change.

## What changed

- **`status_line_text()` (chrome.py)** — the labelled `model X │ agent Y │ cost Z │ ctx W` format is replaced by an unlabelled one: `model · agent    $cost  ctx%`, no `│`/`|` anywhere. Position and text-style carry the grouping instead of labels. Context-usage percent escalates from bare (`16%`) to labelled (`ctx 82%`) only at/past a warn threshold.
- **`_MENU_TABS`** — `Menu`/`Help` labels shrink to `…`/`?`. Same tab, same Enter-opens-drawer mechanism (`MenuBar._move`/`_on_key`) — only the visible label changes.
- **`tui.context_usage_warn_percent`** (new config key, default `80`) — the owner's standing rule ("no unjustified number embedded without either a reasoning comment or a user-facing override") applied to the new ctx-% threshold. Mirrors `image.row_height_cells`'s exact pattern: dataclass field (`TuiConfig` in `config/chat.py`) + parse-with-fallback builder (`_build_tui_config`, rejects out-of-`[0,100]`/non-numeric values) + `docs/reference/config/reyn-yaml.md` table row + block section. Threaded `ReynConfig.tui.context_usage_warn_percent` → `TextualChatApp._status_text` → `status_line_text`'s new `warn_percent` parameter (falls back to the module constant `CTX_WARN_PERCENT` when no config is threaded, e.g. every pre-#4542 direct caller/unit test).
- **`palette.py`** — new `@telemetry@` token (`dim`), the Telemetry segment's dedicated "one step weaker than Navigation" tone. Kept separate from the existing `@recede@` despite sharing today's value (`dim`) — distinct semantic roles that happen to share a mechanism; keeping them apart means changing one later can't silently move the other. `dim`, not `@quiet@`/`$text-muted`: the latter is inert under the `ansi-*` themes (`$text-muted` resolves to the same `ansi_default` marker as ordinary text — #3522/#3528's own measurement), which would make Telemetry read identical to Navigation under exactly the themes this redesign's "visually distinct halves" goal most needs to survive.
- **`MenuBar Tab.-active` CSS** — REVERSES #3326's own "tone down to match the status line" rule (kept as documented history in the code, not silently repaired around). The redesign's own words are "選択中の項目のみ...強調表示を行う" (ONLY the selected item gets emphasis) — the opposite instruction from #3326's "match it to the muted status line so it doesn't jump out". No more `color: @quiet@` on the active tab; `bold` alone is the emphasis now, full-brightness foreground (never toned down).

## Test changes

- `test_menubar_active_tab_toned_down_to_status_line_muted_tone` **deleted**, not repaired — per tonight's own six-questions discipline (question 1: does the OLD relationship it pinned still have standing to be tested? No — the owner directly reversed the design decision it protected). Replaced with `test_menubar_active_tab_is_not_toned_down_to_telemetry_dimness`, pinning the ACTUAL current invariant (active tab: bold + undimmed; Telemetry: dim) rather than the one #4542 deliberately broke.
- Two tests in `test_textual_chat_phase4_3273.py` pinned the old always-labelled `ctx NN%` format at a snapshot value (45%) that's below the new warn threshold — updated to assert the correct below-threshold (bare percent, unlabelled) behavior; one new test (`test_ctx_percent_gains_ctx_label_past_warn_threshold`) proves the label appears once past the threshold.

## Scope note

Navigation and Telemetry currently still interleave via the existing merge-onto-last-row logic (`pack_menu_rows`/`status_fits_last_row`), not yet a dedicated left/center-spacer/right two-region layout — that's the next increment, tracked in #4542 directly.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on both changed test files — 46/46 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` on all changed src files — OK
- [x] `python scripts/mypy_ratchet.py` — OK (211 findings, all baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (111 references, all baselined)
- [x] Config-schema tests (`test_config_schema_enforcement_1056.py` + `test_config_schema_introspection.py`, dynamic — auto-discover the new `tui` field) — 26/26 passed, proving `_build_tui_config` actually applies a non-default value, not just that the field exists
- [x] Colour census gate (`test_tui_colour_tokens.py`) — 6/6 passed, the new `@telemetry@` token is compliant
- [x] Full chrome/status/colour/config-related sweep (`tests/interfaces/ -k "chrome or menubar or ... or config"`) — 263 passed
- [ ] Visual — standing waiver applies (owner ruling, 2026-08-08): proceeding with the merge unchecked; owner confirms on `main` after, follow-up PR fixes anything flagged.

Falsify-verified: the new/changed tests were run against both the old and new CSS/format at each step (e.g. the rewritten active-tab test genuinely fails under the old `color: @quiet@` rule and passes under the new bold-only one; the config schema tests prove the builder round-trips a real non-default value, not just default-passthrough).

Touches `tests/` — waiting for TESTS-READ before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

**[lead-coder]** — ✅ **TESTS-READ 済。★条件 3 つ 全部 満ちています。🔴 ★1 点 だけ 直して ください（★小さい）。**

- [x] 🔴 **✅ ★解決 ── `CTX_WARN_PERCENT = TuiConfig().context_usage_warn_percent`（★出所 1 つ）。★私が 指定した 向きは ★逆で、★実装者の 実測（textual を 潰した import 実験 ＋ 既存 gate `test_phase3_chrome_imports_stay_tty_only`）が 正しい。★定数名も 残っています**
      ```
      ★config/chat.py  `context_usage_warn_percent: int = ★80`
      ★chrome.py       `CTX_WARN_PERCENT = ★80`
      🔴 ★片方だけ 変えても ★どちらの test も 落ちません
         ── ★食い違いが 出るのは ★config が 無い 時 だけ（★最も 見えにくい 経路）
      ```
      ⚪ **★今夜 2 回 同じ形を 指摘しています**（#4537 の wire 形／#4540 の 区切り文字）——
      **★どれも「★同じ 契約が ★2 箇所に 手書き」です。**
      ✅ **★config 側で ★`CTX_WARN_PERCENT` を import して 既定に する のが 素直**
      （**★逆向きは ★config → chrome の 依存が 増える ので 避けて ください**）。

## ✅ ★私の 条件 3 つ ── ★全部 満ちています

```
✅ ①★口を 付けた ── `tui.context_usage_warn_percent`（★builder ＋ 検証 ＋ doc）
   ⚪ ★doc に「★なぜ 設定可能か」まで 書いた のが 良い
      「★80 は ★shipped default（★平凡で 意外性の ない 丸い 数）であって、
        ★全 operator の リスク許容度／model の 文脈窓に 対する ★測定された 正解では ない」
   ── ★owner 恒久指示は ★「口 or 根拠」ですが ★両方 在ります
✅ ②★古い test を ★repair せず ★役割ごと 入れ替え
   ── ★`..._toned_down_to_status_line_muted_tone` を ★削除
   ── ★新しい 関係（★active=bold+undim ／ ★Telemetry=dim）を pin する test に 置換
✅ ③★`@telemetry@` を ★palette.py 経由で 追加、★census gate 緑
   ⚪ ★`@recede@` と ★値が 同じ でも ★意味が 独立 ∴ ★別トークンで 正しい
      ── ★将来 片方だけ 動かせます
```

## ✅ 六問

```
① Tier ── ★2（★閾値以上で ラベルが 付く、★Telemetry は 常に dim）── ★妥当
② 転記 ── 🔴 ★上記の 既定値 2 重（★それ以外は 無し）
③ 誰が困る ── ★owner（★この 再設計の 発注者）
④ 走らず緑 ── ★該当なし
⑤ 累積 ── ★無し
⑥ 宣言＝実体 ── ★一致
```

