### PR TITLE
fix(#4564): drop the undeclared universal_wrappers_enabled gate from Session's embedding-index construction

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -515,8 +515,13 @@ class _RetrievalBundle:
     """#3082 Family 5: the retrieval spine — the embedding block
     (``embedding_provider`` / ``embedding_model_class`` /
     ``action_embedding_index``, three attrs, one conditional construction
-    guarded by ``universal_wrappers_enabled and embedding.enabled`` (FP-0066
-    §7) with a try/except None-fallback).
+    guarded SOLELY by ``embedding.enabled`` (FP-0066 §7 — "Single switch
+    embedding.enabled ... ON → action-retrieval...", no AND with
+    ``universal_wrappers_enabled`` anywhere in the ratified proposal) with
+    a try/except None-fallback. #4564 follow-up: an undeclared
+    ``universal_wrappers_enabled`` AND-condition here used to make
+    #4564's own router_loop.py fix unreachable in a real session — see
+    ``_build_retrieval_bundle``'s docstring for the full account.)
 
     #4552: this bundle used to also carry ``action_usage_tracker`` (hot-list
     freq+recency, a SEPARATE conditional guarded by
@@ -1205,9 +1210,7 @@ class Session:
         # reason no longer applies (nothing here reads audit_events now),
         # but the position is left as-is — see _RetrievalBundle's own
         # docstring for why reverting it is out of scope for this removal.
-        _retrieval_bundle = self._build_retrieval_bundle(
-            self._action_retrieval, embedding_config,
-        )
+        _retrieval_bundle = self._build_retrieval_bundle(embedding_config)
         self._action_embedding_index = _retrieval_bundle.action_embedding_index
         self._embedding_provider = _retrieval_bundle.embedding_provider
         self._embedding_model_class = _retrieval_bundle.embedding_model_class
@@ -4020,17 +4023,31 @@ class Session:
 
     def _build_retrieval_bundle(
         self,
-        action_retrieval: "ActionRetrievalConfig",
         embedding_config: "EmbeddingConfig | None",
     ) -> "_RetrievalBundle":
         """#3082 Family 5: build the retrieval spine — the embedding block
-        (three attrs, one conditional construction guarded by
-        ``universal_wrappers_enabled and embedding.enabled`` (FP-0066 §7,
-        clean-break replacement for the retired ``embedding_class`` truthy
-        gate) with a try/except None-fallback). ``render_bounds`` (never
-        existed in this codebase) and ``subscription_writer`` (WAL-derived
-        task-subscription state, not retrieval) are excluded per the Family
-        4 spec's own DAG corrections.
+        (three attrs, one conditional construction guarded SOLELY by
+        ``embedding.enabled`` (FP-0066 §7, clean-break replacement for the
+        retired ``embedding_class`` truthy gate) with a try/except
+        None-fallback). ``render_bounds`` (never existed in this codebase)
+        and ``subscription_writer`` (WAL-derived task-subscription state,
+        not retrieval) are excluded per the Family 4 spec's own DAG
+        corrections.
+
+        #4564 follow-up: this builder used to ALSO require
+        ``action_retrieval.universal_wrappers_enabled`` in the same AND
+        condition — an undeclared second gate, same defect class #4564
+        fixed in ``router_loop.py``'s PER-TURN visibility check, just one
+        layer earlier (Session CONSTRUCTION time). With that second gate,
+        an operator running ``universal_wrappers_enabled: false`` under
+        ANY scheme (not just the ones #4564 covered) never got an
+        ``ActionEmbeddingIndex``/provider AT ALL for the session's entire
+        lifetime, regardless of ``embedding.enabled`` — #4564's own fix in
+        ``router_loop.py`` could never fire in a REAL session, only in a
+        test that hand-constructs a ready index and bypasses this builder
+        (exactly what #4564's own regression witness did, caught on
+        reopen). The ``action_retrieval`` param is dropped — nothing else
+        in this builder reads it.
 
         #4552: this builder used to also construct ``action_usage_tracker``
         (hot-list freq+recency, a SEPARATE conditional guarded by
@@ -4046,11 +4063,10 @@ class Session:
         run inline in ``__init__``, MODULO one reordering (#3408): the
         call site moved from its ORIGINAL position (line ~1152, BEFORE
         Family 1 / ``_build_audit_event_bundle`` ran) to run right AFTER
-        Family 1 instead — ``action_retrieval`` / ``embedding_config`` are
-        the ``self._action_retrieval`` value / the ``embedding_config``
-        __init__ parameter, resolvable at the new call site exactly as they
-        were at the old one, since nothing between the two positions reads
-        or writes them. (The #3408 identity-vs-name binding rationale this
+        Family 1 instead — ``embedding_config`` is the ``embedding_config``
+        __init__ parameter, resolvable at the new call site exactly as it
+        was at the old one, since nothing between the two positions reads
+        or writes it. (The #3408 identity-vs-name binding rationale this
         docstring used to carry was specific to the now-removed hot-list
         closure and the AST single-assignment guard it motivated,
         ``tests/repo/test_audit_events_single_assignment_3408.py`` — that
@@ -4072,8 +4088,7 @@ class Session:
         embedding_provider: Any = None
         embedding_model_class: str | None = None
         if (
-            action_retrieval.universal_wrappers_enabled
-            and embedding_config is not None
+            embedding_config is not None
             and embedding_config.enabled
         ):
             try:

--- a/tests/core/test_4564_followup_embedding_index_construction_gate.py
+++ b/tests/core/test_4564_followup_embedding_index_construction_gate.py
@@ -1,0 +1,84 @@
+"""Tier 2: #4564 follow-up strip-falsify witness — a REAL Session
+construction, not a hand-fed fake host.
+
+#4564 (PR #4565) fixed router_loop.py's PER-TURN ``_search_visible`` check
+to no longer depend on ``universal_wrappers_enabled``. Its own regression
+witness (``tests/runtime/test_4564_search_actions_scheme_independent.py``)
+passed — but by hand-constructing a fake host and injecting a real, already
+-configured ``ActionEmbeddingIndex`` directly via ``get_action_embedding_index``,
+bypassing ``Session._build_retrieval_bundle`` (the construction-TIME builder)
+entirely. That builder had the SAME undeclared
+``universal_wrappers_enabled and embedding.enabled`` AND-condition #4564
+fixed one layer up — so in a REAL ``Session``, ``action_embedding_index``/
+``embedding_provider`` stayed ``None`` for the session's entire lifetime
+whenever ``universal_wrappers_enabled: false``, regardless of
+``embedding.enabled``, and #4564's own router_loop.py fix could never fire.
+
+Ratified design check (lead-coder's explicit requirement before this fix):
+FP-0066 §7 (``docs/deep-dives/proposals/0066-retrieval-two-groups-two-axes.md``)
+— "Single switch `embedding.enabled: bool = false` (default OFF). ON →
+action-retrieval + knowledge-retrieval + the plugin's embed step." No AND
+with ``universal_wrappers_enabled`` anywhere in the ratified proposal. The
+``_build_retrieval_bundle``/``_RetrievalBundle`` docstrings claiming "AND is
+intentional" were themselves STALE (a #4564-shaped defect one level up: a
+declaration the code faithfully implemented, but the declaration itself was
+wrong) — fixed in the same PR as this test.
+
+This test drives Session construction through ``make_session`` (the SAME
+helper 282+ other tests use, mirroring production's own
+``scoped_session_factory.py`` shape) with
+``action_retrieval_config=ActionRetrievalConfig(universal_wrappers_enabled=False)``
++ a real ``EmbeddingConfig(enabled=True)`` and asserts
+``session._action_embedding_index`` / ``session._embedding_provider`` are
+NOT None — the exact construction path #4564's own witness bypassed.
+"""
+from __future__ import annotations
+
+from reyn.config.embedding import ActionRetrievalConfig, EmbeddingConfig
+from tests._support.agent_session import make_session
+
+
+def test_wrappers_off_real_session_still_constructs_embedding_index(
+    tmp_path,
+) -> None:
+    """Tier 2: #4564 follow-up strip-falsify witness. A REAL Session built
+    with universal_wrappers_enabled=False + embedding.enabled=True still
+    constructs a real ActionEmbeddingIndex/provider — proving the
+    construction-time gate no longer depends on the wrapper flag.
+
+    Strip-falsify: reverting this fix (re-adding
+    ``action_retrieval.universal_wrappers_enabled and`` to
+    ``_build_retrieval_bundle``'s condition) turns this RED —
+    ``session._action_embedding_index`` goes back to None."""
+    session = make_session(
+        agent_name="test-agent-4564-followup",
+        workspace_base_dir=tmp_path,
+        action_retrieval_config=ActionRetrievalConfig(universal_wrappers_enabled=False),
+        embedding_config=EmbeddingConfig(enabled=True),
+    )
+
+    # Read through the real RouterLoopHost Protocol surface
+    # (get_action_embedding_index/get_embedding_provider/
+    # get_embedding_model_class — the same methods RouterLoop.run() itself
+    # calls every turn, per router_loop.py), not a raw private-field peek —
+    # the object under test IS session's real, fully-constructed
+    # RouterHostAdapter, obtained outside the assert so the assert itself
+    # only inspects the PUBLIC method's return value.
+    router_host = session._router_host
+    idx = router_host.get_action_embedding_index()
+    provider = router_host.get_embedding_provider()
+    model_class = router_host.get_embedding_model_class()
+
+    assert idx is not None, (
+        "a real Session with embedding.enabled=True must construct a real "
+        "ActionEmbeddingIndex regardless of universal_wrappers_enabled — "
+        "got None, meaning the undeclared wrapper-flag gate is back"
+    )
+    assert provider is not None, (
+        "embedding_provider must also be constructed — same gate, same "
+        "AND condition this test pins the absence of"
+    )
+    assert model_class == "standard", (
+        "embedding_model_class should resolve to the real default_class "
+        "when the index/provider construction actually ran"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #4564 follow-up: `Session._build_retrieval_bundle` (construction-time) had the SAME undeclared `universal_wrappers_enabled` gate #4564's original fix (#4565) removed one layer down in `router_loop.py` (per-turn). With this gate still in place, a real Session built with `universal_wrappers_enabled: false` never constructed the `ActionEmbeddingIndex`/provider at all, regardless of `embedding.enabled` — #4565's own fix could never fire in production, only in its own hand-constructed test (which bypassed Session's real construction path entirely).

Closes #4564.

## Ratified-design check (required before touching two conflicting declarations)

- `embedding.py`: "search_actions is gated separately via `embedding.enabled`" (no AND).
- `session.py` (pre-fix): "guarded by `universal_wrappers_enabled and embedding.enabled`" (explicit AND, stated as intentional).

Checked FP-0066 §7 (`docs/deep-dives/proposals/0066-retrieval-two-groups-two-axes.md:88-98`): "Single switch `embedding.enabled: bool = false`... ON → action-retrieval + knowledge-retrieval + the plugin's embed step." No AND anywhere in the ratified proposal. `embedding.enabled`-only is the ratified design; `session.py`'s docstring was stale — the code faithfully implemented a WRONG declaration. Named for the record: agreement between declaration and implementation is not itself defect-clearance when the declaration is the thing that's wrong.

## Fix

`Session._build_retrieval_bundle`: dropped `action_retrieval.universal_wrappers_enabled and` from the gate — now `embedding_config is not None and embedding_config.enabled` alone. The now-unused `action_retrieval` parameter is removed from the signature and its call site. Both class docstrings rewritten with the sole gate + the #4564-follow-up history.

## Regression witness (real Session construction this time)

`tests/core/test_4564_followup_embedding_index_construction_gate.py` — builds a REAL `Session` via `make_session` (same helper 282+ tests use) with `ActionRetrievalConfig(universal_wrappers_enabled=False)` + `EmbeddingConfig(enabled=True)`, then reads through the real `RouterLoopHost` Protocol surface (`get_action_embedding_index()`/`get_embedding_provider()`/`get_embedding_model_class()` — the exact methods `RouterLoop.run()` calls every turn) — no private-state assert (`session._router_host` read into a local outside the assert, confirmed 0 Tier-4 violations via `test_tier_audit.py --strict`).

Strip-falsify verified directly: `git checkout --` on `session.py` turns this test RED; restoring turns it green.

## Verification

- `ruff check src tests`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py` (session.py): clean.
- `scripts/test_tier_audit.py --strict` (new test file): 1 test, 0 Tier-4 violations.
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined.
- Full regression sweep (`tests/config`+`core`+`dev`+`llm`+`runtime`+`tools`+`repo`): **6413 passed, 6 skipped**. 6 failures present, all confirmed pre-existing (same 6 as #4564/#4565's own verification).

## Test plan

- [x] Confirmed FP-0066 §7 (ratified proposal) before resolving the doc conflict.
- [x] Strip-falsified the fix via `git checkout --` — test goes RED with the exact pre-fix symptom.
- [x] Confirmed the witness drives real `Session` construction, not a hand-fed fake host (the exact gap in #4565's own witness).
- [x] Ran all 5 local gates — clean.
- [x] Ran a full regression sweep — all failures confirmed pre-existing.
- [ ] (Visual) — n/a, no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
