### PR TITLE
docs(#4552): reyn-yaml.md still documented action_retrieval.mode after #4563 removed it

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1223,7 +1223,6 @@ Universal catalog visibility + retrieval settings.  Scheme *selection* is genera
 ```yaml
 action_retrieval:
   universal_wrappers_enabled: true    # default; set false to opt out
-  mode: default                       # default | minimal | performance
 embedding:
   enabled: false                      # default (off); set true to opt in to search_actions
   # default_class: standard           # which embedding class to use when enabled
@@ -1234,7 +1233,12 @@ embedding:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `universal_wrappers_enabled` | bool | `true` | For a layer whose `tool_use` scheme resolves to `universal-category`, `true` (default) exposes only the 4 universal wrappers (`list_actions`, `search_actions`, `describe_action`, `invoke_action`) in that layer's `tools=`.  Legacy per-kind tools (`invoke_skill`, `call_mcp_tool`, etc.) are no longer surfaced to the LLM on that layer but remain available as wrapper backing handlers.  `search_actions` is gated separately by [`embedding.enabled`](#embedding-block).  Set `false` to disable the wrapper surface entirely for that layer (= legacy tools become the only addressing path again).  Does not affect a layer whose scheme is `enumerate-all` (the `chat` layer's own default) — that scheme never consults this flag. |
-| `mode` | string | `"default"` | Operational mode label: `"minimal"` / `"default"` / `"performance"`.  Free-form string; currently unread — no caller layers semantics on it yet. |
+
+> **#4552 PR-2 (2026-08) — `mode` retired.** The prior `mode: "default" |
+> "minimal" | "performance"` field was always free-form and unread (no
+> caller ever layered semantics on it) — removed, no alias. A `reyn.yaml`
+> still carrying it gets the standard unknown-key tolerance (ignored, not
+> a parse error).
 
 > **#4552 (2026-08) — hot-list retired.** The prior `hot_list_n` / `hot_list_seed`
 > fields (a top-N freq+recency direct-alias projection) are **removed, no


### PR DESCRIPTION
**[docs-maintainer]** — **Correction (lead-coder's own catch, git-blame confirmed): this is a REVERT, not drift.** My original framing below was wrong about the cause — the fix itself is unchanged and correct.

## What actually happened (not what I originally wrote)

`#4563` (`#4552` PR-2, merged) removed `ActionRetrievalConfig.mode` and correctly updated `reyn-yaml.md`'s own YAML example + field table in the SAME PR — no drift ever existed at that point. `#4566` (status bar redesign, an unrelated TUI feature) branched off a base predating `#4563` and squash-merged 10 files; one of them silently carried `reyn-yaml.md` back to its pre-`#4563` state, reverting the `mode`-field removal along with legitimately landing `#4566`'s own TUI changes. `e2e-coder` independently found this (mid-PR-3 doc work) and traced it to commit `7a9f5b8c5` via `git blame`; lead-coder confirmed by auditing the full `#4566` squash diff — only this one line in `reyn-yaml.md` was clobbered (the `.ja.md` sibling and every TUI change from `#4566` survived intact).

I originally diagnosed this as ordinary same-night doc drift (a fix that was simply never made) — wrong causal read; the fix WAS made, then silently undone by a stale-base merge. The distinction matters operationally: drift means "finish the missed edit," a revert means "audit what else the same merge silently undid" — lead-coder did that audit and confirmed the blast radius was this one line only.

## The fix (unchanged)

Removed the stale example line + field-table row. Added a retirement note mirroring the existing hot-list retirement note's own shape (unknown-key tolerance on a `reyn.yaml` still carrying the key, no migration path since there's nothing to migrate to).

## Verification

- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — no error/Aborted line.
- Confirmed via `src/reyn/config/embedding.py`'s `ActionRetrievalConfig` that `mode` genuinely has no field before writing the retirement claim.
- lead-coder independently audited `#4566`'s full squash diff (10 files) — confirmed no other reverted content beyond this one `reyn-yaml.md` line.

part of #4552

## Test plan

- [x] `mkdocs build --strict` — clean, no Aborted/error line (read directly)
- [x] Confirmed `ActionRetrievalConfig` has no `mode` field in current `main` before writing the retirement claim
- [x] Confirmed the ja sibling was already correct (no fix needed there)
- [x] (skipped — docs-only edit, no runtime behavior change, no test to run)
