### PR TITLE
feat(#4542): Navigation/Telemetry visual separation — stretching spacer

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -858,6 +858,16 @@ class TextualChatApp(App):
         height: 1;
         text-style: @telemetry@;
         padding: 0 1;
+        /* #4542: pins the text to the row's RIGHT edge without touching
+           width — in the ``.-shared`` (merged) case the box is already
+           auto-tight to its own text, so this is a no-op there; in the
+           own-row fallback below, width stays 100% (load-bearing — see
+           that rule's own comment on why an auto-width own-row status
+           line can overflow), so text-align is what achieves "pinned
+           right" there instead of a spacer, which would need width: auto
+           to have anything to push against and would reopen the overflow
+           this rule protects against. */
+        text-align: right;
     }
     /* #4194: bold, not a colour — palette.py's own rule (@attention@ is the
        ONLY semantic colour this CUI claims, for the intervention panel;

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1778,6 +1778,19 @@ class MenuBar(Widget, can_focus=True):
         width: 100%;
         layout: horizontal;
     }
+    /* #4542: the stretching gap between Navigation and Telemetry — a plain
+       empty widget, no border/content (the owner's own non-goal: "box や
+       separator を追加しない"). 1fr consumes whatever width the row's
+       natural-width children (tabs + StatusLine) don't need, so Telemetry
+       sits at the row's right edge on any width wide enough to merge at
+       all — see status_fits_last_row's own docstring for the FIT decision
+       this doesn't change (the spacer only expands into slack space that
+       already existed; it never causes a row that used to fit to stop
+       fitting). */
+    MenuBar .menu-spacer {
+        width: 1fr;
+        height: 1;
+    }
     """
 
     class Selected(Message):
@@ -1816,11 +1829,28 @@ class MenuBar(Widget, can_focus=True):
         rows = pack_menu_rows(self._items, width)
         merge_status = status_fits_last_row(rows, width, len(self._status_text))
         self.remove_children()
+        # #4542: Navigation (tabs) / Telemetry (StatusLine) as two visually
+        # distinct regions when they SHARE a row — a stretching
+        # ``.menu-spacer`` between them (see DEFAULT_CSS's own comment)
+        # rather than the tabs and StatusLine sitting immediately adjacent,
+        # so Telemetry reads as pinned to the right edge instead of merely
+        # "the next thing after the last tab". Only the MERGED case needs
+        # the spacer: it requires StatusLine at ``width: auto`` (the
+        # ``-shared`` class) for the spacer to have slack to expand into.
+        # The own-row fallback below does NOT get a spacer — StatusLine
+        # there stays at its base rule's ``width: 100%`` (load-bearing
+        # containment for a long status string, see that CSS rule's own
+        # comment) and is pinned right via ``text-align: right`` instead
+        # (app.py's ``StatusLine`` rule) — a spacer would have nothing to
+        # push against there, since StatusLine already claims the whole row.
         menu_rows = [
             Horizontal(
                 *(Tab(label, id=tab_id) for tab_id, label in row),
                 *(
-                    [StatusLine(self._status_text, classes="-shared")]
+                    [
+                        Static("", classes="menu-spacer"),
+                        StatusLine(self._status_text, classes="-shared"),
+                    ]
                     if merge_status and i == len(rows) - 1
                     else []
                 ),

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -54,6 +54,7 @@ from reyn.interfaces.inline.textual_chat.chrome import (
     _COST_COL_W,
     _COST_LABEL_W,
     _MENU_TABS,
+    _TAB_H_PADDING,
     MenuBar,
     StatusLine,
     cost_pane_lines,
@@ -927,6 +928,91 @@ async def test_every_menu_tab_is_fully_on_screen(
         assert not offenders, (
             f"tabs laid out off-screen at {screen_size} (screen={screen}); "
             f"offender -> (x, right, y, bottom): {offenders}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_telemetry_pins_to_the_right_edge_with_a_gap_from_navigation(
+    tmp_path,
+) -> None:
+    """Tier 2b: #4542 — real-TTY-witnessed geometry guard for the stretching
+    ``.menu-spacer`` between Navigation (tabs) and Telemetry (StatusLine),
+    for the MERGED case specifically (StatusLine shares the last tab row —
+    live-probed: this app's 14 tabs + status text all fit on one row
+    starting at 130 columns, not 100 — an earlier version of this test
+    picked 100 and, without checking, silently exercised the DIFFERENT
+    own-row fallback path instead, where there is no spacer at all — see
+    the sibling test below for that path's own, different mechanism).
+
+    A screen wide enough to merge (130 columns) must show TWO things the
+    spacer specifically causes, neither of which the pre-#4542
+    immediately-adjacent layout produced: (1) StatusLine's region reaches
+    (or comes very close to) the row's right edge — "pinned right", not
+    merely "somewhere after the tabs"; (2) there is a real gap (more than
+    the tabs' own inter-tab padding) between the last tab's right edge and
+    StatusLine's left edge — proving an actual stretching space, not the
+    two widgets sitting flush."""
+    from textual.widgets import Tab
+
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    snap, _session, _registry = await _real_snapshot(tmp_path)
+    app = TextualChatApp(
+        transport=_EventOnlyTransport(), read_model=_MutableSnapshotReadModel(snap)
+    )
+    async with app.run_test(size=(130, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        screen = app.screen.size
+        status = app.query_one(StatusLine)
+        assert "-shared" in status.classes, (
+            "this test requires the MERGED case (status sharing the last tab "
+            "row) — got the own-row fallback instead; widen the screen size"
+        )
+        tabs = list(app.query(Tab))
+        last_tab = max(tabs, key=lambda t: t.region.x)
+        assert screen.width - status.region.right <= 1, (
+            f"StatusLine not pinned to the right edge: right={status.region.right} "
+            f"screen_width={screen.width}"
+        )
+        gap = status.region.x - last_tab.region.right
+        assert gap > _TAB_H_PADDING, (
+            f"no real gap between Navigation and Telemetry — the spacer did not "
+            f"expand (gap={gap}, last_tab.right={last_tab.region.right}, "
+            f"status.x={status.region.x})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_telemetry_own_row_stays_full_width_not_shrunk_by_a_spacer(
+    tmp_path,
+) -> None:
+    """Tier 2b: #4542 — the own-row fallback (no merge — 100 columns, per
+    the sibling test's own live-probed threshold) does NOT get a spacer:
+    StatusLine keeps the base rule's ``width: 100%`` (load-bearing
+    containment for a long status string — see app.py's ``StatusLine``
+    CSS comment; an auto-width own-row status line can overflow past the
+    screen edge) and is pinned right via ``text-align: right`` instead. A
+    spacer here would have nothing to push against, since StatusLine
+    already claims the whole row — this asserts that design choice
+    directly rather than only the merged case above."""
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    snap, _session, _registry = await _real_snapshot(tmp_path)
+    app = TextualChatApp(
+        transport=_EventOnlyTransport(), read_model=_MutableSnapshotReadModel(snap)
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        status = app.query_one(StatusLine)
+        assert "-shared" not in status.classes, (
+            "this test requires the own-row fallback — got the merged case "
+            "instead; narrow the screen size"
+        )
+        assert status.region.width >= status.parent.size.width - 2, (
+            f"own-row StatusLine width shrank ({status.region.width}) — "
+            f"containment protection for a long status string may be lost"
         )
 
 


### PR DESCRIPTION
**[tui-coder]** — part of #4542 (2nd increment: Navigation/Telemetry visual separation). Builds on #4566 (merged — text-format + CSS-styling layer). This lands the layout mechanics: a real left/right split with a stretching center spacer, per the owner's own proposal ("[Navigation ...][Telemetry]").

## Two distinct mechanisms — found live, not assumed

The status bar's two narrow-width shapes (StatusLine merged onto the last tab row, vs. StatusLine getting its own fallback row) needed DIFFERENT fixes, discovered by testing both rather than assuming one mechanism covers both:

1. **Merged case** (StatusLine shares the last tab row): a new empty `.menu-spacer` widget (`width: 1fr`) sits between the tabs and StatusLine (`-shared` class, `width: auto`). The spacer consumes whatever slack space is left, pinning Telemetry to the row's right edge with a real, visually expanding gap. Live-verified at 130 columns (this app's own 14-tab + status-text merge threshold, found by probing widths — not assumed): gap=6 between the last tab and StatusLine, StatusLine's right edge within 1 cell of the screen's own edge.

2. **Own-row fallback** (no room to merge): **no spacer here** — a real bug in my first draft. I initially gave this case a spacer too, and it silently did nothing: StatusLine's base CSS rule has no explicit width, so it already claims 100% of the row on its own — the spacer had no slack to expand into, and the widget order actually put StatusLine right after a near-zero-width spacer at the row's LEFT edge, not the right (caught by the falsified test itself — see below). This 100%-width behavior is deliberate, load-bearing, pre-existing behavior (see `StatusLine.-shared`'s own comment): an auto-width own-row status line can overflow past the screen edge for a long status string. Fixed instead with `text-align: right` on StatusLine's base CSS rule — pins the TEXT to the right edge without touching the width/containment mechanism that protects against overflow.

## Test changes (falsify-verified, not just "written and passed")

Two new real-TTY-witnessed geometry tests, mirroring #3338's own `test_every_menu_tab_is_fully_on_screen` convention:

- `test_telemetry_pins_to_the_right_edge_with_a_gap_from_navigation` — the merged case. **The first draft of this test picked 100 columns without checking and silently exercised the WRONG code path** (the own-row fallback, where there's no spacer at all) — it failed with a genuinely confusing result (`gap=-77`) that led directly to finding bug #2 above. Fixed by probing actual widths and using the live-verified 130-column merge threshold, plus an explicit `assert "-shared" in status.classes` guard so a future width/threshold change can't silently make this test exercise the wrong path again without failing loudly.
- `test_telemetry_own_row_stays_full_width_not_shrunk_by_a_spacer` — the own-row fallback, asserting the containment fix directly (StatusLine still claims ~full row width) rather than only testing the merged case and hoping the other path is fine.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on the changed test file — 30/30 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (211 findings, all baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (111 references, all baselined)
- [x] Full chrome/status/colour/config/phase3 sweep (`tests/interfaces/ -k "chrome or menubar or ... or phase3"`) — 269 passed
- [ ] Visual — standing waiver applies (owner ruling, 2026-08-08); owner confirms on `main` after.

Branch confirmed based on current `origin/main` (post-#4568) before push — the merge-base-silent-revert lesson from tonight's #4566 landing is fresh.

Touches `tests/` — waiting for TESTS-READ before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
