### PR TITLE
docs(#4556): org-design.md's spawn_session synopsis missing agent/session params

### DIFF
--- a/docs/concepts/multi-agent/org-design.md
+++ b/docs/concepts/multi-agent/org-design.md
@@ -58,14 +58,26 @@ so you can reference it in a subsequent `create_topology` call.
 
 ```text
 spawn_session(request: str, mode: "ephemeral" | "persistent" = "persistent",
-              narrowing: dict | None = None)
+              narrowing: dict | None = None, base_dir: str | None = None,
+              agent: str | None = None, session: str | None = None)
 ```
 
-Starts a new Session under your current agent to run `request` in
-isolation — a blank context window, independent workspace, with no memory
-of this conversation. The spawned session begins immediately; this tool
-returns a spawn-ack rather than waiting for the task to complete (async
-dispatch).
+Starts a new Session under your current agent (or, with `agent`, #4556:
+under any agent in your own spawn subtree) to run `request` in isolation —
+a blank context window, independent workspace, with no memory of this
+conversation. The spawned session begins immediately; this tool returns a
+spawn-ack rather than waiting for the task to complete (async dispatch).
+
+**`agent`** (optional, #4556): target any agent in your own spawn subtree —
+yourself, or an agent you created (transitively) via `spawn_agent`. Guarded
+by the same `is_spawn_descendant` predicate `create_topology` already uses
+for its own subtree forge-guard — an attempt to target an agent outside your
+subtree is rejected (`agent_outside_subtree`), not silently redirected.
+Omit to spawn under your own agent (the default, unchanged behavior).
+
+**`session`** (optional, #4556): choose the new session's id yourself
+instead of letting the OS auto-generate one. A duplicate id for the target
+agent is rejected (`session_already_exists`), never silently overwritten.
 
 **Reachable under exclusive-wrapper mode too (#3896, fixed 2026-08-13).** When
 [`action_retrieval.universal_wrappers_enabled`](../tools-integrations/universal-catalog.md)
@@ -113,6 +125,12 @@ nothing about keeps the spawner's restriction on it. So omitting
 wider one. (The composition covers the sid-keyed per-session layer; the
 agent-level layers need no carrying, since the sub-session runs under the
 same agent identity.)
+
+**`base_dir`** (optional, #4200): a working-directory override for the
+spawned session. Restrict-only, same shape as `narrowing` — must resolve
+inside YOUR OWN effective `base_dir`; a path outside it is REJECTED, never
+silently clamped into it. Relative paths resolve against your own
+`base_dir`. Omit to inherit your own `base_dir` unchanged (the default).
 
 Both modes are rewind-safe: a session spawned after a rewind cut is
 dropped during rewind reconstruction.


### PR DESCRIPTION
**[docs-maintainer]** — Same-night doc drift: #4575 (#4556, merged) gave `spawn_session` two new optional parameters (`agent`, `session`) with 3 new typed error kinds, but `org-design.md`'s own synopsis + prose weren't updated in that PR — confirmed via `gh pr view --json files`, no `docs/` files touched.

## What drifted

`org-design.md`'s `spawn_session` synopsis block only listed `request`/`mode`/`narrowing`, and its prose had no mention of `agent`/`session` at all.

## The fix

Added both new parameters to the synopsis line and a prose paragraph each, mirroring the real param descriptions in `src/reyn/tools/descriptions/delegation.py` — the actual LLM-facing text this doc should stay consistent with, not duplicate independently.

**Bonus find while editing the same line**: `base_dir` (#4200, landed well before tonight) was already a real parameter but was in neither the synopsis nor anywhere in this doc's prose — a separate, pre-existing gap this touch surfaced. Added both the synopsis entry and an explanatory paragraph for it too.

## Verification

- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — no error/Aborted line.
- Confirmed via `src/reyn/tools/session_spawn.py` + `src/reyn/tools/descriptions/delegation.py` that `agent`/`session`/`base_dir` are real, current parameters before writing the doc.

part of #4556

## Test plan

- [x] `mkdocs build --strict` — clean, no Aborted/error line (read directly)
- [x] Confirmed the 3 parameters are real/current in `src/reyn/tools/session_spawn.py` before writing the claim
- [x] (skipped — docs-only edit, no runtime behavior change, no test to run)
