### PR TITLE
fix(#4576, #4577): a gate that measured nothing must not exit 0

### DIFF
--- a/scripts/mypy_ratchet.py
+++ b/scripts/mypy_ratchet.py
@@ -69,10 +69,34 @@ file the only one mypy reports on, full stop. ``main()`` prints a distinct
 warning when a new ``[syntax]`` pair appears, because the red's own SHAPE
 carries information a bare pair list does not: fix that one before trusting
 anything else this run says.
+
+#4576 is that same hazard one layer earlier: not "the run was truncated" but
+"the run never happened." With mypy absent from the interpreter's environment,
+``python -m mypy`` writes ``No module named mypy`` to stderr and exits 1 —
+which :func:`run_mypy` deliberately does not raise on (mypy's own error exit
+is the common case), and which :func:`parse_mypy_output` finds no
+``[code]`` lines in. Zero measured pairs minus the baseline is zero new pairs,
+so the script printed ``OK: 0 findings, all baselined (215 declared)`` and
+exited 0 — the ``215 declared`` making it look fully alive, because loading
+the baseline HAD succeeded. Measured directly in a ``python -m venv`` with no
+mypy installed; found because #4575's local run was green and CI's was not,
+and the real ``[call-arg]`` it had been hiding surfaced the moment mypy
+actually ran.
+
+The guard is :func:`mypy_is_importable`, checked BEFORE the run: a structural
+question (is the module there) rather than a textual one (does the output look
+like a real run). Deliberately not a check on mypy's summary wording — that
+would make a third party's output format decide whether we trust our own
+measurement, and mypy is free to reword it. The exit code cannot serve either:
+a missing module and a normal findings-reported run BOTH exit 1 (measured).
+NOT covered, disclosed rather than silently half-closed: mypy installed but
+crashing mid-run in some shape the ``[syntax]`` guard above doesn't already
+name. That shape has never been observed here; this one had.
 """
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import re
 import subprocess
@@ -90,6 +114,26 @@ _TARGET = "src/reyn"
 # trailing "Found N errors in M files" summary line — neither carries a
 # `[code]` a future run can be diffed against.
 _ERROR_LINE = re.compile(r"^(?P<file>[^:]+\.py):\d+: error: .*\[(?P<code>[a-z][a-z0-9-]*)\]\s*$")
+
+
+def mypy_is_importable() -> bool:
+    """Whether ``mypy`` can be imported by the interpreter that will run it.
+
+    The precondition every number this script prints depends on: with mypy
+    absent, the measured set is empty for a reason that has nothing to do with
+    the code under analysis, and "0 new findings" then means "0 findings were
+    looked for" (#4576).
+    """
+    return importlib.util.find_spec("mypy") is not None
+
+
+_MYPY_MISSING = (
+    "mypy is not importable by {exe} — NOTHING WAS MEASURED. This is not "
+    "'0 findings': the baseline may or may not still hold, and this run "
+    "cannot tell you which. Install it (`pip install -e \".[dev]\"`) and run "
+    "again. Green here without mypy present is the #4576 false green, which "
+    "hid a real [call-arg] through a full local pre-PR check."
+)
 
 
 def run_mypy(root: Path = _ROOT, target: str = _TARGET) -> str:
@@ -189,6 +233,13 @@ def main(argv: "list[str] | None" = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+
+    # #4576: before anything else — including --write-baseline, which would
+    # otherwise overwrite the baseline with the empty measurement of a run
+    # that never happened, silently discarding every declared pair.
+    if not mypy_is_importable():
+        print(_MYPY_MISSING.format(exe=sys.executable), file=sys.stderr)
+        return 1
 
     output = run_mypy()
     measured = parse_mypy_output(output)

--- a/scripts/test_tier_audit.py
+++ b/scripts/test_tier_audit.py
@@ -768,8 +768,25 @@ def main(argv: list[str] | None = None) -> int:
     files = collect_files(target_paths)
 
     if not files:
-        print("No test files found.", file=sys.stderr)
-        return 0
+        # #4577: a non-zero exit, not a zero one. CLAUDE.md tells every author
+        # to run this as `--strict <changed test files>`, so the paths are
+        # hand-typed or shell-expanded — a typo (`test/` for `tests/`), a file
+        # another PR moved, or an empty variable all land HERE, and returning 0
+        # turned "I audited nothing" into a green the author then wrote into a
+        # Test plan as done. Nothing in the repo relied on the old 0: CI
+        # computes its own file list with `git diff` and guards `[ -z ]` before
+        # invoking (test.yml:310), and the main-push arm passes `tests/`, which
+        # never resolves empty. The resolved targets are echoed because the
+        # typo is invisible in the old message and obvious next to the path.
+        print(
+            "Audited NOTHING — the "
+            f"{len(target_paths)} target(s) below resolved to 0 test files. "
+            "This is not a pass; nothing was checked.",
+            file=sys.stderr,
+        )
+        for t in target_paths:
+            print(f"  {t}", file=sys.stderr)
+        return 1
 
     auditor = TestAuditor(check_rules=check_rules)
     reports: list[FileReport] = []

--- a/tests/scripts/test_4577_tier_audit_empty_target_set.py
+++ b/tests/scripts/test_4577_tier_audit_empty_target_set.py
@@ -1,0 +1,79 @@
+"""Tier 1: scripts/test_tier_audit.py refuses a target set that resolves to nothing.
+
+CLAUDE.md instructs every author to run the audit as ``--strict <changed test
+files>`` before opening a PR, so the argument list is hand-typed or
+shell-expanded: a typo (``test/`` for ``tests/``), a path another PR has since
+moved, or an empty shell variable all reach ``main()`` as targets that resolve
+to zero files. Until #4577 that printed "No test files found." and returned 0,
+which authors then recorded in a Test plan as a passed gate — the same class as
+#4576's mypy-absent ratchet green, in a different script: a measurement that
+did not happen, reported in the colour of one that did.
+
+Tier 1 because the audit script is the contract surface every tests-touching PR
+is checked through; its exit code is what a human reads as "the gate passed."
+
+Public surface only (no mocks — the script is stdlib-only and its ``main`` is
+directly callable): real ``main(argv)``, real path resolution, real filesystem.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from tests._support.paths import REPO_ROOT
+
+_SCRIPT = REPO_ROOT / "scripts" / "test_tier_audit.py"
+
+
+def _load_audit_module():
+    """Import ``scripts/test_tier_audit.py`` without pytest collecting it.
+
+    Same loader idiom as the sibling ``test_tier_audit_format_pin.py``: the
+    script's filename starts with ``test_``, and ``@dataclass`` needs the
+    module registered in ``sys.modules`` before exec.
+    """
+    spec = importlib.util.spec_from_file_location("_audit_empty_targets_4577", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_targets_resolving_to_zero_files_is_a_failure_not_a_pass(tmp_path: Path) -> None:
+    """Tier 1: a target set that names no test file at all exits non-zero.
+
+    The consumer is the PR author following CLAUDE.md's pre-push instruction:
+    before #4577 a mistyped path here produced exit 0, and the gate's own
+    output ("No test files found.") scrolled past as if it were a result.
+    """
+    audit = _load_audit_module()
+
+    missing = tmp_path / "test_this_file_does_not_exist.py"
+    assert not missing.exists(), "precondition: the path must genuinely resolve to nothing"
+
+    assert audit.main(["--strict", str(missing)]) != 0
+
+
+def test_a_real_test_file_still_audits_and_passes(tmp_path: Path) -> None:
+    """Tier 1: the accept side — a well-formed test file still exits 0.
+
+    Its consumer is every author whose paths ARE correct: a refusal that fires
+    on a resolvable target would block the gate's own users, which is the
+    failure mode the reject test above cannot see.
+    """
+    audit = _load_audit_module()
+
+    good = tmp_path / "test_well_formed.py"
+    good.write_text(
+        '"""Tier 2: a well-formed module for the audit to accept."""\n'
+        "\n"
+        "\n"
+        "def test_something() -> None:\n"
+        '    """Tier 2: asserts a value, pins no format, fakes no collaborator."""\n'
+        "    assert 1 + 1 == 2\n",
+        encoding="utf-8",
+    )
+
+    assert audit.main(["--strict", str(good)]) == 0


### PR DESCRIPTION
**[lead-coder]** — 🔴 **★測っていない ゲートが ★exit 0 して いました。★2 本、★別々の 機構、★同じ クラス。**

★CLAUDE.md が ★「PR を 出す 前に 走らせろ」と ★名指ししている ゲートです。

## ✅ ★直接 測定（★両方、★陽性対照つき）

```
★#4576 ── ★mypy 無しの venv
  $ /tmp/nomypy/bin/python scripts/mypy_ratchet.py
  ★mypy ratchet OK: 0 findings, all baselined (★215 declared).   ★rc=0
  ⚪ ★「215 declared」まで 出ます ── ★baseline の 読み込みは 成功している
     ∴ ★出力は ★完全に 生きているように 見えます

★#4577 ── ★存在しない path ／ ★`test/` の typo
  $ python scripts/test_tier_audit.py --strict tests/runtime/test_DOES_NOT_EXIST.py
  ★No test files found.                                          ★rc=0
```

## ★機構

```
★#4576 ── ★`python -m mypy` は ★「No module named mypy」を stderr に 出して ★exit 1
   ★run_mypy は ★非 0 で raise しない（★mypy の error 終了が 常態 ∴ ★正しい設計）
   ★parse_mypy_output は ★[code] 行を 1 つも 見つけない
   ★0 - baseline = ★0 new  → ★「OK」
★#4577 ── ★`if not files: print(...); ★return 0`
```

## ✅ ★直し

```
★#4576 ── ★mypy_is_importable() を ★走る前に
   🔴 ★--write-baseline より ★前に 置きました ──
      ★走らなかった run の ★空の 測定で ★baseline を 上書きし、
      ★宣言済の pair を ★全部 捨てる ところでした
★#4577 ── ★exit 1 ＋ ★解決した target を ★echo
   ── ★typo は ★旧文面では 見えず、★path の 隣に 並べれば 見えます
```

### 🔴 ★判別子を ★分類される側から 取らない

```
✗ ★mypy の 総括行（"Success: no issues found"）を 見る
   ── ★第三者の 出力書式が ★こちらの 測定の 信頼性を 決める ことに なります
✗ ★exit code
   ── ★モジュール不在も ★通常の finding 報告も ★どちらも ★1（★実測）
✅ ★module が 在るか ── ★構造的、★mypy の 都合に 依存しません
```

## ⚠️ ★覆っていない もの（★黙って 半分 閉じるのでは なく、★書きます）

```
⚠️ ★mypy が 入っている が ★途中で crash する 形
   ── ★既存の [syntax] guard が 名指ししている 形 以外
   ⚪ ★ここでは ★観測されて いません ── ★#4576 の 形は ★観測されました
```

## ⚠️ ★test を 1 本だけ 書いた 理由（★#4577 のみ）

```
✅ ★#4577 ── ★書けます ── ★main(argv) を ★実物で 呼び、★実 path 解決、★fake なし
   ★falsify 実測: ★修正を stash すると ★reject 側が ★落ちます（★accept 側は 両方 緑 ── ★正しい）
🔴 ★#4576 ── ★書きません
   ── ★「mypy 不在」を 作るには ★monkeypatch（★mock 禁止）か ★別 venv 起動（★重い・環境依存）
   ── ★`find_spec` が False を 返すことの test は ★第三者の property（★六問①が 止めます）
   ── ★「mypy 在りで True」だけの test は ★always-True 回帰を 捕まえません（★六問③＝nobody）
∴ ★書けない ことを ★書きます ── ★空の test で 緑を 作るより 正直です
```

## ⚪ ★横展開（★測って 確認済）

| gate | ★deps 無し | ★通常 venv | ★判定 |
|---|---|---|---|
| `verify_module_docstrings.py` | rc=0 同文面 | ★同一 | ✅ ★stdlib のみ ── 穴なし |
| `check_tests_path_literal_reference.py` | rc=0 同文面 | ★同一 | ✅ ★同上 |

⚪ **★CI は ★両方とも 元から 安全です** ── ★test.yml:310 が ★CHANGED を 自前計算して
★`[ -z ]` で skip、★main push 側は ★`tests/`。**★穴は ★ローカルの 事前実行だけ でした。**

## ★見つかり方

```
★#4575（tui-coder）── ★ローカル ratchet 緑、★CI 赤
★切り分け ── ★当該 .venv に ★mypy 未インストール
★実走 ── ★RouterLoopHost の 旧シグネチャ由来の ★本物の [call-arg] が 1 件
∴ ★この false-green は ★実在の 型エラーを ★1 件 通していました
```

## Test plan

- [x] `ruff check src tests scripts` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_4577_tier_audit_empty_target_set.py` — 0 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — n/a（src 変更なし）
- [x] `python scripts/mypy_ratchet.py` — 211 findings, all baselined
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/scripts/` — 790 passed
- [x] ★falsify: 修正を stash → `test_targets_resolving_to_zero_files_is_a_failure_not_a_pass` が FAILED
- [x] ★陽性対照: 通常 venv で ratchet は rc=0（211/215）、実在 test file で audit は rc=0
- [ ] Full CI run (not run locally, per policy)

⚪ **★私が 書いた PR です ∴ ★self-review に なります。**
**★co-vet を ★architect に お願いしています**（★`scripts/` は ★src でも tests でもない ∴
★architect の 役割制約に 触れません）。**★tests/ を 触っている ので ★TESTS-READ も 要ります。**

part of #4576
part of #4577
