### PR TITLE
feat(#4574): render an artifact node in the body + open it

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -44,6 +44,25 @@ class OpContext:
     permission_resolver: "PermissionResolver | None" = None
     actor: str = ""
 
+    # #4574: the live agent's NAME (the "default"/"worker"-style slug
+    # AgentRegistry keys sessions by — NOT `actor` above, a fixed per-CALLER-
+    # ROLE literal like "chat_router"/"pipeline_run_cli", and NOT `agent_id`
+    # below, the `reyn.yaml` `agent.id` / FP-0016 X-Reyn-Agent-Id host
+    # identity, an entirely different string — see `embed.py`'s own docstring
+    # on why `agent_id` is the WRONG key for a per-agent scope). Root-caused
+    # in #4574's own issue thread: `artifact_payload.build_source_artifact_
+    # payload`'s `mint_ref` call was passing `ctx.actor` ("chat_router",
+    # constant) where the artifact-ref store's OWN per-agent scope (`artifact_
+    # ref.py`'s "Scope is per-agent") needs the real agent name — the SAME
+    # name `resolve_ref` is later called with client-side (`self._agent_name`
+    # on the TUI) — so a mint always wrote under "chat_router" and a resolve
+    # always read under the real agent name: permanently orphaned refs,
+    # `/open` unconditionally "artifact not found". `None` (a router op
+    # context this field's supplier doesn't populate, e.g. the
+    # pipeline_run_cli path) is a real "unknown" — a consumer needing this
+    # falls back to something else rather than crashing on a missing name.
+    agent_name: "str | None" = None
+
     model: str = "standard"
     resolver: "ModelResolver | None" = None
     subscribers: list = field(default_factory=list)

--- a/src/reyn/core/op_runtime/present.py
+++ b/src/reyn/core/op_runtime/present.py
@@ -222,15 +222,29 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
     #    strings (resolve_bindings only bound them — it stays pure/I/O-free,
     #    see binding.py's own "artifact" branch comment) into the final
     #    OS-derived payload. This is the layer that legitimately has
-    #    project_root (ctx.workspace.base_dir) / agent_name (ctx.actor) —
+    #    project_root (ctx.workspace.base_dir) / agent_name (ctx.agent_name) —
     #    lead-coder's ruling on where this step belongs, not inside
     #    resolve_bindings or _resolve_presentation. Rewrites rendered.nodes
     #    only — the audit event above already carries refs + stats, never
     #    node content, so ordering relative to it does not matter; placed
     #    here because THIS is the only thing that needs it.
+    #
+    #    #4574 root-cause fix: this used to pass `ctx.actor` — a fixed
+    #    per-CALLER-ROLE literal ("chat_router"/"pipeline_run_cli"), never a
+    #    per-AGENT scope — into `mint_ref`'s `agent_name` parameter.
+    #    `artifact_ref.py`'s own store is documented "Scope is per-agent", and
+    #    the CLIENT-side resolve (`app.py`'s `_handle_open_artifact_request` →
+    #    `resolve_ref(project_root, self._agent_name, ref)`) always used the
+    #    real agent name — so every source-backed artifact was minted under
+    #    "chat_router" and resolved under the real agent, permanently
+    #    orphaning the ref: `/open` was `artifact not found` unconditionally.
+    #    `ctx.agent_name` falls back to `ctx.actor` only when unset (a router
+    #    op-context supplier that doesn't populate it, e.g. pipeline_run_cli)
+    #    — never crashes on a missing name, but never silently keeps the
+    #    wrong-scope value for the path this bug was actually reported on.
     from reyn.core.present.artifact_payload import apply_artifact_resolution
     rendered.nodes = apply_artifact_resolution(
-        rendered.nodes, ctx.workspace.base_dir, ctx.actor,
+        rendered.nodes, ctx.workspace.base_dir, ctx.agent_name or ctx.actor,
     )
 
     # 4. Hand the actually-rendered model to the wired surface (PR-B). Fire-and-

--- a/src/reyn/core/present/artifact_list.py
+++ b/src/reyn/core/present/artifact_list.py
@@ -45,9 +45,15 @@ from typing import Any
 class ArtifactRow:
     """One listable artifact — everything needed to DISPLAY a row and to
     OPEN it, with no further derivation. `ref` is `None` for an inline
-    (no-real-file) artifact — nothing to open with the OS, the content
-    already reached the conversation pane directly (present's own inline
-    rendering handles it, same as any other component).
+    (no-real-file) artifact — no OS file for :func:`~reyn.data.workspace.
+    artifact_ref.resolve_ref` to open the ORDINARY way.
+
+    `inline_content` (#4574 design B): a pure-inline row (`ref is None`,
+    `is_inline` True) still carries its raw text here — #4574's own fix is
+    that the CLIENT (never the agent, never an OS-side mint) materializes
+    this to a temp file + opens it on request, rather than "nothing to
+    open with the OS" being permanent. `None` for a ref-backed row (its
+    content lives at `ref`, not duplicated here) or an error row.
 
     `resolved_path` (#4482 PR-3 review, lead-coder/architect — a real
     block, not a nit): `name` alone is a BASENAME — it names WHAT the
@@ -69,6 +75,7 @@ class ArtifactRow:
     is_inline: bool
     error: "str | None" = None
     resolved_path: "str | None" = None
+    inline_content: "str | None" = None
 
 
 def _artifact_row_from_node(node: dict) -> "ArtifactRow | None":
@@ -95,13 +102,18 @@ def _artifact_row_from_node(node: dict) -> "ArtifactRow | None":
             description=description,
             is_inline=False,
         )
-    # Inline body — no real file, nothing for the OS to open.
+    # Inline body — no real file to point a ref at. #4574 design B: the raw
+    # content is carried on the row so the CLIENT can materialize+open it on
+    # request (never "nothing to open" permanently — see inline_content's
+    # own docstring above).
+    inline = body.get("inline")
     return ArtifactRow(
         ref=None,
         name=str(node.get("name") or "(inline)"),
         media_type=media_type,
         description=description,
         is_inline=True,
+        inline_content=str(inline) if isinstance(inline, str) else None,
     )
 
 

--- a/src/reyn/core/present/artifact_payload.py
+++ b/src/reyn/core/present/artifact_payload.py
@@ -21,10 +21,21 @@ issue thread)::
       media_type  : <IANA, OPTIONAL, best-effort> (None -> "application/octet-stream")
       name        : <str>  required for a source-backed artifact, absent for inline
       description : <str, optional>
-      body        : Inline | Reference
+      body        : Reference | (Reference & Inline) | Inline
     }
-    Inline    := {"inline": <str>}            # text-serialized only, never base64
     Reference := {"ref": <str>, "size": <int>}
+    Inline    := {"inline": <str>}            # text-serialized only, never base64
+
+    #4574 design C (owner GO, 2026-08-13): for a SOURCE-backed artifact, ``body``
+    ALWAYS carries a ``ref`` — never gated on the inline-probe outcome — with the
+    small-and-decodable-text ``inline`` PREVIEW added alongside it when the probe
+    succeeds, never in its place. Before #4574, a small decodable source file got
+    ``Inline`` ONLY: no ``ref`` meant no text-client renderer could show it (the
+    #4574 REPL/TUI ``artifact`` render-branch gap) AND nothing was openable via
+    the OS (the Art tab's row had ``ref=None``) — a real file the agent handed
+    over that the operator could neither see nor open. Bare ``Inline`` (no
+    ``ref``) is now reachable ONLY through :func:`build_inline_artifact_payload`
+    — agent-DECLARED content with no backing file to mint a ref FOR.
 
 **② agent-facing slots** — an agent says EITHER:
   - ``source`` + ``description`` — the OS derives ``media_type``/``name``/
@@ -117,19 +128,25 @@ def build_source_artifact_payload(
     media_type = _derive_media_type(name)
     size = resolved.stat().st_size
 
-    body: "dict | None" = None
+    # #4574 design C (owner GO): a source-backed artifact ALWAYS mints a ref
+    # — never gated on the probe outcome — with the small-and-decodable-text
+    # inline preview added ALONGSIDE it, not instead of it. Before this, a
+    # small decodable file got `{"inline": ...}` and NOTHING ELSE: no `ref`
+    # meant `_artifact_row_from_node` (artifact_list.py) built an
+    # `is_inline=True` row with `ref=None`, so the Art tab's Enter had
+    # nothing to open (#4574's own reported symptom — "gave a real file,
+    # couldn't open it"). The probe's outcome now only decides whether an
+    # inline PREVIEW is attached, never whether the file is openable.
+    ref = mint_ref(project_root, agent_name, resolved)
+    body: dict = {"ref": ref, "size": size}
     if size <= probe_max_bytes:
         probe = resolved.read_bytes()[:probe_max_bytes]
         try:
             inline_text = probe.decode("utf-8")
         except UnicodeDecodeError:
-            body = None
+            pass
         else:
-            body = {"inline": inline_text}
-
-    if body is None:
-        ref = mint_ref(project_root, agent_name, resolved)
-        body = {"ref": ref, "size": size}
+            body["inline"] = inline_text
 
     payload: dict = {"media_type": media_type, "name": name, "body": body}
     if description is not None:

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1160,6 +1160,14 @@ class TextualChatApp(App):
         # the SAME per-pane entry list (``chrome._PANE_ENTRY_BUILDERS``), so the
         # option row and its command never drift.
         self._pane_commands: "dict[str, list[str]]" = {}
+        # #4574 design B: the "artifacts" tab's own rows, cached alongside
+        # ``_pane_commands`` at the SAME refresh (``_refresh_pane``) — a
+        # pure-inline row (`ref is None`) carries no slash command at all
+        # (there is no OS ref to `/open`), so `on_option_list_option_selected`
+        # needs the row OBJECT itself (for `inline_content`/`media_type`) to
+        # materialize+open it, not just the command-string list every other
+        # pane action reads.
+        self._artifact_rows_cache: "list[ArtifactRow]" = []
         # #3288 ③c: in-flight streamed reply, keyed by ``chain_id`` — the SAME
         # authoritative correlation id ``RouterLoop._emit_agent_delta`` stamps
         # on every ``agent_delta`` audit-event AND the one the terminal
@@ -2441,8 +2449,15 @@ class TextualChatApp(App):
         upstream, in :meth:`_history_turns`."""
         snapshot = self._snapshot() if snap is _UNSET else snap
         rows = self._pane_rows(tab_id, snapshot)
+        # #4574 design B: computed ONCE and reused for both the command list
+        # AND the row cache `on_option_list_option_selected` reads for a
+        # pure-inline row's materialize+open path — `_artifact_rows()` does
+        # real I/O (one `stat()` per ref-bearing row), so a second call here
+        # would double that work for no reason.
+        artifact_rows = self._artifact_rows()
+        self._artifact_rows_cache = artifact_rows
         self._pane_commands[tab_id] = pane_commands(  # type: ignore[arg-type]
-            tab_id, snapshot, artifacts=self._artifact_rows(),
+            tab_id, snapshot, artifacts=artifact_rows,
         )
         child = self.query_one(f"#{tab_id}")
         if isinstance(child, OptionList):
@@ -2472,12 +2487,91 @@ class TextualChatApp(App):
         index can never address a different row's action. Non-actionable panes
         (History/Menu, and a category's read-only fallback listing) carry no
         command and just collapse. Then close the drawer and return focus to the
-        composer."""
+        composer.
+
+        **#4574 design B carve-out**: the "artifacts" tab's pure-inline rows
+        (`ref is None`, `is_inline` True) carry NO slash command at all —
+        there is no OS ref for `/open` to address (see :meth:`_artifact_rows`'s
+        own ``ArtifactRow`` docstring) — so the empty-command branch below
+        would silently collapse them, same as a genuinely non-actionable row.
+        Materializing raw artifact content through the SAME text-command
+        pipeline every other row uses is not viable either (arbitrary
+        multi-line/binary-ish text as a command argument), so this ONE pane's
+        rows are special-cased here, reading :attr:`_artifact_rows_cache`
+        (the SAME rows :meth:`_refresh_pane` built alongside the (mostly
+        empty, for this pane's inline rows) command list) directly rather
+        than going through `self._submit`."""
         tab_id = event.option_list.id
+        if tab_id == "artifacts":
+            rows = self._artifact_rows_cache
+            if 0 <= event.option_index < len(rows):
+                row = rows[event.option_index]
+                if row.error is None and row.ref is None and row.inline_content is not None:
+                    await self._handle_open_inline_artifact_request(row)
+                    self._open_drawer(None)
+                    return
         cmds = self._pane_commands.get(tab_id or "", [])
         if 0 <= event.option_index < len(cmds) and cmds[event.option_index]:
             await self._submit(cmds[event.option_index])
         self._open_drawer(None)
+
+    async def _handle_open_inline_artifact_request(self, row: "ArtifactRow") -> None:
+        """#4574 design B: materialize a pure-inline artifact's content to a
+        fresh OS-temp file and open it with the OS default app — the CLIENT
+        doing this, never the agent (which may hold no write permission at
+        all — a read-only session's only output route for rich content IS
+        inline `present`, per the issue's own owner ruling) and never an
+        OS-side mint into the `.reyn` artifact-ref store (this content has
+        no backing project file for a ref to even point at).
+
+        Owner ruling (#4574, verbatim: "/tmp ファイルにすれば良いのでは"):
+        the temp file's retention is the OS's own — reyn does NOT track or
+        clean it up (a FOURTH retention axis reyn would then own, which the
+        owner explicitly declined). Never `delete=True`: the OS opener is a
+        SEPARATE process launched asynchronously (`open_with_os_default`'s
+        own `subprocess.Popen`/`os.startfile`) — a delete-on-close temp file
+        can vanish before that process even gets to read it.
+
+        `media_type` -> extension: architect's #4574 review, verbatim —
+        "the extension is treated as the real permission surface" (`present.
+        md:79`), so a media_type this process cannot map to a real extension
+        does NOT fall back to opening WITHOUT one (an extension-less file
+        resolves to no OS handler on any platform, or worse, an arbitrary
+        one) — it reports a status line instead. The content is not lost:
+        it already rendered in the conversation body (#4574's own fallback
+        render, `present_renderer._render_artifact`)."""
+        import mimetypes
+        import tempfile
+
+        from reyn.interfaces.repl._open_with_os_default import open_with_os_default
+        from reyn.runtime.outbox import OutboxMessage
+
+        ext = mimetypes.guess_extension(row.media_type or "") if row.media_type else None
+        if not ext:
+            self._ingest_frame(OutboxMessage(
+                kind="status",
+                text=(
+                    f"cannot open {row.name!r} — unknown extension for media_type "
+                    f"{row.media_type!r} (content is shown above in the conversation)"
+                ),
+            ))
+            return
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=ext, delete=False, encoding="utf-8",
+            ) as fh:
+                fh.write(row.inline_content or "")
+                temp_path = fh.name
+        except OSError as exc:
+            self._ingest_frame(OutboxMessage(
+                kind="status", text=f"could not write a temp file for {row.name!r}: {exc}",
+            ))
+            return
+        ok = open_with_os_default(temp_path)
+        if not ok:
+            self._ingest_frame(OutboxMessage(
+                kind="status", text=f"could not open {row.name} — no OS opener available",
+            ))
 
     def action_jump_to_latest(self) -> None:
         """Return to the newest output and resume following it (#3712)."""

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -30,7 +30,10 @@ Phase 4 wires every pane to its CANONICAL reyn source (no placeholders):
   resident buffer — see :meth:`TextualChatApp._artifact_rows`'s own docstring
   for why the two are not interchangeable). Each openable row carries an
   ``/open <ref>`` command (:func:`pane_commands`) that launches the OS's own
-  default app on the resolved path.
+  default app on the resolved path. A pure-inline row (no backing file, no
+  ref) instead opens via #4574 design B's own materialize-to-OS-temp route
+  — see :func:`artifact_pane_commands`'s own docstring for why that is NOT
+  expressed as a slash command the way the ref-backed case is.
 - **Cost / Ctx** — the live token/cost + context-window figures from the same
   status snapshot the plain path's status bar reads. Cost is the 5-row ×
   3-scope breakdown table (:func:`_cost_breakdown_table`) plus the cumulative
@@ -934,6 +937,16 @@ def artifact_row_label(row: "ArtifactRow") -> str:
     if row.error is not None:
         return f"✗ {row.name or '(unresolved)'} — {row.error}"
     if row.is_inline:
+        # #4574: the content genuinely IS shown above now (the fallback
+        # `artifact` render branch, `present_renderer._render_artifact`) —
+        # this label used to be written before that branch existed, which
+        # made it false (nothing was shown). A row with content also gets a
+        # materialize+open route (design B, `app._handle_open_inline_
+        # artifact_request`) — mentioned here so the label states what
+        # Enter does, matching a ref-backed row's own convention (the label
+        # names the same thing the open action reaches).
+        if row.inline_content is not None:
+            return f"{row.name} (inline — shown above; Enter opens a copy)"
         return f"{row.name} (inline — already shown above)"
     return row.resolved_path or row.name
 
@@ -946,10 +959,17 @@ def artifact_pane_options(rows: "Sequence[ArtifactRow]") -> list[str]:
 
 def artifact_pane_commands(rows: "Sequence[ArtifactRow]") -> list[str]:
     """The ``/open <ref>`` command parallel to each row in
-    :func:`artifact_pane_options` — empty string (non-actionable, same as
-    History/Menu) for a row with nothing to open: an inline artifact (no
-    real file — the content already reached the conversation pane
-    directly) or an error marker (nothing resolved)."""
+    :func:`artifact_pane_options` — empty string for a ref-less row: an
+    error marker (nothing resolved), or a pure-inline artifact.
+
+    An inline row's empty string here does NOT mean non-actionable
+    (unlike History/Menu, which really have nothing to do) — #4574 design
+    B gave it a materialize+open route, but raw multi-line/binary-ish
+    artifact content cannot safely ride through this module's plain
+    slash-command TEXT pipeline as an argument the way a `ref` token can.
+    ``app.on_option_list_option_selected`` special-cases the "artifacts"
+    pane and reads the ``ArtifactRow`` objects directly (never this
+    command list) for exactly that row shape — see its own docstring."""
     return [
         f"/open {r.ref}" if r.ref is not None else ""
         for r in rows

--- a/src/reyn/interfaces/repl/present_renderer.py
+++ b/src/reyn/interfaces/repl/present_renderer.py
@@ -166,6 +166,67 @@ def _render_list(node: dict) -> "Any":
     return Group(*items)
 
 
+# #4574: an artifact's inline body has NO upstream cap (binding.py's own
+# "artifact" branch comment: the OS-derivation pass that fills `body` runs
+# AFTER resolve_bindings, so `guard.cap_leaf`'s pre-render capping — the
+# thing `_render_code_or_diff` above relies on — never sees it). This is the
+# render layer's own bound instead, matching architect's #4574 fallback spec
+# verbatim ("先頭 N 行" — the first N lines, never the whole file): a small
+# HTML/text file inlined via the size probe (`INLINE_PROBE_MAX_BYTES`,
+# artifact_payload.py) can still run to hundreds of lines, and this is a
+# PREVIEW alongside the real `body["ref"]` (#4574 design C) — the truncation
+# discards nothing that isn't ALSO fully openable via that ref.
+_ARTIFACT_INLINE_PREVIEW_LINES = 20
+
+
+def _render_artifact(node: dict) -> "Any":
+    """#4574: an ``artifact`` node — an LLM-produced file the terminal can't
+    render natively (see ``core/present/catalog.py``'s own "artifact"
+    section). Before this, EVERY artifact node fell through to
+    ``_render_node``'s unregistered-component fallback
+    (``<unsupported present component 'artifact'>``) regardless of source
+    or inline, on every text client (REPL + this TUI's own body renderer,
+    which calls this same module — ``presenter.py``'s ``_render_row``).
+
+    This is a FALLBACK, not a real HTML/office/pdf renderer (out of scope —
+    the terminal genuinely cannot render those) — it shows what the #4574
+    design calls for: name/media_type/description, plus (when the resolved
+    payload carries an inline preview — design C mints a ``ref`` alongside
+    it for small source-backed files, so this is a PREVIEW, not the only
+    way to see the content) the first ``_ARTIFACT_INLINE_PREVIEW_LINES``
+    lines. A row with an ``error`` (e.g. ``source_not_found`` — the source
+    file vanished between present-time and render-time) or nothing resolved
+    yet (a soft binding-miss, present's own philosophy) shows that instead
+    of guessing at a body."""
+    from rich.console import Group
+    from rich.text import Text
+
+    if "error" in node:
+        return Text(f"[artifact: {node['error']}]", style="dim")
+    body = node.get("body")
+    if not isinstance(body, dict):
+        return Text("[artifact: nothing resolved]", style="dim")
+    name = node.get("name")
+    media_type = node.get("media_type") or "unknown type"
+    header = f"📎 {name}" if name else "📎 artifact"
+    header += f" ({media_type})"
+    lines: "list[Any]" = [Text(header, style="bold")]
+    description = node.get("description")
+    if description:
+        lines.append(Text(str(description), style="dim"))
+    inline = body.get("inline")
+    if isinstance(inline, str):
+        preview_lines = inline.splitlines()
+        truncated = len(preview_lines) > _ARTIFACT_INLINE_PREVIEW_LINES
+        preview = "\n".join(preview_lines[:_ARTIFACT_INLINE_PREVIEW_LINES])
+        lines.append(Text(preview))
+        if truncated:
+            lines.append(Text("[preview truncated]", style="dim"))
+    if "ref" in body:
+        lines.append(Text("[open via the Artifacts tab]", style="dim"))
+    return Group(*lines)
+
+
 def _render_code_or_diff(node: dict, *, lexer: str) -> "Any":
     from rich.syntax import Syntax
 
@@ -201,6 +262,8 @@ def _render_node(
         return _render_list(node)
     if component == "image":
         return _render_image(node, image_cache, decoded_image_cache)
+    if component == "artifact":
+        return _render_artifact(node)
     # Unregistered/future component — never crash the render loop over one bad node.
     return Text(f"<unsupported present component {component!r}>", style="dim")
 

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -56,6 +56,7 @@ def build_router_op_context(
     sandbox_policy: Any,  # raw policy → resolve_sandbox_policy here (#1339)
     # ── fields the single supplier resolves per call ───────────────────────
     agent_id: str | None,  # FP-0016 identity → the MCP client's X-Reyn-Agent-Id header
+    agent_name: str | None = None,  # #4574: the live agent's NAME — see OpContext.agent_name's own docstring for why this is a DIFFERENT value from agent_id above
     intervention_bus: Any = None,  # the surface that answers a router op's intervention
     presentation_renderer: Any,  # #2708 P1: REQUIRED (no default) — the present sink must be an EXPLICIT decision (a PresentationRenderer or None), never a silent omission.
     presentation_registry: Any = None,  # FP-0054 PR-C: operator named-template registry (hot-reloadable)
@@ -153,6 +154,7 @@ def build_router_op_context(
         permission_decl=decl,
         permission_resolver=permission_resolver,
         actor="chat_router",
+        agent_name=agent_name,
         mcp_servers=mcp_servers_flat,
         run_id=run_id,
         agent_id=agent_id,
@@ -239,6 +241,7 @@ class RouterOpContextSource:
         sandbox_backend: Any,
         sandbox_policy_fn: Any,
         agent_id: Any,
+        agent_name: Any,  # #4574: the live agent's NAME — see OpContext.agent_name's own docstring
         intervention_bus_factory: Any,
         presentation_renderer_factory: Any,
         presentation_registry_fn: Any,
@@ -272,6 +275,7 @@ class RouterOpContextSource:
         self._sandbox_backend = sandbox_backend
         self._sandbox_policy_fn = sandbox_policy_fn
         self._agent_id = agent_id
+        self._agent_name = agent_name
         self._intervention_bus_factory = intervention_bus_factory
         self._presentation_renderer_factory = presentation_renderer_factory
         self._presentation_registry_fn = presentation_registry_fn
@@ -338,6 +342,7 @@ class RouterOpContextSource:
             sandbox_backend=self._sandbox_backend,
             sandbox_policy=self._resolve(self._sandbox_policy_fn),
             agent_id=self._agent_id,
+            agent_name=self._agent_name,
             intervention_bus=self._resolve(self._intervention_bus_factory),
             presentation_renderer=self._resolve(self._presentation_renderer_factory),
             presentation_registry=self._resolve(self._presentation_registry_fn),

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4250,6 +4250,9 @@ class Session:
             ),
             # FP-0016: this agent's identity → the MCP client's X-Reyn-Agent-Id.
             agent_id=self._agent.agent_id,
+            # #4574: the live agent's NAME — a DIFFERENT string from agent_id
+            # above (see OpContext.agent_name's own docstring).
+            agent_name=self._agent.agent_name,
             # FP-0022 fix (#53) / #3049: bridge-aware — resolved per call so an
             # attached pipeline driver's op reaches the ORIGINATOR's operator.
             intervention_bus_factory=self._make_router_intervention_bus,

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -37,6 +37,7 @@ _INERT_OP_CONTEXT_SOURCE_FIELDS: dict = {
     "sandbox_backend": None,
     "sandbox_policy_fn": None,
     "agent_id": None,
+    "agent_name": None,  # #4574
     "intervention_bus_factory": None,
     "presentation_renderer_factory": None,
     "presentation_registry_fn": None,
@@ -183,6 +184,7 @@ def make_adapter(
             (lambda: workspace_base_dir) if workspace_base_dir is not None else None
         ),
         session_id_fn=(lambda: session_id) if session_id is not None else None,
+        agent_name=agent_name,  # #4574: mirrors the real Session's own wiring
     )
     mcp_gateway_inputs = McpGatewayInputs(
         mcp_connection_service=None,

--- a/tests/core/test_4482_pr2_artifact_payload.py
+++ b/tests/core/test_4482_pr2_artifact_payload.py
@@ -26,14 +26,19 @@ def _write(path: Path, content: bytes) -> Path:
 # ── build_source_artifact_payload ───────────────────────────────────────
 
 
-def test_small_utf8_text_file_is_inlined(tmp_path: Path):
-    """Tier 2: invariant 3 — a small, UTF-8-decodable file inlines its
-    text directly, no ref minted."""
+def test_small_utf8_text_file_is_inlined_alongside_a_ref(tmp_path: Path):
+    """Tier 2: invariant 3 (as of #4574 design C) — a small, UTF-8-decodable
+    file gets an inline PREVIEW *alongside* a minted ref, never inline-only.
+    #4574's own reported symptom was exactly the pre-fix shape this guards
+    against: inline-only meant no `ref`, so the Art tab had nothing to open
+    for a source-backed file the agent handed over."""
     target = _write(tmp_path / "notes.txt", "hello, world\n".encode("utf-8"))
 
     payload = build_source_artifact_payload(tmp_path, "alice", target)
 
-    assert payload["body"] == {"inline": "hello, world\n"}
+    assert payload["body"]["inline"] == "hello, world\n"
+    assert "ref" in payload["body"]
+    assert payload["body"]["size"] == target.stat().st_size
     assert payload["name"] == "notes.txt"
 
 

--- a/tests/core/test_4482_pr2b_artifact_wiring.py
+++ b/tests/core/test_4482_pr2b_artifact_wiring.py
@@ -271,4 +271,7 @@ def test_handle_end_to_end_reaches_the_renderer_with_the_built_payload(tmp_path:
     assert node["component"] == "artifact"
     assert node["media_type"] == "text/html"
     assert node["name"] == "report.html"
-    assert node["body"] == {"inline": "<h1>hi</h1>"}
+    # #4574 design C: a source-backed artifact's body always carries a ref
+    # (the Art tab's openable route) alongside the small-file inline preview.
+    assert node["body"]["inline"] == "<h1>hi</h1>"
+    assert "ref" in node["body"]

--- a/tests/core/test_4574_artifact_ref_scope_mismatch.py
+++ b/tests/core/test_4574_artifact_ref_scope_mismatch.py
@@ -1,0 +1,137 @@
+"""Tier 2: #4574 — the artifact-ref MINT/RESOLVE scope mismatch.
+
+Root cause (architect's #4574 issue-thread diagnosis, confirmed by reading
+``.reyn/cache/artifact_refs.jsonl`` directly): ``op_runtime/present.py``'s
+``handle()`` minted a source-backed artifact's ref under ``ctx.actor`` — a
+FIXED per-caller-ROLE literal (``"chat_router"``), never a per-agent
+scope — while the TUI's ``_handle_open_artifact_request`` always resolved
+it under the real agent NAME (``self._agent_name``, e.g. ``"default"``).
+``artifact_ref.py``'s own store is documented "Scope is per-agent" — minting
+under one string and resolving under a DIFFERENT one means the ref can
+never be found: ``/open`` was ``artifact not found`` unconditionally, for
+every source-backed artifact, on every session.
+
+This is the acceptance shape architect asked for explicitly: "test が mint
+側と resolve 側で異なる値を渡す経路を通ること" — a prior version of this
+class of test could pass vacuously by using the SAME value (e.g. a shared
+``tmp_path``/default-agent/``chdir`` fixture) on both sides, which cannot
+distinguish "scoped correctly" from "scoped consistently by accident". This
+file deliberately uses a caller `actor` DIFFERENT from the live agent's
+`agent_name` throughout, and reads back the ACTUAL ref `handle()` minted
+(via a real recording ``PresentationRenderer``, never re-derived
+independently) — resolving anything OTHER than that captured ref would not
+witness this call site's own behavior.
+
+Real ``OpContext``/``Workspace``/``PermissionResolver`` construction
+throughout (mirrors ``test_4482_pr2b_artifact_wiring.py``'s own policy) —
+no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.present import handle
+from reyn.data.workspace.artifact_ref import resolve_ref
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import PresentIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+# Deliberately NOT the same string — the whole point of this file's own
+# scoping (see module docstring).
+_CALLER_ACTOR = "chat_router"
+_LIVE_AGENT_NAME = "default"
+
+
+class _RecordingRenderer:
+    """Real callable standing in for a wired PresentationRenderer — records
+    what actually reached the render surface, matching
+    ``test_4482_pr2b_artifact_wiring.py``'s own established pattern."""
+
+    surface_name = "inline-cui"
+
+    def __init__(self) -> None:
+        self.rendered: list = []
+
+    def render(self, resolved) -> None:
+        self.rendered.append(resolved)
+
+
+def _ctx(tmp_path: Path, renderer: "_RecordingRenderer") -> "tuple[OpContext, EventLog]":
+    events = EventLog()
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False)
+    ws = Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path)
+    ctx = OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=resolver, actor=_CALLER_ACTOR,
+        agent_name=_LIVE_AGENT_NAME, intervention_bus=None,
+        presentation_renderer=renderer,
+    )
+    return ctx, events
+
+
+async def _present_and_capture_ref(tmp_path: Path, target: Path) -> str:
+    """Drive the REAL ``op_runtime.present.handle()`` end-to-end and return
+    the ``ref`` it ACTUALLY minted (read off the rendered node, never
+    re-derived by calling ``mint_ref`` a second time — that would witness
+    ``mint_ref``'s own idempotency, not this call site's argument choice)."""
+    renderer = _RecordingRenderer()
+    ctx, _events = _ctx(tmp_path, renderer)
+    op = PresentIROp(
+        kind="present", data_inline={},
+        blueprint={"component": "artifact", "source": str(target)},
+    )
+    ack = await handle(op, ctx)
+    assert ack.get("ok"), ack
+    (resolved,) = renderer.rendered
+    node = resolved.nodes[0]
+    assert node["component"] == "artifact"
+    ref = node["body"]["ref"]
+    assert isinstance(ref, str) and ref
+    return ref
+
+
+@pytest.mark.asyncio
+async def test_a_source_backed_artifacts_ref_resolves_under_the_agent_name_it_was_minted_under(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the accept-path — present() an artifact from an OpContext
+    whose `actor` and `agent_name` DIFFER, capture the ACTUAL ref `handle()`
+    minted, then resolve it under the agent name — the SAME
+    (project_root, agent_name, ref) shape `app.py`'s
+    `_handle_open_artifact_request` calls in production. A regression to
+    `ctx.actor` for the mint would make this resolve to `None` (the exact
+    "artifact not found" symptom #4574 reported)."""
+    target = tmp_path / "report.html"
+    target.write_bytes(b"<h1>hi</h1>")
+
+    ref = await _present_and_capture_ref(tmp_path, target)
+
+    resolved = resolve_ref(tmp_path, _LIVE_AGENT_NAME, ref)
+    assert resolved == target.resolve()
+
+
+@pytest.mark.asyncio
+async def test_falsify_resolving_the_captured_ref_under_the_callers_actor_finds_nothing(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: LOAD-BEARING falsification — resolving the SAME captured ref
+    under `actor` (the pre-#4574 bug's own value, `"chat_router"`) finds
+    nothing. Together with the accept-path test above, this proves the ref
+    genuinely lives under the agent-name scope and NOT under actor —
+    the two tests can only BOTH pass if the mint call site really does use
+    `agent_name`; a regression back to `ctx.actor` flips which of the two
+    resolves, it does not make both pass or both fail."""
+    target = tmp_path / "report.html"
+    target.write_bytes(b"<h1>hi</h1>")
+    assert _CALLER_ACTOR != _LIVE_AGENT_NAME, (
+        "test setup: actor and agent_name must differ, or this file's own "
+        "scoping proves nothing"
+    )
+
+    ref = await _present_and_capture_ref(tmp_path, target)
+
+    assert resolve_ref(tmp_path, _CALLER_ACTOR, ref) is None

--- a/tests/core/test_artifact_list_4482.py
+++ b/tests/core/test_artifact_list_4482.py
@@ -47,6 +47,26 @@ def test_collects_a_reference_backed_artifact():
     )]
 
 
+def test_a_ref_carrying_inline_preview_is_still_treated_as_openable():
+    """Tier 1: #4574 design C — a small source-backed file's body carries
+    BOTH `ref` AND an `inline` preview (never inline-ONLY, as of #4574).
+    This must still resolve to an openable (`is_inline=False`) row, not a
+    `(inline — already shown above)` one — the exact label-truthfulness
+    fix #4574 required: before it, a small source-backed file got
+    `is_inline=True` with NO ref, so the Art tab's row both lied about
+    "already shown above" (nothing was shown — the body renderer had no
+    `artifact` branch at all) AND had nothing to open."""
+    node = {
+        "component": "artifact", "media_type": "text/html", "name": "report.html",
+        "body": {"ref": "abc123", "size": 20, "inline": "<h1>hi</h1>"},
+    }
+    rows = collect_artifact_rows([[node]])
+    assert rows == [ArtifactRow(
+        ref="abc123", name="report.html", media_type="text/html",
+        description=None, is_inline=False,
+    )]
+
+
 def test_inline_artifact_has_no_ref_and_is_marked_inline():
     """Tier 1: an inline (no-real-file) artifact has nothing for the OS to
     open — ref is None, is_inline is True, distinguishable from a

--- a/tests/core/test_present_renderer_fp0054_prb.py
+++ b/tests/core/test_present_renderer_fp0054_prb.py
@@ -91,6 +91,58 @@ def test_unsupported_component_does_not_crash_the_render_loop() -> None:
     assert "not-a-real-component" in out
 
 
+# ── 1c. #4574 — the artifact fallback render (was: always "unsupported") ────
+
+
+def test_artifact_node_no_longer_renders_as_unsupported() -> None:
+    """Tier 2: #4574's own reported symptom, directly — an `artifact` node
+    used to fall through to the SAME unregistered-component fallback as a
+    typo'd component name (this file's test right above), on every text
+    client (REPL + this TUI's own body renderer, which calls this exact
+    function). It must now render something ELSE."""
+    node = {
+        "component": "artifact", "media_type": "text/html", "name": "report.html",
+        "body": {"ref": "abc123", "size": 20, "inline": "<h1>hi</h1>"},
+    }
+    out = _render_to_text([node])
+    assert "unsupported present component" not in out
+    assert "report.html" in out
+    assert "<h1>hi</h1>" in out
+
+
+def test_artifact_inline_preview_is_capped_at_a_bounded_line_count() -> None:
+    """Tier 2: an artifact's inline body has NO upstream cap (unlike code/diff,
+    which `guard.cap_leaf` truncates before this renderer ever sees them —
+    see `_render_code_or_diff`'s own comment) — this render layer bounds it
+    itself, per architect's #4574 fallback spec ("先頭 N 行"). A giant inline
+    preview must not reach the terminal whole."""
+    huge = "\n".join(f"line-{i}" for i in range(500))
+    node = {
+        "component": "artifact", "media_type": "text/plain", "name": "big.txt",
+        "body": {"ref": "abc123", "size": len(huge), "inline": huge},
+    }
+    out = _render_to_text([node], width=200)
+    assert "line-0" in out
+    assert "line-499" not in out
+    assert "[preview truncated]" in out
+
+
+def test_artifact_error_marker_renders_the_error_not_a_crash() -> None:
+    """Tier 2: a `source_not_found` error marker (the source file vanished
+    between present-time and render-time — `apply_artifact_resolution`'s own
+    documented shape) renders the error, never raises."""
+    out = _render_to_text([{"component": "artifact", "error": "source_not_found"}])
+    assert "source_not_found" in out
+
+
+def test_artifact_soft_binding_miss_renders_without_a_body() -> None:
+    """Tier 2: a bare `{"component": "artifact"}` (present's own soft-skip
+    philosophy — nothing resolved yet) renders a placeholder, not a crash on
+    a missing `body`/`name`/`media_type`."""
+    out = _render_to_text([{"component": "artifact"}])
+    assert "nothing resolved" in out
+
+
 # ── 1b. #3846 ③ — image_cache real-pixel rendering ───────────────────────────
 
 

--- a/tests/interfaces/test_artifact_list_and_open_4482.py
+++ b/tests/interfaces/test_artifact_list_and_open_4482.py
@@ -12,8 +12,10 @@ import os
 import stat
 import sys
 import time
+from pathlib import Path
 
 import pytest
+from textual.widgets import OptionList
 from textual_flowview import FlowView
 
 from reyn.data.workspace.artifact_ref import mint_ref
@@ -183,3 +185,108 @@ async def test_open_artifact_with_an_unresolvable_ref_reports_not_found(tmp_path
 
         entry = list(app.query_one(FlowView).entries)[-1]
         assert "not found" in entry.item.text
+
+
+# ── #4574 design B: pure-inline artifacts (no source file, no ref) ──────────
+
+
+def _inline_presentation_frame(*, name: str, content: str, media_type: str) -> OutboxMessage:
+    return OutboxMessage(
+        kind="presentation",
+        text="",
+        meta={"nodes": [{
+            "component": "artifact",
+            "media_type": media_type,
+            "name": name,
+            "body": {"inline": content},
+        }]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_inline_artifact_materializes_to_a_temp_file_and_launches_the_opener(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #4574 design B end-to-end — a pure-inline artifact (no
+    `source`, no ref — the agent-declared-content shape, the ONLY output
+    route a read-only session has) is materialized to a fresh OS-temp file
+    with a real ``.html`` extension (derived from ``media_type``) and
+    opened, driven through the SAME production path a real Enter keypress
+    on the Artifacts pane row takes
+    (``on_option_list_option_selected`` -> ``_handle_open_inline_artifact_
+    request``), not called directly — proves the pane-selection wiring
+    reaches it, not just the handler in isolation."""
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    opener_name = "open" if sys.platform == "darwin" else "xdg-open"
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    sink = tmp_path / "opened.txt"
+    script = bindir / opener_name
+    script.write_text(f"#!/bin/sh\necho \"$1\" > {sink}\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", str(bindir) + os.pathsep + os.environ["PATH"])
+
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_inline_presentation_frame(
+            name="report.html", content="<h1>agent-authored</h1>", media_type="text/html",
+        ))
+        await pilot.pause()
+        app._open_drawer("artifacts")
+        await pilot.pause()
+
+        row = app._artifact_rows_cache[0]
+        assert row.ref is None and row.is_inline is True  # test premise
+        artifacts_pane = app.query_one("#artifacts", OptionList)
+        event = OptionList.OptionSelected(
+            artifacts_pane, artifacts_pane.get_option_at_index(0), 0,
+        )
+        await app.on_option_list_option_selected(event)
+        await pilot.pause()
+
+        while not sink.exists():  # unbounded — CI's own timeout is the backstop
+            time.sleep(0.05)
+        opened_path = sink.read_text().strip()
+        assert opened_path.endswith(".html"), opened_path
+        assert Path(opened_path).read_text(encoding="utf-8") == "<h1>agent-authored</h1>"
+
+
+@pytest.mark.asyncio
+async def test_inline_artifact_with_no_mappable_extension_reports_status_never_opens(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: a `media_type` this process cannot map to a real extension
+    does NOT open extension-less (architect's #4574 review: "the extension
+    is the real permission surface") — it reports a status line, and no
+    opener is ever launched (the content already reached the conversation
+    body via the fallback render, so nothing is silently lost)."""
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    sink = tmp_path / "opened.txt"
+    opener_name = "open" if sys.platform == "darwin" else "xdg-open"
+    script = bindir / opener_name
+    script.write_text(f"#!/bin/sh\necho \"$1\" > {sink}\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", str(bindir) + os.pathsep + os.environ["PATH"])
+
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_inline_presentation_frame(
+            name="mystery", content="opaque bytes as text",
+            media_type="application/x-reyn-nonexistent-type",
+        ))
+        await pilot.pause()
+
+        row = app._artifact_rows()[0]
+        await app._handle_open_inline_artifact_request(row)
+        await pilot.pause()
+
+        assert not sink.exists(), "no opener should launch for an unmappable media_type"
+        entry = list(app.query_one(FlowView).entries)[-1]
+        assert "extension" in entry.item.text


### PR DESCRIPTION
**[tui-coder]** — part of #4574.

## What

Implements architect's #4574 design in the sequence lead-coder assigned
(A → C → body-render → B):

- **A / body-render**: `present_renderer._render_node` had NO branch for the
  `artifact` component — every artifact fell through to the unregistered-
  component fallback (`<unsupported present component 'artifact'>`), on
  BOTH the REPL and this TUI (`presenter.py` calls the exact same function).
  Adds a real fallback render: name/media_type/description, and — when the
  payload carries an inline preview — the first `_ARTIFACT_INLINE_PREVIEW_LINES`
  lines of it, bounded (an artifact's inline body has no upstream cap the
  way code/diff get from `guard.cap_leaf`).
- **C**: `build_source_artifact_payload` used to choose EITHER an inline
  body OR a minted ref, based on the probe outcome — never both. A small,
  decodable source file got inline-only, so no ref existed for the Art tab
  to open (#4574's reported symptom — "gave a real file, couldn't open
  it"). Now a source-backed artifact's body ALWAYS carries a ref, with the
  inline preview added alongside it when the probe succeeds. This also
  makes the Art tab's `(inline — already shown above)` label true for
  small source-backed files (it now says "shown above" only when content
  actually IS shown above, post the body-render fix).
- **B**: a pure-inline artifact (agent-declared `content`, no backing
  file — the ONLY output route a read-only session has, per the owner's
  ruling on #4574) still has no ref for the OS to open. The CLIENT (never
  the agent, never an OS-side mint) now materializes it to a fresh OS-temp
  file (extension derived from `media_type` via stdlib `mimetypes`;
  refuses to open extension-less rather than guess — architect: "the
  extension is the real permission surface") and launches the OS default
  app. `on_option_list_option_selected` special-cases the Artifacts pane's
  pure-inline rows, since raw content can't safely ride a slash-command
  text argument the way a `ref` token does. Never `delete=True` (the
  opener is a separate async process) and no reyn-side retention tracking
  — owner's own ruling, verbatim: "/tmp ファイルにすれば良いのでは" — a
  fourth retention axis was explicitly declined.

## A separate root cause found + fixed along the way

While verifying C actually makes `/open` work, I found `op_runtime/
present.py`'s artifact mint call passed `ctx.actor` (a fixed per-CALLER-
ROLE literal, `"chat_router"`) into `mint_ref`'s per-AGENT scope parameter,
while the TUI's own resolve always used the real agent name — permanently
orphaning every minted ref regardless of C. Neither `ctx.actor` nor the
existing `ctx.agent_id` (a DIFFERENT thing — the `reyn.yaml` `agent.id`/
FP-0016 host identity, per `embed.py`'s own docstring on why THAT is also
the wrong key for a per-agent scope) was correct, so this adds a genuine
`OpContext.agent_name` field, threaded through `RouterOpContextSource`/
`build_router_op_context` from `Session._agent.agent_name`, and switches
the mint call site to it (falling back to `ctx.actor` only when unset,
e.g. a router op-context supplier that doesn't populate it — the
`pipeline_run_cli` path, out of scope for this issue's own witness).

## Witness / falsification

- `test_4574_artifact_ref_scope_mismatch.py` (new): drives the real
  end-to-end mint via a REAL recording `PresentationRenderer`, with
  `actor` and `agent_name` deliberately DIFFERENT strings throughout —
  the accept-path resolves the CAPTURED ref (never re-derived
  independently) under `agent_name`; the falsify resolves the SAME ref
  under `actor` and gets nothing. Together they prove the scope genuinely
  moved, not just widened.
- `test_present_renderer_fp0054_prb.py`: 4 new tests — the "unsupported"
  string is gone for an artifact node, the inline preview is bounded, the
  error-marker and soft-binding-miss shapes both render without crashing.
- `test_artifact_list_4482.py`: a new test pins that a body carrying BOTH
  `ref` and `inline` (design C's shape) is still treated as openable
  (`is_inline=False`) — the direct regression guard for the label fix.
- `test_artifact_list_and_open_4482.py`: 2 new end-to-end tests for the
  materialize+open path, driven through the REAL Enter-selection wiring
  (`on_option_list_option_selected`), not the handler called in isolation
  — plus the no-mappable-extension refusal case (status line, no opener
  launched).
- `test_4482_pr2_artifact_payload.py` / `test_4482_pr2b_artifact_wiring.py`:
  updated for the new "ref always present" body shape.

## Test plan

- [x] `ruff check src <changed test files>` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 83/83 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — 211 findings, all baselined (215 declared)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Scoped `pytest tests/core -k "present or artifact" tests/interfaces -k "chrome or textual_chat or artifact"` — 307 passed
- [x] Scoped `pytest tests/runtime -k "session and not test_router_loop"` — 247 passed (session.py/router_op_context.py plumbing regression check)
- [ ] Full CI run (not run locally, per policy)
- [ ] Manual/Visual: a real conversation presenting a source-backed HTML artifact shows content in the body AND opens via the Art tab's Enter (per the standing Visual-gate waiver, owner confirms post-merge on `main`)

Enumerated `part of #4574` mentions before writing this body: this is the
only open PR against #4574; no other PR claims it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
