### PR TITLE
feat(#4496): PR-2 — audit-event write-side backend abstraction (local/discard)

### DIFF
--- a/docs/concepts/runtime/events.md
+++ b/docs/concepts/runtime/events.md
@@ -85,6 +85,31 @@ production overhead zero.
 
 Stable shape makes the log machine-readable without a custom parser per consumer.
 
+## Write-side backend (#4496)
+
+Where an audit-event lands on disk (or doesn't) is a separate axis from
+whether it fires and reaches subscribers. `EventLog.emit()` always: stamps
+`agent_id`/`run_id`/`emitter`/`audit_seq`, dispatches to every subscriber
+(console reporters, the TUI/AG-UI forwarders, hooks, OTEL), and returns —
+regardless of the write-side backend `reyn.yaml`'s `audit_events.backend`
+selects (see [config reference](../../reference/config/reyn-yaml.md#audit_events-block)):
+
+- **`local`** (default) — writes to `.reyn/events`, unchanged from before
+  this abstraction existed.
+- **`discard`** (sink-null) — writes nothing. Subscriber delivery and
+  `audit_seq` continuity are unaffected; only the disk write is skipped.
+  `reyn events replay` / support-bundle / dogfood_trace have nothing to
+  read for a `discard` run — this is a real trade-off (support-bundle in
+  particular is the tool operators use to report bugs), not a free lunch.
+
+The backend is called from inside `emit()`, before the subscriber loop
+runs, wrapped in its own try/except — never inserted as just another
+subscriber. That ordering is what guarantees a backend failure (or a
+future network backend's connection error) can never silence a
+subscriber, and a raising subscriber can never stop the backend from
+having already written. See `src/reyn/core/events/backend.py`'s module
+docstring for the full mechanism.
+
 ## What audit-events are NOT
 
 - **Not application logs.** A workflow author shouldn't emit free-form audit-events. The set is OS-defined.

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -2070,6 +2070,7 @@ audit_events:
   max_age_seconds: 86400           # rotate after 1 day (default)
   cleanup_period_days: 30          # auto-delete files older than 30 days (default)
   max_disk_usage_percent: 10       # auto-delete oldest files past 10% of free space (default)
+  backend: local                   # where events are written (default)
 ```
 
 | Field | Type | Default | Description |
@@ -2078,8 +2079,9 @@ audit_events:
 | `max_age_seconds` | int | `86400` (1 day) | Rotate the active event file when it exceeds this age in seconds. `0` = no age-based rotation. |
 | `cleanup_period_days` | int | `30` | Automatic-purge age axis (#4479) — files whose filename date is older than this many days are deleted. `0` disables this axis. |
 | `max_disk_usage_percent` | float | `10` | Automatic-purge size axis (#4479) — once the events directory's own total size exceeds this percent of the filesystem's current FREE space, oldest files are deleted until back under. `0` disables this axis. |
+| `backend` | string | `local` | **#4496 — where audit-events are WRITTEN.** `local` (default) preserves current behavior — events land under `.reyn/events` exactly as before this field existed. `discard` (sink-null) writes nothing to disk; subscriber delivery (the TUI/AG-UI forwarders, hooks, OTEL) and the per-emitter `audit_seq` continuity (#4496 PR-1) are UNCHANGED either way — see [Concepts: events](../../concepts/runtime/events.md#write-side-backend-4496) for the structural guarantee. **`discard` means `reyn events replay` / support-bundle / dogfood_trace have nothing to read for this run — in particular, support-bundle is the tool operators use to report bugs, so this trades that away.** `network` is not yet a valid value (an unrecognized string, `network` included, falls back to `local`) — its on-failure semantics are an open design question tracked in #4496. |
 
-Setting both `max_bytes` and `max_age_seconds` to `0` disables rotation entirely.
+Setting both `max_bytes` and `max_age_seconds` to `0` disables rotation entirely. `backend: discard` makes both rotation fields moot (nothing is ever written to rotate).
 
 ### Automatic purge (#4479)
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -519,12 +519,22 @@
 # forever) — documented plainly here on purpose: Claude Code carries an
 # open report of its own ``cleanupPeriodDays`` knob being ambiguous about
 # what ``0`` means, and this is that precedent deliberately not repeated.
+#
+# ``backend`` (#4496, default "local"): where audit-events are WRITTEN.
+# "local" (default) is unchanged from before this field existed. "discard"
+# (sink-null) writes nothing to disk — subscriber delivery (TUI/AG-UI,
+# hooks, OTEL) and the per-emitter ``audit_seq`` continuity (#4496 PR-1)
+# are UNCHANGED either way, but ``reyn events replay`` / support-bundle /
+# dogfood_trace have nothing to read for a discard run. "network" is not
+# yet a valid value (falls back to "local") — its on-failure semantics
+# are an open design question tracked in #4496.
 # -----------------------------------------------------------------------------
 # audit_events:
 #   max_bytes: 10485760              # 10 MB
 #   max_age_seconds: 86400           # 1 day
 #   cleanup_period_days: 30          # 0 = never auto-delete by age
 #   max_disk_usage_percent: 10       # 0 = never auto-delete by size
+#   backend: local                   # local | discard
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -515,6 +515,19 @@ class AuditEventsConfig:
     max_age_seconds: int = 24 * 60 * 60   # 1 day
     cleanup_period_days: int = 30
     max_disk_usage_percent: float = 10.0
+    # #4496 PR-2: the WRITE-side backend. `local` (default) preserves
+    # current behavior unchanged — audit-events land under `.reyn/events`
+    # exactly as before this field existed. `discard` writes nothing
+    # (sink-null); subscriber delivery (CUI/AG-UI, hooks, OTEL) and the
+    # per-emitter `audit_seq` continuity are UNCHANGED either way — see
+    # `reyn.core.events.backend`'s module docstring for the structural
+    # guarantee. `network` is NOT yet a valid value here — its on-failure
+    # semantics (discard-and-let-seq-show-it / local spool / halt-the-run)
+    # are still an open owner decision (#4496); an operator who sets it
+    # gets the standard unknown-VALUE-falls-back-to-default tolerance
+    # (this field is validated at parse time, not silently accepted as a
+    # do-nothing string — see the parser below).
+    backend: str = "local"
 
 
 _SANDBOX_BACKENDS = {"auto", "seatbelt", "landlock", "noop"}
@@ -973,11 +986,21 @@ def _build_audit_events_config(raw: object) -> AuditEventsConfig:
             disk_percent_val = defaults.max_disk_usage_percent
     except (TypeError, ValueError):
         disk_percent_val = defaults.max_disk_usage_percent
+    # #4496 PR-2: `network` is a declared future value, not yet backed by an
+    # implementation (see AuditEventsConfig.backend's own docstring) — an
+    # operator who sets it (or any other unrecognized string) falls back
+    # to the default rather than reaching `EventLog` with a value nothing
+    # can resolve to a real backend, same "malformed value falls back"
+    # discipline every other field in this parser already uses.
+    backend_val = raw.get("backend", defaults.backend)
+    if backend_val not in ("local", "discard"):
+        backend_val = defaults.backend
     return AuditEventsConfig(
         max_bytes=int(raw.get("max_bytes", defaults.max_bytes)),
         max_age_seconds=int(raw.get("max_age_seconds", defaults.max_age_seconds)),
         cleanup_period_days=cleanup_val,
         max_disk_usage_percent=disk_percent_val,
+        backend=backend_val,
     )
 
 

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -521,13 +521,18 @@ class AuditEventsConfig:
     # (sink-null); subscriber delivery (CUI/AG-UI, hooks, OTEL) and the
     # per-emitter `audit_seq` continuity are UNCHANGED either way — see
     # `reyn.core.events.backend`'s module docstring for the structural
-    # guarantee. `network` is NOT yet a valid value here — its on-failure
+    # guarantee. `network` is NOT yet a valid value — its on-failure
     # semantics (discard-and-let-seq-show-it / local spool / halt-the-run)
     # are still an open owner decision (#4496); an operator who sets it
-    # gets the standard unknown-VALUE-falls-back-to-default tolerance
-    # (this field is validated at parse time, not silently accepted as a
-    # do-nothing string — see the parser below).
-    backend: str = "local"
+    # (or any other string) gets the standard unknown-VALUE-falls-back-
+    # to-default tolerance — see the parser below. `Literal[...]` (not a
+    # bare `str`, per lead-coder review) matches this repo's convention
+    # for a closed, small value set (`retry_backoff` / `chat.mode` /
+    # `render_mode` / `on_oversize` all use it) — `tool_use.scheme` /
+    # `.transport` stay plain `str` because THEIR domain is an open,
+    # pluggable registry a literal type can't enumerate; this field's
+    # domain is closed, so it belongs on the Literal side of that split.
+    backend: Literal["local", "discard"] = "local"
 
 
 _SANDBOX_BACKENDS = {"auto", "seatbelt", "landlock", "noop"}

--- a/src/reyn/core/events/backend.py
+++ b/src/reyn/core/events/backend.py
@@ -1,0 +1,132 @@
+"""EventBackend — the audit-event WRITE-side abstraction (#4496 PR-2).
+
+Lets an operator choose where `.reyn/events` audit-events are written:
+local disk (default, current behavior), or discarded entirely. A
+`network` backend is a deliberate, flagged scope cut — see below.
+
+Deliberately THIN, per architect's #4496 design (issue comment, 2026-08-13):
+a backend has exactly 2 responsibilities.
+
+    1. receive an event and dispatch it (write / send / discard)
+    2. name what it does NOT retain, so a consumer (`reyn events replay`,
+       support-bundle, dogfood_trace) can tell "this backend doesn't keep
+       that" apart from "nothing happened" (contract 2 — see `declare_gaps`)
+
+The THIRD contract architect names — a monotonic `audit_seq` per emitter
+so a subscriber can detect a gap — is NOT a backend responsibility. It is
+already implemented in `EventLog.emit()` itself (#4496 PR-1): `audit_seq`
+is stamped on every event regardless of backend, including `discard`
+(measured: `emit()` does agent_id/run_id stamp -> emitter+audit_seq stamp
+-> subscriber dispatch -> return; no file I/O happens inside `emit()` at
+all — see `EventLog.emit`'s own docstring). A backend that skipped seq
+under its own logic would be reimplementing (and could diverge from) a
+guarantee `emit()` already provides for free — so backends never touch it.
+
+## Not a subscriber (the structural guarantee this module exists for)
+
+`EventLog.emit()` calls `self._backend.write(event)` directly — wrapped in
+try/except — BEFORE it loops over `self._subscribers` (#4496 PR-2). This
+is deliberate, not incidental:
+
+    - the subscriber loop (`for sub in self._subscribers: sub(event)`) has
+      no per-subscriber try/except (`events.py`, measured) — a raising
+      subscriber aborts the loop and every LATER subscriber in the list is
+      silently skipped. Inserting a backend as JUST ANOTHER subscriber
+      would inherit this hazard: a raising backend (e.g. a future network
+      backend hitting a connection error) would abort delivery to every
+      subscriber registered after it — including the CUI/AG-UI forwarders
+      session.py wires — the exact "discard silences the UI" failure mode
+      the owner's #4496 ruling forbids ("emit は抽象に対して必ず行う、
+      Backend 側で破棄するだけ").
+    - calling the backend FIRST, outside the subscriber loop, with its own
+      try/except, gets both halves of prohibition ③ (backend failure must
+      not reach subscribers, and vice versa) from ORDERING alone: the
+      backend has already run by the time any subscriber could raise, and
+      a backend exception is caught right where it's raised, before the
+      subscriber loop even starts.
+
+## Scope: `network` is deferred, not silently dropped
+
+The owner's #4496 write-up leaves one point genuinely undecided: what a
+`network` backend does when the network call fails (discard-and-let-the-
+seq-gap-show-it / spool-locally / halt-the-run — three real options, see
+issue #4496's "決めるべき残り1点"). Building a `NetworkEventBackend` ahead
+of that decision would mean guessing at owner-owned UX. `local` and
+`discard` need no such decision (their only failure mode is disk I/O
+raising, already covered by contract ③'s try/except at the call site) —
+this PR ships those two; `network` is issue #4496's own next PR once the
+owner has resolved the open question above.
+"""
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from reyn.schemas.models import Event
+
+
+@runtime_checkable
+class EventBackend(Protocol):
+    """The write-side surface `EventLog.emit()` calls into (#4496 PR-2)."""
+
+    def write(self, event: Event) -> None:
+        """Persist / send / discard *event*.
+
+        May raise — the caller (`EventLog.emit`) catches and logs; a
+        backend must never assume its own exception reaches anything
+        downstream (subscribers included)."""
+        ...
+
+    def declare_gaps(self) -> list[str]:
+        """Human-readable statements of what this backend does NOT retain.
+
+        Empty list = no gaps (this backend keeps everything a consumer
+        might expect). A consumer reading `[]` sees "nothing missing",
+        never confuses it with an empty EVENT list (contract 2: "empty"
+        and "unsupported" must be told apart)."""
+        ...
+
+
+class LocalEventBackend:
+    """Writes to local disk via an `EventStore` (the default, current
+    behavior — #4496 PR-2 wraps the EXISTING EventStore.write, no I/O
+    change). No gaps: replay / support-bundle / dogfood_trace all work
+    normally against this backend's output."""
+
+    def __init__(self, store: "EventStoreLike") -> None:
+        self._store = store
+
+    def write(self, event: Event) -> None:
+        self._store.write(event)
+
+    def declare_gaps(self) -> list[str]:
+        return []
+
+
+class DiscardEventBackend:
+    """Writes nothing (sink-null). `emit()` and subscriber dispatch are
+    UNCHANGED when this backend is active (#4496's structural guarantee,
+    see module docstring) — only the write-to-disk step becomes a no-op.
+
+    `reyn events replay` / support-bundle / dogfood_trace must consult
+    `declare_gaps()` and report it explicitly rather than reading an
+    empty local events tree as "nothing happened" (contract 2)."""
+
+    def write(self, event: Event) -> None:
+        return None
+
+    def declare_gaps(self) -> list[str]:
+        return [
+            "this backend does not retain events locally (audit_events."
+            "backend: discard) — `reyn events replay`, support-bundle, "
+            "and dogfood_trace have nothing to read for this run",
+        ]
+
+
+class EventStoreLike(Protocol):
+    """The one method `LocalEventBackend` needs from `EventStore` — kept
+    separate from importing `EventStore` directly so this module has no
+    dependency on `event_store.py`'s file-rotation machinery (P7:
+    OS-level generic infrastructure stays decoupled from any one backend's
+    implementation details)."""
+
+    def write(self, event: Event) -> None: ...

--- a/src/reyn/core/events/events.py
+++ b/src/reyn/core/events/events.py
@@ -7,6 +7,7 @@ from datetime import date
 from pathlib import Path
 from typing import Callable
 
+from reyn.core.events.backend import EventBackend
 from reyn.schemas.models import Event
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,7 @@ class EventLog:
         run_id: str | None = None,
         emitter: str | None = None,
         track_audit_seq: bool = True,
+        backend: "EventBackend | None" = None,
     ) -> None:
         # #3868 PR-1: a folded derived state for `present`'s "was this ref
         # already read this session?" question (source.py's compute_ingested),
@@ -109,6 +111,12 @@ class EventLog:
         # entirely rather than always stamping a meaningless `1`.
         self._track_audit_seq = track_audit_seq
         self._audit_seq = 0
+        # #4496 PR-2: the WRITE-side backend (local disk / discard — see
+        # `backend.py`'s module docstring for the full contract and why
+        # this is NOT a subscriber). None preserves the pre-PR-2 shape
+        # (no write side at all — callers that want persistence add an
+        # EventStore as a plain subscriber, same as before this PR).
+        self._backend = backend
 
     @property
     def subscribers(self) -> list[Callable[[Event], None]]:
@@ -142,6 +150,14 @@ class EventLog:
         return self._run_id
 
     @property
+    def backend(self) -> "EventBackend | None":
+        """The active write-side backend (#4496 PR-2), or None (no write
+        side — pre-PR-2 shape). Public read-only view so a consumer
+        (`reyn events` CLI) can call `declare_gaps()` without reaching into
+        private state."""
+        return self._backend
+
+    @property
     def emitter(self) -> str:
         """The emitter label this EventLog stamps onto every emitted event
         (#4496 PR-1, contract 3) — auto-generated at construction when not
@@ -152,6 +168,15 @@ class EventLog:
 
     def add_subscriber(self, fn: Callable[[Event], None]) -> None:
         self._subscribers.append(fn)
+
+    def set_backend(self, backend: "EventBackend | None") -> None:
+        """Swap the WRITE-side backend (#4496 PR-2) — e.g. re-pointing to a
+        new `EventStore`-backed `LocalEventBackend` after `set_events_dir`
+        re-keys a spawned session's events directory. Deliberately a plain
+        setter, not add/remove: exactly one backend is active at a time
+        (unlike subscribers, which are a list) — the PREVIOUS backend is
+        simply dropped, no explicit "remove" step needed."""
+        self._backend = backend
 
     def remove_subscriber(self, fn: Callable[[Event], None]) -> bool:
         """Detach a previously added subscriber.
@@ -212,6 +237,22 @@ class EventLog:
                             self._ingested[path] = "partial"
                     else:
                         self._ingested[path] = "full"
+        # #4496 PR-2: the backend writes BEFORE the subscriber loop runs,
+        # and its own exception is caught right here — never let a backend
+        # failure (e.g. a future network backend's connection error) reach
+        # a subscriber, and (by running first) never let a raising
+        # subscriber prevent the backend from having already written. See
+        # `backend.py`'s module docstring for the full "not a subscriber"
+        # rationale.
+        if self._backend is not None:
+            try:
+                self._backend.write(event)
+            except Exception:
+                logger.exception(
+                    "event backend write failed (emitter=%s type=%s) — "
+                    "continuing to subscriber dispatch",
+                    self._emitter, type,
+                )
         for sub in self._subscribers:
             sub(event)
         return event

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -37,6 +37,7 @@ from reyn.config import (  # noqa: F401
 )
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.anchor_store import truncate_anchor as _truncate_anchor
+from reyn.core.events.backend import DiscardEventBackend, EventBackend, LocalEventBackend
 from reyn.core.events.event_store import EventStore
 from reyn.core.events.events import EventLog
 from reyn.core.events.snapshot_generations import SnapshotGenerationStore
@@ -1432,11 +1433,13 @@ class Session:
         registry's ``spawn_session`` fixup calls this — parallel to the snapshot/WAL
         re-key — before the run-loop goes live, so no event lands in the shared tree.
 
-        Swaps ONLY the ``EventStore`` subscriber on ``_audit_events`` (remove old, add
-        new); every OTHER subscriber (the ``ChatLifecycleForwarder`` outbox bridge, the
-        state-change converter, any attach-time focus listener) is preserved. A rebuild
-        of the subscriber list would silently drop them and audit events would stop
-        reaching the outbox / TUI — so the swap is surgical, not a reconstruction.
+        #4496 PR-2: swaps ONLY the WRITE-side backend on ``_audit_events``
+        (``set_backend``, a plain setter — the backend is a singleton, not
+        a subscriber list entry, since PR-2 moved ``EventStore`` off the
+        subscriber list entirely). Every SUBSCRIBER (the
+        ``ChatLifecycleForwarder`` outbox bridge, the state-change
+        converter, any attach-time focus listener, OTEL) is untouched by
+        this swap — the subscriber list is never rebuilt here.
         """
         new_store = EventStore(
             events_dir,
@@ -1445,8 +1448,7 @@ class Session:
             cleanup_period_days=self._events_config.cleanup_period_days,
             max_disk_usage_percent=self._events_config.max_disk_usage_percent,
         )
-        self._audit_events.remove_subscriber(self._event_store)
-        self._audit_events.add_subscriber(new_store)
+        self._audit_events.set_backend(self._build_events_backend(new_store))
         self.events_dir = events_dir
         self._event_store = new_store
 
@@ -3760,6 +3762,25 @@ class Session:
         registry-derived-enumeration discipline the family gate itself uses."""
         return self._hot_reloader.seam_names()
 
+    def _build_events_backend(self, event_store: EventStore) -> "EventBackend":
+        """#4496 PR-2: resolve ``self._events_config.backend`` (``"local"`` /
+        ``"discard"`` — ``"network"`` is not yet a real value, see
+        ``AuditEventsConfig.backend``'s own docstring) to a concrete
+        ``EventBackend`` wrapping *event_store*.
+
+        Deliberately NOT threaded as an ``EventLog`` subscriber (unlike
+        pre-PR-2 shape) — see ``reyn.core.events.backend``'s module
+        docstring for why a backend must be called from inside
+        ``EventLog.emit()`` itself, before the subscriber loop, rather than
+        sit in the subscriber list alongside ``ChatLifecycleForwarder`` /
+        the state-change converter / OTEL: a raising backend in the
+        subscriber list would abort delivery to every subscriber
+        registered after it (the exact "discard silences the UI" failure
+        mode #4496 forbids)."""
+        if self._events_config.backend == "discard":
+            return DiscardEventBackend()
+        return LocalEventBackend(event_store)
+
     # ── #3082 Family 1: audit-event spine builder. See session-construction.md. ──
 
     def _build_audit_event_bundle(
@@ -3803,7 +3824,10 @@ class Session:
             max_disk_usage_percent=self._events_config.max_disk_usage_percent,
         )
         audit_events = EventLog(
-            subscribers=[event_store],
+            # #4496 PR-2: event_store is no longer threaded in as a
+            # subscriber (see self._build_events_backend's own docstring
+            # for why) — it's wrapped as the WRITE-side backend instead.
+            backend=self._build_events_backend(event_store),
             agent_id=self._agent.agent_id,  # FP-0016 E: auto-inject agent_id into every event
         )
         otel_exporter = None

--- a/tests/config/test_4496_pr2_audit_events_backend_config.py
+++ b/tests/config/test_4496_pr2_audit_events_backend_config.py
@@ -1,0 +1,55 @@
+"""Tier 1: #4496 PR-2 — `audit_events.backend` config parsing.
+
+`local` (default, preserves pre-PR-2 behavior unchanged) / `discard`
+(sink-null, wired). `network` is a declared-future, not-yet-implemented
+value (see `AuditEventsConfig.backend`'s own docstring for why) — an
+operator who sets it, or any other unrecognized string, gets the standard
+malformed-value-falls-back-to-default discipline this parser already uses
+for its other fields (#4479 precedent), not a raise and not a silent
+accept of a string nothing can resolve to a real backend.
+"""
+from __future__ import annotations
+
+from reyn.config.infra import AuditEventsConfig, _build_audit_events_config
+
+
+def test_default_backend_is_local():
+    """Tier 1: the shipped default — no operator action needed to keep the
+    pre-PR-2 shape (audit-events land under `.reyn/events` as before)."""
+    cfg = _build_audit_events_config(None)
+    assert cfg.backend == "local"
+
+
+def test_explicit_local_parses_through():
+    """Tier 1: an operator who names the default explicitly still gets it."""
+    cfg = _build_audit_events_config({"backend": "local"})
+    assert cfg.backend == "local"
+
+
+def test_discard_parses_through():
+    """Tier 1: `discard` is a real, wired value — read, not ignored."""
+    cfg = _build_audit_events_config({"backend": "discard"})
+    assert cfg.backend == "discard"
+
+
+def test_network_falls_back_to_default_not_accepted_verbatim():
+    """Tier 1: `network` is declared in the docstring as a future value but
+    has no backend implementation behind it yet (#4496's open on-failure-
+    semantics decision) — falls back to `local` rather than reaching
+    `Session._build_events_backend` with a value it can't resolve."""
+    cfg = _build_audit_events_config({"backend": "network"})
+    assert cfg.backend == "local"
+
+
+def test_unrecognized_string_falls_back_to_default():
+    """Tier 1: an operator typo falls back cleanly, same discipline as
+    every other malformed value in this parser (#4479 precedent)."""
+    cfg = _build_audit_events_config({"backend": "s3"})
+    assert cfg.backend == "local"
+
+
+def test_malformed_top_level_raw_still_returns_backend_default():
+    """Tier 1: not a dict at all → defaults, backend included."""
+    cfg = _build_audit_events_config("not-a-dict")
+    assert cfg == AuditEventsConfig()
+    assert cfg.backend == "local"

--- a/tests/core/test_4496_pr2_event_backend.py
+++ b/tests/core/test_4496_pr2_event_backend.py
@@ -1,0 +1,231 @@
+"""Tier 2: #4496 PR-2 — audit-event WRITE-side backend abstraction.
+
+Architect's acceptance criteria (issue #4496 comment, falsifiable form):
+
+  1. ``backend=discard`` — subscribers still receive events (the witness
+     MUST be actual subscriber delivery, not "emit was called").
+  2. ``backend=discard`` — audit_seq still increments 1, 2, 3, ... (discard
+     does not also discard sequence continuity).
+  3. a raising backend does not stop subscriber delivery.
+  4. falsify: moving the backend call INTO the subscriber loop (so a
+     raising backend aborts delivery to later subscribers) flips ①/③ red
+     — the two tests above already ARE that falsify: if a future edit put
+     the backend in ``self._subscribers`` with no isolating try/except,
+     ``test_a_raising_backend_does_not_stop_subscriber_delivery`` goes red
+     immediately (a raising subscriber-list entry aborts every LATER
+     entry — see ``backend.py``'s module docstring for the measured
+     mechanism).
+
+#2 (Session-level, real production path): ``backend=discard`` — the real
+AG-UI/CUI subscriber wiring (``ChatLifecycleForwarder`` et al., attached by
+``Session.__init__`` itself) keeps receiving events, driven through
+``make_session`` (the same helper 282+ other tests use, mirroring
+production's ``scoped_session_factory.py`` shape) — not a hand-built
+EventLog that bypasses the real construction path.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config import AuditEventsConfig
+from reyn.core.events.backend import DiscardEventBackend, LocalEventBackend
+from reyn.core.events.events import EventLog
+from tests._support.agent_session import make_session
+
+
+class _RaisingBackend:
+    def write(self, _event) -> None:
+        raise RuntimeError("backend write failed")
+
+    def declare_gaps(self) -> list[str]:
+        return []
+
+
+# ── 1. discard preserves subscriber delivery ──────────────────────────────
+
+
+def test_discard_backend_subscribers_still_receive_events() -> None:
+    """Tier 2: witness ① — with backend=discard, a subscriber still gets
+    every emitted event. The witness is the subscriber's own received list,
+    not "emit returned an Event"."""
+    log = EventLog(backend=DiscardEventBackend())
+    received = []
+    log.add_subscriber(received.append)
+
+    e1 = log.emit("tool_executed", op="read")
+    e2 = log.emit("tool_executed", op="read")
+
+    assert received == [e1, e2]
+
+
+def test_discard_backend_declares_its_gap() -> None:
+    """Tier 2: contract 2 — discard names what it does NOT retain, so a
+    consumer (`reyn events`/support-bundle/dogfood_trace) can tell "empty"
+    apart from "unsupported"."""
+    backend = DiscardEventBackend()
+    gaps = backend.declare_gaps()
+    assert gaps
+    assert all(isinstance(g, str) and g for g in gaps)
+
+
+def test_local_backend_declares_no_gaps() -> None:
+    """Tier 2: contract 2, accept-side — local retains everything, so its
+    gap list is empty (not "no answer", an explicit empty declaration)."""
+    class _StubStore:
+        def write(self, _event) -> None:
+            pass
+
+    backend = LocalEventBackend(_StubStore())
+    assert backend.declare_gaps() == []
+
+
+# ── 2. discard preserves audit_seq continuity ──────────────────────────────
+
+
+def test_discard_backend_audit_seq_still_monotonic() -> None:
+    """Tier 2: witness ② — audit_seq keeps incrementing under discard; a
+    subscriber can still detect a gap by watching this number, even though
+    nothing is written to disk."""
+    log = EventLog(backend=DiscardEventBackend())
+    e1 = log.emit("tool_executed", op="read")
+    e2 = log.emit("tool_executed", op="read")
+    e3 = log.emit("tool_executed", op="read")
+    assert (e1.data["audit_seq"], e2.data["audit_seq"], e3.data["audit_seq"]) == (1, 2, 3)
+
+
+# ── 3. backend failure isolation (prohibition ③, both directions) ────────
+
+
+def test_a_raising_backend_does_not_stop_subscriber_delivery() -> None:
+    """Tier 2: witness ③ / falsify ④ — a backend that raises on write()
+    must not prevent subscribers from receiving the event. This is the
+    test that goes RED if a future edit ever makes the backend "just
+    another subscriber" with no isolating try/except (see backend.py's
+    module docstring for the measured mechanism: the current subscriber
+    loop has none, so a raising list entry aborts every later one)."""
+    log = EventLog(backend=_RaisingBackend())
+    received = []
+    log.add_subscriber(received.append)
+
+    emitted = log.emit("tool_executed", op="read")
+
+    assert received == [emitted]
+
+
+def test_a_raising_subscriber_does_not_stop_the_backend_from_having_written() -> None:
+    """Tier 2: witness ③, the other direction — a raising subscriber must
+    not prevent the backend from having already written (ordering
+    guarantee: backend runs BEFORE the subscriber loop)."""
+    written = []
+
+    class _RecordingBackend:
+        def write(self, event) -> None:
+            written.append(event)
+
+        def declare_gaps(self) -> list[str]:
+            return []
+
+    def _raising_subscriber(_event) -> None:
+        raise RuntimeError("subscriber failed")
+
+    log = EventLog(backend=_RecordingBackend())
+    log.add_subscriber(_raising_subscriber)
+
+    # The subscriber loop itself has no isolating try/except (a pre-existing,
+    # separately-flagged fact — see backend.py's module docstring), so the
+    # raise propagates out of emit(). What matters here is that the
+    # backend, called BEFORE the subscriber loop, has already written by
+    # the time that happens.
+    with pytest.raises(RuntimeError, match="subscriber failed"):
+        log.emit("tool_executed", op="read")
+
+    assert written and written[0].type == "tool_executed"
+
+
+# ── 4. backend is a settable singleton, not a subscriber-list entry ──────
+
+
+def test_backend_property_reflects_the_active_backend() -> None:
+    """Tier 2: public read-only view — a caller (`reyn events` CLI) reads
+    the active backend without reaching into private state."""
+    backend = DiscardEventBackend()
+    log = EventLog(backend=backend)
+    assert log.backend is backend
+
+
+def test_set_backend_swaps_without_touching_subscribers() -> None:
+    """Tier 2: `set_backend` (used by `Session.set_events_dir`'s live
+    re-key) replaces the backend only — every subscriber registered before
+    the swap keeps receiving events after it."""
+    log = EventLog(backend=DiscardEventBackend())
+    received = []
+    log.add_subscriber(received.append)
+
+    before_swap = log.emit("tool_executed", op="read")
+    log.set_backend(DiscardEventBackend())
+    after_swap = log.emit("tool_executed", op="read")
+
+    assert received == [before_swap, after_swap]
+
+
+def test_no_backend_omits_write_side_entirely() -> None:
+    """Tier 2: accept-side — None (the pre-PR-2 default) means no write
+    side at all; emit + subscriber dispatch behave exactly as before this
+    PR existed."""
+    log = EventLog()  # backend=None, the default
+    received = []
+    log.add_subscriber(received.append)
+    emitted = log.emit("tool_executed", op="read")
+    assert received == [emitted]
+    assert log.backend is None
+
+
+# ── 5. config: `audit_events.backend` parses to a real EventBackend ──────
+
+
+def test_audit_events_config_backend_defaults_to_local() -> None:
+    """Tier 2: default preserves current behavior — no operator action
+    needed to keep the pre-PR-2 shape."""
+    assert AuditEventsConfig().backend == "local"
+
+
+def test_audit_events_config_backend_accepts_discard() -> None:
+    """Tier 2: `discard` is a real, wired value."""
+    cfg = AuditEventsConfig(backend="discard")
+    assert cfg.backend == "discard"
+
+
+# ── 6. Session-level, real production path (not a hand-built EventLog) ────
+
+
+def test_session_with_discard_backend_still_delivers_to_real_subscribers(
+    tmp_path,
+) -> None:
+    """Tier 2: the real production-path witness — driven through
+    `make_session` (`tests/_support/agent_session.py`, mirroring production's
+    `scoped_session_factory.py` construction shape: builds a real `Agent`,
+    calls `Session(agent=agent, **kwargs)`), not a hand-built EventLog that
+    bypasses `_build_audit_event_bundle` / `_build_events_backend`.
+
+    With `audit_events.backend=discard` threaded through at construction, a
+    subscriber attached via `subscribe_audit_events` (Session's own public
+    API — the same method `ChatLifecycleForwarder` et al. are wired through
+    inside `_build_audit_event_bundle`) still receives an event emitted
+    through the session's real `_audit_events.emit()` (the same EventLog
+    `_build_events_backend` wired the discard backend into — accessing it
+    here mirrors `tests/core/test_session_lifecycle_events_1800.py`'s own
+    established pattern for observing session-level emits, not a private-
+    state assertion: `.emit()` is EventLog's public production entry point).
+    """
+    session = make_session(
+        agent_name="discard-backend-test",
+        workspace_state_dir=tmp_path / ".reyn",
+        events_config=AuditEventsConfig(backend="discard"),
+    )
+
+    received = []
+    session.subscribe_audit_events(received.append)
+    emitted = session._audit_events.emit("test_event", foo="bar")
+
+    assert received == [emitted]
+    assert emitted.data.get("foo") == "bar"

--- a/tests/interfaces/test_config_schema_enforcement_1056.py
+++ b/tests/interfaces/test_config_schema_enforcement_1056.py
@@ -51,13 +51,15 @@ from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 # distinguish "loader read+coerced" from a real no-op. Supply a domain-valid
 # non-default so the guard stays decisive. Keyed by dotted key; the iteration
 # itself is still live-walk-derived — this only overrides the candidate VALUE.
-_VALID_NONDEFAULT_OVERRIDES: dict[str, object] = {
-    # #4496 PR-2: `audit_events.backend` accepts only {"local", "discard"} —
-    # any other string (including the generic "local_nd" candidate) falls
-    # back to the default, same discipline as every other malformed value
-    # in this parser. "discard" is a real, wired, non-default value.
-    "audit_events.backend": "discard",
-}
+#
+# `audit_events.backend` (#4496 PR-2) does NOT need an entry here: it is
+# typed `Literal["local", "discard"]`, not a bare coercing `str`, so
+# `_nondefault_candidate`'s existing Literal branch (below) already picks
+# a real, non-default member automatically — no override needed. Left as
+# the discriminator for FUTURE soft-coercing string fields (the override
+# mechanism itself stays correct; this dict is empty because nothing
+# currently needs it, not because it doesn't work).
+_VALID_NONDEFAULT_OVERRIDES: dict[str, object] = {}
 
 
 def _nondefault_candidate(node: SchemaNode) -> object | None:

--- a/tests/interfaces/test_config_schema_enforcement_1056.py
+++ b/tests/interfaces/test_config_schema_enforcement_1056.py
@@ -51,7 +51,13 @@ from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 # distinguish "loader read+coerced" from a real no-op. Supply a domain-valid
 # non-default so the guard stays decisive. Keyed by dotted key; the iteration
 # itself is still live-walk-derived — this only overrides the candidate VALUE.
-_VALID_NONDEFAULT_OVERRIDES: dict[str, object] = {}
+_VALID_NONDEFAULT_OVERRIDES: dict[str, object] = {
+    # #4496 PR-2: `audit_events.backend` accepts only {"local", "discard"} —
+    # any other string (including the generic "local_nd" candidate) falls
+    # back to the default, same discipline as every other malformed value
+    # in this parser. "discard" is a real, wired, non-default value.
+    "audit_events.backend": "discard",
+}
 
 
 def _nondefault_candidate(node: SchemaNode) -> object | None:


### PR DESCRIPTION
**[e2e-coder]** — #4496 PR-2: audit-event WRITE-side backend abstraction (`local` / `discard`; `network` deferred — see Scope below). Design is architect's (issue #4496 comment, 2026-08-13), pre-measured against the real `emit()`/subscriber wiring by lead-coder before I started — no re-derivation needed, implementation follows both directly.

part of #4496

## The structural guarantee this PR exists to deliver

Architect's core insight, verified directly against `events.py` before writing any code: `EventLog.emit()`'s subscriber loop (`for sub in self._subscribers: sub(event)`) has **no per-subscriber try/except** — a raising subscriber aborts delivery to every subscriber registered after it. Inserting a backend as *just another subscriber* would inherit this hazard: a raising `discard`/future-`network` backend could silence the CUI/AG-UI forwarders wired after it — exactly the failure mode the owner's ruling forbids ("emit は抽象に対して必ず行う、Backend 側で破棄するだけ").

Fix: the backend is **not** a subscriber. `emit()` calls `self._backend.write(event)` directly, wrapped in its own try/except, **before** the subscriber loop runs. This ordering gets both halves of architect's prohibition③ for free, from construction alone:
- a raising backend can never reach a subscriber (caught right where it's raised, before the loop starts)
- a raising subscriber can never stop the backend from having already written (the backend already ran)

## What's in this PR

- `src/reyn/core/events/backend.py` (new) — the `EventBackend` Protocol (`write` + `declare_gaps`, 2 contracts, deliberately thin) + `LocalEventBackend` (wraps `EventStore`, byte-identical to pre-PR-2 behavior) + `DiscardEventBackend` (sink-null; declares its own gap so `reyn events replay`/support-bundle/dogfood_trace can say "this backend doesn't retain events" instead of silently returning empty).
- `src/reyn/core/events/events.py` — `EventLog` gains `backend=`/`set_backend()`; `emit()` wires the call as described above; a `backend` public property mirrors the existing `emitter` read-only-view convention.
- `src/reyn/config/infra.py` — `audit_events.backend` field (`"local"` default / `"discard"` wired / any other value, `"network"` included, falls back to `"local"`).
- `src/reyn/runtime/session.py` — `_build_events_backend` resolves config → concrete backend; `_build_audit_event_bundle` threads it into `EventLog` construction instead of adding `EventStore` as a subscriber; `set_events_dir`'s live directory re-key now calls `set_backend` instead of its old remove/add-subscriber surgery.
- Docs: `docs/concepts/runtime/events.md` (new "Write-side backend" section), `docs/reference/config/reyn-yaml.md` (field table), `reyn.local.yaml.example` (caught by `test_config_mirror_coverage_1056.py`'s exhaustive-mirror gate when I first ran the sweep — fixed).

## Scope cut: `network` backend deferred (not silently dropped)

The owner's #4496 write-up leaves one point genuinely open: what a `network` backend does when the network call fails (discard-and-let-the-audit_seq-gap-show-it / local spool / halt-the-run — issue #4496's own "決めるべき残り1点", three real options). Building `NetworkEventBackend` ahead of that decision means guessing at owner-owned UX. `local`/`discard` need no such decision — their only failure mode is disk I/O raising, already covered by the try/except at the `emit()` call site. This PR ships those two; `network` is #4496's own next PR once the owner resolves the open question. Flagged in both `backend.py`'s module docstring and the config field's own docstring, not left silent.

## Verification

- Strip-falsified the core guarantee: removed the isolating try/except around `self._backend.write(event)`, confirmed `test_a_raising_backend_does_not_stop_subscriber_delivery` goes RED, restored, confirmed GREEN again.
- `ruff check src tests`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py` (4 changed src files): clean.
- `scripts/test_tier_audit.py --strict` (2 new test files, 18 tests): 0 Tier-4 violations — iterated once: my first draft of 5 assertions used `len(x) == N` (flagged as a format-pin per CLAUDE.md's own warning about this exact pattern); rewrote each to assert on the actual received/written list *contents* (`received == [e1, e2]`) instead, which is both stronger (proves identity, not just count) and gate-clean.
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `scripts/check_doc_anchors.py`: clean — my first anchor guess (`#write-side-backend`) was wrong (mkdocs's real slug for `## Write-side backend (#4496)` is `#write-side-backend-4496`, confirmed against `permission-model.md`'s own working `## Collapse arc (#571)` → `#collapse-arc-571` precedent, then verified against an actual local `mkdocs build`).
- Full regression sweep (`tests/core`+`config`+`runtime`), rebuilt on latest `main` (past #4585): in progress, will report before merge.
- Real production-path witness (not a hand-built `EventLog`): `test_session_with_discard_backend_still_delivers_to_real_subscribers` drives a real `Session` via `make_session` (`tests/_support/agent_session.py`, mirroring `scoped_session_factory.py`'s own construction shape) with `events_config=AuditEventsConfig(backend="discard")`, subscribes via `Session.subscribe_audit_events` (the same public API `ChatLifecycleForwarder` et al. use), and confirms the subscriber still receives the event.

## Test plan

- [x] Strip-falsified the isolating try/except → confirmed RED → restored → confirmed GREEN.
- [x] Ran all 5 local gates — clean.
- [x] `mkdocs build --strict` + `check_doc_anchors.py` — clean.
- [x] Real-production-path Session-level witness (not a hand-built EventLog bypassing `_build_audit_event_bundle`).
- [x] Full regression sweep on latest `main` (`tests/core`+`config`+`runtime`, 4558 passed) — only the known pre-existing darwin-PATH failure remains.
- [x] (Visual) — n/a, no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔴 Reviewer's blocking item (lead-coder)

- [x] 🔴 ~~**`audit_events.backend` が schema に出ていて set できるのに、`load_config` が読んでいません**~~ 🔴 **私の診断が誤りでした（loader.py:848 で読んでいます — ゲートが出した *推測* の原因をそのまま書きました）。** 解決は型側: `backend: Literal["local", "discard"]` に変更され、生成器の既存 Literal 分岐が非既定メンバを自動で選ぶようになりました。**`_VALID_NONDEFAULT_OVERRIDES` は空のまま**で、なぜ空でよいかがコメントとして残っています — 逃げ道の意味を保ったまま、最初の前例を作らずに済んでいます。lead-coder が head 75df0a85c で確認。元の指摘文（誤診断を含む）は取り消し線で残します — `tests/interfaces/test_config_schema_enforcement_1056.py:173` が両 matrix で検出: `audit_events.backend: set 'local_nd' → reload 'local' (set ignored)`。★operator の値が reload で黙って捨てられます。★ゲートの言い分が正しく、フレークでも版依存でもありません。⚪ 形として: **この PR は「discard は自分の欠落を申告する」を実装しながら、自分の config キーが operator の値を黙って捨てています。**


