### PR TITLE
docs(#4576): record the not-installed instance under the truncated-run hazard

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -751,6 +751,32 @@ running the ratchet FAILED with exactly this message, and a baselined
 `[syntax]` pair still fails on every subsequent run rather than reading as
 known debt).
 
+The proposition that quote states — **a run that did not run is not clean**
+— has a strictly larger instance the same script did not cover for another
+two years: mypy not installed at all (#4576). `python -m mypy` then writes
+"No module named mypy" to stderr and exits 1; `run_mypy` deliberately does
+not raise on a non-zero exit (mypy's own error exit is the common case), no
+`[code]` lines parse out, and zero measured pairs minus the baseline is zero
+new pairs. The script printed `mypy ratchet OK: 0 findings, all baselined
+(215 declared)` and exited 0 — the `215 declared` supplied by a baseline load
+that HAD succeeded, so nothing in the line looked degraded. It hid a real
+`[call-arg]` through a complete local pre-PR check (#4575), and was found
+only because that PR's CI disagreed with its author's green.
+
+Two things are worth taking from it beyond the fix. First, the author had
+already reasoned about truncated runs — the `[syntax]` guard above is that
+reasoning — so this was not an unconsidered case but an unsearched *shape*:
+"ran and stopped early" was looked for, "never ran" was not. Second, the
+general proposition was written down, here, in this document, and neither
+the PR author nor its co-vet reviewer reached it. A hazard catalogue is only
+consulted at the moment someone suspects a hazard; it does not fire on its
+own. The guard added instead is structural — `importlib.util.find_spec`
+before the run, so the question asked is "is the tool present", not "does
+the output look like a real run", which would have put the discriminator on
+the side being classified (mypy's own summary wording, which mypy may
+change at will). The exit code cannot serve either: a missing module and a
+normal findings-reported run both exit 1 (measured).
+
 The `tick()`/`compact_caps`/`fv.cursor`/`Closes` shape itself — "prove the
 named symbol resolves" as a class, beyond what mypy already covers for
 method/attribute calls — is **not yet machinized**, not because it can't


### PR DESCRIPTION
**[lead-coder]** — ✅ **★doc が ★#4576 を 捕まえる 論を ★既に 持っていました。★その 隣に ★実例として 置きます。**

⚪ **★発見は architect**（★#4586 の co-vet 返し）── ★私は ★書き足すだけ です。

## 🔴 ★既に 書いてあった もの（`verification-hazards.md:739`、★逐語）

> ★a fatal parse error stops mypy's ★ENTIRE run, so no other file was actually
> checked this time — ★every OTHER pair this run's output doesn't mention is
> ★UNMEASURED, not confirmed clean.

```
★命題 ──「★走らなかった run は ★clean では ない」
🔴 ★#4576 は ★その ★一段 外側:
   ★doc の 場合 ── ★走った が ★途中で 止まった
   ★#4576   ── ★★そもそも 走っていない
∴ ★同じ 命題の ★より 大きい 実例
```

## 🔴 ★記録する 価値が あるのは ★機構より ★2 点 です

```
🔴 ★① ★著者は ★既に 考えていました
   ── ★[syntax] guard が ★その 思考 そのもの
   ∴ ★考え落ちでは なく ★探さなかった ★形
      ★「走って 途中で 止まった」── ★探した
      ★「そもそも 走らなかった」── ★探していない
🔴 ★② ★一般形は ★この doc に 書いてあり、★PR 著者も ★co-vet も ★辿りませんでした
   ── ★hazard カタログは ★「怪しい」と 思った 人が 開く ものです
   ── ★自分から は 発火しません
```

## ✅ ★guard を ★構造的に した 理由も 残しました

```
✗ ★mypy の 総括行を 見る ── ★第三者の 出力書式に ★測定の 信頼性を 預ける
✗ ★exit code ── ★モジュール不在も ★通常の finding 報告も ★どちらも 1（★実測）
✅ ★find_spec ── ★「道具が 在るか」── ★分類される側に 判別子を 置かない
```

## Test plan

- [x] 変更は `docs/` ★1 ファイルのみ
- [x] ★引用は ★同ファイルの 現行 本文から ★逐語で 取りました（★:739 付近）
- [ ] `docs build (strict)` — ★CI で 確認
- [ ] Full CI run (not run locally, per policy)

⚪ **★docs-only ∴ ★TESTS-READ は 不要**（★`tests/` を 触っていません ── ★この 判断を 明記します）。
⚪ **★自作 PR ですが ★co-vet は 求めません** ── ★内容は ★architect の 観測の 転記 であり、
★新しい 主張を していません。**★違うと 思われたら 止めてください。**

part of #4576
