### PR TITLE
fix(#4584): move artifact_refs.jsonl + spill manifest from cache/ (derived) to persist tier

### DIFF
--- a/docs/reference/cli/storage.md
+++ b/docs/reference/cli/storage.md
@@ -77,12 +77,16 @@ with no `.reyn/agents/` yet reports all-zero for the `history.jsonl` row, not an
 ## Spill-manifest self-prune (#4478)
 
 `MediaStore` tracks which tool-result files it has spilled to disk via a manifest at
-`.reyn/cache/tool_result_spills.jsonl`, read in full on every `MediaStore`
-construction. An entry whose target file no longer exists on disk (deleted manually,
-or by a future Phase 2 GC policy) is dropped from the manifest the next time it's
-loaded — this bounds the manifest's otherwise-unbounded growth. The prune only
-rewrites the manifest itself; it never deletes any actual media/tool-result bytes,
-and a write failure here is best-effort (never fails `MediaStore` construction).
+`.reyn/memory/tool_result_spills.jsonl` (#4584: moved from `.reyn/cache/` — that
+tier's "derived, rebuilt after restore" promise never held for this manifest; see
+[`.reyn/` directory layout](../runtime/reyn-dir-layout.md)), read in full on every
+`MediaStore` construction. An entry whose target file no longer exists on disk
+(deleted manually, or by a future Phase 2 GC policy) is dropped from the manifest
+the next time it's loaded — this bounds the manifest's otherwise-unbounded growth.
+This is a self-PRUNE of existing entries only, never a REBUILD: if the manifest file
+itself were deleted, nothing recreates it. The prune only rewrites the manifest
+itself; it never deletes any actual media/tool-result bytes, and a write failure
+here is best-effort (never fails `MediaStore` construction).
 `reyn storage stats` does not report on the manifest directly — it measures the
 artifact directories the manifest tracks.
 

--- a/docs/reference/runtime/reyn-dir-layout.md
+++ b/docs/reference/runtime/reyn-dir-layout.md
@@ -54,40 +54,61 @@ Everything else is excluded, by one of four reasons:
 │                           `external_transports` config is read from reyn.yaml's own
 │                           `external_transports:` section only
 ├── memory/                 PERSIST — agent knowledge; survives rewind, never reverted
+│   ├── artifact_refs.jsonl (agent, path) → ref table for `present`'s "artifact"
+│   │                       component (#4482 PR-1, moved from `cache/` by #4584):
+│   │                       the mapping exists ONLY at mint time — no WAL event,
+│   │                       no conversation-log entry, nothing else durable
+│   │                       carries it — so it is PRIMARY data, not derived,
+│   │                       however small. Ordinary writable zone (not
+│   │                       write-gated, same as the rest of `memory/`) — a
+│   │                       plain file write, never a dedicated op. "memory" is
+│   │                       an imperfect NAME fit (a ref→path table is neither
+│   │                       knowledge nor a decision) — the doc's own tier
+│   │                       decision rule (below) only points at one place.
+│   └── tool_result_spills.jsonl  persisted provenance of tool-result SPILL
+│                           artifacts under `tool-results/` (#4381/#4432, moved
+│                           from `cache/` by #4584 — same reasoning as
+│                           `artifact_refs.jsonl` above: not literally
+│                           rebuildable, an earlier comment on this file said
+│                           so explicitly while still filing it under
+│                           `cache/`) — one JSON line per `MediaStore.
+│                           save_tool_result` write, read back at every
+│                           `MediaStore` construction so a bare re-read of a
+│                           spilled file (in this process or a later one — a
+│                           reference can outlive the process that wrote it,
+│                           sitting in `history.jsonl`) is detected and errors
+│                           instead of re-spilling. SELF-PRUNES existing
+│                           entries whose target vanished (bounds otherwise-
+│                           unbounded growth) but does NOT rebuild if the
+│                           manifest FILE ITSELF is deleted — pruning and
+│                           rebuilding are not the same claim.
 ├── approvals.yaml          PERSIST — user-authored permission grants; survive rewind
 ├── events/ traces/ logs/   AUDIT — append-only forensic record; never restored
 │   audit-trail/ tool-results/ media/
-├── cache/                  DERIVED — rebuilt after restore
+├── cache/                  DERIVED — rebuilt after restore. ⚠️ "rebuilt after
+│                           restore" describes what belongs in this tier, not a
+│                           blanket safety claim about deleting `cache/` itself:
+│                           `index_drop` (an agent-callable op) deletes
+│                           `cache/index/<source>` behind `require_file_write`
+│                           (#1199 S3.4) — reyn's OWN code already treats
+│                           deleting something under `cache/` as a gated,
+│                           permission-requiring action, not a free one.
 │   ├── index/              rag index data (sqlite), one dir per source —
 │   │   └── actions/        includes the tool-use action catalog since
 │   │                       FP-0057 Phase 0 (was the separate action_index/
 │   │                       implementation pre-consolidation; clean-break,
 │   │                       no migration — see `reyn.tools.action_index`)
 │   ├── registry-cache/     mcp registry cache
-│   ├── tool_result_spills.jsonl  persisted provenance of tool-result SPILL
-│   │                       artifacts under `tool-results/` (#4381/#4432) —
-│   │                       one JSON line per `MediaStore.save_tool_result`
-│   │                       write, read back at every `MediaStore`
-│   │                       construction so a bare re-read of a spilled
-│   │                       file (in this process or a later one — a
-│   │                       reference can outlive the process that wrote
-│   │                       it, sitting in `history.jsonl`) is detected
-│   │                       and errors instead of re-spilling. NOT in
-│   │                       `tool-results/` itself: every file there is
-│   │                       written through the exact same call, so a
-│   │                       consumer counting "N spill artifacts" via a
-│   │                       directory listing is entitled to get exactly
-│   │                       N (#4432 round 3 — mixing the ledger in broke
-│   │                       that count). NOT recovery-core (no dedicated
-│   │                       op) — same ordinary-writable-zone exposure as
-│   │                       everything else under `cache/`, an open gap
-│   │                       flagged, not silently closed by this move.
 │   └── budget_checkpoint.json  compacted per-agent budget totals (#2945),
 │                           anchored to a byte position in
 │                           `state/budget_ledger.jsonl` — fully
-│                           reconstructable from the ledger by re-scanning,
-│                           safe to delete at any time (a write failure is
-│                           logged and swallowed, never blocks startup).
+│                           reconstructable from the ledger by re-scanning.
+│                           UNLIKE the rest of `cache/` (see the ⚠️ above),
+│                           THIS one entry really is safe to delete at any
+│                           time (a write failure is
+│                           logged and swallowed, never blocks startup) —
+│                           scoped to this file specifically, not a claim
+│                           about `cache/` as a whole.
 │                           NOTE: its per-agent totals act as a FLOOR by
 │                           default — whenever the ledger is found
 │                           truncated, missing, or its identity (a hash of

--- a/src/reyn/data/workspace/artifact_ref.py
+++ b/src/reyn/data/workspace/artifact_ref.py
@@ -28,12 +28,36 @@ the SAME file ends up minting two different refs).
 endpoint this feeds is already agent-scoped, ``/agents/{agent}/...``, so
 there is no cross-agent need and no extra cleanup surface to invent).
 
-**Table persisted under ``.reyn/cache/``** — mirrors #4432's tool-result
-spill manifest: same "derived, ordinary agent-writable zone" home, same
-JSONL-append shape, same best-effort write-failure tolerance (a write
-failure here must never fail the mint itself — the ref is still valid for
-this process's lifetime even if a LATER process's table load won't see it,
-the identical tradeoff #4432's own manifest already accepted).
+**Table persisted under ``.reyn/memory/`` — PERSIST tier, not
+``.reyn/cache/``** (#4584 fix; originally mirrored #4432's tool-result
+spill manifest's ``cache/`` home, which turned out to be the wrong
+precedent for BOTH tables to follow — #4584 moved that one too). ``cache/``
+is documented "DERIVED — rebuilt after restore" (``reyn-dir-layout.md``) —
+never true for this table: the (agent, path) → ref mapping exists ONLY at
+the instant :func:`mint_ref` writes it — no WAL event, no
+``ChatMessage``/conversation-log entry, no other durable record anywhere
+carries it (measured directly, #4494/#4584: a ``present`` tool call's own
+tool-result carries only ack STATISTICS, never the resolved ``ref``). An
+operator correctly deleting the table because the doc calls it
+safely-rebuildable, but that in fact cannot be rebuilt, silently kills
+every past ``/open`` — the #4584 defect this move closes.
+
+``reyn-dir-layout.md``'s own persist-tier decision rule ("knowledge /
+decision that must SURVIVE rewind → ``memory/``") is the only rule this
+table's shape actually satisfies among the doc's existing tiers — "memory"
+as a NAME is an imperfect fit (a ref→path table is neither knowledge nor a
+decision), recorded rather than silently accepted; introducing a sibling
+tier for this one table was judged out of scope for #4584 (lead-coder/
+architect co-vet, 2026-08-13).
+
+Same JSONL-append shape, same best-effort write-failure tolerance as
+before (a write failure here must never fail the mint itself — the ref is
+still valid for this process's lifetime even if a LATER process's table
+load won't see it) — only the TIER moved, not the mechanism. **The move
+does NOT change write permissions**: ``security/permissions/file_scope.py``'s
+``ZoneStateDir`` carves out only ``.reyn/config/`` + ``.reyn/state/`` +
+``approvals.yaml`` as the write-gated recovery-core surface — ``memory/``
+is an ordinary agent-writable zone, identically to ``cache/``.
 
 **Never copies bytes.** :func:`mint_ref` never reads the file's content,
 only records its path; :func:`resolve_ref` hands back a path for the
@@ -63,7 +87,10 @@ _REF_TABLE_FILENAME = "artifact_refs.jsonl"
 
 
 def _table_path(project_root: Path) -> Path:
-    return project_root / ".reyn" / "cache" / _REF_TABLE_FILENAME
+    # #4584: PERSIST tier — under `.reyn/memory/`, mirroring the doc's own
+    # decision rule for "must survive rewind" data (see this module's own
+    # docstring for why `memory/` as a NAME is an imperfect but chosen fit).
+    return project_root / ".reyn" / "memory" / _REF_TABLE_FILENAME
 
 
 def _load_table(project_root: Path) -> "list[dict]":

--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -82,8 +82,9 @@ from reyn.services.offload.store import offload_value, read_offloaded
 #: line per :meth:`MediaStore.save_tool_result` write — the persisted
 #: cross-process spill-provenance manifest.
 #:
-#: Lives under ``.reyn/cache/``, NOT under ``tool_results_dir`` (where it
-#: first landed — lead-coder review, #4432 round 3): every file
+#: Lives under ``.reyn/memory/`` — PERSIST tier (#4584 fix; previously
+#: ``.reyn/cache/``, moved there from ``tool_results_dir`` by #4432 round
+#: 3's own review). NOT under ``tool_results_dir``: every file
 #: ``tool_results_dir`` holds is written through this exact path
 #: (``offload_value`` in :meth:`save_tool_result` is its ONLY writer), so a
 #: consumer that lists that directory and expects "N spill artifacts" is
@@ -93,22 +94,39 @@ from reyn.services.offload.store import offload_value, read_offloaded
 #: results/`` is also classified *audit* (append-only forensic record,
 #: never read back) in ``reyn-dir-layout.md`` — this manifest IS read back,
 #: every process start, so it does not belong in an audit-only namespace
-#: either. ``.reyn/cache/`` fits the *derived* classification's spirit
-#: (ordinary writable zone, not recovery-core, ``budget_checkpoint.json``
-#: precedent) even though this manifest is not literally rebuildable from
-#: other state the way that ledger-derived total is.
+#: either.
 #:
-#: NOT a fix for a from-the-sandbox spoof: ``.reyn/cache/`` sits in the
-#: SAME default agent file-write zone as ``.reyn/tool-results/`` did
-#: (``security/permissions/file_scope.py``'s ``ZoneStateDir`` carves out
-#: only ``.reyn/config/`` + ``.reyn/state/`` + ``approvals.yaml`` —
-#: confirmed by reading ``_RECOVERY_CORE_WRITE_PREFIXES`` /
-#: ``_CANONICAL_PROTECTED_WRITE_PATHS`` in
-#: ``security/permissions/permissions.py``, not assumed). A safe-mode
-#: ``file.write`` could still inject or erase a line here before or after
-#: this move. Closing THAT requires ``.reyn/state/`` behind a dedicated
-#: WAL-emitting op — a bigger design call, deliberately not made in this
-#: fixup (same "flag, don't silently half-fix" call as this PR's own
+#: **Why NOT ``cache/`` (#4584 correction of the #4432-era reasoning
+#: above):** this module's own comment already said, verbatim, "this
+#: manifest is not literally rebuildable from other state the way that
+#: [``budget_checkpoint.json``] ledger-derived total is" — i.e. it was
+#: filed under *derived* while explicitly acknowledging it isn't derived.
+#: #4584 measured directly (``artifact_ref.py``'s sibling table hit the
+#: identical shape): no rebuild/reconstruction code path exists anywhere
+#: for this manifest — an operator following ``reyn-dir-layout.md``'s
+#: (now-corrected) "cache/ is derived, safe to clean up" classification
+#: would silently break every already-spilled tool-result reference this
+#: manifest is the ONLY record of. *Persist* (survives rewind, never
+#: reverted, ``reyn-dir-layout.md``'s own "must SURVIVE rewind → memory/"
+#: rule — the same landing spot ``artifact_ref.py``'s sibling table uses,
+#: same "memory as a NAME is an imperfect fit" caveat) is the honest tier:
+#: the entries here were never expected to be reconstructed, only ever
+#: written once and read back.
+#:
+#: **The move does NOT change write permissions** — a real, separate axis
+#: from tier classification, worth stating explicitly since a reader could
+#: otherwise assume "persist" means "harder to write to". ``security/
+#: permissions/file_scope.py``'s ``ZoneStateDir`` carves out ONLY
+#: ``.reyn/config/`` + ``.reyn/state/`` + ``approvals.yaml`` as the
+#: write-gated recovery-core surface (confirmed by reading
+#: ``_RECOVERY_CORE_WRITE_PREFIXES`` / ``_CANONICAL_PROTECTED_WRITE_PATHS``
+#: in ``security/permissions/permissions.py``, not assumed) — ``memory/``
+#: is an ordinary agent-writable zone, identically to ``cache/``. A
+#: safe-mode ``file.write`` could still inject or erase a line here before
+#: or after this move, exactly as it always could under ``cache/``.
+#: Closing THAT requires ``.reyn/state/`` behind a dedicated WAL-emitting
+#: op — a bigger design call, deliberately not made in this fixup (same
+#: "flag, don't silently half-fix" call as this PR's own
 #: ``MAX_CONTROL_IR_RESULT_INLINE_BYTES`` note).
 _SPILL_MANIFEST_FILENAME = "tool_result_spills.jsonl"
 
@@ -356,14 +374,22 @@ class MediaStore:
         # process. Loaded once at construction from
         # :data:`_SPILL_MANIFEST_FILENAME` under ``tool_results_dir``,
         # appended to (one line per write) by :meth:`save_tool_result`.
-        # No NEW cleanup story beyond what ``.reyn/cache/`` already has
-        # (rebuilt/pruned like every other cache entry — see
-        # :data:`_SPILL_MANIFEST_FILENAME`'s own module-level docstring
-        # for why it lives there and not alongside the spill artifacts).
+        # #4584: this manifest self-PRUNES (an existing entry whose target
+        # vanished is dropped — see :meth:`_load_spill_manifest`) but has NO
+        # REBUILD story: if the manifest FILE ITSELF were deleted, nothing
+        # recreates it from another source. An earlier version of this
+        # comment conflated the two ("rebuilt/pruned like every other cache
+        # entry" — false: no rebuild mechanism was ever implemented,
+        # measured directly; see :data:`_SPILL_MANIFEST_FILENAME`'s own
+        # module-level docstring for the full correction). It otherwise
+        # survives for the project's lifetime, same as :mod:`data.workspace.
+        # artifact_ref`'s sibling table.
         self._tool_result_spill_paths: "set[Path]" = self._load_spill_manifest()
 
     def _spill_manifest_path(self) -> Path:
-        return self._project_root / ".reyn" / "cache" / _SPILL_MANIFEST_FILENAME
+        # #4584: PERSIST tier — `.reyn/memory/`, not `.reyn/cache/` (see
+        # :data:`_SPILL_MANIFEST_FILENAME`'s own module docstring).
+        return self._project_root / ".reyn" / "memory" / _SPILL_MANIFEST_FILENAME
 
     def _load_spill_manifest(self) -> "set[Path]":
         manifest = self._spill_manifest_path()
@@ -402,15 +428,27 @@ class MediaStore:
 
     def _persist_spill_manifest(self, paths: "set[Path]") -> None:
         """#4478: rewrite the MANIFEST ONLY — the ledger of which paths
-        this store has spilled, under ``.reyn/cache/``. Never touches an
-        artifact under ``tool_results_dir`` itself; an entry only reaches
-        this rewrite because :meth:`_load_spill_manifest` already found its
-        target file gone from disk (deleted by something else, out of
-        scope for this store). This prune deletes zero bytes of anyone's
-        actual content — it only stops re-reading a manifest line that
-        stopped meaning anything the moment its file disappeared.
+        this store has spilled, under ``.reyn/memory/`` (#4584: moved from
+        ``.reyn/cache/``). Never touches an artifact under
+        ``tool_results_dir`` itself; an entry only reaches this rewrite
+        because :meth:`_load_spill_manifest` already found its target file
+        gone from disk (deleted by something else, out of scope for this
+        store). This prune deletes zero bytes of anyone's actual content —
+        it only stops re-reading a manifest line that stopped meaning
+        anything the moment its file disappeared.
+
+        #4584: this SELF-PRUNE (an existing, real entry dropped once its
+        target vanishes) is NOT the same claim as "this manifest can be
+        REBUILT" (recreated wholesale after the manifest FILE ITSELF is
+        deleted) — an earlier comment on this module conflated the two
+        ("rebuilt/pruned like every other cache entry"). Only pruning is
+        real; there is no reconstruction-from-nothing path, which is
+        exactly why this manifest cannot live under a tier documented
+        "safe to delete, rebuilt after restore" (see
+        :data:`_SPILL_MANIFEST_FILENAME`'s own module docstring).
+
         Best-effort, same as the append path in :meth:`save_tool_result` —
-        a write failure here (e.g. a read-only ``.reyn/cache/``) must
+        a write failure here (e.g. a read-only ``.reyn/memory/``) must
         never fail construction; it only means this process's prune
         didn't stick and the next one retries."""
         manifest = self._spill_manifest_path()

--- a/tests/data/test_4478_media_storage_stats.py
+++ b/tests/data/test_4478_media_storage_stats.py
@@ -68,7 +68,7 @@ def test_storage_stats_never_deletes_or_writes_anything(tmp_path):
 
 
 def _manifest_path(tmp_path: Path) -> Path:
-    return tmp_path / ".reyn" / "cache" / "tool_result_spills.jsonl"
+    return tmp_path / ".reyn" / "memory" / "tool_result_spills.jsonl"  # #4584: moved out of cache/
 
 
 def test_prune_drops_a_manifest_entry_whose_file_was_deleted_out_of_band(tmp_path):
@@ -111,7 +111,8 @@ def test_prune_keeps_a_manifest_entry_whose_file_still_exists(tmp_path):
 
 def test_prune_never_deletes_the_referenced_artifact_itself(tmp_path):
     """Tier 2: #4478 condition ② — the prune rewrites the MANIFEST (the
-    ledger under .reyn/cache/), never a file under tool_results_dir. This
+    ledger under .reyn/memory/, #4584: moved from .reyn/cache/), never a
+    file under tool_results_dir. This
     is the falsifiable form of "prune deletes zero bytes of anyone's
     actual content": construct a mixed manifest (one live entry, one
     entry a test writes by hand pointing at a path that never existed)

--- a/tests/data/test_4482_artifact_ref.py
+++ b/tests/data/test_4482_artifact_ref.py
@@ -116,17 +116,22 @@ def test_minting_never_copies_the_file(tmp_path: Path):
 
     assert before_inode == after_inode
     # The ONLY new file allowed to appear is the ref table itself.
-    assert new_files <= {tmp_path / ".reyn" / "cache" / "artifact_refs.jsonl"}
+    assert new_files <= {tmp_path / ".reyn" / "memory" / "artifact_refs.jsonl"}
 
 
 def test_table_is_a_jsonl_manifest_matching_the_4432_spill_manifest_shape(tmp_path: Path):
-    """Tier 2: (accept-side, format) one JSON object per line under
-    .reyn/cache/ — mirrors #4432's tool-result spill manifest shape, as
-    the brief explicitly asked for."""
+    """Tier 2: (accept-side, format) one JSON object per line, directly under
+    .reyn/memory/ — a PERSIST-tier file (#4584: moved out of .reyn/cache/,
+    which falsely promised "derived, rebuilt after restore" for data that is
+    not reconstructable from anything else — see artifact_ref.py's own
+    module docstring). The JSONL-append SHAPE still mirrors #4432's
+    tool-result spill manifest, as the original #4482 brief asked for; only
+    the tier (where it lives, and what that implies about deleting it)
+    changed."""
     target = _write(tmp_path / "report.pptx")
     ref = mint_ref(tmp_path, "alice", target)
 
-    table_path = tmp_path / ".reyn" / "cache" / "artifact_refs.jsonl"
+    table_path = tmp_path / ".reyn" / "memory" / "artifact_refs.jsonl"
     lines = [line for line in table_path.read_text(encoding="utf-8").splitlines() if line.strip()]
     entries = [json.loads(line) for line in lines]
     (entry,) = [e for e in entries if e["ref"] == ref]

--- a/tests/data/test_4584_persist_tier_survives_wal_truncation.py
+++ b/tests/data/test_4584_persist_tier_survives_wal_truncation.py
@@ -1,0 +1,137 @@
+"""Tier 2: #4584 — two tables moved from ``.reyn/cache/`` (DERIVED,
+"rebuilt after restore") to ``.reyn/memory/`` (PERSIST): ``artifact_ref.py``'s
+(agent, path) -> ref table (#4482 PR-1) and ``media_store.py``'s tool-result
+spill-provenance manifest (#4381/#4432).
+
+Both tables share the SAME defect that motivated the move: the data they
+hold exists ONLY at the instant it is written — no WAL event, no
+conversation-log entry, nothing else durable carries it (measured directly
+in #4494/#4584) — while ``cache/``'s own doc classification promised an
+operator it was safe to delete because it would be "rebuilt after restore".
+Filing genuinely-primary data under a "derived, safe to clean up" tier is
+what let a correctly-following operator (or a future GC policy) destroy it.
+
+This file's job is the CLAUDE.md recovery-feature PR gate, adapted to what
+this PR actually does: not "add reconstruction, prove it survives WAL
+truncation" (there is no reconstruction here — that is the whole point),
+but "prove the table is now genuinely OUTSIDE the WAL-truncation-affected
+tier" — a real ``StateLog.truncate_below`` call, heavy enough to drop
+every WAL entry, followed by a real re-open of a fresh ``StateLog`` over
+the SAME project (the standard "reconstruct" step
+``test_2946_item1_state_log_tail_scan.py`` uses for the identical
+primitive), with each table's own round trip (mint/save -> truncate ->
+resolve/is_spill) still returning the SAME path throughout — "moved" and
+"moved somewhere that survives" are different claims, and only a real
+round trip through the actual persisted files proves the second one (a
+bare path-string diff would go green either way).
+
+Real on-disk state under ``tmp_path``/real ``StateLog``/real ``MediaStore``
+throughout — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.core.events.state_log import StateLog
+from reyn.data.workspace.artifact_ref import mint_ref, resolve_ref
+from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+
+
+def _write(path: Path, content: bytes = b"x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _churn_and_truncate_wal(wal_path: Path) -> None:
+    """Append a handful of WAL entries, then truncate past every one of
+    them — the heaviest truncation short of deleting the file — then
+    re-open a brand-new ``StateLog`` over the result (the "reconstruct"
+    step: a fresh process attaching to this project)."""
+    log = StateLog(wal_path)
+
+    async def _go() -> None:
+        for i in range(5):
+            await log.append("inbox_put", target=f"a{i}", payload={})
+        await log.flush()
+        await log.truncate_below(1_000_000)
+        await log.flush()
+
+    asyncio.run(_go())
+    log2 = StateLog(wal_path)
+    assert log2.current_seq >= 1, "test setup: the truncation must actually have run"
+
+
+def test_both_tables_live_directly_under_memory_never_under_cache_or_state(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: structural witness for WHY truncation cannot touch either
+    table — neither path falls under ``.reyn/state/`` (the WAL) or
+    ``.reyn/config/`` (the write-gated config-generation registries), and
+    neither falls under ``.reyn/cache/`` (the DERIVED tier this PR moves
+    them OUT of) either."""
+    target = _write(tmp_path / "report.pptx")
+    mint_ref(tmp_path, "alice", target)
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    store.save_tool_result("big output", chain_id="c1", tool="exec", seq=1)
+
+    reyn_root = tmp_path / ".reyn"
+    ref_table = reyn_root / "memory" / "artifact_refs.jsonl"
+    spill_manifest = reyn_root / "memory" / "tool_result_spills.jsonl"
+    assert ref_table.is_file()
+    assert spill_manifest.is_file()
+    for table_path in (ref_table, spill_manifest):
+        assert table_path.parent == reyn_root / "memory"
+        assert (reyn_root / "state") not in table_path.parents
+        assert (reyn_root / "config") not in table_path.parents
+        assert (reyn_root / "cache") not in table_path.parents, (
+            f"{table_path} must no longer live under the DERIVED cache/ tier "
+            "(#4584's own fix)"
+        )
+
+
+def test_falsify_artifact_ref_survives_a_real_wal_truncation_and_reconstruct(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: LOAD-BEARING falsification (artifact_ref.py's half) — mint a
+    ref, run the REAL production WAL-truncation primitive across every
+    event this test wrote, re-open a brand-new ``StateLog`` (the
+    reconstruct step), and confirm ``resolve_ref`` still returns the SAME
+    path throughout. The ref was never written to the WAL in the first
+    place, so truncating it has zero effect BY CONSTRUCTION — this test
+    witnesses that construction directly rather than assuming it."""
+    target = _write(tmp_path / "report.pptx")
+    ref = mint_ref(tmp_path, "alice", target)
+    assert resolve_ref(tmp_path, "alice", ref) == target.resolve()  # test premise
+
+    _churn_and_truncate_wal(tmp_path / ".reyn" / "state" / "wal.jsonl")
+
+    resolved = resolve_ref(tmp_path, "alice", ref)
+    assert resolved == target.resolve(), (
+        "the artifact ref was lost across a WAL truncation it was never "
+        "derived from — the #4584 fix (moving the table out of cache/, off "
+        "the WAL entirely) did not hold"
+    )
+
+
+def test_falsify_spill_manifest_survives_a_real_wal_truncation_and_reconstruct(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: LOAD-BEARING falsification (media_store.py's half) — save a
+    tool-result spill, run the SAME real WAL-truncation + reconstruct
+    cycle, then open a BRAND-NEW ``MediaStore`` (mirrors
+    ``test_prune_drops_a_manifest_entry_whose_file_was_deleted_out_of_band``'s
+    own "a fresh construction = a later process" pattern) and confirm
+    ``is_tool_result_spill`` still recognizes the SAME path."""
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    block = store.save_tool_result("big output", chain_id="c1", tool="exec", seq=1)
+    assert store.is_tool_result_spill(block["path"])  # test premise
+
+    _churn_and_truncate_wal(tmp_path / ".reyn" / "state" / "wal.jsonl")
+
+    reopened = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    assert reopened.is_tool_result_spill(block["path"]), (
+        "the spill-manifest entry was lost across a WAL truncation it was "
+        "never derived from — the #4584 fix did not hold"
+    )

--- a/tests/web/test_4482_get_artifact_by_ref.py
+++ b/tests/web/test_4482_get_artifact_by_ref.py
@@ -158,7 +158,7 @@ def test_a_table_entry_pointing_outside_project_root_is_rejected(tmp_project: Pa
 
     outside = tmp_project.parent / "outside-secret.txt"
     outside.write_bytes(b"SECRET")
-    table = tmp_project / ".reyn" / "cache" / "artifact_refs.jsonl"
+    table = tmp_project / ".reyn" / "memory" / "artifact_refs.jsonl"  # #4584: moved out of cache/
     table.parent.mkdir(parents=True, exist_ok=True)
     with table.open("a", encoding="utf-8") as f:
         f.write(json.dumps({"ref": "evil", "agent": "researcher", "path": str(outside)}) + "\n")


### PR DESCRIPTION
**[tui-coder]** — part of #4584.

## What

Both `.reyn/cache/artifact_refs.jsonl` (#4482 PR-1) and
`.reyn/cache/tool_result_spills.jsonl` (#4381/#4432) move to
`.reyn/memory/` (PERSIST tier). Both were filed under `cache/`, documented
"DERIVED — rebuilt after restore" (`reyn-dir-layout.md`) — false for both:
each mapping/entry exists ONLY at the instant it's written, and nothing
else durable carries it. An operator correctly following the doc's own
"safe to clean up" classification (deleting `.reyn/cache/`, or restoring
from a backup that excludes it) permanently kills every past `/open` and
orphans every spill reference.

Full design record (lead-coder/architect co-vet) is on the issue. Summary
of the decisions that shaped this PR:

- **Both move together** — moving one alone would be a double standard
  the doc's own classification rule doesn't support (both tables hit the
  identical shape: neither is reconstructable, both were self-acknowledged
  as such in their own prior comments while still filed under `cache/`).
- **Landing spot is `.reyn/memory/`**, per `reyn-dir-layout.md`'s own
  decision rule ("must SURVIVE rewind → `memory/`") — the only tier its
  own text points at. `memory` is an imperfect NAME fit for a ref/manifest
  table (recorded in both modules' own docstrings, not silently accepted)
  — a sibling tier was judged out of scope for this PR.
- 🔴 **This move does NOT change write permissions.**
  `security/permissions/file_scope.py`'s `ZoneStateDir` write-gates only
  `.reyn/config/` + `.reyn/state/` + `approvals.yaml` — `memory/` is an
  ordinary agent-writable zone, identically to `cache/`. What changes is
  the CLASSIFICATION and the "safe to delete" claim, not the write
  surface. Stated explicitly in both modules' own docstrings, per
  lead-coder's explicit request, so a reader doesn't read "persist" as
  "hardened".

Two corrections that surfaced during the co-vet's own falsification round:

- **media_store.py's "rebuilt/pruned" comment was half-false.** Only
  PRUNING (dropping an existing manifest entry whose target file vanished)
  is real; there is no REBUILD mechanism (recreating the manifest from
  nothing after the manifest file itself is deleted). Corrected in both
  the module docstring and the two method docstrings that touch it —
  pruning and rebuilding are not the same claim, and the prior comment
  conflated them.
- **`reyn-dir-layout.md`'s "safe to delete at any time" was too broad.**
  It sits right under the `cache/` header, readable as a blanket claim
  about the whole tier. Architect measured a positive control: `index_drop`
  (an agent-callable op) already deletes `cache/index/<source>` behind
  `require_file_write` (#1199 S3.4) — reyn's own code already treats
  deleting something under `cache/` as gated, permission-requiring, not
  free. Narrowed the phrase to scope explicitly to `budget_checkpoint.json`
  (the one entry that genuinely is reconstructable) and added a `cache/`-level
  caveat naming `index_drop` as the counter-evidence to a blanket reading.

## Tests

`test_4584_persist_tier_survives_wal_truncation.py` (new) — the CLAUDE.md
recovery-feature PR gate's real intent for this shape: there is no "X's
source events" to truncate past for either table (neither was ever
WAL-derived — that's the whole defect), so the falsification instead runs
a real `StateLog.truncate_below` past every WAL event each test wrote,
re-opens a fresh `StateLog` (the same "reconstruct" step
`test_2946_item1_state_log_tail_scan.py` uses for the identical
primitive), and confirms BOTH tables' own round trip (`mint_ref` →
`resolve_ref`; `save_tool_result` → `is_tool_result_spill`) still returns
the SAME path throughout — "moved" and "moved somewhere that survives"
are different claims; only a real round trip through the actual persisted
files proves the second one (a bare path-string diff would go green
either way). A companion test pins the structural reason why: neither
path falls under `.reyn/state/`, `.reyn/config/`, or `.reyn/cache/`
anymore.

Existing `artifact_ref`/`media_store`/web tests updated for the new
paths (`test_4482_artifact_ref.py`, `test_4482_get_artifact_by_ref.py`,
`test_4478_media_storage_stats.py`).

## Test plan

- [x] `ruff check src <changed test files>` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 27/27 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — 211 findings, all baselined (215 declared)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Scoped `pytest tests/data -k "media or artifact" tests/web -k "artifact" tests/core -k "spill or media_store"` — 69 passed
- [x] Scoped `pytest tests/runtime/test_2425_step1c_chat_chokepoint.py tests/runtime/test_media_cap_272.py tests/runtime/test_router_ctx_media_store_2409.py tests/runtime/test_path_ref_materialisation.py` — 26 passed (broader MediaStore-consumer regression check)
- [ ] Full CI run (not run locally, per policy)

Enumerated `part of #4584` mentions before writing this body: this is the
only open PR against #4584; no other PR claims it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
