### PR TITLE
test(#4584): the falsification watched WAL truncation; the danger was cache removal

### DIFF
--- a/tests/data/test_4584_persist_tier_survives_wal_truncation.py
+++ b/tests/data/test_4584_persist_tier_survives_wal_truncation.py
@@ -51,17 +51,38 @@ def _churn_and_truncate_wal(wal_path: Path) -> None:
     re-open a brand-new ``StateLog`` over the result (the "reconstruct"
     step: a fresh process attaching to this project)."""
     log = StateLog(wal_path)
+    seen: dict[str, str] = {}
 
     async def _go() -> None:
         for i in range(5):
             await log.append("inbox_put", target=f"a{i}", payload={})
         await log.flush()
+        seen["before"] = wal_path.read_text(encoding="utf-8")
         await log.truncate_below(1_000_000)
         await log.flush()
+        seen["after"] = wal_path.read_text(encoding="utf-8")
 
     asyncio.run(_go())
-    log2 = StateLog(wal_path)
-    assert log2.current_seq >= 1, "test setup: the truncation must actually have run"
+    # Positive control on the SOURCE events, not on a counter that survives
+    # either way: `current_seq` is >= 1 the moment five appends land, so
+    # asserting it says nothing about whether anything was removed (#2839's
+    # own shape — assert the source entries before, and their absence after).
+    #
+    # "Absence" here is partial, and deliberately asserted as such:
+    # `_do_truncate` clamps its floor to the highest seq present ("never drop
+    # the highest seq present, even if min_keep_seq exceeds it"), so one entry
+    # always survives a truncate-past-everything. Asserting zero remained
+    # would fail against correct behaviour; asserting "fewer than before" is
+    # what actually witnesses that the rewrite dropped entries.
+    before_n = seen["before"].count('"inbox_put"')
+    after_n = seen["after"].count('"inbox_put"')
+    assert before_n == 5, f"test setup: the appends must have landed (saw {before_n})"
+    assert after_n < before_n, (
+        f"test setup: truncate_below removed nothing ({after_n} of {before_n} "
+        "entries still present) — every assertion below would then be "
+        "measuring an untruncated WAL while claiming otherwise"
+    )
+    StateLog(wal_path)  # the reconstruct step: a fresh process attaching here
 
 
 def test_both_tables_live_directly_under_memory_never_under_cache_or_state(

--- a/tests/data/test_4584_persist_tier_survives_wal_truncation.py
+++ b/tests/data/test_4584_persist_tier_survives_wal_truncation.py
@@ -68,19 +68,19 @@ def _churn_and_truncate_wal(wal_path: Path) -> None:
     # asserting it says nothing about whether anything was removed (#2839's
     # own shape — assert the source entries before, and their absence after).
     #
-    # "Absence" here is partial, and deliberately asserted as such:
-    # `_do_truncate` clamps its floor to the highest seq present ("never drop
-    # the highest seq present, even if min_keep_seq exceeds it"), so one entry
-    # always survives a truncate-past-everything. Asserting zero remained
-    # would fail against correct behaviour; asserting "fewer than before" is
-    # what actually witnesses that the rewrite dropped entries.
-    before_n = seen["before"].count('"inbox_put"')
-    after_n = seen["after"].count('"inbox_put"')
-    assert before_n == 5, f"test setup: the appends must have landed (saw {before_n})"
-    assert after_n < before_n, (
-        f"test setup: truncate_below removed nothing ({after_n} of {before_n} "
-        "entries still present) — every assertion below would then be "
-        "measuring an untruncated WAL while claiming otherwise"
+    # The "after" side reads the primitive's OWN report (`last_truncate_stats`,
+    # the public surface #3180's own truncate-falsify already uses) rather than
+    # counting lines ourselves. Counting works but measures a proxy: an
+    # external guess at what the rewrite did, which also has to encode the
+    # clamp `_do_truncate` applies ("never drop the highest seq present, even
+    # if min_keep_seq exceeds it" — so a truncate-past-everything over a single
+    # kind always leaves one entry, and "zero remain" would fail against
+    # correct behaviour). Asking the mechanism how many it dropped needs none
+    # of that.
+    assert seen["before"].count('"inbox_put"') == 5, "test setup: the appends must have landed"
+    assert log.last_truncate_stats["dropped"] >= 1, (
+        "test setup: truncate_below dropped nothing — every assertion below "
+        "would then be measuring an untruncated WAL while claiming otherwise"
     )
     StateLog(wal_path)  # the reconstruct step: a fresh process attaching here
 

--- a/tests/data/test_4584_persist_tier_survives_wal_truncation.py
+++ b/tests/data/test_4584_persist_tier_survives_wal_truncation.py
@@ -31,6 +31,7 @@ throughout — no mocks.
 from __future__ import annotations
 
 import asyncio
+import shutil
 from pathlib import Path
 
 from reyn.core.events.state_log import StateLog
@@ -110,8 +111,9 @@ def test_falsify_artifact_ref_survives_a_real_wal_truncation_and_reconstruct(
     resolved = resolve_ref(tmp_path, "alice", ref)
     assert resolved == target.resolve(), (
         "the artifact ref was lost across a WAL truncation it was never "
-        "derived from — the #4584 fix (moving the table out of cache/, off "
-        "the WAL entirely) did not hold"
+        "derived from. This does NOT witness #4584 itself (WAL truncation "
+        "never touched cache/, so this passed before the move too) — it "
+        "guards the FUTURE change of deriving the table from the WAL"
     )
 
 
@@ -133,5 +135,67 @@ def test_falsify_spill_manifest_survives_a_real_wal_truncation_and_reconstruct(
     reopened = MediaStore(MediaStoreConfig(), project_root=tmp_path)
     assert reopened.is_tool_result_spill(block["path"]), (
         "the spill-manifest entry was lost across a WAL truncation it was "
-        "never derived from — the #4584 fix did not hold"
+        "never derived from. Same scope as the sibling above: not a witness "
+        "for #4584, a guard against deriving this manifest from the WAL"
+    )
+
+
+# ── the falsification #4584 actually needs: the danger is cache REMOVAL ──
+
+
+def _wipe_cache(project_root: Path) -> None:
+    """Delete ``.reyn/cache/`` outright — what an operator does when the
+    layout doc says a tier is safe to delete, and what ``index_drop`` does
+    to a subtree of it from inside a running agent. This, not WAL
+    truncation, is the event #4584 moved the two tables away from."""
+    cache = project_root / ".reyn" / "cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    shutil.rmtree(cache)
+    assert not cache.exists(), "test setup: the cache tier must really be gone"
+
+
+def test_falsify_artifact_ref_survives_the_cache_tier_being_deleted(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: LOAD-BEARING falsification — mint a ref, delete the whole
+    ``.reyn/cache/`` tier, and resolve it again.
+
+    This is the one that FLIPS: before #4584 the table lived in
+    ``.reyn/cache/artifact_refs.jsonl``, so wiping that tier took the
+    ref with it and ``resolve_ref`` returned ``None``. The sibling
+    WAL-truncation tests above pass either way — WAL truncation never
+    touched ``cache/`` — so they cannot witness this move, which is why
+    this test exists separately rather than as a variation of them.
+    """
+    target = _write(tmp_path / "report.pptx")
+    ref = mint_ref(tmp_path, "alice", target)
+    assert resolve_ref(tmp_path, "alice", ref) == target.resolve()  # test premise
+
+    _wipe_cache(tmp_path)
+
+    assert resolve_ref(tmp_path, "alice", ref) == target.resolve(), (
+        "the artifact ref died when the cache tier was deleted — the table is "
+        "back under a tier the layout doc says is safe to delete, and every "
+        "previously minted /open link is now unresolvable (#4584)"
+    )
+
+
+def test_falsify_spill_manifest_survives_the_cache_tier_being_deleted(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: LOAD-BEARING falsification, media_store.py's half — same
+    flip: the manifest used to live under ``.reyn/cache/`` and a wipe of
+    that tier made every recorded spill unrecognizable to a later
+    process."""
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    block = store.save_tool_result("big output", chain_id="c1", tool="exec", seq=1)
+    assert store.is_tool_result_spill(block["path"])  # test premise
+
+    _wipe_cache(tmp_path)
+
+    reopened = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    assert reopened.is_tool_result_spill(block["path"]), (
+        "the spill-manifest entry died when the cache tier was deleted — the "
+        "manifest is back under the tier the layout doc says is safe to "
+        "delete (#4584)"
     )


### PR DESCRIPTION
**[lead-coder]** — 🔴 **★#4592 の falsify test は ★#4584 の 修正を ★見ていませんでした。★通したのは ★私の TESTS-READ です。**

⚪ **★発見は architect**（★受入条件を 書いた 本人による 自己指摘）。

## ✅ ★測定 ── ★1 回の 実行で 全部 出ます

```
★`_table_path` を ★`.reyn/cache/` に 戻して ★同じ file を 実行:
   🔴 ★FAILED ★test_falsify_artifact_ref_survives_the_cache_tier_being_deleted（★新規）
   🔴 ★FAILED ★test_both_tables_live_directly_under_memory_never_under_cache_or_state
   ✅ ★PASSED ★test_falsify_artifact_ref_survives_a_real_wal_truncation…（★既存）
   ✅ ★PASSED ★test_falsify_spill_manifest_survives_a_real_wal_truncation…（★既存）
∴ ★既存の 2 本は ★修正を 戻しても ★緑 ── ★#4584 を witness できません
```

## 🔴 ★なぜ そう なるか

```
★WAL truncation ── ★`.reyn/state/wal.jsonl` を ★書き直すだけ
🔴 ★`.reyn/cache/` は ★触りません
∴ ★表が cache に 在った ままでも ★resolve は 通ります
🔴 ★test 自身が そう 書いています ──「★zero effect ★BY CONSTRUCTION」
🔴 ★なのに 失敗メッセージは ──「the ★#4584 fix … ★did not hold」
   ── ★できない 検出を ★名乗っていました
```

## ✅ ★足した もの ── ★flip する 側

```
✅ ★mint_ref → ★`.reyn/cache/` を ★丸ごと 削除 → ★resolve_ref
   ── ★doc が「safe to delete」と 言った ときに ★人が する こと
   ── ★`index_drop`（★agent 呼び出し可能）が ★部分に 対して する こと
   ── ★★#4584 が 表を 逃がした 相手 そのもの
✅ ★spill manifest 側も 同形
```

## ✅ ★既存 2 本は ★残します（★消しません）

```
✅ ★将来 ★どちらかの 表を ★WAL 由来に する 変更は ★本物の 退行
   ── ★その 見張りとして ★有効です
🔴 ★ただし ★失敗メッセージを 書き直しました ──
   ★「これは ★#4584 を witness しない。★WAL 由来に する 変更に 対する 見張り」
   ── ★次に 読む 人が ★#4584 の gate だと 誤読しない ように
```

## 🔴 ★私の 誤り（★記録）

```
★私の TESTS-READ ──「★recovery gate ── ★満たしています」
🔴 ★私が 見たのは ★形 でした:
   ★real StateLog ／ ★real truncate_below ／ ★real 再 open ／ ★real 往復
🔴 ★聞かなかった 問い ──「★修正を 戻したら ★落ちるか」
   ── ★★六問③ が ★その ため に 在ります
⚪ ★私は 今夜 ★#4575 で ★同じ 理由で ★falsify test を 1 本 削らせています
   ── ★他人の には 効き、★自分が 通す 番では 効きませんでした
```

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict <the file>` — 0 errors
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/data` — 186 passed
- [x] ★flip の 実測（★上の 4 行）── ★`_table_path` を cache に 戻して 再実行、★元に 戻し済
- [ ] Full CI run (not run locally, per policy)

⚪ **★`tests/` を 触っています ∴ ★TESTS-READ が 要ります** ── **★自作 ∴ ★自分では 出せません。**
**★reyn-reviewer に 依頼します。**

part of #4584
