### PR TITLE
docs(#4590): merge skip-visibility framing into control-ir.md's existing step-7 paragraph

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -1176,10 +1176,14 @@ higher-trust one.
    (probe-then-commit, mirrors `mcp_install_local`) for the root
    `.mcp.json` — a server's `command` is registered AS-IS, no
    venv-interpreter rewrite. Emit `plugin_install_registered`.
-   The return value's `registered`/`skipped` dicts (both keyed by
-   capability kind — `mcp`/`pipelines`/`skills`) record every declared
-   capability that did NOT make it in, by a different mechanism per kind:
-   mcp's probe-then-commit skips BEFORE the write (a probe failure or a
+   Before #4580, this step's own `registered` list was the ONLY signal
+   — a manifest declaring 3 capabilities that only 2 actually registered
+   read identically to "declared 3, registered 3": no count or event let
+   an operator (or a test) tell the two apart. The return value's
+   `registered`/`skipped` dicts (both keyed by capability kind —
+   `mcp`/`pipelines`/`skills`) now record every declared capability that
+   did NOT make it in, by a different mechanism per kind: mcp's
+   probe-then-commit skips BEFORE the write (a probe failure or a
    denied MCP-axis permission gate — `mcp_server_install_skipped`, #4580);
    a pipeline/skill sub-install always runs and is routed to `skipped`
    when its OWN return value's `status` isn't `"installed"` (a bad name,


### PR DESCRIPTION
**[docs-maintainer]** — Correction of this PR's own original framing, per lead-coder's review.

**Original claim (wrong)**: that `control-ir.md`'s `plugin_install` skip-visibility fold-in from #4594 never landed. It did land — `origin/main` carries it at `control-ir.md:1179-1188`, as step 7 of the numbered `plugin_install` lifecycle walkthrough (commit 8469d6b22, `control-ir.md +11 -0`). My error: I only read the general-description prose near the top of the `## plugin_install / plugin_uninstall` section and never scrolled down ~140 lines to the numbered steps further inside that same section — not a stale-tree read (fetch was fresh), just the wrong line range, twice.

**What this revision does instead**: merges my own (per lead-coder, clearer) "declared 3, registered 3" vs "declared 3, registered 2" framing INTO the existing step-7 paragraph, rather than duplicating it as a second standalone paragraph elsewhere in the file. One location, one paragraph, enriched — not two.

## Verification

- `git show origin/main:docs/reference/runtime/control-ir.md | sed -n '1155,1195p'` — read the real, current, freshly-fetched content this time before writing anything.
- `git diff docs/reference/runtime/control-ir.md` — confirmed the diff touches only the one existing step-7 location, no duplication anywhere else in the file.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean, only pre-existing en/ja anchor INFO noise, no "Aborted" line.

part of #4590

## Test plan

- [x] `mkdocs build --strict` clean
- [x] `ruff check src tests` — docs-only change, N/A
- [ ] Visual — N/A (docs prose only)
