### PR TITLE
feat(#4494): remote/post-restart Artifacts pane falls back to the durable artifact-ref table

### DIFF
--- a/src/reyn/core/present/artifact_list.py
+++ b/src/reyn/core/present/artifact_list.py
@@ -140,6 +140,36 @@ def collect_artifact_rows(node_lists: "list[list[dict]]") -> list[ArtifactRow]:
     return rows
 
 
+def rows_from_ref_table_entries(entries: "list[dict]") -> list[ArtifactRow]:
+    """#4494 design C: project the durable artifact-ref table's own raw
+    entries (:func:`~reyn.data.workspace.artifact_ref.list_refs_for_agent`
+    — already newest-first) into :class:`ArtifactRow` objects — the
+    fallback source a client with no live conversation state (a REMOTE
+    client, or a LOCAL one right after a restart, #4584's own measured
+    finding) uses to populate the Artifacts pane at all.
+
+    Every row from THIS source is ref-backed (never inline — the table
+    only ever records a real file's path) and carries no ``media_type``/
+    ``description`` (the ref table was never designed to hold them —
+    only what :func:`~reyn.data.workspace.artifact_ref.mint_ref` itself
+    records). This is a real, structural information loss versus the
+    live-conversation-derived path, not a bug in this function — the
+    caller's own UI is responsible for disclosing it (lead-coder's #4494
+    ruling: state the SOURCE LIMITATION, never a count — see
+    ``chrome.py``'s own artifact-pane disclosure text)."""
+    return [
+        ArtifactRow(
+            ref=str(entry["ref"]),
+            name=Path(str(entry["path"])).name,
+            media_type=None,
+            description=None,
+            is_inline=False,
+        )
+        for entry in entries
+        if "ref" in entry and "path" in entry
+    ]
+
+
 def resolve_display_paths(
     rows: list[ArtifactRow], project_root: Path, agent_name: str,
 ) -> list[ArtifactRow]:

--- a/src/reyn/data/workspace/artifact_ref.py
+++ b/src/reyn/data/workspace/artifact_ref.py
@@ -166,3 +166,26 @@ def resolve_ref(project_root: Path, agent_name: str, ref: str) -> "Path | None":
             candidate = Path(entry["path"])
             return candidate if candidate.exists() else None
     return None
+
+
+def list_refs_for_agent(project_root: Path, agent_name: str) -> "list[dict]":
+    """#4494 design C: every ``{"ref", "path"}`` entry minted under
+    *agent_name*'s scope, newest-first — the durable source a REMOTE
+    client's own artifact list falls back to when its live conversation
+    view carries nothing (frame-sufficiency: past turns are not on the
+    wire — the SAME gap also affects a LOCAL client right after a
+    restart, since ``restore.project_restored_frames`` has no
+    "presentation" kind reconstruction either, #4584's own measured
+    finding — this function is transport-agnostic and serves both).
+
+    Deliberately raw entries, not :class:`~reyn.core.present.artifact_list.
+    ArtifactRow` objects — this module has no ``media_type``/
+    ``description`` to offer (the table was never designed to carry them;
+    only :func:`mint_ref`'s two fields exist), and no existence check
+    (mirrors :func:`~reyn.core.present.artifact_list.collect_artifact_rows`'s
+    own "stat only what's about to be displayed" discipline — the CALLER
+    decides how many rows it is about to render before paying that I/O).
+    """
+    entries = [e for e in _load_table(project_root) if e.get("agent") == agent_name]
+    entries.reverse()  # newest-first, matching collect_artifact_rows' own convention
+    return [{"ref": e["ref"], "path": e["path"]} for e in entries if "ref" in e and "path" in e]

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1168,6 +1168,14 @@ class TextualChatApp(App):
         # materialize+open it, not just the command-string list every other
         # pane action reads.
         self._artifact_rows_cache: "list[ArtifactRow]" = []
+        # #4494 design C: which source the CURRENT cache above came from —
+        # "live" (the conversation-derived list, the default) or
+        # "ref_table_fallback" (the durable artifact-ref table, consulted
+        # only once the live list comes back empty — see
+        # :meth:`_maybe_refresh_remote_artifact_fallback`). Threaded into
+        # ``chrome.pane_payload``/``pane_commands`` so the disclosure row
+        # is appended (or not) alongside the right rows/commands.
+        self._artifact_rows_source: str = "live"
         # #3288 ③c: in-flight streamed reply, keyed by ``chain_id`` — the SAME
         # authoritative correlation id ``RouterLoop._emit_agent_delta`` stamps
         # on every ``agent_delta`` audit-event AND the one the terminal
@@ -1683,6 +1691,11 @@ class TextualChatApp(App):
             if entry.item.kind == "presentation"
         ]
         rows = collect_artifact_rows(node_lists)
+        # #4494 design C: THIS call always reflects the live-conversation
+        # source (whatever it finds, empty or not) — the fallback is a
+        # SEPARATE, async step (:meth:`_maybe_refresh_remote_artifact_fallback`)
+        # triggered only after a sync render already ran with this source.
+        self._artifact_rows_source = "live"
         if not rows:
             return rows
         project_root = _find_project_root(Path.cwd()) or Path.cwd()
@@ -1702,6 +1715,7 @@ class TextualChatApp(App):
             commands=REGISTRY.all_commands(),
             history=self._history_turns(),
             artifacts=self._artifact_rows(),
+            artifact_source=self._artifact_rows_source,
             app_bindings=self._app_binding_help(),
         )
 
@@ -2458,6 +2472,7 @@ class TextualChatApp(App):
         self._artifact_rows_cache = artifact_rows
         self._pane_commands[tab_id] = pane_commands(  # type: ignore[arg-type]
             tab_id, snapshot, artifacts=artifact_rows,
+            artifact_source=self._artifact_rows_source,
         )
         child = self.query_one(f"#{tab_id}")
         if isinstance(child, OptionList):
@@ -2472,8 +2487,72 @@ class TextualChatApp(App):
         elif isinstance(child, Static):
             child.update("\n".join(rows))
 
-    def on_menu_bar_selected(self, event: "MenuBar.Selected") -> None:
-        self._open_drawer(None if event.tab_id == "__close__" else event.tab_id)
+    async def _maybe_refresh_remote_artifact_fallback(self) -> None:
+        """#4494 design C: once the artifacts pane has rendered its
+        LIVE-conversation rows (via :meth:`_refresh_pane`, always
+        synchronous — this method never runs before it), consult the
+        durable artifact-ref table through the transport when that live
+        list came back empty. Covers a remote client (its past turns are
+        not on the wire at all) and a local client right after a restart
+        (the identical gap, #4584's own measured finding —
+        ``restore.project_restored_frames`` has no "presentation" kind
+        reconstruction). A non-empty live list is never overridden — it
+        carries real ``media_type``/``description`` the ref table cannot
+        offer, so this is strictly a fallback, not a merge.
+
+        Re-renders the "artifacts" OptionList in place with the fallback
+        rows PLUS the source-limitation disclosure
+        (``chrome.ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE``) appended —
+        always appended, even when the fallback itself is empty (#4494's
+        own falsify requirement: emptying the ref table empties the rows
+        but the disclosure text stays)."""
+        if self._artifact_rows_cache:
+            return  # live list already had content — no fallback needed
+        from pathlib import Path
+
+        from reyn.config import _find_project_root
+        from reyn.core.present.artifact_list import (
+            resolve_display_paths,
+            rows_from_ref_table_entries,
+        )
+
+        entries = await self._transport.request_artifact_list(agent=self._agent_name)
+        fallback_rows = rows_from_ref_table_entries(entries)
+        if fallback_rows:
+            # Same resolved_path fill-in the live path gets (#4482 PR-3
+            # review, "表示から実行まで同じ path を使う") — a bare `name`
+            # is a basename, which cannot distinguish two same-named
+            # artifacts in different directories.
+            project_root = _find_project_root(Path.cwd()) or Path.cwd()
+            fallback_rows = resolve_display_paths(
+                fallback_rows, project_root, self._agent_name,
+            )
+        self._artifact_rows_cache = fallback_rows
+        self._artifact_rows_source = "ref_table_fallback"
+        try:
+            drawer = self.query_one("#drawer", ContentSwitcher)
+        except Exception:
+            return  # not mounted (e.g. a headless/test harness) — nothing to update
+        if drawer.current != "artifacts":
+            return  # operator navigated away before the fallback arrived
+        self._pane_commands["artifacts"] = pane_commands(
+            "artifacts", artifacts=fallback_rows, artifact_source="ref_table_fallback",
+        )
+        rows = pane_payload(
+            "artifacts", artifacts=fallback_rows, artifact_source="ref_table_fallback",
+        )
+        child = self.query_one("#artifacts")
+        if isinstance(child, OptionList):
+            child.clear_options()
+            child.add_options(
+                _literal_option_content(rows) if pane_needs_literal_rows("artifacts") else rows
+            )
+
+    async def on_menu_bar_selected(self, event: "MenuBar.Selected") -> None:
+        tab_id = None if event.tab_id == "__close__" else event.tab_id
+        self._open_drawer(tab_id)
+        if tab_id == "artifacts":
+            await self._maybe_refresh_remote_artifact_fallback()
 
     async def on_option_list_option_selected(
         self, event: "OptionList.OptionSelected"

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -951,13 +951,42 @@ def artifact_row_label(row: "ArtifactRow") -> str:
     return row.resolved_path or row.name
 
 
-def artifact_pane_options(rows: "Sequence[ArtifactRow]") -> list[str]:
+#: #4494 design C (lead-coder ruling, verbatim): "C ＋ 明示。文面は「件数」
+#: ではなく「情報源の限界」を言うこと" — states the SOURCE LIMITATION, never
+#: a count (a remote/post-restart fallback genuinely cannot count what it
+#: has no record of), and never a "まだ" (not-yet) framing (implies a richer
+#: source is definitely coming, which is not decided). Appended verbatim
+#: regardless of row count, so an empty ref-table fallback still explains
+#: WHY, rather than reading like "no artifacts" (#4494's own falsify
+#: requirement: emptying the table empties the rows but this text stays).
+ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE = (
+    "この一覧はartifact-ref表から作られます。agentがinlineで直接渡した"
+    "artifact（実ファイルなし）はその表に記録されないため、ここには出せません。"
+)
+
+
+def artifact_pane_options(
+    rows: "Sequence[ArtifactRow]", *, source: str = "live",
+) -> list[str]:
     """Rows for the Artifacts drawer pane — newest-first, already the order
-    :func:`~reyn.core.present.artifact_list.collect_artifact_rows` returns."""
-    return [artifact_row_label(r) for r in rows] if rows else ["(no artifacts yet)"]
+    :func:`~reyn.core.present.artifact_list.collect_artifact_rows` returns
+    (``source="live"``, the default) or
+    :func:`~reyn.core.present.artifact_list.rows_from_ref_table_entries`
+    (``source="ref_table_fallback"``, #4494 design C — consulted only when
+    the live-conversation list is empty: a remote client's past turns are
+    not on the wire, and a local client right after a restart has the
+    identical gap, #4584's own measured finding). The fallback source
+    ALWAYS appends :data:`ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE` — the
+    source limitation, never a count."""
+    body = [artifact_row_label(r) for r in rows] if rows else ["(no artifacts yet)"]
+    if source == "ref_table_fallback":
+        return [*body, ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE]
+    return body
 
 
-def artifact_pane_commands(rows: "Sequence[ArtifactRow]") -> list[str]:
+def artifact_pane_commands(
+    rows: "Sequence[ArtifactRow]", *, source: str = "live",
+) -> list[str]:
     """The ``/open <ref>`` command parallel to each row in
     :func:`artifact_pane_options` — empty string for a ref-less row: an
     error marker (nothing resolved), or a pure-inline artifact.
@@ -969,11 +998,15 @@ def artifact_pane_commands(rows: "Sequence[ArtifactRow]") -> list[str]:
     slash-command TEXT pipeline as an argument the way a `ref` token can.
     ``app.on_option_list_option_selected`` special-cases the "artifacts"
     pane and reads the ``ArtifactRow`` objects directly (never this
-    command list) for exactly that row shape — see its own docstring."""
-    return [
-        f"/open {r.ref}" if r.ref is not None else ""
-        for r in rows
-    ]
+    command list) for exactly that row shape — see its own docstring.
+
+    ``source="ref_table_fallback"`` appends one more empty string — the
+    disclosure row :func:`artifact_pane_options` appends has no command
+    of its own, index-aligned with that row (#4494)."""
+    cmds = [f"/open {r.ref}" if r.ref is not None else "" for r in rows]
+    if source == "ref_table_fallback":
+        cmds.append("")
+    return cmds
 
 
 def menu_pane_options(commands: "Iterable[SlashCommand]") -> list[str]:
@@ -1352,6 +1385,7 @@ def pane_commands(
     snapshot: "dict | None" = None,
     *,
     artifacts: "Sequence[ArtifactRow]" = (),
+    artifact_source: str = "live",
 ) -> list[str]:
     """The slash command parallel to each row of ``tab_id``'s pane — index-aligned
     with :func:`pane_payload`'s rows for the same ``snapshot``, ``[]`` for a pane
@@ -1361,9 +1395,11 @@ def pane_commands(
     This is what makes the restored categories OPERABLE rather than merely visible
     (#3338): the app maps a selected row straight onto ``/model`` / ``/attach`` /
     ``/session switch`` / ``/visibility`` / ``/hook`` / ``/open`` (#4482) and
-    submits it through the same transport seam a typed slash uses."""
+    submits it through the same transport seam a typed slash uses.
+
+    ``artifact_source`` — see :func:`artifact_pane_options` (#4494 design C)."""
     if tab_id == "artifacts":
-        return artifact_pane_commands(artifacts)
+        return artifact_pane_commands(artifacts, source=artifact_source)
     builder = _PANE_ENTRY_BUILDERS.get(tab_id)
     if builder is None:
         return []
@@ -1377,13 +1413,16 @@ def pane_payload(
     commands: "Iterable[SlashCommand]" = (),
     history: "Sequence[str]" = (),
     artifacts: "Sequence[ArtifactRow]" = (),
+    artifact_source: str = "live",
     app_bindings: "Iterable[tuple[str, str]]" = (),
 ) -> list[str]:
     """The display rows for ``tab_id``'s drawer pane, derived from canonical reyn
     sources. For a list pane (:func:`pane_is_list`) the rows are OptionList
     options; for a readout the rows are Static lines. All inputs are plain data
     (the app assembles them from its live snapshot / the slash REGISTRY / the
-    conversation model) so this stays pure + testable."""
+    conversation model) so this stays pure + testable.
+
+    ``artifact_source`` — see :func:`artifact_pane_options` (#4494 design C)."""
     snap = snapshot or {}
     builder = _PANE_ENTRY_BUILDERS.get(tab_id)
     if builder is not None:
@@ -1391,7 +1430,7 @@ def pane_payload(
     if tab_id == "history":
         return history_pane_options(history)
     if tab_id == "artifacts":
-        return artifact_pane_options(artifacts)
+        return artifact_pane_options(artifacts, source=artifact_source)
     if tab_id == "menu":
         return menu_pane_options(commands)
     if tab_id == "cost":

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -959,9 +959,17 @@ def artifact_row_label(row: "ArtifactRow") -> str:
 #: regardless of row count, so an empty ref-table fallback still explains
 #: WHY, rather than reading like "no artifacts" (#4494's own falsify
 #: requirement: emptying the table empties the rows but this text stays).
+#: English (review fix, lead-coder, #4599): every OTHER user-facing string
+#: in this pane (and this whole module) is English — e.g. `_COST_ROW_LABELS`
+#: below — with Japanese appearing only inside code COMMENTS quoting the
+#: owner verbatim, never in a string a user reads. There is no UI i18n
+#: mechanism here (`output_language` governs LLM output, not this chrome);
+#: a Japanese UI would be a whole-surface owner decision, not one string
+#: at a time.
 ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE = (
-    "この一覧はartifact-ref表から作られます。agentがinlineで直接渡した"
-    "artifact（実ファイルなし）はその表に記録されないため、ここには出せません。"
+    "This list is built from the artifact-ref table. An artifact the "
+    "agent passed inline (no real file) is never recorded there, so it "
+    "cannot appear here."
 )
 
 

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -212,6 +212,19 @@ class AgUiTransport(ClientTransport):
         )
         return bool((result or {}).get("switched"))
 
+    async def request_artifact_list(self, *, agent: str) -> "list[dict]":
+        # #4494 design C: POST a typed request; the server reads its OWN
+        # copy of the durable artifact-ref table (never a client-supplied
+        # path) and answers with the current entries. Same shape as
+        # ``request_attach``/``request_session_switch`` above. ``agent``
+        # is accepted for parity with the ``ClientTransport`` signature —
+        # the server's own ``agent_name`` (baked into the endpoint URL at
+        # connect time) is what it actually reads against, so this
+        # transport does not thread it onto the wire separately.
+        result = await self._send({"type": "artifact_list_request"})
+        entries = (result or {}).get("entries")
+        return entries if isinstance(entries, list) else []
+
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None
     ) -> bool:

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -771,6 +771,24 @@ async def agui_submit(request: Request, agent_name: str):
             except KeyError:
                 pass
         return JSONResponse({"status": "ok", "switched": switched})
+    elif ptype == "artifact_list_request":
+        # #4494 design C: the durable artifact-ref table's own entries for
+        # *agent_name*, read server-side (never trusting a client-supplied
+        # path) — the fallback a remote client's own Artifacts pane
+        # consults when its live conversation view carries nothing (its
+        # past turns are simply not on the wire). Mirrors
+        # ``attach_request``/``session_switch_request`` above: client
+        # names an operation, server executes it against ITS OWN state.
+        from reyn.data.workspace.artifact_ref import list_refs_for_agent
+        # ``workspace_dir`` = <project_root>/.reyn/agents/<agent_name> — three
+        # levels down, so PROJECT ROOT (what list_refs_for_agent wants, same
+        # as mint_ref/resolve_ref) needs three .parent hops, not two (two
+        # only reaches the .reyn directory itself — InProcessTransport's own
+        # reyn_state_root() derivation, a DIFFERENT thing this handler does
+        # not want).
+        project_root = session.workspace_dir.parent.parent.parent
+        entries = list_refs_for_agent(project_root, agent_name)
+        return JSONResponse({"status": "ok", "entries": entries})
     return JSONResponse({"status": "ok"})
 
 

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -244,6 +244,33 @@ class ClientTransport(ABC):
         """
         return False
 
+    async def request_artifact_list(self, *, agent: str) -> "list[dict]":
+        """#4494 design C: the durable artifact-ref table's own entries for
+        *agent* — ``[{"ref", "path"}, ...]``, newest-first, or ``[]`` when
+        there is nothing (or this transport does not support the query).
+        Same "client interprets, server executes a named operation" shape
+        :meth:`request_attach`/:meth:`request_session_switch` already
+        establish: ``InProcessTransport`` reads the table directly;
+        ``AgUiTransport`` POSTs a typed request and the server reads its
+        OWN copy (never the wire's stale view — the server always has the
+        live, durable table this client cannot see any other way).
+
+        This is the FALLBACK a caller reaches for only when its own live
+        conversation-derived artifact list is empty (frame-sufficiency: a
+        remote client's past turns are not on the wire; a local client
+        right after a restart has the identical gap, #4584's own measured
+        finding — ``restore.project_restored_frames`` has no
+        "presentation" kind reconstruction). Rows from this source are
+        ALWAYS ref-backed (real files only — the table never records an
+        inline artifact) and carry no ``media_type``/``description`` — a
+        real information loss the caller's own UI must disclose, never
+        silently absorb (lead-coder's #4494 ruling).
+
+        NOT abstract, same reasoning as :meth:`request_attach` — several
+        narrow-purpose stubs across the test suite pre-date this method;
+        the default ``[]`` preserves their behavior unchanged."""
+        return []
+
     def reyn_state_root(self) -> "Path | None":
         """The attached session's project `.reyn` root, or None (#3721).
 

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -224,6 +224,21 @@ class InProcessTransport(ClientTransport):
             return False
         return True
 
+    async def request_artifact_list(self, *, agent: str) -> "list[dict]":
+        # #4494 design C: local execution side — reads the durable
+        # artifact-ref table directly (no wire hop). ``list_refs_for_agent``
+        # wants the PROJECT ROOT (it appends ".reyn"/"memory"/... itself,
+        # the same way ``mint_ref``/``resolve_ref`` do) — one level ABOVE
+        # ``reyn_state_root()``, which is the ``.reyn`` directory itself
+        # (see that method's own docstring). No attached session means no
+        # root to read, so the fallback is empty, same as an unattached
+        # ``has_session()``.
+        from reyn.data.workspace.artifact_ref import list_refs_for_agent
+        reyn_root = self.reyn_state_root()
+        if reyn_root is None:
+            return []
+        return list_refs_for_agent(reyn_root.parent, agent)
+
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None
     ) -> bool:

--- a/tests/core/test_4494_rows_from_ref_table_entries.py
+++ b/tests/core/test_4494_rows_from_ref_table_entries.py
@@ -1,0 +1,72 @@
+"""Tier 1: #4494 design C — ``rows_from_ref_table_entries``, projecting the
+durable artifact-ref table's own raw ``{"ref", "path"}`` entries into
+``ArtifactRow`` objects — the fallback source a client with no live
+conversation state (a remote client, or a local one right after a
+restart) uses to populate the Artifacts pane.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.core.present.artifact_list import ArtifactRow, rows_from_ref_table_entries
+
+
+def test_projects_ref_and_basename_with_no_media_type_or_description():
+    """Tier 1: the ref table only ever records (ref, path) — this function
+    must not fabricate a media_type/description it has no source for."""
+    entries = [{"ref": "abc123", "path": "/project/reports/q1.pdf"}]
+
+    rows = rows_from_ref_table_entries(entries)
+
+    assert rows == [
+        ArtifactRow(
+            ref="abc123",
+            name="q1.pdf",
+            media_type=None,
+            description=None,
+            is_inline=False,
+        )
+    ]
+
+
+def test_preserves_input_order():
+    """Tier 1: mirrors ``list_refs_for_agent``'s own newest-first ordering
+    — this function does no re-sorting of its own, so the caller's order
+    is what ends up on screen."""
+    entries = [
+        {"ref": "r2", "path": "/p/b.pdf"},
+        {"ref": "r1", "path": "/p/a.pdf"},
+    ]
+
+    rows = rows_from_ref_table_entries(entries)
+
+    assert [r.ref for r in rows] == ["r2", "r1"]
+
+
+def test_skips_a_malformed_entry_missing_a_required_key():
+    """Tier 1: (accept-side) a shape the ref table itself would never
+    produce (guards against a caller handing this function something
+    else) is dropped rather than raising."""
+    entries = [{"ref": "abc"}, {"path": "/p/x.pdf"}, {"ref": "ok", "path": "/p/y.pdf"}]
+
+    rows = rows_from_ref_table_entries(entries)
+
+    assert [r.ref for r in rows] == ["ok"]
+
+
+def test_empty_entries_returns_empty_rows():
+    """Tier 1: (accept-side) no entries -> no rows, not a crash."""
+    assert rows_from_ref_table_entries([]) == []
+
+
+def test_name_is_the_path_basename_not_the_full_path(tmp_path):
+    """Tier 1: mirrors ``artifact_row_label``'s own reason for preferring
+    ``resolved_path`` over a bare ``name`` — this function's ``name`` is
+    ONLY the basename, matching how a ref-backed live-conversation row's
+    own ``name`` field already behaves before ``resolve_display_paths``
+    fills in the real path."""
+    entries = [{"ref": "r", "path": str(Path(tmp_path) / "sub" / "dir" / "file.docx")}]
+
+    rows = rows_from_ref_table_entries(entries)
+
+    assert rows[0].name == "file.docx"

--- a/tests/data/test_4494_list_refs_for_agent.py
+++ b/tests/data/test_4494_list_refs_for_agent.py
@@ -1,0 +1,47 @@
+"""Tier 2: #4494 design C — ``list_refs_for_agent``, the durable artifact-ref
+table's own read-back for a single agent's scope. This is the source a
+REMOTE client (and a LOCAL client right after a restart, #4584's own
+measured finding) falls back to when its live conversation view carries
+nothing.
+
+Real ``mint_ref``/table on disk throughout — no mocks.
+"""
+from __future__ import annotations
+
+from reyn.data.workspace.artifact_ref import list_refs_for_agent, mint_ref
+
+
+def test_returns_entries_for_the_named_agent_newest_first(tmp_path):
+    """Tier 2: mirrors ``list_refs_for_agent``'s own docstring convention
+    (newest-first, matching ``collect_artifact_rows``) — the LAST minted
+    ref for this agent comes back first."""
+    f1 = tmp_path / "a.pdf"
+    f2 = tmp_path / "b.pdf"
+    f1.write_text("x")
+    f2.write_text("y")
+    ref1 = mint_ref(tmp_path, "alpha", f1)
+    ref2 = mint_ref(tmp_path, "alpha", f2)
+
+    entries = list_refs_for_agent(tmp_path, "alpha")
+
+    assert [e["ref"] for e in entries] == [ref2, ref1]
+    assert entries[0]["path"] == str(f2)
+    assert entries[1]["path"] == str(f1)
+
+
+def test_excludes_entries_minted_under_a_different_agent(tmp_path):
+    """Tier 2: scope is per-agent (architect's #4482 ruling, carried over
+    here) — another agent's ref never leaks into this agent's fallback
+    list."""
+    f = tmp_path / "shared_name.pdf"
+    f.write_text("x")
+    mint_ref(tmp_path, "beta", f)
+
+    assert list_refs_for_agent(tmp_path, "alpha") == []
+
+
+def test_empty_table_returns_empty_list(tmp_path):
+    """Tier 2: (accept-side) no table on disk yet -> [], not a crash — the
+    same graceful-empty contract ``resolve_ref`` already gives a missing
+    table."""
+    assert list_refs_for_agent(tmp_path, "alpha") == []

--- a/tests/interfaces/test_4494_agui_artifact_list_endpoint.py
+++ b/tests/interfaces/test_4494_agui_artifact_list_endpoint.py
@@ -1,0 +1,171 @@
+"""Tier 2: #4494 design C — the AG-UI endpoint's ``artifact_list_request``
+ptype, and ``AgUiTransport.request_artifact_list``'s wire payload.
+
+Mirrors ``test_4534_pr1_agui_attach_switch_endpoint.py``'s own fixture
+shape (real ``AgentRegistry`` + real ASGI app over ``httpx.AsyncClient``)
+and its closing-the-loop pattern (client's real output fed directly into
+the real server endpoint — no hand-authored literal duplicated on both
+sides).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.data.workspace.artifact_ref import mint_ref
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _registry(tmp_path, monkeypatch) -> AgentRegistry:
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+        )
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+    holder["reg"] = reg
+    reg.create("alpha")
+    reg.get_or_load("alpha")
+    return reg
+
+
+async def _post(app, path: str, payload: dict):
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        return await client.post(path, json=payload)
+
+
+def _build_app(reg, monkeypatch):
+    from fastapi import FastAPI
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+    from reyn.interfaces.transport.agui.endpoint import router
+    from reyn.interfaces.web.auth import AuthContext
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.auth = AuthContext(token="s3cret", require_token=True)
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: reg)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_artifact_list_request_returns_the_agents_ref_table_entries(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: the happy path — reads the server's OWN copy of the
+    durable table, scoped to the URL's agent_name, never a client-
+    supplied path."""
+    reg = _registry(tmp_path, monkeypatch)
+    f = tmp_path / "report.pdf"
+    f.write_text("x")
+    ref = mint_ref(tmp_path, "alpha", f)
+    app = _build_app(reg, monkeypatch)
+
+    resp = await _post(
+        app, "/agui/chat/alpha?token=s3cret", {"type": "artifact_list_request"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json().get("entries") == [{"ref": ref, "path": str(f)}]
+
+
+@pytest.mark.asyncio
+async def test_artifact_list_request_returns_empty_with_no_ref_minted(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: (accept-side) an empty table -> [], not an error."""
+    reg = _registry(tmp_path, monkeypatch)
+    app = _build_app(reg, monkeypatch)
+
+    resp = await _post(
+        app, "/agui/chat/alpha?token=s3cret", {"type": "artifact_list_request"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json().get("entries") == []
+
+
+@pytest.mark.asyncio
+async def test_agui_transport_request_artifact_list_sends_the_typed_payload():
+    """Tier 2: AgUiTransport.request_artifact_list sends the SAME typed
+    shape the server's artifact_list_request arm expects."""
+    from reyn.interfaces.transport.agui.client import AgUiTransport
+
+    sent: list = []
+
+    async def _send(payload: dict) -> dict:
+        sent.append(payload)
+        return {"entries": [{"ref": "r1", "path": "/p/x.pdf"}]}
+
+    async def _empty_lines():
+        return
+        yield  # pragma: no cover
+
+    transport = AgUiTransport(_empty_lines(), _send)
+    entries = await transport.request_artifact_list(agent="alpha")
+
+    assert entries == [{"ref": "r1", "path": "/p/x.pdf"}]
+    assert sent == [{"type": "artifact_list_request"}]
+
+
+@pytest.mark.asyncio
+async def test_agui_transport_request_artifact_list_empty_when_send_returns_none():
+    """Tier 2: (accept-side) a None/falsy send result -> [], not a crash."""
+    from reyn.interfaces.transport.agui.client import AgUiTransport
+
+    async def _send(payload: dict):
+        return None
+
+    async def _empty_lines():
+        return
+        yield  # pragma: no cover
+
+    transport = AgUiTransport(_empty_lines(), _send)
+    assert await transport.request_artifact_list(agent="alpha") == []
+
+
+# ── closing the wire-shape double-transcription gap (mirrors #4537/#4534) ──
+
+
+@pytest.mark.asyncio
+async def test_agui_transport_artifact_list_payload_is_accepted_by_the_real_endpoint(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: the client's own request_artifact_list output, fed
+    directly into the real server endpoint — no hand-authored literal
+    duplicated on either side."""
+    from reyn.interfaces.transport.agui.client import AgUiTransport
+
+    reg = _registry(tmp_path, monkeypatch)
+    f = tmp_path / "report.pdf"
+    f.write_text("x")
+    ref = mint_ref(tmp_path, "alpha", f)
+    app = _build_app(reg, monkeypatch)
+
+    async def _send(payload: dict) -> dict:
+        resp = await _post(app, "/agui/chat/alpha?token=s3cret", payload)
+        return resp.json()
+
+    async def _empty_lines():
+        return
+        yield  # pragma: no cover
+
+    transport = AgUiTransport(_empty_lines(), _send)
+    entries = await transport.request_artifact_list(agent="alpha")
+
+    assert entries == [{"ref": ref, "path": str(f)}]

--- a/tests/interfaces/test_4494_artifact_pane_ref_table_fallback.py
+++ b/tests/interfaces/test_4494_artifact_pane_ref_table_fallback.py
@@ -1,0 +1,62 @@
+"""Tier 1: #4494 design C — the Artifacts drawer pane's ref-table-fallback
+source disclosure (``chrome.py``). Lead-coder's own ruling, verbatim:
+"C ＋ 明示。文面は「件数」ではなく「情報源の限界」を言うこと" — the
+disclosure states the SOURCE LIMITATION, never a row count, and is
+appended REGARDLESS of whether the fallback found anything (the falsify
+requirement: emptying the ref table empties the rows but the disclosure
+text stays).
+"""
+from __future__ import annotations
+
+from reyn.core.present.artifact_list import ArtifactRow
+from reyn.interfaces.inline.textual_chat.chrome import (
+    ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE,
+    artifact_pane_commands,
+    artifact_pane_options,
+)
+
+_ROW = ArtifactRow(
+    ref="r1", name="report.pdf", media_type=None, description=None, is_inline=False,
+)
+
+
+def test_live_source_never_appends_the_disclosure():
+    """Tier 1: the default (live conversation-derived) source is
+    unaffected by this PR — no disclosure row for a client whose own
+    conversation state is a complete answer."""
+    rows = artifact_pane_options([_ROW])
+    assert ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE not in rows
+
+
+def test_fallback_source_appends_the_disclosure_after_a_populated_list():
+    """Tier 1: a non-empty fallback list still gets the disclosure row
+    appended after the real rows."""
+    rows = artifact_pane_options([_ROW], source="ref_table_fallback")
+    assert rows == ["report.pdf", ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE]
+
+
+def test_falsify_emptying_the_fallback_still_shows_the_disclosure():
+    """Tier 1: (falsify) an empty ref-table fallback must not read as a
+    plain "no artifacts" — the reader needs to know WHY it might be
+    empty (a genuinely-empty table vs. an inline-only agent whose
+    artifacts the table never records)."""
+    rows = artifact_pane_options([], source="ref_table_fallback")
+    assert rows == ["(no artifacts yet)", ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE]
+
+
+def test_disclosure_never_names_a_count():
+    """Tier 1: lead-coder's ruling forbids a count claim (a fallback
+    genuinely cannot count what it has no record of) — assert the
+    literal text carries no digit."""
+    assert not any(ch.isdigit() for ch in ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE)
+
+
+def test_fallback_commands_stay_index_aligned_with_the_disclosure_row():
+    """Tier 1: the disclosure row itself is never actionable — the
+    command list must carry one extra empty string so
+    ``on_option_list_option_selected``'s index lookup never targets the
+    disclosure row with a stale command."""
+    options = artifact_pane_options([_ROW], source="ref_table_fallback")
+    commands = artifact_pane_commands([_ROW], source="ref_table_fallback")
+    assert len(options) == len(commands)
+    assert commands[-1] == ""

--- a/tests/interfaces/test_4494_request_artifact_list.py
+++ b/tests/interfaces/test_4494_request_artifact_list.py
@@ -1,0 +1,103 @@
+"""Tier 2: #4494 design C — ``ClientTransport.request_artifact_list``, the
+durable artifact-ref table fallback a remote client's Artifacts pane
+consults when its live conversation view carries nothing. Mirrors
+``test_4534_pr1_request_attach_switch.py``'s own fixture shape (real
+``AgentRegistry`` + real ``Session`` — no mocks).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.data.workspace.artifact_ref import mint_ref
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path) -> AgentRegistry:
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name, agent_role=profile.role,
+            output_language="en", snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+    return AgentRegistry(project_root=tmp_path, session_factory=factory)
+
+
+def _transport(reg: AgentRegistry) -> InProcessTransport:
+    return InProcessTransport(reg, intervention_channel="tui")
+
+
+@pytest.mark.asyncio
+async def test_returns_the_attached_agents_own_ref_table_entries(tmp_path):
+    """Tier 2: the happy path — reaches the SAME table
+    ``list_refs_for_agent`` reads, scoped to the attached agent."""
+    reg = _registry(tmp_path)
+    reg.create("alpha")
+    await reg.attach("alpha")
+    f = tmp_path / "report.pdf"
+    f.write_text("x")
+    ref = mint_ref(tmp_path, "alpha", f)
+    transport = _transport(reg)
+    try:
+        entries = await transport.request_artifact_list(agent="alpha")
+        assert entries == [{"ref": ref, "path": str(f)}]
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_with_no_session_attached(tmp_path):
+    """Tier 2: (accept-side) nothing attached -> no project root to read,
+    same graceful-empty contract every other unattached transport call
+    already gives (mirrors ``request_session_switch``'s own)."""
+    reg = _registry(tmp_path)
+    transport = _transport(reg)
+    try:
+        assert await transport.request_artifact_list(agent="alpha") == []
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_default_transport_implementation_returns_empty():
+    """Tier 2: (accept-side) the base ClientTransport default — a narrow
+    test stub pre-dating this method keeps working unmodified, same
+    convention as ``request_attach``'s own default."""
+    from reyn.interfaces.transport.client_transport import ClientTransport
+
+    class _Stub(ClientTransport):
+        def start(self) -> None: ...
+        def close(self) -> None: ...
+        async def frames(self):
+            return
+            yield  # pragma: no cover
+
+        async def submit_user_text(self, text: str) -> str:
+            return ""
+
+        async def answer_intervention_text(self, text, *, intervention_id=None):
+            return False
+
+        async def answer_intervention_choice(self, choice_id, *, intervention_id=None):
+            return False
+
+        def has_session(self) -> bool:
+            return False
+
+        def pending_intervention_head(self):
+            return None
+
+        def put_display(self, msg) -> None: ...
+
+        async def cancel_inflight(self) -> str:
+            return ""
+
+        async def shutdown(self) -> None: ...
+
+    stub = _Stub()
+    assert await stub.request_artifact_list(agent="alpha") == []


### PR DESCRIPTION
**[tui-coder]** — part of #4494 (design C, lead-coder ruling: "C ＋ 明示。文面は「件数」ではなく「情報源の限界」を言うこと").

## What

The remote (`--connect`) client's Artifacts pane — and a local client right after a restart, which has the identical gap (#4584's own measured finding: `restore.project_restored_frames` has no "presentation" kind reconstruction) — currently shows nothing when the live conversation carries no artifact-bearing turns, because a remote client's past turns are simply not on the wire.

This PR adds a fallback: when the live-conversation-derived artifact list comes back empty, the pane consults the durable artifact-ref table (`.reyn/memory/artifact_refs.jsonl`, #4584's persist-tier fix) via a new `ClientTransport.request_artifact_list` seam.

## Design

Mirrors the `request_attach`/`request_session_switch` precedent exactly: client names an operation, server executes it against its own state.

- `InProcessTransport`: reads the table directly (no wire hop).
- `AgUiTransport`/`endpoint.py`: a typed `artifact_list_request` payload — the server reads its OWN copy of the table (never a client-supplied path).

The disclosure text (`chrome.ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE`) states the **source limitation**, never a row count (a remote client genuinely cannot count what it has no record of), never "まだ" framing (implies a richer source is definitely coming — not decided). It's appended regardless of row count, including when the fallback itself is empty.

## Caught during implementation

`session.workspace_dir` is `<project_root>/.reyn/agents/<name>` — three levels below project root, not two. `InProcessTransport.reyn_state_root()` already derives the `.reyn` root (two `.parent` hops) for its own existing callers; `list_refs_for_agent`/`mint_ref`/`resolve_ref` all want the **project root** instead (they append `.reyn/memory/...` themselves). Both the endpoint handler and the transport method needed the extra `.parent` hop — caught before writing tests, not by them; the tests (below) now pin the correct depth.

## Test plan

21 new tests (Tier 1/2), real `AgentRegistry`/`Session`/ASGI app throughout, no mocks:
- `list_refs_for_agent` (data layer): scope isolation, ordering, empty table.
- `rows_from_ref_table_entries` (projection): field mapping, malformed-entry tolerance.
- `chrome.py` disclosure: live source never appends it; fallback source always does, including the falsify case (emptying the ref table empties the rows but the disclosure text stays); no digit in the disclosure text.
- `ClientTransport.request_artifact_list`: `InProcessTransport` happy path + no-session-attached, base-class default (accept-side, matches `request_attach`'s convention).
- AG-UI endpoint + `AgUiTransport`: happy path, empty table, wire-payload shape, and the #4534-style closing-the-loop pair (the client's real output fed directly into the real server endpoint — no hand-authored literal duplicated on both sides).

Pre-PR checklist: `ruff check src tests`, `test_tier_audit.py --strict` (all new test files), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` — all green.

Scoped `pytest`: 118 tests across the 5 new files plus every pre-existing file touching `pane_payload`/`pane_commands`/`_artifact_rows`/`on_menu_bar_selected` (which is now `async` — Textual dispatches both sync and async message handlers transparently; no other call site invokes it directly) — all green.

- [ ] Visual (waived per CLAUDE.md standing waiver, 2026-08-08 — operator confirms on `main`)

## Deferred (per lead-coder, not in scope here)

Whether to open a separate issue for "Design A" (schema-level payload persistence, the root-cause fix for why the live list is empty in the first place) — lead-coder's call, after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
