### PR TITLE
feat(#4570): Agent Plugins 1.0 conversion B — capabilities dropped, derived from directory/file existence

### DIFF
--- a/src/reyn/builtin/discovery.py
+++ b/src/reyn/builtin/discovery.py
@@ -8,13 +8,17 @@ Before this module, the ONLY path by which an LLM could learn that
 WHICH plugin directories are advertised (the allowlist, #3196-shaped: a
 directory appearing under ``src/reyn/builtin/plugins/`` never
 self-advertises); this module answers WHAT each one is, by reading its own
-``plugin.json`` manifest (``description`` + ``capabilities``)
-at call time rather than duplicating that text into the registry (the
-redundant-projection drift class #3164 hit for a different value). Two
-disjoint reads, one SSoT each:
+``plugin.json`` manifest's ``description`` at call time (never duplicated
+into the registry — the redundant-projection drift class #3164 hit for a
+different value) plus its ``capabilities``, derived from directory/file
+existence (#4570 conversion B — the manifest no longer carries a
+capabilities declaration at all, see
+``reyn.plugins.manifest.capability_kinds_present``). Two disjoint reads,
+one SSoT each:
 
   registry (``BUILTIN_PLUGINS``)  -> which names to advertise
-  manifest (``plugin.json``)      -> what a name IS (description, capabilities)
+  manifest (``plugin.json``)      -> what a name IS (description)
+  disk (plugin_dir contents)      -> what a name CAN DO (capabilities)
 
 ``reyn.tools.plugin_management_verbs._handle_plugin_list`` is the tool-level
 consumer that surfaces this to the LLM through the ordinary tool-call flow
@@ -27,7 +31,11 @@ from pathlib import Path
 from typing import Any
 
 import reyn.builtin.registry as _registry
-from reyn.plugins.manifest import PluginManifestError, load_plugin_manifest
+from reyn.plugins.manifest import (
+    PluginManifestError,
+    capability_kinds_present,
+    load_plugin_manifest,
+)
 
 
 def _builtin_plugins_root() -> Path:
@@ -78,7 +86,12 @@ def list_builtin_plugins() -> "list[dict[str, Any]]":
             {
                 "name": name,
                 "description": manifest.description,
-                "capabilities": sorted(manifest.capability_kinds),
+                # #4570 conversion B: derived from directory/file existence
+                # (the manifest itself no longer carries a capabilities
+                # declaration to read) — same derivation plugin_install.py's
+                # registration step consults, see capability_kinds_present's
+                # own docstring.
+                "capabilities": sorted(capability_kinds_present(plugin_dir)),
                 "install": {
                     "tool": "install_plugin",
                     "args": {"source": {"kind": "builtin", "name": name}},

--- a/src/reyn/builtin/plugins/rag/plugin.json
+++ b/src/reyn/builtin/plugins/rag/plugin.json
@@ -2,10 +2,5 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "rag",
   "version": "0.1.0",
-  "description": "Builtin turnkey user RAG (ADR 0064 P5): chunker + vector-store MCP servers, ingest/query pipelines, and its RAG skill (install, embedding-provider setup, the ingest/query workflow, and corpus internals, all bundled with references). External sqlite store the operator names and owns (FP-0057 C2) -- distinct from reyn's own OS-internal index (not agent-callable, FP-0066 P1b).",
-  "capabilities": [
-    {"kind": "mcp"},
-    {"kind": "pipelines"},
-    {"kind": "skills"}
-  ]
+  "description": "Builtin turnkey user RAG (ADR 0064 P5): chunker + vector-store MCP servers, ingest/query pipelines, and its RAG skill (install, embedding-provider setup, the ingest/query workflow, and corpus internals, all bundled with references). External sqlite store the operator names and owns (FP-0057 C2) -- distinct from reyn's own OS-internal index (not agent-callable, FP-0066 P1b)."
 }

--- a/src/reyn/core/op_runtime/plugin_install.py
+++ b/src/reyn/core/op_runtime/plugin_install.py
@@ -155,8 +155,8 @@ from reyn.data.index.build_lock import (
 )
 from reyn.plugins.manifest import (
     PluginManifestError,
+    capability_kinds_present,
     load_plugin_manifest,
-    manifest_path_for,
 )
 from reyn.plugins.source import resolve_name_collision
 from reyn.plugins.tokens import PluginTokenContext, expand_reyn_tokens
@@ -930,8 +930,18 @@ async def handle(op: PluginInstallIROp, ctx: OpContext) -> dict:
         _expand_plugin_files(plugin_root, token_ctx)
 
         # ── 7. Register capabilities (#3209: register-only — no dep materialise) ──
-        manifest_path = manifest_path_for(plugin_root)
-        reloaded_manifest = load_plugin_manifest(plugin_root) if manifest_path.exists() else manifest
+        # #4570 conversion B: capability presence is now derived PURELY
+        # from directory/file existence, never a manifest-declared list —
+        # the manifest no longer carries `capabilities` at all (lead-coder
+        # ruling, #4570: the `entries` explicit-subset feature had 0
+        # production readers and 0 declaring manifests, so it — and the
+        # `capabilities` field it lived on — is DROPPED, not relocated
+        # into `extensions["dev.reyn"]`; a manifest still declaring it is
+        # a typed-error rejection at parse time, `PluginManifest`'s own
+        # `_reject_removed_capabilities_key`). Each sub-install below now
+        # always RUNS when its directory/file exists — no per-kind branch
+        # to skip, no `entries` ternary to narrow which files get picked
+        # up (discover-everything is the only mode left).
         registered: dict[str, list] = {"mcp": [], "pipelines": [], "skills": []}
         # #4590: declared-vs-registered diff, per capability kind. Pipelines
         # and skills DO have a drop path — unlike mcp's probe-then-commit
@@ -950,57 +960,49 @@ async def handle(op: PluginInstallIROp, ctx: OpContext) -> dict:
         # (#4580 dropped quietly; this claimed success for a drop).
         skipped: dict[str, list] = {"mcp": [], "pipelines": [], "skills": []}
 
-        for cap in reloaded_manifest.capabilities:
-            if cap.kind == "mcp":
-                mcp_result = await _register_mcp(
-                    plugin_root, safe_name, ctx, project_root,
+        # mcp: _register_mcp already no-ops gracefully when `.mcp.json` is
+        # absent (returns {"registered": [], "skipped": []}) — safe to call
+        # unconditionally, same as every other install regardless of
+        # whether this plugin ships an mcp server.
+        mcp_result = await _register_mcp(plugin_root, safe_name, ctx, project_root)
+        registered["mcp"] = mcp_result["registered"]
+        skipped["mcp"] = mcp_result["skipped"]
+
+        pipelines_dir = plugin_root / "pipelines"
+        if pipelines_dir.is_dir():
+            for dsl_file in sorted(pipelines_dir.glob("*.yaml")):
+                sub_op = PipelineInstallIROp(
+                    kind="pipeline_install", path=str(dsl_file), plugin_id=safe_name,
                 )
-                registered["mcp"] = mcp_result["registered"]
-                skipped["mcp"] = mcp_result["skipped"]
-            elif cap.kind == "pipelines":
-                pipelines_dir = plugin_root / "pipelines"
-                files = (
-                    [pipelines_dir / e for e in cap.entries]
-                    if cap.entries
-                    else (sorted(pipelines_dir.glob("*.yaml")) if pipelines_dir.is_dir() else [])
-                )
-                for dsl_file in files:
-                    sub_op = PipelineInstallIROp(
-                        kind="pipeline_install", path=str(dsl_file), plugin_id=safe_name,
+                sub_result = await _pipeline_install_handle(sub_op, ctx)
+                if sub_result.get("status") == "installed":
+                    registered["pipelines"].append(sub_result)
+                else:
+                    skipped["pipelines"].append(sub_result)
+                    ctx.events.emit(
+                        "pipeline_install_skipped",
+                        plugin_id=safe_name, path=str(dsl_file),
+                        reason=sub_result.get("status", "error"),
+                        error=sub_result.get("error", ""),
                     )
-                    sub_result = await _pipeline_install_handle(sub_op, ctx)
-                    if sub_result.get("status") == "installed":
-                        registered["pipelines"].append(sub_result)
-                    else:
-                        skipped["pipelines"].append(sub_result)
-                        ctx.events.emit(
-                            "pipeline_install_skipped",
-                            plugin_id=safe_name, path=str(dsl_file),
-                            reason=sub_result.get("status", "error"),
-                            error=sub_result.get("error", ""),
-                        )
-            elif cap.kind == "skills":
-                skills_dir = plugin_root / "skills"
-                dirs = (
-                    [skills_dir / e for e in cap.entries]
-                    if cap.entries
-                    else (sorted(p for p in skills_dir.glob("*") if p.is_dir()) if skills_dir.is_dir() else [])
+
+        skills_dir = plugin_root / "skills"
+        if skills_dir.is_dir():
+            for skill_dir in sorted(p for p in skills_dir.glob("*") if p.is_dir()):
+                sub_op = SkillInstallIROp(
+                    kind="skill_install", path=str(skill_dir), plugin_id=safe_name,
                 )
-                for skill_dir in dirs:
-                    sub_op = SkillInstallIROp(
-                        kind="skill_install", path=str(skill_dir), plugin_id=safe_name,
+                sub_result = await _skill_install_handle(sub_op, ctx)
+                if sub_result.get("status") == "installed":
+                    registered["skills"].append(sub_result)
+                else:
+                    skipped["skills"].append(sub_result)
+                    ctx.events.emit(
+                        "skill_install_skipped",
+                        plugin_id=safe_name, path=str(skill_dir),
+                        reason=sub_result.get("status", "error"),
+                        error=sub_result.get("error", ""),
                     )
-                    sub_result = await _skill_install_handle(sub_op, ctx)
-                    if sub_result.get("status") == "installed":
-                        registered["skills"].append(sub_result)
-                    else:
-                        skipped["skills"].append(sub_result)
-                        ctx.events.emit(
-                            "skill_install_skipped",
-                            plugin_id=safe_name, path=str(skill_dir),
-                            reason=sub_result.get("status", "error"),
-                            error=sub_result.get("error", ""),
-                        )
 
         ctx.events.emit("plugin_install_registered", name=safe_name, registered=registered)
 
@@ -1014,7 +1016,11 @@ async def handle(op: PluginInstallIROp, ctx: OpContext) -> dict:
             "name": safe_name,
             "plugin_root": str(plugin_root),
             "source_kind": source_kind,
-            "capabilities": sorted(reloaded_manifest.capability_kinds),
+            # #4570 conversion B: derived from directory/file existence —
+            # the SAME derivation discovery.py's listing uses
+            # (capability_kinds_present), so "declared" and "listed" can
+            # never independently drift.
+            "capabilities": sorted(capability_kinds_present(plugin_root)),
             "registered": registered,
             "skipped": skipped,  # #4580: declared-but-dropped, per capability kind
         }

--- a/src/reyn/plugins/manifest.py
+++ b/src/reyn/plugins/manifest.py
@@ -1,5 +1,6 @@
 """Typed schema for a plugin's ``plugin.json`` manifest (ADR 0064 §3.1,
-relocated to the plugin root — #4570 conversion A).
+relocated to the plugin root + capabilities dropped — #4570 conversions
+A/B, Agent Plugins 1.0 alignment).
 
 **#4570 conversion A**: the manifest lives at ``<plugin_dir>/plugin.json``
 (the Agent Plugins 1.0 canonical location, agent-plugins.org's
@@ -11,30 +12,36 @@ reyn's own internal state directory (``_install_state.json`` mid-install
 marker, ``_source_kind.json``/``_provenance.json`` sidecars) — only the
 manifest itself moved out of it.
 
-A plugin is a self-contained directory; the manifest declares its identity
-(``name`` / ``version``) and WHICH capability subdirs are present — every
-capability is optional (§3.1: "a valid plugin may be *just* an MCP server,
-*just* a pipeline, or any combination"). Mirrors the house convention for
-typed, discriminated-union side-effect payloads used across reyn's op
-schemas (``reyn.schemas.models`` — ``kind: Literal[...]`` per variant,
-``Field(discriminator="kind")`` on the union) rather than a form-sniffed
-untyped string.
+**#4570 conversion B**: ``capabilities`` (and its nested ``entries``
+subset-selection field) is REMOVED from this schema entirely, not moved
+into ``extensions["dev.reyn"]`` (lead-coder ruling, #4570: "誰も使ってい
+ない機能を extensions に残すのは一本化の逆" — owner's own stated goal
+("互換性あるなら標準に寄せて一本化したい") argues against inventing a
+never-used reyn-specific extension slot at the same moment the standard's
+own root schema (``additionalProperties: false``) is being adopted).
+Measured population before removal: 2 production readers
+(``plugin_install.py``'s registration step), 0 manifests anywhere in this
+repo declaring it (including the shipped ``rag`` plugin), 0 third-party
+manifests (reyn is unreleased). A capability's presence is now derived
+PURELY from directory/file existence at registration time — ``mcp.json``
+for ``mcp``, ``pipelines/*.yaml`` for ``pipelines``, ``skills/*/SKILL.md``
+for ``skills`` (ADR §3.1's own directory layout, unchanged) — mirroring
+exactly how a standard-compliant client discovers ``skills/`` without any
+manifest hint. See ``reyn.core.op_runtime.plugin_install``'s registration
+step for where this presence check actually runs; this module has nothing
+left to say about capabilities at all.
 
-``capabilities`` declares presence + an optional explicit entry list per
-capability; an empty ``entries`` tuple means "discover everything reyn's
-plugin layout convention expects" (root ``.mcp.json`` for ``mcp``,
-``pipelines/*.yaml`` for ``pipelines``, ``skills/*/SKILL.md`` for
-``skills`` — ADR §3.1's directory layout). Discovery/registration itself is
-P2 (install machinery); this module only defines and validates the shape.
-This field is a reyn-native extension the standard's ``additionalProperties:
-false`` root does not permit (#4570 conversion B moves it into
-``extensions["dev.reyn"]`` — not yet done as of this module's own #4570
-conversion A slice; kept here unchanged in the meantime)."""
+**A manifest still declaring ``capabilities`` is a typed-error REJECTION,
+not a silent no-op** (lead-coder ruling, same "config that doesn't take
+effect" trap class as ``_build_tool_use_config``'s ``chat``-key rejection,
+verbatim: "a silently dropped old key is a 'config that doesn't take
+effect' trap") — see :meth:`PluginManifest._reject_removed_capabilities_key`.
+"""
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Annotated, Literal, Union
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
@@ -59,47 +66,10 @@ class PluginManifestError(ValueError):
     one exception type to catch."""
 
 
-class PluginMCPCapability(BaseModel):
-    """The plugin ships an MCP server declared at its root ``.mcp.json``
-    (ADR §3.1 — standard shape, no reyn-specific fields)."""
-
-    kind: Literal["mcp"] = "mcp"
-
-
-class PluginPipelinesCapability(BaseModel):
-    """The plugin ships one or more pipeline DSL files under ``pipelines/``
-    (ADR §3.1 — a declared reyn extension, no standard equivalent).
-
-    ``entries``: explicit list of DSL filenames (relative to ``pipelines/``)
-    to register. Empty = discover every ``pipelines/*.yaml`` file.
-    """
-
-    kind: Literal["pipelines"] = "pipelines"
-    entries: tuple[str, ...] = ()
-
-
-class PluginSkillsCapability(BaseModel):
-    """The plugin ships one or more standard ``SKILL.md`` skills under
-    ``skills/<name>/`` (ADR §3.1 — honoured as-is, the one genuine open
-    standard per §3.6).
-
-    ``entries``: explicit list of skill directory names under ``skills/``
-    to register. Empty = discover every ``skills/*/SKILL.md``.
-    """
-
-    kind: Literal["skills"] = "skills"
-    entries: tuple[str, ...] = ()
-
-
-PluginCapability = Annotated[
-    Union[PluginMCPCapability, PluginPipelinesCapability, PluginSkillsCapability],
-    Field(discriminator="kind"),
-]
-
-
 class PluginManifest(BaseModel):
     """``plugin.json`` (plugin root) — the typed plugin manifest (ADR §3.1,
-    relocated #4570 conversion A).
+    relocated #4570 conversion A; ``capabilities`` removed #4570
+    conversion B).
 
     ``$schema`` (JSON key, Python attribute ``schema_``) is REQUIRED and
     must equal :data:`PLUGIN_MANIFEST_SCHEMA_URL` — the Agent Plugins 1.0
@@ -111,11 +81,6 @@ class PluginManifest(BaseModel):
     ``PipelineInstallIROp``/``SkillInstallIROp``'s namespace-separator
     convention) so a plugin name never collides with a capability's own
     dotted namespace key.
-
-    ``capabilities`` is a discriminated union list (`kind` in
-    ``{"mcp", "pipelines", "skills"}``) — every entry optional, any subset,
-    duplicates of the same ``kind`` rejected (a manifest declares each
-    capability at most once).
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -124,11 +89,28 @@ class PluginManifest(BaseModel):
     name: str
     version: str
     description: str = ""
-    capabilities: tuple[PluginCapability, ...] = ()
 
-    @property
-    def capability_kinds(self) -> frozenset[str]:
-        return frozenset(cap.kind for cap in self.capabilities)
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_removed_capabilities_key(cls, data: Any) -> Any:
+        """#4570 conversion B: ``capabilities`` (the field's whole former
+        purpose) is gone from this schema — a manifest still carrying it
+        must be REJECTED, never silently accepted-and-ignored. Pydantic's
+        default "extra fields dropped" behavior would otherwise turn a
+        plugin author's real declaration into dead JSON with no error
+        anywhere — the exact "wrote it, but it doesn't take effect" trap
+        class lead-coder's ruling names by precedent
+        (``_build_tool_use_config``'s ``chat``-key rejection)."""
+        if isinstance(data, dict) and "capabilities" in data:
+            raise ValueError(
+                "PluginManifest no longer accepts a 'capabilities' field "
+                "(#4570 conversion B: a capability's presence is derived "
+                "from directory/file existence -- mcp.json / pipelines/ / "
+                "skills/ -- never declared in the manifest). Remove the "
+                "'capabilities' key; declaring it here would otherwise "
+                "silently have no effect."
+            )
+        return data
 
     @model_validator(mode="after")
     def _validate(self) -> "PluginManifest":
@@ -144,12 +126,6 @@ class PluginManifest(BaseModel):
                 f"PluginManifest.name {self.name!r} must not contain "
                 f"reserved namespace-separator characters ({_RESERVED_NAME_CHARS!r})"
             )
-        kinds = [cap.kind for cap in self.capabilities]
-        if len(kinds) != len(set(kinds)):
-            raise ValueError(
-                f"PluginManifest.capabilities declares duplicate kinds: {kinds!r} "
-                "(each capability kind may appear at most once)"
-            )
         return self
 
 
@@ -159,6 +135,29 @@ _MANIFEST_RELATIVE_PATH = Path("plugin.json")
 def manifest_path_for(plugin_dir: Path) -> Path:
     """The canonical manifest path inside a plugin directory (ADR §3.1 layout)."""
     return plugin_dir / _MANIFEST_RELATIVE_PATH
+
+
+def capability_kinds_present(plugin_dir: Path) -> "frozenset[str]":
+    """Which capability kinds *plugin_dir* ships, derived PURELY from
+    directory/file existence (#4570 conversion B) — ``.mcp.json`` for
+    ``mcp``, a ``pipelines/`` directory for ``pipelines``, a ``skills/``
+    directory for ``skills`` (ADR §3.1's own layout, unchanged). The ONE
+    derivation both :mod:`reyn.core.op_runtime.plugin_install`'s
+    registration step and :mod:`reyn.builtin.discovery`'s listing consult
+    — so "this plugin has an mcp capability" can never independently
+    drift between what gets REGISTERED and what gets LISTED.
+
+    ``.mcp.json`` is still the DOT-prefixed pre-#4570-conversion-C name
+    here (conversion C renames it to ``mcp.json``, not yet landed as of
+    this function)."""
+    kinds: set[str] = set()
+    if (plugin_dir / ".mcp.json").is_file():
+        kinds.add("mcp")
+    if (plugin_dir / "pipelines").is_dir():
+        kinds.add("pipelines")
+    if (plugin_dir / "skills").is_dir():
+        kinds.add("skills")
+    return frozenset(kinds)
 
 
 def load_plugin_manifest(plugin_dir: Path) -> PluginManifest:

--- a/tests/core/test_3162_plugin_body_read_parity.py
+++ b/tests/core/test_3162_plugin_body_read_parity.py
@@ -84,7 +84,6 @@ def _make_plugin_source(base: Path, name: str = "myplugin") -> Path:
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": name, "version": "0.1.0", "description": "test plugin",
-            "capabilities": [{"kind": "skills"}],
         }),
         encoding="utf-8",
     )

--- a/tests/core/test_3162_rag_skill_body_read_reachable.py
+++ b/tests/core/test_3162_rag_skill_body_read_reachable.py
@@ -73,7 +73,6 @@ def _copy_real_skill_as_plugin_source(base: Path) -> Path:
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": "rag_skill_only", "version": "0.1.0",
             "description": "skills-only witness copy of the real rag skill",
-            "capabilities": [{"kind": "skills"}],
         }),
         encoding="utf-8",
     )

--- a/tests/core/test_3212_plugin_install_concurrency.py
+++ b/tests/core/test_3212_plugin_install_concurrency.py
@@ -106,7 +106,6 @@ def _make_plugin_source(base, name: str = "concplugin"):
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": name, "version": "0.1.0", "description": "concurrency test plugin",
-            "capabilities": [{"kind": "skills"}],
         }),
         encoding="utf-8",
     )

--- a/tests/core/test_4580_plugin_install_skip_visibility.py
+++ b/tests/core/test_4580_plugin_install_skip_visibility.py
@@ -35,7 +35,7 @@ def _make_plugin(root: Path, *, servers: dict) -> Path:
     (root / "plugin.json").write_text(
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
-            "name": root.name, "version": "0.1.0", "capabilities": [{"kind": "mcp"}],
+            "name": root.name, "version": "0.1.0",
         }),
         encoding="utf-8",
     )

--- a/tests/core/test_4590_plugin_install_pipeline_skill_skip.py
+++ b/tests/core/test_4590_plugin_install_pipeline_skill_skip.py
@@ -13,17 +13,31 @@ its own ``status``, so a failed pipeline/skill read as registered, and
 many actually failed. Worse than #4580's own silent drop: #4580 said
 nothing, this said something false.
 
+**#4570 conversion B note**: this file used to construct its failure cases
+via a manifest-declared ``entries`` list naming a file that doesn't exist
+on disk (the ``capabilities`` field's own subset-selection feature,
+dropped entirely by #4570 conversion B — see ``plugins/manifest.py``).
+Registration is now discover-everything (glob ``pipelines/*.yaml`` /
+every ``skills/*`` directory) — a NONEXISTENT file is simply never
+discovered at all, so "declared but missing" is no longer a reachable
+shape. The witnesses below instead use a file/dir that EXISTS on disk
+(so the discover-glob finds it) but is independently broken in a way its
+OWN sub-install rejects — a malformed pipeline DSL file, and a directory
+with no ``SKILL.md`` inside it — reaching the identical ``status="error"``
+return-without-raising path #4590 is actually about.
+
 Real ``OpContext``/``PermissionResolver``/``EventLog``/``Workspace``
 throughout — no hand-rolled stand-in classes (CLAUDE.md: "NEVER fake a
 collaborator ... when a real instance is cheaply constructible"; both are
 cheaply constructible, per #4581/#4587's own real-``EventLog`` and
 #4581's real-``Workspace`` usage the same night). Skip witnessing only
-covers the ``"error"`` sub-status path (a missing DSL/dir, both sub-
-installs' own most common failure); the ``"blocked"`` (threat-scan) path
-isn't separately exercised here — it's already covered end-to-end by
-``pipeline_install.py``/``skill_install.py``'s own threat-scan tests, and
-this file only needs ONE non-``"installed"`` status to prove the routing
-reads ``sub_result["status"]`` rather than assuming success.
+covers the ``"error"`` sub-status path (a malformed DSL / missing
+SKILL.md, both sub-installs' own most common failure); the ``"blocked"``
+(threat-scan) path isn't separately exercised here — it's already covered
+end-to-end by ``pipeline_install.py``/``skill_install.py``'s own
+threat-scan tests, and this file only needs ONE non-``"installed"``
+status to prove the routing reads ``sub_result["status"]`` rather than
+assuming success.
 """
 from __future__ import annotations
 
@@ -42,7 +56,7 @@ from reyn.schemas.models import PluginInstallIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
 
-def _make_pipeline_dsl(path: Path, *, name: str = "hello") -> None:
+def _make_valid_pipeline_dsl(path: Path, *, name: str = "hello") -> None:
     """A minimal VALID pipeline DSL file (same shape as
     test_pipeline_install.py's own ``_make_pipeline_dsl``)."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -55,7 +69,18 @@ def _make_pipeline_dsl(path: Path, *, name: str = "hello") -> None:
     )
 
 
-def _make_skill(path: Path, *, name: str = "hello") -> None:
+def _make_malformed_pipeline_dsl(path: Path) -> None:
+    """A real ``*.yaml`` file the discover-glob WILL find — its content is
+    what makes ``_parse_pipeline_file`` fail (``PipelineParseError``),
+    reaching the same ``status="error"`` return-without-raising path a
+    declared-but-missing entry used to (#4570 conversion B: discover-
+    everything can't construct "missing" any more — see module
+    docstring)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("pipeline: broken\nsteps: \"not-a-list-of-steps\"\n", encoding="utf-8")
+
+
+def _make_valid_skill(path: Path, *, name: str = "hello") -> None:
     """A minimal VALID SKILL.md (same shape as test_plugin_install.py's
     own accept-path fixture)."""
     path.mkdir(parents=True, exist_ok=True)
@@ -65,24 +90,17 @@ def _make_skill(path: Path, *, name: str = "hello") -> None:
     )
 
 
-def _make_plugin(
-    base: Path, *, name: str = "myplugin",
-    pipeline_entries: list[str], skill_entries: list[str],
-) -> Path:
-    """A plugin declaring explicit ``entries`` for both capabilities (so a
-    caller controls exactly which names are declared, valid or not — the
-    manifest's own ``entries`` list is the "declared" side of the
-    declared-vs-registered diff this file tests)."""
+def _make_plugin(base: Path, *, name: str = "myplugin") -> Path:
+    """A minimal plugin dir: manifest only. #4570 conversion B: no
+    ``capabilities``/``entries`` — registration discovers ``pipelines/``
+    and ``skills/`` purely from what the caller separately creates on
+    disk under this returned root."""
     plugin_dir = base / name
     plugin_dir.mkdir(parents=True, exist_ok=True)
     (plugin_dir / "plugin.json").write_text(
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": name, "version": "0.1.0", "description": "test plugin",
-            "capabilities": [
-                {"kind": "pipelines", "entries": pipeline_entries},
-                {"kind": "skills", "entries": skill_entries},
-            ],
         }),
         encoding="utf-8",
     )
@@ -112,20 +130,19 @@ def _ctx(tmp_path: Path, events: EventLog) -> OpContext:
 
 
 @pytest.mark.asyncio
-async def test_a_missing_pipeline_dsl_file_lands_in_skipped_not_registered(
+async def test_a_malformed_pipeline_dsl_lands_in_skipped_not_registered(
     tmp_path: Path, monkeypatch,
 ) -> None:
-    """Tier 2: the core witness — a declared pipeline entry naming a file
-    that doesn't exist under ``pipelines/`` fails inside
-    ``_pipeline_install_handle`` (returns ``status="error"``, doesn't
-    raise) and must NOT appear in ``registered["pipelines"]``."""
+    """Tier 2: the core witness — a discovered ``pipelines/*.yaml`` file
+    whose content fails to parse errors inside ``_pipeline_install_handle``
+    (returns ``status="error"``, doesn't raise) and must NOT appear in
+    ``registered["pipelines"]``."""
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
 
-    src = _make_plugin(
-        tmp_path / "src", pipeline_entries=["missing.yaml"], skill_entries=[],
-    )
+    src = _make_plugin(tmp_path / "src")
+    _make_malformed_pipeline_dsl(src / "pipelines" / "broken.yaml")
     events = EventLog()
     calls: list = []
     events.add_subscriber(calls.append)
@@ -141,7 +158,7 @@ async def test_a_missing_pipeline_dsl_file_lands_in_skipped_not_registered(
     skip_paths = {
         e.data["path"] for e in calls if e.type == "pipeline_install_skipped"
     }
-    assert skip_paths == {str(Path(result["plugin_root"]) / "pipelines" / "missing.yaml")}
+    assert skip_paths == {str(Path(result["plugin_root"]) / "pipelines" / "broken.yaml")}
     skip_reasons = {
         e.data["reason"] for e in calls if e.type == "pipeline_install_skipped"
     }
@@ -149,17 +166,19 @@ async def test_a_missing_pipeline_dsl_file_lands_in_skipped_not_registered(
 
 
 @pytest.mark.asyncio
-async def test_a_missing_skill_dir_lands_in_skipped_not_registered(
+async def test_a_skill_dir_with_no_skill_md_lands_in_skipped_not_registered(
     tmp_path: Path, monkeypatch,
 ) -> None:
-    """Tier 2: same witness, the skills axis."""
+    """Tier 2: same witness, the skills axis — a discovered ``skills/*``
+    directory (the discover-glob only needs ``is_dir()``, #4570 conversion
+    B) with no ``SKILL.md`` inside fails ``skill_install``'s own resolve
+    step."""
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
 
-    src = _make_plugin(
-        tmp_path / "src", pipeline_entries=[], skill_entries=["missing_skill"],
-    )
+    src = _make_plugin(tmp_path / "src")
+    (src / "skills" / "empty_skill").mkdir(parents=True)
     events = EventLog()
     calls: list = []
     events.add_subscriber(calls.append)
@@ -175,27 +194,25 @@ async def test_a_missing_skill_dir_lands_in_skipped_not_registered(
     skip_paths = {
         e.data["path"] for e in calls if e.type == "skill_install_skipped"
     }
-    assert skip_paths == {str(Path(result["plugin_root"]) / "skills" / "missing_skill")}
+    assert skip_paths == {str(Path(result["plugin_root"]) / "skills" / "empty_skill")}
 
 
 @pytest.mark.asyncio
-async def test_one_good_one_bad_pipeline_entry_partitions_correctly(
+async def test_one_good_one_bad_pipeline_partitions_correctly(
     tmp_path: Path, monkeypatch,
 ) -> None:
-    """Tier 2: the realistic shape #4590 reports — a plugin declaring
-    MULTIPLE pipeline entries where only some fail. Proves the fix
-    operates per-entry (partial success), not all-or-nothing: the valid
-    entry must land in ``registered``, the invalid one in ``skipped`` —
-    NEITHER list may absorb the other's member."""
+    """Tier 2: the realistic shape #4590 reports — a plugin shipping
+    MULTIPLE pipeline files where only some fail. Proves the fix operates
+    per-file (partial success), not all-or-nothing: the valid file must
+    land in ``registered``, the invalid one in ``skipped`` — NEITHER list
+    may absorb the other's member."""
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
 
-    src = _make_plugin(
-        tmp_path / "src",
-        pipeline_entries=["good.yaml", "missing.yaml"], skill_entries=[],
-    )
-    _make_pipeline_dsl(src / "pipelines" / "good.yaml", name="good-pipeline")
+    src = _make_plugin(tmp_path / "src")
+    _make_valid_pipeline_dsl(src / "pipelines" / "good.yaml", name="good-pipeline")
+    _make_malformed_pipeline_dsl(src / "pipelines" / "broken.yaml")
 
     events = EventLog()
     calls: list = []
@@ -206,34 +223,29 @@ async def test_one_good_one_bad_pipeline_entry_partitions_correctly(
     result = await install_handle(op, ctx)
 
     assert result["status"] == "installed", result
-    # Identity, not just count: the GOOD entry landed in registered, the
+    # Identity, not just count: the GOOD file landed in registered, the
     # BAD one in skipped — neither list absorbed the other's member.
     registered_names = [
         n for r in result["registered"]["pipelines"] for n in r.get("registered_names", [])
     ]
     assert any("good-pipeline" in n for n in registered_names)
     skipped_paths = {s.get("path") for s in result["skipped"]["pipelines"]}
-    assert skipped_paths == {str(Path(result["plugin_root"]) / "pipelines" / "missing.yaml")}
+    assert skipped_paths == {str(Path(result["plugin_root"]) / "pipelines" / "broken.yaml")}
 
 
 @pytest.mark.asyncio
 async def test_a_working_skill_still_registers_normally(
     tmp_path: Path, monkeypatch,
 ) -> None:
-    """Tier 2: accept-side — a plugin whose entries all succeed sees no
+    """Tier 2: accept-side — a plugin shipping only valid content sees no
     regression: everything lands in ``registered``, ``skipped`` stays
-    empty, no skip event fires. (test_plugin_install.py's own accept-path
-    test already covers this for the discover-everything, no-explicit-
-    entries case; this covers the explicit-entries path this file's other
-    tests exercise, for symmetry.)"""
+    empty, no skip event fires."""
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
 
-    src = _make_plugin(
-        tmp_path / "src", pipeline_entries=[], skill_entries=["hello"],
-    )
-    _make_skill(src / "skills" / "hello", name="hello")
+    src = _make_plugin(tmp_path / "src")
+    _make_valid_skill(src / "skills" / "hello", name="hello")
 
     events = EventLog()
     calls: list = []

--- a/tests/core/test_op_runtime_load_skill_3247.py
+++ b/tests/core/test_op_runtime_load_skill_3247.py
@@ -356,7 +356,6 @@ def test_plugin_install_bakes_plugin_root_load_skill_resolves_the_rest(tmp_path,
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": "loadertest", "version": "0.1.0", "description": "d",
-            "capabilities": [{"kind": "skills"}],
         }),
         encoding="utf-8",
     )

--- a/tests/core/test_plugin_install.py
+++ b/tests/core/test_plugin_install.py
@@ -133,7 +133,6 @@ def _make_git_plugin_repo(base: Path, name: str = "gitplugin") -> Path:
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": name, "version": "0.1.0", "description": "git plugin",
-            "capabilities": [{"kind": "skills"}],
         }),
         encoding="utf-8",
     )
@@ -157,7 +156,6 @@ def _make_plugin_source(base: Path, name: str = "myplugin") -> Path:
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": name, "version": "0.1.0", "description": "test plugin",
-            "capabilities": [{"kind": "skills"}],
         }),
         encoding="utf-8",
     )
@@ -327,7 +325,6 @@ def _make_mcp_plugin_source(base: Path, name: str = "mcpplugin") -> Path:
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": name, "version": "0.1.0", "description": "mcp test plugin",
-            "capabilities": [{"kind": "mcp"}],
         }),
         encoding="utf-8",
     )
@@ -629,7 +626,7 @@ async def test_plugin_install_register_only_no_venv_no_rewrite(tmp_path, monkeyp
     (src / "plugin.json").write_text(
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
-            "name": "registeronly", "version": "0.1.0", "capabilities": [{"kind": "mcp"}],
+            "name": "registeronly", "version": "0.1.0",
         }),
         encoding="utf-8",
     )
@@ -684,7 +681,7 @@ async def test_plugin_install_never_reads_requirements_txt_content(tmp_path, mon
     (src / "plugin.json").write_text(
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
-            "name": "badreqs", "version": "0.1.0", "capabilities": [],
+            "name": "badreqs", "version": "0.1.0",
         }),
         encoding="utf-8",
     )
@@ -827,7 +824,7 @@ async def test_plugin_install_never_hangs_on_pypi_with_unanswering_bus(tmp_path,
     (src / "plugin.json").write_text(
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
-            "name": "needsdeps4", "version": "0.1.0", "capabilities": [],
+            "name": "needsdeps4", "version": "0.1.0",
         }),
         encoding="utf-8",
     )

--- a/tests/interfaces/test_plugin_cli_surface.py
+++ b/tests/interfaces/test_plugin_cli_surface.py
@@ -54,7 +54,6 @@ def _make_git_plugin_repo(base: Path, name: str = "gitplugin") -> Path:
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": name, "version": "0.1.0", "description": "git plugin",
-            "capabilities": [{"kind": "skills"}],
         }),
         encoding="utf-8",
     )
@@ -79,7 +78,6 @@ def _write_local_plugin(base: Path, name: str = "myplugin") -> Path:
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": name, "version": "0.1.0", "description": "test plugin",
-            "capabilities": [{"kind": "skills"}],
         }),
         encoding="utf-8",
     )

--- a/tests/plugins/test_fp0063_p4_builtin_rag_skill.py
+++ b/tests/plugins/test_fp0063_p4_builtin_rag_skill.py
@@ -83,7 +83,7 @@ import pytest
 import yaml
 
 from reyn.data.pipelines.registry import build_pipeline_registry
-from reyn.plugins.manifest import load_plugin_manifest
+from reyn.plugins.manifest import capability_kinds_present, load_plugin_manifest
 from tests._support.builtin_skill_tool_names import (
     qualified_tool_calls_referenced,
     real_catalog_tool_names,
@@ -120,11 +120,13 @@ def _skill_body() -> str:
 
 
 def test_rag_plugin_manifest_declares_skills_capability_and_the_skill_exists() -> None:
-    """Tier 2: the plugin manifest declares a `skills` capability, and the
-    `build-and-query-rag-corpus` SKILL.md really exists at the layout
-    `plugin_install`'s discovery convention expects."""
-    manifest = load_plugin_manifest(_PLUGIN_DIR)
-    assert "skills" in manifest.capability_kinds
+    """Tier 2: the plugin ships a `skills` capability (#4570 conversion B:
+    derived from `skills/` directory presence, not a manifest field any
+    more — `load_plugin_manifest` still confirms the manifest itself
+    loads/validates), and the `build-and-query-rag-corpus` SKILL.md really
+    exists at the layout `plugin_install`'s discovery convention expects."""
+    load_plugin_manifest(_PLUGIN_DIR)  # still validates the manifest loads
+    assert "skills" in capability_kinds_present(_PLUGIN_DIR)
     assert _SKILL_PATH.is_file(), f"expected a SKILL.md at {_SKILL_PATH}"
 
 

--- a/tests/plugins/test_manifest.py
+++ b/tests/plugins/test_manifest.py
@@ -1,11 +1,11 @@
 """Tier 1: Contract — ``plugin.json`` typed manifest schema (ADR 0064 §3.1,
 #3067; relocated to the plugin root + required ``$schema`` — #4570
-conversion A, aligning with the Agent Plugins 1.0 standard).
+conversion A; ``capabilities`` removed entirely — #4570 conversion B,
+Agent Plugins 1.0 alignment).
 
-Round-trips a manifest with non-default values (all three capability kinds,
-non-empty explicit ``entries``, a non-empty ``description``) through the real
-``PluginManifest`` schema and the real ``load_plugin_manifest`` file-reading
-path — no fakes, real ``Path``/JSON I/O via ``tmp_path``.
+Round-trips a manifest through the real ``PluginManifest`` schema and the
+real ``load_plugin_manifest`` file-reading path — no fakes, real
+``Path``/JSON I/O via ``tmp_path``.
 """
 from __future__ import annotations
 
@@ -18,9 +18,7 @@ from reyn.plugins.manifest import (
     PLUGIN_MANIFEST_SCHEMA_URL,
     PluginManifest,
     PluginManifestError,
-    PluginMCPCapability,
-    PluginPipelinesCapability,
-    PluginSkillsCapability,
+    capability_kinds_present,
     load_plugin_manifest,
     manifest_path_for,
 )
@@ -32,20 +30,14 @@ def _write_manifest(plugin_dir, data: dict) -> None:
 
 
 def test_manifest_round_trips_nondefault_values(tmp_path):
-    """Tier 1: non-default round-trip — all 3 capability kinds present,
-    non-empty entries, description set, real file I/O + model_dump_json ->
-    model_validate round-trip."""
+    """Tier 1: non-default round-trip — description set, real file I/O +
+    model_dump_json -> model_validate round-trip."""
     plugin_dir = tmp_path / "my-plugin"
     data = {
         "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
         "name": "rag",
         "version": "1.2.3",
         "description": "builtin RAG plugin (dogfood template, ADR §3.1)",
-        "capabilities": [
-            {"kind": "mcp"},
-            {"kind": "pipelines", "entries": ["ingest.yaml", "query.yaml"]},
-            {"kind": "skills", "entries": ["rag-search"]},
-        ],
     }
     _write_manifest(plugin_dir, data)
 
@@ -55,17 +47,6 @@ def test_manifest_round_trips_nondefault_values(tmp_path):
     assert manifest.name == "rag"
     assert manifest.version == "1.2.3"
     assert manifest.description == "builtin RAG plugin (dogfood template, ADR §3.1)"
-    assert manifest.capability_kinds == frozenset({"mcp", "pipelines", "skills"})
-
-    pipelines_cap = next(
-        cap for cap in manifest.capabilities if isinstance(cap, PluginPipelinesCapability)
-    )
-    assert pipelines_cap.entries == ("ingest.yaml", "query.yaml")
-    skills_cap = next(
-        cap for cap in manifest.capabilities if isinstance(cap, PluginSkillsCapability)
-    )
-    assert skills_cap.entries == ("rag-search",)
-    assert any(isinstance(cap, PluginMCPCapability) for cap in manifest.capabilities)
 
     # Round-trip through model_dump -> model_validate (JSON mode, the
     # serialised shape a P2 install step would persist/copy). by_alias=True
@@ -76,10 +57,10 @@ def test_manifest_round_trips_nondefault_values(tmp_path):
     assert reloaded == manifest
 
 
-def test_manifest_capabilities_are_optional_any_subset(tmp_path):
-    """Tier 1: §3.1 'every capability subdir is optional' — a manifest with
-    zero capabilities (declares only identity) is valid, matching the common
-    case of building just an MCP server with no skill (§1)."""
+def test_manifest_description_defaults_to_empty_string(tmp_path):
+    """Tier 1: description is optional — a manifest declaring only
+    identity is valid (§1: the primary use case is "just an MCP server",
+    which may carry no prose description at all)."""
     plugin_dir = tmp_path / "bare"
     _write_manifest(
         plugin_dir,
@@ -88,8 +69,7 @@ def test_manifest_capabilities_are_optional_any_subset(tmp_path):
 
     manifest = load_plugin_manifest(plugin_dir)
 
-    assert manifest.capabilities == ()
-    assert manifest.capability_kinds == frozenset()
+    assert manifest.description == ""
 
 
 def test_manifest_path_for_matches_the_plugin_root_layout(tmp_path):
@@ -157,6 +137,27 @@ def test_manifest_wrong_schema_value_raises_typed_error(tmp_path):
         load_plugin_manifest(plugin_dir)
 
 
+def test_manifest_declaring_capabilities_raises_typed_error(tmp_path):
+    """Tier 1: (#4570 conversion B) ``capabilities`` is REMOVED from this
+    schema — a manifest still declaring it is a typed-error REJECTION,
+    never a silent no-op (lead-coder ruling: the same "config that
+    doesn't take effect" trap class as ``_build_tool_use_config``'s
+    ``chat``-key rejection). Pydantic's default "drop unknown fields"
+    behavior would otherwise swallow this with no error at all."""
+    plugin_dir = tmp_path / "still-declares-capabilities"
+    _write_manifest(
+        plugin_dir,
+        {
+            "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
+            "name": "old-style", "version": "1.0.0",
+            "capabilities": [{"kind": "mcp"}],
+        },
+    )
+
+    with pytest.raises(PluginManifestError, match="capabilities"):
+        load_plugin_manifest(plugin_dir)
+
+
 def test_manifest_name_rejects_reserved_namespace_separator():
     """Tier 1: ``name`` rejects ``.`` — the reserved namespace-separator
     character (mirrors ``PipelineInstallIROp``/``SkillInstallIROp``)."""
@@ -164,32 +165,33 @@ def test_manifest_name_rejects_reserved_namespace_separator():
         PluginManifest(schema_=PLUGIN_MANIFEST_SCHEMA_URL, name="a.b", version="1.0.0")
 
 
-def test_manifest_rejects_duplicate_capability_kind():
-    """Tier 1: a manifest declaring the same capability kind twice is
-    malformed — each capability is registered at most once (P2 register step
-    has no 'merge two pipelines blocks' semantics to fall back on)."""
-    with pytest.raises(ValidationError):
-        PluginManifest(
-            schema_=PLUGIN_MANIFEST_SCHEMA_URL,
-            name="dup",
-            version="1.0.0",
-            capabilities=[
-                PluginPipelinesCapability(entries=("a.yaml",)),
-                PluginPipelinesCapability(entries=("b.yaml",)),
-            ],
-        )
+# ── capability_kinds_present (directory/file-existence derivation) ─────────
 
 
-def test_manifest_capability_kind_is_a_typed_discriminated_union_not_a_string():
-    """Tier 1: Tool-Contract lens — an unrecognised ``kind`` value fails
-    validation at the schema boundary rather than being silently
-    form-sniffed/ignored."""
-    with pytest.raises(ValidationError):
-        PluginManifest.model_validate(
-            {
-                "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
-                "name": "x",
-                "version": "1.0.0",
-                "capabilities": [{"kind": "not-a-real-capability"}],
-            }
-        )
+def test_capability_kinds_present_detects_mcp_json(tmp_path):
+    """Tier 1: (#4570 conversion B) ``.mcp.json`` presence alone is the mcp
+    capability declaration — no manifest field involved."""
+    plugin_dir = tmp_path / "mcp-only"
+    plugin_dir.mkdir()
+    (plugin_dir / ".mcp.json").write_text("{}", encoding="utf-8")
+
+    assert capability_kinds_present(plugin_dir) == frozenset({"mcp"})
+
+
+def test_capability_kinds_present_detects_pipelines_and_skills_dirs(tmp_path):
+    """Tier 1: a ``pipelines/`` and/or ``skills/`` directory each
+    independently contributes its own capability kind."""
+    plugin_dir = tmp_path / "pipes-and-skills"
+    (plugin_dir / "pipelines").mkdir(parents=True)
+    (plugin_dir / "skills").mkdir(parents=True)
+
+    assert capability_kinds_present(plugin_dir) == frozenset({"pipelines", "skills"})
+
+
+def test_capability_kinds_present_empty_for_bare_plugin_dir(tmp_path):
+    """Tier 1: (accept-side) a plugin directory with none of the three
+    marker paths -> no capabilities, not a crash."""
+    plugin_dir = tmp_path / "bare"
+    plugin_dir.mkdir()
+
+    assert capability_kinds_present(plugin_dir) == frozenset()

--- a/tests/runtime/test_plugin_slash_surface.py
+++ b/tests/runtime/test_plugin_slash_surface.py
@@ -111,7 +111,6 @@ def _write_local_plugin(base: Path, name: str = "myplugin") -> Path:
         json.dumps({
             "$schema": PLUGIN_MANIFEST_SCHEMA_URL,
             "name": name, "version": "0.1.0", "description": "test plugin",
-            "capabilities": [{"kind": "skills"}],
         }),
         encoding="utf-8",
     )

--- a/tests/tools/test_3202_symptom3_plugin_discovery.py
+++ b/tests/tools/test_3202_symptom3_plugin_discovery.py
@@ -142,14 +142,20 @@ def test_rag_description_matches_manifest_verbatim() -> None:
     READ from the manifest at call time, not copied into BUILTIN_PLUGINS (the
     redundant-projection drift class #3164 hit for a different value). Edit
     plugin.json and this test's expectation changes with it -- there is no
-    second string anywhere to fall out of sync."""
+    second string anywhere to fall out of sync.
+
+    #4570 conversion B: `capabilities` is no longer a manifest field at
+    all -- the expected set here is derived the SAME way
+    `list_builtin_plugins` itself derives it (directory/file existence,
+    `capability_kinds_present`), not read back off the manifest JSON."""
+    from reyn.plugins.manifest import capability_kinds_present
+
     manifest = _manifest_json()
     plugins = {p["name"]: p for p in list_builtin_plugins()}
+    rag_dir = Path(registry_module.__file__).parent / "plugins" / "rag"
 
     assert plugins["rag"]["description"] == manifest["description"]
-    assert set(plugins["rag"]["capabilities"]) == {
-        cap["kind"] for cap in manifest["capabilities"]
-    }
+    assert set(plugins["rag"]["capabilities"]) == set(capability_kinds_present(rag_dir))
 
 
 def test_builtin_plugins_registry_holds_no_description_key() -> None:


### PR DESCRIPTION
**[tui-coder]** — part of #4570 (Agent Plugins 1.0 alignment). Builds on #4602 (conversion A, merged).

## What — conversion B of 5

`capabilities` (and its nested `entries` subset-selection field) is REMOVED from `PluginManifest` entirely, not relocated into `extensions["dev.reyn"]`.

Lead-coder's ruling: owner's own stated goal ("互換性あるなら標準に寄せて一本化したい") argues against inventing a never-used reyn-specific extension slot at the same moment the standard's own `additionalProperties: false` root is being adopted. Measured before removal: 2 production readers (`plugin_install.py`'s registration step), 0 declaring manifests anywhere in the repo (including the shipped `rag` plugin), 0 third-party manifests (reyn is unreleased).

## Changes

- `src/reyn/plugins/manifest.py`: `PluginManifest` drops `capabilities`/`entries`/`PluginCapability` entirely. A manifest still declaring `capabilities` is **rejected with a typed error** at parse time (`_reject_removed_capabilities_key`), not silently ignored — the same "config that doesn't take effect" trap class as `_build_tool_use_config`'s `chat`-key rejection (lead-coder's own precedent citation, applied at my request before implementing). New `capability_kinds_present(plugin_dir)` — the ONE derivation both `plugin_install.py`'s registration step and `discovery.py`'s listing now consult, so "registered" and "listed" can never independently drift.
- `src/reyn/core/op_runtime/plugin_install.py`: step 7's per-capability loop is gone — mcp/pipelines/skills each register unconditionally when their directory/file exists (mcp always calls `_register_mcp`, which already no-ops gracefully on a missing `.mcp.json`). The `entries`-based narrowing is gone too — discover-everything is the only mode left.
- `src/reyn/builtin/discovery.py`: `capabilities` in the `list_plugins` tool output now comes from `capability_kinds_present`, not the manifest.
- `src/reyn/builtin/plugins/rag/plugin.json`: `capabilities` key removed.
- ~12 test files: fixture manifests drop `capabilities`/`entries`. `test_manifest.py` gains `capability_kinds_present` coverage + a typed-error-rejection test for a manifest still declaring `capabilities`.
- **`test_4590_plugin_install_pipeline_skill_skip.py`'s fixtures rewritten**: `entries` used to construct a "declared but missing" failure case that discover-everything can no longer represent (a nonexistent file is simply never globbed) — replaced with a REAL but broken file/dir (a malformed pipeline DSL, a `skills/` directory with no `SKILL.md`) reaching the identical `status="error"`-without-raising path #4590 is actually about.

## Note

Rebased onto latest `main` (#4602 merged) on a fresh branch — the prior branch's raw history predates A's squash-merge, so this PR's diff is B-only.

## Test plan

- `ruff check src tests`, `test_tier_audit.py --strict` (109 tests across every touched test file), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` — all green.
- Scoped `pytest`: 190 tests across every touched plugin-related file — all green.
- [ ] Visual (waived per CLAUDE.md standing waiver, 2026-08-08 — not a TUI-facing change)

Next: C (mcp.json `$schema`/`type`/transport rename), D (field-aware `${PLUGIN_ROOT}`/`${PLUGIN_DATA}` expansion), E (full rag-plugin conversion, depends on A–D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
