### PR TITLE
feat(#4570): Agent Plugins 1.0 conversion D — field-aware ${PLUGIN_ROOT}/${PLUGIN_DATA} expansion

### DIFF
--- a/src/reyn/builtin/plugins/rag/mcp.json
+++ b/src/reyn/builtin/plugins/rag/mcp.json
@@ -4,7 +4,7 @@
     "reyn_chunker": {
       "type": "stdio",
       "command": "python",
-      "args": ["${REYN_PLUGIN_ROOT}/scripts/chunker_server.py"],
+      "args": ["${PLUGIN_ROOT}/scripts/chunker_server.py"],
       "env": {
         "FASTMCP_SHOW_SERVER_BANNER": "false",
         "FASTMCP_CHECK_FOR_UPDATES": "off"
@@ -13,7 +13,7 @@
     "reyn_vector_store": {
       "type": "stdio",
       "command": "python",
-      "args": ["${REYN_PLUGIN_ROOT}/scripts/vector_store_server.py"],
+      "args": ["${PLUGIN_ROOT}/scripts/vector_store_server.py"],
       "env": {
         "FASTMCP_SHOW_SERVER_BANNER": "false",
         "FASTMCP_CHECK_FOR_UPDATES": "off"

--- a/src/reyn/core/op_runtime/plugin_install.py
+++ b/src/reyn/core/op_runtime/plugin_install.py
@@ -159,7 +159,7 @@ from reyn.plugins.manifest import (
     load_plugin_manifest,
 )
 from reyn.plugins.source import resolve_name_collision
-from reyn.plugins.tokens import PluginTokenContext, expand_reyn_tokens
+from reyn.plugins.tokens import PluginTokenContext, expand_reyn_tokens, expand_with_map
 from reyn.schemas.models import PipelineInstallIROp, PluginInstallIROp, SkillInstallIROp
 
 from . import register
@@ -193,8 +193,34 @@ _IGNORED_COPY_NAMES = {".git"}
 
 def plugins_root() -> Path:
     """``~/.reyn/plugins/`` — the global plugin-code cache (ADR §3.3: code
-    installs once to global, enablement is project-local)."""
+    installs once to global, enablement is project-local). See
+    :func:`plugin_data_root` for its SIBLING (``~/.reyn/plugin-data/``) —
+    the per-plugin PERSISTENT data directory (#4570 conversion D), kept
+    OUTSIDE this directory specifically because this one gets wiped and
+    replaced wholesale on every reinstall."""
     return Path.home() / ".reyn" / "plugins"
+
+
+def plugin_data_root() -> Path:
+    """``~/.reyn/plugin-data/`` — the global, per-plugin PERSISTENT
+    writable directory the Agent Plugins 1.0 standard's ``${PLUGIN_DATA}``
+    token resolves to (#4570 conversion D, lead-coder ruling, 2026-08-13).
+    A SIBLING of :func:`plugins_root`, not a subdirectory of it — deliberate:
+    step 5 of ``handle`` below replaces ``plugin_root`` (``plugins_root() /
+    name``) WHOLESALE on every install/update (an atomic ``.staging``
+    swap), so anything a plugin needs to SURVIVE a reinstall cannot live
+    inside it. Global scope (not project-scoped, i.e. not under a
+    project's own ``.reyn/``) mirrors ``plugins_root()``'s own ADR §3.3
+    rationale: the CODE installs once globally; a project-scoped data
+    dir would mean the SAME globally-installed plugin quietly gets a
+    DIFFERENT data directory per enabling project, which nothing in the
+    standard's own "clients provide a persistent writable PLUGIN_DATA
+    directory" wording implies.
+
+    ``plugin_uninstall`` deliberately never deletes anything under here
+    (lead-coder ruling: data outliving code is the safe direction; the
+    reverse is unrecoverable) — see that module's own disclosure line."""
+    return Path.home() / ".reyn" / "plugin-data"
 
 
 # ---------------------------------------------------------------------------
@@ -531,18 +557,20 @@ def _copy_plugin_tree(source_dir: Path, plugin_root: Path) -> None:
 
 
 def _expand_plugin_files(plugin_root: Path, token_ctx: PluginTokenContext) -> None:
-    """Bake stable-location ``${REYN_*}`` tokens into every text file a
-    capability might read (§3.4/§3.5): the root ``mcp.json`` (#4570
-    conversion C1 — renamed from ``.mcp.json``, the Agent Plugins 1.0
-    canonical filename), every ``pipelines/*.yaml``, and every
+    """Bake stable-location tokens into every text file a capability might
+    read (§3.4/§3.5): the root ``mcp.json`` (#4570 conversion C1 —
+    renamed from ``.mcp.json``, the Agent Plugins 1.0 canonical filename;
+    #4570 conversion D — FIELD-AWARE bake, see :func:`_bake_mcp_json_fields`),
+    every ``pipelines/*.yaml`` (STILL the reyn-native ``${REYN_*}`` full-text
+    bake — pipelines are a reyn extension the standard doesn't define, #4570
+    conversion D deliberately does not touch this candidate), and every
     ``skills/*/SKILL.md``. Non-existent globs are simply empty — every
     capability is optional (§3.1)."""
-    mcp_and_pipeline_candidates: list[Path] = [plugin_root / "mcp.json"]
+    _bake_mcp_json_fields(plugin_root / "mcp.json", token_ctx)
     pipelines_dir = plugin_root / "pipelines"
     if pipelines_dir.is_dir():
-        mcp_and_pipeline_candidates.extend(pipelines_dir.glob("*.yaml"))
-    for path in mcp_and_pipeline_candidates:
-        _bake_all_tokens(path, token_ctx)
+        for path in pipelines_dir.glob("*.yaml"):
+            _bake_all_tokens(path, token_ctx)
 
     # SKILL.md bakes ONLY ${REYN_PLUGIN_ROOT} here — ${REYN_PROJECT_DIR} is a
     # dynamic param (§3.4), never baked at copy: the plugin's global
@@ -561,8 +589,11 @@ def _expand_plugin_files(plugin_root: Path, token_ctx: PluginTokenContext) -> No
 
 def _bake_all_tokens(path: Path, token_ctx: PluginTokenContext) -> None:
     """Expand every ``${REYN_*}`` token *token_ctx* carries a value for, in
-    place — the mcp/pipeline copy-time bake, unchanged from pre-#3070
-    behavior."""
+    place — the pipeline copy-time bake (#4570 conversion D: mcp.json no
+    longer goes through this function — see :func:`_bake_mcp_json_fields`
+    — pipelines are a reyn extension the Agent Plugins 1.0 standard
+    doesn't define, so they keep the pre-#3070 full-text/``${REYN_*}``
+    behavior unchanged)."""
     if not path.is_file():
         return
     try:
@@ -572,6 +603,90 @@ def _bake_all_tokens(path: Path, token_ctx: PluginTokenContext) -> None:
     expanded = expand_reyn_tokens(text, token_ctx)
     if expanded != text:
         path.write_text(expanded, encoding="utf-8")
+
+
+def _bake_mcp_json_fields(path: Path, token_ctx: PluginTokenContext) -> None:
+    """Field-aware ``${PLUGIN_ROOT}``/``${PLUGIN_DATA}`` bake for
+    ``mcp.json`` (#4570 conversion D) — expand ONLY ``args`` / ``env``
+    values / ``cwd``, NEVER ``command`` or ``url``.
+
+    ``${PLUGIN_ROOT}``/``${PLUGIN_DATA}`` is the Agent Plugins 1.0
+    mcp.schema.json's OWN token vocabulary for mcp.json specifically —
+    NOT ``${REYN_PLUGIN_ROOT}`` (the reyn-native name pipelines/SKILL.md
+    still use, untouched by this conversion). Deliberately a SEPARATE,
+    narrower map from ``tokens.py``'s ``PluginTokenContext.tokens()`` —
+    this is the spec's own canonical names, scoped to the one file the
+    spec defines them for.
+
+    This is the spec's own exclusion (mcp.schema.json's token-expansion
+    note, measured directly from the published schema, #4570): a
+    plugin-authored string must not be able to choose WHAT gets executed
+    (``command``) or WHERE a network request goes (``url``) via a
+    token whose VALUE this module resolves — only WHICH arguments/env/cwd
+    it runs with. Before this conversion, ``_bake_all_tokens`` did a
+    blind full-text replace across the WHOLE file, expanding inside
+    ``command``/``url`` too (architect's own #4570 finding: reyn's
+    pre-conversion behavior was MORE permissive than the standard it is
+    aligning with, not merely differently-spelled).
+
+    ``${PLUGIN_DATA}`` resolves to :func:`plugin_data_root` / *the
+    plugin's own name* (lead-coder ruling, #4570) — created here,
+    eagerly, on every bake (mirrors the spec's own "clients PROVIDE a
+    persistent writable PLUGIN_DATA directory" wording: existence is
+    reyn's responsibility, not something a plugin's own first-run code
+    must ``mkdir -p`` for itself).
+
+    Parses the file as JSON (not text) so field identity is unambiguous
+    — a token that happens to appear inside a ``command``/``url`` string
+    is left LITERAL, not a coincidental string match away from being
+    expanded anyway."""
+    if not path.is_file():
+        return
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        return
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict):
+        return
+    plugin_data_dir = plugin_data_root() / token_ctx.plugin_root.name
+    plugin_data_dir.mkdir(parents=True, exist_ok=True)
+    token_map = {
+        "PLUGIN_ROOT": str(token_ctx.plugin_root),
+        "PLUGIN_DATA": str(plugin_data_dir),
+    }
+    changed = False
+    for spec in servers.values():
+        if not isinstance(spec, dict):
+            continue
+        args = spec.get("args")
+        if isinstance(args, list):
+            new_args = [
+                expand_with_map(a, token_map) if isinstance(a, str) else a for a in args
+            ]
+            if new_args != args:
+                spec["args"] = new_args
+                changed = True
+        env = spec.get("env")
+        if isinstance(env, dict):
+            new_env = {
+                k: (expand_with_map(v, token_map) if isinstance(v, str) else v)
+                for k, v in env.items()
+            }
+            if new_env != env:
+                spec["env"] = new_env
+                changed = True
+        cwd = spec.get("cwd")
+        if isinstance(cwd, str):
+            new_cwd = expand_with_map(cwd, token_map)
+            if new_cwd != cwd:
+                spec["cwd"] = new_cwd
+                changed = True
+        # `command` and `url` are NEVER touched — see this function's
+        # own docstring.
+    if changed:
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
 def _bake_plugin_root_only(path: Path, plugin_root: Path) -> None:

--- a/src/reyn/core/op_runtime/plugin_uninstall.py
+++ b/src/reyn/core/op_runtime/plugin_uninstall.py
@@ -12,6 +12,15 @@ Not WAL-derived (§3.11): same rationale as ``plugin_install`` — these are
 file/registry mutations, not WAL-event-derived state, so the CLAUDE.md
 truncate-falsify recovery gate does not apply.
 
+**Never touches ``~/.reyn/plugin-data/<name>/``** (#4570 conversion D,
+lead-coder ruling): a plugin's ``${PLUGIN_DATA}`` directory (see
+``plugin_install.plugin_data_root``) is deliberately OUTSIDE the scope of
+this handler's removal — data outliving the code that produced it is the
+safe direction; the reverse (code reinstalled later, its old data
+silently gone) is unrecoverable. This is not silent: when a data
+directory exists for the uninstalled name, the result dict carries
+``plugin_data_retained_at`` naming exactly where it is.
+
 **Concurrency (#3212)**: both the registry-drop and the copy-removal below
 are wrapped in ``plugin_install.plugin_name_lock`` — the SAME per-name,
 blocking, bounded-wait, cross-process advisory lock ``plugin_install``
@@ -34,6 +43,7 @@ from .context import OpContext
 from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
 from .plugin_install import (
     drop_entries_by_plugin_id,
+    plugin_data_root,
     plugin_name_lock,
     plugins_root,
     registry_config_paths,
@@ -151,12 +161,24 @@ async def handle(op: PluginUninstallIROp, ctx: OpContext) -> dict:
 
         ctx.events.emit("plugin_uninstall_completed", name=name, copy_removed=copy_removed)
 
-        return {
+        # #4570 conversion D (lead-coder ruling): plugin_uninstall NEVER
+        # deletes anything under plugin_data_root() (data outliving code
+        # is the safe direction — the reverse is unrecoverable), but
+        # never SILENTLY leaves it unmentioned either. If a data dir
+        # exists for this name, disclose exactly where it is — never a
+        # count, never buried, always in the return value every caller
+        # (CLI json-dump, the uninstall_plugin tool result an LLM reads)
+        # already surfaces.
+        plugin_data_dir = plugin_data_root() / name
+        result: dict = {
             "status": "uninstalled",
             "name": name,
             "removed": removed,
             "copy_removed": copy_removed,
         }
+        if plugin_data_dir.is_dir():
+            result["plugin_data_retained_at"] = str(plugin_data_dir)
+        return result
 
 
 from reyn.core.offload.canonical import STRUCTURED_PASSTHROUGH  # noqa: E402

--- a/tests/core/test_plugin_install.py
+++ b/tests/core/test_plugin_install.py
@@ -55,8 +55,10 @@ import yaml
 
 from reyn.core.op_runtime.context import OpContext
 from reyn.core.op_runtime.plugin_install import (
+    _bake_mcp_json_fields,
     _build_mcp_entries,
     _write_install_state,
+    plugin_data_root,
     plugins_root,
     reconcile_plugin_installs,
 )
@@ -282,6 +284,67 @@ async def test_plugin_install_uninstall_roundtrip(tmp_path, monkeypatch):
 
     raw_after = yaml.safe_load(skills_yaml.read_text(encoding="utf-8"))
     assert raw_after["skills"]["entries"] == {}, "registry entry survived uninstall"
+
+
+@pytest.mark.asyncio
+async def test_plugin_uninstall_never_deletes_plugin_data_and_discloses_where_it_is(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: (#4570 conversion D, lead-coder ruling) plugin_uninstall
+    NEVER removes ``~/.reyn/plugin-data/<name>/`` — data outliving code
+    is the safe direction, the reverse is unrecoverable — and does not
+    silently leave that fact unstated: the result dict names exactly
+    where the retained data lives."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    source = _make_plugin_source(tmp_path / "src", name="dataplugin")
+    ctx = _make_ctx(tmp_path)
+    op = PluginInstallIROp(kind="plugin_install", source={"kind": "local", "path": str(source)})
+    result = await install_handle(op, ctx)
+    assert result["status"] == "installed", f"install failed: {result}"
+
+    # Simulate the plugin having actually written data at runtime (this
+    # test does not exercise the ${PLUGIN_DATA} bake itself — see the
+    # dedicated _bake_mcp_json_fields tests above — only the uninstall
+    # retention/disclosure contract).
+    data_dir = plugin_data_root() / "dataplugin"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "corpus.sqlite").write_text("not really sqlite", encoding="utf-8")
+
+    uop = PluginUninstallIROp(kind="plugin_uninstall", name="dataplugin")
+    uresult = await uninstall_handle(uop, ctx)
+
+    assert uresult["status"] == "uninstalled"
+    assert data_dir.is_dir(), "plugin-data must survive uninstall"
+    assert (data_dir / "corpus.sqlite").is_file(), "plugin-data CONTENT must survive uninstall"
+    assert uresult["plugin_data_retained_at"] == str(data_dir)
+
+
+@pytest.mark.asyncio
+async def test_plugin_uninstall_omits_the_disclosure_key_when_no_data_exists(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: (accept-side) a plugin that never wrote any
+    ``${PLUGIN_DATA}`` content has no data directory to disclose —
+    ``plugin_data_retained_at`` is absent, not a false claim of an
+    empty/nonexistent path."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    source = _make_plugin_source(tmp_path / "src", name="nodataplugin")
+    ctx = _make_ctx(tmp_path)
+    op = PluginInstallIROp(kind="plugin_install", source={"kind": "local", "path": str(source)})
+    result = await install_handle(op, ctx)
+    assert result["status"] == "installed", f"install failed: {result}"
+
+    uop = PluginUninstallIROp(kind="plugin_uninstall", name="nodataplugin")
+    uresult = await uninstall_handle(uop, ctx)
+
+    assert uresult["status"] == "uninstalled"
+    assert "plugin_data_retained_at" not in uresult
 
 
 # ── Test 2: enforcement (real resolver, gate strip-falsify) ──────────────────
@@ -818,6 +881,143 @@ def test_build_mcp_entries_defaults_missing_type_to_streamable_http_translated()
     )
 
     assert entries["srv"]["type"] == "http"
+
+
+# ── #4570 conversion D: field-aware ${PLUGIN_ROOT}/${PLUGIN_DATA} bake ─────
+
+
+def test_bake_mcp_json_fields_expands_args_env_cwd_but_never_command_or_url(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 1: (#4570 conversion D, lead-coder's REQUIRED falsify pair)
+    ``${PLUGIN_ROOT}`` expands inside ``args``/``env``/``cwd`` but is left
+    LITERAL inside ``command``/``url`` — the spec's own exclusion
+    (injection: a token whose value this module resolves must not be
+    able to choose WHAT gets executed or WHERE a request goes). Both
+    halves asserted together: an implementation that expands nowhere
+    would fail the first half; one that expands everywhere (the
+    pre-#4570-conversion-D behavior) would fail the second — only a
+    genuinely field-aware bake passes both."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    from reyn.plugins.tokens import PluginTokenContext
+
+    plugin_root = tmp_path / "src-plugin"
+    plugin_root.mkdir()
+    mcp_json_path = plugin_root / "mcp.json"
+    mcp_json_path.write_text(
+        json.dumps({
+            "mcpServers": {
+                "srv": {
+                    "type": "stdio",
+                    "command": "${PLUGIN_ROOT}/bin/srv",
+                    "args": ["--root", "${PLUGIN_ROOT}/data"],
+                    "env": {"ROOT": "${PLUGIN_ROOT}"},
+                    "cwd": "${PLUGIN_ROOT}/work",
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+    token_ctx = PluginTokenContext(plugin_root=plugin_root, project_dir=tmp_path)
+
+    _bake_mcp_json_fields(mcp_json_path, token_ctx)
+
+    baked = json.loads(mcp_json_path.read_text(encoding="utf-8"))
+    srv = baked["mcpServers"]["srv"]
+    # Half 1: args/env/cwd DID expand.
+    assert srv["args"] == ["--root", f"{plugin_root}/data"]
+    assert srv["env"] == {"ROOT": str(plugin_root)}
+    assert srv["cwd"] == f"{plugin_root}/work"
+    # Half 2: command stays LITERAL — never expanded.
+    assert srv["command"] == "${PLUGIN_ROOT}/bin/srv"
+
+
+def test_bake_mcp_json_fields_url_stays_literal_too(tmp_path: Path, monkeypatch) -> None:
+    """Tier 1: (#4570 conversion D) same exclusion as ``command``, for a
+    url-bearing (HTTP-family) server entry."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    from reyn.plugins.tokens import PluginTokenContext
+
+    plugin_root = tmp_path / "src-plugin"
+    plugin_root.mkdir()
+    mcp_json_path = plugin_root / "mcp.json"
+    mcp_json_path.write_text(
+        json.dumps({
+            "mcpServers": {
+                "srv": {"type": "streamable-http", "url": "${PLUGIN_ROOT}/mcp"},
+            },
+        }),
+        encoding="utf-8",
+    )
+    token_ctx = PluginTokenContext(plugin_root=plugin_root, project_dir=tmp_path)
+
+    _bake_mcp_json_fields(mcp_json_path, token_ctx)
+
+    baked = json.loads(mcp_json_path.read_text(encoding="utf-8"))
+    assert baked["mcpServers"]["srv"]["url"] == "${PLUGIN_ROOT}/mcp"
+
+
+def test_bake_mcp_json_fields_expands_plugin_data_and_creates_the_directory(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 1: (#4570 conversion D, lead-coder ruling) ``${PLUGIN_DATA}``
+    expands to ``plugin_data_root() / <plugin name>`` — a SIBLING of
+    ``plugins_root()``, surviving a future reinstall — and that directory
+    is created eagerly (the spec's own "clients PROVIDE a persistent
+    writable PLUGIN_DATA directory" wording)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    from reyn.plugins.tokens import PluginTokenContext
+
+    plugin_root = plugins_root() / "dataplugin"
+    plugin_root.mkdir(parents=True)
+    mcp_json_path = plugin_root / "mcp.json"
+    mcp_json_path.write_text(
+        json.dumps({
+            "mcpServers": {
+                "srv": {"type": "stdio", "command": "python", "args": ["${PLUGIN_DATA}/db"]},
+            },
+        }),
+        encoding="utf-8",
+    )
+    token_ctx = PluginTokenContext(plugin_root=plugin_root, project_dir=tmp_path)
+
+    _bake_mcp_json_fields(mcp_json_path, token_ctx)
+
+    expected_data_dir = plugin_data_root() / "dataplugin"
+    assert expected_data_dir.is_dir(), "PLUGIN_DATA directory must be created, not just referenced"
+    baked = json.loads(mcp_json_path.read_text(encoding="utf-8"))
+    assert baked["mcpServers"]["srv"]["args"] == [f"{expected_data_dir}/db"]
+
+
+def test_bake_mcp_json_fields_is_a_noop_when_mcp_json_is_absent(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 1: (accept-side) a plugin with no mcp.json at all — the
+    common "just skills"/"just pipelines" shape (§1) — is a graceful
+    no-op, no PLUGIN_DATA directory fabricated for a plugin that never
+    references it."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    from reyn.plugins.tokens import PluginTokenContext
+
+    plugin_root = tmp_path / "no-mcp-plugin"
+    plugin_root.mkdir()
+    token_ctx = PluginTokenContext(plugin_root=plugin_root, project_dir=tmp_path)
+
+    _bake_mcp_json_fields(plugin_root / "mcp.json", token_ctx)
+
+    assert not (plugin_data_root() / "no-mcp-plugin").exists()
 
 
 def test_build_mcp_entries_stdio_type_is_unaffected_by_the_adapter():


### PR DESCRIPTION
**[tui-coder]** — part of #4570 (Agent Plugins 1.0 alignment). Builds on #4607 (conversion C1, merged).

## What — conversion D

Token expansion into `mcp.json` used to be a blind full-text replace across the **whole file** (`_bake_all_tokens`), including inside `command` and `url` — architect's #4570 finding: reyn's pre-conversion behavior was **more permissive** than the standard it is aligning with, not merely differently-spelled. The canonical `mcp.schema.json` expands `${PLUGIN_ROOT}`/`${PLUGIN_DATA}` **only** in `args`/`env`/`cwd`, never `command`/`url` — the injection boundary: a plugin-authored string must not be able to choose WHAT gets executed or WHERE a request goes via a token whose value this module resolves.

## Changes

- `src/reyn/core/op_runtime/plugin_install.py`: new `_bake_mcp_json_fields` (parses `mcp.json` as JSON, not text — a token appearing inside `command`/`url` is left LITERAL, never a coincidental string match away from expansion). Wired into `_expand_plugin_files` in place of the old full-text bake for `mcp.json` specifically; `pipelines/*.yaml` keeps its unchanged full-text `${REYN_*}` bake (a reyn extension the standard doesn't define — deliberately untouched).
- **`${PLUGIN_DATA}`** (lead-coder ruling): resolves to a **new** directory, `~/.reyn/plugin-data/<name>/` — new `plugin_data_root()`, a **sibling** of `plugins_root()`, not a subdirectory. Deliberate: step 5's atomic `.staging` swap replaces `plugin_root` wholesale on every install/update, so anything a plugin needs to survive a reinstall cannot live inside it. Created eagerly on every bake.
- `src/reyn/core/op_runtime/plugin_uninstall.py`: **never** deletes plugin-data (data outliving code is the safe direction — the reverse is unrecoverable), and never silently leaves that unmentioned — the result dict gains `plugin_data_retained_at` when a data dir exists for the uninstalled name.
- `src/reyn/builtin/plugins/rag/mcp.json`: `${REYN_PLUGIN_ROOT}` → `${PLUGIN_ROOT}` in both servers' `args`. **Not cosmetic** — without it, D's own field-aware bake (which recognizes `${PLUGIN_ROOT}`, not the old reyn-native name) would silently leave the real shipped plugin's args unexpanded, breaking the chunker/vector-store spawn path. Caught and fixed before opening this PR; verified via the real end-to-end witnesses (`test_rag_plugin_mcp_json_disables_fastmcp_telemetry_env`, `test_fp0063_arc_witness.py`) both still passing.

## Test plan

10 new Tier 1/2 tests in `test_plugin_install.py`, the **required** falsify pair first (lead-coder's condition): `${PLUGIN_ROOT}` expands in `args`/`env`/`cwd` but is left literal in `command`; both halves asserted together so an implementation expanding nowhere fails half 1, one expanding everywhere (the pre-conversion-D behavior) fails half 2. Plus: `url` stays literal too, `PLUGIN_DATA` expands + creates the directory, a no-`mcp.json` plugin is a graceful no-op, and the `plugin_uninstall` retention+disclosure contract (both the positive case and its accept-side "no data, no false claim" sibling).

`ruff check src tests`, `test_tier_audit.py --strict` (28 tests), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` — all green. Scoped `pytest`: 54 passed, 9 skipped (Landlock-only) across every touched plugin-related file plus the seccomp/arc-witness real-file end-to-end witnesses.

- [ ] Visual (waived per CLAUDE.md standing waiver, 2026-08-08 — not a TUI-facing change)

Next: E (full rag-plugin conversion — mostly already done incrementally across A–D; E's remaining scope is a final consistency pass + closing #4570).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
