### PR TITLE
fix(#4601): cap the artifact-ref table fallback, both transports, "newest N of M" disclosed

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -77,6 +77,7 @@ aren't.
 | `chat` | map | PRJ only · **restart** | Chat-session runtime knobs: history compaction, reasoning/"thinking" text handling, the interactive renderer (`render_mode`), TUI gutters, body neutralization, and permitted image-URL schemes. See below. |
 | `voice` | map | PRJ only · **restart** | ⚠️ Currently unavailable (no consumer). See below. |
 | `audit_events` | map | PRJ only · **restart** | Rotation policy (size / age / cleanup period) for the P6 **audit-event** files under `.reyn/events`. Not WAL-events, not hook-events. See below. |
+| `artifacts` | map | PRJ only · **restart** | The artifact-ref table fallback's own row cap (`remote_fallback_limit`, #4601) — used by a remote client's (and a post-restart local client's) Artifacts pane. See below. |
 | `observability` | map | PRJ only · **restart** | Opt-in OpenTelemetry (OTLP) export of P6 audit-events. Off by default. See below. |
 | `tool_use` | map | PRJ only · **restart** | Chat-layer tool-use scheme x transport selector (`scheme`, `transport`). See below. |
 | `mcp` | map | both (`.reyn/config/mcp.yaml` side is **hot-reloaded**) | MCP server definitions. See below. |
@@ -2095,6 +2096,21 @@ Either axis firing deletes files — `cleanup_period_days` OR `max_disk_usage_pe
 Both defaults are **borrowed conventions, not measurements** of reyn's own `.reyn/events` growth rate (unmeasured as of #4479): 30 days borrows the nearest comparable local-agent CLI's own default (Claude Code's `cleanupPeriodDays`); 10% borrows systemd-journald's own `SystemMaxUse` convention. Neither is "the correct" number — both exist as an operator-overridable starting point.
 
 **`0` means disabled on that axis, not rejected** — a deliberate choice, documented here on purpose: Claude Code carries an open report of its own `cleanupPeriodDays` knob being ambiguous about whether `0` means "delete immediately" or "never delete." reyn's own knobs use `0` = never delete, unambiguously, on both axes.
+
+## `artifacts` block
+
+The artifact-ref table fallback's own row cap (#4601). A remote client's — and a local client right after a restart's, #4584's own measured finding — Artifacts pane consults the durable, append-only, persist-tier artifact-ref table when its live conversation view carries nothing. With no cap, this read is unbounded and only ever grows.
+
+```yaml
+artifacts:
+  remote_fallback_limit: 50   # default
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `remote_fallback_limit` | int | `50` | Caps the ref-table fallback to the N NEWEST entries (newest-first). A non-positive or non-numeric value falls back to the default. |
+
+`remote_fallback_limit` is a **UX-scale default, not a performance one** — a single `stat()` costs order-microseconds, so even 10,000 rows costs tens of milliseconds; the binding constraint is how many newest-first rows an operator would ever actually scroll through in a list pane, which is a couple of dozen at most. The Artifacts pane's own disclosure text always states "newest N of M" so a truncation is never silent — raise this value if your own usage wants more history visible at once.
 
 ## `voice` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -538,6 +538,23 @@
 
 
 # -----------------------------------------------------------------------------
+# artifacts: the artifact-ref table fallback's own row cap (#4601). A
+# remote client's (and a local client right after a restart's, #4584)
+# Artifacts pane consults this durable, append-only, persist-tier table
+# when its live conversation view carries nothing — with no cap of its
+# own it would return an ever-growing, unbounded list. ``remote_fallback_limit``
+# (default 50) caps it to the N newest entries; the pane's own disclosure
+# text still names the full count ("newest N of M") so a truncation is
+# never silent. This is a UX-scale default (how many rows a human would
+# ever scroll through), not a performance one (a single stat() costs
+# order-microseconds) — raise it if your own Artifacts pane usage wants
+# more history visible at once.
+# -----------------------------------------------------------------------------
+# artifacts:
+#   remote_fallback_limit: 50
+
+
+# -----------------------------------------------------------------------------
 # observability: downstream OpenTelemetry (OTLP) export. OPT-IN and OFF by
 # default — with no ``observability.otel.endpoint`` (and no
 # ``OTEL_EXPORTER_OTLP_ENDPOINT`` env var) the exporter is never attached and

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -535,6 +535,43 @@ class AuditEventsConfig:
     backend: Literal["local", "discard"] = "local"
 
 
+@dataclass
+class ArtifactsConfig:
+    """``artifacts:`` — the artifact-ref table fallback's own row cap
+    (#4601, lead-coder/architect ruling).
+
+    ``list_refs_for_agent`` (``data/workspace/artifact_ref.py``) is the
+    ONE fallback join point both the AG-UI endpoint's ``artifact_list_request``
+    handler and ``InProcessTransport``'s own local read share (#4494 design
+    C) — the table is append-only and now persist-tier (#4584), so both
+    call sites read an UNBOUNDED, ever-growing list with no cap of their
+    own. This is a single-knob fix at that one join point, not two
+    independent caller-side caps (architect's own #4601 finding: capping
+    only the endpoint leaves the TUI's identical fallback path broken).
+
+    **``remote_fallback_limit`` is a UX-scale cap, not a performance
+    one** (architect's #4601 measurement-by-order-of-magnitude, not a
+    live benchmark): a single ``stat()`` costs order-microseconds, so
+    even 10,000 rows costs tens of milliseconds — the constraint that
+    actually binds is how many newest-first rows a human operator would
+    ever scroll through in a list pane, which is a couple of dozen at
+    most. The default below is therefore a UX default, not a derived
+    number — which is exactly why it MUST be operator-adjustable (owner's
+    standing instruction: never embed a baseless number with no
+    user-facing way to change it) rather than defended with a rationale
+    comment no fixed number could honestly carry (the "correct" N
+    genuinely depends on the pane's own height/usage, which this config
+    layer cannot see).
+
+    The list is newest-first (``list_refs_for_agent``'s own convention,
+    matching ``collect_artifact_rows``), so ``entries[:remote_fallback_limit]``
+    is always the N MOST RECENT artifacts, never an arbitrary slice.
+    Truncation is disclosed, never silent — see ``chrome.py``'s
+    consolidated fallback-source disclosure text ("newest N of M")."""
+
+    remote_fallback_limit: int = 50
+
+
 _SANDBOX_BACKENDS = {"auto", "seatbelt", "landlock", "noop"}
 _SANDBOX_ON_UNSUPPORTED = {"warn", "error", "ignore"}
 # #3823 ①②: compat / strict — NOT "custom" (owner ruling, 2026-08-09:
@@ -1007,5 +1044,26 @@ def _build_audit_events_config(raw: object) -> AuditEventsConfig:
         max_disk_usage_percent=disk_percent_val,
         backend=backend_val,
     )
+
+
+def _build_artifacts_config(raw: object) -> ArtifactsConfig:
+    """Parse `artifacts:` from reyn.yaml (#4601).
+
+    A non-positive or non-numeric `remote_fallback_limit` falls back to
+    the default — same "malformed value falls back, never disables the
+    cap outright" discipline every other numeric field in this module
+    uses (an operator typo must not silently produce an unbounded
+    fallback again, the exact defect #4601 exists to close)."""
+    defaults = ArtifactsConfig()
+    if not isinstance(raw, dict):
+        return defaults
+    limit = raw.get("remote_fallback_limit", defaults.remote_fallback_limit)
+    try:
+        limit_val = int(limit)
+        if limit_val <= 0:
+            limit_val = defaults.remote_fallback_limit
+    except (TypeError, ValueError):
+        limit_val = defaults.remote_fallback_limit
+    return ArtifactsConfig(remote_fallback_limit=limit_val)
 
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -27,6 +27,7 @@ from reyn.config.execution import (  # #1682 #3 cross-section
 )
 from reyn.config.infra import (  # #1682 #3 cross-section
     _build_agent_id,
+    _build_artifacts_config,
     _build_audit_events_config,
     _build_auth_config,
     _build_cron_config,
@@ -846,6 +847,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         auth=_build_auth_config(merged.get("auth")),
         chat=_build_chat_config(merged.get("chat")),
         audit_events=_build_audit_events_config(merged.get("audit_events")),
+        artifacts=_build_artifacts_config(merged.get("artifacts")),
         observability=_build_observability_config(merged.get("observability")),
         cost=cost,
         tool_use=_build_tool_use_config(merged.get("tool_use")),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -49,6 +49,7 @@ from reyn.config.execution import (
     ToolUseConfig,
 )
 from reyn.config.infra import (
+    ArtifactsConfig,
     AuditEventsConfig,
     AuthConfig,
     CronConfig,
@@ -164,6 +165,12 @@ class ReynConfig:
     # Audit-log rotation policy (PR20). #4174 T5: renamed from `events:` —
     # bare "event" is the shape CLAUDE.md's cross-cutting-band note bans.
     audit_events: AuditEventsConfig = field(default_factory=AuditEventsConfig)
+    # The artifact-ref table fallback's row cap (#4601) — the ONE join
+    # point both the AG-UI endpoint and InProcessTransport's local
+    # fallback share. See `ArtifactsConfig`'s own docstring for why the
+    # default is a UX-scale default, not a derived number, and why that's
+    # exactly why it must be operator-adjustable here.
+    artifacts: ArtifactsConfig = field(default_factory=ArtifactsConfig)
     # Downstream observability export (OTLP/OpenTelemetry). Opt-in + off by
     # default: no `observability.otel.endpoint` (and no OTEL_EXPORTER_OTLP_ENDPOINT
     # env) → the OtelExporter is never built and behavior is byte-identical to

--- a/src/reyn/data/workspace/artifact_ref.py
+++ b/src/reyn/data/workspace/artifact_ref.py
@@ -168,7 +168,9 @@ def resolve_ref(project_root: Path, agent_name: str, ref: str) -> "Path | None":
     return None
 
 
-def list_refs_for_agent(project_root: Path, agent_name: str) -> "list[dict]":
+def list_refs_for_agent(
+    project_root: Path, agent_name: str, *, limit: "int | None" = None,
+) -> "tuple[list[dict], int]":
     """#4494 design C: every ``{"ref", "path"}`` entry minted under
     *agent_name*'s scope, newest-first — the durable source a REMOTE
     client's own artifact list falls back to when its live conversation
@@ -178,14 +180,37 @@ def list_refs_for_agent(project_root: Path, agent_name: str) -> "list[dict]":
     "presentation" kind reconstruction either, #4584's own measured
     finding — this function is transport-agnostic and serves both).
 
+    **#4601: the ONE fallback join point both in-repo callers
+    (``InProcessTransport.request_artifact_list`` and the AG-UI
+    endpoint's ``artifact_list_request`` handler) share** — the table is
+    append-only and persist-tier (#4584), so it never shrinks; capping
+    HERE (rather than in each caller separately) is what keeps both
+    transports bounded together, per architect's own #4601 finding that
+    a cap placed only at the endpoint would leave the TUI's identical
+    fallback path unbounded. ``limit`` truncates newest-first (so a
+    truncated list is always the N MOST RECENT artifacts) — pass
+    ``None`` for no cap (existing/internal callers, tests).
+
+    Returns ``(entries, total)`` — ``total`` is the FULL matching count
+    before truncation, so a caller can disclose "newest N of M" rather
+    than silently dropping the tail (owner's standing instruction: no
+    baseless cap without visibility into what it cut).
+
     Deliberately raw entries, not :class:`~reyn.core.present.artifact_list.
     ArtifactRow` objects — this module has no ``media_type``/
     ``description`` to offer (the table was never designed to carry them;
     only :func:`mint_ref`'s two fields exist), and no existence check
     (mirrors :func:`~reyn.core.present.artifact_list.collect_artifact_rows`'s
     own "stat only what's about to be displayed" discipline — the CALLER
-    decides how many rows it is about to render before paying that I/O).
-    """
+    decides how many rows it is about to render before paying that I/O;
+    #4601 architect ruling: that decision now happens in THIS order —
+    truncate first, stat only the N survivors — see
+    :func:`~reyn.core.present.artifact_list.resolve_display_paths`'s own
+    callers)."""
     entries = [e for e in _load_table(project_root) if e.get("agent") == agent_name]
     entries.reverse()  # newest-first, matching collect_artifact_rows' own convention
-    return [{"ref": e["ref"], "path": e["path"]} for e in entries if "ref" in e and "path" in e]
+    rows = [{"ref": e["ref"], "path": e["path"]} for e in entries if "ref" in e and "path" in e]
+    total = len(rows)
+    if limit is not None:
+        rows = rows[:limit]
+    return rows, total

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1176,6 +1176,12 @@ class TextualChatApp(App):
         # ``chrome.pane_payload``/``pane_commands`` so the disclosure row
         # is appended (or not) alongside the right rows/commands.
         self._artifact_rows_source: str = "live"
+        # #4601: the fallback's pre-cap total (M in "newest N of M") —
+        # only meaningful when ``_artifact_rows_source ==
+        # "ref_table_fallback"``; 0 otherwise (the disclosure text is
+        # never rendered for the "live" source, so the stale value is
+        # never read in that state).
+        self._artifact_rows_fallback_total: int = 0
         # #3288 ③c: in-flight streamed reply, keyed by ``chain_id`` — the SAME
         # authoritative correlation id ``RouterLoop._emit_agent_delta`` stamps
         # on every ``agent_delta`` audit-event AND the one the terminal
@@ -1716,6 +1722,7 @@ class TextualChatApp(App):
             history=self._history_turns(),
             artifacts=self._artifact_rows(),
             artifact_source=self._artifact_rows_source,
+            artifact_fallback_total=self._artifact_rows_fallback_total,
             app_bindings=self._app_binding_help(),
         )
 
@@ -2501,11 +2508,14 @@ class TextualChatApp(App):
         offer, so this is strictly a fallback, not a merge.
 
         Re-renders the "artifacts" OptionList in place with the fallback
-        rows PLUS the source-limitation disclosure
-        (``chrome.ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE``) appended —
-        always appended, even when the fallback itself is empty (#4494's
-        own falsify requirement: emptying the ref table empties the rows
-        but the disclosure text stays)."""
+        rows PLUS the consolidated disclosure
+        (``chrome.artifact_fallback_disclosure_text``) appended — always
+        appended, even when the fallback itself is empty (#4494's own
+        falsify requirement: emptying the ref table empties the rows but
+        the disclosure text stays). #4601: the entries this transport
+        call returns are ALREADY capped (newest-first, at the one join
+        point — ``list_refs_for_agent``) — ``total`` is the pre-cap
+        count, threaded into the disclosure's "newest N of M"."""
         if self._artifact_rows_cache:
             return  # live list already had content — no fallback needed
         from pathlib import Path
@@ -2516,7 +2526,7 @@ class TextualChatApp(App):
             rows_from_ref_table_entries,
         )
 
-        entries = await self._transport.request_artifact_list(agent=self._agent_name)
+        entries, total = await self._transport.request_artifact_list(agent=self._agent_name)
         fallback_rows = rows_from_ref_table_entries(entries)
         if fallback_rows:
             # Same resolved_path fill-in the live path gets (#4482 PR-3
@@ -2529,6 +2539,7 @@ class TextualChatApp(App):
             )
         self._artifact_rows_cache = fallback_rows
         self._artifact_rows_source = "ref_table_fallback"
+        self._artifact_rows_fallback_total = total
         try:
             drawer = self.query_one("#drawer", ContentSwitcher)
         except Exception:
@@ -2540,6 +2551,7 @@ class TextualChatApp(App):
         )
         rows = pane_payload(
             "artifacts", artifacts=fallback_rows, artifact_source="ref_table_fallback",
+            artifact_fallback_total=total,
         )
         child = self.query_one("#artifacts")
         if isinstance(child, OptionList):

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -966,15 +966,36 @@ def artifact_row_label(row: "ArtifactRow") -> str:
 #: mechanism here (`output_language` governs LLM output, not this chrome);
 #: a Japanese UI would be a whole-surface owner decision, not one string
 #: at a time.
-ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE = (
-    "This list is built from the artifact-ref table. An artifact the "
-    "agent passed inline (no real file) is never recorded there, so it "
-    "cannot appear here."
-)
+#:
+#: #4601 (lead-coder/architect ruling): CONSOLIDATED into one sentence
+#: with the #4599 disclosure gap architect found (a ref whose FILE was
+#: deleted after being recorded still appears here — it was never
+#: covered, #4599's own wording only ever described what does NOT
+#: appear, never "appears but can't open") and the new "newest N of M"
+#: truncation notice (#4601's own cap — see ``ArtifactsConfig`` in
+#: ``config/infra.py``). ``shown``/``total`` ARE the count this text
+#: states — a deliberate exception to "never a count" above: THAT rule
+#: was about being unable to count something the fallback has no record
+#: of; ``total`` here is exactly what the fallback DOES have a record
+#: of (the full matching-row count before the #4601 cap), so stating it
+#: is not the thing the earlier ruling forbade.
+def artifact_fallback_disclosure_text(shown: int, total: int) -> str:
+    """The Artifacts pane's ref-table-fallback disclosure, naming exactly
+    what this source cannot show (inline artifacts, never recorded;
+    deleted-but-still-referenced files, recorded but unopenable) and how
+    much of it is showing (#4601's own "newest N of M" — never a silent
+    truncation)."""
+    return (
+        "This list is built from the artifact-ref table. An artifact the "
+        "agent passed inline (no real file) is never recorded there, so it "
+        "cannot appear here. A file that was deleted after being recorded "
+        "still appears here but cannot be opened. Showing the newest "
+        f"{shown} of {total}."
+    )
 
 
 def artifact_pane_options(
-    rows: "Sequence[ArtifactRow]", *, source: str = "live",
+    rows: "Sequence[ArtifactRow]", *, source: str = "live", fallback_total: int = 0,
 ) -> list[str]:
     """Rows for the Artifacts drawer pane — newest-first, already the order
     :func:`~reyn.core.present.artifact_list.collect_artifact_rows` returns
@@ -984,11 +1005,14 @@ def artifact_pane_options(
     the live-conversation list is empty: a remote client's past turns are
     not on the wire, and a local client right after a restart has the
     identical gap, #4584's own measured finding). The fallback source
-    ALWAYS appends :data:`ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE` — the
-    source limitation, never a count."""
+    ALWAYS appends :func:`artifact_fallback_disclosure_text` — the
+    source limitation AND the #4601 "newest N of M" truncation notice,
+    where N is ``len(rows)`` (already capped by the caller, #4601's own
+    join point) and M is ``fallback_total`` (the pre-cap count the
+    caller threads through — see ``app._maybe_refresh_remote_artifact_fallback``)."""
     body = [artifact_row_label(r) for r in rows] if rows else ["(no artifacts yet)"]
     if source == "ref_table_fallback":
-        return [*body, ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE]
+        return [*body, artifact_fallback_disclosure_text(len(rows), fallback_total)]
     return body
 
 
@@ -1422,6 +1446,7 @@ def pane_payload(
     history: "Sequence[str]" = (),
     artifacts: "Sequence[ArtifactRow]" = (),
     artifact_source: str = "live",
+    artifact_fallback_total: int = 0,
     app_bindings: "Iterable[tuple[str, str]]" = (),
 ) -> list[str]:
     """The display rows for ``tab_id``'s drawer pane, derived from canonical reyn
@@ -1430,7 +1455,9 @@ def pane_payload(
     (the app assembles them from its live snapshot / the slash REGISTRY / the
     conversation model) so this stays pure + testable.
 
-    ``artifact_source`` — see :func:`artifact_pane_options` (#4494 design C)."""
+    ``artifact_source`` — see :func:`artifact_pane_options` (#4494 design C).
+    ``artifact_fallback_total`` — the #4601 pre-cap count, only meaningful
+    when ``artifact_source == "ref_table_fallback"``."""
     snap = snapshot or {}
     builder = _PANE_ENTRY_BUILDERS.get(tab_id)
     if builder is not None:
@@ -1438,7 +1465,9 @@ def pane_payload(
     if tab_id == "history":
         return history_pane_options(history)
     if tab_id == "artifacts":
-        return artifact_pane_options(artifacts, source=artifact_source)
+        return artifact_pane_options(
+            artifacts, source=artifact_source, fallback_total=artifact_fallback_total,
+        )
     if tab_id == "menu":
         return menu_pane_options(commands)
     if tab_id == "cost":

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -212,7 +212,7 @@ class AgUiTransport(ClientTransport):
         )
         return bool((result or {}).get("switched"))
 
-    async def request_artifact_list(self, *, agent: str) -> "list[dict]":
+    async def request_artifact_list(self, *, agent: str) -> "tuple[list[dict], int]":
         # #4494 design C: POST a typed request; the server reads its OWN
         # copy of the durable artifact-ref table (never a client-supplied
         # path) and answers with the current entries. Same shape as
@@ -221,9 +221,17 @@ class AgUiTransport(ClientTransport):
         # the server's own ``agent_name`` (baked into the endpoint URL at
         # connect time) is what it actually reads against, so this
         # transport does not thread it onto the wire separately.
+        #
+        # #4601: the server's own entries are already capped — ``total``
+        # (the pre-cap count) rides alongside on the wire so this client
+        # can disclose "newest N of M" without a second round-trip.
         result = await self._send({"type": "artifact_list_request"})
         entries = (result or {}).get("entries")
-        return entries if isinstance(entries, list) else []
+        total = (result or {}).get("total")
+        return (
+            entries if isinstance(entries, list) else [],
+            total if isinstance(total, int) else 0,
+        )
 
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -779,6 +779,14 @@ async def agui_submit(request: Request, agent_name: str):
         # past turns are simply not on the wire). Mirrors
         # ``attach_request``/``session_switch_request`` above: client
         # names an operation, server executes it against ITS OWN state.
+        #
+        # #4601: capped at the SAME join point (``list_refs_for_agent``'s
+        # own ``limit``) InProcessTransport's local path caps at too —
+        # this endpoint was the ORIGINAL #4601 finding (unbounded, no
+        # stat), fixed here at the one place both transports share rather
+        # than as an endpoint-only patch (which would leave the TUI's
+        # identical fallback broken, architect's own #4601 correction).
+        from reyn.config.loader import load_config
         from reyn.data.workspace.artifact_ref import list_refs_for_agent
         # ``workspace_dir`` = <project_root>/.reyn/agents/<agent_name> — three
         # levels down, so PROJECT ROOT (what list_refs_for_agent wants, same
@@ -787,8 +795,11 @@ async def agui_submit(request: Request, agent_name: str):
         # reyn_state_root() derivation, a DIFFERENT thing this handler does
         # not want).
         project_root = session.workspace_dir.parent.parent.parent
-        entries = list_refs_for_agent(project_root, agent_name)
-        return JSONResponse({"status": "ok", "entries": entries})
+        config = load_config(project_root)
+        entries, total = list_refs_for_agent(
+            project_root, agent_name, limit=config.artifacts.remote_fallback_limit,
+        )
+        return JSONResponse({"status": "ok", "entries": entries, "total": total})
     return JSONResponse({"status": "ok"})
 
 

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -244,16 +244,17 @@ class ClientTransport(ABC):
         """
         return False
 
-    async def request_artifact_list(self, *, agent: str) -> "list[dict]":
+    async def request_artifact_list(self, *, agent: str) -> "tuple[list[dict], int]":
         """#4494 design C: the durable artifact-ref table's own entries for
-        *agent* — ``[{"ref", "path"}, ...]``, newest-first, or ``[]`` when
-        there is nothing (or this transport does not support the query).
-        Same "client interprets, server executes a named operation" shape
-        :meth:`request_attach`/:meth:`request_session_switch` already
-        establish: ``InProcessTransport`` reads the table directly;
-        ``AgUiTransport`` POSTs a typed request and the server reads its
-        OWN copy (never the wire's stale view — the server always has the
-        live, durable table this client cannot see any other way).
+        *agent* — ``([{"ref", "path"}, ...], total)``, newest-first, or
+        ``([], 0)`` when there is nothing (or this transport does not
+        support the query). Same "client interprets, server executes a
+        named operation" shape :meth:`request_attach`/
+        :meth:`request_session_switch` already establish: ``InProcessTransport``
+        reads the table directly; ``AgUiTransport`` POSTs a typed request
+        and the server reads its OWN copy (never the wire's stale view —
+        the server always has the live, durable table this client cannot
+        see any other way).
 
         This is the FALLBACK a caller reaches for only when its own live
         conversation-derived artifact list is empty (frame-sufficiency: a
@@ -266,10 +267,18 @@ class ClientTransport(ABC):
         real information loss the caller's own UI must disclose, never
         silently absorb (lead-coder's #4494 ruling).
 
+        **#4601**: the entries are already CAPPED (newest-first) by the
+        implementation before this method returns them — ``total`` is
+        the full matching count before that cap, so a caller can
+        disclose "newest N of M" rather than silently dropping the tail
+        (the defect #4601 exists to close: this fallback's underlying
+        table is append-only/persist-tier, #4584, so an uncapped read
+        only ever grows).
+
         NOT abstract, same reasoning as :meth:`request_attach` — several
         narrow-purpose stubs across the test suite pre-date this method;
-        the default ``[]`` preserves their behavior unchanged."""
-        return []
+        the default ``([], 0)`` preserves their behavior unchanged."""
+        return [], 0
 
     def reyn_state_root(self) -> "Path | None":
         """The attached session's project `.reyn` root, or None (#3721).

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -224,7 +224,7 @@ class InProcessTransport(ClientTransport):
             return False
         return True
 
-    async def request_artifact_list(self, *, agent: str) -> "list[dict]":
+    async def request_artifact_list(self, *, agent: str) -> "tuple[list[dict], int]":
         # #4494 design C: local execution side — reads the durable
         # artifact-ref table directly (no wire hop). ``list_refs_for_agent``
         # wants the PROJECT ROOT (it appends ".reyn"/"memory"/... itself,
@@ -233,11 +233,22 @@ class InProcessTransport(ClientTransport):
         # (see that method's own docstring). No attached session means no
         # root to read, so the fallback is empty, same as an unattached
         # ``has_session()``.
+        #
+        # #4601: capped at the SAME join point the AG-UI endpoint's own
+        # handler caps at (``list_refs_for_agent``'s own ``limit``) — this
+        # local path was the one architect measured as identically
+        # unbounded pre-#4601 (``in_process.py:236-240``, cited verbatim
+        # in the issue), reading the SAME table with no cap of its own.
+        from reyn.config.loader import load_config
         from reyn.data.workspace.artifact_ref import list_refs_for_agent
         reyn_root = self.reyn_state_root()
         if reyn_root is None:
-            return []
-        return list_refs_for_agent(reyn_root.parent, agent)
+            return [], 0
+        project_root = reyn_root.parent
+        config = load_config(project_root)
+        return list_refs_for_agent(
+            project_root, agent, limit=config.artifacts.remote_fallback_limit,
+        )
 
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None

--- a/tests/config/test_4601_artifacts_config.py
+++ b/tests/config/test_4601_artifacts_config.py
@@ -1,0 +1,56 @@
+"""Tier 1: #4601 — `artifacts:` config parsing (the ref-table fallback's
+own row cap).
+
+`remote_fallback_limit` — a non-positive or non-numeric value falls back
+to the default, same "malformed value falls back, never disables the cap
+outright" discipline `_build_audit_events_config` (#4479) already
+established for this module — an operator typo must not silently
+reintroduce the exact unbounded-fallback defect #4601 exists to close.
+"""
+from __future__ import annotations
+
+from reyn.config.infra import ArtifactsConfig, _build_artifacts_config
+
+
+def test_default_is_fifty():
+    """Tier 1: the shipped default — a UX-scale default (how many rows a
+    human would scroll through), not a derived/measured number."""
+    cfg = _build_artifacts_config(None)
+    assert cfg.remote_fallback_limit == 50
+
+
+def test_positive_value_passes_through():
+    """Tier 1: an ordinary operator override parses through unmodified."""
+    cfg = _build_artifacts_config({"remote_fallback_limit": 200})
+    assert cfg.remote_fallback_limit == 200
+
+
+def test_zero_falls_back_to_default():
+    """Tier 1: (#4601, unlike #4479's audit_events axes) 0 does NOT mean
+    "disabled" here — an unbounded fallback is exactly the defect this
+    config knob exists to close, so 0 falls back to the default rather
+    than reintroducing it."""
+    cfg = _build_artifacts_config({"remote_fallback_limit": 0})
+    assert cfg.remote_fallback_limit == ArtifactsConfig().remote_fallback_limit
+
+
+def test_negative_value_falls_back_to_default():
+    """Tier 1: a negative cap doesn't mean anything sensible — falls
+    back rather than propagating nonsense into `list[:negative]` slicing."""
+    cfg = _build_artifacts_config({"remote_fallback_limit": -5})
+    assert cfg.remote_fallback_limit == ArtifactsConfig().remote_fallback_limit
+
+
+def test_non_numeric_value_falls_back_to_default():
+    """Tier 1: (accept-side) a malformed/non-numeric value falls back
+    rather than raising or propagating a string into later int math."""
+    cfg = _build_artifacts_config({"remote_fallback_limit": "not-a-number"})
+    assert cfg.remote_fallback_limit == ArtifactsConfig().remote_fallback_limit
+
+
+def test_non_dict_raw_returns_defaults():
+    """Tier 1: (accept-side) no `artifacts:` block at all in reyn.yaml —
+    `raw` is `None` (or any non-dict) — returns the plain defaults, not
+    an error."""
+    assert _build_artifacts_config(None) == ArtifactsConfig()
+    assert _build_artifacts_config("not-a-dict") == ArtifactsConfig()

--- a/tests/data/test_4494_list_refs_for_agent.py
+++ b/tests/data/test_4494_list_refs_for_agent.py
@@ -4,6 +4,11 @@ REMOTE client (and a LOCAL client right after a restart, #4584's own
 measured finding) falls back to when its live conversation view carries
 nothing.
 
+**#4601**: the same join point also caps the fallback (newest-first) and
+reports the pre-cap total, closing the "both in-repo callers read an
+UNBOUNDED, ever-growing table" defect (the table is append-only and
+persist-tier, #4584 — it never shrinks on its own).
+
 Real ``mint_ref``/table on disk throughout — no mocks.
 """
 from __future__ import annotations
@@ -22,11 +27,12 @@ def test_returns_entries_for_the_named_agent_newest_first(tmp_path):
     ref1 = mint_ref(tmp_path, "alpha", f1)
     ref2 = mint_ref(tmp_path, "alpha", f2)
 
-    entries = list_refs_for_agent(tmp_path, "alpha")
+    entries, total = list_refs_for_agent(tmp_path, "alpha")
 
     assert [e["ref"] for e in entries] == [ref2, ref1]
     assert entries[0]["path"] == str(f2)
     assert entries[1]["path"] == str(f1)
+    assert total == 2
 
 
 def test_excludes_entries_minted_under_a_different_agent(tmp_path):
@@ -37,11 +43,57 @@ def test_excludes_entries_minted_under_a_different_agent(tmp_path):
     f.write_text("x")
     mint_ref(tmp_path, "beta", f)
 
-    assert list_refs_for_agent(tmp_path, "alpha") == []
+    entries, total = list_refs_for_agent(tmp_path, "alpha")
+    assert entries == []
+    assert total == 0
 
 
 def test_empty_table_returns_empty_list(tmp_path):
-    """Tier 2: (accept-side) no table on disk yet -> [], not a crash — the
-    same graceful-empty contract ``resolve_ref`` already gives a missing
-    table."""
-    assert list_refs_for_agent(tmp_path, "alpha") == []
+    """Tier 2: (accept-side) no table on disk yet -> ([], 0), not a crash
+    — the same graceful-empty contract ``resolve_ref`` already gives a
+    missing table."""
+    assert list_refs_for_agent(tmp_path, "alpha") == ([], 0)
+
+
+def test_limit_truncates_to_the_newest_n_entries_and_reports_the_full_total(
+    tmp_path,
+):
+    """Tier 2: (#4601) ``limit`` caps the RETURNED entries to the N
+    newest, but ``total`` still names the FULL matching count — a
+    caller can disclose "newest N of M" without a second, uncapped
+    query."""
+    paths = [tmp_path / f"f{i}.pdf" for i in range(5)]
+    for p in paths:
+        p.write_text("x")
+    refs = [mint_ref(tmp_path, "alpha", p) for p in paths]
+
+    entries, total = list_refs_for_agent(tmp_path, "alpha", limit=2)
+
+    # Newest-first: the LAST two minted (refs[4], refs[3]) come back.
+    assert [e["ref"] for e in entries] == [refs[4], refs[3]]
+    assert total == 5
+
+
+def test_limit_none_is_unbounded_same_as_omitting_it(tmp_path):
+    """Tier 2: (accept-side) ``limit=None`` behaves identically to the
+    default (no cap) — existing internal callers that don't pass
+    ``limit`` at all keep their unbounded read."""
+    f = tmp_path / "a.pdf"
+    f.write_text("x")
+    mint_ref(tmp_path, "alpha", f)
+
+    with_none = list_refs_for_agent(tmp_path, "alpha", limit=None)
+    without_arg = list_refs_for_agent(tmp_path, "alpha")
+    assert with_none == without_arg
+
+
+def test_limit_larger_than_available_entries_returns_everything(tmp_path):
+    """Tier 2: (accept-side) a limit bigger than the actual population
+    is a no-op cap, not an error or a padded list."""
+    f = tmp_path / "a.pdf"
+    f.write_text("x")
+    ref = mint_ref(tmp_path, "alpha", f)
+
+    entries, total = list_refs_for_agent(tmp_path, "alpha", limit=1000)
+    assert entries == [{"ref": ref, "path": str(f)}]
+    assert total == 1

--- a/tests/interfaces/test_4494_agui_artifact_list_endpoint.py
+++ b/tests/interfaces/test_4494_agui_artifact_list_endpoint.py
@@ -6,6 +6,10 @@ shape (real ``AgentRegistry`` + real ASGI app over ``httpx.AsyncClient``)
 and its closing-the-loop pattern (client's real output fed directly into
 the real server endpoint — no hand-authored literal duplicated on both
 sides).
+
+**#4601**: the endpoint now caps entries (newest-first) at
+``config.artifacts.remote_fallback_limit`` and returns ``total`` (the
+pre-cap count) alongside them on the wire.
 """
 from __future__ import annotations
 
@@ -18,10 +22,10 @@ from tests._support.agent_session import make_session
 from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
-def _registry(tmp_path, monkeypatch) -> AgentRegistry:
+def _registry(tmp_path, monkeypatch, *, reyn_yaml: str = MINIMAL_REYN_YAML) -> AgentRegistry:
     monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / "state.wal")
-    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(reyn_yaml, encoding="utf-8")
     holder: dict = {}
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
@@ -81,7 +85,9 @@ async def test_artifact_list_request_returns_the_agents_ref_table_entries(
     )
 
     assert resp.status_code == 200
-    assert resp.json().get("entries") == [{"ref": ref, "path": str(f)}]
+    body = resp.json()
+    assert body.get("entries") == [{"ref": ref, "path": str(f)}]
+    assert body.get("total") == 1
 
 
 @pytest.mark.asyncio
@@ -97,7 +103,39 @@ async def test_artifact_list_request_returns_empty_with_no_ref_minted(
     )
 
     assert resp.status_code == 200
-    assert resp.json().get("entries") == []
+    body = resp.json()
+    assert body.get("entries") == []
+    assert body.get("total") == 0
+
+
+@pytest.mark.asyncio
+async def test_artifact_list_request_caps_entries_at_the_configured_limit(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: (#4601) the ORIGINAL finding this issue reports — the
+    endpoint used to return the table's FULL, ever-growing contents with
+    no cap. Minting more refs than ``remote_fallback_limit`` proves the
+    cap is real: entries truncated (newest-first), ``total`` still
+    names the full count."""
+    reg = _registry(
+        tmp_path, monkeypatch,
+        reyn_yaml=MINIMAL_REYN_YAML + "\nartifacts:\n  remote_fallback_limit: 2\n",
+    )
+    refs = []
+    for i in range(5):
+        f = tmp_path / f"f{i}.pdf"
+        f.write_text("x")
+        refs.append(mint_ref(tmp_path, "alpha", f))
+    app = _build_app(reg, monkeypatch)
+
+    resp = await _post(
+        app, "/agui/chat/alpha?token=s3cret", {"type": "artifact_list_request"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [e["ref"] for e in body["entries"]] == [refs[4], refs[3]]
+    assert body["total"] == 5
 
 
 @pytest.mark.asyncio
@@ -110,22 +148,24 @@ async def test_agui_transport_request_artifact_list_sends_the_typed_payload():
 
     async def _send(payload: dict) -> dict:
         sent.append(payload)
-        return {"entries": [{"ref": "r1", "path": "/p/x.pdf"}]}
+        return {"entries": [{"ref": "r1", "path": "/p/x.pdf"}], "total": 1}
 
     async def _empty_lines():
         return
         yield  # pragma: no cover
 
     transport = AgUiTransport(_empty_lines(), _send)
-    entries = await transport.request_artifact_list(agent="alpha")
+    entries, total = await transport.request_artifact_list(agent="alpha")
 
     assert entries == [{"ref": "r1", "path": "/p/x.pdf"}]
+    assert total == 1
     assert sent == [{"type": "artifact_list_request"}]
 
 
 @pytest.mark.asyncio
 async def test_agui_transport_request_artifact_list_empty_when_send_returns_none():
-    """Tier 2: (accept-side) a None/falsy send result -> [], not a crash."""
+    """Tier 2: (accept-side) a None/falsy send result -> ([], 0), not a
+    crash."""
     from reyn.interfaces.transport.agui.client import AgUiTransport
 
     async def _send(payload: dict):
@@ -136,7 +176,7 @@ async def test_agui_transport_request_artifact_list_empty_when_send_returns_none
         yield  # pragma: no cover
 
     transport = AgUiTransport(_empty_lines(), _send)
-    assert await transport.request_artifact_list(agent="alpha") == []
+    assert await transport.request_artifact_list(agent="alpha") == ([], 0)
 
 
 # ── closing the wire-shape double-transcription gap (mirrors #4537/#4534) ──
@@ -166,6 +206,7 @@ async def test_agui_transport_artifact_list_payload_is_accepted_by_the_real_endp
         yield  # pragma: no cover
 
     transport = AgUiTransport(_empty_lines(), _send)
-    entries = await transport.request_artifact_list(agent="alpha")
+    entries, total = await transport.request_artifact_list(agent="alpha")
 
     assert entries == [{"ref": ref, "path": str(f)}]
+    assert total == 1

--- a/tests/interfaces/test_4494_artifact_pane_ref_table_fallback.py
+++ b/tests/interfaces/test_4494_artifact_pane_ref_table_fallback.py
@@ -1,16 +1,24 @@
 """Tier 1: #4494 design C — the Artifacts drawer pane's ref-table-fallback
 source disclosure (``chrome.py``). Lead-coder's own ruling, verbatim:
 "C ＋ 明示。文面は「件数」ではなく「情報源の限界」を言うこと" — the
-disclosure states the SOURCE LIMITATION, never a row count, and is
-appended REGARDLESS of whether the fallback found anything (the falsify
-requirement: emptying the ref table empties the rows but the disclosure
-text stays).
+disclosure states the SOURCE LIMITATION, appended REGARDLESS of whether
+the fallback found anything (the falsify requirement: emptying the ref
+table empties the rows but the disclosure text stays).
+
+**#4601 (lead-coder/architect ruling)**: the disclosure is now
+CONSOLIDATED into one sentence with the #4599 gap architect found (a ref
+whose FILE was deleted after recording still appears here but can't
+open) and the new "newest N of M" truncation notice — a deliberate,
+narrow exception to "never a count": ``total`` is exactly what the
+fallback DOES have a record of (unlike an inline artifact's count, which
+it genuinely cannot know), so stating it is not the thing the original
+"never a count" ruling forbade.
 """
 from __future__ import annotations
 
 from reyn.core.present.artifact_list import ArtifactRow
 from reyn.interfaces.inline.textual_chat.chrome import (
-    ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE,
+    artifact_fallback_disclosure_text,
     artifact_pane_commands,
     artifact_pane_options,
 )
@@ -25,14 +33,14 @@ def test_live_source_never_appends_the_disclosure():
     unaffected by this PR — no disclosure row for a client whose own
     conversation state is a complete answer."""
     rows = artifact_pane_options([_ROW])
-    assert ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE not in rows
+    assert not any("artifact-ref table" in r for r in rows)
 
 
-def test_fallback_source_appends_the_disclosure_after_a_populated_list():
-    """Tier 1: a non-empty fallback list still gets the disclosure row
-    appended after the real rows."""
-    rows = artifact_pane_options([_ROW], source="ref_table_fallback")
-    assert rows == ["report.pdf", ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE]
+def test_fallback_source_appends_the_consolidated_disclosure():
+    """Tier 1: a non-empty fallback list gets the consolidated disclosure
+    row appended after the real rows."""
+    rows = artifact_pane_options([_ROW], source="ref_table_fallback", fallback_total=1)
+    assert rows == ["report.pdf", artifact_fallback_disclosure_text(1, 1)]
 
 
 def test_falsify_emptying_the_fallback_still_shows_the_disclosure():
@@ -40,15 +48,28 @@ def test_falsify_emptying_the_fallback_still_shows_the_disclosure():
     plain "no artifacts" — the reader needs to know WHY it might be
     empty (a genuinely-empty table vs. an inline-only agent whose
     artifacts the table never records)."""
-    rows = artifact_pane_options([], source="ref_table_fallback")
-    assert rows == ["(no artifacts yet)", ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE]
+    rows = artifact_pane_options([], source="ref_table_fallback", fallback_total=0)
+    assert rows == ["(no artifacts yet)", artifact_fallback_disclosure_text(0, 0)]
 
 
-def test_disclosure_never_names_a_count():
-    """Tier 1: lead-coder's ruling forbids a count claim (a fallback
-    genuinely cannot count what it has no record of) — assert the
-    literal text carries no digit."""
-    assert not any(ch.isdigit() for ch in ARTIFACT_REF_TABLE_FALLBACK_DISCLOSURE)
+def test_disclosure_names_the_inline_gap_and_the_deleted_file_gap():
+    """Tier 1: (#4601) the consolidated text covers BOTH source
+    limitations — an inline artifact never recorded (#4494's own gap)
+    AND a recorded-but-since-deleted file that appears but can't open
+    (#4599's own gap architect found unwritten anywhere)."""
+    text = artifact_fallback_disclosure_text(5, 10)
+    assert "inline" in text and "cannot appear" in text
+    assert "deleted" in text and "cannot be opened" in text
+
+
+def test_disclosure_states_the_newest_n_of_m_count():
+    """Tier 1: (#4601) unlike the earlier "never a count" ruling (which
+    was about a count the fallback genuinely cannot know — an inline
+    artifact's count), `total` is a count the fallback DOES have a
+    record of, and lead-coder's #4601 ruling explicitly requires
+    disclosing it as "newest N of M"."""
+    text = artifact_fallback_disclosure_text(3, 12)
+    assert "newest 3 of 12" in text.lower() or "3 of 12" in text
 
 
 def test_fallback_commands_stay_index_aligned_with_the_disclosure_row():
@@ -56,7 +77,7 @@ def test_fallback_commands_stay_index_aligned_with_the_disclosure_row():
     command list must carry one extra empty string so
     ``on_option_list_option_selected``'s index lookup never targets the
     disclosure row with a stale command."""
-    options = artifact_pane_options([_ROW], source="ref_table_fallback")
+    options = artifact_pane_options([_ROW], source="ref_table_fallback", fallback_total=1)
     commands = artifact_pane_commands([_ROW], source="ref_table_fallback")
     assert len(options) == len(commands)
     assert commands[-1] == ""

--- a/tests/interfaces/test_4494_request_artifact_list.py
+++ b/tests/interfaces/test_4494_request_artifact_list.py
@@ -3,6 +3,10 @@ durable artifact-ref table fallback a remote client's Artifacts pane
 consults when its live conversation view carries nothing. Mirrors
 ``test_4534_pr1_request_attach_switch.py``'s own fixture shape (real
 ``AgentRegistry`` + real ``Session`` — no mocks).
+
+**#4601**: the method now returns ``(entries, total)`` — entries capped
+(newest-first) at ``config.artifacts.remote_fallback_limit``, total the
+pre-cap count, so a caller can disclose "newest N of M".
 """
 from __future__ import annotations
 
@@ -13,9 +17,12 @@ from reyn.interfaces.transport.in_process import InProcessTransport
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _registry(tmp_path) -> AgentRegistry:
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+
     def factory(profile: AgentProfile):
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
@@ -42,8 +49,38 @@ async def test_returns_the_attached_agents_own_ref_table_entries(tmp_path):
     ref = mint_ref(tmp_path, "alpha", f)
     transport = _transport(reg)
     try:
-        entries = await transport.request_artifact_list(agent="alpha")
+        entries, total = await transport.request_artifact_list(agent="alpha")
         assert entries == [{"ref": ref, "path": str(f)}]
+        assert total == 1
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_caps_entries_at_the_configured_remote_fallback_limit(tmp_path):
+    """Tier 2: (#4601) more artifacts than ``remote_fallback_limit`` are
+    minted — the returned entries are capped (newest-first), but
+    ``total`` still names the full count."""
+    reg = _registry(tmp_path)
+    # _registry() itself writes the plain MINIMAL_REYN_YAML — overwrite it
+    # AFTER, with the artifacts: section this test actually needs.
+    (tmp_path / "reyn.yaml").write_text(
+        MINIMAL_REYN_YAML + "\nartifacts:\n  remote_fallback_limit: 2\n",
+        encoding="utf-8",
+    )
+    reg.create("alpha")
+    await reg.attach("alpha")
+    refs = []
+    for i in range(5):
+        f = tmp_path / f"f{i}.pdf"
+        f.write_text("x")
+        refs.append(mint_ref(tmp_path, "alpha", f))
+    transport = _transport(reg)
+    try:
+        entries, total = await transport.request_artifact_list(agent="alpha")
+        assert [e["ref"] for e in entries] == [refs[4], refs[3]]
+        assert total == 5
     finally:
         for task in reg.running_tasks():
             task.cancel()
@@ -57,7 +94,7 @@ async def test_returns_empty_with_no_session_attached(tmp_path):
     reg = _registry(tmp_path)
     transport = _transport(reg)
     try:
-        assert await transport.request_artifact_list(agent="alpha") == []
+        assert await transport.request_artifact_list(agent="alpha") == ([], 0)
     finally:
         for task in reg.running_tasks():
             task.cancel()
@@ -100,4 +137,4 @@ async def test_default_transport_implementation_returns_empty():
         async def shutdown(self) -> None: ...
 
     stub = _Stub()
-    assert await stub.request_artifact_list(agent="alpha") == []
+    assert await stub.request_artifact_list(agent="alpha") == ([], 0)


### PR DESCRIPTION
**[tui-coder]** — closes #4601.

## What

Architect's finding (post-#4599 review): the same function, `list_refs_for_agent`, has two in-repo callers reading its own documented contract differently. The TUI (`InProcessTransport`) already pays the docstring's own "stat only what you're about to render" cost. The AG-UI endpoint returns the table's **full, unbounded** contents with no cap and no stat.

Two real consequences: a deleted file's ref can appear in the remote list and fail to open (a disclosure gap #4599 never covered — it only ever described what does NOT appear, never "appears but can't open"), and the row count grows without bound since the table moved to persist-tier in #4584 and never shrinks.

Mid-thread correction (lead-coder/architect): capping only the endpoint would leave the TUI's identical fallback broken (`in_process.py`'s own `request_artifact_list` reads the SAME unbounded table). The fix belongs at the **one join point** both callers share — `list_refs_for_agent` itself. And ordering matters: **cap first, stat only the N survivors** — the docstring's own "how many rows... before paying that I/O" already stated this order; only "whether to stat" had been read before, not "how many first."

## Changes

- `src/reyn/config/infra.py`: new `ArtifactsConfig` (`remote_fallback_limit`, default 50) + parser. Per owner's standing instruction (never embed a baseless number with no user-facing way to change it): the default is explicitly a **UX-scale** default (dozens of rows a human would scroll through — a single `stat()` costs order-microseconds even at 10,000 rows), deliberately NOT defended with a numeric rationale comment (none could honestly be written — the "correct" N depends on the pane's own height/usage), which is exactly why it's config-adjustable instead.
- `src/reyn/data/workspace/artifact_ref.py`: `list_refs_for_agent` gains `limit=` and now returns `(entries, total)` — `total` is the pre-cap count, so callers can disclose "newest N of M".
- `in_process.py` + `agui/endpoint.py`: both now load config and cap at the same join point — the endpoint (the original finding) **and** the TUI's identical path (architect's correction) fixed together.
- `client_transport.py` + `agui/client.py`: `request_artifact_list`'s return type becomes `tuple[list[dict], int]`, threaded across the wire.
- `chrome.py`: the disclosure text is **consolidated** into one sentence covering (1) inline artifacts never recorded, (2) a deleted-but-referenced file appears but can't open, (3) "newest N of M" — a deliberate, narrow exception to the earlier "never state a count" ruling: that rule was about a count the fallback genuinely cannot know (an inline artifact's count); `total` here is exactly what the fallback DOES have a record of.
- `app.py`: threads the cap's total through to the disclosure call sites.
- `reyn.local.yaml.example` + `docs/reference/config/reyn-yaml.md`: new `artifacts:` block documented — required by this repo's own config mirror-coverage gate (caught locally before pushing).

## Test plan

6 new tests in `test_4601_artifacts_config.py` (parser: default, override, 0-falls-back — **not** disables, unlike `audit_events`' purge axes, since an unbounded fallback IS the defect this knob exists to close — negative falls back, non-numeric falls back, no-block-at-all). Existing #4494 test files updated for the new `(entries, total)` contract, each gaining its own #4601 cap test (newest-first truncation + total preserved) at the data layer, the `InProcessTransport` layer, and the real ASGI endpoint layer, plus consolidated-disclosure content tests.

`ruff check src tests`, `test_tier_audit.py --strict` (28 tests), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` — all green. Scoped `pytest`: 294 passed across every touched artifact/transport/config file.

- [ ] Visual (waived per CLAUDE.md standing waiver, 2026-08-08 — TUI-facing text change, owner confirms on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
