### PR TITLE
fix(#4614): doctor C-2's mcp_resource_updated scan window bore on correctness, not just display

### DIFF
--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -79,6 +79,7 @@ External-event producer/consumer pairing (a producer with 0
 subscribing hooks is a real gap; a point with no producer is not
 reported — see 'not checked' below for why some points aren't):
   ✗ file_changed: producer present (1 declared fs_watch path(s)) but 0 subscribing hooks — this point's notifications have nowhere to go
+  ? mcp_resource_updated: not seen in the newest 0 event file(s) scanned — a producer whose last arrival is older than that is not covered here, so this is NOT proof no producer exists
   ? webhook_received: not checked (no config or audit-log surface exists for its producer)
 ```
 
@@ -138,11 +139,19 @@ one directly. Producer evidence differs per point:
   kind lookup has no index — `.reyn/events` is append-only — so this bound keeps a "did
   it ever happen" query cheap even with retention disabled; the question only needs "at
   least once," so an early exit can never turn a real positive into a false negative).
+  **This check is windowed, unlike the other two** (#4614): "not seen in the newest 20
+  files" is NOT proof of "no producer" — a real producer whose last arrival predates the
+  window is indistinguishable from one that never fired. Reporting nothing here (the
+  pre-#4614 behavior) silently hid exactly the state C-2 exists to catch, so this point
+  ALWAYS prints a line — `✓`/`✗` when seen within the window, or `? mcp_resource_updated:
+  not seen in the newest N event file(s) scanned — ... NOT proof no producer exists`
+  otherwise — never folded into the "no producer → no finding" rule below.
 - `webhook_received` — **not checked**: no config declaration and no `AUDIT_EVENT_KINDS`
   entry exist for it, so there is no surface to read a producer from at all. Reported as
   `? webhook_received: not checked`, never silently omitted (D-3).
 
-A point with no producer prints no finding at all — reporting "0 subscribing hooks" for
+A point with a COMPLETE producer read (`file_changed`/`cron_fired`) and no producer
+prints no finding at all — reporting "0 subscribing hooks" for
 a point that will never fire would be noise, not signal.
 
 ## Out of scope for this PR (later slices, same arc)

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -334,13 +334,16 @@ _UNCHECKABLE_EXTERNAL_POINTS: Final[tuple[str, ...]] = ("webhook_received",)
 # kind lookup is a scan. #4479 retention normally bounds the file count, but
 # an operator who disabled retention (0 = off, both axes) has no upper
 # bound. This check only needs "did it happen at least once" (architect's
-# own ruling), so a bounded newest-first scan is exact for that question —
-# an early exit can never turn a real positive into a false negative, only
-# a genuinely-never-happened case stays (correctly) unproven beyond this
-# window. Same "config knob + disclose what was scanned" shape as #4601's
-# own N (architect's note) — a local doctor-only display bound, not a
-# functional correctness cap, so no config knob of its own: the window is
-# always disclosed alongside the result (below), never asserted silently.
+# own ruling), so a bounded newest-first scan is exact for a POSITIVE
+# result — an early exit can never turn a real positive into a false
+# negative. #4614 correction: the negative case is NOT merely a display
+# concern — "not seen in the newest N files" and "genuinely never
+# happened" are indistinguishable from a bool, so a producer whose last
+# arrival is older than the window (0 subscribing hooks, the exact state
+# C-2 exists to catch) silently printed NOTHING before this fix. This
+# DOES bear on correctness, which is why the window is unconditionally
+# disclosed in the output below (D-3), not just alongside a positive
+# finding — never widen this number without keeping that disclosure.
 _MCP_EVENT_SCAN_MAX_FILES: Final[int] = 20
 
 
@@ -453,21 +456,48 @@ def _print_external_point_pairing(config: object, project_root: Path) -> None:
             has_producer = bool(enabled_jobs)
             evidence = f"{len(enabled_jobs)} enabled cron job(s)"
         elif point == "mcp_resource_updated":
+            # #4614: this check is windowed (a bounded scan, see
+            # _MCP_EVENT_SCAN_MAX_FILES's own comment) — unlike
+            # file_changed/cron_fired's complete config reads, "not seen"
+            # here is NOT proof of "no producer": a producer whose last
+            # arrival predates the window is indistinguishable from one
+            # that never fired. Silently printing nothing in that case
+            # (the pre-#4614 shape) hid the exact state C-2 exists to
+            # catch — so this point is disclosed UNCONDITIONALLY (D-3),
+            # never folded into the generic "no producer -> no finding"
+            # rule below.
             seen, scanned = _mcp_resource_updated_seen(events_dir)
-            has_producer = seen
-            evidence = (
-                f"seen in the newest {scanned} event file(s) scanned"
-                if seen
-                else f"not seen in the newest {scanned} event file(s) scanned "
-                f"(no evidence beyond this window)"
-            )
+            consumers = registry.hooks_for(point)  # type: ignore[attr-defined]
+            if seen and consumers:
+                print(
+                    f"  ✓ {point}: producer present (seen in the newest "
+                    f"{scanned} event file(s) scanned), {len(consumers)} "
+                    f"subscribing hook(s)",
+                )
+            elif seen:
+                print(
+                    f"  ✗ {point}: producer present (seen in the newest "
+                    f"{scanned} event file(s) scanned) but 0 subscribing "
+                    f"hooks — this point's notifications have nowhere to go",
+                )
+            else:
+                print(
+                    f"  ? {point}: not seen in the newest {scanned} event "
+                    f"file(s) scanned — a producer whose last arrival is "
+                    f"older than that is not covered here, so this is NOT "
+                    f"proof no producer exists",
+                )
+            continue
         else:  # pragma: no cover — _EXTERNAL_POINTS is the closed population
             continue
 
         if not has_producer:
             # D-2/D-3: a point with no producer gets no finding — reporting
             # "0 hooks" here would be noise, not signal (architect's own
-            # ruling: "report only where a producer exists").
+            # ruling: "report only where a producer exists"). Does NOT
+            # apply to mcp_resource_updated (handled above, its own
+            # branch) — that check is windowed, so "no producer" can't be
+            # asserted the same way a complete config read can.
             continue
 
         consumers = registry.hooks_for(point)  # type: ignore[attr-defined]

--- a/tests/interfaces/test_4364_pr2b_doctor_external_pairing.py
+++ b/tests/interfaces/test_4364_pr2b_doctor_external_pairing.py
@@ -39,11 +39,15 @@ def _write_event(events_dir: Path, filename: str, kind: str) -> None:
 def test_no_producers_configured_reports_only_the_uncheckable_point(
     tmp_path: Path, capsys,
 ) -> None:
-    """Tier 2: (accept-side, absence) with no fs_watch/cron/event-log
-    evidence at all, the only line printed under this section is
-    webhook_received's "not checked" — a point with no producer gets no
-    finding (D-2/D-3: reporting "0 hooks" for a nonexistent producer
-    would be noise, not signal)."""
+    """Tier 2: (accept-side, absence) with no fs_watch/cron evidence at
+    all, file_changed/cron_fired print no finding at all (D-2/D-3:
+    reporting "0 hooks" for a nonexistent producer would be noise, not
+    signal — those two checks are COMPLETE config reads, so "no producer"
+    can be asserted outright). mcp_resource_updated is different (#4614):
+    its own check is windowed, so it prints a "?" disclosure line even
+    with zero event-log evidence — "not seen" there is never proof of
+    "no producer", only "not seen in the window", so silence would hide
+    exactly the state C-2 exists to catch."""
     _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
 
     run(Namespace(project_root=str(tmp_path)))
@@ -53,7 +57,8 @@ def test_no_producers_configured_reports_only_the_uncheckable_point(
     assert "? webhook_received: not checked" in out
     assert "file_changed" not in out
     assert "cron_fired" not in out
-    assert "mcp_resource_updated" not in out
+    assert "? mcp_resource_updated: not seen in the newest" in out
+    assert "NOT proof no producer exists" in out
 
 
 def test_file_changed_producer_with_zero_consumers_is_flagged(
@@ -187,6 +192,45 @@ def test_mcp_resource_updated_with_a_consumer_reports_ok(
     out = capsys.readouterr().out
 
     assert "✓ mcp_resource_updated: producer present" in out
+
+
+def test_mcp_resource_updated_evidence_outside_the_scan_window_is_disclosed_not_silent(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: #4614 — the core regression witness. A real producer whose
+    last arrival predates the scan window (more dated event files exist
+    than ``_MCP_EVENT_SCAN_MAX_FILES`` covers) with 0 subscribing hooks
+    is EXACTLY the state C-2 exists to catch — architect's own finding
+    (#4612 co-vet) was that the pre-#4614 code silently printed nothing
+    here, folded into the generic "no producer -> no finding" rule that
+    is only valid for a COMPLETE read (file_changed/cron_fired), not a
+    windowed one. This test writes evidence, then enough NEWER files
+    with an unrelated kind to push it outside the window, and asserts
+    the '?' disclosure line fires — not silence, and not a false '✗'
+    claiming certainty the window doesn't have."""
+    from reyn.interfaces.cli.commands import doctor as _doctor_mod
+
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+    events_dir = tmp_path / ".reyn" / "events"
+    # Oldest file (real mcp_resource_updated evidence) — outside the
+    # window once enough newer files exist.
+    _write_event(events_dir, "2026-01-01T000000.jsonl", "mcp_resource_updated")
+    # Push it out of the window with newer, unrelated-kind files —
+    # exactly _MCP_EVENT_SCAN_MAX_FILES of them, so the oldest (the real
+    # evidence) is excluded from the newest-N scan.
+    for day in range(1, _doctor_mod._MCP_EVENT_SCAN_MAX_FILES + 1):
+        _write_event(
+            events_dir, f"2026-02-{day:02d}T000000.jsonl", "session_started",
+        )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    # Not silent (the pre-#4614 bug) and not a false "no producer" claim.
+    assert "? mcp_resource_updated: not seen in the newest" in out
+    assert "NOT proof no producer exists" in out
+    assert "✗ mcp_resource_updated" not in out
+    assert "✓ mcp_resource_updated" not in out
 
 
 def test_consumer_declared_only_in_runtime_hooks_yaml_still_counts(


### PR DESCRIPTION
**[e2e-coder]** — fixes the co-vet finding on my own #4612 (found by architect, reported by lead-coder as #4614): the `mcp_resource_updated` scan-window comment contradicted itself, and the negative case was silently dropped instead of disclosed.

Closes #4614 (part of the broader #4364 arc, not closing that one).

## The bug

`doctor.py`'s `_MCP_EVENT_SCAN_MAX_FILES` comment said the 20-file cutoff was "a local doctor-only display bound, not a functional correctness cap" — directly contradicted by its own prior sentence ("only a genuinely-never-happened case stays unproven beyond this window"). A producer whose last arrival predates the window IS the exact state C-2 exists to catch (0 subscribing hooks, real evidence just outside the scanned range) — and the code folded `mcp_resource_updated` into the generic "no producer → print nothing" rule that's only valid for a COMPLETE config read (`file_changed`/`cron_fired`), silently dropping the finding.

Why this got its own issue rather than "just fix the comment": the owner's standing rule is "a new constant needs a rationale comment OR a config knob, not neither." A bare unexplained number invites the next reader's doubt; a **false** rationale removes that doubt, manufacturing "no knob needed" cover for a real correctness gap.

## Fix

lead-coder's recommended option ② — keep N=20, but disclose the window unconditionally (D-3 style, same shape as #4601's own precedent), never fold the negative case into the "no finding" rule. `mcp_resource_updated` now always prints one of three lines:

- seen + subscribers → `✓` (unchanged)
- seen + zero subscribers → `✗` (unchanged)
- **not seen within the window → `?` (new)** — explicitly states this is NOT proof no producer exists, distinct from silence.

Removed the false "display bound, not correctness" comment; replaced with the actual reasoning.

## Tests

- Updated the accept-side "no producers" test in `test_4364_pr2b_doctor_external_pairing.py` — `mcp_resource_updated` now always prints its own disclosure line, unlike `file_changed`/`cron_fired`'s complete-read silence.
- New regression witness (`test_mcp_resource_updated_evidence_outside_the_scan_window_is_disclosed_not_silent`): writes real `mcp_resource_updated` evidence, then pushes it outside the scan window with `_MCP_EVENT_SCAN_MAX_FILES` newer unrelated-kind files, and asserts the `?` disclosure fires — not silence, and not a false `✗`/`✓` claiming certainty the window doesn't have.
- Strip-falsified: reintroduced the pre-fix silent-skip, confirmed both the new regression test AND the accept-side test genuinely go RED, restored, confirmed GREEN.
- `docs/reference/cli/doctor.md`: updated the sample output and the C-2 prose section to describe the windowed-disclosure behavior.

## Verification

- `ruff check src tests`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/test_tier_audit.py --strict` (1 changed test file, 11 tests): 0 Tier-4 violations.
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `scripts/check_doc_anchors.py`: clean.
- `tests/interfaces -k "doctor or 4364"` (27): clean, no regression.

## Test plan

- [x] Strip-falsified the fix (reintroduced the silent-skip) — confirmed both affected tests genuinely RED → restored → confirmed GREEN.
- [x] Ran all 5 local gates — clean, post-rebase onto latest `main`.
- [x] `mkdocs build --strict` + `check_doc_anchors.py` — clean.
- [x] Regression sweep (`doctor`/`4364`) — clean.
- [ ] (Visual) — n/a, CLI text output, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
