### PR TITLE
feat(#4605): emit an arrival audit event for the other 3 external ingress points

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -70,6 +70,7 @@ config_reload_rejected
 config_reloaded
 control_ir_failed
 control_ir_skipped
+cron_fired
 direct_alias_call_salvaged
 elide_evaluated
 embed_attempts
@@ -81,6 +82,7 @@ embedding_index_build_progress
 embedding_index_build_started
 exec_threat_blocked
 exec_threat_match
+file_changed
 file_read_media_denied
 force_close_triggered
 hook_event_emitted
@@ -248,6 +250,7 @@ web_fetch_too_many_redirects
 web_search_completed
 web_search_failed
 web_search_started
+webhook_received
 workspace_updated
 ```
 
@@ -391,6 +394,26 @@ op dispatch:
 None of these events include the human's typed answer or any field *value* —
 only the requested schema's property names, matching the sensitive-field
 handling described in [Concepts: MCP § Elicitation](../../concepts/tools-integrations/mcp.md#elicitation-structured-input-requests-from-a-server).
+
+## External events
+
+The 4 points a hook's `on:` can subscribe to as an external-event source —
+see [Concepts: hooks § External-event points](../../concepts/runtime/hooks.md#external-event-points).
+`mcp_resource_updated` (above, MCP section) is the one of the 4 that has
+always emitted an arrival audit event; #4605 closed the same gap for the
+remaining 3 — each now emits its own arrival event REGARDLESS of whether a
+hook is configured to consume it, so the signal's arrival is reconstructable
+from `.reyn/events` even when nothing was listening.
+
+| Kind | Trigger | Key payload |
+|------|---------|-------------|
+| `file_changed` | A watched path (`fs_watch.paths`) reports a create/modify/delete via the `watchdog` observer, after debounce (`fs_watch.debounce_seconds`) and symlink-path rewrite. See [Concepts: hooks § file_changed](../../concepts/runtime/hooks.md#file_changed). | `path` (rewritten to the operator-configured prefix), `event_type` (`"created"` \| `"modified"` \| `"deleted"`) |
+| `cron_fired` | A scheduled cron job fires, on the job's own resolved `cron:<job_name>` session, right after session resolution. See [Concepts: hooks § cron_fired](../../concepts/runtime/hooks.md#cron_fired). | `job_name`, `to` (operator-authored config, never end-user-supplied) |
+| `webhook_received` | An inbound webhook (slack/line/generic plugin) is routed to its resolved per-sender session, right after session resolution. See [Concepts: hooks § webhook_received](../../concepts/runtime/hooks.md#webhook_received). | `transport`, `sender` — NEVER the raw inbound body/text, which may carry tokens/PII (same discipline as `hook_push_fired`'s "never the message body") |
+
+All three are best-effort: a sink fault logs and is swallowed, never blocking
+the job's inbox delivery / the webhook's HTTP response / the watcher's drain
+loop.
 
 ## Credentials and OAuth
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -241,6 +241,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "config_reloaded",
     "control_ir_failed",
     "control_ir_skipped",
+    "cron_fired",
     "direct_alias_call_salvaged",
     "elide_evaluated",
     "embed_attempts",
@@ -252,6 +253,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "embedding_index_build_started",
     "exec_threat_blocked",
     "exec_threat_match",
+    "file_changed",
     "file_read_media_denied",
     "force_close_triggered",
     "hook_event_emitted",
@@ -419,6 +421,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "web_search_completed",
     "web_search_failed",
     "web_search_started",
+    "webhook_received",
     "workspace_updated",
 })
 

--- a/src/reyn/runtime/cron/routing.py
+++ b/src/reyn/runtime/cron/routing.py
@@ -22,7 +22,11 @@ the same ingress coroutine as the job's own inbox delivery (see
 """
 from __future__ import annotations
 
+import logging
+
 from reyn.hooks.ingress import CronIngressAdapter
+
+_log = logging.getLogger(__name__)
 
 CRON_TRANSPORT = "cron"
 
@@ -70,6 +74,18 @@ def dispatch_cron_fired(session, job_name: str, to: str) -> None:
     ``reyn.runtime.webhook_routing.dispatch_webhook_received``). ``job_name``
     is the matchable field (exact match — not a glob field, see
     ``reyn.hooks.matcher``), e.g. ``matcher: {job_name: "backup"}``.
+
+    #4605: also emits a ``cron_fired`` AUDIT event on ``session._audit_events``
+    (P6, distinct from the hook fire above) — the ARRIVAL of the signal is
+    recorded even when no hook is configured to consume it, mirroring
+    ``ReynMCPMessageHandler.emit_resource_updated``'s ``mcp_resource_updated``
+    precedent (the one of the 4 external points that already did this; #4605
+    closes the other 3). Best-effort: a sink fault must never break the job's
+    own inbox delivery.
     """
+    try:
+        session._audit_events.emit("cron_fired", job_name=job_name, to=to)
+    except Exception:  # noqa: BLE001 — audit emit is best-effort, never blocks the job
+        _log.debug("dispatch_cron_fired: audit emit failed for job %r", job_name, exc_info=True)
     event = _ADAPTER.to_event(job_name, to)
     _ADAPTER.deliver(event, session)

--- a/src/reyn/runtime/fs_watcher.py
+++ b/src/reyn/runtime/fs_watcher.py
@@ -144,10 +144,19 @@ class FsWatcher:
         paths: "list[str] | None" = None,
         hook_trigger: "HookTrigger | None" = None,
         debounce_seconds: float = 0.2,
+        emit_event: "Callable[..., Any] | None" = None,
     ) -> None:
         self._paths: list[str] = list(paths or [])
         self._hook_trigger = hook_trigger
         self._debounce_seconds = debounce_seconds
+        # #4605: audit-emit sink (session._audit_events.emit), distinct from
+        # hook_trigger — records the ARRIVAL of a file_changed signal even
+        # when no hook is configured to consume it, mirroring
+        # ReynMCPMessageHandler.emit_resource_updated's mcp_resource_updated
+        # precedent (the one of the 4 external points that already did
+        # this). None when the caller hasn't wired one (e.g. unit tests
+        # constructing a bare FsWatcher) — _enqueue no-ops the emit then.
+        self._emit_event = emit_event
         self._observer: Any = None
         self._loop: "asyncio.AbstractEventLoop | None" = None
         # Hook-Event Redesign Phase 2 (proposal 0059 §6.3): the bounded
@@ -276,7 +285,19 @@ class FsWatcher:
         just factored into the adapter), then hands it to the SAME bounded
         queue+drain-task bridge ``McpIngressAdapter`` uses (``deliver``) — the
         bound/drop-newest-and-log/drain behaviour is byte-identical, no
-        longer duplicated per-source."""
+        longer duplicated per-source.
+
+        #4605: also emits a ``file_changed`` AUDIT event via ``emit_event``
+        (distinct from the hook-trigger queue below) — best-effort, a sink
+        fault must never break the drain path."""
+        if self._emit_event is not None:
+            try:
+                self._emit_event("file_changed", path=path, event_type=event_type)
+            except Exception:  # noqa: BLE001 — audit emit is best-effort
+                logger.debug(
+                    "FsWatcher: emit_event failed for %r on %r", event_type, path,
+                    exc_info=True,
+                )
         event = self._fs_ingress_adapter.to_event(path, event_type)
         self._fs_ingress_adapter.deliver(event)
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3981,6 +3981,10 @@ class Session:
             paths=fs_watch_cfg.paths,
             debounce_seconds=fs_watch_cfg.debounce_seconds,
             hook_trigger=lambda point, template_vars: self._hook_dispatcher.dispatch(point, template_vars),
+            # #4605: audit-emit sink, mirrors ComposerRegistry's own emit_event
+            # wiring two lines below — records file_changed arrival even when
+            # no hook is configured to consume it.
+            emit_event=lambda et, **kw: self._audit_events.emit(et, **kw),
         )
         # Composer/consumer registry: build != start — starting here has no
         # async context to run in; run() starts/stops them (#2880/#2881;

--- a/src/reyn/runtime/webhook_routing.py
+++ b/src/reyn/runtime/webhook_routing.py
@@ -24,7 +24,11 @@ stable ingress every webhook plugin routes through), right after
 """
 from __future__ import annotations
 
+import logging
+
 from reyn.hooks.ingress import WebhookIngressAdapter
+
+_log = logging.getLogger(__name__)
 
 _GENERIC_WEBHOOK_TRANSPORT = "webhook"
 
@@ -75,6 +79,19 @@ def dispatch_webhook_received(session, sender: str) -> None:
     action must never stall the webhook plugin's HTTP response). Both
     ``transport`` and ``sender`` are exact-match fields (not glob — see
     ``reyn.hooks.matcher``), e.g. ``matcher: {transport: "slack"}``.
+
+    #4605: also emits a ``webhook_received`` AUDIT event on
+    ``session._audit_events`` (P6, distinct from the hook fire above) — the
+    ARRIVAL of the signal is recorded even when no hook is configured to
+    consume it, mirroring ``ReynMCPMessageHandler.emit_resource_updated``'s
+    ``mcp_resource_updated`` precedent. Same SECURITY invariant as the hook
+    payload above: only ``transport``/``sender``, never the raw body.
+    Best-effort: a sink fault must never break the webhook's HTTP response.
     """
+    transport, _external_id = _ADAPTER.parse_sender(sender)
+    try:
+        session._audit_events.emit("webhook_received", transport=transport, sender=sender)
+    except Exception:  # noqa: BLE001 — audit emit is best-effort, never blocks the response
+        _log.debug("dispatch_webhook_received: audit emit failed for sender %r", sender, exc_info=True)
     event = _ADAPTER.to_event(sender)
     _ADAPTER.deliver(event, session)

--- a/tests/runtime/test_2608_h4_fs_watcher.py
+++ b/tests/runtime/test_2608_h4_fs_watcher.py
@@ -372,3 +372,40 @@ async def test_session_owned_watcher_fires_configured_hook_into_inbox(tmp_path):
         assert str(target) in payload["text"]
     finally:
         await session.aclose_fs_watcher()
+
+
+@pytest.mark.asyncio
+async def test_session_owned_watcher_emits_file_changed_audit_event_with_no_hook_configured(tmp_path):
+    """Tier 2: #4605 — the arrival of a ``file_changed`` signal is recorded on
+    ``session._audit_events`` even with NO ``file_changed`` hook configured
+    (empty-registry equivalence, mirroring H1's
+    ``test_no_configured_hook_leaves_hook_side_a_pure_noop``). Before #4605
+    this was the silent gap: 3 of the 4 external points never emitted an
+    arrival audit event regardless of hook config; only ``mcp_resource_updated``
+    did."""
+    from reyn.config.infra import FsWatchConfig
+    from reyn.core.events.state_log import StateLog
+    from tests._support.events import collect_events
+
+    watched_dir = tmp_path / "watched"
+    watched_dir.mkdir()
+    session = make_session(
+        agent_name="test-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        reactivity=ReactivityConfig(hooks_config=None, fs_watch_config=FsWatchConfig(paths=[str(watched_dir)], debounce_seconds=0.05)),
+    )
+    collected = collect_events(session._audit_events)
+    try:
+        await session._fs_watcher.start()
+        assert session.fs_watcher_is_started()
+
+        target = watched_dir / "d.txt"
+        target.write_text("hi")
+
+        await _wait_for(lambda: any(e.type == "file_changed" for e in collected))
+        (event,) = [e for e in collected if e.type == "file_changed"]
+        assert event.data["path"] == str(target)
+        assert event.data["event_type"] in ("created", "modified")
+    finally:
+        await session.aclose_fs_watcher()

--- a/tests/runtime/test_2608_h5_cron_webhook_hooks.py
+++ b/tests/runtime/test_2608_h5_cron_webhook_hooks.py
@@ -39,6 +39,7 @@ from reyn.runtime.session import Session
 from reyn.runtime.session_params import ReactivityConfig
 from reyn.runtime.turn_origin import TurnOrigin
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 
 class _NoRunAgentRegistry(AgentRegistry):
@@ -231,6 +232,39 @@ async def test_cron_empty_registry_leaves_ingress_delivery_unaffected(tmp_path):
     assert payload["text"] == "hi"  # no hook message — pure no-op
 
 
+@pytest.mark.asyncio
+async def test_cron_fire_emits_cron_fired_audit_event_with_no_hook_configured(tmp_path):
+    """Tier 2: #4605 — the arrival of a ``cron_fired`` signal is recorded on
+    ``session._audit_events`` even with NO ``cron_fired`` hook configured
+    (empty-registry equivalence, mirroring H1's own
+    ``test_no_configured_hook_leaves_hook_side_a_pure_noop``). Before #4605
+    this was the silent gap: cron_fired/file_changed/webhook_received never
+    emitted an arrival audit event regardless of hook config; only
+    ``mcp_resource_updated`` did."""
+    reg = _make_registry(tmp_path, hooks_config=None)
+    _seed(tmp_path, "news_agent")
+
+    async def _inbox_pusher(to: str, envelope: dict, native_id: str) -> str:
+        session = resolve_cron_session(reg, to, native_id)
+        dispatch_cron_fired(session, native_id, to)
+        await session._put_inbox(TurnOrigin.CRON, envelope)
+        return "ok"
+
+    runner = build_default_runner(inbox_pusher=_inbox_pusher)
+    # resolve_cron_session is idempotent get-or-spawn — resolving once here
+    # (before the fire) to subscribe collect_events, then letting the
+    # runner's own resolve inside _inbox_pusher return the SAME session.
+    session = resolve_cron_session(reg, "news_agent", "morning_news")
+    collected = collect_events(session._audit_events)
+    job = CronJob(name="morning_news", schedule="0 9 * * *", to="news_agent", message="hi")
+    await runner(job)
+
+    await _wait_for(lambda: any(e.type == "cron_fired" for e in collected))
+    (event,) = [e for e in collected if e.type == "cron_fired"]
+    assert event.data["job_name"] == "morning_news"
+    assert event.data["to"] == "news_agent"
+
+
 # ---------------------------------------------------------------------------
 # Tier 2: (b) an inbound webhook -> webhook_received hook fires with
 # transport/sender
@@ -353,4 +387,36 @@ async def test_webhook_received_template_vars_carry_no_raw_payload_text(tmp_path
     hook_items = [p for k, p in items if k == "hook"]
     (hook_payload,) = hook_items  # exactly one hook fired — unpack asserts the count
     assert hook_payload["text"] == "NO_SECRET"
-    assert "TOP_SECRET_TOKEN_abc123" not in hook_payload["text"]
+
+
+@pytest.mark.asyncio
+async def test_webhook_receipt_emits_webhook_received_audit_event_with_no_hook_configured(tmp_path):
+    """Tier 2: #4605 — the arrival of a ``webhook_received`` signal is recorded
+    on ``session._audit_events`` even with NO ``webhook_received`` hook
+    configured (empty-registry equivalence, mirroring H1's own
+    ``test_no_configured_hook_leaves_hook_side_a_pure_noop``). Same
+    SECURITY invariant as the hook payload: only ``transport``/``sender``,
+    never the raw inbound body."""
+    from reyn.gateway.api import push_to_agent
+    from reyn.hooks.ingress import WebhookIngressAdapter
+
+    reg = _make_registry(tmp_path, hooks_config=None)
+    _seed(tmp_path, "support_agent")
+    # resolve_session is idempotent get-or-spawn — resolving once here
+    # (before the request) to subscribe collect_events, then letting
+    # push_to_agent's own resolve return the SAME session.
+    session = WebhookIngressAdapter().resolve_session(reg, "support_agent", "slack:U456")
+    collected = collect_events(session._audit_events)
+
+    await push_to_agent(
+        target_agent="support_agent",
+        text="TOP_SECRET_TOKEN_abc123",
+        sender="slack:U456",
+        registry=reg,
+    )
+
+    await _wait_for(lambda: any(e.type == "webhook_received" for e in collected))
+    (event,) = [e for e in collected if e.type == "webhook_received"]
+    assert event.data["transport"] == "slack"
+    assert event.data["sender"] == "slack:U456"
+    assert "TOP_SECRET_TOKEN_abc123" not in str(event.data)


### PR DESCRIPTION
**[tui-coder]** — closes #4605.

## What

architect's finding: of the 4 external points a hook's `on:` can subscribe to (`mcp_resource_updated`, `file_changed`, `cron_fired`, `webhook_received`), only 1 emitted an audit event recording its own arrival. The other 3 relied entirely on a configured hook firing to leave any trace — with no hook subscribed, the signal's arrival left nothing in `.reyn/events` at all. Driving consequence: `#4364` C-2's subscription-dead-end detection can only check the 1 point that already had this, and an operator has no way to confirm a webhook/cron/fs-watch signal actually arrived short of a live-configured hook happening to catch it.

## Design (confirmed with lead-coder before implementing)

Per-point kind names matching the existing `mcp_resource_updated` precedent (already both a hook-point name and its own audit-event kind), not a single generic kind with a `point` field — keeps the vocabulary in one convention rather than introducing a second. Payload follows `hook_push_fired`'s "never the message body" discipline. Volume (fs_watch could be high-frequency) is bounded by `fs_watch.debounce_seconds` (already config-adjustable, default 0.2s, measured by lead-coder) and left to #4479/#4480's retention axes.

## Changes

- `src/reyn/core/events/event_schema.py`: 3 new `AUDIT_EVENT_KINDS` entries.
- `src/reyn/runtime/cron/routing.py` / `webhook_routing.py`: `dispatch_cron_fired`/`dispatch_webhook_received` now also emit their own audit event, distinct from the hook fire — best-effort, never blocks the job/response.
- `src/reyn/runtime/fs_watcher.py` + `session.py`: `FsWatcher` gains an `emit_event` param (mirrors `hook_trigger`'s shape), wired the same way `ComposerRegistry`'s own `emit_event` is two lines below in `session.py`.
- `docs/reference/runtime/events.md`: 3 new kinds added to the CI-checked flat enumeration, plus a new "External events" semantic table (the half CI doesn't check but #4589/#4591 showed matters just as much).

## Test plan

3 new Tier-2 tests, each mirroring H1's own `test_no_configured_hook_leaves_hook_side_a_pure_noop` — the audit event fires even with NO hook configured for that point, the exact gap this PR closes. The webhook test also asserts the raw inbound body never reaches `event.data`.

`ruff check src tests`, `test_tier_audit.py --strict` (26 tests, real instances only), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` — all green. Scoped `pytest`: 370 passed (`test_audit_event_kind_vocabulary_3410.py` + `test_2608_h4/h5_*.py` + `tests/hooks/`).

No Visual item — backend audit-emit change, no TUI/CLI output surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
