### PR TITLE
fix(#4597): slice ① — replace 12 _StubWorkspace hand-rolled stand-ins with real Workspace

### DIFF
--- a/tests/builtin/test_0060_phase1_f3a_builtin_tier.py
+++ b/tests/builtin/test_0060_phase1_f3a_builtin_tier.py
@@ -60,15 +60,12 @@ from reyn.builtin.registry import (
 )
 from reyn.config.loader import _merge
 from reyn.core.op_runtime.context import OpContext, provenance_from_ctx
+from reyn.data.workspace.workspace import Workspace
 
 _REPO_ROOT = REPO_ROOT
 
-
-class _StubWorkspace:
-    """Minimal real-attribute workspace stub — OpContext only reads base_dir."""
-
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible.
 
 
 class _Events:
@@ -86,9 +83,10 @@ def _make_ctx(tmp_path: Path, *, turn_origin: "str | None") -> OpContext:
     from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False)
+    events = _Events()
     return OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
-        events=_Events(),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path),
+        events=events,
         permission_decl=PermissionDecl(),
         permission_resolver=resolver,
         actor="test",

--- a/tests/core/test_0060_phase1_layer_a.py
+++ b/tests/core/test_0060_phase1_layer_a.py
@@ -58,6 +58,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
 from reyn.core.op_runtime.presentation_install import handle as presentation_install_handle
 from reyn.core.present import PresentBlueprintError, validate_blueprint
+from reyn.data.workspace.workspace import Workspace
 from reyn.runtime.session import Session
 from reyn.schemas.models import PresentationInstallIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
@@ -67,9 +68,8 @@ from tests._support.router_host_adapter import make_adapter
 # ── shared stubs (real API surface, no mocks) ─────────────────────────────────
 
 
-class _StubWorkspace:
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible.
 
 
 class _Events:
@@ -97,9 +97,10 @@ def _make_ctx(
     decl = PermissionDecl(
         file_write=[{"path": str(config_path), "scope": "just_path"}],
     )
+    events = _Events()
     return OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
-        events=_Events(),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path),
+        events=events,
         permission_decl=decl,
         permission_resolver=resolver,
         actor="test",
@@ -377,9 +378,10 @@ def _skill_ctx(tmp_path: Path) -> OpContext:
     )
     resolver.session_approve_path(str(config_path), "test", "file.write")
     decl = PermissionDecl(file_write=[{"path": str(config_path), "scope": "just_path"}])
+    events = _Events()
     return OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
-        events=_Events(),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path),
+        events=events,
         permission_decl=decl,
         permission_resolver=resolver,
         actor="test",
@@ -398,9 +400,10 @@ def _pipeline_ctx(tmp_path: Path) -> OpContext:
     )
     resolver.session_approve_path(str(config_path), "test", "file.write")
     decl = PermissionDecl(file_write=[{"path": str(config_path), "scope": "just_path"}])
+    events = _Events()
     return OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
-        events=_Events(),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path),
+        events=events,
         permission_decl=decl,
         permission_resolver=resolver,
         actor="test",

--- a/tests/core/test_2248_pr_a2_config_emission.py
+++ b/tests/core/test_2248_pr_a2_config_emission.py
@@ -11,8 +11,6 @@ Real PermissionResolver + StateLog + AgentRegistry + on-disk yaml (no mocks).
 """
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 import yaml
 
@@ -20,14 +18,13 @@ from reyn.core.events.config_recovery import record_config_generation
 from reyn.core.events.snapshot_generations import rewind as _wal_rewind
 from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
 from reyn.runtime.registry import AgentRegistry
 from reyn.schemas.models import MCPDropServerIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
-
-class _StubWorkspace:
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible.
 
 
 class _Events:
@@ -68,9 +65,10 @@ async def test_real_mcp_drop_records_generation_and_rewind_restores(tmp_path):
     )
     canonical = str(mcp_path)
     resolver.session_approve_path(canonical, "test", "file.write")
+    events = _Events()
     ctx = OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
-        events=_Events(),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path),
+        events=events,
         permission_decl=PermissionDecl(
             file_write=[{"path": canonical, "scope": "just_path"}],
         ),

--- a/tests/core/test_2248_prb_config_path_consistency.py
+++ b/tests/core/test_2248_prb_config_path_consistency.py
@@ -20,14 +20,13 @@ from reyn.core.events.config_recovery import record_config_generation, reyn_rela
 from reyn.core.events.snapshot_generations import rewind
 from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
 from reyn.runtime.registry import AgentRegistry
 from reyn.schemas.models import MCPDropServerIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
-
-class _StubWorkspace:
-    def __init__(self, base_dir) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible.
 
 
 class _Events:
@@ -81,9 +80,10 @@ async def test_real_mcp_drop_writes_config_subdir_keyed_path_and_rewind_restores
     )
     canonical = str(mcp_path)
     resolver.session_approve_path(canonical, "test", "file.write")
+    events = _Events()
     ctx = OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
-        events=_Events(),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path),
+        events=events,
         permission_decl=PermissionDecl(
             file_write=[{"path": canonical, "scope": "just_path"}],
         ),

--- a/tests/core/test_2722_pipeline_multi_doc_namespacing.py
+++ b/tests/core/test_2722_pipeline_multi_doc_namespacing.py
@@ -35,6 +35,7 @@ from reyn.core.pipeline.parser import (
 )
 from reyn.core.pipeline.schema import SchemaRegistry
 from reyn.data.pipelines.registry import PipelineLoadError, build_pipeline_registry
+from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import PipelineInstallIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
@@ -336,9 +337,8 @@ class _Events:
         self.emitted.append((kind, kwargs))
 
 
-class _StubWorkspace:
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible.
 
 
 def _install_ctx(tmp_path: Path) -> "tuple[OpContext, _Events]":
@@ -349,7 +349,7 @@ def _install_ctx(tmp_path: Path) -> "tuple[OpContext, _Events]":
     decl = PermissionDecl(file_write=[{"path": str(config_path), "scope": "just_path"}])
     events = _Events()
     ctx = OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path),
         events=events,
         permission_decl=decl,
         permission_resolver=resolver,

--- a/tests/core/test_3212_plugin_install_concurrency.py
+++ b/tests/core/test_3212_plugin_install_concurrency.py
@@ -53,6 +53,7 @@ from reyn.core.op_runtime.plugin_install import (
     reconcile_plugin_installs,
 )
 from reyn.core.op_runtime.plugin_install import handle as install_handle
+from reyn.data.workspace.workspace import Workspace
 from reyn.plugins.manifest import PLUGIN_MANIFEST_SCHEMA_URL
 from reyn.schemas.models import PluginInstallIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
@@ -61,10 +62,8 @@ from reyn.security.permissions.permissions import PermissionDecl, PermissionReso
 # precedent in tests/core/test_action_embedding_index_concurrency.py).
 _DEAD_PID = 2**31 - 1
 
-
-class _StubWorkspace:
-    def __init__(self, base_dir) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible.
 
 
 class _Events:
@@ -89,9 +88,10 @@ def _make_ctx(tmp_path):
             str(project_root / ".reyn" / "config" / cfg), "test", "file.write",
         )
     decl = PermissionDecl(file_write=[{"path": str(plugins_root()), "scope": "recursive"}])
+    events = _Events()
     return OpContext(
-        workspace=_StubWorkspace(base_dir=project_root),
-        events=_Events(),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=project_root),
+        events=events,
         permission_decl=decl,
         permission_resolver=resolver,
         actor="test",

--- a/tests/core/test_config_write_jit_bus_3086.py
+++ b/tests/core/test_config_write_jit_bus_3086.py
@@ -44,6 +44,7 @@ from pathlib import Path
 import pytest
 
 from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
 from reyn.intervention_choices import NO, YES
 from reyn.schemas.models import (
     PipelineInstallIROp,
@@ -55,11 +56,8 @@ from reyn.user_intervention import InterventionAnswer, UserIntervention
 
 # ── shared stubs (real API surface, no mocks; mirrors test_plugin_install.py /
 # test_require_file_jit_ask_1505.py's _FakeBus) ────────────────────────────────
-
-
-class _StubWorkspace:
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible.
 
 
 class _Events:
@@ -101,10 +99,11 @@ def _make_ctx(
         config_permissions={}, project_root=project_root, interactive=True,
     )
     decl = PermissionDecl()  # no declared grants — the zone/sandbox conjunction decides
+    events = _Events()
 
     return OpContext(
-        workspace=_StubWorkspace(base_dir=project_root),
-        events=_Events(),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=project_root),
+        events=events,
         permission_decl=decl,
         permission_resolver=resolver,
         actor="test",

--- a/tests/core/test_mcp_drop_server.py
+++ b/tests/core/test_mcp_drop_server.py
@@ -23,6 +23,7 @@ from typing import Any
 import pytest
 import yaml
 
+from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import MCPDropServerIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from reyn.user_intervention import (
@@ -90,17 +91,12 @@ def _seed_config(path: Path, servers: dict[str, dict]) -> None:
     )
 
 
-class _StubWorkspace:
-    """Workspace stand-in exposing only ``base_dir`` (= what the handler reads).
-
-    The real Workspace class reads CWD eagerly + creates `.reyn/`
-    directories; using it in unit tests pollutes the test filesystem.
-    The handler only consults ``ws.base_dir`` via
-    ``_resolve_project_root`` so a stub is sufficient + cleaner.
-    """
-
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — its docstring's "reads CWD
+# eagerly + pollutes the test filesystem" rationale didn't hold for this
+# file's own call site (always passes tmp_path, never omits base_dir), and
+# Workspace(base_dir=tmp_path) only ever creates tmp_path/.reyn/, which is
+# disposable pytest state, not filesystem pollution. A real Workspace is
+# cheaply constructible (#4581's own precedent).
 
 
 def _phase5_drop_decl(resolver: PermissionResolver, tmp_path: Path) -> PermissionDecl:
@@ -132,9 +128,12 @@ def _make_op_ctx(
         else:
             effective_decl = PermissionDecl()
 
+    effective_events = events or _CapturingEvents()
     return OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
-        events=events or _CapturingEvents(),
+        workspace=Workspace(
+            events=effective_events, permission_resolver=resolver, base_dir=tmp_path,
+        ),
+        events=effective_events,
         permission_decl=effective_decl,
         permission_resolver=resolver,
         actor="test_mcp_drop_server",

--- a/tests/core/test_pipeline_install.py
+++ b/tests/core/test_pipeline_install.py
@@ -36,16 +36,14 @@ from reyn.core.events.snapshot_generations import rewind as _wal_rewind
 from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
 from reyn.data.pipelines.registry import build_pipeline_registry
+from reyn.data.workspace.workspace import Workspace
 from reyn.runtime.registry import AgentRegistry
 from reyn.schemas.models import PipelineInstallIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
 # ── shared stubs (mirrors test_skill_install_pr_c.py / pr_d.py) ──────────────
-
-
-class _StubWorkspace:
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible.
 
 
 class _Events:
@@ -86,7 +84,7 @@ def _make_ctx(
     )
     events = _Events()
     ctx = OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path),
         events=events,
         permission_decl=decl,
         permission_resolver=resolver,

--- a/tests/core/test_plugin_install.py
+++ b/tests/core/test_plugin_install.py
@@ -68,6 +68,7 @@ from reyn.core.op_runtime.plugin_install import (
     handle as install_handle,
 )
 from reyn.core.op_runtime.plugin_uninstall import handle as uninstall_handle
+from reyn.data.workspace.workspace import Workspace
 from reyn.intervention_choices import NO, YES
 from reyn.plugins.manifest import PLUGIN_MANIFEST_SCHEMA_URL
 from reyn.schemas.models import PluginInstallIROp, PluginUninstallIROp
@@ -75,11 +76,10 @@ from reyn.security.permissions.permissions import PermissionDecl, PermissionReso
 from reyn.user_intervention import InterventionAnswer, UserIntervention
 
 # ── shared stubs (real API surface, no mocks) ─────────────────────────────────
-
-
-class _StubWorkspace:
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible (#4581's
+# own 1-line precedent) and only ever creates <base_dir>/.reyn/, which is
+# always a disposable pytest tmp_path/project_root here, not the real CWD.
 
 
 class _Events:
@@ -233,9 +233,10 @@ def _make_ctx(
         file_write=[{"path": str(plugins_root()), "scope": "recursive"}],
         http_get=[{"host": "*"}],
     )
+    events = _Events()
     return OpContext(
-        workspace=_StubWorkspace(base_dir=project_root),
-        events=_Events(),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=project_root),
+        events=events,
         permission_decl=decl,
         permission_resolver=resolver,
         actor="test",

--- a/tests/core/test_skill_install_pr_c.py
+++ b/tests/core/test_skill_install_pr_c.py
@@ -25,15 +25,14 @@ from reyn.core.events.snapshot_generations import rewind as _wal_rewind
 from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
 from reyn.data.skills.registry import build_skill_registry
+from reyn.data.workspace.workspace import Workspace
 from reyn.runtime.registry import AgentRegistry
 from reyn.schemas.models import SkillInstallIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
 # ── shared stubs (real API surface, no mocks) ─────────────────────────────────
-
-class _StubWorkspace:
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible.
 
 
 class _Events:
@@ -61,9 +60,10 @@ def _make_ctx(tmp_path: Path, state_log: StateLog | None = None) -> OpContext:
     decl = PermissionDecl(
         file_write=[{"path": str(config_path), "scope": "just_path"}],
     )
+    events = _Events()
     return OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
-        events=_Events(),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path),
+        events=events,
         permission_decl=decl,
         permission_resolver=resolver,
         actor="test",

--- a/tests/core/test_skill_install_pr_d.py
+++ b/tests/core/test_skill_install_pr_d.py
@@ -29,16 +29,14 @@ import yaml
 
 from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
 from reyn.runtime.registry import AgentRegistry
 from reyn.schemas.models import SkillInstallIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
 # ── shared stubs (mirrors test_skill_install_pr_c.py) ─────────────────────────
-
-
-class _StubWorkspace:
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
+# #4597 slice ①: _StubWorkspace removed — a real Workspace(events=...,
+# permission_resolver=..., base_dir=...) is cheaply constructible.
 
 
 class _Events:
@@ -81,7 +79,7 @@ def _make_ctx(
     )
     events = _Events()
     ctx = OpContext(
-        workspace=_StubWorkspace(base_dir=tmp_path),
+        workspace=Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path),
         events=events,
         permission_decl=decl,
         permission_resolver=resolver,


### PR DESCRIPTION
**[e2e-coder]** — part of #4597 (slice ①: `_StubWorkspace`, 12 files).

## Why

CLAUDE.md: "NEVER fake a collaborator ... when a real instance is cheaply constructible." `Workspace(events=..., permission_resolver=..., base_dir=tmp_path)` is a 1-line construction (#4581's own established precedent) — the 12 `_StubWorkspace` definitions each duplicated the same `{base_dir}` shape for no reason a real instance couldn't serve.

One file (`test_mcp_drop_server.py`) carried a docstring rationale for keeping the stub: *"the real Workspace reads CWD eagerly + creates `.reyn/` directories; using it in unit tests pollutes the test filesystem."* Checked against `Workspace.__init__` directly — it doesn't hold at this file's own call site: `base_dir` is always passed explicitly (`tmp_path`), so `Workspace` never falls back to reading CWD, and its only filesystem effect (`state_dir.mkdir()` under `base_dir`) lands inside the disposable pytest `tmp_path`, not the real test filesystem. Removed the stale rationale along with the stub rather than leaving it to mislead the next reader.

## Change

12 files, one mechanical substitution:
```
_StubWorkspace(base_dir=X)  →  Workspace(events=events, permission_resolver=resolver, base_dir=X)
```
sharing the same `events` instance the `OpContext` itself already uses where one was in scope (most call sites) — a couple of inline `_Events()` call sites left as-is (Workspace's own `events` param doesn't need to be the SAME object `OpContext.events` points at for these tests' own assertions).

**Scope discipline**: exactly `_StubWorkspace` — slice ① of #4597's own proposed 3-slice split. Event-log stand-ins (`_Events`/`_CapturingEvents`, slice ②) and Session stand-ins (slice ③) are untouched — separate follow-ups, per #4597's own scoping (lead-coder explicitly held those back pending separate review).

Files: `test_plugin_install.py`, `test_2248_prb_config_path_consistency.py`, `test_pipeline_install.py`, `test_2722_pipeline_multi_doc_namespacing.py`, `test_config_write_jit_bus_3086.py`, `test_3212_plugin_install_concurrency.py`, `test_skill_install_pr_d.py`, `test_mcp_drop_server.py`, `test_0060_phase1_layer_a.py` (3 call sites), `test_skill_install_pr_c.py`, `test_2248_pr_a2_config_emission.py`, `tests/builtin/test_0060_phase1_f3a_builtin_tier.py`.

## Verification

- Directly exercised a real `Workspace(events=EventLog(), base_dir=tmp)` construction outside pytest to confirm the substitution is load-bearing (base_dir set correctly, state_dir created under it), not decorative.
- `ruff check src tests`: clean.
- `scripts/test_tier_audit.py --strict` (12 changed files, 132 tests): 0 Tier-4 violations.
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined (unchanged).
- All 12 files' own suites: 132/132 pass.
- Broader regression sweep (`plugin_install`/`pipeline_install`/`skill_install`/`mcp_drop`/`2248`/`2722`/`0060`): 231/231 pass.

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Directly verified the real `Workspace` construction behaves as expected (not just "tests still pass").
- [x] Full regression sweep across every affected test area — clean, no doc changes needed (test-only PR, no `mkdocs`/anchor surface touched).
- [ ] (Visual) — n/a, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
