### PR TITLE
fix(#4620): route webhook_received through the same evidence-based check as mcp_resource_updated

### DIFF
--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -80,7 +80,7 @@ subscribing hooks is a real gap; a point with no producer is not
 reported — see 'not checked' below for why some points aren't):
   ✗ file_changed: producer present (1 declared fs_watch path(s)) but 0 subscribing hooks — this point's notifications have nowhere to go
   ? mcp_resource_updated: not seen in the newest 0 event file(s) scanned — a producer whose last arrival is older than that is not covered here, so this is NOT proof no producer exists
-  ? webhook_received: not checked (no config or audit-log surface exists for its producer)
+  ? webhook_received: not seen in the newest 0 event file(s) scanned — a producer whose last arrival is older than that is not covered here, so this is NOT proof no producer exists
 ```
 
 ### `.reyn/events/` — declared vs. actual
@@ -134,21 +134,21 @@ one directly. Producer evidence differs per point:
 
 - `file_changed` — a declared `fs_watch.paths` entry.
 - `cron_fired` — an *enabled* `cron.jobs[]` entry (a disabled job is not a producer).
-- `mcp_resource_updated` — past evidence in `.reyn/events` (this kind IS an audit-event,
-  `event_schema.py`), scanned newest-first, bounded to the most recent 20 dated files (a
-  kind lookup has no index — `.reyn/events` is append-only — so this bound keeps a "did
-  it ever happen" query cheap even with retention disabled; the question only needs "at
-  least once," so an early exit can never turn a real positive into a false negative).
-  **This check is windowed, unlike the other two** (#4614): "not seen in the newest 20
-  files" is NOT proof of "no producer" — a real producer whose last arrival predates the
-  window is indistinguishable from one that never fired. Reporting nothing here (the
-  pre-#4614 behavior) silently hid exactly the state C-2 exists to catch, so this point
-  ALWAYS prints a line — `✓`/`✗` when seen within the window, or `? mcp_resource_updated:
-  not seen in the newest N event file(s) scanned — ... NOT proof no producer exists`
-  otherwise — never folded into the "no producer → no finding" rule below.
-- `webhook_received` — **not checked**: no config declaration and no `AUDIT_EVENT_KINDS`
-  entry exist for it, so there is no surface to read a producer from at all. Reported as
-  `? webhook_received: not checked`, never silently omitted (D-3).
+- `mcp_resource_updated` / `webhook_received` — past evidence in `.reyn/events` (both
+  kinds ARE audit-events, `event_schema.py` — `webhook_received` gained its own kind in
+  #4618, joining this check in #4620), scanned newest-first, bounded to the most recent
+  20 dated files (a kind lookup has no index — `.reyn/events` is append-only — so this
+  bound keeps a "did it ever happen" query cheap even with retention disabled; the
+  question only needs "at least once," so an early exit can never turn a real positive
+  into a false negative). **This check is windowed, unlike the other two** (#4614): "not
+  seen in the newest 20 files" is NOT proof of "no producer" — a real producer whose last
+  arrival predates the window is indistinguishable from one that never fired. Reporting
+  nothing here (the pre-#4614 behavior) silently hid exactly the state C-2 exists to
+  catch, so both points ALWAYS print a line — `✓`/`✗` when seen within the window, or
+  `? <point>: not seen in the newest N event file(s) scanned — ... NOT proof no producer
+  exists` otherwise — never folded into the "no producer → no finding" rule below.
+  `webhook_received` has no config surface of its own (unlike `file_changed`/`cron_fired`),
+  so it can ONLY ever be evidence-based here — there is no complete-read alternative for it.
 
 A point with a COMPLETE producer read (`file_changed`/`cron_fired`) and no producer
 prints no finding at all — reporting "0 subscribing hooks" for

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -1154,7 +1154,9 @@ higher-trust one.
    entries tagged with its `plugin_id` pointing at the dir about to be deleted,
    so those entries are dropped from all three `.reyn/config/*.yaml` registries
    (ungated — OS-internal repair of already-broken entries) BEFORE the copy is
-   removed, or a dangling registry entry would survive.
+   removed, or a dangling registry entry would survive. Emit
+   `plugin_install_reconciled` (`name`, `action` — `"rolled_back"` today, the
+   only value emitted) per plugin actually rolled back.
 1. Resolve `source` → a source directory per its `kind`, applying the source's
    gate(s): `{kind: "git"}` runs the run-code trust gate (2) then
    `require_http_get` before cloning; `builtin`/`local` touch no network.

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -57,13 +57,15 @@ partial one, is the one thing this command must never do). C-2
 (zero-responder subscription, #4364 PR-2b, architect ruling): for each of
 the 4 external ingress points (``hooks.schema_registry._EXTERNAL_POINTS``),
 check whether a PRODUCER exists (declared config for ``file_changed``/
-``cron_fired``, past audit-log evidence for ``mcp_resource_updated`` —
-subscriptions themselves are a volatile op-level concept doctor cannot see
-from a separate process, so the check pairs producer↔consumer, not
-subscription↔consumer) and, only where one does, whether any consumer
-(hook) is registered for it. ``webhook_received`` has no config or
-audit-log surface at all — D-3: named as un-checked, not silently
-skipped. C-5 (sandbox posture) and C-6's other named pairs (listen port,
+``cron_fired``, past audit-log evidence for ``mcp_resource_updated``/
+``webhook_received`` — subscriptions themselves are a volatile op-level
+concept doctor cannot see from a separate process, so the check pairs
+producer↔consumer, not subscription↔consumer) and, only where one does,
+whether any consumer (hook) is registered for it. ``webhook_received``
+had no config or audit-log surface at all until #4618 gave it its own
+audit-event kind (#4620) — it now routes through the SAME windowed
+evidence-based check ``mcp_resource_updated`` already had. C-5 (sandbox
+posture) and C-6's other named pairs (listen port,
 model-name acceptance) are PR-3b — each needs its own NEW measurement
 code (introspecting a live bound socket, a real litellm probe call), not
 reuse of an existing function the way C-1/C-2/C-7 are.
@@ -326,9 +328,22 @@ def _print_hook_probe_results(config: Any) -> None:
 # always readable from config; the producer side is readable ONLY where a
 # static declaration or a past audit-log record exists.
 #
-# `webhook_received` has neither (no config surface, no AUDIT_EVENT_KINDS
-# entry) — D-3: named as un-checked below, never silently skipped.
-_UNCHECKABLE_EXTERNAL_POINTS: Final[tuple[str, ...]] = ("webhook_received",)
+# #4620: `webhook_received` USED to have neither (no config surface, no
+# AUDIT_EVENT_KINDS entry) and lived here — #4618 (same night, same repo)
+# gave it an audit-event of its own (webhook_routing.py), the same
+# evidence-based surface `mcp_resource_updated` already had. That made
+# this constant's own reasoning stale without anyone editing this file:
+# the printed "no config or audit-log surface exists" claim went false
+# the moment #4618 merged. `webhook_received` now routes through the
+# SAME windowed evidence-based check as `mcp_resource_updated` (below) —
+# this constant stays EMPTY, not deleted, so a future point that
+# genuinely has no producer surface has somewhere to land without
+# reinventing the D-3 disclosure. `cron_fired`/`file_changed` do NOT
+# move here or into the windowed check — both already have a COMPLETE
+# config-declared producer surface (`cron.jobs[]` / `fs_watch.paths`),
+# and turning a complete read into a windowed scan would strictly lose
+# information for no gain (architect's own point, #4620).
+_UNCHECKABLE_EXTERNAL_POINTS: Final[tuple[str, ...]] = ()
 
 # .reyn/events is append-only with no kind index (reyn-dir-layout.md) — a
 # kind lookup is a scan. #4479 retention normally bounds the file count, but
@@ -347,11 +362,15 @@ _UNCHECKABLE_EXTERNAL_POINTS: Final[tuple[str, ...]] = ("webhook_received",)
 _MCP_EVENT_SCAN_MAX_FILES: Final[int] = 20
 
 
-def _mcp_resource_updated_seen(events_dir: Path) -> "tuple[bool, int]":
-    """(seen, files_scanned) — whether ``mcp_resource_updated`` appears in
-    any of the newest ``_MCP_EVENT_SCAN_MAX_FILES`` dated ``.jsonl`` files
-    under *events_dir*. ``events_dir`` missing → ``(False, 0)`` (nothing
-    written yet, not an error)."""
+def _external_event_kind_seen(events_dir: Path, kind: str) -> "tuple[bool, int]":
+    """(seen, files_scanned) — whether *kind* appears in any of the newest
+    ``_MCP_EVENT_SCAN_MAX_FILES`` dated ``.jsonl`` files under *events_dir*.
+    ``events_dir`` missing → ``(False, 0)`` (nothing written yet, not an
+    error). Shared by every windowed-evidence external point (#4620:
+    generalized from ``mcp_resource_updated``-only so ``webhook_received``
+    can route through the identical check once it has its own audit-event
+    kind — the scan itself has no point-specific logic, only *kind*
+    differs)."""
     import json
 
     from reyn.core.events.event_purge import collect_dated_files
@@ -373,7 +392,7 @@ def _mcp_resource_updated_seen(events_dir: Path) -> "tuple[bool, int]":
                         obj = json.loads(line)
                     except json.JSONDecodeError:
                         continue
-                    if obj.get("type") == "mcp_resource_updated":
+                    if obj.get("type") == kind:
                         return True, len(window)
         except OSError:
             continue
@@ -455,8 +474,8 @@ def _print_external_point_pairing(config: object, project_root: Path) -> None:
             enabled_jobs = [j for j in jobs if getattr(j, "enabled", True)]
             has_producer = bool(enabled_jobs)
             evidence = f"{len(enabled_jobs)} enabled cron job(s)"
-        elif point == "mcp_resource_updated":
-            # #4614: this check is windowed (a bounded scan, see
+        elif point in ("mcp_resource_updated", "webhook_received"):
+            # #4614/#4620: this check is windowed (a bounded scan, see
             # _MCP_EVENT_SCAN_MAX_FILES's own comment) — unlike
             # file_changed/cron_fired's complete config reads, "not seen"
             # here is NOT proof of "no producer": a producer whose last
@@ -465,8 +484,13 @@ def _print_external_point_pairing(config: object, project_root: Path) -> None:
             # (the pre-#4614 shape) hid the exact state C-2 exists to
             # catch — so this point is disclosed UNCONDITIONALLY (D-3),
             # never folded into the generic "no producer -> no finding"
-            # rule below.
-            seen, scanned = _mcp_resource_updated_seen(events_dir)
+            # rule below. #4620: webhook_received joined this branch once
+            # #4618 gave it its own audit-event kind (matching its own
+            # point name, same convention as mcp_resource_updated) — it
+            # has no config surface at all, so it can ONLY ever be
+            # evidence-based, never a complete config read like
+            # file_changed/cron_fired.
+            seen, scanned = _external_event_kind_seen(events_dir, point)
             consumers = registry.hooks_for(point)  # type: ignore[attr-defined]
             if seen and consumers:
                 print(

--- a/tests/interfaces/test_4364_pr2b_doctor_external_pairing.py
+++ b/tests/interfaces/test_4364_pr2b_doctor_external_pairing.py
@@ -7,8 +7,14 @@ one-shot process) so the check pairs PRODUCER <-> CONSUMER, not
 subscription <-> consumer. Consumer side (a hook registered for a point)
 is always config-readable; producer side is readable only where a static
 declaration (``fs_watch:``/``cron:``) or a past audit-log record
-(``mcp_resource_updated``) exists. ``webhook_received`` has neither —
-named as un-checked (D-3), never silently skipped.
+(``mcp_resource_updated``/``webhook_received``) exists.
+
+#4620: ``webhook_received`` used to have neither and was named
+un-checked (D-3) — #4618 gave it its own audit-event kind, so it now
+routes through the SAME windowed evidence-based check
+``mcp_resource_updated`` already had (never a complete config read like
+``file_changed``/``cron_fired`` — it has no config surface of its own to
+read).
 
 Real CLI invocation (mirrors ``test_4364_pr2_doctor_hook_probe.py``'s own
 established capsys-driven shape) against real config files + a real
@@ -36,28 +42,29 @@ def _write_event(events_dir: Path, filename: str, kind: str) -> None:
     )
 
 
-def test_no_producers_configured_reports_only_the_uncheckable_point(
+def test_no_producers_configured_reports_only_the_windowed_points(
     tmp_path: Path, capsys,
 ) -> None:
     """Tier 2: (accept-side, absence) with no fs_watch/cron evidence at
     all, file_changed/cron_fired print no finding at all (D-2/D-3:
     reporting "0 hooks" for a nonexistent producer would be noise, not
     signal — those two checks are COMPLETE config reads, so "no producer"
-    can be asserted outright). mcp_resource_updated is different (#4614):
-    its own check is windowed, so it prints a "?" disclosure line even
-    with zero event-log evidence — "not seen" there is never proof of
-    "no producer", only "not seen in the window", so silence would hide
-    exactly the state C-2 exists to catch."""
+    can be asserted outright). mcp_resource_updated/webhook_received are
+    different (#4614/#4620): both checks are windowed, so both print a
+    "?" disclosure line even with zero event-log evidence — "not seen"
+    there is never proof of "no producer", only "not seen in the
+    window", so silence would hide exactly the state C-2 exists to
+    catch."""
     _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
 
     run(Namespace(project_root=str(tmp_path)))
     out = capsys.readouterr().out
 
     assert "External-event producer/consumer pairing" in out
-    assert "? webhook_received: not checked" in out
     assert "file_changed" not in out
     assert "cron_fired" not in out
     assert "? mcp_resource_updated: not seen in the newest" in out
+    assert "? webhook_received: not seen in the newest" in out
     assert "NOT proof no producer exists" in out
 
 
@@ -231,6 +238,79 @@ def test_mcp_resource_updated_evidence_outside_the_scan_window_is_disclosed_not_
     assert "NOT proof no producer exists" in out
     assert "✗ mcp_resource_updated" not in out
     assert "✓ mcp_resource_updated" not in out
+
+
+def test_webhook_received_with_past_evidence_and_zero_consumers_is_flagged(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: #4620 — webhook_received's own evidence-based witness, same
+    shape as mcp_resource_updated's: a PAST audit-log record (#4618 gave
+    this kind an emitter) is the producer evidence; no hook subscribes ->
+    ✗. Regression witness for the #4620 fix — before it, this exact case
+    printed the stale '? webhook_received: not checked' claim even though
+    real evidence existed."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_event(
+        tmp_path / ".reyn" / "events", "2026-08-14T000000.jsonl", "webhook_received",
+    )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "✗ webhook_received: producer present" in out
+    assert "seen in the newest" in out
+
+
+def test_webhook_received_with_a_consumer_reports_ok(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: #4620 accept-side — same past evidence, but a hook
+    subscribes to webhook_received -> ✓."""
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "hooks:\n"
+            '  - "on": webhook_received\n'
+            '    name: webhook-watcher\n'
+            '    template_push:\n'
+            '      message: "received"\n'
+        ),
+    )
+    _write_event(
+        tmp_path / ".reyn" / "events", "2026-08-14T000000.jsonl", "webhook_received",
+    )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "✓ webhook_received: producer present" in out
+
+
+def test_webhook_received_evidence_outside_the_scan_window_is_disclosed_not_silent(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: #4620 — same regression shape as
+    test_mcp_resource_updated_evidence_outside_the_scan_window_is_disclosed_not_silent,
+    for webhook_received: a real producer whose last arrival predates the
+    scan window with 0 subscribing hooks must still surface a '?'
+    disclosure, not silence and not a false '✗'/'✓'."""
+    from reyn.interfaces.cli.commands import doctor as _doctor_mod
+
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+    events_dir = tmp_path / ".reyn" / "events"
+    _write_event(events_dir, "2026-01-01T000000.jsonl", "webhook_received")
+    for day in range(1, _doctor_mod._MCP_EVENT_SCAN_MAX_FILES + 1):
+        _write_event(
+            events_dir, f"2026-02-{day:02d}T000000.jsonl", "session_started",
+        )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "? webhook_received: not seen in the newest" in out
+    assert "NOT proof no producer exists" in out
+    assert "✗ webhook_received" not in out
+    assert "✓ webhook_received" not in out
 
 
 def test_consumer_declared_only_in_runtime_hooks_yaml_still_counts(


### PR DESCRIPTION
**[e2e-coder]** — closes #4620.

## The bug

architect's finding, relayed by lead-coder: #4612 (this session, C-2) and #4618 (same night, #4605) were both correct in isolation but false together. `doctor.py:331` declared `webhook_received` "uncheckable" (no config surface, no audit-log surface) — true when #4612 merged. #4618 gave `webhook_received` its own audit-event kind minutes later, in the same merge session, and nobody re-checked whether that changed #4612's own printed claim. It did: "no config or audit-log surface exists for its producer" went false the moment #4618 landed, and doctor kept printing it — (1) a false reason handed to the operator, (2) a check that became possible (the same zero-consumer evidence-based check `mcp_resource_updated` already had) that nobody wired up.

## Fix

`_UNCHECKABLE_EXTERNAL_POINTS` goes empty (not deleted — a future point with a genuine no-producer-surface gap has somewhere to land). `webhook_received` routes through the generalized `_external_event_kind_seen(events_dir, kind)` (renamed from the `mcp_resource_updated`-only `_mcp_resource_updated_seen` — same windowed scan, parametrized by kind instead of hardcoded).

`cron_fired`/`file_changed` are **untouched** per the architect's own point: both already have a COMPLETE config-declared producer surface (`cron.jobs[]`/`fs_watch.paths`) — moving them to a windowed scan would strictly lose information for no gain.

## Doc-drift (CLAUDE.md hard rule, same PR)

The module docstring, `doctor.md`'s sample output, and `doctor.md`'s C-2 prose section all repeated the same "webhook_received has neither [surface]" claim #4618 falsified. Fixed in this PR, not a follow-up.

## Tests

- 3 new (mirroring `mcp_resource_updated`'s own 3): producer+zero-consumers flagged, producer+consumer OK, evidence-outside-window disclosed not silent.
- 1 updated: the "nothing configured" accept-side test now expects `webhook_received`'s own "?" disclosure line instead of the stale "not checked" claim.
- Strip-falsified: reverted `_UNCHECKABLE_EXTERNAL_POINTS` to the pre-fix value, confirmed exactly the 4 affected tests go RED (the new/updated `webhook_received` assertions — the other 10 unaffected tests stayed green, confirming the failure was specific), restored, confirmed GREEN.

## Verification

- `ruff check src tests`: clean.
- `scripts/test_tier_audit.py --strict` (1 changed test file, 14 tests): 0 Tier-4 violations.
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined (unchanged).
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `scripts/check_doc_anchors.py`: clean.
- `tests/interfaces -k "doctor or 4364"` (30): clean, no regression.

## Test plan

- [x] Strip-falsified the fix — confirmed the 4 affected tests genuinely RED for the right reason → restored → confirmed GREEN.
- [x] Ran all 5 local gates — clean.
- [x] `mkdocs build --strict` + `check_doc_anchors.py` — clean.
- [x] Regression sweep (`doctor`/`4364`) — clean.
- [ ] (Visual) — n/a, CLI text output, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔴 Reviewer's blocking item (lead-coder)

- [x] 🔴 **条件 ③ が入っていません** — `control-ir.md` に `plugin_install_reconciled` の 1 行（#4620 のコメント参照、architect が族の数え直しで発見）。★emit は `plugin_install.py:495`、★events.md には在り（#4591）、★control-ir.md の列挙だけ抜けています。★step 自体は同じ節に在る（「0. Reconcile: …」）ので「op の外だから」では説明がつきません。⚪ #4620 で「同梱で可」と条件に書いたものです。★1 行です。 — fixed, commit pushed to this branch.

