### PR TITLE
feat(#4364): doctor C-5 — declared vs. RESOLVED sandbox posture

### DIFF
--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -154,12 +154,49 @@ A point with a COMPLETE producer read (`file_changed`/`cron_fired`) and no produ
 prints no finding at all — reporting "0 subscribing hooks" for
 a point that will never fire would be noise, not signal.
 
+### Sandbox posture — declared vs. RESOLVED (C-5)
+
+```
+Sandbox posture — declared vs. RESOLVED (absence of a declaration
+does not mean unrestricted; see the resolved backend below):
+  declared: sandbox.backend='auto', sandbox.on_unsupported='warn'
+  declared: no sandbox.policy — NOT the same as unrestricted, see resolved backend below
+  resolved: 'seatbelt' (production's own resolution — a backend that cannot enforce is already treated as absent at this step, #2983, so this name IS the enforcement witness)
+```
+
+The motivating real case (architect's own note, #4364): an operator read "no
+`sandbox.policy` declared" as "unrestricted," but the resolved backend was actually
+enforcing all along (`SeatbeltBackend`, `write_paths=[]`) — declaration and
+resolution silently disagreed, and only the resolved side is true.
+
+`reyn doctor` reports declared `sandbox.backend` / `sandbox.on_unsupported` /
+`sandbox.policy` (from config, verbatim — only the write-scope keys,
+`allow_write_paths`/`deny_write_paths`, are echoed) next to the backend
+production's OWN resolution (`reyn.security.sandbox.launcher.resolve_backend`
+— the SAME call C-1's hook probe already makes) actually hands back. This is
+deliberately **not** a second, doctor-invented probe: `get_default_backend()`
+already self-tests a real deny before returning a backend (#2983) and applies
+`sandbox.on_unsupported` to any backend that can't enforce, so "which backend
+resolved" already carries the enforcement witness — doctor reports that
+verdict, never re-derives it. If the declared backend was explicitly forced
+(not `'auto'`) and the resolution fell back to a different one, the line says
+`DOWNGRADED from declared '<name>'` rather than silently agreeing with the
+fallback. If `sandbox.on_unsupported: error` makes resolution itself
+fail-closed, doctor reports `resolved: refuses to run (...)` rather than
+crashing or swallowing the error.
+
+`reyn doctor` has no op context (no LLM tool call it's diagnosing), so it does
+NOT build a `resolve_sandbox_policy()` call — that needs a caller-supplied
+`write_paths` floor ("this op needs this directory") doctor cannot know and
+must not invent a stand-in for. Only the declared `sandbox.policy` dict's own
+write-scope keys are shown, never a merged/resolved policy.
+
 ## Out of scope for this PR (later slices, same arc)
 
-- **C-5 / C-6** (sandbox posture, listen port, and model-name declared-vs-effective
-  pairs) — each needs its own new measurement code (reading the resolved sandbox
-  backend object, introspecting a live bound socket, a real litellm probe call),
-  unlike C-1/C-2/C-7, which reuse existing measurement functions.
+- **C-6** (listen port and model-name declared-vs-effective pairs) — each needs
+  its own new measurement code (introspecting a live bound socket, a real
+  litellm probe call), unlike C-1/C-2/C-5/C-7, which reuse existing measurement
+  functions.
 
 ## Related
 

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -65,10 +65,24 @@ whether any consumer (hook) is registered for it. ``webhook_received``
 had no config or audit-log surface at all until #4618 gave it its own
 audit-event kind (#4620) — it now routes through the SAME windowed
 evidence-based check ``mcp_resource_updated`` already had. C-5 (sandbox
-posture) and C-6's other named pairs (listen port,
-model-name acceptance) are PR-3b — each needs its own NEW measurement
-code (introspecting a live bound socket, a real litellm probe call), not
-reuse of an existing function the way C-1/C-2/C-7 are.
+posture, this slice's own addition): declared ``sandbox.backend``/
+``sandbox.on_unsupported``/``sandbox.policy`` next to the ACTUALLY
+RESOLVED backend (:func:`reyn.security.sandbox.launcher.resolve_backend`
+— the SAME production resolution C-1's probe already calls, which
+self-tests a real deny before returning a backend, #2983). Architect's
+ruling (#4364): "which backend resolved" already witnesses enforcement
+(a backend that cannot enforce is treated as absent at resolution,
+``sandbox.on_unsupported`` applied) — doctor reports that resolution's
+OWN verdict, never a second probe of its own. Doctor has no op context,
+so it does NOT merge a caller-supplied ``write_paths`` floor the way a
+real dispatch would (:func:`reyn.security.sandbox.policy.
+resolve_sandbox_policy` needs one, and inventing a stand-in would
+contrast against nothing real) — only the declared ``sandbox.policy``
+dict's own write-scope keys are shown, next to the resolved backend
+name. C-6's other named pairs (listen port, model-name acceptance) are a
+later slice — each needs its own NEW measurement code (introspecting a
+live bound socket, a real litellm probe call), not reuse of an existing
+function the way C-1/C-2/C-5/C-7 are.
 """
 from __future__ import annotations
 
@@ -102,6 +116,8 @@ def register(sub) -> None:
 _MEASURABLE_LEAF_KEYS: Final[tuple[str, ...]] = (
     "audit_events.cleanup_period_days",
     "audit_events.max_disk_usage_percent",
+    "sandbox.backend",
+    "sandbox.on_unsupported",
 )
 _MEASURABILITY_CRITERION: Final[str] = (
     "a leaf counts as measurable here iff this module reads its LIVE EFFECT "
@@ -237,6 +253,12 @@ def run(args: argparse.Namespace) -> None:
     print("subscribing hooks is a real gap; a point with no producer is not")
     print("reported — see 'not checked' below for why some points aren't):")
     _print_external_point_pairing(config, resolved_root)
+
+    # ── C-5: resolved sandbox posture (#4364, architect ruling) ────────────
+    print()
+    print("Sandbox posture — declared vs. RESOLVED (absence of a declaration")
+    print("does not mean unrestricted; see the resolved backend below):")
+    _print_sandbox_posture(config)
 
 
 def _configured_exec_hooks(config: object) -> "list[HookDef]":
@@ -532,3 +554,82 @@ def _print_external_point_pairing(config: object, project_root: Path) -> None:
                 f"  ✗ {point}: producer present ({evidence}) but 0 subscribing "
                 f"hooks — this point's notifications have nowhere to go",
             )
+
+
+# ── C-5: resolved sandbox posture (#4364, architect ruling) ─────────────────
+#
+# Architect's ruling, verbatim shape: declared = sandbox.policy/sandbox.backend
+# (from config); effective = the resolved backend (+ if downgraded via
+# on_unsupported, that fact). Doctor does not try a write of its own — same
+# reason as C-1 (doctor never changes the environment; a deny is harmless to
+# probe but a SUCCESS would not be, since doctor itself has no business
+# writing files). "Which backend resolved" already carries the enforcement
+# witness (backend.py's own get_default_backend: a backend that cannot
+# enforce is treated exactly like one that is absent) — this is production's
+# own gate reporting its own verdict, not a weaker doctor-invented probe.
+#
+# Doctor has NO op context, so it does not build a resolve_sandbox_policy()
+# call (that needs a caller-supplied write_paths floor "this op needs this
+# directory" — a value doctor cannot know and must not invent a stand-in
+# for, per lead-coder's own ruling on this check). Only the declared
+# sandbox.policy dict's own write-scope keys are shown, never a merged/
+# resolved policy.
+_SANDBOX_POLICY_WRITE_SCOPE_KEYS: Final[tuple[str, ...]] = (
+    "allow_write_paths",
+    "deny_write_paths",
+)
+
+
+def _print_sandbox_posture(config: object) -> None:
+    from reyn.security.sandbox.launcher import resolve_backend
+
+    sandbox_config = getattr(config, "sandbox", None)
+    declared_backend = getattr(sandbox_config, "backend", "auto")
+    declared_on_unsupported = getattr(sandbox_config, "on_unsupported", "warn")
+    declared_policy = getattr(sandbox_config, "policy", None)
+
+    print(
+        f"  declared: sandbox.backend={declared_backend!r}, "
+        f"sandbox.on_unsupported={declared_on_unsupported!r}",
+    )
+    if declared_policy:
+        write_scope = {
+            k: v for k, v in declared_policy.items()
+            if k in _SANDBOX_POLICY_WRITE_SCOPE_KEYS
+        }
+        if write_scope:
+            print(f"  declared write scope (sandbox.policy): {write_scope}")
+        else:
+            print(
+                "  declared: sandbox.policy is set, but neither "
+                "allow_write_paths nor deny_write_paths appears in it",
+            )
+    else:
+        # This is the exact real-world case the check was written for
+        # (#4364 architect note): "sandbox.policy: not declared" reads like
+        # "unrestricted" but is NOT — the resolved backend below is what
+        # actually governs.
+        print("  declared: no sandbox.policy — NOT the same as unrestricted, see resolved backend below")
+
+    try:
+        resolved = resolve_backend(None, sandbox_config)
+    except RuntimeError as exc:
+        # on_unsupported="error" with no real backend available — the
+        # RESOLUTION itself refuses (fail-closed), which doctor reports
+        # rather than swallowing (D-1: measure, don't paper over a raise).
+        print(f"  ✗ resolved: refuses to run ({exc})")
+        return
+
+    downgraded = declared_backend not in ("auto", "noop", resolved.name)
+    if downgraded:
+        print(
+            f"  resolved: {resolved.name!r} — DOWNGRADED from declared "
+            f"{declared_backend!r} (on_unsupported={declared_on_unsupported!r} "
+            f"applied; a backend that cannot enforce is treated as absent, #2983)",
+        )
+    else:
+        print(
+            f"  resolved: {resolved.name!r} (production's own resolution — "
+            f"a backend that cannot enforce is already treated as absent "
+            f"at this step, #2983, so this name IS the enforcement witness)",
+        )

--- a/tests/interfaces/test_4364_c5_sandbox_posture.py
+++ b/tests/interfaces/test_4364_c5_sandbox_posture.py
@@ -1,0 +1,181 @@
+"""Tier 2: #4364 C-5 — ``reyn doctor``'s resolved sandbox posture section.
+
+Architect's ruling (issue #4364): declared ``sandbox.backend``/
+``sandbox.on_unsupported``/``sandbox.policy`` next to the ACTUALLY RESOLVED
+backend — production's own resolution (:func:`reyn.security.sandbox.
+launcher.resolve_backend`, the SAME call C-1's hook probe already makes),
+never a second doctor-invented probe. Motivating real case: an operator read
+"no sandbox.policy declared" as "unrestricted", but the resolved backend was
+actually enforcing (SeatbeltBackend, write_paths=[]) — declaration and
+resolution silently disagreed.
+
+No mocks — drives the real ``run`` against real on-disk state under
+``tmp_path`` and the REAL backend-resolution machinery (whatever backend
+this host's platform actually resolves to), matching this file family's
+established shape (``test_4364_pr3a_doctor_cli.py``).
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.cli.commands.doctor import run
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture()
+def project(tmp_path: Path) -> Path:
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+    return tmp_path
+
+
+def _unavailable_backend_name() -> str:
+    """Whichever of the two platform-specific backends this host does NOT
+    have — real ``.available()`` checks, no mock. Both modules import
+    cleanly on every platform (``available()`` itself gates on
+    ``platform.system()``), so this is portable across CI hosts."""
+    from reyn.security.sandbox.backends.landlock import LandlockBackend
+    from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
+
+    if not LandlockBackend().available():
+        return "landlock"
+    if not SeatbeltBackend().available():
+        return "seatbelt"
+    pytest.skip("both seatbelt and landlock report available on this host")
+
+
+# ── declared vs. resolved — the section exists and shows both ─────────────
+
+
+def test_sandbox_section_prints_declared_and_a_real_resolved_backend(project, capsys):
+    """Tier 2: the section header and both a declared line and a resolved
+    line are present — the resolved backend name is one of the real,
+    concrete backend names production can hand back, never a doctor-
+    invented placeholder."""
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    assert "Sandbox posture" in out
+    declared_line = next(line for line in out.splitlines() if line.strip().startswith("declared: sandbox.backend"))
+    assert "sandbox.backend='auto'" in declared_line
+    assert "sandbox.on_unsupported='warn'" in declared_line
+    resolved_line = next(line for line in out.splitlines() if line.strip().startswith("resolved:"))
+    assert any(name in resolved_line for name in ("'seatbelt'", "'landlock'", "'noop'"))
+
+
+def test_no_sandbox_policy_states_it_is_not_the_same_as_unrestricted(project, capsys):
+    """Tier 2: THE core C-5 value — the exact real-world confusion the
+    check was written for (#4364 architect note: an operator read "no
+    sandbox.policy declared" as "unrestricted", but the resolved backend
+    was enforcing all along). Absence of a declaration must never be
+    reported as if it meant no restriction."""
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    assert "no sandbox.policy" in out
+    assert "NOT the same as unrestricted" in out
+
+
+def test_declared_write_scope_is_shown_verbatim(project, capsys):
+    """Tier 2: an operator-declared allow_write_paths/deny_write_paths is
+    echoed back — the declared side of the declared-vs-resolved pair,
+    never merged with any doctor-invented op-context floor (architect/
+    lead-coder ruling: doctor has no op context)."""
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + "\nsandbox:\n  policy:\n    allow_write_paths: ['/tmp/some-declared-path']\n",
+    )
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    scope_line = next(line for line in out.splitlines() if "declared write scope" in line)
+    assert "/tmp/some-declared-path" in scope_line
+    assert "allow_write_paths" in scope_line
+
+
+def test_declared_policy_with_no_write_scope_keys_says_so(project, capsys):
+    """Tier 2: accept-side — a sandbox.policy block that sets something
+    OTHER than write scope (e.g. network) still reports honestly that
+    neither write-scope key is present, rather than fabricating an empty
+    scope dict that would read as "declared: no write access"."""
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + "\nsandbox:\n  policy:\n    network: false\n",
+    )
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    assert "neither allow_write_paths nor deny_write_paths appears" in out
+
+
+def test_doctor_never_writes_anything_while_reporting_sandbox_posture(project, capsys):
+    """Tier 2: D-2 falsify — resolving a real backend must not itself
+    perform (or leave evidence of) a write doctor didn't declare it was
+    doing; the project directory's only file after the run is still
+    exactly reyn.yaml (+ whatever the OTHER sections legitimately wrote,
+    none of which touch this fixture's sandbox posture path)."""
+    before = {p for p in project.rglob("*") if p.is_file()}
+    run(Namespace(project_root=str(project)))
+    capsys.readouterr()
+    after = {p for p in project.rglob("*") if p.is_file()}
+    assert after == before, "doctor's sandbox-posture check must never write to the project"
+
+
+# ── forced-unavailable backend — downgrade is flagged, not silent ─────────
+
+
+def test_forced_unavailable_backend_downgrades_and_is_flagged(project, capsys):
+    """Tier 2: THE downgrade case — an operator FORCES a specific backend
+    name that this host cannot actually provide, with the default
+    on_unsupported='warn'. Production silently falls back to NoopBackend
+    (by design — #2983's own on_unsupported contract); doctor must NOT
+    silently agree with that silence — the declared/resolved mismatch is
+    named explicitly as a downgrade, never printed as if 'noop' were what
+    was asked for."""
+    forced = _unavailable_backend_name()
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + f"\nsandbox:\n  backend: {forced}\n  on_unsupported: warn\n",
+    )
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    resolved_line = next(line for line in out.splitlines() if line.strip().startswith("resolved:"))
+    assert "DOWNGRADED" in resolved_line
+    assert f"declared {forced!r}" in resolved_line
+    assert "'noop'" in resolved_line
+
+
+def test_forced_unavailable_backend_with_on_unsupported_error_refuses(project, capsys):
+    """Tier 2: on_unsupported='error' makes RESOLUTION ITSELF fail-closed
+    (RuntimeError) rather than silently falling back — doctor must report
+    that refusal (D-1: measure, don't paper over a raise) instead of
+    crashing the whole command or silently swallowing it."""
+    forced = _unavailable_backend_name()
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + f"\nsandbox:\n  backend: {forced}\n  on_unsupported: error\n",
+    )
+    run(Namespace(project_root=str(project)))  # must not raise
+    out = capsys.readouterr().out
+    assert "resolved: refuses to run" in out
+
+
+def test_auto_backend_that_resolves_to_noop_is_not_flagged_as_a_downgrade(project, capsys):
+    """Tier 2: accept-side — when the DECLARED backend is 'auto' (the
+    default; no operator forced anything) and this host has no real
+    backend, the resolution to 'noop' is legitimate auto-selection, not a
+    downgrade from an operator's explicit request — must not print
+    'DOWNGRADED' in that case."""
+    from reyn.security.sandbox.launcher import resolve_backend
+
+    resolved = resolve_backend(None, None)
+    if resolved.name != "noop":
+        pytest.skip("this host resolves 'auto' to a real backend — downgrade-vs-auto distinction not exercised")
+
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+    resolved_line = next(line for line in out.splitlines() if line.strip().startswith("resolved:"))
+    assert "DOWNGRADED" not in resolved_line


### PR DESCRIPTION
**[tui-coder]** — part of #4364 (C-5 slice; the umbrella issue stays open — C-6 and other slices remain).

## What

architect's C-5 spec, motivated by a real confusion architect hit personally: "reviewer can't write" was mistaken for prose in REYN.md, but the real cause was `sandbox.policy` being UNDECLARED — which resolved to `SeatbeltBackend` / `write_paths=[]` (actually restrictive), not "no restriction" the way an undeclared value reads. Declaration and resolution silently disagreed.

## Design (both confirmed in-thread before implementing)

- **declared** = `sandbox.backend` / `sandbox.on_unsupported` / `sandbox.policy`, read straight off config, no merging.
- **effective** = the ACTUALLY RESOLVED backend (`resolve_backend` — the SAME call C-1's hook probe already makes), never a second doctor-invented probe. "Which backend resolved" already carries the enforcement witness: `get_default_backend()` self-tests a real deny before returning a backend (#2983) and applies `on_unsupported` to one that can't enforce.
- doctor never tries a write of its own (same D-2 reason as C-1).
- doctor has **no op context**, so it does NOT build a `resolve_sandbox_policy()` call (that needs a caller-supplied `write_paths` floor doctor cannot know and must not invent a stand-in for). Only the declared `sandbox.policy` dict's own write-scope keys are echoed.
- an explicitly-forced backend that falls back is flagged `DOWNGRADED`, distinct from auto-selection landing on noop (not a downgrade — nothing was forced).
- `on_unsupported=error` makes resolution itself fail-closed; doctor reports `refuses to run` rather than crashing.

## Changes

- `src/reyn/interfaces/cli/commands/doctor.py`: `_print_sandbox_posture` + `_SANDBOX_POLICY_WRITE_SCOPE_KEYS`, wired into `run()` after C-2. `sandbox.backend`/`sandbox.on_unsupported` added to `_MEASURABLE_LEAF_KEYS` (their live effect is now genuinely measured); `sandbox.policy`/`sandbox.mode` are NOT (declaration only).
- `docs/reference/cli/doctor.md`: new "Sandbox posture (C-5)" section, moved out of "Out of scope."

## Test plan

8 new tests: declared+resolved both print; the exact motivating confusion (no `sandbox.policy` ≠ unrestricted); declared write scope echoed verbatim; accept-side (no write-scope keys says so honestly); D-2 falsify (never writes to the project); a forced-unavailable backend downgrades and is flagged; same case with `on_unsupported=error` reports a refusal; accept-side (auto→noop is not flagged as downgrade). The downgrade tests pick whichever of seatbelt/landlock is genuinely unavailable on the CURRENT host (real `.available()` checks) so they're portable across macOS/Linux CI.

`ruff check src tests`, `test_tier_audit.py --strict` (8 tests), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`, `mkdocs build --strict` — all green. Scoped `pytest`: 34 passed across the doctor test family, 792 passed across `tests/interfaces/test_4364_*.py` + `tests/security/`.

No Visual item — CLI text output only, no TUI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
