### PR TITLE
fix(#4624): doctor's windowed disclosure runs empty on a fresh install

### DIFF
--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -79,8 +79,8 @@ External-event producer/consumer pairing (a producer with 0
 subscribing hooks is a real gap; a point with no producer is not
 reported — see 'not checked' below for why some points aren't):
   ✗ file_changed: producer present (1 declared fs_watch path(s)) but 0 subscribing hooks — this point's notifications have nowhere to go
-  ? mcp_resource_updated: not seen in the newest 0 event file(s) scanned — a producer whose last arrival is older than that is not covered here, so this is NOT proof no producer exists
-  ? webhook_received: not seen in the newest 0 event file(s) scanned — a producer whose last arrival is older than that is not covered here, so this is NOT proof no producer exists
+  ? mcp_resource_updated: no event history yet
+  ? webhook_received: no event history yet
 ```
 
 ### `.reyn/events/` — declared vs. actual
@@ -147,6 +147,12 @@ one directly. Producer evidence differs per point:
   catch, so both points ALWAYS print a line — `✓`/`✗` when seen within the window, or
   `? <point>: not seen in the newest N event file(s) scanned — ... NOT proof no producer
   exists` otherwise — never folded into the "no producer → no finding" rule below.
+  **#4624 exception**: when `.reyn/events` has NO dated files at all (a fresh install, or
+  retention already purged everything), N is 0 and "a producer whose last arrival predates
+  the window" cannot be true — there is no window to predate. The #4614 caveat would be a
+  TRUE but EMPTY statement there, and an empty caveat printed on every fresh install trains
+  the reader to skip caveats (architect's finding, #4622 co-vet), so this one case prints
+  the plain fact instead: `? <point>: no event history yet`, no window talk.
   `webhook_received` has no config surface of its own (unlike `file_changed`/`cron_fired`),
   so it can ONLY ever be evidence-based here — there is no complete-read alternative for it.
 

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -526,6 +526,18 @@ def _print_external_point_pairing(config: object, project_root: Path) -> None:
                     f"{scanned} event file(s) scanned) but 0 subscribing "
                     f"hooks — this point's notifications have nowhere to go",
                 )
+            elif scanned == 0:
+                # #4624: scanned == 0 means .reyn/events has NO dated files
+                # at all (a fresh install, or retention already purged
+                # everything) — "a producer whose last arrival predates
+                # the window" cannot be true when there is no window to
+                # predate, so the #4614 caveat below would be a TRUE but
+                # EMPTY statement here. An empty caveat printed on every
+                # fresh install trains the reader to skip caveats, which
+                # is exactly what #4614 introduced the caveat to prevent
+                # (architect's finding, #4622 co-vet). Say the plain fact
+                # instead — no window talk.
+                print(f"  ? {point}: no event history yet")
             else:
                 print(
                     f"  ? {point}: not seen in the newest {scanned} event "

--- a/tests/interfaces/test_4364_pr2b_doctor_external_pairing.py
+++ b/tests/interfaces/test_4364_pr2b_doctor_external_pairing.py
@@ -51,10 +51,15 @@ def test_no_producers_configured_reports_only_the_windowed_points(
     signal — those two checks are COMPLETE config reads, so "no producer"
     can be asserted outright). mcp_resource_updated/webhook_received are
     different (#4614/#4620): both checks are windowed, so both print a
-    "?" disclosure line even with zero event-log evidence — "not seen"
-    there is never proof of "no producer", only "not seen in the
-    window", so silence would hide exactly the state C-2 exists to
-    catch."""
+    "?" disclosure line even with zero event-log evidence.
+
+    #4624: a FRESH install (no `.reyn/events` files at all, scanned==0)
+    is the "no window to predate" case — the #4614 window caveat would
+    be a true but EMPTY statement here, so this prints the plain fact
+    ("no event history yet") instead of the windowed wording. The
+    windowed wording itself is covered separately by
+    ``test_mcp_resource_updated_evidence_outside_the_scan_window_is_disclosed_not_silent``
+    / its webhook_received sibling, where scanned > 0."""
     _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
 
     run(Namespace(project_root=str(tmp_path)))
@@ -63,9 +68,10 @@ def test_no_producers_configured_reports_only_the_windowed_points(
     assert "External-event producer/consumer pairing" in out
     assert "file_changed" not in out
     assert "cron_fired" not in out
-    assert "? mcp_resource_updated: not seen in the newest" in out
-    assert "? webhook_received: not seen in the newest" in out
-    assert "NOT proof no producer exists" in out
+    assert "? mcp_resource_updated: no event history yet" in out
+    assert "? webhook_received: no event history yet" in out
+    assert "not seen in the newest" not in out
+    assert "NOT proof no producer exists" not in out
 
 
 def test_file_changed_producer_with_zero_consumers_is_flagged(


### PR DESCRIPTION
**[e2e-coder]** — closes #4624.

## The bug

architect's finding (#4622 co-vet, relayed by lead-coder): when `.reyn/events` has NO dated files at all (`scanned == 0` — a fresh install, or retention already purged everything), the #4614 windowed caveat ("a producer whose last arrival predates the window ...") is a TRUE but EMPTY statement — there is no window to predate when the window itself is empty. #4622 also doubled the effect: `mcp_resource_updated` and `webhook_received` now BOTH route through the same windowed check, so day-one output showed the empty caveat twice.

An empty caveat printed on every fresh install trains the reader to skip caveats, undermining #4614's whole reason for disclosing the window in the first place.

## Fix

One new branch, `scanned == 0`, printing the plain fact ("no event history yet") instead of the windowed wording. `scanned > 0` keeps the #4614 wording verbatim — that caveat is still load-bearing whenever there IS a real window an old producer could predate.

## Doc-drift (CLAUDE.md hard rule, same PR)

`doctor.md`'s sample output and C-2 prose both described the pre-#4624 always-windowed behavior.

## Tests

- Updated the fresh-install accept-side test to assert the new "no event history yet" line (and the absence of window wording) for both points; the existing evidence-outside-window tests (`scanned > 0`) are untouched, still asserting the #4614 wording.
- Strip-falsified: disabled the new branch, confirmed the updated test goes RED for the right reason (fresh output has neither line), restored, confirmed GREEN.

## Verification

- `ruff check src tests`: clean.
- `scripts/test_tier_audit.py --strict` (1 changed test file, 14 tests): 0 Tier-4 violations.
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined (unchanged).
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `scripts/check_doc_anchors.py`: clean.
- `tests/interfaces -k "doctor or 4364"` (37+1 skip): clean, no regression.

## Test plan

- [x] Strip-falsified the fix — confirmed RED for the right reason → restored → confirmed GREEN.
- [x] Ran all 5 local gates — clean.
- [x] `mkdocs build --strict` + `check_doc_anchors.py` — clean.
- [x] Regression sweep (`doctor`/`4364`) — clean.
- [ ] (Visual) — n/a, CLI text output, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
