### PR TITLE
feat(#4364): doctor C-3(b) — MCP negotiated version/capabilities

### DIFF
--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -197,12 +197,46 @@ NOT build a `resolve_sandbox_policy()` call — that needs a caller-supplied
 must not invent a stand-in for. Only the declared `sandbox.policy` dict's own
 write-scope keys are shown, never a merged/resolved policy.
 
+### MCP servers — last negotiated version/capabilities (C-3(b))
+
+```
+MCP servers — last negotiated version/capabilities (audit-log
+evidence, not a live probe; D-2: doctor never connects):
+  ✓ filesystem: last negotiated '2025-11-25', capabilities=['resources', 'tools']
+  ? brave: no event history yet
+```
+
+The motivating real case (architect's own note, #4364): a protocol-version mismatch
+between reyn (2.0) and a connected server (1.27.1) had already fallen back silently
+to an older shared version — nothing was BROKEN, so nothing raised, and the only way
+to learn it happened was digging through the audit log after the fact. `reyn doctor`
+now surfaces the same fact in one line.
+
+For each MCP server declared under `mcp.servers`, this reuses the SAME windowed
+evidence-based scan C-2's `mcp_resource_updated`/`webhook_received` checks already
+use (`_mcp_initialized_evidence`, sharing `_MCP_EVENT_SCAN_MAX_FILES`) — the newest
+`mcp_initialized` audit-event record per server (emitted once per real (re)connect,
+`mcp/connection_service.py`) carries `negotiated_version` + `capabilities` verbatim.
+`✓` when found within the window; `? <server>: no event history yet` when
+`.reyn/events` has no dated files at all (#4624's fresh-install shape — the #4614
+windowed caveat would be a true but empty statement there); `? <server>: not seen in
+the newest N event file(s) scanned — ... NOT proof the server was never reached`
+otherwise, same #4614 wording as the other windowed checks.
+
+**C-3(a)** (an actual live `tools/list` connect + response check) was ruled
+unnecessary: the evidence this check reports already exists from the connections
+`reyn` itself made — a SEPARATE live reachability probe from doctor's own one-shot
+process would duplicate work, and a held MCP connection is a session concept doctor
+cannot observe directly anyway (the same architect correction C-2's own
+producer↔consumer design rests on). D-2 holds: doctor never connects to a server
+itself, only reads what a real connection already recorded.
+
 ## Out of scope for this PR (later slices, same arc)
 
 - **C-6** (listen port and model-name declared-vs-effective pairs) — each needs
   its own new measurement code (introspecting a live bound socket, a real
-  litellm probe call), unlike C-1/C-2/C-5/C-7, which reuse existing measurement
-  functions.
+  litellm probe call), unlike C-1/C-2/C-3(b)/C-5/C-7, which reuse existing
+  measurement functions.
 
 ## Related
 

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -79,10 +79,22 @@ real dispatch would (:func:`reyn.security.sandbox.policy.
 resolve_sandbox_policy` needs one, and inventing a stand-in would
 contrast against nothing real) — only the declared ``sandbox.policy``
 dict's own write-scope keys are shown, next to the resolved backend
-name. C-6's other named pairs (listen port, model-name acceptance) are a
-later slice — each needs its own NEW measurement code (introspecting a
-live bound socket, a real litellm probe call), not reuse of an existing
-function the way C-1/C-2/C-5/C-7 are.
+name. C-3(b) (MCP negotiated version/capabilities, this slice's own
+addition): for each declared ``mcp.servers`` entry, the newest
+``mcp_initialized`` audit-event's ``negotiated_version``/``capabilities``
+— the SAME windowed evidence-based scan C-2's ``mcp_resource_updated``/
+``webhook_received`` checks already use
+(:func:`_mcp_initialized_evidence`, sharing ``_MCP_EVENT_SCAN_MAX_FILES``
+and #4624's empty-history branch), never a live probe (C-3(a), a real
+``tools/list`` connect, was ruled unnecessary — the evidence already
+exists from connections ``reyn`` itself made, and a held MCP connection
+is a session concept doctor's separate one-shot process cannot observe
+directly anyway, the same architect correction C-2's own
+producer↔consumer design rests on). C-6's other named pairs (listen
+port, model-name acceptance) are a later slice — each needs its own NEW
+measurement code (introspecting a live bound socket, a real litellm
+probe call), not reuse of an existing function the way
+C-1/C-2/C-3(b)/C-5/C-7 are.
 """
 from __future__ import annotations
 
@@ -260,6 +272,12 @@ def run(args: argparse.Namespace) -> None:
     print("does not mean unrestricted; see the resolved backend below):")
     _print_sandbox_posture(config)
 
+    # ── C-3(b): MCP negotiated protocol version + capabilities (#4364) ─────
+    print()
+    print("MCP servers — last negotiated version/capabilities (audit-log")
+    print("evidence, not a live probe; D-2: doctor never connects):")
+    _print_mcp_negotiation(config, resolved_root)
+
 
 def _configured_exec_hooks(config: object) -> "list[HookDef]":
     """Every configured ``exec``/``exec_capture`` ``HookDef`` — the caller
@@ -419,6 +437,53 @@ def _external_event_kind_seen(events_dir: Path, kind: str) -> "tuple[bool, int]"
         except OSError:
             continue
     return False, len(window)
+
+
+def _mcp_initialized_evidence(events_dir: Path) -> "tuple[dict[str, dict], int]":
+    """(per-server evidence, files_scanned) — for each ``server`` named in
+    the newest ``_MCP_EVENT_SCAN_MAX_FILES`` dated ``.jsonl`` files' own
+    ``mcp_initialized`` records, its MOST RECENT ``negotiated_version`` /
+    ``capabilities`` (#4364 C-3(b)). Same windowed-scan shape as
+    :func:`_external_event_kind_seen` — reused rather than re-derived — but
+    per-KEY evidence instead of a single seen/not-seen bool, since C-3(b)
+    is "what did we last negotiate with this server," not "did this point
+    ever fire." Scanning newest-first means the FIRST record seen for a
+    given server is already its most recent — a server already recorded
+    is never overwritten by an older file. ``events_dir`` missing →
+    ``({}, 0)``, matching ``_external_event_kind_seen``'s own contract."""
+    import json
+
+    from reyn.core.events.event_purge import collect_dated_files
+
+    if not events_dir.is_dir():
+        return {}, 0
+    newest_first = list(reversed(collect_dated_files(events_dir)))
+    window = newest_first[:_MCP_EVENT_SCAN_MAX_FILES]
+    evidence: dict[str, dict] = {}
+    for path, _start_date in window:
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if obj.get("type") != "mcp_initialized":
+                        continue
+                    data = obj.get("data") or {}
+                    server = data.get("server")
+                    if not isinstance(server, str) or server in evidence:
+                        continue
+                    evidence[server] = {
+                        "negotiated_version": data.get("negotiated_version"),
+                        "capabilities": data.get("capabilities"),
+                    }
+        except OSError:
+            continue
+    return evidence, len(window)
 
 
 def _merged_hook_registry(config: object, project_root: Path) -> object:
@@ -645,3 +710,46 @@ def _print_sandbox_posture(config: object) -> None:
             f"a backend that cannot enforce is already treated as absent "
             f"at this step, #2983, so this name IS the enforcement witness)",
         )
+
+
+def _print_mcp_negotiation(config: object, project_root: Path) -> None:
+    """#4364 C-3(b): for each declared MCP server, the negotiated protocol
+    version + capabilities from the newest ``mcp_initialized`` audit-event
+    evidence — same windowed evidence-based shape C-2 already uses
+    (:func:`_mcp_initialized_evidence`, reusing #4627's empty-history
+    branch), not a live probe. C-3(a) (an actual `tools/list` connect) was
+    ruled unnecessary — this evidence already exists in the audit log from
+    the connections `reyn` itself already made, so a SEPARATE live
+    reachability check from doctor would duplicate work doctor's own
+    process cannot even perform faster (a held connection is a session
+    concept, #4364 C-2's own architect correction). D-2: report-only,
+    never connects."""
+    mcp_config = getattr(config, "mcp", None) or {}
+    servers = sorted((mcp_config.get("servers") if isinstance(mcp_config, dict) else None) or {})
+    if not servers:
+        print("  no MCP servers declared")
+        return
+
+    events_dir = project_root / ".reyn" / "events"
+    evidence, scanned = _mcp_initialized_evidence(events_dir)
+    for server in servers:
+        seen = evidence.get(server)
+        if seen is not None:
+            version = seen.get("negotiated_version")
+            caps = seen.get("capabilities") or []
+            print(
+                f"  ✓ {server}: last negotiated {version!r}, "
+                f"capabilities={caps}",
+            )
+        elif scanned == 0:
+            # #4627: no window to predate — say the plain fact, not the
+            # windowed caveat (see _external_event_kind_seen's own sibling
+            # branch in _print_external_point_pairing for the same shape).
+            print(f"  ? {server}: no event history yet")
+        else:
+            print(
+                f"  ? {server}: not seen in the newest {scanned} event "
+                f"file(s) scanned — a connection whose last occurrence is "
+                f"older than that is not covered here, so this is NOT "
+                f"proof the server was never reached",
+            )

--- a/tests/interfaces/test_4364_c3b_doctor_mcp_negotiation.py
+++ b/tests/interfaces/test_4364_c3b_doctor_mcp_negotiation.py
@@ -1,0 +1,157 @@
+"""Tier 2: #4364 C-3(b) — ``reyn doctor``'s MCP negotiated
+version/capabilities check.
+
+architect's motivating case: a protocol-version mismatch between reyn and a
+connected server had already fallen back silently to an older shared
+version — nothing raised, and the only way to learn it happened was
+digging through the audit log after the fact. This check surfaces the
+same fact in one line, per declared ``mcp.servers`` entry.
+
+Reuses the SAME windowed evidence-based scan shape C-2's
+``mcp_resource_updated``/``webhook_received`` checks already use
+(``_mcp_initialized_evidence``, sharing ``_MCP_EVENT_SCAN_MAX_FILES`` and
+#4624's empty-history branch) — never a live probe (C-3(a), a real
+``tools/list`` connect, was ruled unnecessary: this evidence already
+exists from connections ``reyn`` itself made).
+
+Real CLI invocation (mirrors ``test_4364_pr2b_doctor_external_pairing.py``'s
+own established capsys-driven shape) against real config files + a real
+``.reyn/events`` tree — no mocks.
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from reyn.interfaces.cli.commands.doctor import run
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_mcp_initialized_event(
+    events_dir: Path, filename: str, *, server: str, version: str, capabilities: list,
+) -> None:
+    import json
+
+    events_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "type": "mcp_initialized",
+        "timestamp": "2026-08-14T00:00:00+00:00",
+        "data": {
+            "server": server, "negotiated_version": version, "capabilities": capabilities,
+        },
+    }
+    (events_dir / filename).write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _mcp_yaml(*servers: str) -> str:
+    body = "mcp:\n  servers:\n"
+    for name in servers:
+        body += f'    {name}:\n      command: npx\n      args: ["-y", "@mcp/{name}"]\n'
+    return body
+
+
+def test_no_servers_declared_prints_the_absence_not_a_finding(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: accept-side — no ``mcp.servers`` declared prints a plain
+    "no MCP servers declared" line, not a per-server "?" finding (nothing
+    to report on)."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "MCP servers — last negotiated version/capabilities" in out
+    assert "no MCP servers declared" in out
+
+
+def test_declared_server_with_evidence_shows_negotiated_version_and_capabilities(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: the core witness — a declared server with a real
+    ``mcp_initialized`` record in ``.reyn/events`` surfaces its
+    ``negotiated_version``/``capabilities`` verbatim."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML + _mcp_yaml("filesystem"))
+    _write_mcp_initialized_event(
+        tmp_path / ".reyn" / "events", "2026-08-14T000000.jsonl",
+        server="filesystem", version="2025-11-25", capabilities=["resources", "tools"],
+    )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "✓ filesystem: last negotiated '2025-11-25'" in out
+    assert "'resources', 'tools'" in out
+
+
+def test_declared_server_with_no_event_history_says_the_plain_fact(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: #4624-shaped fresh-install case — no ``.reyn/events`` files
+    at all (scanned == 0) prints "no event history yet", never the
+    windowed caveat (which would be a true but empty statement with
+    nothing to scan)."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML + _mcp_yaml("filesystem"))
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "? filesystem: no event history yet" in out
+    assert "not seen in the newest" not in out
+
+
+def test_declared_server_evidence_outside_the_scan_window_is_disclosed_not_silent(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: real evidence exists but predates the scan window — must
+    surface the #4614-style '?' disclosure (NOT proof the server was
+    never reached), not silence and not a false '✓'."""
+    from reyn.interfaces.cli.commands import doctor as _doctor_mod
+
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML + _mcp_yaml("filesystem"))
+    events_dir = tmp_path / ".reyn" / "events"
+    _write_mcp_initialized_event(
+        events_dir, "2026-01-01T000000.jsonl",
+        server="filesystem", version="2025-11-25", capabilities=["tools"],
+    )
+    for day in range(1, _doctor_mod._MCP_EVENT_SCAN_MAX_FILES + 1):
+        import json
+        events_dir.mkdir(parents=True, exist_ok=True)
+        (events_dir / f"2026-02-{day:02d}T000000.jsonl").write_text(
+            json.dumps({
+                "type": "session_started", "timestamp": "2026-02-01T00:00:00+00:00", "data": {},
+            }) + "\n",
+            encoding="utf-8",
+        )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "? filesystem: not seen in the newest" in out
+    assert "NOT proof the server was never reached" in out
+    assert "✓ filesystem" not in out
+
+
+def test_a_server_with_evidence_and_one_without_are_reported_independently(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: two declared servers, only one with evidence — each line
+    reflects ONLY its own server's evidence, not a shared verdict."""
+    _write_yaml(
+        tmp_path / "reyn.yaml", MINIMAL_REYN_YAML + _mcp_yaml("filesystem", "brave"),
+    )
+    _write_mcp_initialized_event(
+        tmp_path / ".reyn" / "events", "2026-08-14T000000.jsonl",
+        server="filesystem", version="2025-11-25", capabilities=["tools"],
+    )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "✓ filesystem: last negotiated" in out
+    assert "? brave: not seen in the newest" in out


### PR DESCRIPTION
**[e2e-coder]** — part of #4364 (C-3(b)).

## Why

architect's motivating case: a protocol-version mismatch between reyn and a connected server had already fallen back silently to an older shared version — nothing raised (a fallback isn't a failure), and the only way to learn it happened was digging through the audit log after the fact. `reyn doctor` surfaces the same fact in one line now.

## Change

For each declared `mcp.servers` entry, surfaces the newest `mcp_initialized` audit-event's `negotiated_version` + `capabilities` — reusing the **same windowed evidence-based scan** C-2's `mcp_resource_updated`/`webhook_received` checks already use (`_mcp_initialized_evidence`, sharing `_MCP_EVENT_SCAN_MAX_FILES` and #4624's empty-history branch), generalized from a bool seen/not-seen result to per-server evidence (the newest record per server, since scanning newest-first means the first record seen for a given server is already its most recent).

**C-3(a)** (an actual live `tools/list` connect + response check) was ruled unnecessary this session: the evidence already exists from connections `reyn` itself made, and a held MCP connection is a session concept doctor's separate one-shot process cannot observe directly anyway — the same architect correction C-2's own producer↔consumer design already rests on. D-2 holds throughout: doctor never connects to a server itself, only reads what a real connection already recorded.

## Tests

5 new, mirroring the established C-2 test shapes: no servers declared (accept-side), evidence present (`✓`), fresh-install "no event history yet" (#4624 shape), evidence outside the scan window disclosed not silent (#4614 shape), two servers reported independently (identity, not a shared verdict). Strip-falsified: disabled the print call, confirmed all 5 go RED for the right reason, restored, confirmed GREEN.

## Doc-drift (CLAUDE.md hard rule, same PR)

New C-3(b) section in `doctor.md` (sample output + prose, mirrors C-5's own established shape), module docstring's own scope list updated.

## Verification

- `ruff check src tests`: clean.
- `scripts/test_tier_audit.py --strict` (1 new test file, 5 tests): 0 Tier-4 violations.
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined (unchanged).
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `scripts/check_doc_anchors.py`: clean.
- `tests/interfaces -k "doctor or 4364"` (42+1 skip): clean, no regression.

## Test plan

- [x] Strip-falsified the fix — confirmed all 5 tests genuinely RED → restored → confirmed GREEN.
- [x] Ran all 5 local gates — clean.
- [x] `mkdocs build --strict` + `check_doc_anchors.py` — clean.
- [x] Regression sweep (`doctor`/`4364`) — clean.
- [ ] (Visual) — n/a, CLI text output, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
