### PR TITLE
feat(#4364): doctor C-4 — model/api_base reachability, question replaced (0-token /v1/models)

### DIFF
--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -231,12 +231,52 @@ cannot observe directly anyway (the same architect correction C-2's own
 producer↔consumer design rests on). D-2 holds: doctor never connects to a server
 itself, only reads what a real connection already recorded.
 
+### Model reachability — 0-token `GET {api_base}/v1/models` (C-4)
+
+```
+Model reachability — 0-token GET {api_base}/v1/models (never a
+real completion call; D-2: doctor never spends inference cost):
+  ✓ http://127.0.0.1:8998: reachable (HTTP 200)
+    ✓ light ('gpt-4o'): accepted by the proxy's model list
+    ✗ standard ('gpt-5.6-luna'): NOT in the proxy's model list — check the name form (bare vs 'provider/name')
+```
+
+The motivating real case (architect's own note, #4364): a configured model name
+(`openai/gpt-5.6-luna`) that the LiteLLM proxy expected bare (`gpt-5.6-luna`) — no
+error until the first real chat turn.
+
+**The original ask was replaced, not implemented as first proposed** — a real litellm
+completion probe would make `reyn doctor` itself charge the operator for inference,
+exactly what the cross-cutting cost/budget band exists to keep OS-internal diagnostics
+from doing. The 0-token `GET {api_base}/v1/models` answers the SAME two questions
+(is `api_base` reachable, is the configured model name's form accepted) in one
+request, at zero inference cost — reachability from the HTTP response itself (any
+response, including 401/403, proves reachability; a connection error does not), model
+acceptance from checking each declared `llm.models` entry's BARE name (stripped of the
+`provider/` routing prefix reyn's own config uses) against the response's own model
+list, when the response is a 200 carrying one.
+
+Only `llm.api_base` (a LiteLLM proxy) is checked — a provider with no declared
+`api_base` routes straight to its own hosted endpoint, which this module has no
+per-provider URL table for and was not architect's motivating case (a local proxy).
+`? not checked — no llm.api_base declared` when absent (D-3, same "cannot confirm"
+shape `webhook_received` had before it gained a surface).
+
+**API keys are never read** (litellm-boundary convention, owner's standing
+instruction) — the request carries no `Authorization` header at all; a provider that
+requires one to list models still proves reachability by responding (401/403 is a
+real HTTP response, not a failure this check reports as unreachable).
+
+Uses `reyn._network.build_sync_http_client` (the repo's own single httpx-client
+constructor, #3075) — never a free-hand `httpx.Client(...)`, so this call site is
+covered by the same standard-proxy-env/CA completeness gate every other reyn-owned
+HTTP client is.
+
 ## Out of scope for this PR (later slices, same arc)
 
-- **C-6** (listen port and model-name declared-vs-effective pairs) — each needs
-  its own new measurement code (introspecting a live bound socket, a real
-  litellm probe call), unlike C-1/C-2/C-3(b)/C-5/C-7, which reuse existing
-  measurement functions.
+- **C-6's remaining named pair** (listen port declared-vs-effective) — needs its
+  own new measurement code (introspecting a live bound socket), unlike
+  C-1/C-2/C-3(b)/C-4/C-5/C-7, which reuse existing measurement functions.
 
 ## Related
 

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -90,11 +90,28 @@ and #4624's empty-history branch), never a live probe (C-3(a), a real
 exists from connections ``reyn`` itself made, and a held MCP connection
 is a session concept doctor's separate one-shot process cannot observe
 directly anyway, the same architect correction C-2's own
-producer↔consumer design rests on). C-6's other named pairs (listen
-port, model-name acceptance) are a later slice — each needs its own NEW
-measurement code (introspecting a live bound socket, a real litellm
-probe call), not reuse of an existing function the way
-C-1/C-2/C-3(b)/C-5/C-7 are.
+producer↔consumer design rests on). C-4 (model/api_base reachability,
+this slice's own addition, question REPLACED per this session's
+ruling): the original ask was a real litellm completion call — doctor
+charging the operator for inference is exactly what the cross-cutting
+cost/budget band exists to keep OS-internal diagnostics from doing.
+Replaced with a 0-token ``GET {api_base}/v1/models``
+(:func:`_print_model_reachability`, via
+:func:`reyn._network.build_sync_http_client` — never a free-hand
+``httpx.Client(...)``, so this call site is covered by #3075's
+standard-proxy-env/CA completeness gate) — reachability from the HTTP
+response itself (any response, including 401/403, proves reachability;
+API keys are NEVER read, litellm-boundary convention, no
+``Authorization`` header sent) and, when the response lists models,
+whether each declared ``llm.models`` entry's BARE name (stripped of the
+``provider/`` routing prefix) is in that list — architect's own repro
+was exactly this name-form mismatch. Only ``llm.api_base`` (a LiteLLM
+proxy) is checked; a provider with no declared ``api_base`` has no URL
+this module knows to probe, so it prints "not checked" (D-3) rather
+than guessing a per-provider hosted endpoint. C-6's remaining named pair
+(listen port) is a later slice — it needs its own NEW measurement code
+(introspecting a live bound socket), not reuse of an existing function
+the way C-1/C-2/C-3(b)/C-4/C-5/C-7 are.
 """
 from __future__ import annotations
 
@@ -277,6 +294,12 @@ def run(args: argparse.Namespace) -> None:
     print("MCP servers — last negotiated version/capabilities (audit-log")
     print("evidence, not a live probe; D-2: doctor never connects):")
     _print_mcp_negotiation(config, resolved_root)
+
+    # ── C-4: model/api_base reachability, 0-token (#4364) ──────────────────
+    print()
+    print("Model reachability — 0-token GET {api_base}/v1/models (never a")
+    print("real completion call; D-2: doctor never spends inference cost):")
+    _print_model_reachability(config)
 
 
 def _configured_exec_hooks(config: object) -> "list[HookDef]":
@@ -752,4 +775,87 @@ def _print_mcp_negotiation(config: object, project_root: Path) -> None:
                 f"file(s) scanned — a connection whose last occurrence is "
                 f"older than that is not covered here, so this is NOT "
                 f"proof the server was never reached",
+            )
+
+
+_MODEL_REACHABILITY_TIMEOUT_SECONDS: Final[float] = 3.0
+
+
+def _print_model_reachability(config: object) -> None:
+    """#4364 C-4, question REPLACED per this session's ruling (owner-bound,
+    band-relevant): the original ask was a real litellm completion probe —
+    doctor charging the operator a real inference call is exactly the kind
+    of thing the cross-cutting cost/budget band exists to keep OS-internal
+    diagnostics from doing. Replaced with a 0-token ``GET {api_base}/v1/models``
+    — reachability AND (when the response lists models) whether the
+    declared model name's BARE form is accepted are both answered by the
+    same request, at zero inference cost. API keys are NEVER read here
+    (litellm-boundary convention, owner's standing instruction) — the
+    request carries no Authorization header; a provider that requires one
+    to list models still proves reachability by responding at all (401/403
+    is a real HTTP response, not a connection failure).
+
+    Only ``llm.api_base`` (a LiteLLM proxy) is checked — a provider with no
+    declared ``api_base`` routes straight to its own hosted endpoint, which
+    this module has no per-provider URL table for and is not this check's
+    motivating case (architect's own repro was a local proxy). D-3: prints
+    "cannot confirm" rather than silently omitting the line (same shape as
+    C-2's ``webhook_received`` before it gained a surface, #4618/#4620)."""
+    llm_config = getattr(config, "llm", None)
+    api_base = (getattr(llm_config, "api_base", "") or "").strip()
+    models = getattr(llm_config, "models", None) or {}
+
+    if not api_base:
+        print(
+            "  ? not checked — no llm.api_base declared (a provider-hosted "
+            "endpoint has no URL this check knows to probe)",
+        )
+        return
+
+    from reyn._network import build_sync_http_client
+
+    url = api_base.rstrip("/") + "/v1/models"
+    try:
+        with build_sync_http_client(
+            egress="doctor_model_reachability", timeout=_MODEL_REACHABILITY_TIMEOUT_SECONDS,
+        ) as client:
+            response = client.get(url)
+    except Exception as exc:  # noqa: BLE001 — D-2: report the failure, never raise
+        print(f"  ✗ {api_base}: unreachable ({type(exc).__name__}: {exc})")
+        return
+
+    print(f"  ✓ {api_base}: reachable (HTTP {response.status_code})")
+
+    listed_ids: "set[str] | None" = None
+    if response.status_code == 200:
+        try:
+            body = response.json()
+            data = body.get("data") if isinstance(body, dict) else None
+            if isinstance(data, list):
+                listed_ids = {
+                    str(item["id"]) for item in data
+                    if isinstance(item, dict) and isinstance(item.get("id"), str)
+                }
+        except Exception:  # noqa: BLE001 — malformed body is not a crash
+            listed_ids = None
+
+    if listed_ids is None:
+        print(
+            f"    model name form not checked — HTTP {response.status_code} "
+            f"response did not carry a model list",
+        )
+        return
+
+    for model_class in sorted(models):
+        raw_name = models[model_class]
+        model_name = raw_name if isinstance(raw_name, str) else raw_name.get("model") if isinstance(raw_name, dict) else None
+        if not isinstance(model_name, str):
+            continue
+        bare_name = model_name.split("/", 1)[1] if "/" in model_name else model_name
+        if bare_name in listed_ids:
+            print(f"    ✓ {model_class} ({bare_name!r}): accepted by the proxy's model list")
+        else:
+            print(
+                f"    ✗ {model_class} ({bare_name!r}): NOT in the proxy's model "
+                f"list — check the name form (bare vs 'provider/name')",
             )

--- a/tests/interfaces/test_4364_c4_doctor_model_reachability.py
+++ b/tests/interfaces/test_4364_c4_doctor_model_reachability.py
@@ -1,0 +1,172 @@
+"""Tier 2: #4364 C-4 — ``reyn doctor``'s model/api_base reachability check.
+
+architect's motivating case: a configured model name (``openai/gpt-5.6-luna``)
+that the LiteLLM proxy expected bare (``gpt-5.6-luna``) — no error until the
+first real chat turn.
+
+**Question REPLACED per this session's ruling**, not implemented as first
+proposed: a real litellm completion probe would make ``reyn doctor`` itself
+charge the operator for inference — exactly what the cross-cutting
+cost/budget band exists to keep OS-internal diagnostics from doing. Replaced
+with a 0-token ``GET {api_base}/v1/models`` — reachability from the HTTP
+response itself (any response, including 401/403, proves reachability), and
+(when the response lists models) whether each declared model name's BARE
+form is accepted.
+
+Real HTTP server (stdlib ``http.server`` on a real loopback socket, a real
+collaborator — no mocks) — the exact request `_print_model_reachability`
+makes is driven end-to-end, including the "no Authorization header sent"
+claim (asserted by the handler itself).
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import threading
+
+from reyn.interfaces.cli.commands.doctor import _print_model_reachability
+
+
+class _ModelsHandler(http.server.BaseHTTPRequestHandler):
+    """Serves a fixed ``/v1/models`` listing and records every request it
+    received (path + headers) so tests can assert on what was actually
+    sent — including that no ``Authorization`` header ever arrives."""
+
+    model_ids: "list[str]" = []
+    received_requests: "list[dict]" = []
+
+    def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler's own name
+        type(self).received_requests.append(
+            {"path": self.path, "headers": dict(self.headers)},
+        )
+        if self.path == "/v1/models":
+            body = json.dumps({"data": [{"id": m} for m in type(self).model_ids]}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *_args: object) -> None:  # silence stdlib access log
+        pass
+
+
+def _run_server(model_ids: "list[str]") -> "tuple[http.server.HTTPServer, str]":
+    handler = type("_Handler", (_ModelsHandler,), {"model_ids": model_ids, "received_requests": []})
+    server = http.server.HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    return server, f"http://127.0.0.1:{port}"
+
+
+class _LLM:
+    def __init__(self, *, api_base: str, models: dict) -> None:
+        self.api_base = api_base
+        self.models = models
+
+
+class _Config:
+    def __init__(self, llm: _LLM) -> None:
+        self.llm = llm
+
+
+def test_no_api_base_declared_prints_not_checked(capsys) -> None:
+    """Tier 2: accept-side — no ``llm.api_base`` declared prints the D-3
+    "not checked" line, never attempts a request."""
+    config = _Config(_LLM(api_base="", models={"standard": "openai/gpt-4o"}))
+
+    _print_model_reachability(config)
+    out = capsys.readouterr().out
+
+    assert "? not checked — no llm.api_base declared" in out
+
+
+def test_reachable_proxy_with_accepted_model_name_reports_both_ok(capsys) -> None:
+    """Tier 2: the core witness — a real reachable proxy whose model list
+    contains the declared model's BARE name reports both reachability and
+    acceptance as ✓."""
+    server, base_url = _run_server(["gpt-4o"])
+    try:
+        config = _Config(_LLM(api_base=base_url, models={"light": "openai/gpt-4o"}))
+
+        _print_model_reachability(config)
+        out = capsys.readouterr().out
+
+        assert f"✓ {base_url}: reachable (HTTP 200)" in out
+        assert "✓ light ('gpt-4o'): accepted" in out
+    finally:
+        server.shutdown()
+
+
+def test_model_name_mismatch_is_flagged_bare_vs_prefixed(capsys) -> None:
+    """Tier 2: architect's own repro shape — a declared model name whose
+    BARE form is NOT in the proxy's list is flagged, naming the bare-vs-
+    prefixed hint, not silently treated as accepted."""
+    server, base_url = _run_server(["gpt-4o"])  # does NOT include gpt-5.6-luna
+    try:
+        config = _Config(_LLM(api_base=base_url, models={"standard": "openai/gpt-5.6-luna"}))
+
+        _print_model_reachability(config)
+        out = capsys.readouterr().out
+
+        assert f"✓ {base_url}: reachable" in out
+        assert "✗ standard ('gpt-5.6-luna'): NOT in the proxy's model list" in out
+        assert "bare vs 'provider/name'" in out
+    finally:
+        server.shutdown()
+
+
+def test_unreachable_api_base_reports_failure_not_a_crash(capsys) -> None:
+    """Tier 2: a real connection failure (nothing listening) is reported
+    as ✗ unreachable, not an unhandled exception (D-2: doctor never
+    crashes on an unreachable endpoint)."""
+    # Port 1 is a real, universally-unassignable low port — a real
+    # connection attempt that always refuses on a loopback host.
+    config = _Config(_LLM(api_base="http://127.0.0.1:1", models={"standard": "openai/gpt-4o"}))
+
+    _print_model_reachability(config)
+    out = capsys.readouterr().out
+
+    assert "✗ http://127.0.0.1:1: unreachable" in out
+
+
+def test_no_authorization_header_is_ever_sent(capsys) -> None:
+    """Tier 2: owner's standing instruction (litellm-boundary convention)
+    — the request never carries an Authorization header, asserted against
+    what the REAL server actually received, not what the client claims to
+    send."""
+    server, base_url = _run_server(["gpt-4o"])
+    handler_cls = server.RequestHandlerClass
+    try:
+        config = _Config(_LLM(api_base=base_url, models={}))
+
+        _print_model_reachability(config)
+        capsys.readouterr()
+
+        assert handler_cls.received_requests, "expected the server to receive a request"
+        for req in handler_cls.received_requests:
+            assert "authorization" not in {k.lower() for k in req["headers"]}
+    finally:
+        server.shutdown()
+
+
+def test_non_model_list_response_reports_reachable_but_names_not_checked(capsys) -> None:
+    """Tier 2: a 200 response with no model list still reports reachable
+    (that much is proven) but discloses the name-form check couldn't
+    run, rather than silently skipping it or claiming acceptance."""
+    server, base_url = _run_server([])  # empty data: [] — a real, valid 200
+    try:
+        config = _Config(_LLM(api_base=base_url, models={"standard": "openai/gpt-4o"}))
+
+        _print_model_reachability(config)
+        out = capsys.readouterr().out
+
+        assert f"✓ {base_url}: reachable (HTTP 200)" in out
+        # Empty list IS a model list (just empty) -> the declared model is
+        # correctly reported as not-in-list, not "not checked".
+        assert "✗ standard ('gpt-4o'): NOT in the proxy's model list" in out
+    finally:
+        server.shutdown()


### PR DESCRIPTION
**[e2e-coder]** — part of #4364 (C-4).

## Why

architect's motivating case: a configured model name (`openai/gpt-5.6-luna`) that the LiteLLM proxy expected bare (`gpt-5.6-luna`) — no error until the first real chat turn.

## The question was replaced, not implemented as first proposed

The original ask was a real litellm completion probe — `reyn doctor` charging the operator for inference is exactly what the cross-cutting **cost/budget band** exists to keep OS-internal diagnostics from doing. Replaced with a 0-token `GET {api_base}/v1/models`, ruled this session:

- **Reachability** from the HTTP response itself — any response (including 401/403) proves reachability; a connection error does not.
- **Model-name acceptance** — when the response lists models, each declared `llm.models` entry's BARE name (stripped of the `provider/` routing prefix reyn's own config uses) is checked against that list.
- Only `llm.api_base` (a LiteLLM proxy) is checked — a provider with no declared `api_base` has no URL this module knows to probe; prints `? not checked` (D-3) rather than guessing a per-provider hosted endpoint.
- **API keys are never read** (litellm-boundary convention, owner's standing instruction) — the request carries no `Authorization` header at all.

## Implementation notes

Uses `reyn._network.build_sync_http_client` (the repo's own single httpx-client constructor, #3075) — never a free-hand `httpx.Client(...)`, so this call site is covered by the standard-proxy-env/CA completeness gate.

## Tests

6 new, real `http.server` on a real loopback socket (no mocks): no `api_base` declared, reachable+accepted, name-form mismatch (architect's own repro shape), unreachable connection failure, no `Authorization` header ever sent (asserted against what the server actually received, not what the client claims to send), a 200 response with an empty model list still correctly flags a mismatch (not silently "not checked").

Strip-falsified twice:
1. The bare-name comparison forced always-true → confirmed the 2 dependent tests go RED.
2. An `Authorization` header force-added → confirmed that test goes RED.

Both restored, confirmed GREEN.

## Doc-drift (CLAUDE.md hard rule, same PR)

New C-4 section in `doctor.md` (sample output + prose), module docstring's own scope list updated, and the stale "C-6: listen port and model-name" framing corrected — model-name acceptance is C-4, not C-6.

## Verification

- `ruff check src tests`: clean.
- `scripts/test_tier_audit.py --strict` (1 new test file, 6 tests): 0 Tier-4 violations.
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined (unchanged).
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `scripts/check_doc_anchors.py`: clean.
- `tests/interfaces -k "doctor or 4364"` + `tests/security/test_network_egress_env_completeness_3075.py`: 48 passed, 1 skipped, clean.

## Test plan

- [x] Strip-falsified the fix twice — confirmed the right tests genuinely RED each time → restored → confirmed GREEN.
- [x] Ran all 5 local gates — clean.
- [x] `mkdocs build --strict` + `check_doc_anchors.py` — clean.
- [x] Regression sweep (`doctor`/`4364`/network-egress-completeness) — clean.
- [ ] (Visual) — n/a, CLI text output, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
