### PR TITLE
docs: CLAUDE.md told authors to run a narrower ruff than CI does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ available action.
 This repo is touched by multiple Claude sessions (lead-coder, e2e-coder,
 per-PR coders) authenticating as the same `gh` user.
 
-**Before you open a PR, run `ruff check src tests`, `python
+**Before you open a PR, run `ruff check .`, `python
 scripts/test_tier_audit.py --strict <changed test files>`, `python
 scripts/verify_module_docstrings.py <changed src files>`, `python
 scripts/mypy_ratchet.py`, `python
@@ -259,7 +259,9 @@ This is testing.md's own canonical policy, not a CLAUDE.md-specific rule —
 read `docs/deep-dives/contributing/testing.md` § "Before you push" for the
 full reasoning (why the full run was dropped, not just discouraged; what
 running it locally actually costs vs. CI; the #3750 count history) before
-changing this paragraph, in either doc. A green scoped `pytest` alone is
+changing this paragraph, in either doc. This line said `ruff check src tests` until #4630 measured the gap: CI runs `ruff check .` (`test.yml:162`), so the documented command silently skipped `scripts/` and every other top-level directory — a PR author who followed it exactly still went red, and 17 genuinely-dead imports outside `src/` had been invisible to the whole checklist. Run the same command CI runs; a narrower local gate is a green that does not mean what it says.
+
+A green scoped `pytest` alone is
 **not** a green CI run (`pytest-green ≠ CI-green`): ruff `I001` import-sort
 and a Tier-4 format pin (`len(...) == N`) both fail CI while `pytest`
 passes.


### PR DESCRIPTION
**[lead-coder]** — 🔴 **★CLAUDE.md が ★CI より 狭い ruff を 指示していました。★実測は ★#4630（tui-coder）。**

```
★CLAUDE.md:245 ──「Before you open a PR, run ★`ruff check src tests`」
★.github/workflows/test.yml:162 ── ★`ruff check ★.`
∴ ★`scripts/` ／ ★repo root ／ ★他の top-level は
   ★★指示された ローカル gate の 外、★しかし ★merge gate の 内
```

## ✅ ★実測（★#4630）

```
★手順どおり 走らせた 著者が ★CI で 赤
★CI と 同じ コマンドに 広げたら ── ★`src/` の 外に ★17 件の 死んだ import
   ── ★チェックリスト 全体が ★一度も 見ていなかった 範囲 です
⚪ ★著者の 第一感は「ruff が 誤判定」── ★★CI の コマンドを 走らせたら ★ruff が 正しかった
```

## ⚪ ★同じ 段落が ★既に 警告している 形 です

```
★同 段落の 2 文 後 ──「A green scoped `pytest` alone is ★not a green CI run
   (`★pytest-green ≠ CI-green`)」
🔴 ★その 警告の 隣で、★同じ 段落が 指示する コマンド 自体が ★狭かった
```

## Test plan

- [x] ★`CLAUDE.md:245` の コマンドを ★`ruff check .` に
- [x] ★理由（★#4630 の 実測）を ★同じ 段落に 1 段落
- [x] ★`.venv/bin/ruff check .` ── ★手元で 実行し 差分なしを 確認
- [ ] Full CI run (not run locally, per policy)

⚪ **★`tests/` を 触っていません ∴ ★TESTS-READ 不要。**
⚪ **★自作 PR ですが ★co-vet は 求めません** ── ★変更は ★CI の 現物（`test.yml:162`）に
★合わせる だけ で、★新しい 主張を していません。
