### PR TITLE
fix(#4631): reyn config validate — detect mcp.<name> written where mcp.servers.<name> belongs

### DIFF
--- a/docs/reference/cli/config.md
+++ b/docs/reference/cli/config.md
@@ -45,10 +45,11 @@ reyn config migrate-mcp [--dry-run]
 `reyn config set` always writes to `reyn.local.yaml` (gitignored) — never to `reyn.yaml`.
 
 `reyn config validate` always exits `0`, even when it reports findings — it REPORTS, it
-never gates (owner ruling: warn, never hard-fail, anywhere). It checks four things,
+never gates (owner ruling: warn, never hard-fail, anywhere). It checks five things,
 each printed as its own labeled section (never merged into one list — the fix differs
-per section, and merging would lose "which one do I fix, and how"). Note the last
-check (hook entries) covers three separate config *files* under one section, not one:
+per section, and merging would lose "which one do I fix, and how"). Note the last two
+checks (hook entries, MCP server placement) each cover multiple separate config
+*files* under one section, not one:
 
 - **Unrecognized/renamed/removed keys, policy tier** (`reyn.yaml` / `reyn.local.yaml` /
   `~/.reyn/config.yaml`) — the same check `load_config`'s own startup warning runs.
@@ -82,6 +83,20 @@ check (hook entries) covers three separate config *files* under one section, not
     - **every `.reyn/agents/<name>/hooks.yaml`** — the per-agent layer, one
       finding per agent directory that has a malformed entry.
   Fix: edit the offending hook entry in whichever labeled file the finding names.
+- **MCP server placement** (#4631) — the same class of gap as hook entries above,
+  for a different config surface: `unknown_config_keys` confirms `mcp:` itself is a
+  recognized key but never opens what's under it, so a server entry written
+  directly at `mcp.<name>` (instead of `mcp.servers.<name>`) loads WITHOUT error
+  and WITHOUT warning — `cfg.mcp.servers` silently stays empty and the server is
+  never registered. Detected by shape (a dict directly under `mcp:`, other than
+  the real `servers` key, carrying `command`/`url`/`type` — a scalar config knob
+  like `mcp.timeout_seconds` never takes that shape), checked PER SOURCE FILE
+  (not the merged view the other checks above use) so the finding can name which
+  file to fix: the same 3 static locations `migrate-mcp` already scans
+  (`reyn.yaml` / `reyn.local.yaml` / `~/.reyn/config.yaml`) plus the dynamic
+  `.reyn/config/mcp.yaml`. Fix: add the missing `servers:` key by hand —
+  `migrate-mcp` relocates already-correctly-nested `mcp.servers` entries between
+  files, but does not add a missing `servers:` key to a misplaced entry.
 
 `reyn config migrate` only rewrites an entry whose registered rename has an automatic
 destination (a plain rename, no value transform); a rename that also transforms the

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -271,6 +271,34 @@ def _migrate_mcp(*, dry_run: bool = False) -> None:
         print(f"Removed mcp.servers from {src_label}")
 
 
+# #4631: a shape-based detector — `mcp.<name>` written where
+# `mcp.servers.<name>` belongs is invisible to `unknown_config_keys`
+# (which walks the TOP-LEVEL `ReynConfig` schema only; `mcp` itself IS a
+# recognized key, so nothing under it is ever inspected, same class of
+# gap #4501 closed for hooks[] entries). architect's own discriminator:
+# a dict directly under `mcp:` (other than the real `servers` key)
+# carrying `command`/`url`/`type` is shaped like a server entry, not a
+# scalar config knob (`mcp.timeout_seconds` etc. never take that shape).
+_MCP_SERVER_ENTRY_SHAPE_KEYS: "tuple[str, ...]" = ("command", "url", "type")
+
+
+def _mcp_misplaced_server_entries(mcp_section: object) -> "list[str]":
+    """Every key directly under a raw ``mcp:`` dict (other than the real
+    ``servers`` key) whose value is SHAPED like a server entry — the
+    #4631 defect: written at ``mcp.<name>`` instead of
+    ``mcp.servers.<name>``, loaded without error and without warning
+    (``cfg.mcp.servers`` silently stays empty)."""
+    if not isinstance(mcp_section, dict):
+        return []
+    found = []
+    for key, value in mcp_section.items():
+        if key == "servers" or not isinstance(value, dict):
+            continue
+        if any(shape_key in value for shape_key in _MCP_SERVER_ENTRY_SHAPE_KEYS):
+            found.append(key)
+    return found
+
+
 def _validate() -> None:
     """#4174 T0: report every unknown/renamed config key found in the
     operator-editable POLICY TIER (reyn.yaml / reyn.local.yaml /
@@ -341,6 +369,7 @@ def _validate() -> None:
     from reyn.config.config_schema import disabled_config_keys, unknown_config_keys
     from reyn.config.loader import (
         _find_project_root,
+        _load_yaml,
         build_policy_tier_config,
         load_hot_reload_config,
         load_per_agent_hooks,
@@ -405,7 +434,37 @@ def _validate() -> None:
             except HookConfigError as exc:
                 hook_entry_errors[f".reyn/agents/{agent_dir.name}/hooks.yaml"] = str(exc)
 
-    if not policy_unknown and not disabled and not in_set_unknown and not hook_entry_errors:
+    # #4631: mcp.<name> written where mcp.servers.<name> belongs loads
+    # without error AND without a warning (unknown_config_keys never opens
+    # `mcp:`'s own contents, same class of gap #4501 closed for hooks[]).
+    # Checked PER SOURCE FILE, not the already-merged policy_merged/
+    # in_set_merged dicts above — "which key is unknown" only needs the
+    # merged view (#4174 T0's own question), but "which FILE is wrong"
+    # needs the file identified, the same reasoning C-2's producer/consumer
+    # check (merged is enough) and this check (source must be named) split
+    # on, #4364. The 3 static paths + the 1 dynamic path mirror
+    # `_migrate_mcp`'s own already-established scan list (this module,
+    # above) exactly — not a new, narrower list.
+    mcp_misplaced: dict[str, "list[str]"] = {}
+    static_mcp_sources = {
+        "~/.reyn/config.yaml": Path.home() / ".reyn" / "config.yaml",
+        "reyn.yaml": project_root / "reyn.yaml",
+        "reyn.local.yaml": project_root / "reyn.local.yaml",
+    }
+    for label, path in static_mcp_sources.items():
+        raw = _load_yaml(path)
+        found = _mcp_misplaced_server_entries(raw.get("mcp"))
+        if found:
+            mcp_misplaced[label] = found
+    dynamic_mcp_raw = _load_yaml(project_root / ".reyn" / "config" / "mcp.yaml")
+    dynamic_found = _mcp_misplaced_server_entries(dynamic_mcp_raw.get("mcp"))
+    if dynamic_found:
+        mcp_misplaced[".reyn/config/mcp.yaml"] = dynamic_found
+
+    if (
+        not policy_unknown and not disabled and not in_set_unknown
+        and not hook_entry_errors and not mcp_misplaced
+    ):
         print("No unknown, renamed, or disabled-by-dependency config keys found.")
         return
 
@@ -469,6 +528,28 @@ def _validate() -> None:
         print(
             "\nEach flagged entry will fail to load the next time hooks are "
             "(re)loaded (hot-reload or restart) — fix the key(s) above."
+        )
+
+    if mcp_misplaced:
+        if policy_unknown or disabled or in_set_unknown or hook_entry_errors:
+            print()
+        print(
+            f"MCP server placement — checked ~/.reyn/config.yaml, reyn.yaml, "
+            f"reyn.local.yaml, and .reyn/config/mcp.yaml — "
+            f"{len(mcp_misplaced)} source(s) with a misplaced server entry:\n"
+        )
+        for label, names in sorted(mcp_misplaced.items()):
+            for name in names:
+                print(f"  [{label}] mcp.{name}")
+        print(
+            "\nEach name above is shaped like an MCP server entry "
+            "(command/url/type) but is nested directly under mcp:, not "
+            "mcp.servers: — it loads without error, but 'servers' stays "
+            "empty and the server is never registered. Fix it by hand: "
+            "add the missing 'servers:' key so the entry reads "
+            "'mcp.servers.<name>' ('reyn config migrate-mcp' relocates "
+            "already-correctly-nested mcp.servers entries between files, "
+            "but does not add a missing 'servers:' key)."
         )
 
 

--- a/tests/interfaces/test_4631_config_validate_mcp_placement.py
+++ b/tests/interfaces/test_4631_config_validate_mcp_placement.py
@@ -1,0 +1,186 @@
+"""Tier 2: #4631 — ``reyn config validate``'s MCP server-placement check.
+
+``unknown_config_keys`` walks the TOP-LEVEL ``ReynConfig`` schema only —
+``mcp:`` is a recognized key, so nothing under it is ever inspected. A
+server entry written directly at ``mcp.<name>`` (instead of
+``mcp.servers.<name>``) loads WITHOUT error and WITHOUT warning:
+``cfg.mcp.servers`` silently stays empty and the server is never
+registered — the same "written, loaded, but the runtime value never
+matches" class #4501 (hooks[] entries) closed for a different config
+surface.
+
+Checked PER SOURCE FILE (not the already-merged policy_merged/
+in_set_merged dicts ``_validate`` also reads) — this check answers "which
+FILE is wrong," a different question from #4174 T0's "which key is
+unknown" (merged is enough for that one). The 3 static paths + the 1
+dynamic path mirror ``_migrate_mcp``'s own already-established scan list
+exactly (this module).
+
+Real CLI invocation against real config files (mirrors
+``test_config_validate_migrate_command_4174.py``'s own established
+project fixture) — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    monkeypatch.setattr(
+        "reyn.config._find_project_root", lambda _cwd: tmp_path,
+    )
+    monkeypatch.setattr(
+        "reyn.config.loader._find_project_root", lambda _cwd: tmp_path,
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_a_well_placed_mcp_server_produces_no_finding(project, capsys):
+    """Tier 2: accept-side — a real ``mcp.servers.<name>`` entry (the
+    correct shape) must NOT be flagged as misplaced."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "mcp:\n  servers:\n    myserver:\n"
+            "      command: python\n      args: [\"x\"]\n"
+        ),
+    )
+    _validate()
+    out = capsys.readouterr().out
+    assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
+
+
+def test_a_scalar_mcp_config_key_is_not_flagged(project, capsys):
+    """Tier 2: accept-side — the shape discriminator is 'is the value
+    shaped like a server entry (command/url/type)', not 'is it a
+    non-servers key under mcp:' — a real scalar mcp.* config key must
+    not false-positive."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + "mcp:\n  timeout_seconds: 30\n",
+    )
+    _validate()
+    out = capsys.readouterr().out
+    assert "MCP server placement" not in out
+
+
+def test_a_server_entry_written_directly_under_mcp_in_reyn_yaml_is_flagged(
+    project, capsys,
+):
+    """Tier 2: the core witness (#4631's own repro) — ``mcp.<name>``
+    written where ``mcp.servers.<name>`` belongs is caught and the file
+    is named."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "mcp:\n  myserver:\n    command: python\n    args: [\"x\"]\n"
+        ),
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "MCP server placement" in out
+    assert "[reyn.yaml] mcp.myserver" in out
+    assert "never registered" in out
+
+
+def test_a_server_entry_in_dot_reyn_config_mcp_yaml_is_flagged_with_its_own_file_name(
+    project, capsys,
+):
+    """Tier 2: the SAME misplacement in the dynamic file (architect's
+    own measured extension) — the shape is identical
+    ({"mcp": {"servers": ...}}, same as reyn.yaml's own section per
+    loader.py:678-682's own comment), so the same detector catches it,
+    naming THIS file, not reyn.yaml."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "config" / "mcp.yaml",
+        "mcp:\n  myserver:\n    command: python\n    args: [\"x\"]\n",
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "MCP server placement" in out
+    assert "[.reyn/config/mcp.yaml] mcp.myserver" in out
+    assert "[reyn.yaml]" not in out.split("MCP server placement")[1].split("\n\n")[0]
+
+
+def test_a_server_entry_in_reyn_local_yaml_is_flagged_with_its_own_file_name(
+    project, capsys,
+):
+    """Tier 2: reyn.local.yaml — the second of the 2 project-level static
+    sources — is checked independently of reyn.yaml."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / "reyn.local.yaml",
+        "mcp:\n  myserver:\n    command: python\n    args: [\"x\"]\n",
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "[reyn.local.yaml] mcp.myserver" in out
+
+
+def test_a_server_entry_in_user_global_config_is_flagged_with_its_own_file_name(
+    project, capsys,
+):
+    """Tier 2: ~/.reyn/config.yaml (user_global) — the third static
+    source ``_migrate_mcp`` already scans (this module's own
+    ``legacy_paths``) — is checked too, not silently narrowed to just
+    the 2 project-level files."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    fake_home = Path.home()
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        fake_home / ".reyn" / "config.yaml",
+        "mcp:\n  myserver:\n    command: python\n    args: [\"x\"]\n",
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "[~/.reyn/config.yaml] mcp.myserver" in out
+
+
+def test_two_misplaced_servers_in_the_same_file_are_both_named(project, capsys):
+    """Tier 2: multiple misplaced entries in one file are each named
+    individually, not collapsed into a count."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "mcp:\n"
+            "  serverA:\n    command: python\n    args: [\"a\"]\n"
+            "  serverB:\n    url: \"http://localhost:9000\"\n"
+        ),
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "[reyn.yaml] mcp.serverA" in out
+    assert "[reyn.yaml] mcp.serverB" in out


### PR DESCRIPTION
**[e2e-coder]** — closes #4631.

## The bug

architect's finding, lead-coder's own repro: a server entry written directly at `mcp.<name>` instead of `mcp.servers.<name>` loads WITHOUT error and WITHOUT warning — `unknown_config_keys` walks the TOP-LEVEL `ReynConfig` schema only (`mcp` itself is a recognized key), so nothing under it is ever inspected. `cfg.mcp.servers` silently stays empty and the server is never registered — the 5th "written it, but it does nothing" class this session hit (#4580/#4590/#4156/#4494/this).

Same defect, same shape, in **both** the static side (`reyn.yaml` / `reyn.local.yaml` / `~/.reyn/config.yaml`) and the dynamic side (`.reyn/config/mcp.yaml` — its own top-level shape is `{"mcp": {"servers": {...}}}`, identical to `reyn.yaml`'s own section, `loader.py:678-682`'s own comment) — one detector catches both, per architect's own measurement.

## Fix

Detector is shape-based: a dict directly under `mcp:` (other than the real `servers` key) carrying `command`/`url`/`type` is shaped like a server entry; a scalar config knob (`mcp.timeout_seconds` etc.) never takes that shape.

Checked **per source file**, not the already-merged `policy_merged`/`in_set_merged` dicts `_validate` also reads — this answers "which FILE is wrong", a different question from #4174 T0's "which key is unknown" (merged is enough for that one; C-2's own producer/consumer split on this exact same reasoning, #4364). The 3 static paths + the 1 dynamic path mirror `_migrate_mcp`'s own already-established scan list exactly (this module) — not a narrower, newly-invented list. **Note**: lead-coder's own prescription named only 2 static files (`reyn.yaml`/`reyn.local.yaml`); I widened to the 3 `_migrate_mcp` already scans (adding `~/.reyn/config.yaml`) for consistency with the existing established convention in this same file, not a new one.

Message names the misplaced key, states the runtime consequence ("never registered"), and does **not** claim `reyn config migrate-mcp` fixes it automatically — verified directly that `migrate-mcp` only reads already-correctly-nested `mcp.servers` entries, never adds a missing `servers:` key, so the fix is manual.

## Tests

7 new: 2 accept-side (well-placed entry, a real scalar `mcp.*` key), the core witness in `reyn.yaml`, the SAME defect in `.reyn/config/mcp.yaml` (own file named, `reyn.yaml` not falsely implicated), `reyn.local.yaml`, `~/.reyn/config.yaml`, and 2 misplaced entries in one file both named individually.

Strip-falsified: gutted the detector to always return `[]`, confirmed the 5 detection tests go RED while the 2 accept-side tests stay green (proving the accept-side tests aren't just tautologically green), restored, confirmed GREEN.

## Doc-drift (CLAUDE.md hard rule, same PR)

`config.md`'s "It checks four things" updated to five, new MCP server placement bullet added.

## Verification

- `ruff check src tests`: clean.
- `scripts/test_tier_audit.py --strict` (1 new test file, 7 tests): 0 Tier-4 violations.
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined (unchanged).
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `scripts/check_doc_anchors.py`: clean.
- `tests/config tests/interfaces -k "config or mcp"`: 361 passed, clean, no regression.

## Test plan

- [x] Strip-falsified the fix — confirmed 5/7 tests genuinely RED, 2/7 correctly stayed green → restored → confirmed all GREEN.
- [x] Ran all 5 local gates — clean.
- [x] `mkdocs build --strict` + `check_doc_anchors.py` — clean.
- [x] Regression sweep (`config`/`mcp`, 361 tests) — clean.
- [ ] (Visual) — n/a, CLI text output, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
