### PR TITLE
docs: testing.md still prescribed the narrower ruff CLAUDE.md just stopped prescribing

### DIFF
--- a/docs/deep-dives/contributing/testing.ja.md
+++ b/docs/deep-dives/contributing/testing.ja.md
@@ -467,8 +467,14 @@ REYN_LLM_RECORD=1 python -m pytest tests/ -v
    ```
 2. **ruff** — lint + import-sort（`I001`）:
    ```bash
-   ruff check src tests        # autofix 可能な I001 / format は --fix
+   ruff check .                # autofix 可能な I001 / format は --fix
    ```
+   末尾の `.` は略記ではなく意味を持ちます: CI は `ruff check .`（`test.yml:162`）
+   を走らせるため、これより狭いローカル実行は `scripts/` やリポジトリ直下を
+   ローカルの検査対象から外したまま、merge の可否だけは握らせることになります。
+   この行は #4630 が差を測るまで `ruff check src tests` でした — 手順どおりに
+   走らせた著者が CI で赤になり、範囲を広げたところ `src/` の外に本当に死んでいる
+   import が 17 件見つかりました。
 3. **test-tier audit** — 新規・変更したテストファイルごとに
    `scripts/test_tier_audit.py --strict`（後述の Tier コンプライアンス監査ツールと
    同じ linter）。Tier-4 の format-pin（`len(...) == N`、exact whitespace、行数）は

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -1155,8 +1155,15 @@ silently start running the full suite locally again without updating it.
    replace asking it.
 2. **ruff** — lint + import-sort (`I001`):
    ```bash
-   ruff check src tests        # add --fix for autofixable I001 / formatting
+   ruff check .                # add --fix for autofixable I001 / formatting
    ```
+   The bare `.` is load-bearing, not shorthand: CI runs `ruff check .`
+   (`test.yml:162`), so a narrower local run leaves `scripts/`, the repo root
+   and every other top-level directory ungated locally while they still gate
+   the merge. This line read `ruff check src tests` until #4630 measured the
+   gap — an author who followed it exactly still went red, and widening it
+   surfaced 17 genuinely-dead imports outside `src/` that this checklist had
+   never once looked at.
 3. **test-tier audit** — `scripts/test_tier_audit.py --strict` on each new or
    modified test file (the linter described under
    [Tier compliance auditor](#tier-compliance-auditor)). A Tier-4 format pin


### PR DESCRIPTION
**[lead-coder]** — 🔴 **★#4632 が ★片面 だけ 直していました。★私の 取りこぼし です。**

```
★#4632 ── ★CLAUDE.md:245 を ★`ruff check .` に
🔴 ★残っていた ── ★`docs/deep-dives/contributing/testing.md:1158`
   ── ★`ruff check src tests` の まま
🔴 ★しかも ★こちらが ★★normative です ── ★CLAUDE.md の testing-policy 節が ★ここを 指しています
∴ ★2 面が ★食い違い、★権威の ある 側が ★古い 方 でした
```

## ⚪ ★見つけ方と、★遅かった 点

```
✅ ★#4632 を merge した 後に ★同じ コマンドで grep しました
🔴 ★★merge 前に 問うべき でした ──「★この 記述は ★他の どこに 在るか」
⚪ ★今夜 私は ★「数を 言うと その数が 作業範囲に なる」を ★3 度 記録しました
   ── ★今回は ★「1 面 直すと ★1 面 だけ 直る」── ★同じ 形 です
```

⚪ **★bare `.` が ★load-bearing である 理由**（★CI が `ruff check .`、★狭い ローカルは
★merge gate の 外に 範囲を 残す）も ★同じ 行に 書きました ── ★次に 縮める 人が
★理由を 読めます。

## Test plan

- [x] ★変更は `docs/` ★1 file
- [x] ★`ruff check .` ── ★手元で 実行、★差分なし
- [x] ★`grep -rn "ruff check" CLAUDE.md docs/` ── ★他に 残っていない ことを 確認
- [ ] Full CI run (not run locally, per policy)

⚪ **★`tests/` を 触っていません ∴ ★TESTS-READ 不要。**