### PR TITLE
docs(#4630): testing.md/.ja.md's own "before you push" ruff line was the same narrower command CLAUDE.md just fixed

### DIFF
--- a/docs/deep-dives/contributing/testing.ja.md
+++ b/docs/deep-dives/contributing/testing.ja.md
@@ -467,8 +467,13 @@ REYN_LLM_RECORD=1 python -m pytest tests/ -v
    ```
 2. **ruff** — lint + import-sort（`I001`）:
    ```bash
-   ruff check src tests        # autofix 可能な I001 / format は --fix
+   ruff check .        # autofix 可能な I001 / format は --fix
    ```
+   末尾の `.` は略記ではなく意味を持ちます: CI（`test.yml`）と同じ範囲を実行してください、狭い `src tests` サブセットではありません —
+   #4630 がこの狭いコマンドの穴を測定しました: `scripts/` を含む他のトップレベル
+   ディレクトリ全てが未チェックのままで、`src/` 以外の genuinely-dead import 17 件が
+   このチェックリスト全体から不可視でした。狭いローカルゲートは、その名が意味する
+   ものを意味しない green です。
 3. **test-tier audit** — 新規・変更したテストファイルごとに
    `scripts/test_tier_audit.py --strict`（後述の Tier コンプライアンス監査ツールと
    同じ linter）。Tier-4 の format-pin（`len(...) == N`、exact whitespace、行数）は

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -1155,8 +1155,14 @@ silently start running the full suite locally again without updating it.
    replace asking it.
 2. **ruff** — lint + import-sort (`I001`):
    ```bash
-   ruff check src tests        # add --fix for autofixable I001 / formatting
+   ruff check .        # add --fix for autofixable I001 / formatting
    ```
+   The bare `.` is load-bearing, not shorthand: run the same scope CI runs
+   (`test.yml`), not a narrower `src tests` subset — #4630 measured the gap
+   left by the narrower command: `scripts/` and every other top-level
+   directory went unchecked, and 17 genuinely-dead imports outside `src/`
+   had been invisible to the whole checklist. A narrower local gate is a
+   green that does not mean what it says.
 3. **test-tier audit** — `scripts/test_tier_audit.py --strict` on each new or
    modified test file (the linter described under
    [Tier compliance auditor](#tier-compliance-auditor)). A Tier-4 format pin


### PR DESCRIPTION
**[docs-maintainer]** — part of #4630.

#4632 corrected `CLAUDE.md`'s own PR-workflow paragraph from `ruff check src tests` to `ruff check .`, citing #4630's measurement that CI (`test.yml:162`) runs the wider scope. `CLAUDE.md`'s own paragraph explicitly names `docs/deep-dives/contributing/testing.md` § "Before you push" as the canonical source of this policy — but that section (and its `.ja.md` mirror) still said the old narrower command, independently of `CLAUDE.md`'s own line.

## Verification

- Dewrapped grep (`tr -d '\n' | grep -o`) for the old command in both files post-edit — 0 hits.
- Repo-wide sweep for any other stale mention — the only surviving hit is `CLAUDE.md`'s own intentional historical note (past tense), not a live instruction.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean, only pre-existing en/ja anchor INFO noise, no "Aborted" line.
- Fetched `origin/main` immediately before commit — no new commits since this branch's base.

part of #4630

## Test plan

- [x] `mkdocs build --strict` clean
- [x] docs-only change — `ruff`/`pytest` N/A
- [ ] Visual — N/A (docs prose only)
