### PR TITLE
fix(#4097): remove 21 dead F401 imports across 10 small tests/ directories (slice 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -564,8 +564,11 @@ ignore = [
 # explicit override entry): tests/core/ enforced in #4097's 2nd slice
 # (71 findings, all genuinely dead once checked per-enclosing-function
 # with real code tokens only -- module/comment/docstring/decorator-
-# attribute text excluded). Every other subdirectory stays ignored,
-# each its own future slice. ROOT-level tests/*.py files (conftest.py
+# attribute text excluded). 3rd slice enforced cli/config/data/
+# environment/hooks/http_safety/observability/plugins/services/web (21
+# findings, the 10 smallest remaining directories, each verified the
+# same way). Every other subdirectory stays ignored, each its own
+# future slice. ROOT-level tests/*.py files (conftest.py
 # etc.) are deliberately NOT listed here -- they measured 0 findings
 # already, so leaving them off this list enforces F401 there too, for
 # free. A single-`*` "tests/*.py" pattern was tried first and DISCARDED:
@@ -577,25 +580,15 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/_support/**/*.py" = ["F401"]
 "tests/builtin/**/*.py" = ["F401"]
-"tests/cli/**/*.py" = ["F401"]
-"tests/config/**/*.py" = ["F401"]
-"tests/data/**/*.py" = ["F401"]
 "tests/dev/**/*.py" = ["F401"]
-"tests/environment/**/*.py" = ["F401"]
-"tests/hooks/**/*.py" = ["F401"]
-"tests/http_safety/**/*.py" = ["F401"]
 "tests/interfaces/**/*.py" = ["F401"]
 "tests/llm/**/*.py" = ["F401"]
 "tests/mcp/**/*.py" = ["F401"]
-"tests/observability/**/*.py" = ["F401"]
-"tests/plugins/**/*.py" = ["F401"]
 "tests/repo/**/*.py" = ["F401"]
 "tests/runtime/**/*.py" = ["F401"]
 "tests/scripts/**/*.py" = ["F401"]
 "tests/security/**/*.py" = ["F401"]
-"tests/services/**/*.py" = ["F401"]
 "tests/tools/**/*.py" = ["F401"]
-"tests/web/**/*.py" = ["F401"]
 
 # #3726: wired into CI as a ratchet (.github/workflows/test.yml's "mypy
 # (ratchet)" job), not a blocking full-adoption gate — the tree currently

--- a/tests/cli/test_auth_login_ux.py
+++ b/tests/cli/test_auth_login_ux.py
@@ -18,7 +18,6 @@ substitution (= no ``unittest.mock``; see ``docs/deep-dives/contributing/testing
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 import pytest
 

--- a/tests/cli/test_auth_login_ux_p2.py
+++ b/tests/cli/test_auth_login_ux_p2.py
@@ -17,7 +17,6 @@ no ``unittest.mock`` per ``docs/deep-dives/contributing/testing.ja.md``.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 import pytest
 

--- a/tests/cli/test_auth_login_ux_p3.py
+++ b/tests/cli/test_auth_login_ux_p3.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest

--- a/tests/cli/test_pending_slash_command.py
+++ b/tests/cli/test_pending_slash_command.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass
-from pathlib import Path
 
 import pytest
 

--- a/tests/config/test_config_cascade.py
+++ b/tests/config/test_config_cascade.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 import yaml
 
 # ---------------------------------------------------------------------------

--- a/tests/config/test_config_mirror_coverage_1056.py
+++ b/tests/config/test_config_mirror_coverage_1056.py
@@ -66,7 +66,6 @@ common name reused ACROSS sections, is."""
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 from reyn.config.config_schema import walk_config_schema
 from tests._support.paths import REPO_ROOT

--- a/tests/config/test_config_package_reexport_1682.py
+++ b/tests/config/test_config_package_reexport_1682.py
@@ -11,7 +11,6 @@ resolves on ``reyn.config`` — so an omission fails here, not in 50 unrelated t
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
 import reyn.config
 from tests._support.paths import REPO_ROOT

--- a/tests/data/test_index_backend.py
+++ b/tests/data/test_index_backend.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-import numpy as np
 import pytest
 
 from reyn.data.index.backend import ChunkRecord

--- a/tests/data/test_sqlite_index_pure_helpers.py
+++ b/tests/data/test_sqlite_index_pure_helpers.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from reyn.data.index.backends.sqlite import _db_path, _within_paths
 
 # ── _db_path ──────────────────────────────────────────────────────────────────

--- a/tests/environment/test_devcontainer_build_1341.py
+++ b/tests/environment/test_devcontainer_build_1341.py
@@ -14,8 +14,6 @@ Uses a real injectable fake runner (no mocks), mirroring test_container_launcher
 """
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from reyn.environment.container_launcher import (

--- a/tests/environment/test_router_opcontext_basedir_live_187.py
+++ b/tests/environment/test_router_opcontext_basedir_live_187.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from reyn.environment.container_backend import DockerEnvironmentBackend
-from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 

--- a/tests/hooks/test_1800_hook_config_schema.py
+++ b/tests/hooks/test_1800_hook_config_schema.py
@@ -18,7 +18,6 @@ import pytest
 from reyn.hooks import (
     HookConfigError,
     HookDef,
-    HookRegistry,
     PushBlock,
     load_hooks,
 )

--- a/tests/hooks/test_2608_h3_pipeline_launch_hook.py
+++ b/tests/hooks/test_2608_h3_pipeline_launch_hook.py
@@ -48,7 +48,7 @@ from reyn.core.pipeline.executor import Pipeline, ToolStep
 from reyn.core.pipeline.registry import PipelineRegistry
 from reyn.hooks.dispatcher import HookDispatcher
 from reyn.hooks.registry import HookRegistry
-from reyn.hooks.schema import HookConfigError, HookDef, PipelineLaunchBlock, PushBlock
+from reyn.hooks.schema import HookConfigError, HookDef, PipelineLaunchBlock
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry

--- a/tests/hooks/test_hook_composed_matcher_schema_2889.py
+++ b/tests/hooks/test_hook_composed_matcher_schema_2889.py
@@ -53,7 +53,6 @@ from reyn.hooks import loader as loader_mod
 from reyn.hooks.event_pattern import EventPattern, validate_against_schema
 from reyn.hooks.loader import HookConfigError, load_hooks
 from reyn.hooks.schema_registry import HookSchemaError
-from reyn.runtime.session import Session
 from reyn.runtime.session_params import ReactivityConfig
 from tests._support.agent_session import make_session
 

--- a/tests/hooks/test_hook_event_schema_registry_sync_0059.py
+++ b/tests/hooks/test_hook_event_schema_registry_sync_0059.py
@@ -44,7 +44,6 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 

--- a/tests/http_safety/test_ssrf_guard_pure_helpers.py
+++ b/tests/http_safety/test_ssrf_guard_pure_helpers.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import ipaddress
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/observability/test_otel_exporter.py
+++ b/tests/observability/test_otel_exporter.py
@@ -16,7 +16,6 @@ The two load-bearing gates:
 """
 from __future__ import annotations
 
-import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any

--- a/tests/plugins/test_fp0063_p4_builtin_rag_skill.py
+++ b/tests/plugins/test_fp0063_p4_builtin_rag_skill.py
@@ -77,7 +77,6 @@ No mocks: the real `PluginManifest`, the real skill/pipeline files, the real
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 import pytest
 import yaml

--- a/tests/services/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/services/test_pr_n6_compaction_overflow_retry.py
@@ -22,7 +22,6 @@ Policy compliance:
 from __future__ import annotations
 
 import asyncio
-import json
 import tempfile
 from pathlib import Path
 

--- a/tests/web/test_mcp_sse.py
+++ b/tests/web/test_mcp_sse.py
@@ -22,7 +22,6 @@ docstring used to cite before #4081, does not exist.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 import pytest
 

--- a/tests/web/test_surface_registry.py
+++ b/tests/web/test_surface_registry.py
@@ -28,7 +28,6 @@ tests share.
 from __future__ import annotations
 
 import importlib
-import os
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
**[e2e-coder]** — part of #4097 (tests/ slice 1, src/ already done by tui-coder, #4630).

## What

`tests/` has F401 ignored in `pyproject.toml`. Measured what lifting it would show: 335 hits across `tests/`, mirroring #4630's own src/ measurement approach. This is the first tests/ slice: the 10 smallest directories (`services`, `plugins`, `observability`, `http_safety`, `web`, `environment`, `data`, `config`, `hooks`, `cli` — 21 hits total).

## Verification discipline

lead-coder's own caution: #4597 slice①② removed hand-rolled `Workspace`/`EventLog` stand-ins across many test files this same session, so an import that's F401 *now* could be an artifact of that removal rather than a pre-existing dead import. Verified each of the 21 individually before removal — grepped every symbol's full occurrence count in its own file, confirmed every non-import-line "hit" beyond count=1 was a docstring/comment **prose** mention (e.g. `Session.__init__` inside a Tier-2 docstring, `.json` as a file-extension substring inside `"mult.json"`), never real code usage. None of the 21 files were touched by my own #4597 slice①②, so this particular batch predates that concern either way — the same verification method applies to every future slice.

## Changes

- `ruff --fix` removed the 21 dead imports + resolved 2 resulting import-sort findings.
- `ruff check .` (the corrected pre-PR gate, #4632) clean.
- `mypy_ratchet` unchanged (211/215 baselined — an unused import removal cannot introduce a new finding, confirmed rather than assumed).

## Verification

- `ruff check .`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined (unchanged).
- `scripts/test_tier_audit.py --strict` (20 changed test files, 231 tests): 0 Tier-4 violations.
- The 20 affected files' own suites: 231 pass unchanged — a genuinely-dead import's removal cannot change test behavior, and this confirms it didn't.

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Verified each of the 21 removed imports individually (occurrence-count grep, not blind `--fix`).
- [x] Regression sweep (20 affected files, 231 tests) — clean, unchanged.
- [ ] (Visual) — n/a, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- [x] 🔴 **#4637 着地後に rebase し、★掃除した 10 dir の `per-file-ignores` 行を 消す** ── ★消さないと ignore が 残り、★また 溜まります（★lead 実測: 本 branch で 10 dir とも F401 0 件 ∴ 消せます） — done, rebased onto post-#4637 main, pushed, ruff check . clean.

