### PR TITLE
fix(#4097): remove 48 dead F401 imports in tests/security + tests/tools, enforce going forward

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -563,9 +563,10 @@ ignore = [
 # tests/dev/, tests/repo/, tests/scripts/ (#4097 3rd slice),
 # cli/config/data/environment/hooks/http_safety/observability/plugins/
 # services/web (#4636, the 10 smallest remaining directories, 21
-# findings), and tests/llm/ + tests/mcp/ (14 findings, same per-import
-# verification) are all enforced. Every other subdirectory stays
-# ignored, each its own future slice. ROOT-level tests/*.py files
+# findings), tests/llm/ + tests/mcp/ (14 findings), and tests/security/
+# + tests/tools/ (48 findings, same per-import verification) are all
+# enforced. Every other subdirectory stays ignored, each its own
+# future slice. ROOT-level tests/*.py files
 # (conftest.py etc.) and tests/_support/ are deliberately NOT listed
 # here -- both measured 0 findings already, so leaving them off this
 # list enforces F401 there too, for free (caught in review, #4640: an
@@ -580,8 +581,6 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/interfaces/**/*.py" = ["F401"]
 "tests/runtime/**/*.py" = ["F401"]
-"tests/security/**/*.py" = ["F401"]
-"tests/tools/**/*.py" = ["F401"]
 
 # #3726: wired into CI as a ratchet (.github/workflows/test.yml's "mypy
 # (ratchet)" job), not a blocking full-adoption gate — the tree currently

--- a/tests/security/test_1199_s31b2a_write_gate.py
+++ b/tests/security/test_1199_s31b2a_write_gate.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from reyn.security.permissions.effective import AgentLayer, CapabilityAxis, EffectivePermission
-from reyn.security.permissions.permissions import PermissionDecl
+from reyn.security.permissions.effective import CapabilityAxis
 from tests._support.permissions import make_resolver as _make_resolver
 
 AX = CapabilityAxis

--- a/tests/security/test_1199_s31b2b_read_file_gates.py
+++ b/tests/security/test_1199_s31b2b_read_file_gates.py
@@ -11,9 +11,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
-from reyn.security.permissions.permissions import PermissionDecl
 from tests._support.permissions import make_resolver as _make_resolver
 
 # #1199 S3.1c-1: the require_file_read/write decl-full auto-grant was removed —

--- a/tests/security/test_cli_mcp.py
+++ b/tests/security/test_cli_mcp.py
@@ -14,7 +14,6 @@ Covers:
 from __future__ import annotations
 
 import argparse
-import os
 from pathlib import Path
 
 import pytest
@@ -22,14 +21,12 @@ import yaml
 
 from reyn.interfaces.cli.commands.mcp import (
     _all_servers_with_scope,
-    _get_servers_from_scope,
     _infer_credentials,
     _infer_status,
     _infer_transport,
     _load_yaml_file,
     _scope_path,
     _server_env_keys,
-    _write_yaml_file,
     register,
     run_clear_secret,
     run_list,

--- a/tests/security/test_codeact_runner_1593.py
+++ b/tests/security/test_codeact_runner_1593.py
@@ -374,7 +374,6 @@ def test_harness_subprocess_env_goes_through_the_shared_chokepoint(monkeypatch) 
     this test's positive-and-negative pair below stops moving together (the
     denied name would leak too, since a bespoke copy has no deny mechanism at
     all)."""
-    import os
 
     from reyn.core.kernel.codeact_runner import _harness_subprocess_env
     from reyn.security.sandbox import SandboxPolicy

--- a/tests/security/test_permission_collapse_phase2.py
+++ b/tests/security/test_permission_collapse_phase2.py
@@ -23,8 +23,6 @@ PermissionResolver instances + the real safe.file module — no mocks.
 """
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from reyn.security.permissions.permissions import (

--- a/tests/security/test_permissions.py
+++ b/tests/security/test_permissions.py
@@ -7,11 +7,10 @@ the project-wide config approval.
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 
 import pytest
 
-from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.security.permissions.permissions import PermissionDecl
 from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
 from tests._support.permissions import make_resolver as _make_resolver
 

--- a/tests/security/test_python_axis_removal_falsify.py
+++ b/tests/security/test_python_axis_removal_falsify.py
@@ -18,7 +18,6 @@ import pytest
 from reyn.security.permissions.effective import (
     AgentLayer,
     CapabilityAxis,
-    EffectivePermission,
 )
 from reyn.security.permissions.permissions import PermissionDecl
 

--- a/tests/security/test_require_file_jit_ask_1505.py
+++ b/tests/security/test_require_file_jit_ask_1505.py
@@ -15,7 +15,6 @@ No mocks. Real PermissionResolver + _FakeBus (non-mock fake).
 """
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 
 import pytest

--- a/tests/security/test_sandbox_axis_contract_2983.py
+++ b/tests/security/test_sandbox_axis_contract_2983.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import importlib.util
 import inspect
-from pathlib import Path
 
 import pytest
 

--- a/tests/security/test_secrets_interpolation.py
+++ b/tests/security/test_secrets_interpolation.py
@@ -13,10 +13,7 @@ Pins the contract for ``expand_env()``:
 """
 from __future__ import annotations
 
-import os
 import warnings
-
-import pytest
 
 from reyn.security.secrets.interpolation import expand_env
 

--- a/tests/security/test_secrets_loader.py
+++ b/tests/security/test_secrets_loader.py
@@ -13,11 +13,8 @@ Pins the following invariants for ``reyn.security.secrets.loader.load_secrets_to
 from __future__ import annotations
 
 import os
-import stat
 import warnings
 from pathlib import Path
-
-import pytest
 
 from reyn.security.secrets.loader import load_secrets_to_environ
 

--- a/tests/security/test_secrets_store.py
+++ b/tests/security/test_secrets_store.py
@@ -12,9 +12,6 @@ Pins the contract for the public API in ``reyn.security.secrets.store``:
 """
 from __future__ import annotations
 
-import stat
-from pathlib import Path
-
 import pytest
 
 from reyn.security.secrets.store import (

--- a/tests/security/test_subprocess_cancel_1470.py
+++ b/tests/security/test_subprocess_cancel_1470.py
@@ -16,7 +16,6 @@ import textwrap
 
 import pytest
 
-from reyn.security.sandbox.backend import SandboxResult
 from reyn.security.sandbox.noop_backend import NoopBackend
 from reyn.security.sandbox.policy import SandboxPolicy
 
@@ -244,7 +243,6 @@ async def test_landlock_cancel_none_equivalence() -> None:
 async def test_sandboxed_exec_op_cancel_event_p6_p5() -> None:
     """Tier 2: sandboxed_exec handle() with cancel_event → P6 sandboxed_exec_cancelled
     + P5 result status='cancelled'. Uses real NoopBackend + cancel_event=set."""
-    import dataclasses  # noqa: PLC0415
 
     from reyn.core.events.events import EventLog  # noqa: PLC0415
     from reyn.core.op_runtime import execute_op  # noqa: PLC0415

--- a/tests/tools/test_2073_s3_hooks_write_op.py
+++ b/tests/tools/test_2073_s3_hooks_write_op.py
@@ -22,7 +22,6 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.hot_reload import HotReloader, set_active_hot_reloader
-from reyn.runtime.session import Session
 from reyn.tools.hooks import HOOKS_ADD, _handle_hooks_add
 from reyn.tools.types import ToolContext
 from tests._support.agent_session import make_session

--- a/tests/tools/test_ask_user_unified.py
+++ b/tests/tools/test_ask_user_unified.py
@@ -12,8 +12,6 @@ instances. No private state assertions.
 """
 from __future__ import annotations
 
-import pytest
-
 from reyn.tools import get_default_registry
 from reyn.tools.ask_user import _ASK_USER_DESCRIPTION, _ASK_USER_PARAMETERS, ASK_USER
 

--- a/tests/tools/test_embedding_bench_manifest.py
+++ b/tests/tools/test_embedding_bench_manifest.py
@@ -21,7 +21,6 @@ No mocks. Real manifest load + real LIST_ACTIONS handler enumeration.
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any
 
 import yaml

--- a/tests/tools/test_enumerate_all_scheme_1593.py
+++ b/tests/tools/test_enumerate_all_scheme_1593.py
@@ -14,7 +14,6 @@ substrate (which has its own tests).
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -31,7 +30,6 @@ from reyn.tools.scheme import (
     ExecutionResult,
     PlainText,
     Presentation,
-    SchemeOps,
     ToolUseScheme,
     advertised_entries,
 )

--- a/tests/tools/test_file_grep_glob.py
+++ b/tests/tools/test_file_grep_glob.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-import pytest
-
 from reyn.core.events.events import EventLog
 from reyn.data.workspace.workspace import Workspace
 from reyn.tools.file import (  # noqa: F401 (ToolRegistry imported for type check)

--- a/tests/tools/test_file_unified.py
+++ b/tests/tools/test_file_unified.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from reyn.core.events.events import EventLog
 from reyn.data.workspace.workspace import Workspace
 from reyn.tools.file import (

--- a/tests/tools/test_fp0066_p4a_transport_axis_3247.py
+++ b/tests/tools/test_fp0066_p4a_transport_axis_3247.py
@@ -41,7 +41,6 @@ collaborators to fake.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 import pytest
 

--- a/tests/tools/test_hooks_pure_helpers.py
+++ b/tests/tools/test_hooks_pure_helpers.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/tools/test_list_actions_hidden_state_hint.py
+++ b/tests/tools/test_list_actions_hidden_state_hint.py
@@ -30,8 +30,6 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-import pytest
-
 from reyn.core.events.events import EventLog
 from reyn.tools.types import RouterCallerState, ToolContext
 from reyn.tools.universal_catalog import LIST_ACTIONS

--- a/tests/tools/test_llm_callable_claim_resolves_3548.py
+++ b/tests/tools/test_llm_callable_claim_resolves_3548.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import ast
 import re
-from pathlib import Path
 
 from reyn.tools import get_default_registry
 from tests._support.paths import REPO_ROOT

--- a/tests/tools/test_llm_reachability_gate_3464.py
+++ b/tests/tools/test_llm_reachability_gate_3464.py
@@ -35,7 +35,6 @@ from reyn.tools.llm_reachability import (
     UNREACHABLE_TOOL_REASONS,
     compute_direct_advertisable_tool_names,
     compute_invoke_action_reachable_tool_names,
-    compute_llm_reachable_tool_names,
     compute_router_allow_tool_names,
     compute_unreachable_router_allow_tool_names,
 )

--- a/tests/tools/test_mcp_install_verb_split.py
+++ b/tests/tools/test_mcp_install_verb_split.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Any
 
 import pytest
 import yaml

--- a/tests/tools/test_mcp_unified.py
+++ b/tests/tools/test_mcp_unified.py
@@ -14,8 +14,6 @@ No private state assertions.
 """
 from __future__ import annotations
 
-import pytest
-
 from reyn.tools.mcp import (
     _CALL_MCP_TOOL_DESCRIPTION,
     _CALL_MCP_TOOL_PARAMETERS,

--- a/tests/tools/test_memory_cron_pure_helpers.py
+++ b/tests/tools/test_memory_cron_pure_helpers.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/tools/test_memory_unified.py
+++ b/tests/tools/test_memory_unified.py
@@ -21,7 +21,7 @@ from reyn.tools.memory import (
     REMEMBER_AGENT,
     REMEMBER_SHARED,
 )
-from reyn.tools.types import ToolDefinition, ToolGates
+from reyn.tools.types import ToolDefinition
 
 # ── 1. All 5 are ToolDefinition instances ────────────────────────────────────────
 

--- a/tests/tools/test_no_qualified_tool_names_3429.py
+++ b/tests/tools/test_no_qualified_tool_names_3429.py
@@ -29,8 +29,6 @@ additionally proved live by registering a qualified-named tool into a real
 """
 from __future__ import annotations
 
-import pytest
-
 from reyn.tools import get_default_registry
 from reyn.tools.registry import ToolRegistry
 from reyn.tools.types import ToolDefinition, ToolGates

--- a/tests/tools/test_read_offset_limit_symmetry.py
+++ b/tests/tools/test_read_offset_limit_symmetry.py
@@ -28,8 +28,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from reyn.runtime.reyn_repo import read_text, resolve_reyn_root, safe_resolve_inside
 
 # ── reyn_repo_read slice semantics ────────────────────────────────────────────

--- a/tests/tools/test_reyn_repo_unified.py
+++ b/tests/tools/test_reyn_repo_unified.py
@@ -12,8 +12,6 @@ No private state assertions.
 """
 from __future__ import annotations
 
-import pytest
-
 from reyn.tools.registry import ToolRegistry
 from reyn.tools.reyn_repo import (
     _REYN_REPO_LIST_DESCRIPTION,

--- a/tests/tools/test_router_call_mcp_tool_enum.py
+++ b/tests/tools/test_router_call_mcp_tool_enum.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from reyn.runtime.router_system_prompt import build_system_prompt
 from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 

--- a/tests/tools/test_tier3_op_description_positive_frame.py
+++ b/tests/tools/test_tier3_op_description_positive_frame.py
@@ -38,10 +38,6 @@ freely as long as they don't re-add the failure-mode caveat.
 """
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
-
 _NEGATIVE_PHRASES = (
     "OS rejects at runtime",
     "PermissionError if undeclared",

--- a/tests/tools/test_tool_use_retrieval_content_fence_3376.py
+++ b/tests/tools/test_tool_use_retrieval_content_fence_3376.py
@@ -44,7 +44,6 @@ from reyn.tools.scheme import (
     AdvertisedTools,
     NoToolsChannel,
     Presentation,
-    advertised_entries,
     get_scheme,
 )
 from reyn.tools.schemes._content_fence_cell import ContentFenceCellScheme

--- a/tests/tools/test_universal_catalog.py
+++ b/tests/tools/test_universal_catalog.py
@@ -22,7 +22,6 @@ No mocks. No private-state assertions.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 
 import pytest
 

--- a/tests/tools/test_universal_handlers.py
+++ b/tests/tools/test_universal_handlers.py
@@ -44,7 +44,6 @@ from reyn.tools.types import (
     ToolGates,
 )
 from reyn.tools.universal_catalog import (
-    CATEGORIES,
     DESCRIBE_ACTION,
     INVOKE_ACTION,
     LIST_ACTIONS,


### PR DESCRIPTION
**[e2e-coder]** — part of #4097 (tests/security + tests/tools slice, my assigned scope).

## What

Removes 48 dead F401 imports in `tests/security/` and `tests/tools/`, AND the `per-file-ignores` lines for both directories in the same PR — follows #4637's own shape (blanket → per-dir, absence = enforced).

**Diff-verified the removal** (lead-coder's own caution after #4640's near-miss, a claimed removal that wasn't actually in the diff): `git diff pyproject.toml` shows exactly 2 removed lines, both `"tests/security/**/*.py"` and `"tests/tools/**/*.py"`.

## Verification discipline

Each of the 48 verified individually (occurrence-count grep against **real code tokens**, not comment/docstring/decorator-attribute text) — several required reading past a raw count>1 to confirm:

- `AgentLayer`/`EffectivePermission`/`PermissionDecl`/`PermissionResolver`/`SandboxResult`/`SchemeOps`/`CATEGORIES`/`Session`: every non-import occurrence was module-docstring or inline-comment PROSE (e.g. `"No mocks: real AgentLayer / EffectivePermission ..."`), never a real code reference/construction.
- `stat` in `test_secrets_loader.py`/`test_secrets_store.py`: the other occurrence is `secrets.stat()` — a METHOD CALL on a `secrets` object, not the `stat` MODULE. Easy to misread as "stat used" without checking it's an attribute access, not the import.
- `os` in `test_codeact_runner_1593.py` (a single LOCAL import inside one function, line 377): the file has 4 separate function-scoped `import os` statements; this one's own function body never calls `os.anything`, even though sibling functions with their OWN local `os` import do — function-local imports are independently scoped, confirmed by reading the specific function body, not just grep.
- `Path` in `test_sandbox_axis_contract_2983.py`: the other 2 occurrences are `from pathlib import Path as _Path` (a DIFFERENT alias) inside two functions — the module-level `Path` name itself is never referenced.
- `asyncio` in `test_require_file_jit_ask_1505.py`: 12 more occurrences, all `@pytest.mark.asyncio` decorators (a pytest marker needing no `asyncio` import), never the module.
- The rest: count=1, trivially dead.

## Verification

- `ruff check .`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined (unchanged).
- Full regression sweep (`tests/security` + `tests/tools`): 1664 passed, 26 skipped, 0 failures.

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Verified each of the 48 removed imports individually.
- [x] Diff-verified the pyproject.toml removal (exactly 2 lines, both correct).
- [x] Full regression sweep (1664 tests) — clean.
- [ ] (Visual) — n/a, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
