### PR TITLE
feat(#4604): reyn's own MCP transport vocabulary — "http" -> "streamable-http"

### DIFF
--- a/docs/concepts/runtime/secret-handling.ja.md
+++ b/docs/concepts/runtime/secret-handling.ja.md
@@ -58,7 +58,7 @@ mcp:
         GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
 
     internal_tools:
-      type: http
+      type: streamable-http
       url: https://tools.example.internal/mcp
       headers:
         Authorization: "Bearer ${INTERNAL_TOOLS_TOKEN}"

--- a/docs/concepts/runtime/secret-handling.md
+++ b/docs/concepts/runtime/secret-handling.md
@@ -58,7 +58,7 @@ mcp:
         GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
 
     internal_tools:
-      type: http
+      type: streamable-http
       url: https://tools.example.internal/mcp
       headers:
         Authorization: "Bearer ${INTERNAL_TOOLS_TOKEN}"

--- a/docs/concepts/tools-integrations/mcp.ja.md
+++ b/docs/concepts/tools-integrations/mcp.ja.md
@@ -18,7 +18,7 @@ MCP は AI エージェントがツールを公開する「サーバー」に接
 
 | ロール | 方向 | 仕組み |
 |--------|------|--------|
-| **MCP クライアント** — Reyn が外部サーバーを呼ぶ | アウトバウンド | Phase の `mcp` Control IR op + `permissions.mcp:` 宣言。ワークフローは「このサーバーのこのツールを呼んでほしい」と指示し、OS が `MCPClient`（stdio / http / sse）経由でディスパッチします。例：ワークフローが `filesystem` MCP サーバーを通じてファイルを読む。 |
+| **MCP クライアント** — Reyn が外部サーバーを呼ぶ | アウトバウンド | Phase の `mcp` Control IR op + `permissions.mcp:` 宣言。ワークフローは「このサーバーのこのツールを呼んでほしい」と指示し、OS が `MCPClient`（stdio / streamable-http / sse）経由でディスパッチします。例：ワークフローが `filesystem` MCP サーバーを通じてファイルを読む。 |
 | **MCP サーバー** — 外部クライアントが Reyn を呼ぶ | インバウンド | `reyn mcp serve --project .` を実行すると Reyn が JSON-RPC サーバーになります。Claude Code、Cursor、OpenAI Agents SDK など MCP に対応した任意のクライアントが、`list_agents()` と `send_to_agent(agent_name, message)` の 2 つのツールを通じて Reyn のエージェントを呼び出せます。 |
 
 このページでは以降、各ロールを順に解説します。
@@ -99,14 +99,14 @@ router が自動的に `list_mcp_tools` → `mcp_call_tool` を呼び出しま�
 ```
 phase frontmatter         LLM が Control IR を発行    OS がディスパッチ
   permissions:        →     {kind: mcp,           →   MCPClient
-    mcp: [filesystem]        server: filesystem,        (stdio | http | sse)
+    mcp: [filesystem]        server: filesystem,        (stdio | streamable-http | sse)
                              tool: read_text_file,
                              args: {path: ...}}
 ```
 
 1. ワークフローの Phase は frontmatter で `permissions.mcp: [server_name]` を宣言します。宣言がなければ、ランタイムはそのサーバーへのすべての呼び出しを拒否します。
 2. LLM は `mcp` Control IR op として `{server, tool, args}` を発行します。サーバー名を勝手に作ることはできません。`reyn.yaml` で設定され Phase のパーミッションに宣言されたサーバーだけが到達可能です。
-3. OS はサーバーのトランスポート（`stdio`、`http`、`sse`）を解決し、`MCPClient` 経由でディスパッチして、ツールの結果を Phase ループに返します。
+3. OS はサーバーのトランスポート（`stdio`、`streamable-http`、`sse`）を解決し、`MCPClient` 経由でディスパッチして、ツールの結果を Phase ループに返します。
 4. 呼び出しごとに event が発行されます。呼び出し前に `mcp_called`、正常終了後に `mcp_completed`（またはエラー時に `mcp_failed`）。監査証跡は他の op と同一です。
 
 境界が明確なのは意図的です。ワークフローは何が必要かを記述し、OS がどう取得するかを決めます。新しい MCP サーバーを追加しても OS コードには一切触れません（P7）。
@@ -183,7 +183,7 @@ mcp:
 
     # http: ホスト型サーバー、Streamable HTTP 越しの JSON-RPC
     internal_tools:
-      type: http
+      type: streamable-http
       url: https://tools.example.internal/mcp
       headers:
         Authorization: "Bearer ${INTERNAL_TOOLS_TOKEN}"
@@ -191,7 +191,7 @@ mcp:
 
 | フィールド | stdio | http | 説明 |
 |-----------|-------|------|------|
-| `type` | 必須 | 必須 | `stdio` \| `http` \| `sse` |
+| `type` | 必須 | 必須 | `stdio` \| `streamable-http` \| `sse` |
 | `command` | 必須 | — | 起動する実行ファイル（例：`npx`、`python`、絶対パス） |
 | `args` | 任意 | — | `command` に渡す引数リスト |
 | `env` | 任意 | — | 起動プロセスへの追加環境変数 |
@@ -212,7 +212,7 @@ API キーとトークンは `~/.reyn/secrets.env`（`reyn secret set` で管理
 mcp:
   servers:
     hosted_tool:
-      type: http
+      type: streamable-http
       url: https://tools.example.com/mcp
       auth: oauth   # {type: oauth} の省略形
       # または、scope や特定のクライアントが必要な場合の完全形式:

--- a/docs/concepts/tools-integrations/mcp.md
+++ b/docs/concepts/tools-integrations/mcp.md
@@ -18,7 +18,7 @@ The point: your workflow says "call the `read_text_file` tool on the `filesystem
 
 | Role | Direction | How |
 |------|-----------|-----|
-| **MCP client** — Reyn calls external servers | Outbound | The `mcp` Control IR op + `permissions.mcp:` declaration in a phase. A workflow says "call this tool on this server"; the OS dispatches via `MCPClient` (stdio / http / sse). Example: a workflow reads files through the `filesystem` MCP server. |
+| **MCP client** — Reyn calls external servers | Outbound | The `mcp` Control IR op + `permissions.mcp:` declaration in a phase. A workflow says "call this tool on this server"; the OS dispatches via `MCPClient` (stdio / streamable-http / sse). Example: a workflow reads files through the `filesystem` MCP server. |
 | **MCP server** — external clients call Reyn | Inbound | `reyn mcp serve --project .` launches Reyn as a JSON-RPC server. Claude Code, Cursor, OpenAI Agents SDK, or any MCP-aware client can then call INTO Reyn's agents using two tools: `list_agents()` and `send_to_agent(agent_name, message)`. |
 
 The rest of this page covers each role in turn.
@@ -99,14 +99,14 @@ When a workflow needs an external tool, the flow is:
 ```
 phase frontmatter         LLM emits Control IR        OS dispatches
   permissions:        →     {kind: mcp,           →   MCPClient
-    mcp: [filesystem]        server: filesystem,        (stdio | http | sse)
+    mcp: [filesystem]        server: filesystem,        (stdio | streamable-http | sse)
                              tool: read_text_file,
                              args: {path: ...}}
 ```
 
 1. The workflow's phase declares `permissions.mcp: [server_name]` in frontmatter — without this, the runtime refuses every call to that server.
 2. The LLM emits an `mcp` Control IR op: `{server, tool, args}`. It cannot invent server names; only servers configured in `reyn.yaml` and declared in the phase's permissions are reachable.
-3. The OS resolves the server's transport (`stdio`, `http`, `sse`), dispatches via `MCPClient`, and returns the tool result to the phase loop.
+3. The OS resolves the server's transport (`stdio`, `streamable-http`, `sse`), dispatches via `MCPClient`, and returns the tool result to the phase loop.
 4. Every call emits events — `mcp_called` before, `mcp_completed` (or `mcp_failed`) after. The audit trail is identical to any other op.
 
 The boundary is sharp on purpose: workflows describe what they want, the OS decides how to get it. Adding a new MCP server doesn't touch any OS code (P7).
@@ -183,7 +183,7 @@ mcp:
 
     # http: hosted server, JSON-RPC over Streamable HTTP
     internal_tools:
-      type: http
+      type: streamable-http
       url: https://tools.example.internal/mcp
       headers:
         Authorization: "Bearer ${INTERNAL_TOOLS_TOKEN}"
@@ -191,7 +191,7 @@ mcp:
 
 | Field | stdio | http | Description |
 |-------|-------|------|-------------|
-| `type` | required | required | `stdio` \| `http` \| `sse` |
+| `type` | required | required | `stdio` \| `streamable-http` \| `sse` |
 | `command` | required | — | Executable to spawn (e.g., `npx`, `python`, an absolute path) |
 | `args`    | optional | — | Argument list passed to `command` |
 | `env`     | optional | — | Extra environment variables for the spawned process |
@@ -214,7 +214,7 @@ Streamable HTTP**; `stdio`/`sse` servers reject an `auth` key outright.
 mcp:
   servers:
     hosted_tool:
-      type: http
+      type: streamable-http
       url: https://tools.example.com/mcp
       auth: oauth   # shorthand for {type: oauth}
       # or the long form, when you need scopes / a specific client:

--- a/docs/cookbook/configs/with-mcp.yaml
+++ b/docs/cookbook/configs/with-mcp.yaml
@@ -47,7 +47,7 @@ mcp:
 
     # Remote HTTP example
     # team_search:
-    #   type: http
+    #   type: streamable-http
     #   url: ${TEAM_SEARCH_MCP_URL}
     #   headers:
     #     Authorization: "Bearer ${TEAM_SEARCH_TOKEN}"

--- a/docs/reference/cli/config.md
+++ b/docs/reference/cli/config.md
@@ -45,11 +45,11 @@ reyn config migrate-mcp [--dry-run]
 `reyn config set` always writes to `reyn.local.yaml` (gitignored) — never to `reyn.yaml`.
 
 `reyn config validate` always exits `0`, even when it reports findings — it REPORTS, it
-never gates (owner ruling: warn, never hard-fail, anywhere). It checks five things,
+never gates (owner ruling: warn, never hard-fail, anywhere). It checks six things,
 each printed as its own labeled section (never merged into one list — the fix differs
-per section, and merging would lose "which one do I fix, and how"). Note the last two
-checks (hook entries, MCP server placement) each cover multiple separate config
-*files* under one section, not one:
+per section, and merging would lose "which one do I fix, and how"). Note the last
+three checks (hook entries, MCP server placement, MCP transport type) each cover
+multiple separate config *files* under one section, not one:
 
 - **Unrecognized/renamed/removed keys, policy tier** (`reyn.yaml` / `reyn.local.yaml` /
   `~/.reyn/config.yaml`) — the same check `load_config`'s own startup warning runs.
@@ -97,6 +97,15 @@ checks (hook entries, MCP server placement) each cover multiple separate config
   `.reyn/config/mcp.yaml`. Fix: add the missing `servers:` key by hand —
   `migrate-mcp` relocates already-correctly-nested `mcp.servers` entries between
   files, but does not add a missing `servers:` key to a misplaced entry.
+- **MCP transport type** (#4604) — reyn's own `mcp.servers.<name>.type` vocabulary
+  renamed `"http"` to `"streamable-http"`, aligning with the Agent Plugins 1.0
+  canonical `mcp.schema.json`. `MCPClient` already rejects the old value at
+  connection time with a clear error naming the rename, but that only fires the
+  next time the server is actually used — this check finds a stale `type: http`
+  entry proactively, without connecting to anything, checked PER SOURCE FILE (the
+  same 3 static locations + the dynamic `.reyn/config/mcp.yaml` the placement check
+  above scans). Fix: change `type: http` to `type: streamable-http` by hand in the
+  file the finding names.
 
 `reyn config migrate` only rewrites an entry whose registered rename has an automatic
 destination (a plain rename, no value transform); a rename that also transforms the

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -780,7 +780,7 @@ mcp:
       env:
         GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
     internal_tools:
-      type: http
+      type: streamable-http
       url: https://tools.example.internal/mcp
       headers:
         Authorization: "Bearer ${INTERNAL_TOOLS_TOKEN}"
@@ -920,7 +920,7 @@ mcp:
 
     # http: ホスト型サーバー、Streamable HTTP 越しの JSON-RPC
     internal_tools:
-      type: http
+      type: streamable-http
       url: https://tools.example.internal/mcp
       headers:
         Authorization: "Bearer ${INTERNAL_TOOLS_TOKEN}"
@@ -928,7 +928,7 @@ mcp:
 
 | フィールド | 型 | 必須の対象 | 説明 |
 |-------|------|--------------|-------------|
-| `type` | string | すべて | `stdio` \| `http` \| `sse` |
+| `type` | string | すべて | `stdio` \| `streamable-http` \| `sse` |
 | `command` | string | stdio | 起動する実行ファイル。 |
 | `args` | list[string] | stdio（任意） | `command` に渡す引数ベクター。 |
 | `env` | map[string,string] | stdio（任意） | 起動プロセスへの追加環境変数。値は `${VAR}` 展開に対応。 |
@@ -937,9 +937,9 @@ mcp:
 | `write_paths` | list[string] | stdio（任意） | **サンドボックス化されたサーバーが書き込めるパス**。作業ディレクトリ（常に許可）に追加される。`~` は展開される。オペレーター所有 — モデルは設定不可。launcher はワークスペース外のユーザーごとのキャッシュに bootstrap するため、reyn は認識できる launcher に**デフォルト**のスコープを与える（`npx`/`npm` → `~/.npm`、`uvx`/`uv` → `~/.cache/uv` + `~/.local/share/uv`）。サーバーの runtime がそれ以外の場合、またはキャッシュを移動している場合（`XDG_CACHE_HOME`、`npm_config_cache` など）に設定する — デフォルトは標準の場所を前提としており、移動先を知り得ない。`write_paths` を宣言すると組み込みのデフォルトを**置き換える**ため、拡大だけでなく縮小もできる。サーバーが `Operation not permitted` / `EPERM` で起動に失敗した場合、エラーが拒否されたパスを示すので、そのパスをここで許可する。**スコープは狭く保つこと**: 書き込み許可はそのパスの*読み取り*も再開する。`~` を許可しても sensitive-read deny-list（`~/.ssh`、`~/.aws` 等）は無効化されない — 重なる write 許可より deny が勝つ（#2978）— が、サーフェスを無用に広げるため、ホームディレクトリではなく具体的なキャッシュディレクトリを許可すること。 |
 | `url` | string | http, sse | エンドポイント URL。 |
 | `headers` | map[string,string] | http, sse（任意） | 静的リクエストヘッダー。値は `${VAR}` 展開に対応。 |
-| `call_timeout_seconds` | float | すべて（任意） | **すべての MCP op（list / call / probe）に対する end-to-end の上限**。既定 `120`、`<= 0` で無効化。server への接続と op の実行の両方を含む ∴ **起動（launch）も、この上限で打ち切られる**。特定 server が遅いと分かっている場合は上げ、速いと分かっていて fail-fast したい場合は下げる。per-call としては MCP SDK の `read_timeout_seconds` に渡され、`type: http` で `timeout` が設定する session レベルの既定を override する。 |
+| `call_timeout_seconds` | float | すべて（任意） | **すべての MCP op（list / call / probe）に対する end-to-end の上限**。既定 `120`、`<= 0` で無効化。server への接続と op の実行の両方を含む ∴ **起動（launch）も、この上限で打ち切られる**。特定 server が遅いと分かっている場合は上げ、速いと分かっていて fail-fast したい場合は下げる。per-call としては MCP SDK の `read_timeout_seconds` に渡され、`type: streamable-http` で `timeout` が設定する session レベルの既定を override する。 |
 | `init_timeout` | float | すべて（任意） | **server が MCP handshake を完了するまで待つ上限**。既定 `60`、`0` でこの上限を無効化。handshake のみを縛り、tool call は縛らない ∴ 上げても遅い tool が timeout することはない。**起動したが黙っている** server（典型例: `command: uvx <pkg>` — 初回実行時に PyPI から取得する間、何も喋らない）はここで止まる。expire 時、reyn は原因の候補と対処を名指しするエラーを返す。既定が `call_timeout_seconds` の `120` より **下** なのは意図的: 両方が起動を覆うため、**先に発火した方が operator の読むメッセージを決める** — 汎用の per-op timeout は「なぜ起動が止まったか」を語れない。∴ 本当に遅い server に猶予が要るなら **両方を上げる**（`init_timeout` 単独では `call_timeout_seconds` を超える時間は買えない）。初回起動が遅いことへの恒久的な対処は、パッケージを事前 install して `command` を install 済みの実行ファイルに向けること — offline / proxy 越しでも起動できるようになるのも、この形。 |
-| `auth` | string \| map | すべて（任意、`http` のみ） | サーバーごとの OAuth 2.1 設定。文字列 `"oauth"` または `{type: oauth, scopes?, client_id?, client_secret?}`。`http` トランスポート以外(`stdio`/`sse`)で指定するとエラー。詳細は [コンセプト: MCP § OAuth](../../concepts/tools-integrations/mcp.ja.md#oauth) 参照。 |
+| `auth` | string \| map | すべて（任意、`streamable-http` のみ） | サーバーごとの OAuth 2.1 設定。文字列 `"oauth"` または `{type: oauth, scopes?, client_id?, client_secret?}`。`streamable-http` トランスポート以外(`stdio`/`sse`)で指定するとエラー。詳細は [コンセプト: MCP § OAuth](../../concepts/tools-integrations/mcp.ja.md#oauth) 参照。 |
 | `elicitation` | string | すべて（任意） | `prompt`(デフォルト) — サーバー起動の構造化入力要求(`elicitation/create`)がコンセントプロンプトとして表示される。`auto_decline` — そのようなすべての要求をプロンプトせずに decline する。[コンセプト: MCP § Elicitation](../../concepts/tools-integrations/mcp.ja.md#elicitation-サーバーからの構造化入力要求) 参照。 |
 | `elicitation_timeout_seconds` | float | すべて（任意） | elicitation プロンプトに人間が回答するためのウォールクロック期限。デフォルト `120`。期限を過ぎた未回答の要求はキャンセルされます。 |
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1480,7 +1480,7 @@ mcp:
       env:
         GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
     internal_tools:
-      type: http
+      type: streamable-http
       url: https://tools.example.internal/mcp
       headers:
         Authorization: "Bearer ${INTERNAL_TOOLS_TOKEN}"
@@ -1761,7 +1761,7 @@ mcp:
 
     # http: hosted server, JSON-RPC over Streamable HTTP
     internal_tools:
-      type: http
+      type: streamable-http
       url: https://tools.example.internal/mcp
       headers:
         Authorization: "Bearer ${INTERNAL_TOOLS_TOKEN}"
@@ -1769,7 +1769,7 @@ mcp:
 
 | Field | Type | Required for | Description |
 |-------|------|--------------|-------------|
-| `type` | string | all | `stdio` \| `http` \| `sse` |
+| `type` | string | all | `stdio` \| `streamable-http` \| `sse` |
 | `command` | string | stdio | Executable to spawn. |
 | `args` | list[string] | stdio (optional) | Argument vector passed to `command`. |
 | `env` | map[string,string] | stdio (optional) | Extra environment variables for the spawned process. Values support `${VAR}` expansion. |
@@ -1778,7 +1778,7 @@ mcp:
 | `write_paths` | list[string] | stdio (optional) | **Filesystem paths the sandboxed server may write**, in addition to its working directory (which is always granted). `~` is expanded. Operator-owned — the model cannot set it. A launcher bootstraps into a per-user cache outside the workspace, so reyn grants a **default** scope for the launchers it recognises (`npx`/`npm` → `~/.npm`; `uvx`/`uv` → `~/.cache/uv` + `~/.local/share/uv`). Set this when your server's runtime is not one of those, or when you have relocated its cache (e.g. `XDG_CACHE_HOME`, `npm_config_cache`) — the defaults are keyed to the standard locations and cannot know yours. Declaring `write_paths` **replaces** the built-in defaults, so you can narrow as well as widen. When a write is denied, the error names the denied path and points back at this knob — on BOTH the paths a denial can take: a server that fails to *start* with `Operation not permitted` / `EPERM` (its launcher could not reach its own cache), and a *tool call* refused a write to a path you passed it (the server started fine; the path is simply outside its scope). Grant the named path here — or, for the tool-call case, pass a path inside the server's working directory instead, which needs no declaration at all. **Keep the scope tight**: a write grant also re-opens *reads* for that path. Granting `~` does not defeat the sensitive-read deny-list (`~/.ssh`, `~/.aws`, …) — the deny wins over an overlapping write grant (#2978) — but it needlessly widens the surface, so grant the specific cache directory, never the home directory. |
 | `url` | string | http, sse | Endpoint URL. |
 | `headers` | map[string,string] | http, sse (optional) | Static request headers. Values support `${VAR}` expansion. |
-| `call_timeout_seconds` | float | all (optional) | **End-to-end bound on every MCP op** (list / call / probe), default `120`; `<= 0` opts out. Covers connecting the server *and* running the op, so it also bounds a launch — see `init_timeout` for why that matters. Set it when a server is known to be slow (raise) or known to be quick and you want fail-fast (lower). Per-call, it is passed to the MCP SDK's `read_timeout_seconds`, overriding the session-level default that `timeout` sets for `type: http`. |
+| `call_timeout_seconds` | float | all (optional) | **End-to-end bound on every MCP op** (list / call / probe), default `120`; `<= 0` opts out. Covers connecting the server *and* running the op, so it also bounds a launch — see `init_timeout` for why that matters. Set it when a server is known to be slow (raise) or known to be quick and you want fail-fast (lower). Per-call, it is passed to the MCP SDK's `read_timeout_seconds`, overriding the session-level default that `timeout` sets for `type: streamable-http`. |
 | `init_timeout` | float | all (optional) | **How long to wait for the server to complete the MCP handshake**, default `60`; `0` disables this bound. Bounds only the handshake, never a tool call — so raising it cannot make a slow tool time out. A server that starts but never speaks (the classic case: `command: uvx <pkg>`, which downloads from PyPI on first run and stays silent until it finishes) stalls here; on expiry reyn fails with an error naming the likely cause and the remedy. The default sits below `call_timeout_seconds`' `120` deliberately: both bounds cover the launch, and whichever fires first decides what you get to read — the generic per-op timeout cannot tell you *why* a launch stalled. So if a genuinely slow server needs more room, **raise both** — `init_timeout` alone cannot buy more time than `call_timeout_seconds` allows. The durable fix for a slow first run is to pre-install the package and point `command` at the installed executable, which is also what lets the server start offline or behind a proxy. |
 | `elicitation` | string | all (optional) | `prompt` (default) — a server-initiated structured-input request (`elicitation/create`) surfaces as a consent prompt; `auto_decline` — every such request is declined without prompting. See [Concepts: MCP § Elicitation](../../concepts/tools-integrations/mcp.md#elicitation-structured-input-requests-from-a-server). |
 | `elicitation_timeout_seconds` | float | all (optional) | Wall-clock deadline for a human to answer an elicitation prompt. Default `120`. An unanswered request past the deadline is cancelled. |

--- a/docs/reference/runtime/control-ir.ja.md
+++ b/docs/reference/runtime/control-ir.ja.md
@@ -284,7 +284,7 @@ HTML レスポンスはテキスト抽出されます（script、style、非コ�
 
 > **提示名。** Phase はこの op を chat-tool 名 `call_mcp_tool` として LLM に提示し、OS がパース境界で `mcp` kind にエイリアスし直します。`mcp` は `OP_KIND_MODEL_MAP` 上およびディスパッチされる op 上の正規 kind のままです。
 
-OS は server のトランスポート（`stdio`、`http`、`sse`）を解決し、`MCPClient` 経由でディスパッチして、ツール結果を返します。呼び出しごとに `mcp_called`、`mcp_completed`、（失敗時）`mcp_failed` イベントが発行されます。
+OS は server のトランスポート（`stdio`、`streamable-http`、`sse`）を解決し、`MCPClient` 経由でディスパッチして、ツール結果を返します。呼び出しごとに `mcp_called`、`mcp_completed`、（失敗時）`mcp_failed` イベントが発行されます。
 
 server の設定、トランスポートの選択、セキュリティモデルについては [concepts/tools-integrations/mcp.md](../../concepts/tools-integrations/mcp.md) を参照してください。
 

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -466,7 +466,7 @@ Fields: `server` (required — must match a key under `mcp.servers:` in `reyn.ya
 > boundary. `mcp` remains the canonical kind in `OP_KIND_MODEL_MAP` and on the
 > dispatched op.
 
-The OS resolves the server's transport (`stdio`, `http`, or `sse`), dispatches via `MCPClient`, and returns the tool result. Every call emits `mcp_called`, `mcp_completed`, and (on failure) `mcp_failed` events.
+The OS resolves the server's transport (`stdio`, `streamable-http`, or `sse`), dispatches via `MCPClient`, and returns the tool result. Every call emits `mcp_called`, `mcp_completed`, and (on failure) `mcp_failed` events.
 
 See [concepts/tools-integrations/mcp.md](../../concepts/tools-integrations/mcp.md) for server configuration, transport options, and the security model.
 

--- a/docs/reference/runtime/mcp-conformance.json
+++ b/docs/reference/runtime/mcp-conformance.json
@@ -28,7 +28,7 @@
     "notes": "logging: MCPClient has no representative public call for this capability (architect #3698 design \u00a73); completions: not advertised by this server, no call attempted; elicitation: test server has no elicit-triggering tool (needs a purpose-built server; not yet available in-repo); subscription: MCPCapabilityError = the server does not advertise resources.subscribe (MCPClient's capability gate working as intended, not a reyn defect)"
   },
   {
-    "transport": "http",
+    "transport": "streamable-http",
     "server": "tests/_support/mcp_fastmcp_echo_server.py",
     "dep_version": "fastmcp 3.4.5, mcp-sdk 1.26.0",
     "negotiated": "2025-11-25",

--- a/docs/reference/runtime/mcp-conformance.md
+++ b/docs/reference/runtime/mcp-conformance.md
@@ -31,7 +31,7 @@ Every cell is one of `ok` / `error:<ExceptionType>` / `not_measurable` (with the
 - **teardown**: clean
 - **notes**: logging: MCPClient has no representative public call for this capability (architect #3698 design §3); completions: not advertised by this server, no call attempted; elicitation: test server has no elicit-triggering tool (needs a purpose-built server; not yet available in-repo); subscription: MCPCapabilityError = the server does not advertise resources.subscribe (MCPClient's capability gate working as intended, not a reyn defect)
 
-## http
+## streamable-http
 
 - **server**: `tests/_support/mcp_fastmcp_echo_server.py`
 - **dep_version**: fastmcp 3.4.5, mcp-sdk 1.26.0
@@ -55,7 +55,7 @@ Every cell is one of `ok` / `error:<ExceptionType>` / `not_measurable` (with the
 | reconnect | ok |
 
 - **teardown**: not_measurable
-- **notes**: logging: MCPClient has no representative public call for this capability (architect #3698 design §3); completions: not advertised by this server, no call attempted; elicitation: test server has no elicit-triggering tool (needs a purpose-built server; not yet available in-repo); subscription: MCPCapabilityError = the server does not advertise resources.subscribe (MCPClient's capability gate working as intended, not a reyn defect); teardown: http has no child process of its own to leak
+- **notes**: logging: MCPClient has no representative public call for this capability (architect #3698 design §3); completions: not advertised by this server, no call attempted; elicitation: test server has no elicit-triggering tool (needs a purpose-built server; not yet available in-repo); subscription: MCPCapabilityError = the server does not advertise resources.subscribe (MCPClient's capability gate working as intended, not a reyn defect); teardown: streamable-http has no child process of its own to leak
 
 ## sse
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -264,9 +264,9 @@
 #
 # Per-server entry (kept as a raw dict so new transport options can be added
 # without OS changes per P7):
-#   type:    "stdio" | "http" | "sse"   (required transport selector)
+#   type:    "stdio" | "streamable-http" | "sse"   (required transport selector)
 #   command, args, env, cwd             (stdio)
-#   url, headers, timeout               (http / sse)
+#   url, headers, timeout               (streamable-http / sse)
 #
 # ``headers`` supports ``${VAR}`` interpolation so secrets stay out of YAML.
 #
@@ -287,7 +287,7 @@
 #     - https://mcp-registry.example.com/v1
 #   servers:
 #     github:
-#       type: http
+#       type: streamable-http
 #       url: https://api.githubcopilot.com/mcp/
 #       headers:
 #         Authorization: "Bearer ${GITHUB_TOKEN}"

--- a/scripts/mcp_conformance.py
+++ b/scripts/mcp_conformance.py
@@ -54,7 +54,7 @@ _ECHO_SERVER = _REPO_ROOT / "tests" / "_support" / "mcp_fastmcp_echo_server.py"
 _JSON_OUT = _REPO_ROOT / "docs" / "reference" / "runtime" / "mcp-conformance.json"
 _MD_OUT = _REPO_ROOT / "docs" / "reference" / "runtime" / "mcp-conformance.md"
 
-_TRANSPORTS = ("stdio", "http", "sse")
+_TRANSPORTS = ("stdio", "streamable-http", "sse")
 _CAPABILITIES = ("tools", "resources", "prompts", "logging", "completions")
 
 
@@ -307,7 +307,7 @@ async def _measure_row(transport: str) -> dict:
             for cap in _CAPABILITIES:
                 cell["implemented"][cap] = "not_measurable"
             return cell
-        path = "/mcp" if transport == "http" else "/sse"
+        path = "/mcp" if transport == "streamable-http" else "/sse"
         config = {"type": transport, "url": f"http://127.0.0.1:{port}{path}"}
         cell["_server_task"] = server_task
 

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -115,9 +115,9 @@ class ReynConfig:
     #
     # Per-server schema (raw dict; no dataclass — kept flexible so new MCP SDK
     # transport options can be added without OS changes per P7):
-    #   `type`:  "stdio" | "http" | "sse"   (required; transport selector)
+    #   `type`:  "stdio" | "streamable-http" | "sse"   (required; transport selector)
     #   command, args, env, cwd             (stdio transport)
-    #   url, headers, timeout               (http / streamable-http transport)
+    #   url, headers, timeout               (streamable-http / sse transport)
     #
     # ``headers`` is an optional ``dict[str, str]`` of HTTP headers passed at
     # connection time to HTTP-mode MCP servers (FP-0016 Component A). Used
@@ -130,7 +130,7 @@ class ReynConfig:
     #   mcp:
     #     servers:
     #       github:
-    #         `type`: http
+    #         `type`: streamable-http
     #         url: https://api.githubcopilot.com/mcp/
     #         headers:
     #           Authorization: "Bearer ${GITHUB_TOKEN}"

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -2,8 +2,8 @@
 
 Supports stdio + Streamable HTTP transports (sse deferred). The transport
 is selected per-server via the ``type:`` field in ``mcp.servers.<name>``;
-configs that omit ``type`` default to ``http`` for backward compatibility
-with pre-PR32 reyn.yaml files.
+configs that omit ``type`` default to ``streamable-http`` (#4604 renamed
+from ``http``) for backward compatibility with pre-PR32 reyn.yaml files.
 """
 from __future__ import annotations
 
@@ -34,10 +34,10 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
         return {"kind": "mcp", "status": "error",
                 "error": f"MCP server '{op.server}' config must be a dict."}
 
-    # Backward compat: a config with `url` but no `type` is treated as http.
+    # Backward compat: a config with `url` but no `type` is treated as streamable-http.
     if "type" not in expanded:
         if expanded.get("url"):
-            expanded = {**expanded, "type": "http"}
+            expanded = {**expanded, "type": "streamable-http"}
 
     # #2597 S2a: prefer the session-owned held-open connection service (Option C) when wired —
     # it replaces the per-turn pool on the live (non-ephemeral) session path with one persistent

--- a/src/reyn/core/op_runtime/mcp_get_prompt.py
+++ b/src/reyn/core/op_runtime/mcp_get_prompt.py
@@ -46,7 +46,7 @@ async def _execute(op: MCPGetPromptIROp, ctx: OpContext) -> dict:
                 "error": f"MCP server '{op.server}' config must be a dict."}
 
     if "type" not in expanded and expanded.get("url"):
-        expanded = {**expanded, "type": "http"}
+        expanded = {**expanded, "type": "streamable-http"}
 
     if ctx.mcp_connection_service is None and ctx.mcp_pool is None:
         return {"kind": "mcp_get_prompt", "status": "error", "server": op.server,

--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -131,7 +131,7 @@ def _build_server_entry(pkg_raw: dict, env_keys: list[str]) -> dict:
 
     issue #318: ``type:`` is ALWAYS written (= matches the loader's
     ``MCPClient`` expectation that ``type`` be one of
-    ``stdio | http | sse``). Pre-fix the function omitted the field
+    ``stdio | streamable-http | sse``). Pre-fix the function omitted the field
     for the default stdio case + wrote a ``transport:`` key (not
     ``type:``) for non-stdio — both produced configs that the loader
     rejected with ``Unsupported MCP server type: None``.
@@ -228,7 +228,7 @@ async def probe_mcp_server(
     way the pool's ``__aexit__`` has already torn the transport down (stdio subprocess
     kill via ``kill_process_tree`` / HTTP close) by the time this function returns/
     raises, and because the config write is strictly AFTER this probe, nothing gets
-    committed. **Transport-uniform**: stdio and remote (http/sse) share this one path —
+    committed. **Transport-uniform**: stdio and remote (streamable-http/sse) share this one path —
     ``MCPClient.__aexit__`` owns the transport-appropriate teardown, so the probe never
     branches on transport (mirrors ``RouterHostAdapter.mcp_list_tools``, #3447)."""
     from reyn.mcp.client import expand_env  # noqa: PLC0415
@@ -251,9 +251,9 @@ async def probe_mcp_server(
     expanded = expand_env(server_entry)
     if not isinstance(expanded, dict):
         return f"server config must be a dict, got {type(expanded).__name__}"
-    # A url-only remote entry defaults to http (mirrors mcp_list_tools).
+    # A url-only remote entry defaults to streamable-http (mirrors mcp_list_tools).
     if "type" not in expanded and expanded.get("url"):
-        expanded = {**expanded, "type": "http"}
+        expanded = {**expanded, "type": "streamable-http"}
     gateway = MCPGateway(agent_id=agent_id, cancel_event=cancel_event)
     try:
         await gateway.list_tools(server_name, expanded)

--- a/src/reyn/core/op_runtime/mcp_read_resource.py
+++ b/src/reyn/core/op_runtime/mcp_read_resource.py
@@ -47,7 +47,7 @@ async def _execute(op: MCPReadResourceIROp, ctx: OpContext) -> dict:
                 "error": f"MCP server '{op.server}' config must be a dict."}
 
     if "type" not in expanded and expanded.get("url"):
-        expanded = {**expanded, "type": "http"}
+        expanded = {**expanded, "type": "streamable-http"}
 
     if ctx.mcp_connection_service is None and ctx.mcp_pool is None:
         return {"kind": "mcp_read_resource", "status": "error", "server": op.server,

--- a/src/reyn/core/op_runtime/mcp_subscribe_resource.py
+++ b/src/reyn/core/op_runtime/mcp_subscribe_resource.py
@@ -47,7 +47,7 @@ async def _execute(op: MCPSubscribeResourceIROp, ctx: OpContext) -> dict:
                 "error": f"MCP server '{op.server}' config must be a dict."}
 
     if "type" not in expanded and expanded.get("url"):
-        expanded = {**expanded, "type": "http"}
+        expanded = {**expanded, "type": "streamable-http"}
 
     if ctx.mcp_connection_service is None:
         return {

--- a/src/reyn/core/op_runtime/mcp_unsubscribe_resource.py
+++ b/src/reyn/core/op_runtime/mcp_unsubscribe_resource.py
@@ -31,7 +31,7 @@ async def _execute(op: MCPUnsubscribeResourceIROp, ctx: OpContext) -> dict:
                 "error": f"MCP server '{op.server}' config must be a dict."}
 
     if "type" not in expanded and expanded.get("url"):
-        expanded = {**expanded, "type": "http"}
+        expanded = {**expanded, "type": "streamable-http"}
 
     if ctx.mcp_connection_service is None:
         return {

--- a/src/reyn/core/op_runtime/plugin_install.py
+++ b/src/reyn/core/op_runtime/plugin_install.py
@@ -808,19 +808,14 @@ def _build_mcp_entries(mcp_json: Path) -> dict:
     ``{"mcpServers": {"<name>": {"type", "command", "args", "env"?, "url"?}}}``)
     into reyn's ``mcp.servers.<name>`` entry shape.
 
-    **Transport-type ADAPTER (#4570 conversion C1, temporary)**: the
-    Agent Plugins 1.0 canonical mcp.schema.json spells the HTTP-family
-    transport ``"streamable-http"``; reyn's OWN ``.reyn/config/mcp.yaml``
-    vocabulary still says ``"http"`` (``mcp/client.py``'s
-    ``_SUPPORTED_TYPES``) — that repo-wide rename is split off into #4604
-    (conversion C2, deliberately NOT done here: 18 src files + 9 test
-    files outside the plugin subsystem, lead-coder ruling). This function
-    is the ONE translation point: a spec-legal ``"streamable-http"``
-    becomes reyn-internal ``"http"``; ``"sse"`` passes through UNCHANGED
-    (it is a DISTINCT value in both vocabularies — mapping it into
-    ``"http"`` too would be a real bug, not just an incomplete rename).
-    Remove this translation once #4604 lands and reyn's own vocabulary
-    says ``"streamable-http"`` natively.
+    No transport-type translation any more (#4604): the Agent Plugins 1.0
+    canonical mcp.schema.json's HTTP-family transport, ``"streamable-http"``,
+    is now reyn's OWN ``.reyn/config/mcp.yaml`` vocabulary too
+    (``mcp/client.py``'s ``_SUPPORTED_TYPES``) — a plugin-declared
+    ``"streamable-http"`` passes straight through unchanged. Before #4604 this
+    function was the ONE translation point (#4570 conversion C1's temporary
+    adapter, translating spec-legal ``"streamable-http"`` into reyn-internal
+    ``"http"``); removed once the rename landed repo-wide.
 
     ``command`` is registered AS-IS (#3209 — register-only redesign: no
     venv-interpreter rewrite here any more). A plugin whose server needs a
@@ -842,8 +837,7 @@ def _build_mcp_entries(mcp_json: Path) -> dict:
             continue
         if "url" in spec:
             spec_type = spec.get("type", "streamable-http")
-            reyn_type = "http" if spec_type == "streamable-http" else spec_type
-            entry: dict = {"type": reyn_type, "url": spec["url"]}
+            entry: dict = {"type": spec_type, "url": spec["url"]}
         else:
             entry = {
                 "type": "stdio",

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -299,6 +299,28 @@ def _mcp_misplaced_server_entries(mcp_section: object) -> "list[str]":
     return found
 
 
+# #4604: reyn's own MCP transport-type vocabulary renamed "http" ->
+# "streamable-http" (aligning with the Agent Plugins 1.0 canonical
+# mcp.schema.json). mcp/client.py's MCPClient.__init__ already REJECTS
+# the old value at connection time (a clear ValueError naming the rename)
+# -- this is the earlier, proactive half: `reyn config validate` can find
+# a stale `type: http` entry without ever trying to connect, closing the
+# #4401 shape (a server discovered degraded only much later) for THIS
+# specific value, not just a generic "unsupported type" surprise.
+def _mcp_renamed_http_transport_entries(mcp_section: object) -> "list[str]":
+    """Every ``mcp.servers.<name>`` entry (in a raw, per-source ``mcp:``
+    dict) whose ``type`` is still the pre-#4604 value ``"http"``."""
+    if not isinstance(mcp_section, dict):
+        return []
+    servers = mcp_section.get("servers")
+    if not isinstance(servers, dict):
+        return []
+    return [
+        name for name, entry in servers.items()
+        if isinstance(entry, dict) and entry.get("type") == "http"
+    ]
+
+
 def _validate() -> None:
     """#4174 T0: report every unknown/renamed config key found in the
     operator-editable POLICY TIER (reyn.yaml / reyn.local.yaml /
@@ -445,7 +467,12 @@ def _validate() -> None:
     # on, #4364. The 3 static paths + the 1 dynamic path mirror
     # `_migrate_mcp`'s own already-established scan list (this module,
     # above) exactly — not a new, narrower list.
+    # #4604: the same per-source-file scan as mcp_misplaced's own loop
+    # below checks a SECOND, unrelated defect too — a server entry whose
+    # `type` is still the renamed-away "http" value — so both detectors
+    # run off the SAME loaded raw dict per source, one file read each.
     mcp_misplaced: dict[str, "list[str]"] = {}
+    mcp_renamed_http: dict[str, "list[str]"] = {}
     static_mcp_sources = {
         "~/.reyn/config.yaml": Path.home() / ".reyn" / "config.yaml",
         "reyn.yaml": project_root / "reyn.yaml",
@@ -453,17 +480,25 @@ def _validate() -> None:
     }
     for label, path in static_mcp_sources.items():
         raw = _load_yaml(path)
-        found = _mcp_misplaced_server_entries(raw.get("mcp"))
-        if found:
-            mcp_misplaced[label] = found
+        mcp_section = raw.get("mcp")
+        misplaced_found = _mcp_misplaced_server_entries(mcp_section)
+        if misplaced_found:
+            mcp_misplaced[label] = misplaced_found
+        renamed_found = _mcp_renamed_http_transport_entries(mcp_section)
+        if renamed_found:
+            mcp_renamed_http[label] = renamed_found
     dynamic_mcp_raw = _load_yaml(project_root / ".reyn" / "config" / "mcp.yaml")
-    dynamic_found = _mcp_misplaced_server_entries(dynamic_mcp_raw.get("mcp"))
+    dynamic_mcp_section = dynamic_mcp_raw.get("mcp")
+    dynamic_found = _mcp_misplaced_server_entries(dynamic_mcp_section)
     if dynamic_found:
         mcp_misplaced[".reyn/config/mcp.yaml"] = dynamic_found
+    dynamic_renamed_found = _mcp_renamed_http_transport_entries(dynamic_mcp_section)
+    if dynamic_renamed_found:
+        mcp_renamed_http[".reyn/config/mcp.yaml"] = dynamic_renamed_found
 
     if (
         not policy_unknown and not disabled and not in_set_unknown
-        and not hook_entry_errors and not mcp_misplaced
+        and not hook_entry_errors and not mcp_misplaced and not mcp_renamed_http
     ):
         print("No unknown, renamed, or disabled-by-dependency config keys found.")
         return
@@ -550,6 +585,27 @@ def _validate() -> None:
             "'mcp.servers.<name>' ('reyn config migrate-mcp' relocates "
             "already-correctly-nested mcp.servers entries between files, "
             "but does not add a missing 'servers:' key)."
+        )
+
+    if mcp_renamed_http:
+        if policy_unknown or disabled or in_set_unknown or hook_entry_errors or mcp_misplaced:
+            print()
+        print(
+            f"MCP transport type — checked ~/.reyn/config.yaml, reyn.yaml, "
+            f"reyn.local.yaml, and .reyn/config/mcp.yaml — "
+            f"{len(mcp_renamed_http)} source(s) with a renamed transport type:\n"
+        )
+        for label, names in sorted(mcp_renamed_http.items()):
+            for name in names:
+                print(f"  [{label}] mcp.servers.{name}.type: http")
+        print(
+            "\nMCP server type 'http' was renamed to 'streamable-http' "
+            "(#4604), aligning reyn's own vocabulary with the Agent "
+            "Plugins 1.0 canonical mcp.schema.json. Each entry above "
+            "will FAIL to connect (MCPClient rejects the old value with "
+            "a clear error) the next time this server is used — fix it "
+            "now by hand: change 'type: http' to 'type: streamable-http' "
+            "in the file named above."
         )
 
 

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -918,7 +918,7 @@ def _infer_transport(cfg: dict) -> str:
     if cfg.get("command"):
         return "stdio"
     if cfg.get("url"):
-        return "http"
+        return "streamable-http"
     return "(unknown)"
 
 

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -1,16 +1,18 @@
 """
 MCP client (v#2597 S1; #3698 stage 1; #4282 stage 2 — fastmcp retired).
 
-Supports two transports today: ``stdio`` and ``http`` (Streamable HTTP);
-``sse`` uses the SSE client.
+Supports two transports today: ``stdio`` and ``streamable-http`` (Streamable
+HTTP — #4604 renamed reyn's own vocabulary from ``"http"`` to
+``"streamable-http"``, aligning with the Agent Plugins 1.0 canonical
+``mcp.schema.json``); ``sse`` uses the SSE client.
 
-#4282: EVERY transport — ``stdio``, ``http``/``sse`` with or without OAuth
-configured — now goes through the official ``mcp`` SDK DIRECTLY (``mcp.
-Client`` — #3698 PR-1; was ``mcp.client.session.ClientSession`` — plus
-``mcp.client.{stdio,streamable_http,sse}`` for the transports either way).
-fastmcp is no longer constructed anywhere in this module. #3698 stage 1 had
-already migrated stdio and non-OAuth http/sse;
-#4282 closed the remaining OAuth-configured-http gap by building the
+#4282: EVERY transport — ``stdio``, ``streamable-http``/``sse`` with or
+without OAuth configured — now goes through the official ``mcp`` SDK
+DIRECTLY (``mcp.Client`` — #3698 PR-1; was ``mcp.client.session.ClientSession``
+— plus ``mcp.client.{stdio,streamable_http,sse}`` for the transports either
+way). fastmcp is no longer constructed anywhere in this module. #3698 stage 1
+had already migrated stdio and non-OAuth streamable-http/sse;
+#4282 closed the remaining OAuth-configured-streamable-http gap by building the
 official SDK's own ``mcp.client.auth.OAuthClientProvider`` directly
 instead of fastmcp's ``OAuth`` wrapper around it — this needed two things
 fastmcp provided internally: a browser-redirect + localhost-callback
@@ -340,7 +342,12 @@ class MCPTransportError(MCPError):
     the pre-fix ``except MCPError:`` over-caught both of those)."""
 
 
-_SUPPORTED_TYPES = {"stdio", "http", "sse"}
+_SUPPORTED_TYPES = {"stdio", "streamable-http", "sse"}
+# #4604: the pre-rename value — kept as its own constant (not inlined into
+# the error branch below) so the rename story stays legible at the one
+# call site that reads it, rather than a bare string literal a future
+# grep for "http" would miss.
+_RENAMED_HTTP_TYPE = "http"
 
 
 def _resolve_client_mode(config: dict) -> "str":
@@ -853,6 +860,17 @@ class MCPClient:
         if not isinstance(config, dict):
             raise ValueError(f"MCP server config must be a dict, got {type(config).__name__}")
         srv_type = config.get("type")
+        if srv_type == _RENAMED_HTTP_TYPE:
+            # #4604: name the rename explicitly rather than letting this
+            # fall into the generic "not one of {...}" branch below — an
+            # operator whose config still says the old value needs to be
+            # told what it's now called, not just that it's invalid (the
+            # #4401 shape: a silent/ambiguous failure discovered only when
+            # the server later shows up degraded).
+            raise ValueError(
+                "MCP server type 'http' was renamed to 'streamable-http' "
+                "(#4604) — update this server's 'type' in your MCP config."
+            )
         if srv_type not in _SUPPORTED_TYPES:
             raise ValueError(
                 f"Unsupported MCP server type: {srv_type!r}. "
@@ -861,10 +879,10 @@ class MCPClient:
         # #2597 slice ④: 'auth' (OAuth) only makes sense over Streamable HTTP —
         # reject it eagerly at construction time for stdio/sse rather than
         # silently ignoring it (only _build_oauth_provider ever reads 'auth').
-        if config.get("auth") and srv_type != "http":
+        if config.get("auth") and srv_type != "streamable-http":
             raise ValueError(
-                f"MCP server 'auth' config is only supported for 'http' "
-                f"(Streamable HTTP) servers, not {srv_type!r}."
+                f"MCP server 'auth' config is only supported for "
+                f"'streamable-http' servers, not {srv_type!r}."
             )
         # #2976: same eager-rejection model as 'auth' above — 'write_paths' is a
         # sandbox grant for a spawned subprocess, so only 'stdio' has one. A
@@ -1336,7 +1354,7 @@ class MCPClient:
 
         stack = AsyncExitStack()
         try:
-            if self._type == "http":
+            if self._type == "streamable-http":
                 # #4282: OAuth (if configured — __init__ already rejects it
                 # for sse) is now built as the official SDK's own
                 # OAuthClientProvider (an httpx.Auth) and passed straight
@@ -2236,10 +2254,11 @@ class MCPClient:
                 "'headers' key instead (e.g. headers: {Authorization: "
                 "'Bearer ${TOKEN}'})."
             )
-        # Note: the http-only restriction is already enforced eagerly in
-        # __init__ (config.get("auth") + srv_type != "http" raises there) —
-        # this method is only ever reached via _initialize_http_or_sse's
-        # http branch, so self._type is guaranteed "http" here.
+        # Note: the streamable-http-only restriction is already enforced
+        # eagerly in __init__ (config.get("auth") + srv_type !=
+        # "streamable-http" raises there) — this method is only ever
+        # reached via _initialize_http_or_sse's streamable-http branch, so
+        # self._type is guaranteed "streamable-http" here.
 
         from reyn.mcp.oauth_token_storage import (
             MCPOAuthTokenStorage,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -2041,7 +2041,7 @@ class RouterHostAdapter:
         if not isinstance(expanded, dict):
             return [{"error": f"MCP server {server!r} config must be a dict"}]
         if "type" not in expanded and expanded.get("url"):
-            expanded = {**expanded, "type": "http"}
+            expanded = {**expanded, "type": "streamable-http"}
         return expanded
 
     async def _mcp_list_via_gateway(

--- a/tests/core/test_2761_pr3_mcp_immediate_probe.py
+++ b/tests/core/test_2761_pr3_mcp_immediate_probe.py
@@ -175,7 +175,7 @@ async def test_probe_unreachable_remote_returns_error() -> None:
     """Tier 2: the probe is transport-uniform — an unreachable REMOTE (http) server
     returns an error string via the SAME path (http-transport branch, same rollback)."""
     err = await probe_mcp_server(
-        "remote", {"type": "http", "url": "http://127.0.0.1:1/mcp", "timeout": 3},
+        "remote", {"type": "streamable-http", "url": "http://127.0.0.1:1/mcp", "timeout": 3},
     )
     assert isinstance(err, str) and err
 

--- a/tests/core/test_fp0016_e_agent_id.py
+++ b/tests/core/test_fp0016_e_agent_id.py
@@ -153,7 +153,7 @@ def test_mcp_client_injects_x_reyn_agent_id_header(monkeypatch) -> None:
 
     captured = _capture_http_headers(monkeypatch)
     client = MCPClient(
-        {"type": "http", "url": "https://example.com/mcp", "init_timeout": 1},
+        {"type": "streamable-http", "url": "https://example.com/mcp", "init_timeout": 1},
         agent_id="reyn/test-agent",
     )
     _initialize_and_swallow_connect_failure(client)
@@ -165,7 +165,7 @@ def test_mcp_client_no_agent_id_no_header(monkeypatch) -> None:
     from reyn.mcp.client import MCPClient
 
     captured = _capture_http_headers(monkeypatch)
-    client = MCPClient({"type": "http", "url": "https://example.com/mcp", "init_timeout": 1})
+    client = MCPClient({"type": "streamable-http", "url": "https://example.com/mcp", "init_timeout": 1})
     _initialize_and_swallow_connect_failure(client)
     assert "X-Reyn-Agent-Id" not in captured["headers"]
 
@@ -181,7 +181,7 @@ def test_mcp_client_operator_header_wins(monkeypatch) -> None:
     captured = _capture_http_headers(monkeypatch)
     client = MCPClient(
         {
-            "type": "http",
+            "type": "streamable-http",
             "url": "https://example.com/mcp",
             "headers": {"X-Reyn-Agent-Id": "reyn/spoofed"},
             "init_timeout": 1,

--- a/tests/core/test_mcp_install_ux_fixes_318_319_320.py
+++ b/tests/core/test_mcp_install_ux_fixes_318_319_320.py
@@ -102,12 +102,12 @@ def test_build_server_entry_writes_type_http_when_specified() -> None:
         "registryType": "npm",
         "identifier": "some/http-server",
         "version": "",
-        "transport": {"type": "http"},
+        "transport": {"type": "streamable-http"},
         "environmentVariables": [],
     }
     entry = _build_server_entry(pkg_raw, env_keys=[])
-    assert entry["type"] == "http"
-    # Pre-fix bug: would set entry["transport"] = "http" instead.
+    assert entry["type"] == "streamable-http"
+    # Pre-fix bug: would set entry["transport"] = "streamable-http" instead.
     assert "transport" not in entry
 
 

--- a/tests/core/test_plugin_install.py
+++ b/tests/core/test_plugin_install.py
@@ -829,7 +829,9 @@ def _build_mcp_entries_from_dict(mcp_json: dict) -> dict:
     """Round-trips *mcp_json* through a real temp file into
     ``_build_mcp_entries`` — same real-file-I/O shape as
     ``test_build_mcp_entries_registers_command_as_is`` above, factored out
-    for the #4570 conversion C1 transport-type adapter tests below."""
+    for the transport-type pass-through tests below (#4570 conversion C1
+    added the round-trip helper; #4604 removed the translation those
+    tests originally covered)."""
     import tempfile
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as fh:
         json.dump(mcp_json, fh)
@@ -840,30 +842,23 @@ def _build_mcp_entries_from_dict(mcp_json: dict) -> dict:
         mcp_json_path.unlink()
 
 
-def test_build_mcp_entries_translates_streamable_http_to_reyn_internal_http():
-    """Tier 1: (#4570 conversion C1) the Agent Plugins 1.0 spec's own
-    HTTP-family spelling, ``"streamable-http"``, is translated into reyn's
-    STILL-INTERNAL vocabulary value ``"http"`` (``mcp/client.py``'s
-    ``_SUPPORTED_TYPES`` — the repo-wide rename is #4604, deliberately not
-    done here) — this is the ONE adapter point #4570 conversion C1 adds."""
+def test_build_mcp_entries_passes_streamable_http_through_unchanged():
+    """Tier 1: (#4604) the Agent Plugins 1.0 spec's own HTTP-family
+    spelling, ``"streamable-http"``, is now ALSO reyn's own vocabulary
+    (``mcp/client.py``'s ``_SUPPORTED_TYPES``) — no translation happens
+    any more (#4570 conversion C1's temporary adapter was removed once
+    #4604 landed)."""
     entries = _build_mcp_entries_from_dict(
         {"mcpServers": {"srv": {"type": "streamable-http", "url": "http://localhost:1234"}}},
     )
 
-    assert entries["srv"]["type"] == "http"
+    assert entries["srv"]["type"] == "streamable-http"
 
 
 def test_build_mcp_entries_leaves_sse_unswept(tmp_path):
-    """Tier 1: (#4570 conversion C1, lead-coder review point) ``"sse"`` is
-    a DISTINCT value in both the spec's vocabulary and reyn's own — the
-    adapter above must translate ONLY ``"streamable-http"``, never sweep
-    ``"sse"`` into ``"http"`` too. A translation that maps BOTH would still
-    pass a test asserting "http.type == 'streamable-http' input yields
-    reyn's http" alone; this test is the one that actually distinguishes
-    "one value renamed" from "two values collapsed into one" — the
-    concrete failure mode: an adapter written as `"http" if "http" in
-    spec_type else spec_type` would silently swallow "sse" too, since it
-    is not a literal-equality check."""
+    """Tier 1: (accept-side) ``"sse"`` passes through unchanged — never
+    swept into ``"streamable-http"`` by any pattern-matching mistake in
+    the (now-removed) adapter's former translation logic."""
     entries = _build_mcp_entries_from_dict(
         {"mcpServers": {"srv": {"type": "sse", "url": "http://localhost:1234"}}},
     )
@@ -871,17 +866,16 @@ def test_build_mcp_entries_leaves_sse_unswept(tmp_path):
     assert entries["srv"]["type"] == "sse"
 
 
-def test_build_mcp_entries_defaults_missing_type_to_streamable_http_translated():
+def test_build_mcp_entries_defaults_missing_type_to_streamable_http():
     """Tier 1: (accept-side) a url-bearing entry omitting ``type``
-    entirely (pre-#4570-conversion-C1 shape, or an author who hasn't
-    updated yet) still defaults sanely — through the SAME translation
-    path, landing on reyn's ``"http"``, not a raw untranslated
-    ``"streamable-http"`` leaking into reyn's own vocabulary."""
+    entirely defaults to ``"streamable-http"`` — both the spec's own
+    default and reyn's own vocabulary agree since #4604, so this is a
+    plain default, not a translation."""
     entries = _build_mcp_entries_from_dict(
         {"mcpServers": {"srv": {"url": "http://localhost:1234"}}},
     )
 
-    assert entries["srv"]["type"] == "http"
+    assert entries["srv"]["type"] == "streamable-http"
 
 
 # ── #4570 conversion D: field-aware ${PLUGIN_ROOT}/${PLUGIN_DATA} bake ─────
@@ -1263,11 +1257,11 @@ async def test_plugin_install_stale_token_warning_fires_a_paired_audit_event(
     assert {f["name"] for f in findings} == {"wrongtoken2"}
 
 
-def test_build_mcp_entries_stdio_type_is_unaffected_by_the_adapter():
-    """Tier 1: (accept-side) the adapter only ever touches the url-bearing
-    (HTTP-family) branch — a stdio entry's ``"type": "stdio"`` is set
-    unconditionally by the ELSE branch, never routed through the
-    streamable-http/sse translation at all."""
+def test_build_mcp_entries_stdio_type_is_unaffected_by_the_url_branch():
+    """Tier 1: (accept-side) the ``spec_type`` default/pass-through only
+    ever applies to the url-bearing (HTTP-family) branch — a stdio
+    entry's ``"type": "stdio"`` is set unconditionally by the ELSE
+    branch, never touched by that logic at all."""
     entries = _build_mcp_entries_from_dict(
         {"mcpServers": {"srv": {"type": "stdio", "command": "python"}}},
     )

--- a/tests/interfaces/test_4604_config_validate_mcp_transport_rename.py
+++ b/tests/interfaces/test_4604_config_validate_mcp_transport_rename.py
@@ -1,0 +1,179 @@
+"""Tier 2: #4604 — ``reyn config validate``'s MCP transport-type check.
+
+reyn's own MCP transport-type vocabulary renamed ``"http"`` to
+``"streamable-http"``, aligning with the Agent Plugins 1.0 canonical
+``mcp.schema.json``. ``MCPClient.__init__`` already rejects the old value
+with a clear error naming the rename, but that only fires the next time the
+server is actually connected — the exact #4401 shape (a real failure
+discovered only much later) lead-coder flagged when assigning this issue,
+citing the owner's own real ``.reyn/config/mcp.yaml`` (still ``type: http``
+at assignment time). This check finds a stale ``type: http`` entry
+proactively, without connecting to anything.
+
+Checked PER SOURCE FILE (the SAME scan #4631's own placement check already
+does — this module's ``static_mcp_sources``/dynamic-file loop runs both
+detectors off one loaded raw dict per source, not two separate reads), so
+the finding can name which file to fix.
+
+Real CLI invocation against real config files (mirrors
+``test_4631_config_validate_mcp_placement.py``'s own established project
+fixture) — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    monkeypatch.setattr(
+        "reyn.config._find_project_root", lambda _cwd: tmp_path,
+    )
+    monkeypatch.setattr(
+        "reyn.config.loader._find_project_root", lambda _cwd: tmp_path,
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_a_streamable_http_entry_produces_no_finding(project, capsys):
+    """Tier 2: accept-side — the current, correct value must NOT be
+    flagged."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "mcp:\n  servers:\n    myserver:\n"
+            "      type: streamable-http\n      url: \"https://example.com/mcp\"\n"
+        ),
+    )
+    _validate()
+    out = capsys.readouterr().out
+    assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
+
+
+def test_a_stdio_entry_produces_no_finding(project, capsys):
+    """Tier 2: accept-side — an unrelated transport type (never renamed)
+    must not false-positive."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "mcp:\n  servers:\n    myserver:\n"
+            "      type: stdio\n      command: python\n"
+        ),
+    )
+    _validate()
+    out = capsys.readouterr().out
+    assert "MCP transport type" not in out
+
+
+def test_a_server_entry_with_type_http_in_reyn_yaml_is_flagged(project, capsys):
+    """Tier 2: the core witness (#4604's own motivating case — the
+    owner's real .reyn/config/mcp.yaml had this exact shape at
+    assignment time) — a stale ``type: http`` entry is caught and the
+    file is named."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "mcp:\n  servers:\n    myserver:\n"
+            "      type: http\n      url: \"https://example.com/mcp\"\n"
+        ),
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "MCP transport type" in out
+    assert "[reyn.yaml] mcp.servers.myserver.type: http" in out
+    assert "streamable-http" in out
+
+
+def test_a_server_entry_in_dot_reyn_config_mcp_yaml_is_flagged_with_its_own_file_name(
+    project, capsys,
+):
+    """Tier 2: the SAME stale value in the dynamic file — mirrors #4631's
+    own placement check, one detector per source, both correctly scoped."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "config" / "mcp.yaml",
+        "mcp:\n  servers:\n    myserver:\n      type: http\n      url: \"https://example.com/mcp\"\n",
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "MCP transport type" in out
+    assert "[.reyn/config/mcp.yaml] mcp.servers.myserver.type: http" in out
+    assert "[reyn.yaml]" not in out.split("MCP transport type")[1]
+
+
+def test_two_renamed_servers_in_the_same_file_are_both_named(project, capsys):
+    """Tier 2: multiple stale entries in one file are each named
+    individually, not collapsed into a count."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "mcp:\n  servers:\n"
+            "    serverA:\n      type: http\n      url: \"https://a.example.com/mcp\"\n"
+            "    serverB:\n      type: http\n      url: \"https://b.example.com/mcp\"\n"
+        ),
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "[reyn.yaml] mcp.servers.serverA.type: http" in out
+    assert "[reyn.yaml] mcp.servers.serverB.type: http" in out
+
+
+def test_a_misplaced_and_renamed_entry_is_flagged_by_both_checks(project, capsys):
+    """Tier 2: an entry that is BOTH misplaced (#4631, mcp.<name> instead
+    of mcp.servers.<name>) AND still says type: http (#4604) is caught
+    by #4631's placement check, not this one — this check only reads
+    ``mcp.servers.<name>``, so a misplaced entry is invisible to it
+    (the placement check's own fix — add the missing 'servers:' key —
+    is the prerequisite before this check can even see the entry)."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "mcp:\n  myserver:\n    type: http\n    url: \"https://example.com/mcp\"\n"
+        ),
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "MCP server placement" in out
+    assert "[reyn.yaml] mcp.myserver" in out
+    assert "MCP transport type" not in out
+
+
+def test_real_client_construction_rejects_the_renamed_value_by_name():
+    """Tier 1: the OTHER half of #4604's fix — the actual config-validate
+    proactive check above is a convenience; the real enforcement is
+    MCPClient itself refusing to construct with the old value, naming
+    the rename explicitly (not a generic "not one of {...}" the operator
+    has to decode)."""
+    from reyn.mcp.client import MCPClient
+
+    with pytest.raises(ValueError, match="renamed to 'streamable-http'"):
+        MCPClient({"type": "http", "url": "https://example.com/mcp"})

--- a/tests/mcp/test_config_mcp_headers.py
+++ b/tests/mcp/test_config_mcp_headers.py
@@ -55,7 +55,7 @@ def test_mcp_headers_field_load_with_env_interpolation(tmp_path, monkeypatch):
         "mcp": {
             "servers": {
                 "github": {
-                    "type": "http",
+                    "type": "streamable-http",
                     "url": "https://api.githubcopilot.com/mcp/",
                     "headers": {
                         "Authorization": "Bearer ${GITHUB_TOKEN}",
@@ -73,7 +73,7 @@ def test_mcp_headers_field_load_with_env_interpolation(tmp_path, monkeypatch):
     servers = cfg.mcp.get("servers") or {}
     assert "github" in servers, "github MCP server config should round-trip"
     gh = servers["github"]
-    assert gh["type"] == "http"
+    assert gh["type"] == "streamable-http"
     assert gh["url"] == "https://api.githubcopilot.com/mcp/"
     # ${VAR} resolves at load time
     assert gh["headers"]["Authorization"] == "Bearer ghp_t0pSecret"
@@ -94,7 +94,7 @@ def test_mcp_headers_optional_back_compat(tmp_path, monkeypatch):
         "mcp": {
             "servers": {
                 "local": {
-                    "type": "http",
+                    "type": "streamable-http",
                     "url": "http://localhost:3000/mcp",
                 },
             },
@@ -170,7 +170,7 @@ def test_mcp_headers_reach_http_transport(monkeypatch) -> None:
 
     captured = _capture_streamablehttp_client_kwargs(monkeypatch)
     cfg = {
-        "type": "http",
+        "type": "streamable-http",
         "url": "https://api.example.com/mcp",
         "headers": {
             "Authorization": "Bearer abc123",
@@ -204,7 +204,7 @@ def test_mcp_headers_default_empty_when_omitted(monkeypatch) -> None:
     from reyn.mcp.client import MCPClient, MCPError
 
     captured = _capture_streamablehttp_client_kwargs(monkeypatch)
-    cfg = {"type": "http", "url": "http://x/mcp", "init_timeout": 1}
+    cfg = {"type": "streamable-http", "url": "http://x/mcp", "init_timeout": 1}
     client = MCPClient(cfg)
     try:
         asyncio.run(client.initialize())

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -120,7 +120,7 @@ def test_http_transport_round_trip() -> None:
     async def _run_it():
         async with _HttpEchoServer() as server:
             cfg = {
-                "type": "http",
+                "type": "streamable-http",
                 "url": server.url,
                 "headers": {"Authorization": "Bearer abc"},
             }
@@ -138,7 +138,7 @@ def test_http_transport_forwards_agent_id_header() -> None:
 
     async def _run_it():
         async with _HttpEchoServer() as server:
-            cfg = {"type": "http", "url": server.url}
+            cfg = {"type": "streamable-http", "url": server.url}
             async with MCPClient(cfg, agent_id="reyn/test-agent") as client:
                 result = await client.call_tool("show_headers", {})
                 return result
@@ -181,7 +181,7 @@ def test_env_var_expansion(monkeypatch) -> None:
     monkeypatch.setenv("MY_TOKEN", "s3cret")
     monkeypatch.setenv("MY_HOST", "example.com")
     cfg = {
-        "type": "http",
+        "type": "streamable-http",
         "url": "https://${MY_HOST}/mcp",
         "headers": {"Authorization": "Bearer ${MY_TOKEN}"},
     }
@@ -275,7 +275,7 @@ def test_initialize_against_unreachable_http_raises_mcp_error_not_cancelled() ->
     that boundary, hiding the real ConnectError behind an uninformative
     CancelledError. See _close_stack_after_init_failure's docstring in
     client.py for the full root-cause and live-probe evidence."""
-    cfg = {"type": "http", "url": "http://127.0.0.1:1/mcp", "timeout": 3}
+    cfg = {"type": "streamable-http", "url": "http://127.0.0.1:1/mcp", "timeout": 3}
 
     async def _run_it():
         client = MCPClient(cfg)

--- a/tests/mcp/test_mcp_client_stderr_capture.py
+++ b/tests/mcp/test_mcp_client_stderr_capture.py
@@ -48,7 +48,7 @@ def _client(transport_type: str = "stdio") -> MCPClient:
     """
     if transport_type == "stdio":
         return MCPClient({"type": "stdio", "command": "/bin/true"})
-    return MCPClient({"type": "http", "url": "http://localhost:9999/mcp"})
+    return MCPClient({"type": "streamable-http", "url": "http://localhost:9999/mcp"})
 
 
 # ── 1. tail helpers handle absent capture gracefully ────────────────────
@@ -137,7 +137,7 @@ def test_http_transport_does_not_allocate_capture() -> None:
     Capture is stdio-only; http transport has no subprocess. The
     field stays None so close() is a no-op.
     """
-    client = _client("http")
+    client = _client("streamable-http")
     assert client.stderr_capture is None
     client.close_stderr_capture()  # safe
 

--- a/tests/mcp/test_mcp_oauth_2597_s4.py
+++ b/tests/mcp/test_mcp_oauth_2597_s4.py
@@ -60,7 +60,7 @@ def test_oauth_server_config_parses_via_load_config(tmp_path, monkeypatch) -> No
         "mcp:\n"
         "  servers:\n"
         "    github:\n"
-        "      type: http\n"
+        "      type: streamable-http\n"
         "      url: https://api.githubcopilot.com/mcp/\n"
         "      auth:\n"
         "        type: oauth\n"
@@ -72,7 +72,7 @@ def test_oauth_server_config_parses_via_load_config(tmp_path, monkeypatch) -> No
 
     cfg = load_config(cwd=tmp_path)
     server_cfg = cfg.mcp["servers"]["github"]
-    assert server_cfg["type"] == "http"
+    assert server_cfg["type"] == "streamable-http"
     assert server_cfg["auth"]["type"] == "oauth"
     assert server_cfg["auth"]["scopes"] == ["repo", "read:org"]
     assert server_cfg["auth"]["client_id"] == "my-client-id"
@@ -81,7 +81,7 @@ def test_oauth_server_config_parses_via_load_config(tmp_path, monkeypatch) -> No
 def test_bare_oauth_string_shorthand_parses(oauth_store_path) -> None:
     """Tier 1: ``auth: oauth`` (bare string) is shorthand for ``{"type": "oauth"}``
     — builds a provider without raising."""
-    cfg = {"type": "http", "url": "https://example.com/mcp", "auth": "oauth"}
+    cfg = {"type": "streamable-http", "url": "https://example.com/mcp", "auth": "oauth"}
     client = MCPClient(cfg, non_interactive=False)
     provider = asyncio.run(client._build_oauth_provider(cfg["url"]))
     assert provider is not None
@@ -89,7 +89,7 @@ def test_bare_oauth_string_shorthand_parses(oauth_store_path) -> None:
 
 def test_unsupported_auth_type_rejected() -> None:
     """Tier 1: a non-'oauth' auth.type is a clear config error, not a silent no-op."""
-    cfg = {"type": "http", "url": "https://example.com/mcp", "auth": {"type": "saml"}}
+    cfg = {"type": "streamable-http", "url": "https://example.com/mcp", "auth": {"type": "saml"}}
     client = MCPClient(cfg, non_interactive=False)
     with pytest.raises(MCPError, match="saml"):
         asyncio.run(client._build_oauth_provider(cfg["url"]))
@@ -181,7 +181,7 @@ def test_headless_with_stored_token_proceeds(oauth_store_path) -> None:
     url = "https://mcp.example.com/mcp"
     asyncio.run(MCPOAuthTokenStorage(url, path=oauth_store_path).set_tokens(_token("at-cached-7742")))
 
-    cfg = {"type": "http", "url": url, "auth": {"type": "oauth"}}
+    cfg = {"type": "streamable-http", "url": url, "auth": {"type": "oauth"}}
     client = MCPClient(cfg, non_interactive=True)
     provider = asyncio.run(client._build_oauth_provider(url))  # must not raise
     assert provider is not None
@@ -254,7 +254,7 @@ def test_headless_no_token_raises_clear_mcp_error_not_hang(oauth_store_path) -> 
     immediate MCPError instead of the OAuth flow opening a browser + waiting
     on a localhost callback nobody can complete."""
     cfg = {
-        "type": "http",
+        "type": "streamable-http",
         "url": "https://mcp.example.com/mcp",
         "auth": {"type": "oauth"},
     }
@@ -270,7 +270,7 @@ def test_interactive_client_with_no_token_does_not_raise_preflight_error(
     allowed to proceed to the browser flow even with no cached token — the
     headless guard only fires for non-interactive callers."""
     cfg = {
-        "type": "http",
+        "type": "streamable-http",
         "url": "https://mcp.example.com/mcp",
         "auth": {"type": "oauth"},
     }
@@ -287,7 +287,7 @@ def test_static_bearer_header_auth_unaffected(oauth_store_path) -> None:
     headers path) builds no OAuth provider at all — the ④ wiring is
     additive, never a behavior change for the existing header-auth path."""
     cfg = {
-        "type": "http",
+        "type": "streamable-http",
         "url": "https://mcp.example.com/mcp",
         "headers": {"Authorization": "Bearer static-token-abc"},
     }

--- a/tests/security/test_2976_mcp_sandbox_write_paths.py
+++ b/tests/security/test_2976_mcp_sandbox_write_paths.py
@@ -125,7 +125,7 @@ def test_write_paths_rejected_for_non_stdio_server():
     it would read to the operator as a restriction that was never applied.
     """
     with pytest.raises(ValueError, match="write_paths"):
-        MCPClient({"type": "http", "url": "https://x.test", "write_paths": ["~/.npm"]})
+        MCPClient({"type": "streamable-http", "url": "https://x.test", "write_paths": ["~/.npm"]})
 
 
 @pytest.mark.parametrize("bad", ["~/.npm", [1], {"p": "x"}])

--- a/tests/security/test_cli_mcp.py
+++ b/tests/security/test_cli_mcp.py
@@ -258,8 +258,8 @@ def test_infer_transport_stdio():
 
 
 def test_infer_transport_http():
-    """Tier 2: server with 'url' field inferred as 'http' transport."""
-    assert _infer_transport({"url": "http://localhost:3000/mcp"}) == "http"
+    """Tier 2: server with 'url' field inferred as 'streamable-http' transport."""
+    assert _infer_transport({"url": "http://localhost:3000/mcp"}) == "streamable-http"
 
 
 def test_infer_transport_explicit():


### PR DESCRIPTION
**[tui-coder]** — closes #4604.

## What

Split off #4570 conversion C (lead-coder ruling): reyn's own `.reyn/config/mcp.yaml` transport-type vocabulary rename, `"http"` → `"streamable-http"`, aligning with the Agent Plugins 1.0 canonical `mcp.schema.json`. `"stdio"`/`"sse"` are UNCHANGED — a single-value rename, not a vocabulary redesign.

## The reject-not-skip requirement

Lead-coder's own additional requirement at assignment: the owner's real machine has `type: http` right now. A clean break must not silently skip the operator's existing config — the #4401 shape ("8 MCP servers all degraded", discovered only much later). The old value must be **rejected, naming the new value**, not clamped or silently coerced. Two layers:

- `src/reyn/mcp/client.py`: `MCPClient.__init__` now raises a dedicated `ValueError` for the OLD value specifically — *"MCP server type 'http' was renamed to 'streamable-http' (#4604)..."* — before falling through to the generic "not one of {...}" branch.
- `src/reyn/interfaces/cli/commands/config.py`: a **new `reyn config validate` check** (mirrors #4631's own per-source-file shape-based detector, reusing the same loaded raw dict per source) finds a stale `type: http` entry **proactively, without connecting to anything** — closing the #4401 gap for this specific value before the operator ever tries to use the server.

## Changes

- Adapter removed: `plugin_install.py`'s `_build_mcp_entries` (#4570 conversion C1's temporary translation point) is gone — a plugin-declared `"streamable-http"` now passes straight through, since reyn's own vocabulary matches the spec natively.
- Backward-compat url-but-no-type default-fill sites (7 files) changed their fallback from `"http"` to `"streamable-http"`. `_infer_transport` (the `reyn mcp list` TRANSPORT column) does the same.
- Docs: 8 `.md`/`.ja.md` files, `reyn.local.yaml.example`, `docs/cookbook/configs/with-mcp.yaml`, `mcp-conformance.{json,md}`, `scripts/mcp_conformance.py`.
- Tests: 10 files updated (matches the issue's own 9-file count + a 10th found via `_infer_transport`'s own coverage). `test_plugin_install.py`'s 3 adapter-behavior tests are **rewritten**, not just renamed — the behavior itself changed from "translates" to "passes through unchanged". One new test file (7 tests): the new validate check's own core witness + accept-side cases + a Tier 1 pin on `MCPClient`'s own rejection message.

## Test plan

`ruff check .` (CI's exact gate), `mypy_ratchet.py`, `check_tests_path_literal_reference.py`, `test_tier_audit.py --strict` (189 tests across all touched/new test files), `mkdocs build --strict` — all green.

Scoped `pytest`: 1014 passed, 27 skipped, **2 failed** across `tests/mcp/` + `tests/security/` + the touched `tests/core/` files + both #4604/#4631 config-validate test files. Both failures (`test_fastmcp_core_dep_import_chain.py`, `test_mcp_install_ux_fixes_318_319_320.py`'s Darwin `shutil.which("reyn")` check) confirmed **pre-existing** on a clean `main` checkout via `git stash` — local venv environment state, unrelated to this change. +135 passed across `tests/interfaces/*config*`.

No Visual item — config/CLI text output only, no TUI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
