### PR TITLE
fix(#4097): remove 69 dead F401 imports in tests/interfaces, enforce going forward

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -563,8 +563,9 @@ ignore = [
 # tests/dev/, tests/repo/, tests/scripts/ (#4097 3rd slice),
 # cli/config/data/environment/hooks/http_safety/observability/plugins/
 # services/web (#4636, the 10 smallest remaining directories, 21
-# findings), tests/llm/ + tests/mcp/ (14 findings), and tests/security/
-# + tests/tools/ (48 findings, same per-import verification) are all
+# findings), tests/llm/ + tests/mcp/ (14 findings), tests/security/
+# + tests/tools/ (48 findings, same per-import verification), and
+# tests/interfaces/ (69 findings, same per-import verification) are all
 # enforced. Every other subdirectory stays ignored, each its own
 # future slice. ROOT-level tests/*.py files
 # (conftest.py etc.) and tests/_support/ are deliberately NOT listed
@@ -579,7 +580,6 @@ ignore = [
 # below don't have this failure mode because the directory NAME is the
 # anchor, not a wildcard.
 [tool.ruff.lint.per-file-ignores]
-"tests/interfaces/**/*.py" = ["F401"]
 "tests/runtime/**/*.py" = ["F401"]
 
 # #3726: wired into CI as a ratchet (.github/workflows/test.yml's "mypy

--- a/tests/interfaces/test_2081_s3_delegation_audit.py
+++ b/tests/interfaces/test_2081_s3_delegation_audit.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from reyn.interfaces.cli.commands import audit
 
 _RULE = "gateway:delegation-unsafe"

--- a/tests/interfaces/test_2280_durability_halt_observability.py
+++ b/tests/interfaces/test_2280_durability_halt_observability.py
@@ -52,7 +52,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.interfaces.repl.renderer import ConsoleChatRenderer, InlineChatRenderer
 from reyn.interfaces.repl.status import _snapshot
 from reyn.interfaces.transport.client_transport import ClientTransport
-from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, Frame
+from reyn.interfaces.transport.frames import EventFrame, Frame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry

--- a/tests/interfaces/test_3300_intervention_answer_eventify.py
+++ b/tests/interfaces/test_3300_intervention_answer_eventify.py
@@ -47,7 +47,6 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
 from reyn.interfaces.repl.renderer import (
     ConsoleChatRenderer,
     InlineChatRenderer,

--- a/tests/interfaces/test_3327_answer_bypasses_sentqueue.py
+++ b/tests/interfaces/test_3327_answer_bypasses_sentqueue.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 

--- a/tests/interfaces/test_3328_connect_remote_parity_witness.py
+++ b/tests/interfaces/test_3328_connect_remote_parity_witness.py
@@ -66,7 +66,6 @@ import uvicorn
 from fastapi import FastAPI
 
 from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
-from reyn.interfaces.repl.client_driver import run_chat_client
 from reyn.interfaces.repl.remote_client import run_remote_repl
 from reyn.interfaces.repl.renderer import ChatRenderer
 from reyn.interfaces.transport.agui import endpoint as endpoint_mod

--- a/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
+++ b/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
@@ -29,7 +29,6 @@ queues, and that is unchanged and witnessed in
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
 import pytest
 

--- a/tests/interfaces/test_a2a_capability_claim_interim.py
+++ b/tests/interfaces/test_a2a_capability_claim_interim.py
@@ -110,7 +110,6 @@ def test_push_notifications_claim_backed_by_webhook_post_call_sites() -> None:
     claim test.
     """
     _maybe_skip_if_router_unavailable()
-    from pathlib import Path
 
     repo_root = REPO_ROOT / "src" / "reyn" / "interfaces" / "web"
     a2a_router_src = (repo_root / "routers" / "a2a.py").read_text(

--- a/tests/interfaces/test_a2a_limit_iv_dispatch_1493.py
+++ b/tests/interfaces/test_a2a_limit_iv_dispatch_1493.py
@@ -30,7 +30,6 @@ import pytest
 from reyn.config import OnLimitConfig, SafetyConfig
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus
 from reyn.interfaces.web.run_registry import RunRegistry
-from reyn.runtime.session import Session
 from reyn.user_intervention import InterventionAnswer, UserIntervention
 from tests._support.agent_session import make_session
 

--- a/tests/interfaces/test_a2a_sse_producer_267_gap1.py
+++ b/tests/interfaces/test_a2a_sse_producer_267_gap1.py
@@ -41,7 +41,6 @@ from reyn.core.events.events import EventLog  # noqa: E402
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus  # noqa: E402
 from reyn.interfaces.web.run_registry import RunRegistry  # noqa: E402
 from reyn.user_intervention import (  # noqa: E402
-    InterventionAnswer,
     InterventionChoice,
     UserIntervention,
 )

--- a/tests/interfaces/test_a2a_webhook_progress_267_gap2.py
+++ b/tests/interfaces/test_a2a_webhook_progress_267_gap2.py
@@ -41,7 +41,6 @@ import pytest
 pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missing)")
 
 from reyn.core.events.events import EventLog  # noqa: E402
-from reyn.schemas.models import Event  # noqa: E402
 from tests._support.paths import REPO_ROOT
 
 
@@ -348,7 +347,6 @@ def test_handle_async_mode_attaches_bridge_around_send_to_agent_impl() -> None:
     ``test_handle_async_mode_bridge_is_unconditional_after_gap1``.
     """
     import ast
-    from pathlib import Path
 
     src_path = (
         REPO_ROOT

--- a/tests/interfaces/test_activity_row_3693.py
+++ b/tests/interfaces/test_activity_row_3693.py
@@ -26,7 +26,6 @@ import asyncio
 from typing import AsyncIterator
 
 import pytest
-from textual.content import Span
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp, palette
 from reyn.interfaces.inline.textual_chat.activity_row import (

--- a/tests/interfaces/test_agui_generic_client_degrade.py
+++ b/tests/interfaces/test_agui_generic_client_degrade.py
@@ -13,8 +13,6 @@ Real instances only — the real codec + AgUiTransport; no mocks.
 """
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from reyn.interfaces.transport.agui.client import AgUiTransport

--- a/tests/interfaces/test_agui_generic_client_e2e.py
+++ b/tests/interfaces/test_agui_generic_client_e2e.py
@@ -18,8 +18,6 @@ client below is a plain standard-field consumer written for the test (no mocks).
 """
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from reyn.core.events.events import Event

--- a/tests/interfaces/test_agui_mapping_completeness.py
+++ b/tests/interfaces/test_agui_mapping_completeness.py
@@ -21,7 +21,6 @@ circular.
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
 from reyn.core.events.events import Event
 from reyn.interfaces.transport.agui.protocol import (

--- a/tests/interfaces/test_agui_messages_standard_shape.py
+++ b/tests/interfaces/test_agui_messages_standard_shape.py
@@ -12,8 +12,6 @@ Real instances only — the real codec + AgUiTransport; no mocks.
 """
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from reyn.interfaces.transport.agui.client import AgUiTransport

--- a/tests/interfaces/test_agui_present_on_wire.py
+++ b/tests/interfaces/test_agui_present_on_wire.py
@@ -17,8 +17,6 @@ guard neutralizer; no mocks.
 """
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from reyn.interfaces.transport.agui.client import AgUiTransport

--- a/tests/interfaces/test_agui_reconnect_snapshot.py
+++ b/tests/interfaces/test_agui_reconnect_snapshot.py
@@ -9,8 +9,6 @@ Real instances only — the real emitter, codec, AgUiTransport; no mocks.
 """
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from reyn.interfaces.transport.agui.client import AgUiTransport

--- a/tests/interfaces/test_agui_state_read_model.py
+++ b/tests/interfaces/test_agui_state_read_model.py
@@ -13,8 +13,6 @@ RemoteStatusView; no mocks.
 """
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from reyn.core.events.events import Event

--- a/tests/interfaces/test_browser_reyn_decode_tripwire.py
+++ b/tests/interfaces/test_browser_reyn_decode_tripwire.py
@@ -16,7 +16,6 @@ names the browser's decode function reads and asserts each is a key the real
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 from reyn.interfaces.transport.agui.protocol import _encode_display
 from reyn.interfaces.transport.frames import DisplayFrame

--- a/tests/interfaces/test_chat_exclude_tools_187.py
+++ b/tests/interfaces/test_chat_exclude_tools_187.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_cli_secret.py
+++ b/tests/interfaces/test_cli_secret.py
@@ -13,9 +13,6 @@ Pins the contract for the four ``reyn secret`` subcommands:
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
-
-import pytest
 
 from reyn.interfaces.cli.commands.secret import (
     _get_audit_log,
@@ -26,7 +23,7 @@ from reyn.interfaces.cli.commands.secret import (
     run_rotate,
     run_set,
 )
-from reyn.security.secrets.store import load_secrets, save_secret
+from reyn.security.secrets.store import save_secret
 from tests._support.events import collect_events
 
 # ── helper ────────────────────────────────────────────────────────────────────

--- a/tests/interfaces/test_config_schema_introspection.py
+++ b/tests/interfaces/test_config_schema_introspection.py
@@ -20,8 +20,6 @@ import yaml
 
 from reyn.config import ReynConfig
 from reyn.config.config_schema import (
-    MISSING,
-    SchemaNode,
     is_valid_config_key,
     resolve_config_value,
     walk_config_schema,

--- a/tests/interfaces/test_conversation_chrome_separation.py
+++ b/tests/interfaces/test_conversation_chrome_separation.py
@@ -37,7 +37,7 @@ from reyn.interfaces.inline.textual_chat import Composer, TextualChatApp
 from reyn.interfaces.inline.textual_chat.activity_row import ActivityRow
 from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
 from reyn.interfaces.transport.client_transport import ClientTransport
-from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 

--- a/tests/interfaces/test_copy_mode_3507.py
+++ b/tests/interfaces/test_copy_mode_3507.py
@@ -151,7 +151,6 @@ def _binding_surfaces() -> "dict[str, list[str]]":
     read as "no violations" — the worst direction for this particular check.
     """
     import ast
-    import pathlib
 
     package = REPO_ROOT / (
         "src/reyn/interfaces/inline/textual_chat"

--- a/tests/interfaces/test_fp0001_a2a_endpoints.py
+++ b/tests/interfaces/test_fp0001_a2a_endpoints.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from pathlib import Path
 
 import pytest
 

--- a/tests/interfaces/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/interfaces/test_fp0001_e2e_ask_user_roundtrip.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-import threading
 from pathlib import Path
 
 import pytest

--- a/tests/interfaces/test_fp0001_run_registry.py
+++ b/tests/interfaces/test_fp0001_run_registry.py
@@ -17,7 +17,6 @@ import asyncio
 import pytest
 
 from reyn.interfaces.web.run_registry import RunEntry, RunRegistry
-from reyn.user_intervention import InterventionAnswer, UserIntervention
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/interfaces/test_mcp_refresh_cli.py
+++ b/tests/interfaces/test_mcp_refresh_cli.py
@@ -13,12 +13,7 @@ No unittest.mock / AsyncMock / MagicMock.
 """
 from __future__ import annotations
 
-import asyncio
-import json
-import sys
 from pathlib import Path
-
-import pytest
 
 from reyn.runtime.services.mcp_cache_file import (
     ToolsAnswered,

--- a/tests/interfaces/test_mcp_yaml_mtime_watch.py
+++ b/tests/interfaces/test_mcp_yaml_mtime_watch.py
@@ -16,7 +16,6 @@ mcp_tools_cache_snapshot public properties.
 """
 from __future__ import annotations
 
-import asyncio
 import time
 from pathlib import Path
 
@@ -47,7 +46,6 @@ from reyn.runtime.services.mcp_cache_file import (
     ToolsUnknown,
     cache_file_path,
     read_cache,
-    write_cache,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/interfaces/test_outbox_vocabulary.py
+++ b/tests/interfaces/test_outbox_vocabulary.py
@@ -17,8 +17,6 @@ Real instances only — the real dataclass, the real decode path; no mocks.
 """
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from reyn.interfaces.transport.agui.protocol import decode_event, encode_frame

--- a/tests/interfaces/test_progress_lifecycle_fanout_3357.py
+++ b/tests/interfaces/test_progress_lifecycle_fanout_3357.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import ast
 import asyncio
-from pathlib import Path
 
 import pytest
 

--- a/tests/interfaces/test_repl_renderer_pure_helpers.py
+++ b/tests/interfaces/test_repl_renderer_pure_helpers.py
@@ -20,7 +20,6 @@ strengthened; see each test's own docstring for its specific finding.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_run_registry_persist.py
+++ b/tests/interfaces/test_run_registry_persist.py
@@ -36,8 +36,7 @@ import asyncio
 import json
 from pathlib import Path
 
-from reyn.interfaces.web.run_registry import RunEntry, RunRegistry
-from reyn.user_intervention import InterventionAnswer, UserIntervention
+from reyn.interfaces.web.run_registry import RunRegistry
 
 # ── 1. Default (no persist_path) — legacy in-memory behaviour ──────────
 

--- a/tests/interfaces/test_slash_agent.py
+++ b/tests/interfaces/test_slash_agent.py
@@ -7,7 +7,6 @@ instances or the LLMReplay Fake").
 """
 from __future__ import annotations
 
-import asyncio
 import sys
 from pathlib import Path
 
@@ -181,7 +180,7 @@ async def test_agent_edit_role_persists_to_profile_and_session(tmp_path):
 async def test_agent_edit_role_preserves_other_profile_fields(tmp_path):
     """Tier 2: role edit MUST NOT clobber name / created_at / allowed_mcp."""
     from reyn.interfaces.slash.agent import _edit_role
-    from reyn.runtime.profile import PROFILE_FILENAME, AgentProfile
+    from reyn.runtime.profile import AgentProfile
 
     registry = _build_real_registry(tmp_path)
     registry.create("delta", role="initial")

--- a/tests/interfaces/test_slash_cancel_answer_completer.py
+++ b/tests/interfaces/test_slash_cancel_answer_completer.py
@@ -10,7 +10,6 @@ Pinned:
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_slash_destructive_confirm_parity.py
+++ b/tests/interfaces/test_slash_destructive_confirm_parity.py
@@ -13,10 +13,8 @@ Pinned per task spec:
 """
 from __future__ import annotations
 
-import asyncio
 import sys
 from dataclasses import dataclass
-from pathlib import Path
 
 import pytest
 

--- a/tests/interfaces/test_slash_help_per_command.py
+++ b/tests/interfaces/test_slash_help_per_command.py
@@ -33,7 +33,6 @@ Public surfaces tested:
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_slash_image_completer.py
+++ b/tests/interfaces/test_slash_image_completer.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 from tests._support.paths import REPO_ROOT
 
 _SRC = REPO_ROOT / "src"

--- a/tests/interfaces/test_slash_memory.py
+++ b/tests/interfaces/test_slash_memory.py
@@ -8,7 +8,6 @@ read through ``reyn.data.memory.list_entries`` / ``find_one``.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 import pytest
 

--- a/tests/interfaces/test_slash_pending_extended_and_reset_preview.py
+++ b/tests/interfaces/test_slash_pending_extended_and_reset_preview.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_slash_picker_hint_sweep.py
+++ b/tests/interfaces/test_slash_picker_hint_sweep.py
@@ -11,7 +11,6 @@ No MagicMock / patch per testing policy.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_slash_reset_docs_link.py
+++ b/tests/interfaces/test_slash_reset_docs_link.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_slash_see_also_field.py
+++ b/tests/interfaces/test_slash_see_also_field.py
@@ -17,7 +17,6 @@ Policy compliance:
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 
@@ -40,7 +39,7 @@ def test_slash_command_defaults_see_also_to_empty_tuple() -> None:
 
 def test_slash_decorator_stores_see_also_on_registered_command() -> None:
     """Tier 2: @slash(see_also=(...)) stores the tuple on the registered command."""
-    from reyn.interfaces.slash import REGISTRY, SlashCommand, slash
+    from reyn.interfaces.slash import REGISTRY, slash
 
     @slash(
         "xtest_see_also_reg",

--- a/tests/interfaces/test_slash_suggest_for_unknown.py
+++ b/tests/interfaces/test_slash_suggest_for_unknown.py
@@ -24,7 +24,6 @@ Pins:
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_slash_suggest_prefix_bias.py
+++ b/tests/interfaces/test_slash_suggest_prefix_bias.py
@@ -20,7 +20,6 @@ Public surfaces tested:
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_slash_usage_extension.py
+++ b/tests/interfaces/test_slash_usage_extension.py
@@ -27,7 +27,6 @@ checks to make sure no accidental opt-in slipped through.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_support_bundle_topology_pure_helpers.py
+++ b/tests/interfaces/test_support_bundle_topology_pure_helpers.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-import pytest
-
 from reyn.interfaces.cli.commands.support_bundle import _line_included, _rec_time
 from reyn.interfaces.cli.commands.topology import _format_members
 from reyn.runtime.topology import Topology

--- a/tests/interfaces/test_text_effect_cache_3860.py
+++ b/tests/interfaces/test_text_effect_cache_3860.py
@@ -377,7 +377,6 @@ def test_every_tte_effect_is_offered() -> None:
     pinning the third party's current inventory under reyn's name (CLAUDE.md
     Q1); what reyn actually promises is "whatever TTE ships, all of it".
     """
-    import inspect
     import pkgutil
 
     import terminaltexteffects.effects as tte_effects

--- a/tests/interfaces/test_textual_chat_phase1_3273.py
+++ b/tests/interfaces/test_textual_chat_phase1_3273.py
@@ -17,12 +17,10 @@ from __future__ import annotations
 
 import asyncio
 import tomllib
-from pathlib import Path
 from typing import AsyncIterator
 
 import pytest
 
-from reyn.interfaces.repl.client_driver import run_chat_client
 from reyn.interfaces.repl.renderer import ChatRenderer
 from reyn.interfaces.repl.stream_client import run_output_loop
 from reyn.interfaces.transport.client_transport import ClientTransport

--- a/tests/interfaces/test_textual_chat_phase2_3273.py
+++ b/tests/interfaces/test_textual_chat_phase2_3273.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import asyncio
 import re
 import tomllib
-from pathlib import Path
 from typing import AsyncIterator
 
 import pytest
@@ -182,7 +181,6 @@ def test_flowview_library_is_unmodified_blink_lives_in_reyn() -> None:
     :class:`ReynGutter`. The animation cadence is now the library's own native
     ``FlowView(animation_fps=N)`` clock (reyn passes ``N``; the library is
     unmodified). This is the 'blink glyph is reyn's, cadence is native' contract."""
-    import textual_flowview
     from textual_flowview import Entry, FlowView, StateDecorator
 
     # The library's own primitives are defined in textual_flowview, untouched.

--- a/tests/interfaces/test_textual_chat_phase3_3273.py
+++ b/tests/interfaces/test_textual_chat_phase3_3273.py
@@ -22,7 +22,6 @@ pilot) — no mocks — per the testing policy.
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import AsyncIterator
 
 import pytest

--- a/tests/interfaces/test_transport_dual_stream_completeness.py
+++ b/tests/interfaces/test_transport_dual_stream_completeness.py
@@ -15,7 +15,6 @@ derivation), so the two are bound independently — the gate is not circular.
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
 from reyn.interfaces.repl.status import _WAITING_ON_BY_EVENT
 from reyn.interfaces.transport.frames import forwarded_frame_kinds

--- a/tests/interfaces/test_web_auth_identity_authz.py
+++ b/tests/interfaces/test_web_auth_identity_authz.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from reyn.interfaces.web.auth import (
     OPERATOR_USER_ID,
     AuthContext,


### PR DESCRIPTION
**[e2e-coder]** — part of #4097 (final slice: `tests/interfaces/`, 69 findings — `tests/runtime/` 59 findings to follow as a separate PR, one dir per PR per the standing rule).

## What

Removes 69 dead F401 imports in `tests/interfaces/`, AND the `per-file-ignores` line for that directory in the same PR — follows the established shape (blanket → per-dir, absence = enforced).

**Diff-verified the removal**: `git diff origin/main -- pyproject.toml | grep '^-"tests/'` shows exactly `-"tests/interfaces/**/*.py" = ["F401"]`; the `+` grep is empty (no other slice's line revived).

## Verification discipline

Each of the 69 verified individually (occurrence-count grep against real code tokens, not comment/docstring/decorator-attribute text). Notable non-trivial cases:

- `test_textual_chat_phase1_3273.py` (`Path`, `run_chat_client`): both apparent uses live inside a triple-quoted subprocess-source string with its own independent imports — the outer module-level imports were dead.
- `test_textual_chat_phase2_3273.py` (`textual_flowview`): the function only uses `Entry`/`FlowView`/`StateDecorator` (separately imported) and the string `"textual_flowview"`, never the module object.
- `test_slash_see_also_field.py` (`SlashCommand`): used in three other test functions via their own separate local imports; the flagged occurrence (a fourth function) was an independent, unused copy.
- `test_a2a_limit_iv_dispatch_1493.py` (`Session`) / `test_3328_connect_remote_parity_witness.py` (`run_chat_client`): apparent "uses" were docstring prose describing the mechanism, not real code.
- A batch of `@pytest.mark.asyncio`-decorator-only `asyncio` imports (test_agui_*.py ×6, test_slash_agent.py, test_slash_destructive_confirm_parity.py, test_mcp_yaml_mtime_watch.py, test_mcp_refresh_cli.py) — the decorator is a marker string, not a real module use.
- Several multi-name import lines needed partial edits (one name dead, sibling live): `test_cli_secret.py` (`load_secrets` dead, `save_secret` live), `test_run_registry_persist.py`/`test_fp0001_run_registry.py` (`RunEntry`/`InterventionAnswer`/`UserIntervention` dead, siblings live), `test_config_schema_introspection.py` (`MISSING`/`SchemaNode` dead), `test_2280_durability_halt_observability.py`/`test_conversation_chrome_separation.py` (`DisplayFrame` dead, `EventFrame`/`Frame` live), `test_slash_agent.py` (`PROFILE_FILENAME` dead, `AgentProfile` live).

No case turned out to be a real use ruff mis-flagged — 69/69 genuinely dead, no `# noqa` needed.

## Verification

- `ruff check .`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py`: clean.
- Full regression sweep (`tests/interfaces`): 1762 passed, 4 skipped (pre-existing, `reyn[voice]` extra not installed), 0 failures.

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Verified each of the 69 removed imports individually.
- [x] Diff-verified the pyproject.toml removal (exactly 1 line, correct).
- [x] Full regression sweep (1762 tests) — clean.
- [ ] (Visual) — n/a, no UI surface.

part of #4097

🤖 Generated with [Claude Code](https://claude.com/claude-code)
