### PR TITLE
fix(#4097): remove 59 dead F401 imports in tests/runtime, close out per-file-ignores blanket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -565,9 +565,9 @@ ignore = [
 # services/web (#4636, the 10 smallest remaining directories, 21
 # findings), tests/llm/ + tests/mcp/ (14 findings), tests/security/
 # + tests/tools/ (48 findings, same per-import verification), and
-# tests/interfaces/ (69 findings, same per-import verification) are all
-# enforced. Every other subdirectory stays ignored, each its own
-# future slice. ROOT-level tests/*.py files
+# tests/interfaces/ (69 findings) and tests/runtime/ (59 findings, same
+# per-import verification) are all enforced -- the final #4097 slice,
+# every tests/ subdirectory now enforces F401. ROOT-level tests/*.py files
 # (conftest.py etc.) and tests/_support/ are deliberately NOT listed
 # here -- both measured 0 findings already, so leaving them off this
 # list enforces F401 there too, for free (caught in review, #4640: an
@@ -580,7 +580,6 @@ ignore = [
 # below don't have this failure mode because the directory NAME is the
 # anchor, not a wildcard.
 [tool.ruff.lint.per-file-ignores]
-"tests/runtime/**/*.py" = ["F401"]
 
 # #3726: wired into CI as a ratchet (.github/workflows/test.yml's "mypy
 # (ratchet)" job), not a blocking full-adoption gate — the tree currently

--- a/tests/runtime/test_1128_step3_token_budget_headtail.py
+++ b/tests/runtime/test_1128_step3_token_budget_headtail.py
@@ -124,7 +124,6 @@ def _make_session_with_t_max(tmp_path: Path, monkeypatch, t_max: int):
     from reyn.config import CompactionConfig
     from reyn.core.events.state_log import StateLog
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig
-    from reyn.runtime.session import Session
 
     monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: t_max)
     return make_session(

--- a/tests/runtime/test_2259_pr3_recovery_semantics_falsify.py
+++ b/tests/runtime/test_2259_pr3_recovery_semantics_falsify.py
@@ -23,7 +23,6 @@ Real StateLog + SnapshotJournal + AgentRegistry + restore_all (no mocks).
 from __future__ import annotations
 
 import asyncio
-import json
 from pathlib import Path
 
 import pytest
@@ -234,7 +233,7 @@ async def test_durability_failure_fail_stops_and_surfaces(tmp_path):
     (the owner's "no silent unbounded loss"). RED if the consumer is absent (the op is accepted /
     the loop keeps running)."""
     from reyn.core.events.durability_worker import DurabilityWorker
-    from reyn.runtime.session import DurabilityHaltError, Session
+    from reyn.runtime.session import DurabilityHaltError
 
     worker = DurabilityWorker(max_write_attempts=1)  # fail-fast: no slow backoff in the test
     log = StateLog(tmp_path / "wal.jsonl", worker=worker)

--- a/tests/runtime/test_2425_step1c_chat_chokepoint.py
+++ b/tests/runtime/test_2425_step1c_chat_chokepoint.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import json
 import re
-from pathlib import Path
 
 import yaml
 

--- a/tests/runtime/test_2608_h4_fs_watcher.py
+++ b/tests/runtime/test_2608_h4_fs_watcher.py
@@ -342,7 +342,6 @@ async def test_session_owned_watcher_fires_configured_hook_into_inbox(tmp_path):
     (public) inbox."""
     from reyn.config.infra import FsWatchConfig
     from reyn.core.events.state_log import StateLog
-    from reyn.runtime.session import Session
 
     watched_dir = tmp_path / "watched"
     watched_dir.mkdir()

--- a/tests/runtime/test_3049_driver_router_op_intervention_reaches_originator.py
+++ b/tests/runtime/test_3049_driver_router_op_intervention_reaches_originator.py
@@ -35,7 +35,7 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.state_log import StateLog
-from reyn.intervention_choices import YES, generic_yn_choices
+from reyn.intervention_choices import YES
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
 from reyn.runtime.session_api import _build_agent_step_narrowing, spawn_ephemeral_session

--- a/tests/runtime/test_3704_seq_assigned_to_every_role.py
+++ b/tests/runtime/test_3704_seq_assigned_to_every_role.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 from reyn.runtime.chat_message import ChatMessage
 from tests._support.session import make_session as _make_session
 

--- a/tests/runtime/test_a2a_handler_invariants.py
+++ b/tests/runtime/test_a2a_handler_invariants.py
@@ -235,8 +235,7 @@ async def test_handle_agent_request_appends_history_emits_event(
     assert entry["meta"].get("chain_id") == "chain-test-001"
 
     # Event log must have agent_request_received.
-    from reyn.core.events.event_store import EventStore
-    store: EventStore = trackers["event_log"]._subscribers[0]
+    store = trackers["event_log"]._subscribers[0]
     # We can't directly iterate events; use the WAL as a proxy for chain events.
     # For the EventLog subscriber we verify via the outbox path is not applicable
     # here — but history entry + chain_id propagation is the primary observable.

--- a/tests/runtime/test_a2a_router_cap_wrapup_1538.py
+++ b/tests/runtime/test_a2a_router_cap_wrapup_1538.py
@@ -27,7 +27,6 @@ No mocks — real InterAgentMessaging + real Session + real scripted LLM callabl
 """
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 import pytest
@@ -38,7 +37,6 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.errors import RouterCapExceeded
 from reyn.runtime.services.chain_manager import ChainManager
 from reyn.runtime.services.inter_agent_messaging import InterAgentMessaging
-from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 from tests._support.router_loop import FakeEventLog
 

--- a/tests/runtime/test_action_retrieval_wiring.py
+++ b/tests/runtime/test_action_retrieval_wiring.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from reyn.config import ReynConfig, load_config
 from reyn.runtime.router_tools import build_tools
 from reyn.runtime.services.router_host_adapter import (

--- a/tests/runtime/test_cost_warn_session_wiring_2230.py
+++ b/tests/runtime/test_cost_warn_session_wiring_2230.py
@@ -16,7 +16,6 @@ from reyn.config import CostWarnConfig
 from reyn.core.events.state_log import StateLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.model_cost_warn import maybe_block_high_cost_model
-from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 

--- a/tests/runtime/test_embedding_cost_tracking.py
+++ b/tests/runtime/test_embedding_cost_tracking.py
@@ -173,8 +173,6 @@ def test_reset_all_clears_embedding_aggregate() -> None:
 
 
 def _registry(tmp_path, tracker: "BudgetTracker | None" = None) -> AgentRegistry:
-    from reyn.runtime.session import Session
-
     shared = tracker if tracker is not None else BudgetTracker(CostConfig())
 
     def factory(profile: AgentProfile):

--- a/tests/runtime/test_execution_driver_seam.py
+++ b/tests/runtime/test_execution_driver_seam.py
@@ -20,7 +20,6 @@ Policy compliance (docs/deep-dives/contributing/testing.md):
 from __future__ import annotations
 
 from reyn.runtime.services.router_loop_driver import RouterLoopDriver
-from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime/test_force_close_chat_activation_1092.py
+++ b/tests/runtime/test_force_close_chat_activation_1092.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from reyn.core.events.state_log import StateLog
-from reyn.runtime.session import Session
 from reyn.services.compaction.engine import estimate_tokens
 from reyn.services.turn_budget import (
     DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS,

--- a/tests/runtime/test_fp0009_b_e2e_scheduler.py
+++ b/tests/runtime/test_fp0009_b_e2e_scheduler.py
@@ -10,15 +10,14 @@ config→CronJob→CronScheduler→runner pipeline end-to-end without LLM.
 """
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import pytest
 import yaml
 
-from reyn.config import CronConfig, CronJobConfig, _build_cron_config, load_config
+from reyn.config import CronConfig, _build_cron_config, load_config
 from reyn.runtime.cron import CronJob as CronJobRuntime
 from reyn.runtime.cron import CronScheduler
 

--- a/tests/runtime/test_fp0036_live_runner.py
+++ b/tests/runtime/test_fp0036_live_runner.py
@@ -24,13 +24,10 @@ Policy compliance (docs/deep-dives/contributing/testing.md):
 """
 from __future__ import annotations
 
-import asyncio
-import shutil
 from pathlib import Path
 
 import pytest
 
-from reyn.core.events.state_log import StateLog
 from reyn.dev.dogfood.scenarios import Scenario
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage

--- a/tests/runtime/test_fp0041_prc_external_routing.py
+++ b/tests/runtime/test_fp0041_prc_external_routing.py
@@ -28,7 +28,6 @@ import pytest
 from reyn.runtime.external_routing import (
     ExternalTransportEntry,
     ExternalTransportRouting,
-    RouteResult,
     build_mcp_args,
     parse_external_transports,
     route_to_mcp,

--- a/tests/runtime/test_intervention_agent_routing.py
+++ b/tests/runtime/test_intervention_agent_routing.py
@@ -26,8 +26,6 @@ import asyncio
 import inspect
 from pathlib import Path
 
-import pytest
-
 from reyn.runtime.agent import Agent
 from reyn.runtime.services.recovery import build_recovery, default_snapshot_path
 from reyn.runtime.session import Session

--- a/tests/runtime/test_intervention_agent_subscriber.py
+++ b/tests/runtime/test_intervention_agent_subscriber.py
@@ -30,8 +30,6 @@ import asyncio
 import inspect
 from pathlib import Path
 
-import pytest
-
 from reyn.runtime.session import Session
 from reyn.runtime.session_buses import AgentRequestBus
 from reyn.user_intervention import (

--- a/tests/runtime/test_intervention_bus_protocols.py
+++ b/tests/runtime/test_intervention_bus_protocols.py
@@ -36,7 +36,6 @@ import inspect
 from pathlib import Path
 
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus
-from reyn.runtime.session import Session
 from reyn.runtime.session_buses import ChatInterventionBus
 from reyn.user_intervention import (
     InterventionAnswer,

--- a/tests/runtime/test_intervention_source_agent.py
+++ b/tests/runtime/test_intervention_source_agent.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import sys
 from contextvars import copy_context
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/runtime/test_intervention_subscriber_guard.py
+++ b/tests/runtime/test_intervention_subscriber_guard.py
@@ -36,7 +36,6 @@ import pytest
 from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.services.intervention_registry import InterventionRegistry
-from reyn.runtime.session import Session
 from reyn.user_intervention import InterventionAnswer, UserIntervention
 from tests._support.agent_session import make_session
 

--- a/tests/runtime/test_lifecycle_forwarder_tool_call_events.py
+++ b/tests/runtime/test_lifecycle_forwarder_tool_call_events.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/runtime/test_limit_deny_force_close_router_cap_1496.py
+++ b/tests/runtime/test_limit_deny_force_close_router_cap_1496.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
+from reyn.config import LoopConfig, SafetyConfig
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig

--- a/tests/runtime/test_mcp_cache_warm_start.py
+++ b/tests/runtime/test_mcp_cache_warm_start.py
@@ -16,7 +16,6 @@ added in the same PR per Tier policy).
 """
 from __future__ import annotations
 
-import asyncio
 import time
 from pathlib import Path
 

--- a/tests/runtime/test_mcp_search_tool_invariants.py
+++ b/tests/runtime/test_mcp_search_tool_invariants.py
@@ -18,7 +18,7 @@ Policy compliance (docs/deep-dives/contributing/testing.ja.md):
 """
 from __future__ import annotations
 
-from reyn.runtime.router_tools import MCP_SEARCH_THRESHOLD, build_mcp_search_tool, build_tools
+from reyn.runtime.router_tools import build_mcp_search_tool, build_tools
 
 # ── Shared fixtures ───────────────────────────────────────────────────────────
 

--- a/tests/runtime/test_media_cap_272.py
+++ b/tests/runtime/test_media_cap_272.py
@@ -24,7 +24,6 @@ handler with a real MediaStore.
 """
 from __future__ import annotations
 
-import asyncio
 import base64
 import json
 from pathlib import Path
@@ -35,7 +34,6 @@ from reyn.runtime.router_loop import (
     _build_media_followup_message,
 )
 from reyn.services.compaction.engine import _IMAGE_FIXED_TOKEN_COST, estimate_tokens
-from reyn.tools.types import RouterCallerState, ToolContext
 
 
 def _store(tmp_path: Path) -> MediaStore:

--- a/tests/runtime/test_pending_intervention_268.py
+++ b/tests/runtime/test_pending_intervention_268.py
@@ -44,7 +44,6 @@ import pytest
 
 from reyn.runtime.pending_op_view import PendingOpView
 from reyn.runtime.services.intervention_registry import InterventionRegistry
-from reyn.runtime.session import Session
 from reyn.user_intervention import (
     InterventionAnswer,
     UserIntervention,

--- a/tests/runtime/test_permission_prompt_phrasing.py
+++ b/tests/runtime/test_permission_prompt_phrasing.py
@@ -19,9 +19,7 @@ This file pins:
 """
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -31,7 +29,6 @@ from reyn.runtime.services.intervention_handler import InterventionHandler
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from reyn.user_intervention import (
     InterventionAnswer,
-    InterventionBus,
     UserIntervention,
 )
 

--- a/tests/runtime/test_pipeline_driver_resource_caller_state_2567.py
+++ b/tests/runtime/test_pipeline_driver_resource_caller_state_2567.py
@@ -39,7 +39,6 @@ and ``tests/tools/test_pipeline_is5_surfacing.py``).
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 

--- a/tests/runtime/test_reasoning_integration_1652.py
+++ b/tests/runtime/test_reasoning_integration_1652.py
@@ -41,7 +41,6 @@ _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
 
-from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 _REASONING = "REYN_1652_THOUGHTS: 17*23 = 391."

--- a/tests/runtime/test_registry_multi_session_1726.py
+++ b/tests/runtime/test_registry_multi_session_1726.py
@@ -15,7 +15,6 @@ import pytest
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
-from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 

--- a/tests/runtime/test_router_host_adapter_invariants.py
+++ b/tests/runtime/test_router_host_adapter_invariants.py
@@ -6,11 +6,6 @@ callbacks are used throughout. No private state assertions — public surface on
 """
 from __future__ import annotations
 
-import asyncio
-from pathlib import Path
-
-import pytest
-
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.router_loop import RouterLoopHost

--- a/tests/runtime/test_router_loop_pure_helpers.py
+++ b/tests/runtime/test_router_loop_pure_helpers.py
@@ -15,7 +15,6 @@ runtime/services/memory_service.py with the read_body operation that calls it).
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/runtime/test_router_loop_swallow_instrument_187.py
+++ b/tests/runtime/test_router_loop_swallow_instrument_187.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import pytest
 
-from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events
 

--- a/tests/runtime/test_router_system_prompt.py
+++ b/tests/runtime/test_router_system_prompt.py
@@ -7,8 +7,6 @@ OS frame with no tool-use SP.
 """
 from __future__ import annotations
 
-import pytest
-
 from reyn.runtime.router_system_prompt import build_system_prompt
 from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 

--- a/tests/runtime/test_router_system_prompt_wrapper_visibility.py
+++ b/tests/runtime/test_router_system_prompt_wrapper_visibility.py
@@ -12,8 +12,6 @@ Coverage:
 """
 from __future__ import annotations
 
-import pytest
-
 from reyn.runtime.router_system_prompt import build_system_prompt
 from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 

--- a/tests/runtime/test_scoped_session_factory_invariant_1402.py
+++ b/tests/runtime/test_scoped_session_factory_invariant_1402.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import ast
 import dataclasses
 import inspect
-from pathlib import Path
 
 from reyn.runtime.factory_config import SessionFactoryConfig
 from reyn.runtime.scoped_session_factory import build_scoped_chat_session

--- a/tests/runtime/test_session_cost_accumulation.py
+++ b/tests/runtime/test_session_cost_accumulation.py
@@ -18,7 +18,6 @@ from reyn.core.events.events import EventLog
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage, estimate_cost
 from reyn.runtime.router_loop import RouterLoop
-from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime/test_session_invariants.py
+++ b/tests/runtime/test_session_invariants.py
@@ -26,7 +26,6 @@ Policy compliance (`docs/deep-dives/contributing/testing.ja.md`):
 from __future__ import annotations
 
 import asyncio
-import json
 from pathlib import Path
 
 import pytest

--- a/tests/runtime/test_session_notify_state_change.py
+++ b/tests/runtime/test_session_notify_state_change.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.session import Session

--- a/tests/runtime/test_session_pure_extraction_3679_s1.py
+++ b/tests/runtime/test_session_pure_extraction_3679_s1.py
@@ -34,7 +34,6 @@ import inspect
 import os
 import subprocess
 import sys
-from pathlib import Path
 
 from reyn.runtime.session_pure import (
     merge_memory_indexes,

--- a/tests/runtime/test_session_pure_helpers.py
+++ b/tests/runtime/test_session_pure_helpers.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 

--- a/tests/runtime/test_sp_environment_sysinfo_1479.py
+++ b/tests/runtime/test_sp_environment_sysinfo_1479.py
@@ -16,7 +16,6 @@ No mocks. Real-construct fakes.
 """
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 from reyn.runtime.router_system_prompt import build_system_prompt

--- a/tests/runtime/test_spawn_routing_gate_2708.py
+++ b/tests/runtime/test_spawn_routing_gate_2708.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import ast
 import inspect
-from pathlib import Path
 
 import pytest
 

--- a/tests/runtime/test_transport_ref.py
+++ b/tests/runtime/test_transport_ref.py
@@ -25,7 +25,6 @@ from reyn.runtime.transport import (
     AgentRef,
     McpRef,
     SystemRef,
-    TransportRef,
     TuiRef,
 )
 from tests._support.agent_session import make_session

--- a/tests/runtime/test_untrusted_profile_1827_s4.py
+++ b/tests/runtime/test_untrusted_profile_1827_s4.py
@@ -22,7 +22,7 @@ from reyn.security.permissions.capability_profile import (
     resolve_profile,
 )
 from reyn.security.permissions.effective import CapabilityAxis, ContextualLayer
-from reyn.user_intervention import InterventionAnswer, UserIntervention
+from reyn.user_intervention import UserIntervention
 
 # ── the built-in secure default + override ──────────────────────────────────
 

--- a/tests/runtime/test_user_image_input.py
+++ b/tests/runtime/test_user_image_input.py
@@ -21,8 +21,6 @@ import asyncio
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import pytest
-
 from reyn.config import MultimodalConfig
 from reyn.interfaces.slash import REGISTRY
 from reyn.runtime.chat_message import ChatMessage


### PR DESCRIPTION
**[e2e-coder]** — part of #4097 (final slice: `tests/runtime/`, 59 findings). This is the last remaining `tests/` subdirectory — every other one is already enforced.

## What

Removes 59 dead F401 imports in `tests/runtime/`, and the `per-file-ignores` line for that directory — this leaves `[tool.ruff.lint.per-file-ignores]` with zero remaining `tests/*` entries (confirmed: `grep -n '^"tests/' pyproject.toml` returns nothing after this PR).

**Diff-verified the removal**: `git diff origin/main -- pyproject.toml | grep '^-"tests/'` shows exactly `-"tests/runtime/**/*.py" = ["F401"]`; the `+` grep is empty.

## Verification discipline

Each of the 59 verified individually. This directory is `tests/runtime/` — Session's own test suite — so the ~15 `reyn.runtime.session.Session` findings got extra scrutiny (grepped for `Session(` construction, `isinstance(x, Session)`, and `-> Session` return annotations before removing, not just occurrence count):

- All ~15 Session findings were genuinely dead: every file uses the `make_session()` factory helper (`tests/_support/agent_session.py`), which returns an instance without the caller ever naming the `Session` class directly.
- `test_a2a_handler_invariants.py:238` — a local `from reyn.core.events.event_store import EventStore` whose only use was a variable annotation (`store: EventStore = ...`). The file has `from __future__ import annotations` (PEP 563), so the annotation is never evaluated at runtime — a dead, redundant shadow of the already-live module-level import. Removed the local import and the now-unnecessary annotation.
- Standard cases: `@pytest.mark.asyncio`-decorator-only `asyncio` imports, docstring-prose-only mentions, count==1 trivial removals.

No case turned out to be a real use ruff mis-flagged — 59/59 genuinely dead, no `# noqa` needed.

## Verification

- `ruff check .`: clean.
- `scripts/mypy_ratchet.py`: 211 findings, all baselined (unchanged).
- `scripts/test_tier_audit.py --strict`: 395 tests inspected, 0 errors.
- `scripts/check_tests_path_literal_reference.py`: 111 refs, all baselined.
- Full regression sweep (`tests/runtime`): 1744 passed, 1 skipped, 0 failures.

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Verified each of the 59 removed imports individually, with extra care on the Session-factory-pattern files.
- [x] Diff-verified the pyproject.toml removal (exactly 1 line, correct) and confirmed zero `tests/*` entries remain.
- [x] Full regression sweep (1744 tests) — clean.
- [ ] (Visual) — n/a, no UI surface.

part of #4097

🤖 Generated with [Claude Code](https://claude.com/claude-code)
