### PR TITLE
feat(#4653): select F821 (undefined name) — 35 findings, per-item disposition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -527,14 +527,34 @@ ignore = [
     # F811: local imports inside functions for clarity (e.g. lazy
     # imports of optional deps) trigger this.
     "F811",
-    # F821: forward references in string annotations
-    # (`x: "Foo | None"`) confuse pyflakes; the actual import lives
-    # under TYPE_CHECKING.
-    "F821",
     # F841: explicit `_ = ...` placeholders or guard variables that
     # aren't used outside an assertion are intentional.
     "F841",
 ]
+
+# #4653 (F401's own sibling): F821 (undefined name) was unignored repo-wide,
+# not sliced -- 35 findings, an order of magnitude smaller than #4097's F401
+# population, so no per-directory rollout was needed. The stale rationale
+# above this used to claim a forward ref under TYPE_CHECKING "confuses"
+# pyflakes; it doesn't -- pyflakes correctly flags a name that resolves to
+# nothing at runtime. Each finding was one of two genuinely different
+# shapes, never decided from the count alone: (a) a missing import -- 32
+# cases, all but 2 a TYPE_CHECKING-only import (the annotation is never
+# evaluated at runtime under `from __future__ import annotations`); 2 cases
+# (`ExternalTransportRouting` in config/root.py, `OAuthProviderConfig` in
+# config/infra.py) needed a CONCRETE import instead, because
+# config_schema.py's own `walk_config_schema` calls `get_type_hints()`,
+# which eagerly resolves every forward ref against the class's real module
+# globals -- a TYPE_CHECKING-only name is never in there, so the field would
+# have silently dropped from the schema walk. (b) a wrong name in the
+# annotation -- 3 cases where the annotation referenced a name that never
+# existed anywhere in the file (a typo'd class, e.g. `_OnLimitConfig` for
+# the real `OnLimitConfig`) and the fix was correcting the name, not adding
+# an import. Landing (a)'s 2 concrete-import cases also let
+# config_schema.py drop its own hardcoded `_patch_localns` workaround that
+# duplicated those same two names in a second file, specifically to paper
+# over this exact gap for `get_type_hints()` alone -- the workaround is now
+# unnecessary because both names are real module attributes.
 
 # #4097: F401 (unused import) — enforced in src/, still ignored in tests/.
 # A blanket F401 ignore meant no gate could ever say "nobody uses this

--- a/scripts/mypy_ratchet_baseline.json
+++ b/scripts/mypy_ratchet_baseline.json
@@ -24,14 +24,6 @@
     "code": "attr-defined"
   },
   {
-    "file": "src/reyn/config/infra.py",
-    "code": "name-defined"
-  },
-  {
-    "file": "src/reyn/config/root.py",
-    "code": "name-defined"
-  },
-  {
     "file": "src/reyn/core/events/agent_snapshot.py",
     "code": "arg-type"
   },
@@ -42,10 +34,6 @@
   {
     "file": "src/reyn/core/events/event_store.py",
     "code": "misc"
-  },
-  {
-    "file": "src/reyn/core/events/state_log.py",
-    "code": "name-defined"
   },
   {
     "file": "src/reyn/core/kernel/codeact_runner.py",
@@ -288,10 +276,6 @@
     "code": "attr-defined"
   },
   {
-    "file": "src/reyn/interfaces/cli/commands/dogfood.py",
-    "code": "name-defined"
-  },
-  {
     "file": "src/reyn/interfaces/cli/commands/embeddings.py",
     "code": "attr-defined"
   },
@@ -358,10 +342,6 @@
   {
     "file": "src/reyn/interfaces/inline/textual_chat/app.py",
     "code": "attr-defined"
-  },
-  {
-    "file": "src/reyn/interfaces/inline/textual_chat/app.py",
-    "code": "name-defined"
   },
   {
     "file": "src/reyn/interfaces/inline/textual_chat/app.py",
@@ -494,10 +474,6 @@
   {
     "file": "src/reyn/interfaces/web/deps.py",
     "code": "attr-defined"
-  },
-  {
-    "file": "src/reyn/interfaces/web/deps.py",
-    "code": "name-defined"
   },
   {
     "file": "src/reyn/interfaces/web/routers/a2a.py",
@@ -664,10 +640,6 @@
     "code": "attr-defined"
   },
   {
-    "file": "src/reyn/runtime/router_loop.py",
-    "code": "name-defined"
-  },
-  {
     "file": "src/reyn/runtime/router_op_context.py",
     "code": "arg-type"
   },
@@ -706,10 +678,6 @@
   {
     "file": "src/reyn/runtime/session.py",
     "code": "attr-defined"
-  },
-  {
-    "file": "src/reyn/runtime/session.py",
-    "code": "name-defined"
   },
   {
     "file": "src/reyn/runtime/session.py",

--- a/src/reyn/config/config_schema.py
+++ b/src/reyn/config/config_schema.py
@@ -10,12 +10,12 @@ now removed).
 Design notes
 ------------
 - **Forward-ref robustness**: ``from __future__ import annotations``
-  makes all type annotations strings.  Naively calling
-  ``typing.get_type_hints(ReynConfig)`` fails on forward refs like
-  ``'ExternalTransportRouting'`` that are lazily imported in
-  ``config.py``.  We resolve per-dataclass using the *class module's*
-  own ``__dict__`` as ``globalns``, extended with the two known
-  lazy-import types.  See :func:`_get_hints_safe`.
+  makes all type annotations strings.  ``typing.get_type_hints(ReynConfig)``
+  resolves each forward ref against the *class module's* own ``__dict__``
+  as ``globalns`` — every dataclass field type referenced only as a string
+  (``ExternalTransportRouting``, ``OAuthProviderConfig``, ...) MUST be a
+  concrete, non-``TYPE_CHECKING`` import in that module or the field
+  silently drops from the schema (#4653).  See :func:`_get_hints_safe`.
 
 - **Dict leaf (free-form)**: any field whose unwrapped type is ``dict``
   or ``dict[K, V]`` is treated as a free-form dict — the operator may
@@ -658,39 +658,22 @@ def _get_hints_safe(cls: type) -> dict[str, Any]:
     """Call ``typing.get_type_hints`` robustly for *cls*.
 
     Uses the class's own module namespace as ``globalns`` to resolve
-    forward refs declared in that module.  Adds the two known
-    lazy-imported types (``ExternalTransportRouting``,
-    ``OAuthProviderConfig``) which are not present in ``reyn.config``'s
-    module globals at import time.
+    forward refs declared in that module.  Every forward-ref field type
+    (``ExternalTransportRouting``, ``OAuthProviderConfig``, ...) must
+    already be a concrete import in that module (#4653) — this no longer
+    patches in a hardcoded name list; a missing import surfaces as a
+    ruff F821 finding at the declaration site instead of a silent schema
+    drop here.
 
     Returns an empty dict on failure (= walk falls back to skipping).
     """
     try:
         localns: dict[str, Any] = dict(vars(sys.modules[cls.__module__]))
-        # Patch in lazy-import types that are referenced as forward refs
-        # but not imported at the top of config.py.
-        _patch_localns(localns)
         return typing.get_type_hints(cls, globalns=localns)
     except Exception:
         # Fallback: return empty so the walk skips this class cleanly
         # rather than crashing.  Callers will log / skip silently.
         return {}
-
-
-def _patch_localns(ns: dict[str, Any]) -> None:
-    """Inject lazy-import types that appear as forward refs in config.py."""
-    if "ExternalTransportRouting" not in ns:
-        try:
-            from reyn.runtime.external_routing import ExternalTransportRouting  # noqa: PLC0415
-            ns["ExternalTransportRouting"] = ExternalTransportRouting
-        except ImportError:
-            pass
-    if "OAuthProviderConfig" not in ns:
-        try:
-            from reyn.security.secrets.oauth import OAuthProviderConfig  # noqa: PLC0415
-            ns["OAuthProviderConfig"] = OAuthProviderConfig
-        except ImportError:
-            pass
 
 
 def _unwrap_optional(ftype: Any) -> Any:

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -5,6 +5,8 @@ import socket
 from dataclasses import dataclass, field
 from typing import Literal
 
+from reyn.security.secrets.oauth import OAuthProviderConfig
+
 
 def _default_agent_id() -> str:
     """Compute the default ``agent_id`` used when reyn.yaml's ``agent_id:`` is
@@ -395,8 +397,6 @@ def _build_auth_config(raw: object) -> AuthConfig:
     ``None`` / missing → empty AuthConfig.providers.
     Unknown provider fields are ignored (= forward-compatible).
     """
-    from reyn.security.secrets.oauth import OAuthProviderConfig
-
     if raw is None:
         return AuthConfig()
     if not isinstance(raw, dict):

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -61,17 +61,7 @@ from reyn.config.observability import (
     ObservabilityConfig,
 )
 from reyn.runtime.budget.budget import CostConfig
-
-
-def _empty_external_transports():
-    """Lazy import shim for the default ``ExternalTransportRouting``.
-
-    Avoids importing ``reyn.runtime.external_routing`` at module-load time
-    (= ``reyn.config`` is imported very early; the chat-side import
-    would create a cycle).
-    """
-    from reyn.runtime.external_routing import ExternalTransportRouting
-    return ExternalTransportRouting()
+from reyn.runtime.external_routing import ExternalTransportRouting
 
 
 @dataclass
@@ -298,7 +288,7 @@ class ReynConfig:
     # key (config_schema.py's ``unknown_config_keys`` docstring has the
     # full incident this fixes).
     external_transports: "ExternalTransportRouting" = field(
-        default_factory=lambda: _empty_external_transports(),
+        default_factory=ExternalTransportRouting,
         metadata={"dict_leaf": True},
     )
     # #2548 PR-A: skill registry config. Raw dict passed to

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -49,7 +49,10 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
+
+if TYPE_CHECKING:
+    from reyn.core.events.durability_worker import DurabilityWorker
 
 WAL_EVENT_KINDS = (
     # Existing PR21 — inbox and chain lifecycle

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -22,11 +22,15 @@ import asyncio
 import json
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from reyn.interfaces.cli.env_backend import (
     build_environment_backend,
     register_env_backend_args,
 )
+
+if TYPE_CHECKING:
+    from reyn.runtime.session import Session
 
 
 def register(sub) -> None:

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -109,6 +109,7 @@ from .search_bar import SearchBar
 from .sent_queue import SentQueue
 
 if TYPE_CHECKING:
+    from textual.geometry import Offset
     from textual.timer import Timer
     from textual_flowview import VisibilityHandle
 

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -30,6 +30,7 @@ from fastapi import Depends, Request
 
 if TYPE_CHECKING:
     from reyn.interfaces.web.run_registry import RunRegistry
+    from reyn.runtime.session import Session
 
 # ---------------------------------------------------------------------------
 # project_root discovery

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -38,7 +38,8 @@ from reyn.services.compaction.engine import (
 from reyn.services.turn_budget import wrap_up_system_prompt
 
 if TYPE_CHECKING:
-    pass
+    from reyn.llm.llm import LLMToolCallResult
+    from reyn.tools.scheme import ExecutionResult
 
 logger = logging.getLogger(__name__)
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -12,7 +12,20 @@ import re
 from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
+    from reyn.config.chat import CompactionConfig, ReasoningConfig
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.hooks.bus import HookBus
+    from reyn.hooks.composed_consumer import ComposedEventConsumer
+    from reyn.hooks.composer import ComposerRegistry
+    from reyn.hooks.dispatcher import HookDispatcher
     from reyn.interfaces.slash import SlashContext
+    from reyn.mcp.connection_service import MCPConnectionService
+    from reyn.runtime.fs_watcher import FsWatcher
+    from reyn.runtime.hot_reload import HotReloader
+    from reyn.runtime.registry import AgentRegistry
+    from reyn.runtime.services.chain_timeout_glue import ChainTimeoutGlue
+    from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
+    from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
 
 logger = logging.getLogger(__name__)
 from dataclasses import asdict, dataclass
@@ -1907,7 +1920,7 @@ class Session:
         return self._on_perm_persist_cb
 
     @property
-    def on_limit(self) -> "_OnLimitConfig":
+    def on_limit(self) -> "OnLimitConfig":
         """Read-only accessor for the safety-loop OnLimit config.
 
         Captured at construction from ``SafetyConfig.on_limit``; tests

--- a/tests/core/test_install_package_visibility_1471.py
+++ b/tests/core/test_install_package_visibility_1471.py
@@ -16,6 +16,8 @@ that raises RegistryError — same sanctioned seam used in test_mcp_install_work
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from reyn.core.events.events import EventLog

--- a/tests/llm/test_codeact_coexistence_1593.py
+++ b/tests/llm/test_codeact_coexistence_1593.py
@@ -44,7 +44,7 @@ class _FakeHost:
         self._events = EventLog()
 
     @property
-    def events(self) -> _FakeEvents:
+    def events(self) -> EventLog:
         return self._events
 
     # context / catalog inputs (all empty — the CodeAct scheme ignores them)

--- a/tests/runtime/test_retry_loop_chat_wiring_1125.py
+++ b/tests/runtime/test_retry_loop_chat_wiring_1125.py
@@ -28,6 +28,8 @@ import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from reyn.config import CompactionConfig
 from reyn.core.events.state_log import StateLog
 from reyn.llm.pricing import TokenUsage

--- a/tests/runtime/test_session_invariants.py
+++ b/tests/runtime/test_session_invariants.py
@@ -77,7 +77,7 @@ class _FakeRegistry:
 
     def __init__(self):
         # Map agent_name → fake target session (if needed)
-        self._targets: dict[str, "_FakeTarget"] = {}
+        self._targets: dict[str, "Session"] = {}
         self.sent_requests: list[dict] = []
         self.sent_responses: list[dict] = []
 

--- a/tests/scripts/test_3726_mypy_ratchet.py
+++ b/tests/scripts/test_3726_mypy_ratchet.py
@@ -20,6 +20,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from tests._support.paths import REPO_ROOT
 
 _SCRIPT = REPO_ROOT / "scripts" / "mypy_ratchet.py"


### PR DESCRIPTION
**[tui-coder]** — #4097's sibling gate: F821 (undefined name) was in ruff's `ignore` list, with a stale comment claiming a TYPE_CHECKING forward ref "confuses" pyflakes. It doesn't — pyflakes was correctly flagging genuinely undefined names.

Measured the real population directly (`ruff check --select F821 --no-cache src tests scripts`) rather than trusting the issue's own count: 35, close to the 36 cited (natural drift). An order of magnitude smaller than #4097's F401 population, so no per-directory slicing — one PR.

**Classified every finding individually before choosing a fix, never from the count alone:**

- **32 missing-import cases.** 30 are TYPE_CHECKING-only additions (`session.py`, `router_loop.py`, `app.py`, `state_log.py`, `dogfood.py`, `deps.py`, plus `import pytest` / `from pathlib import Path` in two test files). 2 needed a CONCRETE (non-TYPE_CHECKING) import instead — `ExternalTransportRouting` (config/root.py) and `OAuthProviderConfig` (config/infra.py) — because `config_schema.py`'s `walk_config_schema` calls `get_type_hints()`, which eagerly resolves every forward ref against the class's real module globals; a TYPE_CHECKING-only name is never there, so both fields would have silently dropped from the schema walk. root.py's own header comment already named this constraint. Verified empirically that the concrete imports introduce no cycle (`reyn.runtime.__init__` re-exports `Session` lazily via PEP 562; neither `external_routing.py` nor `oauth.py` import `reyn.config` at module level; `import reyn` succeeds cleanly with both added).
- **3 wrong-name cases** — a typo'd class that never existed anywhere in the file, not a missing import: `_OnLimitConfig` → `OnLimitConfig` (session.py), `_FakeEvents` → `EventLog` (test_codeact_coexistence_1593.py), `_FakeTarget` → `Session` (test_session_invariants.py).

Landing the two concrete-import fixes let `config_schema.py` drop its own `_patch_localns`/`_get_hints_safe` workaround, which hardcoded the same two names in a second file specifically to paper over this exact gap for `get_type_hints()` alone — now unnecessary and removed, closing a duplicate/fragile source of truth.

**mypy overlap** (lead-coder flagged this as unverified on their end): cross-checked mypy's own view — all 8 affected src files already carried a live `name-defined` error for these exact names, silently permitted via `scripts/mypy_ratchet_baseline.json`. Verified each of the 8 files has zero remaining `name-defined` errors after the fix and removed their now-stale baseline entries (215 → 207 declared pairs).

## Test plan
- [x] `ruff check .` — clean, whole repo
- [x] `ruff check --select F821 --no-cache src tests scripts` — 0 findings (was 35)
- [x] `python scripts/mypy_ratchet.py` — OK, 203 findings / 207 declared
- [x] `python scripts/test_tier_audit.py --strict <5 changed test files>` — 42 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py <9 changed src files>` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest <5 changed test files> tests/config -q` — 240 passed
- [ ] (Visual — N/A, no UI-visible change)

Closes #4653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
