### PR TITLE
fix(#4364): doctor's MCP negotiation check names a misplaced mcp.<name> entry

### DIFF
--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -746,12 +746,38 @@ def _print_mcp_negotiation(config: object, project_root: Path) -> None:
     reachability check from doctor would duplicate work doctor's own
     process cannot even perform faster (a held connection is a session
     concept, #4364 C-2's own architect correction). D-2: report-only,
-    never connects."""
+    never connects.
+
+    Also flags the #4631 shape defect (``mcp.<name>`` written where
+    ``mcp.servers.<name>`` belongs) when it explains why nothing is
+    declared here — reusing ``reyn config validate``'s own detector
+    against the SAME merged ``mcp:`` dict this function already has, not
+    a second raw-file read (validate needs to name which SOURCE FILE is
+    wrong; this only needs to say the shape is wrong at all). Report-only,
+    same as everything else here (D-2) — doctor never rewrites the entry."""
+    from reyn.interfaces.cli.commands.config import _mcp_misplaced_server_entries
+
     mcp_config = getattr(config, "mcp", None) or {}
     servers = sorted((mcp_config.get("servers") if isinstance(mcp_config, dict) else None) or {})
+    misplaced = _mcp_misplaced_server_entries(mcp_config)
     if not servers:
-        print("  no MCP servers declared")
+        if misplaced:
+            print(
+                f"  no MCP servers declared under mcp.servers — but "
+                f"{len(misplaced)} entr{'y' if len(misplaced) == 1 else 'ies'} "
+                f"directly under mcp: ({', '.join(sorted(misplaced))}) "
+                f"look like misplaced server entries (see `reyn config validate`)",
+            )
+        else:
+            print("  no MCP servers declared")
         return
+    if misplaced:
+        print(
+            f"  note: {len(misplaced)} entr{'y' if len(misplaced) == 1 else 'ies'} "
+            f"directly under mcp: ({', '.join(sorted(misplaced))}) also look "
+            f"like misplaced server entries, alongside the declared servers "
+            f"below (see `reyn config validate`)",
+        )
 
     events_dir = project_root / ".reyn" / "events"
     evidence, scanned = _mcp_initialized_evidence(events_dir)

--- a/tests/interfaces/test_4364_c3b_doctor_mcp_negotiation.py
+++ b/tests/interfaces/test_4364_c3b_doctor_mcp_negotiation.py
@@ -155,3 +155,50 @@ def test_a_server_with_evidence_and_one_without_are_reported_independently(
 
     assert "✓ filesystem: last negotiated" in out
     assert "? brave: not seen in the newest" in out
+
+
+def test_misplaced_mcp_name_explains_why_nothing_is_declared(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: #4631's own shape defect (``mcp.<name>`` written where
+    ``mcp.servers.<name>`` belongs) loads without error and without a
+    warning — ``mcp.servers`` stays empty. Before this fix doctor printed
+    the plain "no MCP servers declared" line here, which reads as "you
+    never wrote anything", even though the operator DID write an entry —
+    just at the wrong nesting. Doctor must name the misplaced entry
+    instead of the bare absence."""
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        MINIMAL_REYN_YAML
+        + 'mcp:\n  filesystem:\n    command: npx\n    args: ["-y", "@mcp/filesystem"]\n',
+    )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "no MCP servers declared under mcp.servers" in out
+    assert "filesystem" in out
+    assert "misplaced server entries" in out
+    assert "reyn config validate" in out
+
+
+def test_misplaced_mcp_name_alongside_a_real_server_is_noted_not_hidden(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: a real ``mcp.servers.<name>`` entry AND a misplaced
+    ``mcp.<name>`` entry can coexist — the misplaced one must still surface
+    as a note, not be swallowed because the section wasn't empty."""
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        MINIMAL_REYN_YAML
+        + 'mcp:\n  servers:\n    filesystem:\n      command: npx\n'
+        + '      args: ["-y", "@mcp/filesystem"]\n'
+        + '  brave:\n    command: npx\n    args: ["-y", "@mcp/brave"]\n',
+    )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "✓ filesystem" in out or "? filesystem" in out
+    assert "misplaced server entries" in out
+    assert "brave" in out


### PR DESCRIPTION
**[tui-coder]** — lead-coder dispatch (#4364 follow-up, spun out of the C-5 pause-resolution): `doctor`'s C-3(b) MCP negotiation check said "no MCP servers declared" whenever `config.mcp.servers` was empty — true as measured, but not a diagnosis for the #4631 shape defect (`mcp.<name>:` written where `mcp.servers.<name>:` belongs, which loads silently with `mcp.servers` staying empty). The operator who DID write an entry gets told "you declared nothing" — the same entry point as #4401 (owner's real env: 8 MCP servers degraded, no diagnostic pointed at why).

`reyn config validate` already has the detector (`_mcp_misplaced_server_entries`, #4631) — reused directly against the same merged `mcp:` dict doctor already has (doctor doesn't need per-source-file attribution the way `validate` does; it only needs to say the shape looks wrong). Two cases:
- `servers` empty + misplaced entries present → replaces the bare "no MCP servers declared" with the misplaced names + a pointer to `reyn config validate`.
- `servers` non-empty + misplaced entries ALSO present → a note alongside the normal per-server report, so a misplaced entry doesn't hide behind an otherwise-healthy section.

D-2 (report-only) preserved — doctor never rewrites the entry, only names it.

## Test plan
- [x] `ruff check .` — clean, whole repo
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4364_c3b_doctor_mcp_negotiation.py` — 7 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/doctor.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/interfaces/test_4364_c3b_doctor_mcp_negotiation.py tests/interfaces/test_4364_pr3a_doctor_cli.py tests/interfaces/test_4364_pr2b_doctor_external_pairing.py -q` — 33 passed
- [ ] (Visual — N/A, CLI text output only)

part of #4364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
