### PR TITLE
fix(#4646): derive pipeline step-kind vocabulary from executor.STEP_KINDS

### DIFF
--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -853,7 +853,7 @@ def _step_kind(step: Step) -> str:
     """The step's kind string (``transform`` / ``tool`` / ``agent`` / ``call``) for
     the IS-6 live-progress events — the same vocabulary the serde ``kind`` marker
     uses, derived from the dataclass type so it never drifts from the union."""
-    return _STEP_KINDS.get(type(step), "unknown")
+    return STEP_KINDS.get(type(step), "unknown")
 
 
 # ---------------------------------------------------------------------------
@@ -1805,7 +1805,14 @@ STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool
 }
 
 # Type -> kind-string, the inverse vocabulary the serde ``kind`` marker uses.
-_STEP_KINDS: "dict[type, str]" = {
+# #4646: public (not `_`-prefixed) because parser.py now DERIVES its
+# `kind`-string vocabulary from this map's values (`tuple(STEP_KINDS.values())`)
+# rather than hand-duplicating a separate str tuple — the same shape #1983
+# used for op kind (`Op` DERIVES from `OP_KIND_MODEL_MAP`, not compared
+# against a second population). Before this, parser.py's `_ALL_STEP_KINDS`
+# and this map were two independently-maintained 8-entry populations with
+# no gate keeping them in sync.
+STEP_KINDS: "dict[type, str]" = {
     TransformStep: "transform",
     ToolStep: "tool",
     AgentStep: "agent",

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -103,6 +103,7 @@ from typing import Any
 import yaml
 
 from reyn.core.pipeline.executor import (
+    STEP_KINDS,
     AgentStep,
     CallStep,
     ExprRef,
@@ -217,11 +218,13 @@ _PipelineLoader.add_constructor("!expr", _construct_expr_tag)
 # so a future Appendix-B step kind beyond this module's current scope has an
 # obvious place to land — see the parser module docstring).
 _UNSUPPORTED_STEP_KINDS: "tuple[str, ...]" = ()
-_LINEAR_STEP_KINDS = ("transform", "tool", "agent")
-# ``call``/``match``/``fold``/``for_each``/``parallel`` are compositional, not
-# linear, but ARE executable — listed separately so error text distinguishes
-# "the linear kinds" from the full supported set.
-_SUPPORTED_STEP_KINDS = _LINEAR_STEP_KINDS + ("call", "match", "fold", "for_each", "parallel")
+# #4646: DERIVED from executor.STEP_KINDS (the type->kind-string map already
+# authoritative for dispatch/serde), not hand-duplicated — closes the same
+# "two independent populations, no gate" hole #1983 closed for op kind (`Op`
+# DERIVES from `OP_KIND_MODEL_MAP`). Order matches STEP_KINDS' own insertion
+# order: the 3 linear kinds (transform/tool/agent) first, then the 5
+# compositional ones (call/match/fold/for_each/parallel).
+_SUPPORTED_STEP_KINDS = tuple(STEP_KINDS.values())
 _ALL_STEP_KINDS = _SUPPORTED_STEP_KINDS + _UNSUPPORTED_STEP_KINDS
 
 # Pipeline-level fields the full grammar allows but the linear executor has


### PR DESCRIPTION
**[e2e-coder]** — part of #4646.

## What

`tests/interfaces`/`tests/runtime` aside — this is a separate, architect-discovered finding: pipeline step kind had **two independently-maintained populations** with no gate keeping them in sync — parser.py's hand-written `_ALL_STEP_KINDS` str tuple (8 entries) vs executor.py's `_STEP_KINDS` type→str dict (8 entries). Today they happen to agree (8-for-8), but nothing enforced that.

## Why derivation, not a gate (per the issue's own correction)

The issue's initial framing ("op kind has a CI gate, pipeline doesn't — add one here too") was corrected in-thread: op kind's real fix was **#1983 making `Op` DERIVE from `OP_KIND_MODEL_MAP`** — the CI pair-check (`Op` union ↔ `OP_KIND_MODEL_MAP`) is a layer riding on top of an already-single population, not the mechanism itself. Pipeline step kind needed the same treatment: make one side derive from the other, not add a comparison gate between two hand-maintained populations.

## Fix

- `executor._STEP_KINDS` → `executor.STEP_KINDS` (made public — it's now a cross-module derivation source, not an internal-only detail).
- `parser._SUPPORTED_STEP_KINDS = tuple(STEP_KINDS.values())`, replacing the hand-written `_LINEAR_STEP_KINDS + (...)` concatenation.
- **`_LINEAR_STEP_KINDS` removed** — its only use was building the now-derived `_SUPPORTED_STEP_KINDS` tuple; once that's derived from `STEP_KINDS.values()`, the manual linear/compositional split has no consumer left. (`STEP_KINDS`' own insertion order already puts the 3 linear kinds first, so the derived tuple's order is unchanged.)

## Strip-falsify (proves derivation, not coincidental match)

Temporarily removed `ParallelStep: "parallel"` from `executor.STEP_KINDS`, touching zero lines of `parser.py`:
```
before strip: ('transform', 'tool', 'agent', 'call', 'match', 'fold', 'for_each', 'parallel')
after strip:  ('transform', 'tool', 'agent', 'call', 'match', 'fold', 'for_each')
```
`parser._ALL_STEP_KINDS` shrank automatically — confirming the population really is derived, not two lists that happen to agree today. This is also the witness that the pair was actually CLOSED, not just gated: a comparison-gate approach couldn't produce this result (stripping one side would fail the gate, not silently shrink the other side's population). Restored and re-verified before commit.

## Verification

- `ruff check .`: clean.
- `scripts/mypy_ratchet.py`: 203 findings, all baselined (unchanged).
- `tests/core -k pipeline`: 382 passed.
- `tests/runtime tests/hooks tests/interfaces tests/mcp tests/tools -k pipeline`: 91 passed.

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Strip-falsified the derivation (see above).
- [x] Full pipeline-scoped regression (473 tests across the kind's producers/consumers) — clean.
- [ ] (Visual) — n/a, no UI surface.

part of #4646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
