### PR TITLE
fix(#4658): #4604's rename error names WHEN a fix applies — file-dependent

### DIFF
--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -607,6 +607,30 @@ def _validate() -> None:
             "now by hand: change 'type: http' to 'type: streamable-http' "
             "in the file named above."
         )
+        # #4658: WHEN a fix takes effect differs by file — an agent (or
+        # operator) that isn't told this fixes the line, retries, hits the
+        # SAME error (nothing re-probed the server yet), and fixes it again
+        # in a loop. Measured, not assumed: unlike this dict's other keys,
+        # ~/.reyn/config.yaml / reyn.yaml / reyn.local.yaml are watched by
+        # RouterHostAdapter.maybe_refresh_mcp_tools_from_yaml's own
+        # independent per-turn mtime-check and self-heal on the very next
+        # message — .reyn/config/mcp.yaml, despite being the general
+        # hot-reload IN-set, is NOT covered by that specific watch and
+        # needs an explicit `/reload` (or `reyn mcp refresh`) first.
+        in_set_sources = sorted(s for s in mcp_renamed_http if s == ".reyn/config/mcp.yaml")
+        policy_sources = sorted(s for s in mcp_renamed_http if s != ".reyn/config/mcp.yaml")
+        if policy_sources:
+            print(
+                f"\n{', '.join(policy_sources)} self-heal automatically once "
+                f"fixed — the corrected value is re-probed on your very next "
+                f"message, no /reload and no restart needed."
+            )
+        if in_set_sources:
+            print(
+                "\n.reyn/config/mcp.yaml does not self-heal automatically — "
+                "run `/reload` (or `reyn mcp refresh`) after fixing it there "
+                "to apply the change without restarting."
+            )
 
 
 def _migrate(*, dry_run: bool = False) -> None:

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -867,9 +867,29 @@ class MCPClient:
             # told what it's now called, not just that it's invalid (the
             # #4401 shape: a silent/ambiguous failure discovered only when
             # the server later shows up degraded).
+            #
+            # #4658: this error alone doesn't say WHEN a fix takes effect —
+            # an agent that edits the file and immediately retries hits the
+            # SAME stale error (the server isn't reconstructed until
+            # something re-probes it) and can loop fixing the same line
+            # over and over. This constructor has no idea which file the
+            # config came from, so it can't give a single unconditional
+            # answer — measured (not guessed) both halves instead of
+            # picking one: a change to ~/.reyn/config.yaml / reyn.yaml /
+            # reyn.local.yaml is picked up by
+            # RouterHostAdapter.maybe_refresh_mcp_tools_from_yaml's own
+            # independent per-turn mtime-watch (re-probed automatically on
+            # the very next message); a change to .reyn/config/mcp.yaml is
+            # NOT covered by that watch and needs an explicit `/reload`
+            # (or `reyn mcp refresh`) to apply before a restart would.
             raise ValueError(
                 "MCP server type 'http' was renamed to 'streamable-http' "
-                "(#4604) — update this server's 'type' in your MCP config."
+                "(#4604) — update this server's 'type' in your MCP config. "
+                "If it's declared in reyn.yaml/reyn.local.yaml/"
+                "~/.reyn/config.yaml the fix is picked up automatically on "
+                "your next message; if it's in .reyn/config/mcp.yaml, run "
+                "`/reload` (or `reyn mcp refresh`) to apply it without "
+                "restarting."
             )
         if srv_type not in _SUPPORTED_TYPES:
             raise ValueError(

--- a/tests/interfaces/test_4604_config_validate_mcp_transport_rename.py
+++ b/tests/interfaces/test_4604_config_validate_mcp_transport_rename.py
@@ -104,6 +104,33 @@ def test_a_server_entry_with_type_http_in_reyn_yaml_is_flagged(project, capsys):
     assert "streamable-http" in out
 
 
+def test_a_reyn_yaml_finding_says_it_self_heals_with_no_reload_or_restart(
+    project, capsys,
+):
+    """Tier 2: #4658 — a stale entry in a policy-tier file (reyn.yaml /
+    reyn.local.yaml / ~/.reyn/config.yaml) is watched by
+    RouterHostAdapter.maybe_refresh_mcp_tools_from_yaml's own independent
+    per-turn mtime-check (measured directly, not assumed) — the fix must
+    say it applies automatically on the next message, so an agent that
+    just fixed the line doesn't retry-and-loop waiting for something that
+    already happened."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "mcp:\n  servers:\n    myserver:\n"
+            "      type: http\n      url: \"https://example.com/mcp\"\n"
+        ),
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "reyn.yaml self-heal automatically" in out
+    assert "no /reload and no restart needed" in out
+    assert "does not self-heal automatically" not in out
+
+
 def test_a_server_entry_in_dot_reyn_config_mcp_yaml_is_flagged_with_its_own_file_name(
     project, capsys,
 ):
@@ -122,6 +149,56 @@ def test_a_server_entry_in_dot_reyn_config_mcp_yaml_is_flagged_with_its_own_file
     assert "MCP transport type" in out
     assert "[.reyn/config/mcp.yaml] mcp.servers.myserver.type: http" in out
     assert "[reyn.yaml]" not in out.split("MCP transport type")[1]
+
+
+def test_a_dot_reyn_mcp_yaml_finding_says_it_needs_reload_not_restart(
+    project, capsys,
+):
+    """Tier 2: #4658 — the IN-set file is NOT covered by
+    maybe_refresh_mcp_tools_from_yaml's mtime-watch (measured: that watch
+    only stats the 3 policy-tier paths) — a fix there needs an explicit
+    `/reload`, and the finding must say so rather than silently matching
+    the policy-tier "self-heals" wording (which would be false here) or
+    telling the operator to restart (which overstates what's needed)."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "config" / "mcp.yaml",
+        "mcp:\n  servers:\n    myserver:\n      type: http\n      url: \"https://example.com/mcp\"\n",
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "does not self-heal automatically" in out
+    assert "/reload" in out
+    assert "reyn mcp refresh" in out
+    assert "self-heal automatically once fixed" not in out
+
+
+def test_findings_in_both_kinds_of_file_get_both_kinds_of_guidance(project, capsys):
+    """Tier 2: #4658 — a policy-tier finding and an IN-set finding present
+    at once must each get their OWN correct guidance, not one overwriting
+    or hiding the other."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        MINIMAL_REYN_YAML + (
+            "mcp:\n  servers:\n    policyserver:\n"
+            "      type: http\n      url: \"https://a.example.com/mcp\"\n"
+        ),
+    )
+    _write_yaml(
+        project / ".reyn" / "config" / "mcp.yaml",
+        "mcp:\n  servers:\n    dynamicserver:\n"
+        "      type: http\n      url: \"https://b.example.com/mcp\"\n",
+    )
+    _validate()
+    out = capsys.readouterr().out
+
+    assert "reyn.yaml self-heal automatically" in out
+    assert "does not self-heal automatically" in out
 
 
 def test_two_renamed_servers_in_the_same_file_are_both_named(project, capsys):
@@ -177,3 +254,23 @@ def test_real_client_construction_rejects_the_renamed_value_by_name():
 
     with pytest.raises(ValueError, match="renamed to 'streamable-http'"):
         MCPClient({"type": "http", "url": "https://example.com/mcp"})
+
+
+def test_client_construction_error_names_both_when_it_could_apply():
+    """Tier 1: #4658 — MCPClient never knows which file its config dict
+    came from, so unlike `reyn config validate` (which DOES know the
+    source file and can give one definitive answer) it cannot say a
+    single unconditional "when does this apply". It must give a safe
+    answer that covers BOTH real cases instead of guessing one — an
+    agent fixing this from the raw error alone (no validate run first)
+    still gets a correct next step regardless of which file it edits."""
+    from reyn.mcp.client import MCPClient
+
+    with pytest.raises(ValueError) as exc_info:
+        MCPClient({"type": "http", "url": "https://example.com/mcp"})
+
+    message = str(exc_info.value)
+    assert "reyn.yaml" in message
+    assert "picked up automatically on your next message" in message
+    assert ".reyn/config/mcp.yaml" in message
+    assert "/reload" in message


### PR DESCRIPTION
**[tui-coder]** — architect's discovery (a reviewer actually looped in #3698's own observation): an agent fixing a stale `type: http` MCP entry retries immediately, hits the SAME "renamed to streamable-http" error, fixes it again — a real loop. Neither error site said WHEN the fix takes effect.

**Measured first, per the issue's own instruction** — and the initial hypothesis (mcp.yaml=IN-set=self-heals, reyn.yaml=OUT-set=restart-only) turned out backwards for the un-flagged half:

- `~/.reyn/config.yaml` / `reyn.yaml` / `reyn.local.yaml` — otherwise restart-only for everything else — ARE watched by `RouterHostAdapter.maybe_refresh_mcp_tools_from_yaml`, an **independent** per-turn mtime-check (`yaml_scope_paths()`, no HotReloader trigger needed) that re-reads MCP server config and re-probes on ANY mtime advance across exactly these 3 files. A fix there is re-probed on the operator's very next message — no `/reload`, no restart.
- `.reyn/config/mcp.yaml` — despite being the general hot-reload IN-set (`_HOT_RELOAD_FILES`) — is **not** in `yaml_scope_paths()`, so this specific watch never sees it. `HotReloader.request_reload()` (the mechanism that would pick it up, via the `_reapply_mcp` seam) only fires from an explicit `/reload` slash command or an `llm_op` reload tool call — never automatically on a bare file edit. A fix there needs `/reload` (or `reyn mcp refresh`), not a restart.

Verified via direct code trace (`router_host_adapter.py`'s `maybe_refresh_mcp_tools_from_yaml`/`yaml_scope_paths`/`_probe_all`, `session.py`'s per-turn priming chain, `hot_reload.py`'s `request_reload()` call sites) and corroborated by the existing `test_mcp_yaml_mtime_watch.py` suite, which independently pins the same "yaml mtime advance → re-probe" contract this relies on.

Both error sites now say the correct, file-dependent thing:
- `MCPClient.__init__` doesn't know its config's source file, so it states BOTH cases conditionally.
- `reyn config validate`'s MCP-transport-type check already knows the file per finding — it states the definitive answer for whichever file(s) are flagged.

## Test plan
- [x] `ruff check .` — clean, whole repo
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4604_config_validate_mcp_transport_rename.py` — 11 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/mcp/client.py src/reyn/interfaces/cli/commands/config.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/interfaces/test_4604_config_validate_mcp_transport_rename.py tests/mcp/test_mcp_client.py tests/interfaces/test_mcp_yaml_mtime_watch.py tests/interfaces/test_4631_config_validate_mcp_placement.py -q` — 44 passed
- [ ] (Visual — N/A, CLI/error text only)

Enumerated before writing `Closes`: `gh pr list --state all --search "#4658 in:body"` returned no in-progress sub-PR on this issue; scope (both error sites, per the issue's own prescription) is complete in this one PR.

Closes #4658

🤖 Generated with [Claude Code](https://claude.com/claude-code)
