### PR TITLE
docs(#4651): CLAUDE.md/testing.md never named scripts/check_doc_anchors.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,21 @@ full reasoning (why the full run was dropped, not just discouraged; what
 running it locally actually costs vs. CI; the #3750 count history) before
 changing this paragraph, in either doc. This line said `ruff check src tests` until #4630 measured the gap: CI runs `ruff check .` (`test.yml:162`), so the documented command silently skipped `scripts/` and every other top-level directory — a PR author who followed it exactly still went red, and 17 genuinely-dead imports outside `src/` had been invisible to the whole checklist. Run the same command CI runs; a narrower local gate is a green that does not mean what it says.
 
+**If your PR touches `docs/`, also run `mkdocs build --strict -f
+.mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py`** — as a
+pair, in that order, not either alone. CI's "docs build (strict)" job
+runs both steps (`test.yml`'s `docs` job); `mkdocs build --strict`
+catches a dangling *file* reference but never checks whether `#anchor`
+actually exists on the target page, which is `check_doc_anchors.py`'s
+own job, run against the `site/` the mkdocs step just built (#3557/
+#3592: 42/42 line-number citations in `charter.md` had drifted,
+silently, before this script existed). Running `check_doc_anchors.py`
+alone without a prior `mkdocs build` first raises an `AssertionError`
+from a missing `site/` — which reads as "main is broken," not as "run
+the other command first" (#4651: this exact confusion, the same
+`git grep` finding 0 mentions of the script in either this file or
+`testing.md`, until now).
+
 A green scoped `pytest` alone is
 **not** a green CI run (`pytest-green ≠ CI-green`): ruff `I001` import-sort
 and a Tier-4 format pin (`len(...) == N`) both fail CI while `pytest`

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -1225,6 +1225,25 @@ rather than "suite passed" — that phrase implies the full local run this
 section no longer asks for, and CI is the only place all six now run
 together.
 
+**A PR that touches `docs/` also owes a seventh, separate check — the
+"docs build (strict)" CI job runs two steps, and both must pass:**
+
+```bash
+mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py
+```
+
+Run them as a pair, in that order, not either alone. `mkdocs build
+--strict` catches a dangling *file* reference but never checks whether
+`#anchor` actually exists on the target page — that's
+`check_doc_anchors.py`'s own job, checked against the `site/` the
+mkdocs step just built (#3557/#3592: 42/42 line-number citations in
+`charter.md` had drifted, silently, before this script existed).
+Running `check_doc_anchors.py` alone, without a prior `mkdocs build`,
+raises an `AssertionError` from a missing `site/` — which reads as
+"main is broken," not as "run the other command first" (#4651: this
+exact confusion, live, the same night a `git grep` first found this
+script named in neither this file nor `CLAUDE.md`).
+
 ---
 
 ## Coverage checklist for a new OS feature


### PR DESCRIPTION
**[docs-maintainer]** — part of #4651. Branched off a fresh `main`.

Same class as #4630/#4632: the procedure docs' command set was narrower than what CI's "docs build (strict)" job actually runs. `grep -rn check_doc_anchors CLAUDE.md docs/deep-dives/contributing/testing.md` found 0 hits — CI runs two steps (`mkdocs build --strict` then `scripts/check_doc_anchors.py`, both against the same freshly-built `site/`), and only the first was ever documented.

This bit #4650 tonight: the author reported "mkdocs build --strict all green" — a correct report — while CI still went red on the second, undocumented step. Running `check_doc_anchors.py` alone (without the mkdocs build first) also fails its own way, with an `AssertionError` from a missing `site/` that reads as "main is broken" rather than "wrong invocation order" — so both files now say to run the pair together, in order, not either alone.

Added to `CLAUDE.md`'s "Before you open a PR" (conditional — only for a PR touching `docs/`) and `testing.md`'s "Before you push" (as a seventh, separate check alongside the existing six — a different CI job, not folded into that numbered list).

## Verification

- Ran the documented pair myself against this very PR's own diff: `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py` — both clean, exit 0.
- Read `test.yml`'s `docs` job directly (lines ~200-243) before writing either paragraph.
- Fetched `origin/main` immediately before commit — no new commits since this branch's base.

Not touching `testing.ja.md` — it never asserted anything false about this script (it simply never mentioned it); no blanket mirror obligation applies (CLAUDE.md rule 5).

part of #4651

## Test plan

- [x] `mkdocs build --strict && python scripts/check_doc_anchors.py` — both clean, exit 0
- [x] docs-only change — `ruff`/`pytest` N/A
- [ ] Visual — N/A (docs prose only)
