### PR TITLE
feat(#4497 Phase 2): /resident measures the LLM-client Router cache

### DIFF
--- a/docs/reference/cli/chat.md
+++ b/docs/reference/cli/chat.md
@@ -96,7 +96,7 @@ While a session is active, lines starting with `/` are intercepted and never rou
 | `/quit` | Exit the chat (alias: `/exit`, Ctrl+D) |
 | `/reload` | Hot-reload runtime config (`.reyn/*.yaml`) at the next turn boundary |
 | `/reset confirm` | Reset in-flight run state (snapshots + WAL; audit logs preserved) |
-| `/resident` | Approximate resident-memory breakdown by in-process container — count + shallow `sys.getsizeof` estimate, session-lifetime and process-global, no threshold, no eviction (#4497 Phase 1) |
+| `/resident` | Approximate resident-memory breakdown by in-process container — count + shallow `sys.getsizeof` estimate, session-lifetime and process-global (including the LLM-client Router cache), no threshold, no eviction (#4497) |
 | `/rewind [seq]` | Time-travel to an earlier checkpoint — no arg opens the picker menu; `seq` jumps directly (see [Time-travel](../../concepts/runtime/time-travel.md) · [How-to](../../guide/for-users/time-travel.md)) |
 | `/session new \| switch <sid> \| list` | Open / switch / list conversation sessions for the attached agent (see [Sessions](../../concepts/multi-agent/sessions.md)) |
 | `/visibility on\|off <tool\|mcp\|category> <name>` | Toggle this session's LLM visibility of a capability (hidden next turn / restored up to the agent's authorized envelope — an envelope-denied capability stays hidden) |

--- a/src/reyn/runtime/resident_stats.py
+++ b/src/reyn/runtime/resident_stats.py
@@ -109,14 +109,28 @@ def session_container_stats(session: "Session") -> "list[ContainerStat]":
 
 
 def process_global_container_stats() -> "list[ContainerStat]":
-    """Count + approximate bytes for the 3 process-global
-    ``WeakKeyDictionary`` registries #4497's issue names — these are
-    NOT per-session; they aggregate every session/loop this PROCESS has
-    ever touched (bounded by garbage collection reclaiming a dead
-    session/loop key, not by this module). Imported lazily so this
-    module itself carries no import-time coupling to the 3 owning
-    modules — a diagnostic surface should not widen anyone's import
-    graph just by existing.
+    """Count + approximate bytes for the process-global
+    ``WeakKeyDictionary`` registries #4497's issue names, plus
+    ``_ROUTERS_BY_LOOP`` (#4497 Phase 2 — the "LLM client-related memory"
+    item the issue names as unmeasured; #4376 only ever covered the
+    image cache, a different layer). These are NOT per-session; they
+    aggregate every session/loop this PROCESS has ever touched (bounded
+    by garbage collection reclaiming a dead session/loop key, not by
+    this module). Imported lazily so this module itself carries no
+    import-time coupling to the owning modules — a diagnostic surface
+    should not widen anyone's import graph just by existing.
+
+    **Verified before adding `_ROUTERS_BY_LOOP` — same surface, checked
+    for the same reason #4485/#4488's surface was rejected**: it lives
+    in `reyn.llm.llm`, imported and cached in the SAME process as
+    `reyn chat` (not a separate MCP-server subprocess), so `/resident`
+    is the correct place for it. The OTHER Phase-2 candidate the issue
+    names, the embedding/sqlite index backend (`SqliteIndexBackend`),
+    was checked and found to hold NO persistent in-process state — it
+    opens/closes a fresh sqlite connection per call (no `self._conn`,
+    no cache dict); its growth is a disk metric, already the domain of
+    `reyn storage stats`, not this module. Reported to the issue, no
+    code added for it here.
     """
     stats = []
     try:
@@ -141,6 +155,23 @@ def process_global_container_stats() -> "list[ContainerStat]":
         stats.append(
             ContainerStat(
                 name=f"{base.name} ({inner_paths} path-keys across "
+                     f"{base.count} loop(s))",
+                count=base.count,
+                approx_bytes=base.approx_bytes,
+            ),
+        )
+    except ImportError:
+        pass
+    try:
+        from reyn.llm.llm import _ROUTERS_BY_LOOP
+        # Same two-level shape as `_LOCKS_BY_LOOP` above: the outer
+        # WeakKeyDictionary's own count (number of loops) undersells the
+        # real footprint — sum the inner per-loop Router caches too.
+        inner_routers = sum(len(v) for v in _ROUTERS_BY_LOOP.values())
+        base = _stat("_ROUTERS_BY_LOOP", _ROUTERS_BY_LOOP)
+        stats.append(
+            ContainerStat(
+                name=f"{base.name} ({inner_routers} router(s) across "
                      f"{base.count} loop(s))",
                 count=base.count,
                 approx_bytes=base.approx_bytes,

--- a/tests/runtime/test_4497_resident_stats.py
+++ b/tests/runtime/test_4497_resident_stats.py
@@ -93,17 +93,58 @@ def test_session_container_stats_never_writes_to_the_session():
     assert first == second
 
 
-def test_process_global_container_stats_resolves_the_three_real_registries():
+def test_process_global_container_stats_resolves_the_four_real_registries():
     """Tier 2: process_global_container_stats successfully imports and
-    measures the 3 real module-level WeakKeyDictionary registries #4497's
-    issue names, not a stand-in — a broken import path would silently
-    drop a row (caught by ImportError -> skip), so this test names all 3
-    explicitly to catch that."""
+    measures the 4 real module-level WeakKeyDictionary registries (the 3
+    #4497 Phase 1 named, plus Phase 2's `_ROUTERS_BY_LOOP`), not a
+    stand-in — a broken import path would silently drop a row (caught by
+    ImportError -> skip), so this test names all 4 explicitly to catch
+    that."""
     stats = process_global_container_stats()
     names = [s.name for s in stats]
     assert any(n == "_session_bridges" for n in names)
     assert any(n == "_REWIND_INDEXES" for n in names)
     assert any(n.startswith("_LOCKS_BY_LOOP") for n in names)
+    assert any(n.startswith("_ROUTERS_BY_LOOP") for n in names)
+
+
+def _inner_router_count(row_name: str) -> int:
+    # Row name shape: "_ROUTERS_BY_LOOP (N router(s) across M loop(s))".
+    return int(row_name.split("(", 1)[1].split(" router", 1)[0])
+
+
+def test_process_global_stats_reflect_a_real_router_cache_entry():
+    """Tier 2: #4497 Phase 2 — a real entry placed in `_ROUTERS_BY_LOOP`
+    (the actual module global, not a stand-in) is reflected in the
+    reported inner router count, the same "real write shows up" check
+    Phase 1 ran for `_LOCKS_BY_LOOP`. The loop is kept alive (referenced
+    by this test function, never run/closed) for the duration of the
+    assertion — `_ROUTERS_BY_LOOP` is a WeakKeyDictionary, so a loop
+    that's already been GC'd would make this test observe nothing real,
+    not the write it just made. Asserts a DELTA, not an absolute count —
+    this is process-global state another test/real Router-build in the
+    same pytest process may have already populated."""
+    import asyncio
+
+    from reyn.llm.llm import _ROUTERS_BY_LOOP
+
+    before_row = next(
+        (s for s in process_global_container_stats() if s.name.startswith("_ROUTERS_BY_LOOP")),
+        None,
+    )
+    before = _inner_router_count(before_row.name) if before_row is not None else 0
+
+    loop = asyncio.new_event_loop()
+    try:
+        _ROUTERS_BY_LOOP[loop] = {"fake-cache-key-1": object(), "fake-cache-key-2": object()}
+
+        after_row = next(
+            s for s in process_global_container_stats() if s.name.startswith("_ROUTERS_BY_LOOP")
+        )
+        assert _inner_router_count(after_row.name) == before + 2
+    finally:
+        del _ROUTERS_BY_LOOP[loop]
+        loop.close()
 
 
 def test_process_global_stats_are_real_module_state_not_copies(monkeypatch):


### PR DESCRIPTION
**[e2e-coder]** — part of #4497 (Phase 2: the 2 areas #4524/#4524's own PR body named as still-unmeasured — cache/index growth and LLM-client memory).

## Verified before implementing (per lead-coder's explicit caution)

Last night's mistake was aligning `/resident`'s surface with `reyn storage stats` without checking who actually reads it (a separate CLI process can't see this process's live memory). Applied the same check to both Phase 2 candidates before touching anything:

- **LLM client** (`reyn.llm.llm._ROUTERS_BY_LOOP`) — a process-global `WeakKeyDictionary[loop, dict[cache_key, Router]]`, same two-level shape as the already-measured `_LOCKS_BY_LOOP`. Confirmed it's imported/populated in the SAME process as `reyn chat` (not a separate MCP-server subprocess) by reading the actual import graph. `/resident` is the correct surface — **added**.
- **Embedding/sqlite index** (`SqliteIndexBackend` + its callers `ActionEmbeddingIndex`/`knowledge.py`) — read the actual consumer code. Every method opens/closes its own sqlite connection per call; no `self._conn`, no cache dict, no persistent in-process state at all. Its growth is purely a disk metric, already the domain of `reyn storage stats` (renamed from `reyn media stats`, #4478) — not this module's job. **No code added** — measured, no-work-needed finding, same pattern as this session's earlier #4364 B-2/B-4 findings.

## What

- `resident_stats.py`'s `process_global_container_stats()` gains a 4th row for `_ROUTERS_BY_LOOP`, same two-level (outer loop count + inner per-loop key count) measurement `_LOCKS_BY_LOOP` already uses.
- `chat.md`'s `/resident` table row updated to mention the LLM-client Router cache.

## Strip-falsify

Renamed `_ROUTERS_BY_LOOP` in `llm.py` — both the registry-presence test and the real-write test flip RED (`ImportError` → row silently dropped → assertion fails), confirming they read the real module global. Restored, re-verified green.

## Verification

- `ruff check .`: clean.
- `scripts/mypy_ratchet.py`: 203 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/test_tier_audit.py --strict`: 11 tests inspected, 0 errors.
- `mkdocs build --strict`: clean (no Aborted/error line — only pre-existing ja-mirror INFO notes).
- `tests/runtime/test_4497_resident_stats.py tests/interfaces/test_4497_resident_slash.py`: 15 passed.
- `tests/llm -k router`: 88 passed (confirms no regression to the Router-cache machinery itself).

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Verified "who reads from where" for both Phase 2 candidates before writing code.
- [x] Strip-falsified the new measurement.
- [x] `mkdocs build --strict` — clean.
- [x] Scoped regression (15 + 88 tests) — clean.
- [ ] (Visual) — n/a, no UI surface beyond the text reply itself.

part of #4497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
