### PR TITLE
feat(#3329): gutter retrieval-demotion, derived from ToolDefinition.purity

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from textual_flowview import Entry
 
     from reyn.runtime.outbox import OutboxMessage
+    from reyn.tools import ToolRegistry
 
 # EntryState → gutter colour (Phase 2 state-color gutter). The CC state
 # palette: RUNNING amber, SUCCESS green, ERROR coral. DEFAULT has NO entry
@@ -138,6 +139,57 @@ _MARK_RAIL = "▏"
 #: POSITION, so it must not borrow the ``_STATE_COLOR`` vocabulary either.
 _MARK_COLOR = _CC_TEXT
 
+# #3329: retrieval-demotion. A tool call's op-class taxonomy is NOT hardcoded
+# here as a name list (the #3273 deferred-track incident this issue names
+# twice: "手動列挙は次も漏れる") — it is DERIVED from the existing, complete
+# ``ToolDefinition.purity`` axis already declared per tool in ``reyn.tools``
+# (measured #3329: all 76 registered tools declare ``purity`` explicitly;
+# no tool relies on the dataclass default). ``purity="read_only"`` is the
+# authoritative "取得系" signal this table's left column names.
+#
+# One explicit exemption, not an accident of today's values (lead-coder
+# ruling, #3329): every dynamically-installed MCP server tool dispatches
+# through ONE of these two fixed wrapper tools (``mcp_tool_name``/
+# ``<server>__<tool>`` is an ARGUMENT, never the invoked function name — see
+# ``dispatcher.py``'s ``tool_called`` event, whose ``tool`` field is always
+# the wrapper's own name) — so no INDIVIDUAL MCP tool's real read/write
+# behaviour is knowable from ``purity`` here; the wrapper's own
+# ``purity="side_effect"`` already keeps this case un-demoted, but is
+# written explicitly below so that stays true ON PURPOSE, not by
+# coincidence if either wrapper's declared purity ever changes.
+_MCP_DYNAMIC_DISPATCH_EXEMPT: "frozenset[str]" = frozenset({
+    "call_mcp_tool", "mcp_call_tool",
+})
+
+
+def _default_tool_registry() -> "ToolRegistry":
+    """The default :class:`ToolRegistry`, built once and cached.
+
+    :func:`reyn.tools.get_default_registry` documents itself as a fresh,
+    lightweight construction callers may cache — :func:`_gutter_glyph_color`
+    runs on every gutter repaint (its own docstring's constraint), so this
+    module builds it once rather than on every frame."""
+    global _TOOL_REGISTRY
+    if _TOOL_REGISTRY is None:
+        from reyn.tools import get_default_registry
+        _TOOL_REGISTRY = get_default_registry()
+    return _TOOL_REGISTRY
+
+
+_TOOL_REGISTRY: "ToolRegistry | None" = None
+
+
+def _is_retrieval_tool(tool_name: str) -> bool:
+    """True iff *tool_name* is a "取得系" (retrieval) tool for #3329's gutter
+    demotion — derived from :attr:`ToolDefinition.purity`, never a hardcoded
+    name list (see the module-level note above this function)."""
+    if tool_name in _MCP_DYNAMIC_DISPATCH_EXEMPT:
+        return False
+    definition = _default_tool_registry().lookup(tool_name)
+    if definition is None:
+        return False
+    return definition.purity == "read_only"
+
 
 def _gutter_glyph_color(msg: "OutboxMessage") -> "tuple[str, str]":
     """The gutter glyph + kind-colour for one display frame, keyed off ``_KIND_LINE``.
@@ -147,11 +199,21 @@ def _gutter_glyph_color(msg: "OutboxMessage") -> "tuple[str, str]":
     tool-result markers otherwise. The colour returned here is the KIND colour;
     a non-DEFAULT :class:`EntryState` overrides it in :meth:`ReynGutter.decorate`
     (state-driven colour, Phase 2). Kept cheap — ``decorate`` runs on every repaint.
+
+    #3329: a SUCCESSFUL retrieval tool call (started/completed, never
+    failed — a failure still needs the operator's attention regardless of
+    the tool's op-class, so ``tool_call_failed`` is deliberately NOT
+    demoted below) carries no gutter marker at all — see
+    :func:`_is_retrieval_tool`.
     """
     kind = msg.kind
     if kind == "tool_call_started":
+        if _is_retrieval_tool(str((msg.meta or {}).get("tool", ""))):
+            return "", _CC_DIM
         return "●", _CC_TEXT
     if kind == "tool_call_completed":
+        if _is_retrieval_tool(str((msg.meta or {}).get("tool", ""))):
+            return "", _CC_DIM
         return "⎿", _CC_DIM
     if kind == "tool_call_failed":
         return "⎿", _CC_ERR

--- a/tests/interfaces/test_textual_chat_phase2_3273.py
+++ b/tests/interfaces/test_textual_chat_phase2_3273.py
@@ -47,6 +47,7 @@ from reyn.interfaces.inline.textual_chat.gutter import (
     _RUNNING_FRAMES,
     _cell_pad_right,
     _gutter_glyph_color,
+    _is_retrieval_tool,
 )
 from reyn.interfaces.repl.renderer import (
     _CC_DONE,
@@ -494,8 +495,103 @@ def test_left_gutter_vocabulary_is_all_single_cell() -> None:
 
     assert glyphs, "enumeration produced no glyphs — registry sources changed shape"
     for glyph in glyphs:
+        # #3329: the retrieval-demotion "no marker" case is the ONE
+        # deliberate 0-cell glyph (an intentional absence, not a vocabulary
+        # entry to pad) — `_cell_pad_right` already handles an empty label
+        # correctly (all spaces), so it is exempt from the 1-cell rule
+        # below rather than silently wrong.
+        if glyph == "":
+            continue
         assert cell_len(glyph) == 1, (
             f"{glyph!r} measures {cell_len(glyph)} cells, not 1 — a new "
             "vocabulary entry (e.g. an emoji marker) needs its column "
             "accounting revisited, not a silent single-cell assumption"
         )
+
+
+def test_retrieval_tool_call_carries_no_gutter_marker() -> None:
+    """Tier 1: #3329 — a started/completed call to a ``purity="read_only"``
+    tool (the real registry, ``read_file``) gets no gutter glyph at all —
+    the table's "gutter: 無し" cell. Contrasts with a side-effect tool
+    (``write_file``), which keeps today's ``●``/``⎿`` markers."""
+    glyph, _ = _gutter_glyph_color(
+        OutboxMessage(kind="tool_call_started", text="read_file", meta={"tool": "read_file"})
+    )
+    assert glyph == ""
+    glyph, _ = _gutter_glyph_color(
+        OutboxMessage(kind="tool_call_completed", text="", meta={"tool": "read_file"})
+    )
+    assert glyph == ""
+
+    glyph, _ = _gutter_glyph_color(
+        OutboxMessage(kind="tool_call_started", text="write_file", meta={"tool": "write_file"})
+    )
+    assert glyph == "●"
+    glyph, _ = _gutter_glyph_color(
+        OutboxMessage(kind="tool_call_completed", text="", meta={"tool": "write_file"})
+    )
+    assert glyph == "⎿"
+
+
+def test_a_failed_retrieval_tool_call_still_gets_a_marker() -> None:
+    """Tier 1: #3329 — demotion applies ONLY to started/completed
+    (the successful/in-flight path); a FAILURE still needs the operator's
+    attention regardless of the tool's op-class, so ``tool_call_failed``
+    is deliberately excluded from :func:`_is_retrieval_tool`'s reach."""
+    glyph, color = _gutter_glyph_color(
+        OutboxMessage(kind="tool_call_failed", text="", meta={"tool": "read_file"})
+    )
+    assert glyph == "⎿"
+    assert color == _CC_ERR
+
+
+def test_is_retrieval_tool_derives_from_the_real_registry_not_a_hardcoded_list() -> None:
+    """Tier 1: #3329's own completeness requirement — the demotion decision
+    reads :attr:`~reyn.tools.types.ToolDefinition.purity` off the REAL
+    default :class:`~reyn.tools.ToolRegistry`, not a name list living in
+    this display module (the #3273 deferred-track's own repeated failure
+    mode: "手動列挙は次も漏れる"). Witnessed by enumerating the real
+    registry rather than asserting on a handful of literals."""
+    from reyn.tools import get_default_registry
+
+    registry = get_default_registry()
+    names = registry.names()
+    assert names, "the default registry enumerated no tools — nothing to witness"
+
+    read_only_names = [n for n in names if registry.lookup(n).purity == "read_only"]
+    side_effect_names = [n for n in names if registry.lookup(n).purity == "side_effect"]
+    assert read_only_names and side_effect_names, (
+        "the real registry no longer has both purity values — this test's "
+        "own premise (a real read/write split exists to derive from) broke"
+    )
+
+    for name in read_only_names:
+        expected = name not in ("call_mcp_tool", "mcp_call_tool")
+        assert _is_retrieval_tool(name) is expected, (
+            f"{name!r}: purity=read_only but demotion={_is_retrieval_tool(name)}"
+        )
+    for name in side_effect_names:
+        assert _is_retrieval_tool(name) is False, (
+            f"{name!r}: purity=side_effect but demoted as retrieval"
+        )
+
+
+def test_dynamic_mcp_tool_calls_are_exempt_from_demotion_on_purpose() -> None:
+    """Tier 1: #3329 — lead-coder ruling: an individual MCP-server tool
+    installed at runtime (e.g. a genuinely read-only ``filesystem.read``)
+    dispatches through ONE of two fixed wrapper tools whose OWN name
+    (never the underlying MCP tool's identifier) is what
+    ``dispatcher.py``'s ``tool_called`` event — and therefore this
+    module's ``meta["tool"]`` — actually carries. No per-underlying-tool
+    purity is knowable here, so both wrappers are excluded explicitly,
+    not by coincidence of their current ``purity="side_effect"`` value."""
+    assert _is_retrieval_tool("call_mcp_tool") is False
+    assert _is_retrieval_tool("mcp_call_tool") is False
+
+
+def test_unknown_tool_name_is_not_demoted() -> None:
+    """Tier 1: #3329 — accept-side: a tool name absent from the registry
+    (e.g. a message replayed against an older/mismatched build) fails
+    closed to the PRE-#3329 behaviour (a normal marker), not to a silent
+    "no marker" that would hide an unrecognized entry from the operator."""
+    assert _is_retrieval_tool("this_tool_does_not_exist") is False


### PR DESCRIPTION
**[tui-coder]** — #3273's deferred track: a retrieval tool call (`read_file`/`grep_files`/...) carried the same `●`/state-coloured gutter marker as a side-effect one (write/exec/edit), making a plain read visually as loud as a mutation.

The issue's own blocker — "the registry has no op-class taxonomy" — turned out to be a wrong diagnosis of WHERE the taxonomy lives, not that it's missing (measured before implementing, per the issue's own explicit first step, see #3329's comment thread): `OP_KIND_MODEL_MAP` (the Control-IR op layer) has none, but `ToolDefinition.purity` (`src/reyn/tools/types.py`) is exactly this axis, already declared explicitly for all 76 registered tools (measured: zero tools rely on the dataclass default) — `read_file`/`grep_files`/`glob_files`/`list_directory` are `purity="read_only"`; `write_file`/`delete_file`/`edit_file` are `purity="side_effect"`. lead-coder's ruling: reuse `purity`, don't add a second axis for the same distinction.

**Falsified the one real divergence candidate before landing** (lead-coder's own falsification bar: "same target, two disagreeing values" — a target with no second value doesn't count): individual MCP-server tools installed at runtime all dispatch through ONE of two fixed wrapper tools (`call_mcp_tool` / `mcp_call_tool`) — the underlying tool name is an ARGUMENT (`mcp_tool_name`), never the invoked function name `dispatcher.py`'s `tool_called` event records — so no per-underlying-tool purity is knowable here. Both wrappers are excluded explicitly in the demotion decision (not by coincidence of their current `purity="side_effect"` value), per lead-coder's instruction.

`_is_retrieval_tool(tool_name) -> bool` (`gutter.py`) is the derivation: a cached default `ToolRegistry` lookup against `.purity`, with the MCP exemption. Wired into `_gutter_glyph_color` for `tool_call_started`/`tool_call_completed` only — `tool_call_failed` is deliberately excluded (a failure needs the operator's attention regardless of the tool's op-class). **Completeness gate**: a new test enumerates the REAL registry (every `read_only` name + every `side_effect` name) and asserts the demotion decision against each one, not a handful of hand-picked literals.

**Deliberately out of scope** (filed as #4662): the table's other cell — a demoted call's body should ALSO collapse to one dim "…（展開可）" line by default. That's a flowview entry-coalescing question (the same family as the existing history-restore header+result fold, #3310), not a `gutter.py` glyph decision — reuses this PR's `_is_retrieval_tool` once it lands.

## Test plan
- [x] `ruff check .` — clean, whole repo
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_textual_chat_phase2_3273.py` — 17 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/gutter.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/interfaces/test_textual_chat_phase2_3273.py tests/interfaces/test_textual_chat_phase4_right_gutter_3283.py tests/interfaces/test_rail_right_gutter_3526.py tests/interfaces/test_textual_chat_row_contrast_3367.py tests/interfaces/test_textual_chat_intervention_panel_3299.py tests/interfaces/test_tui_colour_tokens.py -q` — 72 passed
- [ ] Visual — **standing waiver applies** (owner directive, 2026-08-08): lead-coder's ruling on this issue explicitly said proceed to merge, owner checks the actual look on `main`.

Closes #3329

🤖 Generated with [Claude Code](https://claude.com/claude-code)
