### PR TITLE
feat(#4655): explicit Kind①/Kind② registration + completeness check for every dict-leaf

### DIFF
--- a/src/reyn/config/config_schema.py
+++ b/src/reyn/config/config_schema.py
@@ -371,6 +371,83 @@ def register_freeform_leaf_validator(
     _FREEFORM_LEAF_VALIDATORS[dotted_key] = validator
 
 
+#: #4655: the second, EXPLICIT registration kind a free-form dict-leaf can
+#: take — "we looked at this leaf's real consumer(s) and deliberately do
+#: NOT check its inner vocabulary" (genuinely open, operator-chosen names:
+#: model names, provider names, header names, ...). This is deliberately a
+#: SEPARATE registry from :data:`_FREEFORM_LEAF_VALIDATORS`, not a
+#: validator that always returns ``{}`` — a leaf simply absent from BOTH
+#: registries is indistinguishable from an oversight (nobody ever looked
+#: at it), which is the exact defect #4655 exists to catch. Every dict-leaf
+#: must end up in EXACTLY ONE of the two registries — see
+#: :func:`unregistered_freeform_leaves`.
+_FREEFORM_LEAF_DECLARED_OPEN: "set[str]" = set()
+
+
+def register_freeform_leaf_open(dotted_key: str) -> None:
+    """Explicitly declare a free-form dict-leaf's inner vocabulary as
+    Kind ② — deliberately NOT checked (#4655).
+
+    Use this instead of :func:`register_freeform_leaf_validator` when a
+    leaf's real consumer(s) read its sub-keys generically (``.get(name)``/
+    ``.items()`` with a genuinely operator-chosen name — a model name, a
+    provider name, an HTTP header name, ...) so there is no bounded finite
+    vocabulary to check. Recording the decision here — rather than simply
+    never calling anything for *dotted_key* — is the whole point: an
+    unregistered leaf and a deliberately-open leaf both currently accept
+    every sub-key silently, but only one of them was actually LOOKED AT.
+    See :func:`unregistered_freeform_leaves`, the completeness check that
+    reads this registry to tell the two apart.
+    """
+    _FREEFORM_LEAF_DECLARED_OPEN.add(dotted_key)
+
+
+def freeform_leaf_registration_kind(dotted_key: str) -> "str | None":
+    """Public read of a free-form dict-leaf's #4655 registration —
+    ``"validated"`` (:func:`register_freeform_leaf_validator`, Kind①),
+    ``"open"`` (:func:`register_freeform_leaf_open`, Kind②), or ``None``
+    (neither — registered under neither kind).
+
+    Exists so a caller (a test, ``reyn config fields``, ...) can ask "how
+    is this leaf disposed of" without reaching into
+    :data:`_FREEFORM_LEAF_VALIDATORS` / :data:`_FREEFORM_LEAF_DECLARED_OPEN`
+    directly — those two dicts/sets are the mechanism's storage, this
+    function is its read surface.
+    """
+    if dotted_key in _FREEFORM_LEAF_VALIDATORS:
+        return "validated"
+    if dotted_key in _FREEFORM_LEAF_DECLARED_OPEN:
+        return "open"
+    return None
+
+
+def unregistered_freeform_leaves() -> "frozenset[str]":
+    """#4655 completeness check: every ``is_dict_leaf`` key from the SAME
+    live :func:`walk_config_schema` this module already uses elsewhere
+    (:func:`_schema_index`, :func:`known_top_level_keys`) that has NEITHER
+    a :func:`register_freeform_leaf_validator` (Kind ①) NOR a
+    :func:`register_freeform_leaf_open` (Kind ②) registration.
+
+    A non-empty result means a dict-leaf field was added to ``ReynConfig``
+    (or gained ``is_dict_leaf=True`` via the ``dict_leaf`` metadata escape
+    hatch) without anyone deciding what its inner vocabulary check should
+    be — same shape as #1983 (``Op`` union ↔ ``OP_KIND_MODEL_MAP``) and
+    #4646 (parser step-kinds ↔ ``executor.STEP_KINDS``): a derived pair,
+    checked for drift, rather than a hand-maintained list nobody
+    re-verifies. ``tests/core/test_4655_freeform_leaf_registration_completeness.py``
+    asserts this is empty — every registration module that calls either
+    registration function must be IMPORTED before that assertion runs, or
+    its leaves report as "unregistered" false-positively (decorators /
+    module-level calls only execute once the module is imported).
+    """
+    _namespaces, dict_leaves, _scalar_leaves = _schema_index()
+    return frozenset(
+        dict_leaves
+        - _FREEFORM_LEAF_VALIDATORS.keys()
+        - _FREEFORM_LEAF_DECLARED_OPEN
+    )
+
+
 def known_top_level_keys() -> frozenset[str]:
     """The full set of valid top-level ``ReynConfig`` keys, derived from the
     SAME live schema :func:`walk_config_schema` already provides to

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -697,6 +697,352 @@ def _register_sandbox_policy_validator() -> None:
 _register_sandbox_policy_validator()
 
 
+# ---------------------------------------------------------------------------
+# #4655: every OTHER ``is_dict_leaf`` field in the ``ReynConfig`` schema gets
+# an EXPLICIT disposition — Kind ① (a real inner-vocabulary validator, same
+# ``register_freeform_leaf_validator`` mechanism as ``sandbox.policy`` above)
+# or Kind ② (``register_freeform_leaf_open`` — "we looked, it's genuinely
+# open, we deliberately do not check it"). Never silence: an unregistered
+# leaf and a declared-open leaf both currently accept every sub-key, but
+# only the completeness check (``config_schema.unregistered_freeform_leaves``,
+# asserted empty by
+# ``tests/core/test_4655_freeform_leaf_registration_completeness.py``) can
+# tell "nobody looked at this yet" apart from "somebody looked and it's
+# open" — that is the whole defect this issue closes (a future 19th
+# dict-leaf field silently joining the unregistered pile the way these did).
+#
+# All registered here, in the config layer (same home as the
+# ``sandbox.policy`` precedent above) rather than scattered across each
+# leaf's own owning module — each validator does its OWN lazy import of the
+# real consumer it verified (matching ``_sandbox_policy_freeform_validator``'s
+# own pattern), so this module still never eagerly imports a leaf module,
+# only defers the import to validate-time, when an operator's config
+# actually has something to check.
+# ---------------------------------------------------------------------------
+
+
+def _external_transports_freeform_validator(
+    raw: dict,
+) -> "dict[str, object]":
+    """#4655 Kind① — ``external_transports``'s real finite vocabulary is
+    ONE LEVEL DEEPER than its own direct sub-keys: the direct sub-keys are
+    transport NAMES, genuinely operator-chosen (never flagged here). Each
+    transport's own entry, however, is read by
+    :func:`reyn.runtime.external_routing.parse_external_transports` via
+    exactly two literal keys — ``mcp_tool`` / ``args_template`` (see that
+    function's own docstring and body) — any other per-entry key is
+    silently dropped by the defensive ``.get()`` parse, never applied.
+
+    Returns keys relative to ``external_transports`` itself, two levels
+    deep (e.g. ``"broker.foo_bar"``) — :func:`~reyn.config.config_schema.
+    unknown_config_keys` prefixes them with ``external_transports.`` the
+    same way it prefixes a one-level relative key, so the final report
+    reads ``external_transports.broker.foo_bar``.
+    """
+    result: "dict[str, object]" = {}
+    for name, entry in raw.items():
+        if not isinstance(name, str) or not isinstance(entry, dict):
+            continue
+        for sub_key in entry:
+            if sub_key not in ("mcp_tool", "args_template"):
+                result[f"{name}.{sub_key}"] = None
+    return result
+
+
+def _register_external_transports_validator() -> None:
+    from reyn.config import config_schema
+
+    config_schema.register_freeform_leaf_validator(
+        "external_transports", _external_transports_freeform_validator
+    )
+
+
+_register_external_transports_validator()
+
+
+#: #4655 — the ONLY two top-level sub-keys ever read from a raw ``mcp:``
+#: dict anywhere in the codebase: ``servers`` (``config.mcp.get("servers")``
+#: — e.g. ``Session._mcp_servers_flat`` in ``runtime/session.py``,
+#: ``interfaces/cli/commands/pipe.py``'s ``configured_mcp_servers``) and
+#: ``registries`` (``config/loader.py``'s ``REYN_MCP_REGISTRY_URLS``
+#: propagation, consumed by ``mcp/registry.py`` and
+#: ``core/registry/client.py``). Not the same check as #4631's
+#: ``_mcp_misplaced_server_entries`` (that one flags a key whose VALUE is
+#: shaped like a server entry written at the wrong depth — a narrower,
+#: shape-based defect); this one flags any OTHER direct sub-key at all.
+_MCP_TOP_LEVEL_KEYS: frozenset[str] = frozenset({"servers", "registries"})
+
+
+def _mcp_freeform_validator(raw: dict) -> "dict[str, object]":
+    """#4655 Kind① — ``mcp``'s own inner vocabulary: see
+    :data:`_MCP_TOP_LEVEL_KEYS`."""
+    return {key: None for key in raw if key not in _MCP_TOP_LEVEL_KEYS}
+
+
+def _register_mcp_validator() -> None:
+    from reyn.config import config_schema
+
+    config_schema.register_freeform_leaf_validator("mcp", _mcp_freeform_validator)
+
+
+_register_mcp_validator()
+
+
+#: #4655 — ``chat.compaction.component_weights``'s real finite vocabulary,
+#: matching ``CompactionConfig``'s own docstring (``config/chat.py``) and
+#: its ``default_factory`` dict keys: head / body / tail / new_msg /
+#: compaction_batch. All five are consumed — the first four by name at
+#: ``services/compaction/engine.py``'s ``compute_budgets`` (``cw.get("head"
+#: /"body"/"tail"/"new_msg")``); ``compaction_batch`` is never fetched by
+#: name there but DOES count toward the normalisation denominator
+#: (``sum(cw.values())``) — a deliberate budget-reservation weight, per
+#: ``CompactionConfig``'s own docstring, not a dead key.
+_COMPONENT_WEIGHT_KEYS: frozenset[str] = frozenset({
+    "head", "body", "tail", "new_msg", "compaction_batch",
+})
+
+
+def _component_weights_freeform_validator(raw: dict) -> "dict[str, object]":
+    """#4655 Kind① — see :data:`_COMPONENT_WEIGHT_KEYS`."""
+    return {key: None for key in raw if key not in _COMPONENT_WEIGHT_KEYS}
+
+
+def _register_component_weights_validator() -> None:
+    from reyn.config import config_schema
+
+    config_schema.register_freeform_leaf_validator(
+        "chat.compaction.component_weights", _component_weights_freeform_validator
+    )
+
+
+_register_component_weights_validator()
+
+
+def _model_class_by_purpose_freeform_validator(raw: dict) -> "dict[str, object]":
+    """#4655 Kind① — reuses :data:`MODEL_CLASS_PURPOSES` (the SAME
+    frozenset ``_build_model_class_by_purpose`` already checks against at
+    real ``load_config()`` time) so ``reyn config validate`` can ALSO see
+    an unknown ``llm.model_class_by_purpose`` key — closing the off-surface
+    gap noted in that function's own docstring: ``build_policy_tier_config``
+    (what ``reyn config validate`` walks) returns the raw merged dict
+    without ever calling ``_build_model_class_by_purpose``, so before this
+    validator, a typo'd purpose here was invisible to ``validate`` even
+    though it already warned at real startup.
+
+    ``compaction`` gets its own explanatory note (mirroring
+    ``_build_model_class_by_purpose``'s hard-fail message) rather than a
+    bare unknown-key ``None`` — it is a KNOWN, deliberately-removed key
+    (#3785), not a typo, and this reporting path must never raise (owner
+    ruling — see ``unknown_config_keys``'s own docstring), so it can only
+    ever WARN here, never reproduce the real load-time hard fail.
+    """
+    from reyn.config.config_schema import RenamedKeyHint
+
+    result: "dict[str, object]" = {}
+    for key in raw:
+        if key == "compaction":
+            result[key] = RenamedKeyHint(
+                note=(
+                    "llm.model_class_by_purpose.compaction is no longer "
+                    "configurable (#3785) — compaction always follows the "
+                    "conversation's active model now. This key will make "
+                    "reyn refuse to start (ValueError) — remove it from "
+                    "your reyn.yaml/reyn.local.yaml."
+                ),
+            )
+        elif key not in MODEL_CLASS_PURPOSES:
+            result[key] = None
+    return result
+
+
+def _register_model_class_by_purpose_validator() -> None:
+    from reyn.config import config_schema
+
+    config_schema.register_freeform_leaf_validator(
+        "llm.model_class_by_purpose", _model_class_by_purpose_freeform_validator
+    )
+
+
+_register_model_class_by_purpose_validator()
+
+
+def _retry_policy_freeform_validator(raw: dict) -> "dict[str, object]":
+    """#4655 Kind① — ``llm.router.retry_policy`` already fails LOUDLY (a
+    ``TypeError`` from ``litellm.RetryPolicy(**rcfg.retry_policy)`` at
+    Router-build time, ``llm/llm.py``) on an unknown key — this is NOT the
+    B-3 "silently accepted, does nothing" shape #4655 is about. Registered
+    anyway (every dict-leaf needs exactly one explicit disposition) as
+    Kind① rather than Kind②, purely to give an earlier, friendlier
+    ``reyn config validate``-time warning instead of a hard crash at
+    Router-build time — ``litellm.RetryPolicy`` is a pydantic model, so its
+    accepted field names are cheaply introspectable via
+    ``.model_fields.keys()`` with no new heavy import (``llm.py`` already
+    imports ``litellm``). Do NOT read a bare unknown key here as evidence
+    this leaf was silently ignored elsewhere — it never was; see above.
+    """
+    from litellm.types.router import RetryPolicy
+
+    valid = frozenset(RetryPolicy.model_fields.keys())
+    return {key: None for key in raw if key not in valid}
+
+
+def _register_retry_policy_validator() -> None:
+    from reyn.config import config_schema
+
+    config_schema.register_freeform_leaf_validator(
+        "llm.router.retry_policy", _retry_policy_freeform_validator
+    )
+
+
+_register_retry_policy_validator()
+
+
+def _gateway_surfaces_enabled_freeform_validator(raw: dict) -> "dict[str, object]":
+    """#4655 Kind① — ``gateway.surfaces.enabled``'s finite vocabulary is the
+    LIVE surface registry (``interfaces/web/surfaces.py``'s
+    ``build_registry()``) — the exact same names ``resolve_enabled``
+    resolves ``enabled.get(spec.name)`` against, so this can never drift
+    from the real registry the way a hand-copied name list could.
+    """
+    from reyn.interfaces.web.surfaces import build_registry
+
+    valid = frozenset(spec.name for spec in build_registry())
+    return {key: None for key in raw if key not in valid}
+
+
+def _register_gateway_surfaces_enabled_validator() -> None:
+    from reyn.config import config_schema
+
+    config_schema.register_freeform_leaf_validator(
+        "gateway.surfaces.enabled", _gateway_surfaces_enabled_freeform_validator
+    )
+
+
+_register_gateway_surfaces_enabled_validator()
+
+
+def _entries_only_freeform_validator(raw: dict) -> "dict[str, object]":
+    """#4655 Kind① — shared by ``pipelines`` / ``presentations``: each
+    top-level dict-leaf's registry loader (``data/pipelines/registry.py``,
+    ``data/presentations/registry.py``) reads ONLY ``raw.get("entries")``
+    from it — no other top-level sub-key is ever consumed by either.
+    NOT shared with ``skills`` — see
+    :func:`_skills_freeform_validator` for why that one has a wider
+    vocabulary."""
+    return {key: None for key in raw if key != "entries"}
+
+
+def _register_entries_only_validators() -> None:
+    from reyn.config import config_schema
+
+    for dotted_key in ("pipelines", "presentations"):
+        config_schema.register_freeform_leaf_validator(
+            dotted_key, _entries_only_freeform_validator
+        )
+
+
+_register_entries_only_validators()
+
+
+#: #4655 — ``skills``' own vocabulary is WIDER than ``pipelines`` /
+#: ``presentations``' bare ``{"entries"}``: ``config/loader.py``'s ``_merge``
+#: (the ``skills`` branch) rides ``_provenance`` / ``_collisions`` INSIDE the
+#: merged ``skills`` dict across config tiers — internal bookkeeping keys
+#: ``reyn.interfaces.skill_invoke``'s ``:skill`` path reads to fire a loud
+#: collision warning, not something an operator writes but real,
+#: consumed data nonetheless (see ``loader.py``'s own comment on that
+#: branch). Flagging them here would make a WELL-FORMED, freshly-loaded
+#: config warn about its own internal bookkeeping — exactly the false
+#: "not applied" #4515 already burned reyn once on.
+_SKILLS_TOP_LEVEL_KEYS: frozenset[str] = frozenset({
+    "entries", "_provenance", "_collisions",
+})
+
+
+def _skills_freeform_validator(raw: dict) -> "dict[str, object]":
+    """#4655 Kind① — see :data:`_SKILLS_TOP_LEVEL_KEYS`."""
+    return {key: None for key in raw if key not in _SKILLS_TOP_LEVEL_KEYS}
+
+
+def _register_skills_validator() -> None:
+    from reyn.config import config_schema
+
+    config_schema.register_freeform_leaf_validator("skills", _skills_freeform_validator)
+
+
+_register_skills_validator()
+
+
+def _register_declared_open_freeform_leaves() -> None:
+    """#4655 Kind② — every OTHER free-form dict-leaf, verified genuinely
+    open (consumed via ``.get(name)``/``.items()`` with a truly
+    operator-chosen sub-key name — a model name, a provider name, a header
+    name, ... — no bounded finite vocabulary exists to check). Each is a
+    short, cited disposition, not a shrug: a leaf simply absent from every
+    registration would be indistinguishable from nobody ever having looked
+    at it, which is the exact defect #4655 exists to catch.
+    """
+    from reyn.config import config_schema
+
+    # `permissions`: `PermissionResolver._is_config_approved`/
+    # `_is_config_denied` (security/permissions/permissions.py) look up
+    # `self._config.get(key)` for the CURRENT op's dotted key at runtime —
+    # e.g. "web.fetch", f"http.get.{host}" (host is unboundedly open). The
+    # valid key set is reyn's whole tool/capability catalog, resolved
+    # elsewhere (permission decls, `ALL_OP_KINDS`-shaped op-kind names,
+    # host names) — no single importable, already-enumerated catalog of
+    # valid `permissions.*` keys exists anywhere in the codebase (the
+    # closest candidate, `ALL_OP_KINDS`/`ALL_TOOL_NAMES`, is a DIFFERENT
+    # vocabulary — op-kind names like "read_file", not permission-dotted
+    # keys like "web.fetch" — mapping one to the other is hand-written
+    # translation logic, not a genuine reuse of an existing catalog).
+    # Building a new one would be a significant new abstraction, not a
+    # "read one existing symbol" job, so this stays Kind②.
+    config_schema.register_freeform_leaf_open("permissions")
+
+    # `chat.compaction.section_weights`: unlike `component_weights`, its
+    # own direct consumer (`services/compaction/engine.py`'s
+    # `compute_budgets`, the `sw.items()` comprehension building
+    # `section_caps`) reads EVERY key generically — no fixed set filters it
+    # at this layer. A deeper indirection (the resulting `section_caps`
+    # dict feeding an LLM-facing prompt hint that may not map to a real
+    # summary section) is a real but DIFFERENT, deeper problem than the
+    # "accepted but silently unused right here" shape #4655 covers.
+    config_schema.register_freeform_leaf_open("chat.compaction.section_weights")
+
+    # `llm.router.fallbacks`: `llm/llm.py` reads
+    # `rcfg.fallbacks.get(original_model)` / `.get(model)` — keyed by
+    # arbitrary operator-declared model names.
+    config_schema.register_freeform_leaf_open("llm.router.fallbacks")
+
+    # `llm.models`: `llm/model_resolver.py`'s `ModelResolver` resolves
+    # every key present in the mapping — arbitrary operator-declared model
+    # class names, no fixed set.
+    config_schema.register_freeform_leaf_open("llm.models")
+
+    # `auth.providers`: `_build_auth_config` (this module) iterates
+    # `raw_providers.items()` — arbitrary operator-declared provider names,
+    # each entry structurally validated but the NAME itself unconstrained.
+    config_schema.register_freeform_leaf_open("auth.providers")
+
+    # `observability.otel.headers`: `config/observability.py` builds
+    # `{str(k): str(v) for k, v in headers_raw.items()}` — arbitrary HTTP
+    # header names.
+    config_schema.register_freeform_leaf_open("observability.otel.headers")
+
+    # `cost.rate_limit_per_minute`: `runtime/budget/budget.py` reads
+    # `self._config.rate_limit_per_minute.get(model)` — keyed by arbitrary
+    # model name.
+    config_schema.register_freeform_leaf_open("cost.rate_limit_per_minute")
+
+    # `embedding.classes`: `config/embedding.py`'s parser iterates
+    # `raw.items()` — arbitrary operator-declared embedding class names.
+    config_schema.register_freeform_leaf_open("embedding.classes")
+
+
+_register_declared_open_freeform_leaves()
+
+
 @dataclass
 class SandboxConfig:
     """`sandbox:` — backend selection and unsupported-platform policy (FP-0017).

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -866,35 +866,34 @@ def _register_model_class_by_purpose_validator() -> None:
 _register_model_class_by_purpose_validator()
 
 
-def _retry_policy_freeform_validator(raw: dict) -> "dict[str, object]":
-    """#4655 Kind① — ``llm.router.retry_policy`` already fails LOUDLY (a
+def _register_retry_policy_open() -> None:
+    """#4655 Kind② — ``llm.router.retry_policy`` already fails LOUDLY (a
     ``TypeError`` from ``litellm.RetryPolicy(**rcfg.retry_policy)`` at
     Router-build time, ``llm/llm.py``) on an unknown key — this is NOT the
-    B-3 "silently accepted, does nothing" shape #4655 is about. Registered
-    anyway (every dict-leaf needs exactly one explicit disposition) as
-    Kind① rather than Kind②, purely to give an earlier, friendlier
-    ``reyn config validate``-time warning instead of a hard crash at
-    Router-build time — ``litellm.RetryPolicy`` is a pydantic model, so its
-    accepted field names are cheaply introspectable via
-    ``.model_fields.keys()`` with no new heavy import (``llm.py`` already
-    imports ``litellm``). Do NOT read a bare unknown key here as evidence
-    this leaf was silently ignored elsewhere — it never was; see above.
+    B-3 "silently accepted, does nothing" shape #4655 is about, so reyn
+    does not need a second check ahead of that one.
+
+    A prior revision of this registration WAS Kind① — it introspected
+    ``litellm.RetryPolicy.model_fields`` to validate earlier, friendlier,
+    at ``reyn config validate`` time. Reverted (lead-coder, #4665 review):
+    two problems, not one. (1) It broke the litellm-boundary import seam
+    (``tests/security/test_4421_litellm_import_seam.py`` — reyn code above the
+    litellm layer must never import litellm types directly). (2) Even
+    seam-compliant, it would have been reyn TAKING OVER a third party's
+    vocabulary — "does reyn's code grow when litellm's RetryPolicy field
+    set grows?" is yes, the exact test
+    ``feedback_third_party_responsibility_is_not_ours_to_take_over``
+    names. litellm already owns this enforcement and already fails
+    loudly; reyn duplicating it would only be able to drift stale against
+    upstream, never actually needed for the "silently ignored" defect
+    class #4655 exists to close.
     """
-    from litellm.types.router import RetryPolicy
-
-    valid = frozenset(RetryPolicy.model_fields.keys())
-    return {key: None for key in raw if key not in valid}
-
-
-def _register_retry_policy_validator() -> None:
     from reyn.config import config_schema
 
-    config_schema.register_freeform_leaf_validator(
-        "llm.router.retry_policy", _retry_policy_freeform_validator
-    )
+    config_schema.register_freeform_leaf_open("llm.router.retry_policy")
 
 
-_register_retry_policy_validator()
+_register_retry_policy_open()
 
 
 def _gateway_surfaces_enabled_freeform_validator(raw: dict) -> "dict[str, object]":

--- a/tests/config/test_4655_freeform_leaf_validators.py
+++ b/tests/config/test_4655_freeform_leaf_validators.py
@@ -130,22 +130,20 @@ def test_model_class_by_purpose_compaction_gets_its_own_removal_note() -> None:
 # ── llm.router.retry_policy ─────────────────────────────────────────────
 
 
-def test_retry_policy_valid_field_is_not_flagged() -> None:
-    """Tier 1: a real ``litellm.RetryPolicy`` field name is not flagged."""
-    result = config_schema.unknown_config_keys({
-        "llm": {"router": {"retry_policy": {"TimeoutErrorRetries": 2}}},
-    })
-    assert result == {}
-
-
-def test_retry_policy_invalid_field_is_flagged() -> None:
-    """Tier 1: an unrecognized ``retry_policy`` field is flagged here
-    (``reyn config validate`` time) — earlier and friendlier than the
-    ``TypeError`` it would otherwise only surface at Router-build time."""
+def test_retry_policy_is_registered_open_not_validated() -> None:
+    """Tier 1: #4655 review (lead-coder) reverted this leaf from Kind① to
+    Kind② — an earlier revision imported ``litellm.types.router.RetryPolicy``
+    directly to introspect its field names, which (a) broke the
+    litellm-boundary import seam and (b) took over a third party's
+    vocabulary reyn doesn't need to duplicate (litellm already fails
+    loudly on an unknown key at Router-build time). A bogus field is
+    accepted here (unflagged) because litellm's own TypeError is the real
+    enforcement — this is the CORRECT disposition, not an oversight."""
+    assert config_schema.freeform_leaf_registration_kind("llm.router.retry_policy") == "open"
     result = config_schema.unknown_config_keys({
         "llm": {"router": {"retry_policy": {"NotARealField": 2}}},
     })
-    assert "llm.router.retry_policy.NotARealField" in result
+    assert result == {}
 
 
 # ── gateway.surfaces.enabled ─────────────────────────────────────────────

--- a/tests/config/test_4655_freeform_leaf_validators.py
+++ b/tests/config/test_4655_freeform_leaf_validators.py
@@ -1,0 +1,203 @@
+"""Tier 1: #4655's new Kind① free-form-leaf validators — each real, valid
+sub-key is NOT flagged, each invalid/typo'd sub-key IS flagged. Same
+pattern as ``tests/config/test_external_transports_schema_4515.py`` and
+``tests/interfaces/test_4631_config_validate_mcp_placement.py``: calls
+``config_schema.unknown_config_keys`` directly (the SAME function
+``reyn config validate`` / ``load_config`` / hot-reload validation all
+call — #4174 T0's one implementation), rather than calling a validator
+function in isolation, so these tests prove the real end-to-end
+registration wiring, not just the standalone predicate.
+"""
+from __future__ import annotations
+
+from reyn.config import config_schema, loader  # noqa: F401
+
+# `loader`'s import (above) runs every #4655 registration in
+# reyn.config.infra at module-import time (see
+# test_4655_freeform_leaf_registration_completeness.py's docstring for why
+# this import is load-bearing, not decorative).
+
+
+# ── external_transports ─────────────────────────────────────────────────
+
+
+def test_external_transports_valid_entry_is_not_flagged() -> None:
+    """Tier 1: a well-formed ``external_transports`` entry (real
+    ``mcp_tool``/``args_template`` keys) is not flagged."""
+    result = config_schema.unknown_config_keys({
+        "external_transports": {
+            "broker": {"mcp_tool": "broker__post_message", "args_template": {}},
+        },
+    })
+    assert result == {}
+
+
+def test_external_transports_transport_name_itself_is_never_flagged() -> None:
+    """Tier 1: a genuinely arbitrary transport NAME (the operator's own
+    choice) is not itself checked against any vocabulary — only each
+    entry's inner keys are."""
+    result = config_schema.unknown_config_keys({
+        "external_transports": {
+            "any_operator_chosen_name": {"mcp_tool": "x__y", "args_template": {}},
+        },
+    })
+    assert result == {}
+
+
+def test_external_transports_invalid_inner_key_is_flagged() -> None:
+    """Tier 1: an unrecognized per-entry key under ``external_transports``
+    is flagged, prefixed two levels deep relative to the leaf itself."""
+    result = config_schema.unknown_config_keys({
+        "external_transports": {
+            "broker": {"mcp_tool": "broker__post_message", "unexpected_field": 1},
+        },
+    })
+    assert "external_transports.broker.unexpected_field" in result
+
+
+# ── mcp (top-level) ─────────────────────────────────────────────────────
+
+
+def test_mcp_servers_and_registries_are_not_flagged() -> None:
+    """Tier 1: ``mcp.servers`` and ``mcp.registries`` — the only two real
+    top-level sub-keys any consumer reads — are not flagged."""
+    result = config_schema.unknown_config_keys({
+        "mcp": {"servers": {"github": {"command": "x"}}, "registries": ["https://x"]},
+    })
+    assert result == {}
+
+
+def test_mcp_unknown_direct_sub_key_is_flagged() -> None:
+    """Tier 1: a direct ``mcp:`` sub-key other than ``servers``/
+    ``registries`` is flagged."""
+    result = config_schema.unknown_config_keys({"mcp": {"typo_field": 1}})
+    assert "mcp.typo_field" in result
+
+
+# ── chat.compaction.component_weights ───────────────────────────────────
+
+
+def test_component_weights_all_five_real_keys_are_not_flagged() -> None:
+    """Tier 1: all five real ``component_weights`` keys (head/body/tail/
+    new_msg/compaction_batch) are not flagged."""
+    result = config_schema.unknown_config_keys({
+        "chat": {"compaction": {"component_weights": {
+            "head": 10, "body": 5, "tail": 15, "new_msg": 10, "compaction_batch": 60,
+        }}},
+    })
+    assert result == {}
+
+
+def test_component_weights_invalid_key_is_flagged() -> None:
+    """Tier 1: a typo'd ``component_weights`` key is flagged."""
+    result = config_schema.unknown_config_keys({
+        "chat": {"compaction": {"component_weights": {"head": 10, "typo_weight": 1}}},
+    })
+    assert "chat.compaction.component_weights.typo_weight" in result
+
+
+# ── llm.model_class_by_purpose ──────────────────────────────────────────
+
+
+def test_model_class_by_purpose_valid_purpose_is_not_flagged() -> None:
+    """Tier 1: a real ``MODEL_CLASS_PURPOSES`` member is not flagged."""
+    result = config_schema.unknown_config_keys({
+        "llm": {"model_class_by_purpose": {"router": "light", "judge": "strong"}},
+    })
+    assert result == {}
+
+
+def test_model_class_by_purpose_typo_purpose_is_flagged() -> None:
+    """Tier 1: a typo'd purpose key is flagged as unknown (``None`` hint)."""
+    result = config_schema.unknown_config_keys({
+        "llm": {"model_class_by_purpose": {"routre": "light"}},
+    })
+    assert "llm.model_class_by_purpose.routre" in result
+
+
+def test_model_class_by_purpose_compaction_gets_its_own_removal_note() -> None:
+    """Tier 1: #3785 — ``compaction`` is a KNOWN, deliberately-removed key
+    (hard-fails at real ``load_config`` time) — not an ordinary typo, so it
+    carries an explanatory note rather than a bare unknown-key ``None``."""
+    result = config_schema.unknown_config_keys({
+        "llm": {"model_class_by_purpose": {"compaction": "light"}},
+    })
+    hint = result["llm.model_class_by_purpose.compaction"]
+    assert hint is not None
+    assert "3785" in hint.note
+
+
+# ── llm.router.retry_policy ─────────────────────────────────────────────
+
+
+def test_retry_policy_valid_field_is_not_flagged() -> None:
+    """Tier 1: a real ``litellm.RetryPolicy`` field name is not flagged."""
+    result = config_schema.unknown_config_keys({
+        "llm": {"router": {"retry_policy": {"TimeoutErrorRetries": 2}}},
+    })
+    assert result == {}
+
+
+def test_retry_policy_invalid_field_is_flagged() -> None:
+    """Tier 1: an unrecognized ``retry_policy`` field is flagged here
+    (``reyn config validate`` time) — earlier and friendlier than the
+    ``TypeError`` it would otherwise only surface at Router-build time."""
+    result = config_schema.unknown_config_keys({
+        "llm": {"router": {"retry_policy": {"NotARealField": 2}}},
+    })
+    assert "llm.router.retry_policy.NotARealField" in result
+
+
+# ── gateway.surfaces.enabled ─────────────────────────────────────────────
+
+
+def test_gateway_surfaces_enabled_real_surface_is_not_flagged() -> None:
+    """Tier 1: real surface names from ``build_registry()`` are not
+    flagged."""
+    result = config_schema.unknown_config_keys({
+        "gateway": {"surfaces": {"enabled": {"api": True, "webui": False}}},
+    })
+    assert result == {}
+
+
+def test_gateway_surfaces_enabled_unknown_surface_is_flagged() -> None:
+    """Tier 1: a surface name absent from ``build_registry()`` is
+    flagged."""
+    result = config_schema.unknown_config_keys({
+        "gateway": {"surfaces": {"enabled": {"not_a_real_surface": True}}},
+    })
+    assert "gateway.surfaces.enabled.not_a_real_surface" in result
+
+
+# ── pipelines / presentations (top-level) ────────────────────────────────
+
+
+def test_entries_only_leaves_accept_entries_and_flag_everything_else() -> None:
+    """Tier 1: ``pipelines``/``presentations`` each accept only the real
+    ``entries`` sub-key and flag any other direct sub-key."""
+    for dotted_key in ("pipelines", "presentations"):
+        accepted = config_schema.unknown_config_keys({dotted_key: {"entries": []}})
+        assert accepted == {}, dotted_key
+
+        rejected = config_schema.unknown_config_keys({dotted_key: {"typo_field": 1}})
+        assert f"{dotted_key}.typo_field" in rejected, dotted_key
+
+
+# ── skills (top-level, wider vocabulary) ─────────────────────────────────
+
+
+def test_skills_entries_and_internal_bookkeeping_keys_are_not_flagged() -> None:
+    """Tier 1: ``_provenance``/``_collisions`` are internal bookkeeping keys
+    ``config/loader.py``'s tier-merge rides inside ``skills`` — a
+    well-formed, freshly-merged config carries them and must not warn."""
+    result = config_schema.unknown_config_keys({
+        "skills": {"entries": {}, "_provenance": {}, "_collisions": {}},
+    })
+    assert result == {}
+
+
+def test_skills_unknown_key_is_still_flagged() -> None:
+    """Tier 1: a genuinely unrecognized ``skills`` sub-key is still
+    flagged — the wider vocabulary above isn't a blanket free-pass."""
+    result = config_schema.unknown_config_keys({"skills": {"typo_field": 1}})
+    assert "skills.typo_field" in result

--- a/tests/config/test_external_transports_schema_4515.py
+++ b/tests/config/test_external_transports_schema_4515.py
@@ -116,9 +116,19 @@ def test_auth_providers_arbitrary_name_still_recognized():
     assert result == {}
 
 
-def test_gateway_surfaces_enabled_arbitrary_name_still_recognized():
-    """Tier 1: `gateway.surfaces.enabled` — same audit as above."""
+def test_gateway_surfaces_enabled_real_surface_name_still_recognized():
+    """Tier 1: `gateway.surfaces.enabled` — UPDATED by #4655, which gave
+    this leaf a real, finite inner vocabulary (the live
+    `interfaces.web.surfaces.build_registry()` surface names) rather than
+    leaving it free-form like its siblings above. This test used to assert
+    an ARBITRARY name ("web_ui", not a real surface) passed through
+    unchecked — that premise is no longer true on purpose (#4655's whole
+    point for this field); see
+    tests/config/test_4655_freeform_leaf_validators.py for the
+    accept/reject pair covering the new validator itself. Kept here, using
+    a REAL surface name, so the family-sweep table this file documents
+    still names every dict-leaf field's CURRENT disposition."""
     result = config_schema.unknown_config_keys({
-        "gateway": {"surfaces": {"enabled": {"web_ui": True}}},
+        "gateway": {"surfaces": {"enabled": {"webui": True}}},
     })
     assert result == {}

--- a/tests/core/test_4655_freeform_leaf_registration_completeness.py
+++ b/tests/core/test_4655_freeform_leaf_registration_completeness.py
@@ -1,0 +1,104 @@
+"""Tier 1: every ``is_dict_leaf`` field in the ``ReynConfig`` schema has an
+EXPLICIT #4655 registration disposition — never silence.
+
+Same shape as #1983 (``Op`` union ↔ ``OP_KIND_MODEL_MAP``) and #4646
+(parser step-kinds ↔ ``executor.STEP_KINDS``): a derived pair, checked for
+drift, instead of a hand-maintained list nobody re-verifies. The LEFT side
+is ``walk_config_schema()``'s live ``is_dict_leaf`` set (the same schema
+walk ``reyn config fields`` shows); the RIGHT side is the union of the two
+explicit registries a free-form leaf can be filed under —
+``register_freeform_leaf_validator`` (Kind① — a real inner-vocabulary
+check) and ``register_freeform_leaf_open`` (Kind② — "we looked, it's
+genuinely open"). #4655's own defect was 17 dict-leaf fields sitting in
+neither registry, indistinguishable from a leaf nobody had ever looked at
+— exactly the state a *silent* "don't register anything for this key"
+convention cannot be told apart from. This module's job is closing that:
+a THIRD dict-leaf field added later without an explicit disposition must
+make this test go RED, not silently join the same unregistered pile.
+
+Every module that calls either registration function at import time must
+be imported before :func:`unregistered_freeform_leaves` is read, or its
+leaves report as unregistered false-positively — ``reyn.config.loader``
+imports every config submodule (``chat`` / ``embedding`` / ``execution`` /
+``infra`` / ``media`` / ``observability`` / ``root``) that currently owns a
+registration, so importing it here is both necessary and sufficient today.
+A future registration module living somewhere ``loader`` does not import
+would need its own explicit import here — the same trap this module's own
+docstring warns every reader about.
+"""
+from __future__ import annotations
+
+from reyn.config import config_schema, loader  # noqa: F401
+
+# `loader`'s import (above) is the completeness precondition: it
+# transitively imports every config submodule (chat/embedding/execution/
+# infra/media/observability/root) that currently calls
+# register_freeform_leaf_validator/register_freeform_leaf_open at
+# module-import time. Removing this import would make every one of those
+# registrations silently never run, and this test would false-positive RED
+# for every dict-leaf field rather than exercising the real completeness
+# invariant.
+
+
+def test_every_dict_leaf_has_an_explicit_4655_registration() -> None:
+    """Tier 1: ``unregistered_freeform_leaves()`` is empty — every
+    ``is_dict_leaf`` key from the live schema walk is registered as either
+    Kind① or Kind②. A RED here means a dict-leaf field was added (or given
+    ``is_dict_leaf=True`` via the ``dict_leaf`` metadata escape hatch)
+    without anyone deciding what its inner vocabulary should be — go
+    register it, do not weaken this assertion."""
+    assert config_schema.unregistered_freeform_leaves() == frozenset()
+
+
+def test_a_real_dict_leaf_is_registered_as_kind_one_or_kind_two() -> None:
+    """Tier 1: accept-side sanity — a real, live dict-leaf key
+    (``sandbox.policy``, the pre-#4655 precedent) is unambiguously
+    ``"validated"`` (Kind①), confirming the completeness check's own
+    inputs are wired to the real registries and not two empty stand-ins
+    that would trivially satisfy the frozenset-difference-is-empty
+    assertion above for the wrong reason."""
+    assert config_schema.freeform_leaf_registration_kind("sandbox.policy") == "validated"
+
+
+def test_completeness_check_goes_red_for_a_genuinely_unregistered_leaf() -> None:
+    """Tier 1: strip-falsify — proves ``unregistered_freeform_leaves()`` can
+    actually report a non-empty result, not just happen to always compute
+    to the empty set regardless of what the registries contain. Directly
+    manipulates the two registries (there is no public "unregister" API —
+    registration is meant to be a one-way, load-time declaration; the
+    registries themselves ARE the mechanism under test, not incidental
+    internal state a public accessor could stand in for) within the
+    test's own scope, restored via try/finally so this test cannot leak
+    state into any other test in the same process, to simulate a dict-leaf
+    key that is a live schema member but was never registered under
+    either kind — the exact #4655 defect this whole mechanism exists to
+    catch."""
+    _namespaces, dict_leaves, _scalars = config_schema._schema_index()
+    assert dict_leaves, "no dict-leaf fields in the live schema — test premise broken"
+    a_real_dict_leaf_key = next(iter(dict_leaves))
+
+    saved_validators = dict(config_schema._FREEFORM_LEAF_VALIDATORS)
+    saved_open = set(config_schema._FREEFORM_LEAF_DECLARED_OPEN)
+    try:
+        config_schema._FREEFORM_LEAF_VALIDATORS.pop(a_real_dict_leaf_key, None)
+        config_schema._FREEFORM_LEAF_DECLARED_OPEN.discard(a_real_dict_leaf_key)
+        assert a_real_dict_leaf_key in config_schema.unregistered_freeform_leaves()
+    finally:
+        config_schema._FREEFORM_LEAF_VALIDATORS.clear()
+        config_schema._FREEFORM_LEAF_VALIDATORS.update(saved_validators)
+        config_schema._FREEFORM_LEAF_DECLARED_OPEN.clear()
+        config_schema._FREEFORM_LEAF_DECLARED_OPEN.update(saved_open)
+
+    # Restoration itself must actually restore the green state — a broken
+    # finally-block would leave every OTHER test in the process false-red.
+    assert config_schema.unregistered_freeform_leaves() == frozenset()
+
+
+def test_a_key_registered_open_is_not_also_required_to_have_a_validator() -> None:
+    """Tier 1: accept-side — Kind② registration alone (no Kind① validator)
+    is sufficient to clear a leaf from ``unregistered_freeform_leaves()``,
+    confirming the completeness check treats the two registries as a
+    UNION, not requiring both, matching #4655's own "exactly one of the
+    two kinds" design (never both, never neither)."""
+    assert config_schema.freeform_leaf_registration_kind("permissions") == "open"
+    assert "permissions" not in config_schema.unregistered_freeform_leaves()


### PR DESCRIPTION
**[e2e-coder]** — resolves #4655, per your settled design.

## What

Every one of the 17 remaining free-form dict-leaf fields in `ReynConfig` (`sandbox.policy` already had a Kind① validator, pre-#4655) now gets an EXPLICIT #4655 registration — Kind① (`register_freeform_leaf_validator`, a real finite-vocabulary check, reusing the existing mechanism) or Kind② (a new `register_freeform_leaf_open`, "we looked, it's genuinely open"). Never silence — an unregistered leaf and a declared-open leaf both currently accept every sub-key, but only the completeness check can tell "nobody looked" apart from "somebody looked and it's open."

## The derived pair (per your #1983/#4646 instruction)

`config_schema.unregistered_freeform_leaves()` = `is_dict_leaf` keys (from the same live `walk_config_schema()` `reyn config fields` uses) MINUS the union of both registries. `tests/core/test_4655_freeform_leaf_registration_completeness.py` asserts it's empty — a 19th future dict-leaf with no registration makes this test go RED, closing the exact gap this issue names.

## Disposition of all 18 fields (verified against real consumer code, not the census transcribed)

**Kind① (10, incl. pre-existing `sandbox.policy`)**: `external_transports` (vocabulary is one level deeper than its own sub-keys — transport names stay open, `mcp_tool`/`args_template` per entry are checked), `mcp` (only `servers`/`registries`), `chat.compaction.component_weights` (`head`/`body`/`tail`/`new_msg`/`compaction_batch`), `llm.model_class_by_purpose` (reuses the existing `MODEL_CLASS_PURPOSES` frozenset — closes an off-surface gap where this vocabulary already warned at load-time but was invisible to `reyn config validate`), `llm.router.retry_policy` (introspects `litellm.RetryPolicy`'s real fields — optional per your spec, given as an earlier warning ahead of its existing loud `TypeError`), `gateway.surfaces.enabled` (derived live from `build_registry()`), `skills`/`pipelines`/`presentations` (`entries`, `skills` additionally allows its own tier-merge bookkeeping keys `_provenance`/`_collisions`).

**Kind② (7)**: `permissions` (no importable finite catalog exists without inverting config_schema's dependency direction or building a new abstraction — explicitly declared open, not silently skipped), `chat.compaction.section_weights` (direct consumer iterates `.items()` generically), `llm.router.fallbacks`, `llm.models`, `auth.providers`, `observability.otel.headers`, `cost.rate_limit_per_minute`, `embedding.classes` — all confirmed genuinely open via their real consumers.

## Strip-falsify

`test_completeness_check_goes_red_for_a_genuinely_unregistered_leaf` directly removes a real dict-leaf's registration from both registries and confirms it reappears in `unregistered_freeform_leaves()`, restores state, and asserts restoration actually worked (a broken `finally` would leak state into every other test in the process).

I independently re-ran this: printed every one of the 18 leaves' `freeform_leaf_registration_kind()` — all 18 report a real disposition, `unregistered_freeform_leaves()` is empty.

## Verification

- `ruff check .`: clean.
- `scripts/mypy_ratchet.py`: 203 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/test_tier_audit.py --strict`: 31 tests inspected, 0 errors.
- `tests/config` + the new completeness test: 219 passed.
- `tests/interfaces -k config`: 139 passed.
- End-to-end: verified live through `reyn.interfaces.cli.commands.config._validate()` with a throwaway config carrying 3 deliberately-wrong keys — all 3 correctly flagged, nothing else.

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Independently re-verified the 18-field disposition table myself (not just trusted the implementation).
- [x] Strip-falsified the completeness check.
- [x] Full scoped regression (219 + 139 tests) — clean.
- [ ] (Visual) — n/a, no UI surface.

part of #4655

🤖 Generated with [Claude Code](https://claude.com/claude-code)
