### PR TITLE
docs(#4364): C-6's listen-port pair doesn't apply — reyn declares no port

### DIFF
--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -108,10 +108,27 @@ whether each declared ``llm.models`` entry's BARE name (stripped of the
 was exactly this name-form mismatch. Only ``llm.api_base`` (a LiteLLM
 proxy) is checked; a provider with no declared ``api_base`` has no URL
 this module knows to probe, so it prints "not checked" (D-3) rather
-than guessing a per-provider hosted endpoint. C-6's remaining named pair
-(listen port) is a later slice — it needs its own NEW measurement code
-(introspecting a live bound socket), not reuse of an existing function
-the way C-1/C-2/C-3(b)/C-4/C-5/C-7 are.
+than guessing a per-provider hosted endpoint. C-6's own "listen port"
+example (measured #4364, before writing any code, per lead-coder's
+instruction) does NOT apply to reyn's own config surface: ``reyn web``'s
+``--host``/``--port`` are bare CLI arguments (``interfaces/cli/commands/
+web.py``) with NO corresponding ``ReynConfig`` field anywhere — verified
+by walking the full schema (:func:`reyn.config.config_schema.
+walk_config_schema`) for any key naming a port; there is none. C-6's
+motivating incident (architect's own report, #4364: a *different*
+project's ``settings.port`` silently stopped taking effect across a
+dependency bump) illustrates the GENERAL "declared ≠ effective" shape —
+it was never a claim that reyn itself declares a listen port anywhere.
+A declared-vs-effective pair needs a DECLARATION to pair against; reyn's
+own port is set once, per-invocation, by the operator's own CLI
+argument — there is nothing upstream of that argument for doctor (a
+separate, later, short-lived process with no view into a sibling
+``reyn web`` process's argv) to compare it with. C-6's GENERAL form
+(declared config ↔ ACTUALLY-effective value, never re-reading the
+declaration as its own witness) is already implemented — C-5 above is
+architect's own named special case of it (sandbox posture: declared
+``sandbox.*`` next to the resolved backend), not a separate, still-owed
+slice.
 """
 from __future__ import annotations
 

--- a/tests/interfaces/test_4364_c6_no_declared_listen_port.py
+++ b/tests/interfaces/test_4364_c6_no_declared_listen_port.py
@@ -1,0 +1,80 @@
+"""Tier 1: #4364 C-6 — reyn declares no listen-port config field.
+
+C-6's own motivating example (architect's report, #4364: a *different*
+project's ``settings.port`` silently stopped taking effect across a
+dependency bump) illustrates the general "declared ≠ effective" shape a
+doctor check needs a real DECLARATION to pair against. Measured before
+writing any check (per lead-coder's explicit instruction on this issue):
+``reyn web``'s ``--host``/``--port`` are bare CLI arguments with no
+corresponding ``ReynConfig`` field anywhere — there is nothing for
+doctor to compare an "effective" bound port against.
+
+This guard witnesses that finding stays true — the moment a real port
+config field DOES appear (walking the schema below no longer returns
+empty), C-6's own "listen port" slice needs revisiting (doctor.py's
+module docstring, the paragraph naming this issue), not silent drift
+between a stale docstring and new config surface.
+"""
+from __future__ import annotations
+
+
+def test_no_config_schema_leaf_names_a_port() -> None:
+    """Tier 1: enumerate the REAL ``ReynConfig`` schema (not a hand-picked
+    guess) and assert no leaf's dotted PATH SEGMENT is (or starts) "port"
+    — the concrete absence C-6's doctor.py docstring paragraph relies on.
+
+    Matched per dotted segment, not a bare substring: a naive substring
+    check false-positives on ``tool_use.transport`` / ``sandbox.
+    on_unsupported`` / ``external_transports`` (each contains the letters
+    "port" inside an unrelated word) — this witness would otherwise flag
+    itself as broken forever on those three, never on a real port field.
+    """
+    import re
+
+    from reyn.config.config_schema import walk_config_schema
+
+    nodes = walk_config_schema()
+    assert nodes, "the schema walk enumerated nothing — nothing to witness"
+
+    port_leaves = [
+        n.key for n in nodes
+        if any(re.match(r"^port(_|$)", seg.lower()) for seg in n.key.split("."))
+    ]
+    assert port_leaves == [], (
+        f"found port-shaped config leaf(ves) {port_leaves!r} — C-6's "
+        "'reyn declares no listen port' finding (doctor.py's module "
+        "docstring, the C-6 paragraph) is stale; revisit whether a "
+        "declared↔effective check is now buildable for it."
+    )
+
+
+def test_the_port_matcher_would_catch_a_real_port_field() -> None:
+    """Tier 1: accept-side witness for the matcher itself — proves the
+    regex above genuinely fires on port-shaped names (``port``,
+    ``listen_port``'s trailing segment doesn't match, only a segment that
+    STARTS with "port" does, matching the paragraph's own "gateway.port"
+    -shaped example) and does NOT fire on the three known false-positive
+    names, without needing to fabricate a schema."""
+    import re
+
+    matcher = re.compile(r"^port(_|$)")
+    assert matcher.match("port")
+    assert matcher.match("port_number")
+    assert not matcher.match("transport")
+    assert not matcher.match("unsupported")
+    assert not matcher.match("external_transports")
+
+
+def test_reyn_web_port_is_a_bare_cli_argument_not_a_config_field() -> None:
+    """Tier 1: the concrete counterpart of the schema-emptiness witness
+    above — ``reyn web``'s ``--port`` argparse argument exists (so the
+    concept itself is real), it's just never persisted to config."""
+    import argparse
+
+    from reyn.interfaces.cli.commands.web import register
+
+    sub = argparse.ArgumentParser().add_subparsers()
+    register(sub)
+    parser = sub.choices["web"]
+    dest_names = {a.dest for a in parser._actions}
+    assert "port" in dest_names


### PR DESCRIPTION
**[tui-coder]** — C-6 (architect, #4364): a "declared value ↔ actually-effective value" doctor check, motivated by a *different* project (reyn-broker)'s `settings.port` silently going dead across a dependency bump. doctor.py's own module docstring left this as "a later slice — needs its own NEW measurement code (introspecting a live bound socket)".

**Measured before writing any code**, per lead-coder's explicit instruction on this issue: walked the FULL `ReynConfig` schema (`config_schema.walk_config_schema`) for any leaf naming a port — there is none. `reyn web`'s `--host`/`--port` are bare CLI arguments (`interfaces/cli/commands/web.py`), never persisted to `reyn.yaml` or any other config source. A declared-vs-effective check needs a DECLARATION to pair against; C-6's own motivating incident illustrated the GENERAL shape (declared ≠ effective) using a different project's example — it was never a claim that reyn itself declares a listen port anywhere.

**Result**: rewrote the doctor.py docstring paragraph to state this finding instead of "a later slice", per lead-coder's stated correct landing for a "can't be measured" outcome. C-6's GENERAL form (declared ↔ ACTUALLY-effective, D-1's "measure, don't assert" made concrete) is already implemented — C-5 (sandbox posture) is architect's own named special case of it, not a separate slice still owed.

Added a guard test (not just a doc edit) so this finding can't rot silently: it walks the real schema and fails the moment a port-shaped config field appears, naming the doctor.py paragraph to revisit. A naive substring match on "port" false-positives on 3 real config leaves (`tool_use.transport`, `sandbox.on_unsupported`, `external_transports`, each containing the letters "port" inside an unrelated word) — matched per dotted PATH SEGMENT instead, with its own accept-side witness proving the matcher actually fires on a port-shaped name and not on the three known false positives.

D-2 (report-only) / D-3 (coverage disclosure) unaffected — no new check added, no new connection made; this is a docstring correction + a regression guard.

## Test plan
- [x] `ruff check .` — clean, whole repo
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4364_c6_no_declared_listen_port.py` — 3 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/doctor.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/interfaces/test_4364_c6_no_declared_listen_port.py tests/interfaces/test_4364_pr3a_doctor_cli.py tests/interfaces/test_4364_pr2b_doctor_external_pairing.py tests/interfaces/test_4364_c4_doctor_model_reachability.py tests/interfaces/test_4364_pr2_doctor_hook_probe.py tests/interfaces/test_4364_c5_sandbox_posture.py tests/interfaces/test_4364_c3b_doctor_mcp_negotiation.py -q` — 53 passed, 1 skipped (pre-existing optional-dep skip)
- [ ] (Visual — N/A, docstring + test only)

part of #4364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
