### PR TITLE
docs(#4364): doctor.md's "Out of scope" section still framed C-6 as a later slice

### DIFF
--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -272,11 +272,26 @@ constructor, #3075) — never a free-hand `httpx.Client(...)`, so this call site
 covered by the same standard-proxy-env/CA completeness gate every other reyn-owned
 HTTP client is.
 
-## Out of scope for this PR (later slices, same arc)
+## Not applicable, measured (not a later slice)
 
-- **C-6's remaining named pair** (listen port declared-vs-effective) — needs its
-  own new measurement code (introspecting a live bound socket), unlike
-  C-1/C-2/C-3(b)/C-4/C-5/C-7, which reuse existing measurement functions.
+C-6's "listen port declared-vs-effective" example does NOT apply to reyn's
+own config surface (measured before writing any code, per lead-coder's
+instruction, #4364): `reyn web`'s `--host`/`--port` are bare CLI arguments
+(`interfaces/cli/commands/web.py`) with no corresponding `ReynConfig` field
+anywhere — verified by walking the full schema
+(`reyn.config.config_schema.walk_config_schema`) for any key naming a port;
+there is none. A declared-vs-effective PAIR needs a DECLARATION to pair
+against, and reyn's own port is set once, per-invocation, by the
+operator's own CLI argument — there is nothing upstream of that argument
+for doctor (a separate, later, short-lived process with no view into a
+sibling `reyn web` process's argv) to compare it with. C-6's motivating
+incident (a *different* project's `settings.port` silently going dead
+across a dependency bump) illustrated the GENERAL "declared ≠ effective"
+shape, never a claim that reyn itself declares a listen port. C-6's
+GENERAL form is already implemented — C-5 above is architect's own named
+special case of it, not a separate slice still owed. A regression guard
+(`tests/interfaces/test_4364_c6_no_declared_listen_port.py`) fails the
+moment a port-shaped config field appears, naming this section to revisit.
 
 ## Related
 


### PR DESCRIPTION
**[docs-maintainer]** — part of #4364. Part of tonight's full doc-drift sweep since last night's pass (~15 PRs).

#4668 (same night) established C-6's "listen port declared-vs-effective" example doesn't apply to reyn's config surface at all — `reyn web`'s `--host`/`--port` are bare CLI args, never a `ReynConfig` field, verified by walking the full schema. `doctor.py`'s own docstring was updated to say so; `doctor.md`'s own "Out of scope for this PR (later slices, same arc)" section — the reference doc a reader actually opens for the command's current status — still said C-6 "needs its own new measurement code," implying it will eventually be built. #4668 didn't touch `docs/`, so this drifted.

Rewrote the section to match `doctor.py`'s own current framing: not applicable (measured, not deferred), C-6's general form already implemented via C-5, and the new regression guard test named so a future reader knows what re-opens this if it ever needs revisiting.

## Verification

- Read `doctor.py`'s own updated docstring paragraph directly before writing the doc fix, not paraphrased from the PR body.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` clean; ran the docs job's other two checks too (`check_doc_anchors.py`, `check_retired_config_keys_denylist.py`) — both exit 0.
- Fetched `origin/main` immediately before commit — no new commits since this branch's base.

part of #4364

## Test plan

- [x] `mkdocs build --strict` + `check_doc_anchors.py` + `check_retired_config_keys_denylist.py` — all clean
- [x] docs-only change — `ruff`/`pytest` N/A
- [ ] Visual — N/A (docs prose only)
