### PR TITLE
feat(#4662): retrieval tool rows fold to one dim line by default

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -42,6 +42,7 @@ from ._meta_keys import PIPELINE_RUN_KEY as _PIPELINE_RUN_KEY
 from ._meta_keys import RESULT_KIND_KEY as _RESULT_KIND_KEY
 from ._meta_keys import RESULT_META_KEY as _RESULT_META_KEY
 from ._meta_keys import RUNNING_SINCE_KEY as _RUNNING_SINCE_KEY
+from .gutter import _is_retrieval_tool
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -324,6 +325,52 @@ def _tool_result_line(msg: "OutboxMessage") -> "tuple[Text, str | None]":
     )
 
 
+def _collapsed_retrieval_line(msg: "OutboxMessage") -> "Text | None":
+    """#4662 (#3329's deferred body half): a SETTLED, non-expanded,
+    non-failed retrieval tool call's row, folded to ONE dim line —
+    ``tool(args) → summary`` — instead of the usual two-line ``tool(args)``
+    header + ``⎿ summary`` result. Returns ``None`` when the row does not
+    qualify (not settled, not retrieval, currently expanded, or failed),
+    so the caller falls through to the ordinary two-line form unchanged.
+
+    Reuses :func:`_is_retrieval_tool` (#3329's own ``ToolDefinition.purity``
+    derivation — no second taxonomy) and the SAME
+    :func:`summarize_tool_result` the two-line form already calls, so a
+    row reads identically whichever shape it takes, just spread over one
+    line instead of two.
+
+    The full result is not lost: #3508's existing highlight-expand
+    mechanism (:func:`_tool_result_line`) still fires when the row's
+    highlight arrives, exactly as it does for a side-effect tool's row —
+    this function only changes the COLLAPSED, unhighlighted default,
+    never removes the expand path.
+
+    Failure is excluded on purpose, mirroring #3329's gutter demotion:
+    a failed retrieval call still needs the operator's attention
+    regardless of the tool's op-class, so it keeps the ordinary
+    two-line/coral-tinted form."""
+    meta = msg.meta or {}
+    if meta.get(_EXPANDED_KEY):
+        return None
+    result_kind = meta.get(_RESULT_KIND_KEY)
+    if result_kind is None or result_kind == "tool_call_failed":
+        return None
+    tool = str(meta.get("tool", msg.text))
+    if not _is_retrieval_tool(tool):
+        return None
+    result_meta = meta.get(_RESULT_META_KEY) or {}
+    if result_kind == _ORPHANED_RESULT_KIND:
+        summary = "(no result — turn ended)"
+    else:
+        summary = summarize_tool_result(tool, result_meta.get("result"))
+        if summary.startswith("✗"):
+            return None  # a summary-shaped failure (D-2 kind, non-raising) — same exclusion
+    args = _summarize_args(meta.get("args"))
+    return Text.assemble(
+        (tool, _CC_DIM), (f"({args})", _CC_DIM), (" → ", _CC_DIM), (summary, _CC_DIM),
+    )
+
+
 def _running_indicator(msg: "OutboxMessage", now: float) -> Text:
     """The live ``⠙ elapsed Ns`` indicator line for an in-flight tool row.
 
@@ -416,12 +463,19 @@ def _body_and_background(
     # kind == "intervention" is intercepted earlier, in ``ReynPresenter.present``
     # (the pending/resolved placeholder — #3299 P1), so it never reaches here.
     if kind == "tool_call_started":
-        head = _tool_head(msg)
         if meta.get(_RESULT_KIND_KEY) is not None:
+            # #4662: a settled, non-expanded, non-failed retrieval call folds
+            # to ONE dim line instead of the usual header+result pair —
+            # checked BEFORE the two-line form below, never after (the two-
+            # line form is the fallback, not the default this overrides).
+            collapsed = _collapsed_retrieval_line(msg)
+            if collapsed is not None:
+                return collapsed, None
             # Settled (coalesced): the tool call folded together with its result.
+            head = _tool_head(msg)
             result_line, background = _tool_result_line(msg)
             return Group(head, result_line), background
-        return head, None
+        return _tool_head(msg), None
     if kind == "tool_call_completed":
         summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
         failed = summary.startswith("✗")

--- a/tests/interfaces/test_retrieval_row_collapse_4662.py
+++ b/tests/interfaces/test_retrieval_row_collapse_4662.py
@@ -1,0 +1,123 @@
+"""#4662 — a settled retrieval tool call's row folds to ONE dim line by
+default (#3329's deferred body-treatment half).
+
+Measured before building (#4662's own comment thread): the "展開可"
+(expandable) half of #3329's original table cell was ALREADY satisfied by
+#3508's existing highlight-expand mechanism, which fires for every settled
+tool row regardless of op-class — no new operation, no new keybinding.
+This PR's own scope is therefore narrow: change ONLY the COLLAPSED,
+unhighlighted default from a two-line ``tool(args)`` header + ``⎿ summary``
+result to ONE dim ``tool(args) → summary`` line, for a retrieval tool
+(#3329's ``_is_retrieval_tool``) that is settled, not currently expanded,
+and did not fail.
+
+Asserted on the PAINTED body via the presenter, mirroring
+``test_tool_detail_on_highlight_3508.py``'s own discipline — the meta flag
+is an implementation detail, not the thing that reaches the screen.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat._meta_keys import (
+    EXPANDED_KEY,
+    RESULT_KIND_KEY,
+    RESULT_META_KEY,
+)
+from reyn.interfaces.inline.textual_chat.presenter import _body_and_background
+from reyn.runtime.outbox import OutboxMessage
+
+
+def _settled_tool(
+    result: object, tool: str, *, expanded: bool = False, failed: bool = False,
+) -> OutboxMessage:
+    meta = {
+        "tool": tool,
+        "args": {"path": "a.py"},
+        RESULT_KIND_KEY: "tool_call_failed" if failed else "tool_call_completed",
+        RESULT_META_KEY: {"error_message": result} if failed else {"result": result},
+    }
+    if expanded:
+        meta[EXPANDED_KEY] = True
+    return OutboxMessage(kind="tool_call_started", text=tool, meta=meta)
+
+
+def _plain(renderable) -> str:
+    from rich.console import Console
+
+    console = Console(width=120, file=None, record=True)
+    console.begin_capture()
+    console.print(renderable)
+    return console.end_capture()
+
+
+def test_a_settled_retrieval_call_renders_one_dim_line() -> None:
+    """Tier 1: a settled, non-expanded ``read_file`` (purity=read_only, #3329)
+    call folds its header and result summary together — the ``⎿`` nested
+    result marker (the visual signal of a SEPARATE result line under the
+    header, #3283's own coalesce vocabulary) is gone, and the header + the
+    result summary both appear on the SAME line as each other (not the
+    header on one line and the summary on the next)."""
+    msg = _settled_tool(["line one", "line two", "line three"], "read_file")
+    body, _ = _body_and_background(msg, now=None, image_cache=None, decoded_image_cache=None)
+
+    text = _plain(body)
+    assert "⎿" not in text
+    header_line = next(l for l in text.splitlines() if "read_file" in l)
+    assert "3 items" in header_line, (
+        f"the result summary is not on the same line as the header: {text!r}"
+    )
+
+
+def test_a_settled_side_effect_call_keeps_the_two_line_form() -> None:
+    """Tier 1: accept-side — a settled ``write_file`` (purity=side_effect)
+    call is UNAFFECTED — #4662 only changes retrieval rows. Its ``⎿``
+    nested-result marker (the header/result separation #3283 established)
+    still appears, on a line that does NOT also carry the header text."""
+    msg = _settled_tool("ok", "write_file")
+    body, _ = _body_and_background(msg, now=None, image_cache=None, decoded_image_cache=None)
+
+    text = _plain(body)
+    assert "⎿" in text
+    result_line = next(l for l in text.splitlines() if "⎿" in l)
+    assert "write_file" not in result_line, (
+        f"the header and result collapsed onto one line for a side-effect "
+        f"tool — #4662 must not touch this case: {text!r}"
+    )
+
+
+def test_an_expanded_retrieval_call_keeps_the_two_line_expanded_form() -> None:
+    """Tier 1: #3508's highlight-expand mechanism is untouched — an EXPANDED
+    retrieval row (the highlight is on it) still shows the full detail via
+    the ordinary two-line form, never the one-line collapse."""
+    msg = _settled_tool(["line one", "line two"], "read_file", expanded=True)
+    body, _ = _body_and_background(msg, now=None, image_cache=None, decoded_image_cache=None)
+
+    text = _plain(body)
+    assert "line one" in text and "line two" in text
+    assert "⎿" in text
+
+
+def test_a_failed_retrieval_call_keeps_the_two_line_failure_form() -> None:
+    """Tier 1: mirrors #3329's own gutter-demotion exclusion — a FAILED
+    retrieval call still needs the operator's attention regardless of the
+    tool's op-class, so it is excluded from the one-line collapse."""
+    msg = _settled_tool("no such file", "read_file", failed=True)
+    body, _ = _body_and_background(msg, now=None, image_cache=None, decoded_image_cache=None)
+
+    text = _plain(body)
+    assert "no such file" in text
+    assert "✗" in text
+    assert "⎿" in text
+
+
+def test_an_unsettled_retrieval_call_is_unaffected() -> None:
+    """Tier 1: accept-side — a RUNNING (not yet settled) retrieval call has
+    no result to fold; #4662's collapse never fires before a result lands."""
+    msg = OutboxMessage(
+        kind="tool_call_started", text="read_file",
+        meta={"tool": "read_file", "args": {"path": "a.py"}},
+    )
+    body, _ = _body_and_background(msg, now=None, image_cache=None, decoded_image_cache=None)
+
+    text = _plain(body)
+    assert "→" not in text
+    assert "read_file" in text


### PR DESCRIPTION
**[tui-coder]** — #3329's own deferred body-treatment half (the table's right column: a retrieval call's body should collapse to one dim "…（展開可）" line by default). Measured before building, per this issue's own first step and lead-coder's explicit instruction: is the folded content already visible somewhere else, so no new operation is needed?

**Yes.** #3508's existing highlight-expand mechanism (`presenter.py`'s `_tool_result_line` / `app.py`'s `_set_expanded`) already shows a settled tool row's FULL result the moment the keyboard cursor's highlight arrives on it, for EVERY tool call regardless of op-class — no new keybinding, no new discoverability problem (#3508 already solved that: "使いづらいから使ってない" was Claude Code's failing, an affordance costing a deliberate action, not a missing capability). Per lead-coder's ruling on this finding: do NOT add a "where to see it" hint text to the collapsed row — the highlight-expand operation already reaches every row, so a hint would only add noise to the exact row this issue wants quieter.

This narrows #4662's actual scope to precisely one thing: change the COLLAPSED (non-highlighted) default from today's two-line `tool(args)` header + `⎿ summary` result to ONE dim `tool(args) → summary` line — for a retrieval tool (#3329's `_is_retrieval_tool`, no second taxonomy), settled, not currently expanded, and not failed. A failure is excluded on purpose, mirroring #3329's own gutter-demotion exclusion: it still needs the operator's attention regardless of the tool's op-class.

`_collapsed_retrieval_line` (`presenter.py`) computes the merged line and returns `None` when the row doesn't qualify, so the caller falls straight through to the existing two-line form unchanged for every other case — side-effect tools, in-flight calls, expanded rows, and failures are all byte-identical to before this PR.

## Test plan
- [x] `ruff check .` — clean, whole repo
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_retrieval_row_collapse_4662.py` — 5 tests inspected, 0 errors, 0 warnings (2 initial format-pinning violations caught by the audit and rewritten to assert behavior — ⎿ marker presence/absence — instead of raw line counts)
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/presenter.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/interfaces/test_tool_detail_on_highlight_3508.py tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py tests/interfaces/test_textual_chat_row_contrast_3367.py tests/interfaces/test_textual_chat_phase2_3273.py tests/interfaces/test_3318_body_neutralize.py tests/interfaces/test_textual_chat_orphan_sweep_72.py tests/interfaces/test_retrieval_row_collapse_4662.py tests/interfaces/test_tui_colour_tokens.py tests/runtime/test_textual_chat_phase5_3273.py -q` — 87 passed
- [ ] Visual — standing waiver applies (owner directive, 2026-08-08): same ruling as #4663 (#3329) covers this PR — owner checks the actual look on main.

Closes #4662

🤖 Generated with [Claude Code](https://claude.com/claude-code)
