### PR TITLE
docs: record blocked:external label durably (was broker-chat only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,23 @@ available action.
 This repo is touched by multiple Claude sessions (lead-coder, e2e-coder,
 per-PR coders) authenticating as the same `gh` user.
 
+**Issue-triage label: `blocked:external`** (owner-introduced, 2026-08-14).
+An open issue carrying it needs owner judgment or an upstream
+third-party dependency before an OS-side session can move it forward
+alone — an open issue WITHOUT it is pickable by any peer session.
+Measured containment (#4549's own methodology, re-applied to all four
+labels): `owner:decide` / `needs:owner-decision` / `owner:verify-only` /
+`wait_owner_iv` are each entirely a SUBSET of `blocked:external`, but
+not the reverse — `blocked:external` also covers external blockers
+with none of those four labels (a pure third-party wait, no
+owner-decision axis at all — verified narrower the same night this
+paragraph was written: a first-pass reading of the gap between the
+four-label union and `blocked:external` mistook 3 genuinely
+owner-pending issues for third-party waits, because they were missing
+an owner-axis label, not because the containment claim itself was
+wrong). This paragraph is the label's only durable record; it existed
+only as broker chat before this.
+
 **Before you open a PR, run `ruff check .`, `python
 scripts/test_tier_audit.py --strict <changed test files>`, `python
 scripts/verify_module_docstrings.py <changed src files>`, `python


### PR DESCRIPTION
**[docs-maintainer]** — dispatched by lead-coder (broker only, no issue number — this rule itself never had a durable home before now).

Owner introduced `blocked:external` today (2026-08-13) as the issue-triage convention — "no label = pickable by any peer session" — but the rule existed only in a broker message, not on any doc surface. `CLAUDE.md`'s own PR-workflow section already carries the multi-session audience this rule is for, so it's the natural home even though the convention is about issue-picking, prior to a PR existing at all.

Measured the label's containment relationship directly (#4549's own methodology, re-applied): `owner:decide` / `needs:owner-decision` / `owner:verify-only` / `wait_owner_iv` are each entirely a subset of `blocked:external`, but not the reverse.

**Correction (lead-coder's catch, PR comment)**: my first pass read the whole gap between the 4-label union and `blocked:external`'s own count as "pure third-party wait" — wrong. Opening the actual gap, 3 of those issues (#3825, #4571, #4666) were genuinely owner-decision-pending but missing an owner-axis label (lead-coder's own labeling gap, since fixed — the 4th "invisible wait" class caught tonight); only 2 (#4412, #4457, both a provisional upstream MCP SDK extension point) are real third-party waits with no owner-decision axis at all. **Not embedding the count in `CLAUDE.md`'s own committed paragraph** — labels move (this PR's own review is a live demonstration), so the doc states the qualitative relationship only, no numbers to go stale.

Kept short per lead-coder's own instruction — one label needs one paragraph, not a new section.

## Verification

- Queried every label's actual open-issue membership via `gh issue list --label ... --json number` directly before writing the containment claim.
- Re-verified after lead-coder's correction: confirmed #3825/#4571/#4666 now carry `owner:decide`, and #4412/#4457 carry `blocked:external` with none of the four owner-axis labels, directly via `gh issue view`.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean, only pre-existing en/ja anchor INFO noise, no "Aborted" line.
- Fetched `origin/main` immediately before commit.

## Test plan

- [x] `mkdocs build --strict` clean
- [x] docs-only change — `ruff`/`pytest` N/A
- [ ] Visual — N/A (docs prose only)
