### PR TITLE
fix(#4673): describe_mcp_tool carries annotations — was less than list

### DIFF
--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -607,11 +607,26 @@ def _enrich_router_schema(rendered: dict, state: "RouterCallerState") -> dict:
 async def _handle_describe_mcp_tool(
     args: Mapping[str, Any], ctx: ToolContext
 ) -> ToolResult:
-    """Return {name, description, input_schema} for the requested mcp_tool.
+    """Return {name, description, input_schema, annotations} for the
+    requested mcp_tool.
 
     Calls host.mcp_list_tools(server) to get the tool listing, then
     filters to the requested mcp_tool_name. The dotted form
     ``<server>.<tool>`` is resolved to the bare tool name for the lookup.
+
+    #4673: ``annotations`` (the MCP SDK's ``ToolAnnotations`` —
+    ``read_only_hint``/``destructive_hint``/``idempotent_hint``/
+    ``open_world_hint``/``title``, all "know before you call" signals)
+    is explicitly included alongside the 3 pre-existing keys — measured
+    (#3329's own follow-up): ``list_mcp_tools`` already carries it
+    verbatim (a shallow ``dict(t)`` copy of the SDK's full tool dict,
+    ``tools/mcp.py``'s own list handler above), so a "詳しく" (describe)
+    call returning LESS than the list it followed up on was the wrong
+    way round. Deliberately still a named, hand-picked key — not a
+    switch to ``dict(t)`` here (lead-coder's own recommendation,
+    #4673): passing through whatever fields the SDK happens to add next
+    is a different, "third-party vocabulary flows through unfiltered"
+    decision this one field addition does not make on its own.
     """
     host = _require_host(ctx)
     server = str(args["server"])
@@ -624,6 +639,7 @@ async def _handle_describe_mcp_tool(
                 "name": t.get("name"),
                 "description": t.get("description", ""),
                 "input_schema": t.get("inputSchema", {}),
+                "annotations": t.get("annotations"),
             }
     return {
         "error": (

--- a/tests/tools/test_router_call_mcp_tool_enum.py
+++ b/tests/tools/test_router_call_mcp_tool_enum.py
@@ -259,6 +259,93 @@ def test_describe_mcp_tool_handler_returns_input_schema():
     }
 
 
+def test_describe_mcp_tool_handler_carries_annotations() -> None:
+    """Tier 2: #4673 — describe_mcp_tool must not return LESS than
+    list_mcp_tools for the SAME tool. Before this fix it built a
+    hand-picked {name, description, input_schema} dict that never read
+    the SDK's ``annotations`` (read_only_hint/destructive_hint/
+    idempotent_hint/open_world_hint/title) — list_mcp_tools already
+    carries it verbatim (a shallow ``dict(t)`` copy), so a "describe"
+    call returning less than the "list" it followed up on was the wrong
+    way round. Real handler + real ToolContext, mirroring
+    ``test_describe_mcp_tool_handler_returns_input_schema`` above."""
+    annotations = {
+        "title": "Search the web", "read_only_hint": True,
+        "destructive_hint": False, "idempotent_hint": None, "open_world_hint": True,
+    }
+
+    class _FakeHost:
+        async def mcp_list_tools(self, server: str) -> list[dict]:
+            return [
+                {
+                    "name": "search",
+                    "description": "Search the web",
+                    "inputSchema": {"type": "object", "properties": {}},
+                    "annotations": annotations,
+                },
+            ]
+        async def mcp_list_servers(self) -> list[dict]:
+            return [{"name": "brave", "description": "Brave"}]
+        async def mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
+            return {}
+
+    host = _FakeHost()
+    rs = RouterCallerState(host=host)
+    ctx = ToolContext(
+        caller_kind="router",
+        events=None,
+        permission_resolver=None,
+        workspace=None,
+        router_state=rs,
+    )
+
+    result = asyncio.run(
+        DESCRIBE_MCP_TOOL.handler(
+            {"server": "brave", "mcp_tool_name": "brave.search"},
+            ctx,
+        )
+    )
+    assert "error" not in result, f"describe_mcp_tool returned error: {result}"
+    assert result.get("annotations") == annotations
+
+
+def test_describe_mcp_tool_handler_annotations_absent_is_none_not_a_crash() -> None:
+    """Tier 2: accept-side — a tool whose listing carries no ``annotations``
+    key at all (an older cache entry, or a server that predates the SDK
+    field) must not raise; the new key is simply ``None``, matching
+    list_mcp_tools' own behaviour for the same absent-field case (a plain
+    ``dict(t).get("annotations")`` there would be ``None`` too)."""
+    class _FakeHost:
+        async def mcp_list_tools(self, server: str) -> list[dict]:
+            return [
+                {"name": "search", "description": "Search the web", "inputSchema": {}},
+            ]
+        async def mcp_list_servers(self) -> list[dict]:
+            return [{"name": "brave", "description": "Brave"}]
+        async def mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
+            return {}
+
+    host = _FakeHost()
+    rs = RouterCallerState(host=host)
+    ctx = ToolContext(
+        caller_kind="router",
+        events=None,
+        permission_resolver=None,
+        workspace=None,
+        router_state=rs,
+    )
+
+    result = asyncio.run(
+        DESCRIBE_MCP_TOOL.handler(
+            {"server": "brave", "mcp_tool_name": "brave.search"},
+            ctx,
+        )
+    )
+    assert "error" not in result, f"describe_mcp_tool returned error: {result}"
+    assert "annotations" in result
+    assert result["annotations"] is None
+
+
 # ---------------------------------------------------------------------------
 # (7) describe_mcp_tool enum mirrors call_mcp_tool (symmetry invariant)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[tui-coder]** — Found as a byproduct of #3329's own MCP-annotations follow-up measurement: `list_mcp_tools` and `describe_mcp_tool` return different information for the SAME tool. `list_mcp_tools` carries the MCP SDK's `ToolAnnotations` (`read_only_hint`/`destructive_hint`/`idempotent_hint`/`open_world_hint`/`title` — verified, `MCPClient._tool_to_dict` calls `tool.model_dump()` unrestricted, and `tools/mcp.py`'s list handler does `entry = dict(t)`, a shallow copy of every field) verbatim; `describe_mcp_tool` built its own `{name, description, input_schema}` dict BY HAND, never reading `annotations` at all — the more specific verb ("describe this tool in detail") returned strictly less than the "list" call an agent would have just made to find it. `destructive_hint` (arguably the single most consequential of the four before actually invoking a tool) was specifically unreachable from `describe_mcp_tool`.

Minimal, additive fix per lead-coder's own recommendation on #4673: explicitly add the `annotations` key, not a switch to `dict(t)` here — that would be a different, "pass through whatever the SDK adds next unfiltered" decision this one field addition doesn't make.

## Test plan
- [x] `ruff check .` — clean, whole repo
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/test_tier_audit.py --strict tests/tools/test_router_call_mcp_tool_enum.py` — 18 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/tools/mcp.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/tools/test_router_call_mcp_tool_enum.py tests/tools/test_mcp_unified.py tests/tools/test_mcp_invoke_action_tool_args_1646.py tests/runtime/test_mcp_search_tool_invariants.py tests/runtime/test_router_tools.py tests/interfaces/test_inline_tool_result_summary.py -q` — 111 passed
- [ ] (Visual — N/A, LLM-facing tool-result payload only)

Closes #4673

🤖 Generated with [Claude Code](https://claude.com/claude-code)
