### PR TITLE
fix(#4671): history_file_stats' TOCTOU crashes doctor, same shape found + fixed in 2 siblings

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -238,9 +238,19 @@ def _dir_stats(directory: Path) -> tuple[int, int]:
     storage dirs use (see the module docstring's filename convention —
     neither dir nests subdirectories). Missing directory → ``(0, 0)``,
     same as "nothing written yet" rather than an error; a file that
-    disappears mid-scan (a concurrent delete) is skipped rather than
-    raising, since this is a best-effort snapshot, not a transactional
-    read."""
+    disappears mid-scan (a concurrent delete, raising
+    ``FileNotFoundError``) is skipped rather than propagating, since this
+    is a best-effort snapshot, not a transactional read.
+
+    #4671 census: any OTHER ``OSError`` (e.g. a permission error) is
+    deliberately NOT swallowed here — a prior revision caught bare
+    ``OSError``, which would silently under-count a file this process
+    genuinely could not measure, with no disclosure that anything was
+    skipped (same defect class as ``history_tail_reader.history_file_stats``,
+    #4671's own reported crash — there the same overbroad-except shape
+    manifested as a raised exception instead of a silent undercount,
+    because the failing check and the failing use weren't in the same
+    try block there)."""
     if not directory.is_dir():
         return 0, 0
     count = 0
@@ -250,7 +260,7 @@ def _dir_stats(directory: Path) -> tuple[int, int]:
             if entry.is_file():
                 count += 1
                 total += entry.stat().st_size
-        except OSError:
+        except FileNotFoundError:
             continue
     return count, total
 

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -177,18 +177,32 @@ def _events_dir_stats(root: Path) -> "tuple[int, int, date | None]":
     """(file_count, total_bytes, oldest_start_date) for every dated
     ``.jsonl`` under ``root`` — read-only, mirrors
     ``event_purge.collect_dated_files``'s own file discovery so this
-    reports on exactly the population a real purge would consider."""
+    reports on exactly the population a real purge would consider.
+
+    #4364 C-7 census (#4671): ``count`` used to be fixed to
+    ``len(files)`` BEFORE the per-file ``stat()`` loop, so a file that
+    vanished mid-scan (e.g. a concurrent ``reyn events purge``) still
+    counted toward ``count`` while silently NOT counting toward
+    ``total_bytes`` — the two figures could disagree with no disclosure
+    (a D-3 gap). Fixed by only incrementing ``count`` alongside a
+    successful ``stat()``, keeping both figures over the SAME population.
+    Only ``FileNotFoundError`` is treated as "vanished mid-scan, skip
+    silently" — any OTHER ``OSError`` (e.g. a permission error) is
+    deliberately not swallowed; see
+    ``history_tail_reader.history_file_stats``'s identical reasoning.
+    """
     from reyn.core.events.event_purge import collect_dated_files
 
     files = collect_dated_files(root)
-    count = len(files)
+    count = 0
     total_bytes = 0
     oldest: "date | None" = None
     for path, start_date in files:
         try:
             total_bytes += path.stat().st_size
-        except OSError:
+        except FileNotFoundError:
             continue
+        count += 1
         if start_date is not None and (oldest is None or start_date < oldest):
             oldest = start_date
     return count, total_bytes, oldest

--- a/src/reyn/runtime/history_tail_reader.py
+++ b/src/reyn/runtime/history_tail_reader.py
@@ -346,15 +346,32 @@ def history_file_stats(path: Path) -> "tuple[int, int]":
     :func:`read_history_after` already uses — so this count agrees with
     what a durable-store reader actually sees, not a raw ``wc -l``.
     Missing file → ``(0, 0)``, matching "nothing written yet" rather than
-    an error."""
-    if not path.is_file():
+    an error.
+
+    #4671: a prior revision checked ``path.is_file()`` BEFORE ``stat()``/
+    ``open()`` — a TOCTOU window (the file can vanish between the check
+    and the use, e.g. a concurrent ``/clear-history`` unlink, or a
+    short-lived spawned agent's session ending) that made this function
+    raise ``FileNotFoundError`` in EXACTLY the case its own docstring
+    promised would return ``(0, 0)``. ``reyn doctor`` walks every
+    ``history.jsonl`` under a project (C-7's disk-visibility scan), so a
+    session clearing its history WHILE doctor is running crashed the
+    diagnostic tool an operator reaches for specifically when something
+    looks wrong. Fixed by wrapping the stat+open+read in one ``try``,
+    catching ``FileNotFoundError`` only — any OTHER ``OSError`` (e.g. a
+    permission error) is deliberately NOT swallowed: silently returning
+    ``(0, 0)`` for a file that genuinely could not be measured would
+    misreport it as empty, which is worse than an honest failure (D-1:
+    measure, don't fake)."""
+    try:
+        total_bytes = path.stat().st_size
+        lines = 0
+        with path.open("r", encoding="utf-8") as f:
+            for raw in f:
+                if raw.strip():
+                    lines += 1
+    except FileNotFoundError:
         return 0, 0
-    total_bytes = path.stat().st_size
-    lines = 0
-    with path.open("r", encoding="utf-8") as f:
-        for raw in f:
-            if raw.strip():
-                lines += 1
     return total_bytes, lines
 
 

--- a/tests/data/test_media_store_pure_helpers.py
+++ b/tests/data/test_media_store_pure_helpers.py
@@ -5,10 +5,17 @@ any '; charset=...' suffix. Returns '' for unknown types.
 
 _safe_token(value) sanitises a string for embedding in a filename, replacing
 path-separators, spaces, and other shell-unfriendly characters with '_'.
+
+_dir_stats(directory) is (file_count, total_bytes) for a flat directory —
+see its own #4671 census tests below for the narrowed-except behavior.
 """
 from __future__ import annotations
 
-from reyn.data.workspace.media_store import _ext_for_mime, _safe_token
+from pathlib import Path
+
+import pytest
+
+from reyn.data.workspace.media_store import _dir_stats, _ext_for_mime, _safe_token
 
 # ── _ext_for_mime ─────────────────────────────────────────────────────────────
 
@@ -98,3 +105,63 @@ def test_safe_token_special_chars_replaced() -> None:
 def test_safe_token_empty_returns_empty() -> None:
     """Tier 2: empty string returns empty string."""
     assert _safe_token("") == ""
+
+
+# ── _dir_stats ───────────────────────────────────────────────────────────
+
+
+def test_dir_stats_missing_directory_reports_zero(tmp_path: Path) -> None:
+    """Tier 2: no directory at all — (0, 0), not an error."""
+    assert _dir_stats(tmp_path / "does-not-exist") == (0, 0)
+
+
+def test_dir_stats_counts_files_and_bytes(tmp_path: Path) -> None:
+    """Tier 2: real files on disk — count and byte total match exactly."""
+    (tmp_path / "a.bin").write_bytes(b"x" * 10)
+    (tmp_path / "b.bin").write_bytes(b"y" * 25)
+    assert _dir_stats(tmp_path) == (2, 35)
+
+
+def test_dir_stats_file_vanishing_mid_scan_is_skipped(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: #4671 — a file that disappears between ``iterdir()`` listing
+    it and this function's own ``stat()`` call (a concurrent delete) is
+    skipped, not raised — the existing, intentional best-effort behavior,
+    now scoped to ``FileNotFoundError`` specifically rather than a blanket
+    ``OSError`` (see the next test for why that distinction matters)."""
+    survivor = tmp_path / "survivor.bin"
+    vanishing = tmp_path / "vanishing.bin"
+    survivor.write_bytes(b"x" * 10)
+    vanishing.write_bytes(b"y" * 25)
+
+    real_stat = Path.stat
+
+    def _stat_raises_for_vanishing(self, *args, **kwargs):
+        if self == vanishing:
+            raise FileNotFoundError(f"simulated race: {self} vanished mid-scan")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _stat_raises_for_vanishing)
+
+    assert _dir_stats(tmp_path) == (1, 10)
+
+
+def test_dir_stats_permission_error_is_not_swallowed(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: #4671 — only ``FileNotFoundError`` is treated as "vanished,
+    skip silently". A ``PermissionError`` on one file must propagate, not
+    be silently absorbed as "this file doesn't count" — swallowing it
+    would under-report the directory's real footprint with no disclosure
+    that anything was skipped (D-1: measure, don't fake)."""
+    blocked = tmp_path / "blocked.bin"
+    blocked.write_bytes(b"z" * 5)
+
+    real_stat = Path.stat
+
+    def _stat_raises_permission_error(self, *args, **kwargs):
+        if self == blocked:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _stat_raises_permission_error)
+
+    with pytest.raises(PermissionError):
+        _dir_stats(tmp_path)

--- a/tests/interfaces/test_4364_pr3a_doctor_cli.py
+++ b/tests/interfaces/test_4364_pr3a_doctor_cli.py
@@ -17,7 +17,12 @@ from pathlib import Path
 
 import pytest
 
-from reyn.interfaces.cli.commands.doctor import _MEASURABLE_LEAF_KEYS, register, run
+from reyn.interfaces.cli.commands.doctor import (
+    _MEASURABLE_LEAF_KEYS,
+    _events_dir_stats,
+    register,
+    run,
+)
 from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
@@ -135,6 +140,58 @@ def test_events_reports_real_file_count_and_bytes(project, capsys):
     actual_line = next(line for line in out.splitlines() if line.strip().startswith("actual:"))
     assert "2 file(s)" in actual_line
     assert "50 bytes" in actual_line  # 42 + 8
+
+
+def test_events_dir_stats_count_and_bytes_stay_consistent_when_a_file_vanishes_mid_scan(
+    project, monkeypatch,
+):
+    """Tier 2: #4671 census — a prior revision fixed ``count`` to
+    ``len(files)`` BEFORE the per-file ``stat()`` loop, so a file that
+    vanished mid-scan (e.g. a concurrent ``reyn events purge``) still
+    counted toward ``count`` while silently not counting toward
+    ``total_bytes`` — the two figures could disagree with no disclosure.
+    Fixed by only incrementing ``count`` alongside a successful ``stat()``
+    — this asserts both figures now describe the SAME population."""
+    events_dir = project / ".reyn" / "events"
+    survivor = _write_event_file(events_dir, start_date=date.today(), size_bytes=10, suffix="s")
+    vanishing = _write_event_file(
+        events_dir, start_date=date.today(), size_bytes=25, suffix="v",
+    )
+
+    real_stat = Path.stat
+
+    def _stat_raises_for_vanishing(self, *args, **kwargs):
+        if self == vanishing:
+            raise FileNotFoundError(f"simulated race: {self} vanished mid-scan")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _stat_raises_for_vanishing)
+
+    count, total_bytes, _oldest = _events_dir_stats(events_dir)
+    assert count == 1
+    assert total_bytes == 10
+    assert survivor.is_file()
+
+
+def test_events_dir_stats_permission_error_is_not_swallowed(project, monkeypatch):
+    """Tier 2: #4671 census — only ``FileNotFoundError`` (a race-vanished
+    file) is treated as "skip silently". A ``PermissionError`` must
+    propagate, not be absorbed into a quietly-undercounted total (D-1:
+    measure, don't fake)."""
+    events_dir = project / ".reyn" / "events"
+    blocked = _write_event_file(events_dir, start_date=date.today(), size_bytes=10, suffix="b")
+
+    real_stat = Path.stat
+
+    def _stat_raises_permission_error(self, *args, **kwargs):
+        if self == blocked:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _stat_raises_permission_error)
+
+    with pytest.raises(PermissionError):
+        _events_dir_stats(events_dir)
 
 
 def test_a_declared_policy_violation_is_detected(project, capsys):

--- a/tests/runtime/test_4476_history_storage_stats.py
+++ b/tests/runtime/test_4476_history_storage_stats.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from reyn.runtime.history_tail_reader import (
     aggregate_history_stats,
     history_file_stats,
@@ -46,6 +48,53 @@ def test_counts_bytes_and_nonempty_lines(tmp_path: Path):
     b, lines = history_file_stats(hist)
     assert b == hist.stat().st_size
     assert lines == 3
+
+
+def test_file_vanishing_between_stat_and_open_still_reports_zero(tmp_path: Path, monkeypatch):
+    """Tier 2: #4671 — a prior revision checked ``path.is_file()`` BEFORE
+    ``stat()``/``open()``, a TOCTOU window where a concurrent unlink
+    (``/clear-history``, or a short-lived spawned agent's session ending)
+    between the check and the use raised ``FileNotFoundError`` in exactly
+    the case this function's own docstring promises ``(0, 0)`` for.
+    Simulates the race by making a REAL, existing file's ``open()`` raise
+    ``FileNotFoundError`` (the file vanished after ``stat()`` succeeded,
+    before ``open()`` ran) — proves the fix wraps stat+open in ONE try,
+    not just the entry check."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+
+    real_open = Path.open
+
+    def _open_raises_after_stat_succeeded(self, *args, **kwargs):
+        if self == hist:
+            raise FileNotFoundError(f"simulated race: {self} vanished before open()")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _open_raises_after_stat_succeeded)
+
+    assert history_file_stats(hist) == (0, 0)
+
+
+def test_permission_error_is_not_swallowed(tmp_path: Path, monkeypatch):
+    """Tier 2: #4671 — only ``FileNotFoundError`` (the TOCTOU race) is
+    treated as "vanished, report (0, 0)". Any OTHER ``OSError`` (a
+    permission error being the real-world example) must propagate, not
+    be silently reported as an empty file — a lie about coverage
+    (D-1: measure, don't fake)."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+
+    real_stat = Path.stat
+
+    def _stat_raises_permission_error(self, *args, **kwargs):
+        if self == hist:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _stat_raises_permission_error)
+
+    with pytest.raises(PermissionError):
+        history_file_stats(hist)
 
 
 def test_never_writes_to_the_file_it_measures(tmp_path: Path):


### PR DESCRIPTION
**[e2e-coder]** — part of #4671 (a #4364 C-7 census follow-up).

## What

`history_file_stats`'s docstring promised "missing file → `(0, 0)`, matching 'nothing written yet' rather than an error" — but the implementation checked `path.is_file()` BEFORE `stat()`/`open()`, a TOCTOU window where a concurrent unlink (`/clear-history`, or a short-lived spawned agent's session ending) between the check and the use raised `FileNotFoundError` in exactly the case the docstring promised `(0, 0)` for. `reyn doctor` walks every `history.jsonl` under a project (C-7's disk-visibility scan), so a session clearing its history WHILE doctor is running crashed the diagnostic tool an operator reaches for specifically when something looks wrong — you confirmed reachability directly (`/clear-history` unlinks, doctor scans all history).

## Fix

Wrap the whole stat+open+read in one `try`, catching `FileNotFoundError` only — any OTHER `OSError` (a permission error) is deliberately NOT swallowed, since silently returning `(0, 0)` for a file that genuinely could not be measured would misreport it as empty (D-1: measure, don't fake).

## Census before fixing (per your instruction)

Counted the same shape (`is_file()`-then-`stat()`/`open()` TOCTOU, or a blanket `except OSError` that would swallow a permission error alongside a legitimate race) across every surface doctor's C-7 disk scan reaches:

- **`media_store.py`'s `_dir_stats`** (doctor-reachable via `MediaStore.storage_stats`): already combined the `is_file()`/`stat()` check in one `try` (no crash), but caught blanket `OSError` — same "silently lies about coverage" defect, manifesting as an undercount instead of a crash. Narrowed to `FileNotFoundError`.
- **`doctor.py`'s own `_events_dir_stats`** (doctor-reachable): `count` was fixed to `len(files)` BEFORE the per-file `stat()` loop, so a raced file still counted toward `count` while silently not counting toward `total_bytes` — the two figures could disagree with no disclosure (this is the same finding my C-7 census already flagged separately). Fixed by only incrementing `count` alongside a successful `stat()`, same narrowed except.
- **`history_tail_reader.py`'s `read_last_line`/`read_history_tail`/`read_history_after`/`read_history_before`**: same `is_file`-then-use shape, but used exclusively by `Session`'s own history-loading paths (session startup / `_load_older_entries`), NOT doctor's scan — different reachability/risk profile (a session racing its OWN history file is narrower than doctor scanning every agent's history concurrently). Left unfixed here, noted for a separately-scoped follow-up rather than folded into this diff.

## Strip-falsify

Reverted each of the 3 fixes to its prior buggy shape one at a time, confirmed the new tests fail for the right reason (a race-simulated `FileNotFoundError` propagates instead of being caught; a `PermissionError`-swallowing regression is separately caught by its own dedicated test), restored, re-verified green.

## Verification

- `ruff check .`: clean.
- `scripts/mypy_ratchet.py`: 203 findings, all baselined (unchanged).
- `scripts/verify_module_docstrings.py`: clean.
- `scripts/test_tier_audit.py --strict`: 43 tests inspected, 0 errors.
- Full `tests/runtime` + `tests/data` + `tests/interfaces` regression: 3728 passed, 2 pre-existing optional-extra skips (unrelated, `reyn[voice]`).

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Strip-falsified all 3 fixes individually.
- [x] Full 3-directory regression sweep (3728 tests) — clean.
- [ ] (Visual) — n/a, no UI surface.

part of #4671 (a #4364 C-7 census follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
