### PR TITLE
feat(#4677): empty-stop resume retry is operator-configurable, default off

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -511,6 +511,7 @@ chat:
     right: true           # TUI right gutter (elapsed/tokens, 12 cols) shown at start
   neutralize_body: false  # opt-in ESC/OSC strip on agent-reply/tool-result body text
   image_url_schemes: []   # opt-in scheme allowlist for present's image src fetch
+  empty_stop_retry: false # opt-in resend on an empty router response
 ```
 
 ### `chat.render_mode`
@@ -585,6 +586,29 @@ independent of this scheme setting.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `image_url_schemes` | list[str] | `[]` | Restrict `present`'s image-src fetch to these schemes; empty = unrestricted (http + https). |
+
+### `chat.empty_stop_retry`
+
+Opt-in retry of an empty router response (#4677). When the LLM returns
+`finish_reason="stop"` with no content and no tool calls — a provider-level
+glitch, observed at ~50% rate with weak models (B7-G12 measurement) — reyn
+can resend ONE "resume" continuation prompt before surfacing the failure.
+Owner default is now `false` (2026-08-14) — the retry was previously
+hardcoded on in production with no config knob at all, until an incident
+where 30 empty-response detections in one `reyn-self` run each cost a
+second LLM call (30 turns → 63 `llm_called`). A measured benefit exists for
+some environments (Trace-patch-replay: 0/10 → 10/10 narration recovery on a
+specific empty-stop case with the retry on) — reports of this shape have
+come from weaker/local-model setups (Qwen, LM Studio, Ollama, vLLM,
+LiteLLM-fronted proxies); an operator on one of those sets this back to
+`true`. This does **not** fix empty responses themselves — their root cause
+is unmeasured (#3698's anyio cancel-scope is a candidate) — it only changes
+what happens *after* one is detected. The `router_empty_response_detected`
+audit event fires regardless of this setting.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `empty_stop_retry` | bool | `false` | Resend one "resume" prompt when the router loop detects an empty `finish_reason="stop"` response. |
 
 ### `chat.reasoning` fields
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -486,6 +486,21 @@
 # always rejected regardless of this list (nothing else is fetchable).
 #   image_url_schemes: []
 
+# chat.empty_stop_retry: opt-in retry of an empty router response (#4677).
+# When the LLM returns finish_reason="stop" with no content and no tool
+# calls (a provider-level glitch, observed at ~50% rate with weak models),
+# reyn can resend ONE "resume" continuation prompt. Owner default is now
+# false (2026-08-14) — was hardcoded true with no config knob at all,
+# after an incident where 30 empty-response detections in one reyn-self
+# run each cost a second LLM call. Set true to restore the retry — a
+# measured benefit exists for some environments (Trace-patch-replay:
+# 0/10 -> 10/10 narration recovery on a specific case), particularly with
+# weaker/local models (Qwen/LM Studio/Ollama/vLLM/LiteLLM-fronted setups
+# have reported this shape). This does NOT fix empty responses themselves
+# (root cause unmeasured, #3698's anyio cancel-scope is a candidate) — it
+# only changes what happens after one is detected.
+#   empty_stop_retry: false
+
 
 # -----------------------------------------------------------------------------
 # audit_events: audit-log rotation + automatic purge policy (#4174 T5:

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -890,6 +890,25 @@ class ChatConfig:
     httpx client cannot fetch anything else). Same rationale as
     ``neutralize_body`` for living under ``chat:`` rather than ``safety:`` —
     this is a display-boundary narrowing, not a stop condition.
+
+    ``empty_stop_retry`` (#4677, owner instruction 2026-08-14: "resume 注入を
+    デフォルト off にしてくれないかな"): the B42-NF-W6-1 empty-response
+    detect-and-retry (one resend, with the uniform "resume" directive, when
+    the router loop sees an empty ``finish_reason="stop"``) was previously
+    ALWAYS ON in production (``RouterLoopDriver`` hardcoded
+    ``empty_stop_retry_auto=True``, no config knob at all). Owner default is
+    now OFF, after an incident where 30 empty-response detections in one
+    ``reyn-self`` run each cost a second LLM call (30 turns → 63
+    ``llm_called``) — see #4677 for the measured amplification. Architect's
+    own recorded measurement (``router_loop.py``'s
+    ``empty_stop_retry_directive``-adjacent comment) is real: Trace-patch-
+    replay showed 0/10 → 10/10 narration recovery on a specific empty-stop
+    case with the retry ON — turning this OFF trades that recovery away in
+    whatever environment relies on it, which is why the knob exists at all
+    rather than deleting the retry outright. Do NOT write "empty responses
+    are fixed" anywhere this flag is discussed — the empty response's own
+    root cause is unmeasured (#3698's anyio cancel-scope is a candidate);
+    this flag only changes what happens AFTER one occurs.
     """
     compaction: CompactionConfig = field(default_factory=CompactionConfig)
     reasoning: ReasoningConfig = field(default_factory=ReasoningConfig)
@@ -897,6 +916,7 @@ class ChatConfig:
     gutters: GutterConfig = field(default_factory=GutterConfig)
     neutralize_body: bool = False
     image_url_schemes: "list[str]" = field(default_factory=list)
+    empty_stop_retry: bool = False
 
 
 def _build_reasoning_config(raw: object) -> ReasoningConfig:
@@ -956,11 +976,15 @@ def _build_chat_config(raw: object) -> ChatConfig:
     image_url_schemes = (
         [str(s) for s in raw_schemes] if isinstance(raw_schemes, list) else []
     )
+    # #4677: so does the empty-stop-retry knob (owner default False — see the
+    # field's own docstring for the incident + the tradeoff being made).
+    empty_stop_retry = bool(raw.get("empty_stop_retry", ChatConfig().empty_stop_retry))
     compaction_raw = raw.get("compaction") or {}
     if not isinstance(compaction_raw, dict):
         return ChatConfig(  # type: ignore[arg-type]
             reasoning=reasoning, render_mode=render_mode, gutters=gutters,
             neutralize_body=neutralize_body, image_url_schemes=image_url_schemes,
+            empty_stop_retry=empty_stop_retry,
         )
     # #1128: head_size/tail_size (step 3) + trigger_total_tokens/min_compact_batch
     # (PR-a, axis-1 removal) were removed — head/tail sizing is token-budget via
@@ -1041,7 +1065,7 @@ def _build_chat_config(raw: object) -> ChatConfig:
     return ChatConfig(
         compaction=compaction, reasoning=reasoning, render_mode=render_mode,  # type: ignore[arg-type]
         gutters=gutters, neutralize_body=neutralize_body,
-        image_url_schemes=image_url_schemes,
+        image_url_schemes=image_url_schemes, empty_stop_retry=empty_stop_retry,
     )
 
 

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -679,6 +679,7 @@ def _run(args: argparse.Namespace) -> None:
             agent_role=profile.role,
             compaction_config=session_cfg.config.chat.compaction,
             reasoning_config=session_cfg.config.chat.reasoning,  # #1652
+            empty_stop_retry=session_cfg.config.chat.empty_stop_retry,  # #4677
             registry=registry,  # back-reference for :agents / :attach + PR11 messaging
             allowed_mcp=profile.allowed_mcp,
             events_config=session_cfg.config.audit_events,

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -555,6 +555,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 agent_role=profile.role,
                 compaction_config=config.chat.compaction,
                 reasoning_config=config.chat.reasoning,  # #1652
+                empty_stop_retry=config.chat.empty_stop_retry,  # #4677
                 registry=_reg,  # #3593 ②: always the real registry — see the note above
                 allowed_mcp=profile.allowed_mcp,
                 events_config=config.audit_events,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -469,6 +469,7 @@ def run_serve(args: argparse.Namespace) -> None:
             agent_role=profile.role,
             compaction_config=session_cfg.config.chat.compaction,
             reasoning_config=session_cfg.config.chat.reasoning,  # #1652
+            empty_stop_retry=session_cfg.config.chat.empty_stop_retry,  # #4677
             registry=registry,
             allowed_mcp=profile.allowed_mcp,
             events_config=session_cfg.config.audit_events,

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -363,6 +363,7 @@ def _get_registry():
                 agent_role=profile.role,
                 compaction_config=config.chat.compaction,
                 reasoning_config=config.chat.reasoning,  # #1652
+                empty_stop_retry=config.chat.empty_stop_retry,  # #4677
                 registry=registry,
                 events_config=config.audit_events,
                 state_log=state_log,

--- a/src/reyn/runtime/registry_bootstrap.py
+++ b/src/reyn/runtime/registry_bootstrap.py
@@ -206,6 +206,7 @@ def build_agent_registry_from_project(
             agent_role=profile.role,
             compaction_config=config.chat.compaction,
             reasoning_config=config.chat.reasoning,
+            empty_stop_retry=config.chat.empty_stop_retry,  # #4677
             registry=registry,
             allowed_mcp=profile.allowed_mcp,
             events_config=config.audit_events,

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -402,8 +402,10 @@ def _is_empty_router_response(response: Any) -> bool:
     Reyn does not retry at all, which stopped matching production the
     moment B42-NF-W6-1 landed): the OS-level retry decision is NOT made
     here either — see the "Option F" block at the `_is_empty_router_response`
-    call site, and `empty_stop_retry_auto` (default `True` in production,
-    `router_loop_driver.py`) for the actual current behavior.
+    call site, and `empty_stop_retry_auto` (#4677: config-driven via
+    `chat.empty_stop_retry`, owner default `False` since 2026-08-14 —
+    was hardcoded `True`, `router_loop_driver.py`) for the actual current
+    behavior.
     """
     if response is None:
         return True
@@ -882,7 +884,7 @@ class RouterLoop:
         contextual_permission: "object | None" = None,  # #1827 S1: per-session ContextualPermission (TOOL-axis enforcement); None → bridged from exclude_tools
         memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
         empty_stop_retry_directive: str | None = None,  # B42-NF-W6-1 opt-in retry
-        empty_stop_retry_auto: bool = False,  # #187: always-on (no env opt-in); all prod sites pass True
+        empty_stop_retry_auto: bool = False,  # #187/#4677: config-driven (chat.empty_stop_retry, owner default False since 2026-08-14) — the one prod site (router_loop_driver.py) reads it from config, not a hardcoded True
         max_tool_calls_per_turn: int = 50,  # #1666 — safety.loop.max_tool_calls_per_turn (0 = unlimited)
         on_limit: "Any | None" = None,  # OnLimitConfig | None — FP-0005 max_iterations checkpoint
         llm_caller: "Any | None" = None,  # Tier 2 test seam: real-fake injection
@@ -2198,9 +2200,10 @@ class RouterLoop:
             # switch models when it fires.  #4486 drift fix: this comment
             # previously also said "does NOT retry" — that stopped matching
             # production the moment B42-NF-W6-1 shipped `empty_stop_retry_auto`
-            # (see below; the real driver, `router_loop_driver.py`, wires it
-            # `True`, so a retry attempt IS the default production behavior,
-            # not an opt-in one).
+            # (see below; the real driver, `router_loop_driver.py`, reads it
+            # from `chat.empty_stop_retry` — #4677, owner default `False`
+            # since 2026-08-14, was hardcoded `True`; an operator on a weak
+            # model that needs the retry sets the config key back on).
             #
             # #4486: this is turn-scoped, not response-scoped — a tool call
             # dispatched EARLIER this turn (`_tool_calls_attempted > 0`) means

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -79,6 +79,7 @@ class RouterLoopDriver:
         next_seq_fn: Callable[[], int], # Session._next_seq reader
         append_history_fn: Callable,    # Session._append_history
         chat_scheme_name: "str | None" = None,  # #1593 PR-2: chat-layer ToolUseScheme name → RouterLoop(scheme_name=); None → universal default
+        empty_stop_retry: bool = False,  # #4677: chat.empty_stop_retry (owner default False, 2026-08-14) — was hardcoded True below
         _loop_observer: "Callable | None" = None,  # Tier-2 test seam: called with the constructed RouterLoop before run
     ) -> None:
         self._router_host = router_host
@@ -104,6 +105,7 @@ class RouterLoopDriver:
         self._next_seq_fn = next_seq_fn
         self._append_history_fn = append_history_fn
         self._chat_scheme_name = chat_scheme_name  # #1593 PR-2
+        self._empty_stop_retry = empty_stop_retry  # #4677
         # #1468: per-turn cooperative cancellation flag + asyncio.Event for
         # deep-cancel propagation into running subprocess ops (#1470).
         self._turn_cancel_requested: bool = False
@@ -357,10 +359,16 @@ class RouterLoopDriver:
                 if self._contextual_for_turn_fn is not None
                 else self._contextual_permission
             ),
-            # B43-NF-W6-1 / #187: chat router empty-stop retry — always-on +
-            # uniform "resume" directive.
+            # B43-NF-W6-1 / #187: chat router empty-stop retry + uniform
+            # "resume" directive. #4677 (owner, 2026-08-14): the auto-retry
+            # switch is now config-driven (chat.empty_stop_retry, default
+            # False) rather than hardcoded True — see that field's own
+            # docstring for the incident + tradeoff. The directive itself
+            # is still always threaded (it is inert unless
+            # empty_stop_retry_auto is True), so a config-driven re-enable
+            # needs no other change here.
             empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
-            empty_stop_retry_auto=True,
+            empty_stop_retry_auto=self._empty_stop_retry,
             # #1666: per-turn tool_call count cap (cost-bound).
             max_tool_calls_per_turn=_max_tool_calls_per_turn,
             # FP-0005: wire safety.on_limit so max_iterations exhaustion routes

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -837,6 +837,7 @@ class Session:
         project_context_path: "Path | None" = None,
         compaction_config: "CompactionConfig | None" = None,
         reasoning_config: "ReasoningConfig | None" = None,  # #1652 chat.reasoning
+        empty_stop_retry: bool = False,  # #4677 chat.empty_stop_retry (owner default False, 2026-08-14)
         registry: "AgentRegistry | None" = None,
         allowed_mcp: list[str] | None = None,
         events_config: AuditEventsConfig | None = None,
@@ -1182,6 +1183,7 @@ class Session:
         from reyn.config import CompactionConfig, ReasoningConfig
         self._compaction = compaction_config or CompactionConfig()
         self._reasoning = reasoning_config or ReasoningConfig()  # #1652: reasoning capture/continuity/display, on-by-default
+        self._empty_stop_retry = empty_stop_retry  # #4677
         self._next_seq = 1
 
         # agents/<name>/ is state-only (PR20); Agent-derived workspace_dir, ensure it exists (FP-0043 Stage 2)
@@ -1405,6 +1407,7 @@ class Session:
                 next_seq_fn=lambda: self._next_seq,
                 append_history_fn=self._append_history,
                 chat_scheme_name=self._chat_tool_use_scheme,  # #1593 PR-2
+                empty_stop_retry=self._empty_stop_retry,  # #4677
             )
         )
 

--- a/tests/core/test_4677_empty_stop_retry_config.py
+++ b/tests/core/test_4677_empty_stop_retry_config.py
@@ -1,0 +1,55 @@
+"""Tier 1: `chat.empty_stop_retry` config parsing (#4677, owner instruction
+2026-08-14: "resume 注入をデフォルト off にしてくれないかな").
+
+Default False — the B42-NF-W6-1 empty-response detect-and-retry (one
+resend on an empty `finish_reason="stop"`) was previously hardcoded ON in
+production with no config knob at all (`router_loop_driver.py`'s own
+`empty_stop_retry_auto=True`). See `ChatConfig.empty_stop_retry`'s own
+docstring for the incident + the measured tradeoff being made. The knob
+must remain settable back to True — an operator/environment relying on
+the retry's measured narration-recovery benefit needs a way to keep it.
+"""
+from __future__ import annotations
+
+from reyn.config.chat import ChatConfig, _build_chat_config
+
+
+def test_empty_stop_retry_defaults_to_false() -> None:
+    """Tier 1: ChatConfig.empty_stop_retry defaults to False (owner
+    instruction, 2026-08-14 — was previously hardcoded True with no
+    config field at all)."""
+    assert ChatConfig().empty_stop_retry is False
+
+
+def test_chat_empty_stop_retry_parses_true() -> None:
+    """Tier 1: `chat.empty_stop_retry: true` in reyn.yaml turns it back
+    on — the required "config で on にできる形" condition (#4677)."""
+    assert _build_chat_config({"empty_stop_retry": True}).empty_stop_retry is True
+
+
+def test_chat_empty_stop_retry_absent_stays_false() -> None:
+    """Tier 1: falsification pair — omitting the key keeps the False
+    default (this field does not accidentally flip on for any other
+    chat: block)."""
+    assert _build_chat_config({"render_mode": "plain"}).empty_stop_retry is False
+
+
+def test_chat_empty_stop_retry_parses_when_compaction_block_present() -> None:
+    """Tier 1: the field parses correctly whether or not a sibling
+    `chat.compaction:` block is present — `_build_chat_config` has an
+    early-return branch when `compaction` is absent/malformed, and this
+    field's parse must survive BOTH branches, not just the one every
+    other test in this file happens to exercise."""
+    assert _build_chat_config({
+        "empty_stop_retry": True,
+        "compaction": {"body_token_cap": 5000},
+    }).empty_stop_retry is True
+    assert _build_chat_config({"empty_stop_retry": True}).empty_stop_retry is True
+
+
+def test_chat_empty_stop_retry_non_bool_value_is_coerced_not_crashed() -> None:
+    """Tier 1: a malformed value does not crash config load — same
+    defensive-parse contract every other chat: field in this loader
+    follows (bool() coercion, mirroring neutralize_body's own parse)."""
+    assert _build_chat_config({"empty_stop_retry": "yes"}).empty_stop_retry is True
+    assert _build_chat_config({"empty_stop_retry": ""}).empty_stop_retry is False

--- a/tests/llm/test_router_empty_response.py
+++ b/tests/llm/test_router_empty_response.py
@@ -528,11 +528,13 @@ async def test_empty_response_after_a_tool_call_stays_exempt_even_with_retry_aut
 ):
     """Tier 2: #4486 — the turn-scoped exemption takes priority over the
     empty-stop retry, even when `empty_stop_retry_auto=True` (production's
-    own default — `router_loop_driver.py`). Without this ordering, a
-    tool-call-only turn would still burn a retry round-trip before landing
-    on the same (correct) silent-completion outcome — this proves it
-    doesn't, by asserting the SAME two-call count as the auto-off case
-    above (`make_loop`'s default)."""
+    switch when `chat.empty_stop_retry` is turned on — #4677,
+    `router_loop_driver.py`; owner default is now False, but the ordering
+    this test pins must hold whenever the retry IS enabled). Without this
+    ordering, a tool-call-only turn would still burn a retry round-trip
+    before landing on the same (correct) silent-completion outcome — this
+    proves it doesn't, by asserting the SAME two-call count as the
+    auto-off case above (`make_loop`'s default)."""
     from reyn.prompt.loop_control import EMPTY_STOP_RETRY_DIRECTIVE
     from reyn.runtime.router_loop import RouterLoop
 

--- a/tests/llm/test_router_loop_empty_stop_retry.py
+++ b/tests/llm/test_router_loop_empty_stop_retry.py
@@ -9,11 +9,14 @@ Pinned invariants:
 - When the env var is unset, the directive is plumbed in but ignored — the
   loop falls through to the existing "observe + surface" path (= no behaviour
   change for the default chat-router policy).
-- #187: when ``empty_stop_retry_auto=True`` (= the agent-path always-on flag
-  set by phase_executor), the retry fires WITHOUT the env var. The directive
-  gate still holds (auto replaces the env opt-in, it does not fabricate a
-  missing directive). chat / plan-step sites leave auto False so they stay
-  env-gated (no regression).
+- #187/#4677: when ``empty_stop_retry_auto=True``, the retry fires WITHOUT
+  the env var. The directive gate still holds (auto replaces the env
+  opt-in, it does not fabricate a missing directive). The single
+  production wiring site is ``router_loop_driver.py``, reading
+  ``chat.empty_stop_retry`` (owner default ``False`` since 2026-08-14 —
+  was hardcoded ``True``, #4677); these tests exercise the flag's own
+  mechanism directly at the ``RouterLoop`` level, independent of that
+  production default.
 - When the directive is None, the env var is also ignored — no retry attempt
   even with the env var set.
 - Retries are bounded at 1 per turn: a second empty-stop in the same turn
@@ -165,17 +168,19 @@ async def test_no_retry_when_directive_is_none(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# #187: agent-path always-on flag — retry fires WITHOUT the env var
+# #187/#4677: the auto flag — retry fires WITHOUT the env var when True
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_auto_flag_fires_retry_without_env_var(monkeypatch):
     """Tier 2: #187 — ``empty_stop_retry_auto=True`` fires the retry with the
-    ``REYN_EMPTY_STOP_RETRY`` env var UNSET. This is the agent-path always-on
-    path (phase_executor sets auto=True): the agent op-loop must recover from a
-    post-tool empty stop without an operator opt-in, because a dead-ended agent
-    cannot make progress (real-task: 67% empty-stop). Mirror of
+    ``REYN_EMPTY_STOP_RETRY`` env var UNSET — the mechanism itself, exercised
+    directly at the ``RouterLoop`` level. Whether production actually passes
+    ``True`` here is a SEPARATE, config-driven question (#4677,
+    ``chat.empty_stop_retry``, owner default ``False`` since 2026-08-14) —
+    this test only pins that the flag, when set, works without needing the
+    env var too. Mirror of
     ``test_retry_path_injects_user_msg_when_env_var_set`` with env unset + auto.
     """
     monkeypatch.delenv("REYN_EMPTY_STOP_RETRY", raising=False)

--- a/tests/runtime/test_chat_router_empty_stop_directive_wired.py
+++ b/tests/runtime/test_chat_router_empty_stop_directive_wired.py
@@ -1,15 +1,22 @@
 """Tier 2: Session wires the empty-stop retry into the chat router's
-RouterLoop — now the SHARED uniform ``"resume"`` directive, always-on (#187).
+RouterLoop — the SHARED uniform ``"resume"`` directive is always threaded;
+the actual retry SWITCH is config-driven (#4677, owner default ``False``
+since 2026-08-14 — was hardcoded ``True``/always-on, #187).
 
 Pinned invariants:
 
 - ``Session._handle_user_message`` constructs ``RouterLoop`` with
   ``empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE`` (the single shared
-  "resume" directive — NOT a chat-specific string) AND
-  ``empty_stop_retry_auto=True`` (always-on; the ``REYN_EMPTY_STOP_RETRY`` env
-  opt-in is retired). Pinned via a real ``CapturingRouterLoop`` subclass
-  injected through ``pytest.monkeypatch`` (= module-attribute setup, not
-  fake-collaborator mocking per testing.ja.md).
+  "resume" directive — NOT a chat-specific string) UNCONDITIONALLY — the
+  directive is inert unless ``empty_stop_retry_auto`` is also True, so
+  threading it costs nothing and a config-driven re-enable needs no other
+  wiring change.
+- ``empty_stop_retry_auto`` reflects ``chat.empty_stop_retry`` — ``False``
+  by default (a session built with no override), ``True`` when the
+  operator/test explicitly turns it on. Pinned via a real
+  ``CapturingRouterLoop`` subclass injected through ``pytest.monkeypatch``
+  (= module-attribute setup, not fake-collaborator mocking per
+  testing.ja.md).
 
 History (#187 owner decision, 2026-06-07): the previous chat-specific directive
 (B43-NF-W6-1: "Now write your reply to the user … Do not call another tool.")
@@ -17,9 +24,21 @@ was RETIRED. It was unevidenced per-site differentiation, and its anti-invoke
 framing ("do not call another tool") was itself suspect — chat models also
 tool-call. All sites (chat / plan-step / agent op-loop) now use the single
 content-neutral ``EMPTY_STOP_RETRY_DIRECTIVE`` = "resume". The cross-site
-uniform-wiring invariant is pinned in
-``test_empty_stop_retry_uniform_187``; this file pins the chat site's wiring
-behaviourally (driving the real Session construction).
+uniform-DIRECTIVE-wiring invariant is pinned in
+``test_empty_stop_retry_uniform_187``; this file pins the chat site's
+directive wiring AND the config-driven auto-flag, behaviourally (driving
+the real Session construction).
+
+#4677 (owner, 2026-08-14, "resume 注入をデフォルト off にしてくれないかな"):
+after an incident where 30 empty-response detections in one ``reyn-self``
+run each cost a second LLM call, the retry's auto-fire switch moved from
+hardcoded ``True`` to ``chat.empty_stop_retry`` (default ``False``). This
+does NOT mean empty responses stopped happening — their root cause is
+still unmeasured (#3698's anyio cancel-scope is a candidate) — only that
+a detected empty response no longer automatically costs a second LLM
+call unless the operator opts back in (the retry still helps recovery in
+some environments, per architect's own Trace-patch-replay measurement:
+0/10 → 10/10 narration recovery on a specific case — see #4677).
 """
 from __future__ import annotations
 
@@ -60,8 +79,8 @@ class _ScriptedLLM:
         return result
 
 
-def _make_session(tmp_path: Path) -> Session:
-    return make_session(agent_name="test_agent_b44")
+def _make_session(tmp_path: Path, *, empty_stop_retry: bool = False) -> Session:
+    return make_session(agent_name="test_agent_b44", empty_stop_retry=empty_stop_retry)
 
 
 # ---------------------------------------------------------------------------
@@ -82,16 +101,7 @@ class _CapturingRouterLoop(rl.RouterLoop):
         super().__init__(**kwargs)
 
 
-@pytest.mark.asyncio
-async def test_chat_session_passes_shared_resume_directive_always_on(monkeypatch, tmp_path):
-    """Tier 2c: ``Session._handle_user_message`` wires the SHARED
-    ``EMPTY_STOP_RETRY_DIRECTIVE`` ("resume") + ``empty_stop_retry_auto=True``
-    to ``RouterLoop`` (#187 uniform always-on).
-
-    Without this wiring the chat router would either miss the retry or carry a
-    chat-specific directive (the retired per-site differentiation). Pin both the
-    kwarg's presence AND its identity against the shared module-level constant,
-    plus the always-on flag (env-gate retired)."""
+async def _run_and_capture(monkeypatch, tmp_path: Path, *, empty_stop_retry: bool) -> dict:
     monkeypatch.chdir(tmp_path)
     # session._handle_user_message does ``from reyn.runtime.router_loop import
     # RouterLoop`` inside the function, so the module-level patch is observed.
@@ -99,18 +109,51 @@ async def test_chat_session_passes_shared_resume_directive_always_on(monkeypatch
     scripted = _ScriptedLLM([_text_result("ok")])
     monkeypatch.setattr(rl, "call_llm_tools", scripted)
 
-    session = _make_session(tmp_path)
+    session = _make_session(tmp_path, empty_stop_retry=empty_stop_retry)
 
     await session._handle_inbox_text("hello", chain_id="chain-test-b44")
+    return _CapturingRouterLoop.last_kwargs
 
-    captured = _CapturingRouterLoop.last_kwargs
+
+@pytest.mark.asyncio
+async def test_chat_session_always_passes_the_shared_resume_directive(monkeypatch, tmp_path):
+    """Tier 2c: the shared ``EMPTY_STOP_RETRY_DIRECTIVE`` is threaded
+    regardless of whether the auto-retry switch is on — the directive is
+    inert unless ``empty_stop_retry_auto`` is also True (#4677), so it
+    costs nothing to always pass it and lets a config-driven re-enable
+    skip any other wiring change."""
+    captured = await _run_and_capture(monkeypatch, tmp_path, empty_stop_retry=False)
     assert captured.get("empty_stop_retry_directive") == EMPTY_STOP_RETRY_DIRECTIVE, (
         "Session must pass the shared EMPTY_STOP_RETRY_DIRECTIVE, not an "
         "inlined or chat-specific string. Got: "
         + repr(captured.get("empty_stop_retry_directive"))
     )
-    assert captured.get("empty_stop_retry_auto") is True, (
-        "Session must pass empty_stop_retry_auto=True (#187 always-on; the "
-        "REYN_EMPTY_STOP_RETRY env opt-in is retired). Got kwargs: "
+
+
+@pytest.mark.asyncio
+async def test_chat_session_defaults_empty_stop_retry_auto_to_false(monkeypatch, tmp_path):
+    """Tier 2c: #4677 — a session built with no override (the operator's
+    real default) passes ``empty_stop_retry_auto=False``. Before this PR
+    Session always passed ``True`` regardless of any config; this is the
+    owner-directed default flip (2026-08-14)."""
+    captured = await _run_and_capture(monkeypatch, tmp_path, empty_stop_retry=False)
+    assert captured.get("empty_stop_retry_auto") is False, (
+        "Session's default (no chat.empty_stop_retry override) must be "
+        "False (#4677, owner default since 2026-08-14). Got kwargs: "
         + str(sorted(captured))
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_session_honours_an_explicit_empty_stop_retry_opt_in(monkeypatch, tmp_path):
+    """Tier 2c: #4677's own required condition ② — an operator (or an
+    environment relying on the retry's measured narration-recovery
+    benefit, e.g. a weak model) MUST be able to turn it back on via
+    config. Losing this path would be a real regression for whoever
+    depends on it, not just a config-plumbing nicety."""
+    captured = await _run_and_capture(monkeypatch, tmp_path, empty_stop_retry=True)
+    assert captured.get("empty_stop_retry_auto") is True, (
+        "chat.empty_stop_retry=True must still reach RouterLoop as "
+        "empty_stop_retry_auto=True — the config knob must actually turn "
+        "the retry back on. Got kwargs: " + str(sorted(captured))
     )


### PR DESCRIPTION
**[tui-coder]** — Owner instruction (2026-08-14, verbatim): 「resume 注入をデフォルト off にしてくれないかな」. The B42-NF-W6-1 empty-response detect-and-retry (one resend, with the uniform "resume" directive, when the router loop sees an empty `finish_reason="stop"`) was hardcoded on in production (`router_loop_driver.py`'s own `empty_stop_retry_auto=True`) with no config knob at all — an operator could not turn it off.

**Motivating incident** (owner's own reyn-self run, 2026-08-14): 30 empty-response detections in one 30-turn run each cost a second LLM call (30 turns → 63 `llm_called`) — one of 4 amplification stages in that incident (#4501), the other 3 already addressed separately. This does **not** mean empty responses are fixed — their root cause is still unmeasured (#3698's anyio cancel-scope is a candidate); this change only means a detected empty response no longer automatically costs a second LLM call unless the operator opts back in.

**architect's own recorded concern** (not withdrawn, kept as a record per lead-coder's own note on the issue): Trace-patch-replay measured 0/10 → 10/10 narration recovery on a specific empty-stop case with the retry on — turning it off by default trades that recovery away wherever it matters (reports concentrate on weak/local models — Qwen, LM Studio, Ollama, vLLM, LiteLLM-fronted setups). The owner made this call knowing the tradeoff, which is why the config knob to restore it MUST exist — condition ② of 4 lead-coder set for this PR.

New `chat.empty_stop_retry: bool` config field (default `False`), threaded Session → RouterLoopDriver → RouterLoop (`empty_stop_retry_auto`), through all 5 Session-construction call sites. The `router_empty_response_detected` audit event (emitted BEFORE the retry decision) is untouched — condition ④, this event is how architect traced the amplification incident and must survive regardless of the retry switch.

Updated 3 test files whose docstrings/assertions assumed the old always-on default (condition ③):
- `tests/runtime/test_chat_router_empty_stop_directive_wired.py` — the one assertion pinning "Session must pass `empty_stop_retry_auto=True`" rewritten into 3 tests: the shared directive is ALWAYS threaded (inert unless auto is also True), the new default is `False`, and an explicit opt-in still reaches RouterLoop as `True`.
- `tests/llm/test_router_loop_empty_stop_retry.py` / `tests/llm/test_router_empty_response.py` — assertions were already correct (these construct RouterLoop directly, independent of the driver's production default), but 3 docstrings/comments claiming "production's own default" / "agent-path always-on flag set by phase_executor" were stale — corrected to name the actual single production wiring site and the new config-driven default.

Also fixed the config-mirror-coverage gate (`tests/config/test_config_mirror_coverage_1056.py`) this new field tripped: documented in `reyn.local.yaml.example` and `docs/reference/config/reyn-yaml.md` (no JA mirror — sibling `chat.*` fields aren't mirrored there either, no blanket en/ja obligation).

## Test plan
- [x] `ruff check .` — clean, whole repo
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/test_tier_audit.py --strict <4 changed/new test files>` — 34 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py <9 changed src files>` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `mkdocs build --strict` — exit 0
- [x] `python scripts/check_doc_anchors.py` — no dangling anchors into published pages
- [x] `pytest tests/core/test_4677_empty_stop_retry_config.py tests/runtime/test_chat_router_empty_stop_directive_wired.py tests/llm/test_router_loop_empty_stop_retry.py tests/llm/test_router_empty_response.py tests/config -q` — 248 passed (includes the config-mirror-coverage gate this field previously tripped)
- [x] scoped regression: `tests/runtime/test_scoped_session_factory_invariant_1402.py tests/runtime/test_session_invariants.py` — 20 passed
- [ ] (Visual — N/A, config/behavior change only)

Closes #4677

🤖 Generated with [Claude Code](https://claude.com/claude-code)
