### PR TITLE
docs: don't bundle a final answer with a completion-signaling tool call

### DIFF
--- a/docs/concepts/tools-integrations/skills.md
+++ b/docs/concepts/tools-integrations/skills.md
@@ -355,6 +355,42 @@ Use `pypdf` for form-field operations...
 
 **`name` spelling.** The [Agent Skills specification](https://agentskills.io/specification) constrains `name` to **lowercase letters, numbers, and hyphens only** (max 64 characters, no leading/trailing hyphen, no consecutive hyphens, and it must match the parent directory name). Every skill reyn itself ships obeys that rule — `reyn-cheat-sheet`, `draft-judge-revise`, `reactive-orchestration-plugins`, and the `rag` plugin's `build-and-query-rag-corpus` (#3567 renamed all four from an earlier underscore spelling; there is no alias for the old spelling, so `:draft-judge-revise` is the only way to invoke it). Note what reyn does **not** do: it does not *enforce* the rule on an operator-registered or third-party skill. The `:name` token grammar and the install-time path-safety check (below) both still accept `_`, because rejecting a non-conformant third-party `SKILL.md` outright would be a separate decision from spelling reyn's own skills to the standard.
 
+## Design pattern: don't bundle a final answer with a completion-signaling tool call
+
+If a skill (or any agent-authoring convention on top of reyn) has the model
+signal "I'm done" via a tool call — a `.turn_done`-style exec, a completion
+marker, anything the loop reads as "stop here" — instruct the model to send
+that signal in its OWN message, never in the same message as the final
+answer text. Correct order:
+
+1. One message containing ONLY the completion-signaling tool call, no
+   answer content.
+2. The next message (after the tool result comes back) contains ONLY the
+   answer text.
+
+**Why this matters** (architect's measurement, a real `reyn-self` incident,
+2026-08-14): when a message carries both real answer content AND a tool
+call, the presence of the tool call keeps the loop going — the LLM reading
+that history back sees its own answer sitting alongside a still-open tool
+call and treats the answer as **intermediate**, not final, so it writes the
+answer again on the next turn. Contrast, from the same `history.jsonl` (all
+22 entries after a `/clear`, not a filtered sample):
+
+| Turn shape | `content` | `tool_calls` | Outcome |
+|---|---|---|---|
+| 3 normal answer-only turns (seq 976/982/988) | present | 0 | answer stands, no repeat |
+| 3 completion-signal-only turns (seq 974/980/986) | empty | 1 | signal fires, no repeat |
+| **1 mixed turn (seq 1010)** | **2,060 chars (a full answer)** | **1** (`.turn_done` exec) | the SAME ~2,252-char answer was written again at seq 1012 |
+
+**What this data does and doesn't support.** The "answer becomes
+intermediate output, triggering another turn" mechanism is well-supported —
+6 contrasting examples land exactly where the pattern predicts. The
+duplicate-answer OUTCOME itself is N=1 — only one mixed turn has been
+observed, so "a mixed message always duplicates the answer" is not
+established, only "a mixed message keeps the loop open, and in the one
+case observed, that produced a duplicate." Design against the mechanism
+(don't mix), not against a guaranteed-duplication claim.
+
 ## Three-layer exposure
 
 | Layer | What the model sees | Mechanism |

--- a/docs/guide/for-reyn-developers/index.md
+++ b/docs/guide/for-reyn-developers/index.md
@@ -8,7 +8,11 @@ audience: [human]
 
 Orientation for contributors to the Reyn OS core. If you're adding a new op kind, fixing a runtime bug, or extending the event system, start here.
 
-If you're building workflows on top of Reyn rather than modifying the OS itself, see the workflow authoring docs instead.
+If you're building on top of Reyn rather than modifying the OS itself, see
+[Skills](../../concepts/tools-integrations/skills.md) (writing a `SKILL.md`)
+or [Pipeline DSL](../../reference/runtime/pipeline-dsl.md) (writing a
+pipeline) instead — there is no single "workflow authoring docs" landing
+page today; this line named one that doesn't exist.
 
 ---
 


### PR DESCRIPTION
**[docs-maintainer]** — dispatched by lead-coder (broker only).

architect diagnosed an owner-reported "writes the same answer twice" incident — a `.turn_done`-style completion tool call mixed into the SAME message as the actual final answer keeps the loop open (the LLM reading its own history back sees the answer sitting next to a still-open tool call and treats it as intermediate, not final), producing a second, near-duplicate answer on the next turn. This knowledge only existed in reyn-self's own REYN.md — everyone authoring an agent/skill on top of reyn hits the same shape, so it needed a home in reyn's own docs.

Added to `skills.md`'s "Writing a SKILL.md" section (the closest existing guide for the actual audience — `for-reyn-developers/index.md`'s own claimed "workflow authoring docs" turned out not to exist at all, a separate small drift fixed in the same commit since it was discovered while placing this).

Wrote the finding at the precision architect actually measured, not past it: 6 contrasting turns (3 clean answer-only, 3 clean signal-only) support "a mixed message keeps the loop open" solidly; the actual duplicate-answer OUTCOME is N=1 (one incident), so the section says "keeps the loop open, and in the one case observed, that produced a duplicate" — not "always duplicates."

## Bonus fix in the same commit

`for-reyn-developers/index.md` pointed at "the workflow authoring docs" — no such page exists anywhere in the repo (`git log` shows this line replaced a since-removed "For skill authors" link without ever landing a working target). Repointed to `skills.md` + `pipeline-dsl.md`, the two docs that actually cover this today.

## Verification

- Read architect's own measurement message directly (seq numbers, char counts, the 3-way contrast) before writing the section.
- Confirmed the "workflow authoring docs" phrase has no matching file anywhere in `docs/` via repo-wide grep before rewriting it.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `check_doc_anchors.py` — both clean.
- Fetched `origin/main` immediately before commit.

## Test plan

- [x] `mkdocs build --strict` + `check_doc_anchors.py` — both clean
- [x] docs-only change — `ruff`/`pytest` N/A
- [ ] Visual — N/A (docs prose only)
