### PR TITLE
fix(#4676): history_tail_reader's 4 read functions had #4671's own TOCTOU

### DIFF
--- a/src/reyn/runtime/history_tail_reader.py
+++ b/src/reyn/runtime/history_tail_reader.py
@@ -95,16 +95,32 @@ def read_last_line(path: Path, *, chunk_size: int = 8192) -> "str | None":
     real assigned ``seq`` (post-#3704: every append does) — if it does not,
     ``load_history`` falls back to a full forward read rather than trust a
     partial tail slice for ``_next_seq`` derivation (see that module's own
-    reasoning)."""
-    if not path.is_file():
+    reasoning).
+
+    #4676 (sibling of #4671's ``history_file_stats`` fix, same reasoning):
+    a prior revision checked ``path.is_file()`` BEFORE ``stat()``/
+    ``open()`` — this docstring's own opening line promises ``None`` for
+    "missing", but a file that vanishes in the gap between the check and
+    the use instead raised ``FileNotFoundError``, breaking that promise.
+    Fixed the same way #4671 fixed ``history_file_stats``: catch
+    ``FileNotFoundError`` only — any OTHER ``OSError`` (e.g. a permission
+    error) is deliberately NOT swallowed, since silently returning the
+    "missing" result for a file that genuinely could not be read would
+    misreport it (D-1: measure, don't fake). (#4676 measured whether this
+    gap is reachable at all before fixing it — see that issue for the
+    finding; not restated here, since HOW a file could vanish is not this
+    docstring's promise to keep, only THAT a vanished file returns the
+    documented result rather than raising.)"""
+    try:
+        size = path.stat().st_size
+        if size == 0:
+            return None
+        read_size = min(chunk_size, size)
+        with path.open("rb") as f:
+            f.seek(size - read_size)
+            buf = f.read(read_size)
+    except FileNotFoundError:
         return None
-    size = path.stat().st_size
-    if size == 0:
-        return None
-    read_size = min(chunk_size, size)
-    with path.open("rb") as f:
-        f.seek(size - read_size)
-        buf = f.read(read_size)
     search_end = len(buf) - 1 if buf.endswith(b"\n") else len(buf)
     idx = buf.rfind(b"\n", 0, search_end)
     if idx == -1:
@@ -123,30 +139,36 @@ def read_history_tail(
     """Read *path* backward from EOF, returning raw JSON-line strings in
     FILE order (oldest line in the returned slice first). Empty list if the
     file is missing or empty. See module docstring for the stop condition.
-    """
-    if not path.is_file():
-        return []
 
+    #4676: see :func:`read_last_line`'s docstring — same TOCTOU shape,
+    same fix: this function's own opening line already promises an empty
+    list for "missing"; catching ``FileNotFoundError`` (only) around the
+    read that can raise it, instead of a preceding ``is_file()`` check,
+    is what keeps that promise."""
     collected: list[str] = []
     seen_summary = False
-    # Stop condition is (seen_summary AND collected >= min_lines) — NEVER
-    # "collected >= min_lines" alone. Without a summary, we cannot tell
-    # "no compaction has EVER run" (everything is uncompacted, so a
-    # short-circuit here would violate the watermark-completeness invariant
-    # every bounded consumer depends on) apart from "the summary is just
-    # further back than min_lines" (test_read_history_tail_reads_past_the_
-    # floor_to_include_the_latest_summary) — both look identical until BOF
-    # is actually reached, so BOF is the only safe fallback stop.
-    for line in _iter_raw_lines_reverse(path, chunk_size=chunk_size):
-        collected.append(line)
-        if not seen_summary:
-            try:
-                if json.loads(line).get("role") == "summary":
-                    seen_summary = True
-            except (json.JSONDecodeError, AttributeError):
-                pass
-        if len(collected) >= min_lines and seen_summary:
-            break
+    try:
+        # Stop condition is (seen_summary AND collected >= min_lines) —
+        # NEVER "collected >= min_lines" alone. Without a summary, we
+        # cannot tell "no compaction has EVER run" (everything is
+        # uncompacted, so a short-circuit here would violate the
+        # watermark-completeness invariant every bounded consumer depends
+        # on) apart from "the summary is just further back than min_lines"
+        # (test_read_history_tail_reads_past_the_floor_to_include_the_
+        # latest_summary) — both look identical until BOF is actually
+        # reached, so BOF is the only safe fallback stop.
+        for line in _iter_raw_lines_reverse(path, chunk_size=chunk_size):
+            collected.append(line)
+            if not seen_summary:
+                try:
+                    if json.loads(line).get("role") == "summary":
+                        seen_summary = True
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+            if len(collected) >= min_lines and seen_summary:
+                break
+    except FileNotFoundError:
+        return []
 
     collected.reverse()
     return collected
@@ -247,30 +269,34 @@ def read_history_after(
     here. #4477's own first task is measuring ``head_budget + tail_budget``'s
     worst case, not implementing the warn — reachability is confirmed
     before a mechanism is built.
-    """
-    if not path.is_file():
-        return [], False
 
+    #4676: see :func:`read_last_line`'s docstring — same TOCTOU shape,
+    same fix (this docstring's own promise for a missing file, kept by
+    the implementation).
+    """
     collected: list[str] = []
     total_bytes = 0
     truncated = False
-    with path.open("r", encoding="utf-8") as f:
-        for raw in f:
-            line = raw.strip()
-            if not line:
-                continue
-            try:
-                seq = int(json.loads(line).get("seq", 0) or 0)
-            except (json.JSONDecodeError, AttributeError, TypeError, ValueError):
-                seq = 0
-            if seq != 0 and seq <= after_seq:
-                continue
-            line_bytes = len(line.encode("utf-8"))
-            if collected and total_bytes + line_bytes > max_bytes:
-                truncated = True
-                break
-            collected.append(line)
-            total_bytes += line_bytes
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    seq = int(json.loads(line).get("seq", 0) or 0)
+                except (json.JSONDecodeError, AttributeError, TypeError, ValueError):
+                    seq = 0
+                if seq != 0 and seq <= after_seq:
+                    continue
+                line_bytes = len(line.encode("utf-8"))
+                if collected and total_bytes + line_bytes > max_bytes:
+                    truncated = True
+                    break
+                collected.append(line)
+                total_bytes += line_bytes
+    except FileNotFoundError:
+        return [], False
 
     return collected, truncated
 
@@ -292,21 +318,25 @@ def read_history_before(
     whatever got the caller its current ``self.history`` in the first
     place); it is only answering "give me up to N more lines older than
     what I already have," which ``min_lines`` alone answers correctly.
-    """
-    if not path.is_file():
-        return []
 
+    #4676: see :func:`read_last_line`'s docstring — same TOCTOU shape,
+    same fix (this docstring's own promise for a missing file, kept by
+    the implementation).
+    """
     collected: list[str] = []
-    for line in _iter_raw_lines_reverse(path, chunk_size=chunk_size):
-        try:
-            seq = int(json.loads(line).get("seq", 0) or 0)
-        except (json.JSONDecodeError, AttributeError, TypeError, ValueError):
-            seq = 0
-        if seq >= before_seq:
-            continue
-        collected.append(line)
-        if len(collected) >= min_lines:
-            break
+    try:
+        for line in _iter_raw_lines_reverse(path, chunk_size=chunk_size):
+            try:
+                seq = int(json.loads(line).get("seq", 0) or 0)
+            except (json.JSONDecodeError, AttributeError, TypeError, ValueError):
+                seq = 0
+            if seq >= before_seq:
+                continue
+            collected.append(line)
+            if len(collected) >= min_lines:
+                break
+    except FileNotFoundError:
+        return []
 
     collected.reverse()
     return collected

--- a/tests/runtime/test_4676_history_tail_reader_toctou.py
+++ b/tests/runtime/test_4676_history_tail_reader_toctou.py
@@ -1,0 +1,233 @@
+"""Tier 2: #4676 — the 4 history_tail_reader read functions
+(`read_last_line`/`read_history_tail`/`read_history_after`/
+`read_history_before`) had the SAME TOCTOU shape #4671 fixed in
+`history_file_stats`: `path.is_file()` checked BEFORE `stat()`/`open()`,
+so a file vanishing in that gap raised `FileNotFoundError` in exactly
+the case each function's own docstring promises a "missing" result for
+(`None`, `[]`, `([], False)`, `[]` respectively).
+
+Measured before fixing (#4676's own first step, per this repo's
+"measure before build" discipline): unreachable WITHIN one process
+(every call site here is synchronous with no thread-offload, and the
+only in-session unlinker, `/clear-history`, is equally synchronous —
+Python's single-threaded cooperative asyncio model makes two such
+blocks structurally unable to interleave); reachable ACROSS processes
+(`path_locks.py`'s own docstring: reyn's path-lock is deliberately
+in-process only per ADR-0018, "cross-process mutual exclusion is
+deferred to the A2A-server model"; no PID/socket single-instance guard
+exists at session startup) — two `reyn` processes attached to the same
+agent is unguarded, so one process's `/clear-history` racing another
+process's own history read is real, if narrow.
+
+The FIX's own reason does not rest on that reachability finding, only on
+each function's own documented contract (mirroring #4671's own framing):
+catch `FileNotFoundError` only — any OTHER `OSError` (a permission error
+being the real-world example) must propagate, never be silently
+misreported as an empty/missing file (D-1: measure, don't fake).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.history_tail_reader import (
+    read_history_after,
+    read_history_before,
+    read_history_tail,
+    read_last_line,
+)
+
+
+def _write_history(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n" if lines else "", encoding="utf-8")
+
+
+def _open_raises_after_stat_succeeded(hist: Path, monkeypatch) -> None:
+    """Simulate the race: `stat()` (or the generator's own `stat()`)
+    succeeds — the file existed a moment ago — but `open()` then raises
+    `FileNotFoundError`, exactly as it would if the file vanished in the
+    gap. Only the TARGET path is intercepted; every other `Path.open`
+    call (including this test's own setup writes) is unaffected."""
+    real_open = Path.open
+
+    def _raiser(self, *args, **kwargs):
+        if self == hist:
+            raise FileNotFoundError(f"simulated race: {self} vanished before open()")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _raiser)
+
+
+def _stat_raises_permission_error(hist: Path, monkeypatch) -> None:
+    real_stat = Path.stat
+
+    def _raiser(self, *args, **kwargs):
+        if self == hist:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _raiser)
+
+
+# ── read_last_line ───────────────────────────────────────────────────────
+
+
+def test_read_last_line_missing_file_returns_none(tmp_path: Path):
+    """Tier 2: no history.jsonl yet — None, not an error (accept-side)."""
+    assert read_last_line(tmp_path / "does-not-exist" / "history.jsonl") is None
+
+
+def test_read_last_line_vanishing_between_stat_and_open_still_returns_none(
+    tmp_path: Path, monkeypatch,
+):
+    """Tier 2: #4676 — a real, existing file whose `open()` raises
+    `FileNotFoundError` (vanished after `stat()` succeeded) still
+    returns None, proving the fix wraps stat+open in ONE try, not just
+    a preceding entry check."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+    _open_raises_after_stat_succeeded(hist, monkeypatch)
+
+    assert read_last_line(hist) is None
+
+
+def test_read_last_line_permission_error_is_not_swallowed(tmp_path: Path, monkeypatch):
+    """Tier 2: #4676 — only FileNotFoundError (the TOCTOU race) is
+    treated as "vanished". Any other OSError (permission, the
+    real-world example) must propagate, not be silently reported as a
+    missing file (D-1: measure, don't fake)."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+    _stat_raises_permission_error(hist, monkeypatch)
+
+    with pytest.raises(PermissionError):
+        read_last_line(hist)
+
+
+# ── read_history_tail ────────────────────────────────────────────────────
+
+
+def test_read_history_tail_missing_file_returns_empty(tmp_path: Path):
+    """Tier 2: no history.jsonl yet — [], not an error (accept-side)."""
+    assert read_history_tail(tmp_path / "does-not-exist" / "history.jsonl") == []
+
+
+def test_read_history_tail_vanishing_mid_generator_still_returns_empty(
+    tmp_path: Path, monkeypatch,
+):
+    """Tier 2: #4676 — `_iter_raw_lines_reverse` (the shared
+    backward-reader generator) calls `path.stat()` at the START of its
+    FIRST iteration — raising there, from inside the caller's `for`
+    loop, must be caught by the SAME `try` the caller wraps the loop
+    in."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+
+    real_stat = Path.stat
+
+    def _raiser(self, *args, **kwargs):
+        if self == hist:
+            raise FileNotFoundError(f"simulated race: {self} vanished before stat()")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _raiser)
+
+    assert read_history_tail(hist) == []
+
+
+def test_read_history_tail_permission_error_is_not_swallowed(tmp_path: Path, monkeypatch):
+    """Tier 2: #4676 — a permission error must propagate, not be
+    silently reported as an empty file."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+    _stat_raises_permission_error(hist, monkeypatch)
+
+    with pytest.raises(PermissionError):
+        read_history_tail(hist)
+
+
+# ── read_history_after ───────────────────────────────────────────────────
+
+
+def test_read_history_after_missing_file_returns_empty_not_truncated(tmp_path: Path):
+    """Tier 2: no history.jsonl yet — ([], False), not an error
+    (accept-side)."""
+    lines, truncated = read_history_after(
+        tmp_path / "does-not-exist" / "history.jsonl", after_seq=0,
+    )
+    assert (lines, truncated) == ([], False)
+
+
+def test_read_history_after_vanishing_between_stat_and_open_still_returns_empty(
+    tmp_path: Path, monkeypatch,
+):
+    """Tier 2: #4676 — a real, existing file whose `open()` raises
+    `FileNotFoundError` still returns ([], False), not a raise."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+    _open_raises_after_stat_succeeded(hist, monkeypatch)
+
+    assert read_history_after(hist, after_seq=0) == ([], False)
+
+
+def test_read_history_after_permission_error_is_not_swallowed(tmp_path: Path, monkeypatch):
+    """Tier 2: #4676 — a permission error must propagate, not be
+    silently reported as an empty/no-content read."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+
+    real_open = Path.open
+
+    def _raiser(self, *args, **kwargs):
+        if self == hist:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _raiser)
+
+    with pytest.raises(PermissionError):
+        read_history_after(hist, after_seq=0)
+
+
+# ── read_history_before ──────────────────────────────────────────────────
+
+
+def test_read_history_before_missing_file_returns_empty(tmp_path: Path):
+    """Tier 2: no history.jsonl yet — [], not an error (accept-side)."""
+    assert read_history_before(
+        tmp_path / "does-not-exist" / "history.jsonl", before_seq=100,
+    ) == []
+
+
+def test_read_history_before_vanishing_mid_generator_still_returns_empty(
+    tmp_path: Path, monkeypatch,
+):
+    """Tier 2: #4676 — same shared-generator shape as
+    `read_history_tail`'s own race test: `_iter_raw_lines_reverse`'s
+    `stat()` raising must be caught by the caller's `try`."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+
+    real_stat = Path.stat
+
+    def _raiser(self, *args, **kwargs):
+        if self == hist:
+            raise FileNotFoundError(f"simulated race: {self} vanished before stat()")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _raiser)
+
+    assert read_history_before(hist, before_seq=100) == []
+
+
+def test_read_history_before_permission_error_is_not_swallowed(tmp_path: Path, monkeypatch):
+    """Tier 2: #4676 — a permission error must propagate, not be
+    silently reported as an empty file."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+    _stat_raises_permission_error(hist, monkeypatch)
+
+    with pytest.raises(PermissionError):
+        read_history_before(hist, before_seq=100)


### PR DESCRIPTION
**[tui-coder]** — #4675 (the #4671 fix landing) deliberately left this out of scope — 4 functions in this same module (`read_last_line` / `read_history_tail` / `read_history_after` / `read_history_before`) still checked `path.is_file()` BEFORE `stat()`/`open()`, the same TOCTOU shape #4671 fixed in `history_file_stats`.

**Measured before fixing**, per this issue's own first step: is there a reachable path for a session's own `history.jsonl` to vanish WHILE that same session is reading it? Two candidates, neither previously traced:

- **Same-session `/clear-history` race: unreachable.** All 4 read functions are synchronous with no internal await/thread-offload, and `/clear-history`'s own unlink is equally synchronous. Python's single-threaded cooperative asyncio model makes two such blocks structurally unable to interleave — not "probably serialized," but provably so, since there is no yield point for a task switch to land in between the check and the use.
- **Cross-process race: reachable, though narrow.** `path_locks.py`'s own docstring states reyn's path-lock is deliberately in-process only per ADR-0018 ("cross-process mutual exclusion is deferred to the A2A-server model"), and no PID/socket single-instance guard exists at session startup (`registry.py`/`session.py` both grep-clean for one). Two reyn processes attached to the same agent is unguarded, so one process's `/clear-history` racing another process's own history read is real.

**The fix's own justification does NOT rest on that reachability finding** (explicit correction mid-investigation, lead-coder): ADR-0018 declares multi-process support intentionally out of scope, so "fixes a multi-process crash" would read as an implicit promise to support what ADR-0018 declines to. The correct reason, matching #4671's own framing exactly: each function's own docstring already promises a specific "missing" result (`None` / `[]` / `([], False)` / `[]`) for a file that doesn't exist — the implementation didn't keep that promise when the file vanished in the check-to-use gap. HOW the file could vanish informed the measurement, not the fix's reason.

Same treatment as #4671: catch `FileNotFoundError` only, wrapping the stat+open(+read) in one try per function. Any OTHER `OSError` (a permission error being the real-world example) is deliberately NOT swallowed — silently reporting "missing" for a file that genuinely could not be read would misreport it (D-1: measure, don't fake).

## Test plan
- [x] `ruff check .` — clean, whole repo
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_4676_history_tail_reader_toctou.py` — 12 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/history_tail_reader.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsification: reverted the src change, confirmed all 4 race-simulation tests genuinely fail against pre-fix code (not vacuous), then re-confirmed all 12 pass against the fix
- [x] `pytest tests/runtime/test_4676_history_tail_reader_toctou.py tests/runtime/test_4476_history_storage_stats.py tests/runtime/test_4387_bounded_history_hydration.py tests/runtime/test_4387_extend_history_backward.py tests/core/test_4387_active_branch_history_extend_on_demand.py tests/interfaces/test_4387_read_model_load_older_conversation_history.py -q` — 38 passed
- [ ] (Visual — N/A, backend fix + tests only)

Closes #4676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
