### PR TITLE
fix(#4685): /model <class> switch raises — turn_budget resolver bugs

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1694,8 +1694,23 @@ class Session:
         section for the fuller argument).
         """
         from reyn.services.turn_budget import try_build_default_turn_budget_engine
+        # #4685: `self.model` was pre-resolved through `self._resolver` here,
+        # then handed to `try_build_default_turn_budget_engine`'s `model`
+        # param WITHOUT `resolver=` — a CLASS-position API fed an
+        # already-resolved NAME (e.g. "gpt-5.6-terra", not the class
+        # "terra"), against an internal empty resolver (`resolver=None` ->
+        # `ModelResolver({})`) that knows no classes either. Any /model
+        # switch to a real class raised ValueError ("not found among known
+        # classes (none)") — architect's + lead-coder's diagnosis, both
+        # halves independently sufficient to break this. `self.model` is
+        # ALREADY the right CLASS-position value (the property returns the
+        # active override's class name, or the agent's configured model id
+        # when no override is active — both are exactly what `resolve()`
+        # expects at this position); passing it straight through, with this
+        # session's own real resolver, fixes both at once.
         engine = try_build_default_turn_budget_engine(
-            self._resolver.resolve(self.model).model,
+            self.model,
+            resolver=self._resolver,
             use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
             # #3580: operator-tunable offload ceiling feeds the layer-1 reserve.
             max_inline_bytes=self._offload_config.max_inline_bytes,
@@ -4255,8 +4270,17 @@ class Session:
         # unchanged, just realized lazily instead of at construction.
         def _build_chat_turn_budget_engine() -> Any:
             from reyn.services.turn_budget import try_build_default_turn_budget_engine
+            # #4685: the same pre-resolve-then-empty-resolver bug as
+            # `_rebuild_derived_model_engines_for_model` (see that method's
+            # own comment) — a second, independent call site with the
+            # identical defect shape, not previously named in the
+            # investigation. Same fix: pass `self.model` (already the
+            # right CLASS-position value) with this session's real
+            # resolver, instead of pre-resolving through it and dropping
+            # the resolver on the floor.
             return try_build_default_turn_budget_engine(
-                self._resolver.resolve(self.model).model,
+                self.model,
+                resolver=self._resolver,
                 use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
                 # #3580: operator-tunable offload ceiling feeds the layer-1 reserve.
                 max_inline_bytes=self._offload_config.max_inline_bytes,

--- a/src/reyn/services/turn_budget/engine.py
+++ b/src/reyn/services/turn_budget/engine.py
@@ -195,8 +195,20 @@ class TurnBudgetEngine:
         self._T_wrap_SP: int = estimate_tokens(
             _WRAP_UP_SYSTEM_PROMPT, self._model, use_chars4=use_chars4
         )
+        # #4685: pass the ORIGINAL *model* here, not `self._model` — `self._model`
+        # is ALREADY resolved (the line above), and `compute_turn_budget` does its
+        # OWN `resolver.resolve(...)` call. Resolving an ALREADY-resolved model
+        # NAME a second time raises whenever that name is not itself a declared
+        # class key and carries no provider prefix (e.g. a bare `gpt-5.6-terra`
+        # class value with no "/") — `resolve()`'s class-position closed-world
+        # check (#4349) does not know "this string is already a resolved name,
+        # skip the class lookup". `resolver.resolve()` is idempotent for the
+        # SAME input (a class resolves to the same ModelSpec every time), so
+        # resolving the original `model` again here is safe and correct — the
+        # double-resolve on `self._model` was the actual defect, independent of
+        # whether `resolver` itself is real or the empty default.
         self._budget: TurnBudget = compute_turn_budget(
-            self._model,
+            model,
             T_wrap_SP=self._T_wrap_SP,
             output_reserve=output_reserve,
             offload_cap=offload_cap,

--- a/tests/runtime/test_slash_model.py
+++ b/tests/runtime/test_slash_model.py
@@ -359,3 +359,74 @@ async def test_compaction_engine_rebuilt_on_model_switch(tmp_path):
     after = session._compaction_controller._engine
     assert after is not before  # rebuilt, not the same cached engine
     assert after.model != before_model  # ...and resolves against the NEW model
+
+
+# ===========================================================================
+# Group E: #4685 — /model switch to a bare (no provider-prefix) model name
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_turn_budget_engine_rebuild_does_not_raise_for_a_bare_model_name(tmp_path):
+    """Tier 2: #4685 — real bug, owner's real config shape. Every model
+    value in ``_make_resolver()`` (the fixture Group D's own tests reuse)
+    happens to carry a provider prefix ("openai/gpt-4o", ...), which is
+    EXACTLY why the pre-#4685 bug never showed up here: the buggy call
+    pre-resolved the class into its NAME, then fed that NAME to an
+    internal EMPTY resolver — but a NAME containing "/" still passes that
+    empty resolver's own passthrough branch (``ModelResolver.resolve``
+    checks "/" in name before it ever needs a class table), so the
+    coincidence hid the defect. The owner's real ``reyn.yaml`` used a bare
+    model id with no provider prefix (``gpt-5.6-terra``) — this test
+    reproduces exactly that shape: a class ("terra") whose resolved model
+    value carries NO "/", so a caller that (incorrectly) hands the empty
+    resolver a bare NAME instead of the real CLASS+resolver pair hits
+    ``ModelResolver.resolve``'s class-position raise
+    ("model class 'gpt-5.6-terra' not found among known classes (none)").
+
+    Two independent bugs stacked to break this, both fixed in the same
+    PR: (1) this call site pre-resolved the class and dropped the
+    resolver (architect's/lead-coder's own diagnosis); (2)
+    ``TurnBudgetEngine.__init__`` ITSELF double-resolves — it resolves
+    ``model`` once into ``self._model``, then passes that
+    ALREADY-RESOLVED name to ``compute_turn_budget``, which resolves it
+    a SECOND time; a resolved NAME with no "/" is never itself a
+    declared class key, so the second resolve always raised regardless
+    of whether the real resolver reached this far (found while writing
+    THIS test — not in the original issue/diagnosis, which only reached
+    the Session-level bug).
+
+    Only the PUBLIC surface (construction did not raise, and a real
+    engine — not None — resulted) is asserted; ``TurnBudgetEngine``
+    exposes no public accessor for the resolved model string, and
+    reading ``._model`` would be a private-state assertion."""
+    session = _make_session(tmp_path, model="standard")
+    session._resolver = _make_resolver({"terra": {"model": "gpt-5.6-terra"}})
+
+    ctx = _ctx(session)
+    await model_cmd(ctx, "terra")  # must not raise
+
+    engine = session._router_host._turn_budget_engine
+    assert engine is not None, "a viable model must produce a real engine, not None"
+
+
+def test_lazy_startup_turn_budget_engine_does_not_raise_for_a_bare_model_name(tmp_path):
+    """Tier 2: #4685 — the SECOND, independent Session-level call site
+    with the identical defect shape (``Session``'s lazy
+    ``_build_chat_turn_budget_engine`` closure, built at RouterHostAdapter
+    construction and realized on first reference — #3671's deferred-build
+    discipline). Not named in the original issue/diagnosis; found while
+    fixing the first site. Also exercises the SAME ``TurnBudgetEngine``
+    double-resolve bug the sibling test above documents.
+
+    An override already in effect BEFORE the lazy engine is first
+    referenced (a session resumed/constructed with a prior ``/model``
+    switch already applied, whose first force-close check comes later —
+    the realistic shape #3671's own deferred-build discipline describes)
+    reproduces the same bug independently of the ``/model`` command path
+    tested above."""
+    session = _make_session(tmp_path, model="standard")
+    session._resolver = _make_resolver({"terra": {"model": "gpt-5.6-terra"}})
+    session._model_override = "terra"
+
+    engine = session._router_host._ensure_turn_budget_engine()  # must not raise
+    assert engine is not None

--- a/tests/services/test_turn_budget_foundation_1092.py
+++ b/tests/services/test_turn_budget_foundation_1092.py
@@ -139,6 +139,32 @@ def test_engine_resolves_model_class_for_wrap_sp_and_budget() -> None:
     assert via_class.budget.T_wrap_SP == via_literal.budget.T_wrap_SP
 
 
+def test_engine_does_not_double_resolve_a_class_with_no_provider_prefix() -> None:
+    """Tier 2: #4685 — every OTHER test in this file (including its sibling
+    directly above) maps a class to a "/"-containing model value
+    (``_MODEL = "openai/gpt-4o-mini"``), which is EXACTLY why the bug this
+    test pins survived undetected: ``TurnBudgetEngine.__init__`` resolved
+    ``model`` once into ``self._model``, then passed that ALREADY-RESOLVED
+    name to ``compute_turn_budget``, which resolved it a SECOND time — a
+    resolved NAME with no "/" is never itself a declared class key, so the
+    second resolve always raised, but only when the resolved value had no
+    provider prefix to fall through on (as the real owner config did:
+    ``gpt-5.6-terra``, no "/"). ``resolver.resolve()`` is idempotent for
+    the SAME input, so resolving the ORIGINAL ``model`` argument twice
+    (once inside ``__init__``, once inside ``compute_turn_budget``) is
+    safe; the defect was resolving the ALREADY-RESOLVED name a second
+    time instead.
+
+    Falsification: reverting the src fix (passing ``self._model`` instead
+    of ``model`` to ``compute_turn_budget`` inside ``__init__``)
+    reproduces this exact raise."""
+    resolver = ModelResolver({"myclass": {"model": "gpt-5.6-terra"}})
+    eng = TurnBudgetEngine(  # must not raise
+        "myclass", output_reserve=4000, offload_cap=8000, resolver=resolver,
+    )
+    assert eng.budget.T_wrap_SP > 0
+
+
 # ── fail-fast bounds (sibling of compaction assert_static_bounds) ─────────────
 
 


### PR DESCRIPTION
**[tui-coder]** — Owner-reported crash, traceback captured, reproduced on owner's real machine (2026-08-14): `/model <class>` and the Model tab both fail with `ValueError: model class 'gpt-5.6-terra' not found among known classes (none)` — not specific to any one class, breaks the switch for all of them the moment a project declares more than one (reyn-self had only 1 class until architect added a second, so this path had never actually been exercised — same shape as #4683's own ①).

architect's diagnosis, confirmed independently by lead-coder: two bugs stack at the ONE named call site (`session.py`'s `_rebuild_derived_model_engines_for_model`):
1. the empty-resolver default (`services/turn_budget/engine.py`'s `if resolver is None: resolver = _MR({})`) fires because the caller never threads the session's own resolver through — the "(none)" in the error IS this empty resolver's own class list.
2. the value handed to that resolver's `.resolve()` call is a NAME position value (an already-resolved model id) fed into a CLASS position API — `resolve()`'s own #4349 closed-world check (a bare, "/"-free string that isn't a declared class always raises) rejects it regardless of whether the resolver behind it is real or empty.

**Fix** (architect's recommended option A, lead-coder's ruling): the call site passes `self.model` (already the correct CLASS-position value) together with `resolver=self._resolver`, instead of pre-resolving through the resolver and dropping it. A **SECOND, independent call site** with the identical shape (`_build_chat_turn_budget_engine`, the lazy startup-time engine build — #3671's deferred-build discipline) was not named in the original diagnosis; found and fixed the same way while investigating the first.

A **THIRD, deeper bug** — found only while writing a falsifying regression test, not in the original diagnosis — sits inside `TurnBudgetEngine.__init__` itself: it resolves `model` once into `self._model` at construction, then hands that ALREADY-RESOLVED name to `compute_turn_budget`, which resolves it AGAIN internally. A resolved NAME with no provider prefix is never itself a declared class key, so this second, redundant resolve always raised — independent of whether either fix above landed, and independent of whether the resolver passed in is real. Every existing test in both `test_turn_budget_foundation_1092.py` and `test_slash_model.py` maps its test classes to a "/"-containing literal model string, which is EXACTLY why this was never caught before — the owner's real `reyn.yaml` used a bare model id (`gpt-5.6-terra`, no prefix), the one shape that exposes it. Fixed by passing the ORIGINAL `model` argument to `compute_turn_budget` instead of the already-resolved `self._model` — `resolver.resolve()` is idempotent for the same input, so resolving the original class/name twice is safe; resolving the ALREADY-RESOLVED name a second time was the actual defect.

**Falsified all three independently**: reverting any ONE of the three fixes in isolation reproduces a raise (verified for session.py-only-reverted, engine.py-only-reverted, and both-reverted) — all three are independently necessary for the owner's exact scenario to stop raising.

**Not touched** (explicitly out of scope): #4573's own separate owner:decide question (raise-vs-warn at startup for a different defect class); the closed-world class-gate bypass architect flagged as a secondary observation (a "/"-containing literal always passes through `resolve()` regardless of class validity) — a real design question, but not part of this bug's fix.

## Test plan
- [x] `ruff check .` — clean, whole repo
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/test_tier_audit.py --strict tests/services/test_turn_budget_foundation_1092.py tests/runtime/test_slash_model.py` — 27 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py src/reyn/services/turn_budget/engine.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsification (3 independent reverts, each reproduces a raise; see commit body)
- [x] `pytest tests/services/test_turn_budget_foundation_1092.py tests/runtime/test_slash_model.py tests/runtime/test_force_close_chat_activation_1092.py tests/interfaces/test_3595_s4_slash_handler_seam.py -q` — 44 passed
- [ ] (Visual — N/A, backend fix + tests only)

Closes #4685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
