### PR TITLE
feat(#4206 slice 1): the preference axis — free-override agent/session config, output_language wired

### DIFF
--- a/docs/reference/cli/agent.md
+++ b/docs/reference/cli/agent.md
@@ -99,11 +99,54 @@ Each agent owns `.reyn/agents/<name>/`:
 
 | Path | Purpose |
 |------|---------|
-| `profile.yaml` | name / role / created_at / allowed_mcp |
+| `profile.yaml` | name / role / created_at / allowed_mcp / preferences |
 | `history.jsonl` | append-only conversation + agent message log |
 | `events.jsonl` | runtime event audit log |
 | `memory/MEMORY.md` + body files | agent-scoped memory layer |
 | `runs/<run_id>/` | per-workflow-spawn workspace |
+
+## `preferences` (#4206 slice 1) — the ③ axis: free-override, not restrict-only
+
+A `preferences:` mapping in `profile.yaml` sets an agent-layer override for
+one or more of a fixed set of dotted config keys
+(`reyn.runtime.preferences.PREFERENCE_KEYS`) — today: `output_language`,
+`chat.reasoning.display`, one `warn_ratio` per `cost.*` dimension
+(`per_agent_tokens` / `per_agent_cost_usd` / `daily_tokens` /
+`daily_cost_usd` / `monthly_tokens` / `monthly_cost_usd`), and
+`cost.rate_limit_warn_ratio`.
+
+```yaml
+# .reyn/agents/researcher/profile.yaml
+name: researcher
+role: deep technical research, prefers primary sources
+created_at: "2026-08-14T00:00:00+00:00"
+preferences:
+  output_language: ja
+```
+
+**Free override, unlike `allowed_mcp`'s restrict-only intersection**: an
+agent-layer preference REPLACES the project-level default outright — there
+is no "child can only narrow" check, because this axis (owner/lead-coder
+classification, #4206) covers settings that don't consume a shared,
+bounded resource (unlike `model`, which is ② bounding — see #4206). A
+session spawned under this agent can further override the SAME key in its
+own `<session-state-dir>/config.yaml` `preferences:` mapping — session
+wins over agent wins over the project default.
+
+An unrecognized key under `preferences:` (a typo, or a key retired from
+`PREFERENCE_KEYS`) fails LOUDLY at load time (`reyn.runtime.preferences.
+UnknownPreferenceKeyError`) rather than silently doing nothing — the same
+discipline #4655 established for config-schema dict-leaves.
+
+**Scope of this slice**: read/resolve only — this PR wires the 8 keys
+above into `Session.output_language`; `chat.reasoning.display` and the 7
+`warn_ratio` keys are not yet threaded through their own consumers (a
+follow-up). No `preferences`-specific CLI/slash write surface exists yet
+— set an agent-layer value by editing `profile.yaml` directly (the same
+existing pattern `allowed_mcp` already uses); a session-layer value by
+whatever spawns the session passing a `narrowing` dict whose own
+`preferences` sub-key is set (`AgentRegistry.spawn_session`'s existing
+`narrowing=` parameter — no new API).
 
 ## See also
 

--- a/docs/reference/cli/agent.md
+++ b/docs/reference/cli/agent.md
@@ -138,11 +138,12 @@ An unrecognized key under `preferences:` (a typo, or a key retired from
 UnknownPreferenceKeyError`) rather than silently doing nothing — the same
 discipline #4655 established for config-schema dict-leaves.
 
-**Scope of this slice**: read/resolve only — this PR wires the 8 keys
-above into `Session.output_language`; `chat.reasoning.display` and the 7
-`warn_ratio` keys are not yet threaded through their own consumers (a
-follow-up). No `preferences`-specific CLI/slash write surface exists yet
-— set an agent-layer value by editing `profile.yaml` directly (the same
+**Scope of this slice**: read/resolve only — of the 9 keys above, this PR
+wires `output_language` into `Session.output_language`; `chat.reasoning.
+display` and the 7 `warn_ratio` keys are declared in `PREFERENCE_KEYS`
+but not yet threaded through their own consumers (a follow-up). No
+`preferences`-specific CLI/slash write surface exists yet — set an
+agent-layer value by editing `profile.yaml` directly (the same
 existing pattern `allowed_mcp` already uses); a session-layer value by
 whatever spawns the session passing a `narrowing` dict whose own
 `preferences` sub-key is set (`AgentRegistry.spawn_session`'s existing

--- a/docs/reference/config/state-dir.md
+++ b/docs/reference/config/state-dir.md
@@ -47,7 +47,7 @@ JSONL files are replayable with `reyn events <file>`. See [events reference](../
 
 Per-agent workspace. One directory per named agent (created by `reyn agent new`). The `default` agent always exists.
 
-- `profile.yaml` — agent identity: name, role, optional `allowed_mcp`. See profile-yaml reference.
+- `profile.yaml` — agent identity: name, role, optional `allowed_mcp`, optional `preferences` (#4206 ③: free-override, non-capability config — see [agent.md § Workspace layout](../cli/agent.md#workspace-layout)). See profile-yaml reference.
 - `history.jsonl` — append-only conversation log (user + assistant turns; cross-agent messages include `chain_id` for tracing).
 - `memory/` — agent-scoped memory (`MEMORY.md` index + body files). Recalled and written automatically during the router phase.
 - `state/skills/<run_id>.snapshot.json` — WAL snapshots for crash recovery of in-flight skill runs.

--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -45,6 +45,15 @@ block):
   `build_environment_backend`'s backend) — otherwise `read_file`/`grep`/`glob` resolve
   against the host cwd and the agent never sees the target tree (the #187 step-3 empty-FS
   defect this param closes).
+- `output_language` (#4206 slice 1) — public `@property`, NOT a plain constructor-set
+  attribute since this slice: live-resolves `reyn.runtime.preferences`'s ③ (free-override)
+  axis — session-layer `<session-state-dir>/config.yaml` `preferences.output_language` wins
+  over agent-layer `profile.yaml` `preferences.output_language` wins over
+  `_project_output_language` (the value this `Session` was constructed with, `config.
+  output_language` for the default factory). Live re-read on every access, the SAME
+  "session layer in front of agent layer, re-read every time" shape `_workspace_base_dir`
+  below already established for `base_dir` — an operator editing either file by hand takes
+  effect on the next read, not just the next process start.
 - `_sandbox_backend` (#1200 PR-F2) — the agent's `SandboxBackend` INSTANCE for the chat exec
   seam (the router `OpContext`); `None` → `get_default_backend`. This is the INSTANCE, not
   the `sandbox_config.backend` STRING used for exec-tool gating — for a docker agent it is

--- a/src/reyn/runtime/preferences.py
+++ b/src/reyn/runtime/preferences.py
@@ -29,7 +29,7 @@ future task, deliberately not mixed into this slice.
 """
 from __future__ import annotations
 
-#: The 8 keys #4206's confirmed classification places in axis ③ for this
+#: The 9 keys #4206's confirmed classification places in axis ③ for this
 #: first slice: ``output_language``, ``chat.reasoning.display``, one
 #: ``warn_ratio`` per of the 6 ``CostLimitConfig`` dimensions
 #: (``runtime/budget/budget.py``'s ``CostConfig``), and

--- a/src/reyn/runtime/preferences.py
+++ b/src/reyn/runtime/preferences.py
@@ -1,0 +1,113 @@
+"""#4206 slice 1 — the ③ preference axis: free-override, non-capability,
+non-bounding config that an operator (any layer) or a parent session
+(session layer only) may set, always winning over the project default with
+NO restriction/ceiling check — unlike ① capability (restrict-only, ∩) and
+② bounding (child narrows only, ceiling stays with the operator).
+
+Composition rule (lead-coder ruling, #4206): project default -> agent-layer
+override (if present) -> session-layer override (if present); the LAST one
+present wins outright. There is no "child cannot widen past parent" check
+here — that's what makes this axis ③, not ②.
+
+## PREFERENCE_KEYS — a hand-maintained declaration, not derived
+
+The set below is the ONE place this axis's key vocabulary is declared.
+Lead-coder ruling: a typed dataclass per key was rejected (breaks "the
+mechanism stays the same as ③ grows" — #4206's own explicit requirement),
+so this is a flat ``dict[str, object]`` keyed by dotted config-path string
+instead. That shape alone would reproduce the #4655 "silent no-op" defect
+class (a typo'd/renamed key silently doing nothing forever) — closed the
+same way #4655 closed it for config-schema dict-leaves: :func:`validate_preferences`
+raises LOUDLY on any key not in this set, rather than accepting and
+ignoring it.
+
+**Known, accepted tradeoff (lead-coder, explicit)**: this IS "one more
+declaration" to keep in sync as the ③ set grows — #4206's own classification
+of which config keys belong to which axis is not yet derivable from code
+(it lives in the issue's own prose), and making it derivable is a SEPARATE
+future task, deliberately not mixed into this slice.
+"""
+from __future__ import annotations
+
+#: The 8 keys #4206's confirmed classification places in axis ③ for this
+#: first slice: ``output_language``, ``chat.reasoning.display``, one
+#: ``warn_ratio`` per of the 6 ``CostLimitConfig`` dimensions
+#: (``runtime/budget/budget.py``'s ``CostConfig``), and
+#: ``cost.rate_limit_warn_ratio``. Every entry is a dotted path matching
+#: the SAME key names ``reyn.yaml`` uses for the project-level default
+#: (``config/chat.py``'s own parsing), so an agent/session override reads
+#: as "the same setting, one layer down" — not a renamed shadow key.
+PREFERENCE_KEYS: "frozenset[str]" = frozenset({
+    "output_language",
+    "chat.reasoning.display",
+    "cost.per_agent_tokens.warn_ratio",
+    "cost.per_agent_cost_usd.warn_ratio",
+    "cost.daily_tokens.warn_ratio",
+    "cost.daily_cost_usd.warn_ratio",
+    "cost.monthly_tokens.warn_ratio",
+    "cost.monthly_cost_usd.warn_ratio",
+    "cost.rate_limit_warn_ratio",
+})
+
+
+class UnknownPreferenceKeyError(ValueError):
+    """A ``preferences:`` mapping (agent ``profile.yaml`` or session
+    ``config.yaml``) names a dotted key outside :data:`PREFERENCE_KEYS` —
+    raised loudly rather than silently ignored, so a typo'd or
+    since-renamed preference key cannot silently do nothing forever (the
+    same defect class #4655 closed for config-schema dict-leaves)."""
+
+
+def validate_preferences(preferences: "dict[str, object]", *, source: str) -> None:
+    """Raise :class:`UnknownPreferenceKeyError` for any key in *preferences*
+    that is not in :data:`PREFERENCE_KEYS`. *source* names where this
+    mapping came from (e.g. an agent name or a session id) so the error is
+    actionable. A caller with an EMPTY ``preferences: {}`` (the common case
+    — most agents/sessions set none) never reaches this check's failure
+    path at all, only its no-op success one."""
+    unknown = set(preferences) - PREFERENCE_KEYS
+    if unknown:
+        raise UnknownPreferenceKeyError(
+            f"{source}: unrecognized preference key(s) {sorted(unknown)!r} — "
+            f"not in PREFERENCE_KEYS ({sorted(PREFERENCE_KEYS)!r}). A typo'd "
+            f"or renamed preference key would otherwise silently do nothing."
+        )
+
+
+def resolve_preference(
+    key: str,
+    default: object,
+    *,
+    agent_preferences: "dict[str, object] | None" = None,
+    session_preferences: "dict[str, object] | None" = None,
+) -> object:
+    """Free-override resolution for ONE ③ preference *key*: *default* (the
+    project-level value), then the agent-layer override if *key* is present
+    in *agent_preferences*, then the session-layer override if *key* is
+    present in *session_preferences* — the LAST one present wins outright,
+    no restriction/ceiling check (see module docstring for why this axis is
+    ③, not ②).
+
+    *key* MUST be a member of :data:`PREFERENCE_KEYS` — an unknown key
+    raises :class:`UnknownPreferenceKeyError` rather than silently always
+    returning *default* (which would look identical to "no override was
+    ever set" for a caller who mistyped the key)."""
+    if key not in PREFERENCE_KEYS:
+        raise UnknownPreferenceKeyError(
+            f"resolve_preference: {key!r} is not in PREFERENCE_KEYS "
+            f"({sorted(PREFERENCE_KEYS)!r})"
+        )
+    value = default
+    if agent_preferences and key in agent_preferences:
+        value = agent_preferences[key]
+    if session_preferences and key in session_preferences:
+        value = session_preferences[key]
+    return value
+
+
+__all__ = [
+    "PREFERENCE_KEYS",
+    "UnknownPreferenceKeyError",
+    "resolve_preference",
+    "validate_preferences",
+]

--- a/src/reyn/runtime/profile.py
+++ b/src/reyn/runtime/profile.py
@@ -10,10 +10,17 @@ config. Semantics:
 
 The `role` text is injected into the LLM's system prompt so each agent
 gets a distinct persona without changing the OS layer.
+
+#4206 slice 1 adds `preferences`: an agent-layer ③ (free-override, see
+`reyn.runtime.preferences`) mapping — dotted config key -> value, keys
+restricted to `reyn.runtime.preferences.PREFERENCE_KEYS`. Absent/empty is
+the common case (most agents set no preference override at all); a
+malformed key raises at `load()` time rather than being silently ignored
+(the `preferences` module's own `validate_preferences`).
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -35,6 +42,11 @@ class AgentProfile:
     # (inherits project config). "all" in YAML normalizes to None here.
     # list[str] = intersect with project allow-list.
     allowed_mcp: list[str] | None = None
+    # #4206 slice 1: ③ preference overrides, dotted key -> value. Empty
+    # dict (not None) is the "nothing set" case, matching the flat-dict
+    # shape `reyn.runtime.preferences.resolve_preference` expects directly
+    # (no None-check needed at every call site).
+    preferences: "dict[str, object]" = field(default_factory=dict)
 
     @classmethod
     def new(cls, name: str, role: str = "") -> "AgentProfile":
@@ -46,7 +58,15 @@ class AgentProfile:
 
     @classmethod
     def load(cls, agent_dir: Path) -> "AgentProfile":
-        """Load profile.yaml from `agent_dir`. Raises FileNotFoundError if missing."""
+        """Load profile.yaml from `agent_dir`. Raises FileNotFoundError if missing.
+
+        #4206 slice 1: a `preferences:` mapping with a key outside
+        `reyn.runtime.preferences.PREFERENCE_KEYS` raises
+        `UnknownPreferenceKeyError` — a typo'd/renamed preference key must
+        not silently do nothing, the same discipline #4655 established for
+        config-schema dict-leaves."""
+        from reyn.runtime.preferences import validate_preferences
+
         path = agent_dir / PROFILE_FILENAME
         if not path.is_file():
             raise FileNotFoundError(path)
@@ -57,18 +77,24 @@ class AgentProfile:
             allowed_mcp: list[str] | None = None
         else:
             allowed_mcp = [str(s) for s in raw_allowed_mcp]
+        name = str(data.get("name", agent_dir.name))
+        raw_preferences = data.get("preferences") or {}
+        preferences = dict(raw_preferences) if isinstance(raw_preferences, dict) else {}
+        validate_preferences(preferences, source=f"agent {name!r} profile.yaml")
         return cls(
-            name=str(data.get("name", agent_dir.name)),
+            name=name,
             role=str(data.get("role", "") or ""),
             created_at=str(data.get("created_at", "") or ""),
             allowed_mcp=allowed_mcp,
+            preferences=preferences,
         )
 
     def save(self, agent_dir: Path) -> None:
         agent_dir.mkdir(parents=True, exist_ok=True)
         path = agent_dir / PROFILE_FILENAME
-        # Hand-roll the dict so absent allowed_mcp (None) doesn't appear
-        # in the yaml as `null` — keep the on-disk shape minimal.
+        # Hand-roll the dict so absent allowed_mcp (None) / empty
+        # preferences don't appear in the yaml as `null`/`{}` — keep the
+        # on-disk shape minimal.
         payload: dict = {
             "name": self.name,
             "role": self.role,
@@ -76,6 +102,8 @@ class AgentProfile:
         }
         if self.allowed_mcp is not None:
             payload["allowed_mcp"] = list(self.allowed_mcp)
+        if self.preferences:
+            payload["preferences"] = dict(self.preferences)
         path.write_text(
             yaml.safe_dump(payload, allow_unicode=True, sort_keys=False),
             encoding="utf-8",

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1046,7 +1046,11 @@ class Session:
         _fs_watch_cfg = (
             fs_watch_config if isinstance(fs_watch_config, FsWatchConfig) else FsWatchConfig()
         )
-        self.output_language = output_language
+        # #4206 slice 1: renamed to a private default — `output_language` is
+        # now a live-resolved @property (session pref -> agent pref ->
+        # this project-level default), same "live re-read, session layer in
+        # front of agent layer" shape `_workspace_base_dir` already uses.
+        self._project_output_language = output_language
         self._prompt_cache_enabled = prompt_cache_enabled
         self._project_context = project_context
         # Back-reference for slash commands (/agents, /attach) and agent-to-agent routing; wired by the chat factory (PR11)
@@ -1759,6 +1763,35 @@ class Session:
             return None
         return Path(str(value))
 
+    def _read_preferences_override(self, path: "Path") -> "dict[str, object]":
+        """#4206 slice 1: read a ``preferences:`` mapping from *path* — this
+        session's own per-session config or the calling agent's own
+        ``profile.yaml`` (this method is generic over which file; callers
+        pass the path) — or ``{}`` when absent/unset/malformed.
+
+        Same "raw read, not through ``load_capability_profile``" reasoning
+        as :meth:`_read_base_dir_override` — a ``preferences:`` key would
+        silently vanish through that loader's unknown-key-ignored contract.
+        A malformed file is surfaced (log, not a crash) and treated as "no
+        override" — a typo must not crash session construction, and (free
+        override, unlike capability narrowing) skipping it only falls back
+        to the next layer's own value, never widens/narrows anything by
+        itself."""
+        if not path.is_file():
+            return {}
+        import yaml
+        try:
+            raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001 — hand/LLM-written yaml, surface not crash
+            logger.warning(
+                "#4206: skipping malformed preferences override config %s: %s", path, e,
+            )
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        value = raw.get("preferences")
+        return dict(value) if isinstance(value, dict) else {}
+
     @property
     def _workspace_base_dir(self) -> "Path | None":
         """#4200: this session's EFFECTIVE base_dir.
@@ -1802,6 +1835,65 @@ class Session:
     @property
     def _workspace_state_dir(self) -> "Path | None":
         return self._agent.workspace_state_dir
+
+    def _agent_profile_preferences(self) -> "dict[str, object]":
+        """#4206 slice 1: this agent's `profile.yaml` `preferences:` mapping
+        — a live re-read (same "session layer in front of agent layer"
+        shape `_workspace_base_dir` uses for `base_dir`), `{}` when the
+        profile is missing/malformed/carries none. A live re-read rather
+        than a value captured once at construction so an operator editing
+        `profile.yaml` by hand takes effect on the next preference read,
+        not just the next process start."""
+        from reyn.runtime.profile import AgentProfile
+
+        try:
+            return dict(AgentProfile.load(self.workspace_dir).preferences)
+        except FileNotFoundError:
+            # No profile.yaml on disk at all — the ordinary case for a
+            # programmatically-constructed Session (every make_session()
+            # test call, `reyn pipe run`'s default identity, ...), not an
+            # error. Silent {} here, matching _read_base_dir_override's own
+            # "absent file -> no override" contract, one level down.
+            return {}
+        except ValueError as e:
+            # UnknownPreferenceKeyError (validate_preferences, raised
+            # inside AgentProfile.load) — a REAL problem (a typo'd/renamed
+            # preference key sitting in a real, existing profile.yaml) —
+            # surfaced, not silently eaten, but does not crash session
+            # construction/property access; the caller falls back to "no
+            # agent-layer override" for this read.
+            logger.warning(
+                "#4206: skipping unreadable agent preferences at %s: %s",
+                self.workspace_dir, e,
+            )
+            return {}
+
+    @property
+    def output_language(self) -> "str | None":
+        """#4206 slice 1: ③ preference axis, free-override composition —
+        session-layer `config.yaml` `preferences.output_language` wins over
+        agent-layer `profile.yaml` `preferences.output_language` wins over
+        the project-level default this Session was constructed with
+        (`self._project_output_language`). Live re-read on every access,
+        same shape `_workspace_base_dir` already uses for `base_dir`."""
+        from reyn.runtime.preferences import resolve_preference
+
+        session_preferences = self._read_preferences_override(
+            Path(self._snapshot_path).parent / "config.yaml"
+        )
+        agent_preferences = self._agent_profile_preferences()
+        resolved = resolve_preference(
+            "output_language",
+            self._project_output_language,
+            agent_preferences=agent_preferences,
+            session_preferences=session_preferences,
+        )
+        # resolve_preference's return type is `object` (it's generic across
+        # every ③ key, not just this str-typed one) — an override value
+        # that isn't a str is a config-authoring mistake (a non-string
+        # output_language was never a valid value at ANY layer), so this
+        # narrows rather than silently propagating the wrong type.
+        return str(resolved) if resolved is not None else None
 
     @property
     def _reyn_state_root(self) -> "Path":

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -399,7 +399,20 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: kind of thin public wrapper ``conversation_history`` already is over
 #: ``self.history`` — a read-model seam reads ``Session`` through public
 #: members by design, unlike a slash handler reaching into private state.
-_PUBLIC_MEMBER_CEILING = 105
+#:
+#: Raised 105 -> 106 for #4206 slice 1: ``output_language`` was ALREADY a
+#: public Session field before this change — a plain ``self.output_language
+#: = ...`` instance attribute set in ``__init__``. This gate's own
+#: enumeration (``dir(Session)``, the CLASS, not an instance) never counted
+#: it, because a plain instance attribute assigned in ``__init__`` is
+#: invisible to ``dir()`` on the class itself. Converting it to a
+#: ``@property`` (so it can live-resolve the new ③ preference-axis
+#: session/agent overrides — see ``reyn.runtime.preferences``) makes the
+#: SAME external name a class-level descriptor for the first time, which is
+#: what this ceiling actually measures. No new slash-reachable capability
+#: was added — the name, its meaning, and every external caller's access
+#: pattern (``session.output_language``) are unchanged.
+_PUBLIC_MEMBER_CEILING = 106
 
 
 def test_session_public_surface_does_not_grow() -> None:

--- a/tests/runtime/test_4206_preference_axis_slice1.py
+++ b/tests/runtime/test_4206_preference_axis_slice1.py
@@ -1,0 +1,242 @@
+"""Tier 2: #4206 slice 1 — the ③ preference axis (free-override composition).
+
+Real instances only: `reyn.runtime.preferences`'s pure functions are tested
+directly (duck-typed dict-in/value-out helpers, same category as
+`test_events_pure_helpers.py`); `AgentProfile.preferences` and
+`Session.output_language` are tested against real on-disk files and a real
+`Session` (`make_session`), never a stand-in.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.preferences import (
+    PREFERENCE_KEYS,
+    UnknownPreferenceKeyError,
+    resolve_preference,
+    validate_preferences,
+)
+from reyn.runtime.profile import AgentProfile
+from tests._support.agent_session import make_session
+
+# ── PREFERENCE_KEYS / validate_preferences ──────────────────────────────
+
+
+def test_preference_keys_names_all_8_confirmed_keys():
+    """Tier 2: the 8 keys #4206's confirmed classification names for this
+    slice — output_language, chat.reasoning.display, 6x cost.*.warn_ratio,
+    cost.rate_limit_warn_ratio."""
+    assert PREFERENCE_KEYS == frozenset({
+        "output_language",
+        "chat.reasoning.display",
+        "cost.per_agent_tokens.warn_ratio",
+        "cost.per_agent_cost_usd.warn_ratio",
+        "cost.daily_tokens.warn_ratio",
+        "cost.daily_cost_usd.warn_ratio",
+        "cost.monthly_tokens.warn_ratio",
+        "cost.monthly_cost_usd.warn_ratio",
+        "cost.rate_limit_warn_ratio",
+    })
+
+
+def test_validate_preferences_accepts_a_known_key():
+    """Tier 2: accept-side — a real declared key passes without raising."""
+    validate_preferences({"output_language": "ja"}, source="test")
+
+
+def test_validate_preferences_accepts_empty_dict():
+    """Tier 2: accept-side — the common "no override set" case."""
+    validate_preferences({}, source="test")
+
+
+def test_validate_preferences_raises_on_unknown_key():
+    """Tier 2: a typo'd/unrecognized key raises loudly rather than being
+    silently ignored — the #4655 Kind① discipline applied to this axis."""
+    with pytest.raises(UnknownPreferenceKeyError, match="typo_key"):
+        validate_preferences({"typo_key": "x"}, source="test-source")
+
+
+# ── resolve_preference ──────────────────────────────────────────────────
+
+
+def test_resolve_preference_returns_default_when_no_overrides():
+    """Tier 2: no agent/session override present — the project default
+    passes through unchanged."""
+    assert resolve_preference("output_language", "en") == "en"
+
+
+def test_resolve_preference_agent_override_wins_over_default():
+    """Tier 2: an agent-layer override, with no session-layer override
+    present, wins over the project default."""
+    assert resolve_preference(
+        "output_language", "en", agent_preferences={"output_language": "ja"},
+    ) == "ja"
+
+
+def test_resolve_preference_session_override_wins_over_agent_and_default():
+    """Tier 2: THE free-override composition rule — session beats agent
+    beats project default, no restriction/ceiling check (unlike ①/②)."""
+    assert resolve_preference(
+        "output_language", "en",
+        agent_preferences={"output_language": "ja"},
+        session_preferences={"output_language": "fr"},
+    ) == "fr"
+
+
+def test_resolve_preference_agent_override_survives_an_absent_session_key():
+    """Tier 2: a session_preferences dict that doesn't mention this key
+    falls through to the agent override, not the default."""
+    assert resolve_preference(
+        "output_language", "en",
+        agent_preferences={"output_language": "ja"},
+        session_preferences={"chat.reasoning.display": True},
+    ) == "ja"
+
+
+def test_resolve_preference_rejects_an_unknown_key():
+    """Tier 2: resolve_preference itself enforces PREFERENCE_KEYS membership
+    — a caller cannot silently resolve a key that isn't declared."""
+    with pytest.raises(UnknownPreferenceKeyError):
+        resolve_preference("not_a_real_key", "default")
+
+
+# ── AgentProfile.preferences ─────────────────────────────────────────────
+
+
+def test_agent_profile_preferences_defaults_to_empty_dict():
+    """Tier 2: a freshly-created AgentProfile has no preference overrides —
+    the common case for most agents."""
+    profile = AgentProfile.new("alice")
+    assert profile.preferences == {}
+
+
+def test_agent_profile_preferences_round_trips_through_save_and_load(tmp_path: Path):
+    """Tier 2: a real save() then load() cycle preserves preferences
+    exactly — the on-disk YAML shape round-trips."""
+    profile = AgentProfile.new("alice")
+    object.__setattr__(profile, "preferences", {"output_language": "ja"})
+    profile.save(tmp_path)
+
+    loaded = AgentProfile.load(tmp_path)
+    assert loaded.preferences == {"output_language": "ja"}
+
+
+def test_agent_profile_load_raises_on_an_unknown_preference_key(tmp_path: Path):
+    """Tier 2: a hand-edited profile.yaml with a typo'd preferences key
+    fails LOUDLY at load time, matching #4655's own Kind① discipline."""
+    (tmp_path / "profile.yaml").write_text(
+        "name: alice\nrole: ''\ncreated_at: ''\n"
+        "preferences:\n  not_a_real_key: x\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(UnknownPreferenceKeyError):
+        AgentProfile.load(tmp_path)
+
+
+def test_agent_profile_save_omits_empty_preferences_from_the_yaml(tmp_path: Path):
+    """Tier 2: (accept-side) the on-disk shape stays minimal when no
+    preference is set — same discipline as the existing allowed_mcp field."""
+    profile = AgentProfile.new("alice")
+    profile.save(tmp_path)
+    assert "preferences" not in (tmp_path / "profile.yaml").read_text(encoding="utf-8")
+
+
+# ── Session.output_language — real Session, real files ──────────────────
+
+
+def _agent_dir(session) -> Path:
+    return session.workspace_dir
+
+
+def _session_config_path(session) -> Path:
+    return Path(session._snapshot_path).parent / "config.yaml"
+
+
+def test_output_language_reads_the_project_level_default_with_no_overrides(tmp_path: Path):
+    """Tier 2: a real Session with no agent/session preference file at all
+    — output_language reads the project-level default it was constructed
+    with, byte-identical to pre-#4206 behavior."""
+    session = make_session(
+        agent_name="pref-test-1", workspace_state_dir=tmp_path / ".reyn",
+        output_language="en",
+    )
+    assert session.output_language == "en"
+
+
+def _write_agent_preferences(session, name: str, preferences: dict) -> None:
+    # Session construction does not itself write profile.yaml to disk
+    # (make_session builds Agent/Session directly) — a fresh AgentProfile
+    # is the real on-disk shape a caller like `reyn agent new` produces.
+    profile = AgentProfile.new(name)
+    object.__setattr__(profile, "preferences", preferences)
+    profile.save(_agent_dir(session))
+
+
+def test_output_language_agent_layer_override_wins_over_project_default(tmp_path: Path):
+    """Tier 2: a real profile.yaml `preferences.output_language` override,
+    written to the SAME on-disk location `AgentProfile.load` reads, wins
+    over the Session's own project-level default."""
+    session = make_session(
+        agent_name="pref-test-2", workspace_state_dir=tmp_path / ".reyn",
+        output_language="en",
+    )
+    _write_agent_preferences(session, "pref-test-2", {"output_language": "ja"})
+
+    assert session.output_language == "ja"
+
+
+def test_output_language_session_layer_override_wins_over_agent_layer(tmp_path: Path):
+    """Tier 2: THE composition witness for a real Session — a session-layer
+    config.yaml override wins over BOTH the agent-layer profile.yaml
+    override and the project default, matching resolve_preference's own
+    unit-level composition test above but through the real file-reading
+    path this time."""
+    import yaml
+
+    session = make_session(
+        agent_name="pref-test-3", workspace_state_dir=tmp_path / ".reyn",
+        output_language="en",
+    )
+    _write_agent_preferences(session, "pref-test-3", {"output_language": "ja"})
+
+    cfg_path = _session_config_path(session)
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump({"name": "_session_x", "preferences": {"output_language": "fr"}}),
+        encoding="utf-8",
+    )
+
+    assert session.output_language == "fr"
+
+
+def test_output_language_is_a_live_re_read_not_a_frozen_snapshot(tmp_path: Path):
+    """Tier 2: (accept-side) editing profile.yaml AFTER Session construction
+    takes effect on the next read — same "live re-read" shape
+    `_workspace_base_dir` already established for `base_dir`."""
+    session = make_session(
+        agent_name="pref-test-4", workspace_state_dir=tmp_path / ".reyn",
+        output_language="en",
+    )
+    assert session.output_language == "en"
+
+    _write_agent_preferences(session, "pref-test-4", {"output_language": "de"})
+
+    assert session.output_language == "de"
+
+
+def test_output_language_malformed_agent_preferences_falls_back_not_crashes(tmp_path: Path):
+    """Tier 2: an unknown preference key in profile.yaml is surfaced (not a
+    crash) — output_language falls back to the project default rather than
+    raising through a live property access."""
+    session = make_session(
+        agent_name="pref-test-5", workspace_state_dir=tmp_path / ".reyn",
+        output_language="en",
+    )
+    (_agent_dir(session) / "profile.yaml").write_text(
+        "name: pref-test-5\nrole: ''\ncreated_at: ''\n"
+        "preferences:\n  not_a_real_key: x\n",
+        encoding="utf-8",
+    )
+    assert session.output_language == "en"

--- a/tests/runtime/test_4206_preference_axis_slice1.py
+++ b/tests/runtime/test_4206_preference_axis_slice1.py
@@ -24,8 +24,8 @@ from tests._support.agent_session import make_session
 # ── PREFERENCE_KEYS / validate_preferences ──────────────────────────────
 
 
-def test_preference_keys_names_all_8_confirmed_keys():
-    """Tier 2: the 8 keys #4206's confirmed classification names for this
+def test_preference_keys_names_all_9_confirmed_keys():
+    """Tier 2: the 9 keys #4206's confirmed classification names for this
     slice — output_language, chat.reasoning.display, 6x cost.*.warn_ratio,
     cost.rate_limit_warn_ratio."""
     assert PREFERENCE_KEYS == frozenset({


### PR DESCRIPTION
**[e2e-coder]** — part of #4206 (slice 1: the ③ preference axis mechanism + `output_language` wired).

## What

Lands the ③ preference axis's core mechanism (free-override composition, per lead-coder's 3-part ruling in the issue) and wires the first key, `output_language`, end-to-end. Measured before building anything: confirmed neither `AgentProfile` (profile.yaml) nor session `config.yaml` had any preference-shaped field — both capability+identity only, matching #4206's own claim exactly.

## Mechanism (`reyn.runtime.preferences`)

- `PREFERENCE_KEYS: frozenset[str]` — the one declaration of the 8 keys this slice covers (`output_language`, `chat.reasoning.display`, 6× `cost.*.warn_ratio`, `cost.rate_limit_warn_ratio`). Per your ruling: flat dict + this frozenset, not a typed dataclass (would break "mechanism stays the same as ③ grows"). Accepted tradeoff: hand-maintained, deriving membership from code is separate future work.
- `resolve_preference()` — free-override: project default → agent override (if present) → session override (if present), last-present wins, no restriction/ceiling check.
- `validate_preferences()` — raises `UnknownPreferenceKeyError` on any key outside `PREFERENCE_KEYS`, loud not silent — the #4655 Kind① discipline applied to this axis.

## Storage

`AgentProfile.preferences: dict[str, object]`, validated at `load()`. Session `config.yaml` carries `preferences` as a sibling key inside the existing open narrowing dict — no new writer needed (`_persist_session_narrowing`'s `**narrowing` spread already round-trips it via `per_session_narrowing()`). New `Session._read_preferences_override` reader (raw YAML, not through `load_capability_profile` — that loader silently drops unknown keys).

## Wired: `output_language`

Was a plain instance attribute set once at construction. Now a live-resolved `@property` (session → agent → project default), the same "layer in front, re-read every access" shape `_workspace_base_dir` already established for `base_dir`.

## Not wired in this slice (found real integration wrinkles, reporting rather than guessing)

- `chat.reasoning.display`: straightforward, same shape as `output_language` — deferred only for time, not blocked.
- The 7 `cost.*.warn_ratio` keys: their real consumer, `BudgetTracker`, is constructed **once, process-shared**, at bootstrap **before the Registry exists** — no per-agent/session resolver injection point exists today. Wiring this needs a design decision (e.g. an optional resolver callback threaded post-construction) I didn't want to build without a sign-off, since it touches a process-shared object outside the Session-construction pattern the other keys use.

## Regressions caught + fixed during verification

- A first cut warned on `FileNotFoundError` (no profile.yaml on disk) — the ORDINARY case for every programmatically-constructed Session, not an error. Broke 4 tests asserting "exactly one warning logged." Fixed: silent `{}` for absence, warn only on a genuinely malformed *existing* file.
- `tests/interfaces/test_3595_s4_slash_handler_seam.py`'s `_PUBLIC_MEMBER_CEILING` raised 105→106: `output_language` was already a public Session field (a plain instance attribute), just invisible to `dir(Session)` (the class) until converted to a `@property`. Not a new slash-reachable capability — same name, same access pattern, documented in the same PR per the gate's own instructions.

## Verification

- `ruff check .`, `mypy_ratchet.py`, `verify_module_docstrings.py`, `test_tier_audit.py --strict`, `mkdocs build --strict`: all clean.
- Strip-falsified the composition logic and the fixed warning regression.
- Full regression: `tests/runtime` 1765 passed; `tests/core` + `tests/interfaces` 4465 passed.

## Scope discipline (per your ruling)

- Read/resolve mechanism + `output_language` wired only — no new slash command.
- Doc in this PR (`agent.md` / `state-dir.md` / `session-construction.md`).
- **No ADR in this PR** — the axis rule itself is #4206's own full scope; ratifying it via one implementation slice would be the wrong order.

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Strip-falsified the free-override composition and the caplog regression.
- [x] Full regression (1765 + 4465 tests) — clean.
- [x] `mkdocs build --strict` — clean.
- [ ] (Visual) — n/a, no UI surface.

part of #4206

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- [x] 🔴 **test 名と docstring の「8」を「9」に** ── `test_preference_keys_names_all_8_confirmed_keys` ／「the 8 keys」。★assert の中身は 9 件（output_language ＋ chat.reasoning.display ＋ cost.*.warn_ratio ×6 ＋ cost.rate_limit_warn_ratio）。★assert 自体は正しく、直すのは★名前と docstring だけ。⚪ 出所は★lead-coder の指示（「8 キー分の配線まで」）です。

