### PR TITLE
fix(#4680): turn_budget's get_max_input_tokens call never threaded events=

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1714,6 +1714,10 @@ class Session:
             use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
             # #3580: operator-tunable offload ceiling feeds the layer-1 reserve.
             max_inline_bytes=self._offload_config.max_inline_bytes,
+            # #4680: so a cold/unrecognized model lookup here is visible via
+            # the same model_budget_fallback audit-event compaction's own
+            # lookup already emits.
+            events=self._audit_events,
         )
         self._router_host.set_turn_budget_engine(engine)
         self._compaction_controller.rebuild_engine()
@@ -4284,6 +4288,10 @@ class Session:
                 use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
                 # #3580: operator-tunable offload ceiling feeds the layer-1 reserve.
                 max_inline_bytes=self._offload_config.max_inline_bytes,
+                # #4680: so a cold/unrecognized model lookup here is visible
+                # via the same model_budget_fallback audit-event compaction's
+                # own lookup already emits.
+                events=self._audit_events,
             )
 
         # #3607: the ONE chat-router op-context supplier for this Session.

--- a/src/reyn/services/turn_budget/engine.py
+++ b/src/reyn/services/turn_budget/engine.py
@@ -40,6 +40,7 @@ from reyn.prompt.turn_budget import (
 from reyn.services.compaction.engine import estimate_tokens
 
 if TYPE_CHECKING:
+    from reyn.core.events.events import EventLog
     from reyn.llm.model_resolver import ModelResolver
 
 # _WRAP_UP_SYSTEM_PROMPT / wrap_up_system_prompt: relocated to
@@ -80,6 +81,7 @@ def compute_turn_budget(
     output_reserve: int,
     offload_cap: int,
     resolver: "ModelResolver | None" = None,
+    events: "EventLog | None" = None,
 ) -> TurnBudget:
     """Derive the layer-1 force-close threshold (§5) — pure, no I/O beyond the
     model catalog lookup.
@@ -101,6 +103,15 @@ def compute_turn_budget(
         Upper bound on the tokens a single post-offload increment (one more
         normal turn's new content) can add — this is what makes "one more turn"
         a finite, known quantity (size axis = #1093 / ``services/offload/``).
+    events:
+        #4680: threaded into ``get_max_input_tokens`` so a cold/unrecognized
+        model landing on the conservative fallback here emits the SAME
+        ``model_budget_fallback`` audit-event compaction's own lookup already
+        does — before this, the call below passed no ``events`` at all, so a
+        turn_budget-side cold value was invisible to both the audit log AND
+        (if compaction's own lookup for the same model had already warned once)
+        the process logger's de-duplicated warning, making the miscount
+        unmeasurable from the outside.
 
     Returns
     -------
@@ -117,7 +128,7 @@ def compute_turn_budget(
         resolver = _MR({})
     resolved_model = resolver.resolve(model).model
 
-    max_input = get_max_input_tokens(resolved_model)
+    max_input = get_max_input_tokens(resolved_model, events=events)
     threshold = max_input - T_wrap_SP - output_reserve - offload_cap
     return TurnBudget(
         max_input=max_input,
@@ -184,6 +195,7 @@ class TurnBudgetEngine:
         offload_cap: int,
         resolver: "ModelResolver | None" = None,
         use_chars4: bool = False,
+        events: "EventLog | None" = None,
     ) -> None:
         if resolver is None:
             from reyn.llm.model_resolver import ModelResolver as _MR
@@ -213,6 +225,7 @@ class TurnBudgetEngine:
             output_reserve=output_reserve,
             offload_cap=offload_cap,
             resolver=resolver,
+            events=events,
         )
         assert_turn_budget_bounds(self._budget)
 
@@ -249,6 +262,7 @@ def build_default_turn_budget_engine(
     resolver: "ModelResolver | None" = None,
     use_chars4: bool = False,
     max_inline_bytes: "int | None" = None,
+    events: "EventLog | None" = None,
 ) -> TurnBudgetEngine:
     """Construct a TurnBudgetEngine with the shared cross-axis default reserves.
 
@@ -293,6 +307,7 @@ def build_default_turn_budget_engine(
         offload_cap=offload_cap,
         resolver=resolver,
         use_chars4=use_chars4,
+        events=events,
     )
 
 
@@ -302,6 +317,7 @@ def try_build_default_turn_budget_engine(
     resolver: "ModelResolver | None" = None,
     use_chars4: bool = False,
     max_inline_bytes: "int | None" = None,
+    events: "EventLog | None" = None,
 ) -> "TurnBudgetEngine | None":
     """:func:`build_default_turn_budget_engine`, but returns ``None`` instead of
     raising when the model's context is too small to satisfy the by-construction
@@ -323,7 +339,7 @@ def try_build_default_turn_budget_engine(
     try:
         return build_default_turn_budget_engine(
             model, resolver=resolver, use_chars4=use_chars4,
-            max_inline_bytes=max_inline_bytes
+            max_inline_bytes=max_inline_bytes, events=events,
         )
     except AssertionError:
         return None

--- a/tests/services/test_turn_budget_foundation_1092.py
+++ b/tests/services/test_turn_budget_foundation_1092.py
@@ -165,6 +165,44 @@ def test_engine_does_not_double_resolve_a_class_with_no_provider_prefix() -> Non
     assert eng.budget.T_wrap_SP > 0
 
 
+def test_cold_model_lookup_emits_model_budget_fallback_when_events_threaded() -> None:
+    """Tier 2: #4680 — a cold/unrecognized model landing on the conservative
+    fallback inside ``compute_turn_budget`` must be observable: with a real
+    ``EventLog`` passed as ``events=``, the SAME ``model_budget_fallback``
+    audit-event ``CompactionEngine``'s own lookup already emits must fire
+    here too. Before this fix, ``compute_turn_budget``'s call to
+    ``get_max_input_tokens`` passed no ``events=`` at all, so a turn_budget-
+    side cold value was invisible to the audit log (and to the process
+    logger too, if compaction's own lookup for the same model had already
+    warned once — the module-global ``_warned_models`` de-dupe is shared).
+
+    Real ``EventLog`` + a real subscriber, no mock — the audit-event
+    surface itself is what this test verifies exists."""
+    from reyn.core.events.events import EventLog
+
+    captured: list[str] = []
+    log = EventLog(subscribers=[lambda e: captured.append(e.type)])
+    eng = TurnBudgetEngine(
+        "openai/totally-unrecognized-model-xyz",
+        output_reserve=4000,
+        offload_cap=8000,
+        events=log,
+    )
+    assert eng.budget.max_input > 0  # the fallback value, not a raise
+    assert "model_budget_fallback" in captured
+
+
+def test_events_omitted_is_still_backward_compatible() -> None:
+    """Tier 2: #4680 — every pre-existing caller of ``TurnBudgetEngine``/
+    ``compute_turn_budget`` that never passes ``events=`` (the default,
+    ``None``) must keep working unchanged — the new parameter is additive,
+    never required."""
+    eng = TurnBudgetEngine(
+        _MODEL, output_reserve=4000, offload_cap=8000,
+    )
+    assert eng.budget.max_input > 0
+
+
 # ── fail-fast bounds (sibling of compaction assert_static_bounds) ─────────────
 
 


### PR DESCRIPTION
**[docs-maintainer]** — dispatched by lead-coder (broker only), part of #4680.

architect's measurement: a cold/unrecognized model lookup in `turn_budget/engine.py`'s `compute_turn_budget` landed on the conservative 128,000-token fallback with no observability at all — the call passed no `events=` to `get_max_input_tokens`, so no `model_budget_fallback` audit-event fired, and if compaction's own lookup for the same model had already warned once (the process-lifetime `_warned_models` de-dupe), even the `logger.warning()` fallback stayed silent too. This made the miscount unmeasurable from outside — which is what blocked architect from confirming or ruling out "turn_budget reads a cold value" for the owner's actual incident.

## Scope (per lead-coder's explicit boundary)

`events=` wiring only. Not touched: the `TurnBudget`/`Uncataloged` type-change proposal (owner judgment pending) or the fallback wording itself (not requested).

## Change

Threaded `events` through the whole call chain, all keyword-only, default `None` (backward compatible for any caller that doesn't have one): `compute_turn_budget` → `TurnBudgetEngine.__init__` → `build_default_turn_budget_engine` → `try_build_default_turn_budget_engine`, and both real call sites in `session.py` now pass `events=self._audit_events`.

2 new Tier 2 tests in `test_turn_budget_foundation_1092.py`: a real `EventLog` + real subscriber (no mock) confirms `model_budget_fallback` fires for a cold model when `events=` is threaded; a sibling confirms events omitted (the old default) still works unchanged.

## Note on landing order

Branched while #4687 ("turn_budget resolver bugs", same file, same night) was mid-flight — merged cleanly via `git stash` + `git merge --ff-only origin/main` + `git stash pop` once #4687 landed, then re-verified every gate + the exact regression set #4687 itself used, against the merged state.

## Verification

- Strip-falsified both new tests independently: reverted the `get_max_input_tokens` call to the pre-fix shape (no `events=`), confirmed the fallback-emission test goes RED for the right reason (`captured == []`) while the omitted-events test stays green; restored, confirmed both green again.
- Live smoke test against the real `EventLog` class (not just the test) before writing the test, to confirm the exact captured event shape.
- `ruff check`, `mypy_ratchet`, `verify_module_docstrings`, `check_tests_path_literal_reference`, `test_tier_audit --strict` — all clean.
- `pytest`: the exact regression set #4687 used for its own turn_budget resolver fix, plus the 2 new tests — 46 passed.

## Test plan

- [x] Strip-falsified both new tests independently — confirmed RED for the right reason → restored → confirmed GREEN.
- [x] Ran all 5 local gates — clean.
- [x] Regression: 46 passed (`test_turn_budget_foundation_1092.py` + `test_slash_model.py` + `test_force_close_chat_activation_1092.py` + `test_3595_s4_slash_handler_seam.py`).
- [ ] (Visual) — N/A, backend/audit-event change only.

part of #4680
