### PR TITLE
docs(#4206): profile.yaml field enumerations across 5 files missed #4688's new preferences key

### DIFF
--- a/docs/concepts/multi-agent/multi-agent.ja.md
+++ b/docs/concepts/multi-agent/multi-agent.ja.md
@@ -46,7 +46,9 @@ Reyn はマルチ agent 機能を 1 つ持つのではなく、**2 つの独立�
 
 Agent は `.reyn/agents/<name>/` にあるディレクトリ（その永続的なアイデンティティ）と、ランタイムがオンデマンドで起動する 1 つ以上のインメモリ **Session** です：
 
-- `profile.yaml` — 名前、役割(システムプロンプトのペルソナ)、`allowed_mcp`(オプション)
+- `profile.yaml` — 名前、役割(システムプロンプトのペルソナ)、`allowed_mcp`(オプション)、
+  `preferences`(オプション、#4206 ③ — free-override 設定、例: `output_language`;
+  [agent.md § `preferences`](../../reference/cli/agent.md#preferences-4206-slice-1-the-3-axis-free-override-not-restrict-only) 参照)
 - `history.jsonl` — 追記専用の会話ログ
 - `events.jsonl` — ランタイム監査ログ
 - `memory/` — agent スコープの memory レイヤー（`.reyn/memory/` の共有レイヤーはすべての agent から見える）

--- a/docs/concepts/multi-agent/multi-agent.md
+++ b/docs/concepts/multi-agent/multi-agent.md
@@ -46,7 +46,9 @@ Reyn does not have a single multi-agent feature. It has two distinct composition
 
 An agent is a directory at `.reyn/agents/<name>/` (its persistent identity) plus one or more in-memory **Sessions** the runtime spins up on demand:
 
-- `profile.yaml` — name, role (system-prompt persona), `allowed_mcp` (optional)
+- `profile.yaml` — name, role (system-prompt persona), `allowed_mcp` (optional),
+  `preferences` (optional, #4206 ③ — free-override config, e.g. `output_language`;
+  see [agent.md § `preferences`](../../reference/cli/agent.md#preferences-4206-slice-1-the-3-axis-free-override-not-restrict-only))
 - `history.jsonl` — append-only conversation log
 - `events.jsonl` — runtime audit log
 - `memory/` — agent-scoped memory layer (the shared layer at `.reyn/memory/` is visible to every agent)

--- a/docs/reference/cli/chat.ja.md
+++ b/docs/reference/cli/chat.ja.md
@@ -53,7 +53,8 @@ chat 固有のフラグ:
 
 各 agent は `.reyn/agents/<name>/` 配下に状態を永続化します:
 
-- `profile.yaml` — 名前、ロール、オプションの `allowed_mcp`(リファレンス)
+- `profile.yaml` — 名前、ロール、オプションの `allowed_mcp`、オプションの `preferences`
+  (#4206 ③: free-override 設定 — [agent.md § `preferences`](agent.md#preferences-4206-slice-1-the-3-axis-free-override-not-restrict-only) 参照)(リファレンス)
 - `history.jsonl` — 追記専用の会話ログ（chat + agent 間メッセージ、クロス agent トレース用の chain_id 付き）
 - `events.jsonl` — `reyn events` 用のランタイムイベント
 - `memory/` — agent スコープの Memory レイヤー（`MEMORY.md` + body ファイル）

--- a/docs/reference/cli/chat.md
+++ b/docs/reference/cli/chat.md
@@ -52,7 +52,8 @@ Chat-specific flags:
 
 Each agent persists state under `.reyn/agents/<name>/`:
 
-- `profile.yaml` — name, role, optional `allowed_mcp`
+- `profile.yaml` — name, role, optional `allowed_mcp`, optional `preferences`
+  (#4206 ③: free-override config — see [agent.md § `preferences`](agent.md#preferences-4206-slice-1-the-3-axis-free-override-not-restrict-only))
 - `history.jsonl` — append-only conversation log (chat + agent-to-agent messages, with chain_id for cross-agent trace)
 - `events.jsonl` — runtime events for `reyn events`
 - `memory/` — agent-scoped memory layer (`MEMORY.md` + body files)

--- a/docs/reference/config/state-dir.ja.md
+++ b/docs/reference/config/state-dir.ja.md
@@ -73,7 +73,7 @@ JSONL ファイルは `reyn events <file>` でリプレイ可能。[events リ�
 
 エージェントごとの Workspace。名前付きエージェントごとに 1 ディレクトリ（`reyn agent new` で作成）。`default` エージェントは常に存在します。
 
-- `profile.yaml` — エージェントのアイデンティティ: 名前、ロール、オプションの `allowed_mcp`。profile-yaml リファレンス を参照。
+- `profile.yaml` — エージェントのアイデンティティ: 名前、ロール、オプションの `allowed_mcp`、オプションの `preferences`(#4206 ③: free-override 設定 — [agent.md § Workspace layout](../cli/agent.md#preferences-4206-slice-1-the-3-axis-free-override-not-restrict-only) 参照)。profile-yaml リファレンス を参照。
 - `history.jsonl` — 追記専用の会話ログ（ユーザー + アシスタントのターン; クロスエージェントメッセージにはトレース用の `chain_id` が含まれます）。
 - `memory/` — エージェントスコープの Memory（`MEMORY.md` インデックス + body ファイル）。ルーターフェーズ中に自動的に検索・書き込み。
 - `state/skills/<run_id>.snapshot.json` — 実行中の Skill ランのクラッシュリカバリー用 WAL スナップショット。


### PR DESCRIPTION
**[docs-maintainer]** — part of #4206.

lead-coder caught the first instance (`multi-agent.md:49` + its `.ja.md` mirror): #4688 added `AgentProfile.preferences`, but touched only `agent.md`/`state-dir.md`/`session-construction.md`, missing this page's own "What is an agent?" enumeration of `profile.yaml`'s fields.

Widened the sweep per lead-coder's own request and found 3 more genuinely stale enumerations #4688 also missed: `state-dir.ja.md` (the `.ja.md` mirror of the EN file #4688 DID fix — same class, not a mirror obligation, the ja file's own claim is now independently false), `chat.md`, and `chat.ja.md` (neither language touched by #4688 at all).

Checked the second angle lead-coder flagged — session `config.yaml`'s narrowing dict enumeration — separately: no doc enumerates its specific field set as a closed list (`agent.md`'s own narrowing example shows `tool_deny` etc. as illustrative, not exhaustive), so nothing there is falsified by `preferences` becoming a sibling key.

Each new mention cross-links to `agent.md`'s own `preferences` section rather than re-explaining the mechanism — verified the anchor slug directly against the built site (mkdocs's ③ circled-digit slugifies to a bare "3", not what a first guess would produce) before writing each link, not guessed.

## Verification

- Verified the exact anchor slug against the built `site/` HTML before writing any of the 5 links.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `check_doc_anchors.py` — both clean, no new dangling-anchor lines for any touched file.
- Fetched `origin/main` immediately before commit — no new commits since this branch's base.

part of #4206

## Test plan

- [x] `mkdocs build --strict` + `check_doc_anchors.py` — both clean
- [x] docs-only change — `ruff`/`pytest` N/A
- [ ] Visual — N/A (docs prose only)
