### PR TITLE
feat(#4689): llm.models.<tier>.max_input_tokens overrides the catalog unconditionally (owner instruction)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -195,13 +195,14 @@ llm:
 | `provider` | no | Per-class litellm `custom_llm_provider` — a routing field, not forwarded as a litellm kwarg. |
 | `stream` | no | Whether calls for this class stream. A **reyn** field, not forwarded to litellm; overrides the capability query in both directions. Omit to let reyn decide — see below. |
 | `stream_options` | no | **Not settable.** No reyn meaning, and it breaks the collect-whole branch — **rejected at load**. |
+| `max_input_tokens` | no | Operator-declared context-window CEILING for this class (#4689). A **reyn** field, not forwarded to litellm — takes priority over the LiteLLM catalog UNCONDITIONALLY (not just when the catalog lookup fails). Omit to let reyn read the catalog, falling back to a conservative 128,000-token default if the model isn't cataloged. |
 | *(any other field)* | no | Silently passed through to litellm (passthrough policy). |
 
 > **Cost limit**: use `max_completion_tokens`, not `max_tokens`.  `max_tokens` is a legacy
 > soft hint that many providers ignore; it has no enforcement power on OpenAI o1+ or
 > Anthropic models.  `max_completion_tokens` is enforced at the API level.
 
-**Field policy**: `model` is the only required field. Most other fields are passed directly to `litellm.acompletion` without validation — unknown fields are silently forwarded (future-proof); typos cause silent litellm failures, not reyn errors. Three exceptions are handled at load instead: `reasoning_effort` (below), `stream` (consumed by reyn, type-checked), and `stream_options` (**rejected outright**).
+**Field policy**: `model` is the only required field. Most other fields are passed directly to `litellm.acompletion` without validation — unknown fields are silently forwarded (future-proof); typos cause silent litellm failures, not reyn errors. Four exceptions are handled at load instead: `reasoning_effort` (below), `stream` (consumed by reyn, type-checked), `stream_options` (**rejected outright**), and `max_input_tokens` (consumed by reyn, type-checked — never forwarded to litellm, closing the same "accepted but silently does nothing" gap the other three exceptions close).
 
 ### `stream` — whether this class's calls stream
 
@@ -249,6 +250,50 @@ here would otherwise never reach anything that could complain about it.
 Rejected at config load (`ValueError`, fail-fast). It has no reyn meaning, and
 riding the kwargs passthrough it produces the same broken shape described
 above.
+
+### `max_input_tokens` (per-class context-window ceiling, #4689)
+
+Declare the context window reyn should budget against for a class — overriding
+the LiteLLM catalog **unconditionally**, not just when the catalog lookup
+fails:
+
+```yaml
+llm:
+  models:
+    gpt-5-6-luna:
+      model: openai/gpt-5.6-luna
+      max_input_tokens: 128000   # operator's own answer, wins over the catalog
+```
+
+Every consumer of `reyn.llm.model_budget.get_max_input_tokens` (compaction, the
+turn-budget force-close threshold, the status-bar context chip, ...) only ever
+holds an already-resolved LiteLLM model STRING, never a class name — none of
+those call sites change. Instead, at each `reyn.llm.model_resolver.ModelResolver`
+construction (session/CLI/web startup), every class's declared
+`max_input_tokens` is resolved to its model string and registered into a
+process-shared table `get_max_input_tokens` consults FIRST, ahead of the
+catalog.
+
+**Two classes resolving to the SAME model string must agree.** If `light` and
+`standard` both point at `openai/gpt-4o` but declare different
+`max_input_tokens` values, registration raises
+`reyn.llm.model_budget.MaxInputTokensConflictError` — which value should win is
+ambiguous, so reyn refuses to guess (give them the same value, or point them at
+different model strings). The SAME check applies across sessions sharing one
+process with different configs — a later, conflicting declaration for a model
+string another session already registered raises rather than silently
+overwriting the first.
+
+A non-positive or non-integer value is rejected at load, the same discipline
+`stream` above uses — a config typo here would otherwise silently ride
+`spec.kwargs` into `litellm.acompletion` as an unrecognized kwarg (accepted,
+does nothing).
+
+Complementary, not exclusive: some LiteLLM proxies also advertise a model's
+window via `GET /model/info` (verified live for some providers, not yet for
+others) — `max_input_tokens` here is the operator's own, explicit override,
+useful specifically when that proxy-side declaration is absent, wrong, or the
+model predates reyn's bundled catalog snapshot.
 
 ### `reasoning_effort` (per-model reasoning budget)
 

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -493,6 +493,11 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
         purpose_classes=config.llm.model_class_by_purpose,
         model_max_class=config.llm.model_max_class,  # #4206 T1 (②bounding)
     )
+    # #4689: same registration registry_bootstrap.py's own ModelResolver
+    # construction does — see that call site's comment.
+    from reyn.llm.model_budget import register_max_input_overrides
+
+    register_max_input_overrides(resolver.max_input_token_overrides())
     model = config.llm.model
     output_language = config.output_language
     safety = config.safety

--- a/src/reyn/interfaces/cli/invocation_context.py
+++ b/src/reyn/interfaces/cli/invocation_context.py
@@ -26,12 +26,18 @@ class InvocationContext:
         # here was purely redundant (``load_config`` above already exported it via
         # idempotent ``setdefault``); a single-writer AST guard now enforces this.
         config = load_config()
-        return cls(config=config, resolver=ModelResolver(
+        resolver = ModelResolver(
             config.llm.models,
             default_class=config.llm.model,
             purpose_classes=config.llm.model_class_by_purpose,
             model_max_class=config.llm.model_max_class,  # #4206 T1 (②bounding)
-        ))
+        )
+        # #4689: same registration registry_bootstrap.py's own
+        # ModelResolver construction does — see that call site's comment.
+        from reyn.llm.model_budget import register_max_input_overrides
+
+        register_max_input_overrides(resolver.max_input_token_overrides())
+        return cls(config=config, resolver=resolver)
 
     # ── argparse-aware setting resolution (CLI > config) ─────────────────────
 

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -317,6 +317,11 @@ def _get_registry():
             purpose_classes=config.llm.model_class_by_purpose,
             model_max_class=config.llm.model_max_class,  # #4206 T1 (②bounding)
         )
+        # #4689: same registration registry_bootstrap.py's own
+        # ModelResolver construction does — see that call site's comment.
+        from reyn.llm.model_budget import register_max_input_overrides
+
+        register_max_input_overrides(resolver.max_input_token_overrides())
         model = config.llm.model
         output_language = config.output_language
 

--- a/src/reyn/llm/model_budget.py
+++ b/src/reyn/llm/model_budget.py
@@ -12,6 +12,17 @@ Fallback policy (unknown models):
     knows the model is not cataloged. 128_000 was chosen as a floor that is
     below all commercial production models' actual context windows, so the
     compaction logic errs on the side of compacting more rather than less.
+
+Priority order (#4689, owner instruction): operator-declared config >
+LiteLLM catalog > the 128K fallback above — unconditionally, not just when
+the catalog lookup fails. ``register_max_input_overrides`` is how a
+``llm.models.<tier>.max_input_tokens`` declaration reaches this module:
+every one of this file's 8 call sites only ever holds an already-resolved
+LiteLLM model STRING (never a class name or a ``ModelResolver``), so the
+override is registered ONCE, wherever a ``ModelResolver`` is actually
+constructed (``reyn.llm.model_resolver.ModelResolver.max_input_token_overrides``
+does the class-name -> model-string resolution), keyed by model string —
+every call site here benefits without any of them changing.
 """
 from __future__ import annotations
 
@@ -33,6 +44,54 @@ _FALLBACK_MAX_INPUT_TOKENS = 128_000
 # Emit the fallback warning at most once per process per model string so noisy
 # repeated calls don't flood logs. Keyed by model string.
 _warned_models: set[str] = set()
+
+# #4689: operator-declared max_input_tokens, keyed by resolved LiteLLM
+# model string. PROCESS-SHARED, same lifetime/scope as _warned_models
+# above — reyn can hold multiple sessions (possibly different projects,
+# different configs) in one process. Cumulative collision detection (see
+# register_max_input_overrides) is what keeps that sharing safe: a second,
+# DIFFERENT declaration for the same model string is rejected loudly
+# rather than silently overwriting the first session's value (lead-coder
+# ruling, #4689 — the same "config wins here, silently doesn't win there"
+# confusion #4680 already caused, this time from cross-session sharing
+# rather than cross-call-site sharing).
+_config_max_input_overrides: "dict[str, int]" = {}
+
+
+class MaxInputTokensConflictError(ValueError):
+    """Two DIFFERENT registrations (same process, possibly different
+    sessions/configs) declared a different max_input_tokens for the SAME
+    resolved model string. Raised rather than silently letting the later
+    registration win — an operator whose config IS being honored must
+    never end up unknowingly overridden by another session's config for
+    the same model."""
+
+
+def register_max_input_overrides(mapping: "dict[str, int]") -> None:
+    """Register *mapping* (``{model string: max_input_tokens}``, typically
+    ``ModelResolver.max_input_token_overrides()``'s own return value) into
+    the process-shared registry ``_resolve_max_input`` consults first,
+    ahead of the LiteLLM catalog.
+
+    Idempotent for an identical re-registration (the same model string,
+    the same value — e.g. two Sessions sharing one project's config) —
+    only a GENUINE conflict (same model string, a DIFFERENT value) raises
+    :class:`MaxInputTokensConflictError`. Call once per ``ModelResolver``
+    construction (``registry_bootstrap.py`` and the 3 other sites that
+    build one) — never inside a hot path, this is a startup-time
+    registration, not a per-call operation."""
+    for model, value in mapping.items():
+        existing = _config_max_input_overrides.get(model)
+        if existing is not None and existing != value:
+            raise MaxInputTokensConflictError(
+                f"conflicting max_input_tokens registered for model "
+                f"{model!r}: {existing} (already registered) vs {value} "
+                f"(new registration) — two different sessions/configs in "
+                f"this process declared different values for the same "
+                f"model string. Give them the same value, or route them "
+                f"through different model classes/strings."
+            )
+        _config_max_input_overrides[model] = value
 
 
 def _lookup_max_input(model: str) -> "int | None":
@@ -68,7 +127,16 @@ def _resolve_max_input(model: str) -> "tuple[int, str, bool]":
     ``get_max_input_tokens`` and ``get_max_input_tokens_source`` both delegate
     to, so the #1162 prefix-strip-retry resolution order exists in ONE spot
     (previously duplicated across the two functions, a silent-drift risk if
-    the order ever changed in only one place)."""
+    the order ever changed in only one place).
+
+    #4689: an operator-declared config override (registered via
+    ``register_max_input_overrides``) wins UNCONDITIONALLY — checked
+    before the catalog lookup, not as a fallback for when the catalog
+    lookup fails (owner instruction: "catalog が外れた時だけ、ではない")."""
+    config_override = _config_max_input_overrides.get(model)
+    if config_override is not None:
+        return config_override, f"config: llm.models.<tier>.max_input_tokens ({model})", False
+
     max_input = _lookup_max_input(model)
     if max_input is not None:
         return max_input, f"litellm catalog: {model}", False

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -121,6 +121,18 @@ class ModelSpec:
     # finished reply (#3627). ``None`` = no operator opinion, decide from the
     # catalog.
     stream: bool | None = None
+    # #4689 (owner instruction): operator-declared CEILING OVERRIDE for
+    # ``reyn.llm.model_budget.get_max_input_tokens`` — takes priority over
+    # the litellm catalog lookup unconditionally (not just when the catalog
+    # lookup fails). A REYN field, same reasoning as ``stream`` above: left
+    # in ``kwargs`` it would silently pass through to litellm as an unknown
+    # completion kwarg (accepted, does nothing) — the #4655 B-3 shape this
+    # field exists specifically to NOT reproduce. ``None`` = no operator
+    # opinion, defer to the catalog (byte-identical to before this field
+    # existed). See ``ModelResolver.max_input_token_overrides`` for how this
+    # reaches ``get_max_input_tokens`` without threading a resolver/class
+    # name through every one of its 8 call sites.
+    max_input_tokens: int | None = None
 
     def __post_init__(self) -> None:
         # #1650: validate the operator-declared ``reasoning_effort`` at
@@ -256,13 +268,32 @@ class ModelSpec:
                 raise ValueError(
                     f"ModelSpec 'stream' must be a boolean, got {type(stream).__name__}"
                 )
+            # #4689: same explicit-field treatment as api_base/provider/stream
+            # above — left in kwargs it would silently pass through to
+            # litellm as an unrecognized completion kwarg (accepted, does
+            # nothing — see ModelSpec.max_input_tokens's own docstring).
+            max_input_tokens = value.get("max_input_tokens")
+            if max_input_tokens is not None:
+                if isinstance(max_input_tokens, bool) or not isinstance(max_input_tokens, int):
+                    raise ValueError(
+                        "ModelSpec 'max_input_tokens' must be an int, got "
+                        f"{type(max_input_tokens).__name__}"
+                    )
+                if max_input_tokens <= 0:
+                    raise ValueError(
+                        f"ModelSpec 'max_input_tokens' must be positive, got {max_input_tokens}"
+                    )
             kwargs = {
                 k: v for k, v in value.items()
-                if k not in ("model", "extends", "api_base", "provider", "stream")
+                if k not in (
+                    "model", "extends", "api_base", "provider", "stream",
+                    "max_input_tokens",
+                )
             }
             return cls(
                 model=model, kwargs=kwargs, api_base=api_base,
                 provider=provider, stream=stream,
+                max_input_tokens=max_input_tokens,
             )
         raise ValueError(
             f"ModelSpec.from_config expects str or dict, got {type(value).__name__}"
@@ -326,9 +357,26 @@ def model_family(model: str) -> str:
 
 
 def _spec_to_dict(spec: ModelSpec) -> dict[str, Any]:
-    """Convert a ModelSpec back to a flat dict for merging."""
+    """Convert a ModelSpec back to a flat dict for merging (the ``extends``
+    resolution path's base-class side). Carries every explicit ModelSpec
+    field (``api_base``/``provider``/``stream``/``max_input_tokens``), not
+    just ``model``/``kwargs`` — #4689: a prior revision omitted these,
+    which meant a base class's ``stream``/``api_base``/``provider`` never
+    reached an ``extends``-ing override at all (the field simply vanished
+    on that path, even though the override side round-tripped correctly
+    through ``ModelSpec.from_config``). Only a set (non-``None``) field is
+    included, so an override's own value is never masked by a base's
+    unset default via ``_deep_merge``."""
     result: dict[str, Any] = {"model": spec.model}
     result.update(spec.kwargs)
+    if spec.api_base is not None:
+        result["api_base"] = spec.api_base
+    if spec.provider is not None:
+        result["provider"] = spec.provider
+    if spec.stream is not None:
+        result["stream"] = spec.stream
+    if spec.max_input_tokens is not None:
+        result["max_input_tokens"] = spec.max_input_tokens
     return result
 
 
@@ -476,6 +524,48 @@ class ModelResolver:
         """
         return self._model_max_class
 
+    def max_input_token_overrides(self) -> "dict[str, int]":
+        """#4689: ``{resolved LiteLLM model string: declared max_input_tokens}``
+        for every class in this resolver's namespace that set one — the
+        bridge from "operator declares a CEILING per model CLASS"
+        (``llm.models.<tier>.max_input_tokens``) to
+        ``reyn.llm.model_budget.get_max_input_tokens``, which only ever
+        sees the already-resolved model STRING, at 8 call sites that have
+        no access to a class name or this resolver. The caller (wherever a
+        ``ModelResolver`` is constructed — ``registry_bootstrap.py`` and 3
+        other sites) registers this dict once via
+        ``model_budget.register_max_input_overrides``; ``_resolve_max_input``
+        then consults that registration by MODEL STRING, so all 8 call
+        sites benefit without any of them changing.
+
+        Every namespace entry is already resolved (``__init__``'s own
+        "resolve all entries at startup, fail-fast" pass), so this is a
+        pure read — no re-resolution, no I/O.
+
+        Raises ``ValueError`` if two classes in THIS resolver's own
+        namespace resolve to the SAME model string with DIFFERENT declared
+        ``max_input_tokens`` — ambiguous (which one wins?), caught here
+        before it ever reaches the process-shared registration step
+        (which does its OWN, separate collision check across resolvers —
+        see that function's docstring for why both checks exist)."""
+        result: "dict[str, int]" = {}
+        for name, spec in self._resolved.items():
+            if spec.max_input_tokens is None:
+                continue
+            existing = result.get(spec.model)
+            if existing is not None and existing != spec.max_input_tokens:
+                raise ValueError(
+                    f"conflicting max_input_tokens for model {spec.model!r}: "
+                    f"multiple classes resolve to this same model string "
+                    f"with different declared values ({existing} vs "
+                    f"{spec.max_input_tokens}, class {name!r}) — which one "
+                    f"should win is ambiguous; give the model classes "
+                    f"agreeing max_input_tokens values, or point them at "
+                    f"different model strings."
+                )
+            result[spec.model] = spec.max_input_tokens
+        return result
+
     def class_for_purpose(self, purpose: str) -> str:
         """#1672: the model CLASS for a logical call *purpose* (router / control_ir
         / tool / judge — NOT compaction, #3785: compaction always follows
@@ -615,8 +705,20 @@ class ModelResolver:
                         f"ModelSpec for '{name}' is missing a 'model' field "
                         f"after resolving extends chain"
                     )
-                model = merged.pop("model")
-                return ModelSpec(model=model, kwargs=merged)
+                # #4689: reuse from_config's own field extraction, rather
+                # than constructing ModelSpec(model=model, kwargs=merged)
+                # directly — the direct-construction form left
+                # api_base/provider/stream (and now max_input_tokens) in
+                # kwargs instead of extracting them as their own fields
+                # (a pre-existing gap on the extends-merge path specifically:
+                # _spec_to_dict already carries them into `merged` via
+                # `base_dict`, but nothing pulled them back OUT before this
+                # constructor call). Routing through from_config closes
+                # that for all four fields at once, in the same PR that
+                # would otherwise have left max_input_tokens as the sole
+                # newly-added field with the same bug the other three
+                # already had.
+                return ModelSpec.from_config(merged)
             else:
                 # Plain dict form (no extends): use from_config.
                 return ModelSpec.from_config(value)

--- a/src/reyn/runtime/registry_bootstrap.py
+++ b/src/reyn/runtime/registry_bootstrap.py
@@ -174,6 +174,16 @@ def build_agent_registry_from_project(
         purpose_classes=config.llm.model_class_by_purpose,
         model_max_class=config.llm.model_max_class,  # #4206 T1 (②bounding)
     )
+    # #4689: register this resolver's llm.models.<tier>.max_input_tokens
+    # declarations (class -> resolved model string -> declared ceiling)
+    # into the process-shared registry reyn.llm.model_budget's 8 call
+    # sites all consult — done HERE (a ModelResolver-construction site),
+    # not inside config parsing, because a class -> model-string
+    # resolution needs the resolver itself, which does not exist yet at
+    # config-load time.
+    from reyn.llm.model_budget import register_max_input_overrides
+
+    register_max_input_overrides(resolver.max_input_token_overrides())
     factory_config = SessionFactoryConfig.from_config(config, project_root)
     ws_base_dir = project_root
     ws_state_dir = project_root / ".reyn"

--- a/tests/llm/test_4689_max_input_tokens_priority.py
+++ b/tests/llm/test_4689_max_input_tokens_priority.py
@@ -1,0 +1,187 @@
+"""Tier 2: #4689 (owner instruction) — llm.models.<tier>.max_input_tokens
+takes priority over the LiteLLM catalog unconditionally.
+
+Real instances only: ModelSpec/ModelResolver are constructed for real
+(no mocks); model_budget's process-shared registry is exercised directly,
+each test using a UNIQUE model string to avoid cross-test collision (the
+same discipline test_model_budget.py's own fallback tests already use for
+the SAME reason — this module's state is process-shared and not reset
+between tests).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.llm.model_budget import (
+    MaxInputTokensConflictError,
+    get_max_input_tokens,
+    register_max_input_overrides,
+)
+from reyn.llm.model_resolver import ModelResolver, ModelSpec
+
+# ── ModelSpec.max_input_tokens field ─────────────────────────────────────
+
+
+def test_from_config_extracts_max_input_tokens_as_its_own_field():
+    """Tier 2: max_input_tokens is a real ModelSpec field, not left in
+    kwargs (which would silently pass through to litellm untouched — the
+    #4655 B-3 shape this field exists to avoid)."""
+    spec = ModelSpec.from_config({
+        "model": "openai/gpt-4o", "max_input_tokens": 500_000,
+    })
+    assert spec.max_input_tokens == 500_000
+    assert "max_input_tokens" not in spec.kwargs
+
+
+def test_from_config_defaults_max_input_tokens_to_none():
+    """Tier 2: no operator opinion -> None, byte-identical to before this
+    field existed."""
+    spec = ModelSpec.from_config({"model": "openai/gpt-4o"})
+    assert spec.max_input_tokens is None
+
+
+def test_from_config_rejects_a_non_positive_max_input_tokens():
+    """Tier 2: 0 or negative is a config-authoring mistake, rejected at
+    load time rather than silently accepted as a real ceiling."""
+    with pytest.raises(ValueError, match="positive"):
+        ModelSpec.from_config({"model": "openai/gpt-4o", "max_input_tokens": 0})
+
+
+def test_from_config_rejects_a_non_int_max_input_tokens():
+    """Tier 2: a string/float value fails loudly (a real config-authoring
+    mistake, not silently coerced)."""
+    with pytest.raises(ValueError, match="int"):
+        ModelSpec.from_config({"model": "openai/gpt-4o", "max_input_tokens": "500000"})
+
+
+def test_from_config_rejects_a_bool_max_input_tokens():
+    """Tier 2: (accept-side gap check) bool is an int SUBCLASS in Python —
+    `isinstance(True, int)` is True — so this must be checked explicitly,
+    not just `isinstance(x, int)`."""
+    with pytest.raises(ValueError, match="int"):
+        ModelSpec.from_config({"model": "openai/gpt-4o", "max_input_tokens": True})
+
+
+# ── extends path — the pre-existing gap this PR also closes ─────────────
+
+
+def test_extends_path_propagates_max_input_tokens_from_the_base_class():
+    """Tier 2: a class the operator extends carries its max_input_tokens
+    forward when the override doesn't redeclare it."""
+    resolver = ModelResolver({
+        "base": {"model": "openai/gpt-4o", "max_input_tokens": 500_000},
+        "child": {"extends": "base", "temperature": 0.1},
+    })
+    assert resolver.resolve("child").max_input_tokens == 500_000
+
+
+def test_extends_path_lets_the_override_replace_the_base_value():
+    """Tier 2: (accept-side) an override that DOES redeclare
+    max_input_tokens replaces the base's value, not merges with it."""
+    resolver = ModelResolver({
+        "base": {"model": "openai/gpt-4o", "max_input_tokens": 500_000},
+        "child": {"extends": "base", "max_input_tokens": 200_000},
+    })
+    assert resolver.resolve("child").max_input_tokens == 200_000
+
+
+def test_extends_path_propagates_stream_from_the_base_class():
+    """Tier 2: the pre-existing gap this PR's from_config-routing fix also
+    closes — before, a base class's stream/api_base/provider never
+    reached an extends-ing override at all (silently dropped, left in
+    kwargs where stream's own __post_init__ guard would reject it as an
+    unknown litellm passthrough kwarg — or worse, silently pass through)."""
+    resolver = ModelResolver({
+        "base": {"model": "openai/gpt-4o", "stream": True},
+        "child": {"extends": "base", "temperature": 0.1},
+    })
+    assert resolver.resolve("child").stream is True
+    assert "stream" not in resolver.resolve("child").kwargs
+
+
+# ── ModelResolver.max_input_token_overrides ──────────────────────────────
+
+
+def test_max_input_token_overrides_maps_resolved_model_string_to_value():
+    """Tier 2: the class -> resolved-model-string -> declared value map,
+    the exact shape register_max_input_overrides expects."""
+    resolver = ModelResolver({
+        "standard": {"model": "openai/gpt-4o", "max_input_tokens": 500_000},
+        "light": "openai/gpt-4o-mini",
+    })
+    assert resolver.max_input_token_overrides() == {"openai/gpt-4o": 500_000}
+
+
+def test_max_input_token_overrides_is_empty_when_no_class_declares_one():
+    """Tier 2: (accept-side) no class in the namespace set max_input_tokens
+    — an empty map, not an error."""
+    resolver = ModelResolver({"standard": "openai/gpt-4o"})
+    assert resolver.max_input_token_overrides() == {}
+
+
+def test_max_input_token_overrides_two_classes_agreeing_on_the_same_model_is_fine():
+    """Tier 2: (accept-side) two classes resolving to the SAME model
+    string with the SAME declared value is not a conflict — only a
+    DIFFERENT value is."""
+    resolver = ModelResolver({
+        "a": {"model": "openai/gpt-4o", "max_input_tokens": 500_000},
+        "b": {"model": "openai/gpt-4o", "max_input_tokens": 500_000},
+    })
+    assert resolver.max_input_token_overrides() == {"openai/gpt-4o": 500_000}
+
+
+def test_max_input_token_overrides_raises_on_conflicting_values_within_one_resolver():
+    """Tier 2: two classes in the SAME resolver resolving to the same
+    model string with DIFFERENT declared values is ambiguous — raised
+    before it ever reaches the process-shared registration step."""
+    resolver = ModelResolver({
+        "a": {"model": "openai/gpt-4o", "max_input_tokens": 500_000},
+        "b": {"model": "openai/gpt-4o", "max_input_tokens": 200_000},
+    })
+    with pytest.raises(ValueError, match="conflicting max_input_tokens"):
+        resolver.max_input_token_overrides()
+
+
+# ── model_budget.register_max_input_overrides ────────────────────────────
+
+
+def test_register_max_input_overrides_wins_over_the_catalog_unconditionally():
+    """Tier 2: THE #4689 witness — a config override wins even for a
+    model that WOULD resolve from the real litellm catalog (priority is
+    config > catalog unconditionally, not just when the catalog misses,
+    per the owner's own explicit instruction)."""
+    model = "gemini/gemini-2.5-flash-lite-4689-test-a"
+    register_max_input_overrides({model: 999_999})
+    assert get_max_input_tokens(model) == 999_999
+
+
+def test_register_max_input_overrides_is_idempotent_for_the_same_value():
+    """Tier 2: (accept-side) re-registering the SAME model with the SAME
+    value (e.g. two Sessions sharing one project's config) does not
+    raise."""
+    model = "gemini/gemini-2.5-flash-lite-4689-test-b"
+    register_max_input_overrides({model: 111_111})
+    register_max_input_overrides({model: 111_111})  # must not raise
+    assert get_max_input_tokens(model) == 111_111
+
+
+def test_register_max_input_overrides_raises_on_a_conflicting_re_registration():
+    """Tier 2: lead-coder's explicit condition — the module-level registry
+    is process-shared (reyn holds multiple sessions per process), so a
+    SECOND, DIFFERENT registration for the same model string must raise
+    rather than silently overwrite the first (the same "config wins here,
+    silently doesn't win there" confusion #4680 already caused, this time
+    from cross-session sharing)."""
+    model = "gemini/gemini-2.5-flash-lite-4689-test-c"
+    register_max_input_overrides({model: 111_111})
+    with pytest.raises(MaxInputTokensConflictError, match="conflicting"):
+        register_max_input_overrides({model: 222_222})
+
+
+def test_a_model_with_no_registered_override_still_uses_the_catalog():
+    """Tier 2: (accept-side) the registration is per-model-string — an
+    unrelated model never registered still resolves through the normal
+    catalog/fallback path, unaffected."""
+    result = get_max_input_tokens("unknown/garbage-model-4689-unregistered")
+    from reyn.llm.model_budget import _FALLBACK_MAX_INPUT_TOKENS
+    assert result == _FALLBACK_MAX_INPUT_TOKENS

--- a/tests/llm/test_stream_key_rejected_at_config_load_3627.py
+++ b/tests/llm/test_stream_key_rejected_at_config_load_3627.py
@@ -112,15 +112,28 @@ def test_the_stream_field_survives_the_reyn_config_models_layer():
     assert "stream" not in spec.kwargs
 
 
-def test_stream_key_rejected_through_extends_merge_path():
-    """Tier 1: #3627 — a `stream` introduced via an `extends` merge (the
-    OTHER ModelSpec producer besides `from_config`) is rejected too — single
-    validation site (`__post_init__`) covers both producers by construction."""
-    with pytest.raises(ValueError, match="reyn decides"):
-        ModelResolver({
-            "base": {"model": "openai/gpt-4o"},
-            "child": {"extends": "base", "stream": True},
-        })
+def test_stream_key_accepted_and_consumed_through_extends_merge_path():
+    """Tier 1: #4689 — inverted (again) from what this test used to pin, for
+    the SAME reason `test_a_model_class_stream_field_is_accepted_and_consumed`
+    above already inverted the plain-`from_config` case: the owner decision
+    that made `stream` a real, accepted ModelSpec field applies uniformly
+    to every producer of one, not just `from_config`. Before #4689, the
+    `extends`-merge path bypassed `from_config`'s field extraction entirely
+    (a direct `ModelSpec(model=model, kwargs=merged)` call), so `stream`
+    landed in `kwargs` unextracted and tripped THIS file's own rejection
+    guard — an inconsistency with the plain-dict path, not an intentional
+    stricter rule for `extends` specifically. #4689 routes the `extends`
+    path through `from_config` too (needed for that PR's own
+    `max_input_tokens` field to propagate through `extends` at all),
+    which closes the inconsistency as a side effect: `stream` via `extends`
+    now behaves identically to `stream` via a plain dict."""
+    resolver = ModelResolver({
+        "base": {"model": "openai/gpt-4o"},
+        "child": {"extends": "base", "stream": True},
+    })
+    spec = resolver.resolve("child")
+    assert spec.stream is True
+    assert "stream" not in spec.kwargs
 
 
 def test_no_stream_key_is_unaffected():


### PR DESCRIPTION
**[e2e-coder]** — part of #4689 (owner instruction, via architect/lead-coder).

## What

`llm.models.<tier>.max_input_tokens` — priority order **config > litellm catalog > 128,000 fallback**, checked unconditionally (not just when the catalog lookup fails), per the owner's own explicit instruction.

## Measured before implementing

- `llm.models`' dict branch (`config/infra.py:339`) currently accepts a raw, unvalidated dict — `ModelSpec.from_config` only extracts `model`/`extends`/`api_base`/`provider`/`stream`; every OTHER key falls into `ModelSpec.kwargs` and passes through to litellm untouched. A naive `max_input_tokens` declaration would have been the exact #4655 B-3 shape (accepted, silently does nothing).
- Census of `get_max_input_tokens`' 8 call sites: only 1 (`services/turn_budget/engine.py`) has `ModelResolver`/class-name context at the point it calls in; the other 7 only ever hold an already-resolved LiteLLM model STRING — confirming architect's "cold path" concern concretely.

## Design (lead-coder ruling — rejected "wire 1 site, leave 7 for later")

- `ModelSpec.max_input_tokens: int | None` — a real field (same `stream` precedent), extracted at load, validated (positive int, not bool).
- `ModelResolver.max_input_token_overrides()` — resolves every class's declared value to its LiteLLM model string, `{model_string: value}`. Raises on a WITHIN-resolver collision.
- `model_budget.register_max_input_overrides()` — a process-shared registry keyed by model string, populated at each of the 4 `ModelResolver` construction sites (`registry_bootstrap.py`, `web/deps.py`, `cli/invocation_context.py`, `cli/commands/dogfood.py`). **Zero changes to the 8 `get_max_input_tokens` call sites.**
- `_resolve_max_input` checks the registry FIRST, before the catalog.
- **Cross-registration collision detection** (lead-coder's own added condition — the registry is process-shared, reyn holds multiple sessions per process, the same `_warned_models`-shaped class of confusion #4680 hit): a second, DIFFERENT registration for a model string another session already registered raises `MaxInputTokensConflictError` rather than silently last-write-wins. Same value re-registered is a no-op.

## Found + fixed a related pre-existing bug

The `extends` merge path built `ModelSpec` directly (`kwargs=merged`) instead of routing through `from_config`, so `stream`/`api_base`/`provider` ALSO silently leaked into kwargs on that path — for `stream` specifically this actually **crashed** (tripped `__post_init__`'s "stream must not be set" guard), a real, hit-able bug, confirmed live via strip-falsify. Routing the extends path through `from_config` fixes all four fields (including the new `max_input_tokens`) at once. Updated the one existing test that pinned the old buggy behavior to assert the corrected, consistent one.

## Strip-falsify

Config-vs-catalog priority, cross-registration collision detection, and the extends-path field-propagation fix — each reverted individually, confirmed the right test goes RED for the right reason, restored.

## Verification

- `ruff check .`, `mypy_ratchet.py`, `verify_module_docstrings.py`, `test_tier_audit.py --strict`, `mkdocs build --strict`: all clean.
- Full regression (`tests/llm` + `tests/core/test_model_budget.py` + `tests/runtime/test_live_model_budget_consumers_1752.py` + `tests/web` + `tests/config/test_pipe_proxy_bootstrap_2682.py`): 809 passed. (One pre-existing, timing-sensitive litellm-catalog-warmup flake outside this sweep, confirmed identical on unmodified main.)

## Out of scope (per architect's explicit caution)

Does NOT touch the proxy-side `GET /model/info` declaration path (whether reyn reads it is unverified) — this config override is complementary, not designed as the sole mechanism.

## Test plan

- [x] Ran all 5 local gates — clean.
- [x] Strip-falsified all 3 core mechanisms individually.
- [x] Full 809-test regression — clean.
- [x] `mkdocs build --strict` — clean.
- [ ] (Visual) — n/a, no UI surface.

part of #4689

🤖 Generated with [Claude Code](https://claude.com/claude-code)
