### PR TITLE
feat(#4691): gutter shows the completion boundary via per-call figures

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -577,7 +577,20 @@ class ReynTurnUsageGutter:
 
     ``usage_lookup=None`` (no read model / pre-session / plain fallback) makes
     every row's lookup unknown, so a row that names a turn still renders ``—``
-    rather than silently nothing."""
+    rather than silently nothing.
+
+    **#4691: a per-call figure embedded in the row's own meta wins over the
+    lookup above.** A turn with multiple ``kind="agent"`` anchor rows (a
+    tool-turn's explanatory text, a spawn ack — see router_loop.py) used to
+    paint the SAME turn total on every one of them, which reads as the
+    figure repeating rather than a distinct call — exactly the duplicate
+    this class's own docstring above says it exists to avoid, just not
+    caught for the multi-anchor-row case. Each such row now carries its
+    OWN call's real ``prompt_tokens``/``completion_tokens`` in
+    ``entry.item.meta`` (known synchronously at the emit call site — no
+    read-model plumbing needed), and :meth:`label` prefers that over the
+    turn-total lookup when present. The terminal no-tool-calls reply row
+    is unchanged (still turn-anchored via the lookup)."""
 
     def __init__(
         self,
@@ -598,7 +611,29 @@ class ReynTurnUsageGutter:
         every gutter repaint and must never be able to kill a render."""
         if entry.item.kind != TURN_ANCHOR_KIND:
             return ""
-        chain_id = (entry.item.meta or {}).get("chain_id")
+        meta = entry.item.meta or {}
+        # #4691: a PER-CALL figure embedded directly in this row's own meta
+        # at emit time (router_loop.py's non-terminal tool-turn-text /
+        # spawn-ack rows, session.py's force-close wrap-up row) takes
+        # precedence over the turn-total lookup below. This is what fixes
+        # the "same total painted on every anchor row of a multi-call turn"
+        # bug #4691 names: a row that names its OWN call's real tokens is a
+        # genuine per-row figure, not a repeated one, and a call boundary
+        # reads directly off two adjacent rows differing — no new glyph,
+        # no Group/nesting needed (the owner's own accepted framing,
+        # #4691's scoping comment). Falls through to the turn-total lookup
+        # for any row that does NOT carry a per-call figure (the terminal
+        # no-tool-calls reply, still turn-anchored as before — unchanged).
+        call_prompt = meta.get("prompt_tokens")
+        call_completion = meta.get("completion_tokens")
+        if isinstance(call_prompt, (int, float)) and isinstance(
+            call_completion, (int, float)
+        ):
+            return (
+                f"{PROMPT_TOKENS_MARKER}{_format_tokens(int(call_prompt))} "
+                f"{COMPLETION_TOKENS_MARKER}{_format_tokens(int(call_completion))}"
+            )
+        chain_id = meta.get("chain_id")
         if not isinstance(chain_id, str) or not chain_id:
             return ""
         usage: "dict | None" = None

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2045,6 +2045,12 @@ class RouterLoop:
                             "chain_id": self.chain_id,
                             "source": "router_tool_turn_text",
                             "reasoning": result.reasoning,
+                            # #4691: this row IS the call that just returned
+                            # ``result`` — its own real per-call tokens, not
+                            # the turn total (see gutter.py's ReynTurnUsageGutter
+                            # docstring for why this is the boundary fix).
+                            "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
+                            "completion_tokens": getattr(result.usage, "completion_tokens", None),
                         },
                     )
                 # F5 fix (dogfood batch 1): dedupe duplicate async
@@ -2145,6 +2151,9 @@ class RouterLoop:
                         meta={
                             "chain_id": self.chain_id,
                             "source": "agent_spawn_ack",
+                            # #4691: same call as the tool-turn text row above.
+                            "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
+                            "completion_tokens": getattr(result.usage, "completion_tokens", None),
                         },
                     )
                     return self._total_usage
@@ -2279,6 +2288,9 @@ class RouterLoop:
                     meta={
                         "chain_id": self.chain_id,
                         "source": "router_empty_response",
+                        # #4691: a genuine (if content-empty) call's own usage.
+                        "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
+                        "completion_tokens": getattr(result.usage, "completion_tokens", None),
                     },
                 )
                 return self._total_usage  # no retry

--- a/tests/interfaces/test_4691_gutter_per_call_boundary.py
+++ b/tests/interfaces/test_4691_gutter_per_call_boundary.py
@@ -1,0 +1,129 @@
+"""Tier 1: #4691 — a per-call figure embedded in the row's own meta wins
+over the turn-total lookup on ``ReynTurnUsageGutter``.
+
+Root problem (architect's measurement, issue #4691): a turn with more than
+one ``kind="agent"`` anchor row (a tool-turn's own explanatory text +
+its terminal reply, an async spawn ack, an empty-response failure) used to
+paint the SAME turn-total figure on every one of them — the exact
+"one number N times" duplication ``ReynTurnUsageGutter``'s own docstring
+says it exists to avoid, just not caught for the multi-anchor-row case.
+
+Owner-approved fix (issue #4691, tui-coder's own approved 1-line
+declaration): the completion boundary IS the existing row boundary — no
+new glyph, no Group/nesting. Each such row now carries its OWN call's
+real ``prompt_tokens``/``completion_tokens`` in ``entry.item.meta``
+(known synchronously at the ``put_outbox`` call site — see
+``router_loop.py``'s ``kind="agent"`` emit sites), and the gutter prefers
+that over the ``chain_id``-keyed turn-total lookup when present. A row
+with two adjacent, genuinely different call figures self-evidently marks
+two distinct completions.
+
+Real ``FlowModel``/``Entry``/``OutboxMessage`` — no mocks, mirrors
+``test_textual_chat_phase4_turn_cost_gutter_3283.py``'s own collaborator
+choice for this exact class.
+"""
+from __future__ import annotations
+
+from textual_flowview import FlowModel
+
+from reyn.interfaces.inline.textual_chat.gutter import (
+    RIGHT_GUTTER_WIDTH,
+    TURN_ANCHOR_KIND,
+    TURN_USAGE_UNKNOWN,
+    ReynTurnUsageGutter,
+)
+from reyn.runtime.outbox import OutboxMessage
+
+
+def _entry(item: OutboxMessage):
+    model: "FlowModel[OutboxMessage]" = FlowModel()
+    return model.append(item)
+
+
+def _label(gutter: ReynTurnUsageGutter, item: OutboxMessage) -> str:
+    return gutter.decorate(_entry(item), RIGHT_GUTTER_WIDTH, 1).plain.strip()
+
+
+def test_a_per_call_figure_in_meta_is_rendered_directly() -> None:
+    """Tier 1: prompt_tokens/completion_tokens embedded in meta render
+    without needing a usage_lookup at all — proving the new branch reads
+    the row's own data, not a keyed side-channel."""
+    gutter = ReynTurnUsageGutter(usage_lookup=None)
+    row = OutboxMessage(
+        kind=TURN_ANCHOR_KIND, text="reply",
+        meta={"chain_id": "turn-A", "prompt_tokens": 45890, "completion_tokens": 82},
+    )
+    assert _label(gutter, row) == "↑46k ↓82"
+
+
+def test_two_anchor_rows_of_one_turn_no_longer_show_the_same_duplicated_total() -> None:
+    """Tier 1: THE core #4691 regression — two ``kind="agent"`` rows sharing
+    ONE chain_id (a tool-turn's own text row, then its terminal reply) get
+    DIFFERENT figures when each carries its own call's real tokens, instead
+    of both reading the same turn-total via the shared chain_id lookup."""
+    def _lookup(chain_id: str) -> "dict | None":
+        # A turn-total lookup that WOULD paint the same number on both rows
+        # if either row fell through to it — the exact pre-#4691 bug shape.
+        return {"chain_id": chain_id, "tokens": 999, "prompt_tokens": 900, "completion_tokens": 99}
+
+    gutter = ReynTurnUsageGutter(usage_lookup=_lookup)
+    tool_turn_text_row = OutboxMessage(
+        kind=TURN_ANCHOR_KIND, text="let me check that",
+        meta={"chain_id": "turn-A", "prompt_tokens": 12000, "completion_tokens": 31},
+    )
+    terminal_reply_row = OutboxMessage(
+        kind=TURN_ANCHOR_KIND, text="done",
+        meta={"chain_id": "turn-A", "prompt_tokens": 45973, "completion_tokens": 46},
+    )
+    first = _label(gutter, tool_turn_text_row)
+    second = _label(gutter, terminal_reply_row)
+    assert first == "↑12k ↓31"
+    assert second == "↑46k ↓46"
+    assert first != second, (
+        "two distinct calls in the same turn must render distinct figures — "
+        "identical figures here would reproduce the exact duplication bug "
+        "#4691 exists to close"
+    )
+    # Neither row fell through to the shared-total lookup.
+    assert "999" not in first and "999" not in second
+
+
+def test_a_row_with_no_per_call_figure_still_falls_back_to_the_turn_total_lookup() -> None:
+    """Tier 1: the terminal no-tool-calls reply — the ONLY anchor row in an
+    ordinary single-call turn — is UNCHANGED: with no per-call meta fields,
+    it still uses the existing chain_id-keyed turn-total lookup exactly as
+    before #4691 (this file's own scoping decision: only rows that carry
+    the new fields opt into per-call rendering; nothing that doesn't carry
+    them regresses)."""
+    def _lookup(chain_id: str) -> "dict | None":
+        assert chain_id == "turn-B"
+        return {"chain_id": chain_id, "tokens": 130, "prompt_tokens": 100, "completion_tokens": 30}
+
+    gutter = ReynTurnUsageGutter(usage_lookup=_lookup)
+    row = OutboxMessage(kind=TURN_ANCHOR_KIND, text="done", meta={"chain_id": "turn-B"})
+    assert _label(gutter, row) == "↑100 ↓30"
+
+
+def test_a_non_numeric_or_partial_per_call_pair_falls_back_not_crashes() -> None:
+    """Tier 1: meta carrying only ONE of the two fields (a malformed/partial
+    emit) is not treated as a valid per-call pair — falls through to the
+    turn-total lookup rather than rendering a bogus half-figure or raising."""
+    gutter = ReynTurnUsageGutter(usage_lookup=lambda cid: None)
+    row = OutboxMessage(
+        kind=TURN_ANCHOR_KIND, text="reply",
+        meta={"chain_id": "turn-C", "prompt_tokens": 100},  # completion_tokens missing
+    )
+    assert _label(gutter, row) == TURN_USAGE_UNKNOWN
+
+
+def test_a_real_per_call_zero_still_renders_as_a_measured_zero() -> None:
+    """Tier 1: a call that genuinely reported 0 prompt/completion tokens
+    renders ``↑0 ↓0`` (a fact), not treated as "no figure" — mirrors the
+    turn-total lookup path's own real-zero-vs-unknown distinction, now
+    extended to the per-call path."""
+    gutter = ReynTurnUsageGutter(usage_lookup=None)
+    row = OutboxMessage(
+        kind=TURN_ANCHOR_KIND, text="reply",
+        meta={"chain_id": "turn-D", "prompt_tokens": 0, "completion_tokens": 0},
+    )
+    assert _label(gutter, row) == "↑0 ↓0"


### PR DESCRIPTION
**[tui-coder]** — part of #4691 (Phase A only — Phase B/flowview Group deferred, lead-coder's ruling)

## What

Owner ruling: "1ターン1行にする必要はない。completion境界が分かる表示が望ましい". The gutter's per-anchor-row token figure currently paints the SAME turn-total on every `kind="agent"` row of a multi-call turn (architect's measurement: non-terminal tool-turn-text/spawn-ack/empty-response emits in `router_loop.py` all share the turn's `chain_id`, so they all hit the same lookup) — the exact "one number N times" duplication `ReynTurnUsageGutter`'s own docstring already names as the thing it exists to avoid, just not caught for this case.

**Boundary declaration (approved by lead-coder before implementation, per their explicit condition):** the boundary IS the existing row boundary — no new glyph, no Group/nesting. Each `kind="agent"` row already corresponds to exactly one completion call; giving each row its own real `prompt_tokens`/`completion_tokens` (instead of the repeated turn total) is what makes two adjacent rows read as two distinct events.

## Implementation

- `gutter.py`: `ReynTurnUsageGutter.label()` now prefers `prompt_tokens`/`completion_tokens` embedded directly in the row's own `meta` over the `chain_id`-keyed turn-total lookup, when both are present and numeric. A row without them (the ordinary single-call-turn terminal reply) is **unchanged** — still the existing lookup, exactly as before.
- `router_loop.py`: 3 non-terminal `kind="agent"` emit sites (tool-turn text, spawn ack, empty-response failure) now embed that call's own `result.usage.prompt_tokens`/`completion_tokens` — all three already had the real per-call usage object in scope; no new read-model plumbing needed.

## Deliberately NOT touched (scope discipline)

- The terminal no-tool-calls reply row and the `response_format` structured-answer row keep the existing turn-total lookup path — changing those too would be a broader behavior change than what's needed to fix the demonstrated duplication bug, and risks disagreeing with well-tested existing semantics without a specific go-ahead for that expansion.
- §6 (decoupling highlight-move from tool-detail expand/collapse in `app.py`, + a new `z`/`tab` keybinding) — reported separately to lead-coder as deferred. This file's `BINDINGS` list shows a real collision-verification discipline (measured against every binding source, confirmed with an actual pilot press) for every key added; it deserves its own focused pass rather than being folded into this change.
- `_run_structured_answer_turn` doesn't currently return its own `result.usage` to its caller — a small, isolated, disclosed gap (its row keeps today's pre-existing behavior, not made worse).

## Falsification

Reverted `gutter.py` alone → 3 of 5 new tests fail, including the core duplicate-total regression test, which shows the pre-fix shape directly (both rows fall through to the shared lookup and render the identical figure).

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4691_gutter_per_call_boundary.py` — 5/5 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] Scoped pytest: `tests/interfaces/test_4691_gutter_per_call_boundary.py` (5 new) + `tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py` + `tests/llm/test_router_loop_empty_stop_retry.py` `test_3633_history_double_append.py` `test_router_empty_response.py` `test_router_loop_tool_turn_text_1642.py` + `tests/runtime/test_3636_config_reloaded_history_duplicate.py` `test_router_loop.py` — 82 passed, no regressions
- [ ] (waived, Visual axis only — standing 2026-08-08 owner waiver) not visually confirmed in this session; operator confirms on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
