### PR TITLE
feat(#4691): Phase A.5 — signed context-growth on every kind="agent" row

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -434,6 +434,20 @@ def _format_tokens(tokens: int) -> str:
     return f"{round(n / 1_000_000)}M"
 
 
+def _format_signed_tokens(delta: int) -> str:
+    """A compact SIGNED delta — ``"+83"`` / ``"-120k"`` — the sign NEVER
+    dropped even when the magnitude must lose precision to fit
+    (owner ruling, via lead-coder: a bare unsigned number reads as a total,
+    the exact ambiguity this format replaces).
+
+    Bounded to 5 characters (:func:`_format_tokens`'s own 4-char magnitude
+    bound + 1 for the sign — whole-``k``/``M`` rounding, no ``.1f`` band,
+    same as that function). ``RIGHT_GUTTER_WIDTH`` was widened by 1 to fit
+    this — see its own comment."""
+    sign = "+" if delta >= 0 else "-"
+    return f"{sign}{_format_tokens(abs(delta))}"
+
+
 #: FlowView RIGHT-gutter column width (Phase ④, #3283) — wired into ``app.py``'s
 #: ``FlowView(right_gutter_width=…)`` config. COMPUTED in terminal CELLS
 #: (:func:`rich.cells.cell_len`, the renderer's own measure) from the widest
@@ -441,23 +455,26 @@ def _format_tokens(tokens: int) -> str:
 #:
 #: - elapsed (:func:`_format_elapsed`) — 3 (``"99s"``);
 #: - per-turn tokens (:class:`ReynTurnUsageGutter`) — the two-figure split
-#:   ``↑<prompt> ↓<completion>``: marker (1) + :func:`_format_tokens` (4) +
-#:   space (1) + marker (1) + :func:`_format_tokens` (4) = **11**
-#:   (e.g. ``"↑120k ↓120k"``). Both markers measure 1 cell — see
+#:   ``↑<growth> ↓<completion>``: marker (1) + :func:`_format_signed_tokens`
+#:   (5 — #4691 Phase A.5, ``sign`` + :func:`_format_tokens`'s own 4-char
+#:   magnitude bound) + space (1) + marker (1) + :func:`_format_tokens` (4)
+#:   = **12** (e.g. ``"↑-120k ↓120k"``). Both markers measure 1 cell — see
 #:   :data:`PROMPT_TOKENS_MARKER` for the ambiguous-width measurement.
 #:
 #: The two families are mutually exclusive on any one row by construction
 #: (elapsed lives on ``tool_call_started`` rows, the token figure on
-#: :data:`TURN_ANCHOR_KIND` rows), so the widest cell is ``max(3, 11) = 11``,
-#: not their sum — 11 + one column of breathing room = 12. If that exclusivity
-#: ever stopped holding, the combined label would simply be clipped by
-#: flowview's own fixed-width gutter — never allowed to steal body columns.
+#: :data:`TURN_ANCHOR_KIND` rows), so the widest cell is ``max(3, 12) = 12``,
+#: not their sum — 12 + one column of breathing room = 13 (#4691 Phase A.5
+#: raised this from 12 — the signed ↑ half costs one more character than the
+#: absolute figure it replaced). If that exclusivity ever stopped holding,
+#: the combined label would simply be clipped by flowview's own fixed-width
+#: gutter — never allowed to steal body columns.
 #:
 #: ★ Bound re-justified against #3337's body-width floor gate at THIS width
 #: (``test_right_gutter_leaves_the_body_at_least_half_the_terminal_width``):
-#: on an 80-column terminal the body keeps ``80 - 2 (left gutter) - 12 = 66``
+#: on an 80-column terminal the body keeps ``80 - 2 (left gutter) - 13 = 65``
 #: columns against a 40-column floor.
-RIGHT_GUTTER_WIDTH = 12
+RIGHT_GUTTER_WIDTH = 13
 
 
 class ReynTimingGutter:
@@ -586,11 +603,39 @@ class ReynTurnUsageGutter:
     figure repeating rather than a distinct call — exactly the duplicate
     this class's own docstring above says it exists to avoid, just not
     caught for the multi-anchor-row case. Each such row now carries its
-    OWN call's real ``prompt_tokens``/``completion_tokens`` in
-    ``entry.item.meta`` (known synchronously at the emit call site — no
-    read-model plumbing needed), and :meth:`label` prefers that over the
-    turn-total lookup when present. The terminal no-tool-calls reply row
-    is unchanged (still turn-anchored via the lookup)."""
+    OWN call's real ``completion_tokens`` (unchanged, absolute — no
+    ambiguity: a per-call completion count has no other figure it could be
+    confused with) plus a signed **context-growth** delta (see below) in
+    ``entry.item.meta``, and :meth:`label` prefers that over the turn-total
+    lookup when present.
+
+    **Phase A.5 (co-vet finding, architect + lead-coder; format decided by
+    the owner) — the ↑ half is a SIGNED DELTA, not an absolute figure, and
+    the terminal no-tool-calls reply row carries it too**, not just the
+    three non-terminal sites Phase A covered.
+
+    Two problems, one fix. (1) Leaving the terminal row on the turn-total
+    lookup kept the owner's ORIGINAL reported symptom alive for any turn
+    whose only ``kind="agent"`` row IS this terminal one (a turn of
+    content-less tool calls never fires the non-terminal emits, which are
+    gated on non-empty text). (2) Phase A's own first attempt put the
+    absolute per-call ``prompt_tokens`` on ↑ — which duplicated ctx tab's
+    own absolute figure in a SECOND place, reproducing the exact confusion
+    ("which number is which") the owner hit. Measured: the absolute figure
+    varies ~0.18% within one turn (near-zero information — the SAME
+    argument that rejected the pre-#4691 repeated turn total), while the
+    signed delta between consecutive calls (``BudgetTracker.
+    last_context_growth()``) varies meaningfully call to call (a real
+    session: 82/98/94/40/…/496) — a SIGN also makes it structurally
+    impossible to mistake for a total. ``None`` (no prior call this session
+    to diff against — a fresh session, or the row right after a restore)
+    renders as :data:`TURN_USAGE_UNKNOWN`, never a fabricated ``+0``. A
+    negative delta (a compaction shrank the context) renders WITH its
+    sign — see :func:`_format_signed_tokens`.
+
+    The turn-total lookup now only answers for a row that carries NO
+    per-call ``completion_tokens`` at all (a restored/legacy frame — every
+    LIVE emit site stamps one)."""
 
     def __init__(
         self,
@@ -612,25 +657,26 @@ class ReynTurnUsageGutter:
         if entry.item.kind != TURN_ANCHOR_KIND:
             return ""
         meta = entry.item.meta or {}
-        # #4691: a PER-CALL figure embedded directly in this row's own meta
-        # at emit time (router_loop.py's non-terminal tool-turn-text /
-        # spawn-ack rows, session.py's force-close wrap-up row) takes
-        # precedence over the turn-total lookup below. This is what fixes
-        # the "same total painted on every anchor row of a multi-call turn"
-        # bug #4691 names: a row that names its OWN call's real tokens is a
-        # genuine per-row figure, not a repeated one, and a call boundary
-        # reads directly off two adjacent rows differing — no new glyph,
-        # no Group/nesting needed (the owner's own accepted framing,
-        # #4691's scoping comment). Falls through to the turn-total lookup
-        # for any row that does NOT carry a per-call figure (the terminal
-        # no-tool-calls reply, still turn-anchored as before — unchanged).
-        call_prompt = meta.get("prompt_tokens")
+        # #4691 Phase A.5: a PER-CALL row (every LIVE kind="agent" emit site
+        # stamps completion_tokens — see router_loop.py) takes precedence
+        # over the turn-total lookup below. ↓ is this call's own real
+        # completion count (absolute, unambiguous). ↑ is the SIGNED context-
+        # growth delta (BudgetTracker.last_context_growth(), stamped at the
+        # same emit site as "context_growth") — None renders as
+        # TURN_USAGE_UNKNOWN for that half rather than a fabricated "+0"
+        # (see the class docstring for why this replaced an absolute
+        # per-call prompt figure, and #4691's scoping comment for why no
+        # new glyph/Group is needed to mark the call boundary either way).
         call_completion = meta.get("completion_tokens")
-        if isinstance(call_prompt, (int, float)) and isinstance(
-            call_completion, (int, float)
-        ):
+        if isinstance(call_completion, (int, float)):
+            growth = meta.get("context_growth")
+            growth_label = (
+                _format_signed_tokens(int(growth))
+                if isinstance(growth, (int, float))
+                else TURN_USAGE_UNKNOWN
+            )
             return (
-                f"{PROMPT_TOKENS_MARKER}{_format_tokens(int(call_prompt))} "
+                f"{PROMPT_TOKENS_MARKER}{growth_label} "
                 f"{COMPLETION_TOKENS_MARKER}{_format_tokens(int(call_completion))}"
             )
         chain_id = meta.get("chain_id")

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -1042,6 +1042,17 @@ class BudgetTracker:
         # "the last turn's cost" does not have to know a chain_id. None until
         # a call with a turn in scope is recorded.
         self._last_turn_chain_id: str | None = None
+        # #4691 Phase A.5: session-persistent baseline for the gutter's
+        # per-row "context growth" figure (the signed delta of prompt_tokens
+        # between the two most recent LLM calls) — deliberately tracked HERE,
+        # not on RouterLoop, because a fresh RouterLoop is constructed per
+        # TURN (router_loop_driver.py), so nothing turn-local could see the
+        # PREVIOUS turn's last call to diff against. In-memory only, same
+        # posture as the per-turn buckets above — a restart/restore starts
+        # both at None, which is exactly "no baseline yet" (never a
+        # fabricated 0 growth).
+        self._last_prompt_tokens: int | None = None
+        self._last_context_growth: int | None = None
         self._last_save_monotonic: float = 0.0  # 0 = never saved
         # R-D8: True once load_state was called. The loaded state already
         # includes every committed step's usage, so memo-hit forward-calc
@@ -1358,6 +1369,21 @@ class BudgetTracker:
         """
         # rate limit window
         self._call_window[model].append(time.monotonic())
+
+        # #4691 Phase A.5: this call's own contribution to context growth —
+        # the signed delta against the LAST call's prompt_tokens (None on
+        # the very first call this tracker has ever recorded — no baseline
+        # to diff against, never coerced to 0). Computed unconditionally
+        # (every real LLM call updates the baseline, whether or not it
+        # produces a visible outbox row), matching record_llm's own
+        # unconditional-call-site cadence — the ONE place every completion
+        # this session makes is guaranteed to pass through, unlike any
+        # router_loop.py emit site.
+        self._last_context_growth = (
+            None if self._last_prompt_tokens is None
+            else usage.prompt_tokens - self._last_prompt_tokens
+        )
+        self._last_prompt_tokens = usage.prompt_tokens
 
         warn_dims: list[str] = []
         priced_cost_usd, _ = estimate_cost(model, usage)
@@ -1833,6 +1859,20 @@ class BudgetTracker:
         if chain_id is None:
             return None
         return self._turn_usage_dict(chain_id)
+
+    def last_context_growth(self) -> int | None:
+        """#4691 Phase A.5: the signed delta of ``prompt_tokens`` between the
+        two most recent :meth:`record_llm` calls — ``None`` before this
+        tracker has recorded a second call (no baseline to diff against;
+        never coerced to a fabricated 0 — the same real-zero-vs-unknown
+        discipline the gutter's own per-turn lookup already applies).
+        Negative after a compaction shrinks the context.
+
+        Read ONCE, immediately after the call it describes, by the
+        ``kind="agent"`` emit call sites that stamp it onto that row's
+        ``meta`` — a later read would see whatever the NEXT call moved it
+        to, not this one's own figure."""
+        return self._last_context_growth
 
     def turn_usage(self, chain_id: str) -> dict | None:
         """#3283 ④: ``{"chain_id", "tokens", "prompt_tokens",

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2049,7 +2049,10 @@ class RouterLoop:
                             # ``result`` — its own real per-call tokens, not
                             # the turn total (see gutter.py's ReynTurnUsageGutter
                             # docstring for why this is the boundary fix).
-                            "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
+                            "context_growth": (
+                                self.budget.last_context_growth()
+                                if self.budget is not None else None
+                            ),
                             "completion_tokens": getattr(result.usage, "completion_tokens", None),
                         },
                     )
@@ -2152,7 +2155,10 @@ class RouterLoop:
                             "chain_id": self.chain_id,
                             "source": "agent_spawn_ack",
                             # #4691: same call as the tool-turn text row above.
-                            "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
+                            "context_growth": (
+                                self.budget.last_context_growth()
+                                if self.budget is not None else None
+                            ),
                             "completion_tokens": getattr(result.usage, "completion_tokens", None),
                         },
                     )
@@ -2289,7 +2295,10 @@ class RouterLoop:
                         "chain_id": self.chain_id,
                         "source": "router_empty_response",
                         # #4691: a genuine (if content-empty) call's own usage.
-                        "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
+                        "context_growth": (
+                            self.budget.last_context_growth()
+                            if self.budget is not None else None
+                        ),
                         "completion_tokens": getattr(result.usage, "completion_tokens", None),
                     },
                 )
@@ -2328,7 +2337,32 @@ class RouterLoop:
                 text=result.content or "",
                 # #1652: supply the turn's reasoning; the host applies the
                 # display/continuity gates + the discrete kind="reasoning" emit.
-                meta={"chain_id": self.chain_id, "reasoning": result.reasoning},
+                meta={
+                    "chain_id": self.chain_id,
+                    "reasoning": result.reasoning,
+                    # #4691 Phase A.5 (co-vet finding, architect + lead-coder,
+                    # format decided by the owner): Phase A left this row on
+                    # the turn-total lookup, which kept the owner's ORIGINAL
+                    # reported symptom alive for any turn whose only
+                    # kind="agent" row IS this terminal one (every
+                    # intermediate tool-turn-text emit above is gated on
+                    # non-empty content — a turn of content-less tool calls
+                    # never fires them). Embedding this call's own
+                    # context-growth delta here closes it. The owner's own
+                    # ruling picked the SIGNED DELTA over the absolute
+                    # prompt-window value Phase A first tried: an absolute
+                    # figure duplicates ctx tab's own number in a second
+                    # place (which is what confused the owner in the first
+                    # place), while the delta carries real per-row
+                    # information and a sign that can never be mistaken for
+                    # a total — see gutter.py's ReynTurnUsageGutter
+                    # docstring for the full reasoning.
+                    "context_growth": (
+                        self.budget.last_context_growth()
+                        if self.budget is not None else None
+                    ),
+                    "completion_tokens": getattr(result.usage, "completion_tokens", None),
+                },
             )
             return self._total_usage
 

--- a/tests/interfaces/test_4691_gutter_per_call_boundary.py
+++ b/tests/interfaces/test_4691_gutter_per_call_boundary.py
@@ -1,22 +1,33 @@
 """Tier 1: #4691 — a per-call figure embedded in the row's own meta wins
-over the turn-total lookup on ``ReynTurnUsageGutter``.
+over the turn-total lookup on ``ReynTurnUsageGutter``, and (Phase A.5) ↑ is
+a SIGNED context-growth delta, not an absolute prompt figure.
 
 Root problem (architect's measurement, issue #4691): a turn with more than
-one ``kind="agent"`` anchor row (a tool-turn's own explanatory text +
-its terminal reply, an async spawn ack, an empty-response failure) used to
-paint the SAME turn-total figure on every one of them — the exact
-"one number N times" duplication ``ReynTurnUsageGutter``'s own docstring
-says it exists to avoid, just not caught for the multi-anchor-row case.
+one ``kind="agent"`` anchor row (a tool-turn's own explanatory text, an
+async spawn ack, an empty-response failure, and — Phase A.5 — the terminal
+no-tool-calls reply too) used to paint the SAME turn-total figure on every
+one of them — the exact "one number N times" duplication
+``ReynTurnUsageGutter``'s own docstring says it exists to avoid, just not
+caught for the multi-anchor-row case.
 
-Owner-approved fix (issue #4691, tui-coder's own approved 1-line
-declaration): the completion boundary IS the existing row boundary — no
-new glyph, no Group/nesting. Each such row now carries its OWN call's
-real ``prompt_tokens``/``completion_tokens`` in ``entry.item.meta``
-(known synchronously at the ``put_outbox`` call site — see
-``router_loop.py``'s ``kind="agent"`` emit sites), and the gutter prefers
-that over the ``chain_id``-keyed turn-total lookup when present. A row
-with two adjacent, genuinely different call figures self-evidently marks
-two distinct completions.
+Owner-approved boundary declaration (tui-coder's own 1-line decision,
+approved by lead-coder before implementation): the completion boundary IS
+the existing row boundary — no new glyph, no Group/nesting.
+
+Phase A's first attempt put the per-call call's ABSOLUTE
+``prompt_tokens`` on ↑. co-vet (architect + lead-coder) found this left
+the owner's ORIGINAL reported symptom open (the terminal reply row —
+the only anchor row for a turn whose tool calls all had empty content —
+was never updated) AND introduced a NEW problem: an absolute per-call
+figure duplicates ctx tab's own number in a second place, reproducing the
+exact "which number is which" confusion that motivated this issue. Phase
+A.5 (owner ruling): ↑ is the SIGNED delta of prompt_tokens between the two
+most recent LLM calls this session (``BudgetTracker.
+last_context_growth()``) — real per-row information (varies meaningfully
+call to call), a sign that can never be mistaken for a total, ``None``
+(no prior call to diff against) rendering as unknown rather than a
+fabricated ``+0``, and every ``kind="agent"`` emit site (including the
+terminal reply) now stamps it.
 
 Real ``FlowModel``/``Entry``/``OutboxMessage`` — no mocks, mirrors
 ``test_textual_chat_phase4_turn_cost_gutter_3283.py``'s own collaborator
@@ -44,23 +55,36 @@ def _label(gutter: ReynTurnUsageGutter, item: OutboxMessage) -> str:
     return gutter.decorate(_entry(item), RIGHT_GUTTER_WIDTH, 1).plain.strip()
 
 
-def test_a_per_call_figure_in_meta_is_rendered_directly() -> None:
-    """Tier 1: prompt_tokens/completion_tokens embedded in meta render
-    without needing a usage_lookup at all — proving the new branch reads
-    the row's own data, not a keyed side-channel."""
+def test_a_per_call_row_renders_signed_growth_and_absolute_completion() -> None:
+    """Tier 1: context_growth (signed) + completion_tokens (absolute)
+    embedded in meta render without needing a usage_lookup at all — proving
+    the new branch reads the row's own data, not a keyed side-channel."""
     gutter = ReynTurnUsageGutter(usage_lookup=None)
     row = OutboxMessage(
         kind=TURN_ANCHOR_KIND, text="reply",
-        meta={"chain_id": "turn-A", "prompt_tokens": 45890, "completion_tokens": 82},
+        meta={"chain_id": "turn-A", "context_growth": 82, "completion_tokens": 82},
     )
-    assert _label(gutter, row) == "↑46k ↓82"
+    assert _label(gutter, row) == "↑+82 ↓82"
+
+
+def test_a_negative_growth_after_compaction_keeps_its_sign() -> None:
+    """Tier 1: owner ruling (via lead-coder) — a negative delta (a
+    compaction shrank the context) renders WITH its minus sign; the sign is
+    never dropped even though the magnitude may lose precision to fit."""
+    gutter = ReynTurnUsageGutter(usage_lookup=None)
+    row = OutboxMessage(
+        kind=TURN_ANCHOR_KIND, text="reply",
+        meta={"chain_id": "turn-A", "context_growth": -120_000, "completion_tokens": 46},
+    )
+    assert _label(gutter, row) == "↑-120k ↓46"
 
 
 def test_two_anchor_rows_of_one_turn_no_longer_show_the_same_duplicated_total() -> None:
     """Tier 1: THE core #4691 regression — two ``kind="agent"`` rows sharing
     ONE chain_id (a tool-turn's own text row, then its terminal reply) get
-    DIFFERENT figures when each carries its own call's real tokens, instead
-    of both reading the same turn-total via the shared chain_id lookup."""
+    DIFFERENT figures when each carries its own call's real growth/
+    completion, instead of both reading the same turn-total via the shared
+    chain_id lookup."""
     def _lookup(chain_id: str) -> "dict | None":
         # A turn-total lookup that WOULD paint the same number on both rows
         # if either row fell through to it — the exact pre-#4691 bug shape.
@@ -69,16 +93,16 @@ def test_two_anchor_rows_of_one_turn_no_longer_show_the_same_duplicated_total() 
     gutter = ReynTurnUsageGutter(usage_lookup=_lookup)
     tool_turn_text_row = OutboxMessage(
         kind=TURN_ANCHOR_KIND, text="let me check that",
-        meta={"chain_id": "turn-A", "prompt_tokens": 12000, "completion_tokens": 31},
+        meta={"chain_id": "turn-A", "context_growth": 82, "completion_tokens": 31},
     )
     terminal_reply_row = OutboxMessage(
         kind=TURN_ANCHOR_KIND, text="done",
-        meta={"chain_id": "turn-A", "prompt_tokens": 45973, "completion_tokens": 46},
+        meta={"chain_id": "turn-A", "context_growth": 496, "completion_tokens": 46},
     )
     first = _label(gutter, tool_turn_text_row)
     second = _label(gutter, terminal_reply_row)
-    assert first == "↑12k ↓31"
-    assert second == "↑46k ↓46"
+    assert first == "↑+82 ↓31"
+    assert second == "↑+496 ↓46"
     assert first != second, (
         "two distinct calls in the same turn must render distinct figures — "
         "identical figures here would reproduce the exact duplication bug "
@@ -88,13 +112,12 @@ def test_two_anchor_rows_of_one_turn_no_longer_show_the_same_duplicated_total() 
     assert "999" not in first and "999" not in second
 
 
-def test_a_row_with_no_per_call_figure_still_falls_back_to_the_turn_total_lookup() -> None:
-    """Tier 1: the terminal no-tool-calls reply — the ONLY anchor row in an
-    ordinary single-call turn — is UNCHANGED: with no per-call meta fields,
-    it still uses the existing chain_id-keyed turn-total lookup exactly as
-    before #4691 (this file's own scoping decision: only rows that carry
-    the new fields opt into per-call rendering; nothing that doesn't carry
-    them regresses)."""
+def test_a_row_with_no_completion_figure_falls_back_to_the_turn_total_lookup() -> None:
+    """Tier 1: a row that carries NO per-call ``completion_tokens`` at all
+    (a restored/legacy frame — every LIVE ``kind="agent"`` emit site now
+    stamps one, Phase A.5) still uses the existing chain_id-keyed
+    turn-total lookup exactly as before #4691 — this is the ONLY case the
+    turn-total lookup answers for now."""
     def _lookup(chain_id: str) -> "dict | None":
         assert chain_id == "turn-B"
         return {"chain_id": chain_id, "tokens": 130, "prompt_tokens": 100, "completion_tokens": 30}
@@ -104,26 +127,67 @@ def test_a_row_with_no_per_call_figure_still_falls_back_to_the_turn_total_lookup
     assert _label(gutter, row) == "↑100 ↓30"
 
 
-def test_a_non_numeric_or_partial_per_call_pair_falls_back_not_crashes() -> None:
-    """Tier 1: meta carrying only ONE of the two fields (a malformed/partial
-    emit) is not treated as a valid per-call pair — falls through to the
-    turn-total lookup rather than rendering a bogus half-figure or raising."""
+def test_the_owners_originally_reported_symptom_is_closed() -> None:
+    """Tier 1: Phase A.5's own regression target (co-vet finding, architect +
+    lead-coder) — a turn whose ONLY ``kind="agent"`` row is the terminal
+    no-tool-calls reply (every intermediate tool call in it had EMPTY
+    content, so router_loop.py's non-terminal tool-turn-text emit never
+    fired — the exact shape of the owner's originally-reported turn) must
+    render THAT row's own per-call growth/completion, never falling through
+    to a stale turn-total lookup (the owner's original complaint: ctx tab
+    showed 45,973 while the row showed an unrelated, much larger 138k
+    turn total)."""
+    def _stale_turn_total(chain_id: str) -> "dict | None":
+        # If the row fell through to this, it would reproduce the owner's
+        # exact reported mismatch — present so a regression is caught, not
+        # masked by usage_lookup=None.
+        return {"chain_id": chain_id, "tokens": 138_000, "prompt_tokens": 137_954, "completion_tokens": 46}
+
+    gutter = ReynTurnUsageGutter(usage_lookup=_stale_turn_total)
+    only_row_in_the_turn = OutboxMessage(
+        kind=TURN_ANCHOR_KIND, text="done",
+        meta={"chain_id": "turn-owner-repro", "context_growth": 496, "completion_tokens": 46},
+    )
+    assert _label(gutter, only_row_in_the_turn) == "↑+496 ↓46"
+    assert "138" not in _label(gutter, only_row_in_the_turn)
+
+
+def test_no_baseline_renders_growth_as_unknown_never_a_fabricated_zero() -> None:
+    """Tier 1: owner ruling (via lead-coder) — the FIRST call this session
+    (or the row right after a restore) has no prior call to diff against.
+    ``context_growth`` is ``None`` in that case, and MUST render as unknown
+    (``—``), never a fabricated ``+0`` (a real 0 growth is a different,
+    measured fact this test does not claim happened). Mirrors the spirit
+    of the turn-total lookup's own real-zero-vs-unknown discipline."""
+    gutter = ReynTurnUsageGutter(usage_lookup=None)
+    row = OutboxMessage(
+        kind=TURN_ANCHOR_KIND, text="reply",
+        meta={"chain_id": "turn-first-ever", "context_growth": None, "completion_tokens": 31},
+    )
+    assert _label(gutter, row) == f"↑{TURN_USAGE_UNKNOWN} ↓31"
+
+
+def test_a_missing_completion_figure_falls_back_not_crashes() -> None:
+    """Tier 1: meta carrying context_growth but NOT completion_tokens (a
+    malformed/partial emit) is not treated as a valid per-call row — falls
+    through to the turn-total lookup rather than rendering a bogus
+    half-figure or raising."""
     gutter = ReynTurnUsageGutter(usage_lookup=lambda cid: None)
     row = OutboxMessage(
         kind=TURN_ANCHOR_KIND, text="reply",
-        meta={"chain_id": "turn-C", "prompt_tokens": 100},  # completion_tokens missing
+        meta={"chain_id": "turn-C", "context_growth": 100},  # completion_tokens missing
     )
     assert _label(gutter, row) == TURN_USAGE_UNKNOWN
 
 
-def test_a_real_per_call_zero_still_renders_as_a_measured_zero() -> None:
-    """Tier 1: a call that genuinely reported 0 prompt/completion tokens
-    renders ``↑0 ↓0`` (a fact), not treated as "no figure" — mirrors the
-    turn-total lookup path's own real-zero-vs-unknown distinction, now
-    extended to the per-call path."""
+def test_a_real_zero_completion_still_renders_as_a_measured_zero() -> None:
+    """Tier 1: a call that genuinely reported 0 completion tokens renders
+    ``↓0`` (a fact), not treated as "no figure" — mirrors the turn-total
+    lookup path's own real-zero-vs-unknown distinction, now extended to
+    the per-call path."""
     gutter = ReynTurnUsageGutter(usage_lookup=None)
     row = OutboxMessage(
         kind=TURN_ANCHOR_KIND, text="reply",
-        meta={"chain_id": "turn-D", "prompt_tokens": 0, "completion_tokens": 0},
+        meta={"chain_id": "turn-D", "context_growth": 0, "completion_tokens": 0},
     )
-    assert _label(gutter, row) == "↑0 ↓0"
+    assert _label(gutter, row) == "↑+0 ↓0"

--- a/tests/services/test_4691_context_growth.py
+++ b/tests/services/test_4691_context_growth.py
@@ -1,0 +1,85 @@
+"""Tier 2: #4691 Phase A.5 — ``BudgetTracker.last_context_growth()``.
+
+Owner ruling (via lead-coder, issue #4691): the gutter's per-row figure is
+the SIGNED delta of ``prompt_tokens`` between the two most recent LLM calls
+this session made — not a per-turn total (already displayed on the cost
+tab) and not an absolute per-call figure (duplicates ctx tab's own number).
+Tracked on ``BudgetTracker`` rather than ``RouterLoop`` because a fresh
+``RouterLoop`` is constructed per TURN (``router_loop_driver.py``), so
+nothing turn-local could see the PREVIOUS turn's last call to diff
+against — ``BudgetTracker`` is the one session-persistent object every
+call already passes through (``record_llm``).
+
+Real ``BudgetTracker``/``TokenUsage`` — no mocks.
+"""
+from __future__ import annotations
+
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+
+_MODEL = "gpt-4o"
+
+
+def _record(tracker: BudgetTracker, prompt: int) -> None:
+    tracker.record_llm(
+        model=_MODEL, agent="alpha",
+        usage=TokenUsage(prompt_tokens=prompt, completion_tokens=1),
+    )
+
+
+def test_the_first_call_this_session_has_no_baseline_to_diff_against() -> None:
+    """Tier 2: no prior call recorded yet — None, never a fabricated 0."""
+    tracker = BudgetTracker(CostConfig())
+    assert tracker.last_context_growth() is None
+    _record(tracker, prompt=1000)
+    assert tracker.last_context_growth() is None, (
+        "the FIRST call has nothing to diff against — still no baseline "
+        "after it, only from the SECOND call onward"
+    )
+
+
+def test_the_second_call_reports_the_signed_delta_from_the_first() -> None:
+    """Tier 2: the core contract — growth is prompt_tokens(this call) minus
+    prompt_tokens(the immediately preceding call), positive when the
+    context grew."""
+    tracker = BudgetTracker(CostConfig())
+    _record(tracker, prompt=45_808)
+    _record(tracker, prompt=45_890)
+    assert tracker.last_context_growth() == 82
+
+
+def test_consecutive_calls_each_report_their_own_delta_not_a_running_total() -> None:
+    """Tier 2: a real session's own shape (issue #4691's measured example) —
+    each call's growth is against the IMMEDIATELY PRECEDING call, not the
+    first call in the sequence (which would make later deltas balloon into
+    a running total, reproducing the very "near-zero information" problem
+    the signed-delta design replaced)."""
+    tracker = BudgetTracker(CostConfig())
+    prompts = [45_808, 45_890, 45_984, 46_024, 46_100]
+    deltas = []
+    for p in prompts:
+        _record(tracker, prompt=p)
+        deltas.append(tracker.last_context_growth())
+    assert deltas == [None, 82, 94, 40, 76]
+
+
+def test_a_compaction_shrinking_the_context_reports_a_negative_delta() -> None:
+    """Tier 2: owner ruling — a compaction between two calls (the next
+    call's prompt_tokens smaller than the last) reports a NEGATIVE growth,
+    with its sign — the gutter is responsible for keeping the sign
+    visible; this tracker just reports the honest signed number."""
+    tracker = BudgetTracker(CostConfig())
+    _record(tracker, prompt=138_000)
+    _record(tracker, prompt=18_000)  # a compaction just ran
+    assert tracker.last_context_growth() == -120_000
+
+
+def test_a_call_with_no_turn_in_scope_still_updates_the_growth_baseline() -> None:
+    """Tier 2: growth tracking is unconditional — record_llm's existing
+    per-turn attribution is guarded on chain_id being non-None (a call with
+    no turn in scope skips ITS bucket), but context growth is a SESSION-wide
+    concept independent of turn attribution, so it updates regardless."""
+    tracker = BudgetTracker(CostConfig())
+    tracker.record_llm(model=_MODEL, agent=None, usage=TokenUsage(prompt_tokens=1000), chain_id=None)
+    tracker.record_llm(model=_MODEL, agent=None, usage=TokenUsage(prompt_tokens=1100), chain_id=None)
+    assert tracker.last_context_growth() == 100


### PR DESCRIPTION
**[tui-coder]** — part of #4691 (Phase A.5, co-vet finding on merged #4696)

## What

co-vet (architect + lead-coder) on merged #4696 found the owner's ORIGINALLY reported symptom (ctx tab 45,973 vs history ↑138k) was still open, and Phase A's own fix introduced a second problem:

1. **The terminal reply row was never updated.** A turn whose intermediate tool calls all had empty content never fires the non-terminal tool-turn-text emit (gated on non-empty text) — that turn has exactly ONE `kind="agent"` row (the terminal one), which still painted the stale multi-call turn total. The owner's own repro was exactly this shape.
2. **Phase A's absolute per-call figure duplicated ctx tab's own number** in a second place — the same "which number is which" confusion that motivated this issue.

## Owner ruling (via lead-coder)

The row's ↑ half is a **signed delta** (context growth between the two most recent LLM calls this session made), not an absolute figure. Measured: the absolute figure varies ~0.18% within one turn (near-zero information — the same argument that rejected the pre-#4691 repeated turn total); the signed delta varies meaningfully call to call (a real session: 82/98/94/40/…/496), and a sign makes it structurally impossible to mistake for a total.

Two policy decisions (owner, via lead-coder):
- **No baseline yet** (first call this session, or the row right after a restore) → unknown (`—`), never a fabricated `+0`.
- **A compaction-driven negative delta renders WITH its sign** — digits get dropped before the sign does.

## Implementation

- `budget.py`: `BudgetTracker.last_context_growth()` — a session-persistent baseline, tracked here (not `RouterLoop`, which is reconstructed per turn and can't see the previous turn's last call). `record_llm()` updates it unconditionally.
- `gutter.py`: `ReynTurnUsageGutter.label()`'s per-call branch keys off `completion_tokens` (still absolute — no ambiguity there) and reads a signed `context_growth` for ↑ via the new `_format_signed_tokens` (sign never dropped, 5-char bound). `RIGHT_GUTTER_WIDTH` raised 12→13 to fit the extra sign character.
- `router_loop.py`: all 4 `kind="agent"` emit sites (the 3 Phase A sites + the terminal reply, newly added) now stamp `context_growth` instead of the call's own absolute `prompt_tokens`.

## Falsification

Reverted all 3 src files → 11 of 13 new/changed tests fail (`AttributeError: no last_context_growth`, confirming real production code is exercised).

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4691_gutter_per_call_boundary.py tests/services/test_4691_context_growth.py` — 13/13 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] Scoped pytest: 13 new/changed tests + `tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py` + `tests/llm/test_turn_cost_attribution_3339.py` + router_loop/empty-response/history-duplicate regressions (98) + full `tests/llm/ -k budget` sweep (88) — all green
- [ ] (waived, Visual axis only — standing 2026-08-08 owner waiver) not visually confirmed in this session; operator confirms on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
