### PR TITLE
feat(#4700): send prompt_cache_key at session-unit granularity

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -2053,6 +2053,7 @@ async def recorded_acompletion(
     routing: dict | None = None,  # #309: per-class api_base/provider; None → global proxy_kwargs()
     on_content_delta: "Callable[[str], None] | None" = None,  # #3288 ③b: opt-in per-chunk content-delta callback (see _stream_and_reconstruct)
     stream_override: "bool | None" = None,  # a model class's ``stream:`` — operator policy, NOT a litellm kwarg
+    prompt_cache_key: str | None = None,  # #4700: routing hint — see the call-kwargs block below for the full reasoning
 ) -> object:
     """Single cost-observability chokepoint for ALL ``litellm.acompletion`` calls (#1190).
 
@@ -2100,6 +2101,13 @@ async def recorded_acompletion(
     LLM call it is merely narrating. The reconstructed WHOLE response (below) is
     unaffected either way — this is purely an additional notification channel, not a
     change to what this function returns or records.
+
+    ``prompt_cache_key`` (#4700): OPTIONAL — sent to litellm only when set
+    (``None``, the default, is byte-identical to before #4700). See the
+    inline comment at the ``base_kwargs`` assembly below for the full
+    session-unit-granularity measurement and reasoning; whitelisted via
+    ``allowed_openai_params`` the same way ``reasoning_effort`` already is,
+    so it never raises regardless of proxy vs. direct-provider routing.
     """
     # #4206 T1: enforce BEFORE anything else — before ensure_litellm_ready(),
     # before litellm is even imported, so a rejected call touches litellm in
@@ -2216,6 +2224,46 @@ async def recorded_acompletion(
         _allowed = list(base_kwargs.get("allowed_openai_params") or [])
         if "reasoning_effort" not in _allowed:
             _allowed.append("reasoning_effort")
+        base_kwargs["allowed_openai_params"] = _allowed
+
+    # #4700: send OpenAI's ``prompt_cache_key`` — the public spec (developers.
+    # openai.com/api/docs/guides/prompt-caching) states requests are routed to
+    # a machine keyed FIRST on this value, prefix-hash only as a secondary
+    # signal; reyn sent nothing, so every call fell back to prefix-hash-only
+    # routing. Granularity = SESSION (not agent), decided against real
+    # measurement, not a default:
+    #   reyn-self, 2026-08-14, cached_tokens breakdown across 84 hits —
+    #     A (shared head, e.g. system prompt + tool schemas): 9,728 tokens,
+    #       hit 43 times across 10 DIFFERENT files (session-crossing reuse)
+    #     B (session-specific tail): 163,328-280,064 tokens, each hit only
+    #       WITHIN its own single file (session-local reuse)
+    #   B is worth ~20x more than A by volume in this sample — a session-unit
+    #   key protects B (the 20x side) at the cost of A's session-crossing
+    #   reuse (~4% of the total, 9,728 / ~240,000) — the ratio is THIS
+    #   day/agent's value; a short-conversation agent (small B, A dominates
+    #   proportionally) could invert it.
+    #   Selection reason: OpenAI's own spec text — "use more keys for
+    #   higher-volume workloads" — points AT finer-grained keys as volume
+    #   grows, and per-session is the natural finer unit above per-agent.
+    #   Unmeasured, carried as assumptions: (1) the provider's cache capacity
+    #   is ORGANIZATION-wide, not per-key (read from the spec's prose, not
+    #   measured); (2) parallel sessions were never run for real — this is
+    #   extrapolated from a single sequential session log; (3) what the
+    #   shared 9,728-token head actually IS (system prompt + tool schemas is
+    #   the working guess, matched against the session's own measured
+    #   minimum prompt size of 14,540 — not confirmed against a payload dump).
+    # Whitelisted via ``allowed_openai_params`` for the SAME reason as
+    # ``reasoning_effort`` above (proxy forces custom_llm_provider="openai";
+    # a direct, non-proxy provider route, #309, would otherwise raise
+    # UnsupportedParamsError — verified live against both shapes with the
+    # installed litellm: bare-model+custom_llm_provider="openai" already
+    # passes unwhitelisted, gemini/anthropic direct-provider raises without
+    # the whitelist and passes with it).
+    if prompt_cache_key:
+        base_kwargs["prompt_cache_key"] = prompt_cache_key
+        _allowed = list(base_kwargs.get("allowed_openai_params") or [])
+        if "prompt_cache_key" not in _allowed:
+            _allowed.append("prompt_cache_key")
         base_kwargs["allowed_openai_params"] = _allowed
 
     # #1678 → delegated to litellm at #3288-follow-up (issue #3288 comment
@@ -2627,6 +2675,7 @@ async def call_llm_tools(
     on_content_delta: "Callable[[str], None] | None" = None,  # #3288 ③b: forwarded to recorded_acompletion — see its docstring
     model_class: "str | None" = None,  # #4206 T1: forwarded to recorded_acompletion — see its docstring (None = not subject to ceiling enforcement)
     model_class_ceiling: "str | None" = None,  # #4206 T1: the caller's effective ceiling, if any (None = unbounded)
+    prompt_cache_key: str | None = None,  # #4700: forwarded to recorded_acompletion — see its docstring for the full reasoning
 ) -> LLMToolCallResult:
     """Tool-use variant of call_llm. Returns raw assistant message.
 
@@ -2661,6 +2710,12 @@ async def call_llm_tools(
     callers (tests, other op-loop shapes) that are not subject to the ceiling
     axis at all; ``RouterLoop`` — the one caller whose calls ARE class-based —
     passes its resolved ``router_model`` class explicitly at every call site.
+
+    ``prompt_cache_key`` (#4700): forwarded verbatim to ``recorded_acompletion``
+    — see its docstring / inline comment for the full session-unit-granularity
+    reasoning. ``None`` (every call site that does not pass one) is
+    byte-identical to before #4700 — nothing is sent, matching today's
+    behavior exactly.
     """
     # Normalize model to ModelSpec — accept both str (backward compat) and ModelSpec.
     spec: ModelSpec = model if isinstance(model, ModelSpec) else ModelSpec(model=model, kwargs={})
@@ -2820,6 +2875,7 @@ async def call_llm_tools(
             stream_override=spec.stream,  # operator policy from the model class
             model_class=model_class,  # #4206 T1: forwarded straight through
             model_class_ceiling=model_class_ceiling,  # #4206 T1: forwarded straight through
+            prompt_cache_key=prompt_cache_key,  # #4700: forwarded straight through
         )
 
     # #2210 HIGH layer: when the per-call HTTP timeout + the Router/Reyn retries are ALL

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1119,12 +1119,22 @@ class RouterLoop:
         other per-turn identity value in this file is read (never the
         construction-time ``session_id``, which is stale for a spawned
         session — see ``RouterHostAdapter.live_session_id``'s own docstring).
-        ``getattr``-guarded → a test host without ``live_session_id`` gets
-        ``None`` → nothing is sent, byte-identical to before #4700. See
-        ``recorded_acompletion``'s inline comment (``llm.py``) for the full
-        session-vs-agent granularity measurement and reasoning — not
-        repeated here."""
-        return getattr(self.host, "live_session_id", None)
+
+        ``or "main"`` (lead-coder review, #4704): ``live_session_id`` is
+        ``str | None`` and ``registry.py``'s own docstring states
+        ``sid=None`` means the IMPLICIT "main" session — an ordinary
+        interactive chat, not a spawned sub-session. Without this
+        normalization, a bare ``getattr(..., None)`` would send NO key for
+        exactly the case #4690 measured (reyn-self's own main session, 7.1%
+        hit rate) — the feature would be inert in the scenario it exists to
+        fix. Same normalization ``pipeline_verbs.py:516`` already uses for
+        the identical ``live_session_id`` ambiguity (``reply_sid``), not a
+        new constant. A ``getattr``-guarded test host with no
+        ``live_session_id`` attribute AT ALL still falls through the same
+        ``or`` to ``"main"`` — see ``recorded_acompletion``'s inline
+        comment (``llm.py``) for the full session-vs-agent granularity
+        measurement and reasoning, not repeated here."""
+        return getattr(self.host, "live_session_id", None) or "main"
 
     def _emit_agent_delta(self, text: str) -> None:
         """#3288 ③b: forward one streamed content-delta chunk as an audit-event

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1112,6 +1112,20 @@ class RouterLoop:
         start of each ``run()`` like ``total_usage``."""
         return self._last_call_usage
 
+    def _prompt_cache_key(self) -> "str | None":
+        """#4700: the ``prompt_cache_key`` sent with every LLM call this loop
+        makes — SESSION-unit granularity, read live each call (not cached at
+        loop construction) via ``host.live_session_id`` the same way every
+        other per-turn identity value in this file is read (never the
+        construction-time ``session_id``, which is stale for a spawned
+        session — see ``RouterHostAdapter.live_session_id``'s own docstring).
+        ``getattr``-guarded → a test host without ``live_session_id`` gets
+        ``None`` → nothing is sent, byte-identical to before #4700. See
+        ``recorded_acompletion``'s inline comment (``llm.py``) for the full
+        session-vs-agent granularity measurement and reasoning — not
+        repeated here."""
+        return getattr(self.host, "live_session_id", None)
+
     def _emit_agent_delta(self, text: str) -> None:
         """#3288 ③b: forward one streamed content-delta chunk as an audit-event
         — the owner-ratified L4 replacement (issue #3288 comment thread): a
@@ -1864,6 +1878,7 @@ class RouterLoop:
                         # — subject to the ceiling.
                         model_class=self.router_model,
                         model_class_ceiling=self._model_class_ceiling,
+                        prompt_cache_key=self._prompt_cache_key(),  # #4700
                     )
                 # Record the fresh result for future resume hit. Defensive:
                 # never let recording failure break the loop. NOT for a
@@ -2623,6 +2638,7 @@ class RouterLoop:
                     # main tool-turn call.
                     model_class=self.router_model,
                     model_class_ceiling=self._model_class_ceiling,
+                    prompt_cache_key=self._prompt_cache_key(),  # #4700
                 )
             except Exception as exc:
                 if attempt == 0:
@@ -2710,6 +2726,7 @@ class RouterLoop:
             # router-purpose class — same ceiling applies.
             model_class=self.router_model,
             model_class_ceiling=self._model_class_ceiling,
+            prompt_cache_key=self._prompt_cache_key(),  # #4700
         )
 
     async def _force_close_call_with_retry(

--- a/tests/llm/test_4700_prompt_cache_key.py
+++ b/tests/llm/test_4700_prompt_cache_key.py
@@ -180,17 +180,41 @@ async def test_router_loop_prompt_cache_key_reads_live_session_id():
 
 
 @pytest.mark.asyncio
-async def test_router_loop_prompt_cache_key_none_when_host_has_no_live_session_id():
-    """Tier 2: (accept-side) a test host without a live session id (the
-    common test-construction shape, ``FakeRouterHost`` — no
-    ``live_session_id`` attribute at all) passes prompt_cache_key=None —
-    getattr-guarded, never a raise. ``call_llm_tools`` itself always names
-    the kwarg (its own default is ``None``); it is the DEEPER
-    ``recorded_acompletion`` boundary (see the earlier litellm-stub tests
-    above) that omits it from the wire entirely when falsy — the layer this
-    test observes (an injected ``llm_caller``, standing in for
-    ``call_llm_tools`` itself) sees every one of that function's named
-    params, by construction."""
+async def test_router_loop_prompt_cache_key_is_main_for_the_implicit_main_session():
+    """Tier 2: #4700 — THE lead-coder-caught regression guard. ``registry.py``'s
+    own docstring: ``live_session_id`` is ``str | None``, and ``sid=None``
+    means the IMPLICIT "main" session — an ordinary interactive chat, not a
+    spawned sub-session. This is the exact scenario #4690 measured
+    (reyn-self's own main session, 7.1% cache-hit rate) — a bare
+    ``getattr(host, "live_session_id", None)`` with no ``or "main"``
+    normalization would send NO key for precisely the case #4700 exists to
+    fix. Same normalization ``pipeline_verbs.py:516`` already uses for the
+    identical ambiguity, not a new constant. RED without the fix:
+    prompt_cache_key is None (nothing sent) even for a real, live-session-id
+    -capable host whose main session has no explicit sid."""
+    from reyn.llm.model_resolver import ModelResolver
+    from reyn.runtime.router_loop import RouterLoop
+    from tests._support.router_host_adapter import make_adapter
+
+    host = make_adapter(
+        session_id=None,  # the documented "implicit main session" shape
+        universal_wrappers_enabled=False,
+        resolver=ModelResolver({"standard": "openai/gpt-4o"}),
+    )
+    assert host.live_session_id is None, "setup: main session must report None"
+    llm = _CapturingFinishLLM()
+    await RouterLoop(host=host, chain_id="c1", llm_caller=llm).run("hi", [])
+
+    assert llm.last_kwargs.get("prompt_cache_key") == "main"
+
+
+@pytest.mark.asyncio
+async def test_router_loop_prompt_cache_key_is_main_when_host_has_no_live_session_id():
+    """Tier 2: (accept-side) a test host without a ``live_session_id``
+    attribute at all (``FakeRouterHost``, the common test-construction
+    shape) falls through the SAME ``or "main"`` normalization —
+    ``getattr``-guarded, never a raise, consistent with the real-host
+    None-case above rather than a special test-only path."""
     from reyn.runtime.router_loop import RouterLoop
     from tests._support.router_loop import FakeRouterHost
 
@@ -198,4 +222,4 @@ async def test_router_loop_prompt_cache_key_none_when_host_has_no_live_session_i
     llm = _CapturingFinishLLM()
     await RouterLoop(host=host, chain_id="c1", llm_caller=llm).run("hi", [])
 
-    assert llm.last_kwargs.get("prompt_cache_key") is None
+    assert llm.last_kwargs.get("prompt_cache_key") == "main"

--- a/tests/llm/test_4700_prompt_cache_key.py
+++ b/tests/llm/test_4700_prompt_cache_key.py
@@ -1,0 +1,201 @@
+"""Tier 2: #4700 — reyn sends OpenAI's ``prompt_cache_key`` (session-unit
+granularity), where before it sent nothing and every call fell back to
+prefix-hash-only routing.
+
+Mirrors ``test_reasoning_effort_config_1650.py``'s own shape exactly (the
+established precedent for "a per-call litellm param that must be threaded
+AND whitelisted for proxy passthrough"): a real async capturing litellm
+stub records the kwargs ``call_llm_tools`` actually hands to
+``litellm.acompletion`` — no mocks, the litellm BOUNDARY itself is the
+thing under test, not reyn's own intent to send it.
+
+``RouterLoop._prompt_cache_key()`` (the session-unit read) is covered
+directly against a real ``RouterHostAdapter`` (``tests/_support/
+router_host_adapter.make_adapter``), not a fake — ``live_session_id`` is a
+real property on the real adapter class.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.model_resolver import ModelSpec
+from reyn.llm.pricing import TokenUsage
+
+
+class _CapturingFinishLLM:
+    """Real callable (testing policy, mirrors test_force_close_trigger_1092.py's
+    own class of the same name): records the kwargs of the LAST call and
+    returns a finish (no tool_calls) so RouterLoop.run terminates after one
+    round — a single, unambiguous capture."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.last_kwargs: dict = {}
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.call_count += 1
+        self.last_kwargs = kwargs
+        return LLMToolCallResult(
+            content="ok", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
+
+
+def _fake_litellm_response():
+    msg = type("_Msg", (), {"content": "ok", "tool_calls": None})()
+    choice = type("_Choice", (), {"message": msg, "finish_reason": "stop"})()
+    usage = type("_Usage", (), {"prompt_tokens": 10, "completion_tokens": 5})()
+    return type("_Resp", (), {"choices": [choice], "usage": usage})()
+
+
+class _CapturingLLM:
+    """Real async callable stub (testing policy) recording the kwargs it gets."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def __call__(self, **kwargs: Any):
+        self.calls.append(kwargs)
+        return _fake_litellm_response()
+
+
+# ── Tier 2: the value ARRIVES at the litellm boundary (not dropped) ─────────
+
+
+@pytest.mark.asyncio
+async def test_prompt_cache_key_arrives_at_litellm_call(monkeypatch):
+    """Tier 2: #4700 — a prompt_cache_key passed to call_llm_tools threads
+    through the REAL call chain and ARRIVES in the kwargs handed to
+    litellm.acompletion. RED without the fix: the key never reaches the
+    stub's captured kwargs."""
+    import litellm
+
+    from reyn.llm.llm import call_llm_tools
+
+    stub = _CapturingLLM()
+    monkeypatch.setattr(litellm, "acompletion", stub)
+
+    await call_llm_tools(
+        model=ModelSpec(model="gemini/gemini-2.5-flash-lite", kwargs={}),
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        max_retries=0,
+        prompt_cache_key="session-abc123",
+    )
+
+    assert stub.calls, "litellm.acompletion was never reached"
+    assert stub.calls[0].get("prompt_cache_key") == "session-abc123", (
+        f"prompt_cache_key was dropped before the litellm call; "
+        f"got kwargs keys: {sorted(stub.calls[0])}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prompt_cache_key_whitelisted_for_proxy_passthrough(monkeypatch):
+    """Tier 2: #4700 — on the openai-compat PROXY path (reyn's default
+    routing), prompt_cache_key must be whitelisted via allowed_openai_params
+    or a DIRECT-provider route (#309, e.g. an operator's `provider: gemini`
+    model class bypassing the proxy) would have litellm reject it as an
+    unsupported param before ever reaching the wire (UnsupportedParamsError
+    — confirmed live against the installed litellm: `get_optional_params
+    (model=..., custom_llm_provider="gemini", prompt_cache_key=...)` raises
+    without this whitelist, passes with it; caught by that live check, not
+    by this monkeypatch, which bypasses litellm's own validation — same
+    caveat `test_reasoning_effort_whitelisted_for_proxy_passthrough` states
+    for its own sibling param)."""
+    import litellm
+
+    from reyn.llm.llm import call_llm_tools
+
+    stub = _CapturingLLM()
+    monkeypatch.setattr(litellm, "acompletion", stub)
+
+    await call_llm_tools(
+        model=ModelSpec(model="gemini/gemini-2.5-flash-lite", kwargs={}),
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        max_retries=0,
+        prompt_cache_key="session-abc123",
+    )
+
+    assert stub.calls, "litellm.acompletion was never reached"
+    kw = stub.calls[0]
+    assert "prompt_cache_key" in (kw.get("allowed_openai_params") or []), (
+        f"prompt_cache_key not whitelisted for proxy/direct-provider "
+        f"forwarding; allowed_openai_params={kw.get('allowed_openai_params')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_prompt_cache_key_is_unaffected(monkeypatch):
+    """Tier 2: (accept-side) #4700 — no prompt_cache_key passed (the default,
+    every pre-#4700 call site) means NOTHING is sent — byte-identical to
+    before this feature, not an empty-string / None literal riding the
+    wire."""
+    import litellm
+
+    from reyn.llm.llm import call_llm_tools
+
+    stub = _CapturingLLM()
+    monkeypatch.setattr(litellm, "acompletion", stub)
+
+    await call_llm_tools(
+        model=ModelSpec(model="gemini/gemini-2.5-flash-lite", kwargs={}),
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        max_retries=0,
+    )
+
+    assert stub.calls, "litellm.acompletion was never reached"
+    assert "prompt_cache_key" not in stub.calls[0]
+
+
+# ── Tier 2: RouterLoop reads SESSION-unit granularity ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_router_loop_prompt_cache_key_reads_live_session_id():
+    """Tier 2: #4700 — RouterLoop._prompt_cache_key() reads the real
+    RouterHostAdapter's live_session_id property (session-unit granularity,
+    the ratified design — see llm.py's recorded_acompletion inline comment
+    for the A/B measurement this decision is based on). Driven through the
+    PUBLIC ``RouterLoop.run`` surface (a real turn's captured LLM-call
+    kwargs), not the private helper directly (testing.md's private-state
+    ban)."""
+    from reyn.llm.model_resolver import ModelResolver
+    from reyn.runtime.router_loop import RouterLoop
+    from tests._support.router_host_adapter import make_adapter
+
+    host = make_adapter(
+        session_id="session-xyz-789", universal_wrappers_enabled=False,
+        resolver=ModelResolver({"standard": "openai/gpt-4o"}),
+    )
+    llm = _CapturingFinishLLM()
+    await RouterLoop(host=host, chain_id="c1", llm_caller=llm).run("hi", [])
+
+    assert llm.last_kwargs.get("prompt_cache_key") == "session-xyz-789"
+
+
+@pytest.mark.asyncio
+async def test_router_loop_prompt_cache_key_none_when_host_has_no_live_session_id():
+    """Tier 2: (accept-side) a test host without a live session id (the
+    common test-construction shape, ``FakeRouterHost`` — no
+    ``live_session_id`` attribute at all) passes prompt_cache_key=None —
+    getattr-guarded, never a raise. ``call_llm_tools`` itself always names
+    the kwarg (its own default is ``None``); it is the DEEPER
+    ``recorded_acompletion`` boundary (see the earlier litellm-stub tests
+    above) that omits it from the wire entirely when falsy — the layer this
+    test observes (an injected ``llm_caller``, standing in for
+    ``call_llm_tools`` itself) sees every one of that function's named
+    params, by construction."""
+    from reyn.runtime.router_loop import RouterLoop
+    from tests._support.router_loop import FakeRouterHost
+
+    host = FakeRouterHost()  # no live_session_id attribute
+    llm = _CapturingFinishLLM()
+    await RouterLoop(host=host, chain_id="c1", llm_caller=llm).run("hi", [])
+
+    assert llm.last_kwargs.get("prompt_cache_key") is None


### PR DESCRIPTION
**[e2e-coder]** — #4700 実装: `prompt_cache_key` を **session 単位**で送信します（owner確定、architect実測に基づく設計）。

## 何をしたか

- `recorded_acompletion`（llm.py）に `prompt_cache_key: str | None = None` を追加。設定時のみ送信、`None`（既定）は #4700 前と byte-identical。`#1650` の `reasoning_effort` と同じ理由で `allowed_openai_params` に whitelist — proxy 経路は `custom_llm_provider="openai"` を強制するため、direct-provider 経路（#309）だと whitelist なしでは `UnsupportedParamsError` になります。
- `call_llm_tools` に同パラメータを追加、そのまま転送。
- `router_loop.py`: 新規 `RouterLoop._prompt_cache_key()` が `host.live_session_id` を読みます（getattr guard — 無い host は何も送らない、既存 test 全て不変）。act-turn / structured-answer turn / force-close wrap-up の 3 call site すべてに配線。

## コードコメント（必須条件①②）

理由は③（公開仕様「高ボリュームは key を分けよ」）のみを残しました。①②（15 req/min論・agent単位だと台を奪い合う論）は死んだ論拠のため**書いていません**。測定日 2026-08-14、A/B の数値、20倍比が「この日・このagentの値」であること、短い会話のagentでは逆転し得ること、仮定3点（provider容量/並列session未実走/9,728の中身未確認）を併記しています。

## 実装前の必須確認（実装前に確認した内容）

無条件送信だと direct-provider 経路（`provider:` 設定、api_base なし）で `UnsupportedParamsError` が起きることを、実際にインストール済み litellm の `get_optional_params` で確認しました（reasoning_effort と同じ whitelist で解消、両経路とも実際に raise しないことを確認済み）。

## 受入条件（このPRでは閉じません）

lead-coderの条件どおり、「送った」だけでは閉じません。① proxy 自身のリクエストログに現れるか（owner のみ可視の可能性）／② 見えなければ同一 prefix を TTL 内反復、key 有/無 各 n≥10。本 PR はメカニズムの実装＋strip-falsify＋回帰のみで、実トラフィックでの受入条件測定は含んでいません。

## 検証

- strip-falsify: llm.py/router_loop.py の変更を revert → 5 test中3件が正しい理由でRED、accept-side 2件はgreenのまま。復元してgreen。
- `tests/llm`（702 passed）、`tests/runtime -k "router_loop or force_close or turn_budget"`（74 passed）。
- ローカル5 gate + tests/系3 script、すべてgreen。

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict tests/llm/test_4700_prompt_cache_key.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py src/reyn/runtime/router_loop.py`
- [x] `python scripts/check_bare_tests_import_reference.py && python scripts/check_file_depth_reference.py && python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python -m pytest tests/llm -q`（702 passed）
- [x] `python -m pytest tests/runtime -q -k "router_loop or force_close or turn_budget"`（74 passed）
- [x] strip-falsify（上記）
- [ ] Visual — N/A（no UI）

part of #4700

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## レビュア追記（lead-coder, TESTS-READ 済）

- [x] 🔴 `_prompt_cache_key()` が main session で `None` を返し、**key が送られない**（`registry.py:4104` 逐語「`live_session_id` is `str | None`」「`sid=None` means the implicit "main" session」）。#4690 で 7.1% を測ったのは main session ∴ **直そうとした場面で機能が無効**。`pipeline_verbs.py:516` の既存正規化 `... or "main"` と同じ形に — `cf75c9d5d`、strip-falsify で正規化を外すと新規2 test がRED になることを確認済み
- [x] 🔴 `test_router_loop_prompt_cache_key_none_when_host_has_no_live_session_id` が上の欠陥を「意図した挙動」として固定している。正規化後に `"main"` を期待する形へ — `cf75c9d5d`、実 host(session_id=None) の regression guard + FakeRouterHost の2 testに置換

