### PR TITLE
feat(#4701): file.read threat-scans a skill's reference files

### DIFF
--- a/docs/concepts/tools-integrations/skills.md
+++ b/docs/concepts/tools-integrations/skills.md
@@ -531,10 +531,31 @@ step. The description scan above stays as an install-time fail-fast (reject
 before persisting to disk); it is additive UX, not what makes a loaded body
 safe — that guarantee comes from `load_skill`'s own scan alone.
 
+### References get the same treatment via a directory-containment tag (#4701)
+
 `references/*.md` files a skill body points at are read through the ordinary
-`file.read` op when the model opens them, which carries no skill-specific
-provenance and is therefore NOT covered by this scan — tracked separately
-(see #4701).
+`file.read` op when the model opens them, not through `load_skill` — so the
+scan above never sees them by default. Owner ruling (#4701): a skill's
+reference files are the SAME content class as its SKILL.md body — both are
+instructions the model reads and follows — so `file.read` applies the SAME
+strict+block scan (reusing the identical event kinds, `skill_body_threat_match`
+/`skill_body_threat_blocked`) whenever the resolved path is CONTAINED under a
+**registered** skill's own directory (the parent of its `SKILL.md`, checked
+against `ctx.available_skills` the same way `load_skill`'s own provenance
+check is — never a hand-curated path list). This is deliberately narrower than
+"scan every read": `file.read`'s other callers (ordinary project files) are
+completely unaffected — applying strict+block to every read would spread
+false-positives across all file reading, which the ruling explicitly rejected.
+
+A blocked reference never reaches the model (`status: "blocked"`, empty
+`content`, same as a blocked SKILL.md body); a CLEAN reference is additionally
+tagged `_external_source` on the op's own result — a **per-call** override of
+the (otherwise static) `returns_external_content` tool flag, so only THIS
+read gets fenced at the tool-result chokepoint, not every `read_file` call.
+An undeterminable containment check (e.g. a broken/malicious symlink in a
+registered skill's own path) errs toward treating the read as skill content
+rather than silently excluding it — the reverse would let a single symlink
+evade the check entirely.
 
 ## What's out of scope (for now)
 

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -27,7 +27,7 @@ from .path_locks import get_path_lock, locked_paths
 # #4701 (lead-coder review, condition③): reuse skill_install.py's own
 # containment check rather than a second, independently-drifting
 # reimplementation of the same resolve+relative_to logic.
-from .skill_install import _contained_under
+from .skill_install import _contained_under, _resolve_skill_md
 
 _WRITE_OPS = frozenset({"write", "edit", "delete", "regenerate_index", "mkdir", "move"})
 _READ_OPS = frozenset({"read", "glob", "grep", "stat"})
@@ -100,6 +100,21 @@ def _skill_reference_provenance(ctx: OpContext, resolved_path: str) -> bool:
     ③ containment itself reuses ``skill_install.py``'s own
        ``_contained_under`` (not a second, independently-drifting
        implementation of the same resolve+relative_to check).
+
+    #4701 follow-up review (lead-coder): ``SkillEntry.path`` is declared
+    "as-is" (``registry.py``'s own docstring) — it may name the SKILL.md
+    file directly OR its containing directory (``skills.md``: "Path to
+    SKILL.md (or its containing directory)"), and the registry does NOT
+    normalize between the two. Taking ``.parent`` unconditionally silently
+    assumed the file form; for a directory-form entry (``path: skills/foo``)
+    that widened ``skill_dir`` by one level (``skills/``), pulling every
+    OTHER sibling skill's files into strict+block scope — safe-DIRECTION
+    (② still errs toward scanning on failure) but excessively WIDE, not the
+    narrow per-skill containment this function promises. Reuses
+    ``skill_install.py``'s own ``_resolve_skill_md`` (the SAME
+    file-vs-directory normalization ``skill_install`` already applies to
+    this exact field) to anchor on the true SKILL.md path before taking
+    ``.parent`` — not a second, independently-drifting normalization.
     """
     entries = getattr(ctx, "available_skills", None)
     if not entries:
@@ -117,6 +132,9 @@ def _skill_reference_provenance(ctx: OpContext, resolved_path: str) -> bool:
         p = Path(entry_path).expanduser()
         if not p.is_absolute():
             p = base_dir / p
+        # Normalize file-vs-directory BEFORE resolving — same helper
+        # skill_install.py itself uses for this exact field.
+        p = _resolve_skill_md(str(p))
         try:
             skill_dir = p.resolve().parent
         except (OSError, RuntimeError):

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -12,11 +12,22 @@ from reyn.data.text_codec import decode_text_or_none, encode_text
 from reyn.plugins.body_read import read_plugin_body_bytes
 from reyn.schemas.models import FileIROp
 
+# Module-level import so tests can monkeypatch the threat-scan callables —
+# same reasoning skill_install.py/load_skill.py state for the identical
+# import (#4701: the SAME strict+block treatment #4699 gave SKILL.md's own
+# body, extended to a skill's reference files under its own directory).
+from reyn.security.content_guard import first_blocking_match, scan_for_threats
+
 from . import register
 from .context import OpContext
 from .context import resolve_path_for_gate as _resolve_for_gate
 from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
 from .path_locks import get_path_lock, locked_paths
+
+# #4701 (lead-coder review, condition③): reuse skill_install.py's own
+# containment check rather than a second, independently-drifting
+# reimplementation of the same resolve+relative_to logic.
+from .skill_install import _contained_under
 
 _WRITE_OPS = frozenset({"write", "edit", "delete", "regenerate_index", "mkdir", "move"})
 _READ_OPS = frozenset({"read", "glob", "grep", "stat"})
@@ -48,6 +59,80 @@ def _image_mime_for_path(path: str) -> str | None:
 # ~8-suggestion shape that invoke_action's UnknownActionError emits so the
 # LLM's "did you mean X" narration looks the same across both surfaces.
 _NOT_FOUND_SUGGESTIONS_LIMIT = 8
+
+
+def _skill_reference_provenance(ctx: OpContext, resolved_path: str) -> bool:
+    """#4701: True when *resolved_path* — an ALREADY ``resolve_path_for_gate``d
+    absolute path — is CONTAINED under a registered skill's own directory
+    (the parent of its ``SKILL.md``), i.e. is a ``references/*.md``-shaped
+    file (or any other file) the skill's own body might point a model at.
+
+    Owner ruling (#4701 comment thread, lead-coder): a skill's reference
+    files are the SAME content class as the SKILL.md body itself — both are
+    instructions the model reads and follows — so a reference gets the SAME
+    strict+block treatment ``load_skill.py`` already gives the body, not a
+    weaker one. This is a CONTAINMENT check (directory, not exact path),
+    deliberately broader than ``load_skill.py``'s own
+    ``_config_registered_skill_body_provenance`` (which matches ONLY the
+    SKILL.md file itself) — that sibling function is unaffected and stays
+    exact-match; this one exists for everything ELSE under the same skill's
+    directory tree.
+
+    Enumerated from ``ctx.available_skills`` — the SAME registered-skill
+    snapshot ``load_skill.py``'s own provenance check and ``:skill``
+    invocation resolve against, never a hand-curated path list (the #3194
+    "curated subset diverges from the registry" bug class). ``None``/empty
+    (test/phase-fallback construction) returns ``False`` — no skill is
+    registered at all, so there is no directory to be "under".
+
+    #4701 review (lead-coder), 4 conditions:
+    ① the tag's source is config-derived containment ONLY — never a
+       model-supplied claim about the path.
+    ② an UNDETERMINABLE resolution (an entry's own path fails to resolve —
+       e.g. a broken/malicious symlink somewhere in its chain) returns
+       ``True`` (treat as skill content), never ``False``. The reverse
+       (silently skip an entry whose resolution failed) would let a single
+       broken symlink evade the check entirely — the exact class of gap
+       ``resolve_path_for_gate``'s own #3196 discipline exists to close
+       elsewhere. Only a CONFIDENT non-containment (both sides resolved
+       fine, genuinely different subtrees — ``_contained_under``'s
+       ``ValueError`` branch) counts as a real "no".
+    ③ containment itself reuses ``skill_install.py``'s own
+       ``_contained_under`` (not a second, independently-drifting
+       implementation of the same resolve+relative_to check).
+    """
+    entries = getattr(ctx, "available_skills", None)
+    if not entries:
+        return False
+    ws = getattr(ctx, "workspace", None)
+    base_dir = ws.base_dir if ws is not None else Path.cwd()
+    try:
+        resolved = Path(resolved_path)
+    except (OSError, ValueError):
+        return True  # ②: cannot even parse the candidate — err toward scanning
+    for entry in entries:
+        entry_path = getattr(entry, "path", None)
+        if not entry_path:
+            continue
+        p = Path(entry_path).expanduser()
+        if not p.is_absolute():
+            p = base_dir / p
+        try:
+            skill_dir = p.resolve().parent
+        except (OSError, RuntimeError):
+            # ②: this entry's OWN path can't resolve — err toward scanning.
+            # RuntimeError, not just OSError: a genuine symlink LOOP (the
+            # exact evasion shape ② names) raises ``RuntimeError("Symlink
+            # loop from ...")`` from ``Path.resolve()``, not ``OSError`` —
+            # confirmed live on the installed Python (pathlib wraps the
+            # underlying ELOOP OSError and re-raises RuntimeError). Catching
+            # only OSError here would let that exact loop propagate
+            # uncaught (crashing the whole read) instead of degrading to
+            # the safe "treat as skill content" default.
+            return True
+        if _contained_under(resolved, skill_dir):  # ③: reused, not reimplemented
+            return True
+    return False
 
 
 def _binary_skipped_result(ctx: OpContext, path: str, byte_size: int) -> dict:
@@ -390,6 +475,67 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         content, _detected_encoding = decode_text_or_none(raw_bytes)
         if content is None:
             return _binary_skipped_result(ctx, op.path, len(raw_bytes))
+
+        # ── #4701: skill-reference threat-scan (strict+block, same content
+        # class as #4699's SKILL.md-body scan) ─────────────────────────────
+        # A skill's own reference file (e.g. `references/*.md`, but ANY path
+        # under the skill's directory) is read through THIS ordinary
+        # read_file op — the model chooses when to open it, per the
+        # SKILL.md body's own text. `load_skill.py`'s strict+block scan
+        # never sees it. Scoped to ONLY the skill's own directory tree
+        # (`_skill_reference_provenance`) — read_file's other callers are
+        # completely unaffected; making every read strict+block would
+        # spread false-positives across all file reading, which the #4701
+        # ruling explicitly rejected. Reuses the SAME event kinds
+        # `load_skill.py` emits (`skill_body_threat_match`/`_blocked`) —
+        # same payload shape, same meaning ("skill content matched a threat
+        # pattern"), regardless of which op the content came through.
+        #
+        # `_is_skill_reference` is also the source of the `_external_source`
+        # tag on every content-bearing return below (fence, #4701 condition
+        # ④/lead-coder review) — computed ONCE here, condition①: the tag's
+        # ONLY source is this config-derived containment check, never a
+        # model-supplied claim about the path.
+        _is_skill_reference = (
+            _resolved_read_path is not None
+            and _skill_reference_provenance(ctx, _resolved_read_path)
+        )
+        if _is_skill_reference:
+            _ts = getattr(ctx, "threat_scan", None)
+            if _ts is not None and getattr(_ts, "enabled", True):  # #4523: shadow default matches ThreatScanConfig.enabled's own declared True
+                _matches = scan_for_threats(content, _ts, scope="strict")
+                if _matches:
+                    for _m in _matches:
+                        ctx.events.emit(
+                            "skill_body_threat_match",
+                            pattern_id=_m.pattern_id,
+                            severity=_m.severity,
+                            scope=_m.scope,
+                        )
+                    _block = first_blocking_match(
+                        _matches, getattr(_ts, "block_severity", "block"),
+                    )
+                    if _block is not None:
+                        ctx.events.emit(
+                            "skill_body_threat_blocked",
+                            pattern_id=_block.pattern_id,
+                            severity=_block.severity,
+                            path=op.path,
+                        )
+                        return {
+                            "kind": "file",
+                            "op": "read",
+                            "path": op.path,
+                            "status": "blocked",
+                            "content": "",
+                            "error": (
+                                f"read blocked: this file is a skill reference "
+                                f"that matched threat pattern '{_block.pattern_id}' "
+                                f"({_block.scope}/{_block.severity}). The content "
+                                "was not loaded into context."
+                            ),
+                        }
+
         # `encoding` is surfaced ONLY when a non-UTF-8 codec was used (BOM or
         # charset-normalizer); the plain-UTF-8 fast path keeps the result shape
         # byte-identical (no `encoding` field) for the common case.
@@ -426,7 +572,7 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
             # multi-byte content against a byte-denominated cap.
             if len(joined.encode("utf-8")) <= cap:
                 ctx.events.emit("tool_executed", op="read_file", path=op.path)
-                return {
+                _window_result: dict = {
                     "kind": "file",
                     "op": "read",
                     "path": op.path,
@@ -434,6 +580,9 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
                     "content": joined,
                     **_enc_field,
                 }
+                if _is_skill_reference:  # #4701: fence at the tool-result chokepoint
+                    _window_result["_external_source"] = True
+                return _window_result
 
         # #1209 read-bounding (keep-in-decide-context, not offloaded-out-of-view) + #2335 char-level
         # truncation. Accumulate WHOLE lines from (start_line, start_char); a multi-line overflow
@@ -556,10 +705,12 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
             if next_char_offset is not None:
                 # #2335: mid-line resume position (set ONLY when a single line was char-truncated).
                 result["next_char_offset"] = next_char_offset
+            if _is_skill_reference:  # #4701: fence at the tool-result chokepoint
+                result["_external_source"] = True
             return result
 
         ctx.events.emit("tool_executed", op="read_file", path=op.path)
-        return {
+        _full_result: dict = {
             "kind": "file",
             "op": "read",
             "path": op.path,
@@ -567,6 +718,9 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
             "content": "".join(shown),
             **_enc_field,
         }
+        if _is_skill_reference:  # #4701: fence at the tool-result chokepoint
+            _full_result["_external_source"] = True
+        return _full_result
 
     if op.op == "glob":
         # #2782: offloaded — pure read (tree-walk), no atomicity concern, safe to

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -464,6 +464,17 @@ class ToolDefinition:
     # The content-threat guard fences (structurally marks as data) such results
     # at the tool-result chokepoint; trusted-internal results are scan-only.
     # P7: a generic OS-level bool the tool sets — not a hardcoded tool-name list.
+    #
+    # #4701: this default can be overridden PER-CALL — an op's own result dict
+    # may set ``result["_external_source"] = True`` directly (router_loop.py's
+    # ``_execute_all`` only ever sets the tag TRUE from this flag, never resets
+    # it False, so an op-level True always wins). ``read_file`` is the first
+    # user: most reads of ordinary project files are trusted-internal (this
+    # flag stays False), but a read that lands under a REGISTERED skill's own
+    # directory (a `references/*.md`-shaped file, #4701) is the SAME content
+    # class as a SKILL.md body — external, per-call, without making every
+    # read_file call external. Externality is a property of the CONTENT'S
+    # OWN provenance, not of which tool happened to fetch it.
     returns_external_content: bool = False
 
     # #2123: the tool declares it routes through the unified registry dispatch path

--- a/tests/core/test_4701_skill_reference_threat_scan.py
+++ b/tests/core/test_4701_skill_reference_threat_scan.py
@@ -189,6 +189,47 @@ def test_ordinary_file_outside_any_skill_directory_is_unaffected(tmp_path, monke
     assert not [e for e in collected if e.type in ("skill_body_threat_match", "skill_body_threat_blocked")]
 
 
+# ── lead-coder follow-up: a directory-form SkillEntry.path must not widen
+# containment to the parent of the SKILLS directory ─────────────────────────
+
+
+def test_a_directory_form_entry_path_does_not_scan_sibling_skills(tmp_path, monkeypatch):
+    """Tier 2: #4701 follow-up (lead-coder review) — `SkillEntry.path` may
+    name SKILL.md directly OR its containing directory (`registry.py`'s own
+    docstring: "as declared"; the registry does not normalize). Taking
+    `.parent` unconditionally, without first normalizing via
+    `_resolve_skill_md`, would treat a directory-form entry
+    (`path: "skills/my-skill"`) as if its OWN directory were `skills/` —
+    pulling every SIBLING skill's files into strict+block scope. RED
+    without the fix: a sibling skill's ordinary file gets scanned even
+    though it belongs to a DIFFERENT skill than the registered entry."""
+    project_root = tmp_path / "project"
+    my_skill_dir = project_root / "skills" / "my-skill"
+    _write(my_skill_dir / "SKILL.md", "---\nname: my-skill\n---\nbody\n")
+    sibling_file = project_root / "skills" / "sibling-skill" / "notes.md"
+    _write(sibling_file, "EVIL_REFERENCE_THREAT_MARKER\n")
+
+    # Directory-form path (no SKILL.md suffix) — the shape the registry
+    # accepts as-is per its own docstring.
+    entry = SkillEntry(name="my-skill", description="d", path=str(my_skill_dir))
+    threat_config = ThreatScanConfig()
+    ctx, events = _make_ctx(project_root, threat_scan=threat_config, available_skills=[entry])
+    collected = collect_events(events)
+
+    def _fail_if_called(*_a, **_k):
+        raise AssertionError("scan_for_threats must not run on a SIBLING skill's file")
+
+    monkeypatch.setattr("reyn.core.op_runtime.file.scan_for_threats", _fail_if_called)
+
+    result = _run(file_handle(
+        FileIROp(kind="file", op="read", path=str(sibling_file)), ctx,
+    ))
+
+    assert result["status"] == "ok", result
+    assert "EVIL_REFERENCE_THREAT_MARKER" in result["content"]
+    assert not [e for e in collected if e.type in ("skill_body_threat_match", "skill_body_threat_blocked")]
+
+
 def test_the_skill_own_directory_covers_nested_reference_subdirectories(tmp_path, monkeypatch):
     """Tier 2: (accept-side) containment is not limited to a literal
     `references/` name — ANY path under the skill's own directory tree

--- a/tests/core/test_4701_skill_reference_threat_scan.py
+++ b/tests/core/test_4701_skill_reference_threat_scan.py
@@ -1,0 +1,290 @@
+"""Tier 2: #4701 — `file.read` threat-scans a skill's REFERENCE files (any
+file under a registered skill's own directory) with the SAME strict+block
+treatment #4699 already gives the SKILL.md body itself.
+
+Owner ruling (#4701 comment thread): a skill's reference files are the SAME
+content class as its SKILL.md body — both are instructions the model reads
+and follows — so `load_skill.py`'s strict+block scan alone left a real gap:
+`references/*.md` is opened through the ordinary `file.read` op (the
+model's own choice, per the body's text), which carried none of that
+enforcement.
+
+No mocks: real Workspace / PermissionResolver / EventLog / SkillEntry /
+ThreatScanConfig / ThreatMatch throughout. Only `scan_for_threats` is
+monkeypatched at `file.py`'s own import site (same technique
+`test_4699_load_skill_threat_scan.py` uses for the sibling `load_skill`
+module) — `first_blocking_match` is the REAL function.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+from reyn.config.chat import ThreatScanConfig
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.file import handle as file_handle
+from reyn.data.skills.registry import SkillEntry
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import FileIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.security.threat_patterns import ThreatMatch
+from tests._support.events import collect_events
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_ctx(
+    project_root: Path, *, threat_scan=None, available_skills=None,
+) -> tuple[OpContext, EventLog]:
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=project_root)
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=project_root, interactive=False,
+    )
+    ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=resolver,
+        actor="test_skill_reference_threat_scan",
+        threat_scan=threat_scan,
+        available_skills=available_skills,
+    )
+    return ctx, events
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+# ── the central witness: a reference file under a REGISTERED skill's own
+# directory is blocked the same way the body is ──────────────────────────
+
+
+def test_reference_under_a_skill_directory_is_blocked(tmp_path, monkeypatch):
+    """Tier 2: #4701's own reason for existing — a file under a registered
+    skill's directory (e.g. `references/notes.md`), opened through the
+    ORDINARY file.read op, is threat-scanned at strict+block — the SAME
+    treatment the SKILL.md body gets from load_skill.py. RED without the
+    fix: status='ok' and the threatening reference content reaches
+    `content`."""
+    project_root = tmp_path / "project"
+    skill_md = project_root / "skills" / "my-skill" / "SKILL.md"
+    _write(skill_md, "---\nname: my-skill\n---\nSee references/notes.md.\n")
+    ref_path = project_root / "skills" / "my-skill" / "references" / "notes.md"
+    _write(ref_path, "EVIL_REFERENCE_THREAT_MARKER\n")
+
+    entry = SkillEntry(name="my-skill", description="d", path=str(skill_md))
+    threat_config = ThreatScanConfig()
+    ctx, events = _make_ctx(project_root, threat_scan=threat_config, available_skills=[entry])
+    collected = collect_events(events)
+
+    def _fake_scan(content, config, *, scope="context"):
+        if "EVIL_REFERENCE_THREAT_MARKER" in content:
+            return [ThreatMatch(pattern_id="test-threat", scope="strict", severity="block")]
+        return []
+
+    monkeypatch.setattr("reyn.core.op_runtime.file.scan_for_threats", _fake_scan)
+
+    result = _run(file_handle(
+        FileIROp(kind="file", op="read", path=str(ref_path)), ctx,
+    ))
+
+    assert result["status"] == "blocked", result
+    assert result["content"] == ""
+    assert "EVIL_REFERENCE_THREAT_MARKER" not in result["content"]
+    blocked = [e for e in collected if e.type == "skill_body_threat_blocked"]
+    assert blocked, "no skill_body_threat_blocked event was emitted"
+    assert blocked[-1].data["pattern_id"] == "test-threat"
+
+
+# ── fence: a CLEAN (non-blocked) skill reference is still tagged external ──
+
+
+def test_clean_skill_reference_read_is_tagged_external_source(tmp_path, monkeypatch):
+    """Tier 2: #4701 (lead-coder review, fence condition) — a skill reference
+    read that does NOT trip the threat scan is still tagged
+    `_external_source=True` on the op's own result dict — the per-call
+    dynamic override `router_loop.py`'s `_execute_all` reads (an op-level
+    True is never reset by the static `returns_external_content` check).
+    This is what makes `router_loop.py`'s fence wrap this content at the
+    tool-result chokepoint, mirroring the SAME treatment `load_skill`'s
+    static `returns_external_content=True` gives the SKILL.md body."""
+    project_root = tmp_path / "project"
+    skill_md = project_root / "skills" / "my-skill" / "SKILL.md"
+    _write(skill_md, "---\nname: my-skill\n---\nbody\n")
+    ref_path = project_root / "skills" / "my-skill" / "references" / "notes.md"
+    _write(ref_path, "A clean, harmless reference.\n")
+
+    entry = SkillEntry(name="my-skill", description="d", path=str(skill_md))
+    threat_config = ThreatScanConfig()
+    ctx, _events = _make_ctx(project_root, threat_scan=threat_config, available_skills=[entry])
+
+    def _fake_scan(content, config, *, scope="context"):
+        return []  # nothing matches — the clean-content path
+
+    monkeypatch.setattr("reyn.core.op_runtime.file.scan_for_threats", _fake_scan)
+
+    result = _run(file_handle(
+        FileIROp(kind="file", op="read", path=str(ref_path)), ctx,
+    ))
+
+    assert result["status"] == "ok", result
+    assert result.get("_external_source") is True
+
+
+def test_ordinary_file_read_is_not_tagged_external_source(tmp_path):
+    """Tier 2: (accept-side) an ordinary read — no registered skills at all
+    — is NEVER tagged `_external_source`, matching the pre-#4701 default
+    (`returns_external_content=False`) for every read_file call that isn't
+    a skill reference."""
+    project_root = tmp_path / "project"
+    plain = project_root / "src" / "app.py"
+    _write(plain, "print('hello')\n")
+
+    ctx, _events = _make_ctx(project_root)  # no threat_scan, no available_skills
+
+    result = _run(file_handle(
+        FileIROp(kind="file", op="read", path=str(plain)), ctx,
+    ))
+
+    assert result["status"] == "ok", result
+    assert "_external_source" not in result
+
+
+def test_ordinary_file_outside_any_skill_directory_is_unaffected(tmp_path, monkeypatch):
+    """Tier 2: (accept-side) a plain project file — NOT under any registered
+    skill's directory — is never scanned at all: read_file's other callers
+    are completely unaffected (the #4701 ruling's explicit boundary: making
+    every read strict+block would spread false-positives across all file
+    reading)."""
+    project_root = tmp_path / "project"
+    plain = project_root / "src" / "app.py"
+    _write(plain, "EVIL_REFERENCE_THREAT_MARKER\n")  # same marker, different location
+
+    threat_config = ThreatScanConfig()
+    unrelated_entry = SkillEntry(
+        name="unrelated", description="d",
+        path=str(project_root / "skills" / "unrelated" / "SKILL.md"),
+    )
+    ctx, events = _make_ctx(project_root, threat_scan=threat_config, available_skills=[unrelated_entry])
+    collected = collect_events(events)
+
+    def _fail_if_called(*_a, **_k):
+        raise AssertionError("scan_for_threats must not run outside a skill directory")
+
+    monkeypatch.setattr("reyn.core.op_runtime.file.scan_for_threats", _fail_if_called)
+
+    result = _run(file_handle(
+        FileIROp(kind="file", op="read", path=str(plain)), ctx,
+    ))
+
+    assert result["status"] == "ok", result
+    assert "EVIL_REFERENCE_THREAT_MARKER" in result["content"]
+    assert not [e for e in collected if e.type in ("skill_body_threat_match", "skill_body_threat_blocked")]
+
+
+def test_the_skill_own_directory_covers_nested_reference_subdirectories(tmp_path, monkeypatch):
+    """Tier 2: (accept-side) containment is not limited to a literal
+    `references/` name — ANY path under the skill's own directory tree
+    counts as the same content class (a deeper-nested file included)."""
+    project_root = tmp_path / "project"
+    skill_md = project_root / "skills" / "my-skill" / "SKILL.md"
+    _write(skill_md, "---\nname: my-skill\n---\nbody\n")
+    nested = project_root / "skills" / "my-skill" / "docs" / "deep" / "notes.md"
+    _write(nested, "EVIL_REFERENCE_THREAT_MARKER\n")
+
+    entry = SkillEntry(name="my-skill", description="d", path=str(skill_md))
+    threat_config = ThreatScanConfig()
+    ctx, events = _make_ctx(project_root, threat_scan=threat_config, available_skills=[entry])
+
+    def _fake_scan(content, config, *, scope="context"):
+        if "EVIL_REFERENCE_THREAT_MARKER" in content:
+            return [ThreatMatch(pattern_id="test-threat", scope="strict", severity="block")]
+        return []
+
+    monkeypatch.setattr("reyn.core.op_runtime.file.scan_for_threats", _fake_scan)
+
+    result = _run(file_handle(
+        FileIROp(kind="file", op="read", path=str(nested)), ctx,
+    ))
+
+    assert result["status"] == "blocked", result
+
+
+def test_no_threat_scan_config_leaves_reference_read_unaffected(tmp_path, monkeypatch):
+    """Tier 2: (accept-side) `ctx.threat_scan` absent (None) — no scan runs
+    even for a path under a registered skill's directory, matching the
+    #4699 precedent's own "no scan without config" contract."""
+    project_root = tmp_path / "project"
+    skill_md = project_root / "skills" / "my-skill" / "SKILL.md"
+    _write(skill_md, "---\nname: my-skill\n---\nbody\n")
+    ref_path = project_root / "skills" / "my-skill" / "references" / "notes.md"
+    _write(ref_path, "Anything at all.\n")
+
+    entry = SkillEntry(name="my-skill", description="d", path=str(skill_md))
+    ctx, events = _make_ctx(project_root, threat_scan=None, available_skills=[entry])
+
+    def _fail_if_called(*_a, **_k):
+        raise AssertionError("scan_for_threats must not run when threat_scan is None")
+
+    monkeypatch.setattr("reyn.core.op_runtime.file.scan_for_threats", _fail_if_called)
+
+    result = _run(file_handle(
+        FileIROp(kind="file", op="read", path=str(ref_path)), ctx,
+    ))
+
+    assert result["status"] == "ok", result
+    assert "Anything at all." in result["content"]
+
+
+# ── condition ②: an undeterminable resolution errs toward scanning ─────────
+
+
+def test_a_broken_registered_skill_path_errs_toward_scanning(tmp_path, monkeypatch):
+    """Tier 2: #4701 (lead-coder review, condition ②) — a registered skill
+    ENTRY whose own declared path cannot be resolved (a genuine symlink
+    LOOP — the exact evasion shape ② names: "a single symlink must not be
+    able to evade the check") must NOT silently let an unrelated read skip
+    the scan. The read here has NOTHING to do with the broken entry, but
+    because that entry's resolution is undeterminable, the whole
+    registry-derived answer errs toward "treat as skill content" rather
+    than quietly excluding the broken entry from consideration.
+
+    ``RuntimeError`` (not ``OSError``) is the load-bearing detail: a
+    symlink loop raises ``RuntimeError("Symlink loop from ...")`` from
+    ``Path.resolve()`` on the installed Python, confirmed live — a fix
+    that only caught ``OSError`` would leave this uncaught (crashing the
+    whole read) rather than degrading safely."""
+    project_root = tmp_path / "project"
+    # A genuine symlink loop for the REGISTERED skill's own path.
+    loop_a = project_root / "skills" / "broken" / "a"
+    loop_b = project_root / "skills" / "broken" / "b"
+    loop_a.parent.mkdir(parents=True)
+    os.symlink(loop_b, loop_a)
+    os.symlink(loop_a, loop_b)
+
+    unrelated_read = project_root / "src" / "app.py"
+    _write(unrelated_read, "EVIL_REFERENCE_THREAT_MARKER\n")
+
+    broken_entry = SkillEntry(name="broken", description="d", path=str(loop_a))
+    threat_config = ThreatScanConfig()
+    ctx, events = _make_ctx(project_root, threat_scan=threat_config, available_skills=[broken_entry])
+
+    def _fake_scan(content, config, *, scope="context"):
+        if "EVIL_REFERENCE_THREAT_MARKER" in content:
+            return [ThreatMatch(pattern_id="test-threat", scope="strict", severity="block")]
+        return []
+
+    monkeypatch.setattr("reyn.core.op_runtime.file.scan_for_threats", _fake_scan)
+
+    result = _run(file_handle(
+        FileIROp(kind="file", op="read", path=str(unrelated_read)), ctx,
+    ))
+
+    assert result["status"] == "blocked", result


### PR DESCRIPTION
**[e2e-coder]** — #4701 実装: `file.read` がスキルの reference file（登録済み skill の自ディレクトリ配下）を `load_skill` と同じ strict+block+fence で扱います。

## 何をしたか

- `_skill_reference_provenance(ctx, resolved_path)`: `ctx.available_skills` の各 entry の親ディレクトリに対する containment 判定（`load_skill.py` と同じレジストリを参照、判別子=「本文と同じ内容クラス」）。
- 該当時、`load_skill.py` と同一の strict+block scan・同一 event kind（`skill_body_threat_match`/`skill_body_threat_blocked`）を再利用。
- fence: クリーンな reference は `result["_external_source"] = True` を per-call で乗せます（`returns_external_content` 静的フラグの新しい per-call 上書きパターン — `tools/types.py` にも明記）。

## レビュー4条件、すべて対応

- ①タグの出所は`ctx.available_skills`のcontainmentのみ（モデルの主張は使いません）
- ②判定不能(entry自身のpath解決失敗、symlinkループ含む)は external側に倒す — symlinkループは`RuntimeError`（`OSError`ではない）で上がることを実機確認し明示的にcatch
- ③containmentは`skill_install.py`の`_contained_under`を再利用
- ④`tools/types.py`の`returns_external_content`docstringにper-call上書き可能と明記

## 検証

- strip-falsify: ②のfail-toward-scan・fenceタグの両方を個別にrevert → 対応testがそれぞれ正しい理由でRED、復元してgreen。
- `tests/core -k "file or skill"`（302 passed）。
- ローカル5 gate + docs3 script（docs変更のため）+ tests系3 script、すべてgreen。

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict tests/core/test_4701_skill_reference_threat_scan.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/op_runtime/file.py src/reyn/tools/types.py`
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py`
- [x] `python scripts/check_bare_tests_import_reference.py && python scripts/check_file_depth_reference.py && python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python -m pytest tests/core -k "file or skill" -q`（302 passed）
- [x] strip-falsify（上記）
- [ ] Visual — N/A（no UI）

part of #4701

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## レビュア追記（lead-coder, TESTS-READ 済）

- [x] 🔴 `skill_dir = p.resolve().parent` が、`SkillEntry.path` を常に SKILL.md ファイルと仮定している。**registry は正規化しません**（registry.py:10「points at the skill's `SKILL.md` / **directory**」、:84「as declared」、skills.md「Path to `SKILL.md` (**or its containing directory**)」）∴ `path: skills/foo` 表記だと包含の根が `skills/` になり、**他の全 skill が strict+block 対象**に。`path: .` ならプロジェクト根。`skill_install.py:65` の `_resolve_skill_md` を再利用（条件③と同じ理由） — `1f03e8509`
- [x] 🔴 上記のテストを 1 本追加 — `path` がディレクトリのエントリで、**兄弟 skill のファイルがスキャンされないこと** — `1f03e8509`、strip-falsifyでREDになることを確認済み


