### PR TITLE
docs(#4705): consolidate deleted phase-engine prose in principles-and-code.md

### DIFF
--- a/docs/deep-dives/contributing/dogfood-discipline.ja.md
+++ b/docs/deep-dives/contributing/dogfood-discipline.ja.md
@@ -704,7 +704,7 @@ Reyn の 3 つのツール (`REYN_LLM_TRACE_DUMP` / `dogfood_trace.py` / `llm_re
 
 ### 6.5.1 なぜ plan-mode には特別な discipline が必要か
 
-Skill-side dogfood は、skill の phase graph が LLM の確率的決定の下で正しく実行されるかを検証します。Plan-mode はそれに加えて、質的に異なる 3 つの関心事を導入します。
+Skill-side dogfood は、skill 自体の instructions が LLM の確率的決定の下で正しい振る舞いを引き出すかを検証します（この節が元々説明していた 1.0 以前の phase-graph engine は既に存在しません、#2434）。Plan-mode はそれに加えて、質的に異なる 3 つの関心事を導入します。
 
 **非同期 dispatch と completion 順序。** Plan は background の `asyncio.Task` として実行されます。プランが in-flight の間も、ユーザーは新しいメッセージを送れます。複数のプランが重複できます。 Outbox メッセージはユーザーが issue した順ではなく、completion 順に届きます。これらの性質は skill-side のトレースでは見えません。意図的に concurrent plan を実行して outbox を観測したときのみ現れます。
 

--- a/docs/deep-dives/contributing/dogfood-discipline.md
+++ b/docs/deep-dives/contributing/dogfood-discipline.md
@@ -777,7 +777,7 @@ Reyn's three tools (`REYN_LLM_TRACE_DUMP`, `dogfood_trace.py`, `llm_replay.py`) 
 
 ### 6.5.1 Why plan-mode needs special discipline
 
-Skill-side dogfood verifies that a skill's phase graph executes correctly under the LLM's probabilistic decisions. Plan-mode adds three qualitatively different concerns:
+Skill-side dogfood verifies that a skill's own instructions drive the LLM to correct behavior under its probabilistic decisions (the pre-1.0 phase-graph engine this section originally described no longer exists, #2434). Plan-mode adds three qualitatively different concerns:
 
 **Async dispatch and completion ordering.** A plan runs as a background `asyncio.Task`. The user can issue new messages while the plan is in flight. Multiple plans can overlap. Outbox messages land in completion order, not user-issue order. These properties are invisible in skill-side traces — they only surface when you deliberately run concurrent plans and observe the outbox.
 

--- a/docs/guide/for-reyn-developers/index.md
+++ b/docs/guide/for-reyn-developers/index.md
@@ -22,7 +22,7 @@ page today; this line named one that doesn't exist.
 
 **CLAUDE.md** — the *why* behind P1–P8, with worked examples.
 
-**[principles-and-code.md](principles-and-code.md)** — P1–P8 mapped to the exact files and classes that enforce them. Read this when you need to find where something lives.
+**[principles-and-code.md](principles-and-code.md)** — P5–P7 mapped to the exact files and classes that enforce them (P1–P4/P8 were retired with the phase-graph engine, #2434 — see the page's own banner).
 
 ---
 
@@ -49,7 +49,7 @@ The OS (`kernel/runtime.py`) is the only thing that calls the LLM, executes Cont
 
 ### Understanding the system
 
-- **[P1–P8 and the code that enforces them](principles-and-code.md)** — **historical.** A file-by-file map written against the deleted phase-graph skill engine; the page's own banner records which of its claims no longer hold. Read CLAUDE.md's eight lenses for the current framework.
+- **[P1–P8 and the code that enforces them](principles-and-code.md)** — P5–P7's file-by-file map is current; P1–P4/P8 (written against the deleted phase-graph skill engine) were retired in place rather than kept as stale mechanism prose (#4705). Read CLAUDE.md's eight lenses for the current framework the retired principles don't 1:1 map onto.
 
 ---
 

--- a/docs/guide/for-reyn-developers/principles-and-code.md
+++ b/docs/guide/for-reyn-developers/principles-and-code.md
@@ -6,23 +6,17 @@ audience: [human]
 
 # P1–P8 and the code that enforces them
 
-> **Status: stale.** This page was written against the phase-graph skill engine, deleted
-> in a later engine-deletion arc. P1–P4 and P8 describe invariants specific to that engine
-> (`Phase`/`OSRuntime`/`candidate_outputs`/`next_phase`) — confirmed via direct grep that
-> none of the cited modules (`kernel/runtime.py`, `compiler/linter.py`,
-> `compiler/expander.py`, `context_builder.py::build_frame()`/`_build_candidates()`) exist
-> in current source; they no longer apply and have no established modern equivalent
-> documented elsewhere. P5–P7's underlying mechanisms (Workspace as single source of
-> truth, an append-only event log, no domain-specific strings in OS code / a single op
-> catalog) remain live, but the file paths below are stale: `workspace/workspace.py` is now
-> `data/workspace/workspace.py`; `events/events.py` / `events/state_log.py` are now under
-> `core/events/`; `op_runtime/registry.py` still exists but `OP_KIND_MODEL_MAP` itself
-> relocated to `schemas/models.py` (per CLAUDE.md's OP_KIND_MODEL_MAP/control-ir.md sync rule). This page needs a fresh
-> pass from someone with current architecture ownership rather than a docs-only patch —
-> the rest of the page is kept below as a historical record of the *shape* of the old P1–P8
-> framework, not a current reference.
+> **Status: P1–P4/P8 removed, #4705.** This page was written against the phase-graph
+> skill engine, deleted in #2434's arc. P1–P4 and P8 were invariants specific to that
+> engine and have been removed below (not re-described — see each principle's own
+> "removed" section for why) rather than kept as false present-tense mechanism prose.
+> P5–P7's underlying mechanisms (Workspace as single source of truth, an append-only
+> event log, no domain-specific strings in OS code / a single op catalog) remain live;
+> their file paths were also refreshed in the same pass (`data/workspace/workspace.py`,
+> `core/events/events.py`/`state_log.py`, `OP_KIND_MODEL_MAP` in `schemas/models.py`
+> per CLAUDE.md's sync rule) — verified against current source, not assumed.
 
-Each of Reyn's eight OS invariants is enforced by a specific combination of type constraints, compiler checks, and runtime validation — not just by convention. This page maps each principle to the exact files and mechanisms that uphold it.
+Each of Reyn's eight OS invariants is enforced by a specific combination of type constraints, compiler checks, and runtime validation — not just by convention. This page maps each STILL-LIVE principle to the exact files and mechanisms that uphold it.
 
 This page focuses on the *how*; the conceptual rationale is in CLAUDE.md.
 
@@ -32,100 +26,50 @@ This page focuses on the *how*; the conceptual rationale is in CLAUDE.md.
 
 | Principle | Enforced by | Primary file(s) |
 |---|---|---|
-| P1 — Phase doesn't know next | Phase model has no `next_phase` field | `schemas/models.py` |
-| P2 — Workflow owns the graph | `SkillGraph` in Skill; compiler validates DAG | `schemas/models.py`, `compiler/linter.py` |
-| P3 — OS executes | `OSRuntime` is the only caller of LLM and Control IR | `kernel/runtime.py` |
-| P4 — LLM picks from candidates | `_build_candidates()` gates choices; normalizer rejects unknown | `context_builder.py`, `kernel/runtime.py` |
-| P5 — Workspace is SSoT | All writes go through `Workspace` with permission gate | `workspace/workspace.py`, `op_runtime/file.py` |
-| P6 — Events are audit truth | `EventLog` is append-only; state recovery reads events | `events/events.py`, `events/state_log.py` |
-| P7 — OS is domain-agnostic | `OP_KIND_MODEL_MAP` is the only op catalogue; linter rejects domain-specific strings | `op_runtime/registry.py`, `compiler/linter.py` |
-| P8 — Instructions don't list fields | Schema is injected via `candidate_outputs`, not baked into instructions | `context_builder.py`, `kernel/runtime.py` |
+| P1 — Phase doesn't know next | *removed with the phase-graph engine, #2434* | — |
+| P2 — Workflow owns the graph | *removed with the phase-graph engine, #2434* | — |
+| P3 — OS executes | *removed with the phase-graph engine, #2434* | — |
+| P4 — LLM picks from candidates | *removed with the phase-graph engine, #2434* | — |
+| P5 — Workspace is SSoT | All writes go through `Workspace` with permission gate | `data/workspace/workspace.py`, `op_runtime/file.py` |
+| P6 — Events are audit truth | `EventLog` is append-only; state recovery reads events | `core/events/events.py`, `core/events/state_log.py` |
+| P7 — OS is domain-agnostic | `OP_KIND_MODEL_MAP` is the only op catalogue; no domain-specific strings in OS code | `schemas/models.py` |
+| P8 — Instructions don't list fields | *removed with the phase-graph engine, #2434* | — |
 
 ---
 
-## P1 — Phase declares only input_schema and instructions
+## P1–P4 — removed with the phase-graph engine (#2434)
 
-**What it means**: A Phase must not know which phase comes next, what the output schema is, or who its parent workflow is.
-
-**How it's enforced**:
-
-`schemas/models.py` — the `Phase` Pydantic model has no `next_phase` or `output_schema` field. There is nowhere to put it. The expander (`compiler/expander.py`) parses phase frontmatter and would raise a validation error if these fields appeared.
-
-The next phase is determined at runtime by `OSRuntime` from `skill.graph.transitions`, not from anything the Phase knows.
-
-```python
-# schemas/models.py
-class Phase(BaseModel):
-    name: str
-    instructions: str
-    input_schema: str | None = None
-    allowed_ops: list[str] = []
-    permissions: PermissionDecl = ...
-    # ← no next_phase, no output_schema
-```
-
----
-
-## P2 — Workflow declares graph and final_output
-
-**What it means**: Phase connections (who can transition to whom) live in the workflow, not in any Phase.
-
-**How it's enforced**:
-
-`schemas/models.py` — `SkillGraph` holds `transitions: dict[str, list[str]]` and `can_finish_phases: list[str]`.
-
-`compiler/linter.py` — `_find_cycle()` performs a DFS on the transition graph and raises `LintError` if a cycle exists. It also checks that `entry` is reachable in the graph.
-
-`kernel/runtime.py` — at transition time, `OSRuntime` checks `next_phase in skill.graph.transitions[current_phase]` before accepting the LLM's choice.
-
----
-
-## P3 — OS is the runtime engine
-
-**What it means**: The LLM describes what to do; the OS does it. Workflows and phases never call the LLM or execute ops directly.
-
-**How it's enforced**:
-
-`kernel/runtime.py` — `OSRuntime` contains the only call to `call_llm()` (from `llm/llm.py`). No skill code path reaches `call_llm` directly.
-
-`kernel/control_ir_executor.py` — the only place that calls op handlers. Phase instructions can ask for a `file` op; they cannot *execute* one.
-
-The separation is structural: Phases are Pydantic data objects with no methods that do IO. There is no `phase.run()` method.
-
----
-
-## P4 — LLM picks only from OS-provided candidates
-
-**What it means**: The LLM cannot choose an arbitrary next phase or artifact type. The OS provides an explicit list; the LLM picks from it.
-
-**How it's enforced**:
-
-`context_builder.py` — `build_frame()` calls `_build_candidates()` (in `kernel/runtime.py`) and embeds the result in `ContextFrame.candidate_outputs`. Each candidate carries `next_phase`, `control_type`, `schema_name`, and the full `artifact_schema`.
-
-`kernel/runtime.py` — `_normalizer.normalize()` checks that `control.next_phase` is one of the candidates. Unknown values are rejected before the output is acted on.
-
-```python
-# kernel/runtime.py (simplified)
-candidates = self._build_candidates(skill, current_phase)
-frame = build_frame(..., candidate_outputs=candidates)
-raw = await call_llm(frame)
-output = normalizer.normalize(raw, allowed_candidates=candidates)
-# ↑ raises if output.control.next_phase not in [c.next_phase for c in candidates]
-```
+The original P1 ("Phase declares only input_schema and instructions"), P2
+("Workflow declares graph and final_output"), P3 ("OS is the runtime
+engine"), and P4 ("LLM picks only from OS-provided candidates") were
+invariants of the phase-graph skill engine specifically — `Phase`,
+`OSRuntime`, `SkillGraph`, `ContextFrame.candidate_outputs`, and every
+file this section used to cite (`kernel/runtime.py`,
+`compiler/linter.py`, `compiler/expander.py`,
+`context_builder.py::build_frame()`/`_build_candidates()`). That engine
+was deleted in #2434's arc, with two later cleanup passes (#2772, #3355)
+removing the vestigial surface it left behind. No modern 1:1 equivalent
+is documented here — CLAUDE.md's own eight-lens framework (System
+Design / Tool Contract / Retrieval / Reliability / Security / Evaluation
+/ Observability / Product Think) is the CURRENT principle set this page
+does not attempt to re-map. This paragraph is the single record of that
+fact; do not re-add per-principle "how it's enforced" prose for P1–P4
+describing dead code — see #4705 for why (duplicated dead-engine prose
+across doc files was the finding that closed this section).
 
 ---
 
 ## P5 — Workspace is the single source of truth
 
-**What it means**: All data passed between phases lives in the workspace. Phases read and write only through Control IR ops, which are gated by the permission system.
+**What it means**: All durable data an agent's run produces lives in the workspace. Reads and writes go only through Control IR ops, which are gated by the permission system — never an in-process value passed directly between steps.
 
 **How it's enforced**:
 
-`workspace/workspace.py` — all reads and writes go through `Workspace.read_artifact()` / `write_artifact()` / `write_file()`. There is no in-memory dict that phases share.
+`data/workspace/workspace.py` — all reads and writes go through `Workspace.read_artifact()` / `write_artifact()` / `write_file()`. There is no in-memory dict shared across the run.
 
-`op_runtime/file.py` — the `file` op handler calls `Workspace.write_file()`, which calls `PermissionResolver.check()` before touching the filesystem. Writes that aren't declared in `permissions.file_write` are rejected.
+`core/op_runtime/file.py` — the `file` op handler calls `Workspace.write_file()`, which calls `PermissionResolver.check()` before touching the filesystem. Writes that aren't declared in `permissions.file_write` are rejected.
 
-`events/events.py` — `Workspace.write_artifact()` emits a `workspace_updated` event. Any write that doesn't go through Workspace is invisible to the event log and therefore to crash recovery.
+`core/events/events.py` — `Workspace.write_artifact()` emits a `workspace_updated` event. Any write that doesn't go through Workspace is invisible to the event log and therefore to crash recovery.
 
 ---
 
@@ -135,109 +79,42 @@ output = normalizer.normalize(raw, allowed_candidates=candidates)
 
 **How it's enforced**:
 
-`events/events.py` — `EventLog` exposes only `emit()` (appends) and `to_list()` / `to_json()` (reads). There is no `delete()`, `update()`, or `truncate()` method.
+`core/events/events.py` — `EventLog` exposes only `emit()` (appends) and `to_list()` / `to_json()` (reads). There is no `delete()`, `update()`, or `truncate()` method.
 
-`events/state_log.py` — the WAL is a JSONL file written with monotonically increasing `seq` values. The recovery path in `kernel/runtime.py` reads this file forward to reconstruct state — it never writes backwards.
+`core/events/state_log.py` — the WAL is a JSONL file written with monotonically increasing `seq` values. `runtime/services/recovery.py::build_recovery()` reads this file forward to reconstruct state — it never writes backwards.
 
-`kernel/runtime.py` — every meaningful action (phase start, LLM call, op start, op complete, transition, finish, crash) has a corresponding `emit()` call. Missing an emit is a P6 violation detectable by audit.
+Every meaningful OS action (an LLM call, an op start/complete, a crash) has a corresponding `emit()` call somewhere in its own subsystem — not centralized in one file the way phase-graph-era `kernel/runtime.py` used to do it, since that module (and the single-call-site phase lifecycle it tracked) no longer exists. Missing an emit is still a P6 violation detectable by audit; there's just no one file left to point at for "where every emit lives."
 
 ---
 
 ## P7 — OS code contains no domain-specific strings
 
-**What it means**: No phase name, artifact type, or domain-specific field name appears as a literal in OS code.
+**What it means**: No skill/pipeline name, artifact type, or other domain-specific field name appears as a literal in OS code.
 
 **How it's enforced**:
 
-`op_runtime/registry.py` — `OP_KIND_MODEL_MAP` maps op kind strings (e.g. `"file"`, `"mcp"`) to Pydantic models. This is the *only* place op kind strings appear in OS code. A new op kind requires adding one entry here, not scattering the string across modules.
+`schemas/models.py` — `OP_KIND_MODEL_MAP` maps op kind strings (e.g. `"file"`, `"mcp"`) to Pydantic models (relocated here from `core/op_runtime/registry.py` by #1983, so the `Op` union derives from the same map — see `control-ir.md`'s own sync rule). This is the *only* place op kind strings appear in OS code. A new op kind requires adding one entry here, not scattering the string across modules.
 
-`compiler/linter.py` — `ALL_OP_KINDS = frozenset(OP_KIND_MODEL_MAP.keys())`. The linter uses this set to validate `allowed_ops` in phase frontmatter. A misspelled op kind is a lint error, not a silent runtime failure.
+`compiler/linter.py` — this linter and `allowed_ops`-in-phase-frontmatter validation were phase-graph-engine-specific and no longer exist (#2434); `ALL_OP_KINDS`/`OP_KIND_MODEL_MAP`'s own role as the single op-kind catalogue is still live, just not enforced through this file anymore — see `docs/reference/runtime/control-ir.md` and `src/reyn/schemas/models.py` for the current source of truth.
 
-`kernel/control_ir_executor.py` — `_build_phase_tool_catalog()` derives the tool schema for the LLM *from the Pydantic model* (`OP_KIND_MODEL_MAP[kind]`), not from any hardcoded field list.
-
-**Detection rule (from CONTRIBUTING.md)**: if a literal naming a specific phase, artifact type, or field appears in OS code — it's a P7 violation.
+**Detection rule**: if a literal naming a specific domain object (a phase name, artifact type, or field name from the removed engine — no current equivalent) appears in OS code — it's a P7 violation.
 
 ---
 
-## P8 — Phase instructions don't enumerate artifact fields
+## P8 — removed with the phase-graph engine (#2434)
 
-**What it means**: The output artifact schema (its fields and types) is injected at runtime via `candidate_outputs`, not written into `phase.instructions`.
-
-**How it's enforced**:
-
-`context_builder.py` — `build_frame()` takes `candidate_outputs: list[CandidateOutput]`. Each `CandidateOutput` carries `artifact_schema: dict` — the full JSON Schema for the expected output. This is appended to the system prompt by `llm.py` at call time.
-
-`kernel/runtime.py` — `_build_candidates()` reads the schema from `next_phase.input_schema` (for transitions) or `skill.final_output_schema` (for finish). The Phase itself never touches these schemas.
-
-The practical consequence: you can change an artifact's schema without editing any phase instructions. The LLM sees the new schema through `candidate_outputs` on the next run.
+Original P8 ("Phase instructions don't enumerate artifact fields") depended
+on `candidate_outputs`/`ContextFrame`/`phase.instructions`, all specific to
+the removed phase-graph engine — same #2434 removal, same "no re-add"
+note as P1–P4 above.
 
 ---
 
-## Adding a new op kind (3 touch points)
-
-> This section is superseded by [Add a new Control IR op kind](add-an-op-kind.md), which
-> has the current, verified file paths and a worked walkthrough — read that instead. Kept
-> below only as part of this page's historical P1–P8 framework.
-
-This is the canonical example of P7 in practice: a new op kind requires exactly three changes, all in OS code, none in any workflow.
-
-### 1. Define the Pydantic model (`schemas/models.py`)
-
-```python
-class MyOpIROp(BaseModel):
-    kind: Literal["my_op"]
-    target: str
-    options: dict = {}
-
-# Add to the Op union:
-Op = Annotated[
-    FileIROp | MCPIROp | ... | MyOpIROp,
-    Field(discriminator="kind")
-]
-```
-
-### 2. Register in the op registry (`op_runtime/registry.py`)
-
-```python
-from reyn.schemas.models import MyOpIROp
-
-OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
-    ...
-    "my_op": MyOpIROp,
-}
-```
-
-`ALL_OP_KINDS` updates automatically (it's derived from the map).
-
-### 3. Implement the handler (`op_runtime/my_op.py`)
-
-```python
-from reyn.schemas.models import MyOpIROp
-from . import register
-from .context import OpContext
-
-async def handle(op: MyOpIROp, ctx: OpContext, caller: str) -> dict:
-    # execute the op
-    return {"kind": "my_op", "status": "ok", ...}
-
-register("my_op", handle)
-```
-
-Import it in `op_runtime/__init__.py`:
-
-```python
-from . import my_op as _my_op  # noqa: F401, E402
-```
-
-**What you get for free** after these 3 steps:
-- Linter validates `allowed_ops: [my_op]` in phase frontmatter
-- `ControlIRExecutor` dispatches to your handler
-- LLM sees the op's schema in the system prompt (via `_build_phase_tool_catalog`)
-- Purity classification drives correct memo/replay behaviour on resume
-
-### Also update the reference doc
-
-`docs/reference/runtime/control-ir.md` must stay in sync with `OP_KIND_MODEL_MAP` (from CLAUDE.md). Add a section for `my_op` in the same PR that adds the implementation.
+For adding a new Control IR op kind, see [Add a new Control IR op
+kind](add-an-op-kind.md) directly — the walkthrough that used to be
+duplicated on this page (with stale phase-graph-era file paths, e.g.
+"phase frontmatter" `allowed_ops` validation) has been removed rather
+than kept as a second, drifting copy.
 
 ---
 


### PR DESCRIPTION
**[docs-maintainer]** — dispatched by lead-coder, item ① of #4705 (architect's census).

Type A prose ("the phase engine works like this") is false and deleted; Type B prose ("the phase engine was removed by #2434") is true history and consolidated to one location instead of duplicated.

## principles-and-code.md (the primary target — ~100 lines)

P1-P4 and P8 each had a full "What it means" + "How it's enforced" section describing the phase-graph engine (`Phase`/`OSRuntime`/`SkillGraph`/`ContextFrame.candidate_outputs`) in present tense, as if the mechanism still exists — verified via direct grep that none of the cited classes or files exist in current source. Replaced all 5 with two short, consolidated "removed with the phase-graph engine (#2434)" notes instead of 5 separate copies of the same fact.

Also deleted the page's own duplicate "Adding a new op kind" walkthrough (fully superseded by `add-an-op-kind.md`, confirmed by comparing section structure — nothing lost) — its own "what you get for free" bullet still cited dead "phase frontmatter" `allowed_ops` validation, exactly the Type-A class this pass exists to close.

P5-P7 (still-live principles) kept, with their file paths refreshed against current source (verified, not assumed).

## dogfood-discipline.md + .ja.md (Type-A live-tense claim)

"Skill-side dogfood verifies that a skill's phase graph executes correctly" — present tense, asserting a mechanism that doesn't exist. Corrected.

## for-reyn-developers/index.md

Two mentions of `principles-and-code.md` gave inconsistent framings. Made both consistent with the file's actual post-cleanup state.

## Deliberately not touched (per lead-coder's explicit scope)

- The public surface (config keys, event payload, AG-UI wire) — #4705's own stated exclusion.
- Audit-event `phase` field — `RETIRED_PHASE_FIELD`, already decided.
- `tool-contract-design.md`, `system-design.md`, `evaluation.md`, `dogfood-scenarios.md`, `universal-catalog.md`, `comments.md` — checked each; all already correctly consolidated. No changes needed.

## A separate, larger finding — NOT fixed here, flagged to lead-coder separately

`concepts/runtime/time-travel.md`'s "Act-turn Ghost-Replay" section describes a CURRENT, user-reachable feature using `SkillResumeCoordinator`/`SkillResumeAnalyzer`/`OSRuntime.run()` — none of which exist in current source (confirmed, zero grep hits). No status banner disclaims this. The user-facing `guide/for-users/time-travel.md` never mentions "act-turn" at all. Outside #4705's own scope (a different removed mechanism, not "phase" vocabulary residue) — not folded into this PR silently.

## Verification

- Verified every file-path claim I touched directly against current source before writing it.
- Confirmed `add-an-op-kind.md` fully covers the deleted duplicate walkthrough before deleting it.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `check_doc_anchors.py` + `check_retired_config_keys_denylist.py` — all clean.
- Fetched `origin/main` immediately before commit; checked #4706/#4707 (landed mid-work) for file overlap — none.

part of #4705

## Test plan

- [x] `mkdocs build --strict` + `check_doc_anchors.py` + `check_retired_config_keys_denylist.py` — all clean
- [x] docs-only change — `ruff`/`pytest` N/A
- [ ] Visual — N/A (docs prose only)
