### PR TITLE
feat(#4697): Space toggles tool-detail fold, decoupled from highlight move

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -352,17 +352,76 @@ class KeyCommitted(Message, namespace="flow_view"):
         return self.flow_view
 
 
+class ToggleFoldRequested(Message, namespace="flow_view"):
+    """#4697: posted by :meth:`_CursorFlowView.action_toggle_fold` when
+    Space is pressed OUTSIDE character-cursor mode (``cursor_visible`` was
+    already ``False`` at post time — the app-side handler does not
+    re-check it). Distinct from :class:`KeyCommitted` (Enter/Space's copy
+    commit, #3624): this is the entry-mode fold/unfold request, #4691 §6's
+    owner ruling that highlight movement and open/close are two different
+    intents and must not share a trigger."""
+
+    def __init__(self, flow_view: "FlowView[object]", entry: "Entry[object]") -> None:
+        self.flow_view = flow_view
+        self.entry = entry
+        super().__init__()
+
+    @property
+    def control(self) -> "FlowView[object]":
+        return self.flow_view
+
+
 class _CursorFlowView(FlowView["OutboxMessage"]):
     """FlowView with the Enter/Space commit split from the click commit
     (#3624) — posts :class:`KeyCommitted` in addition to upstream's
     ``Selected``, so :meth:`TextualChatApp.on_flow_view_key_committed` can
-    copy on a KEYBOARD commit without also firing on a click."""
+    copy on a KEYBOARD commit without also firing on a click.
+
+    #4697: Space is ALSO rebound (overriding upstream's own
+    ``Binding("space", "activate")`` for this subclass — Enter keeps its
+    original meaning, only Space moves) to fold/unfold the highlighted
+    entry's tool detail instead of committing — #4691 §6's owner ruling
+    that decoupled that from highlight movement. See
+    :meth:`action_toggle_fold` for the character-cursor-mode guard this
+    needed before implementation (measured, issue #4697)."""
+
+    BINDINGS = [
+        Binding("space", "toggle_fold", "Fold/unfold tool detail", show=False),
+    ]
 
     def action_activate(self) -> None:
         entry = self.current
         super().action_activate()
         if entry is not None:
             self.post_message(KeyCommitted(self, entry))
+
+    def action_toggle_fold(self) -> None:
+        """#4697: Space, outside character-cursor mode, requests a fold
+        toggle on the highlighted entry (the app handles the actual
+        ``_set_expanded`` flip — see ``on_flow_view_toggle_fold_requested``).
+        Inside character-cursor mode, falls through to the ordinary
+        Enter/Space activate (copy) path instead, so an in-progress text
+        selection is never disrupted by a stray fold.
+
+        ``cursor_visible`` (public property) is used as the guard rather
+        than upstream's own private ``_text_active()`` — measured
+        equivalent (#4697 issue thread): ``_text_active()`` is
+        ``cursor_visible or _tc_anchor is not None``, but every
+        ``_set_cursor_visible(False)`` path ALSO clears ``_tc_anchor``
+        (installed flowview 0.19.0, read directly), so the anchor can
+        never be set while ``cursor_visible`` is ``False`` — ``cursor_
+        visible`` alone is a complete public-API proxy for it TODAY. This
+        is a DERIVED equivalence, not a contract upstream promises: if a
+        future flowview version stops clearing the anchor on hide, this
+        guard falls out of sync SILENTLY — Space would start folding an
+        entry mid text-selection instead of extending it, no exception,
+        no warning."""
+        if self.cursor_visible:
+            self.action_activate()
+            return
+        entry = self.current
+        if entry is not None:
+            self.post_message(ToggleFoldRequested(self, entry))
 
 
 class ScrollableDrawer(ContentSwitcher):
@@ -2270,13 +2329,31 @@ class TextualChatApp(App):
 
     def on_flow_view_highlighted(self, event: "FlowView.Highlighted") -> None:
         """#3490: move the rail with the highlight — repaint the row it left as
-        well as the one it arrived on. #3508: and unfold the arrived row's tool
-        detail, folding the one left behind."""
+        well as the one it arrived on.
+
+        #4691 §6 (owner ruling, #4697): highlight movement no longer
+        auto-expands/folds tool detail — moving to read the conversation
+        and choosing to open ONE row's detail are two different intents,
+        and coupling them meant a reader could never move past a big
+        result without collapsing it first (#3508's original own
+        trade-off). Space (:meth:`_CursorFlowView.action_toggle_fold`,
+        outside character-cursor mode) is the dedicated open/close
+        trigger now — see ``on_flow_view_toggle_fold_requested``."""
         previous, self._marked_cursor = self._marked_cursor, event.entry
-        self._set_expanded(previous, False)
-        self._set_expanded(event.entry, True)
         self._remark_entry(previous)
         self._remark_entry(event.entry)
+
+    def on_flow_view_toggle_fold_requested(self, event: "ToggleFoldRequested") -> None:
+        """#4697: Space (outside character-cursor mode —
+        :meth:`_CursorFlowView.action_toggle_fold` already applied that
+        guard before posting this) flips ONE entry's tool-detail fold,
+        independent of the highlight/cursor position — #4691 §6's owner
+        ruling."""
+        entry = event.entry
+        meta = entry.item.meta
+        if not meta or _RESULT_KIND_KEY not in meta:
+            return  # not a settled tool row — nothing to fold
+        self._set_expanded(entry, not bool(meta.get(_EXPANDED_KEY)))
 
     def _set_expanded(self, entry: "Entry[OutboxMessage] | None", expanded: bool) -> None:
         """Stamp/clear the expansion flag on ``entry``'s ITEM and re-present it.

--- a/tests/interfaces/test_conversation_cursor_3476.py
+++ b/tests/interfaces/test_conversation_cursor_3476.py
@@ -176,9 +176,13 @@ async def test_enter_copies_the_cursor_entry_directly(clipboard) -> None:
 
 
 @pytest.mark.asyncio
-async def test_space_also_activates_the_cursor_entry(clipboard) -> None:
-    """Tier 2b: Space is flowview's other built-in activate key — same effect
-    as Enter, verified independently rather than assumed from Enter's test."""
+async def test_space_no_longer_copies_since_4697_repurposed_it_for_folding(clipboard) -> None:
+    """Tier 2b: #4697 repurposed Space for tool-detail fold/unfold (owner
+    ruling, #4691 §6) — it is no longer flowview's second activate/copy
+    key (Enter alone still copies; see the Enter test above). On an
+    ordinary row with no foldable tool detail, Space is a no-op: it must
+    NOT copy (the pre-#4697 behavior this test used to pin) and must not
+    crash."""
     app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
@@ -187,11 +191,12 @@ async def test_space_also_activates_the_cursor_entry(clipboard) -> None:
         await _focus_flow(pilot, app)
 
         await pilot.press("space")
-        for _ in range(30):
-            await pilot.pause()
-            if clipboard() is not None:
-                break
-        assert clipboard() == "reply text"
+        await pilot.pause()
+        await pilot.pause()
+        assert clipboard() is None, (
+            "Space still copied — #4697 was supposed to move copy off Space "
+            "entirely, leaving it solely on Enter"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_conversation_cursor_3476.py
+++ b/tests/interfaces/test_conversation_cursor_3476.py
@@ -182,7 +182,20 @@ async def test_space_no_longer_copies_since_4697_repurposed_it_for_folding(clipb
     key (Enter alone still copies; see the Enter test above). On an
     ordinary row with no foldable tool detail, Space is a no-op: it must
     NOT copy (the pre-#4697 behavior this test used to pin) and must not
-    crash."""
+    crash.
+
+    Positive control (lead-coder's own TESTS-READ block on #4713):
+    ``clipboard() is None`` right after Space cannot by itself tell
+    "Space correctly doesn't copy" from "the copy mechanism is dead" —
+    and absence can't be waited on, so a fixed pause count would be an
+    unjustified constant (testing.md § Time) that quietly goes green the
+    day copying starts taking one more tick. Pressing Enter immediately
+    after and condition-waiting for the REAL clipboard value closes both
+    gaps at once: it proves copying still works at all (so the earlier
+    ``is None`` really means Space-specific, not broken-entirely), it is
+    an "wait for something to happen" condition (so it can be waited on
+    unboundedly, no pause constant needed), and it doubles as a witness
+    that #4697 did not break Enter's own copy path."""
     app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
@@ -192,10 +205,17 @@ async def test_space_no_longer_copies_since_4697_repurposed_it_for_folding(clipb
 
         await pilot.press("space")
         await pilot.pause()
-        await pilot.pause()
         assert clipboard() is None, (
             "Space still copied — #4697 was supposed to move copy off Space "
             "entirely, leaving it solely on Enter"
+        )
+
+        await pilot.press("enter")
+        while clipboard() is None:
+            await pilot.pause()
+        assert clipboard() == "reply text", (
+            "Enter's own copy path broke — positive control failed, so the "
+            "earlier Space assertion cannot be trusted either"
         )
 
 

--- a/tests/interfaces/test_tool_detail_on_highlight_3508.py
+++ b/tests/interfaces/test_tool_detail_on_highlight_3508.py
@@ -1,12 +1,15 @@
-"""#3508 — a settled tool row shows its FULL result while the highlight is on it.
+"""#3508 — a settled tool row shows its FULL result via its tool-detail fold.
 
 The one-line summary (`⎿ Read 42 lines`) is what the pane normally shows; the
 raw result survives on the frame, so "expand" is a different rendering of data
-the row already carries. Moving the highlight onto the row unfolds it and moving
-away folds it back — no extra keystroke, which is the whole point: the owner's
-report on Claude Code's expand was **"使いづらいから使ってない"** (not "I don't
-want it"), so an affordance that costs a deliberate action was the thing that
-failed, not the capability.
+the row already carries.
+
+#4697 (owner ruling, #4691 §6): the fold no longer follows the highlight —
+moving the highlight and choosing to open/close ONE row's detail are two
+different intents, and coupling them meant a reader could never move past a
+big result without collapsing it first. Space (outside flowview's character-
+cursor mode — `c` toggles that) is the dedicated open/close trigger now; the
+highlight moves the read position without touching any row's fold state.
 
 Asserted on the PAINTED body via the presenter, never on the meta flag: the flag
 is an implementation detail of how the presenter is told, and a test that
@@ -100,11 +103,36 @@ async def _focus(pilot, app) -> FlowView:
     return app.query_one(FlowView)
 
 
+async def _toggle_fold(pilot, flow: FlowView) -> None:
+    """#4697: press Space to fold/unfold the highlighted entry — the
+    dedicated trigger that replaced #3508's auto-expand-on-highlight.
+
+    Waits on TWO actual conditions in sequence, rather than a fixed pause
+    count (testing.md § Time): first the current entry's ``_EXPANDED_KEY``
+    meta flag settling to its post-press value (Space now round-trips
+    through ``ToggleFoldRequested``, a POSTED message handled on a LATER
+    event-loop tick than #3508's original synchronous ``_set_expanded``
+    call was), then the row's own rendered content clearing flowview's
+    lazy-render ``"Loading..."`` placeholder (``Entry.update()``'s reflow
+    is itself a further tick after the flag flips)."""
+    from reyn.interfaces.inline.textual_chat._meta_keys import EXPANDED_KEY
+
+    entry = flow.current
+    assert entry is not None
+    before = bool((entry.item.meta or {}).get(EXPANDED_KEY))
+    await pilot.press("space")
+    while bool((entry.item.meta or {}).get(EXPANDED_KEY)) == before:
+        await pilot.pause()
+    while "Loading..." in _painted(flow):
+        await pilot.pause()
+
+
 @pytest.mark.asyncio
-async def test_the_highlighted_tool_row_shows_the_full_result() -> None:
-    """Tier 2b: the row summarised as one line unfolds to the whole result when
-    the highlight arrives — and the summary line stays, so the row reads the
-    same shape expanded or not."""
+async def test_space_unfolds_the_highlighted_tool_row() -> None:
+    """Tier 2b: #4697 — the row summarised as one line unfolds to the whole
+    result on Space, and the summary line stays, so the row reads the same
+    shape expanded or not. Arriving via highlight ALONE (no Space) must NOT
+    unfold it — #4691 §6's owner ruling decoupled the two."""
     # A LIST is the clearest hidden case: the summary collapses it to "3 items"
     # and shows none of the content. (A short scalar result is NOT hidden — the
     # summary falls back to the value itself, so such a row looks the same
@@ -124,18 +152,24 @@ async def test_the_highlighted_tool_row_shows_the_full_result() -> None:
         )
 
         await _focus(pilot, app)
+        assert "line two" not in _painted(flow), (
+            "highlight arrival alone unfolded the row — #4697 decoupled this"
+        )
+
+        await _toggle_fold(pilot, flow)
         painted = _painted(flow)
         assert "line two" in painted and "line three" in painted, (
-            f"the highlighted tool row did not unfold; pane shows:\n{painted}"
+            f"Space did not unfold the highlighted tool row; pane shows:\n{painted}"
         )
         assert "⎿" in painted, "the summary line was replaced instead of extended"
 
 
 @pytest.mark.asyncio
-async def test_moving_the_highlight_away_folds_the_row_back() -> None:
-    """Tier 2b: the expansion follows the highlight — the row left behind
-    returns to its one-line summary, so a walk through the log does not leave a
-    trail of unfolded rows that pushes everything off screen."""
+async def test_moving_the_highlight_away_no_longer_folds_the_row_back() -> None:
+    """Tier 2b: #4697 — an EXPANDED row stays expanded when the highlight
+    moves away (inverts #3508's original auto-fold-on-move-away — the
+    whole point of decoupling movement from open/close: a reader can walk
+    past a big result without it collapsing under them)."""
     app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
@@ -146,14 +180,60 @@ async def test_moving_the_highlight_away_folds_the_row_back() -> None:
 
         await pilot.press("up")
         await pilot.pause()
+        await _toggle_fold(pilot, flow)
         assert "expanded detail line" in _painted(flow), (
-            "setup: the highlight did not reach the tool row"
+            "setup: Space did not unfold the tool row"
         )
 
         await pilot.press("down")
         await pilot.pause()
+        assert "expanded detail line" in _painted(flow), (
+            "the row folded back after the highlight left it — #4697 decoupled this"
+        )
+
+
+@pytest.mark.asyncio
+async def test_space_folds_an_expanded_row_back() -> None:
+    """Tier 2b: #4697 — Space is a TOGGLE, not just an unfold — pressing it
+    again on an already-expanded row folds it back."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.conversation.append(_settled_tool(["expanded detail line", "second"]))
+        await pilot.pause()
+        flow = await _focus(pilot, app)
+
+        await _toggle_fold(pilot, flow)
+        assert "expanded detail line" in _painted(flow), "setup: Space did not unfold"
+
+        await _toggle_fold(pilot, flow)
         assert "expanded detail line" not in _painted(flow), (
-            "the row stayed unfolded after the highlight left it"
+            "a second Space press did not fold the row back"
+        )
+
+
+@pytest.mark.asyncio
+async def test_space_in_character_cursor_mode_still_copies_not_folds() -> None:
+    """Tier 2b: #4697's own explicit measurement/guard — while flowview's
+    character-cursor mode is engaged (toggled by ``c``), Space must fall
+    through to the ordinary copy commit, never fold, so an in-progress
+    text selection is never disrupted."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.conversation.append(_settled_tool(["expanded detail line", "second"]))
+        await pilot.pause()
+        flow = await _focus(pilot, app)
+
+        await pilot.press("c")  # engage character-cursor mode
+        await pilot.pause()
+        assert flow.cursor_visible, "setup: character-cursor mode did not engage"
+
+        await pilot.press("space")
+        await pilot.pause()
+        assert "expanded detail line" not in _painted(flow), (
+            "Space folded the row while the character cursor was engaged — "
+            "the #4697 guard did not fire"
         )
 
 
@@ -188,10 +268,12 @@ async def test_an_ordinary_row_is_untouched_by_the_highlight() -> None:
 async def test_a_huge_result_is_capped_and_says_so() -> None:
     """Tier 2b: a large result does not shove the conversation off screen.
 
-    The expansion is triggered by the highlight merely ARRIVING, so an uncapped
-    body would be a side effect of pressing ``k`` that the reader never asked
-    for. The cap is stated in the row rather than silently truncating, and the
-    untruncated text stays reachable through the row's own copy."""
+    #4697: the expansion is now triggered by an explicit Space, not the
+    highlight merely arriving — so an uncapped body is no longer a side
+    effect of pressing ``k``/``j`` at all; the cap protects the deliberate
+    Space press instead. The cap is stated in the row rather than silently
+    truncating, and the untruncated text stays reachable through the row's
+    own copy."""
     from reyn.interfaces.inline.textual_chat.presenter import _EXPANDED_MAX_LINES
 
     detail = [f"line {i}" for i in range(_EXPANDED_MAX_LINES + 25)]
@@ -204,6 +286,7 @@ async def test_a_huge_result_is_capped_and_says_so() -> None:
         app.conversation.append(_settled_tool(detail))
         await pilot.pause()
         flow = await _focus(pilot, app)
+        await _toggle_fold(pilot, flow)
 
         painted = _painted(flow)
         assert "more lines" in painted, (
@@ -258,9 +341,10 @@ async def test_a_result_the_summary_already_shows_is_not_duplicated() -> None:
         app.conversation.append(_settled_tool("Presented to the user. rows=0"))
         await pilot.pause()
         flow = await _focus(pilot, app)
+        await _toggle_fold(pilot, flow)
 
         painted = _painted(flow)
         assert painted.count("Presented to the user. rows=0") == 1, (
-            "the highlighted row repeated its own summary as 'detail':\n"
+            "the expanded row repeated its own summary as 'detail':\n"
             f"{painted}"
         )


### PR DESCRIPTION
**[tui-coder]** — part of #4697 (#4691 §6's own scope split — decoupling logic + the space keybinding, both owner-approved)

## What

Owner ruling (#4691 §6): moving the highlight and opening/closing one row's tool detail are two different intents — #3508's original coupling meant a reader could never move past a big result without collapsing it first.

**Two measurements, both done before implementing (lead-coder's explicit conditions):**
1. Can existing operations already express open/close, avoiding a new keybinding? No (`c`/toggle_cursor is a view-wide bool, not per-entry; Enter/Space both duplicate the same copy action; mouse click is deliberately a no-op) → owner picked Space (architect's own finding: Space and Enter both map to flowview's `"activate"`, so Space isn't independently used for anything — repurposing it loses nothing, Enter still copies).
2. Does flowview's `check_action` already gate Space by character-cursor mode (so a naive rebind wouldn't disrupt text selection)? No — measured directly against the installed flowview 0.19.0 source. Needed an explicit guard.

## Implementation

- `on_flow_view_highlighted` no longer calls `_set_expanded` — highlight only moves the read position now.
- `_CursorFlowView` (already the Enter/Space split point from #3624) overrides just Space's binding (`Binding("space", "toggle_fold")`) — Enter keeps flowview's own copy meaning. `action_toggle_fold`:
  - falls through to the ordinary copy path when `cursor_visible` is True (the measured guard);
  - otherwise posts a new `ToggleFoldRequested` message the app handles by flipping that one entry's fold state, independent of highlight position.
- The `cursor_visible`-as-proxy-for-flowview's-private-`_text_active()` equivalence is commented as DERIVED, not a contract (lead-coder's explicit condition, comments.md residue form — names what breaks if the derivation stops holding, not "don't touch this").

## Test changes

- `test_tool_detail_on_highlight_3508.py`: rewritten for the new trigger — highlight alone no longer unfolds; Space does (and toggles back); an expanded row now SURVIVES the highlight moving away (inverting the old behavior — the whole point); a new test pins the character-cursor guard directly.
- `test_conversation_cursor_3476.py`: the old "Space also copies" test's premise is now false — rewritten to pin the new contract (Space no-ops on an ordinary row; Enter alone still copies).

## Falsification

Reverted `app.py` → the #3508 file's Space-driven tests hang (the condition-wait loop never resolves without the fix — CI's own timeout is the intended backstop here, not a self-imposed one); the #3476 regression test fails outright.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_tool_detail_on_highlight_3508.py tests/interfaces/test_conversation_cursor_3476.py` — 13/13 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] Scoped pytest: both changed files + `test_click_does_not_copy_3624.py` + `test_textual_chat_copy_rewind_3362.py` + `test_textual_chat_esc_sufficiency_3365.py` + `test_3354_composer_completion.py` (composer's own unrelated space presses) — 80 passed, no regressions
- [ ] (waived, Visual axis only — standing 2026-08-08 owner waiver) not visually confirmed in this session; operator confirms on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## レビュア追記（lead-coder, TESTS-READ 済）

- [x] 🔴 `test_space_no_longer_copies_since_4697_repurposed_it_for_folding` の `clipboard() is None` は「Space がコピーしない」と「**コピー機構自体が死んでいる**」を区別できず、不在は待てないので `await pilot.pause()` ×2 が根拠のない定数になっています。**同じテストに陽性対照を**: Space の後に Enter を押し、`clipboard() == "reply text"` を条件待ち（起きることを待つので無限待ちで書け、pause 定数も消えます）

