### PR TITLE
chore(#4705 ②): remove dead OpContext.preprocessor_phase_name

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -74,7 +74,6 @@ class OpContext:
     sub_state_dir_override: str | None = None
     state_dir_strategy: str = "control_ir"  # "control_ir" or "preprocessor"
     # Used when state_dir_strategy=="preprocessor"
-    preprocessor_phase_name: str = ""
     preprocessor_step_index: int = 0
 
     # MCP

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -68,14 +68,6 @@ class OpContext:
     subscribers: list = field(default_factory=list)
     output_language: str | None = None
 
-    # Sub-run state_dir layout strategy.
-    # When set, the sub-run handler uses this path verbatim. When None, the
-    # handler computes a layout based on `state_dir_strategy`.
-    sub_state_dir_override: str | None = None
-    state_dir_strategy: str = "control_ir"  # "control_ir" or "preprocessor"
-    # Used when state_dir_strategy=="preprocessor"
-    preprocessor_step_index: int = 0
-
     # MCP
     mcp_servers: dict = field(default_factory=dict)
     # #a359 P2: the per-turn structured MCP client pool (owns open+reuse+close in one task). Replaces

--- a/src/reyn/tools/exec.py
+++ b/src/reyn/tools/exec.py
@@ -122,8 +122,6 @@ async def op_context_from_tool_context(ctx: ToolContext) -> Any:
         resolver=ctx.resolver,
         subscribers=getattr(ctx.events, "subscribers", []),
         output_language=None,
-        sub_state_dir_override=None,
-        state_dir_strategy="control_ir",
         mcp_servers={},
         intervention_bus=None,
         caller="direct",

--- a/src/reyn/tools/web_search.py
+++ b/src/reyn/tools/web_search.py
@@ -74,8 +74,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         resolver=ctx.resolver,
         subscribers=getattr(ctx.events, "subscribers", []),
         output_language=None,
-        sub_state_dir_override=None,
-        state_dir_strategy="control_ir",
         mcp_servers={},
         intervention_bus=None,
         caller="direct",


### PR DESCRIPTION
**[e2e-coder]** — #4705② 実装: 死んだ phase 識別子は測定の結果 **1 件のみ**でした（architect見立ての約80とは大きく乖離、issueに理由を記録済み）。

## 何をしたか

`OpContext.preprocessor_phase_name`（context.py）を削除。`state_dir_strategy` は "control_ir"/"preprocessor" の2値を宣言しますが、構築箇所2つ（tools/exec.py, tools/web_search.py）とも "control_ir" 固定で "preprocessor" 分岐は一度も選ばれず、死んでいることを確認済みです。

issueで名指しされた他の候補（PhaseRouterLoopHost / for_phase / _phase_preview_strategy / phase_executor.py / current_phase系 / gates.phase / last_phase_applied_seq）はすべて既に実体が無く、削除済みであることを説明する comment/docstring のみでした（①の対象）。`max_phase_visits` は公開面ですが `_REMOVED_CONFIG_KEYS` に意図的に保持された「削除済みキー案内」で、見落としではなく設計どおりのため対象外です。

## 公開面

config key でも event payload でも AG-UI wire でもありません（OpContext内部field、serializeされません）。

## 隣接した気づき(スコープ外)

同じ死んだ分岐の兄弟field `preprocessor_step_index` も同様に死んでいますが、"phase"を含まないため本issueのスコープ外として触っていません。issueコメントに記録済み、判断は別途。

## 検証

- 削除後 `preprocessor_phase_name` を全repo grep → 0件（journalの過去記録1件のみ、更新不要な歴史的記録）
- `tests/core -k "op_runtime or context or exec or web_search"`（190 passed）+ #4699/#4701のskill-scan系（60 passed）

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/op_runtime/context.py`
- [x] `python -m pytest tests/core -k "op_runtime or context or exec or web_search" -q`（190 passed）
- [x] repo全体grepで0件確認
- [ ] Visual — N/A（no UI）

part of #4705

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## レビュア追記（lead-coder）

**[e2e-coder]** — #4705② 実装: 死んだ phase 識別子は測定の結果 **1 件のみ**でした（architect見立ての約80とは大きく乖離、issueに理由を記録済み）。

## 何をしたか

`OpContext.preprocessor_phase_name`（context.py）を削除。`state_dir_strategy` は "control_ir"/"preprocessor" の2値を宣言しますが、構築箇所2つ（tools/exec.py, tools/web_search.py）とも "control_ir" 固定で "preprocessor" 分岐は一度も選ばれず、死んでいることを確認済みです。

issueで名指しされた他の候補（PhaseRouterLoopHost / for_phase / _phase_preview_strategy / phase_executor.py / current_phase系 / gates.phase / last_phase_applied_seq）はすべて既に実体が無く、削除済みであることを説明する comment/docstring のみでした（①の対象）。`max_phase_visits` は公開面ですが `_REMOVED_CONFIG_KEYS` に意図的に保持された「削除済みキー案内」で、見落としではなく設計どおりのため対象外です。

## 公開面

config key でも event payload でも AG-UI wire でもありません（OpContext内部field、serializeされません）。

## 隣接した気づき(スコープ外)

同じ死んだ分岐の兄弟field `preprocessor_step_index` も同様に死んでいますが、"phase"を含まないため本issueのスコープ外として触っていません。issueコメントに記録済み、判断は別途。

## 検証

- 削除後 `preprocessor_phase_name` を全repo grep → 0件（journalの過去記録1件のみ、更新不要な歴史的記録）
- `tests/core -k "op_runtime or context or exec or web_search"`（190 passed）+ #4699/#4701のskill-scan系（60 passed）

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/op_runtime/context.py`
- [x] `python -m pytest tests/core -k "op_runtime or context or exec or web_search" -q`（190 passed）
- [x] repo全体grepで0件確認
- [ ] Visual — N/A（no UI）

part of #4705

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## レビュア追記（lead-coder）

- [x] 🔴 死んだ枝は 1 フィールドではなく **4 つ**。定義ファイルを除いた全参照を測ると `preprocessor_step_index`（読み手 0 / 書き手 0）、`state_dir_strategy`（読み手 **0** / 書き手 2、どちらも既定値 `"control_ir"`）、`sub_state_dir_override`（読み手 **0** / 書き手 2、どちらも既定値 `None`）。**誰も `"preprocessor"` を設定しないので「preprocessor 戦略」という分岐全体が死んでいます**。1 つだけ消すとコメント「Used when `state_dir_strategy=="preprocessor"`」が偽のまま残り、穴は閉じてもクラスが残ります（owner 恒久指示）。4 つとも削除し、呼び出し側 2 箇所（exec.py:125-126 / web_search.py:77-78）から引数を落とす — どちらも既定値の明示なので**挙動変化ゼロ** — `ae84f6a61`、grepで4フィールドとも0件、tests/core -k "op_runtime or context or exec or web_search" 190件green

 — どちらも既定値の明示なので**挙動変化ゼロ** — `ae84f6a61`、grepで4フィールドとも0件、tests/core -k "op_runtime or context or exec or web_search" 190件green


