### PR TITLE
docs(#4715): mark ADR-0002 Superseded by ADR-0038, status line only

### DIFF
--- a/docs/deep-dives/decisions/0002-forward-replay-resume.md
+++ b/docs/deep-dives/decisions/0002-forward-replay-resume.md
@@ -1,6 +1,13 @@
 # ADR-0002: Forward-replay resume (no phase-head re-execution)
 
-**Status**: Accepted (2026-05-02)
+**Status**: Superseded by ADR-0038 (2026-08-14) — the phase/op-level
+forward-replay this ADR adopted (op memoization within an in-flight phase)
+was removed with the phase-graph engine (#2434/#2439). The question it
+answered — crash resume without re-running completed work — is answered
+today by `AgentSnapshot` generation + WAL-diff reconstruct
+(`snapshot_generations.py`: "Crash recovery is the special case
+`reconstruct(head)`"), recorded in ADR-0038. The op-memoization
+**granularity itself has no successor**.
 **Track**: D-track (D3b)
 
 ## Context


### PR DESCRIPTION
**[docs-maintainer]** — Marks ADR-0002's status line Superseded by ADR-0038, per lead-coder's ruling on #4715 (status-line-only, body untouched — the ADR-immutable-body gate).

## Background

ADR-0002 ("Forward-replay resume — no phase-head re-execution") said `**Status**: Accepted (2026-05-02)` with no supersession marker, but the phase/op-level forward-replay it adopted was removed with the phase-graph engine in #2434/#2439 (confirmed via `git log -S` on `SkillResumeCoordinator`/`OSRuntime` during #4711).

## Why Superseded, not Retired

lead-coder's ruling: Retired = the function is gone; Superseded = the same question has a different answer today. ADR-0002's question — crash resume without re-running completed work — is still answered, just by a different mechanism: `AgentSnapshot` generation + WAL-diff reconstruct, recorded in ADR-0038 (`snapshot_generations.py`: "Crash recovery is the special case `reconstruct(head)`"). One caveat folded into the wording: the specific *granularity* ADR-0002 chose (op-level memoization within an in-flight phase) has no successor — only "Superseded" alone would misread as "the same thing exists under a new name."

Wording is lead-coder's own proposal on #4715, used verbatim.

## Precedent for the shape

ADR-0038 already carries a dated `**Status correction** (2026-08-11, docs-maintainer): ...` addendum, and ADR-0036 already carries an inline partial-supersession note pointing at ADR-0042 — both status-line-only edits to an otherwise-immutable ADR body. This PR is the same shape.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no Aborted/WARNING
- [x] `python scripts/check_doc_anchors.py` — clean
- [x] `python scripts/check_retired_config_keys_denylist.py` — clean (unrelated but same CI job)
- [x] Diff scoped to the Status line only — `git diff` shows no body content touched
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Closing-intent self-grep on commit message + this body: no keyword adjacent to any issue number
- [x] (skipped — no user-facing/Visual surface touched by this PR)

Closes #4715
