### PR TITLE
docs(#4709): BudgetGateway.last_call_usage's 2-writer invariant

### DIFF
--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -142,7 +142,21 @@ class BudgetGateway:
         sending nearly the same growing context; summing them would wildly
         overstate "how much of the context window is currently occupied"
         (status-bar ctx chip's headline figure). Overwritten (not
-        accumulated) on each call."""
+        accumulated) on each call.
+
+        #4703/#4709: this field's only two writers today are
+        :meth:`accumulate` (``session.py``'s own router-turn-result path)
+        and :meth:`add_router_usage` (``router_loop_driver.py``) — both
+        ROUTER calls. That is why the ctx chip's figure never needs a
+        ``purpose`` filter: compaction's own LLM call (a real, separate
+        recorder — ``BudgetTracker`` via ``recorder=self._budget_tracker``
+        in ``session.py``, never this gateway) has no path to this field at
+        all. If a THIRD writer is ever wired to this gateway from a
+        non-router call site (a purpose OTHER than the conversation turn),
+        it will overwrite this property with that call's usage instead —
+        silently, no exception, no raise — and the ctx chip will start
+        showing that OTHER call's prompt size as if it were the
+        conversation's own."""
         return self._last_call_usage
 
     def accumulate(self, result) -> None:


### PR DESCRIPTION
**[tui-coder]** — Closes #4709

## What

`BudgetGateway.last_call_usage`'s "no purpose filter needed" contract was implicit — nowhere written down that it holds only because both writers today are router calls.

Docstring adds: the two real writers (`Session.accumulate`'s router-turn-result path, `RouterLoopDriver.add_router_usage`) and why compaction's own LLM call never reaches this field (a separate recorder, `BudgetTracker` via `session.py`'s `recorder=self._budget_tracker`, not this gateway). Written in comments.md's residue form (what breaks, not a prohibition, per the issue's own explicit instruction): a third non-router writer would silently overwrite this property, no exception, and the ctx chip would start showing that other call's prompt size as the conversation's own.

**Code unchanged** — docstring only, per the issue's own explicit scope.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/services/budget_gateway.py` — clean
- [x] `tests/llm/test_budget_gateway_invariants.py` — 10 passed (no behavior change, confirms nothing regressed)
- [ ] (waived, Visual axis only — standing 2026-08-08 owner waiver) N/A, no UI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
