### PR TITLE
chore(#4705 3): cross-reference the two unrelated "phase" fields

### DIFF
--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -55,6 +55,14 @@ from dataclasses import dataclass
 # value would require a NEW runtime concept, which is a design decision, not a
 # repair. If such a concept ever lands, name it accurately instead of reviving
 # ``phase``.
+#
+# Name collision, not the same field: ``interfaces/transport/agui/protocol.py``
+# (``_encode_event``, the RUN_STARTED/RUN_FINISHED branch) also writes a
+# ``"phase"`` key — that one is the AG-UI wire protocol's own standard field,
+# live and populated with the run-lifecycle type string. It is unrelated to
+# THIS field and cannot be renamed either (it's the AG-UI spec's own
+# vocabulary). Two different "phase"s that happen to share a name — do not
+# read one as explaining the other.
 RETIRED_PHASE_FIELD = ""
 
 # Events that must carry these audit fields (FP-0021)

--- a/src/reyn/interfaces/transport/agui/protocol.py
+++ b/src/reyn/interfaces/transport/agui/protocol.py
@@ -336,6 +336,17 @@ def _encode_event(frame: EventFrame) -> AgUiEvent:
             "status": "error" if etype == "tool_failed" else "ok",
         }
     elif ag_type in (RUN_STARTED, RUN_FINISHED):
+        # This "phase" is the AG-UI wire protocol's own standard field for a
+        # RUN_STARTED/RUN_FINISHED event — it carries the run-lifecycle type
+        # string itself (``etype``, e.g. "run_started"), a live, populated
+        # value read by AG-UI clients. Same name, unrelated meaning to
+        # ``core.events.event_schema.RETIRED_PHASE_FIELD`` (reyn's own
+        # audit-event ``phase`` field, permanently the empty string since
+        # #2696 — the phase engine that once populated it is gone). Neither
+        # can be renamed: this one is the AG-UI spec's own vocabulary; that
+        # one is a persisted, replay-compatible audit-event schema field. Two
+        # different "phase"s that happen to sit in the same codebase — do not
+        # assume one explains the other.
         std = {"phase": etype}
     else:  # CUSTOM — user_answered_intervention et al.
         std = {"name": f"reyn.event.{etype}", "value": edata}


### PR DESCRIPTION
**[docs-maintainer]** — Last remainder of #4705 (①=#4710, ②=#4714, this is ③): cross-references the two unrelated `"phase"` fields at both their definition sites, per lead-coder's ruling on the issue.

## The collision

- `src/reyn/interfaces/transport/agui/protocol.py:339` (`_encode_event`'s `RUN_STARTED`/`RUN_FINISHED` branch) — `std = {"phase": etype}`. This is the AG-UI wire protocol's own standard field, live and populated with the run-lifecycle type string. Cannot be renamed — it's the AG-UI spec's own vocabulary.
- `src/reyn/core/events/event_schema.py` — `RETIRED_PHASE_FIELD = ""`. reyn's own audit-event schema's `phase` field, permanently the empty string since the phase engine that populated it was deleted (#2434/#2438, #2696). Cannot be renamed either — it's a persisted, replay-compatible audit-event schema field; dropping it breaks `reyn events replay` against every event file already written.

Neither side can move, so the prescription (lead-coder's, verbatim ruling on #4705) isn't cleanup or a rename — it's writing each field's own definition-site comment to say what it carries and why the other one is empty, so the collision is visible to the next reader rather than silently re-discovered. Per the explicit warning on the issue: "same name → same thing" is this repo's most common misreading, so each comment doesn't stop at "these are different" — it says what one carries and why the other is empty.

## Scope

Comment-only, no behavior change. Not proposing the 1,002-occurrence `phase`→`step` rename `architect` explicitly ruled out of scope on the issue (#2772/#3355 already handle dead-layer removal; renaming the live layer is a separate decision the owner deferred).

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/verify_module_docstrings.py <changed files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, 203/207 baselined, no new findings
- [x] `git diff` reviewed — comment-only on both files, no logic touched
- [x] Fetch-checked against `origin/main` before push — no drift on touched files
- [x] Closing-intent self-grep on commit message + this body: no keyword adjacent to any issue number
- [x] (skipped — no user-facing/Visual surface, comment-only change)

Closes #4705
