### PR TITLE
feat(#4206 slice 2): wire chat.reasoning.display into the ③ preference axis

### DIFF
--- a/docs/reference/cli/agent.md
+++ b/docs/reference/cli/agent.md
@@ -138,16 +138,24 @@ An unrecognized key under `preferences:` (a typo, or a key retired from
 UnknownPreferenceKeyError`) rather than silently doing nothing — the same
 discipline #4655 established for config-schema dict-leaves.
 
-**Scope of this slice**: read/resolve only — of the 9 keys above, this PR
-wires `output_language` into `Session.output_language`; `chat.reasoning.
-display` and the 7 `warn_ratio` keys are declared in `PREFERENCE_KEYS`
-but not yet threaded through their own consumers (a follow-up). No
-`preferences`-specific CLI/slash write surface exists yet — set an
-agent-layer value by editing `profile.yaml` directly (the same
-existing pattern `allowed_mcp` already uses); a session-layer value by
-whatever spawns the session passing a `narrowing` dict whose own
-`preferences` sub-key is set (`AgentRegistry.spawn_session`'s existing
-`narrowing=` parameter — no new API).
+**Scope so far**: read/resolve only — of the 9 keys, `output_language`
+(slice 1) and `chat.reasoning.display` (slice 2, #4206) are wired into a
+live `Session` property (`Session.output_language` /
+`Session.reasoning_display`) that re-resolves the session/agent/project
+composition on every access. The remaining 7 `warn_ratio` keys are
+declared in `PREFERENCE_KEYS` but not yet wired — they all funnel into ONE
+process-shared `BudgetTracker` (built once per process from the
+project-level config only), so wiring them needs a collision-safe
+per-agent/session override registry (the same shape `#4700`'s
+`register_max_input_overrides` established for `llm.models.<tier>.
+max_input_tokens`), not a bare live property — tracked as a follow-up, not
+mixed into this slice. No `preferences`-specific CLI/slash write surface
+exists yet for any key — set an agent-layer value by editing
+`profile.yaml` directly (the same existing pattern `allowed_mcp` already
+uses); a session-layer value by whatever spawns the session passing a
+`narrowing` dict whose own `preferences` sub-key is set
+(`AgentRegistry.spawn_session`'s existing `narrowing=` parameter — no new
+API).
 
 ## See also
 

--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -54,6 +54,16 @@ block):
   "session layer in front of agent layer, re-read every time" shape `_workspace_base_dir`
   below already established for `base_dir` — an operator editing either file by hand takes
   effect on the next read, not just the next process start.
+- `reasoning_display` (#4206 slice 2) — public `@property`, the SAME shape as
+  `output_language` immediately above, factored through a shared
+  `Session._resolve_session_preference(key, project_default)` helper both now
+  call. Resolves ONLY `chat.reasoning.display` — `chat.reasoning.continuity`/
+  `recent_turns` stay ② bounding (read directly off `self._reasoning`,
+  unaffected). `RouterHostAdapter.reasoning_display_enabled()` consults this
+  live via a `reasoning_display_fn` callback wired at construction (the SAME
+  callback shape `reasoning_continuity_section_fn` already established for
+  the sibling continuity-section renderer) — `None` (every pre-slice-2 host)
+  falls back to the frozen `reasoning_config.display` read, byte-identical.
 - `_sandbox_backend` (#1200 PR-F2) — the agent's `SandboxBackend` INSTANCE for the chat exec
   seam (the router `OpContext`); `None` → `get_default_backend`. This is the INSTANCE, not
   the `sandbox_config.backend` STRING used for exec-tool gating — for a docker agent it is

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -407,6 +407,12 @@ class RouterHostAdapter:
         # history + applies the continuity gate). None → reasoning disabled.
         reasoning_config: Any = None,
         reasoning_continuity_section_fn: "Callable[[], str] | None" = None,
+        # #4206 slice 2: ③ preference-axis live override for `display` ONLY
+        # (continuity/recent_turns stay ② bounding, read off
+        # `reasoning_config` unchanged) — None (every pre-slice-2 caller,
+        # every test host) falls back to the frozen `reasoning_config.display`
+        # value, byte-identical to before this slice.
+        reasoning_display_fn: "Callable[[], bool] | None" = None,
         # Issue #383 PR-C: media + tool-result file storage.
         media_store: Any = None,
         # #1128 size axis: per-turn tool-result cap/offload callable. Takes the
@@ -597,6 +603,8 @@ class RouterHostAdapter:
         # #1652: reasoning capture/continuity/display config + the section renderer.
         self._reasoning_config = reasoning_config
         self._reasoning_continuity_section_fn = reasoning_continuity_section_fn
+        # #4206 slice 2: ③ preference-axis live override for `display` ONLY.
+        self._reasoning_display_fn = reasoning_display_fn
         # Issue #383 PR-C: store the MediaStore for path-ref save/read.
         self._media_store = media_store
         # #1128 size axis: per-turn tool-result cap/offload callable (or None).
@@ -1979,7 +1987,17 @@ class RouterHostAdapter:
 
     def reasoning_display_enabled(self) -> bool:
         """Whether the model's reasoning text should be surfaced to the UI
-        (config ``chat.reasoning.display``; default False when unconfigured)."""
+        (config ``chat.reasoning.display``; default False when unconfigured).
+
+        #4206 slice 2: when ``reasoning_display_fn`` was supplied (the
+        production `Session` path), calls it fresh EVERY time — the ③
+        preference-axis live re-resolution (session/agent overrides), not
+        the frozen ``reasoning_config.display`` this adapter was
+        constructed with. ``None`` (every pre-slice-2 caller, every test
+        host that doesn't pass the new callback) falls back to the
+        original frozen-config read, byte-identical to before this slice."""
+        if self._reasoning_display_fn is not None:
+            return bool(self._reasoning_display_fn())
         return bool(getattr(self._reasoning_config, "display", False))
 
     def reasoning_continuity_enabled(self) -> bool:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1872,6 +1872,29 @@ class Session:
             )
             return {}
 
+    def _resolve_session_preference(self, key: str, project_default: object) -> object:
+        """#4206: shared ③ preference-axis resolution — session-layer
+        `config.yaml` `preferences.<key>` wins over agent-layer
+        `profile.yaml` `preferences.<key>` wins over *project_default*.
+        Live re-read on every call (never cached), same shape
+        `_workspace_base_dir` uses for `base_dir`. Factored out of
+        `output_language` (slice 1's own implementation) so every
+        subsequent ③ key (this one's first user: `reasoning_display`,
+        slice 2) shares ONE resolution path rather than re-deriving the
+        same three-step read — the exact "mechanism stays the same as ③
+        grows" promise `preferences.py`'s own module docstring makes."""
+        from reyn.runtime.preferences import resolve_preference
+
+        session_preferences = self._read_preferences_override(
+            Path(self._snapshot_path).parent / "config.yaml"
+        )
+        agent_preferences = self._agent_profile_preferences()
+        return resolve_preference(
+            key, project_default,
+            agent_preferences=agent_preferences,
+            session_preferences=session_preferences,
+        )
+
     @property
     def output_language(self) -> "str | None":
         """#4206 slice 1: ③ preference axis, free-override composition —
@@ -1880,17 +1903,8 @@ class Session:
         the project-level default this Session was constructed with
         (`self._project_output_language`). Live re-read on every access,
         same shape `_workspace_base_dir` already uses for `base_dir`."""
-        from reyn.runtime.preferences import resolve_preference
-
-        session_preferences = self._read_preferences_override(
-            Path(self._snapshot_path).parent / "config.yaml"
-        )
-        agent_preferences = self._agent_profile_preferences()
-        resolved = resolve_preference(
-            "output_language",
-            self._project_output_language,
-            agent_preferences=agent_preferences,
-            session_preferences=session_preferences,
+        resolved = self._resolve_session_preference(
+            "output_language", self._project_output_language,
         )
         # resolve_preference's return type is `object` (it's generic across
         # every ③ key, not just this str-typed one) — an override value
@@ -1898,6 +1912,24 @@ class Session:
         # output_language was never a valid value at ANY layer), so this
         # narrows rather than silently propagating the wrong type.
         return str(resolved) if resolved is not None else None
+
+    @property
+    def reasoning_display(self) -> bool:
+        """#4206 slice 2: ③ preference axis — session-layer
+        `preferences.chat.reasoning.display` wins over agent-layer wins
+        over the project-level default this Session was constructed with
+        (`self._reasoning.display`). Live re-read on every access, same
+        shape `output_language` uses.
+
+        Deliberately narrow: only `display` (whether reasoning text is
+        SURFACED to the UI) is ③. `chat.reasoning.continuity` /
+        `chat.reasoning.recent_turns` are ② bounding (#4206's own ratified
+        classification) and stay read directly off `self._reasoning` —
+        this property does not touch them."""
+        resolved = self._resolve_session_preference(
+            "chat.reasoning.display", bool(self._reasoning.display),
+        )
+        return bool(resolved)
 
     @property
     def _reyn_state_root(self) -> "Path":
@@ -4617,6 +4649,14 @@ class Session:
             # the router loop for emit-gating, persist-gating, and SP replay.
             reasoning_config=self._reasoning,
             reasoning_continuity_section_fn=self.reasoning_continuity_section,
+            # #4206 slice 2: ③ preference-axis live override for `display`
+            # ONLY (continuity/recent_turns stay ② bounding, read off
+            # `reasoning_config` above, untouched) — a callback, same shape
+            # as `reasoning_continuity_section_fn` immediately above, so the
+            # adapter re-resolves session/agent overrides on every call
+            # instead of reading the frozen `reasoning_config.display` this
+            # session was constructed with.
+            reasoning_display_fn=lambda: self.reasoning_display,
             # Issue #383 PR-C: shared MediaStore for image + tool-result storage.
             media_store=self._media_store,
             # #1128 size axis: per-turn tool-result cap/offload (dead-end #1).

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -421,7 +421,14 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: the LLM-facing ``list_mcp_subscriptions`` tool (via
 #: ``RouterHostAdapter``) both call — not a private-state leak a slash
 #: handler needed publishing to keep reaching into the session.
-_PUBLIC_MEMBER_CEILING = 107
+#: Raised 107 -> 108 for #4206 slice 2: ``reasoning_display`` — a NEW
+#: ``@property``, the second ③ preference-axis key (after slice 1's
+#: ``output_language``) to get a live session/agent-override-resolving
+#: accessor. Same shape, same reason as the 106->107 entry above: not a
+#: private-state leak, a new read surface the ③ axis's own mechanism
+#: requires by design (``RouterHostAdapter.reasoning_display_enabled()``
+#: consults it via a callback).
+_PUBLIC_MEMBER_CEILING = 108
 
 
 def test_session_public_surface_does_not_grow() -> None:

--- a/tests/runtime/test_4206_slice2_reasoning_display.py
+++ b/tests/runtime/test_4206_slice2_reasoning_display.py
@@ -1,0 +1,147 @@
+"""Tier 2: #4206 slice 2 — ③ preference axis, ``chat.reasoning.display``.
+
+Extends slice 1 (``output_language``) to a second ③ key, wired through the
+new shared ``Session._resolve_session_preference`` helper and a
+``reasoning_display_fn`` callback into ``RouterHostAdapter`` — the same
+"live callback, not a frozen construction-time value" shape
+``reasoning_continuity_section_fn`` already established. Deliberately
+narrow: ``chat.reasoning.continuity``/``recent_turns`` are ② bounding
+(#4206's own ratified classification), unaffected by this slice, and NOT
+tested here (their own coverage is unchanged).
+
+Real instances only: a real ``Session`` (``make_session``) + a real
+``RouterHostAdapter`` reached through ``session.router_host``, never a
+stand-in.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.config.chat import ReasoningConfig
+from reyn.runtime.preferences import PREFERENCE_KEYS
+from reyn.runtime.profile import AgentProfile
+from tests._support.agent_session import make_session
+
+
+def _agent_dir(session) -> Path:
+    return session.workspace_dir
+
+
+def _session_config_path(session) -> Path:
+    return Path(session._snapshot_path).parent / "config.yaml"
+
+
+def _write_agent_preferences(session, name: str, preferences: dict) -> None:
+    profile = AgentProfile.new(name)
+    object.__setattr__(profile, "preferences", preferences)
+    profile.save(_agent_dir(session))
+
+
+def test_chat_reasoning_display_is_a_declared_preference_key():
+    """Tier 2: (accept-side) chat.reasoning.display is in PREFERENCE_KEYS —
+    slice 1 already declared it; slice 2 wires it, doesn't add it."""
+    assert "chat.reasoning.display" in PREFERENCE_KEYS
+
+
+def test_reasoning_display_reads_the_project_level_default_with_no_overrides(tmp_path: Path):
+    """Tier 2: a real Session with no agent/session preference file at all
+    — reasoning_display reads the project-level default (ReasoningConfig.display)
+    it was constructed with, byte-identical to pre-#4206-slice-2 behavior."""
+    session = make_session(
+        agent_name="reasoning-pref-1", workspace_state_dir=tmp_path / ".reyn",
+        reasoning_config=ReasoningConfig(display=True),
+    )
+    assert session.reasoning_display is True
+
+
+def test_reasoning_display_agent_layer_override_wins_over_project_default(tmp_path: Path):
+    """Tier 2: a real profile.yaml preferences.chat.reasoning.display
+    override wins over the Session's own project-level default."""
+    session = make_session(
+        agent_name="reasoning-pref-2", workspace_state_dir=tmp_path / ".reyn",
+        reasoning_config=ReasoningConfig(display=False),
+    )
+    _write_agent_preferences(
+        session, "reasoning-pref-2", {"chat.reasoning.display": True},
+    )
+
+    assert session.reasoning_display is True
+
+
+def test_reasoning_display_session_layer_override_wins_over_agent_layer(tmp_path: Path):
+    """Tier 2: session-layer config.yaml override wins over BOTH the
+    agent-layer profile.yaml override and the project default."""
+    import yaml
+
+    session = make_session(
+        agent_name="reasoning-pref-3", workspace_state_dir=tmp_path / ".reyn",
+        reasoning_config=ReasoningConfig(display=False),
+    )
+    _write_agent_preferences(
+        session, "reasoning-pref-3", {"chat.reasoning.display": True},
+    )
+
+    cfg_path = _session_config_path(session)
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump({"name": "_session_x", "preferences": {"chat.reasoning.display": False}}),
+        encoding="utf-8",
+    )
+
+    assert session.reasoning_display is False
+
+
+def test_reasoning_display_is_a_live_re_read_not_a_frozen_snapshot(tmp_path: Path):
+    """Tier 2: (accept-side) editing profile.yaml AFTER Session construction
+    takes effect on the next read — same live-re-read shape output_language
+    already established."""
+    session = make_session(
+        agent_name="reasoning-pref-4", workspace_state_dir=tmp_path / ".reyn",
+        reasoning_config=ReasoningConfig(display=False),
+    )
+    assert session.reasoning_display is False
+
+    _write_agent_preferences(
+        session, "reasoning-pref-4", {"chat.reasoning.display": True},
+    )
+
+    assert session.reasoning_display is True
+
+
+# ── RouterHostAdapter callback wiring ────────────────────────────────────
+
+
+def test_router_host_reasoning_display_enabled_reflects_the_live_session_property(tmp_path: Path):
+    """Tier 2: THE end-to-end witness — RouterHostAdapter.reasoning_display_enabled()
+    (what the router loop actually consults) reflects the SAME live
+    session/agent-preference override as Session.reasoning_display, via the
+    reasoning_display_fn callback wired at construction — not the frozen
+    reasoning_config.display value the adapter was built with."""
+    session = make_session(
+        agent_name="reasoning-pref-5", workspace_state_dir=tmp_path / ".reyn",
+        reasoning_config=ReasoningConfig(display=False),
+    )
+    assert session.router_host.reasoning_display_enabled() is False
+
+    _write_agent_preferences(
+        session, "reasoning-pref-5", {"chat.reasoning.display": True},
+    )
+
+    assert session.reasoning_display is True
+    assert session.router_host.reasoning_display_enabled() is True
+
+
+def test_reasoning_display_fn_none_falls_back_to_frozen_config():
+    """Tier 2: (accept-side) a RouterHostAdapter built WITHOUT
+    reasoning_display_fn (every pre-slice-2 caller, every existing test
+    host) falls back to the original frozen reasoning_config.display read
+    — byte-identical to before this slice."""
+    from reyn.runtime.services.router_host_adapter import RouterHostAdapter
+    from tests._support.router_host_adapter import make_adapter
+
+    adapter: RouterHostAdapter = make_adapter(
+        universal_wrappers_enabled=False,
+    )
+    # make_adapter doesn't accept reasoning_config directly, so the default
+    # (None -> getattr fallback -> False) is exercised here.
+    assert adapter.reasoning_display_enabled() is False


### PR DESCRIPTION
**[e2e-coder]** — #4206③ slice 2: `chat.reasoning.display` を③軸に配線します。

## 何をしたか

slice 1（`output_language`）の続きです。owner裁定どおり `chat.reasoning.display` のみ（`continuity`/`recent_turns`は②bounding、対象外）を、`output_language`と全く同じ形（live property、session→agent→projectのfree-override合成）で配線しました。

## スコープ（issueに事前に置いた測定どおり）

残り8key は「output_languageと同型のコピー×8」ではありませんでした。`chat.reasoning.display`（Session所有、非process-shared）だけが同型で簡単、残り7件（cost系warn_ratio）は全て1つのprocess-shared BudgetTrackerに焼き込まれており、`#4700`の`register_max_input_overrides`型の新設計が要る別の課題です。lead-coder裁定で政策面（capを動かさない・帯を緩めない）は決着済みですが、機構自体は未設計のため本PRのスコープ外とし、Slice Bとして別issueに切り出す前提です。

## 実装

- `Session._resolve_session_preference(key, project_default)` — 3層合成ロジックを共通化（output_languageもこちらを呼ぶよう変更、挙動不変）
- `Session.reasoning_display` — output_languageと同型のlive property
- `RouterHostAdapter.reasoning_display_fn` — `reasoning_continuity_section_fn`と同型のcallback、`None`は既存のfrozen configへfall back(挙動不変)
- `_PUBLIC_MEMBER_CEILING` 107→108（新規public property、slice1の105→106と同じ理由）
- doc更新(agent.md / session-construction.md)、実装と同PR

## 検証

- strip-falsify: session.py/router_host_adapter.py の変更をrevert → 7test中5件が正しい理由でRED、accept-side 2件はgreenのまま。復元してgreen。
- `tests/llm -k reasoning`（22/23 passed、1件は無関係な既存litellmカタログドリフト、mainでも同一失敗確認済み）
- `tests/runtime -k "reasoning or router_host or 4206"`（60 passed）

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_4206_slice2_reasoning_display.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py src/reyn/runtime/services/router_host_adapter.py`
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py`
- [x] `python scripts/check_bare_tests_import_reference.py && python scripts/check_file_depth_reference.py && python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python -m pytest tests/llm -k reasoning -q`（22/23、無関係な既存失敗1件）
- [x] `python -m pytest tests/runtime -q -k "reasoning or router_host or 4206"`（60 passed）
- [x] strip-falsify（上記）
- [ ] Visual — N/A（no UI）

part of #4206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
