### PR TITLE
feat(#4691): thread call_id/finish_reason onto RouterLoop's outbox meta

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -704,6 +704,19 @@ class LLMToolCallResult:
                                      # empty list if none
     finish_reason: str | None
     usage: TokenUsage
+    # #4691 Phase 1 ②: the litellm response's own ``id`` — the same value
+    # ``_emit_chat_cost_events`` stamps as ``call_id`` on the
+    # ``llm_response_received`` audit event (item ①, #4722). Threaded through
+    # here so RouterLoop's ``kind="agent"`` outbox rows can carry the SAME key
+    # their own audit-event counterpart carries, without re-deriving it from
+    # ``raw_message`` (which is the assistant *message*, not the response
+    # envelope the id lives on). ``None`` when the provider omitted it — never
+    # a minted placeholder, same discipline as ``finish_reason`` above. Also
+    # ``None`` for litellm's own empty-string id (see the ``or None`` at the
+    # assignment site) — #4722 review found ``""``, not ``None``, is what a
+    # genuinely id-less reconstructed stream response carries, and left
+    # unfixed every such row would share the SAME falsy key.
+    call_id: str | None = None
     # raw message for debugging:
     raw_message: object | None = None
     # #1652/②: the model's reasoning as a normalized BUNDLE
@@ -2996,6 +3009,10 @@ async def call_llm_tools(
         tool_calls=tool_calls,
         finish_reason=finish_reason,
         usage=usage,
+        # #4691 Phase 1 ②: ``or None`` collapses litellm's own empty-string
+        # id (see ``LLMToolCallResult.call_id``'s own docstring) to a genuine
+        # absence — same fix #4722 applied at the audit-event call site.
+        call_id=getattr(response, "id", None) or None,
         raw_message=msg,
         # #1652/②: capture the provider reasoning as a normalized BUNDLE
         # (reasoning_content + thinking_blocks, the litellm cross-provider

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -710,12 +710,8 @@ class LLMToolCallResult:
     # here so RouterLoop's ``kind="agent"`` outbox rows can carry the SAME key
     # their own audit-event counterpart carries, without re-deriving it from
     # ``raw_message`` (which is the assistant *message*, not the response
-    # envelope the id lives on). ``None`` when the provider omitted it — never
-    # a minted placeholder, same discipline as ``finish_reason`` above. Also
-    # ``None`` for litellm's own empty-string id (see the ``or None`` at the
-    # assignment site) — #4722 review found ``""``, not ``None``, is what a
-    # genuinely id-less reconstructed stream response carries, and left
-    # unfixed every such row would share the SAME falsy key.
+    # envelope the id lives on). Populated via ``_response_call_id`` — see
+    # its own docstring for the "" vs None collapse both call sites share.
     call_id: str | None = None
     # raw message for debugging:
     raw_message: object | None = None
@@ -1483,6 +1479,27 @@ def _read_usage_source(response: object) -> UsageSource:
     reads UNKNOWN only for a hand-built object. Never PROVIDER by default.
     """
     return parse_usage_source(getattr(response, _USAGE_SOURCE_ATTR, None))
+
+
+def _response_call_id(response: object) -> "str | None":
+    """The litellm response's own ``id``, or ``None`` when genuinely absent.
+
+    #4691 Phase 1 ①②: the ONE place this collapse lives (lead-coder review,
+    #4722/#4725 — it was duplicated inline at both call sites before this,
+    same "one rule, not two" condition as #4708). litellm's own
+    ``ChunkProcessor._get_chunk_id`` returns ``""``, not ``None``, when no
+    stream chunk carried an id, and ``ModelResponse.__init__`` only mints a
+    fresh id when the field is ``None`` — so a genuinely id-less STREAMED
+    response reconstructs with ``id=""``, never ``id=None``. The sync path
+    never hits this (litellm's own sync response either carries a real id or
+    leaves the attribute unset), but the collapse is unconditional here so a
+    future change to that assumption doesn't silently reopen the bug this
+    closes: every row missing a real id must share the SAME reported absence
+    (``None``), never a shared empty-string key — a future consumer (#4691
+    Phase B's tree) keying on ``call_id`` would otherwise bundle unrelated
+    calls as one.
+    """
+    return getattr(response, "id", None) or None
 
 
 def proxy_kwargs() -> dict:
@@ -2669,17 +2686,9 @@ async def recorded_acompletion(
     if emit_cost_events:
         # #4691 Phase 1 ①: measured directly off the response, never
         # invented — a provider that omits either field means None, not a
-        # minted placeholder (see _emit_chat_cost_events's own docstring).
-        # ``or None`` (lead-coder review, #4722): litellm's own
-        # ``ChunkProcessor._get_chunk_id`` returns "" — not None — when no
-        # stream chunk carried an id, and litellm's ``ModelResponse.__init__``
-        # only mints a fresh id when the field is None, so "" survives
-        # untouched onto the reconstructed response. Left as "", every row
-        # missing an id would share the SAME falsy key and get bundled as one
-        # call by any future consumer keying on it (#4691 Phase B's tree) —
-        # worse than a missing key, since it fabricates a false grouping. The
-        # `or None` collapses any falsy id (`""`, `0`) to a genuine absence.
-        _call_id = getattr(response, "id", None) or None
+        # minted placeholder (see _emit_chat_cost_events's own docstring and
+        # _response_call_id's own docstring for the "" vs None collapse).
+        _call_id = _response_call_id(response)
         _finish_reason = None
         _choices = getattr(response, "choices", None)
         if _choices:
@@ -3009,10 +3018,9 @@ async def call_llm_tools(
         tool_calls=tool_calls,
         finish_reason=finish_reason,
         usage=usage,
-        # #4691 Phase 1 ②: ``or None`` collapses litellm's own empty-string
-        # id (see ``LLMToolCallResult.call_id``'s own docstring) to a genuine
-        # absence — same fix #4722 applied at the audit-event call site.
-        call_id=getattr(response, "id", None) or None,
+        # #4691 Phase 1 ②: same collapse #4722's call site uses — see
+        # ``_response_call_id``'s own docstring for the "" vs None reasoning.
+        call_id=_response_call_id(response),
         raw_message=msg,
         # #1652/②: capture the provider reasoning as a normalized BUNDLE
         # (reasoning_content + thinking_blocks, the litellm cross-provider

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2076,6 +2076,13 @@ class RouterLoop:
                             # docstring for why this is the boundary fix).
                             "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
                             "completion_tokens": getattr(result.usage, "completion_tokens", None),
+                            # #4691 Phase 1 ②: same call-granularity key item ①
+                            # stamps on this call's own llm_response_received —
+                            # threaded onto the row so a future flowview tree
+                            # (#4691 Phase B) can tell which litellm call this
+                            # row belongs to and whether it was a tool round.
+                            "call_id": result.call_id,
+                            "finish_reason": result.finish_reason,
                         },
                     )
                 # F5 fix (dogfood batch 1): dedupe duplicate async
@@ -2179,6 +2186,10 @@ class RouterLoop:
                             # #4691: same call as the tool-turn text row above.
                             "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
                             "completion_tokens": getattr(result.usage, "completion_tokens", None),
+                            # #4691 Phase 1 ②: see the tool-turn-text row above
+                            # for the full reasoning.
+                            "call_id": result.call_id,
+                            "finish_reason": result.finish_reason,
                         },
                     )
                     return self._total_usage
@@ -2316,6 +2327,10 @@ class RouterLoop:
                         # #4691: a genuine (if content-empty) call's own usage.
                         "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
                         "completion_tokens": getattr(result.usage, "completion_tokens", None),
+                        # #4691 Phase 1 ②: see the tool-turn-text row's own
+                        # comment (~line 2073) for the full reasoning.
+                        "call_id": result.call_id,
+                        "finish_reason": result.finish_reason,
                     },
                 )
                 return self._total_usage  # no retry
@@ -2372,6 +2387,10 @@ class RouterLoop:
                     # full reasoning.
                     "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
                     "completion_tokens": getattr(result.usage, "completion_tokens", None),
+                    # #4691 Phase 1 ②: see the tool-turn-text row's own comment
+                    # (~line 2073) for the full reasoning.
+                    "call_id": result.call_id,
+                    "finish_reason": result.finish_reason,
                 },
             )
             return self._total_usage

--- a/tests/llm/test_router_empty_response.py
+++ b/tests/llm/test_router_empty_response.py
@@ -349,6 +349,29 @@ async def test_empty_response_puts_failure_message_in_outbox(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_empty_response_outbox_meta_carries_call_id_and_finish_reason(monkeypatch):
+    """Tier 2: #4691 Phase 1 ② — the outbox row's meta carries the SAME
+    call_id/finish_reason as the LLMToolCallResult that triggered it, the
+    call-granularity key #4722 (item ①) stamps on this call's own
+    llm_response_received. A row with no per-call figure at all (a legacy/
+    restored frame) is a different, pre-existing case — untouched here."""
+    host = FakeRouterHost()
+    loop = make_loop(host)
+    result = LLMToolCallResult(
+        content=None, tool_calls=[], finish_reason="stop",
+        usage=_BASE_USAGE, call_id="resp-empty-glitch",
+    )
+    scripted = _ScriptedLLM([result])
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", scripted)
+
+    await loop.run("do something", [])
+
+    (msg,) = host.outbox
+    assert msg["meta"]["call_id"] == "resp-empty-glitch"
+    assert msg["meta"]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
 async def test_empty_response_failure_message_is_p7_clean(monkeypatch):
     """Tier 2: failure message sent to user contains no skill/tool-specific names (P7)."""
     host = FakeRouterHost()


### PR DESCRIPTION
**[tui-coder]** — part of #4691 Phase 1 (item ② of ①②③④, following #4722's item ①)

## What

`call_id`/`finish_reason` threaded onto RouterLoop's `kind="agent"` outbox meta at all 4 emit sites — the same call-granularity key item ① (#4722) stamps on this call's own `llm_response_received`, so a future consumer (#4691 Phase B's flowview tree) can tell which litellm call an outbox row belongs to and whether it was a tool round (`finish_reason == "tool_calls"`) or the turn's own reply (`"stop"`).

## Changes

- `llm.py`: `LLMToolCallResult` gains `call_id: str | None = None`, populated in `call_llm_tools` from `getattr(response, "id", None) or None` — same `""` → `None` collapse #4722's review required at the audit-event call site.
- `router_loop.py`: all 4 `kind="agent"` outbox sites (tool-turn text, async spawn ack, empty-response failure, terminal reply) stamp `result.call_id`/`result.finish_reason` onto the row's meta.
- `test_router_empty_response.py`: new test on the file's own real `FakeRouterHost`/`_ScriptedLLM` harness — a scripted `LLMToolCallResult` carrying `call_id="resp-empty-glitch"` produces an outbox row whose meta carries that exact `call_id`/`finish_reason`.

## Falsification

Reverting `router_loop.py` alone → new test fails with `KeyError: 'call_id'`.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/llm/test_router_empty_response.py` — 19/19 OK
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py src/reyn/runtime/router_loop.py` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] Scoped pytest: `test_router_empty_response.py` (19) + `test_router_loop_tool_turn_text_1642.py` + `test_router_loop_empty_stop_retry.py` + `test_4691_gutter_per_call_boundary.py` + `test_textual_chat_phase4_turn_cost_gutter_3283.py` + `test_router_loop.py` + `test_usage_provenance_3351.py` — 86 passed
- [ ] (waived, Visual axis only — standing 2026-08-08 owner waiver) not visually confirmed in this session; operator confirms on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## レビュア追記（lead-coder, TESTS-READ 済）

- [x] 🔴 `""` → `None` の収束規則が **llm.py の 2 箇所**になります（#4722 の event 側と本 PR の `LLMToolCallResult` 側）。片方だけ直る未来は、**今朝 #4722 で潰した欠陥そのもの**を 2 面の食い違いとして再生産します（outbox の call_id と event の call_id が別の答えを持つ）。**module-level の `_response_call_id(response)` を 1 つ**作り、両サイトから呼ぶ。#4708 で私が出した条件と同じ理由（規則が 1 つか 2 つかの問題であって、行数の問題ではない）
- [x] ⚪ マージ順 — #4722 を先に着地させ、本 PR はその上に

