### PR TITLE
feat(#4206 Slice B, #4724): caller-resolved cost.*.warn_ratio overrides (Design C)

### DIFF
--- a/docs/reference/cli/agent.md
+++ b/docs/reference/cli/agent.md
@@ -138,19 +138,25 @@ An unrecognized key under `preferences:` (a typo, or a key retired from
 UnknownPreferenceKeyError`) rather than silently doing nothing — the same
 discipline #4655 established for config-schema dict-leaves.
 
-**Scope so far**: read/resolve only — of the 9 keys, `output_language`
-(slice 1) and `chat.reasoning.display` (slice 2, #4206) are wired into a
-live `Session` property (`Session.output_language` /
-`Session.reasoning_display`) that re-resolves the session/agent/project
-composition on every access. The remaining 7 `warn_ratio` keys are
-declared in `PREFERENCE_KEYS` but not yet wired — they all funnel into ONE
-process-shared `BudgetTracker` (built once per process from the
-project-level config only), so wiring them needs a collision-safe
-per-agent/session override registry (the same shape `#4700`'s
-`register_max_input_overrides` established for `llm.models.<tier>.
-max_input_tokens`), not a bare live property — tracked as a follow-up, not
-mixed into this slice. No `preferences`-specific CLI/slash write surface
-exists yet for any key — set an agent-layer value by editing
+**Scope**: read/resolve only, all 9 keys now wired (#4206 Slices 1/2/B).
+`output_language`/`chat.reasoning.display` are live `Session` properties
+(`Session.output_language` / `Session.reasoning_display`) re-resolving the
+session/agent/project composition on every access. The 7 `cost.*.warn_ratio`
+keys use a DIFFERENT shape ("Design C", #4724): `BudgetTracker` is
+process-shared (one instance across every agent/session in a process, built
+once from the project-level config), so it never resolves a session/agent
+identity itself — instead `Session.warn_ratio_overrides()` resolves the ③
+composition (the SAME session/agent-preference files, collected into a
+`dict[str, float]` of only the keys actually overridden at either layer)
+and the CALLER (`RouterLoop`, via `RouterHostAdapter.warn_ratio_overrides()`,
+and the `/budget` display via `BudgetGateway`) passes that resolved mapping
+straight into `BudgetTracker.check_pre_llm`/`record_llm`/`format_budget_full`
+as an explicit argument. The tracker's own counters (token/cost totals)
+stay PROCESS-SHARED and unaffected by this — only the RATIO that decides
+WHEN to warn about an already-shared number is caller-resolvable; an
+unknown key in the mapping raises `UnknownPreferenceKeyError` the same way
+`validate_preferences` does. No `preferences`-specific CLI/slash write
+surface exists yet for any key — set an agent-layer value by editing
 `profile.yaml` directly (the same existing pattern `allowed_mcp` already
 uses); a session-layer value by whatever spawns the session passing a
 `narrowing` dict whose own `preferences` sub-key is set

--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -64,6 +64,22 @@ block):
   callback shape `reasoning_continuity_section_fn` already established for
   the sibling continuity-section renderer) — `None` (every pre-slice-2 host)
   falls back to the frozen `reasoning_config.display` read, byte-identical.
+- `warn_ratio_overrides()` (#4206 Slice B, #4724) — public METHOD (not a
+  property — returns a fresh `dict[str, float]` each call, not a scalar), the
+  ③ resolution for the 7 `cost.*.warn_ratio` keys. A DIFFERENT shape from
+  `output_language`/`reasoning_display` above: `BudgetTracker` is
+  process-shared (one instance across every agent/session in a process), so
+  it cannot resolve a session/agent identity itself the way a per-`Session`
+  property can — this method collects only the keys actually overridden at
+  either the agent or session layer (an omitted key means "use the
+  tracker's own project-level ratio, unchanged") and the CALLER
+  (`RouterLoop`/`BudgetGateway`, via `RouterHostAdapter.
+  warn_ratio_overrides()` / `BudgetGateway`'s own `warn_ratio_overrides_fn`
+  callback, both wired at construction the SAME way `reasoning_display_fn`
+  is) passes the resulting mapping into `BudgetTracker.check_pre_llm`/
+  `record_llm`/`format_budget_full` as an explicit argument ("Design C",
+  #4724 — no process-shared override registry, no session-id plumbed into
+  the tracker itself).
 - `_sandbox_backend` (#1200 PR-F2) — the agent's `SandboxBackend` INSTANCE for the chat exec
   seam (the router `OpContext`); `None` → `get_default_backend`. This is the INSTANCE, not
   the `sandbox_config.backend` STRING used for exec-tool gating — for a docker agent it is

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -2740,6 +2740,7 @@ async def call_llm_tools(
     model_class: "str | None" = None,  # #4206 T1: forwarded to recorded_acompletion — see its docstring (None = not subject to ceiling enforcement)
     model_class_ceiling: "str | None" = None,  # #4206 T1: the caller's effective ceiling, if any (None = unbounded)
     prompt_cache_key: str | None = None,  # #4700: forwarded to recorded_acompletion — see its docstring for the full reasoning
+    warn_ratio_overrides: "dict[str, float] | None" = None,  # #4206 Slice B (#4724): forwarded to budget.check_pre_llm/record_llm — see BudgetTracker's own docstring
 ) -> LLMToolCallResult:
     """Tool-use variant of call_llm. Returns raw assistant message.
 
@@ -2780,6 +2781,14 @@ async def call_llm_tools(
     reasoning. ``None`` (every call site that does not pass one) is
     byte-identical to before #4700 — nothing is sent, matching today's
     behavior exactly.
+
+    ``warn_ratio_overrides`` (#4206 Slice B, #4724): forwarded verbatim to
+    ``budget.check_pre_llm``/``budget.record_llm`` when ``budget`` is set —
+    Design C (lead-coder ruling): the CALLER resolves the ③ preference-axis
+    override (session/agent/project composition) and passes the final
+    ratio map in; ``BudgetTracker`` never resolves it itself. ``None``
+    (every call site that does not pass one) is byte-identical to before
+    Slice B.
     """
     # Normalize model to ModelSpec — accept both str (backward compat) and ModelSpec.
     spec: ModelSpec = model if isinstance(model, ModelSpec) else ModelSpec(model=model, kwargs={})
@@ -2787,7 +2796,10 @@ async def call_llm_tools(
     # Budget pre-check — runs before the LLM call
     if budget is not None:
         from reyn.runtime.budget.budget import BudgetExceeded, format_refusal_message
-        check = budget.check_pre_llm(model=spec.model, agent=budget_agent)
+        check = budget.check_pre_llm(
+            model=spec.model, agent=budget_agent,
+            warn_ratio_overrides=warn_ratio_overrides,
+        )
         if not check.allowed:
             # #1868: route the exceed through the 3-mode limit policy (deny /
             # auto-allow / ask-user). Denied — or NO policy context (fail-closed)
@@ -2977,6 +2989,7 @@ async def call_llm_tools(
             # — this path records its own call, so it must key it too or a
             # tool-bearing turn's spend would silently miss its bucket.
             chain_id=get_active_turn_chain_id(),
+            warn_ratio_overrides=warn_ratio_overrides,
         )
 
     # Normalize tool_calls to plain dicts so callers don't depend on litellm internals

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -43,6 +43,19 @@ from reyn.llm.pricing import (
 
 logger = logging.getLogger(__name__)
 
+#: #4206 Slice B (#4724): the cost.* warn-ratio subset of
+#: ``reyn.runtime.preferences.PREFERENCE_KEYS`` — DERIVED, not a second
+#: hand-maintained literal set (PREFERENCE_KEYS stays the ONE declaration
+#: of the ③ axis's vocabulary; this module only needs to know which of
+#: those keys IT is the consumer for).
+def _load_warn_ratio_preference_keys() -> "frozenset[str]":
+    from reyn.runtime.preferences import PREFERENCE_KEYS
+
+    return frozenset(k for k in PREFERENCE_KEYS if k.startswith("cost."))
+
+
+_WARN_RATIO_PREFERENCE_KEYS: "frozenset[str]" = _load_warn_ratio_preference_keys()
+
 #: Models already reported as unpriced (#3695). Once per model per process:
 #: the condition holds for every call to that model, so a per-call warning
 #: would be a flood, and a flood is read as noise and filtered out — which is
@@ -126,6 +139,59 @@ class CostLimitConfig:
     @property
     def is_active(self) -> bool:
         return self.hard_limit is not None
+
+
+def _effective_warn_threshold(
+    cap: "CostLimitConfig", override_ratio: "float | None",
+) -> "float | None":
+    """#4206 Slice B (#4724): *cap*'s warn threshold, using *override_ratio*
+    in place of ``cap.warn_ratio`` when given.
+
+    Design C (lead-coder ruling, #4724): the CALLER resolves the ③
+    preference-axis override (session/agent/project composition, via
+    ``reyn.runtime.preferences.resolve_preference``) and passes the final
+    ratio in — ``BudgetTracker`` itself never learns a session or agent
+    identity beyond the ``agent: str | None`` it already had. This mirrors
+    the SAME shape #4723 used for ``reasoning_display``: the tracker is a
+    read-only consumer of an already-resolved value, not a second
+    resolution point.
+
+    Never mutates ``cap`` — the SAME ``CostLimitConfig`` instance is shared
+    by every agent/session in this process (``self._config``), so mutating
+    it in place to reflect one caller's preference would leak that
+    preference to every OTHER caller reading the same field next."""
+    if cap.hard_limit is None:
+        return None
+    ratio = cap.warn_ratio if override_ratio is None else override_ratio
+    if ratio <= 0:
+        return None
+    return cap.hard_limit * ratio
+
+
+def _validate_warn_ratio_overrides(overrides: "dict[str, float] | None") -> None:
+    """#4724 condition (lead-coder): *overrides*' keys are checked against
+    the SAME ``PREFERENCE_KEYS`` vocabulary the ③ axis declares them in
+    (narrowed to the ``cost.*`` warn-ratio subset) — an unknown/typo'd key
+    raises loudly rather than silently doing nothing, the #4655 defect
+    class reproduced on the TRANSPORT side (a resolved override that never
+    reaches the tracker) rather than the storage side slice 1/#4655 already
+    closed."""
+    if not overrides:
+        return
+    from reyn.runtime.preferences import PREFERENCE_KEYS, UnknownPreferenceKeyError
+
+    unknown = set(overrides) - _WARN_RATIO_PREFERENCE_KEYS
+    if unknown:
+        raise UnknownPreferenceKeyError(
+            f"warn_ratio_overrides: unrecognized key(s) {sorted(unknown)!r} — "
+            f"not in the cost.* warn-ratio subset of PREFERENCE_KEYS "
+            f"({sorted(_WARN_RATIO_PREFERENCE_KEYS)!r})."
+        )
+    # Defensive: PREFERENCE_KEYS itself is the ONE declaration (#4206); this
+    # subset is DERIVED from it (never a second, independently-drifting
+    # literal set), so the assert below is a not-both-drifted guard, not a
+    # live check against operator input.
+    assert _WARN_RATIO_PREFERENCE_KEYS <= PREFERENCE_KEYS  # noqa: S101
 
 
 @dataclass
@@ -1281,10 +1347,22 @@ class BudgetTracker:
 
     def check_pre_llm(
         self, *, model: str, agent: str | None,
+        warn_ratio_overrides: "dict[str, float] | None" = None,
     ) -> BudgetCheck:
-        """Run before every LLM call. Returns allowed=False to refuse."""
+        """Run before every LLM call. Returns allowed=False to refuse.
+
+        ``warn_ratio_overrides`` (#4206 Slice B, #4724): an OPTIONAL,
+        already-resolved ③ preference-axis mapping (dotted PREFERENCE_KEYS
+        string -> ratio) the CALLER built (session/agent/project
+        composition, ``reyn.runtime.preferences.resolve_preference``) —
+        this tracker never resolves it itself. ``None``/absent-key falls
+        back to ``self._config``'s own project-level ratio, byte-identical
+        to before this slice. Only ``cost.rate_limit_warn_ratio`` affects
+        THIS method (via ``_check_rate_limit``); the cap/hard_limit checks
+        below are unaffected — warn ratio never moves a cap."""
+        _validate_warn_ratio_overrides(warn_ratio_overrides)
         # 1. Rate limit (per model)
-        rl_check = self._check_rate_limit(model)
+        rl_check = self._check_rate_limit(model, warn_ratio_overrides)
         if not rl_check.allowed:
             return rl_check
 
@@ -1328,8 +1406,15 @@ class BudgetTracker:
         usage: TokenUsage,
         purpose: str | None = None,
         chain_id: str | None = None,
+        warn_ratio_overrides: "dict[str, float] | None" = None,
     ) -> BudgetCheck:
         """Update counters after a successful LLM call.
+
+        ``warn_ratio_overrides`` (#4206 Slice B, #4724): see
+        ``check_pre_llm``'s own docstring — the same caller-resolved ③
+        mapping, threaded here to the per_agent_tokens/per_agent_cost_usd
+        warn-crossing checks below AND (via ``_check_period_warn``) the
+        daily/monthly ones. Never affects a hard_limit/cap.
 
         Computes USD cost via litellm (`reyn.pricing.estimate_cost`).
         Returns a BudgetCheck whose warn_dimensions list any dimensions
@@ -1356,6 +1441,7 @@ class BudgetTracker:
         traced back to a provider figure or to a local
         ``litellm.token_counter`` estimate instead of being indistinguishable.
         """
+        _validate_warn_ratio_overrides(warn_ratio_overrides)
         # rate limit window
         self._call_window[model].append(time.monotonic())
 
@@ -1397,13 +1483,19 @@ class BudgetTracker:
                 self._agent_cost_breakdown[agent] += breakdown
 
             cap = self._config.per_agent_tokens
-            if cap.is_active and cap.warn_threshold is not None:
-                if new_tokens >= cap.warn_threshold:
+            if cap.is_active:
+                threshold = _effective_warn_threshold(
+                    cap, (warn_ratio_overrides or {}).get("cost.per_agent_tokens.warn_ratio"),
+                )
+                if threshold is not None and new_tokens >= threshold:
                     self._maybe_warn(warn_dims, "per_agent_tokens", agent)
 
             cap = self._config.per_agent_cost_usd
-            if cap.is_active and cap.warn_threshold is not None:
-                if new_cost >= cap.warn_threshold:
+            if cap.is_active:
+                threshold = _effective_warn_threshold(
+                    cap, (warn_ratio_overrides or {}).get("cost.per_agent_cost_usd.warn_ratio"),
+                )
+                if threshold is not None and new_cost >= threshold:
                     self._maybe_warn(warn_dims, "per_agent_cost_usd", agent)
 
         # PR25: update daily / monthly counters and append to ledger
@@ -1423,7 +1515,7 @@ class BudgetTracker:
             )
 
         # Warn on daily / monthly thresholds
-        self._check_period_warn(warn_dims)
+        self._check_period_warn(warn_dims, warn_ratio_overrides)
 
         # R-D8: persist state for crash recovery (throttled)
         self._maybe_auto_save()
@@ -1706,7 +1798,9 @@ class BudgetTracker:
         self._warned.add(wkey)
         warn_dims.append(dimension)
 
-    def _check_rate_limit(self, model: str) -> BudgetCheck:
+    def _check_rate_limit(
+        self, model: str, warn_ratio_overrides: "dict[str, float] | None" = None,
+    ) -> BudgetCheck:
         cap = self._config.rate_limit_per_minute.get(model)
         if cap is None:
             return BudgetCheck(allowed=True)
@@ -1723,7 +1817,12 @@ class BudgetTracker:
                 context={"model": model, "current": used, "hard": cap},
             )
         warn_dims: list[str] = []
-        warn_threshold = int(cap * self._config.rate_limit_warn_ratio)
+        # #4724: caller-resolved override wins; falls back to the
+        # project-level ratio, byte-identical to before Slice B.
+        _ratio = (warn_ratio_overrides or {}).get(
+            "cost.rate_limit_warn_ratio", self._config.rate_limit_warn_ratio,
+        )
+        warn_threshold = int(cap * _ratio)
         if warn_threshold > 0 and used >= warn_threshold:
             wkey = ("rate_limit", model)
             if wkey not in self._warned:
@@ -1989,16 +2088,27 @@ class BudgetTracker:
             )
         return BudgetCheck(allowed=True)
 
-    def _check_period_warn(self, warn_dims: list[str]) -> None:
-        """Append warning dimension names for daily / monthly thresholds."""
+    def _check_period_warn(
+        self, warn_dims: list[str],
+        warn_ratio_overrides: "dict[str, float] | None" = None,
+    ) -> None:
+        """Append warning dimension names for daily / monthly thresholds.
+
+        ``warn_ratio_overrides`` (#4724): the counter (`used`) stays
+        PROCESS-SHARED, unchanged by this slice — only the ratio that
+        decides WHEN to warn about it is caller-resolvable, per lead-coder's
+        ruling ("同じ1つの数字について誰がいつ知らされるか")."""
         for dim, used, cap_cfg in (
             ("daily_tokens", self._daily_tokens, self._config.daily_tokens),
             ("daily_cost_usd", self._daily_cost_usd, self._config.daily_cost_usd),
             ("monthly_tokens", self._monthly_tokens, self._config.monthly_tokens),
             ("monthly_cost_usd", self._monthly_cost_usd, self._config.monthly_cost_usd),
         ):
-            if cap_cfg.is_active and cap_cfg.warn_threshold is not None:
-                if used >= cap_cfg.warn_threshold:
+            if cap_cfg.is_active:
+                threshold = _effective_warn_threshold(
+                    cap_cfg, (warn_ratio_overrides or {}).get(f"cost.{dim}.warn_ratio"),
+                )
+                if threshold is not None and used >= threshold:
                     key = self._day_key[1] if "daily" in dim else (
                         self._month_key[1] if self._month_key else "month"
                     )
@@ -2185,8 +2295,20 @@ _FLOOR_REASON_LABEL = {
 }
 
 
-def format_budget_full(snapshot: dict, attached: str | None) -> str:
-    """`/budget` full breakdown across all dimensions."""
+def format_budget_full(
+    snapshot: dict, attached: str | None,
+    warn_ratio_overrides: "dict[str, float] | None" = None,
+) -> str:
+    """`/budget` full breakdown across all dimensions.
+
+    ``warn_ratio_overrides`` (#4206 Slice B, #4724): same caller-resolved ③
+    mapping as ``BudgetTracker.check_pre_llm``/``record_llm`` — this
+    DISPLAY function is the 4th (and final) consumer of the cost.*
+    warn-ratio subset, so what an operator sees in ``/budget`` matches
+    what actually gated their own session's warn events, not silently the
+    project default."""
+    _validate_warn_ratio_overrides(warn_ratio_overrides)
+    _wr = warn_ratio_overrides or {}
     cfg: CostConfig = snapshot["config"]
     lines: list[str] = ["Usage (process invocation):", ""]
 
@@ -2281,7 +2403,9 @@ def format_budget_full(snapshot: dict, attached: str | None) -> str:
         cost = snapshot["agent_cost_usd"].get(agent, 0.0)
         tok_cap = cfg.per_agent_tokens
         if tok_cap.is_active:
-            warn = int(tok_cap.warn_threshold or 0)
+            warn = int(_effective_warn_threshold(
+                tok_cap, _wr.get("cost.per_agent_tokens.warn_ratio"),
+            ) or 0)
             mark = "  ⚠ approaching" if tok >= warn > 0 else ""
             lines.append(
                 f"    tokens:  {tok:>10,} / {int(tok_cap.hard_limit):,}  "
@@ -2291,7 +2415,9 @@ def format_budget_full(snapshot: dict, attached: str | None) -> str:
             lines.append(f"    tokens:  {tok:>10,}             (no cap)")
         cost_cap = cfg.per_agent_cost_usd
         if cost_cap.is_active:
-            warn = (cost_cap.warn_threshold or 0)
+            warn = _effective_warn_threshold(
+                cost_cap, _wr.get("cost.per_agent_cost_usd.warn_ratio"),
+            ) or 0
             mark = "  ⚠ approaching" if cost >= warn > 0 else ""
             lines.append(
                 f"    cost:    ${cost:>9.4f} / ${cost_cap.hard_limit:.2f}     "
@@ -2318,7 +2444,8 @@ def format_budget_full(snapshot: dict, attached: str | None) -> str:
         for model, used in sorted(snapshot["rate_window"].items()):
             cap = cfg.rate_limit_per_minute.get(model)
             if cap is not None:
-                warn = int(cap * cfg.rate_limit_warn_ratio)
+                _ratio = _wr.get("cost.rate_limit_warn_ratio", cfg.rate_limit_warn_ratio)
+                warn = int(cap * _ratio)
                 mark = "  ⚠" if used >= warn > 0 else ""
                 lines.append(f"    {model}:  {used} / {cap}  (warn at {warn}){mark}")
             else:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1136,6 +1136,17 @@ class RouterLoop:
         measurement and reasoning, not repeated here."""
         return getattr(self.host, "live_session_id", None) or "main"
 
+    def _warn_ratio_overrides(self) -> "dict[str, float]":
+        """#4206 Slice B (#4724): the ③ preference-axis overrides for the 7
+        cost.*.warn_ratio keys, read live each call via
+        ``host.warn_ratio_overrides()`` — ``getattr``-guarded so a test
+        host without the method (every pre-Slice-B host) gets ``{}``,
+        byte-identical to before this slice. Forwarded to
+        ``call_llm_tools`` at every LLM-call site in this file, matching
+        ``_prompt_cache_key`` immediately above."""
+        _fn = getattr(self.host, "warn_ratio_overrides", None)
+        return _fn() if _fn is not None else {}
+
     def _emit_agent_delta(self, text: str) -> None:
         """#3288 ③b: forward one streamed content-delta chunk as an audit-event
         — the owner-ratified L4 replacement (issue #3288 comment thread): a
@@ -1889,6 +1900,7 @@ class RouterLoop:
                         model_class=self.router_model,
                         model_class_ceiling=self._model_class_ceiling,
                         prompt_cache_key=self._prompt_cache_key(),  # #4700
+                        warn_ratio_overrides=self._warn_ratio_overrides(),  # #4206 Slice B
                     )
                 # Record the fresh result for future resume hit. Defensive:
                 # never let recording failure break the loop. NOT for a
@@ -2653,6 +2665,7 @@ class RouterLoop:
                     model_class=self.router_model,
                     model_class_ceiling=self._model_class_ceiling,
                     prompt_cache_key=self._prompt_cache_key(),  # #4700
+                    warn_ratio_overrides=self._warn_ratio_overrides(),  # #4206 Slice B
                 )
             except Exception as exc:
                 if attempt == 0:
@@ -2741,6 +2754,7 @@ class RouterLoop:
             model_class=self.router_model,
             model_class_ceiling=self._model_class_ceiling,
             prompt_cache_key=self._prompt_cache_key(),  # #4700
+            warn_ratio_overrides=self._warn_ratio_overrides(),  # #4206 Slice B
         )
 
     async def _force_close_call_with_retry(

--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -39,10 +39,17 @@ class BudgetGateway:
         events: EventLog,
         agent_name: str,
         default_router_cap: int = 3,
+        # #4206 Slice B (#4724): ③ preference-axis live override for the
+        # cost.*.warn_ratio keys, same callback shape as RouterHostAdapter's
+        # own `warn_ratio_overrides_fn` — makes `/budget`'s display match
+        # the SAME overrides gating this session's own warn events. None
+        # (every pre-Slice-B caller) -> {} -> byte-identical display.
+        warn_ratio_overrides_fn=None,  # Callable[[], dict[str, float]] | None
     ) -> None:
         self._tracker = budget_tracker
         self._events = events
         self._agent_name = agent_name
+        self._warn_ratio_overrides_fn = warn_ratio_overrides_fn
         self._total_usage: TokenUsage = TokenUsage()
         self._last_call_usage: TokenUsage = TokenUsage()
         self._total_cost_usd: float = 0.0
@@ -297,12 +304,18 @@ class BudgetGateway:
         """Return the full budget breakdown for ``/budget``.
 
         Returns None when tracker is None (unlimited mode).
+
+        #4206 Slice B (#4724): the displayed "warn at" figures reflect the
+        SAME ③ preference-axis overrides (``warn_ratio_overrides_fn``, when
+        supplied) that gate this session's own warn events — not silently
+        the project default.
         """
         if self._tracker is None:
             return None
         from reyn.runtime.budget.budget import format_budget_full
         snap = self._tracker.snapshot()
-        return format_budget_full(snap, attached=self._agent_name)
+        _overrides = self._warn_ratio_overrides_fn() if self._warn_ratio_overrides_fn else None
+        return format_budget_full(snap, attached=self._agent_name, warn_ratio_overrides=_overrides)
 
     def reset_all(self) -> dict | None:
         """Reset BudgetTracker if present, emit ``budget_reset`` event, and

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -413,6 +413,11 @@ class RouterHostAdapter:
         # every test host) falls back to the frozen `reasoning_config.display`
         # value, byte-identical to before this slice.
         reasoning_display_fn: "Callable[[], bool] | None" = None,
+        # #4206 Slice B (#4724): ③ preference-axis live overrides for the 7
+        # cost.*.warn_ratio keys — same callback shape as
+        # reasoning_display_fn above. None (every pre-Slice-B caller, every
+        # test host) means "no overrides", byte-identical to before Slice B.
+        warn_ratio_overrides_fn: "Callable[[], dict[str, float]] | None" = None,
         # Issue #383 PR-C: media + tool-result file storage.
         media_store: Any = None,
         # #1128 size axis: per-turn tool-result cap/offload callable. Takes the
@@ -605,6 +610,9 @@ class RouterHostAdapter:
         self._reasoning_continuity_section_fn = reasoning_continuity_section_fn
         # #4206 slice 2: ③ preference-axis live override for `display` ONLY.
         self._reasoning_display_fn = reasoning_display_fn
+        # #4206 Slice B (#4724): ③ preference-axis live override for the
+        # cost.*.warn_ratio keys.
+        self._warn_ratio_overrides_fn = warn_ratio_overrides_fn
         # Issue #383 PR-C: store the MediaStore for path-ref save/read.
         self._media_store = media_store
         # #1128 size axis: per-turn tool-result cap/offload callable (or None).
@@ -1999,6 +2007,15 @@ class RouterHostAdapter:
         if self._reasoning_display_fn is not None:
             return bool(self._reasoning_display_fn())
         return bool(getattr(self._reasoning_config, "display", False))
+
+    def warn_ratio_overrides(self) -> "dict[str, float]":
+        """#4206 Slice B (#4724): the caller-resolved ③ preference-axis
+        overrides for the cost.*.warn_ratio keys, or ``{}`` when
+        ``warn_ratio_overrides_fn`` was not supplied (every pre-Slice-B
+        caller, every test host) — byte-identical to before this slice."""
+        if self._warn_ratio_overrides_fn is not None:
+            return self._warn_ratio_overrides_fn()
+        return {}
 
     def reasoning_continuity_enabled(self) -> bool:
         """Whether reasoning is persisted to history + replayed into the next

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1931,6 +1931,41 @@ class Session:
         )
         return bool(resolved)
 
+    def warn_ratio_overrides(self) -> "dict[str, float]":
+        """#4206 Slice B (#4724): the ③ preference-axis overrides for the 7
+        ``cost.*.warn_ratio`` keys, as a dotted-key -> ratio mapping — the
+        SAME shape ``BudgetTracker.check_pre_llm``/``record_llm`` accept
+        directly (Design C, lead-coder ruling: the CALLER resolves, the
+        tracker never learns a session/agent identity).
+
+        Deliberately does NOT call ``resolve_preference`` (which needs a
+        project-level *default* this Session does not hold — the
+        project-level ratio lives inside the process-shared
+        ``BudgetTracker``'s own ``CostConfig``, not on Session): a key is
+        included ONLY when an agent or session preference for it actually
+        exists (session wins over agent, same precedence order), and
+        omitted otherwise — an omitted key means "use the tracker's own
+        project-level ratio, unchanged", which is EXACTLY what
+        ``resolve_preference`` would have returned anyway had a project
+        default been available to pass it (last-present-wins over an
+        absent default is the default itself). Live re-read on every call,
+        same shape as `reasoning_display`/`output_language`."""
+        from reyn.runtime.preferences import PREFERENCE_KEYS
+
+        session_preferences = self._read_preferences_override(
+            Path(self._snapshot_path).parent / "config.yaml"
+        )
+        agent_preferences = self._agent_profile_preferences()
+        overrides: "dict[str, float]" = {}
+        for key in PREFERENCE_KEYS:
+            if not key.startswith("cost."):
+                continue
+            if key in agent_preferences:
+                overrides[key] = float(agent_preferences[key])  # type: ignore[arg-type]
+            if key in session_preferences:  # session wins — checked LAST
+                overrides[key] = float(session_preferences[key])  # type: ignore[arg-type]
+        return overrides
+
     @property
     def _reyn_state_root(self) -> "Path":
         """#3705: the SAME anchor `Agent.workspace_dir` resolves against
@@ -4205,6 +4240,14 @@ class Session:
             events=audit_events,
             agent_name=agent_name,
             default_router_cap=router_cap,
+            # #4206 Slice B (#4724): same bound-method-reference-at-
+            # construction-time pattern as `reasoning_display_fn` above —
+            # `self.warn_ratio_overrides` isn't CALLED here, just captured;
+            # by the time `/budget` actually invokes it, Session is fully
+            # constructed. Makes the `/budget` display match the SAME
+            # overrides that gate this session's own warn events, not
+            # silently the project default.
+            warn_ratio_overrides_fn=self.warn_ratio_overrides,
         )
 
     def _build_retrieval_bundle(
@@ -4657,6 +4700,10 @@ class Session:
             # instead of reading the frozen `reasoning_config.display` this
             # session was constructed with.
             reasoning_display_fn=lambda: self.reasoning_display,
+            # #4206 Slice B (#4724): ③ preference-axis live override for
+            # the cost.*.warn_ratio keys — same callback shape immediately
+            # above.
+            warn_ratio_overrides_fn=self.warn_ratio_overrides,
             # Issue #383 PR-C: shared MediaStore for image + tool-result storage.
             media_store=self._media_store,
             # #1128 size axis: per-turn tool-result cap/offload (dead-end #1).

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -428,7 +428,12 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: private-state leak, a new read surface the ③ axis's own mechanism
 #: requires by design (``RouterHostAdapter.reasoning_display_enabled()``
 #: consults it via a callback).
-_PUBLIC_MEMBER_CEILING = 108
+#: Raised 108 -> 109 for #4206 Slice B (#4724): ``warn_ratio_overrides`` — a
+#: NEW method, the ③ preference-axis resolution for the 7
+#: cost.*.warn_ratio keys (Design C: the caller resolves, BudgetTracker
+#: never learns a session/agent identity itself). Same shape, same reason
+#: as the 107->108 entry above.
+_PUBLIC_MEMBER_CEILING = 109
 
 
 def test_session_public_surface_does_not_grow() -> None:

--- a/tests/llm/test_4724_warn_ratio_overrides.py
+++ b/tests/llm/test_4724_warn_ratio_overrides.py
@@ -1,0 +1,264 @@
+"""Tier 2: #4206 Slice B (#4724) — caller-resolved ③ preference-axis
+overrides for the 7 ``cost.*.warn_ratio`` keys.
+
+Design C (lead-coder ruling): the CALLER resolves the override
+(session/agent/project composition) and passes a ``dict[str, float]``
+(dotted PREFERENCE_KEYS string -> ratio) straight into ``BudgetTracker`` —
+no process-shared registry, no session-id plumbing into the tracker. The
+tracker's own counters stay PROCESS-SHARED and unaffected; only the ratio
+that decides WHEN to warn about an already-shared number is caller-
+resolvable.
+
+Real ``BudgetTracker``/``CostConfig`` throughout — no mocks, mirrors
+``test_budget_rate_limit_window.py``'s own construction style.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.budget.budget import (
+    _WARN_RATIO_PREFERENCE_KEYS,
+    BudgetTracker,
+    CostConfig,
+    CostLimitConfig,
+    _effective_warn_threshold,
+    _validate_warn_ratio_overrides,
+    format_budget_full,
+)
+from reyn.runtime.preferences import UnknownPreferenceKeyError
+
+
+def _record(bt: BudgetTracker, *, model: str = "m", agent: str | None = "a", n: int = 1) -> None:
+    for _ in range(n):
+        bt.record_llm(model=model, agent=agent, usage=TokenUsage(prompt_tokens=1, completion_tokens=0))
+
+
+# ── pure helpers ─────────────────────────────────────────────────────────
+
+
+def test_effective_warn_threshold_uses_override_when_given():
+    """Tier 2: an override ratio replaces cap.warn_ratio in the threshold
+    computation."""
+    cap = CostLimitConfig(hard_limit=100.0, warn_ratio=0.8)
+    assert _effective_warn_threshold(cap, 0.5) == 50.0
+
+
+def test_effective_warn_threshold_falls_back_to_cap_ratio_when_none():
+    """Tier 2: (accept-side) no override — byte-identical to the pre-Slice-B
+    cap.warn_threshold computation."""
+    cap = CostLimitConfig(hard_limit=100.0, warn_ratio=0.8)
+    assert _effective_warn_threshold(cap, None) == cap.warn_threshold == 80.0
+
+
+def test_effective_warn_threshold_none_when_no_hard_limit():
+    """Tier 2: (accept-side) an inactive cap (no hard_limit) has no
+    threshold regardless of override."""
+    cap = CostLimitConfig(hard_limit=None, warn_ratio=0.8)
+    assert _effective_warn_threshold(cap, 0.5) is None
+
+
+def test_effective_warn_threshold_never_mutates_the_shared_cap():
+    """Tier 2: (accept-side) computing an effective threshold with an
+    override does NOT mutate the CostLimitConfig instance — it is shared
+    by every agent/session in the process; leaking one caller's override
+    into it would apply it to every OTHER caller too."""
+    cap = CostLimitConfig(hard_limit=100.0, warn_ratio=0.8)
+    _effective_warn_threshold(cap, 0.1)
+    assert cap.warn_ratio == 0.8
+
+
+def test_warn_ratio_preference_keys_is_the_cost_subset_of_preference_keys():
+    """Tier 2: (accept-side) the derived subset is exactly the 7 cost.*
+    warn-ratio keys — no drift from PREFERENCE_KEYS's own declaration."""
+    assert _WARN_RATIO_PREFERENCE_KEYS == frozenset({
+        "cost.per_agent_tokens.warn_ratio",
+        "cost.per_agent_cost_usd.warn_ratio",
+        "cost.daily_tokens.warn_ratio",
+        "cost.daily_cost_usd.warn_ratio",
+        "cost.monthly_tokens.warn_ratio",
+        "cost.monthly_cost_usd.warn_ratio",
+        "cost.rate_limit_warn_ratio",
+    })
+
+
+def test_validate_warn_ratio_overrides_accepts_known_keys():
+    """Tier 2: (accept-side) a real cost.* key passes without raising."""
+    _validate_warn_ratio_overrides({"cost.per_agent_tokens.warn_ratio": 0.5})
+
+
+def test_validate_warn_ratio_overrides_accepts_none_and_empty():
+    """Tier 2: (accept-side) the common "no override" cases."""
+    _validate_warn_ratio_overrides(None)
+    _validate_warn_ratio_overrides({})
+
+
+def test_validate_warn_ratio_overrides_rejects_a_non_cost_preference_key():
+    """Tier 2: a key that IS in PREFERENCE_KEYS but NOT in the cost.*
+    warn-ratio subset (e.g. output_language) is still rejected — this
+    transport only accepts the 7 keys it is the consumer for."""
+    with pytest.raises(UnknownPreferenceKeyError, match="output_language"):
+        _validate_warn_ratio_overrides({"output_language": 1.0})
+
+
+def test_validate_warn_ratio_overrides_rejects_a_typo():
+    """Tier 2: a typo'd key raises loudly — the #4655 defect class
+    reproduced on the transport side, closed the same way."""
+    with pytest.raises(UnknownPreferenceKeyError, match="cost.typo.warn_ratio"):
+        _validate_warn_ratio_overrides({"cost.typo.warn_ratio": 0.5})
+
+
+# ── BudgetTracker.record_llm — per-agent warn-crossing ──────────────────
+
+
+def test_per_agent_tokens_warn_fires_earlier_with_a_tighter_override():
+    """Tier 2: THE central witness — an override ratio TIGHTER than the
+    project default makes the warn fire at a LOWER usage level. RED
+    without the fix: warn never fires until the project-default 80%
+    threshold, ignoring the override entirely."""
+    cfg = CostConfig(per_agent_tokens=CostLimitConfig(hard_limit=100.0, warn_ratio=0.8))
+    bt = BudgetTracker(cfg)
+
+    # 50 tokens is BELOW the project default's 80-token threshold...
+    check = bt.record_llm(
+        model="m", agent="a", usage=TokenUsage(prompt_tokens=50, completion_tokens=0),
+        warn_ratio_overrides={"cost.per_agent_tokens.warn_ratio": 0.4},  # threshold=40
+    )
+    # ...but ABOVE the override's 40-token threshold.
+    assert "per_agent_tokens" in check.warn_dimensions
+
+
+def test_per_agent_tokens_warn_does_not_fire_with_no_override():
+    """Tier 2: (accept-side) the SAME usage level, no override — stays
+    below the project-default threshold, no warn. Confirms the witness
+    above is really about the override, not just "any 50-token call warns"."""
+    cfg = CostConfig(per_agent_tokens=CostLimitConfig(hard_limit=100.0, warn_ratio=0.8))
+    bt = BudgetTracker(cfg)
+
+    check = bt.record_llm(
+        model="m", agent="a", usage=TokenUsage(prompt_tokens=50, completion_tokens=0),
+    )
+    assert "per_agent_tokens" not in check.warn_dimensions
+
+
+def test_per_agent_cost_usd_warn_ratio_override():
+    """Tier 2: (accept-side) same witness, the cost dimension."""
+    cfg = CostConfig(per_agent_cost_usd=CostLimitConfig(hard_limit=1.0, warn_ratio=0.9))
+    bt = BudgetTracker(cfg)
+    # gpt-4o-mini priced call — exact $ amount doesn't matter, just that
+    # SOME cost was recorded; use a model reyn's pricing table covers.
+    check = bt.record_llm(
+        model="gemini/gemini-2.5-flash-lite", agent="a",
+        usage=TokenUsage(prompt_tokens=100_000, completion_tokens=0),
+        warn_ratio_overrides={"cost.per_agent_cost_usd.warn_ratio": 0.0001},
+    )
+    assert "per_agent_cost_usd" in check.warn_dimensions
+
+
+def test_unrelated_override_key_does_not_affect_a_different_dimension():
+    """Tier 2: (accept-side) an override for per_agent_cost_usd does not
+    leak into the per_agent_tokens check."""
+    cfg = CostConfig(per_agent_tokens=CostLimitConfig(hard_limit=100.0, warn_ratio=0.8))
+    bt = BudgetTracker(cfg)
+    check = bt.record_llm(
+        model="m", agent="a", usage=TokenUsage(prompt_tokens=50, completion_tokens=0),
+        warn_ratio_overrides={"cost.per_agent_cost_usd.warn_ratio": 0.01},
+    )
+    assert "per_agent_tokens" not in check.warn_dimensions
+
+
+# ── BudgetTracker._check_rate_limit (via check_pre_llm) ──────────────────
+
+
+def test_rate_limit_warn_ratio_override_fires_earlier():
+    """Tier 2: THE rate-limit witness — a tighter override ratio makes
+    the rate-limit warn fire at a lower call count than the project
+    default."""
+    model = "warn-model"
+    cap = 10
+    cfg = CostConfig(rate_limit_per_minute={model: cap}, rate_limit_warn_ratio=0.8)
+    bt = BudgetTracker(cfg)
+
+    _record(bt, model=model, n=3)  # 3/10 — below the default's 8 threshold, above the override's 2
+
+    result = bt.check_pre_llm(
+        model=model, agent=None,
+        warn_ratio_overrides={"cost.rate_limit_warn_ratio": 0.2},  # threshold = 2
+    )
+    assert "rate_limit" in result.warn_dimensions
+
+
+def test_rate_limit_warn_ratio_no_override_uses_project_default():
+    """Tier 2: (accept-side) same call count, no override — stays below
+    the project-default (0.8 * 10 = 8) threshold."""
+    model = "warn-model-2"
+    cap = 10
+    cfg = CostConfig(rate_limit_per_minute={model: cap}, rate_limit_warn_ratio=0.8)
+    bt = BudgetTracker(cfg)
+
+    _record(bt, model=model, n=3)
+
+    result = bt.check_pre_llm(model=model, agent=None)
+    assert "rate_limit" not in result.warn_dimensions
+
+
+# ── BudgetTracker._check_period_warn (daily/monthly, via record_llm) ─────
+
+
+def test_daily_tokens_warn_ratio_override():
+    """Tier 2: (accept-side) same witness, the daily_tokens period
+    dimension. The counter itself stays process-shared/period-cumulative;
+    only the ratio deciding when to warn about it is overridden."""
+    cfg = CostConfig(daily_tokens=CostLimitConfig(hard_limit=1000.0, warn_ratio=0.9))
+    bt = BudgetTracker(cfg)
+    check = bt.record_llm(
+        model="m", agent=None, usage=TokenUsage(prompt_tokens=300, completion_tokens=0),
+        warn_ratio_overrides={"cost.daily_tokens.warn_ratio": 0.2},  # threshold = 200
+    )
+    assert "daily_tokens" in check.warn_dimensions
+
+
+def test_daily_tokens_no_override_uses_project_default():
+    """Tier 2: (accept-side) same usage, no override — below the
+    project-default 90% threshold."""
+    cfg = CostConfig(daily_tokens=CostLimitConfig(hard_limit=1000.0, warn_ratio=0.9))
+    bt = BudgetTracker(cfg)
+    check = bt.record_llm(
+        model="m", agent=None, usage=TokenUsage(prompt_tokens=300, completion_tokens=0),
+    )
+    assert "daily_tokens" not in check.warn_dimensions
+
+
+# ── format_budget_full (the /budget display) ──────────────────────────────
+
+
+def test_format_budget_full_warn_marker_reflects_the_override():
+    """Tier 2: the /budget display's "warn at" figure and ⚠ marker use the
+    caller-resolved override, matching what actually gates this session's
+    warn events — not silently the project default."""
+    cfg = CostConfig(per_agent_tokens=CostLimitConfig(hard_limit=100.0, warn_ratio=0.8))
+    bt = BudgetTracker(cfg)
+    bt.record_llm(model="m", agent="a", usage=TokenUsage(prompt_tokens=50, completion_tokens=0))
+    snap = bt.snapshot()
+
+    text_no_override = format_budget_full(snap, attached="a")
+    text_with_override = format_budget_full(
+        snap, attached="a",
+        warn_ratio_overrides={"cost.per_agent_tokens.warn_ratio": 0.4},
+    )
+
+    assert "(warn at 80)" in text_no_override
+    assert "(warn at 40)" in text_with_override
+    assert "⚠ approaching" in text_with_override
+    assert "⚠ approaching" not in text_no_override
+
+
+def test_format_budget_full_rejects_an_unknown_override_key():
+    """Tier 2: (accept-side) the display function validates too — the SAME
+    loud-reject contract as check_pre_llm/record_llm, not a silently
+    ignored key on the display-only path."""
+    cfg = CostConfig()
+    bt = BudgetTracker(cfg)
+    snap = bt.snapshot()
+    with pytest.raises(UnknownPreferenceKeyError):
+        format_budget_full(snap, attached="a", warn_ratio_overrides={"cost.bogus.warn_ratio": 0.5})

--- a/tests/runtime/test_4724_slice_b_session_wiring.py
+++ b/tests/runtime/test_4724_slice_b_session_wiring.py
@@ -1,0 +1,187 @@
+"""Tier 2: #4206 Slice B (#4724) — Session/RouterHostAdapter wiring for the
+7 ``cost.*.warn_ratio`` overrides.
+
+Design C (lead-coder ruling): ``Session.warn_ratio_overrides()`` builds a
+dotted-key -> ratio mapping from the SAME session/agent-preference files
+slice 1/2 already read (``config.yaml``/``profile.yaml``), and hands it to
+``BudgetTracker.check_pre_llm``/``record_llm`` via a callback chain
+(``RouterHostAdapter.warn_ratio_overrides_fn`` -> ``RouterLoop.
+_warn_ratio_overrides()`` -> ``call_llm_tools(warn_ratio_overrides=...)``)
+— the tracker itself never resolves a session/agent identity.
+
+Real ``Session`` (``make_session``) + real ``RouterHostAdapter`` reached
+through ``session.router_host``, never a stand-in.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.profile import AgentProfile
+from tests._support.agent_session import make_session
+
+
+def _agent_dir(session) -> Path:
+    return session.workspace_dir
+
+
+def _session_config_path(session) -> Path:
+    return Path(session._snapshot_path).parent / "config.yaml"
+
+
+def _write_agent_preferences(session, name: str, preferences: dict) -> None:
+    profile = AgentProfile.new(name)
+    object.__setattr__(profile, "preferences", preferences)
+    profile.save(_agent_dir(session))
+
+
+def test_warn_ratio_overrides_is_empty_with_no_preferences_set(tmp_path: Path):
+    """Tier 2: (accept-side) the common case — no agent/session preference
+    file at all — returns {} (tracker falls back to project defaults
+    entirely, byte-identical to before Slice B)."""
+    session = make_session(
+        agent_name="warn-ratio-1", workspace_state_dir=tmp_path / ".reyn",
+    )
+    assert session.warn_ratio_overrides() == {}
+
+
+def test_warn_ratio_overrides_includes_only_the_agent_set_key(tmp_path: Path):
+    """Tier 2: an agent-layer preferences.cost.*.warn_ratio entry appears
+    in the returned mapping; unset cost.* keys are simply absent (not
+    filled with a default this Session doesn't itself hold)."""
+    session = make_session(
+        agent_name="warn-ratio-2", workspace_state_dir=tmp_path / ".reyn",
+    )
+    _write_agent_preferences(
+        session, "warn-ratio-2",
+        {"cost.per_agent_tokens.warn_ratio": 0.5},
+    )
+
+    overrides = session.warn_ratio_overrides()
+    assert overrides == {"cost.per_agent_tokens.warn_ratio": 0.5}
+
+
+def test_warn_ratio_overrides_session_layer_wins_over_agent_layer(tmp_path: Path):
+    """Tier 2: THE composition witness — a session-layer config.yaml
+    override wins over the agent-layer profile.yaml override for the SAME
+    key, matching output_language/reasoning_display's own precedence."""
+    import yaml
+
+    session = make_session(
+        agent_name="warn-ratio-3", workspace_state_dir=tmp_path / ".reyn",
+    )
+    _write_agent_preferences(
+        session, "warn-ratio-3",
+        {"cost.per_agent_tokens.warn_ratio": 0.5},
+    )
+    cfg_path = _session_config_path(session)
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump({"name": "_session_x", "preferences": {"cost.per_agent_tokens.warn_ratio": 0.2}}),
+        encoding="utf-8",
+    )
+
+    overrides = session.warn_ratio_overrides()
+    assert overrides == {"cost.per_agent_tokens.warn_ratio": 0.2}
+
+
+def test_warn_ratio_overrides_is_a_live_re_read(tmp_path: Path):
+    """Tier 2: (accept-side) editing profile.yaml AFTER Session construction
+    takes effect on the next call — same live-re-read shape output_language
+    /reasoning_display already established."""
+    session = make_session(
+        agent_name="warn-ratio-4", workspace_state_dir=tmp_path / ".reyn",
+    )
+    assert session.warn_ratio_overrides() == {}
+
+    _write_agent_preferences(
+        session, "warn-ratio-4",
+        {"cost.rate_limit_warn_ratio": 0.3},
+    )
+
+    assert session.warn_ratio_overrides() == {"cost.rate_limit_warn_ratio": 0.3}
+
+
+# ── RouterHostAdapter callback wiring ────────────────────────────────────
+
+
+def test_router_host_warn_ratio_overrides_reflects_the_live_session_property(tmp_path: Path):
+    """Tier 2: THE end-to-end witness — RouterHostAdapter.warn_ratio_overrides()
+    (what RouterLoop actually consults) reflects the SAME live
+    session/agent-preference override as Session.warn_ratio_overrides(),
+    via the warn_ratio_overrides_fn callback wired at construction."""
+    session = make_session(
+        agent_name="warn-ratio-5", workspace_state_dir=tmp_path / ".reyn",
+    )
+    assert session.router_host.warn_ratio_overrides() == {}
+
+    _write_agent_preferences(
+        session, "warn-ratio-5",
+        {"cost.daily_tokens.warn_ratio": 0.6},
+    )
+
+    assert session.warn_ratio_overrides() == {"cost.daily_tokens.warn_ratio": 0.6}
+    assert session.router_host.warn_ratio_overrides() == {"cost.daily_tokens.warn_ratio": 0.6}
+
+
+def test_warn_ratio_overrides_fn_none_falls_back_to_empty_dict():
+    """Tier 2: (accept-side) a RouterHostAdapter built WITHOUT
+    warn_ratio_overrides_fn (every pre-Slice-B caller, every existing test
+    host) returns {} — byte-identical to before this slice."""
+    from tests._support.router_host_adapter import make_adapter
+
+    adapter = make_adapter(universal_wrappers_enabled=False)
+    assert adapter.warn_ratio_overrides() == {}
+
+
+# ── end-to-end: RouterLoop -> call_llm_tools carries the resolved overrides ─
+
+
+class _CapturingFinishLLM:
+    """Real callable (testing policy, mirrors test_4700_prompt_cache_key.py's
+    own class of the same name): records the kwargs of the LAST call and
+    returns a finish (no tool_calls) so RouterLoop.run terminates after one
+    round."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.last_kwargs: dict = {}
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.call_count += 1
+        self.last_kwargs = kwargs
+        return LLMToolCallResult(
+            content="ok", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
+
+
+@pytest.mark.asyncio
+async def test_router_loop_carries_the_resolved_overrides_to_call_llm_tools(tmp_path: Path):
+    """Tier 2: THE full end-to-end witness — a real turn through
+    RouterLoop.run, driven by a real Session with an agent-layer
+    cost.*.warn_ratio preference set, delivers that SAME resolved mapping
+    as the ``warn_ratio_overrides`` kwarg the injected LLM callable
+    receives (standing in for ``call_llm_tools`` itself)."""
+    from reyn.llm.model_resolver import ModelResolver
+    from reyn.runtime.router_loop import RouterLoop
+
+    session = make_session(
+        agent_name="warn-ratio-6", workspace_state_dir=tmp_path / ".reyn",
+        resolver=ModelResolver({"standard": "openai/gpt-4o"}),
+    )
+    _write_agent_preferences(
+        session, "warn-ratio-6",
+        {"cost.per_agent_tokens.warn_ratio": 0.5},
+    )
+
+    llm = _CapturingFinishLLM()
+    await RouterLoop(host=session.router_host, chain_id="c1", llm_caller=llm).run("hi", [])
+
+    assert llm.last_kwargs.get("warn_ratio_overrides") == {
+        "cost.per_agent_tokens.warn_ratio": 0.5,
+    }


### PR DESCRIPTION
**[e2e-coder]** — #4206 Slice B（#4724）実装: 残り7 `cost.*.warn_ratio` key を Design C（呼び出し側解決）で配線します。#4206 が完了、9 key すべて配線済みになります。

## 何をしたか

lead-coder 裁定「Design C」: BudgetTracker は誰が問い合わせているか(session/agent)を一切知る必要がありません。process-shared なカウンタ自体は変わらず、「いつ知らせるか」の比率だけ呼び出し側が解決して渡します。①②実測（4箇所全てにlive Session到達経路あり）を経てから実装しています。

- `_effective_warn_threshold` / `_WARN_RATIO_PREFERENCE_KEYS`（PREFERENCE_KEYS由来）/ `_validate_warn_ratio_overrides`（未知keyはloudに落とす）
- `check_pre_llm`/`record_llm`/`_check_rate_limit`/`_check_period_warn`/`format_budget_full` に `warn_ratio_overrides: dict[str, float] | None = None` を追加（`None`は挙動変化ゼロ）
- `Session.warn_ratio_overrides()` — session/agent preferenceを収集(session勝ち)
- `RouterHostAdapter.warn_ratio_overrides_fn` / `BudgetGateway` 同型callback — `reasoning_display_fn`と同じ形
- `RouterLoop._warn_ratio_overrides()` — `_prompt_cache_key()`と同型、3 call site全てに配線
- `/budget` 表示（`format_budget_full`）も同じ overrides を反映
- `_PUBLIC_MEMBER_CEILING` 108→109
- doc更新（agent.md / session-construction.md）、実装と同PR

## 検証

- strip-falsify: budget.py全体revert → 新規testファイルがcollection ImportError。per_agent_tokens箇所のみrevert → 中心witness testが正しい理由でRED。両方復元してgreen。
- `tests/llm`（722 passed）、`tests/runtime -k "budget or router_loop or 4206 or 4724 or session"`（391 passed）、`tests/interfaces -k "budget or cost"`（80 passed）、`tests/services -k budget`（25 passed）

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict tests/llm/test_4724_warn_ratio_overrides.py tests/runtime/test_4724_slice_b_session_wiring.py`
- [x] `python scripts/verify_module_docstrings.py`（変更ファイル全て）
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py`
- [x] `python scripts/check_bare_tests_import_reference.py && python scripts/check_file_depth_reference.py && python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python -m pytest tests/llm -q`（722 passed）
- [x] `python -m pytest tests/runtime -q -k "budget or router_loop or 4206 or 4724 or session"`（391 passed）
- [x] `python -m pytest tests/interfaces -q -k "budget or cost"`（80 passed）
- [x] `python -m pytest tests/services -q -k budget`（25 passed）
- [x] strip-falsify（上記）
- [ ] Visual — N/A（no UI）

part of #4206
part of #4724

🤖 Generated with [Claude Code](https://claude.com/claude-code)
