### PR TITLE
feat(#4206 ②): bounding axis for model — restrict-only, narrowest wins

### DIFF
--- a/docs/reference/cli/agent.md
+++ b/docs/reference/cli/agent.md
@@ -99,7 +99,7 @@ Each agent owns `.reyn/agents/<name>/`:
 
 | Path | Purpose |
 |------|---------|
-| `profile.yaml` | name / role / created_at / allowed_mcp / preferences |
+| `profile.yaml` | name / role / created_at / allowed_mcp / preferences / bounding |
 | `history.jsonl` | append-only conversation + agent message log |
 | `events.jsonl` | runtime event audit log |
 | `memory/MEMORY.md` + body files | agent-scoped memory layer |
@@ -162,6 +162,55 @@ uses); a session-layer value by whatever spawns the session passing a
 `narrowing` dict whose own `preferences` sub-key is set
 (`AgentRegistry.spawn_session`'s existing `narrowing=` parameter — no new
 API).
+
+## `bounding` (#4206 ②) — restrict-only: a child may narrow, never widen
+
+A `bounding:` mapping in `profile.yaml` sets an agent-layer CEILING for one
+or more of a fixed set of dotted config keys
+(`reyn.runtime.bounding.BOUNDING_KEYS`) — today: `model` only. Unlike
+`preferences:` above, this axis exists BECAUSE the key it covers consumes
+a shared, bounded resource (the process-shared `BudgetTracker`'s
+daily/monthly quota) — a free override here would let a child exhaust the
+parent's own budget, so the composition is restrict-only instead.
+
+```yaml
+# .reyn/agents/researcher/profile.yaml
+name: researcher
+role: deep technical research, prefers primary sources
+created_at: "2026-08-14T00:00:00+00:00"
+bounding:
+  model: light
+```
+
+**Narrowest wins, restrict-only**: the EFFECTIVE `model` ceiling a session
+enforces (`Session.model_class_ceiling`) is the narrowest (cheapest, per
+`reyn.llm.model_resolver.STANDARD_CLASSES`' own `light < standard < strong`
+order) of three layers — the project's own `llm.model_max_class`, this
+agent's `bounding.model`, and (session wins over agent, same precedence
+③ uses) the spawned session's own `<session-state-dir>/config.yaml`
+`bounding.model`. A layer that declares a WIDER class than a layer above
+it never widens the effective ceiling — only a NARROWER declaration moves
+it. A layer that declares no ceiling at all, or a class outside the 3
+standard tiers, is simply ignored (not comparable), the same "not an
+error, just not a narrowing" shape `model_class_exceeds_ceiling` itself
+already has for an incomparable value.
+
+An unrecognized key under `bounding:` (a typo, or a key outside
+`BOUNDING_KEYS`) fails LOUDLY at load time (`reyn.runtime.bounding.
+UnknownBoundingKeyError`) rather than silently doing nothing — the same
+discipline `preferences:` above uses.
+
+**Enforcement**: the composed ceiling reaches the SAME #1190 chokepoint
+(`recorded_acompletion`) #4206 T1 already enforced a project-only ceiling
+at — a call whose resolved class exceeds it is REJECTED
+(`ModelClassExceedsCeilingError`) before `litellm.acompletion` is ever
+invoked. ②'s own change is only WHERE the ceiling value comes from: a
+live per-call 3-layer composition instead of a value read once at
+`RouterLoop` construction.
+
+**Scope**: `model` only — `timeout`/`router_max_iterations` are explicitly
+OUT of `BOUNDING_KEYS` for now (no driving reason measured yet for
+`timeout`, and `router_max_iterations` has no config key at all today).
 
 ## See also
 

--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -80,6 +80,27 @@ block):
   `record_llm`/`format_budget_full` as an explicit argument ("Design C",
   #4724 — no process-shared override registry, no session-id plumbed into
   the tracker itself).
+- `model_class_ceiling` (#4206 ②) — public `@property`, the ②bounding
+  axis's ONE key so far (`model`). A DIFFERENT composition from
+  `output_language`/`reasoning_display`/`warn_ratio_overrides` above: those
+  are ③ (free-override, last-present-wins); this one is restrict-only
+  (narrowest-of-project/agent/session wins, via
+  `reyn.runtime.bounding.compose_model_ceiling`) because `model` consumes a
+  shared, bounded resource (`BudgetTracker`'s quota) that a free override
+  could exhaust. Composed from `self._resolver.class_ceiling()` (project)
+  + this agent's `profile.yaml` `bounding.model` + this session's own
+  `config.yaml` `bounding.model` (session wins over agent when both narrow,
+  same precedence order ③ uses) — a layer that declares a WIDER class than
+  a layer above it never widens the effective value. Live re-read on every
+  access, same shape as the ③ properties above. `RouterHostAdapter.
+  model_class_ceiling()` consults this live via a `model_class_ceiling_fn`
+  callback wired at construction (the SAME callback shape
+  `reasoning_display_fn` established) — `None` (every pre-② host) falls
+  back to `resolver.class_ceiling()` directly, byte-identical to
+  `RouterLoop`'s prior construction-time-cached read. The composed value
+  feeds the SAME #1190 chokepoint (`recorded_acompletion`) `model_class_ceiling`
+  has always fed — ② only changes WHERE that value comes from, not the
+  enforcement itself.
 - `_sandbox_backend` (#1200 PR-F2) — the agent's `SandboxBackend` INSTANCE for the chat exec
   seam (the router `OpContext`); `None` → `get_default_backend`. This is the INSTANCE, not
   the `sandbox_config.backend` STRING used for exec-tool gating — for a docker agent it is

--- a/src/reyn/runtime/bounding.py
+++ b/src/reyn/runtime/bounding.py
@@ -55,10 +55,26 @@ class UnknownBoundingKeyError(ValueError):
     for the ③ axis."""
 
 
+class InvalidBoundingValueError(ValueError):
+    """A ``bounding.model`` value is not one of ``STANDARD_CLASSES`` —
+    raised loudly at the SAME entry point :class:`UnknownBoundingKeyError`
+    guards, for the same reason (lead-coder review, #4727): unlike
+    ``model_class_exceeds_ceiling``'s own "not comparable -> ignore"
+    scope limit (a LOCAL, single-judgment deferral), letting a typo'd
+    value (``"strogn"``) reach :func:`compose_model_ceiling` silently
+    drops that LAYER's ceiling from the composition entirely — if every
+    other layer is also unset, the composed result is ``None``
+    (unbounded), turning "restrict to standard" into "no restriction at
+    all" with no exception and no warning. Closed at the validation
+    entry point, not by adding a branch to the composition function."""
+
+
 def validate_bounding(bounding: "dict[str, object]", *, source: str) -> None:
     """Raise :class:`UnknownBoundingKeyError` for any key in *bounding* that
-    is not in :data:`BOUNDING_KEYS`. *source* names where this mapping came
-    from (an agent name or a session id) so the error is actionable."""
+    is not in :data:`BOUNDING_KEYS`, and :class:`InvalidBoundingValueError`
+    for a ``model`` value outside ``STANDARD_CLASSES``. *source* names
+    where this mapping came from (an agent name or a session id) so the
+    error is actionable."""
     unknown = set(bounding) - BOUNDING_KEYS
     if unknown:
         raise UnknownBoundingKeyError(
@@ -66,6 +82,15 @@ def validate_bounding(bounding: "dict[str, object]", *, source: str) -> None:
             f"not in BOUNDING_KEYS ({sorted(BOUNDING_KEYS)!r}). A typo'd "
             f"or renamed bounding key would otherwise silently fail to "
             f"narrow anything."
+        )
+    if "model" in bounding and bounding["model"] not in STANDARD_CLASSES:
+        raise InvalidBoundingValueError(
+            f"{source}: bounding.model={bounding['model']!r} is not one of "
+            f"STANDARD_CLASSES ({list(STANDARD_CLASSES)!r}). A typo'd or "
+            f"stale class name would otherwise silently fail to narrow "
+            f"anything (compose_model_ceiling ignores an incomparable "
+            f"value), which can silently WIDEN the effective ceiling to "
+            f"unbounded if no other layer sets one."
         )
 
 
@@ -78,11 +103,19 @@ def compose_model_ceiling(*ceilings: "str | None") -> "str | None":
     A ceiling value outside :data:`reyn.llm.model_resolver.
     STANDARD_CLASSES` is NOT comparable on this axis (mirrors
     ``model_class_exceeds_ceiling``'s own "can only judge violations it can
-    actually order" scope limit) and is ignored rather than raised — the
-    layer that declared it simply does not narrow anything, the same
-    silent-no-op-on-an-incomparable-value shape the enforcement predicate
-    itself already has. Returns ``None`` when every layer is ``None``/
-    incomparable (fully unbounded, the compat default)."""
+    actually order" scope limit) and is ignored rather than raised HERE —
+    this is defense-in-depth for the one caller this function does NOT
+    validate first (the PROJECT layer, ``resolver.class_ceiling()``, which
+    predates ② and is validated by ``ModelResolver`` itself, not
+    ``validate_bounding``). The agent/session layers ARE validated before
+    they ever reach this function (:func:`validate_bounding` raises
+    :class:`InvalidBoundingValueError` at the entry point instead) — an
+    incomparable value from an agent/session layer should never actually
+    arrive here; a project-layer value slipping through uncomparable still
+    degrades to "this layer doesn't narrow", not a raise, matching
+    ``model_class_exceeds_ceiling``'s own local scope limit for THAT one
+    layer. Returns ``None`` when every layer is ``None``/incomparable
+    (fully unbounded, the compat default)."""
     comparable = [c for c in ceilings if c in STANDARD_CLASSES]
     if not comparable:
         return None
@@ -91,6 +124,7 @@ def compose_model_ceiling(*ceilings: "str | None") -> "str | None":
 
 __all__ = [
     "BOUNDING_KEYS",
+    "InvalidBoundingValueError",
     "UnknownBoundingKeyError",
     "compose_model_ceiling",
     "validate_bounding",

--- a/src/reyn/runtime/bounding.py
+++ b/src/reyn/runtime/bounding.py
@@ -1,0 +1,97 @@
+"""#4206 ② — the bounding axis: agent/session layers may narrow a ceiling,
+never widen it. Owner motivation (issue body): ``model`` is not a
+"preference" — it consumes a shared, bounded resource (the process-shared
+``BudgetTracker``'s daily/monthly quota), so a free-override composition
+(③, ``reyn.runtime.preferences``) is the wrong shape: a child that could
+freely override would let it exhaust the parent's own budget.
+
+## Why a SEPARATE declaration from ``PREFERENCE_KEYS``
+
+Architect's own measurement (#4206 comment thread, #4726 co-vet): mixing ②
+into ``PREFERENCE_KEYS`` would make the composition function branch per-key
+(③ = "last one present wins"; ② = "narrowest one present wins") — the SAME
+"same name, two different mechanisms" trap #4726's Design C already closed
+for ③ itself (a live-property key vs. a caller-resolved key). ``BOUNDING_KEYS``
+keeps the SAME flat-dict-declaration shape ``PREFERENCE_KEYS`` established
+(a typo'd/renamed key raises loudly rather than silently doing nothing —
+the #4655 defect class), with only the composition function swapped.
+
+## Scope: ``model`` only (#4206 ②, lead-coder ruling 2026-08-14)
+
+Architect measured that ``timeout``/``router_max_iterations`` are NOT ready
+for this axis: ``router_max_iterations`` has no config key at all today
+(only a hardcoded default), and no driving reason was presented for
+opening ``timeout`` to agent/session layers. Both stay OUT of
+``BOUNDING_KEYS`` until a real need is measured — adding an unused key
+here would repeat the exact "declared but nobody reads it" shape #4655
+closed for config-schema leaves.
+
+## Composition: narrowest wins, restrict-only
+
+Unlike ③'s free-override ("last one present wins", no ceiling check), ②'s
+composition is a MINIMUM over ``STANDARD_CLASSES``' own ascending-cost
+order (light < standard < strong) — a layer's declared value can only
+LOWER the effective ceiling relative to layers above it, never raise it.
+``model_class_exceeds_ceiling`` (``model_resolver.py``) is the existing
+predicate this axis's enforcement already uses at the #1190 chokepoint
+(``recorded_acompletion``); this module only adds the LAYER composition
+that predicate consumes — the ordering, the predicate, and the enforcement
+chokepoint are #4206 T1's, already implemented, unchanged.
+"""
+from __future__ import annotations
+
+from reyn.llm.model_resolver import STANDARD_CLASSES
+
+#: The ONE key #4206 ②'s current scope covers — see the module docstring
+#: for why ``timeout``/``router_max_iterations`` are not (yet) here.
+BOUNDING_KEYS: "frozenset[str]" = frozenset({"model"})
+
+
+class UnknownBoundingKeyError(ValueError):
+    """A ``bounding:`` mapping (agent ``profile.yaml`` or session
+    ``config.yaml``) names a dotted key outside :data:`BOUNDING_KEYS` —
+    raised loudly rather than silently ignored, the same discipline
+    :class:`reyn.runtime.preferences.UnknownPreferenceKeyError` established
+    for the ③ axis."""
+
+
+def validate_bounding(bounding: "dict[str, object]", *, source: str) -> None:
+    """Raise :class:`UnknownBoundingKeyError` for any key in *bounding* that
+    is not in :data:`BOUNDING_KEYS`. *source* names where this mapping came
+    from (an agent name or a session id) so the error is actionable."""
+    unknown = set(bounding) - BOUNDING_KEYS
+    if unknown:
+        raise UnknownBoundingKeyError(
+            f"{source}: unrecognized bounding key(s) {sorted(unknown)!r} — "
+            f"not in BOUNDING_KEYS ({sorted(BOUNDING_KEYS)!r}). A typo'd "
+            f"or renamed bounding key would otherwise silently fail to "
+            f"narrow anything."
+        )
+
+
+def compose_model_ceiling(*ceilings: "str | None") -> "str | None":
+    """②'s composition rule for the ONE ordered key this axis covers so
+    far: the NARROWEST (lowest ``STANDARD_CLASSES`` index) of *ceilings*,
+    ignoring ``None`` entries (a layer that declared no ceiling never
+    widens the effective one — the restrict-only guarantee).
+
+    A ceiling value outside :data:`reyn.llm.model_resolver.
+    STANDARD_CLASSES` is NOT comparable on this axis (mirrors
+    ``model_class_exceeds_ceiling``'s own "can only judge violations it can
+    actually order" scope limit) and is ignored rather than raised — the
+    layer that declared it simply does not narrow anything, the same
+    silent-no-op-on-an-incomparable-value shape the enforcement predicate
+    itself already has. Returns ``None`` when every layer is ``None``/
+    incomparable (fully unbounded, the compat default)."""
+    comparable = [c for c in ceilings if c in STANDARD_CLASSES]
+    if not comparable:
+        return None
+    return min(comparable, key=STANDARD_CLASSES.index)
+
+
+__all__ = [
+    "BOUNDING_KEYS",
+    "UnknownBoundingKeyError",
+    "compose_model_ceiling",
+    "validate_bounding",
+]

--- a/src/reyn/runtime/profile.py
+++ b/src/reyn/runtime/profile.py
@@ -17,6 +17,14 @@ restricted to `reyn.runtime.preferences.PREFERENCE_KEYS`. Absent/empty is
 the common case (most agents set no preference override at all); a
 malformed key raises at `load()` time rather than being silently ignored
 (the `preferences` module's own `validate_preferences`).
+
+#4206 ② adds `bounding`: an agent-layer ceiling mapping (see
+`reyn.runtime.bounding`) — SAME flat dotted-key shape as `preferences`
+above, but a DIFFERENT composition (narrowest wins, never widens) and a
+DIFFERENT, disjoint key vocabulary (`BOUNDING_KEYS`, currently `{"model"}`
+only). Kept as a separate field/key rather than folded into `preferences`
+because the two axes' composition functions differ — see
+`reyn.runtime.bounding`'s module docstring for the full reasoning.
 """
 from __future__ import annotations
 
@@ -47,6 +55,10 @@ class AgentProfile:
     # shape `reyn.runtime.preferences.resolve_preference` expects directly
     # (no None-check needed at every call site).
     preferences: "dict[str, object]" = field(default_factory=dict)
+    # #4206 ②: bounding-axis ceilings, dotted key -> value, keys restricted
+    # to `reyn.runtime.bounding.BOUNDING_KEYS`. Same "empty dict, not None"
+    # shape as `preferences` above.
+    bounding: "dict[str, object]" = field(default_factory=dict)
 
     @classmethod
     def new(cls, name: str, role: str = "") -> "AgentProfile":
@@ -64,7 +76,12 @@ class AgentProfile:
         `reyn.runtime.preferences.PREFERENCE_KEYS` raises
         `UnknownPreferenceKeyError` — a typo'd/renamed preference key must
         not silently do nothing, the same discipline #4655 established for
-        config-schema dict-leaves."""
+        config-schema dict-leaves.
+
+        #4206 ②: a `bounding:` mapping with a key outside
+        `reyn.runtime.bounding.BOUNDING_KEYS` raises `UnknownBoundingKeyError`
+        the same way."""
+        from reyn.runtime.bounding import validate_bounding
         from reyn.runtime.preferences import validate_preferences
 
         path = agent_dir / PROFILE_FILENAME
@@ -81,12 +98,16 @@ class AgentProfile:
         raw_preferences = data.get("preferences") or {}
         preferences = dict(raw_preferences) if isinstance(raw_preferences, dict) else {}
         validate_preferences(preferences, source=f"agent {name!r} profile.yaml")
+        raw_bounding = data.get("bounding") or {}
+        bounding = dict(raw_bounding) if isinstance(raw_bounding, dict) else {}
+        validate_bounding(bounding, source=f"agent {name!r} profile.yaml")
         return cls(
             name=name,
             role=str(data.get("role", "") or ""),
             created_at=str(data.get("created_at", "") or ""),
             allowed_mcp=allowed_mcp,
             preferences=preferences,
+            bounding=bounding,
         )
 
     def save(self, agent_dir: Path) -> None:
@@ -104,6 +125,8 @@ class AgentProfile:
             payload["allowed_mcp"] = list(self.allowed_mcp)
         if self.preferences:
             payload["preferences"] = dict(self.preferences)
+        if self.bounding:
+            payload["bounding"] = dict(self.bounding)
         path.write_text(
             yaml.safe_dump(payload, allow_unicode=True, sort_keys=False),
             encoding="utf-8",

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -914,18 +914,18 @@ class RouterLoop:
         self.router_model = resolve_purpose_class(
             router_model, _resolver, "router",
         )
-        # #4206 T1 (②bounding): the project-declared ceiling, if any — read
-        # once here (not re-fetched per call) since the resolver is
-        # process-wide and its ceiling doesn't change mid-session. No
-        # ``hasattr`` fallback here (unlike ``resolve_purpose_class`` above):
-        # that fallback's failure direction is a harmless value default
-        # ("standard"); this one's is a WIDENING one — a resolver that can't
-        # answer ``class_ceiling()`` would silently make the ceiling
-        # disappear. A host whose ``resolver`` is not a real ``ModelResolver``
-        # should raise (fail loud), not go unbounded (lead-coder review, #4318).
-        self._model_class_ceiling = (
-            _resolver.class_ceiling() if _resolver is not None else None
-        )
+        # #4206 T1 (②bounding): the project-declared ceiling. ``_resolver``
+        # itself is kept (not the resolved ceiling value) so
+        # ``_model_class_ceiling()`` below can re-read it LIVE on every
+        # call (#4206 ②'s own session/agent-layer composition, which can
+        # change mid-session as an operator edits config, unlike the
+        # single project-only value this ivar held before ②). ``None``
+        # when the host has no ``resolver`` at all (byte-identical to
+        # before — a compat default, never a raise); once a resolver
+        # exists, a resolver that can't answer ``class_ceiling()`` still
+        # raises (fail loud, not silently unbounded — lead-coder review,
+        # #4318, unchanged by ②'s conversion to a live read).
+        self._resolver = _resolver
         self.budget = budget
         # When set, RouterLoop skips ``build_system_prompt(host=...)`` and uses
         # this string verbatim as the system message. Plan executor uses this
@@ -1146,6 +1146,30 @@ class RouterLoop:
         ``_prompt_cache_key`` immediately above."""
         _fn = getattr(self.host, "warn_ratio_overrides", None)
         return _fn() if _fn is not None else {}
+
+    def _model_class_ceiling(self) -> "str | None":
+        """#4206 ②: the composed model-class ceiling, read live each call —
+        replaces the former construction-time-cached ``self.
+        _model_class_ceiling`` ivar (#4206 T1) with a per-call read so the
+        session/agent bounding-axis composition (#4206 ②) is reflected on
+        every call, not frozen at the value in effect when RouterLoop was
+        constructed.
+
+        ``self._resolver is None`` (a host with no ``resolver`` at all) ->
+        ``None``, byte-identical to the pre-② construction-time read.
+        Once a resolver exists, ``host.model_class_ceiling()`` is preferred
+        when the host offers it (the real ``RouterHostAdapter`` path, live
+        3-layer composition); a host that has a resolver but not that
+        method falls back to ``self._resolver.class_ceiling()`` directly —
+        the SAME un-guarded call the pre-② code made, so a resolver that
+        can't answer it still raises (fail loud, not silently unbounded —
+        lead-coder review, #4318, unchanged by this conversion)."""
+        if self._resolver is None:
+            return None
+        _fn = getattr(self.host, "model_class_ceiling", None)
+        if _fn is not None:
+            return _fn()
+        return self._resolver.class_ceiling()
 
     def _emit_agent_delta(self, text: str) -> None:
         """#3288 ③b: forward one streamed content-delta chunk as an audit-event
@@ -1898,7 +1922,7 @@ class RouterLoop:
                         # class via ``class_for_purpose`` (self.router_model)
                         # — subject to the ceiling.
                         model_class=self.router_model,
-                        model_class_ceiling=self._model_class_ceiling,
+                        model_class_ceiling=self._model_class_ceiling(),  # #4206 ②
                         prompt_cache_key=self._prompt_cache_key(),  # #4700
                         warn_ratio_overrides=self._warn_ratio_overrides(),  # #4206 Slice B
                     )
@@ -2663,7 +2687,7 @@ class RouterLoop:
                     # #4206 T1 (②bounding): same router-purpose class as the
                     # main tool-turn call.
                     model_class=self.router_model,
-                    model_class_ceiling=self._model_class_ceiling,
+                    model_class_ceiling=self._model_class_ceiling(),  # #4206 ②
                     prompt_cache_key=self._prompt_cache_key(),  # #4700
                     warn_ratio_overrides=self._warn_ratio_overrides(),  # #4206 Slice B
                 )
@@ -2752,7 +2776,7 @@ class RouterLoop:
             # #4206 T1 (②bounding): the wrap-up call still resolves the
             # router-purpose class — same ceiling applies.
             model_class=self.router_model,
-            model_class_ceiling=self._model_class_ceiling,
+            model_class_ceiling=self._model_class_ceiling(),  # #4206 ②
             prompt_cache_key=self._prompt_cache_key(),  # #4700
             warn_ratio_overrides=self._warn_ratio_overrides(),  # #4206 Slice B
         )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -418,6 +418,11 @@ class RouterHostAdapter:
         # reasoning_display_fn above. None (every pre-Slice-B caller, every
         # test host) means "no overrides", byte-identical to before Slice B.
         warn_ratio_overrides_fn: "Callable[[], dict[str, float]] | None" = None,
+        # #4206 ②: bounding-axis live composed `model` ceiling — same
+        # callback shape as warn_ratio_overrides_fn above. None (every
+        # pre-② caller, every test host) falls back to the resolver's own
+        # project-level ceiling, byte-identical to before this slice.
+        model_class_ceiling_fn: "Callable[[], str | None] | None" = None,
         # Issue #383 PR-C: media + tool-result file storage.
         media_store: Any = None,
         # #1128 size axis: per-turn tool-result cap/offload callable. Takes the
@@ -613,6 +618,8 @@ class RouterHostAdapter:
         # #4206 Slice B (#4724): ③ preference-axis live override for the
         # cost.*.warn_ratio keys.
         self._warn_ratio_overrides_fn = warn_ratio_overrides_fn
+        # #4206 ②: bounding-axis live composed `model` ceiling.
+        self._model_class_ceiling_fn = model_class_ceiling_fn
         # Issue #383 PR-C: store the MediaStore for path-ref save/read.
         self._media_store = media_store
         # #1128 size axis: per-turn tool-result cap/offload callable (or None).
@@ -2016,6 +2023,16 @@ class RouterHostAdapter:
         if self._warn_ratio_overrides_fn is not None:
             return self._warn_ratio_overrides_fn()
         return {}
+
+    def model_class_ceiling(self) -> "str | None":
+        """#4206 ②: the caller-resolved bounding-axis composed ``model``
+        ceiling, or ``self._resolver.class_ceiling()`` (the project-only
+        value, #4206 T1's own accessor, unchanged) when
+        ``model_class_ceiling_fn`` was not supplied (every pre-② caller,
+        every test host) — byte-identical to before this slice."""
+        if self._model_class_ceiling_fn is not None:
+            return self._model_class_ceiling_fn()
+        return self._resolver.class_ceiling()
 
     def reasoning_continuity_enabled(self) -> bool:
         """Whether reasoning is persisted to history + replayed into the next

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1970,10 +1970,23 @@ class Session:
         """#4206 ②: read a ``bounding:`` mapping from *path* (this session's
         own ``config.yaml``) — or ``{}`` when absent/unset/malformed. Same
         raw-read/malformed-is-log-not-crash shape as
-        :meth:`_read_preferences_override`, one key name apart."""
+        :meth:`_read_preferences_override`, one key name apart, PLUS a
+        ``validate_bounding`` call this session-layer read didn't
+        originally have (lead-coder review, #4727): unlike ``preferences``,
+        an unvalidated bounding value reaching ``compose_model_ceiling``
+        doesn't just get ignored for THIS layer — a typo'd
+        ``bounding.model`` can silently drop the ONLY layer that would
+        have narrowed the ceiling, composing to unbounded with no
+        exception at all. Validated the same way ``AgentProfile.load``
+        validates the agent-layer file; a validation failure degrades to
+        ``{}`` (this layer contributes no override) rather than crashing
+        every subsequent property access on a hand-edited config typo."""
         if not path.is_file():
             return {}
         import yaml
+
+        from reyn.runtime.bounding import validate_bounding
+
         try:
             raw = yaml.safe_load(path.read_text(encoding="utf-8"))
         except Exception as e:  # noqa: BLE001 — hand/LLM-written yaml, surface not crash
@@ -1984,7 +1997,15 @@ class Session:
         if not isinstance(raw, dict):
             return {}
         value = raw.get("bounding")
-        return dict(value) if isinstance(value, dict) else {}
+        bounding = dict(value) if isinstance(value, dict) else {}
+        try:
+            validate_bounding(bounding, source=f"session config {path}")
+        except ValueError as e:
+            logger.warning(
+                "#4206: skipping unreadable session bounding at %s: %s", path, e,
+            )
+            return {}
+        return bounding
 
     def _agent_profile_bounding(self) -> "dict[str, object]":
         """#4206 ②: this agent's `profile.yaml` `bounding:` mapping — live

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1966,6 +1966,79 @@ class Session:
                 overrides[key] = float(session_preferences[key])  # type: ignore[arg-type]
         return overrides
 
+    def _read_bounding_override(self, path: "Path") -> "dict[str, object]":
+        """#4206 ②: read a ``bounding:`` mapping from *path* (this session's
+        own ``config.yaml``) — or ``{}`` when absent/unset/malformed. Same
+        raw-read/malformed-is-log-not-crash shape as
+        :meth:`_read_preferences_override`, one key name apart."""
+        if not path.is_file():
+            return {}
+        import yaml
+        try:
+            raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001 — hand/LLM-written yaml, surface not crash
+            logger.warning(
+                "#4206: skipping malformed bounding override config %s: %s", path, e,
+            )
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        value = raw.get("bounding")
+        return dict(value) if isinstance(value, dict) else {}
+
+    def _agent_profile_bounding(self) -> "dict[str, object]":
+        """#4206 ②: this agent's `profile.yaml` `bounding:` mapping — live
+        re-read, `{}` when the profile is missing/malformed/carries none.
+        Mirrors :meth:`_agent_profile_preferences` one key name apart."""
+        from reyn.runtime.profile import AgentProfile
+
+        try:
+            return dict(AgentProfile.load(self.workspace_dir).bounding)
+        except FileNotFoundError:
+            return {}
+        except ValueError as e:
+            # UnknownBoundingKeyError (validate_bounding, raised inside
+            # AgentProfile.load) — surfaced, not silently eaten, but does
+            # not crash session construction/property access.
+            logger.warning(
+                "#4206: skipping unreadable agent bounding at %s: %s",
+                self.workspace_dir, e,
+            )
+            return {}
+
+    @property
+    def model_class_ceiling(self) -> "str | None":
+        """#4206 ②: the bounding axis's ONE current key (`model`) — the
+        EFFECTIVE model-class ceiling this session's turns must respect,
+        composed via ``compose_model_ceiling`` (narrowest wins, restrict-
+        only — a layer that declares no ceiling, or an incomparable value,
+        never WIDENS the effective one) across three layers:
+
+        - project: ``self._resolver.class_ceiling()`` (#4206 T1, unchanged)
+        - agent-layer: this agent's `profile.yaml` `bounding.model`
+        - session-layer: this session's own `config.yaml` `bounding.model`
+
+        Live re-read on every access, same shape `reasoning_display`/
+        `output_language` already use. The composed value feeds the SAME
+        #1190 chokepoint (`recorded_acompletion`) `model_class_ceiling` has
+        always fed — this property only changes WHERE that value comes
+        from (a live 3-layer composition, not a single project-only read
+        cached once at RouterLoop construction)."""
+        from reyn.runtime.bounding import compose_model_ceiling
+
+        project_ceiling = self._resolver.class_ceiling()
+        agent_bounding = self._agent_profile_bounding()
+        session_bounding = self._read_bounding_override(
+            Path(self._snapshot_path).parent / "config.yaml"
+        )
+        agent_ceiling = agent_bounding.get("model")
+        session_ceiling = session_bounding.get("model")
+        return compose_model_ceiling(
+            project_ceiling,
+            str(agent_ceiling) if agent_ceiling is not None else None,
+            str(session_ceiling) if session_ceiling is not None else None,
+        )
+
     @property
     def _reyn_state_root(self) -> "Path":
         """#3705: the SAME anchor `Agent.workspace_dir` resolves against
@@ -4704,6 +4777,11 @@ class Session:
             # the cost.*.warn_ratio keys — same callback shape immediately
             # above.
             warn_ratio_overrides_fn=self.warn_ratio_overrides,
+            # #4206 ②: bounding-axis live composed ceiling for `model` —
+            # same callback shape immediately above; replaces RouterLoop's
+            # prior construction-time-cached `_resolver.class_ceiling()`
+            # read with a live 3-layer (project/agent/session) composition.
+            model_class_ceiling_fn=lambda: self.model_class_ceiling,
             # Issue #383 PR-C: shared MediaStore for image + tool-result storage.
             media_store=self._media_store,
             # #1128 size axis: per-turn tool-result cap/offload (dead-end #1).

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -433,7 +433,14 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: cost.*.warn_ratio keys (Design C: the caller resolves, BudgetTracker
 #: never learns a session/agent identity itself). Same shape, same reason
 #: as the 107->108 entry above.
-_PUBLIC_MEMBER_CEILING = 109
+#: Raised 109 -> 110 for #4206 ②: ``model_class_ceiling`` — a NEW
+#: ``@property``, the ②bounding-axis's live composed ``model`` ceiling
+#: (project resolver + agent-layer + session-layer, narrowest wins,
+#: restrict-only — see ``reyn.runtime.bounding``). Same "a new read
+#: surface the axis's own mechanism requires by design" reason as the
+#: 107->108/108->109 entries above (``RouterHostAdapter.model_class_ceiling()``
+#: consults it via the same callback shape), not a private-state leak.
+_PUBLIC_MEMBER_CEILING = 110
 
 
 def test_session_public_surface_does_not_grow() -> None:

--- a/tests/runtime/test_4206_2_bounding.py
+++ b/tests/runtime/test_4206_2_bounding.py
@@ -37,6 +37,7 @@ from reyn.llm.model_resolver import (
 )
 from reyn.runtime.bounding import (
     BOUNDING_KEYS,
+    InvalidBoundingValueError,
     UnknownBoundingKeyError,
     compose_model_ceiling,
     validate_bounding,
@@ -78,10 +79,15 @@ def test_compose_model_ceiling_narrowest_wins_a_wider_child_cannot_widen() -> No
     assert compose_model_ceiling("light", "strong", "standard") == "light"
 
 
-def test_compose_model_ceiling_incomparable_value_ignored_not_raised() -> None:
-    """Tier 1: contract — a ceiling value outside STANDARD_CLASSES mirrors
-    ``model_class_exceeds_ceiling``'s own "not comparable" scope limit:
-    ignored, not raised, and never narrows anything by itself."""
+def test_compose_model_ceiling_project_layer_incomparable_value_ignored_not_raised() -> None:
+    """Tier 1: contract — compose_model_ceiling itself stays a LOCAL,
+    per-layer "not comparable" deferral (mirrors model_class_exceeds_
+    ceiling's own scope limit), for the ONE caller its own value is not
+    pre-validated by validate_bounding: the PROJECT layer
+    (resolver.class_ceiling(), validated by ModelResolver itself, not
+    this module). An agent/session-layer value can never reach this
+    function un-validated — see test_validate_bounding_raises_on_unknown_
+    model_value below for where THAT gets closed."""
     assert compose_model_ceiling("standard", "custom-tier") == "standard"
     assert compose_model_ceiling("custom-tier", "custom-tier-2") is None
 
@@ -94,8 +100,21 @@ def test_validate_bounding_raises_on_unknown_key() -> None:
 
 
 def test_validate_bounding_accepts_known_key() -> None:
-    """Tier 1: accept-side — a recognized key does not raise."""
+    """Tier 1: accept-side — a recognized key with a valid value does not
+    raise."""
     validate_bounding({"model": "light"}, source="test")
+
+
+def test_validate_bounding_raises_on_unknown_model_value() -> None:
+    """Tier 1: THE silent-widening-closure witness (lead-coder review,
+    #4727) — a typo'd/stale bounding.model value (e.g. "strogn") is NOT
+    silently ignored (which would let compose_model_ceiling drop that
+    layer entirely and, if no other layer sets a ceiling, compose to
+    None = unbounded with no exception/warning at all). Raised at the
+    SAME validate_bounding entry point UnknownBoundingKeyError uses, not
+    as a new branch in compose_model_ceiling."""
+    with pytest.raises(InvalidBoundingValueError):
+        validate_bounding({"model": "strogn"}, source="test")
 
 
 # ---------------------------------------------------------------------------
@@ -173,6 +192,23 @@ def test_agent_profile_load_raises_on_unknown_bounding_key(tmp_path: Path) -> No
         encoding="utf-8",
     )
     with pytest.raises(UnknownBoundingKeyError):
+        AgentProfile.load(agent_dir)
+
+
+def test_agent_profile_load_raises_on_invalid_bounding_model_value(tmp_path: Path) -> None:
+    """Tier 1: contract — a profile.yaml with a bounding.model value
+    outside STANDARD_CLASSES raises InvalidBoundingValueError at load()
+    time, the same entry point the unknown-key case above uses."""
+    agent_dir = tmp_path / "agents" / "bounder-3b"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "profile.yaml").write_text(
+        yaml.safe_dump({
+            "name": "bounder-3b", "role": "", "created_at": "",
+            "bounding": {"model": "strogn"},
+        }),
+        encoding="utf-8",
+    )
+    with pytest.raises(InvalidBoundingValueError):
         AgentProfile.load(agent_dir)
 
 
@@ -260,6 +296,76 @@ def test_model_class_ceiling_session_layer_also_cannot_widen(tmp_path: Path) -> 
     )
 
     assert session.model_class_ceiling == "standard"
+
+
+def test_model_class_ceiling_agent_layer_typo_is_logged_not_silent(
+    tmp_path: Path, caplog,
+) -> None:
+    """Tier 2: THE silent-widening-closure witness at Session level
+    (lead-coder review, #4727) — a typo'd agent-layer bounding.model
+    ("strogn") does not just fail to narrow anything invisibly: it is
+    LOGGED (validate_bounding raises InvalidBoundingValueError, caught
+    and surfaced by _agent_profile_bounding's own warning, the same
+    degrade-and-log shape UnknownPreferenceKeyError already uses).
+    Without this, an operator has NO way to discover why their intended
+    restriction never applied. The composed ceiling still correctly
+    falls back to the project's own value (standard) either way — the
+    thing THIS test proves is the log, not the value (compose_model_
+    ceiling already tolerates an incomparable value silently by design;
+    see test_compose_model_ceiling_project_layer_incomparable_value_
+    ignored_not_raised above — the fix is entirely about visibility)."""
+    import logging
+
+    resolver = ModelResolver({"standard": "openai/gpt-4o"}, model_max_class="standard")
+    session = make_session(
+        agent_name="bound-3c", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+    agent_dir = _agent_dir(session)
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "profile.yaml").write_text(
+        yaml.safe_dump({
+            "name": "bound-3c", "role": "", "created_at": "",
+            "bounding": {"model": "strogn"},
+        }),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert session.model_class_ceiling == "standard"
+
+    assert any("bounding" in r.message.lower() for r in caplog.records), (
+        "a typo'd bounding.model value must be logged, not silently ignored"
+    )
+
+
+def test_model_class_ceiling_session_layer_typo_is_logged_not_silent(
+    tmp_path: Path, caplog,
+) -> None:
+    """Tier 2: the reverse leg of the same witness — a typo'd
+    SESSION-layer config.yaml bounding.model is ALSO logged (this is the
+    leg #4727 review actually caught: _read_bounding_override originally
+    had no validate_bounding call at all, so a session-layer typo was
+    invisible even though the agent-layer one already routed through
+    AgentProfile.load's validation)."""
+    import logging
+
+    resolver = ModelResolver({"standard": "openai/gpt-4o"}, model_max_class="standard")
+    session = make_session(
+        agent_name="bound-5b", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+    cfg_path = _session_config_path(session)
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump({"name": "_session_x", "bounding": {"model": "strogn"}}),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert session.model_class_ceiling == "standard"
+
+    assert any("bounding" in r.message.lower() for r in caplog.records), (
+        "a typo'd bounding.model value must be logged, not silently ignored"
+    )
 
 
 def test_model_class_ceiling_narrowest_of_all_three_layers_wins(tmp_path: Path) -> None:

--- a/tests/runtime/test_4206_2_bounding.py
+++ b/tests/runtime/test_4206_2_bounding.py
@@ -1,0 +1,376 @@
+"""Tier 1/2: #4206 ② — the bounding axis (``model`` key only).
+
+Unlike ③'s free-override composition (last-present-wins, no ceiling), ②'s
+composition is restrict-only: an agent/session layer may narrow the
+effective ``model`` ceiling, never widen it. This file covers, bottom-up:
+
+- ``reyn.runtime.bounding``'s own pure functions (Tier 1: contract).
+- ``AgentProfile.bounding`` round-trip + unknown-key validation (Tier 1).
+- ``Session.model_class_ceiling``'s live 3-layer composition, INCLUDING the
+  mandatory falsify-side restrict-only witness lead-coder specified
+  verbatim for #4206 ②: parent ceiling=standard, child declares strong ->
+  the composed ceiling must still enforce rejection (child cannot widen);
+  child narrows to light -> must be allowed (Tier 2).
+- ``RouterHostAdapter.model_class_ceiling()`` callback wiring (Tier 2).
+- an end-to-end witness: a real turn through ``RouterLoop.run``, backed by
+  a real ``Session``/resolver/``recorded_acompletion``, where a widened
+  child declaration is REJECTED before ``litellm.acompletion`` is ever
+  invoked (Tier 2).
+
+Real ``Session`` (``make_session``) + real ``RouterHostAdapter`` reached
+through ``session.router_host``, never a stand-in — same discipline
+``test_4724_slice_b_session_wiring.py`` established for ③.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import litellm
+import pytest
+import yaml
+
+from reyn.llm.model_resolver import (
+    ModelClassExceedsCeilingError,
+    ModelResolver,
+    model_class_exceeds_ceiling,
+)
+from reyn.runtime.bounding import (
+    BOUNDING_KEYS,
+    UnknownBoundingKeyError,
+    compose_model_ceiling,
+    validate_bounding,
+)
+from reyn.runtime.profile import AgentProfile
+from tests._support.agent_session import make_session
+
+# ---------------------------------------------------------------------------
+# bounding.py — pure functions (Tier 1: contract)
+# ---------------------------------------------------------------------------
+
+
+def test_bounding_keys_is_model_only() -> None:
+    """Tier 1: contract — #4206 ②'s current scope is exactly {"model"}
+    (lead-coder ruling narrowing the axis from architect's proposal)."""
+    assert BOUNDING_KEYS == frozenset({"model"})
+
+
+def test_compose_model_ceiling_ignores_none_layers() -> None:
+    """Tier 1: contract — a layer that declares no ceiling never widens
+    the effective one; all-None composes to None (unbounded)."""
+    assert compose_model_ceiling(None, None, None) is None
+    assert compose_model_ceiling("standard", None) == "standard"
+    assert compose_model_ceiling(None, "light") == "light"
+
+
+def test_compose_model_ceiling_narrowest_wins_a_wider_child_cannot_widen() -> None:
+    """Tier 1: THE restrict-only witness at the pure-function level — a
+    child layer declaring a WIDER (more expensive) class than the parent
+    does not move the composed ceiling; only a NARROWER child does."""
+    # Parent (project) ceiling=standard, child declares strong (wider) —
+    # composed stays standard, the parent's own ceiling.
+    assert compose_model_ceiling("standard", "strong") == "standard"
+    # Parent ceiling=standard, child narrows to light — composed follows
+    # the child down to light.
+    assert compose_model_ceiling("standard", "light") == "light"
+    # Three layers, mixed order — still the narrowest of all of them.
+    assert compose_model_ceiling("strong", "standard", "light") == "light"
+    assert compose_model_ceiling("light", "strong", "standard") == "light"
+
+
+def test_compose_model_ceiling_incomparable_value_ignored_not_raised() -> None:
+    """Tier 1: contract — a ceiling value outside STANDARD_CLASSES mirrors
+    ``model_class_exceeds_ceiling``'s own "not comparable" scope limit:
+    ignored, not raised, and never narrows anything by itself."""
+    assert compose_model_ceiling("standard", "custom-tier") == "standard"
+    assert compose_model_ceiling("custom-tier", "custom-tier-2") is None
+
+
+def test_validate_bounding_raises_on_unknown_key() -> None:
+    """Tier 1: contract — the #4655 "Kind① loud, not silent" discipline:
+    a typo'd/renamed bounding key raises, not silently does nothing."""
+    with pytest.raises(UnknownBoundingKeyError):
+        validate_bounding({"timeout": "30s"}, source="test")
+
+
+def test_validate_bounding_accepts_known_key() -> None:
+    """Tier 1: accept-side — a recognized key does not raise."""
+    validate_bounding({"model": "light"}, source="test")
+
+
+# ---------------------------------------------------------------------------
+# THE mandatory falsify-side restrict-only witness (lead-coder's own
+# required condition, verbatim): parent ceiling=standard, child declares
+# strong -> reject; child narrows to light -> allowed. Composed at the
+# compose_model_ceiling level, fed straight into the SAME enforcement
+# predicate (model_class_exceeds_ceiling) recorded_acompletion's #1190
+# chokepoint already uses — proving the composed value, not just the raw
+# layers, is what a "strong" call gets rejected against.
+# ---------------------------------------------------------------------------
+
+
+def test_child_declaring_a_wider_class_than_parent_is_still_rejected() -> None:
+    """Tier 2: falsify direction — parent(project) ceiling=standard, child
+    (agent/session layer) declares strong: the COMPOSED ceiling is still
+    standard (restrict-only held), so a "strong"-class call is REJECTED by
+    the same predicate the #1190 chokepoint enforces with."""
+    composed = compose_model_ceiling("standard", "strong")
+    assert composed == "standard"
+    assert model_class_exceeds_ceiling("strong", composed) is True
+
+
+def test_child_narrowing_to_a_lighter_class_is_allowed() -> None:
+    """Tier 2: accept direction (the reverse leg of the same required
+    test) — parent ceiling=standard, child narrows to light: the composed
+    ceiling follows the child, so a "light"-class call is ALLOWED."""
+    composed = compose_model_ceiling("standard", "light")
+    assert composed == "light"
+    assert model_class_exceeds_ceiling("light", composed) is False
+
+
+# ---------------------------------------------------------------------------
+# AgentProfile.bounding — round-trip + validation (Tier 1)
+# ---------------------------------------------------------------------------
+
+
+def test_agent_profile_bounding_round_trips_through_save_and_load(tmp_path: Path) -> None:
+    """Tier 1: contract — a profile's bounding mapping survives a
+    save()/load() cycle unchanged, same shape as preferences'."""
+    profile = AgentProfile.new("bounder-1")
+    object.__setattr__(profile, "bounding", {"model": "standard"})
+    agent_dir = tmp_path / "agents" / "bounder-1"
+    profile.save(agent_dir)
+
+    loaded = AgentProfile.load(agent_dir)
+    assert loaded.bounding == {"model": "standard"}
+
+
+def test_agent_profile_bounding_empty_by_default_and_omitted_from_yaml(tmp_path: Path) -> None:
+    """Tier 1: accept-side — the common case (no bounding declared) stays
+    {} and the on-disk YAML omits the key entirely, matching preferences'
+    own "empty dict, not None, minimal on-disk shape" contract."""
+    profile = AgentProfile.new("bounder-2")
+    agent_dir = tmp_path / "agents" / "bounder-2"
+    profile.save(agent_dir)
+
+    raw = yaml.safe_load((agent_dir / "profile.yaml").read_text(encoding="utf-8"))
+    assert "bounding" not in raw
+
+    loaded = AgentProfile.load(agent_dir)
+    assert loaded.bounding == {}
+
+
+def test_agent_profile_load_raises_on_unknown_bounding_key(tmp_path: Path) -> None:
+    """Tier 1: contract — a profile.yaml with a bounding key outside
+    BOUNDING_KEYS raises UnknownBoundingKeyError at load() time."""
+    agent_dir = tmp_path / "agents" / "bounder-3"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "profile.yaml").write_text(
+        yaml.safe_dump({
+            "name": "bounder-3", "role": "", "created_at": "",
+            "bounding": {"router_max_iterations": 10},
+        }),
+        encoding="utf-8",
+    )
+    with pytest.raises(UnknownBoundingKeyError):
+        AgentProfile.load(agent_dir)
+
+
+# ---------------------------------------------------------------------------
+# Session.model_class_ceiling — live 3-layer composition (Tier 2)
+# ---------------------------------------------------------------------------
+
+
+def _agent_dir(session) -> Path:
+    return session.workspace_dir
+
+
+def _session_config_path(session) -> Path:
+    return Path(session._snapshot_path).parent / "config.yaml"
+
+
+def _write_agent_bounding(session, name: str, bounding: dict) -> None:
+    profile = AgentProfile.new(name)
+    object.__setattr__(profile, "bounding", bounding)
+    profile.save(_agent_dir(session))
+
+
+def test_model_class_ceiling_is_project_only_with_no_layers_set(tmp_path: Path) -> None:
+    """Tier 2: accept-side — no agent/session bounding override, the
+    project resolver's own class_ceiling() is the effective value,
+    byte-identical to before this slice (RouterLoop's prior
+    construction-time-cached read)."""
+    resolver = ModelResolver({"standard": "openai/gpt-4o"}, model_max_class="standard")
+    session = make_session(
+        agent_name="bound-1", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+    assert session.model_class_ceiling == "standard"
+
+
+def test_model_class_ceiling_project_unbounded_with_no_layers_set(tmp_path: Path) -> None:
+    """Tier 2: accept-side — no project ceiling AND no agent/session
+    override at all -> fully unbounded (None), the compat default."""
+    resolver = ModelResolver({"standard": "openai/gpt-4o"})  # model_max_class unset
+    session = make_session(
+        agent_name="bound-2", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+    assert session.model_class_ceiling is None
+
+
+def test_model_class_ceiling_agent_layer_widening_is_rejected(tmp_path: Path) -> None:
+    """Tier 2: THE mandatory falsify witness at Session level — project
+    ceiling=standard, agent-layer bounding.model=strong (a WIDER
+    declaration): the effective ceiling stays standard, the child cannot
+    widen it."""
+    resolver = ModelResolver({"standard": "openai/gpt-4o"}, model_max_class="standard")
+    session = make_session(
+        agent_name="bound-3", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+    _write_agent_bounding(session, "bound-3", {"model": "strong"})
+
+    assert session.model_class_ceiling == "standard"
+
+
+def test_model_class_ceiling_agent_layer_narrowing_is_allowed(tmp_path: Path) -> None:
+    """Tier 2: THE reverse leg — project ceiling=standard, agent-layer
+    bounding.model=light (a NARROWER declaration): the effective ceiling
+    follows the child down to light."""
+    resolver = ModelResolver({"standard": "openai/gpt-4o"}, model_max_class="standard")
+    session = make_session(
+        agent_name="bound-4", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+    _write_agent_bounding(session, "bound-4", {"model": "light"})
+
+    assert session.model_class_ceiling == "light"
+
+
+def test_model_class_ceiling_session_layer_also_cannot_widen(tmp_path: Path) -> None:
+    """Tier 2: falsify witness, session-layer leg — project ceiling=
+    standard, session-layer config.yaml bounding.model=strong: still
+    rejected (composed stays standard)."""
+    resolver = ModelResolver({"standard": "openai/gpt-4o"}, model_max_class="standard")
+    session = make_session(
+        agent_name="bound-5", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+    cfg_path = _session_config_path(session)
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump({"name": "_session_x", "bounding": {"model": "strong"}}),
+        encoding="utf-8",
+    )
+
+    assert session.model_class_ceiling == "standard"
+
+
+def test_model_class_ceiling_narrowest_of_all_three_layers_wins(tmp_path: Path) -> None:
+    """Tier 2: composition witness — project=strong (unbounded-ish, the
+    widest tier), agent narrows to standard, session narrows further to
+    light: the NARROWEST of all three layers wins, matching
+    compose_model_ceiling's own three-layer pure-function test above."""
+    resolver = ModelResolver({"strong": "anthropic/claude-opus-5"}, model_max_class="strong")
+    session = make_session(
+        agent_name="bound-6", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+    _write_agent_bounding(session, "bound-6", {"model": "standard"})
+    cfg_path = _session_config_path(session)
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump({"name": "_session_x", "bounding": {"model": "light"}}),
+        encoding="utf-8",
+    )
+
+    assert session.model_class_ceiling == "light"
+
+
+def test_model_class_ceiling_is_a_live_re_read(tmp_path: Path) -> None:
+    """Tier 2: accept-side — editing profile.yaml AFTER Session
+    construction takes effect on the next access, same live-re-read shape
+    output_language/reasoning_display/warn_ratio_overrides already use."""
+    resolver = ModelResolver({"standard": "openai/gpt-4o"}, model_max_class="standard")
+    session = make_session(
+        agent_name="bound-7", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+    assert session.model_class_ceiling == "standard"
+
+    _write_agent_bounding(session, "bound-7", {"model": "light"})
+
+    assert session.model_class_ceiling == "light"
+
+
+# ---------------------------------------------------------------------------
+# RouterHostAdapter.model_class_ceiling() — callback wiring (Tier 2)
+# ---------------------------------------------------------------------------
+
+
+def test_model_class_ceiling_fn_none_falls_back_to_resolver_class_ceiling() -> None:
+    """Tier 2: accept-side — a RouterHostAdapter built WITHOUT
+    model_class_ceiling_fn (every pre-② caller, every existing test host)
+    falls back to the resolver's own class_ceiling(), byte-identical to
+    before this slice."""
+    from tests._support.router_host_adapter import make_adapter
+
+    resolver = ModelResolver({"standard": "openai/gpt-4o"}, model_max_class="standard")
+    adapter = make_adapter(universal_wrappers_enabled=False, resolver=resolver)
+    assert adapter.model_class_ceiling() == "standard"
+
+
+def test_router_host_model_class_ceiling_reflects_the_live_session_composition(tmp_path: Path) -> None:
+    """Tier 2: THE end-to-end witness — RouterHostAdapter.model_class_ceiling()
+    (what RouterLoop actually consults) reflects the SAME live composed
+    value as Session.model_class_ceiling, via the model_class_ceiling_fn
+    callback wired at construction."""
+    resolver = ModelResolver({"standard": "openai/gpt-4o"}, model_max_class="standard")
+    session = make_session(
+        agent_name="bound-8", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+    assert session.router_host.model_class_ceiling() == "standard"
+
+    _write_agent_bounding(session, "bound-8", {"model": "light"})
+
+    assert session.model_class_ceiling == "light"
+    assert session.router_host.model_class_ceiling() == "light"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: RouterLoop -> recorded_acompletion enforcement (Tier 2)
+# ---------------------------------------------------------------------------
+
+
+def test_router_loop_rejects_a_call_whose_class_exceeds_the_composed_ceiling(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: THE full end-to-end falsify witness — a real turn through
+    RouterLoop.run, driven by a real Session whose project resolver
+    declares a "strong" default router class but a "standard" ceiling:
+    ModelClassExceedsCeilingError is raised BEFORE litellm.acompletion is
+    ever invoked (recorded_acompletion's own #1190 chokepoint), proving
+    the LIVE per-call composition (not just the construction-time-cached
+    value RouterLoop used before ②) actually reaches enforcement."""
+    from reyn.runtime.router_loop import RouterLoop
+
+    called = {"n": 0}
+
+    async def _spy(model, messages, **kw):  # noqa: ANN001, ANN003
+        called["n"] += 1
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+        )
+    monkeypatch.setattr(litellm, "acompletion", _spy)
+
+    resolver = ModelResolver(
+        {"strong": "anthropic/claude-opus-5"},
+        default_class="strong",
+        model_max_class="standard",
+    )
+    session = make_session(
+        agent_name="bound-9", workspace_state_dir=tmp_path / ".reyn", resolver=resolver,
+    )
+
+    with pytest.raises(ModelClassExceedsCeilingError) as excinfo:
+        asyncio.run(RouterLoop(host=session.router_host, chain_id="c1").run("hi", []))
+
+    assert called["n"] == 0, "litellm.acompletion must never be invoked on a rejected call"
+    assert excinfo.value.requested == "strong"
+    assert excinfo.value.ceiling == "standard"


### PR DESCRIPTION
**[e2e-coder]** — #4206 ②bounding, `model` only (lead-coder's scope ruling, 2026-08-14). Restrict-only composition: an agent/session-layer `bounding.model` may narrow the effective ceiling, never widen it.

## What
- `reyn.runtime.bounding`: `BOUNDING_KEYS = {"model"}`, `compose_model_ceiling` (narrowest of project/agent/session wins), `validate_bounding` (loud on unknown key, same #4655 discipline `preferences` uses).
- `AgentProfile.bounding`: same flat-dict/empty-omitted-from-yaml shape as `.preferences`.
- `Session.model_class_ceiling`: new live `@property`, project (`resolver.class_ceiling()`) + agent-layer + session-layer composition.
- `RouterHostAdapter.model_class_ceiling_fn`/`.model_class_ceiling()`: same callback-injection shape as `reasoning_display_fn`/`warn_ratio_overrides_fn`.
- `RouterLoop`: the former construction-time-cached `self._model_class_ceiling` ivar is now a live per-call `self._model_class_ceiling()` method, at all 3 existing `call_llm_tools` sites.
- Docs updated in this PR: `docs/reference/cli/agent.md` (new `bounding:` section), `docs/reference/runtime/session-construction.md`.

## 🔴 Mandatory condition (lead-coder's own requirement, verbatim)
> 親 ceiling=standard で子が strong を宣言 → reject。逆向き（子が light に狭める）は通ること。

Covered three ways: pure `compose_model_ceiling` level, `Session.model_class_ceiling` level (both agent- and session-layer legs), and end-to-end through a real `RouterLoop.run` turn where `ModelClassExceedsCeilingError` is raised before `litellm.acompletion` is ever invoked (`test_router_loop_rejects_a_call_whose_class_exceeds_the_composed_ceiling`).

## Strip-falsify
- `compose_model_ceiling`'s narrowest-wins swapped for last-wins → 4 tests RED for the right reason, restored GREEN.
- `recorded_acompletion`'s enforcement check disabled → the new end-to-end test and #4206 T1's own falsify test both went RED, restored GREEN.

## Gates
- `ruff check .`, `python scripts/mypy_ratchet.py`, `python scripts/verify_module_docstrings.py <changed>`, `python scripts/test_tier_audit.py --strict tests/runtime/test_4206_2_bounding.py` — all green.
- `mkdocs build --strict`, `check_doc_anchors.py`, `check_retired_config_keys_denylist.py` — all green (docs touched).
- Scoped regression: `pytest tests/runtime tests/llm` — 2546 passed, 1 skipped, 0 failed (re-run after the review-fix commit, 4 more tests than the original run).
- `_PUBLIC_MEMBER_CEILING` raised 109 → 110 for the new `Session.model_class_ceiling` public property, rationale comment in place.

## Remainder
`timeout`/`router_max_iterations` stay explicitly out of `BOUNDING_KEYS` (no config key for the latter, no driving reason measured for the former) — the remainder is recorded by name on the umbrella issue already, not a new implicit "later."

part of #4206

Test plan:
- [x] `ruff check .` green
- [x] `python scripts/mypy_ratchet.py` green
- [x] `python scripts/verify_module_docstrings.py` on changed src files, green
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_4206_2_bounding.py`, green
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py`, all green
- [x] `pytest tests/runtime tests/llm` scoped regression, 2546 passed / 1 skipped / 0 failed (re-run after review-fix commit)
- [x] Strip-falsify on `compose_model_ceiling` and on `recorded_acompletion`'s enforcement check, both confirmed RED for the right reason then restored GREEN
- [ ] (skipped — no visual/TUI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## レビュア追記（lead-coder, TESTS-READ 済）

- [x] 🔴 `validate_bounding` が**キーだけ検査し、値を検査していません**。`model: strogn`（typo）は通過し、`compose_model_ceiling` が黙って無視 ∴ **全層が未知値なら合成結果は `None` ＝ 上限なし** — typo 1 つで「standard までに抑えるつもり」が**無制限**になり、例外も警告も出ません。この PR 自身の `UnknownBoundingKeyError` の文面（「a typo'd or renamed bounding key would otherwise **silently fail to narrow anything**」）が値にもそのまま当てはまります。**`validate_bounding` で値も `STANDARD_CLASSES` に対して検査し raise** — 合成側に分岐を足すのではなく**入口を閉じる**
- [x] 🔴 `test_compose_model_ceiling_incomparable_value_ignored_not_raised` を削除し、`validate_bounding({"model": "strogn"})` が raise する test に差し替え（上の修正で未知値は合成関数に到達しなくなるため）


