### PR TITLE
feat(#4691): bump textual-flowview 0.19.0 -> 0.21.1, migrate present()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,7 @@ dependencies = [
     # FlowView's virtualized painting model at all, on the terminals reyn
     # targets — #3970's trade-off no longer applies because the option it
     # was weighing against never actually worked here.
-    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@ec10edb21516ca062a546f0511e69ca2500beca1",
+    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@728eb0070115ddea92153b5b9aca557b92f329b9",
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
     "charset-normalizer>=3.0",  # #1452 read_file encoding detection (MIT, pure-python)

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -848,6 +848,31 @@ class TextualChatApp(App):
         height: 1fr;
         scrollbar-size-vertical: 0;
         margin-bottom: 1;
+        /* #4691 Phase 2: NO-OP today, measured, not assumed — kept for what
+           breaks if `scrollbar-size-vertical: 0` above is ever removed.
+           flowview 0.21.0's CHANGELOG names a real cost: a fold that shrinks
+           content below the viewport drops the scrollbar, which widens the
+           body — and width is part of the presentation cache key, so
+           everything re-presents (upstream's own 50-entry-group figure: 0
+           presents reserved vs 12 unreserved). A local repro of that exact
+           collapse (1 parent + 50 children + 3 filler rows, 20-row viewport,
+           counting presents on collapse) measured FOUR configurations:
+           neither declaration = 8 presents; `scrollbar-gutter: stable` alone
+           (upstream's own fix) = 4; `scrollbar-size-vertical: 0` ALONE
+           (reyn's pre-existing CSS, one line up) = 4 — already the full
+           mitigation, because a scrollbar whose SIZE is fixed at 0 never has
+           a size to remove, so the body width never moves regardless of
+           gutter reservation; adding `scrollbar-gutter: stable` on top of
+           `scrollbar-size-vertical: 0` = still 4 — no measurable change.
+           Declared anyway, at zero measured cost, because it is the residue
+           that survives the day `scrollbar-size-vertical: 0` above is
+           removed or changed: without this line, that edit would silently
+           reopen the exact re-present storm this comment describes, with no
+           test in this repo pinned to catch it (upstream's own mitigation
+           lives in ITS test suite, not reyn's, and reyn does not fold/nest
+           entries yet — #4691 Phase B — so there is nothing here to exercise
+           the interaction today). */
+        scrollbar-gutter: stable;
     }
     /* #3496 / flowview#5: ``flowview--highlight`` (``--selected`` was its
        0.11.x synonym for the SAME class; 0.12.0 / #3624 removed the alias, so

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Callable
 from rich.console import Console, Group, RenderableType
 from rich.text import Text
 from textual.content import Content
-from textual_flowview import Presentation
+from textual_flowview import Entry, Presentation
 
 from reyn.interfaces.repl.renderer import (
     _CC_ACCENT,
@@ -816,7 +816,13 @@ class ReynPresenter:
         head_h = self._measure(head, width)
         return Presentation(height=head_h + 1, renderable=Group(head, indicator))
 
-    async def present(self, item: "OutboxMessage", width: int) -> Presentation:
+    async def present(self, entry: "Entry[OutboxMessage]", width: int) -> Presentation:
+        # #4691 Phase 2: flowview 0.21.0 breaking change — present() now
+        # receives the Entry, not the item, so FlowView can carry state
+        # (entry.depth, entry.collapsed) without mirroring it into reyn's own
+        # item. Unpack immediately; everything below is byte-identical to the
+        # pre-0.21.0 body, which always operated on the item.
+        item = entry.item
         meta = item.meta or {}
         if item.kind == "intervention":
             return self._present_intervention_pending(item, width)

--- a/tests/_support/textual_chat_test_helpers.py
+++ b/tests/_support/textual_chat_test_helpers.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import asyncio
 from typing import AsyncIterator
 
+from textual_flowview import Entry
+
 from reyn.interfaces.inline.textual_chat import ReynPresenter
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
@@ -87,6 +89,6 @@ class WidthRecordingPresenter(ReynPresenter):
         super().__init__()
         self.widths: "list[int]" = []
 
-    async def present(self, item: "OutboxMessage", width: int):
+    async def present(self, entry: "Entry[OutboxMessage]", width: int):
         self.widths.append(width)
-        return await super().present(item, width)
+        return await super().present(entry, width)

--- a/tests/core/test_3846_image_resolution_e2e.py
+++ b/tests/core/test_3846_image_resolution_e2e.py
@@ -94,7 +94,7 @@ async def _entry_text(app: TextualChatApp, entry: object) -> str:
 
     from rich.console import Console
 
-    presentation = await app._presenter.present(entry.item, width=100)
+    presentation = await app._presenter.present(entry, width=100)
     buf = io.StringIO()
     Console(file=buf, color_system=None, width=100).print(presentation.renderable)
     return buf.getvalue()

--- a/tests/interfaces/test_3318_body_neutralize.py
+++ b/tests/interfaces/test_3318_body_neutralize.py
@@ -24,6 +24,7 @@ import io
 import pytest
 from rich.console import Console
 from rich.text import Text
+from textual_flowview import FlowModel
 
 from reyn.config.chat import ChatConfig, _build_chat_config
 from reyn.config.root import ReynConfig
@@ -268,7 +269,7 @@ async def test_textual_chat_app_wires_config_neutralize_body_into_default_presen
     config = ReynConfig(chat=ChatConfig(neutralize_body=True))
     app = TextualChatApp(transport=QueueTransport(), config=config)
     presentation = await app._presenter.present(
-        OutboxMessage(kind="status", text=_RAW_ESC), width=80
+        FlowModel().append(OutboxMessage(kind="status", text=_RAW_ESC)), width=80
     )
     rendered = _render_to_text(presentation.renderable)
     assert "\x1b" not in rendered
@@ -283,7 +284,7 @@ async def test_textual_chat_app_default_config_leaves_presenter_off() -> None:
     presenter that always neutralizes regardless of the flag)."""
     app = TextualChatApp(transport=QueueTransport())
     presentation = await app._presenter.present(
-        OutboxMessage(kind="status", text=_RAW_ESC), width=80
+        FlowModel().append(OutboxMessage(kind="status", text=_RAW_ESC)), width=80
     )
     rendered = _render_to_text(presentation.renderable)
     assert "\x1b" in rendered

--- a/tests/interfaces/test_4464_image_prep_off_thread_and_indicator.py
+++ b/tests/interfaces/test_4464_image_prep_off_thread_and_indicator.py
@@ -113,7 +113,7 @@ async def _entry_text(app: TextualChatApp, entry: object) -> str:
 
     from rich.console import Console
 
-    presentation = await app._presenter.present(entry.item, width=100)
+    presentation = await app._presenter.present(entry, width=100)
     buf = io.StringIO()
     Console(file=buf, color_system=None, width=100).print(presentation.renderable)
     return buf.getvalue()

--- a/tests/interfaces/test_right_gutter_label_visible_3536.py
+++ b/tests/interfaces/test_right_gutter_label_visible_3536.py
@@ -26,6 +26,7 @@ from typing import AsyncIterator
 import pytest
 from rich.console import Console
 from rich.text import Text
+from textual_flowview import FlowModel
 
 from reyn.interfaces.inline.textual_chat.presenter import ReynPresenter
 from reyn.interfaces.repl.renderer import _CC_AMBIENT, _CC_DIM
@@ -150,7 +151,7 @@ async def test_the_rows_carrying_these_labels_have_no_tint() -> None:
             kind="tool_call_started", text="read_file", meta={"tool": "read_file"}
         ),
     ):
-        presentation = await presenter.present(message, 80)
+        presentation = await presenter.present(FlowModel().append(message), 80)
         assert presentation.background is None, (
             f"a {message.kind!r} row now carries the tint "
             f"{presentation.background!r} — the right gutter's label sits on it "

--- a/tests/interfaces/test_textual_chat_intervention_panel_3299.py
+++ b/tests/interfaces/test_textual_chat_intervention_panel_3299.py
@@ -454,7 +454,7 @@ async def test_pending_intervention_flow_entry_has_no_chip_options_rendered() ->
         await pilot.pause()
         await pilot.pause()
         entry = _iv_entry(app)
-        presentation = await app._presenter.present(entry.item, 80)
+        presentation = await app._presenter.present(entry, 80)
 
     console = Console(width=80, no_color=True)
     with console.capture() as cap:

--- a/tests/interfaces/test_textual_chat_orphan_sweep_72.py
+++ b/tests/interfaces/test_textual_chat_orphan_sweep_72.py
@@ -141,7 +141,7 @@ async def test_orphaned_running_tool_settles_neutral_on_turn_settled() -> None:
         assert (entry.item.meta or {}).get(_RUNNING_SINCE_KEY) is None
         meta = entry.item.meta or {}
         assert meta.get(_RESULT_KIND_KEY) not in ("tool_call_completed", "tool_call_failed")
-        pres = await ReynPresenter(clock=lambda: 100.0).present(entry.item, 80)
+        pres = await ReynPresenter(clock=lambda: 100.0).present(entry, 80)
         body = pres.renderable
         from rich.console import Console
 
@@ -193,7 +193,7 @@ async def test_completed_tool_is_untouched_by_the_sweep() -> None:
 
         assert entry.state is EntryState.SUCCESS
         assert (entry.item.meta or {}).get(_RESULT_KIND_KEY) == "tool_call_completed"
-        pres = await ReynPresenter(clock=lambda: 100.0).present(entry.item, 80)
+        pres = await ReynPresenter(clock=lambda: 100.0).present(entry, 80)
         from rich.console import Console
 
         console = Console(width=80)

--- a/tests/interfaces/test_textual_chat_phase2_3273.py
+++ b/tests/interfaces/test_textual_chat_phase2_3273.py
@@ -391,7 +391,7 @@ async def test_running_to_error_turns_gutter_coral_and_tints_failure_row() -> No
 
         # The coalesced failure entry is tinted edge-to-edge with the dark
         # failure block — NOT with the coral foreground colour (#3367).
-        pres = await ReynPresenter().present(started.item, 80)
+        pres = await ReynPresenter().present(started, 80)
         assert pres.background == _CC_ERR_BG
 
 

--- a/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
+++ b/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
@@ -37,7 +37,7 @@ from typing import AsyncIterator
 
 import pytest
 from rich.console import Console
-from textual_flowview import EntryState, FlowView
+from textual_flowview import Entry, EntryState, FlowModel, FlowView
 
 from reyn.interfaces.inline.textual_chat import ReynPresenter, TextualChatApp
 from reyn.interfaces.inline.textual_chat.presenter import (
@@ -199,11 +199,12 @@ class _CountingPresenter(ReynPresenter):
         super().__init__()
         self.present_counts: "dict[object, int]" = {}
 
-    async def present(self, item: "OutboxMessage", width: int):
+    async def present(self, entry: "Entry[OutboxMessage]", width: int):
+        item = entry.item
         if item.kind == "tool_call_started":
             op = (item.meta or {}).get("op_id")
             self.present_counts[op] = self.present_counts.get(op, 0) + 1
-        return await super().present(item, width)
+        return await super().present(entry, width)
 
 
 def _fast_app(**kwargs) -> TextualChatApp:
@@ -236,13 +237,13 @@ def test_running_tool_body_advances_as_the_clock_advances() -> None:
     body then does NOT change — so this positive assertion is load-bearing."""
     now = [1000.0]
     presenter = ReynPresenter(clock=lambda: now[0])
-    item = _running_item("op-live", since=1000.0)
+    entry = FlowModel().append(_running_item("op-live", since=1000.0))
 
     async def go() -> None:
         now[0] = 1002.0
-        a = await presenter.present(item, 80)
+        a = await presenter.present(entry, 80)
         now[0] = 1007.0
-        b = await presenter.present(item, 80)
+        b = await presenter.present(entry, 80)
         # Fixed height across ticks (no reflow): header row + the indicator row.
         assert a.height == b.height == 2
         ta, tb = _render(a.renderable), _render(b.renderable)
@@ -261,11 +262,11 @@ def test_frozen_clock_leaves_a_static_running_body() -> None:
     positive test proves it moves when the clock advances, so the animation is the
     only thing driving the change (not incidental noise)."""
     presenter = ReynPresenter(clock=lambda: 500.0)
-    item = _running_item("op-frozen", since=490.0)
+    entry = FlowModel().append(_running_item("op-frozen", since=490.0))
 
     async def go() -> None:
-        a = await presenter.present(item, 80)
-        b = await presenter.present(item, 80)
+        a = await presenter.present(entry, 80)
+        b = await presenter.present(entry, 80)
         assert _render(a.renderable) == _render(b.renderable), "frozen clock must not animate"
 
     asyncio.run(go())
@@ -292,7 +293,7 @@ def test_settled_tool_body_is_static_and_matches_the_header() -> None:
     spinner. Presented at two DIFFERENT clock readings the body is identical."""
     now = [10.0]
     presenter = ReynPresenter(clock=lambda: now[0])
-    settled = _started("op-settled")  # no _RUNNING_SINCE_KEY marker
+    settled = FlowModel().append(_started("op-settled"))  # no _RUNNING_SINCE_KEY marker
 
     async def go() -> None:
         a = await presenter.present(settled, 80)
@@ -300,7 +301,7 @@ def test_settled_tool_body_is_static_and_matches_the_header() -> None:
         b = await presenter.present(settled, 80)
         assert _render(a.renderable) == _render(b.renderable), "settled body must be static"
         assert a.height == 1  # header only, no indicator row
-        assert _render(a.renderable).strip() == _tool_head(settled).plain
+        assert _render(a.renderable).strip() == _tool_head(settled.item).plain
 
     asyncio.run(go())
 
@@ -322,7 +323,7 @@ async def test_app_marks_running_body_live_then_coalesces_on_success() -> None:
         entry = _entry_by_kind(live_app, "tool_call_started")[0]
         assert entry.state is EntryState.RUNNING
         assert (entry.item.meta or {}).get(_RUNNING_SINCE_KEY) is not None
-        pres = await ReynPresenter().present(entry.item, 80)
+        pres = await ReynPresenter().present(entry, 80)
         assert pres.height == 2  # header + live indicator row
         assert any(frame in _render(pres.renderable) for frame in _SPINNER)
 
@@ -336,7 +337,7 @@ async def test_app_marks_running_body_live_then_coalesces_on_success() -> None:
         entry = _entry_by_kind(done_app, "tool_call_started")[0]
         assert entry.state is EntryState.SUCCESS
         assert (entry.item.meta or {}).get(_RUNNING_SINCE_KEY) is None
-        pres = await ReynPresenter().present(entry.item, 80)
+        pres = await ReynPresenter().present(entry, 80)
         body = _render(pres.renderable)
         assert "⎿" in body  # the folded-in result sub-line
         assert not any(frame in body for frame in _SPINNER)  # no lingering spinner
@@ -356,7 +357,7 @@ async def test_app_coalesces_a_failure_and_tints_it() -> None:
         started = _entry_by_kind(app, "tool_call_started")[0]
         assert started.state is EntryState.ERROR
         assert (started.item.meta or {}).get(_RUNNING_SINCE_KEY) is None
-        pres = await ReynPresenter().present(started.item, 80)
+        pres = await ReynPresenter().present(started, 80)
         from reyn.interfaces.repl.renderer import _CC_ERR, _CC_ERR_BG
 
         # #3367: the failure tint is the dark failure BLOCK, never the coral
@@ -389,7 +390,7 @@ async def test_correlated_pair_coalesces_into_exactly_one_entry() -> None:
         assert [e.item.kind for e in flow.entries] == ["tool_call_started"]
         entry = flow.entries[0]
         assert (entry.item.meta or {}).get(_RESULT_KIND_KEY) == "tool_call_completed"
-        body = _render((await ReynPresenter().present(entry.item, 80)).renderable)
+        body = _render((await ReynPresenter().present(entry, 80)).renderable)
         assert "grep" in body and "⎿" in body  # call header AND result, one block
 
 

--- a/tests/interfaces/test_textual_chat_phase4_right_gutter_3283.py
+++ b/tests/interfaces/test_textual_chat_phase4_right_gutter_3283.py
@@ -48,7 +48,7 @@ import re
 from typing import AsyncIterator
 
 import pytest
-from textual_flowview import EntryState, FlowModel, FlowView
+from textual_flowview import Entry, EntryState, FlowModel, FlowView
 
 from reyn.interfaces.inline.textual_chat import (
     ReynGutter,
@@ -227,9 +227,9 @@ class _WidthRecordingPresenter(ReynPresenter):
         super().__init__()
         self.widths: "list[int]" = []
 
-    async def present(self, item: "OutboxMessage", width: int):
+    async def present(self, entry: "Entry[OutboxMessage]", width: int):
         self.widths.append(width)
-        return await super().present(item, width)
+        return await super().present(entry, width)
 
 
 # ── Gate 1: content for an entry that has it (Tier 1, pure decorate()) ────────

--- a/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
+++ b/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
@@ -66,7 +66,7 @@ from typing import AsyncIterator
 
 import pytest
 from rich.cells import cell_len
-from textual_flowview import FlowModel, FlowView
+from textual_flowview import Entry, FlowModel, FlowView
 
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.inline.textual_chat import (
@@ -823,9 +823,9 @@ async def test_widened_gutter_still_leaves_the_body_most_of_the_terminal() -> No
             super().__init__()
             self.widths: "list[int]" = []
 
-        async def present(self, item: "OutboxMessage", width: int):
+        async def present(self, entry: "Entry[OutboxMessage]", width: int):
             self.widths.append(width)
-            return await super().present(item, width)
+            return await super().present(entry, width)
 
     transport = _QueueTransport()
     presenter = _WidthRecordingPresenter()

--- a/tests/interfaces/test_textual_chat_row_contrast_3367.py
+++ b/tests/interfaces/test_textual_chat_row_contrast_3367.py
@@ -250,7 +250,7 @@ async def test_row_ink_is_never_painted_in_its_own_background() -> None:
     checked = 0
     tinted_kinds: set[str] = set()
     for label, msg in _scenarios():
-        presentation = await presenter.present(msg, _WIDTH)
+        presentation = await presenter.present(FlowModel().append(msg), _WIDTH)
         background = presentation.background
         if background is not None:
             tinted_kinds.add(msg.kind)
@@ -298,12 +298,20 @@ async def test_failure_rows_keep_a_distinct_row_tint() -> None:
     """
     presenter = ReynPresenter(clock=lambda: 0.0)
     failed = await presenter.present(
-        OutboxMessage(kind="tool_call_failed", text="boom", meta={"error_message": "boom"}),
+        FlowModel().append(
+            OutboxMessage(kind="tool_call_failed", text="boom", meta={"error_message": "boom"}),
+        ),
         _WIDTH,
     )
-    errored = await presenter.present(OutboxMessage(kind="error", text="boom"), _WIDTH)
-    user = await presenter.present(OutboxMessage(kind="user", text="hello"), _WIDTH)
-    agent = await presenter.present(OutboxMessage(kind="agent", text="hello"), _WIDTH)
+    errored = await presenter.present(
+        FlowModel().append(OutboxMessage(kind="error", text="boom")), _WIDTH,
+    )
+    user = await presenter.present(
+        FlowModel().append(OutboxMessage(kind="user", text="hello")), _WIDTH,
+    )
+    agent = await presenter.present(
+        FlowModel().append(OutboxMessage(kind="agent", text="hello")), _WIDTH,
+    )
 
     assert failed.background is not None
     assert errored.background == failed.background


### PR DESCRIPTION
**[tui-coder]** — #4691 Phase 2 (owner-approved split; condition set by lead-coder: measurement before implementation)

## Breaking-change enumeration (all 3 releases the bump crosses, not just 0.21.1)

- **0.20.0**: additive only (`FlowModel.set_hidden_many`, batch visibility). No breaking change.
- **0.21.0**: 3 breaking changes ("Nested groups with folding — FlowView now owns the tree") — `FlowPresenter.present` receives the `Entry`, not the item; `FlowModel.insert`/`insert_many`'s index becomes sibling-relative (byte-identical for a flat model); removing an entry removes its subtree.
- **0.21.1**: CI-only fix (ruff pin), no functional/breaking change.

Reyn has no Group/nesting yet (#4691 Phase B) — confirmed only `present()`'s signature change is live; insert/insert_many and subtree-deletion are both explicitly no-ops for a flat model per the CHANGELOG's own text, and produced an empty diff here.

## Measure-then-implement, not assume-then-implement

Bumped the pin (`ec10edb2…` → `728eb007…`), ran `tests/interfaces/` (51 files touch flowview) **before writing any migration code**.

- First pass: **50 failed**, all `'Entry' object has no attribute 'meta'` — confirmed `present()`'s signature is the sole live breaking surface.
- Migrated `presenter.py`'s ONE `present()` override (unpack `entry.item` at the top; body otherwise byte-identical).
- Re-run: **17 failed**, a new class — 8 test files calling `.present(item, ...)` directly with a bare `OutboxMessage`, bypassing FlowView's own `Entry` construction.

## Per-file repair-vs-delete determination (lead-coder's condition, CLAUDE.md: "ask 'should this exist' before 'how do I make it pass again'")

All 8 are **repair (①)**, decided per-file, not by default — none pinned "call `present()` with a bare item" as their own subject, and every fix uses a REAL collaborator (a `FlowModel`-constructed `Entry`, or an already-real `Entry` a mounted app already held):

- `test_3318_body_neutralize.py` — tests config→presenter wiring via a direct `present()` call as a mounting-cost shortcut; what's tested (neutralize_body reaching rendered output) is unchanged, production builds the same chain the fix now constructs explicitly.
- `test_4464_image_prep_off_thread_and_indicator.py` — already held a REAL `Entry` from a mounted app and redundantly unwrapped it (`entry.item`) before the now-obsolete unwrap inside `present()` itself; removing the redundant `.item` is a pure bug fix, not a shape question.
- `test_right_gutter_label_visible_3536.py` — same shape as 3318.
- `test_textual_chat_intervention_panel_3299.py`, `test_textual_chat_orphan_sweep_72.py`, `test_textual_chat_phase2_3273.py` — same shape as 4464 (real mounted-app `Entry`, redundant unwrap removed).
- `test_textual_chat_phase2b_live_tool_3283.py` — mixed: 3 unit-level sites needed `FlowModel` wrapping (same reasoning as 3318); 4 sites already held real mounted-app `Entry`s (same as 4464); its own `_CountingPresenter` subclass override needed the same unpack `presenter.py` itself got.
- `test_textual_chat_row_contrast_3367.py` — a cross-product legibility gate over synthetic `(kind, state)` pairs; `FlowModel().append()` per scenario is the real construction, not a stub.
- `test_textual_chat_phase4_right_gutter_3283.py`, `test_textual_chat_phase4_turn_cost_gutter_3283.py`, `tests/_support/textual_chat_test_helpers.py` — 3 pass-through `*WidthRecordingPresenter` subclasses that only ever read `width`, never `item`'s attributes; functionally correct at runtime even unmigrated (a misnamed local var silently held an `Entry`), but the type annotation was wrong — migrated for correctness, not because anything failed.
- `test_3846_image_resolution_e2e.py` (`tests/core/`, found in a repo-wide `.present(` sweep AFTER the `tests/interfaces/` pass — not in the original 17) — same shape as 4464.

## `scrollbar-gutter: stable` (architect's own upstream-cited mitigation)

Measured, not cargo-culted. Local repro of the CHANGELOG's collapse scenario (1 parent + 50 children + 3 filler rows, 20-row viewport, presents counted on collapse):

| config | presents |
|---|---|
| neither declaration | 8 |
| `scrollbar-gutter: stable` alone (upstream's own fix) | 4 |
| `scrollbar-size-vertical: 0` alone (reyn's PRE-EXISTING css) | 4 |
| `scrollbar-size-vertical: 0` + `scrollbar-gutter: stable` (this PR) | 4 |

Reyn's pre-existing `scrollbar-size-vertical: 0` already IS the full mitigation — a scrollbar whose size is fixed at 0 never has a size to remove, so the body width never moves. Adding `scrollbar-gutter: stable` measured **zero further change**. Declared anyway, at zero measured cost, as the residue that survives the day `scrollbar-size-vertical: 0` is ever removed — the CSS comment states the actual numbers, not "upstream says so" (lead-coder's explicit condition on this point).

## Verification

`tests/interfaces/` (1807 passed) + `tests/runtime/` + `test_3846_image_resolution_e2e.py` → **3602 passed, 0 failed, 5 skipped** (pre-existing optional-extra skips).

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py src/reyn/interfaces/inline/textual_chat/presenter.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `python scripts/test_tier_audit.py --strict <11 changed test files>` — 124/124 OK, 0 Tier-4
- [x] Full sweep: `tests/interfaces/` + `tests/runtime/` + `test_3846_image_resolution_e2e.py` — 3602 passed, 0 failed
- [ ] (waived, Visual axis only — standing 2026-08-08 owner waiver) not visually confirmed in this session; operator confirms on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
