### PR TITLE
chore(#4728): fix the stale "attached only" comment, not the docstring

### DIFF
--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -222,7 +222,8 @@ def get_default_registry() -> ToolRegistry:
     registry.register(AGENT_SPAWN)
     registry.register(TOPOLOGY_CREATE)
     registry.register(SEND_TO_SESSION)  # proposal 0067 P5 (#3978)
-    registry.register(RUN_PROMPT)  # proposal 0067 P4d (#3978), collect="attached" only
+    registry.register(RUN_PROMPT)  # proposal 0067 P4d (#3978, collect="attached")
+    # + P4e (#4138, collect="async") — both registered, one ToolDefinition
     registry.register(REYN_REPO_LIST)
     registry.register(REYN_REPO_READ)
     # FP-0041 #489 PR-B2: cron action category (= LLM-callable cron


### PR DESCRIPTION
**[docs-maintainer]** — Corrects #4728's own framing: neither of the two proposed readings holds. `collect="async"` is genuinely registered and fully wired end-to-end; `run_prompt.py`'s module docstring is accurate as-is. The stale artifact is a different file's one-line comment.

## What I verified directly (fresh `main`, not inference)

- `run_prompt.py`'s `_RUN_PROMPT_PARAMETERS` — `"collect"` IS a required parameter, `enum=["attached", "async"]` (lines 64–70).
- `_handle` dispatches `args["collect"] == "async"` → `rs.run_prompt_async_fn`.
- `router_loop.py:4141` — `run_prompt_async_fn=_run_prompt_async_bound` is populated (not `None`).
- `session_api.run_prompt_async` — a full, non-stub implementation (register-per-call chain, `task_id ≡ chain_id`, `cancel` wiring — architect-ruled, #3978).
- `descriptions/delegation.py` — the LLM-facing tool description already documents both `collect` values.
- `git log -- run_prompt.py`: P4d (attached-only) landed in `50facdac0` (#4117); P4e (async) landed later in `61a6e5e0c` (#4138) and wired every layer above.
- `git blame tools/__init__.py:225`: the `collect="attached" only` registration comment dates to the **P4d** commit and was never touched when P4e landed — a plain stale comment, not a layering ambiguity.

None of `feature-map.md`, `multi-agent.md`, `delegation-policy.md`, or `reference/config/multi-agent.md` describe `run_prompt` as attached-only either — all already correctly describe both `collect` values.

## Fix

One comment, `tools/__init__.py:225` — from `collect="attached" only` to noting both P4d and P4e landed and are both registered.

## Why report rather than silently diverge

The issue's own measurement ("run_prompt.py's parameters ... collect is missing") doesn't hold against the current file — reporting the correction with evidence rather than fixing quietly, per this repo's convention that a peer's claim gets independently verified, not propagated.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/tools/__init__.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] Swept `docs/` for other stray "attached only" claims about `run_prompt` — none found
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Closing-intent self-grep on commit message + this body: no keyword adjacent to any issue number
- [x] (skipped — comment-only change, no user-facing/Visual surface)

Closes #4728
