### PR TITLE
chore(#4729): re-verify the Space-fold guard's derived equivalence

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -407,15 +407,22 @@ class _CursorFlowView(FlowView["OutboxMessage"]):
         than upstream's own private ``_text_active()`` — measured
         equivalent (#4697 issue thread): ``_text_active()`` is
         ``cursor_visible or _tc_anchor is not None``, but every
-        ``_set_cursor_visible(False)`` path ALSO clears ``_tc_anchor``
-        (installed flowview 0.19.0, read directly), so the anchor can
-        never be set while ``cursor_visible`` is ``False`` — ``cursor_
-        visible`` alone is a complete public-API proxy for it TODAY. This
-        is a DERIVED equivalence, not a contract upstream promises: if a
-        future flowview version stops clearing the anchor on hide, this
-        guard falls out of sync SILENTLY — Space would start folding an
-        entry mid text-selection instead of extending it, no exception,
-        no warning."""
+        ``_set_cursor_visible(False)`` path ALSO clears ``_tc_anchor``,
+        so the anchor can never be set while ``cursor_visible`` is
+        ``False`` — ``cursor_visible`` alone is a complete public-API
+        proxy for it TODAY. Re-verified directly against
+        ``_view.py``'s source after #4729's 0.19.0 -> 0.21.1 bump
+        (``_set_cursor_visible`` still unconditionally does
+        ``self._tc_anchor = None`` inside its own ``if not visible:``
+        branch, same as at 0.19.0) — installed pin tracked in
+        ``pyproject.toml``, not repeated here as a number that would
+        just go stale again on the next bump. This is a DERIVED
+        equivalence, not a contract upstream promises: if a future
+        flowview version stops clearing the anchor on hide, this guard
+        falls out of sync SILENTLY — Space would start folding an entry
+        mid text-selection instead of extending it, no exception, no
+        warning. Re-verify this docstring's claim on every future
+        textual-flowview version bump."""
         if self.cursor_visible:
             self.action_activate()
             return


### PR DESCRIPTION
**[docs-maintainer]** — Re-verifies (not fixes — no bug found) the `_CursorFlowView.action_toggle_fold` guard's derived equivalence after #4729's textual-flowview 0.19.0 → 0.21.1 bump, and stops pinning a version number in the comment that will just go stale on the next bump.

## Why

The guard's own docstring (#4697) pins its "`cursor_visible` alone is a complete proxy for `_text_active()`" equivalence to "installed flowview 0.19.0, read directly" and explicitly names the failure mode if a future version breaks it: "this guard falls out of sync SILENTLY ... no exception, no warning." #4729 bumped the pin without touching this guard or its comment's own re-verify condition — exactly the scenario the comment warned about, just not yet acted on.

## What I verified (not inferred)

Installed the exact `pyproject.toml` git+sha pin (`728eb0070115ddea92153b5b9aca557b92f329b9`) in a scratch venv and read `textual_flowview/_view.py` directly: `_set_cursor_visible` still unconditionally does `self._tc_anchor = None` inside its own `if not visible:` branch, identical in shape to 0.19.0. **The equivalence holds — no behavior change, no bug.**

## Change

Comment-only. Records the re-verification, drops the repeated version number (points at `pyproject.toml`'s own pin instead — a number here just goes stale again on the next bump, which is exactly what happened this time), and adds an explicit "re-verify this docstring's claim on every future textual-flowview version bump" instruction so the next bump doesn't silently skip it the way this one did.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] Independently verified the guard's underlying assumption against the actual installed flowview source at the new pin (see above) — not just updating the comment's wording
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Closing-intent self-grep on commit message + this body: no keyword adjacent to any issue number
- [x] (skipped — no user-facing/Visual surface, comment-only change, guard behavior unchanged)

Part of #4729 (verification follow-up, not a defect in that PR)
