### PR TITLE
fix(#4735): prompt_cache_key must be agent-qualified, not sid alone

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1120,21 +1120,40 @@ class RouterLoop:
         construction-time ``session_id``, which is stale for a spawned
         session — see ``RouterHostAdapter.live_session_id``'s own docstring).
 
-        ``or "main"`` (lead-coder review, #4704): ``live_session_id`` is
-        ``str | None`` and ``registry.py``'s own docstring states
-        ``sid=None`` means the IMPLICIT "main" session — an ordinary
-        interactive chat, not a spawned sub-session. Without this
-        normalization, a bare ``getattr(..., None)`` would send NO key for
-        exactly the case #4690 measured (reyn-self's own main session, 7.1%
-        hit rate) — the feature would be inert in the scenario it exists to
-        fix. Same normalization ``pipeline_verbs.py:516`` already uses for
-        the identical ``live_session_id`` ambiguity (``reply_sid``), not a
-        new constant. A ``getattr``-guarded test host with no
-        ``live_session_id`` attribute AT ALL still falls through the same
-        ``or`` to ``"main"`` — see ``recorded_acompletion``'s inline
-        comment (``llm.py``) for the full session-vs-agent granularity
-        measurement and reasoning, not repeated here."""
-        return getattr(self.host, "live_session_id", None) or "main"
+        #4735 (lead-coder review, owner-caught): the key is
+        ``f"{agent_name}:{sid or 'main'}"``, NOT ``sid`` alone —
+        ``live_session_id`` (= sid) is namespaced by ``(agent_name, sid)``
+        on disk (``registry.py``'s own ``_session_state_dir(self, name,
+        sid)`` docstring: "on-disk state dir for ``(name, sid)``"), so a
+        bare sid is not process-wide-unique — and ``sid=None`` (the
+        implicit main session) collapses EVERY agent's main session to the
+        identical unqualified key. ``prompt_cache_key`` is litellm/OpenAI's
+        PRIMARY routing key (same machine ⇒ same key), so pre-#4735 every
+        agent's unrelated main-session tail (#4700 measured B at 20x A's
+        size) was contending for cache slots on ONE machine — worse than
+        sending no key at all, and the exact "unrelated prefixes collide
+        on the same box" failure architect already rejected agent-only
+        granularity for, now happening at a COARSER grain than agent.
+        ``host.agent_name`` is the same identity value ``budget_agent=``
+        already reads at this file's call sites.
+
+        ``or "main"`` (lead-coder review, #4704, unchanged by #4735):
+        ``live_session_id`` is ``str | None`` and ``registry.py``'s own
+        docstring states ``sid=None`` means the IMPLICIT "main" session —
+        an ordinary interactive chat, not a spawned sub-session. Without
+        this normalization, a bare ``getattr(..., None)`` would send NO
+        key for exactly the case #4690 measured (reyn-self's own main
+        session, 7.1% hit rate) — the feature would be inert in the
+        scenario it exists to fix. Same normalization
+        ``pipeline_verbs.py:516`` already uses for the identical
+        ``live_session_id`` ambiguity (``reply_sid``), not a new constant.
+        A ``getattr``-guarded test host with no ``live_session_id``
+        attribute AT ALL still falls through the same ``or`` to ``"main"``
+        — see ``recorded_acompletion``'s inline comment (``llm.py``) for
+        the full session-vs-agent granularity measurement and reasoning,
+        not repeated here."""
+        sid = getattr(self.host, "live_session_id", None) or "main"
+        return f"{self.host.agent_name}:{sid}"
 
     def _warn_ratio_overrides(self) -> "dict[str, float]":
         """#4206 Slice B (#4724): the ③ preference-axis overrides for the 7

--- a/tests/llm/test_4700_prompt_cache_key.py
+++ b/tests/llm/test_4700_prompt_cache_key.py
@@ -164,7 +164,8 @@ async def test_router_loop_prompt_cache_key_reads_live_session_id():
     for the A/B measurement this decision is based on). Driven through the
     PUBLIC ``RouterLoop.run`` surface (a real turn's captured LLM-call
     kwargs), not the private helper directly (testing.md's private-state
-    ban)."""
+    ban). #4735: the key is ``agent_name:sid``, not sid alone — see the
+    dedicated agent-collision tests below for why."""
     from reyn.llm.model_resolver import ModelResolver
     from reyn.runtime.router_loop import RouterLoop
     from tests._support.router_host_adapter import make_adapter
@@ -176,7 +177,7 @@ async def test_router_loop_prompt_cache_key_reads_live_session_id():
     llm = _CapturingFinishLLM()
     await RouterLoop(host=host, chain_id="c1", llm_caller=llm).run("hi", [])
 
-    assert llm.last_kwargs.get("prompt_cache_key") == "session-xyz-789"
+    assert llm.last_kwargs.get("prompt_cache_key") == f"{host.agent_name}:session-xyz-789"
 
 
 @pytest.mark.asyncio
@@ -191,7 +192,10 @@ async def test_router_loop_prompt_cache_key_is_main_for_the_implicit_main_sessio
     fix. Same normalization ``pipeline_verbs.py:516`` already uses for the
     identical ambiguity, not a new constant. RED without the fix:
     prompt_cache_key is None (nothing sent) even for a real, live-session-id
-    -capable host whose main session has no explicit sid."""
+    -capable host whose main session has no explicit sid. #4735: the
+    "main" tail is now agent-qualified (``agent_name:main``) — see the
+    dedicated agent-collision tests below for why a bare "main" alone
+    would collide across agents."""
     from reyn.llm.model_resolver import ModelResolver
     from reyn.runtime.router_loop import RouterLoop
     from tests._support.router_host_adapter import make_adapter
@@ -205,7 +209,7 @@ async def test_router_loop_prompt_cache_key_is_main_for_the_implicit_main_sessio
     llm = _CapturingFinishLLM()
     await RouterLoop(host=host, chain_id="c1", llm_caller=llm).run("hi", [])
 
-    assert llm.last_kwargs.get("prompt_cache_key") == "main"
+    assert llm.last_kwargs.get("prompt_cache_key") == f"{host.agent_name}:main"
 
 
 @pytest.mark.asyncio
@@ -214,7 +218,8 @@ async def test_router_loop_prompt_cache_key_is_main_when_host_has_no_live_sessio
     attribute at all (``FakeRouterHost``, the common test-construction
     shape) falls through the SAME ``or "main"`` normalization —
     ``getattr``-guarded, never a raise, consistent with the real-host
-    None-case above rather than a special test-only path."""
+    None-case above rather than a special test-only path. #4735:
+    agent-qualified the same way."""
     from reyn.runtime.router_loop import RouterLoop
     from tests._support.router_loop import FakeRouterHost
 
@@ -222,4 +227,77 @@ async def test_router_loop_prompt_cache_key_is_main_when_host_has_no_live_sessio
     llm = _CapturingFinishLLM()
     await RouterLoop(host=host, chain_id="c1", llm_caller=llm).run("hi", [])
 
-    assert llm.last_kwargs.get("prompt_cache_key") == "main"
+    assert llm.last_kwargs.get("prompt_cache_key") == f"{host.agent_name}:main"
+
+
+# ── Tier 2: #4735 — the agent-collision falsify witness ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prompt_cache_key_differs_across_agents_for_the_same_main_session():
+    """Tier 2: THE mandatory falsify witness (lead-coder's own required
+    condition, #4735) — agent A's main session and agent B's main session
+    MUST send DIFFERENT prompt_cache_key values. Before #4735, both sent
+    the bare, agent-unqualified "main" — the same litellm/OpenAI routing
+    key, so unrelated agents' cache tails contended for the same machine
+    (worse than sending no key at all: prompt_cache_key is the PRIMARY
+    routing key, same key -> same machine). RED without the fix: both
+    assertions below would see the same "main" value for agent_a and
+    agent_b."""
+    from reyn.llm.model_resolver import ModelResolver
+    from reyn.runtime.router_loop import RouterLoop
+    from tests._support.router_host_adapter import make_adapter
+
+    resolver = ModelResolver({"standard": "openai/gpt-4o"})
+    host_a = make_adapter(
+        agent_name="agent-a", session_id=None,
+        universal_wrappers_enabled=False, resolver=resolver,
+    )
+    host_b = make_adapter(
+        agent_name="agent-b", session_id=None,
+        universal_wrappers_enabled=False, resolver=resolver,
+    )
+
+    llm_a = _CapturingFinishLLM()
+    await RouterLoop(host=host_a, chain_id="c1", llm_caller=llm_a).run("hi", [])
+    llm_b = _CapturingFinishLLM()
+    await RouterLoop(host=host_b, chain_id="c2", llm_caller=llm_b).run("hi", [])
+
+    key_a = llm_a.last_kwargs.get("prompt_cache_key")
+    key_b = llm_b.last_kwargs.get("prompt_cache_key")
+    assert key_a == "agent-a:main"
+    assert key_b == "agent-b:main"
+    assert key_a != key_b, (
+        "agent A's and agent B's main-session prompt_cache_key must differ "
+        f"— both resolved to {key_a!r}, which would route their unrelated "
+        f"cache tails onto the same machine"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prompt_cache_key_same_for_the_same_agent_and_session():
+    """Tier 2: accept-side of the same witness — the SAME agent, the SAME
+    session, across two separate turns/loops, sends the SAME
+    prompt_cache_key (the whole point of the feature: repeat traffic from
+    one identity routes to the same machine)."""
+    from reyn.llm.model_resolver import ModelResolver
+    from reyn.runtime.router_loop import RouterLoop
+    from tests._support.router_host_adapter import make_adapter
+
+    resolver = ModelResolver({"standard": "openai/gpt-4o"})
+    host_1 = make_adapter(
+        agent_name="agent-c", session_id="sess-1",
+        universal_wrappers_enabled=False, resolver=resolver,
+    )
+    host_2 = make_adapter(
+        agent_name="agent-c", session_id="sess-1",
+        universal_wrappers_enabled=False, resolver=resolver,
+    )
+
+    llm_1 = _CapturingFinishLLM()
+    await RouterLoop(host=host_1, chain_id="c1", llm_caller=llm_1).run("hi", [])
+    llm_2 = _CapturingFinishLLM()
+    await RouterLoop(host=host_2, chain_id="c2", llm_caller=llm_2).run("hi", [])
+
+    assert llm_1.last_kwargs.get("prompt_cache_key") == "agent-c:sess-1"
+    assert llm_2.last_kwargs.get("prompt_cache_key") == "agent-c:sess-1"


### PR DESCRIPTION
**[e2e-coder]** — #4704's `_prompt_cache_key()` sent `live_session_id or "main"` alone. `registry.py`'s own `_session_state_dir(self, name, sid)` docstring: the on-disk state dir is keyed by `(name, sid)` — a bare sid is not process-wide-unique. Worse, `sid=None` (the implicit main session) normalizes to the same literal `"main"` for every agent, so every agent's main session sent the identical `prompt_cache_key`.

## Why this is worse than sending no key at all

`prompt_cache_key` is litellm/OpenAI's PRIMARY routing key (same key → same machine). Unrelated agents' cache tails (#4700 measured up to 20x size difference between sessions) were contending for cache slots on ONE machine — the exact cross-identity-collision failure architect already rejected agent-only granularity for (#4700's own A/B measurement), now happening at a COARSER grain than agent.

## Fix

`key = f"{agent_name}:{sid or 'main'}"` — `host.agent_name` is the same identity value `budget_agent=` already reads at these call sites.

Swept the other 3 `live_session_id or "main"` sites in `router_host_adapter.py` — all pass `agent_name` as a SEPARATE paired parameter to the registry (`get_session(self._agent_name, sid)`, `caller_agent=...`), so they were never vulnerable to this collision. Only `_prompt_cache_key`'s single-string external key needed the fix.

## 🔴 Mandatory falsify test (lead-coder's own required condition)
Agent A's main session and agent B's main session must send DIFFERENT `prompt_cache_key` values (`test_prompt_cache_key_differs_across_agents_for_the_same_main_session`). Accept-side: the same agent+session sends the same key across separate turns.

## Strip-falsify
Reverted to the bare-sid form → all 5 agent-name-dependent assertions RED (including the mandatory cross-agent-collision witness), restored GREEN.

## Gates
- `ruff check .`, `python scripts/mypy_ratchet.py`, `python scripts/verify_module_docstrings.py src/reyn/runtime/router_loop.py`, `python scripts/test_tier_audit.py --strict tests/llm/test_4700_prompt_cache_key.py` — all green.
- `pytest tests/llm tests/runtime` — 2548 passed, 1 skipped, 0 failed.

Closes #4735

Test plan:
- [x] `ruff check .` green
- [x] `python scripts/mypy_ratchet.py` green
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/router_loop.py` green
- [x] `python scripts/test_tier_audit.py --strict tests/llm/test_4700_prompt_cache_key.py` green
- [x] `pytest tests/llm tests/runtime` — 2548 passed / 1 skipped / 0 failed
- [x] Strip-falsify confirmed RED for the right reason (all 5 agent-name-dependent assertions), restored GREEN
- [ ] (skipped — no visual/TUI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
