### PR TITLE
fix(#4737): retire the phase-execution description from 3 product-facing surfaces

### DIFF
--- a/REYN.md
+++ b/REYN.md
@@ -1,15 +1,15 @@
 # Reyn Project Context
 
-This file is auto-injected into the system prompt for every phase via
+This file is auto-injected into the system prompt on every turn via
 `project_context_path` in `reyn.yaml`. Put project-wide background here that
 all skills should implicitly know — domain glossary, conventions, references.
 
 ## About this project
 
-Reyn is an LLM-driven phase execution engine with a Markdown DSL.
-The runtime constrains LLM autonomy with closed candidate transitions,
-JSON-schema validated outputs, and per-phase permission scopes — see
-`CLAUDE.md` for the full architectural contract.
+Reyn is an operating system for LLM agents — they decide, organize, and
+orchestrate; the OS makes every action typed, permissioned, audited, and
+recoverable by construction — see `CLAUDE.md` for the full architectural
+contract.
 
 ## Conventions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,11 @@ build-backend = "hatchling.build"
 [project]
 name = "reyn"
 version = "0.1.0a2"
-description = "LLM-driven phase execution engine with a Markdown DSL"
+# #4737: "LLM-driven phase execution engine with a Markdown DSL" described
+# the phase-graph skill engine, removed #2434/#2438 — same class as
+# interfaces/cli/__init__.py's --help description, kept in sync with it.
+# Proposal wording, not an owner decision — see that PR's alternatives.
+description = "Agent OS — decide, spawn, orchestrate, bounded by construction"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 readme = "README.md"

--- a/src/reyn/interfaces/cli/__init__.py
+++ b/src/reyn/interfaces/cli/__init__.py
@@ -14,7 +14,15 @@ from .commands import ALL as _COMMANDS
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="reyn",
-        description="Agent OS MVP — LLM-driven phase execution",
+        # #4737: "Agent OS MVP — LLM-driven phase execution" described the
+        # phase-graph skill engine, removed #2434/#2438 — a false present-
+        # tense claim on the single most user-visible surface (`reyn --help`,
+        # every user's first command). This wording is a PROPOSAL, not an
+        # owner decision — the PR that landed this change lists alternative
+        # candidates; this string is the owner's own face on the product,
+        # so it should be picked deliberately rather than accepted as
+        # this default.
+        description="Agent OS — decide, spawn, orchestrate, bounded by construction",
     )
     sub = parser.add_subparsers(dest="command", metavar="<command>")
     sub.required = True

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -575,10 +575,10 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     def get_project_context(self) -> str:
         """Project context text (= REYN.md / `project_context_path` content),
         or empty string when the operator has not configured one. Threaded
-        into the router's system prompt so the chat reply path knows about
-        the user's project — without this, only the phase-execution path
-        sees REYN.md and casual chat queries get answered without
-        project-specific context."""
+        into the router's system prompt (`build_system_prompt`) on every
+        turn — see `router_system_prompt.py`'s "Project context" section —
+        so every turn's model has the operator's project-specific
+        background, not only some turns."""
         ...
 
     def get_universal_wrappers_enabled(self) -> bool:


### PR DESCRIPTION
**[docs-maintainer]** — 🔴 **Do not merge yet — the `reyn --help`/`pyproject.toml` wording needs owner sign-off, not a docs-maintainer decision.** REYN.md's part is complete and safe to land on its own if that's preferred; happy to split if that's cleaner.

Reopened #4737 (per lead-coder's process correction: closing without a landing PR left the content unfixed inside two already-CLOSED issues). Sweeping for the same "phase execution" string surfaced 3 instances, not 1.

## 1. `interfaces/cli/__init__.py:17` — `reyn --help`'s description (the original #4737 finding)

`"Agent OS MVP — LLM-driven phase execution"` describes the phase-graph skill engine removed in #2434/#2438. This is the single most user-visible surface in the product — every user's first command. **Proposal, not a decision**: landed candidate A below as the default, commented in-code as a proposal, with B/C as alternatives:

- **A** (landed): `"Agent OS — decide, spawn, orchestrate, bounded by construction"` — mirrors CLAUDE.md's own T3 tagline
- **B**: `"Agent OS for LLM agents"` — shortest, safest, no overclaim
- **C**: `"An agent OS where agency is bounded by construction"` — direct fragment of CLAUDE.md's T3 one-liner/meta

## 2. `pyproject.toml`'s package `description` — same class, what PyPI / `pip show reyn` display

`"LLM-driven phase execution engine with a Markdown DSL"` — same fix, same candidate set, kept in sync with #1 (also a proposal).

## 3. `REYN.md` — live and load-bearing, not dormant

`REYN.md` is auto-injected into **every turn's system prompt** (`project_context_path` in `reyn.yaml` → `router_system_prompt.py`'s `build_system_prompt`, called every turn per `router_loop.py:1495`'s own comment) — this repo's own `REYN.md` describes itself with the same dead "phase execution engine" framing, right now, in this session's own system prompt. Plausibly explains dogfood journal entries surfaced earlier this session where an agent replied *"I am ... an LLM-driven phase execution engine"* almost verbatim.

**This part is NOT a proposal** — replaced with **CLAUDE.md's own ratified Constitution line, verbatim**: "Reyn is an operating system for LLM agents — they decide, organize, and orchestrate; the OS makes every action typed, permissioned, audited, and recoverable by construction." Also fixed the file's own meta-comment ("for every phase" → "on every turn," confirmed against `router_loop.py`'s actual call-site comment, not guessed) and "per-phase permission scopes" (same dead concept — current permission gating is per-op, not per-phase).

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/__init__.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — parses clean
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (REYN.md isn't in the docs nav; checked anyway)
- [x] Swept for other stray "phase execution"/"Agent OS MVP" references — space-variant only pass initially missed the hyphenated "phase-execution" form (caught by lead-coder, fixed in a follow-up commit); re-swept space/hyphen/underscore delimiter variants across .py/.toml/.md — remaining hits are CHANGELOG.md + proposals 0018/0026, all historical record, correctly untouched
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Closing-intent self-grep on commit message + this body: no keyword adjacent to any issue number
- [ ] 🔴 **Owner: pick A/B/C (or your own wording) for #1 and #2 before merge** — REYN.md's fix (#3) does not depend on this choice.

Part of #4737

