### PR TITLE
docs(#4736): record the second instance of the unstated-ref hazard, and correct CLAUDE.md's pointer scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,13 @@ call sites. That is a habit, not a gate.
 The testing policy is at **`docs/deep-dives/contributing/testing.ja.md`** (English:
 `docs/deep-dives/contributing/testing.md`). It is normative — read it before adding
 or modifying tests. For co-vet review and gate-design specifically, also read
-`docs/deep-dives/contributing/verification-hazards.md` — a checklist of ways a
-green result can mean less than it looks like it means, each with a real instance
-and a detection technique that closed it.
+`docs/deep-dives/contributing/verification-hazards.md` — a checklist built on one
+root, stated in the doc's own words: **an observation does not name its own
+referent**. Most instances are a green that means less than it looks like, but
+the doc covers the other direction too (a red that overstates — a misattributed
+failure count, an absence that was really a stale tree), so do not read it as
+green-only. Each entry carries a real instance and a detection technique that
+closed it.
 
 ## Comment policy (READ BEFORE WRITING OR MOVING A COMMENT)
 
@@ -604,8 +608,9 @@ and run the checklist below before continuing:
 
 ## When in doubt — read these
 
-- **Verification hazards** (why a green result can mean less than it looks
-  like — co-vet review, gate design): `docs/deep-dives/contributing/verification-hazards.md`
+- **Verification hazards** (why an observation may not name its own referent —
+  a green that means less, or a red that overstates; co-vet review, gate
+  design): `docs/deep-dives/contributing/verification-hazards.md`
 - **Workspace** (single source of truth): `docs/concepts/runtime/workspace.md`
 - **Events / replay** (audit truth): `docs/concepts/runtime/events.md`
 - **`.reyn/` directory layout** (what's recovery-core vs persist/audit/cache/outside, the

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -842,6 +842,31 @@ missing one.
   but the fix here is choosing the inspecting command itself, not adding a
   separate identity-check step: prefer a command whose own invocation
   states the ref over one that defaults to an ambient, unstated state.
+  **The same hazard recurred a second time, and the second instance
+  explains why writing the rule down was not enough to stop it.** A
+  reviewing session ran `.venv/bin/reyn doctor --help` in its own
+  worktree, got `invalid choice: 'doctor'`, and filed the command as
+  unregistered — plus a blocker on a separate issue saying an
+  owner-facing recommendation was unrunnable. Both were false: the
+  worktree was ~5 hours old and the registering commit had landed after
+  its checkout, so `origin/main` had the command all along (#4736,
+  2026-08-14). What makes this worth recording next to #4215 rather
+  than as its own hazard is the MOTIVE, which the prescription above
+  does not reach: **execution looks like stronger evidence than a grep,
+  so it removes the felt need to state the scope — while actually being
+  NARROWER, pinned to one tree and one venv where `git show
+  origin/main:<path>` is tree-independent.** A doc that says "choose the
+  self-documenting command" is not read as applying here, because the
+  author believes they used a *better* method than the one being
+  regulated. So the trigger to write down is the strength of the
+  evidence, not its weakness: **an absence or a crash confirmed by
+  RUNNING something needs its `HEAD` SHA more than one confirmed by
+  grepping, not less** — absence reproduces from staleness just as
+  faithfully as from a real gap. One corollary, from what actually
+  contained this instance: once a single claim from a given tree is
+  falsified, re-derive every other claim drawn from that same tree —
+  they share its age. Here that was 5 claims re-run against
+  `origin/main`, of which 4 held and only the reported one fell.
 
 **This is where B combines with §16**, not a coincidence: the sessions that
 trusted a stale environment did so *because* their result matched `main`'s


### PR DESCRIPTION
**[architect]** — 🔴 **CLAUDE.md を触りますが、規則の追加・変更はありません。射程の記述（pointer の正確性）だけです。** owner の就寝中の変更なので、veto しやすいよう差分を全部ここに書きます。

part of #4736

---

## 1. `verification-hazards.md` §18 B — 新節ではなく既存 bullet への追記

lead-coder の当初の指示は「§23 を新設」でしたが、**同じ危険が既にその doc の 2 箇所にあります**:

| 既存箇所 | 逐語 |
|---|---|
| §1 行4 | `the same file at two different times is as much "a different object" as two different worktrees are` |
| §18 B の #4215 bullet | `` `python3 <path>` run directly names no ref at all: it silently reads the WORKING TREE, and "I ran it and confirmed" carries no record of which version that was `` |

∴ **#4736 は新しい危険ではなく、#4215 bullet の 2 件目の実例**です。**別節にすると「同じ危険が 2 回起きた」という情報が消えます** — これが置き場所の決め手で、lead-coder も新節指示を撤回しています。

**追記した内容**（bullet 末尾）:
- 実例: 約5時間古い worktree で `.venv/bin/reyn doctor --help` を実行 → `invalid choice` → 「未登録」と起票 ＋ 別 issue に「owner 推奨は実行不能」と偽ブロッカー。実際は登録 commit が checkout 後に入っていただけ。
- **既存の prescription が届かなかった理由**（doc に無かったのはこの部分だけ。`stronger|feels like|motivation` 系を grep 済み、当たったのは無関係の 1 行のみ）: **実行は grep より強い証拠に見えるので、範囲の限界を書く動機が消える。実際は実行の方が範囲が狭い**（木＋venv に固定、`git show origin/main:<path>` は木から独立）。doc が「self-documenting な command を選べ」と書いても、書き手は**もっと強い方法で確かめた**と思っているので選び直さない。
- ∴ 書く引き金は証拠の**強さ**であって弱さではない: **実行で確かめた不在／クラッシュこそ HEAD の SHA を要する**。不在は木の古さでも忠実に再現する。
- 収束させた対処: **1 件 falsify されたら同じ木で引いた主張を全部引き直す**（年齢を共有するため）。今回は 5 件を `origin/main` で再測、4 件は現存、落ちたのは報告した 1 件のみ。

## 2. `CLAUDE.md` — pointer の射程が doc より狭かった（2 箇所）

**これは規則ではなく、doc を指している文の記述です。**

```
before ── 「a checklist of ways a green result can mean less than it looks like it means」
before ── 「(why a green result can mean less than it looks like ...)」
```

doc 自身の射程宣言は逐語 **`an observation does not name its own referent`** で、**green 限定ではありません**。§1 行5 は 17/18 の **red** の誤帰属が実例です。**指している文の方が、指されている doc より狭い**状態でした。

```
after ── root を doc 自身の言葉で述べ、「多くは green だが逆方向（誇張する red
         ── 誤帰属した失敗数、実は古い木だった不在）も扱う ∴ green 限定と読むな」
```

**追加された規則はありません。** 「read it before ...」という既存の義務も、各節の内容も、検出法も無改変です。差分は `git diff` の CLAUDE.md 側 2 hunk のみで、いずれも doc を紹介する説明文です。

---

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — Documentation built in 35.69 seconds
- [x] `python scripts/check_doc_anchors.py` — `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` — `retired-config-key denylist OK: 0 hits (25 retired top-level key(s) checked)`
- [x] `tests/` 無変更 ∴ tier audit / flat-tests ratchet / tests-path-literal は対象外
- [x] `src/` 無変更 ∴ module docstring / mypy ratchet は対象外
- [x] 置き場所の根拠は doc の実文から引用（上表の 2 つの逐語）。「無いのは動機だけ」は grep で確認済みで、範囲は `verification-hazards.md` 1 ファイル、HEAD `56eab5c4c` — **この PR 自身が記録している規律に従って書いています**。
- [ ] 🔴 owner 確認待ち: CLAUDE.md の射程記述の変更（規則変更ではない、と本文で宣言済み）。veto があれば CLAUDE.md 側 2 hunk だけを revert すれば、`verification-hazards.md` の追記は独立して残ります。
