### PR TITLE
fix(#4737): REYN.md + router_loop.py — facts only, no wording choice

### DIFF
--- a/REYN.md
+++ b/REYN.md
@@ -1,8 +1,10 @@
 # Reyn Project Context
 
-This file is auto-injected into the system prompt on every turn via
-`project_context_path` in `reyn.yaml`. Put project-wide background here that
-all skills should implicitly know — domain glossary, conventions, references.
+This file is auto-injected into the system prompt on every turn (except
+where a caller supplies its own system-prompt override — the plan
+executor's step-specific prompt) via `project_context_path` in
+`reyn.yaml`. Put project-wide background here that all skills should
+implicitly know — domain glossary, conventions, references.
 
 ## About this project
 

--- a/REYN.md
+++ b/REYN.md
@@ -1,15 +1,15 @@
 # Reyn Project Context
 
-This file is auto-injected into the system prompt for every phase via
+This file is auto-injected into the system prompt on every turn via
 `project_context_path` in `reyn.yaml`. Put project-wide background here that
 all skills should implicitly know — domain glossary, conventions, references.
 
 ## About this project
 
-Reyn is an LLM-driven phase execution engine with a Markdown DSL.
-The runtime constrains LLM autonomy with closed candidate transitions,
-JSON-schema validated outputs, and per-phase permission scopes — see
-`CLAUDE.md` for the full architectural contract.
+Reyn is an operating system for LLM agents — they decide, organize, and
+orchestrate; the OS makes every action typed, permissioned, audited, and
+recoverable by construction — see `CLAUDE.md` for the full architectural
+contract.
 
 ## Conventions
 

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -575,10 +575,10 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     def get_project_context(self) -> str:
         """Project context text (= REYN.md / `project_context_path` content),
         or empty string when the operator has not configured one. Threaded
-        into the router's system prompt so the chat reply path knows about
-        the user's project — without this, only the phase-execution path
-        sees REYN.md and casual chat queries get answered without
-        project-specific context."""
+        into the router's system prompt (`build_system_prompt`) on every
+        turn — see `router_system_prompt.py`'s "Project context" section —
+        so every turn's model has the operator's project-specific
+        background, not only some turns."""
         ...
 
     def get_universal_wrappers_enabled(self) -> bool:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -576,8 +576,11 @@ class RouterLoopHost(RouterLoopCore, Protocol):
         """Project context text (= REYN.md / `project_context_path` content),
         or empty string when the operator has not configured one. Threaded
         into the router's system prompt (`build_system_prompt`) on every
-        turn — see `router_system_prompt.py`'s "Project context" section —
-        so every turn's model has the operator's project-specific
+        turn (except where a caller supplies its own system-prompt
+        override — `self._system_prompt_override`, the plan executor's
+        step-specific narrow prompt, skips `build_system_prompt` entirely)
+        — see `router_system_prompt.py`'s "Project context" section — so
+        every turn's model has the operator's project-specific
         background, not only some turns."""
         ...
 


### PR DESCRIPTION
**[docs-maintainer]** — Split from #4741 per lead-coder's ruling: that PR bundled a real, urgent fix with a genuinely undecided owner-facing wording choice, so the urgent half was waiting on a decision it has no dependency on.

## Why this half is ready now, not blocked on owner input

Test: "would a different owner-picked wording require rewriting this?" — no, for both edits here. Each quotes/restates a settled source rather than inventing new phrasing:

- **REYN.md**'s "About this project" section — replaced with **CLAUDE.md's own ratified Constitution line, verbatim**. This one is **live, not dormant**: REYN.md is auto-injected into **every turn's system prompt** (`project_context_path` in `reyn.yaml` → `router_system_prompt.py`'s `build_system_prompt`, called every turn per `router_loop.py`'s own call-site comment). Until this lands, the model keeps describing itself with dead terminology every single turn.
- **`router_loop.py:579`** — `get_project_context`'s docstring described a now-dead two-path distinction ("phase-execution path" vs "chat reply path") from before the phase-graph engine's removal (#2434/#2438). Simplified to describe current behavior only. Also fixes REYN.md's own meta-line ("for every phase" → "on every turn," confirmed against this exact call-site comment, not guessed).

## What stays in #4741 (PR-B, draft, owner-blocked)

The `reyn --help` description and `pyproject.toml`'s package description — genuinely undecided wording (candidates A/B/C in that PR's body), which DOES need rewriting if the owner picks differently. That PR stays draft.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/router_loop.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (REYN.md isn't in the docs nav; checked anyway)
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Closing-intent self-grep on commit message + this body: no keyword adjacent to any issue number
- [x] (skipped — no user-facing/Visual surface, comment/prose-only change)

Part of #4737
