### PR TITLE
docs(#4737): propose new reyn --help / pyproject.toml description wording

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,11 @@ build-backend = "hatchling.build"
 [project]
 name = "reyn"
 version = "0.1.0a2"
-description = "LLM-driven phase execution engine with a Markdown DSL"
+# #4737: "LLM-driven phase execution engine with a Markdown DSL" described
+# the phase-graph skill engine, removed #2434/#2438 — same class as
+# interfaces/cli/__init__.py's --help description, kept in sync with it.
+# Proposal wording, not an owner decision — see that PR's alternatives.
+description = "Agent OS — decide, spawn, orchestrate, bounded by construction"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0a2"
 # #4737: "LLM-driven phase execution engine with a Markdown DSL" described
 # the phase-graph skill engine, removed #2434/#2438 — same class as
 # interfaces/cli/__init__.py's --help description, kept in sync with it.
-# Proposal wording, not an owner decision — see that PR's alternatives.
+# Owner ruling 2026-08-15: A (see #4745 for B/C, the alternatives not chosen).
 description = "Agent OS — decide, spawn, orchestrate, bounded by construction"
 requires-python = ">=3.11"
 license = { text = "MIT" }

--- a/src/reyn/interfaces/cli/__init__.py
+++ b/src/reyn/interfaces/cli/__init__.py
@@ -14,7 +14,15 @@ from .commands import ALL as _COMMANDS
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="reyn",
-        description="Agent OS MVP — LLM-driven phase execution",
+        # #4737: "Agent OS MVP — LLM-driven phase execution" described the
+        # phase-graph skill engine, removed #2434/#2438 — a false present-
+        # tense claim on the single most user-visible surface (`reyn --help`,
+        # every user's first command). This wording is a PROPOSAL, not an
+        # owner decision — the PR that landed this change lists alternative
+        # candidates; this string is the owner's own face on the product,
+        # so it should be picked deliberately rather than accepted as
+        # this default.
+        description="Agent OS — decide, spawn, orchestrate, bounded by construction",
     )
     sub = parser.add_subparsers(dest="command", metavar="<command>")
     sub.required = True

--- a/src/reyn/interfaces/cli/__init__.py
+++ b/src/reyn/interfaces/cli/__init__.py
@@ -17,11 +17,8 @@ def build_parser() -> argparse.ArgumentParser:
         # #4737: "Agent OS MVP — LLM-driven phase execution" described the
         # phase-graph skill engine, removed #2434/#2438 — a false present-
         # tense claim on the single most user-visible surface (`reyn --help`,
-        # every user's first command). This wording is a PROPOSAL, not an
-        # owner decision — the PR that landed this change lists alternative
-        # candidates; this string is the owner's own face on the product,
-        # so it should be picked deliberately rather than accepted as
-        # this default.
+        # every user's first command). Owner ruling 2026-08-15: A (see
+        # #4745 for B/C, the alternatives not chosen).
         description="Agent OS — decide, spawn, orchestrate, bounded by construction",
     )
     sub = parser.add_subparsers(dest="command", metavar="<command>")


### PR DESCRIPTION
**[docs-maintainer]** — ✅ **Owner ruling landed (2026-08-15): A.** No longer blocked.

## Background

`reyn --help`'s description and `pyproject.toml`'s package description (what PyPI / `pip show reyn` display) both currently read "...LLM-driven phase execution..." — describing the phase-graph skill engine removed in #2434/#2438, same false-present-tense class as #4705/#4711/#4744.

## Why this was an owner decision, not a docs-maintainer one

This is the single most user-visible product surface — every user's first command, and PyPI's own listing. Landed **candidate A** as the default:

- **A** (owner ruling — chosen): `"Agent OS — decide, spawn, orchestrate, bounded by construction"` — mirrors CLAUDE.md's own T3 tagline
- **B**: `"Agent OS for LLM agents"` — shortest, safest, no overclaim
- **C**: `"An agent OS where agency is bounded by construction"` — direct fragment of CLAUDE.md's T3 one-liner/meta

## Post-ruling fix (same PR)

The wording (A) was already landed as the default before the ruling, so the diff body needs no change. The two in-code comments that said "this is a proposal, not an owner decision" were now false the moment the ruling landed — corrected to `Owner ruling 2026-08-15: A (see #4745 for B/C, the alternatives not chosen)` in both `pyproject.toml` and `src/reyn/interfaces/cli/__init__.py`, so a future reader doesn't re-propose an already-settled question.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/__init__.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — parses clean
- [x] Rebased onto fresh `origin/main` (branch was 52 commits behind) and fetch-checked again before push — no drift
- [x] Closing-intent self-grep on commit messages + this body: no keyword adjacent to any issue number
- [x] Owner: picked A (2026-08-15)

Part of #4737
