### PR TITLE
fix(#4740): SpawnTracker's trusted spawn record keyed by (agent, sid), not sid alone

### DIFF
--- a/src/reyn/runtime/services/inter_agent_messaging.py
+++ b/src/reyn/runtime/services/inter_agent_messaging.py
@@ -203,7 +203,9 @@ class InterAgentMessaging:
         # #2103 S1bc-exec: this session's LIVE sid (for the responder_sid tag when a
         # spawned session replies) + the spawner's trusted spawned-task lookup.
         session_id_fn: "Callable[[], str | None] | None" = None,
-        lookup_spawned_task: "Callable[[str | None], str | None] | None" = None,
+        # #4740: (agent_name, sid) — sid alone collides across agents (see
+        # SpawnTracker's own comment for the defect).
+        lookup_spawned_task: "Callable[[str | None, str | None], str | None] | None" = None,
         # Proposal 0067 P4e (#3978): fires task_settled for a settled
         # kind="prompt" chain — the SAME dispatch_external_event seam
         # PipelineExecutorDriver._finish uses, injected here rather than a
@@ -582,8 +584,14 @@ class InterAgentMessaging:
         # preserve verbatim (the compensating condition for collapsing the
         # kind axis at all).
         responder_sid = payload.get("responder_sid")
+        # #4740: the responder's agent identity is `from_agent` (the agent
+        # THIS agent_response arrived from) — a spawned child's result
+        # routes back with `from_agent` == the child agent we recorded the
+        # trusted task under. Required alongside sid — sid alone collides
+        # across agents (see SpawnTracker's own comment for the defect).
         spawned_task = (
-            self._lookup_spawned_task(responder_sid) if self._lookup_spawned_task else None
+            self._lookup_spawned_task(from_agent, responder_sid)
+            if self._lookup_spawned_task else None
         )
         if spawned_task is not None:
             injected_text = (

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -269,7 +269,9 @@ class RouterHostAdapter:
         pipeline_registry: Any = None,          # PipelineRegistry | None — IS-5
         chains: Any = None,                     # ChainManager | None — #3978 P4
         presentation_registry: Any = None,      # PresentationRegistry | None — FP-0054 PR-C
-        record_spawned_task: "Callable[[str, str], None] | None" = None,  # #2103 S1bc-exec
+        # #4740: (agent_name, sid, task) — sid alone collides across agents
+        # (see SpawnTracker's own constructor comment for the full defect).
+        record_spawned_task: "Callable[[str, str, str], None] | None" = None,  # #2103 S1bc-exec
         agent_workspace_dir: Path,
         # MCP op callbacks
         mcp_call_tool: Callable[..., Awaitable[dict]],
@@ -1466,11 +1468,13 @@ class RouterHostAdapter:
                 "status": "error", "kind": "session_already_exists",
                 "error": str(exc),
             }
-        # #2103 S1bc-exec: record sid→task BEFORE submitting, so a fast result finds the
-        # trusted task on return (else it falls back to the from=-only rendering — both
-        # still kind=prompt, proposal 0067 P4 #3978, architect ruling 2026-08-10).
+        # #2103 S1bc-exec: record (target_agent, sid)→task BEFORE submitting, so a
+        # fast result finds the trusted task on return (else it falls back to the
+        # from=-only rendering — both still kind=prompt, proposal 0067 P4 #3978,
+        # architect ruling 2026-08-10). #4740: agent_name included — sid alone
+        # collides across agents (see SpawnTracker's own comment for the defect).
         if self._record_spawned_task is not None:
-            self._record_spawned_task(sid, request)
+            self._record_spawned_task(target_agent, sid, request)
         spawned_session = self._registry.ensure_session_running(target_agent, sid)
         if spawned_session is not None:
             await spawned_session.submit_agent_request(

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3867,15 +3867,19 @@ class Session:
     # ── #2103 S1bc-exec: spawned-task correlation (SpawnTracker). See
     # session-construction.md. ──
 
-    def record_spawned_task(self, sid: str, task: str) -> None:
-        """Record a session-I-spawned's ``sid → task`` BEFORE submitting it. Thin
-        forwarder — see ``SpawnTracker.record_spawned_task`` for the full rationale."""
-        self._spawn_tracker.record_spawned_task(sid, task)
+    def record_spawned_task(self, agent_name: str, sid: str, task: str) -> None:
+        """Record a session-I-spawned's ``(agent_name, sid) → task`` BEFORE submitting
+        it. Thin forwarder — see ``SpawnTracker.record_spawned_task`` for the full
+        rationale (#4740: agent_name added — sid alone collides across agents)."""
+        self._spawn_tracker.record_spawned_task(agent_name, sid, task)
 
-    def lookup_and_evict_spawned_task(self, sid: "str | None") -> "str | None":
-        """The TRUSTED task for a spawned ``sid``, or None. Thin forwarder — see
-        ``SpawnTracker.lookup_and_evict_spawned_task`` for the full rationale."""
-        return self._spawn_tracker.lookup_and_evict_spawned_task(sid)
+    def lookup_and_evict_spawned_task(
+        self, agent_name: "str | None", sid: "str | None",
+    ) -> "str | None":
+        """The TRUSTED task for a spawned ``(agent_name, sid)``, or None. Thin
+        forwarder — see ``SpawnTracker.lookup_and_evict_spawned_task`` for the full
+        rationale (#4740: agent_name added)."""
+        return self._spawn_tracker.lookup_and_evict_spawned_task(agent_name, sid)
 
     async def shutdown(self) -> None:
         # `shutdown` is a control signal, not recovery state — skip WAL/snapshot.

--- a/src/reyn/runtime/spawn_tracker.py
+++ b/src/reyn/runtime/spawn_tracker.py
@@ -103,35 +103,86 @@ class SpawnTracker:
         self._agent_name = agent_name
         self._session_id_provider = session_id_provider
         self._ephemeral_provider = ephemeral_provider
-        # sid -> trusted original-task record for spawned sessions, so a compromised
-        # sub-session can't forge task framing (#2103 S1bc-exec)
-        self._spawned_tasks: "OrderedDict[str, str]" = OrderedDict()
+        # #4740: (agent_name, sid) -> trusted original-task record for spawned
+        # sessions, so a compromised sub-session can't forge task framing
+        # (#2103 S1bc-exec). Two-level dict, SAME shape as registry.py's own
+        # `self._sessions.setdefault(name, {})[sid] = session` — sid alone is
+        # NOT process-wide-unique (registry.py's own `_session_state_dir(self,
+        # name, sid)` docstring: on-disk state dir is keyed by (name, sid)), so
+        # this spawner recording two DIFFERENT agents' sessions that happen to
+        # share a sid (both "main", the common default) would previously let
+        # the second record silently overwrite the first, and later let an
+        # UNRELATED agent's result consume and render the wrong trusted task=
+        # in the result header — the exact forgery this record exists to
+        # prevent, now reachable from an ordinary same-sid collision rather
+        # than a compromised sub-session (#4735's own agent-collision defect
+        # class, one level down: this is #4735's OWN "census remainder half"
+        # that got folded into #4735 and lost its open face when #4735 closed
+        # — lead-coder review, #4740).
+        self._spawned_tasks: "dict[str, OrderedDict[str, str]]" = {}
+        # #4740: GLOBAL (across every agent) insertion-order tracker for the
+        # `_MAX_SPAWNED_TASKS` bound — the nested dict above has no single
+        # order of its own once split by agent, so eviction needs a
+        # companion structure to keep the SAME "oldest in-flight, across
+        # every spawned agent" bound the prior flat OrderedDict enforced
+        # (not narrowed to a PER-agent cap, which would let N agents each
+        # hold their own 256-entry tail — an unintended widening of the
+        # bound while fixing the collision).
+        self._spawn_order: "OrderedDict[tuple[str, str], None]" = OrderedDict()
         # Spawned EPHEMERAL session auto-vanish state (#2103)
         self._vanish_scheduled: bool = False
         self._vanish_task: "asyncio.Task | None" = None
 
     # ── #2103 S1bc-exec: spawned-task correlation record (bounded) ──────────────
 
-    def record_spawned_task(self, sid: str, task: str) -> None:
-        """Record a session-I-spawned's ``sid -> task`` BEFORE submitting it, so when its
-        result routes back the header renders ``task=<my OWN request>`` from this TRUSTED
-        record (not the spawned session's echo). Bounded: evicted on result arrival;
-        ``_MAX_SPAWNED_TASKS`` cap evicts oldest so a never-arriving result can't grow it."""
-        self._spawned_tasks[sid] = task
-        self._spawned_tasks.move_to_end(sid)
-        while len(self._spawned_tasks) > _MAX_SPAWNED_TASKS:
-            self._spawned_tasks.popitem(last=False)  # evict oldest in-flight
+    def record_spawned_task(self, agent_name: str, sid: str, task: str) -> None:
+        """Record a session-I-spawned's ``(agent_name, sid) -> task`` BEFORE submitting
+        it, so when its result routes back the header renders ``task=<my OWN request>``
+        from this TRUSTED record (not the spawned session's echo). Bounded: evicted on
+        result arrival; ``_MAX_SPAWNED_TASKS`` cap evicts oldest (globally, across every
+        spawned agent) so a never-arriving result can't grow it.
 
-    def lookup_and_evict_spawned_task(self, sid: "str | None") -> "str | None":
-        """The TRUSTED task for a spawned ``sid``, or None (not one I spawned / already
-        consumed). Evict-on-read — a result is consumed once; a spoofed/unknown sid → None
-        → the caller renders the safe from=-only fallback (still fenced, still kind=prompt
-        — proposal 0067 P4 (#3978): the sid/from distinction rides the header's OTHER
-        field, not `kind`, since architect's 2026-08-10 ruling collapsed both branches
-        to `kind=prompt`)."""
-        if not sid:
+        #4740: keyed by ``(agent_name, sid)``, not ``sid`` alone — see this
+        class's own constructor comment for why a bare sid collides across
+        agents."""
+        key = (agent_name, sid)
+        self._spawned_tasks.setdefault(agent_name, OrderedDict())[sid] = task
+        self._spawned_tasks[agent_name].move_to_end(sid)
+        self._spawn_order[key] = None
+        self._spawn_order.move_to_end(key)
+        while len(self._spawn_order) > _MAX_SPAWNED_TASKS:
+            oldest_agent, oldest_sid = next(iter(self._spawn_order))
+            self._spawn_order.popitem(last=False)  # evict oldest in-flight
+            inner = self._spawned_tasks.get(oldest_agent)
+            if inner is not None:
+                inner.pop(oldest_sid, None)
+                if not inner:
+                    del self._spawned_tasks[oldest_agent]
+
+    def lookup_and_evict_spawned_task(
+        self, agent_name: "str | None", sid: "str | None",
+    ) -> "str | None":
+        """The TRUSTED task for a spawned ``(agent_name, sid)``, or None (not one I
+        spawned / already consumed). Evict-on-read — a result is consumed once; a
+        spoofed/unknown (agent_name, sid) → None → the caller renders the safe
+        from=-only fallback (still fenced, still kind=prompt — proposal 0067 P4
+        (#3978): the sid/from distinction rides the header's OTHER field, not
+        `kind`, since architect's 2026-08-10 ruling collapsed both branches to
+        `kind=prompt`).
+
+        #4740: agent_name is now REQUIRED alongside sid — see
+        :meth:`record_spawned_task`'s own docstring for why."""
+        if not sid or not agent_name:
             return None
-        return self._spawned_tasks.pop(sid, None)
+        inner = self._spawned_tasks.get(agent_name)
+        if inner is None:
+            return None
+        task = inner.pop(sid, None)
+        if task is not None:
+            self._spawn_order.pop((agent_name, sid), None)
+            if not inner:
+                del self._spawned_tasks[agent_name]
+        return task
 
     def attach_anchor_store(self, anchor_store: object) -> None:
         """Attach the shared per-checkpoint anchor store (#1547).

--- a/tests/runtime/test_2103_s1bc_exec_result_routing.py
+++ b/tests/runtime/test_2103_s1bc_exec_result_routing.py
@@ -95,8 +95,9 @@ async def test_main_spawn_result_routes_back_correlated_as_spawned_session(tmp_p
     sid = await reg.spawn_session_recorded("worker", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     spawned = reg.ensure_session_running("worker", sid)
     assert spawned is not None
-    # the spawner records the trusted sid→task (= what the adapter does at spawn time).
-    main.record_spawned_task(sid, "summarize the Q3 report")
+    # the spawner records the trusted (agent, sid)→task (= what the adapter
+    # does at spawn time). #4740: agent_name included.
+    main.record_spawned_task("worker", sid, "summarize the Q3 report")
 
     chain_id = "chain-spawn-verify-1"
     # The spawned session completes + routes the result back (the run-loop's completion
@@ -114,7 +115,7 @@ async def test_main_spawn_result_routes_back_correlated_as_spawned_session(tmp_p
     assert "task=summarize the Q3 report" in txt
     assert chain_id in txt
     # the trusted record is evicted on arrival (bounded-by-construction).
-    assert main.lookup_and_evict_spawned_task(sid) is None
+    assert main.lookup_and_evict_spawned_task("worker", sid) is None
 
 
 @pytest.mark.asyncio
@@ -269,7 +270,10 @@ async def test_gone_spawner_sid_drops_does_not_fallback_to_main(tmp_path, caplog
 @pytest.mark.asyncio
 async def test_spawned_tasks_record_is_bounded(tmp_path):
     """Tier 2: S1bc-exec — the trusted spawned-task record is bounded (evict-oldest past
-    the cap) so never-arriving results can't grow it unbounded."""
+    the cap) so never-arriving results can't grow it unbounded. #4740: the bound is
+    GLOBAL across every agent, not per-agent — this test uses a single agent
+    ("worker") throughout, so it does not itself distinguish global-vs-per-agent;
+    see test_spawned_tasks_bound_is_global_across_agents below for that leg."""
     from reyn.runtime.spawn_tracker import _MAX_SPAWNED_TASKS
     reg = _registry(tmp_path)
     main = reg.get_or_load("worker")
@@ -277,9 +281,86 @@ async def test_spawned_tasks_record_is_bounded(tmp_path):
     # 10..cap+9 (exactly cap entries) are kept. Proven via the public lookup, not the
     # internal length.
     for i in range(_MAX_SPAWNED_TASKS + 10):
-        main.record_spawned_task(f"sid{i}", f"task{i}")
-    assert main.lookup_and_evict_spawned_task("sid0") is None      # oldest evicted
-    assert main.lookup_and_evict_spawned_task("sid9") is None      # last of the overflow
-    assert main.lookup_and_evict_spawned_task("sid10") == "task10"  # first kept (cap boundary)
-    assert main.lookup_and_evict_spawned_task(f"sid{_MAX_SPAWNED_TASKS + 9}") == \
-        f"task{_MAX_SPAWNED_TASKS + 9}"                            # newest kept
+        main.record_spawned_task("worker", f"sid{i}", f"task{i}")
+    assert main.lookup_and_evict_spawned_task("worker", "sid0") is None      # oldest evicted
+    assert main.lookup_and_evict_spawned_task("worker", "sid9") is None      # last of the overflow
+    assert main.lookup_and_evict_spawned_task("worker", "sid10") == "task10"  # first kept (cap boundary)
+    assert main.lookup_and_evict_spawned_task(
+        "worker", f"sid{_MAX_SPAWNED_TASKS + 9}",
+    ) == f"task{_MAX_SPAWNED_TASKS + 9}"                            # newest kept
+
+
+# ── #4740: agent-qualified spawned-task record (the collision fix) ──────────
+
+
+@pytest.mark.asyncio
+async def test_spawned_task_lookup_requires_matching_agent_not_just_sid(tmp_path):
+    """Tier 2: THE mandatory falsify witness (lead-coder's own required
+    condition, #4740) — a spawner that recorded TWO different agents'
+    sessions sharing the SAME sid (the common "main" default, or any
+    sid collision) does not let one agent's lookup consume the other's
+    record. Before #4740, sid alone was the key — the second
+    record_spawned_task call for the SAME sid, a DIFFERENT agent, would
+    silently overwrite the first, and either agent's result could
+    consume the other's trusted task=, defeating the anti-forgery record
+    this class exists for (SpawnTracker's own docstring: "so a
+    compromised sub-session can't forge task framing")."""
+    reg = _registry(tmp_path)
+    reg.create("agent-a")
+    reg.create("agent-b")
+    main = reg.get_or_load("worker")
+
+    main.record_spawned_task("agent-a", "sid-shared", "agent-a's own task")
+    main.record_spawned_task("agent-b", "sid-shared", "agent-b's own task")
+
+    # Looked up in REVERSE insertion order deliberately — a strip that
+    # ignores agent_name and searches by sid alone would return whichever
+    # agent's entry it happens to find FIRST in iteration order (agent-a,
+    # inserted first), which would make the "agent-a" lookup accidentally
+    # correct and mask the defect. Asking for agent-b's task FIRST forces
+    # the argument itself, not insertion order, to decide the answer.
+    assert main.lookup_and_evict_spawned_task("agent-b", "sid-shared") == "agent-b's own task"
+    assert main.lookup_and_evict_spawned_task("agent-a", "sid-shared") == "agent-a's own task"
+
+
+@pytest.mark.asyncio
+async def test_spawned_task_lookup_agent_mismatch_misses(tmp_path):
+    """Tier 2: accept-side of the same witness — looking up the SAME sid
+    under the WRONG agent name misses entirely (None), never returning a
+    different agent's task under a mismatched identity."""
+    reg = _registry(tmp_path)
+    reg.create("agent-a")
+    reg.create("agent-b")
+    main = reg.get_or_load("worker")
+
+    main.record_spawned_task("agent-a", "sid-shared", "agent-a's own task")
+
+    assert main.lookup_and_evict_spawned_task("agent-b", "sid-shared") is None
+    # the real record is still there, untouched by the mismatched lookup.
+    assert main.lookup_and_evict_spawned_task("agent-a", "sid-shared") == "agent-a's own task"
+
+
+@pytest.mark.asyncio
+async def test_spawned_tasks_bound_is_global_across_agents(tmp_path):
+    """Tier 2: the ``_MAX_SPAWNED_TASKS`` cap is GLOBAL across every
+    spawned agent, not a per-agent allowance — N agents cannot each hold
+    their own full-cap tail (that would be an unintended widening of the
+    bound while fixing the collision, #4740's own explicit constraint)."""
+    from reyn.runtime.spawn_tracker import _MAX_SPAWNED_TASKS
+    reg = _registry(tmp_path)
+    reg.create("agent-a")
+    reg.create("agent-b")
+    main = reg.get_or_load("worker")
+
+    # Fill to exactly the cap under agent-a, then add ONE more under
+    # agent-b — the oldest entry (agent-a's sid0) must be evicted, proving
+    # the two agents share ONE global bound, not `cap` each.
+    for i in range(_MAX_SPAWNED_TASKS):
+        main.record_spawned_task("agent-a", f"sid{i}", f"task{i}")
+    main.record_spawned_task("agent-b", "sid-extra", "task-extra")
+
+    assert main.lookup_and_evict_spawned_task("agent-a", "sid0") is None, (
+        "agent-a's oldest entry must be evicted once the GLOBAL cap is exceeded "
+        "by agent-b's new entry — a per-agent bound would keep it"
+    )
+    assert main.lookup_and_evict_spawned_task("agent-b", "sid-extra") == "task-extra"


### PR DESCRIPTION
**[e2e-coder]** — `SpawnTracker._spawned_tasks` recorded `sid -> task` alone. `registry.py`'s own `_session_state_dir(self, name, sid)` docstring: the on-disk state dir is keyed by `(name, sid)` — sid is not process-wide-unique. A spawner recording two DIFFERENT agents' sessions sharing a sid (both `"main"`, the common default) let the second record silently overwrite the first, and later let an UNRELATED agent's result consume and render the wrong trusted `task=` in the result header — the exact forgery this record exists to prevent (`SpawnTracker`'s own docstring: "so a compromised sub-session can't forge task framing"), now reachable from an ordinary same-sid collision rather than an actual compromise.

This is #4735's own census remainder — folded into #4735 by lead-coder and lost its open face when #4735 closed via #4739's `Closes` keyword. Reopened as its own issue (#4740).

## Fix

Two-level dict, same shape as `registry.py`'s own `self._sessions.setdefault(name, {})[sid] = session`. `record_spawned_task`/`lookup_and_evict_spawned_task` now take `agent_name` alongside `sid`. The bound (`_MAX_SPAWNED_TASKS`) stays GLOBAL across every agent via a companion insertion-order tracker — not narrowed to a per-agent cap, which would let N agents each hold their own full-cap tail (an unintended widening of the bound while fixing the collision).

Call sites updated: `RouterHostAdapter.spawn_session` (`target_agent` is already resolved there) and `inter_agent_messaging.handle_agent_response` (`from_agent` — the responder's own agent identity, already read at the top of the method).

## The falsify-test discovery worth recording (lead-coder specifically asked this be in the PR body)

The mandatory falsify test's FIRST draft passed even against the stripped, sid-only (pre-fix) implementation — a false positive. The test recorded agent-a's then agent-b's task under the same sid, then looked them up in the SAME order (agent-a first, agent-b second). Because Python dicts preserve insertion order, a strip that ignores `agent_name` and searches by sid alone happens to return whichever agent's entry it finds FIRST in iteration order — which was agent-a, the same order the test asked for it in. The test's PASS was masking the exact defect it existed to catch.

Caught by strip-falsifying the fix and finding the "mandatory" test still green. Fixed by looking the two up in REVERSE insertion order instead — that forces the `agent_name` argument itself, not insertion order, to decide the answer. Re-stripped afterward: now both the falsify test and its accept-side sibling correctly flip RED.

Generalizing the technique: when a falsify test can't obviously distinguish "the fix works" from "the test's own construction happens to agree with the fix," running the SAME inputs through in REVERSE order is a cheap, deterministic way to check whether the test secretly depends on insertion/call order rather than on the mechanism under test.

## Strip-falsify (2 mechanisms, independently)

- Reverting the lookup to sid-only search (ignoring `agent_name`) flips the mandatory falsify test AND its accept-side mismatch sibling RED.
- Reverting the bound to per-agent (instead of global) flips the dedicated global-bound test RED.

Both restored GREEN.

## Gates

- `ruff check .`, `python scripts/mypy_ratchet.py`, `python scripts/verify_module_docstrings.py` on all 4 changed src files, `python scripts/test_tier_audit.py --strict tests/runtime/test_2103_s1bc_exec_result_routing.py` — all green.
- `pytest tests/runtime tests/core` — 4536 passed, 3 skipped, 0 failed.

Closes #4740

Test plan:
- [x] `ruff check .` green
- [x] `python scripts/mypy_ratchet.py` green
- [x] `python scripts/verify_module_docstrings.py` on all 4 changed src files, green
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_2103_s1bc_exec_result_routing.py` green
- [x] `pytest tests/runtime tests/core` — 4536 passed / 3 skipped / 0 failed
- [x] Strip-falsify confirmed RED for the right reason on 2 independent mechanisms, restored GREEN; the falsify test's own initial false-positive (order-dependency) was caught and fixed before landing
- [ ] (skipped — no visual/TUI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
