### PR TITLE
docs(#4740): fix module-docstring drift + re-verify the ownership claim by grep

### DIFF
--- a/src/reyn/runtime/spawn_tracker.py
+++ b/src/reyn/runtime/spawn_tracker.py
@@ -13,10 +13,23 @@ does not construct a bundle and unpack it back into its own fields (the
 
 Ownership split:
 
-- **Owned here**: ``_spawned_tasks`` (bounded ``sid -> task`` OrderedDict),
-  ``_vanish_scheduled`` (bool), ``_vanish_task`` (the detached teardown
-  task's strong ref) — mutated ONLY by the four methods below, no other
-  ``Session`` code path touches them (verified by grep).
+- **Owned here**: ``_spawned_tasks`` (bounded, two-level
+  ``dict[str, OrderedDict[str, str]]`` — ``agent_name -> (sid -> task)``,
+  #4740: was a flat ``sid -> task`` OrderedDict until #4740 keyed it by
+  agent too, since sid alone is not process-wide-unique), ``_spawn_order``
+  (#4740: the companion ``OrderedDict[tuple[str, str], None]`` tracking
+  GLOBAL insertion order across every agent, for ``_MAX_SPAWNED_TASKS``
+  eviction — the nested dict above has no order of its own once split by
+  agent), ``_vanish_scheduled`` (bool), ``_vanish_task`` (the detached
+  teardown task's strong ref) — mutated ONLY by ``__init__`` +
+  ``record_spawned_task`` + ``lookup_and_evict_spawned_task`` +
+  ``_maybe_schedule_ephemeral_vanish`` (the four methods below), no other
+  ``Session`` code path touches them (re-verified by grep at #4740 review,
+  2026-08-14: grepped ``_spawned_tasks``, ``_spawn_order``,
+  ``_vanish_scheduled``, and ``_vanish_task`` across ``src/`` and
+  ``tests/`` separately — every hit outside this file is either a
+  read-only test bridge (``._vanish_task`` awaited in 3 vanish tests) or a
+  comment, never an assignment).
 - **Injected dependency (constructor)**: ``registry`` / ``journal`` /
   ``chains`` / ``inbox`` — stable for the session's lifetime, read but never
   reassigned here. ``agent_name`` is likewise stable (``Agent`` is frozen,


### PR DESCRIPTION
**[e2e-coder]** — #4740 follow-up from architect's co-vet on #4746 (relayed by lead-coder). No new issue — small, direct PR per lead-coder's instruction.

## What was stale

`spawn_tracker.py`'s module docstring "Owned here" enumeration, unread during #4746's own review (tests + implementation were read; the module docstring was not):

1. Type description still said `_spawned_tasks` was a flat `sid -> task` OrderedDict — #4740 changed the actual type to a two-level `dict[str, OrderedDict[str, str]]` (`agent_name -> (sid -> task)`).
2. `_spawn_order` (#4740's new companion state — the GLOBAL insertion-order tracker the bound eviction needs, since the nested dict has no order of its own once split by agent) was missing from the enumeration entirely.

## The completeness claim

The enumeration asserts completeness: *"mutated ONLY by the four methods below, no other `Session` code path touches them (verified by grep)"*. `scripts/verify_module_docstrings.py` only checks structure (no stale refactor-narrative phrasing) — CI green was never evidence this specific claim was still true, only that nobody had re-checked it since `_spawn_order` was added.

Re-ran the grep this PR, across `src/` and `tests/`, for all 4 owned fields (`_spawned_tasks`, `_spawn_order`, `_vanish_scheduled`, `_vanish_task`): every hit outside `spawn_tracker.py` is either a read-only test bridge (`._vanish_task` awaited in 3 vanish tests) or a comment, never an assignment. The claim holds — kept it, with the re-verification dated in the docstring rather than left as an unchecked assertion from before `_spawn_order` existed.

## Caller audit (architect's own unconfirmed point)

Architect read only `spawn_tracker.py`'s own 4 lines and reported the other files as unread. Grepped every production call site of `record_spawned_task` / `lookup_and_evict_spawned_task` (and their `Session`-forwarder aliases `_record_spawned_task` / `_lookup_spawned_task`) across the whole repo — **4 call sites total, all 4 opened and read**:

1. `session.py:3874` — `Session.record_spawned_task`, thin forwarder to `SpawnTracker.record_spawned_task`, passes `agent_name` straight through (no transformation).
2. `session.py:3882` — `Session.lookup_and_evict_spawned_task`, same, forwards `agent_name` straight through.
3. `router_host_adapter.py:1477` — `RouterHostAdapter.spawn_session`'s `record_spawned_task(target_agent, sid, request)` call. `target_agent` is assigned ONCE at line 1298 (`target_agent = agent if agent is not None else self._agent_name`) and never reassigned before this call — confirmed correct, no staleness risk.
4. `inter_agent_messaging.py:593` — `handle_agent_response`'s `lookup_and_evict_spawned_task(from_agent, responder_sid)` call. `from_agent` is `payload.get("from_agent", "")`, assigned once at line 555. Traced its origin: `send_agent_response` (the method a spawned child calls when it completes) sets `from_agent=self.agent_name` — the RESPONDING session's own agent identity, which for a spawned child's result IS the child agent `record_spawned_task` recorded it under. Confirmed correct.

All 4 already pass `agent_name` correctly — no code change needed at any call site, only the docstring fix above.

## Gates

- `ruff check .`, `python scripts/mypy_ratchet.py`, `python scripts/verify_module_docstrings.py src/reyn/runtime/spawn_tracker.py` — all green.
- `pytest tests/runtime` — 1829 passed, 1 skipped, 0 failed.

No behavior change — docs only.

part of #4740

Test plan:
- [x] `ruff check .` green
- [x] `python scripts/mypy_ratchet.py` green
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/spawn_tracker.py` green
- [x] `pytest tests/runtime` — 1829 passed / 1 skipped / 0 failed
- [x] Re-verified the docstring's own "verified by grep" completeness claim by actually re-running the grep (4 fields, across src/ and tests/) — held
- [x] Enumerated and opened all 4 production call sites of record_spawned_task / lookup_and_evict_spawned_task — all correct, no code change needed
- [ ] (skipped — no visual/TUI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
