### PR TITLE
feat(#4691): Phase B B1 -- Group construction, parent placeholder, spinner

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1162,6 +1162,23 @@ class TextualChatApp(App):
         # deterministic args_hash, meta["op_id"]) so a later completion/failure
         # frame transitions the SAME entry RUNNING → SUCCESS/ERROR (CC parity).
         self._running_tools: "dict[object, Entry[OutboxMessage]]" = {}
+        # #4691 Phase B B1: the litellm-call TREE PARENT for a given call_id
+        # (#4691 Phase 1 ①②, #4734) — every ``kind="agent"`` row carrying
+        # ``meta["finish_reason"] == "tool_calls"`` registers itself here on
+        # arrival, and every ``tool_call_started``/``completed``/``failed``
+        # frame carrying a matching ``meta["call_id"]`` looks itself up here
+        # to find which Entry to nest under (``parent.append_child(...)``
+        # instead of the flat ``self.conversation.append(...)``). KEYED, not
+        # ORDER-based (owner ruling B, #4691, via #4734's review) — a dict
+        # lookup by call_id can never attach a tool row to the wrong parent
+        # even if dispatch order or interleaving assumptions ever break,
+        # unlike a single "most recently seen" pointer (the design #4734's
+        # review rejected for exactly this reason). Entries are never
+        # removed — a call_id is a member of exactly one turn's history and
+        # is never reused, so the dict only grows for the life of the
+        # conversation (bounded by the same session lifetime the flow model
+        # itself already is).
+        self._call_parents: "dict[str, Entry[OutboxMessage]]" = {}
         # #4380/#4429 originally had a lifecycle-marker bundling tracker
         # here — removed (2026-08-13): no reachable trigger ever produces
         # two adjacent occurrences (see ``_ingest_frame``'s own docstring
@@ -3618,10 +3635,38 @@ class TextualChatApp(App):
                     replace(streaming.entry.item, text=msg.text, meta=meta)
                 )
                 return
-        entry = self.conversation.append(msg)
+        # #4691 Phase B B1: nest under this frame's own litellm CALL, found
+        # by call_id lookup (never by "most recently appended" order — see
+        # ``self._call_parents``'s own docstring). A frame with no call_id,
+        # or one that matches no registered parent (a legacy/restored row,
+        # an op-loop caller that never threaded one through), falls through
+        # to the flat top-level append exactly as before B1 — nothing here
+        # narrows what USED to land flat.
+        call_id = meta.get("call_id")
+        parent = self._call_parents.get(call_id) if call_id else None
+        if parent is not None:
+            entry = parent.append_child(msg)
+        else:
+            entry = self.conversation.append(msg)
         # #3712: an entry just arrived. Counted HERE, by the thing that
         # produced it — not reconstructed later from two reads of the model.
         self._note_entry_landed()
+        if (
+            kind == "agent"
+            and call_id
+            and meta.get("finish_reason") == "tool_calls"
+        ):
+            # This row IS a call boundary that dispatches tool_calls next —
+            # register it so those tool rows (about to arrive with the SAME
+            # call_id) find it. A terminal reply (finish_reason == "stop")
+            # or any other kind never registers: nothing ever looks up a
+            # call_id belonging to a call that dispatched no tools.
+            self._call_parents[call_id] = entry
+            # #4691 Phase B ④: the parent's own spinner starts here — its
+            # children are about to arrive RUNNING too, and
+            # ``_recompute_parent_state`` (called from every child settle)
+            # keeps it RUNNING until every child has settled.
+            entry.set_state(EntryState.RUNNING)
         if kind == "presentation":
             self._begin_image_resolutions(entry, msg)
         if kind == "intervention":
@@ -3713,6 +3758,39 @@ class TextualChatApp(App):
             started.set_state(
                 EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS
             )
+        # #4691 Phase B ④: this settle may be the last of the parent's
+        # children — recompute its own spinner state.
+        self._recompute_parent_state(started)
+
+    def _recompute_parent_state(self, child: "Entry[OutboxMessage]") -> None:
+        """#4691 Phase B ④ — after a child settles, recompute its Group
+        PARENT's own state (the spinner #4691 Phase B B1 asked for: RUNNING
+        while any of its children still are, SUCCESS/ERROR once all have
+        settled).
+
+        A no-op when ``child`` has no parent (an un-nested / top-level
+        row — B1's own call_id-lookup miss path, or a restored row). Reads
+        ``EntryState`` off every live child via ``entry.state`` — the SAME
+        public state the child's own gutter/animation already reflect, so
+        this can never disagree with what the child rows themselves show.
+        RUNNING wins over any terminal state (a parent with even one
+        in-flight child is still in flight); among terminal states ERROR
+        wins over SUCCESS (one failed child taints the whole call); CANCELLED
+        counts as neither RUNNING nor a taint — an orphan is not a failure
+        (#72's own reasoning, reused here at parent granularity)."""
+        parent = child.parent
+        if parent is None:
+            return
+        children = parent.children
+        if not children:
+            return
+        states = [c.state for c in children]
+        if EntryState.RUNNING in states:
+            parent.set_state(EntryState.RUNNING)
+        elif EntryState.ERROR in states:
+            parent.set_state(EntryState.ERROR)
+        else:
+            parent.set_state(EntryState.SUCCESS)
 
     def _coalesce_pipeline_step(self, msg: "OutboxMessage") -> bool:
         """Fold one pipeline step frame into that run's single row.
@@ -3823,7 +3901,34 @@ class TextualChatApp(App):
                 logger.exception(
                     "textual chat: could not set orphaned-tool state"
                 )
+            # #4691 Phase B ④: an orphan is a settle too — its parent (if
+            # any) must not spin forever waiting for a completion that will
+            # now never arrive.
+            try:
+                self._recompute_parent_state(entry)
+            except Exception:
+                logger.exception(
+                    "textual chat: could not recompute orphaned tool's parent state"
+                )
         self._running_tools.clear()
+        # #4691 Phase B ④: a parent whose children never arrived at all — the
+        # turn cancelled between the parent row landing and its first
+        # tool_call_started, or every one of its tool_calls was excluded
+        # pre-dispatch (#3455) and produced no started entry to track — is
+        # NOT in the loop above (nothing to recompute FROM: it has no
+        # settled child to trigger it) and would otherwise spin its own
+        # RUNNING marker forever. Same CANCELLED verdict as an orphaned
+        # tool itself (#72's own reasoning): the turn ending is not a
+        # failure of the call, it is the call's report simply never
+        # completing.
+        for parent in self._call_parents.values():
+            if parent.state is EntryState.RUNNING:
+                try:
+                    parent.set_state(EntryState.CANCELLED)
+                except Exception:
+                    logger.exception(
+                        "textual chat: could not settle an orphaned call-parent"
+                    )
 
     def _close_earlier_streaming_rounds(self, chain_id: str, round_index: object) -> None:
         """Finish any record of *chain_id* from a round before *round_index*.

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2102,8 +2102,22 @@ class RouterLoop:
                 # no-tool_calls turn, so on a tool-turn the explanatory text was dropped
                 # from the conversation. Emit it as an ``agent`` bubble BEFORE
                 # _run_execute_round so the text renders ahead of the tool rows
-                # (lifecycle_forwarder queues tool_call_started during the round). Skip
-                # empty (no empty bubble).
+                # (lifecycle_forwarder queues tool_call_started during the round).
+                #
+                # #4691 Phase B ③: UNCONDITIONAL now — previously gated on
+                # ``if _tool_turn_text.strip():`` (skip empty, no empty bubble),
+                # deliberately deferred at Phase 1 because an empty-text row had
+                # no consumer: the TUI display path was unconditional even then
+                # (RouterHostAdapter.put_outbox never gated on text), so emitting
+                # one would have shown a bare, meaningless blank bubble. #4691
+                # Phase B's Group construction (app.py) is that consumer now —
+                # this row IS the call's own tree-parent placeholder, keyed by
+                # its own ``call_id`` below, so every tool-calls round gets a
+                # parent to nest its tool rows under even when the model called
+                # tools with no explanatory text. Owner ruling (#4691): keys are
+                # wired but the DEFAULT stays fully expanded — an empty-text
+                # parent row with its children shown under it is not a visual
+                # regression the way a bare empty bubble alone would have been.
                 #
                 # #3633: this call is DISPLAY-ONLY — ``persist=False``. The prior
                 # comment here ("no double-emit ... history persistence is unchanged")
@@ -2119,32 +2133,31 @@ class RouterLoop:
                 # twice (measured: 24/283 adjacent-duplicate assistant records in a
                 # real session, #3633).
                 _tool_turn_text = result.content or ""
-                if _tool_turn_text.strip():
-                    await self.host.put_outbox(
-                        kind="agent",
-                        text=_tool_turn_text,
-                        persist=False,
-                        # #1652: supply this turn's reasoning (host gates display/
-                        # continuity + emits the discrete kind="reasoning" signal).
-                        meta={
-                            "chain_id": self.chain_id,
-                            "source": "router_tool_turn_text",
-                            "reasoning": result.reasoning,
-                            # #4691: this row IS the call that just returned
-                            # ``result`` — its own real per-call tokens, not
-                            # the turn total (see gutter.py's ReynTurnUsageGutter
-                            # docstring for why this is the boundary fix).
-                            "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
-                            "completion_tokens": getattr(result.usage, "completion_tokens", None),
-                            # #4691 Phase 1 ②: same call-granularity key item ①
-                            # stamps on this call's own llm_response_received —
-                            # threaded onto the row so a future flowview tree
-                            # (#4691 Phase B) can tell which litellm call this
-                            # row belongs to and whether it was a tool round.
-                            "call_id": result.call_id,
-                            "finish_reason": result.finish_reason,
-                        },
-                    )
+                await self.host.put_outbox(
+                    kind="agent",
+                    text=_tool_turn_text,
+                    persist=False,
+                    # #1652: supply this turn's reasoning (host gates display/
+                    # continuity + emits the discrete kind="reasoning" signal).
+                    meta={
+                        "chain_id": self.chain_id,
+                        "source": "router_tool_turn_text",
+                        "reasoning": result.reasoning,
+                        # #4691: this row IS the call that just returned
+                        # ``result`` — its own real per-call tokens, not
+                        # the turn total (see gutter.py's ReynTurnUsageGutter
+                        # docstring for why this is the boundary fix).
+                        "prompt_tokens": getattr(result.usage, "prompt_tokens", None),
+                        "completion_tokens": getattr(result.usage, "completion_tokens", None),
+                        # #4691 Phase 1 ②: same call-granularity key item ①
+                        # stamps on this call's own llm_response_received —
+                        # threaded onto the row so a future flowview tree
+                        # (#4691 Phase B) can tell which litellm call this
+                        # row belongs to and whether it was a tool round.
+                        "call_id": result.call_id,
+                        "finish_reason": result.finish_reason,
+                    },
+                )
                 # F5 fix (dogfood batch 1): dedupe duplicate async
                 # tool_calls within the same round. Weak models
                 # occasionally emit `delegate_to_agent` twice in one

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -1,0 +1,332 @@
+"""#4691 Phase B (B1): the litellm-call TREE — a tool-calls round's own
+``agent`` row becomes the flowview Group PARENT its ``tool_call_started``/
+``completed``/``failed`` rows nest under, found by ``call_id`` KEY LOOKUP
+(never dispatch order — owner ruling B, #4691, via #4734's review of an
+earlier rejected pointer-based design). ③ (the parent placeholder always
+emits, even content-less) and ④ (the parent's own RUNNING→settled spinner,
+aggregated from its children) are this Group construction's direct
+consumers — the reason both were deferred to Phase B in the first place.
+
+Default stays fully EXPANDED (owner ruling, #4691) — B1 wires the fold keys
+(flowview 0.21.1's own vim z-prefix, no reyn-side binding needed) but never
+calls ``.collapse()`` itself, so this file also pins that a freshly built
+Group is never auto-folded.
+
+All use a real, mounted :class:`TextualChatApp`, real
+:class:`~reyn.runtime.outbox.OutboxMessage` / EventFrame, and a real
+:class:`~reyn.schemas.models.Event` — no mocks, per the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import EntryState, FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+def _parent_row(call_id: str, *, text: str = "") -> OutboxMessage:
+    """The tool-turn-text row (#4691 ③'s own placeholder) — a real call
+    boundary, carrying the SAME call_id/finish_reason shape router_loop.py
+    stamps (#4691 Phase 1 ①②)."""
+    return OutboxMessage(
+        kind="agent",
+        text=text,
+        meta={
+            "chain_id": "chain-test",
+            "source": "router_tool_turn_text",
+            "call_id": call_id,
+            "finish_reason": "tool_calls",
+            "prompt_tokens": 100,
+            "completion_tokens": 5,
+        },
+    )
+
+
+def _started(op_id: str, call_id: "str | None", tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_started",
+        text=tool,
+        meta={"tool": tool, "op_id": op_id, "args": {}, "call_id": call_id},
+    )
+
+
+def _completed(op_id: str, call_id: "str | None", tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_completed",
+        text="",
+        meta={
+            "tool": tool, "op_id": op_id, "call_id": call_id,
+            "result": {"op": tool, "count": 3},
+        },
+    )
+
+
+def _failed(op_id: str, call_id: "str | None", tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_failed",
+        text=tool,
+        meta={
+            "tool": tool, "op_id": op_id, "call_id": call_id,
+            "error_kind": "Boom", "error_message": "it broke",
+        },
+    )
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time from a
+    queue — display OR event frames — so a test can push frames one at a
+    time and inspect the tree between each (same shape as #72's own
+    ``QueueTransport``, kept local to this file since neither test module
+    exports its collaborator)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_display(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
+
+    async def push_event(self, event_type: str) -> None:
+        await self._queue.put(EventFrame(Event(type=event_type)))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _entries(app: TextualChatApp):
+    return app.query_one(FlowView).entries
+
+
+@pytest.mark.asyncio
+async def test_tool_rows_nest_under_the_matching_call_id_parent() -> None:
+    """Tier 2b: a tool_call_started/completed pair carrying the SAME call_id
+    as an already-landed parent row nests as that parent's CHILD (Entry.parent
+    is the parent row, Entry.children holds it) — not a second top-level row."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        # FlowView.entries is the full document-order traversal (each
+        # parent immediately followed by its subtree, per flowview's own
+        # CHANGELOG) — 2 entries here means "1 parent + its 1 child", not
+        # "2 unrelated top-level rows". depth/parent below is what actually
+        # proves the nesting.
+        # Unpacking (not a bare len() check) pins "exactly 1 parent + 1
+        # nested child" the same way a count would, but reads as a
+        # structural shape check.
+        parent, child = _entries(app)
+        assert parent.item.meta.get("call_id") == "resp-1"
+        assert parent.depth == 0
+        assert child.item.kind == "tool_call_started"
+        assert child.depth == 1
+        assert child.parent is parent
+        assert parent.children == (child,)
+
+
+@pytest.mark.asyncio
+async def test_a_row_with_no_call_id_still_lands_flat() -> None:
+    """Tier 2b: regression guard — a tool row carrying NO call_id (a legacy/
+    restored frame, or an op-loop caller that never threaded one through)
+    lands top-level exactly as it did before B1, never mis-nested under an
+    unrelated parent."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id=None))
+        await pilot.pause()
+
+        # Unpacking pins "exactly 2 unrelated top-level rows" — the
+        # structural shape a bare count would only approximate.
+        first_row, second_row = _entries(app)
+        assert second_row.item.kind == "tool_call_started"
+        assert second_row.parent is None
+
+
+@pytest.mark.asyncio
+async def test_a_tool_row_with_an_unregistered_call_id_lands_flat() -> None:
+    """Tier 2b: a call_id that matches NO registered parent (the parent row
+    hasn't arrived yet, or never will) falls through to the flat top-level
+    append — never raises, never silently drops the row."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-never-registered"))
+        await pilot.pause()
+
+        top_level = _entries(app)
+        (only,) = top_level
+        assert only.item.kind == "tool_call_started"
+        assert only.parent is None
+
+
+@pytest.mark.asyncio
+async def test_parent_starts_running_and_settles_success_once_children_complete() -> None:
+    """Tier 2b: #4691 Phase B ④ — the parent goes RUNNING the instant it
+    lands (children about to arrive), stays RUNNING while any child is
+    still in flight, and settles to SUCCESS only once every child has."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        parent = _entries(app)[0]
+        assert parent.state is EntryState.RUNNING
+
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await transport.push_display(_started("op-2", call_id="resp-1"))
+        await pilot.pause()
+        assert parent.state is EntryState.RUNNING, (
+            "still RUNNING — both children are still in flight"
+        )
+
+        await transport.push_display(_completed("op-1", call_id="resp-1"))
+        await pilot.pause()
+        assert parent.state is EntryState.RUNNING, (
+            "still RUNNING — one child (op-2) has not settled yet"
+        )
+
+        await transport.push_display(_completed("op-2", call_id="resp-1"))
+        await pilot.pause()
+        assert parent.state is EntryState.SUCCESS, (
+            "every child settled clean — the parent must settle too"
+        )
+
+
+@pytest.mark.asyncio
+async def test_one_failed_child_taints_the_parent_to_error() -> None:
+    """Tier 2b: #4691 Phase B ④ — a single failed child taints the WHOLE
+    parent to ERROR, even when its sibling succeeded — a reader scanning
+    collapsed parent rows must see the failure without expanding."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        parent = _entries(app)[0]
+
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await transport.push_display(_started("op-2", call_id="resp-1"))
+        await pilot.pause()
+        await transport.push_display(_completed("op-1", call_id="resp-1"))
+        await pilot.pause()
+        await transport.push_display(_failed("op-2", call_id="resp-1"))
+        await pilot.pause()
+
+        assert parent.state is EntryState.ERROR
+
+
+@pytest.mark.asyncio
+async def test_an_orphaned_call_parent_settles_cancelled_not_stuck_running() -> None:
+    """Tier 2b: #4691 Phase B ④ — a parent whose children never arrived at
+    all (every tool_call excluded pre-dispatch, or the turn cancelled before
+    any started frame reached the TUI) must not spin RUNNING forever once
+    the turn ends — same CANCELLED verdict #72 gives an orphaned tool
+    itself, applied here at parent granularity."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        parent = _entries(app)[0]
+        assert parent.state is EntryState.RUNNING
+
+        await transport.push_event("turn_settled")
+        await pilot.pause()
+
+        assert parent.state is EntryState.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_without_the_recompute_the_parent_would_stay_running() -> None:
+    """Tier 2b: non-vacuity witness for ④ — with the SAME child settling but
+    the recompute call itself skipped, the parent stays RUNNING; this test
+    proves it by checking the app's own real code path rather than
+    asserting a tautology, mirroring #72's own paired witness shape."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        parent = _entries(app)[0]
+
+        # Directly settle the child WITHOUT going through the real
+        # coalesce path (which calls _recompute_parent_state) — a child
+        # created and settled entirely OUTSIDE app's own machinery.
+        child = parent.append_child(_started("op-1", call_id="resp-1"))
+        child.set_state(EntryState.SUCCESS)
+        await pilot.pause()
+
+        assert parent.state is EntryState.RUNNING, (
+            "the parent recomputes only when app's own settle path runs it "
+            "— an externally-mutated child must not retroactively affect it"
+        )
+
+
+@pytest.mark.asyncio
+async def test_default_stays_fully_expanded() -> None:
+    """Tier 2b: owner ruling (#4691) — B1 wires the fold keys but the
+    DEFAULT is unchanged: neither the parent nor its children are ever
+    auto-collapsed by construction."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        parent = _entries(app)[0]
+        assert parent.collapsed is False
+        (child,) = parent.children
+        assert child.collapsed is False

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -286,11 +286,22 @@ async def test_an_orphaned_call_parent_settles_cancelled_not_stuck_running() -> 
 
 
 @pytest.mark.asyncio
-async def test_without_the_recompute_the_parent_would_stay_running() -> None:
-    """Tier 2b: non-vacuity witness for ④ — with the SAME child settling but
-    the recompute call itself skipped, the parent stays RUNNING; this test
-    proves it by checking the app's own real code path rather than
-    asserting a tautology, mirroring #72's own paired witness shape."""
+async def test_the_parent_has_no_reactive_watcher_on_its_children() -> None:
+    """Tier 2b: #4748 review (lead-coder) — this is NOT ④'s non-vacuity
+    witness (that is the neighboring
+    ``test_parent_starts_running_and_settles_success_once_children_complete``,
+    which genuinely fails if ``_recompute_parent_state`` is removed — this
+    test does not, since it never calls the real settle path at all, so its
+    own earlier docstring calling it one was wrong).
+
+    What this DOES pin: ``_recompute_parent_state`` is called explicitly
+    from app's own settle paths (``_coalesce_tool_result``, the #72 orphan
+    sweep) — the parent is NOT a reactive/observed property that
+    re-evaluates itself whenever ANY child's state changes by whatever
+    means. A child mutated entirely outside app's own machinery (as this
+    test does, directly on the Entry) leaves the parent exactly as it was
+    — no polling, no watcher, no hidden recomputation trigger other than
+    the two call sites #4691 Phase B ④ actually wired."""
     transport = QueueTransport()
     app = TextualChatApp(transport=transport, clock=lambda: 100.0)
     async with app.run_test(size=(100, 30)) as pilot:
@@ -307,8 +318,9 @@ async def test_without_the_recompute_the_parent_would_stay_running() -> None:
         await pilot.pause()
 
         assert parent.state is EntryState.RUNNING, (
-            "the parent recomputes only when app's own settle path runs it "
-            "— an externally-mutated child must not retroactively affect it"
+            "the parent must not have re-evaluated itself — recompute only "
+            "runs from the two explicit call sites, never as a side effect "
+            "of a child's state changing by any other means"
         )
 
 

--- a/tests/llm/test_router_empty_response.py
+++ b/tests/llm/test_router_empty_response.py
@@ -538,7 +538,14 @@ async def test_empty_response_after_a_tool_call_this_turn_is_not_the_glitch_fail
         f"expected no empty-response detection/retry event after a tool "
         f"call this turn, got: {empty_events}"
     )
-    assert not host.outbox, f"expected no failure message in outbox, got: {host.outbox}"
+    # #4691 Phase B ③: the tool-calls round's own tree-parent placeholder
+    # row is now expected in the outbox (content-less here, since
+    # tool_result([...]) carries no text) — narrow to the one kind this
+    # test is actually about: no router_empty_response FAILURE marker.
+    failure_msgs = [
+        m for m in host.outbox if m["meta"].get("source") == "router_empty_response"
+    ]
+    assert not failure_msgs, f"expected no failure message in outbox, got: {failure_msgs}"
     assert scripted.call_count == 2, (
         "expected exactly the tool-call round + the empty round — a third "
         "call would mean the (now-exempted) retry path still fired"
@@ -582,7 +589,14 @@ async def test_empty_response_after_a_tool_call_stays_exempt_even_with_retry_aut
     assert not empty_events, (
         f"expected no empty-response detection/retry event, got: {empty_events}"
     )
-    assert not host.outbox, f"expected no failure message in outbox, got: {host.outbox}"
+    # #4691 Phase B ③: the tool-calls round's own tree-parent placeholder
+    # row is now expected in the outbox (content-less here, since
+    # tool_result([...]) carries no text) — narrow to the one kind this
+    # test is actually about: no router_empty_response FAILURE marker.
+    failure_msgs = [
+        m for m in host.outbox if m["meta"].get("source") == "router_empty_response"
+    ]
+    assert not failure_msgs, f"expected no failure message in outbox, got: {failure_msgs}"
     assert scripted.call_count == 2, (
         "the exemption must win before the retry check runs — a retry "
         "would make this 3, not 2"

--- a/tests/llm/test_router_loop_tool_turn_text_1642.py
+++ b/tests/llm/test_router_loop_tool_turn_text_1642.py
@@ -99,9 +99,20 @@ async def test_no_tool_calls_turn_emits_content_once(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_tool_turn_empty_content_skipped(monkeypatch):
-    """Tier 3a: a tool-turn with empty/whitespace content emits NO agent bubble on the
-    tool-turn (no empty-bubble noise) — only the terminal text appears."""
+async def test_tool_turn_empty_content_still_emits_a_placeholder_row(monkeypatch):
+    """Tier 3a: #4691 Phase B ③ — a tool-turn with empty/whitespace content
+    STILL emits its ``agent`` bubble (reversing #1642's original "no empty-
+    bubble noise" behavior, this test's own prior name and premise).
+
+    #1642 skipped this row because it had no consumer — displaying an empty
+    bubble was pure noise. #4691 Phase B gave it one: this row IS the tree-
+    parent placeholder every tool-calls round needs so its tool rows have
+    something to nest under (owner ruling, #4691) — every intermediate
+    round needs a parent, including a content-less one, or the Group
+    structure has a gap exactly where a weak model calls tools with no
+    explanatory text. The row is still marked with the fix's own
+    ``source="router_tool_turn_text"`` and carries its call_id/finish_reason
+    (#4691 Phase 1 ①②) same as a non-empty round."""
     host = FakeRouterHost()
     host._files["notes.txt"] = "file body"
     loop = make_loop(host)
@@ -113,5 +124,12 @@ async def test_tool_turn_empty_content_skipped(monkeypatch):
     await loop.run("go", [])
 
     agent = [m for m in host.outbox if m["kind"] == "agent"]
-    assert not any(m["meta"].get("source") == "router_tool_turn_text" for m in agent)
-    assert [m["text"] for m in agent] == ["done"]  # only the terminal text
+    placeholder = next(
+        (m for m in agent if m["meta"].get("source") == "router_tool_turn_text"), None,
+    )
+    assert placeholder is not None, (
+        "the tool-turn round must still emit its own row — #4691 Phase B's "
+        "Group parent, even with empty text"
+    )
+    assert placeholder["text"] == "   "  # verbatim — never neutralized/invented
+    assert [m["text"] for m in agent] == ["   ", "done"]

--- a/tests/llm/test_safety_max_iterations_fp0005.py
+++ b/tests/llm/test_safety_max_iterations_fp0005.py
@@ -147,9 +147,11 @@ async def test_max_iterations_interactive_yes_extends_loop() -> None:
     # Bus was asked exactly once (first exhaustion)
     (ask,) = bus.asks  # unpack-assertion: exactly 1 ask
     assert "max_iterations" in ask.kind
-    # Loop continued: agent reply emitted (not an error)
+    # Loop continued: agent reply emitted (not an error). #4691 Phase B ③:
+    # each exhausted/extra tool-calls round also emits its own (content-less)
+    # tree-parent placeholder now — the terminal reply is still LAST.
     agent_msgs = [m for m in host.outbox if m["kind"] == "agent"]
-    (agent_msg,) = agent_msgs
+    agent_msg = agent_msgs[-1]
     assert agent_msg["text"] == "done after extension"
 
 
@@ -255,9 +257,11 @@ async def test_max_iterations_limit_deny_fires_force_close_wrap_up() -> None:
         _univ_enabled=False,
     )
 
-    # Agent message emitted (wrap-up text), not canned error
+    # Agent message emitted (wrap-up text), not canned error. #4691 Phase B
+    # ③: the exhausted tool-calls round's own (content-less) tree-parent
+    # placeholder lands first now — the wrap-up text is still LAST.
     agent_msgs = [m for m in host.outbox if m["kind"] == "agent"]
-    (msg,) = agent_msgs  # unpack: exactly one
+    msg = agent_msgs[-1]
     assert msg["text"] == "work done: X; remaining: Y; stopped by limit"
     assert msg["meta"].get("limit_stopped") is True
     assert msg["meta"].get("limit_kind") == "max_iterations"
@@ -304,9 +308,10 @@ async def test_record_force_close_called_when_wrap_up_has_content() -> None:
     # record_force_close called exactly once with the wrap-up result
     (fc_result,) = host.recorded_fc
     assert getattr(fc_result, "content", None) == "step done; remaining: cleanup"
-    # agent message emitted
+    # agent message emitted — #4691 Phase B ③: the exhausted round's own
+    # placeholder lands first now, the wrap-up text is still LAST.
     agent_msgs = [m for m in host.outbox if m["kind"] == "agent"]
-    (msg,) = agent_msgs
+    msg = agent_msgs[-1]
     assert msg["meta"].get("limit_stopped") is True
 
 

--- a/tests/runtime/test_router_loop.py
+++ b/tests/runtime/test_router_loop.py
@@ -61,8 +61,10 @@ async def test_max_iterations_exhausted(monkeypatch):
     await loop.run("do stuff", [])
 
     assert scripted.call_count == 3
-    (msg,) = host.outbox
-    assert msg["kind"] == "error"
+    # #4691 Phase B ③: each of the 3 tool-calls rounds also emits its own
+    # (content-less, since always_tool has no text) tree-parent placeholder
+    # row now — filter to the one kind this test is actually about.
+    (msg,) = [m for m in host.outbox if m["kind"] == "error"]
     assert "max iterations" in msg["text"]
     assert "3" in msg["text"]
 
@@ -94,7 +96,9 @@ async def test_unknown_tool_returns_error_in_result(monkeypatch):
     # #2425 案B: a dispatch error renders the plain ``Error (<kind>): <message>`` string, not JSON.
     assert tool_msg["content"].startswith("Error (unknown_tool): ")
     assert "bogus" in tool_msg["content"]
-    assert host.outbox[0]["text"] == "Recovered."
+    # #4691 Phase B ③: round 1's own (content-less) tree-parent placeholder
+    # row lands first now — the terminal reply is still the LAST row.
+    assert host.outbox[-1]["text"] == "Recovered."
 
 
 @pytest.mark.asyncio
@@ -136,7 +140,9 @@ async def test_remember_shared_writes_file_and_regenerates_index(monkeypatch):
     (regen,) = host.index_regenerations
     assert regen["output_path"] == host.memory.memory_path("shared", "MEMORY")
 
-    assert host.outbox[0]["text"] == "Saved."
+    # #4691 Phase B ③: the tool-calls round's own tree-parent placeholder
+    # row lands first now — the terminal reply is still the LAST row.
+    assert host.outbox[-1]["text"] == "Saved."
 
 
 @pytest.mark.asyncio
@@ -371,7 +377,9 @@ async def test_forget_memory_deletes_file_and_regenerates_index(monkeypatch):
 
     assert existing_path in host.file_deletes
     (only_regen,) = host.index_regenerations
-    assert host.outbox[0]["text"] == "Forgotten."
+    # #4691 Phase B ③: the tool-calls round's own tree-parent placeholder
+    # row lands first now — the terminal reply is still the LAST row.
+    assert host.outbox[-1]["text"] == "Forgotten."
 
 
 @pytest.mark.asyncio
@@ -458,8 +466,10 @@ async def test_unknown_tool_name_returns_error_not_dispatched(monkeypatch):
     assert tool_msg["content"].startswith("Error (unknown_tool): ")
     assert "no_such_tool_xyz" in tool_msg["content"]
 
-    # Loop recovered and produced a reply
-    assert host.outbox[0]["text"] == "Sorry, let me try differently."
+    # Loop recovered and produced a reply — #4691 Phase B ③: the tool-calls
+    # round's own tree-parent placeholder row lands first now — the
+    # terminal reply is still the LAST row.
+    assert host.outbox[-1]["text"] == "Sorry, let me try differently."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** — #4691 Phase B, slice B1 (Group construction + ③ + ④)

## Keys wired, default NOT changed

After this merges, pressing `za` on a tool-calls row in the conversation pane folds it; `zo`/`zc`/`zR`/`zM` work the same way — all for free from flowview 0.21.1's own vim z-prefix handling (`_view.py`'s `on_key`), no reyn-side key binding needed. **If you do nothing, the conversation looks exactly as it did before this PR** — same rows, same order, same text, same left column. **Correction (architect finding, post-merge): the sentence that used to stand here claimed the child rows are visually indented one level — that was WRONG, verified empirically post-merge (see the PR comment).** `entry.depth` is structural DATA the Group now carries; reyn's own presenter never reads it for drawing (grep confirms zero relevant hits in `textual_chat/`), and flowview's own grammar is explicit — "FlowView never indents, never draws chevrons or tree guides." Owner ruling ① (#4691: turn/completion group views must NOT indent — parent/child is a data structure, not something the user needs to see) and flowview's own ② are both intact; B1 never violated either. What actually changes with nothing pressed: nothing, at the pixel level — `za` becomes available, that's all.

## What

Item ① (#4722/#4725/#4734) put `call_id` on every audit event, outbox meta, and tool event — the key B1's Group construction needs. ③④ were deferred to Phase B specifically because they had no consumer until this tree existed; this PR is that consumer landing.

- **③ (`router_loop.py`)**: the tool-turn-text row (#1642) used to skip emission when `result.content` was empty/whitespace. That gate is gone — the row is unconditional now, since it's the tree PARENT every tool-calls round needs (including a content-less one).
- **Group construction (`app.py`)**: `self._call_parents: dict[str, Entry]` maps a `call_id` to its registered parent Entry. A frame carrying a matching `meta["call_id"]` nests as `parent.append_child(...)`; a frame with no call_id, or one matching no registered parent, falls through to the same flat append every row used before B1. **Keyed, not order-based** (owner ruling B, #4691, via #4734's own review) — the `_pending_call_parent`-style "most recently seen" pointer design was rejected earlier in this arc for exactly the failure mode a dict lookup structurally cannot have.
- **④ (`app.py`)**: a parent goes RUNNING the instant it registers. `_recompute_parent_state(child)` — called from every child settle path, including the #72 orphan sweep — aggregates: RUNNING wins while any child still is; ERROR wins over SUCCESS among terminal states; CANCELLED counts as neither. A parent whose children never arrive at all is swept the same way at the turn boundary.

## Falsification

Both mechanisms disabled independently (temporarily): with Group nesting off, the nesting test fails on `child.depth == 1` (got 0); with the ④ recompute call removed, the settle test fails on the parent staying RUNNING after every child completed. Both restored, both pass.

## Tests

- `test_4691_phase_b_group_construction.py` — 8 new tests (real mounted `TextualChatApp`, no mocks): nesting by call_id, no-call_id/unregistered-call_id regression guards, parent RUNNING→SUCCESS across partial completion, one failed child taints the parent to ERROR, an orphaned parent settles CANCELLED not stuck RUNNING, a non-vacuity witness for ④, and the default-expanded guard.
- `test_router_loop_tool_turn_text_1642.py`'s `test_tool_turn_empty_content_skipped` rewritten (not deleted — its subject still matters, the owner-ruled answer flipped) to `test_tool_turn_empty_content_still_emits_a_placeholder_row`.
- 5 pre-existing tests (`test_router_loop.py` / `test_router_empty_response.py` / `test_safety_max_iterations_fp0005.py`) updated — each indexed `host.outbox[0]` or unpacked `(msg,) = agent_msgs` assuming no placeholder row could precede the terminal reply; now `outbox[-1]` / a narrowed filter. Each fix is a one-line indexing correction to a test whose own subject is unaffected by ③.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py src/reyn/runtime/router_loop.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — clean
- [x] `python scripts/test_tier_audit.py --strict <6 changed/new test files>` — 58/58 OK, 0 Tier-4
- [x] Regression sweep: `tests/interfaces/` + `tests/llm/` + `tests/runtime/` — 4369 passed, 0 failed, 5 skipped (pre-existing optional-extra skips). Two full-sweep-only flakes observed and ruled out as pre-existing/unrelated (reproduced on baseline `main` too, different test each run, neither touches outbox/router_loop mechanics).
- [ ] (waived, Visual axis only — standing 2026-08-08 owner waiver) not visually confirmed in this session; operator confirms on `main`. This is where the owner's own judgment on B2's remaining decisions (fold default/threshold, highlight-on-group-vs-entry, folded-row minimal-form) gets its first real material — B1's whole point per lead-coder is making those observable rather than argued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## レビュア追記（lead-coder, TESTS-READ 済）

- [x] 🔴 `test_without_the_recompute_the_parent_would_stay_running` は**非空虚性の witness になっていません** — docstring は「proves it by checking the app's own **real code path**」と書いていますが、本文は自分で「**WITHOUT going through the real coalesce path** … **entirely OUTSIDE app's own machinery**」と書いており、**`_recompute_parent_state` を丸ごと削除しても緑のまま**です（何も呼んでいないので親が RUNNING なのは当然）。本当の witness は隣の `..._settles_success_once_children_complete`（real path、recompute を消せば落ちる）。**A: 名前と docstring を実際に pin しているもの（外部変更が親に遡及しない＝reactive watcher を持たない）に直す**か、B: 本物の falsify にする。**A 推奨**（B は隣が担っており重複）


対応コミット: `03b1199f0` fix(#4748): stop calling the non-watcher test a non-vacuity witness（案A採用、`test_the_parent_has_no_reactive_watcher_on_its_children`にリネーム、詳細はPRコメント参照）



