### PR TITLE
fix(#4691): a collapsed Group parent must show its child count

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -835,6 +835,21 @@ class ReynPresenter:
             decoded_image_cache=self._decoded_image_cache,
             now=self._clock(),
         )
+        # #4691 Phase B B1 (dogfood follow-up, lead-coder review): a
+        # collapsed Group parent must show its child COUNT — "count is
+        # information, not design" (lead-coder's own framing). Without
+        # this, folding a content-less tool-turn-text row (#4691 ③) left
+        # a bare state glyph with NOTHING indicating anything was even
+        # hidden — worse than not being able to fold at all, since the
+        # owner has no way to tell "nothing here" from "3 rows folded
+        # away". Deliberately minimal per the same review's scope: a
+        # bare count, no summary wording, no icon vocabulary beyond the
+        # existing dim style every other secondary line already uses —
+        # the SHAPE of the summary (#4691 issue §5's own "▸ read_file,
+        # grep ×2" example) is B2's call, not this fix's.
+        if entry.collapsed and entry.children:
+            count_line = Text(f"  ({len(entry.children)} folded)", style=_CC_DIM)
+            body = Group(body, count_line)
         return Presentation(
             height=self._measure(body, width),
             renderable=body,

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -134,6 +134,13 @@ def _entries(app: TextualChatApp):
     return app.query_one(FlowView).entries
 
 
+def _painted(flow: FlowView) -> str:
+    return "\n".join(
+        "".join(seg.text for seg in flow.render_line(y))
+        for y in range(flow.size.height)
+    )
+
+
 @pytest.mark.asyncio
 async def test_tool_rows_nest_under_the_matching_call_id_parent() -> None:
     """Tier 2b: a tool_call_started/completed pair carrying the SAME call_id
@@ -342,3 +349,60 @@ async def test_default_stays_fully_expanded() -> None:
         assert parent.collapsed is False
         (child,) = parent.children
         assert child.collapsed is False
+
+
+@pytest.mark.asyncio
+async def test_a_collapsed_parent_shows_its_child_count() -> None:
+    """Tier 2b: dogfood finding (#4691, post-#4748 merge) — a collapsed
+    Group parent must show its child COUNT, or folding hides both the
+    children AND any sign that anything was hidden at all (worse than not
+    being able to fold — a reader cannot tell "nothing here" from "3 rows
+    folded away"). Deliberately minimal: pins that the count is present
+    and correct, not any particular wording/symbol (design is #4691 Phase
+    B B2's own call, per lead-coder's explicit review scope)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await transport.push_display(_started("op-2", call_id="resp-1"))
+        await pilot.pause()
+
+        parent = _entries(app)[0]
+        flow = app.query_one(FlowView)
+
+        parent.collapse()
+        await pilot.pause()
+        collapsed_text = _painted(flow)
+        assert "2" in collapsed_text, (
+            f"a collapsed parent with 2 children must show the count "
+            f"somewhere on its own row, got: {collapsed_text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_expanded_parent_shows_no_count_line() -> None:
+    """Tier 2b: accept-side pair — the count line is collapsed-only; an
+    ordinary EXPANDED parent (today's default, and B1's own "zero visual
+    regression" promise) renders exactly as it did before this fix."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1", text="checking"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        parent = _entries(app)[0]
+        assert parent.collapsed is False
+        pres = await app._presenter.present(parent, 80)
+        from rich.console import Console
+
+        console = Console(width=80)
+        with console.capture() as cap:
+            console.print(pres.renderable)
+        text = cap.get()
+        assert "folded" not in text and "1" not in text


### PR DESCRIPTION
**[tui-coder]** — #4691 Phase B B1 follow-up: a collapsed Group parent must show its child count

## What

Dogfood finding (real TUI, ~30 seconds in, right after #4748 merged): folding a tool-calls parent row left it as a bare state glyph (`●` + gutter figures) with nothing indicating anything was hidden — worse than not being able to fold at all, since a reader can't tell "nothing here" from "3 rows folded away".

Root cause: B1's own condition for landing was "the parent's text + the child **count**" as the minimal folded form, with only the wording/symbols/summary shape deferred to B2 (owner's own visual judgment). `presenter.py` was never touched to read `entry.collapsed`/`entry.children` at all — the count itself, not just the design around it, was missed.

**Scope, per review: count only.** No summary wording, no icon vocabulary beyond the dim style every other secondary line already uses. The shape of a real summary (the #4691 issue's own "▸ read_file, grep ×2" example) stays B2's call.

## Changes

`presenter.py`: `present()` appends a dim `" (N folded)"` line when `entry.collapsed and entry.children` — after the ordinary body is built, so every existing kind/branch is untouched when NOT collapsed (B1's own "zero visual regression" promise for the default-expanded state holds).

## Falsification

Reverting the change alone — `test_a_collapsed_parent_shows_its_child_count` fails (collapsed row renders with no digit anywhere). Restored, passes.

## Visually verified on the real TUI (condition from #4748's review — same gap not seen twice)

Drove a real tool-calls turn, folded the parent row via `za`, confirmed the rendered row:
```
●   (2 folded)                                                      ↑1.8k ↓102
```

## Tests

- `test_a_collapsed_parent_shows_its_child_count` — the positive case, real fold via `Entry.collapse()`.
- `test_an_expanded_parent_shows_no_count_line` — accept-side pair: the count line is collapsed-only, expanded stays exactly as B1 left it.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/presenter.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4691_phase_b_group_construction.py` — 10/10 OK
- [x] Regression sweep: `tests/interfaces/` — 1817 passed, 0 failed, 4 skipped
- [x] **Visual: confirmed on the real TUI, not waived** — see above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
