### PR TITLE
docs(#4691): verification-hazards §23 — a stated limitation does not travel

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1198,6 +1198,72 @@ every time: state the real precondition explicitly in the test (call the
 real chokepoint, or reset the relevant global in an autouse fixture)
 instead of relying on some other file having already done it first.
 
+## 23. A stated limitation does not travel — the structure gets copied, the caveat does not
+
+Every hazard above is about reading a result. This one is about *writing*
+one, and it is the only member of that class here so far: the shape you
+choose for a finding decides which of its parts survive being passed on.
+
+Two mechanisms, which showed up the same night and compound each other.
+
+**The change-verb asserts the state before the change.** "It disappears on
+expand," "the count is lost," "that used to hold" — each names two states
+and claims to have observed both. Reviewing #4750 against a settled spec
+item (a tool-execution count on a completion group's parent row), a
+reviewer with no TTY wrote the finding as a contrast: *collapsed shows the
+count, expanding loses it; the spec says it should stay.* The conclusion —
+"do not count this spec item as satisfied" — was right. The route was
+false. A session with a real terminal then looked: **there is no tool count
+on that parent row in either state.** The collapsed row's `(2 folded)` is a
+fold affordance whose number coincides with the tool count only because the
+children happen to be tool rows. The reviewer had disclosed the inference
+("collapsed and expanded look alike is derived from item ②, not observed —
+no TTY"), and the disclosure was true and did nothing, because *"loses it"*
+had already asserted the collapsed state as observed fact (#4691 ⑤ / #4750,
+2026-08-14).
+
+**A qualifier does not survive transcription; a table does.** The lead
+copied that contrast into the tracking issue and framed the open decision
+as "on expand, keep the count or drop it" — a question whose premise was
+false, since nothing was there to keep. The scope note stayed behind as the
+word "inference," attached to nothing the question depended on. The same
+night, the same asymmetry with a number instead of a table: a criterion for
+"does this event kind have a documentation row" was declared up front
+(a token in a markdown table row outside the flat enum block; *prose-only
+mentions do not count*), producing "130 of 221 have no row" — and only the
+130 was carried into every later report. The criterion was itself wrong —
+`events.md` says in its own text that "the per-kind sections below document
+the payloads **in prose**" — so what got dropped in transit was precisely
+the part that was falsifiable, leaving a number that looked like a
+measurement and could not be argued with (#4738, 2026-08-14).
+
+Note which direction the loss runs. It is not that qualified claims get
+weakened in transit — it is that the *load-bearing, checkable* half is the
+half that gets dropped, because tables, counts, and contrasts are the parts
+worth copying. §14 is the neighbouring hazard (a completion *declaration*
+propagating into a second person's model without its referent ever being
+checked); this one is not about a declaration of completion but about which
+*parts* of any finding are structurally copyable.
+
+### The detection technique
+
+- **Before writing "A does X, B does Y", confirm you observed both A and
+  B.** If one is derived, do not write a contrast — write the observed side
+  and list the other as unobserved, with what it was derived from. The
+  contrast form is not a stylistic choice; it is an existence claim about
+  both sides.
+- **Treat change-verbs — disappears, is lost, stays, reverts, regresses —
+  as assertions about the prior state.** If you did not observe the prior
+  state, no change-verb is available to you.
+- **Put the limit inside the structure, not after it.** A row reading
+  `expanded | not observed (inferred from ②)` travels; a closing paragraph
+  saying "some of the above is inferred" does not. Same rule for a count:
+  if the criterion can change the number, the criterion belongs in the same
+  sentence as the number, every time it is repeated.
+- **When a session with the real instrument exists, ask before you infer.**
+  The TTY-holding session was mid-dogfood and answered in minutes; the
+  false route existed only because nobody spent one message.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.


### PR DESCRIPTION
**[architect]** — `verification-hazards.md` に §23 を追加します。**CLAUDE.md は触っていません**（この doc への pointer は #4743 で既に射程を直済み）。

part of #4691

## なぜ新節か — 前回（#4743）と逆の結論なので理由を書きます

**先に既存の被覆を確認しました**（14 語で grep）:

```
caveat / disclos / footnote / hedge / scope note / transcrib /
survives the copy / quoted onward ── 全て 0 件
qualif(1) copied(1) propagat(1) contrast(1) comparison(2) ── 全て別文脈
   832=flowview local-copy の警告文 / 580=fake host の手写し /
   541=§14 / 917-928=色のコントラスト比
```

**最近接は §14**「A declaration of completion is not a witness of completion」で、逐語 `the claim's own referent … was never checked before it propagated into a second person's mental model` は**この危険の半分そのもの**です。

**それでも足さない理由**: §14 の主語は **completion の宣言**。足すには題名から "completion" を外す必要があり、**§14 をぼかします**。#4743 で追記を選んだのは、#4215 bullet が**主語ごと同一**（「実行して確かめた、が ref を記録しない」）で追記が既存を薄めなかったからです。**今回は同一ではなく上位概念**なので、逆の判断になりました。

**もう 1 つ**: この doc は現在**ほぼ全て読み手側**（結果をどう読むか）です。§23 は**書き手側**——finding をどの形で書くと、どの部分が転記に耐えるか——で、**同類の member が存在しません**。新節はその不在も可視化します。

## 中身

**2 つの機構**（同じ晩に別々に発火し、互いを増幅した）:

1. **変化の動詞は変化前の状態を主張する。** `#4691 ⑤ / #4750`: TTY を持たない私が「畳むと件数が出る／展開すると消える／裁定では残るはず」と**対比**で書きました。結論（⑤ を残件から落とすな）は正しく、**経路が偽**。実測（tui-coder、実 TTY）は「**どちらの状態にも tool 実行数は無い**」——`(2 folded)` は fold の手がかりで、子がたまたま tool 行だから数が一致して見えるだけ。**私は推論であることを申告しており、申告は真で、かつ無力でした**——「消える」が既に「畳んだ状態には在る」を観測事実として主張していたからです。

2. **注記は転記に耐えない。構造は耐える。** 上の表は #4691 にそのまま転記され、B2 の問いが「**展開時に残すか消すか**」と立ちました——**前提が偽なので問い自体が偽**。同じ晩、数字版が `#4738`: 「表の行のみ／prose 不算入」という判定基準を**先に宣言**した上で「221 中 130 が該当行なし」が出ましたが、以後の報告では**130 だけ**が運ばれました。**基準自体が誤り**で（`events.md` 自身が逐語 `the per-kind sections below document the payloads in prose` と述べている）、**落ちた側に誤りが入っていた** ∴ 数字だけを見る人には誤りが見えません。

**損失の向きが要点**です: 限定つきの主張が伝言で弱まるのではなく、**荷重のかかる・反証可能な半分の方が落ちます**——表・数・対比が「写す価値のある部分」だからです。

**検出法 4 つ**（節末）: ①対比を書く前に両辺を観測したか ②変化の動詞は変化前の主張と見なす ③限界は構造の中に置く（`expanded | not observed (inferred from ②)` は転記され、末尾の「一部は推論」は落ちる）④実機を持つ session が居るなら推論の前に頼む。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — Documentation built in 5.87 seconds
- [x] `python scripts/check_doc_anchors.py` — `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] `src/` `tests/` 無変更 ∴ tier audit / ratchet 系は対象外
- [x] **引用は自分で開いて確かめました** — `events.md:32` の `document the payloads in prose` は lead-coder から逐語で受け取った後、私が `docs/reference/runtime/events.md` を開いて一致を確認。**この PR の §23 自身が「転記で落ちる」を扱っている以上、転記を検証せずに書くのは自己矛盾**なので。
- [x] 被覆確認の範囲を明記: grep 対象は `verification-hazards.md` 1 ファイル、14 語、HEAD `8fac806c7`。**他の doc に同種の記述があるかは見ていません。**
