### PR TITLE
fix(#4753): a failed exec's summary must show its returncode + stderr, not bare "error"

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -654,6 +654,23 @@ def _summarize_result(tool, result) -> str:
             return f"exit {returncode}"
         if isinstance(returncode, int) and status in ("cancelled", "timeout"):
             return f"✗ {status} (exit {returncode})"
+        # #4753: an ordinary nonzero exit (sandboxed_exec.py's `status = "ok" if
+        # returncode == 0 else ("timeout" if returncode == -1 else "error")`) fell
+        # through every branch above to the bare `str(status)` = "error", discarding
+        # returncode AND stderr — both present right here in `result`. This function
+        # is DISPLAY-ONLY (all 3 call sites are under `interfaces/`; the LLM's own
+        # `role: "tool"` content comes from `render_tool_result` via
+        # `sandboxed_exec_to_canonical`, which already carries stdout/stderr and the
+        # returncode). So what was lost was the OPERATOR's signal, not the model's:
+        # a human saw a bare "error" and had to expand the row to learn why.
+        # `stderr` is truncated via the SAME `_short(..., 78)` boundary the
+        # `error`/`error_message` branches above already use (don't mint a new
+        # constant when one for the same purpose — a one-line error summary —
+        # already exists in this file).
+        if isinstance(returncode, int) and status == "error":
+            stderr = result.get("stderr")
+            detail = _short(stderr, 78) if isinstance(stderr, str) and stderr else ""
+            return f"✗ exit {returncode}" + (f": {detail}" if detail else "")
         freed_tokens = result.get("freed_tokens")
         if isinstance(freed_tokens, int):
             return f"Freed {freed_tokens} token{'s' if freed_tokens != 1 else ''}"

--- a/tests/interfaces/test_inline_tool_result_summary.py
+++ b/tests/interfaces/test_inline_tool_result_summary.py
@@ -648,3 +648,52 @@ def test_sandboxed_exec_timeout_shows_failure_text() -> None:
         {"kind": "sandboxed_exec", "status": "timeout",
          "backend": "local", "returncode": -1, "stdout": "partial", "stderr": ""},
     ) == "✗ timeout (exit -1)"
+
+
+def test_sandboxed_exec_error_shows_returncode_and_stderr() -> None:
+    """Tier 2: #4753 — an ORDINARY nonzero exit (sandboxed_exec.py's own
+    ``status = "ok" if returncode == 0 else ("timeout" if returncode == -1
+    else "error")``, e.g. the command itself failed — not a sandbox
+    timeout/cancel) previously fell through every branch to the bare
+    fallback string ``"error"``, discarding ``returncode`` AND ``stderr``
+    even though both are present in the result dict. Display-only surface
+    (REPL renderer + inline TUI presenter): what a bare 'error' cost was
+    the OPERATOR's ability to see why the command failed. RED without the
+    fix: the summary is the bare 'error'."""
+    assert summarize_tool_result(
+        "exec",
+        {"kind": "sandboxed_exec", "status": "error", "backend": "landlock",
+         "returncode": 1, "stdout": "", "stderr": "printf: brace-expansion not supported",
+         "truncated": False, "denial_class": None, "argv0_resolved": "/usr/bin/printf"},
+    ) == "✗ exit 1: printf: brace-expansion not supported"
+
+
+def test_sandboxed_exec_error_with_no_stderr_still_shows_returncode() -> None:
+    """Tier 2: (accept-side) a nonzero exit with empty/absent stderr still
+    surfaces the returncode alone — never a bare 'error' with NO signal at
+    all, even in the degraded case where the failing process wrote
+    nothing to stderr."""
+    assert summarize_tool_result(
+        "exec",
+        {"kind": "sandboxed_exec", "status": "error", "backend": "local",
+         "returncode": 2, "stdout": "", "stderr": ""},
+    ) == "✗ exit 2"
+
+
+def test_sandboxed_exec_error_truncates_long_stderr() -> None:
+    """Tier 2: (accept-side) long stderr is truncated, not dumped verbatim
+    into the one-line summary — via the SAME ``_short(...)`` boundary the
+    ``error``/``error_message`` branches in this function already use for
+    a one-line error summary, not a freshly-minted constant (owner
+    instruction: reuse an existing truncation boundary for the same
+    purpose before adding a new one)."""
+    long_stderr = "x" * 200
+    summary = summarize_tool_result(
+        "exec",
+        {"kind": "sandboxed_exec", "status": "error", "backend": "local",
+         "returncode": 1, "stdout": "", "stderr": long_stderr},
+    )
+    assert summary.startswith("✗ exit 1: ")
+    detail = summary[len("✗ exit 1: "):]
+    assert len(detail) < len(long_stderr), "long stderr must be truncated, not dumped verbatim"
+    assert detail.endswith("…")


### PR DESCRIPTION
**[e2e-coder]** — `renderer.py:652-655`'s exec summary branches only cover `status in ("ok", "cancelled", "timeout")`. `sandboxed_exec.py`'s own status resolution — `status = "ok" if returncode == 0 else ("timeout" if returncode == -1 else "error")` — means an ordinary nonzero exit (the command itself failed, not a sandbox timeout/cancel) produces `status == "error"`, which fell through every branch to the bottom-of-function bare `str(status)` fallback, discarding `returncode` AND `stderr` even though both are present in the same result dict.

## 🔴 Correction to the original framing (traced after the fact, per lead-coder's catch)

The original claim — "this summary string round-trips back to the LLM, so a failing model gets zero signal to self-correct" — is **wrong**, confirmed by tracing the real `role: "tool"` content path: `router_loop.py`'s tool-turn builds `content_str` via `render_tool_result(frontmatter, text)` (`core/offload/seam.py:191`, own docstring: "Assemble the LLM-visible `role: tool` content"), where `text`/`meta` come from the canonical mapper — for exec, `sandboxed_exec_to_canonical` (`core/offload/canonical.py:498`), which ALREADY puts `stdout`+`stderr` into `text` and a nonzero `returncode` into `meta`. **The model already receives the real returncode + stderr.** `summarize_tool_result` (this function) has exactly 3 call sites, all under `interfaces/` (display-only — its own docstring: "Human one-line summary of a tool result") and never reaches the LLM's path.

## Why this is still worth fixing

Purely a display-side gap: a human operator watching the TUI/REPL sees a bare `"error"` with no detail, even though the model already got the real reason. Real, worth fixing — just not the agent-self-correction-loop severity the original framing claimed.

## Boundary decided before implementing (lead-coder's own required condition)

`returncode` is always included (a single int, cheap). `stderr` is truncated via the SAME `_short(..., 78)` boundary this function's own `error`/`error_message` branches already use for a one-line error summary — found the existing boundary instead of minting a new constant (owner's standing instruction: no new constant without checking for an existing one serving the same purpose first).

## Tests

3 new: the exact issue repro (returncode + stderr both present), the degraded case (no stderr — returncode alone, never a bare `"error"`), and long-stderr truncation (behavior-level — "shorter than original, ends with an ellipsis" — not a pinned length; `test_tier_audit.py --strict` caught the first draft's `len(detail) == 78` pin as a Tier 4 format-pinning violation and it was corrected).

## Strip-falsify

Removing the new branch flips all 3 new tests RED for the right reason (all assert on the fixed summary text, none reference the implementation's own expression), restored GREEN.

## Gates

- `ruff check .`, `python scripts/mypy_ratchet.py`, `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py`, `python scripts/test_tier_audit.py --strict tests/interfaces/test_inline_tool_result_summary.py` — all green.
- `pytest tests/interfaces -k "renderer or presenter or tool_result or textual_chat"` — 342 passed, 0 failed.

part of #4753

Test plan:
- [x] `ruff check .` green
- [x] `python scripts/mypy_ratchet.py` green
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` green
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_inline_tool_result_summary.py` green (0 Tier 4 violations, after fixing one)
- [x] `pytest tests/interfaces -k "renderer or presenter or tool_result or textual_chat"` — 342 passed / 0 failed
- [x] Strip-falsify confirmed RED for the right reason on all 3 new tests, restored GREEN
- [ ] (skipped — visual gate; live TUI verification is owner's own face per the standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**[lead-coder]** — レビューでの blocking 項（本体は https://github.com/tya5/reyn/pull/4754 のコメント）:

- [x] 🔴 `renderer.py` の追加コメント（+13〜+16）と test docstring（+45〜+47）が、この PR 自身が否定した機構の主張（「LLM に届く」「モデルが自己修正できない」）をなお述べている。表示専用である事実に置換する。 — fixed in e863ca614 (verbatim replacement text lead-coder supplied), force-pushed.

