### PR TITLE
docs(#4697): fix 4 sibling comments/docstrings still describing the pre-Space-toggle expand mechanism

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/_meta_keys.py
+++ b/src/reyn/interfaces/inline/textual_chat/_meta_keys.py
@@ -28,10 +28,10 @@ RESULT_KIND_KEY = "_result_kind"
 #: frame's ``meta`` (carries ``result`` / ``error_message`` / ``error_kind``).
 RESULT_META_KEY = "_result"
 
-#: Present (and truthy) on a settled tool frame while the addressed-row
-#: highlight is ON it — the app stamps it in ``Highlighted`` and clears it when
-#: the highlight leaves, and the presenter renders the FULL result instead of
-#: the one-line summary while it is set (#3508).
+#: Present (and truthy) on a settled tool frame while its row is expanded —
+#: the app stamps/clears it on Space (:meth:`_CursorFlowView.action_toggle_fold`,
+#: #4697/#4691§6), and the presenter renders the FULL result instead of the
+#: one-line summary while it is set (#3508).
 #:
 #: It lives on the ITEM rather than in the view because ``FlowPresenter.present``
 #: is contractually pure with respect to ``(item, width)``: "expanded" has to be

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2407,9 +2407,12 @@ class TextualChatApp(App):
     def _set_expanded(self, entry: "Entry[OutboxMessage] | None", expanded: bool) -> None:
         """Stamp/clear the expansion flag on ``entry``'s ITEM and re-present it.
 
-        #3508 — a settled tool row shows its FULL result while the highlight is
-        on it, and its one-line summary otherwise. Two properties make this safe
-        rather than a hack:
+        #3508 — a settled tool row shows its FULL result when expanded, and its
+        one-line summary otherwise. #4697 (owner ruling #4691§6) decoupled this
+        from the highlight: Space (:meth:`_CursorFlowView.action_toggle_fold`)
+        is the trigger now, not highlight arrival — see
+        :meth:`on_flow_view_highlighted`. Two properties make this safe rather
+        than a hack:
 
         * the flag lives on the item, not in this app, because
           ``FlowPresenter.present`` is pure with respect to ``(item, width)`` —

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -293,11 +293,12 @@ def _tool_result_line(msg: "OutboxMessage") -> "tuple[Text, str | None]":
     summary = summarize_tool_result(meta.get("tool"), result_meta.get("result"))
     failed = summary.startswith("✗")
     if meta.get(_EXPANDED_KEY) and not failed:
-        # #3508: the highlight is on this row — show the result the summary
+        # #3508: the row is expanded (Space toggles this, #4697/#4691§6 —
+        # decoupled from highlight movement) — show the result the summary
         # dropped. The summary line is KEPT as the first line so the row reads
         # the same whether or not it is expanded; the detail is added under it
-        # rather than replacing it, which is what makes moving the highlight
-        # through a log feel like the rows are unfolding rather than swapping.
+        # rather than replacing it, which is what makes toggling a row feel
+        # like it's unfolding rather than swapping.
         lines = _result_detail_lines(msg)
         # Only unfold when the summary is actually WITHHOLDING something. For a
         # short scalar result ``summarize_tool_result`` falls back to the value
@@ -339,11 +340,11 @@ def _collapsed_retrieval_line(msg: "OutboxMessage") -> "Text | None":
     row reads identically whichever shape it takes, just spread over one
     line instead of two.
 
-    The full result is not lost: #3508's existing highlight-expand
-    mechanism (:func:`_tool_result_line`) still fires when the row's
-    highlight arrives, exactly as it does for a side-effect tool's row —
-    this function only changes the COLLAPSED, unhighlighted default,
-    never removes the expand path.
+    The full result is not lost: #3508's existing expand mechanism
+    (:func:`_tool_result_line`, Space-toggled per #4697/#4691§6) still
+    fires when the row is expanded, exactly as it does for a side-effect
+    tool's row — this function only changes the COLLAPSED, non-expanded
+    default, never removes the expand path.
 
     Failure is excluded on purpose, mirroring #3329's gutter demotion:
     a failed retrieval call still needs the operator's attention


### PR DESCRIPTION
**[tui-coder]** — #4697's own doc-drift, 4 sibling comments/docstrings missed in that PR

## What

#4697 (`72a1ee06f`, "Space toggles tool-detail fold, decoupled from highlight move", owner ruling #4691§6) correctly rewrote `app.py`'s `on_flow_view_highlighted` docstring to describe the new Space-toggle behavior. It never touched `presenter.py` or `_meta_keys.py` (confirmed: `git show 72a1ee06f --stat`), and left `app.py`'s own `_set_expanded` docstring unfixed too — 4 places describing the OLD highlight-coupled mechanism in the present tense, in a PR whose whole point was decoupling it:

- `app.py:2410` (`_set_expanded`): "a settled tool row shows its FULL result **while the highlight is on it**" — no longer true.
- `presenter.py:296`: "**the highlight is on this row** — show the result..."
- `presenter.py:342`: "**highlight-expand mechanism**... fires **when the row's highlight arrives**"
- `_meta_keys.py:31-34` (`EXPANDED_KEY`'s own flag definition — caught by lead-coder's review after the first 3): "the app stamps it in ``Highlighted`` and clears it when the highlight leaves" — the flag's own docstring, the definition site, still described the replaced mechanism.

Found via dogfood: tried to reproduce the documented highlight-auto-expand on a real `exec` row (a big multi-line result), it didn't fire, traced it to #4697's own intentional change — the doc was still describing the mechanism it replaced. CLAUDE.md's own rule: "re-read the whole section the change touches, not just the line whose keyword you already had in mind."

`app.py:382` ("fold/unfold the highlighted" row) is intentionally left unchanged — correct as written, Space acts on whichever row currently holds the highlight; that phrasing was never about highlight-*driven* expansion.

## Changes

Comment-only, no behavior change — all 4 sites now describe the actual current trigger (Space, `_CursorFlowView.action_toggle_fold`, cross-referenced to `on_flow_view_highlighted`).

## Tests

None added — no behavior changed, nothing to falsify.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py src/reyn/interfaces/inline/textual_chat/presenter.py src/reyn/interfaces/inline/textual_chat/_meta_keys.py` — clean
- [x] Regression sweep: `tests/interfaces/` — 1817 passed, 0 failed, 4 skipped
- [x] Visual: N/A — comment-only

part of #4691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
