### PR TITLE
fix(#4756): a multi-line string field in a dict tool-result must expand to real lines

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -243,6 +243,73 @@ def _tool_head(msg: "OutboxMessage") -> Text:
 _EXPANDED_MAX_LINES = 40
 
 
+def _dict_detail_lines(result: dict) -> "list[str]":
+    """#4756: ``json.dumps(result, indent=2)``'s ``indent`` only inserts real
+    newlines BETWEEN a dict's structural elements (keys/values) — never
+    inside a string VALUE's own content, so a multi-line string field
+    (``exec``'s ``stdout``, ``read_file``'s ``content``, ...) collapses to
+    one JSON-escaped line of literal ``\\n`` text, defeating the whole
+    point of expanding the row: the field a reader opened it to actually
+    read becomes unreadable. Scoped to the TOP-LEVEL fields of a dict
+    result (every #4756 repro — ``sandboxed_exec``, ``read_file`` — is
+    this shape; a value nested a level deeper falls back to plain
+    ``json.dumps`` for that sub-structure, unchanged from before this fix,
+    since no repro exercises that depth).
+
+    A top-level string field containing ``\\n`` gets its OWN real lines
+    (opening ``"key": "``, its raw content lines verbatim, a closing
+    ``"``), matching a human's mental model of "the file/output's actual
+    lines" rather than JSON's escaped single-line encoding. Every other
+    field keeps the ordinary compact ``"key": value,`` JSON rendering.
+
+    lead-coder review, #4757: ``json.dumps`` incidentally neutralized
+    terminal-control bytes in the value it was replacing (it escapes
+    ``\\x1b`` etc. to ``\\u001b``) — an accidental side effect, not a
+    designed defense, but a real one this fix silently removed by
+    ``splitlines()``-ing the raw value verbatim. ``exec``'s ``stdout`` /
+    ``read_file``'s ``content`` are arbitrary bytes from the world, not
+    operator-typed ``reyn.yaml`` text — the SAME rule
+    :func:`_neutralized_label` (this module) already states for exactly
+    this reason (FP-0054): "text is not from the operator... must go
+    through here". The multi-line value is neutralized via the SAME
+    ``get_neutralizer("terminal")`` seam BEFORE splitting — its own
+    control-char regex explicitly excludes tab/newline/carriage-return,
+    so splitting on the neutralized value's real newlines is unaffected."""
+    if not result:
+        return ["{}"]
+    from reyn.core.present.guard import get_neutralizer
+    _terminal = get_neutralizer("terminal")
+    lines: "list[str]" = ["{"]
+    items = list(result.items())
+    for i, (key, value) in enumerate(items):
+        comma = "," if i < len(items) - 1 else ""
+        try:
+            key_json = json.dumps(str(key), ensure_ascii=False)
+        except Exception:
+            key_json = f'"{key}"'
+        if isinstance(value, str) and "\n" in value:
+            clean_value, _ = _terminal.neutralize(value)
+            lines.append(f"  {key_json}: \"")
+            lines.extend(clean_value.splitlines())
+            lines.append(f"\"{comma}")
+        else:
+            try:
+                value_json = json.dumps(value, ensure_ascii=False, indent=2)
+            except Exception:
+                value_json = json.dumps(str(value), ensure_ascii=False)
+            # Re-indent a multi-line nested structure (list/dict) by 2 spaces
+            # so it still reads as nested under this key, not flush-left.
+            value_lines = value_json.splitlines()
+            if len(value_lines) == 1:
+                lines.append(f"  {key_json}: {value_lines[0]}{comma}")
+            else:
+                lines.append(f"  {key_json}: {value_lines[0]}")
+                lines.extend(f"  {line}" for line in value_lines[1:-1])
+                lines.append(f"  {value_lines[-1]}{comma}")
+    lines.append("}")
+    return lines
+
+
 def _result_detail_lines(msg: "OutboxMessage") -> "list[str]":
     """The FULL tool result as display lines — what the one-line summary drops.
 
@@ -251,17 +318,31 @@ def _result_detail_lines(msg: "OutboxMessage") -> "list[str]":
     expansion is a different RENDERING of data the row already carries, not a
     re-fetch. A dict/list is pretty-printed rather than ``repr``'d so a JSON-ish
     result reads as structure; anything unprintable degrades to ``str`` rather
-    than raising, because a presenter that raises takes the whole row down."""
+    than raising, because a presenter that raises takes the whole row down.
+
+    #4756: a dict result routes through :func:`_dict_detail_lines` instead of
+    a flat ``json.dumps`` — see that function's own docstring for why. A bare
+    STRING result is neutralized here too (lead-coder review, #4757 follow-up
+    sweep: this branch never went through ``json.dumps`` at all, so it was
+    open to the SAME unneutralized-control-byte gap independently of, and
+    predating, this PR's own dict fix — same function, same seam, closed in
+    the same PR rather than left open one branch over)."""
+    from reyn.core.present.guard import get_neutralizer
     result = ((msg.meta or {}).get(_RESULT_META_KEY) or {}).get("result")
     if result is None or result == "":
         return []
     if isinstance(result, str):
-        text = result
-    else:
+        text = get_neutralizer("terminal").neutralize(result)[0]
+        return text.splitlines() or [text]
+    if isinstance(result, dict):
         try:
-            text = json.dumps(result, ensure_ascii=False, indent=2)
+            return _dict_detail_lines(result)
         except Exception:
-            text = str(result)
+            pass  # fall through to the generic json.dumps below
+    try:
+        text = json.dumps(result, ensure_ascii=False, indent=2)
+    except Exception:
+        text = str(result)
     return text.splitlines() or [text]
 
 

--- a/tests/interfaces/test_4756_dict_detail_lines.py
+++ b/tests/interfaces/test_4756_dict_detail_lines.py
@@ -1,0 +1,151 @@
+"""Tier 1/2: #4756 — ``_dict_detail_lines``'s own pure-function behavior.
+
+Direct, fast unit coverage of the function ``_result_detail_lines`` (the
+tool-detail-fold expander, #3508) delegates to for a dict result — the full
+app-driven integration coverage (real multi-line unfold + the
+``_EXPANDED_MAX_LINES`` cap engaging) lives in
+``test_tool_detail_on_highlight_3508.py``, alongside this fix's sibling
+mechanisms; this file is the cheaper, more exhaustive complement.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.presenter import _dict_detail_lines
+
+
+def test_multiline_field_splits_onto_real_lines() -> None:
+    """Tier 1: contract — the exact #4756 issue repro (``sandboxed_exec``'s
+    ``stdout``). Real newlines, not one JSON-escaped line."""
+    result = {
+        "kind": "sandboxed_exec", "status": "ok", "backend": "landlock",
+        "returncode": 0, "stdout": "line 1\nline 2\nline 3\n", "stderr": "",
+        "truncated": False, "denial_class": None, "argv0_resolved": "/bin/bash",
+    }
+    lines = _dict_detail_lines(result)
+    assert "line 1" in lines
+    assert "line 2" in lines
+    assert "line 3" in lines
+    assert not any("\\n" in line for line in lines), (
+        "a real newline must not survive as a literal backslash-n in any line"
+    )
+
+
+def test_second_repro_read_file_content_field() -> None:
+    """Tier 1: the issue's second confirmed shape (``read_file``'s
+    ``content``) — same fix, same code path, independently exercised."""
+    result = {
+        "op": "read", "path": "foo.py", "status": "ok",
+        "content": "def a():\n    pass\n\ndef b():\n    pass\n",
+    }
+    lines = _dict_detail_lines(result)
+    assert "def a():" in lines
+    assert "    pass" in lines
+    assert "def b():" in lines
+
+
+def test_non_string_fields_stay_compact_json() -> None:
+    """Tier 1: accept-side — a field that is NOT a multi-line string (int,
+    bool, None, a short string) keeps the ordinary compact ``"key": value``
+    JSON rendering, unaffected by the multi-line special case."""
+    result = {"returncode": 1, "truncated": False, "denial_class": None, "path": "a.py"}
+    lines = _dict_detail_lines(result)
+    joined = "\n".join(lines)
+    assert '"returncode": 1' in joined
+    assert '"truncated": false' in joined
+    assert '"denial_class": null' in joined
+    assert '"path": "a.py"' in joined
+
+
+def test_single_line_string_field_stays_on_one_line() -> None:
+    """Tier 1: accept-side — a string field with NO newline is not
+    special-cased into the multi-line block form; it stays a normal
+    one-line JSON string value."""
+    result = {"path": "a.py", "status": "ok"}
+    lines = _dict_detail_lines(result)
+    assert '  "path": "a.py",' in lines
+
+
+def test_empty_dict_renders_empty_braces() -> None:
+    """Tier 1: accept-side — an empty dict result renders as ``{}``, not an
+    empty line list (which would collapse to nothing on screen)."""
+    assert _dict_detail_lines({}) == ["{}"]
+
+
+def test_multiline_field_is_neutralized_before_splitting() -> None:
+    """Tier 1: THE mandatory security witness (lead-coder review, #4757) —
+    ``json.dumps`` (what this function replaces) incidentally neutralized
+    terminal-control bytes in the value (it escapes ``\\x1b`` etc. to
+    ``\\u001b``, an accidental side effect, not a designed defense, but a
+    real one). ``exec``'s ``stdout`` / ``read_file``'s ``content`` are
+    ARBITRARY BYTES FROM THE WORLD, not operator-typed ``reyn.yaml`` text
+    — the same FP-0054 rule ``_neutralized_label`` (this module) already
+    states. A multi-line field must be neutralized via the SAME
+    ``get_neutralizer("terminal")`` seam BEFORE splitting, so an ESC/CSI/
+    OSC control sequence embedded in real-world exec output or file
+    content cannot reach the terminal raw."""
+    malicious = "before\x1b[2Jinjected\nafter"
+    lines = _dict_detail_lines({"stdout": malicious})
+    joined = "\n".join(lines)
+    assert "\x1b" not in joined, "an ESC byte reached the rendered lines unneutralized"
+    assert "before" in joined
+    assert "injected" in joined
+    assert "after" in joined
+
+
+def test_multiline_field_neutralize_preserves_real_newlines() -> None:
+    """Tier 1: accept-side of the same witness — the terminal neutralizer
+    explicitly preserves tab/newline/carriage-return (its own control-char
+    regex excludes them), so neutralizing BEFORE splitting must not
+    collapse the real line breaks the whole #4756 fix exists to
+    preserve."""
+    result = {"stdout": "line one\nline two\nline three"}
+    lines = _dict_detail_lines(result)
+    assert "line one" in lines
+    assert "line two" in lines
+    assert "line three" in lines
+
+
+def test_result_detail_lines_delegates_to_dict_detail_lines_for_dicts() -> None:
+    """Tier 2: THE wiring witness — ``_result_detail_lines`` (what the
+    presenter's expand path actually calls) routes a dict result through
+    ``_dict_detail_lines``, not the old flat ``json.dumps``. RED without
+    the wiring: a multi-line field would collapse to one escaped line."""
+    from reyn.interfaces.inline.textual_chat._meta_keys import RESULT_META_KEY
+    from reyn.interfaces.inline.textual_chat.presenter import _result_detail_lines
+    from reyn.runtime.outbox import OutboxMessage
+
+    msg = OutboxMessage(
+        kind="tool_call_started", text="exec",
+        meta={RESULT_META_KEY: {"result": {
+            "kind": "sandboxed_exec", "status": "ok", "returncode": 0,
+            "stdout": "alpha\nbeta\ngamma", "stderr": "",
+        }}},
+    )
+    lines = _result_detail_lines(msg)
+    assert "alpha" in lines
+    assert "beta" in lines
+    assert "gamma" in lines
+    assert not any("\\n" in line for line in lines)
+
+
+def test_bare_string_result_is_also_neutralized() -> None:
+    """Tier 1: THE mandatory security witness's sibling leg (lead-coder's
+    own follow-up sweep, #4757) — a BARE STRING result (the
+    ``isinstance(result, str)`` branch) never went through ``json.dumps``
+    at all, so it was open to the SAME unneutralized-control-byte gap
+    independently of, and predating, #4756's own dict fix — same
+    function, same seam. Closed in the same PR rather than left open one
+    branch over."""
+    from reyn.interfaces.inline.textual_chat._meta_keys import RESULT_META_KEY
+    from reyn.interfaces.inline.textual_chat.presenter import _result_detail_lines
+    from reyn.runtime.outbox import OutboxMessage
+
+    msg = OutboxMessage(
+        kind="tool_call_started", text="some_tool",
+        meta={RESULT_META_KEY: {"result": "before\x1b[2Jinjected\nafter"}},
+    )
+    lines = _result_detail_lines(msg)
+    joined = "\n".join(lines)
+    assert "\x1b" not in joined, "an ESC byte reached the rendered lines unneutralized"
+    assert "before" in joined
+    assert "injected" in joined
+    assert "after" in joined

--- a/tests/interfaces/test_tool_detail_on_highlight_3508.py
+++ b/tests/interfaces/test_tool_detail_on_highlight_3508.py
@@ -298,6 +298,71 @@ async def test_a_huge_result_is_capped_and_says_so() -> None:
 
 
 @pytest.mark.asyncio
+async def test_multiline_field_in_a_dict_result_expands_to_real_lines() -> None:
+    """Tier 2b: #4756 — a dict result whose FIELD is itself a multi-line
+    string (``exec``'s ``stdout``, ``read_file``'s ``content``) unfolds to
+    its REAL lines, not one JSON-escaped line of literal ``\\n`` text. The
+    pre-#4756 bug: ``json.dumps(result, indent=2)`` only inserts real
+    newlines between dict structural elements, never inside a string
+    VALUE's own escaped content — the whole point of expanding a row (see
+    the content a reader opened it for) was defeated for exactly this
+    shape."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.conversation.append(_settled_tool(
+            {"kind": "sandboxed_exec", "status": "ok", "returncode": 0,
+             "stdout": "line one\nline two\nline three", "stderr": "",
+             "truncated": False, "denial_class": None},
+            tool="exec",
+        ))
+        await pilot.pause()
+        flow = await _focus(pilot, app)
+        await _toggle_fold(pilot, flow)
+
+        painted = _painted(flow)
+        assert "line one" in painted and "line two" in painted and "line three" in painted, (
+            f"the multi-line stdout field did not unfold to real lines; pane shows:\n{painted}"
+        )
+        assert "\\n" not in painted, (
+            "the multi-line field rendered as one JSON-escaped line "
+            f"(literal backslash-n) instead of real lines; pane shows:\n{painted}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_big_multiline_field_makes_the_cap_engage() -> None:
+    """Tier 2b: #4756's own required permanent condition — the fix must
+    make ``_EXPANDED_MAX_LINES`` actually ENGAGE for a dict result whose
+    size lives inside one multi-line field, not just for a top-level list
+    (the pre-existing ``test_a_huge_result_is_capped_and_says_so`` case).
+    Before #4756, a big ``content``/``stdout`` field collapsed to ONE
+    structural JSON line, so the line-count cap never saw the real size —
+    the cap that exists specifically to stop a huge result shoving the
+    conversation off-screen did not engage for this shape at all."""
+    from reyn.interfaces.inline.textual_chat.presenter import _EXPANDED_MAX_LINES
+
+    big_content = "\n".join(f"line {i}" for i in range(_EXPANDED_MAX_LINES + 25))
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 60)) as pilot:
+        await pilot.pause()
+        app.conversation.append(_settled_tool(
+            {"op": "read", "path": "big.py", "status": "ok", "content": big_content},
+        ))
+        await pilot.pause()
+        flow = await _focus(pilot, app)
+        await _toggle_fold(pilot, flow)
+
+        painted = _painted(flow)
+        assert "more lines" in painted, (
+            f"the cap did not engage for a big multi-line dict field; pane shows:\n{painted}"
+        )
+        assert f"line {_EXPANDED_MAX_LINES + 24}" not in painted, (
+            "the cap did not hold — the whole multi-line field was rendered"
+        )
+
+
+@pytest.mark.asyncio
 async def test_a_failed_tool_row_keeps_its_failure_line() -> None:
     """Tier 2b: a FAILURE row is not expanded. Its body is already the error
     message rather than a summary hiding a result, and it carries the failure


### PR DESCRIPTION
**[e2e-coder]** — `_result_detail_lines` (`presenter.py:242-266`) did `json.dumps(result, indent=2)` whenever `result` isn't itself a bare string. `indent=2` only inserts real newlines BETWEEN a dict's structural elements (keys/values) — never inside a string VALUE's own content, so a multi-line string field (`exec`'s `stdout`, `read_file`'s `content`) collapsed to one JSON-escaped line of literal `\n` text — defeating the entire point of expanding a settled tool-call row (#3508, Space to open): the content a reader opened the row to actually see became unreadable.

## Scope

Not exec-specific: any tool whose result is a dict with a big multi-line text field hits this identically — confirmed live for `exec`, confirmed via isolated repro (same code path) for `read_file`.

## Fix

A dict result now routes through a new `_dict_detail_lines` helper instead of a flat `json.dumps`. A top-level string field containing `\n` gets its OWN real lines (opening `"key": "`, its raw content lines verbatim, a closing `"`); every other field keeps the ordinary compact `"key": value,` JSON rendering. Scoped to the TOP-LEVEL fields of a dict result — every repro is this shape; a value nested a level deeper still falls back to plain `json.dumps` for that sub-structure, unchanged from before this fix.

## 🔴 Security fix (lead-coder review, added to this PR)

`json.dumps` (what this PR replaces) incidentally neutralized terminal-control bytes in the value it was escaping — an accidental side effect, not a designed defense, but a real one the first draft of this fix silently removed by `splitlines()`-ing the raw multi-line value verbatim. `exec`'s `stdout` / `read_file`'s `content` are arbitrary bytes from the world, not operator-typed `reyn.yaml` text — the SAME FP-0054 rule `_neutralized_label` (this module) already states. The multi-line value is now neutralized via the SAME `get_neutralizer("terminal")` seam BEFORE splitting (its own control-char regex explicitly excludes tab/newline/carriage-return, so real newlines survive).

**Follow-up sweep (lead-coder's own):** the bare-string-result branch of `_result_detail_lines` never went through `json.dumps` at all, so it was open to the SAME gap independently of, and predating, this PR's dict fix — same function, same seam. Closed in this PR too, with its own strip-falsify witness.

## Permanent condition (lead-coder's own required scope)

`_EXPANDED_MAX_LINES=40` previously never engaged for this shape — counting `text.splitlines()` saw only ~1 structural JSON line for a 10,000-line file's `content` field, so the cap that exists specifically to stop a huge result shoving the conversation off-screen did not fire at all. Verified it now DOES engage (`test_a_big_multiline_field_makes_the_cap_engage`) — fixing the collapse also fixes the cap, since both read the same real line count. **No new constant** — reuses the existing `_EXPANDED_MAX_LINES`.

## Tests + six questions (lead-coder asked these be answered in the PR body)

11 new tests: 9 pure unit tests (`test_4756_dict_detail_lines.py`, direct calls, no TUI) + 2 app-driven integration tests added to the existing #3508 test file (mirrors that file's own established Tier 2b app-driving convention).

1. **Tier** — Tier 2 (unit) / Tier 2b (app-driven, matching the file's own convention). "A multi-line field expands to real lines, and the cap engages" is #4756's own named behavioral promise — not a third party's property, not a past bug's fingerprint.
2. **Transcription?** — No. Every assertion checks for literal expected substrings (`"line one"`, absence of `"\\n"`, `"more lines"`) or a fixed shape (`== ["{}"]`), never the implementation's own expression echoed back.
3. **Who'd miss it?** — A reader who expands a tool-result row expecting to see real output; the exact operator the #4756 dogfood finding names.
4. **Stays green never-run?** — No; `tests/interfaces/` collects normally, no optional extra gates it.
5. **What accumulates?** — Nothing unbounded: fixed-size synthetic strings/dicts in every test, no loop keyed to an external pace.
6. **Declared Tier == true Tier?** — Yes, matches ①'s answer.

## Strip-falsify (4 mechanisms, independently)

- Removing the dict → `_dict_detail_lines` routing flips 3 tests RED (2 wiring witnesses + 1 app-level unfold test).
- Disabling the multi-line-string special case inside `_dict_detail_lines` flips 6 tests RED (every test asserting on real-line content, including the cap-engagement test).
- Removing the dict-branch neutralize call flips exactly 1 test RED (the mandatory security witness).
- Removing the bare-string-branch neutralize call flips exactly 1 test RED (its sibling witness).

All restored GREEN.

## Gates

- `ruff check .`, `python scripts/mypy_ratchet.py`, `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/presenter.py`, `python scripts/test_tier_audit.py --strict tests/interfaces/test_4756_dict_detail_lines.py tests/interfaces/test_tool_detail_on_highlight_3508.py` — all green.
- `pytest tests/interfaces -k "presenter or tool_result or textual_chat or 3508 or neutraliz"` — 287 passed, 0 failed.

part of #4756

Test plan:
- [x] `ruff check .` green
- [x] `python scripts/mypy_ratchet.py` green
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/presenter.py` green
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4756_dict_detail_lines.py tests/interfaces/test_tool_detail_on_highlight_3508.py` green (0 Tier 4 violations)
- [x] `pytest tests/interfaces -k "presenter or tool_result or textual_chat or 3508 or neutraliz"` — 287 passed / 0 failed
- [x] Strip-falsify confirmed RED for the right reason on 4 independent mechanisms, restored GREEN
- [ ] (skipped — visual gate; live TUI verification is owner's own face per the standing waiver; tui-coder available on request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**[lead-coder]** — レビューでの blocking 項:

- [ ] 🔴 `_dict_detail_lines` の multi-line 分岐が ESC/制御文字を生のまま端末へ出す。変更前は `json.dumps` が偶然エスケープしていた（実測: `json.dumps` は ESC を `\\^[` に、`splitlines()` は生のまま残す）。同ファイル `_neutralized_label` (`presenter.py:127`) の `get_neutralizer("terminal")` (FP-0054) を通すこと。単一行 JSON 側は変更不要。
- [ ] 🔴 ESC を含む content の deny 側テストを 1 本（純関数側で十分）
- [ ] 🔴 `test_last_field_has_no_trailing_comma` を削除（表示書式の pin。docstring 自身が「not correctness」と認めており、六問③の答えが「誰も」）

