### PR TITLE
fix(#4758): neutralize summarize_tool_result's own single return boundary

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -538,11 +538,34 @@ def summarize_tool_result(tool, result) -> str:
     Best-effort per tool name / result shape; ALWAYS degrades gracefully — any
     unrecognised shape (or an error reading it) falls back to a truncated repr,
     so it never raises and never loses the result entirely.
-    """
+
+    #4758 (lead-coder design decision, e2e-coder): every branch of
+    :func:`_summarize_result` can fold WORLD-derived bytes into the
+    returned summary — ``stderr``/``content``/``answer`` and friends are
+    arbitrary output from a sandboxed process or a fetched URL, not
+    operator-typed ``reyn.yaml`` text. ``_short``'s own truncation
+    (``" ".join(s.split())``) does NOT strip ESC/control sequences —
+    ``str.split()`` splits on whitespace, and ESC is not whitespace — so
+    a naive per-branch fix would need repeating at every CURRENT branch
+    and remembering at every FUTURE one (the #4754 gap this issue
+    reopened: that PR added exactly one such branch and missed it).
+    Neutralized ONCE here instead, at this function's own SINGLE return
+    boundary — every one of its 7 call sites, across 3 modules
+    (``renderer.py`` itself, ``presenter.py`` x3, ``app.py`` x3; grepped
+    at #4758 review after a stale "3 call sites" claim from #4753/#4754
+    was caught, uncounted, sitting a few lines above this docstring)
+    receives an already-safe string, structurally, not by each call
+    site remembering to ask for one. Same ``get_neutralizer("terminal")``
+    seam FP-0054 already established (``presenter.py``'s own
+    ``_neutralized_label``, applied there to a different leaf — labels,
+    not tool-result summaries — same discipline, different call site)."""
+    from reyn.core.present.guard import get_neutralizer
+
     try:
-        return _summarize_result(tool, result)
+        summary = _summarize_result(tool, result)
     except Exception:
-        return _short(result, 80)
+        summary = _short(result, 80)
+    return get_neutralizer("terminal").neutralize(summary)[0]
 
 
 def _summarize_result(tool, result) -> str:
@@ -658,7 +681,8 @@ def _summarize_result(tool, result) -> str:
         # returncode == 0 else ("timeout" if returncode == -1 else "error")`) fell
         # through every branch above to the bare `str(status)` = "error", discarding
         # returncode AND stderr — both present right here in `result`. This function
-        # is DISPLAY-ONLY (all 3 call sites are under `interfaces/`; the LLM's own
+        # is DISPLAY-ONLY (all 7 call sites, across 3 modules — renderer.py,
+        # presenter.py x3, app.py x3 — are under `interfaces/`; the LLM's own
         # `role: "tool"` content comes from `render_tool_result` via
         # `sandboxed_exec_to_canonical`, which already carries stdout/stderr and the
         # returncode). So what was lost was the OPERATOR's signal, not the model's:

--- a/tests/interfaces/test_inline_tool_result_summary.py
+++ b/tests/interfaces/test_inline_tool_result_summary.py
@@ -697,3 +697,37 @@ def test_sandboxed_exec_error_truncates_long_stderr() -> None:
     detail = summary[len("✗ exit 1: "):]
     assert len(detail) < len(long_stderr), "long stderr must be truncated, not dumped verbatim"
     assert detail.endswith("…")
+
+
+def test_stderr_with_terminal_control_bytes_is_neutralized() -> None:
+    """Tier 2: THE mandatory security witness (#4758, lead-coder review) —
+    ``stderr`` is arbitrary bytes from a sandboxed process (world-derived),
+    not operator-typed ``reyn.yaml`` text. ``_short``'s own truncation
+    (``" ".join(s.split())``) does NOT strip ESC/control sequences —
+    ``str.split()`` splits on whitespace, and ESC is not whitespace — so
+    an ESC/CSI sequence embedded in real-world stderr survived to the
+    terminal through #4754's own new branch (the exact gap #4757 closed
+    for the tool-DETAIL expand path; this is the same class, in the
+    tool-SUMMARY line instead). ``summarize_tool_result``'s own single
+    return boundary is now neutralized via the SAME
+    ``get_neutralizer("terminal")`` FP-0054 seam."""
+    summary = summarize_tool_result(
+        "exec",
+        {"kind": "sandboxed_exec", "status": "error", "backend": "local",
+         "returncode": 1, "stdout": "", "stderr": "boom\x1b[2Jgone"},
+    )
+    assert "\x1b" not in summary, "an ESC byte reached the summary unneutralized"
+    assert "boom" in summary
+    assert "gone" in summary
+
+
+def test_neutralize_preserves_ordinary_text() -> None:
+    """Tier 2: accept-side of the same witness — neutralizing the summary
+    does not corrupt ordinary, control-byte-free content (the common
+    case, every pre-#4758 test in this file)."""
+    summary = summarize_tool_result(
+        "exec",
+        {"kind": "sandboxed_exec", "status": "error", "backend": "local",
+         "returncode": 1, "stdout": "", "stderr": "ordinary error text"},
+    )
+    assert summary == "✗ exit 1: ordinary error text"


### PR DESCRIPTION
**[e2e-coder]** — #4754 added a stderr-carrying branch to `summarize_tool_result`: `detail = _short(stderr, 78); return f"exit {returncode}: {detail}"`. `_short`'s own truncation (`" ".join(s.split())`) does NOT strip ESC/control sequences — `str.split()` splits on whitespace, and ESC is not whitespace — so an ESC/CSI sequence embedded in real-world `stderr` (arbitrary bytes from a sandboxed process, not operator-typed `reyn.yaml` text) reached the terminal unneutralized through both consumers of this function: the plain REPL renderer directly, and the inline TUI's `presenter.py` via the same import (`Text()` does not strip control sequences either — not a markup-injection concern, a separate axis).

This is the same class of hole #4757 just closed for `_result_detail_lines` (the tool-DETAIL expand path) — #4754 (reviewed by lead-coder, six questions passed, comment truthfulness checked) introduced it in the tool-SUMMARY line instead, one hour before #4757 closed the sibling gap; lead-coder's own review missed it at the time.

## Design decision (explicitly left open by lead-coder — three options, mine to pick)

- **A** — inside `_short` itself, applying to every caller uniformly.
- **B** — only at world-derived-value call sites, requiring per-site vigilance as new ones are added.
- **C** — at a display boundary, closer to `_neutralized_label`'s own precedent, but that precedent is label-only.

Chose a variant of **C**, scoped to `summarize_tool_result`'s own **SINGLE return boundary** rather than `_short` (too broad — touches unrelated reyn-internal truncations like tool args) or scattered call sites (too narrow — repeats the exact "forgot at the next branch" failure mode that created this issue). Every current branch of `_summarize_result`, and every future one, is covered structurally by this one wrapping point — not by each branch author remembering to ask for neutralization. Same `get_neutralizer("terminal")` FP-0054 seam `_neutralized_label` already established, applied to a different leaf.

## Scope note (recorded, not silently expanded or silently dropped)

`renderer.py`'s sibling `tool_call_failed` branch (`_short(err, 80)`, a DIFFERENT summary path outside `summarize_tool_result`) carries the same class of risk (`error_message` can also be world-derived) but is **NOT touched by this PR** — the issue scoped this fix to `summarize_tool_result` specifically. Flagging the sibling site as a named remainder here rather than leaving it silently unaddressed or unilaterally expanding this PR's scope.

## Tests

2 new: the mandatory security witness (ESC byte must not survive to the summary) and its accept-side sibling (ordinary control-byte-free text is unaffected).

## Strip-falsify

Removing the neutralize call flips exactly 1 test RED (the mandatory security witness), restored GREEN.

## Gates

- `ruff check .`, `python scripts/mypy_ratchet.py`, `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py`, `python scripts/test_tier_audit.py --strict tests/interfaces/test_inline_tool_result_summary.py` — all green.
- `pytest tests/interfaces -k "renderer or presenter or tool_result or textual_chat"` — 344 passed, 0 failed.

part of #4758

Test plan:
- [x] `ruff check .` green
- [x] `python scripts/mypy_ratchet.py` green
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` green
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_inline_tool_result_summary.py` green (0 Tier 4 violations)
- [x] `pytest tests/interfaces -k "renderer or presenter or tool_result or textual_chat"` — 344 passed / 0 failed
- [x] Strip-falsify confirmed RED for the right reason, restored GREEN
- [ ] (skipped — visual gate; live TUI verification is owner's own face per the standing waiver; tui-coder available on request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[lead-coder]** — レビューでの blocking 項:

- [x] 🔴 本 PR の docstring「every caller (the plain REPL renderer directly, the inline TUI's `presenter.py` ...)」が `app.py` を落としている。実測は 7 箇所 / 3 モジュール（app.py:226,:233,:3758 / presenter.py:293,:366,:481 / renderer.py:898）。 — fixed in 3f4a8b7c5, docstring names all 3 modules + total (7).
- [x] 🔴 `renderer.py:661` の既存コメント「all 3 call sites are under `interfaces/`」の**数が偽**（実測 7）。★lead-coder が #4754 のレビューで逐語案として渡した文言であり、実装者の誤りではない。同じ関数の同じファイルにつき本 PR の範囲。 — fixed in 3f4a8b7c5, corrected to 7 across 3 modules.



- [ ] 🔴 コメント内 `renderer.py:919` の行番号を落とす（同ファイルへの自己参照は 1 行の追加で無言に腐る。`presenter.py x3` / `app.py x3` の形は正しい）
