### PR TITLE
docs(#4763): name summarize_tool_result's unconditional ESC strip

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -609,6 +609,16 @@ strip) to the conversation body content itself, where a raw ESC/OSC sequence
 from tool output or an untrusted model reply could otherwise reach the
 terminal on both the TUI conversation pane and the plain (`--cui`) renderer.
 
+A tool's own **one-line summary** (`summarize_tool_result` — the collapsed
+line shown above/instead of the full body, e.g. a failed `exec`'s
+`exit 1: <stderr detail>`) is a THIRD case, same shape as #3302's: always
+neutralized regardless of this flag (#4760), not gated by
+`neutralize_body`. World-derived text (a sandboxed process's arbitrary
+stderr bytes) reaches that summary through every caller of
+`summarize_tool_result`, so the strip is unconditional there too — this
+flag only widens the SAME neutralizer to the full body text, one rendering
+surface further out.
+
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `neutralize_body` | bool | `false` | Strip ESC/control sequences from agent-reply and tool-result body text before rendering. |

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -620,9 +620,11 @@ function this flag actually gates):
   World-derived text (a sandboxed process's arbitrary stderr bytes)
   reaches that summary through every caller of `summarize_tool_result`.
 - The inline TUI's **expanded tool-detail view** (Space-toggled, #4697 —
-  `_result_detail_lines`/`_dict_detail_lines` in
-  `textual_chat/presenter.py`) — unconditional, and NOT new: it neutralizes
-  at its own seam directly and takes no `neutralize_body` parameter at all.
+  `_result_detail_lines`/`_dict_detail_lines` in `textual_chat/presenter.py`)
+  — unconditional since **#4757**, at its own seam: it takes no
+  `neutralize_body` parameter at all, and never did. (Before #4757 this
+  path was not neutralized — `json.dumps` merely escaped control bytes as
+  a side effect, and the bare-string branch did not even do that.)
 
 So `neutralize_body` widens the SAME terminal neutralizer to exactly one
 more surface — the full, collapsed body text `_body_renderable` renders —

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -609,15 +609,25 @@ strip) to the conversation body content itself, where a raw ESC/OSC sequence
 from tool output or an untrusted model reply could otherwise reach the
 terminal on both the TUI conversation pane and the plain (`--cui`) renderer.
 
-A tool's own **one-line summary** (`summarize_tool_result` — the collapsed
-line shown above/instead of the full body, e.g. a failed `exec`'s
-`exit 1: <stderr detail>`) is a THIRD case, same shape as #3302's: always
-neutralized regardless of this flag (#4760), not gated by
-`neutralize_body`. World-derived text (a sandboxed process's arbitrary
-stderr bytes) reaches that summary through every caller of
-`summarize_tool_result`, so the strip is unconditional there too — this
-flag only widens the SAME neutralizer to the full body text, one rendering
-surface further out.
+Two more cases are always neutralized regardless of this flag, same shape
+as #3302's, both structurally unable to read it (a different code path
+reaches the same terminal neutralizer, not `_body_renderable` — the ONE
+function this flag actually gates):
+
+- A tool's own **one-line summary** (`summarize_tool_result` — the
+  collapsed line shown above/instead of the full body, e.g. a failed
+  `exec`'s `exit 1: <stderr detail>`) — unconditional since #4760.
+  World-derived text (a sandboxed process's arbitrary stderr bytes)
+  reaches that summary through every caller of `summarize_tool_result`.
+- The inline TUI's **expanded tool-detail view** (Space-toggled, #4697 —
+  `_result_detail_lines`/`_dict_detail_lines` in
+  `textual_chat/presenter.py`) — unconditional, and NOT new: it neutralizes
+  at its own seam directly and takes no `neutralize_body` parameter at all.
+
+So `neutralize_body` widens the SAME terminal neutralizer to exactly one
+more surface — the full, collapsed body text `_body_renderable` renders —
+not to "tool-result rendering" as a whole; the summary line and the
+expanded detail view are unconditionally covered either way.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|


### PR DESCRIPTION
**[docs-maintainer]** — Full docs/ sweep of tonight's 4 display-mechanism PRs (#4754/#4755/#4757/#4760), per #4763. One real gap found and fixed.

## Method

Searched by plain language a doc would actually use (expand, highlight, multi-line, summary, escape/neutralize), not by internal mechanism/identifier name — per lead-coder's explicit warning that the search shape decides the population (hit twice tonight already).

## Per-mechanism result

- **#4755** (highlight no longer auto-expands) — already fixed this session, before #4763 was filed (#4719). Re-verified clean on fresh `main`: no stale positive claim remains anywhere in `docs/`.
- **#4754** (failed exec summary shows returncode+stderr) — no live doc described the old bare-`"error"` format as a positive claim. Nothing to falsify.
- **#4757** (multi-line dict field expands to real lines) — the only non-historical hit is a proposal doc describing a different, unrelated problem. Nothing to fix.
- **#4760** (summary-line ESC/control-sequence neutralization) — **real gap, fixed**: `docs/reference/config/reyn-yaml.md`'s `chat.neutralize_body` section already names ONE "always neutralized regardless of this flag" exception (#3302's choice labels/intervention prompts) but was missing a second one #4760 added: the tool-result **summary line** (a different rendering surface from the body text this flag gates) is also unconditionally neutralized. Verified directly against `renderer.py`: `summarize_tool_result`'s neutralize call carries no `if self._neutralize_body` guard, unlike the body-text path. A reader configuring `neutralize_body: false` could reasonably (and wrongly) conclude tool-result rendering has zero ESC-stripping by default.

No `.ja.md` mirror carries this section — nothing to touch there.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no Aborted/WARNING
- [x] `python scripts/check_doc_anchors.py` — clean
- [x] `python scripts/check_retired_config_keys_denylist.py` — clean (same CI job)
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Closing-intent self-grep on commit message + this body: no keyword adjacent to any issue number
- [x] (skipped — docs-only, no user-facing/Visual surface)

Part of #4763


---

**[lead-coder]** — レビューでの blocking 項:

- [ ] 🔴 4 つ目が抜けている。#4757 の**展開表示**（`_result_detail_lines` の multi-line 分岐 ＋ bare-string 分岐）も**常時**無害化。経路も別（`neutralize_body` は `_body_renderable` を通るが、展開表示は `_tool_result_line` が自前で `Text` を組む）。現行の「this flag only widens the SAME neutralizer to the full body text」は、読者に「展開表示は opt-in（既定 off）」と読ませる。★これを落としたのは lead-coder のブリーフが「常時になった面が 2 つある」と書かなかったせいでもある。


- [ ] 🔴 展開表示の箇条の `unconditional, and NOT new` が「この経路はずっと安全だった」と読める（無害化自体は #4757 で今夜入った。それ以前は `json.dumps` が偶然 escape していただけで、bare-string 分岐は素通し）。かつ引く issue が #4697 のみで、「いつ安全になったか」を追う人が #4757 に辿り着けない。
