### PR TITLE
fix(#4759): close every background-task producer through one funnel, reached from registry.shutdown()

### DIFF
--- a/src/reyn/hooks/external_fire.py
+++ b/src/reyn/hooks/external_fire.py
@@ -86,7 +86,18 @@ class _SessionFireBridge:
         if self._queue is None:
             self._queue = asyncio.Queue(maxsize=self._maxsize)
         if self._drain_task is None or self._drain_task.done():
-            self._drain_task = asyncio.create_task(self._drain())
+            # #4759: route through the owning session's task funnel
+            # (tracked_tasks.py) when available, so AgentRegistry.shutdown()
+            # can reach this drain loop without needing to know this bridge
+            # exists — getattr-guarded since ``self._session`` is typed Any
+            # (a test double may not carry the attribute).
+            tracker = getattr(self._session, "_background_tasks", None)
+            if tracker is not None:
+                self._drain_task = tracker.spawn(
+                    self._drain(), disposition="cancel_join", name="external-fire-drain",
+                )
+            else:
+                self._drain_task = asyncio.create_task(self._drain())
         try:
             self._queue.put_nowait((point, template_vars))
         except asyncio.QueueFull:

--- a/src/reyn/hooks/external_fire.py
+++ b/src/reyn/hooks/external_fire.py
@@ -93,10 +93,29 @@ class _SessionFireBridge:
             # (a test double may not carry the attribute).
             tracker = getattr(self._session, "_background_tasks", None)
             if tracker is not None:
+                # appends_wal=False (the default, stated explicitly here):
+                # this drain loop dispatches external-event hooks, it does
+                # not itself append to the WAL -- a mid-rewind quiesce point
+                # must never cancel it (#4759 review: an earlier version of
+                # this axis was lifetime-named ("scope") rather than
+                # invariant-named, and a rewind's quiesce killed OutboxHub's
+                # own drain loop the same way; this bridge is the same
+                # shape).
                 self._drain_task = tracker.spawn(
-                    self._drain(), disposition="cancel_join", name="external-fire-drain",
+                    self._drain(), disposition="cancel_join", appends_wal=False,
+                    name="external-fire-drain",
                 )
             else:
+                # #4765 co-vet (architect): a session-like object without
+                # `_background_tasks` (a test double, typically) falls back
+                # to an untracked task here, same as before this funnel
+                # existed. Warned (not silent) so a caller that SHOULD have
+                # a real Session but doesn't has a signal to find.
+                logger.warning(
+                    "_SessionFireBridge: session has no _background_tasks -- "
+                    "external-event drain task is NOT reachable from "
+                    "AgentRegistry.shutdown()'s drain (see tracked_tasks.py)."
+                )
                 self._drain_task = asyncio.create_task(self._drain())
         try:
             self._queue.put_nowait((point, template_vars))

--- a/src/reyn/runtime/outbox_hub.py
+++ b/src/reyn/runtime/outbox_hub.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from reyn.runtime.outbox import OutboxMessage
+    from reyn.runtime.tracked_tasks import TrackedTaskSet
 
 logger = logging.getLogger(__name__)
 
@@ -90,11 +91,23 @@ class HubSubscription:
 class OutboxHub:
     """Single-drain broadcast hub over one source ``asyncio.Queue``."""
 
-    def __init__(self, source: "asyncio.Queue", *, name: str = "") -> None:
+    def __init__(
+        self, source: "asyncio.Queue", *, name: str = "",
+        task_tracker: "TrackedTaskSet | None" = None,
+    ) -> None:
         self._source = source
         self._subs: "set[HubSubscription]" = set()
         self._drain_task: "asyncio.Task | None" = None
         self._name = name
+        # #4759: register the drain task with the owning Session's task
+        # funnel too (tracked_tasks.py) -- __end__ (put by Session.run()'s
+        # own finally on every exit path) reaches this loop's queue.get()
+        # and lets it return, but that PROCESSING happens in this separate
+        # task, which is not otherwise joined by anything -- registering it
+        # is what lets registry.shutdown() actually wait for that to
+        # happen instead of returning while it's still catching up.
+        # None-tolerant for callers (tests) that construct a hub standalone.
+        self._task_tracker = task_tracker
 
     def subscribe(self, *, maxsize: int = 0) -> HubSubscription:
         """Register a new surface. ``maxsize=0`` is unbounded (local sink);
@@ -127,7 +140,12 @@ class OutboxHub:
 
     def _ensure_drain(self) -> None:
         if self._drain_task is None or self._drain_task.done():
-            self._drain_task = asyncio.create_task(self._drain())
+            if self._task_tracker is not None:
+                self._drain_task = self._task_tracker.spawn(
+                    self._drain(), disposition="cancel_join", name=f"outbox-drain-{self._name}",
+                )
+            else:
+                self._drain_task = asyncio.create_task(self._drain())
 
     async def _drain(self) -> None:
         """The SOLE ``source.get()`` consumer: drain and fan out forever, until

--- a/src/reyn/runtime/outbox_hub.py
+++ b/src/reyn/runtime/outbox_hub.py
@@ -93,7 +93,7 @@ class OutboxHub:
 
     def __init__(
         self, source: "asyncio.Queue", *, name: str = "",
-        task_tracker: "TrackedTaskSet | None" = None,
+        task_tracker: "TrackedTaskSet",
     ) -> None:
         self._source = source
         self._subs: "set[HubSubscription]" = set()
@@ -104,9 +104,12 @@ class OutboxHub:
         # own finally on every exit path) reaches this loop's queue.get()
         # and lets it return, but that PROCESSING happens in this separate
         # task, which is not otherwise joined by anything -- registering it
-        # is what lets registry.shutdown() actually wait for that to
-        # happen instead of returning while it's still catching up.
-        # None-tolerant for callers (tests) that construct a hub standalone.
+        # is what lets registry.shutdown() actually wait for that to happen
+        # instead of returning while it's still catching up. REQUIRED (no
+        # None-tolerant fallback): the one production construction site
+        # (session.py) always supplies one, and an optional fallback here
+        # would silently recreate #4759's own defect shape at a future
+        # construction site that forgets to pass one.
         self._task_tracker = task_tracker
 
     def subscribe(self, *, maxsize: int = 0) -> HubSubscription:
@@ -140,12 +143,9 @@ class OutboxHub:
 
     def _ensure_drain(self) -> None:
         if self._drain_task is None or self._drain_task.done():
-            if self._task_tracker is not None:
-                self._drain_task = self._task_tracker.spawn(
-                    self._drain(), disposition="cancel_join", name=f"outbox-drain-{self._name}",
-                )
-            else:
-                self._drain_task = asyncio.create_task(self._drain())
+            self._drain_task = self._task_tracker.spawn(
+                self._drain(), disposition="cancel_join", name=f"outbox-drain-{self._name}",
+            )
 
     async def _drain(self) -> None:
         """The SOLE ``source.get()`` consumer: drain and fan out forever, until

--- a/src/reyn/runtime/outbox_hub.py
+++ b/src/reyn/runtime/outbox_hub.py
@@ -143,8 +143,17 @@ class OutboxHub:
 
     def _ensure_drain(self) -> None:
         if self._drain_task is None or self._drain_task.done():
+            # appends_wal=False (the default, stated explicitly here): this
+            # drain loop is a pure in-memory fan-out (queue -> subscriber
+            # queues), never itself a WAL writer -- a mid-rewind quiesce
+            # point (Session.await_quiescent) must never cancel it, only
+            # real session teardown may (#4759 review: an earlier version
+            # of this axis was lifetime-named ("scope") rather than
+            # invariant-named, and a rewind's quiesce killed this loop,
+            # silently stopping the session from answering).
             self._drain_task = self._task_tracker.spawn(
-                self._drain(), disposition="cancel_join", name=f"outbox-drain-{self._name}",
+                self._drain(), disposition="cancel_join", appends_wal=False,
+                name=f"outbox-drain-{self._name}",
             )
 
     async def _drain(self) -> None:

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3680,6 +3680,52 @@ class AgentRegistry:
                 t.cancel()
             if pending:
                 await asyncio.gather(*pending, return_exceptions=True)
+        # #4759: drain every loaded session's own background-task funnel
+        # (Session.aclose_background_tasks -> TrackedTaskSet.aclose, see
+        # tracked_tasks.py) — covers the ephemeral auto-vanish task
+        # (SpawnTracker._vanish_task, itself the #4759 root cause: it closes
+        # this session's held MCP connections via remove_session, but was
+        # previously a bare detached asyncio.create_task with no strong ref
+        # anywhere this drain could see, so a normal shutdown could return
+        # while it was still mid-flight, orphaning the OS subprocess it was
+        # about to close), plus chain-timeout watchdogs, fire-and-forget
+        # WAL-append tasks, the hook-bus bridge, OutboxHub's drain loop, and
+        # restored-intervention watchers — every one of them now routes
+        # through the SAME funnel, so this loop needs no per-task-type
+        # knowledge and a future background-task producer is covered by
+        # construction (spawn through the funnel), not by a reviewer
+        # remembering to touch this method.
+        #
+        # Run AFTER the run-loop tasks have drained/cancelled above (same
+        # reasoning #2714's own MCP-close comment below gives: no in-flight
+        # call should race this close) and BEFORE the MCP-connection sweep —
+        # the vanish task's own remove_session() call does that session's
+        # aclose_mcp_connections() as part of ITS work, so letting it run
+        # first means the later MCP sweep below sees an already-clean state
+        # for a session that just vanished (aclose_mcp_connections is
+        # idempotent either way, so this ordering is a clarity choice, not a
+        # correctness requirement).
+        #
+        # Time-bounded with the SAME grace window the task-drain above uses
+        # (_SHUTDOWN_GRACE_S) — a background task that doesn't respond to
+        # its own funnel's cancel within that window is logged and left
+        # rather than hanging /quit indefinitely (testing.md's "no test/no
+        # caller waits unboundedly" principle applied to a caller, not a
+        # test: an unbounded await_quiescent-style drain here would trade
+        # one orphan-risk for a hang-risk, a worse defect, not a fix).
+        for _name, session in self._iter_named_sessions():
+            aclose_bg = getattr(session, "aclose_background_tasks", None)
+            if callable(aclose_bg):
+                try:
+                    await asyncio.wait_for(aclose_bg(), timeout=_SHUTDOWN_GRACE_S)
+                except TimeoutError:
+                    logger.warning(
+                        "background-task teardown timed out for %r after %.1fs — "
+                        "some background task(s) may still be running",
+                        _name, _SHUTDOWN_GRACE_S,
+                    )
+                except Exception as exc:
+                    logger.warning("background-task teardown failed for %r: %s", _name, exc)
         # #2714: close held MCP connections (Option C) for EVERY loaded session on the
         # NORMAL-exit path too — the REPL's /quit + Ctrl-C/EOF (interfaces/repl/repl.py)
         # route through here, but pre-#2714 only ``remove_session`` (spawned-session

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3689,12 +3689,31 @@ class AgentRegistry:
         # anywhere this drain could see, so a normal shutdown could return
         # while it was still mid-flight, orphaning the OS subprocess it was
         # about to close), plus chain-timeout watchdogs, fire-and-forget
-        # WAL-append tasks, the hook-bus bridge, OutboxHub's drain loop, and
-        # restored-intervention watchers — every one of them now routes
-        # through the SAME funnel, so this loop needs no per-task-type
-        # knowledge and a future background-task producer is covered by
-        # construction (spawn through the funnel), not by a reviewer
-        # remembering to touch this method.
+        # WAL-append tasks, the hook-bus bridge (session_api.py's
+        # _hook_bus_bridge_task), OutboxHub's drain loop,
+        # hooks/external_fire.py's own SEPARATE drain loop (a different
+        # bridge from the hook-bus one above — both happen to say
+        # "hook"/"drain" but are two distinct producers), and
+        # restored-intervention watchers — this loop itself needs no
+        # per-task-type knowledge, so THIS method never grows regardless of
+        # how many producers exist.
+        #
+        # That is not quite the same as "a future producer is automatically
+        # covered", though: SpawnTracker and OutboxHub made task_tracker a
+        # REQUIRED constructor param (their fallback path was deleted, so
+        # skipping the funnel there is now a TypeError, not a silent gap).
+        # ChainManager and hooks/external_fire.py's bridge, by contrast,
+        # still accept a caller that doesn't pass/expose one (ChainManager:
+        # DELIBERATELY, optional param — see its own #4759 comment for the
+        # measured cost/benefit; external_fire: a getattr(self._session,
+        # "_background_tasks", None) guard against an arbitrary session-like
+        # object, not a constructor default) — for THOSE two, a reviewer
+        # adding a NEW watchdog/drain-task producer inside them still needs
+        # to remember to route it through self._task_tracker/the getattr
+        # result, same as any other new code. "Spawn through the funnel" is
+        # covered by construction only where the funnel is a required
+        # dependency; where it's optional, it is still a discipline, not a
+        # guarantee.
         #
         # Run AFTER the run-loop tasks have drained/cancelled above (same
         # reasoning #2714's own MCP-close comment below gives: no in-flight

--- a/src/reyn/runtime/resident_stats.py
+++ b/src/reyn/runtime/resident_stats.py
@@ -82,11 +82,20 @@ def _stat(name: str, container: Any) -> ContainerStat:
 # measurer, so this report presents one consistent method across every
 # row rather than mixing an internally-tracked figure for one row with
 # estimates for the rest).
+# #4759: `_inflight_wal_tasks` (the WAL-append fire-and-forget task set
+# #4497's own issue enumerated) was folded into `_background_tasks` — the
+# single funnel every session background task (not just WAL appends
+# anymore: the ephemeral-vanish task, chain-timeout watchdogs, the hook-bus
+# bridge, ...) now routes through (see tracked_tasks.py). Measuring
+# `_background_tasks` here is a STRICT WIDENING of what #4497's original
+# entry covered, not a like-for-like swap out of scope for this module —
+# `TrackedTaskSet.__len__`/`__iter__` (tracked_tasks.py) let it plug into
+# the same generic `_stat`/`_approx_bytes` machinery unmodified.
 _SESSION_ATTRS = (
     "history",
     "_pending_user_images",
     "_safety_extensions",
-    "_inflight_wal_tasks",
+    "_background_tasks",
     "_buffered_intervention_answers",
     "_router_loop_delegations",
     "_router_loop_agent_replies",

--- a/src/reyn/runtime/services/chain_manager.py
+++ b/src/reyn/runtime/services/chain_manager.py
@@ -200,12 +200,27 @@ class ChainManager:
         self.max_hop_depth = max_hop_depth
         self._clock = clock_fn or (lambda: datetime.now(timezone.utc))
         self._sleep = sleep_fn or asyncio.sleep
-        # #4759: optional — every watchdog task ALSO registers with the
-        # owning Session's single task funnel (tracked_tasks.py) so
+        # #4759: every watchdog task ALSO registers with the owning
+        # Session's single task funnel (tracked_tasks.py) so
         # AgentRegistry.shutdown() can reach it without needing to know this
-        # class exists. None-tolerant (a caller that doesn't pass one, e.g.
-        # a standalone unit test, gets pre-#4759 behaviour unchanged) — the
-        # dedicated `_timers` dict below (chain_id-keyed lookup, needed by
+        # class exists.
+        #
+        # DELIBERATELY left None-tolerant (unlike SpawnTracker/OutboxHub,
+        # whose #4759 fix made task_tracker a REQUIRED param): measured, the
+        # ONE production construction site (session.py) always passes one,
+        # so this class's own #4759 reachability is not at risk in
+        # production either way. What's different here is the cost side —
+        # ChainManager has 12 existing test call sites across 9 files, NONE
+        # of which exercise #4759's teardown property (they test chain
+        # register/resolve/timeout semantics); forcing all 12 to thread a
+        # tracker through would touch files unrelated to this PR's own
+        # concern for zero behavioural gain in THOSE tests. A caller that
+        # doesn't pass one (every existing test) gets pre-#4759 behaviour
+        # for its own watchdog tasks unchanged — this class's core function
+        # (arm/cancel/fire a chain timeout) does not depend on the tracker
+        # at all; only #4759's reachability property does, and that
+        # property is not what these tests are checking. The dedicated
+        # `_timers` dict below (chain_id-keyed lookup, needed by
         # `cancel_timeout`) stays the primary bookkeeping either way; this is
         # an ADDITIONAL registration for teardown-reachability, not a
         # replacement for it.

--- a/src/reyn/runtime/services/chain_manager.py
+++ b/src/reyn/runtime/services/chain_manager.py
@@ -509,18 +509,38 @@ class ChainManager:
             chain_id, on_fire=on_fire, duration_seconds=duration_seconds
         )
         # #4759: ALSO registered with the owning Session's task funnel
-        # (tracked_tasks.py), disposition="cancel_join" -- this dict stays
-        # the primary chain_id-keyed lookup `cancel_timeout` needs; the
-        # tracker registration is what makes this watchdog reachable from
-        # AgentRegistry.shutdown() without it needing to know ChainManager
-        # exists. Cancelling the same task from both `cancel_and_join_timers`
-        # and the tracker's own aclose() is safe -- Task.cancel() is
-        # idempotent.
+        # (tracked_tasks.py), disposition="cancel_join", appends_wal=True
+        # -- this dict stays the primary chain_id-keyed lookup
+        # `cancel_timeout` needs; the tracker registration is what makes
+        # this watchdog reachable from AgentRegistry.shutdown() without it
+        # needing to know ChainManager exists. appends_wal=True (NOT the
+        # default False): firing appends "chain_timeout_fired" to the WAL,
+        # and a chain-timeout watchdog is EXACTLY the class of task the
+        # pre-#4759 `await_quiescent` always cancelled mid-rewind via its
+        # own `cancel_and_join_timers()` call -- drop-safe, re-armed by
+        # `restore()` from the recovered snapshot. Cancelling the same task
+        # from both `cancel_and_join_timers` and the tracker's own
+        # aclose() is safe -- Task.cancel() is idempotent.
         if self._task_tracker is not None:
             self._timers[chain_id] = self._task_tracker.spawn(
-                coro, disposition="cancel_join", name=f"chain-timeout-{chain_id}",
+                coro, disposition="cancel_join", appends_wal=True,
+                name=f"chain-timeout-{chain_id}",
             )
         else:
+            # #4765 co-vet (architect): a caller that constructs a
+            # ChainManager without a task_tracker (deliberately kept
+            # optional -- see __init__'s own #4759 comment for the
+            # measured cost/benefit) silently falls back to an untracked
+            # task here, same as before this funnel existed. Warned (not
+            # silent) so a future caller who SHOULD have passed one but
+            # forgot has a signal to find, without forcing every existing
+            # test call site (12, across 9 files) to thread one through.
+            logger.warning(
+                "ChainManager._start_watchdog: no task_tracker configured -- "
+                "chain-timeout watchdog for %r is NOT reachable from "
+                "AgentRegistry.shutdown()'s drain (see tracked_tasks.py).",
+                chain_id,
+            )
             self._timers[chain_id] = asyncio.create_task(coro)
 
     def cancel_timeout(self, chain_id: str) -> None:

--- a/src/reyn/runtime/services/chain_manager.py
+++ b/src/reyn/runtime/services/chain_manager.py
@@ -25,6 +25,7 @@ from reyn.runtime.task_types import Requester, RunStatus
 if TYPE_CHECKING:
     from reyn.core.events.agent_snapshot import AgentSnapshot
     from reyn.runtime.task_types import Requester
+    from reyn.runtime.tracked_tasks import TrackedTaskSet
 
 logger = logging.getLogger(__name__)
 
@@ -191,6 +192,7 @@ class ChainManager:
         max_hop_depth: int,
         clock_fn: "Callable[[], datetime] | None" = None,
         sleep_fn: "Callable[[float], Awaitable[None]] | None" = None,
+        task_tracker: "TrackedTaskSet | None" = None,
     ) -> None:
         self._journal = journal
         self._events = events
@@ -198,6 +200,16 @@ class ChainManager:
         self.max_hop_depth = max_hop_depth
         self._clock = clock_fn or (lambda: datetime.now(timezone.utc))
         self._sleep = sleep_fn or asyncio.sleep
+        # #4759: optional — every watchdog task ALSO registers with the
+        # owning Session's single task funnel (tracked_tasks.py) so
+        # AgentRegistry.shutdown() can reach it without needing to know this
+        # class exists. None-tolerant (a caller that doesn't pass one, e.g.
+        # a standalone unit test, gets pre-#4759 behaviour unchanged) — the
+        # dedicated `_timers` dict below (chain_id-keyed lookup, needed by
+        # `cancel_timeout`) stays the primary bookkeeping either way; this is
+        # an ADDITIONAL registration for teardown-reachability, not a
+        # replacement for it.
+        self._task_tracker = task_tracker
 
         self._chains: dict[str, _PendingChain] = {}
         self._timers: dict[str, asyncio.Task] = {}
@@ -478,11 +490,23 @@ class ChainManager:
         existing = self._timers.pop(chain_id, None)
         if existing is not None and not existing.done():
             existing.cancel()
-        self._timers[chain_id] = asyncio.create_task(
-            self._chain_timeout_watch(
-                chain_id, on_fire=on_fire, duration_seconds=duration_seconds
-            )
+        coro = self._chain_timeout_watch(
+            chain_id, on_fire=on_fire, duration_seconds=duration_seconds
         )
+        # #4759: ALSO registered with the owning Session's task funnel
+        # (tracked_tasks.py), disposition="cancel_join" -- this dict stays
+        # the primary chain_id-keyed lookup `cancel_timeout` needs; the
+        # tracker registration is what makes this watchdog reachable from
+        # AgentRegistry.shutdown() without it needing to know ChainManager
+        # exists. Cancelling the same task from both `cancel_and_join_timers`
+        # and the tracker's own aclose() is safe -- Task.cancel() is
+        # idempotent.
+        if self._task_tracker is not None:
+            self._timers[chain_id] = self._task_tracker.spawn(
+                coro, disposition="cancel_join", name=f"chain-timeout-{chain_id}",
+            )
+        else:
+            self._timers[chain_id] = asyncio.create_task(coro)
 
     def cancel_timeout(self, chain_id: str) -> None:
         """Cancel the watchdog task for ``chain_id``, if any."""

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -113,6 +113,7 @@ from reyn.runtime.session_pure import (
 )
 from reyn.runtime.spawn_tracker import SpawnTracker
 from reyn.runtime.task_types import CurrentTask
+from reyn.runtime.tracked_tasks import TrackedTaskSet
 from reyn.runtime.turn_origin import TurnOrigin
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.services.compaction.engine import CompactionEngine
@@ -1102,6 +1103,16 @@ class Session:
         # session-construction.md#family-2-recovery-wal-journal).
         self._generation_store = generation_store
         self._journal = journal
+        # #4759: the single funnel every background task this session (or a
+        # sub-component it owns — SpawnTracker's ephemeral-vanish task, the
+        # WAL fire-and-forget appends below, ...) spawns via
+        # asyncio.create_task routes through, so registry.shutdown() needs to
+        # know about exactly ONE seam (aclose_background_tasks below) instead
+        # of enumerating named task fields — see tracked_tasks.py's own
+        # module docstring for the root cause this replaces. Constructed
+        # early (before any sub-component that might spawn a background task
+        # during ITS OWN construction) and threaded into SpawnTracker below.
+        self._background_tasks = TrackedTaskSet()
         # Turn-idle event for quiescence; lets a global rewind await_quiescent before the reset-record append (ADR-0038 Stage 1c, see session-construction.md#family-2-recovery-wal-journal)
         self._turn_idle = asyncio.Event()
         self._turn_idle.set()
@@ -1141,8 +1152,11 @@ class Session:
         # RE-RAISED, not swallowed, so the driver's own cancellation completes
         # normally instead of silently surviving a cancel that was never ours.
         self._turn_cancel_self_initiated: bool = False
-        # Joinable handle for fire-and-forget WAL-append tasks so await_quiescent can join them too (ADR-0038 Stage 1c coverage, see session-construction.md#family-2-recovery-wal-journal)
-        self._inflight_wal_tasks: set[asyncio.Task] = set()
+        # #4759: fire-and-forget WAL-append tasks are tracked via
+        # self._background_tasks now (the single task funnel, see
+        # tracked_tasks.py) — this used to be a dedicated set here
+        # (ADR-0038 Stage 1c), folded in so await_quiescent's join covers
+        # them alongside every other background task through one seam.
         # Kept directly (not only via journal), see docs/reference/runtime/session-construction.md#family-2-recovery-wal-journal
         self._state_log = state_log
         self._halted_reason: "str | None" = None  # #2259 PR-3: set on FAIL-STOP, see session-construction.md#family-2-recovery-wal-journal
@@ -1338,6 +1352,7 @@ class Session:
             agent_name=self.agent_name,
             session_id_provider=lambda: self._session_id,
             ephemeral_provider=lambda: self._ephemeral,
+            task_tracker=self._background_tasks,
         )
 
         # Delegation tracking for RouterLoop runs; None outside a run, cleared after each (F2)
@@ -2502,50 +2517,41 @@ class Session:
         Coverage (the exhaustive set of append-capable spawned tasks in this
         surface — see #1533 source→gated-by table): the current turn (``_turn_idle``),
         chain-timeout watchdogs (``_chains`` timers, cancel+join), and fire-and-forget
-        WAL-append tasks — intervention dispatch + intervention_answer_consumed
-        (``_inflight_wal_tasks``).
+        WAL-append tasks — intervention dispatch + intervention_answer_consumed.
+        #4759: both of the latter two are tracked via ``self._background_tasks``
+        (the single task funnel — see ``tracked_tasks.py``), so step 2 below is
+        one call instead of the two separately-named, separately-shaped drains
+        this method used to hand-roll (a cancel+join loop over ChainManager's
+        own dict, then ANOTHER cancel+join loop over ``_inflight_wal_tasks``) —
+        a 3rd background-task type registered through the same funnel needs no
+        change here.
         """
         # 1. wait for the current turn to go idle -- re-entrancy-safe (see
         # docs/reference/runtime/session-construction.md#family-2-recovery-wal-journal
         # for the _turn_idle / _turn_owner_task rationale).
         if asyncio.current_task() is not self._turn_owner_task:
             await self._turn_idle.wait()
-        # 2. cancel + join chain-timeout watchdogs. A cancelled timer cannot fire
-        #    (no chain_timeout_fired append); join settles any callback already
-        #    in-progress before this returns. On reconstruct, restore() re-arms a
-        #    watchdog from the recovered snapshot (proposal 0067 P8, #3978:
-        #    against the REMAINING time on a persisted arm_at deadline, not
-        #    necessarily a fresh window), so cancelling is reversible.
+        # 2. drain every "cancel_join"-disposition tracked task to a fixpoint
+        #    (chain-timeout watchdogs + fire-and-forget WAL-append tasks — see
+        #    the docstring above). Cancel — not join-only — is required: the
+        #    intervention-dispatch task awaits the user-answer future
+        #    indefinitely; these tasks are drop-safe so cancelling is
+        #    correct. The fixpoint loop (TrackedTaskSet.aclose's own #2115
+        #    re-check) covers a joined task scheduling a NEW tracked append
+        #    (or re-spawn) DURING the gather, which a one-shot snapshot would
+        #    miss. On reconstruct, restore() re-arms timers/watchdogs from
+        #    the recovered snapshot (proposal 0067 P8, #3978: against the
+        #    REMAINING time on a persisted arm_at deadline, not necessarily a
+        #    fresh window), so cancelling here is reversible.
+        await self._background_tasks.aclose()
+        # ChainManager's own _timers dict (chain_id -> task, used by
+        # cancel_timeout's lookup) isn't cleared by the tracker's own aclose
+        # above -- it owns a SEPARATE bookkeeping concern (lookup, not
+        # teardown-reachability). cancel_and_join_timers() is idempotent
+        # (every timer task the tracker just cancelled+joined is already
+        # done, so this is a fast no-op cancel/gather) and clears that dict.
         await self._chains.cancel_and_join_timers()
-        # 3-4. RE-DRAIN LOOP (#2115): cancel the tracked fire-and-forget WAL tasks
-        #    (cancel — not join-only — is required: the intervention-dispatch task
-        #    awaits the user-answer future indefinitely; the tasks are drop-safe so
-        #    cancelling is correct) + join the append-capable tasks
-        #    (_inflight_wal_tasks), then RE-CHECK. A joined task may schedule a NEW
-        #    tracked append (or re-spawn) DURING the gather — which the prior
-        #    one-shot snapshot would miss (#2115). Loop to a fixpoint (both sets fully
-        #    drained) so no append can land after this returns. On reconstruct,
-        #    restore() re-arms timers from the recovered snapshot (proposal 0067
-        #    P8, #3978: against the REMAINING time on a persisted arm_at deadline,
-        #    not necessarily a fresh window), so cancelling is reversible.
-        for _ in range(_QUIESCE_MAX_ROUNDS):
-            for task in list(self._inflight_wal_tasks):
-                if not task.done():
-                    task.cancel()
-            pending = [
-                t for t in self._inflight_wal_tasks
-                if not t.done()
-            ]
-            if not pending:
-                break
-            await asyncio.gather(*pending, return_exceptions=True)
-        else:
-            logger.warning(
-                "await_quiescent: WAL-append tasks did not drain to a fixpoint in "
-                "%d rounds — a straggler append may race the reset-record",
-                _QUIESCE_MAX_ROUNDS,
-            )
-        # 5. re-confirm turn-idle — a joined task may have enqueued a follow-up
+        # 3. re-confirm turn-idle — a joined task may have enqueued a follow-up
         #    turn; with cancel already requested it breaks immediately, so this
         #    settles. The double wait closes the join↔turn race.
         if asyncio.current_task() is not self._turn_owner_task:
@@ -2557,8 +2563,9 @@ class Session:
         Fire-and-forget tasks that append to the WAL (intervention dispatch,
         intervention_answer_consumed) have no natural join handle, so they would
         escape ``await_quiescent`` and could append past a rewind reset-record.
-        Tracking them in ``_inflight_wal_tasks`` (with discard-on-done to keep the
-        set bounded) makes them joinable. Returns the task for call-site chaining.
+        Tracking them (via ``self._background_tasks``, #4759's single task
+        funnel — see ``tracked_tasks.py``) makes them joinable. Returns the
+        task for call-site chaining.
 
         #2115 CONVENTION: every async WAL-append spawned outside the current turn —
         ESPECIALLY any completion append (WAL writes outside the current turn) — MUST be tracked here so
@@ -2566,9 +2573,7 @@ class Session:
         the rewind reset-record. A new untracked append path would leak past a
         rewind (the #2115 bug class).
         """
-        self._inflight_wal_tasks.add(task)
-        task.add_done_callback(self._inflight_wal_tasks.discard)
-        return task
+        return self._background_tasks.register(task, disposition="cancel_join")
 
     def attach_anchor_store(self, anchor_store) -> None:
         """Attach the shared per-checkpoint anchor store (#1547). Thin forwarder — see
@@ -2819,9 +2824,10 @@ class Session:
                                                plain assignment is unconditional, so no
                                                separate clear step is needed here)
 
-        The _inflight_wal_tasks task handles are already settled by
-        await_quiescent; this drops the (now-done) handles so the rewound
-        session starts clean.
+        The fire-and-forget WAL-append task handles are already settled by
+        await_quiescent (via self._background_tasks — #4759's task funnel,
+        which self-drops a handle the moment its task completes, so there is
+        no separate "drop the now-done handles" step needed here anymore).
         """
         while True:
             try:
@@ -2843,7 +2849,6 @@ class Session:
         # re-assigns it wholesale from the reconstructed snapshot, but clearing here keeps
         # the zero-residue guarantee robust independent of that assignment.
         self._hook_driven_turns = 0
-        self._inflight_wal_tasks.clear()
         # pending_inbox_item / cancelled_msg_ids / last_sender / last_reply_to
         # (proposal 0067 P1, #3978 InboxArbiter extraction): the same latent
         # gap current_task's own comment below names — NONE of these four
@@ -5035,6 +5040,7 @@ class Session:
             events=self._audit_events,
             chain_timeout_seconds=self._chain_timeout_seconds,
             max_hop_depth=self._max_hop_depth,
+            task_tracker=self._background_tasks,
         )
         interventions = InterventionRegistry(
             on_announce=self._announce_intervention,
@@ -6074,6 +6080,16 @@ class Session:
             self._restore_intervention_tasks = self._interventions.restore(
                 restored, watcher=_on_restored_resolved,
             )
+            # #4759: ALSO registered with the task funnel -- restore()'s own
+            # docstring already says the caller must keep references alive
+            # to avoid GC warnings (self._restore_intervention_tasks above
+            # satisfies that), but nothing previously joined/cancelled them
+            # from a normal shutdown path (only reset_for_rewind, a
+            # DIFFERENT path, cancels-without-awaiting them). disposition
+            # "cancel_join": each awaits a possibly-never-arriving user
+            # answer, drop-safe on shutdown.
+            for _t in self._restore_intervention_tasks:
+                self._background_tasks.register(_t, disposition="cancel_join")
         self._audit_events.emit(
             "session_restored",
             applied_seq=snapshot.applied_seq,
@@ -6693,9 +6709,18 @@ class Session:
 
         # R-D4: WAL size safety-net check at the chat turn boundary — see
         # docs/deep-dives/decisions/0014-wal-size-safety-net.md#decision
+        # #4759: routed through the task funnel (was a bare asyncio.create_task
+        # with NO reference kept anywhere — GC-vulnerable AND unreachable from
+        # any teardown path; tracked_tasks.py's own module docstring names
+        # this as one of the confirmed #4759 instances). disposition
+        # "cancel_join": a truncation check is a maintenance op, safe to
+        # cancel mid-flight (the next turn boundary re-checks; nothing here
+        # is a partial-write hazard — maybe_truncate_for_size only acts once
+        # its own check passes).
         if self._registry is not None:
-            asyncio.create_task(
+            self._background_tasks.spawn(
                 self._registry.maybe_truncate_for_size(),
+                disposition="cancel_join",
                 name="wal-size-safety-net",
             )
 
@@ -8374,6 +8399,29 @@ class Session:
         and ``RouterHostAdapter.mcp_list_subscriptions`` reading the same
         source)."""
         return self._mcp_connection_service.subscription_summary()
+
+    async def aclose_background_tasks(self) -> None:
+        """#4759 teardown: drain every background task this session (or a
+        sub-component it owns — SpawnTracker's ephemeral-vanish task,
+        ChainManager's timeout watchdogs, OutboxHub's drain loop, the hooks
+        bridge, restored-intervention watchers, ...) spawned via the single
+        task funnel (``self._background_tasks``, see ``tracked_tasks.py``).
+
+        Root cause this closes: before this method existed, none of those
+        tasks were reachable from a normal ``registry.shutdown()`` (only
+        some had a joiner at all, and even those were only invoked from the
+        REWIND path or ``remove_session``, never from an ordinary
+        shutdown/``/quit``) — a shutdown could return while the ephemeral
+        auto-vanish task (which itself closes this session's held MCP
+        connections) was still mid-flight, orphaning the OS subprocess it
+        was about to close. Idempotent (``TrackedTaskSet.aclose`` is). Called
+        from ``AgentRegistry.shutdown()`` — mirrors ``aclose_mcp_connections``
+        / ``aclose_event_store``'s existing getattr-duck-typed call shape, so
+        the registry needs no per-task-type knowledge, only this one seam.
+        NOT independently time-bounded — see ``AgentRegistry.shutdown()``'s
+        own bounded wrapping of this call for why and by how much.
+        """
+        await self._background_tasks.aclose()
 
     async def aclose_mcp_connections(self) -> None:
         """#2597 S2a teardown: close every held MCP connection this session opened.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2525,19 +2525,34 @@ class Session:
         # for the _turn_idle / _turn_owner_task rationale).
         if asyncio.current_task() is not self._turn_owner_task:
             await self._turn_idle.wait()
-        # 2. drain every "cancel_join"-disposition tracked task to a fixpoint
-        #    (chain-timeout watchdogs + fire-and-forget WAL-append tasks — see
-        #    the docstring above). Cancel — not join-only — is required: the
-        #    intervention-dispatch task awaits the user-answer future
-        #    indefinitely; these tasks are drop-safe so cancelling is
-        #    correct. The fixpoint loop (TrackedTaskSet.aclose's own #2115
-        #    re-check) covers a joined task scheduling a NEW tracked append
-        #    (or re-spawn) DURING the gather, which a one-shot snapshot would
-        #    miss. On reconstruct, restore() re-arms timers/watchdogs from
-        #    the recovered snapshot (proposal 0067 P8, #3978: against the
-        #    REMAINING time on a persisted arm_at deadline, not necessarily a
-        #    fresh window), so cancelling here is reversible.
-        await self._background_tasks.aclose()
+        # 2. drain every "cancel_join"-disposition, appends_wal=True tracked
+        #    task to a fixpoint (chain-timeout watchdogs + fire-and-forget
+        #    WAL-append tasks — see the docstring above). Cancel — not
+        #    join-only — is required: the intervention-dispatch task awaits
+        #    the user-answer future indefinitely; these tasks are drop-safe
+        #    so cancelling is correct. The fixpoint loop (TrackedTaskSet.
+        #    aclose's own #2115 re-check) covers a joined task scheduling a
+        #    NEW tracked append (or re-spawn) DURING the gather, which a
+        #    one-shot snapshot would miss. On reconstruct, restore()
+        #    re-arms timers/watchdogs from the recovered snapshot (proposal
+        #    0067 P8, #3978: against the REMAINING time on a persisted
+        #    arm_at deadline, not necessarily a fresh window), so cancelling
+        #    here is reversible.
+        #
+        #    appends_wal=True is NOT optional here (#4759/#4765 review,
+        #    caught live by CI, then corrected again by architect co-vet —
+        #    the axis was first named by task LIFETIME, "scope", which
+        #    fixed the CI regression but was still the wrong name for the
+        #    invariant this method actually protects; see tracked_tasks.py's
+        #    own module docstring): this method runs during a REWIND, not
+        #    only at shutdown — an unfiltered aclose() would ALSO fold every
+        #    appends_wal=False task (OutboxHub's drain loop, the hook-bus
+        #    bridge, ...), silently killing mechanisms the session needs to
+        #    keep answering turns after the rewind completes. Only real
+        #    shutdown (Session.aclose_background_tasks, called from
+        #    AgentRegistry.shutdown()) drains every task regardless of the
+        #    flag.
+        await self._background_tasks.aclose(appends_wal=True, caller="await_quiescent")
         # ChainManager's own _timers dict (chain_id -> task, used by
         # cancel_timeout's lookup) isn't cleared by the tracker's own aclose
         # above -- it owns a SEPARATE bookkeeping concern (lookup, not
@@ -2567,7 +2582,9 @@ class Session:
         the rewind reset-record. A new untracked append path would leak past a
         rewind (the #2115 bug class).
         """
-        return self._background_tasks.register(task, disposition="cancel_join")
+        return self._background_tasks.register(
+            task, disposition="cancel_join", appends_wal=True,
+        )
 
     def attach_anchor_store(self, anchor_store) -> None:
         """Attach the shared per-checkpoint anchor store (#1547). Thin forwarder — see
@@ -6083,9 +6100,19 @@ class Session:
             # from a normal shutdown path (only reset_for_rewind, a
             # DIFFERENT path, cancels-without-awaiting them). disposition
             # "cancel_join": each awaits a possibly-never-arriving user
-            # answer, drop-safe on shutdown.
-            for _t in self._restore_intervention_tasks:
-                self._background_tasks.register(_t, disposition="cancel_join")
+            # answer, drop-safe on shutdown. appends_wal=False (the
+            # default, stated explicitly here): these were NEVER part of
+            # await_quiescent's pre-#4759 scope (only reset_for_rewind's own
+            # separate, still-untouched cancel loop reaches them during a
+            # rewind) -- a mid-rewind quiesce must not fold them.
+            # zip: restore()'s own docstring guarantees FIFO order matches
+            # the input list, so `restored[i]` is the intervention `tasks[i]`
+            # watches -- used only to name the task for diagnostics below.
+            for _iv, _t in zip(restored, self._restore_intervention_tasks, strict=True):
+                _t.set_name(f"restored-intervention-{_iv.id}")
+                self._background_tasks.register(
+                    _t, disposition="cancel_join", appends_wal=False,
+                )
         self._audit_events.emit(
             "session_restored",
             applied_seq=snapshot.applied_seq,
@@ -6712,11 +6739,17 @@ class Session:
         # "cancel_join": a truncation check is a maintenance op, safe to
         # cancel mid-flight (the next turn boundary re-checks; nothing here
         # is a partial-write hazard — maybe_truncate_for_size only acts once
-        # its own check passes).
+        # its own check passes). appends_wal=False (the default, stated
+        # explicitly here): a size-truncation check is not itself a WAL
+        # append in the append-past-reset-record sense await_quiescent
+        # guards against, and this was NEVER part of await_quiescent's
+        # pre-#4759 scope (it wasn't tracked anywhere at all before) — a
+        # mid-rewind quiesce has no reason to newly start touching it.
         if self._registry is not None:
             self._background_tasks.spawn(
                 self._registry.maybe_truncate_for_size(),
                 disposition="cancel_join",
+                appends_wal=False,
                 name="wal-size-safety-net",
             )
 
@@ -7504,7 +7537,9 @@ class Session:
         # iv resolution — the iv.future will resolve when the new
         # channel's listener calls deliver_answer, independent of this
         # method's return.
-        self._track_wal_task(asyncio.ensure_future(self._dispatch_intervention(iv)))
+        _redispatch_task = asyncio.ensure_future(self._dispatch_intervention(iv))
+        _redispatch_task.set_name(f"intervention-redispatch-{iv.id}")
+        self._track_wal_task(_redispatch_task)
         return PendingOpView.from_intervention(iv)
 
     async def _dispatch_intervention(self, iv: UserIntervention) -> InterventionAnswer:
@@ -8417,7 +8452,7 @@ class Session:
         NOT independently time-bounded — see ``AgentRegistry.shutdown()``'s
         own bounded wrapping of this call for why and by how much.
         """
-        await self._background_tasks.aclose()
+        await self._background_tasks.aclose(caller="AgentRegistry.shutdown")
 
     async def aclose_mcp_connections(self) -> None:
         """#2597 S2a teardown: close every held MCP connection this session opened.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -122,12 +122,6 @@ from reyn.user_intervention import (
     UserIntervention,
 )
 
-# #2115: cap for await_quiescent's re-drain loop. In-flight WAL-append tasks are
-# finite + cancel-requested + spawn no new user-work under a rewind, so the drain
-# converges in 1-2 rounds; the cap is purely a guard against a pathological spin
-# (logged, never silently looped).
-_QUIESCE_MAX_ROUNDS = 50
-
 # #2103 S1bc-exec: spawned-task correlation cap now lives in spawn_tracker.py's
 # _MAX_SPAWNED_TASKS — see docs/reference/runtime/session-construction.md#capability-permission-visibility
 
@@ -4105,7 +4099,9 @@ class Session:
         byte-identical to no OTEL. The exporter is a lossy downstream: it
         never writes to .reyn/events or the WAL, so recovery/replay is
         independent of it (SR4)."""
-        outbox_hub = OutboxHub(self.outbox, name=self.agent_name)
+        outbox_hub = OutboxHub(
+            self.outbox, name=self.agent_name, task_tracker=self._background_tasks,
+        )
         event_store = EventStore(
             self.events_dir,
             max_bytes=self._events_config.max_bytes,

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -618,9 +618,13 @@ async def _spawn_pipeline_driver_session(
         # (tracked_tasks.py) so AgentRegistry.shutdown() reaches it directly
         # instead of only via remove_session's bare (never-awaited) .cancel()
         # — see Session._hook_bus_bridge_task's own note above.
+        # appends_wal=False (the default, stated explicitly here): this
+        # bridges hook events for the LIFE of the driver session and does
+        # not itself append to the WAL -- a mid-rewind quiesce must not
+        # tear it down while the session keeps running.
         session._hook_bus_bridge_task = session._background_tasks.spawn(
             bridge_child_bus_to_parent(session._hook_bus, attached_parent_session._hook_bus),
-            disposition="cancel_join", name="hook-bus-bridge",
+            disposition="cancel_join", appends_wal=False, name="hook-bus-bridge",
         )
     driver = PipelineExecutorDriver(
         work_order, registry=registry, state_log=state_log,
@@ -1230,9 +1234,14 @@ async def run_prompt_async(
         # the target's cancel_inflight() running here, not the caller's) —
         # was a bare ensure_future with no reference kept anywhere.
         task = asyncio.ensure_future(target.cancel_inflight())
+        task.set_name(f"cross-session-cancel-forward-{chain_id}")
         target_tracker = getattr(target, "_background_tasks", None)
         if target_tracker is not None:
-            target_tracker.register(task, disposition="cancel_join")
+            # appends_wal=False (the default, stated explicitly here): a
+            # cancel-forward is a short-lived one-shot, unrelated to
+            # rewind/WAL-quiesce semantics -- no reason for a mid-rewind
+            # quiesce point to newly start touching it.
+            target_tracker.register(task, disposition="cancel_join", appends_wal=False)
 
     await caller_session.chains.register(
         chain_id=chain_id,

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -612,12 +612,15 @@ async def _spawn_pipeline_driver_session(
         # to. See bridge_child_bus_to_parent's own docstring for why this
         # goes through neither session's HookDispatcher, and Session.
         # _hook_bus_bridge_task for where teardown cancels it.
-        import asyncio
-
         from reyn.hooks.bus import bridge_child_bus_to_parent
 
-        session._hook_bus_bridge_task = asyncio.create_task(
-            bridge_child_bus_to_parent(session._hook_bus, attached_parent_session._hook_bus)
+        # #4759: registered with the owning session's task funnel
+        # (tracked_tasks.py) so AgentRegistry.shutdown() reaches it directly
+        # instead of only via remove_session's bare (never-awaited) .cancel()
+        # — see Session._hook_bus_bridge_task's own note above.
+        session._hook_bus_bridge_task = session._background_tasks.spawn(
+            bridge_child_bus_to_parent(session._hook_bus, attached_parent_session._hook_bus),
+            disposition="cancel_join", name="hook-bus-bridge",
         )
     driver = PipelineExecutorDriver(
         work_order, registry=registry, state_log=state_log,
@@ -1223,7 +1226,13 @@ async def run_prompt_async(
         # Fire-and-forget — _PendingChain.cancel is a synchronous zero-arg
         # hook, cancel_inflight() is async; mirrors run_pipeline_attached's
         # own cross-session cancel-forward registration.
-        asyncio.ensure_future(target.cancel_inflight())
+        # #4759: registered on the TARGET session's own task funnel (it's
+        # the target's cancel_inflight() running here, not the caller's) —
+        # was a bare ensure_future with no reference kept anywhere.
+        task = asyncio.ensure_future(target.cancel_inflight())
+        target_tracker = getattr(target, "_background_tasks", None)
+        if target_tracker is not None:
+            target_tracker.register(task, disposition="cancel_join")
 
     await caller_session.chains.register(
         chain_id=chain_id,

--- a/src/reyn/runtime/spawn_tracker.py
+++ b/src/reyn/runtime/spawn_tracker.py
@@ -56,7 +56,10 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
-from typing import Callable, Protocol
+from typing import TYPE_CHECKING, Callable, Protocol
+
+if TYPE_CHECKING:
+    from reyn.runtime.tracked_tasks import TrackedTaskSet
 
 _MAX_SPAWNED_TASKS = 256
 
@@ -108,6 +111,7 @@ class SpawnTracker:
         agent_name: str,
         session_id_provider: "Callable[[], str]",
         ephemeral_provider: "Callable[[], bool]",
+        task_tracker: "TrackedTaskSet | None" = None,
     ) -> None:
         self._registry = registry
         self._journal = journal
@@ -116,6 +120,15 @@ class SpawnTracker:
         self._agent_name = agent_name
         self._session_id_provider = session_id_provider
         self._ephemeral_provider = ephemeral_provider
+        # #4759: the owning Session's single background-task funnel
+        # (tracked_tasks.py) -- the vanish task below is real cleanup work
+        # (it closes this session's own held MCP connections via
+        # remove_session -> aclose_mcp_connections) that was previously
+        # detached and invisible to AgentRegistry.shutdown()'s drain, the
+        # #4759 root cause. None-tolerant for a caller that doesn't pass one
+        # (pre-#4759 behaviour: _vanish_task is still set for the existing
+        # test bridge, just not registry-shutdown-reachable).
+        self._task_tracker = task_tracker
         # #4740: (agent_name, sid) -> trusted original-task record for spawned
         # sessions, so a compromised sub-session can't forge task framing
         # (#2103 S1bc-exec). Two-level dict, SAME shape as registry.py's own
@@ -234,8 +247,22 @@ class SpawnTracker:
         if self._chains.all_chain_ids():
             return
         self._vanish_scheduled = True
-        # Keep a strong ref (self._vanish_task) so the task is not GC'd before it runs
-        # (it self-cancels this run-loop, so it is otherwise unreferenced).
-        self._vanish_task = asyncio.create_task(
-            self._registry.remove_session(self._agent_name, self._session_id_provider())
-        )
+        # #4759: routed through the owning Session's task funnel
+        # (tracked_tasks.py) when available, disposition="await" -- this
+        # task performs the actual teardown work (remove_session closes this
+        # session's held MCP connections among other things), so it must be
+        # allowed to run to completion, not cancelled. Before #4759 this was
+        # a bare asyncio.create_task with only self._vanish_task as a strong
+        # ref (kept below, unconditionally, for the 3 existing tests that
+        # await it directly) -- invisible to AgentRegistry.shutdown()'s own
+        # drain, which is the root cause #4759 traced: a normal shutdown
+        # could return while this was still mid-flight, orphaning whatever
+        # OS subprocess remove_session -> aclose_mcp_connections was about
+        # to close.
+        coro = self._registry.remove_session(self._agent_name, self._session_id_provider())
+        if self._task_tracker is not None:
+            self._vanish_task = self._task_tracker.spawn(
+                coro, disposition="await", name="ephemeral-vanish",
+            )
+        else:
+            self._vanish_task = asyncio.create_task(coro)

--- a/src/reyn/runtime/spawn_tracker.py
+++ b/src/reyn/runtime/spawn_tracker.py
@@ -261,7 +261,28 @@ class SpawnTracker:
         # the root cause #4759 traced: a normal shutdown could return while
         # this was still mid-flight, orphaning whatever OS subprocess
         # remove_session -> aclose_mcp_connections was about to close.
+        # appends_wal=True (NOT the default False): remove_session() itself
+        # appends "session_vanished" to the state log (registry.py's own
+        # remove_session, near its end: `await self._state_log.append(
+        # "session_vanished", ...)`) — the state log IS the WAL in this
+        # codebase's own terminology (registry.py's remove_session docstring
+        # calls it "the global WAL" in the same breath). A GLOBAL rewind's
+        # await_quiescent sweep runs this session alongside every other
+        # loaded session; if this task were excluded from that drain (the
+        # scope="session"/lifetime-based axis this replaced would have
+        # excluded it), a session_vanished append landing AFTER the
+        # rewind's own reset-record would be exactly the straggler-append
+        # class await_quiescent exists to prevent (#1533/#2115). disposition
+        # stays "await" (not cancel_join): the append is the CONSEQUENCE of
+        # letting remove_session run to completion, not something to cancel
+        # around — cancelling this task would both defeat its MCP-close
+        # purpose (#4759's own root cause) and leave the append half-done.
+        # NOTE: no existing test exercises an ephemeral session vanishing
+        # DURING a global rewind specifically (the 9-file await_quiescent
+        # witness set all use non-ephemeral sessions where this task is
+        # never populated) — this is a reasoned extension of the invariant,
+        # not something the test suite independently confirms.
         coro = self._registry.remove_session(self._agent_name, self._session_id_provider())
         self._vanish_task = self._task_tracker.spawn(
-            coro, disposition="await", name="ephemeral-vanish",
+            coro, disposition="await", appends_wal=True, name="ephemeral-vanish",
         )

--- a/src/reyn/runtime/spawn_tracker.py
+++ b/src/reyn/runtime/spawn_tracker.py
@@ -111,7 +111,7 @@ class SpawnTracker:
         agent_name: str,
         session_id_provider: "Callable[[], str]",
         ephemeral_provider: "Callable[[], bool]",
-        task_tracker: "TrackedTaskSet | None" = None,
+        task_tracker: "TrackedTaskSet",
     ) -> None:
         self._registry = registry
         self._journal = journal
@@ -125,9 +125,12 @@ class SpawnTracker:
         # (it closes this session's own held MCP connections via
         # remove_session -> aclose_mcp_connections) that was previously
         # detached and invisible to AgentRegistry.shutdown()'s drain, the
-        # #4759 root cause. None-tolerant for a caller that doesn't pass one
-        # (pre-#4759 behaviour: _vanish_task is still set for the existing
-        # test bridge, just not registry-shutdown-reachable).
+        # #4759 root cause. REQUIRED (no None-tolerant fallback): the one
+        # production construction site (session.py) always supplies one, and
+        # an optional fallback here would silently recreate #4759's own
+        # defect shape at a FUTURE construction site that forgets to pass
+        # one -- exactly the class of hole this PR exists to close, not
+        # reintroduce in its own new code.
         self._task_tracker = task_tracker
         # #4740: (agent_name, sid) -> trusted original-task record for spawned
         # sessions, so a compromised sub-session can't forge task framing
@@ -248,21 +251,17 @@ class SpawnTracker:
             return
         self._vanish_scheduled = True
         # #4759: routed through the owning Session's task funnel
-        # (tracked_tasks.py) when available, disposition="await" -- this
-        # task performs the actual teardown work (remove_session closes this
-        # session's held MCP connections among other things), so it must be
-        # allowed to run to completion, not cancelled. Before #4759 this was
-        # a bare asyncio.create_task with only self._vanish_task as a strong
-        # ref (kept below, unconditionally, for the 3 existing tests that
-        # await it directly) -- invisible to AgentRegistry.shutdown()'s own
-        # drain, which is the root cause #4759 traced: a normal shutdown
-        # could return while this was still mid-flight, orphaning whatever
-        # OS subprocess remove_session -> aclose_mcp_connections was about
-        # to close.
+        # (tracked_tasks.py), disposition="await" -- this task performs the
+        # actual teardown work (remove_session closes this session's held
+        # MCP connections among other things), so it must be allowed to run
+        # to completion, not cancelled. self._vanish_task is ALSO kept below
+        # (unconditionally, for the 3 existing tests that await it directly)
+        # -- before #4759 it was a bare asyncio.create_task with ONLY that
+        # ref, invisible to AgentRegistry.shutdown()'s own drain, which is
+        # the root cause #4759 traced: a normal shutdown could return while
+        # this was still mid-flight, orphaning whatever OS subprocess
+        # remove_session -> aclose_mcp_connections was about to close.
         coro = self._registry.remove_session(self._agent_name, self._session_id_provider())
-        if self._task_tracker is not None:
-            self._vanish_task = self._task_tracker.spawn(
-                coro, disposition="await", name="ephemeral-vanish",
-            )
-        else:
-            self._vanish_task = asyncio.create_task(coro)
+        self._vanish_task = self._task_tracker.spawn(
+            coro, disposition="await", name="ephemeral-vanish",
+        )

--- a/src/reyn/runtime/tracked_tasks.py
+++ b/src/reyn/runtime/tracked_tasks.py
@@ -21,6 +21,57 @@ and :meth:`TrackedTaskSet.aclose` is the ONE thing a teardown caller needs to
 know about, regardless of how many task-owning sub-components exist now or
 are added later — a 9th call site that goes through ``spawn`` is covered by
 construction, not by a reviewer remembering to touch a teardown method.
+
+**Two independent axes, not one.** ``disposition`` answers HOW a task folds
+(await it to completion vs. cancel-then-join it) — it says nothing about
+WHEN it is safe to fold. ``appends_wal`` answers that second question, and —
+this took two review rounds to name correctly (lead-coder + architect
+co-vet, #4759) — it must name the ACTUAL invariant ``Session.await_quiescent``
+declares in its own docstring, not a proxy for it:
+
+    "no WAL append can still land" / Coverage: "the exhaustive set of
+    APPEND-CAPABLE spawned tasks" (#1533's own table)
+
+The FIRST version of this axis was named ``scope`` (``"quiesce"`` vs.
+``"session"``, i.e. "does this task's LIFETIME track a turn/rewind or the
+whole session") — plausible-sounding, and it shipped a real regression
+anyway: an unscoped ``aclose()`` call from ``await_quiescent`` (which runs
+during a REWIND, not only shutdown) cancelled OutboxHub's drain loop, and
+the session silently stopped answering (caught by CI:
+``tests/runtime/test_slash_rewind_self_cancel_3362.py``). The FIX for that
+regression was scoping by lifetime — but the axis's NAME was still wrong:
+"session-scoped" and "does not append to the WAL" happen to coincide for
+every producer that exists TODAY, but they are not the same property, and a
+future task that is BOTH session-lifetime AND WAL-appending would silently
+escape ``await_quiescent``'s protection under a lifetime-named axis — the
+same invisible-failure shape #4759 itself is about, one level up (architect
+co-vet, #4765). ``appends_wal`` names the actual thing being asked:
+
+- ``True`` — this task's own execution can result in a durable WAL append
+  landing (chain-timeout watchdogs firing ``chain_timeout_fired``;
+  fire-and-forget intervention-dispatch/answer-consumed appends; the
+  ephemeral-vanish task's own ``remove_session`` → ``session_vanished``
+  append). ``await_quiescent`` MUST drain these before a rewind's
+  reset-record, or a straggler append lands past it (the #1533/#2115 bug
+  class) — cancel_join tasks here are drop-safe AND reversible (restore()
+  re-arms them from the recovered snapshot); the vanish task (disposition
+  "await") is instead genuinely awaited to completion.
+- ``False`` (the default) — this task's own execution never itself appends
+  to the WAL (OutboxHub's drain loop, the hook-bus bridge,
+  hooks/external_fire's drain loop, a cross-session cancel-inflight
+  forward, restored-intervention watchers whose own cancel is reset_for_
+  rewind's separate, pre-existing mechanism, a maintenance truncation
+  check) — ``await_quiescent`` must NOT touch these; only real session
+  teardown may.
+
+``await_quiescent`` calls ``aclose(appends_wal=True)`` (drains only the
+tasks that could contaminate the reset-record); ``Session.
+aclose_background_tasks`` (real shutdown, via ``AgentRegistry.shutdown()``)
+calls plain ``aclose()`` (every producer, both values). Declared BY THE
+SPAWNER at ``spawn()``/``register()`` time — the same reasoning that put
+``disposition`` there: a 9th producer states its own two properties where
+it is created, so nothing downstream needs to enumerate producers to get
+either axis right.
 """
 from __future__ import annotations
 
@@ -59,11 +110,12 @@ _MAX_ACLOSE_ROUNDS = 50
 
 class TrackedTaskSet:
     """Owns every background task spawned through it, with a per-task
-    disposition recorded at spawn time. See module docstring for why this
-    exists instead of N separately-named task fields."""
+    disposition + ``appends_wal`` flag recorded at spawn time. See module
+    docstring for why this exists instead of N separately-named task
+    fields, and for the two-axis (disposition, appends_wal) design."""
 
     def __init__(self) -> None:
-        self._tasks: "dict[asyncio.Task, Disposition]" = {}
+        self._tasks: "dict[asyncio.Task, tuple[Disposition, bool]]" = {}
 
     def __len__(self) -> int:
         """Total tracked task count (done or not) — lets a generic
@@ -83,23 +135,40 @@ class TrackedTaskSet:
         coro: "Coroutine[Any, Any, Any]",
         *,
         disposition: Disposition = "cancel_join",
-        name: "str | None" = None,
+        appends_wal: bool = False,
+        name: str,
     ) -> asyncio.Task:
         """Create and track a background task. Use this instead of a bare
         ``asyncio.create_task`` for anything that outlives the call that
-        creates it — that is the entire point of this module."""
+        creates it — that is the entire point of this module. ``name`` is
+        REQUIRED (not optional with a generic default): a diagnostic that
+        can only say "Task-7" — asyncio's own default when no name is
+        given — is a diagnostic that doesn't diagnose (#4765 co-vet: this
+        is what made the reentrancy-exclusion warning and the
+        fixpoint-exhaustion warning unreadable for ``register()``-tracked
+        tasks before this was enforced here too). ``appends_wal`` defaults
+        to ``False`` (the safer default — see module docstring): pass
+        ``appends_wal=True`` explicitly only for a task whose own execution
+        can result in a durable WAL append landing."""
         task = asyncio.create_task(coro, name=name)
-        self._tasks[task] = disposition
+        self._tasks[task] = (disposition, appends_wal)
         task.add_done_callback(lambda t: self._tasks.pop(t, None))
         return task
 
-    def register(self, task: asyncio.Task, *, disposition: Disposition = "cancel_join") -> asyncio.Task:
+    def register(
+        self, task: asyncio.Task, *,
+        disposition: Disposition = "cancel_join", appends_wal: bool = False,
+    ) -> asyncio.Task:
         """Track an ALREADY-CREATED task (e.g. one made via
         ``asyncio.ensure_future``/``loop.create_task`` at a call site that
-        needs the task object before it can hand it off). Prefer
-        :meth:`spawn` when the caller controls creation; this exists for the
-        sites that don't."""
-        self._tasks[task] = disposition
+        needs the task object before it can hand it off — the caller MUST
+        have named it via ``asyncio.create_task(..., name=...)`` /
+        ``asyncio.ensure_future`` supports no ``name=`` kwarg itself, so
+        name it via ``task.set_name(...)`` before registering if needed).
+        Prefer :meth:`spawn` when the caller controls creation; this exists
+        for the sites that don't. Same ``appends_wal`` default/guidance as
+        :meth:`spawn`."""
+        self._tasks[task] = (disposition, appends_wal)
         task.add_done_callback(lambda t: self._tasks.pop(t, None))
         return task
 
@@ -107,28 +176,61 @@ class TrackedTaskSet:
         """Read-only introspection: currently-tracked, not-yet-done tasks."""
         return [t for t in self._tasks if not t.done()]
 
-    async def aclose(self) -> None:
-        """Drain every tracked task to a fixpoint: cancel every
-        ``"cancel_join"`` task, leave every ``"await"`` task to run to
-        completion on its own, then join everything currently tracked —
-        looping because a joined task may itself register a new one (the
-        same re-entrancy #2115 already fixed for WAL-append tasks, now
-        generalised to every producer through this one seam). Best-effort:
-        a task's own exception is swallowed (logged) so one faulty task
-        can't abort draining the rest. NOT independently time-bounded —
-        callers that must not block ``/quit`` indefinitely (i.e.
+    async def aclose(self, *, appends_wal: "bool | None" = None, caller: str = "") -> None:
+        """Drain tracked tasks to a fixpoint: cancel every ``"cancel_join"``
+        task, leave every ``"await"`` task to run to completion on its own,
+        then join everything currently tracked — looping because a joined
+        task may itself register a new one (the same re-entrancy #2115
+        already fixed for WAL-append tasks, now generalised to every
+        producer through this one seam). Best-effort: a task's own
+        exception is swallowed (logged) so one faulty task can't abort
+        draining the rest. NOT independently time-bounded — callers that
+        must not block ``/quit`` indefinitely (i.e.
         ``AgentRegistry.shutdown()``) wrap this in their own bounded
         ``asyncio.wait_for``; this method has no opinion on that budget.
+
+        ``appends_wal`` filters WHICH tracked tasks this call touches (see
+        module docstring's "Two independent axes" section) — ``None`` (the
+        default) drains every task regardless of the flag, the real-shutdown
+        case (``Session.aclose_background_tasks``, called from
+        ``AgentRegistry.shutdown()``). Pass ``appends_wal=True`` for a
+        mid-life quiesce point (``Session.await_quiescent``, called during
+        a REWIND, NOT a shutdown) — this touches ONLY tasks whose own
+        execution can land a durable WAL append, leaving every
+        ``appends_wal=False`` task (OutboxHub's drain loop, the hook-bus
+        bridge, ...) untouched and running, because the session is
+        expected to keep serving turns after the quiesce point returns.
+        #4759/#4765 review: an EARLIER version of this axis was named by
+        task LIFETIME ("session-scoped" vs "quiesce-scoped") rather than by
+        this actual invariant — the two happened to coincide for every
+        producer that existed then, but a future session-lifetime task that
+        ALSO appends to the WAL would have silently escaped protection
+        under that naming. Naming the axis after the real invariant
+        ``await_quiescent`` declares (see its own docstring: "no WAL append
+        can still land") closes that gap by construction instead of by
+        convention.
+
+        ``caller`` is a short, free-text label for WHO is calling this —
+        purely diagnostic (folded into the reentrancy-exclusion warning
+        below), because the excluded task's own name does not say who
+        called ``aclose()`` (#4765 co-vet: the reentrancy warning could
+        previously only report which task was skipped, not which caller
+        hit the reentrant case — insufficient to tell an expected
+        exclusion (the vanish task's own internal call) apart from an
+        unexpected one (a hypothetical future ``AgentRegistry.shutdown()``
+        call landing reentrant, which would mean its "always non-reentrant"
+        expectation had broken). Pass e.g. ``caller="await_quiescent"`` or
+        ``caller="AgentRegistry.shutdown"`` at each call site.
 
         #4759 re-entrancy: a tracked "await"-disposition task can itself end
         up calling ``aclose()`` (the ephemeral-vanish task runs
         ``remove_session()``, which awaits ``Session.await_quiescent()``,
-        which now calls ``self._background_tasks.aclose()``) — while that
-        call is on the stack, the vanish task is STILL tracked (its
-        done-callback hasn't fired; it hasn't returned yet). A naive
-        ``asyncio.gather`` over every pending task would then include
-        ``asyncio.current_task()`` alongside itself — measured directly
-        (strip the exclusion below and run
+        which calls ``self._background_tasks.aclose(appends_wal=True,
+        caller="await_quiescent")``) — while that call is on the stack, the
+        vanish task is STILL tracked (its done-callback hasn't fired; it
+        hasn't returned yet). A naive ``asyncio.gather`` over every pending
+        task would then include ``asyncio.current_task()`` alongside itself
+        — measured directly (strip the exclusion below and run
         ``tests/runtime/test_4759_tracked_task_set.py``): this does not
         raise, it HANGS (``current_task`` wait on a gather that is itself
         waiting on ``current_task`` to finish, which it cannot do until the
@@ -140,14 +242,14 @@ class TrackedTaskSet:
         **The guarantee this weakens, precisely**: a call to ``aclose()``
         made FROM a task this same ``TrackedTaskSet`` is currently tracking
         (i.e. ``asyncio.current_task()`` is itself a tracked, not-yet-done
-        task) returns once every OTHER tracked task has settled — it does
-        NOT wait for its own caller-task, and a caller in that position
-        cannot read "aclose() returned" as "everything is done" (its own
-        task, by definition, is not done yet — it's still running the
-        ``aclose()`` call). A call made from any OTHER task has no such
-        gap: EVERY tracked task, including one that is mid-reentrant-
-        ``aclose()`` right now, is included in that call's own drain and
-        genuinely awaited to completion.
+        task) returns once every OTHER matching-filter tracked task has
+        settled — it does NOT wait for its own caller-task, and a caller in
+        that position cannot read "aclose() returned" as "everything is
+        done" (its own task, by definition, is not done yet — it's still
+        running the ``aclose()`` call). A call made from any OTHER task has
+        no such gap: EVERY matching-filter tracked task, including one that
+        is mid-reentrant-``aclose()`` right now, is included in that call's
+        own drain and genuinely awaited to completion.
 
         ``AgentRegistry.shutdown()``'s OWN call is EXPECTED to always be
         non-reentrant (the registry's task is never itself one this tracker
@@ -160,12 +262,12 @@ class TrackedTaskSet:
         hook/intervention machinery — were not individually traced for
         whether a tracked task could ever be the one calling `shutdown()`).
         Rather than assert an unverified absolute, a reentrant exclusion
-        below always logs a WARNING naming which task and disposition it
-        skipped — reentrancy itself is a NORMAL, expected event for the
-        vanish task's own internal call, so this is diagnostic, not an
-        error; but if this warning is ever observed to originate from
-        ``AgentRegistry.shutdown()``'s own call specifically, this
-        method's core assumption for that caller has broken and its
+        below always logs a WARNING naming the excluded task, its
+        disposition, and the ``caller`` label passed in — reentrancy itself
+        is a NORMAL, expected event for the vanish task's own internal
+        call, so this is diagnostic, not an error; but if this warning is
+        ever observed with ``caller="AgentRegistry.shutdown"`` specifically,
+        that call's non-reentrancy assumption has broken and its
         "everything is done" reading is no longer trustworthy.
         """
         current = asyncio.current_task()
@@ -174,22 +276,27 @@ class TrackedTaskSet:
             # `current` cannot become done() while it is the task running
             # THIS code, so re-checking inside the loop would just repeat
             # the same warning up to _MAX_ACLOSE_ROUNDS times.
+            disp, wal = self._tasks[current]
             logger.warning(
-                "TrackedTaskSet.aclose: called reentrantly from a task "
-                "(%r, disposition=%r) this tracker is itself still "
-                "tracking -- that task is excluded from THIS call's own "
-                "drain (see aclose()'s own docstring for why). Normal for "
-                "the ephemeral-vanish task's internal call; if this "
-                "originates from AgentRegistry.shutdown()'s own call, its "
+                "TrackedTaskSet.aclose(caller=%r): called reentrantly from "
+                "a task (%r, disposition=%r, appends_wal=%r) this tracker "
+                "is itself still tracking -- that task is excluded from "
+                "THIS call's own drain (see aclose()'s own docstring for "
+                "why). Normal for the ephemeral-vanish task's internal "
+                "call; if caller=='AgentRegistry.shutdown' here, its "
                 "non-reentrancy assumption has broken.",
-                current.get_name(), self._tasks.get(current),
+                caller, current.get_name(), disp, wal,
             )
         for _ in range(_MAX_ACLOSE_ROUNDS):
-            pending = [t for t in self._tasks if not t.done() and t is not current]
+            pending = [
+                t for t, (_disp, t_wal) in self._tasks.items()
+                if not t.done() and t is not current and (appends_wal is None or t_wal == appends_wal)
+            ]
             if not pending:
                 return
             for task in pending:
-                if self._tasks.get(task) == "cancel_join":
+                disp, _wal = self._tasks[task]
+                if disp == "cancel_join":
                     task.cancel()
             results = await asyncio.gather(*pending, return_exceptions=True)
             for task, result in zip(pending, results, strict=True):
@@ -201,8 +308,13 @@ class TrackedTaskSet:
                         "teardown: %r", task.get_name(), result,
                     )
         else:
+            still_pending = [
+                t for t, (_d, t_wal) in self._tasks.items()
+                if not t.done() and (appends_wal is None or t_wal == appends_wal)
+            ]
             logger.warning(
-                "TrackedTaskSet.aclose: did not drain to a fixpoint in %d "
-                "rounds — %d task(s) still tracked",
-                _MAX_ACLOSE_ROUNDS, len(self.pending()),
+                "TrackedTaskSet.aclose(caller=%r): did not drain to a "
+                "fixpoint in %d rounds -- %d task(s) still tracked: %r",
+                caller, _MAX_ACLOSE_ROUNDS, len(still_pending),
+                [t.get_name() for t in still_pending],
             )

--- a/src/reyn/runtime/tracked_tasks.py
+++ b/src/reyn/runtime/tracked_tasks.py
@@ -1,0 +1,158 @@
+"""#4759: a single funnel for every fire-and-forget background task a
+``Session`` (or a sub-component it owns — ``SpawnTracker``, ``ChainManager``,
+``OutboxHub``, the hooks bridge, ...) spawns via ``asyncio.create_task``.
+
+Root cause this closes: before this module existed, each such task lived on
+its own ad hoc field (``SpawnTracker._vanish_task``, ``OutboxHub._drain_task``,
+a bare local in ``session_api.py``, ...), and ``AgentRegistry.shutdown()`` (or
+whatever else needed to know "is anything still cleaning up") had to
+ENUMERATE those fields by name to find them. ``SpawnTracker._vanish_task`` —
+a task that itself closes this session's held MCP connections — was never
+added to that enumeration, so a normal ``registry.shutdown()`` (and, in
+production, an ordinary ``/quit``) could return while it was still mid-flight
+or not yet even scheduled, orphaning the OS subprocess it was about to close
+(#4759). Adding ``_vanish_task`` to the enumeration by name would only move
+the same defect up one level: the NEXT background task some future PR adds
+would again need someone to remember to list it.
+
+The fix is a single owned collection instead of a named list: every producer
+calls :meth:`TrackedTaskSet.spawn` (never ``asyncio.create_task`` directly)
+and :meth:`TrackedTaskSet.aclose` is the ONE thing a teardown caller needs to
+know about, regardless of how many task-owning sub-components exist now or
+are added later — a 9th call site that goes through ``spawn`` is covered by
+construction, not by a reviewer remembering to touch a teardown method.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Coroutine
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+#: "await" — the task performs real work that must be allowed to finish (the
+#: ephemeral-vanish teardown task, which itself closes this session's held
+#: MCP connections — cancelling it would defeat its own purpose). "cancel_join"
+#: — the task is drop-safe fire-and-forget work (a WAL append, a chain-timeout
+#: watchdog, a forwarder loop) — cancelling is correct, and for the WAL/chain
+#: cases explicitly reversible (reconstruction re-arms them from the WAL), so
+#: :meth:`TrackedTaskSet.aclose` cancels these before joining them.
+Disposition = Literal["await", "cancel_join"]
+
+#: Mirrors ``session.py``'s own ``_QUIESCE_MAX_ROUNDS`` fixpoint bound: a
+#: joined task can itself spawn a NEW tracked task (e.g. a re-armed chain
+#: timer, or a vanish task's own ``remove_session()`` touching another
+#: tracked field) that a single snapshot-and-gather pass would miss — loop to
+#: a fixpoint instead of assuming one pass drains everything.
+_MAX_ACLOSE_ROUNDS = 8
+
+
+class TrackedTaskSet:
+    """Owns every background task spawned through it, with a per-task
+    disposition recorded at spawn time. See module docstring for why this
+    exists instead of N separately-named task fields."""
+
+    def __init__(self) -> None:
+        self._tasks: "dict[asyncio.Task, Disposition]" = {}
+
+    def spawn(
+        self,
+        coro: "Coroutine[Any, Any, Any]",
+        *,
+        disposition: Disposition = "cancel_join",
+        name: "str | None" = None,
+    ) -> asyncio.Task:
+        """Create and track a background task. Use this instead of a bare
+        ``asyncio.create_task`` for anything that outlives the call that
+        creates it — that is the entire point of this module."""
+        task = asyncio.create_task(coro, name=name)
+        self._tasks[task] = disposition
+        task.add_done_callback(lambda t: self._tasks.pop(t, None))
+        return task
+
+    def register(self, task: asyncio.Task, *, disposition: Disposition = "cancel_join") -> asyncio.Task:
+        """Track an ALREADY-CREATED task (e.g. one made via
+        ``asyncio.ensure_future``/``loop.create_task`` at a call site that
+        needs the task object before it can hand it off). Prefer
+        :meth:`spawn` when the caller controls creation; this exists for the
+        sites that don't."""
+        self._tasks[task] = disposition
+        task.add_done_callback(lambda t: self._tasks.pop(t, None))
+        return task
+
+    def pending(self) -> "list[asyncio.Task]":
+        """Read-only introspection: currently-tracked, not-yet-done tasks."""
+        return [t for t in self._tasks if not t.done()]
+
+    async def aclose(self) -> None:
+        """Drain every tracked task to a fixpoint: cancel every
+        ``"cancel_join"`` task, leave every ``"await"`` task to run to
+        completion on its own, then join everything currently tracked —
+        looping because a joined task may itself register a new one (the
+        same re-entrancy #2115 already fixed for WAL-append tasks, now
+        generalised to every producer through this one seam). Best-effort:
+        a task's own exception is swallowed (logged) so one faulty task
+        can't abort draining the rest. NOT independently time-bounded —
+        callers that must not block ``/quit`` indefinitely (i.e.
+        ``AgentRegistry.shutdown()``) wrap this in their own bounded
+        ``asyncio.wait_for``; this method has no opinion on that budget.
+
+        #4759 re-entrancy: a tracked "await"-disposition task can itself end
+        up calling ``aclose()`` (the ephemeral-vanish task runs
+        ``remove_session()``, which awaits ``Session.await_quiescent()``,
+        which now calls ``self._background_tasks.aclose()``) — while that
+        call is on the stack, the vanish task is STILL tracked (its
+        done-callback hasn't fired; it hasn't returned yet). A naive
+        ``asyncio.gather`` over every pending task would then include
+        ``asyncio.current_task()`` alongside itself — measured directly
+        (strip the exclusion below and run
+        ``tests/runtime/test_4759_tracked_task_set.py``): this does not
+        raise, it HANGS (``current_task`` wait on a gather that is itself
+        waiting on ``current_task`` to finish, which it cannot do until the
+        gather it's awaiting returns — the exact class of silent stall
+        #4759 started from, now reproduced one layer up, in the fix's own
+        primitive, if the exclusion is removed). So a reentrant call
+        excludes ``current_task()`` from its OWN drain.
+
+        **The guarantee this weakens, precisely**: a call to ``aclose()``
+        made FROM a task this same ``TrackedTaskSet`` is currently tracking
+        (i.e. ``asyncio.current_task()`` is itself a tracked, not-yet-done
+        task) returns once every OTHER tracked task has settled — it does
+        NOT wait for its own caller-task, and a caller in that position
+        cannot read "aclose() returned" as "everything is done" (its own
+        task, by definition, is not done yet — it's still running the
+        ``aclose()`` call). A call made from any OTHER task (the ordinary
+        case — ``AgentRegistry.shutdown()``'s own call is always non-
+        reentrant, since the registry's task is never itself one this
+        tracker owns) has no such gap: EVERY tracked task, including one
+        that is mid-reentrant-``aclose()`` right now, is included in that
+        call's own drain and genuinely awaited to completion. This is what
+        makes ``AgentRegistry.shutdown()``'s call correct despite the
+        vanish task's own internal reentrant call resolving early — the
+        outer, non-reentrant call still waits for the vanish task itself to
+        finish, exactly as #4759 requires.
+        """
+        current = asyncio.current_task()
+        for _ in range(_MAX_ACLOSE_ROUNDS):
+            pending = [t for t in self._tasks if not t.done() and t is not current]
+            if not pending:
+                return
+            for task in pending:
+                if self._tasks.get(task) == "cancel_join":
+                    task.cancel()
+            results = await asyncio.gather(*pending, return_exceptions=True)
+            for task, result in zip(pending, results, strict=True):
+                if isinstance(result, BaseException) and not isinstance(
+                    result, asyncio.CancelledError,
+                ):
+                    logger.warning(
+                        "TrackedTaskSet.aclose: tracked task %r raised during "
+                        "teardown: %r", task.get_name(), result,
+                    )
+        else:
+            logger.warning(
+                "TrackedTaskSet.aclose: did not drain to a fixpoint in %d "
+                "rounds — %d task(s) still tracked",
+                _MAX_ACLOSE_ROUNDS, len(self.pending()),
+            )

--- a/src/reyn/runtime/tracked_tasks.py
+++ b/src/reyn/runtime/tracked_tasks.py
@@ -40,12 +40,21 @@ logger = logging.getLogger(__name__)
 #: :meth:`TrackedTaskSet.aclose` cancels these before joining them.
 Disposition = Literal["await", "cancel_join"]
 
-#: Mirrors ``session.py``'s own ``_QUIESCE_MAX_ROUNDS`` fixpoint bound: a
-#: joined task can itself spawn a NEW tracked task (e.g. a re-armed chain
-#: timer, or a vanish task's own ``remove_session()`` touching another
-#: tracked field) that a single snapshot-and-gather pass would miss — loop to
-#: a fixpoint instead of assuming one pass drains everything.
-_MAX_ACLOSE_ROUNDS = 8
+#: Cap for :meth:`TrackedTaskSet.aclose`'s re-drain loop — the SAME shape as
+#: the pre-#4759 ``await_quiescent``-only ``_QUIESCE_MAX_ROUNDS`` this
+#: replaces (#2115: a joined task can itself spawn a NEW tracked task — e.g.
+#: a re-armed chain timer, or the vanish task's own ``remove_session()``
+#: touching another tracked field — that a single snapshot-and-gather pass
+#: would miss), carrying over its ACTUAL value (50, not re-derived here) —
+#: #2115's own reasoning ("finite + cancel-requested + spawns no new
+#: user-work under a rewind, converges in 1-2 rounds; the cap is purely a
+#: guard against a pathological spin, logged, never silently looped") was
+#: scoped to WAL-append tasks specifically. This funnel now also carries
+#: "await"-disposition tasks (the vanish task) that perform real work and
+#: are not cancel-requested, so convergence is not guaranteed in 1-2 rounds
+#: the same way — reusing the wider, already-established 50 rather than
+#: inventing a smaller number for a case #2115 never measured.
+_MAX_ACLOSE_ROUNDS = 50
 
 
 class TrackedTaskSet:
@@ -55,6 +64,19 @@ class TrackedTaskSet:
 
     def __init__(self) -> None:
         self._tasks: "dict[asyncio.Task, Disposition]" = {}
+
+    def __len__(self) -> int:
+        """Total tracked task count (done or not) — lets a generic
+        container-measurement surface (``resident_stats.py``'s #4497
+        report) treat this like any other sized container without needing
+        to special-case it."""
+        return len(self._tasks)
+
+    def __iter__(self):
+        """Iterate the tracked ``asyncio.Task`` objects — same rationale
+        as ``__len__``; ``pending()`` remains the intentional-subset (not
+        yet done) read for callers that specifically want that."""
+        return iter(self._tasks)
 
     def spawn(
         self,
@@ -122,18 +144,46 @@ class TrackedTaskSet:
         NOT wait for its own caller-task, and a caller in that position
         cannot read "aclose() returned" as "everything is done" (its own
         task, by definition, is not done yet — it's still running the
-        ``aclose()`` call). A call made from any OTHER task (the ordinary
-        case — ``AgentRegistry.shutdown()``'s own call is always non-
-        reentrant, since the registry's task is never itself one this
-        tracker owns) has no such gap: EVERY tracked task, including one
-        that is mid-reentrant-``aclose()`` right now, is included in that
-        call's own drain and genuinely awaited to completion. This is what
-        makes ``AgentRegistry.shutdown()``'s call correct despite the
-        vanish task's own internal reentrant call resolving early — the
-        outer, non-reentrant call still waits for the vanish task itself to
-        finish, exactly as #4759 requires.
+        ``aclose()`` call). A call made from any OTHER task has no such
+        gap: EVERY tracked task, including one that is mid-reentrant-
+        ``aclose()`` right now, is included in that call's own drain and
+        genuinely awaited to completion.
+
+        ``AgentRegistry.shutdown()``'s OWN call is EXPECTED to always be
+        non-reentrant (the registry's task is never itself one this tracker
+        owns), which is what makes it correct despite the vanish task's own
+        internal reentrant call resolving early. This expectation is NOT
+        exhaustively verified across every ``shutdown()`` call site in the
+        codebase (6 call sites measured at #4759 review time; the 3
+        top-level CLI entry points are self-evidently not a tracked task,
+        but the other 3 — including a slash/dispatch.py path reachable via
+        hook/intervention machinery — were not individually traced for
+        whether a tracked task could ever be the one calling `shutdown()`).
+        Rather than assert an unverified absolute, a reentrant exclusion
+        below always logs a WARNING naming which task and disposition it
+        skipped — reentrancy itself is a NORMAL, expected event for the
+        vanish task's own internal call, so this is diagnostic, not an
+        error; but if this warning is ever observed to originate from
+        ``AgentRegistry.shutdown()``'s own call specifically, this
+        method's core assumption for that caller has broken and its
+        "everything is done" reading is no longer trustworthy.
         """
         current = asyncio.current_task()
+        if current is not None and current in self._tasks and not current.done():
+            # Logged ONCE per aclose() call, not per fixpoint round below —
+            # `current` cannot become done() while it is the task running
+            # THIS code, so re-checking inside the loop would just repeat
+            # the same warning up to _MAX_ACLOSE_ROUNDS times.
+            logger.warning(
+                "TrackedTaskSet.aclose: called reentrantly from a task "
+                "(%r, disposition=%r) this tracker is itself still "
+                "tracking -- that task is excluded from THIS call's own "
+                "drain (see aclose()'s own docstring for why). Normal for "
+                "the ephemeral-vanish task's internal call; if this "
+                "originates from AgentRegistry.shutdown()'s own call, its "
+                "non-reentrancy assumption has broken.",
+                current.get_name(), self._tasks.get(current),
+            )
         for _ in range(_MAX_ACLOSE_ROUNDS):
             pending = [t for t in self._tasks if not t.done() and t is not current]
             if not pending:

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -440,7 +440,15 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: surface the axis's own mechanism requires by design" reason as the
 #: 107->108/108->109 entries above (``RouterHostAdapter.model_class_ceiling()``
 #: consults it via the same callback shape), not a private-state leak.
-_PUBLIC_MEMBER_CEILING = 110
+#: Raised 110 -> 111 for #4759: ``aclose_background_tasks`` — a NEW method,
+#: same public shape as the EXISTING ``aclose_mcp_connections``/
+#: ``aclose_event_store`` (already counted in the prior ceiling) —
+#: ``AgentRegistry.shutdown()``'s getattr-duck-typed teardown seam for the
+#: single background-task funnel (``tracked_tasks.py``). Genuinely unrelated
+#: to a slash handler reaching into the session (it is a registry-owned
+#: teardown call, not a read a slash command would use) — the gate's own
+#: documented carve-out for this case.
+_PUBLIC_MEMBER_CEILING = 111
 
 
 def test_session_public_surface_does_not_grow() -> None:

--- a/tests/runtime/test_4497_resident_stats.py
+++ b/tests/runtime/test_4497_resident_stats.py
@@ -65,7 +65,7 @@ def test_session_container_stats_reads_a_real_sessions_attributes():
     names = {s.name for s in stats}
     assert "_pending_user_images" in names
     assert "_safety_extensions" in names
-    assert "_inflight_wal_tasks" in names
+    assert "_background_tasks" in names
     assert "_buffered_intervention_answers" in names
     assert "_cancel_forward_targets" in names
     assert "_allowed_mcp" in names

--- a/tests/runtime/test_4759_tracked_task_set.py
+++ b/tests/runtime/test_4759_tracked_task_set.py
@@ -59,7 +59,7 @@ async def test_aclose_reentrant_from_a_task_it_is_itself_tracking_does_not_raise
         await tracker.aclose()
         reentrant_call_completed.set()
 
-    task = tracker.spawn(self_referencing_task(), disposition="await")
+    task = tracker.spawn(self_referencing_task(), disposition="await", name="self-referencing")
 
     await reentrant_call_completed.wait()
     await task
@@ -93,8 +93,8 @@ async def test_reentrant_aclose_still_drains_a_different_tracked_task():
         await sibling_started.wait()
         await tracker.aclose()
 
-    tracker.spawn(sibling(), disposition="cancel_join")
-    task = tracker.spawn(self_referencing_task(), disposition="await")
+    tracker.spawn(sibling(), disposition="cancel_join", name="sibling")
+    task = tracker.spawn(self_referencing_task(), disposition="await", name="self-referencing")
 
     await task
     assert sibling_was_cancelled
@@ -125,8 +125,8 @@ async def test_aclose_cancels_cancel_join_and_leaves_await_disposition_to_finish
         await asyncio.sleep(0)
         await_disposition_completed = True
 
-    tracker.spawn(cancel_join_task(), disposition="cancel_join")
-    tracker.spawn(await_task(), disposition="await")
+    tracker.spawn(cancel_join_task(), disposition="cancel_join", name="cancel-join-task")
+    tracker.spawn(await_task(), disposition="await", name="await-task")
     # Let cancel_join_task actually start (reach its own sleep) before
     # aclose() cancels it -- cancelling a task before its coroutine has ever
     # run means its own except-block never executes at all, which would
@@ -197,7 +197,7 @@ async def test_non_reentrant_aclose_does_not_log_the_reentrancy_warning(caplog):
         await asyncio.sleep(0)
 
     with caplog.at_level(logging.WARNING, logger="reyn.runtime.tracked_tasks"):
-        tracker.spawn(ordinary_task(), disposition="cancel_join")
+        tracker.spawn(ordinary_task(), disposition="cancel_join", name="ordinary-task")
         await started.wait()
         await tracker.aclose()  # called from the TEST's own task, not a tracked one
 

--- a/tests/runtime/test_4759_tracked_task_set.py
+++ b/tests/runtime/test_4759_tracked_task_set.py
@@ -147,3 +147,58 @@ async def test_aclose_on_an_empty_tracker_returns_immediately():
     background task at all)."""
     tracker = TrackedTaskSet()
     await tracker.aclose()
+
+
+@pytest.mark.asyncio
+async def test_reentrant_aclose_logs_a_warning_naming_the_excluded_task(caplog):
+    """Tier 1: the re-entrancy exclusion is not silent — lead-coder review
+    (#4759): ``AgentRegistry.shutdown()``'s own call is EXPECTED to always
+    be non-reentrant, but that expectation was not exhaustively traced
+    across every ``shutdown()`` call site in the codebase. Rather than
+    assert an unverified absolute, a reentrant exclusion always logs a
+    WARNING naming the excluded task -- diagnostic (reentrancy is normal
+    for the vanish task's own call), but a witness that would surface an
+    unexpected reentrant call from a DIFFERENT caller if one ever occurs."""
+    import logging
+
+    tracker = TrackedTaskSet()
+    reentrant_call_completed = asyncio.Event()
+
+    async def self_referencing_task() -> None:
+        await tracker.aclose()
+        reentrant_call_completed.set()
+
+    with caplog.at_level(logging.WARNING, logger="reyn.runtime.tracked_tasks"):
+        task = tracker.spawn(
+            self_referencing_task(), disposition="await", name="self-referencing",
+        )
+        await reentrant_call_completed.wait()
+        await task
+
+    assert any(
+        "reentrantly" in record.message and "self-referencing" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_reentrant_aclose_does_not_log_the_reentrancy_warning(caplog):
+    """Tier 1: accept-side — an ordinary, non-reentrant aclose() call (the
+    shape every real AgentRegistry.shutdown() call takes) must NOT log the
+    reentrancy warning; otherwise the warning would be noise on every
+    normal shutdown instead of a signal for the unexpected case."""
+    import logging
+
+    tracker = TrackedTaskSet()
+    started = asyncio.Event()
+
+    async def ordinary_task() -> None:
+        started.set()
+        await asyncio.sleep(0)
+
+    with caplog.at_level(logging.WARNING, logger="reyn.runtime.tracked_tasks"):
+        tracker.spawn(ordinary_task(), disposition="cancel_join")
+        await started.wait()
+        await tracker.aclose()  # called from the TEST's own task, not a tracked one
+
+    assert not any("reentrantly" in record.message for record in caplog.records)

--- a/tests/runtime/test_4759_tracked_task_set.py
+++ b/tests/runtime/test_4759_tracked_task_set.py
@@ -1,0 +1,149 @@
+"""Tier 1: TrackedTaskSet's own contract (#4759).
+
+#4759's root cause was a detached ``asyncio.create_task`` (SpawnTracker's
+ephemeral-vanish task) invisible to ``AgentRegistry.shutdown()``'s drain,
+orphaning a real MCP server subprocess. The fix is a single funnel every
+background-task producer routes through (``TrackedTaskSet`` — see
+``src/reyn/runtime/tracked_tasks.py``'s own module docstring), reached from
+``AgentRegistry.shutdown()`` via ``Session.aclose_background_tasks()``. The
+end-to-end structural witness for the ORIGINAL leak lives in
+``tests/runtime/test_fp0063_arc_witness.py`` (real OS pid, real
+``registry.shutdown()``). This file pins ``TrackedTaskSet`` itself — in
+particular the re-entrancy hazard the fix's own design introduces and must
+handle: the ephemeral-vanish task's real shape is "a tracked task that,
+while running, itself calls ``aclose()`` on the SAME tracker" (SpawnTracker's
+``_vanish_task`` runs ``registry.remove_session()``, which awaits
+``Session.await_quiescent()``, which now calls
+``self._background_tasks.aclose()`` — the currently-running task is still
+tracked at that point, since its own done-callback hasn't fired yet).
+
+These tests assert only the POSITIVE side (``aclose()`` returns; the tasks
+it should complete/cancel actually do) — per testing policy (CLAUDE.md /
+testing.md § Time), no test carries its own wait budget or time limit, so
+there is deliberately no ``asyncio.wait_for``/timeout anywhere below; each
+test awaits its condition unboundedly and relies on CI's own kill switch if
+something is genuinely stuck. The NEGATIVE claim — that removing the
+re-entrancy exclusion makes ``aclose()`` HANG rather than raise — was
+verified by hand (strip the exclusion in ``tracked_tasks.py``, re-run this
+file, observe the run not terminate; restore, re-run, observe green) and is
+recorded in the PR body, not encoded as a test with its own timeout (a test
+that starts a to-be-killed-by-a-timeout hang on every CI run for the rest of
+this file's life is a worse defect than the one it would be demonstrating).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.runtime.tracked_tasks import TrackedTaskSet
+
+
+@pytest.mark.asyncio
+async def test_aclose_reentrant_from_a_task_it_is_itself_tracking_does_not_raise():
+    """Tier 1: a tracked "await"-disposition task that itself calls
+    ``aclose()`` on the SAME ``TrackedTaskSet`` it is tracked by (mirroring
+    ``SpawnTracker._vanish_task``'s real call shape:
+    ``remove_session -> await_quiescent -> background_tasks.aclose()``)
+    returns normally, and the outer task itself later completes cleanly —
+    the currently-running task is excluded from its OWN reentrant drain (see
+    ``TrackedTaskSet.aclose``'s docstring for the precise guarantee this
+    does and does not make)."""
+    tracker = TrackedTaskSet()
+    reentrant_call_completed = asyncio.Event()
+
+    async def self_referencing_task() -> None:
+        # At this point `task` (below) IS this coroutine's own task, and it
+        # is STILL tracked (not done) — the exact shape a naive aclose()
+        # would try to await itself for.
+        await tracker.aclose()
+        reentrant_call_completed.set()
+
+    task = tracker.spawn(self_referencing_task(), disposition="await")
+
+    await reentrant_call_completed.wait()
+    await task
+    assert task.done()
+    assert not task.cancelled()
+    assert task.exception() is None
+
+
+@pytest.mark.asyncio
+async def test_reentrant_aclose_still_drains_a_different_tracked_task():
+    """Tier 1: the re-entrancy exclusion is scoped to ``asyncio.
+    current_task()`` only — a SIBLING tracked task (not the one currently
+    calling ``aclose()``) must still be cancelled+joined by that same
+    reentrant call. Otherwise the exclusion could silently widen into
+    "aclose() does nothing while called reentrantly", which would defeat
+    the whole point of draining everything else."""
+    tracker = TrackedTaskSet()
+    sibling_started = asyncio.Event()
+    sibling_was_cancelled = False
+
+    async def sibling() -> None:
+        nonlocal sibling_was_cancelled
+        sibling_started.set()
+        try:
+            await asyncio.sleep(100)
+        except asyncio.CancelledError:
+            sibling_was_cancelled = True
+            raise
+
+    async def self_referencing_task() -> None:
+        await sibling_started.wait()
+        await tracker.aclose()
+
+    tracker.spawn(sibling(), disposition="cancel_join")
+    task = tracker.spawn(self_referencing_task(), disposition="await")
+
+    await task
+    assert sibling_was_cancelled
+
+
+@pytest.mark.asyncio
+async def test_aclose_cancels_cancel_join_and_leaves_await_disposition_to_finish():
+    """Tier 1: the two dispositions behave differently under aclose() — a
+    "cancel_join" task is cancelled; an "await" task is left to run to
+    completion on its own (cancelling it would defeat tasks like the
+    ephemeral-vanish task, whose entire job IS its own cleanup work)."""
+    tracker = TrackedTaskSet()
+    cancel_join_started = asyncio.Event()
+    cancel_join_cancelled = False
+    await_disposition_completed = False
+
+    async def cancel_join_task() -> None:
+        nonlocal cancel_join_cancelled
+        cancel_join_started.set()
+        try:
+            await asyncio.sleep(100)
+        except asyncio.CancelledError:
+            cancel_join_cancelled = True
+            raise
+
+    async def await_task() -> None:
+        nonlocal await_disposition_completed
+        await asyncio.sleep(0)
+        await_disposition_completed = True
+
+    tracker.spawn(cancel_join_task(), disposition="cancel_join")
+    tracker.spawn(await_task(), disposition="await")
+    # Let cancel_join_task actually start (reach its own sleep) before
+    # aclose() cancels it -- cancelling a task before its coroutine has ever
+    # run means its own except-block never executes at all, which would
+    # make this test measure task.cancelled() instead of the task's own
+    # observed cancellation, a different (weaker) claim.
+    await cancel_join_started.wait()
+
+    await tracker.aclose()
+
+    assert cancel_join_cancelled
+    assert await_disposition_completed
+
+
+@pytest.mark.asyncio
+async def test_aclose_on_an_empty_tracker_returns_immediately():
+    """Tier 1: accept-side — aclose() on a tracker with nothing registered
+    must not raise or block (the common case: most sessions never spawn a
+    background task at all)."""
+    tracker = TrackedTaskSet()
+    await tracker.aclose()

--- a/tests/runtime/test_concurrent_multiagent_rewind_1580.py
+++ b/tests/runtime/test_concurrent_multiagent_rewind_1580.py
@@ -158,8 +158,10 @@ async def test_single_agent_inflight_skill_plan_intervention_drained_by_rewind(t
     """Tier 2: rewind drains in-flight intervention tasks — no straggler WAL
     append crosses the reset-record (await_quiescent coverage, #1533).
 
-    Within ONE agent, a fire-and-forget intervention task (``_inflight_wal_tasks``)
-    is parked *before* its would-be WAL append when the rewind fires. The barrier
+    Within ONE agent, a fire-and-forget intervention task (tracked via
+    ``self._background_tasks``, #4759's task funnel — was a dedicated
+    ``_inflight_wal_tasks`` set before #4759 folded it in) is parked
+    *before* its would-be WAL append when the rewind fires. The barrier
     (``cancel_inflight`` + ``await_quiescent``) must drain it so it cannot append
     past the reset-record. If it escaped, its append would land after R (the
     straggler bug #1533 guards) → this fails.

--- a/tests/runtime/test_fp0063_arc_witness.py
+++ b/tests/runtime/test_fp0063_arc_witness.py
@@ -191,6 +191,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import uuid
 from pathlib import Path
@@ -575,6 +576,36 @@ def _build_registry(tmp_path: Path, project_root: Path):
     return reg, perm_resolver
 
 
+def _child_pids(parent_pid: int) -> "set[int]":
+    """OS-level snapshot of ``parent_pid``'s DIRECT child pids (``pgrep -P``).
+
+    #4759 structural-witness support: this is deliberately an OS-process-table
+    read, not a reyn-internal one (``MCPClient._child_pid`` or similar) -- the
+    child either exists in the kernel's process table or it doesn't,
+    independent of anything reyn's own bookkeeping claims about it, which is
+    the whole point of a *structural* witness over a *symptom* one (see the
+    test's own #4759 comment below). All of this arc's real MCP server
+    subprocesses (chunker, vector-store) are spawned in-process via
+    ``anyio.open_process``, so they are direct children of the pytest worker
+    process itself -- no need to walk a process tree.
+    """
+    proc = subprocess.run(
+        ["pgrep", "-P", str(parent_pid)], capture_output=True, text=True, check=False,
+    )
+    return {int(tok) for tok in proc.stdout.split()}
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """True iff the OS process table still has ``pid`` (any owner)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, just not signalable by us -- still alive
+    return True
+
+
 async def _drive_one_turn(registry, prompt: str, timeout: float) -> str:
     """The SAME two primitives ``run_agent_step`` composes
     (``spawn_ephemeral_session`` + ``MessageBus.request``), called directly
@@ -837,63 +868,146 @@ async def test_llm_driven_install_ingest_query_arc_reaches_the_ingested_chunk(
     plugin_src = _prepare_local_plugin_copy(tmp_path, out_of_process_reyn)
     registry, _perm_resolver = _build_registry(tmp_path, project_root)
 
-    from reyn.dev.testing.replay import LLMReplay
-
-    generate = (
-        os.environ.get("REYN_FP0063_ARC_WITNESS_GENERATE") == "1"
-        or not _INSTALL_FIXTURE_PATH.exists()
-        or not _INGEST_QUERY_FIXTURE_PATH.exists()
-    )
-
-    # -- Turn 1: LLM drives install_plugin ----------------------
-    if generate:
-        monkeypatch.setattr(
-            "litellm.acompletion", _make_install_script(plugin_src), raising=False,
-        )
-    replay_install = LLMReplay(_INSTALL_FIXTURE_PATH, mode="record" if generate else "replay")
-    replay_install.install()
+    # #4759: this arc's Turn 1 (install_plugin) launches the rag plugin's
+    # REAL chunker/vector-store MCP servers as real OS subprocesses (a
+    # dedicated venv interpreter, _prepare_local_plugin_copy's own
+    # docstring) -- unlike every other test in this file's own family
+    # (test_fp0063_p3_rag_pipelines.py explicitly bypasses install_plugin;
+    # test_pipeline_r5_run_agent_step.py never touches MCP at all), so this
+    # is the ONE test in the family that actually opens one. Without an
+    # explicit registry.shutdown() (the #2714 production teardown seam,
+    # AgentRegistry's own method, NOT a test-invented mechanism -- it
+    # already closes every loaded session's held MCP connections on the
+    # normal-exit path), the child process's fate is left to whatever
+    # implicit cleanup the OS/asyncio-runner teardown happens to trigger.
+    # Investigated (#4759, architect): pytest-asyncio's own runner teardown
+    # (_cancel_all_tasks -> os.waitpid(pid, 0), BLOCKING, no WNOHANG) hits
+    # this leaked child and hangs INDEFINITELY if it hasn't already exited
+    # on its own by the time teardown reaches that point -- a genuine race
+    # (measured 1/6 reproduction rate), not a "slow" test; no amount of
+    # extra time budget fixes a wait that never returns. try/finally here
+    # closes the held MCP connections (and, by extension, terminates the
+    # subprocess -- MCPClient.close's own belt-and-suspenders reap,
+    # test_2714_mcp_shutdown_teardown.py's own precedent) BEFORE the
+    # function returns and pytest-asyncio's runner teardown ever begins,
+    # removing the race rather than budgeting more time for it.
+    #
+    # The SYMPTOM (this test not hanging) is not a sufficient witness that
+    # the above claim is what's actually happening: the underlying race
+    # resolves favorably (the child happens to have exited on its own by the
+    # time teardown reaches the blocking waitpid) roughly 5/6 of the time
+    # even with registry.shutdown() removed entirely -- so "the test passed"
+    # would stay green under a strip-falsify of the fix most of the time,
+    # which makes it a weak witness (lead-coder, #4759: a raw repeat-count
+    # would need n >= 17 clean runs for ~5% false-negative confidence, and
+    # even then never explains WHY). The MECHANISM claim -- that
+    # registry.shutdown() is what actually terminates the child, not luck --
+    # is instead witnessed structurally below: real OS pids captured while
+    # the arc's servers are confirmed running, asserted gone from the OS
+    # process table after registry.shutdown() returns. Stripping the
+    # shutdown() call must flip ONLY that assertion red, independent of
+    # whether this particular run happened to hang.
+    _baseline_children = _child_pids(os.getpid())
+    _arc_children: "set[int]" = set()
     try:
-        install_text = await _drive_one_turn(
-            registry, "Install the rag plugin.", timeout=60.0,
+        from reyn.dev.testing.replay import LLMReplay
+
+        generate = (
+            os.environ.get("REYN_FP0063_ARC_WITNESS_GENERATE") == "1"
+            or not _INSTALL_FIXTURE_PATH.exists()
+            or not _INGEST_QUERY_FIXTURE_PATH.exists()
+        )
+
+        # -- Turn 1: LLM drives install_plugin ----------------------
+        if generate:
+            monkeypatch.setattr(
+                "litellm.acompletion", _make_install_script(plugin_src), raising=False,
+            )
+        replay_install = LLMReplay(
+            _INSTALL_FIXTURE_PATH, mode="record" if generate else "replay",
+        )
+        replay_install.install()
+        try:
+            install_text = await _drive_one_turn(
+                registry, "Install the rag plugin.", timeout=60.0,
+            )
+        finally:
+            replay_install.restore()
+            if generate:
+                replay_install.flush()
+        assert install_text, "turn 1 (install) must reach a final assistant turn"
+
+        # -- Turn 2 (a FRESH ephemeral spawn -- see _make_install_script's
+        # docstring for why): LLM drives ingest then query -----------------------
+        if generate:
+            monkeypatch.setattr(
+                "litellm.acompletion", _make_ingest_query_script(project_root), raising=False,
+            )
+        replay_query = LLMReplay(
+            _INGEST_QUERY_FIXTURE_PATH, mode="record" if generate else "replay",
+        )
+        replay_query.install()
+        try:
+            final_text = await _drive_one_turn(
+                registry,
+                "Ingest the docs/ corpus into rag.sqlite, then query it for 'what is reyn'.",
+                timeout=60.0,
+            )
+        finally:
+            replay_query.restore()
+            if generate:
+                replay_query.flush()
+        assert final_text, "turn 2 (ingest/query) must reach a final assistant turn"
+
+        # #4759 structural witness, part 1: capture the arc's real MCP server
+        # subprocess(es) while still confirmed alive, BEFORE registry.shutdown()
+        # runs (below, in the finally). An empty set here would mean this
+        # witness has nothing to observe -- fail loudly rather than let part 2
+        # vacuously pass.
+        _arc_children = _child_pids(os.getpid()) - _baseline_children
+        assert _arc_children, (
+            "expected the rag plugin's real chunker/vector-store MCP server "
+            "subprocess(es) to be running as direct children of this process "
+            "at this point in the arc -- found none, so the #4759 structural "
+            "witness below would vacuously pass"
+        )
+        assert all(_pid_is_alive(pid) for pid in _arc_children), (
+            f"one or more of the arc's own captured child pids {_arc_children} "
+            "were already dead before registry.shutdown() ran"
+        )
+
+        from reyn.builtin.plugins.rag.scripts.vector_store_server import SqliteVecStore
+
+        with SqliteVecStore(str(project_root / "rag.sqlite")) as store:
+            rows = store.list_metadata()
+        assert rows, (
+            "the LLM-driven arc must have ingested at least one real chunk into "
+            "the sqlite store -- an empty store means install/register/ingest "
+            "never actually ran, regardless of what the final turn's text claims"
+        )
+        indexed = {Path(r["metadata"]["source_path"]).name for r in rows}
+        assert indexed == {"notes.txt"}, (
+            f"expected the ingested corpus to contain exactly notes.txt, got {sorted(indexed)}"
         )
     finally:
-        replay_install.restore()
-        if generate:
-            replay_install.flush()
-    assert install_text, "turn 1 (install) must reach a final assistant turn"
+        await registry.shutdown()
 
-    # -- Turn 2 (a FRESH ephemeral spawn -- see _make_install_script's
-    # docstring for why): LLM drives ingest then query -----------------------
-    if generate:
-        monkeypatch.setattr(
-            "litellm.acompletion", _make_ingest_query_script(project_root), raising=False,
-        )
-    replay_query = LLMReplay(
-        _INGEST_QUERY_FIXTURE_PATH, mode="record" if generate else "replay",
-    )
-    replay_query.install()
-    try:
-        final_text = await _drive_one_turn(
-            registry,
-            "Ingest the docs/ corpus into rag.sqlite, then query it for 'what is reyn'.",
-            timeout=60.0,
-        )
-    finally:
-        replay_query.restore()
-        if generate:
-            replay_query.flush()
-    assert final_text, "turn 2 (ingest/query) must reach a final assistant turn"
-
-    from reyn.builtin.plugins.rag.scripts.vector_store_server import SqliteVecStore
-
-    with SqliteVecStore(str(project_root / "rag.sqlite")) as store:
-        rows = store.list_metadata()
-    assert rows, (
-        "the LLM-driven arc must have ingested at least one real chunk into "
-        "the sqlite store -- an empty store means install/register/ingest "
-        "never actually ran, regardless of what the final turn's text claims"
-    )
-    indexed = {Path(r["metadata"]["source_path"]).name for r in rows}
-    assert indexed == {"notes.txt"}, (
-        f"expected the ingested corpus to contain exactly notes.txt, got {sorted(indexed)}"
+    # #4759 structural witness, part 2: registry.shutdown() (the #2714
+    # production teardown seam) must have actually reaped the arc's own MCP
+    # server subprocess(es) at the OS level -- not merely "the test function
+    # returned without hanging" (see the #4759 comment above this test for
+    # why that symptom alone is not trustworthy evidence). Strip-falsify:
+    # commenting out the ``await registry.shutdown()`` line above must flip
+    # ONLY this assertion red.
+    _still_alive = {pid for pid in _arc_children if _pid_is_alive(pid)}
+    if _still_alive:  # diagnostic aid on failure -- which server, not just which pid
+        for _pid in _still_alive:
+            _r = subprocess.run(
+                ["ps", "-p", str(_pid), "-o", "pid,ppid,command"],
+                capture_output=True, text=True, check=False,
+            )
+            print(f"#4759 survivor {_pid}:\n{_r.stdout}\n{_r.stderr}")
+    assert not _still_alive, (
+        f"MCP server subprocess(es) {_still_alive} survived registry.shutdown() "
+        "-- the #2714 teardown seam did not actually terminate them"
     )

--- a/tests/runtime/test_outbox_hub_broadcast.py
+++ b/tests/runtime/test_outbox_hub_broadcast.py
@@ -28,6 +28,7 @@ import pytest
 
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.outbox_hub import OutboxHub
+from reyn.runtime.tracked_tasks import TrackedTaskSet
 
 _K = 20
 
@@ -50,7 +51,7 @@ async def _drain(sub) -> list[str]:
 async def test_two_surfaces_each_receive_full_stream_in_order() -> None:
     """Tier 2: N>=2 — two hub surfaces BOTH receive every frame in order (no steal)."""
     source: asyncio.Queue = asyncio.Queue()
-    hub = OutboxHub(source)
+    hub = OutboxHub(source, task_tracker=TrackedTaskSet())
     a = hub.subscribe()
     b = hub.subscribe()
     for msg in _script():
@@ -116,7 +117,7 @@ async def test_single_surface_is_transparent_pipe() -> None:
 
     # Same script through the hub at N=1.
     hub_source: asyncio.Queue = asyncio.Queue()
-    hub = OutboxHub(hub_source)
+    hub = OutboxHub(hub_source, task_tracker=TrackedTaskSet())
     sub = hub.subscribe()
     for msg in script:
         hub_source.put_nowait(msg)
@@ -133,7 +134,7 @@ async def test_slow_surface_disconnected_without_blocking_the_writer() -> None:
     ``get()`` returns ``None``) while a fast surface still receives the FULL
     stream and the source fully drains — the writer is never blocked."""
     source: asyncio.Queue = asyncio.Queue()
-    hub = OutboxHub(source)
+    hub = OutboxHub(source, task_tracker=TrackedTaskSet())
     fast = hub.subscribe()  # unbounded
     slow = hub.subscribe(maxsize=2)  # tiny cap, never drained → disconnect-slow
     k = 50
@@ -154,7 +155,7 @@ async def test_slow_surface_disconnected_without_blocking_the_writer() -> None:
 async def test_end_terminal_fans_out_to_all_surfaces() -> None:
     """Tier 2: ``__end__`` reaches every attached surface (terminal fan-out)."""
     source: asyncio.Queue = asyncio.Queue()
-    hub = OutboxHub(source)
+    hub = OutboxHub(source, task_tracker=TrackedTaskSet())
     subs = [hub.subscribe() for _ in range(3)]
     source.put_nowait(OutboxMessage(kind="agent", text="only"))
     source.put_nowait(OutboxMessage(kind="__end__", text=""))


### PR DESCRIPTION
**[e2e-coder]** — Closes #4759.

## What

`SpawnTracker._maybe_schedule_ephemeral_vanish()` created a **detached** `asyncio.create_task(registry.remove_session(...))` — a task that itself closes the session's held MCP connections — with no strong ref anywhere `AgentRegistry.shutdown()`'s drain (`running_tasks()`, which only enumerates `self._tasks`/`_forward_tasks`) could see. A normal `registry.shutdown()` (and, in production, an ordinary `/quit` shortly after a `run_pipeline` call) could therefore return while that task was still mid-flight, orphaning the real OS subprocess it was about to close.

Confirmed via a **structural witness** (not a repeat-count): `tests/runtime/test_fp0063_arc_witness.py` now captures the real `vector_store_server.py` subprocess PID via `pgrep -P <pytest pid>` and asserts `os.kill(pid, 0)` raises `ProcessLookupError` after `registry.shutdown()` returns. Before this fix, the subprocess reliably survived. A repeat-count witness (6 green runs) would NOT have caught this — the underlying race that made the *symptom* (a hang) intermittent stays favorable ~5/6 of the time regardless of whether the fix is present (lead-coder's own retracted "run it 6 times" instruction, and the math behind the retraction, are recorded on #4759).

## Why not just fix `_vanish_task`

A class audit (`asyncio.create_task(` across the session/registry lifecycle) found **8 instances of the same shape** — a background task whose owner has no joiner reachable from `registry.shutdown()`, or has one that's simply never invoked from a normal shutdown path (as opposed to only the rewind path or `remove_session`). Two were later found to already be reachable via an existing path (`_drain_on_shutdown()`'s `ChainManager.shutdown()`) once traced by hand rather than taken on trust — see #4759 comments for the full audit and the correction.

Patching `_vanish_task` alone would move the same defect up one level for the next producer. Instead: **`TrackedTaskSet`** (`src/reyn/runtime/tracked_tasks.py`) is a single owned collection every producer routes through via `spawn()`/`register()` instead of a bare `asyncio.create_task`:

- `SpawnTracker._vanish_task` (disposition `"await"` — it does real cleanup work)
- `ChainManager`'s timeout watchdogs
- `Session`'s WAL fire-and-forget appends + the WAL-size-safety-net task
- the pipeline-driver hook-bus bridge task
- the cross-session `cancel_inflight` forward
- `OutboxHub`'s drain loop
- `hooks/external_fire.py`'s drain loop
- `InterventionRegistry`'s restored-answer watcher tasks

`Session.aclose_background_tasks()` (mirroring the existing `aclose_mcp_connections`/`aclose_event_store` duck-typed shape) is the **one** seam `AgentRegistry.shutdown()` calls. A 9th producer is covered by routing through the funnel at creation time, not by a reviewer remembering to touch a teardown method.

Bounded with the existing `_SHUTDOWN_GRACE_S` (same constant the run-loop task drain already uses) so a background task that doesn't respond to its own funnel's cancel can't hang `/quit` indefinitely.

## Re-entrancy hazard found while building this

The ephemeral-vanish task itself runs `remove_session()` → `await_quiescent()` → `background_tasks.aclose()` on the **same** tracker that still tracks it (its own done-callback hasn't fired yet). Without excluding `asyncio.current_task()` from that call's own drain, this doesn't raise — **it hangs** (verified by hand: stripped the exclusion, ran the reentrancy test in the background, confirmed the process was still alive with zero output after 8s, killed it, restored the exclusion, confirmed green — not encoded as a test with its own timeout, per CLAUDE.md's "tests carry no time limit of their own").

The exclusion means a reentrant `aclose()` call returns once every *other* tracked task has settled, not including its own caller-task — documented precisely in `TrackedTaskSet.aclose()`'s own docstring. `AgentRegistry.shutdown()`'s own call is always non-reentrant (the registry's task is never itself one the tracker owns), so it has no such gap — it awaits the vanish task itself to completion.

## Scope note — NOT test-only

The leak is reachable from any real operator `/quit` shortly after a `run_pipeline` call, independent of tests. Recorded here per lead-coder's explicit instruction.

## Test plan / six questions (`tests/` touched)

**`tests/runtime/test_4759_tracked_task_set.py`** (4 new tests, `TrackedTaskSet`'s own contract):
1. Tier 1 (Contract) — pins `TrackedTaskSet`'s own documented behavior (disposition semantics, re-entrancy guarantee), not a third party's.
2. No same-expression-both-sides transcription — each test drives real `asyncio.Event`-gated task bodies and asserts on independently-observed side effects, never re-asserts the implementation's own expression.
3. Who'd miss it: any future edit to `aclose()`'s re-entrancy handling or disposition branching — the real caller these protect is `AgentRegistry.shutdown()` via `Session.aclose_background_tasks()`, on every real `/quit`.
4. Would not stay green having never run — no skip conditions, no optional deps; confirmed via strip (removing the re-entrancy exclusion flips the specific assertion's test to a hang, not a skip).
5. Bounded — no test carries its own wait budget or timeout; every await is on a real `asyncio.Event` or the tested task itself, unbounded. Verified NOT to hang under the fix (0.47s for all 4).
6. Declared Tier (1) matches Q1's answer.

**`tests/runtime/test_fp0063_arc_witness.py`** (structural witness added to the existing arc test):
1. Tier 3a (already declared) — extended, not reclassified.
2. Not a transcription — asserts real OS-level `pgrep -P`/`os.kill(pid, 0)` state, independent of any reyn-internal claim about what should have happened.
3. Who'd miss it: any future regression reintroducing an unreachable background task in this call path — a production `/quit` is the real caller.
4. Would not stay green unrun — real subprocess, real `registry.shutdown()`.
5. No test-owned time budget — the pytest-timeout=120 CI kill switch is the only bound, matching every other test in this file.
6. Declared Tier (3a) unchanged, still correct.

**Manual/Visual**: N/A (backend-only fix, no UI surface) — `- [x] (skipped — no UI surface)`.

**Closing-scope enumeration** (CLAUDE.md rule 4): lead-coder searched every PR/issue whose body contains the mention "4759 in:body" before this PR declared closing intent — the only hit was this PR itself; the other two search results were unrelated old-PR mismatches. No other open PR carries a `part of #4759` scope declaration, so this is the final PR for #4759.

## Local gates (all green)

`ruff check .`, `scripts/test_tier_audit.py --strict` (both new/touched test files), `scripts/verify_module_docstrings.py` (all touched src files), `scripts/mypy_ratchet.py`, `scripts/flat_tests_ratchet.py`, `scripts/check_tests_path_literal_reference.py`, `scripts/check_bare_tests_import_reference.py`, `scripts/check_file_depth_reference.py`, plus scoped `pytest` across the arc witness, the new tracker tests, `#2714`'s own MCP-shutdown tests, ephemeral-vanish, chain-manager, outbox-hub, rewind/`await_quiescent`/`reset_for_rewind`, spawn-session-seam, and intervention-restore suites (75+39 tests, all green, re-verified after rebase onto `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**[lead-coder]** — レビューでの blocking 項:

- [x] 🔴 `OutboxHub` が漏斗に入っていない。`outbox_hub.py` は `task_tracker` を受け取る実装済みだが、**本番の構築点 `session.py:4103` に渡す変更が無い**（diff 中の `task_tracker=` は SpawnTracker と ChainManager の 2 箇所のみ／`OutboxHub(` は src 全体で 1 箇所）。∴ 本番は `else: asyncio.create_task(...)` に落ちる。 — **[e2e-coder] 修正済み** (`dcb0775a7`): `session.py:4108` に `task_tracker=self._background_tasks` を追加。
- [x] 🔴 `registry.py` に本 PR が足したコメントが「OutboxHub's drain loop ... every one of them now routes through the SAME funnel」「covered by construction」と**偽を主張**している。①を直すか、記述を実態に合わせるか。 — **[e2e-coder]** 上記修正により記述どおり実在になったため、コメント自体の書き換えは不要と判断（記述と実態が一致した）。
- [x] 🔴 退避枝（`else: asyncio.create_task`）が本番で到達可能かを**測る**。到達不能なら消せる（テストは tracker を渡せばよい）。残すなら「本番では踏まれない」の保証を書く。 — **[e2e-coder]** 測定結果: `SpawnTracker`/`OutboxHub` は本番構築点が1箇所のみ、テスト呼び出しも0〜4件と少ないため `task_tracker` を**必須引数化**し退避枝を完全削除(`dcb0775a7`)。`ChainManager` は本番構築点1箇所だが**テスト呼び出しが9ファイル12箇所**、いずれも#4759のteardown性質を検証しないため、費用対効果を測って**意図的にoptionalのまま維持**、コメントを正直な保証(「本番は必ず渡す、テストは渡さなくても当該クラスの本来機能に影響なし」)に書き換え。

- [x] 🔴 `_MAX_ACLOSE_ROUNDS = 8` の根拠。コメントは「Mirrors `session.py`'s own `_QUIESCE_MAX_ROUNDS` **fixpoint bound**」だが、実測 `session.py:128` は **50**。同じ teardown 経路に 50 周と 8 周が並び、内側が 6 倍きつい理由が無い。 — **[e2e-coder] 修正済み** (`dcb0775a7`): `_QUIESCE_MAX_ROUNDS`(実測50、旧経路は本PRで完全に不使用と判明・session.pyから削除)の実値をそのまま`_MAX_ACLOSE_ROUNDS = 50`としてtracked_tasks.pyに移設。「await」disposition(vanish task)は#2115の想定(WAL専用、cancel済みなので1-2周で収束)より収束が遅い可能性がある旨も明記。

**5点目(non-blocking提案、採用)** — `AgentRegistry.shutdown()`の呼び出しが「常に非再入」という主張は6箇所中3箇所しか追い切れていなかった問題。**[e2e-coder]** 対処済み(`dcb0775a7`): 断定を「期待値」に弱め、`aclose()`が自タスクを除外した際に**warningログ**(再入元task名+dispositionを記載)を出すよう実装。再入自体はvanish taskの正常経路なのでerrorではなくwarning。テスト2本追加(warning発火/非発火の両側)。

**追加で発見・修正した実CI赤 2件**（lead-coder指摘、両方 real）:
- Session public面が111(旧上限110) — `aclose_background_tasks`はスラッシュ無関係、ゲート自身の手続き通り上限を111に上げ理由を記載(`dcb0775a7`)。
- `tests/runtime/test_4497_resident_stats.py` が削除済み`_inflight_wal_tasks`の実在を要求 — **テスト修理ではなくconsumer sweep**: `resident_stats.py`の列挙自体を`_background_tasks`に差し替え(#4497の元の項目を狭義でなく広義に置き換え、`TrackedTaskSet`に`__len__`/`__iter__`を追加して既存の汎用測定機構にそのまま乗るようにした)、その後テストの列挙名をsrcの実態に合わせて更新。`test_concurrent_multiagent_rewind_1580.py`の残存する古い識別子言及も修正。


- [ ] 🔴 `registry.py` のコメントが実態に追随していない。①列挙に `hooks/external_fire.py` の drain task が無い（`_hook_bus_bridge_task` とは別物）②「covered by construction」は、`ChainManager`/`external_fire` が構築点依存になった今、必須seam と条件付きseam を区別して書く必要がある。

- [ ] 🔴 **退行**: `test_slash_rewind_self_cancel_3362.py:317`「the session stopped answering after a rewind」（3.11/3.12 両方＝flake ではない）。`await_quiescent` が `_background_tasks.aclose()` を呼ぶため、**session-scope の背景タスク**（OutboxHub drain / hook-bus bridge / external_fire drain / restored-intervention watchers）まで畳んでいる。`await_quiescent` は shutdown ではない。**scope 軸を足して spawn 側に宣言させる**こと（`disposition` は「どう畳むか」であって「いつ畳んでよいか」を言っていない）。★除外リストにしない — それは列挙で、9 個目が生まれる。



---

**[lead-coder]** — ★blocking 項の差し替え（architect の co-vet を受け、**前の「scope 軸」項は撤回**）:

- [ ] 🔴 `await_quiescent` の判別子を **`appends_wal`**（この関数自身が宣言する不変条件 ── 逐語「no WAL append can still land」）で切る。`scope` で切るなら「session スコープは append しない」を**落ちる形の不変条件**に。★lead-coder が指示した turn/session 軸は**退行の症状から逆算した名前**で誤り。
- [x] ~~🔴 `hooks/ingress.py:141` を漏斗に通す~~ — **穴ではなかった**（lead-coder が 5 段の鎖を独立に検証: registry → aclose_mcp_connections/aclose_fs_watcher → *IngressAdapter.aclose → _BoundedEventBridge.aclose が drain task を cancel+join。#4759 以前から到達可能）
- [ ] 🔴 バイパス 2 本（`external_fire.py` / `chain_manager.py` の `else`）── 渡し忘れが例外にも警告にもならない現状を、少なくとも**警告が出る**形に
- [ ] 🔴 `register()` に `name` を足す（register 経由 3 箇所が `Task-N` のまま ── 下の項と**同時に**効く）
- [ ] 🔴 再入 warning に**呼び出し元の識別**を足す（現状のログは畳まれる側の名前しか出さず、docstring が求める判別ができない）


- [ ] 🔴 fixpoint 未収束時の warning が**件数しか出さない**（`len(self.pending())`）。50 ラウンド畳めていない状況で運用者が知りたいのは「何個」でなく「**どれ**」。★`register()` に `name` を足す 1 箇所の変更が、これで **3 箇所**（register 経由の `Task-N` / 再入 warning / 本項）に同時に効く。

