### PR TITLE
fix(#4762): neutralize tool_call_failed's own world-derived error text

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -370,7 +370,14 @@ def _tool_result_line(msg: "OutboxMessage") -> "tuple[Text, str | None]":
             or result_meta.get("text")
             or ""
         )
-        return Text(f"  ⎿ ✗ {err}", style=_CC_ERR), _CC_ERR_BG
+        # #4762: err is WORLD-derived -- dispatcher.py's own
+        # `message=f"{type(e).__name__}: {e}"` wraps ANY tool-handler
+        # exception (an MCP call, a sandboxed subprocess, a provider HTTP
+        # error), the same class #4758 fixed for tool_call_completed's own
+        # stderr branch. #4758's own fix never covered this branch
+        # (explicitly scoped out, tracked as #4762 -- measured here: err
+        # does mix in external content, so this IS the same hole).
+        return Text(f"  ⎿ ✗ {_neutralized_label(err)}", style=_CC_ERR), _CC_ERR_BG
     summary = summarize_tool_result(meta.get("tool"), result_meta.get("result"))
     failed = summary.startswith("✗")
     if meta.get(_EXPANDED_KEY) and not failed:
@@ -564,8 +571,13 @@ def _body_and_background(
         style = _CC_ERR if failed else _CC_DIM
         return Text(summary, style=style), (_CC_ERR_BG if failed else None)
     if kind == "tool_call_failed":
-        err = meta.get("error_message") or meta.get("error_kind") or msg.text
-        return Text(f"✗ {err}", style=_CC_ERR), _CC_ERR_BG
+        err = meta.get("error_message") or meta.get("error_kind") or msg.text or ""
+        # #4762: err is WORLD-derived -- see _tool_result_line's own #4762
+        # comment above for the full trace (dispatcher.py's exception-
+        # wrapping f-string). Same fix, this branch's own copy of it (the
+        # pre-coalesce standalone tool_call_failed row, not the coalesced
+        # nested one).
+        return Text(f"✗ {_neutralized_label(str(err))}", style=_CC_ERR), _CC_ERR_BG
     line = _KIND_LINE.get(kind)
     body_style = line[2] if line else _CC_TEXT
     body = _body_renderable(

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -925,7 +925,19 @@ def format_inline_message(msg: OutboxMessage, *, neutralize_body: bool = False):
         return _gutter_grid("  ⎿ ", s, Text(summary, style=s))
     if kind == "tool_call_failed":
         err = meta.get("error_message") or meta.get("error_kind") or msg.text
-        return _gutter_grid("  ⎿ ", _CC_ERR, Text(f"✗ {_short(err, 80)}", style=_CC_ERR))
+        # #4762: err is WORLD-derived -- dispatcher.py's own
+        # `message=f"{type(e).__name__}: {e}"` wraps ANY tool-handler
+        # exception (an MCP call, a sandboxed subprocess, a provider HTTP
+        # error), the same class #4758 fixed for tool_call_completed's own
+        # stderr branch (via summarize_tool_result's single return
+        # boundary) -- that fix never covered this branch (explicitly
+        # scoped out, tracked as #4762; measured here: err does mix in
+        # external content, so this IS the same hole). _short's own
+        # truncation (" ".join(s.split())) does not strip ESC/control —
+        # neutralize AFTER truncating (same order #4758 used).
+        from reyn.core.present.guard import get_neutralizer
+        safe_err = get_neutralizer("terminal").neutralize(_short(err, 80))[0]
+        return _gutter_grid("  ⎿ ", _CC_ERR, Text(f"✗ {safe_err}", style=_CC_ERR))
 
     # #2770: an intervention announcement carries a `present`-shaped render model
     # (meta["nodes"], neutralized at the source in InterventionHandler.announce).

--- a/tests/interfaces/test_4762_tool_call_failed_neutralize.py
+++ b/tests/interfaces/test_4762_tool_call_failed_neutralize.py
@@ -1,0 +1,139 @@
+"""Tier 2: #4762 — tool_call_failed's own ``err`` display line is WORLD-derived
+and was NOT covered by #4758's fix.
+
+#4758 neutralized ``summarize_tool_result``'s single return boundary (the
+``tool_call_completed`` summary line — a ✓/✗ SHAPE-derived one-liner).
+``tool_call_failed`` is a SEPARATE code path in both the REPL renderer
+(``renderer.py``'s ``format_inline_message``) and the TUI presenter
+(``presenter.py``'s ``_tool_result_line`` / ``_body_and_background``) that
+never goes through ``summarize_tool_result`` at all — #4758/#4760 explicitly
+scoped it out, tracked as #4762.
+
+Measured (this issue's own required first step, per lead-coder): ``err`` is
+built from ``meta.get("error_message")``, which traces to
+``dispatch/dispatcher.py``'s ``except Exception as e: message=f"{type(e).
+__name__}: {e}"`` — a catch-all around ANY tool-handler invocation (an MCP
+call, a sandboxed subprocess, a provider HTTP error). ``str(e)`` on an
+arbitrary caught exception can embed WORLD-derived bytes (an MCP server's own
+error text, subprocess stderr folded into an exception message, ...), the
+same class #4758 fixed for ``tool_call_completed``'s ``stderr`` branch — so
+this is a real hole, not a false positive from "looks similar".
+
+Same required witness shape as #4758's own test file
+(``tests/interfaces/test_inline_tool_result_summary.py::
+test_stderr_with_terminal_control_bytes_is_neutralized`` /
+``test_neutralize_preserves_ordinary_text``): one reject-side test per
+render site (an ESC/CSI sequence must not reach the rendered text) plus one
+accept-side test (ordinary error text must render unchanged) — both REPL and
+TUI, per lead-coder's standing "display surface is REPL AND TUI, never one
+side" requirement.
+"""
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from reyn.interfaces.inline.textual_chat.presenter import (
+    _body_and_background,
+    _tool_result_line,
+)
+from reyn.interfaces.repl.renderer import format_inline_message
+from reyn.runtime.outbox import OutboxMessage
+
+_ESC_ERR = "boom\x1b[2Jgone"
+
+
+def _render_to_text(renderable) -> str:
+    """Render any Rich renderable to a plain string via a no-color Console —
+    mirrors tests/interfaces/test_3318_body_neutralize.py's own helper,
+    needed here for renderer.py's ``format_inline_message`` (returns a
+    ``Table.grid``, not a bare ``Text`` with a ``.plain`` attribute)."""
+    buf = io.StringIO()
+    Console(file=buf, color_system=None, width=100).print(renderable)
+    return buf.getvalue()
+
+
+# ── REPL (renderer.py, format_inline_message) ──────────────────────────────
+
+
+def test_repl_tool_call_failed_strips_control_bytes() -> None:
+    """Tier 2: reject-side — an ESC/CSI byte in error_message must not reach
+    the rendered REPL line."""
+    msg = OutboxMessage(
+        kind="tool_call_failed", text="",
+        meta={"error_message": _ESC_ERR},
+    )
+    rendered = _render_to_text(format_inline_message(msg))
+    assert "\x1b" not in rendered, "an ESC byte reached the REPL tool_call_failed line"
+    assert "boom" in rendered
+    assert "gone" in rendered
+
+
+def test_repl_tool_call_failed_preserves_ordinary_text() -> None:
+    """Tier 2: accept-side — ordinary (control-byte-free) error text renders
+    unchanged."""
+    msg = OutboxMessage(
+        kind="tool_call_failed", text="",
+        meta={"error_message": "ordinary error text"},
+    )
+    rendered = _render_to_text(format_inline_message(msg))
+    assert "ordinary error text" in rendered
+
+
+# ── TUI, coalesced/nested row (presenter.py, _tool_result_line) ────────────
+
+
+def test_tui_coalesced_tool_call_failed_strips_control_bytes() -> None:
+    """Tier 2: reject-side — the TUI's nested ⎿ row (a tool_call_started
+    entry coalesced with its own tool_call_failed result)."""
+    msg = OutboxMessage(
+        kind="tool_call_started", text="",
+        meta={
+            "_result_kind": "tool_call_failed",
+            "_result": {"error_message": _ESC_ERR},
+        },
+    )
+    text, _bg = _tool_result_line(msg)
+    assert "\x1b" not in text.plain, "an ESC byte reached the TUI coalesced row"
+    assert "boom" in text.plain
+    assert "gone" in text.plain
+
+
+def test_tui_coalesced_tool_call_failed_preserves_ordinary_text() -> None:
+    """Tier 2: accept-side, same row shape as above."""
+    msg = OutboxMessage(
+        kind="tool_call_started", text="",
+        meta={
+            "_result_kind": "tool_call_failed",
+            "_result": {"error_message": "ordinary error text"},
+        },
+    )
+    text, _bg = _tool_result_line(msg)
+    assert "ordinary error text" in text.plain
+
+
+# ── TUI, standalone row (presenter.py, _body_and_background) ───────────────
+
+
+def test_tui_standalone_tool_call_failed_strips_control_bytes() -> None:
+    """Tier 2: reject-side — the TUI's own pre-coalesce standalone
+    tool_call_failed row (the entry's own kind, not a coalesced result)."""
+    msg = OutboxMessage(
+        kind="tool_call_failed", text="",
+        meta={"error_message": _ESC_ERR},
+    )
+    body, _bg = _body_and_background(msg)
+    assert "\x1b" not in body.plain, "an ESC byte reached the TUI standalone row"
+    assert "boom" in body.plain
+    assert "gone" in body.plain
+
+
+def test_tui_standalone_tool_call_failed_preserves_ordinary_text() -> None:
+    """Tier 2: accept-side, same row shape as above."""
+    msg = OutboxMessage(
+        kind="tool_call_failed", text="",
+        meta={"error_message": "ordinary error text"},
+    )
+    body, _bg = _body_and_background(msg)
+    assert "ordinary error text" in body.plain


### PR DESCRIPTION
**[e2e-coder]** — Closes #4762.

## What

`#4758`/`#4760` explicitly scoped out `tool_call_failed`'s own `err` display line, tracked as this issue. First-step measurement (required before any fix): `err`/`error_message` traces to `dispatch/dispatcher.py`'s `except Exception as e: message=f"{type(e).__name__}: {e}"` — a catch-all wrapping **any** tool-handler invocation (an MCP call, a sandboxed subprocess, a provider HTTP error). `str(e)` on an arbitrary caught exception can embed world-derived bytes, the same class `#4758` fixed for `tool_call_completed`'s own `stderr` branch. **This confirms a real hole**, not a false positive from "looks similar" — `tool_call_failed` is a separate code path in both the REPL renderer (`renderer.py`'s `format_inline_message`) and the TUI presenter (`presenter.py`'s `_tool_result_line` / `_body_and_background`) that never goes through `summarize_tool_result`'s single return boundary at all.

## Fix

Neutralized at each of the 3 render call sites (same `get_neutralizer("terminal")` FP-0054 seam `#4758` used; TUI sites reuse `presenter.py`'s own established `_neutralized_label` helper):
- `renderer.py`'s `format_inline_message` (REPL)
- `presenter.py`'s `_tool_result_line` (TUI, coalesced/nested row)
- `presenter.py`'s `_body_and_background` (TUI, standalone pre-coalesce row)

Both display surfaces covered (REPL and TUI), per the issue's own standing requirement.

## Test plan / six questions (`tests/` touched)

**`tests/interfaces/test_4762_tool_call_failed_neutralize.py`** (6 new tests, one reject-side + one accept-side per render site, mirroring `#4758`'s own witness pair in `test_inline_tool_result_summary.py`):
1. Tier 2 — pins a real reyn security boundary (ESC/control-byte neutralization at a display surface receiving world-derived content), not a third party's property or reyn's own trivia.
2. No same-expression-both-sides transcription — each test drives a real `OutboxMessage` through the real render function and asserts on the rendered plain text, never re-asserts the implementation's own string.
3. Who'd miss it: any future edit to these 3 render sites that drops the neutralize call — the real caller these tests protect is an operator whose terminal renders a `tool_call_failed` row after a tool handler's exception message embedded a world-derived ESC/CSI sequence.
4. Would not stay green having never run — no skip conditions, no optional deps; confirmed via strip (removing the neutralize call at all 3 sites flips exactly the 3 reject-side tests red, for the right reason: `"an ESC byte reached the ... row"`).
5. Bounded — no wait budget or timeout anywhere; each test is a direct synchronous render call.
6. Declared Tier (2) matches Q1's answer.

**Manual/Visual**: N/A (verified via the reject/accept-side test pair directly, matching `#4758`'s own precedent for this exact fix class rather than a manual terminal check) — `- [x] (skipped — verified via automated reject/accept-side tests, same precedent as #4758)`.

## Local gates (all green)

`ruff check .`, `scripts/test_tier_audit.py --strict`, `scripts/verify_module_docstrings.py`, `scripts/mypy_ratchet.py`, plus scoped `pytest` across the new test file, `#4758`'s own tool-result-summary suite, `#3318`'s body-neutralize suite, `#4756`'s dict-detail-lines suite, and the Session public-surface gate (94 tests total, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
