### PR TITLE
docs(#4762): add the 5th unconditional-neutralization case

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -609,8 +609,8 @@ strip) to the conversation body content itself, where a raw ESC/OSC sequence
 from tool output or an untrusted model reply could otherwise reach the
 terminal on both the TUI conversation pane and the plain (`--cui`) renderer.
 
-Two more cases are always neutralized regardless of this flag, same shape
-as #3302's, both structurally unable to read it (a different code path
+Three more cases are always neutralized regardless of this flag, same shape
+as #3302's, all structurally unable to read it (a different code path
 reaches the same terminal neutralizer, not `_body_renderable` — the ONE
 function this flag actually gates):
 
@@ -625,11 +625,22 @@ function this flag actually gates):
   `neutralize_body` parameter at all, and never did. (Before #4757 this
   path was not neutralized — `json.dumps` merely escaped control bytes as
   a side effect, and the bare-string branch did not even do that.)
+- A **failed tool call's own error line** (`tool_call_failed`'s
+  `err`/`error_message`, shown on both the plain `--cui` renderer's
+  `format_inline_message` and the TUI's `_tool_result_line`/
+  `_body_and_background`) — unconditional since **#4762**. Traces to
+  `dispatcher.py`'s own catch-all (`f"{type(e).__name__}: {e}"` wrapping
+  any tool-handler exception — an MCP call, a sandboxed subprocess, a
+  provider HTTP error), the same class #4760 fixed for
+  `summarize_tool_result`'s stderr branch but explicitly did not cover —
+  this is a structurally separate code path that never goes through
+  `summarize_tool_result`'s own return boundary.
 
 So `neutralize_body` widens the SAME terminal neutralizer to exactly one
 more surface — the full, collapsed body text `_body_renderable` renders —
-not to "tool-result rendering" as a whole; the summary line and the
-expanded detail view are unconditionally covered either way.
+not to "tool-result rendering" as a whole; the summary line, the expanded
+detail view, and a failed call's own error line are unconditionally
+covered either way.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -628,7 +628,7 @@ function this flag actually gates):
 - A **failed tool call's own error line** (`tool_call_failed`'s
   `err`/`error_message`, shown on both the plain `--cui` renderer's
   `format_inline_message` and the TUI's `_tool_result_line`/
-  `_body_and_background`) — unconditional since **#4762**. Traces to
+  `_body_and_background`) — unconditional since **#4770**. Traces to
   `dispatcher.py`'s own catch-all (`f"{type(e).__name__}: {e}"` wrapping
   any tool-handler exception — an MCP call, a sandboxed subprocess, a
   provider HTTP error), the same class #4760 fixed for


### PR DESCRIPTION
**[docs-maintainer]** — Self-initiated: #4770 (`fix(#4762): neutralize tool_call_failed's own world-derived error text`) just merged, closing an explicitly-named remainder from #4760's own scope note. Same pattern as the two prior additions I made to this section tonight — verified the new call site is genuinely unconditional before adding it.

## What's new

`tool_call_failed`'s own `err`/`error_message` display line — shown on both the plain `--cui` renderer's `format_inline_message` and the TUI's `_tool_result_line`/`_body_and_background` — is neutralized unconditionally since #4762. Traces to `dispatcher.py`'s own catch-all exception-message wrapping (`f"{type(e).__name__}: {e}"`, wrapping any tool-handler exception), the same world-derived-text class #4760 fixed for `summarize_tool_result`'s stderr branch but explicitly scoped out — a structurally separate code path.

Verified directly against the merged diff: `get_neutralizer("terminal")` is called with no `neutralize_body` guard, same shape as the other 3 always-on cases already documented here.

## Change

Added as a 3rd bullet ("two more cases" → "three more cases"), same format as the existing two; closing sentence updated to name all three unconditional surfaces alongside the one `neutralize_body` actually gates.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no Aborted/WARNING
- [x] `python scripts/check_doc_anchors.py` — clean
- [x] Verified unconditional directly against the merged `#4770` diff, not the PR description
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Closing-intent self-grep on commit message + this body: no keyword adjacent to any issue number
- [x] (skipped — docs-only, no user-facing/Visual surface)

Part of #4762
