### PR TITLE
docs: audit-event body field is `data`, not `payload`

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -276,6 +276,8 @@ Every event has:
 }
 ```
 
+**The body field is `data`, read `e["data"][...]`, not `e["payload"]`** — "payload" is only the prose word this page (and elsewhere) uses to describe what `data` holds, never a key on the record itself. For a `llm_response_received` event, `e["data"]["finish_reason"]` / `e["data"]["call_id"]` are where those fields live; for `tool_called`, `e["data"]["caller_kind"]` / `e["data"]["caller_id"]` / `e["data"]["tool"]` / `e["data"]["args"]`. `e.get("payload", {})` returns `{}` for EVERY event, silently — every field reads as absent, not because it wasn't emitted, but because the read itself targeted a key that was never there.
+
 ## Agent ID field (all events)
 
 Every event emitted from a session whose `agent_id` is configured (in `reyn.yaml`) automatically carries an `agent_id` field in its payload. The default value is `reyn/<hostname>`. This enables RBAC and multi-agent audit trails per SOC2 / ISO 27001 / METI v1.1 requirements.

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -276,7 +276,19 @@ Every event has:
 }
 ```
 
-**The body field is `data`, read `e["data"][...]`, not `e["payload"]`** — "payload" is only the prose word this page (and elsewhere) uses to describe what `data` holds, never a key on the record itself. For a `llm_response_received` event, `e["data"]["finish_reason"]` / `e["data"]["call_id"]` are where those fields live; for `tool_called`, `e["data"]["caller_kind"]` / `e["data"]["caller_id"]` / `e["data"]["tool"]` / `e["data"]["args"]`. `e.get("payload", {})` returns `{}` for EVERY event, silently — every field reads as absent, not because it wasn't emitted, but because the read itself targeted a key that was never there.
+**An AUDIT-event's body field is `data`, read `e["data"][...]`, not
+`e["payload"]`.** For a `llm_response_received` event, `e["data"]["finish_reason"]`
+/ `e["data"]["call_id"]` are where those fields live; for `tool_called`,
+`e["data"]["caller_kind"]` / `e["data"]["caller_id"]` / `e["data"]["tool"]` /
+`e["data"]["args"]`. `e.get("payload", {})` returns `{}` for EVERY audit-event,
+silently — every field reads as absent, not because it wasn't emitted, but
+because the read itself targeted a key that was never on THIS vocabulary.
+`payload` is a real key, but on the WAL-event's own vocabulary (`.reyn/state/wal.jsonl`
+— see [Time-Travel § WAL vs audit-event separation](../../concepts/runtime/time-travel.md#wal-vs-audit-event-separation),
+and CLAUDE.md's "'event' is three distinct things"): `agent_snapshot.py`'s
+`inbox_put` replay reads `event.get("payload", {})` for real. Mixing the two
+vocabularies returns empty in EITHER direction — an audit-event read as
+`e["payload"]`, or (the mirror mistake) a WAL-event read as `e["data"]`.
 
 ## Agent ID field (all events)
 


### PR DESCRIPTION
**[docs-maintainer]** — One line, real same-night incident: lead-coder and architect both read `e["payload"]` (or `.get("payload", {})`) while inspecting audit events, got an empty dict for every event, and nearly concluded a real field was unemitted ("0 hits"). The field was there — the read targeted a key name that never existed on the record. Two independent people hitting the identical error the same night is a doc gap, not carelessness.

## Placement

`docs/reference/runtime/events.md`'s own "Event envelope" section, not `dogfood-tracing.md` — this is where the envelope's JSON shape is shown, and the section's own surrounding prose is part of what caused the confusion: `"data"` is the key, but the comment right next to it calls the contents "kind-specific **payload**," and the very next section says an event "carries an `agent_id` field in its **payload**" — using "payload" as an ordinary English word for "what the field holds," right beside a field actually named `data`. Fixing at the source of the ambiguous wording, not in a downstream doc.

## Form

Positive ("the body field is `data`"), not a prohibition — per instruction, a "don't write X" line doesn't stop the next person from writing a *different* wrong name. One concrete example per the requirement: `llm_response_received`'s `finish_reason`/`call_id`, `tool_called`'s `caller_kind`/`caller_id`/`tool`/`args` — the exact fields that read as absent in the actual incident.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no Aborted/WARNING
- [x] `python scripts/check_doc_anchors.py` — clean
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Closing-intent self-grep on commit message + this body: no keyword adjacent to any issue number
- [x] (skipped — docs-only, no user-facing/Visual surface)

Not normative — no owner veto sought, per instruction. No issue filed, per instruction.
