### PR TITLE
fix(#4777): completion Group registration provider-independent

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1163,9 +1163,11 @@ class TextualChatApp(App):
         # frame transitions the SAME entry RUNNING → SUCCESS/ERROR (CC parity).
         self._running_tools: "dict[object, Entry[OutboxMessage]]" = {}
         # #4691 Phase B B1: the litellm-call TREE PARENT for a given call_id
-        # (#4691 Phase 1 ①②, #4734) — every ``kind="agent"`` row carrying
-        # ``meta["finish_reason"] == "tool_calls"`` registers itself here on
-        # arrival, and every ``tool_call_started``/``completed``/``failed``
+        # (#4691 Phase 1 ①②, #4734) — every ``kind="agent"`` row carrying a
+        # ``call_id`` registers itself here on arrival (#4777: unconditional,
+        # NOT gated on a provider's own ``finish_reason`` string — see the
+        # registration site's own comment, ``_ingest_frame``), and every
+        # ``tool_call_started``/``completed``/``failed``
         # frame carrying a matching ``meta["call_id"]`` looks itself up here
         # to find which Entry to nest under (``parent.append_child(...)``
         # instead of the flat ``self.conversation.append(...)``). KEYED, not
@@ -3654,22 +3656,38 @@ class TextualChatApp(App):
         # #3712: an entry just arrived. Counted HERE, by the thing that
         # produced it — not reconstructed later from two reads of the model.
         self._note_entry_landed()
-        if (
-            kind == "agent"
-            and call_id
-            and meta.get("finish_reason") == "tool_calls"
-        ):
-            # This row IS a call boundary that dispatches tool_calls next —
-            # register it so those tool rows (about to arrive with the SAME
-            # call_id) find it. A terminal reply (finish_reason == "stop")
-            # or any other kind never registers: nothing ever looks up a
-            # call_id belonging to a call that dispatched no tools.
+        if kind == "agent" and call_id:
+            # #4777 (owner-reported, provider-dependence bug): registration no
+            # longer gates on ``finish_reason`` — a PROVIDER's own summary
+            # string, self-reported at its own discretion (litellm passes it
+            # through verbatim, ``llm.py``'s own ``choices[0].finish_reason``).
+            # The owner's own provider never returns ``"tool_calls"``, so the
+            # old gate here never fired on their screen — #4691 Phase B's
+            # entire Group construction was provider-dependent and silently
+            # inert for them, despite being green in every test written
+            # against a provider that DOES report it correctly.
+            #
+            # Registering unconditionally for every ``call_id``-bearing agent
+            # row is harmless even for an ordinary terminal reply that
+            # dispatched no tools: nothing ever looks up a call_id belonging
+            # to a call that dispatched no tools, so an unused entry here is
+            # dead weight, never a wrong nesting (#4776 tracks this dict's
+            # own session-lifetime growth separately — not this fix's scope).
             self._call_parents[call_id] = entry
-            # #4691 Phase B ④: the parent's own spinner starts here — its
-            # children are about to arrive RUNNING too, and
-            # ``_recompute_parent_state`` (called from every child settle)
-            # keeps it RUNNING until every child has settled.
-            entry.set_state(EntryState.RUNNING)
+            if meta.get("dispatched_tool_calls"):
+                # #4691 Phase B ④: the parent's own spinner starts here — its
+                # children are about to arrive RUNNING too, and
+                # ``_recompute_parent_state`` (called from every child
+                # settle) keeps it RUNNING until every child has settled.
+                #
+                # #4777: gated on ``dispatched_tool_calls`` — a REYN-OBSERVED
+                # fact (router_loop.py stamps it from the LLM result's own
+                # ``tool_calls`` list, non-empty precisely when this round
+                # actually dispatches tools), not the provider's
+                # ``finish_reason`` string. A terminal reply that dispatches
+                # no tools registers (harmless, above) but never spins —
+                # there is nothing for it to wait on.
+                entry.set_state(EntryState.RUNNING)
         if kind == "presentation":
             self._begin_image_resolutions(entry, msg)
         if kind == "intervention":

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2156,6 +2156,20 @@ class RouterLoop:
                         # row belongs to and whether it was a tool round.
                         "call_id": result.call_id,
                         "finish_reason": result.finish_reason,
+                        # #4777: a REYN-OBSERVED fact (the result's own
+                        # ``tool_calls`` list, non-empty here by construction
+                        # — this call site is reached only inside
+                        # ``if isinstance(interp, Execute):``, and Execute's
+                        # own classification is itself derived from
+                        # ``result.tool_calls`` being non-empty), never a
+                        # provider's self-reported ``finish_reason`` string.
+                        # The consumer (app.py's Group-parent spinner) reads
+                        # THIS, not ``finish_reason`` — a provider that never
+                        # returns ``finish_reason == "tool_calls"`` (a real,
+                        # owner-observed case, #4777) still gets a correct
+                        # spinner, because this fact is not sourced from that
+                        # provider string at all.
+                        "dispatched_tool_calls": bool(result.tool_calls),
                     },
                 )
                 # F5 fix (dogfood batch 1): dedupe duplicate async
@@ -2265,6 +2279,11 @@ class RouterLoop:
                             # for the full reasoning.
                             "call_id": result.call_id,
                             "finish_reason": result.finish_reason,
+                            # #4777: see the tool-turn-text row above (~line
+                            # 2157) for the full reasoning — this row is the
+                            # SAME call, still inside the Execute branch, so
+                            # ``result.tool_calls`` is non-empty here too.
+                            "dispatched_tool_calls": bool(result.tool_calls),
                         },
                     )
                     return self._total_usage
@@ -2406,6 +2425,11 @@ class RouterLoop:
                         # comment (~line 2073) for the full reasoning.
                         "call_id": result.call_id,
                         "finish_reason": result.finish_reason,
+                        # #4777: this is the empty-response terminal path — no
+                        # tool call was dispatched, so this is False here (see
+                        # the tool-turn-text row, ~line 2157, for the fact's
+                        # full reasoning).
+                        "dispatched_tool_calls": bool(result.tool_calls),
                     },
                 )
                 return self._total_usage  # no retry
@@ -2466,6 +2490,11 @@ class RouterLoop:
                     # (~line 2073) for the full reasoning.
                     "call_id": result.call_id,
                     "finish_reason": result.finish_reason,
+                    # #4777: this is the ordinary terminal-reply path — no
+                    # tool call was dispatched, so this is False here (see
+                    # the tool-turn-text row, ~line 2157, for the fact's
+                    # full reasoning).
+                    "dispatched_tool_calls": bool(result.tool_calls),
                 },
             )
             return self._total_usage

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -9,9 +9,10 @@ consumers — the reason both were deferred to Phase B in the first place.
 
 Default stays fully EXPANDED (owner ruling, #4691) — B1 itself never calls
 ``.collapse()``, so this file also pins that a freshly built Group is never
-auto-folded. Two fold paths reach a Group parent: flowview's own vim
-z-prefix (``za``, no reyn-side binding needed) and, since #4775 (owner-
-reported: Space was silently inert on a Group parent), Space itself.
+auto-folded. flowview's own vim z-prefix (``za``, no reyn-side binding
+needed) reaches a Group parent's fold; Space does NOT yet (owner-reported,
+#4775 — separately scoped, its own test lives in that PR, not this file
+until #4775 lands).
 
 All use a real, mounted :class:`TextualChatApp`, real
 :class:`~reyn.runtime.outbox.OutboxMessage` / EventFrame, and a real
@@ -26,7 +27,6 @@ import pytest
 from textual_flowview import EntryState, FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.inline.textual_chat.chrome import Composer
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
@@ -420,64 +420,6 @@ async def test_an_expanded_parent_shows_no_count_line() -> None:
             console.print(pres.renderable)
         text = cap.get()
         assert "folded" not in text and "1" not in text
-
-
-async def _focus_flow(pilot, app: TextualChatApp) -> FlowView:
-    app.query_one(Composer).focus()
-    await pilot.pause()
-    await pilot.press("shift+tab")
-    await pilot.pause()
-    return app.query_one(FlowView)
-
-
-@pytest.mark.asyncio
-async def test_space_folds_a_group_parent() -> None:
-    """Tier 2b: #4775 (owner-reported, live TUI) — Space, the owner's
-    documented/expected fold trigger, used to be silently inert on a Group
-    parent: ``on_flow_view_toggle_fold_requested`` early-returns for any
-    entry whose meta lacks ``_RESULT_KIND_KEY``, which a Group parent's
-    placeholder row (#4691 ③) always does. flowview's own ``za`` z-prefix
-    key sequence already reached ``toggle_fold()`` (a SEPARATE key path,
-    #4691's own doc), so a route existed — just not the one the owner
-    actually pressed. This drives the REAL Space key through the app
-    (not a direct ``.collapse()`` call, which #4750's own test already
-    covers as a presentation-only concern) to falsify the wiring gap
-    itself, not just the presenter's rendering of an already-collapsed
-    state."""
-    transport = QueueTransport()
-    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
-    async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
-        await transport.push_display(_parent_row("resp-1"))
-        await pilot.pause()
-        await transport.push_display(_started("op-1", call_id="resp-1"))
-        await transport.push_display(_started("op-2", call_id="resp-1"))
-        await pilot.pause()
-
-        parent = _entries(app)[0]
-        assert parent.collapsed is False, "setup: parent starts expanded"
-        flow = await _focus_flow(pilot, app)
-
-        # Arrival highlights the LAST entry (the second child) — move up
-        # twice to reach the parent itself before pressing Space.
-        await pilot.press("up")
-        await pilot.press("up")
-        await pilot.pause()
-        assert flow.current is parent, "setup: highlight must be on the parent"
-
-        await pilot.press("space")
-        while parent.collapsed is False:
-            await pilot.pause()
-        assert parent.collapsed is True, (
-            "Space on a highlighted Group parent must fold it — the owner's "
-            "own reported, expected trigger"
-        )
-
-        # Toggle: pressing Space again unfolds it.
-        await pilot.press("space")
-        while parent.collapsed is True:
-            await pilot.pause()
-        assert parent.collapsed is False
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -7,10 +7,11 @@ emits, even content-less) and ④ (the parent's own RUNNING→settled spinner,
 aggregated from its children) are this Group construction's direct
 consumers — the reason both were deferred to Phase B in the first place.
 
-Default stays fully EXPANDED (owner ruling, #4691) — B1 wires the fold keys
-(flowview 0.21.1's own vim z-prefix, no reyn-side binding needed) but never
-calls ``.collapse()`` itself, so this file also pins that a freshly built
-Group is never auto-folded.
+Default stays fully EXPANDED (owner ruling, #4691) — B1 itself never calls
+``.collapse()``, so this file also pins that a freshly built Group is never
+auto-folded. Two fold paths reach a Group parent: flowview's own vim
+z-prefix (``za``, no reyn-side binding needed) and, since #4775 (owner-
+reported: Space was silently inert on a Group parent), Space itself.
 
 All use a real, mounted :class:`TextualChatApp`, real
 :class:`~reyn.runtime.outbox.OutboxMessage` / EventFrame, and a real
@@ -25,16 +26,28 @@ import pytest
 from textual_flowview import EntryState, FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-def _parent_row(call_id: str, *, text: str = "") -> OutboxMessage:
+def _parent_row(
+    call_id: str,
+    *,
+    text: str = "",
+    finish_reason: "str | None" = "tool_calls",
+    dispatched_tool_calls: bool = True,
+) -> OutboxMessage:
     """The tool-turn-text row (#4691 ③'s own placeholder) — a real call
-    boundary, carrying the SAME call_id/finish_reason shape router_loop.py
-    stamps (#4691 Phase 1 ①②)."""
+    boundary, carrying the SAME call_id/finish_reason/dispatched_tool_calls
+    shape router_loop.py stamps (#4691 Phase 1 ①②, #4777). Defaults match a
+    provider that DOES report ``finish_reason == "tool_calls"`` correctly;
+    ``finish_reason`` is overridable so a test can pin #4777's own claim —
+    registration/spinner keyed on ``dispatched_tool_calls`` (a REYN-OBSERVED
+    fact) survives a provider that never reports it (#4777, owner-observed:
+    ``finish_reason`` stayed "stop" on every call, provider-side)."""
     return OutboxMessage(
         kind="agent",
         text=text,
@@ -42,7 +55,8 @@ def _parent_row(call_id: str, *, text: str = "") -> OutboxMessage:
             "chain_id": "chain-test",
             "source": "router_tool_turn_text",
             "call_id": call_id,
-            "finish_reason": "tool_calls",
+            "finish_reason": finish_reason,
+            "dispatched_tool_calls": dispatched_tool_calls,
             "prompt_tokens": 100,
             "completion_tokens": 5,
         },
@@ -406,3 +420,141 @@ async def test_an_expanded_parent_shows_no_count_line() -> None:
             console.print(pres.renderable)
         text = cap.get()
         assert "folded" not in text and "1" not in text
+
+
+async def _focus_flow(pilot, app: TextualChatApp) -> FlowView:
+    app.query_one(Composer).focus()
+    await pilot.pause()
+    await pilot.press("shift+tab")
+    await pilot.pause()
+    return app.query_one(FlowView)
+
+
+@pytest.mark.asyncio
+async def test_space_folds_a_group_parent() -> None:
+    """Tier 2b: #4775 (owner-reported, live TUI) — Space, the owner's
+    documented/expected fold trigger, used to be silently inert on a Group
+    parent: ``on_flow_view_toggle_fold_requested`` early-returns for any
+    entry whose meta lacks ``_RESULT_KIND_KEY``, which a Group parent's
+    placeholder row (#4691 ③) always does. flowview's own ``za`` z-prefix
+    key sequence already reached ``toggle_fold()`` (a SEPARATE key path,
+    #4691's own doc), so a route existed — just not the one the owner
+    actually pressed. This drives the REAL Space key through the app
+    (not a direct ``.collapse()`` call, which #4750's own test already
+    covers as a presentation-only concern) to falsify the wiring gap
+    itself, not just the presenter's rendering of an already-collapsed
+    state."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await transport.push_display(_started("op-2", call_id="resp-1"))
+        await pilot.pause()
+
+        parent = _entries(app)[0]
+        assert parent.collapsed is False, "setup: parent starts expanded"
+        flow = await _focus_flow(pilot, app)
+
+        # Arrival highlights the LAST entry (the second child) — move up
+        # twice to reach the parent itself before pressing Space.
+        await pilot.press("up")
+        await pilot.press("up")
+        await pilot.pause()
+        assert flow.current is parent, "setup: highlight must be on the parent"
+
+        await pilot.press("space")
+        while parent.collapsed is False:
+            await pilot.pause()
+        assert parent.collapsed is True, (
+            "Space on a highlighted Group parent must fold it — the owner's "
+            "own reported, expected trigger"
+        )
+
+        # Toggle: pressing Space again unfolds it.
+        await pilot.press("space")
+        while parent.collapsed is True:
+            await pilot.pause()
+        assert parent.collapsed is False
+
+
+@pytest.mark.asyncio
+async def test_group_construction_survives_a_provider_that_never_reports_tool_calls() -> None:
+    """Tier 2b: #4777 (owner-reported, provider-dependence bug) — the OWNER's
+    own live turns never had ``finish_reason == "tool_calls"`` on the parent
+    row (their provider reports every response as ``"stop"``, tool calls or
+    not), so B1's entire Group construction was silently inert on their
+    screen despite being green here — every existing test in this file used
+    a provider shape (``finish_reason == "tool_calls"``) that happened to
+    always be true. This is the ONE test in the suite that pins the
+    provider-INDEPENDENT claim directly: registration and the RUNNING
+    spinner both survive ``finish_reason="stop"`` as long as
+    ``dispatched_tool_calls`` (the REYN-OBSERVED fact, from the LLM result's
+    own ``tool_calls`` list, not the provider's self-reported string) is
+    true."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(
+            _parent_row("resp-1", finish_reason="stop", dispatched_tool_calls=True)
+        )
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        parent, child = _entries(app)
+        assert child.parent is parent, (
+            "a call whose OWN parent row was never labeled "
+            '\'finish_reason == "tool_calls"\' by the provider must still '
+            "nest its children — the registration fact is reyn's own "
+            "observation (dispatched_tool_calls), never the provider string"
+        )
+        assert parent.state is EntryState.RUNNING, (
+            "the spinner must still start — gated on dispatched_tool_calls, "
+            "not on finish_reason"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_terminal_reply_with_a_call_id_registers_but_never_spins() -> None:
+    """Tier 2b: accept-side pair — #4777's registration is now UNCONDITIONAL
+    for any call_id-bearing agent row (harmless per the code's own comment:
+    nothing ever looks up a call_id belonging to a call that dispatched no
+    tools), but the spinner stays gated on dispatched_tool_calls. An ordinary
+    terminal reply (no tools dispatched) must register without ever
+    spinning RUNNING — the accept side of the same fix.
+
+    Registration is proved through its only PUBLIC effect (a later same-
+    call_id tool row actually nesting as a child), not by reading the
+    private ``_call_parents`` dict directly (testing.md Tier 4)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(
+            _parent_row("resp-1", finish_reason="stop", dispatched_tool_calls=False)
+        )
+        await pilot.pause()
+
+        (entry,) = _entries(app)
+        assert entry.state is not EntryState.RUNNING, (
+            "a call that dispatched no tools must never show a spinner"
+        )
+
+        # A same-call_id tool row would never nest at all if registration
+        # were skipped — this is unrealistic in production (a terminal
+        # reply's call never actually dispatches a tool), but it is the
+        # only way to observe "did registration happen" through the
+        # public surface rather than the private dict.
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+        _, child = _entries(app)
+        assert child.parent is entry, (
+            "registration is unconditional now — a terminal reply's "
+            "call_id still registers (harmless, nothing ever looks it "
+            "up in production; a real caller with unused entries pays "
+            "only dict growth, tracked separately by #4776)"
+        )


### PR DESCRIPTION
**[tui-coder]** — completion Group registration made provider-independent (#4691 arc, item 1 of 4)

## What

Owner-reported (real TUI): their provider never returns `finish_reason == "tool_calls"` — every `llm_response_received` reports `"stop"`, tool calls or not. #4691 Phase B B1's entire Group construction gated registration on that provider string, so it was **silently inert on the owner's screen** — every test in the suite happened to use a provider shape where the string is correct, so nothing caught it.

Root cause traced to the same `LLMToolCallResult` object's own `tool_calls` list (litellm's raw shape, empty list if none) — a fact reyn already observes directly, never a provider's self-reported summary string.

## Changes

`router_loop.py`: stamp `"dispatched_tool_calls": bool(result.tool_calls)` alongside the existing `"finish_reason"` at all 4 `call_id`-bearing outbox emit sites (tool-turn-text, agent_spawn_ack, empty-response, terminal reply) — uniform with the existing pattern. `result.tool_calls` is non-empty by construction at the tool-turn-text site (the round is only classified `Execute` when it is — an existing comment there already says "byte-identical to the former `if result.tool_calls:` gate").

`app.py`: registration drops the `finish_reason` condition entirely — unconditional for any `call_id`-bearing agent row (harmless per the existing comment: nothing ever looks up a call_id belonging to a call that dispatched no tools; #4776 tracks the dict's own session-lifetime growth separately, not touched here). The RUNNING spinner stays conditional, now gated on `dispatched_tool_calls` instead of the provider string.

Also fixed a stale comment (`_call_parents`'s own docstring still described the `finish_reason`-gated registration this PR replaces).

## Cannot self-witness

My own provider already returns `finish_reason == "tool_calls"` correctly, so I cannot reproduce the owner's exact symptom live. Per lead-coder's own gate ("owner-environment observation is the witness — your environment already works, so it can't be used"), the **headless test is the substitute witness**: a provider shape with `finish_reason="stop"` + non-empty `tool_calls`.

## Tests (six questions, per policy — tests/ touched)

- `test_group_construction_survives_a_provider_that_never_reports_tool_calls` — the core #4777 claim: registration + spinner both survive a provider that never reports `"tool_calls"`.
  1. **Tier**: 2b (OS invariant — a real `TextualChatApp`, real transport, real Entry tree).
  2. **Transcribed?** No — asserts `child.parent is parent` and `parent.state is RUNNING`, neither read back from the same expression that produces them.
  3. **Who'd miss it?** The owner, directly — this is their exact reported symptom.
  4. **Green having never run?** No — asserted, not skipped; no optional dependency.
  5. **What does it accumulate?** Nothing — 2 pushed frames, bounded.
  6. **Declared Tier is true?** Yes.
- `test_a_terminal_reply_with_a_call_id_registers_but_never_spins` — accept-side pair: registration is unconditional now, but the spinner stays gated. Same 6 answers, with ③ = "a future PR relying on 'registration always spins' would misbehave"; the private-state read (`app._call_parents.get(...)`) I first wrote was caught by `test_tier_audit.py --strict` and replaced with a public-surface effect check (a later same-`call_id` row actually nests as a child) — kept here as evidence the gate did its job.

**Falsification** (both new tests): reverting `app.py`'s diff alone (keeping `router_loop.py` + the test file) makes both fail — confirmed, then restored.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/verify_module_docstrings.py <changed files>` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4691_phase_b_group_construction.py` — 13/13 OK (0 Tier-4 errors after the private-state fix above)
- [x] Regression sweep: `tests/interfaces/` — 1841 passed, 0 failed, 4 skipped (unrelated optional-extra skips, #4104); `tests/runtime/test_router_loop.py` + `tests/llm/` — 745 passed, 0 failed
- [x] Visual: N/A for this PR — cannot witness on the owner's screen from this environment (see above); the headless test is the documented substitute

## Acceptance-criteria table (#4691)

This PR addresses **row ⑦** (parent RUNNING spinner) directly, and is the precondition every other row (①②⑤⑥) needs — Group construction firing at all. **Not yet addressed**: default `completion=hide`, the `turn` Group (①) — both separately scoped, next in the arc (#4775, then hide, then turn Group). Cannot witness on the owner's own screen from this environment — the headless test above is the documented substitute per lead-coder's gate.

part of #4691

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[lead-coder]** — レビューでの blocking 項:

- [ ] 🔴 `test_space_folds_a_group_parent`（本 PR で新規）は **#4775 の挙動**を待っており、その fix は未着地のため**永久に真にならない条件**を待つ（`while parent.collapsed is True: await pilot.pause()` → CI の 120s kill switch で赤）。**本 PR から外し、#4775 の PR へ移す**こと。traceback の `timeout=0.017`（`-1` でない）が、ブロックでなく条件待ちループであることの witness。
