### PR TITLE
fix(#4775): Space folds a Group parent (owner's expected trigger)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2399,8 +2399,25 @@ class TextualChatApp(App):
         :meth:`_CursorFlowView.action_toggle_fold` already applied that
         guard before posting this) flips ONE entry's tool-detail fold,
         independent of the highlight/cursor position — #4691 §6's owner
-        ruling."""
+        ruling.
+
+        #4775 (owner-reported, live TUI): a Group parent (``entry.children``
+        truthy — #4691 B1's ONLY producer of ``append_child``, confirmed by
+        grep, so this is an exclusive signal, never a false positive on some
+        unrelated children-bearing row) is not a settled tool row and used to
+        hit the early return below unconditionally, leaving #4750's collapsed
+        child-count display unreachable from Space — the owner's own expected
+        trigger. ``Entry.toggle_collapsed()`` (flowview's own fold/unfold
+        primitive, already the mechanism ``za`` reaches through flowview's
+        OWN z-prefix key handling — this only wires the SAME primitive to
+        Space, no new key) is called for a Group parent BEFORE the settled-
+        tool-row check, since a Group parent's own ``meta`` has no
+        ``_RESULT_KIND_KEY`` and would otherwise never reach a fold path at
+        all."""
         entry = event.entry
+        if entry.children:
+            entry.toggle_collapsed()
+            return
         meta = entry.item.meta
         if not meta or _RESULT_KIND_KEY not in meta:
             return  # not a settled tool row — nothing to fold

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -9,10 +9,16 @@ consumers — the reason both were deferred to Phase B in the first place.
 
 Default stays fully EXPANDED (owner ruling, #4691) — B1 itself never calls
 ``.collapse()``, so this file also pins that a freshly built Group is never
-auto-folded. flowview's own vim z-prefix (``za``, no reyn-side binding
-needed) reaches a Group parent's fold; Space does NOT yet (owner-reported,
-#4775 — separately scoped, its own test lives in that PR, not this file
-until #4775 lands).
+auto-folded. Two fold paths reach a Group parent: flowview's own vim
+z-prefix (``za``, no reyn-side binding needed) and, since #4775 (owner-
+reported: Space was silently inert on a Group parent — the documented/
+expected trigger, not the z-prefix sequence a typical user wouldn't know
+about), Space itself.
+
+Registration (and therefore the whole Group construction firing at all)
+is provider-independent since #4777 — keyed on ``dispatched_tool_calls``
+(the LLM result's own ``tool_calls`` list), never a provider's
+self-reported ``finish_reason`` string.
 
 All use a real, mounted :class:`TextualChatApp`, real
 :class:`~reyn.runtime.outbox.OutboxMessage` / EventFrame, and a real
@@ -27,6 +33,7 @@ import pytest
 from textual_flowview import EntryState, FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
@@ -500,3 +507,61 @@ async def test_a_terminal_reply_with_a_call_id_registers_but_never_spins() -> No
             "up in production; a real caller with unused entries pays "
             "only dict growth, tracked separately by #4776)"
         )
+
+
+async def _focus_flow(pilot, app: TextualChatApp) -> FlowView:
+    app.query_one(Composer).focus()
+    await pilot.pause()
+    await pilot.press("shift+tab")
+    await pilot.pause()
+    return app.query_one(FlowView)
+
+
+@pytest.mark.asyncio
+async def test_space_folds_a_group_parent() -> None:
+    """Tier 2b: #4775 (owner-reported, live TUI) — Space, the owner's
+    documented/expected fold trigger, used to be silently inert on a Group
+    parent: ``on_flow_view_toggle_fold_requested`` early-returns for any
+    entry whose meta lacks ``_RESULT_KIND_KEY``, which a Group parent's
+    placeholder row (#4691 ③) always does. flowview's own ``za`` z-prefix
+    key sequence already reached ``toggle_fold()`` (a SEPARATE key path,
+    #4691's own doc), so a route existed — just not the one the owner
+    actually pressed. This drives the REAL Space key through the app
+    (not a direct ``.collapse()`` call, which #4750's own test already
+    covers as a presentation-only concern) to falsify the wiring gap
+    itself, not just the presenter's rendering of an already-collapsed
+    state."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await transport.push_display(_started("op-2", call_id="resp-1"))
+        await pilot.pause()
+
+        parent = _entries(app)[0]
+        assert parent.collapsed is False, "setup: parent starts expanded"
+        flow = await _focus_flow(pilot, app)
+
+        # Arrival highlights the LAST entry (the second child) — move up
+        # twice to reach the parent itself before pressing Space.
+        await pilot.press("up")
+        await pilot.press("up")
+        await pilot.pause()
+        assert flow.current is parent, "setup: highlight must be on the parent"
+
+        await pilot.press("space")
+        while parent.collapsed is False:
+            await pilot.pause()
+        assert parent.collapsed is True, (
+            "Space on a highlighted Group parent must fold it — the owner's "
+            "own reported, expected trigger"
+        )
+
+        # Toggle: pressing Space again unfolds it.
+        await pilot.press("space")
+        while parent.collapsed is True:
+            await pilot.pause()
+        assert parent.collapsed is False


### PR DESCRIPTION
**[tui-coder]** — Space folds a Group parent (owner's expected trigger) — #4691 arc, item 2 of 4

## What

Owner-reported (real TUI): "group のトグルてスペース？効かないけど" — Space, the documented/expected fold trigger, was silently inert on a Group parent. `on_flow_view_toggle_fold_requested` early-returns for any entry whose meta lacks `_RESULT_KIND_KEY`, which a Group parent's placeholder row (#4691 ③) always does — it is not a settled tool row. flowview's own `za` z-prefix key sequence already reached `toggle_fold()` (a separate key path, #4691's own doc), so a route existed — just not the one the owner actually pressed.

## Changes

`on_flow_view_toggle_fold_requested`: for a Group parent (`entry.children` truthy — #4691 B1's ONLY producer of `append_child`, confirmed by grep, an exclusive signal), call `entry.toggle_collapsed()` (flowview's own fold/unfold primitive, the SAME one `za` already reaches) BEFORE the settled-tool-row check.

**Population census** (independently confirmed by architect, a second method — tracing where children are born, not `grep("Binding(")`): exactly one producer of children in the whole codebase. Since #4779 (provider-independent registration), the "no children yet" state now covers **3 real production shapes**, not 1 — (1) the brief window before a call's first tool row arrives, (2) an orphaned call-parent whose tool report never arrived, (3) every ordinary terminal reply that dispatched no tools at all (now registered unconditionally, per #4777). "A row with no children never folds" (rather than "not yet arrived" or "orphaned") is the one framing that covers all three — `entry.children` is a reliable, exclusive signal for all of them.

## Live-verified

Verified on the real TUI before opening this PR: a 2-tool-call turn, highlighted the Group parent, pressed Space — folded to `(2 folded)`; pressed again — unfolded. Toggle confirmed both ways.

## Tests

- `test_space_folds_a_group_parent` — drives the REAL Space key through the app (not a direct `.collapse()` call, which #4750's own test already covers as presentation-only) to falsify the wiring gap itself.
  1. **Tier**: 2b.
  2. **Transcribed?** No.
  3. **Who'd miss it?** The owner, directly.
  4. **Green having never run?** No.
  5. **What does it accumulate?** Nothing bounded — 2 pushed frames, a fixed key sequence.
  6. **Declared Tier true?** Yes.

**Falsification**: reverting `app.py`'s diff alone makes this test hang — `pytest -k test_space_folds_a_group_parent` under `timeout 30` exits 124 (timeout-killed, a genuine unbounded wait on a condition that never becomes true), confirmed, then restored.

**Note on this file's history**: this test previously rode along accidentally in #4777's PR (a mistake, caught by CI) and was removed there, saved locally, and is only now reintroduced here where its fix actually lands.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/verify_module_docstrings.py <changed files>` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4691_phase_b_group_construction.py` — 13/13 OK
- [x] Regression sweep: `tests/interfaces/` — 1842 passed, 0 failed, 4 skipped (unrelated optional-extra skips, #4104)
- [x] **Visual: confirmed live on the real TUI before opening this PR** — see above, `(2 folded)` observed both fold and unfold

## Acceptance-criteria table (#4691)

This PR addresses **row ⑥** (Space) — `za`/`zR`/`zM` are unrelated code paths, not independently retested here (unchanged). **Not yet addressed**: default `completion=hide`, the `turn` Group (①) — both separately scoped, next in the arc.

part of #4691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
