### PR TITLE
fix(#4776): _call_parents' lifetime claim was false — bound it to the session, not the process

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1123,6 +1123,7 @@ class TextualChatApp(App):
         "_queue_item_meta",
         "_streaming_replies",
         "_pending_own_cancels",
+        "_call_parents",
     )
 
     def __init__(

--- a/tests/interfaces/test_3310_n2_reset_hydrate.py
+++ b/tests/interfaces/test_3310_n2_reset_hydrate.py
@@ -648,6 +648,74 @@ async def test_reset_streaming_replies_stale_chain_id_does_not_finalize_into_gho
         await asyncio.wait_for(reg.shutdown(), timeout=5.0)
 
 
+@pytest.mark.asyncio
+async def test_reset_call_parents_stale_call_id_does_not_nest_into_ghost_parent(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: ``_call_parents`` witness (#4776) — an ``agent`` row carrying a
+    ``call_id`` on alpha registers itself as a potential tree-parent
+    (``_call_parents``, #4691 Phase B B1). Left un-child'd at switch time
+    (nobody nested under it before the switch — the common no-tool-calls
+    case, made the DEFAULT registration shape by #4777/#4779: EVERY
+    call_id-bearing agent row registers now, not only ones that go on to
+    dispatch tools), its Entry is exactly the shape ``_call_parents`` was
+    never previously proven to release.
+
+    ``_call_parents`` was OMITTED from :attr:`TextualChatApp.
+    _PER_SESSION_DICT_STATE` before this fix — its own docstring claimed a
+    conversation/session-bounded lifetime the code never actually enforced
+    (the real bound was the whole app PROCESS's lifetime). After switching
+    to beta, a tool_call_started frame carrying the SAME call_id must NOT be
+    silently nested under the (now off-model, orphaned) alpha-session
+    parent Entry — if ``_call_parents`` were not cleared,
+    ``parent.append_child(msg)`` would attach the child to a parent no
+    longer reachable from the current (freshly cleared) FlowModel, and the
+    row would vanish from the visible flow with zero trace — the identical
+    silent-swallow discriminator shape ``_running_tools``/
+    ``_streaming_replies`` above use for their own witnesses."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            transport.push_display(OutboxMessage(
+                kind="agent", text="alpha's own reply",
+                meta={"call_id": "call-stale"},
+            ))
+            await _settle(pilot)
+            assert _rows(app) == [("agent", "alpha's own reply")]
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+            assert _rows(app) == [], "switch must clear the retained model"
+
+            # Same call_id, now on beta — must NOT nest under the stale
+            # (removed-from-model) alpha parent Entry.
+            transport.push_display(OutboxMessage(
+                kind="tool_call_started", text="grep",
+                meta={"tool": "grep", "op_id": "op-1", "args": {}, "call_id": "call-stale"},
+            ))
+            await _settle(pilot)
+
+            rows = _rows(app)
+            assert rows == [("tool_call_started", "grep")], (
+                "a tool row for a call_id registered before the switch must "
+                "land as a fresh, flat top-level row after reset — a "
+                f"leftover _call_parents entry would swallow it silently: {rows!r}"
+            )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
 def _install_hanging_run_turn(session: Session):
     """Same no-mock seam ``tests/interfaces/test_3300_p2a_queue_state_publish.py`` uses
     (itself mirroring ``tests/core/test_2242_hard_cancel.py``): a real, plain


### PR DESCRIPTION
**[e2e-coder]** — Closes #4776.

## What

`_call_parents`'s own docstring claims *"the dict only grows for the life of the conversation (bounded by the same session lifetime the flow model itself already is)"* — but the dict was never in `_PER_SESSION_DICT_STATE`, the tuple `_handle_session_attached_event`'s reset loop iterates over. A session switch clears `self.conversation` (the FlowModel) and every OTHER per-session dict, but `_call_parents` survives untouched — its real bound was the whole app **process's** lifetime, not the session's.

`#4779` recently widened what registers into this dict: previously only a completion that dispatched tool calls did; now (owner-reported provider-dependence fix) **every** `call_id`-bearing agent row registers unconditionally — including every turn's ordinary terminal reply. Growth accelerated without the underlying lifetime bug being touched.

## Fix

Option A of the two the issue named (make the claim true, vs. B: document a deliberate exclusion the way `_streaming_catchup` does). Deliberate exclusion has no positive justification here — nothing ever looks up a `call_id` from a *previous* session (`call_id`s aren't reused), so a surviving entry serves no purpose; it is pure accumulation, and the orphan-sweep at turn-end (which walks every `_call_parents` value to force-settle any still-`RUNNING` parent) would keep walking dead prior-session entries forever too.

Added `"_call_parents"` to `_PER_SESSION_DICT_STATE` — one line; the dict's own docstring needed no wording change, since the claim it already made becomes true once the reset loop actually reaches it.

Registration condition is untouched (out of this issue's scope — `#4691`'s own arc owns it).

## Test plan / six questions (`tests/` touched)

**`tests/interfaces/test_3310_n2_reset_hydrate.py`** (1 new test, added alongside its 4 existing per-state reset siblings for the same session-switch barrier, following the file's own established discriminator pattern):
1. Tier 2 — pins a real per-session state-reset invariant (this app's own documented switch-barrier contract), the same Tier every sibling test in this file already claims.
2. No same-expression-both-sides transcription — asserts on the rendered flow rows after a real frame ingest, never re-reads `_call_parents` itself (a private dict; testing.md Tier 4 would forbid that anyway).
3. Who'd miss it: any future edit that reverts or narrows the tuple entry — the real consumer is an operator switching sessions shortly after any turn that produced an agent reply with a `call_id` (now the common case post-`#4779`, not a rare tool-call path).
4. Would not stay green having never run — strip-falsified (removing `"_call_parents"` from the tuple) flips it red, surfacing an even sharper failure than "row silently vanishes": the orphaned parent's `append_child` raises `IndexError` inside `_ingest_frame`'s own try/except, logged and swallowed, so the row is simply absent from the rendered flow — confirmed, then restored.
5. Bounded — 2 pilot-pause settle cycles per step, same fixed shape every sibling test in this file already uses; no test-owned time budget.
6. Declared Tier (2) matches Q1's answer.

**Manual/Visual**: N/A (a headless `TextualChatApp` harness, matching every sibling test in this file — no live-TUI-only behaviour here) — `- [x] (skipped — no UI surface beyond the headless harness)`.

## Local gates (all green)

`ruff check .`, `scripts/test_tier_audit.py --strict`, `scripts/verify_module_docstrings.py`, `scripts/mypy_ratchet.py`, plus scoped `pytest` across the touched file (10/10), `#4691`'s own Group-construction suite, and both sibling `#3310` session-switch suites (38 tests total, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
