### PR TITLE
fix(#4691): the turn-total token figure moves to the user row (arc item 4)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -4462,6 +4462,16 @@ class TextualChatApp(App):
             if msg_id:
                 self._sent_queue.remove_item(msg_id)
             meta = self._queue_item_meta.pop(msg_id, {}) if msg_id else {}
+            # #4691 arc item ④: stamp THIS turn's own chain_id onto the
+            # user row itself — the row is created here, at promotion time,
+            # before chain_id existed at queue time (a queued item's own
+            # meta predates the turn actually starting), so this is the
+            # first point it can be threaded through. ReynTurnUsageGutter
+            # reads it to show the turn's aggregate token total, now
+            # anchored to this row instead of an agent reply (see that
+            # class's own docstring for why the two were split).
+            meta = dict(meta)
+            meta.setdefault("chain_id", chain_id)
             text = _neutralized_label(str(item.get("text", "")))
             self._ingest_frame(OutboxMessage(kind="user", text=text, meta=meta))
 

--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -653,7 +653,11 @@ class ReynTurnUsageGutter:
         read here; :attr:`_usage_lookup` never runs for an agent row."""
         meta = entry.item.meta or {}
         # #4691: every LIVE kind="agent" emit site stamps
-        # prompt_tokens/completion_tokens (see router_loop.py). Both halves
+        # prompt_tokens/completion_tokens (see router_loop.py), INCLUDING
+        # the terminal no-tool-calls reply row (Phase A.5) — without that
+        # stamp, a turn whose only agent row IS the terminal one renders an
+        # EMPTY cell here now (there is no turn-total fallback left to
+        # catch it; arc item ④ removed that path entirely). Both halves
         # are ABSOLUTE (owner ruling — see the class docstring for why an
         # absolute figure replaced #4698's signed-delta attempt): ↑ this
         # call's own real prompt_tokens, ↓ its own completion_tokens. No

--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -374,11 +374,21 @@ def _format_elapsed(seconds: float) -> str:
 #: would read as "this turn used nothing".
 TURN_USAGE_UNKNOWN = "—"
 
-#: The one display-frame kind the per-turn token figure is anchored to — the
-#: agent reply, i.e. the row that CONCLUDES a turn's visible output. See
-#: :class:`ReynTurnUsageGutter` for why the figure is anchored rather than
-#: repeated on every row of the turn.
+#: The display-frame kind a PER-CALL absolute token figure is anchored to —
+#: the agent reply, i.e. the row that carries that specific litellm call's
+#: own real ``prompt_tokens``/``completion_tokens`` in its meta. See
+#: :class:`ReynTurnUsageGutter` for why this and :data:`TURN_TOTAL_ANCHOR_KIND`
+#: are two DIFFERENT rows now, not one row wearing two meanings.
 TURN_ANCHOR_KIND = "agent"
+
+#: The display-frame kind the TURN TOTAL is anchored to — the ``"user"`` row
+#: that opens the turn, never an ``agent`` row (#4691 arc item ④, owner
+#: ruling). See :class:`ReynTurnUsageGutter`'s docstring for why an agent
+#: row's own per-call figure and a turn's aggregate total were AMBIGUOUS
+#: sharing one anchor: the same visual slot answered two different
+#: questions depending on an incidental fact (did THIS specific frame happen
+#: to carry its own ``prompt_tokens``?) invisible to the reader.
+TURN_TOTAL_ANCHOR_KIND = "user"
 
 #: Direction markers for the per-turn token split — ``↑`` what the turn SENT
 #: (prompt) and ``↓`` what it generated (completion), e.g. ``"↑12k ↓1.8k"``.
@@ -448,7 +458,8 @@ def _format_tokens(tokens: int) -> str:
 #:
 #: The two families are mutually exclusive on any one row by construction
 #: (elapsed lives on ``tool_call_started`` rows, the token figure on
-#: :data:`TURN_ANCHOR_KIND` rows), so the widest cell is ``max(3, 11) = 11``,
+#: :data:`TURN_ANCHOR_KIND`/:data:`TURN_TOTAL_ANCHOR_KIND` rows), so the
+#: widest cell is ``max(3, 11) = 11``,
 #: not their sum — 12 + one column of breathing room = 13 (#4691 Phase A.5
 #: raised this from 12 — the signed ↑ half costs one more character than the
 #: absolute figure it replaced). If that exclusivity ever stopped holding,
@@ -548,20 +559,39 @@ class ReynTurnUsageGutter:
     all the way from ``TokenUsage`` at the call site through
     ``BudgetTracker``'s per-turn buckets; it is never re-derived here.
 
-    **Anchored to one row per turn, not repeated on every row.** The figure is
-    a TURN total, so it is rendered on the row that concludes the turn's visible
-    output — the :data:`TURN_ANCHOR_KIND` (``"agent"``) reply. Painting the same
-    total onto the turn's user line and each of its tool rows would show one
-    number N times in a column whose every other label (elapsed) IS per-row,
-    which reads as N separate per-row figures. One turn, one figure.
+    **Two DIFFERENT anchors for two DIFFERENT figures (#4691 arc item ④,
+    owner ruling) — not one row wearing two meanings.** Earlier revisions of
+    this class anchored BOTH the turn total and a per-call absolute figure
+    to the same :data:`TURN_ANCHOR_KIND` (``"agent"``) row, falling back to
+    the turn total whenever a specific agent row happened not to carry its
+    own ``prompt_tokens``. That was AMBIGUOUS: the same visual slot answered
+    "this call's own tokens" or "the whole turn's total" depending on an
+    incidental fact — did THIS specific frame happen to carry per-call
+    figures in its meta? — invisible to the reader. A reader could not tell
+    which question a number on an agent row was answering without already
+    knowing that frame's own hidden shape.
 
-    **Three distinct renders, and they are distinct on purpose:**
+    - :data:`TURN_ANCHOR_KIND` (``"agent"``) rows now show ONLY their own
+      per-call absolute figure, straight from ``entry.item.meta`` — never a
+      turn-total fallback. A row with no per-call figure (a restored/legacy
+      frame, or an agent-kind emit site that never threaded one through)
+      renders an EMPTY cell — no ambiguous number, no silent substitution.
+    - :data:`TURN_TOTAL_ANCHOR_KIND` (``"user"``) rows — the line that OPENS
+      a turn — show the turn TOTAL via ``usage_lookup(chain_id)``, never a
+      per-call figure (a user row carries no LLM call of its own to report).
+      Anchoring to the opening line rather than a settled reply also means
+      the figure never repeats across a turn's multiple ``agent`` rows the
+      way the shared-anchor design risked (a tool-turn's explanatory text,
+      a spawn ack — see router_loop.py — one turn, one total, one row).
 
-    - the anchor row's turn HAS a figure → its token split (``"↑12k ↓1.8k"``).
+    **Three distinct renders on the ``user`` anchor, and they are distinct
+    on purpose:**
+
+    - the row's turn HAS a figure → its token split (``"↑12k ↓1.8k"``).
       Including a REAL zero (``"↑0 ↓0"``): a turn whose calls reported no usage
       genuinely used 0 tokens, and that is a fact, not an absence;
-    - the anchor row NAMES a turn (``meta["chain_id"]``) but the runtime holds
-      no figure for it → :data:`TURN_USAGE_UNKNOWN` (``"—"``). Covers a turn
+    - the row NAMES a turn (``meta["chain_id"]``) but the runtime holds no
+      figure for it → :data:`TURN_USAGE_UNKNOWN` (``"—"``). Covers a turn
       that made no LLM call, a turn EVICTED from the bounded buckets
       (``TURN_BUCKET_CAP`` — an old row scrolled far back), an unknown
       chain_id, and a REMOTE client (the buckets are session-local and not on
@@ -578,46 +608,23 @@ class ReynTurnUsageGutter:
       for elapsed.
 
     ``usage_lookup=None`` (no read model / pre-session / plain fallback) makes
-    every row's lookup unknown, so a row that names a turn still renders ``—``
-    rather than silently nothing.
+    every ``user`` row's lookup unknown, so a row that names a turn still
+    renders ``—`` rather than silently nothing.
 
-    **#4691: a per-call figure embedded in the row's own meta wins over the
-    lookup above.** A turn with multiple ``kind="agent"`` anchor rows (a
-    tool-turn's explanatory text, a spawn ack — see router_loop.py) used to
-    paint the SAME turn total on every one of them, which reads as the
-    figure repeating rather than a distinct call — exactly the duplicate
-    this class's own docstring above says it exists to avoid, just not
-    caught for the multi-anchor-row case. Each such row now carries its
-    OWN call's real ``prompt_tokens``/``completion_tokens`` in
-    ``entry.item.meta``, and :meth:`label` prefers that over the turn-total
-    lookup when present.
-
-    **Phase A.5 (co-vet finding, architect + lead-coder) — the terminal
-    no-tool-calls reply row carries a per-call figure too**, not just the
-    three non-terminal sites Phase A covered. Leaving it on the turn-total
-    lookup kept the owner's ORIGINAL reported symptom alive for any turn
-    whose only ``kind="agent"`` row IS this terminal one (a turn of
-    content-less tool calls never fires the non-terminal emits, which are
-    gated on non-empty text).
-
-    **The ↑ half is the call's real ABSOLUTE ``prompt_tokens`` — an owner
-    ruling (#4691), not a signed delta.** #4698 tried a signed
-    context-growth delta between consecutive calls first, reasoning that
-    an absolute figure duplicates ctx tab's own number in a second place.
-    The owner's final ruling reversed this: an absolute figure is
-    PRIMITIVE (a reader can derive the delta by subtracting adjacent
-    rows), while a delta is DERIVED and the absolute value can never be
-    recovered from it. #4698's own "9 exception cases" for a
-    session-shared delta baseline (cross-purpose/cross-session pollution,
-    ``/model`` switches, rewind, fork, compaction) all evaporate with an
-    absolute figure — only "no usage on the response" (``None``, never a
-    fabricated ``0``) remains. "Showing the jump" between calls is Group/
-    fold's own job (#4691 Phase B): the fold's summary row is what
-    concentrates a turn down to its call boundaries, not this column.
-
-    The turn-total lookup now only answers for a row that carries NO
-    per-call figure at all (a restored/legacy frame — every LIVE emit
-    site stamps one)."""
+    **The ↑ half of an agent row's per-call figure is the call's real
+    ABSOLUTE ``prompt_tokens`` — an owner ruling (#4691), not a signed
+    delta.** #4698 tried a signed context-growth delta between consecutive
+    calls first, reasoning that an absolute figure duplicates ctx tab's own
+    number in a second place. The owner's final ruling reversed this: an
+    absolute figure is PRIMITIVE (a reader can derive the delta by
+    subtracting adjacent rows), while a delta is DERIVED and the absolute
+    value can never be recovered from it. #4698's own "9 exception cases"
+    for a session-shared delta baseline (cross-purpose/cross-session
+    pollution, ``/model`` switches, rewind, fork, compaction) all evaporate
+    with an absolute figure — only "no usage on the response" (``None``,
+    never a fabricated ``0``) remains. "Showing the jump" between calls is
+    Group/fold's own job (#4691 Phase B): the fold's summary row is what
+    concentrates a turn down to its call boundaries, not this column."""
 
     def __init__(
         self,
@@ -627,24 +634,34 @@ class ReynTurnUsageGutter:
         self._usage_lookup = usage_lookup
 
     def label(self, entry: "Entry[OutboxMessage]") -> str:
-        """This entry's per-turn token label: the count, ``"—"`` when the row
-        names a turn with no known figure, or ``""`` when it names no turn.
-
-        Only ``tokens`` is read off the looked-up dict; ``cost_usd`` is present
-        and valid but not displayed (see the class docstring). A missing or
-        non-numeric ``tokens`` is treated as "no figure" rather than coerced.
+        """This entry's token label — an agent row's OWN per-call figure, a
+        user row's TURN total (``"—"`` when it names a turn with no known
+        figure), or ``""`` when the row is neither / names no turn.
 
         A lookup that raises is treated exactly like "no figure" — this runs on
         every gutter repaint and must never be able to kill a render."""
-        if entry.item.kind != TURN_ANCHOR_KIND:
-            return ""
+        kind = entry.item.kind
+        if kind == TURN_ANCHOR_KIND:
+            return self._per_call_label(entry)
+        if kind == TURN_TOTAL_ANCHOR_KIND:
+            return self._turn_total_label(entry)
+        return ""
+
+    def _per_call_label(self, entry: "Entry[OutboxMessage]") -> str:
+        """An agent row's OWN call figure, straight off its meta — never a
+        turn-total fallback (#4691 arc item ④). Only ``entry.item.meta`` is
+        read here; :attr:`_usage_lookup` never runs for an agent row."""
         meta = entry.item.meta or {}
-        # #4691: a PER-CALL row (every LIVE kind="agent" emit site stamps
-        # prompt_tokens/completion_tokens — see router_loop.py) takes
-        # precedence over the turn-total lookup below. Both halves are
-        # ABSOLUTE (owner ruling — see the class docstring for why an
+        # #4691: every LIVE kind="agent" emit site stamps
+        # prompt_tokens/completion_tokens (see router_loop.py). Both halves
+        # are ABSOLUTE (owner ruling — see the class docstring for why an
         # absolute figure replaced #4698's signed-delta attempt): ↑ this
-        # call's own real prompt_tokens, ↓ its own completion_tokens.
+        # call's own real prompt_tokens, ↓ its own completion_tokens. No
+        # figure here (a restored/legacy frame, or a future agent-kind emit
+        # site that never threaded one through) is an EMPTY cell — #4691
+        # arc item ④ removed the turn-total fallback that used to sit here,
+        # which is what made this row's own figure ambiguous with a turn
+        # total sharing the same slot.
         call_prompt = meta.get("prompt_tokens")
         call_completion = meta.get("completion_tokens")
         if isinstance(call_prompt, (int, float)) and isinstance(
@@ -654,6 +671,14 @@ class ReynTurnUsageGutter:
                 f"{PROMPT_TOKENS_MARKER}{_format_tokens(int(call_prompt))} "
                 f"{COMPLETION_TOKENS_MARKER}{_format_tokens(int(call_completion))}"
             )
+        return ""
+
+    def _turn_total_label(self, entry: "Entry[OutboxMessage]") -> str:
+        """The TURN total for a ``user`` row (#4691 arc item ④) — the line
+        that opens the turn, looked up by ``meta["chain_id"]``. See the
+        class docstring's "Three distinct renders" for the figure /
+        :data:`TURN_USAGE_UNKNOWN` / empty-cell trichotomy this implements."""
+        meta = entry.item.meta or {}
         chain_id = meta.get("chain_id")
         if not isinstance(chain_id, str) or not chain_id:
             return ""

--- a/tests/interfaces/test_4691_gutter_per_call_boundary.py
+++ b/tests/interfaces/test_4691_gutter_per_call_boundary.py
@@ -1,5 +1,10 @@
-"""Tier 1: #4691 — a per-call figure embedded in the row's own meta wins
-over the turn-total lookup on ``ReynTurnUsageGutter``.
+"""Tier 1: #4691 — an ``agent`` row's per-call figure, embedded in the
+row's own meta, on ``ReynTurnUsageGutter``. Since arc item ④ this is the
+ONLY thing an agent row ever shows — the turn-total lookup moved off this
+kind entirely, onto the ``user`` row (:data:`TURN_TOTAL_ANCHOR_KIND`,
+covered in ``test_textual_chat_phase4_turn_cost_gutter_3283.py``), so an
+agent row without its own per-call figure now renders an empty cell
+rather than falling back to a lookup that used to sit on this same kind.
 
 Root problem (architect's measurement, issue #4691): a turn with more than
 one ``kind="agent"`` anchor row (a tool-turn's own explanatory text, an
@@ -35,7 +40,6 @@ from textual_flowview import FlowModel
 from reyn.interfaces.inline.textual_chat.gutter import (
     RIGHT_GUTTER_WIDTH,
     TURN_ANCHOR_KIND,
-    TURN_USAGE_UNKNOWN,
     ReynTurnUsageGutter,
 )
 from reyn.runtime.outbox import OutboxMessage
@@ -94,18 +98,28 @@ def test_two_anchor_rows_of_one_turn_no_longer_show_the_same_duplicated_total() 
     assert "999" not in first and "999" not in second
 
 
-def test_a_row_with_no_per_call_figure_still_falls_back_to_the_turn_total_lookup() -> None:
-    """Tier 1: a row that carries NO per-call meta at all (a restored/legacy
-    frame — every LIVE ``kind="agent"`` emit site stamps these fields)
-    still uses the existing chain_id-keyed turn-total lookup exactly as
-    before #4691 — the ONLY case that lookup answers for now."""
+def test_a_row_with_no_per_call_figure_renders_empty_never_a_turn_total() -> None:
+    """Tier 1: #4691 arc item ④ (owner ruling) — a row that carries NO
+    per-call meta at all (a restored/legacy frame, or a future agent-kind
+    emit site that never threaded one through) renders an EMPTY cell, never
+    the chain_id-keyed turn-total lookup. That lookup moved to the ``user``
+    row entirely (:data:`TURN_TOTAL_ANCHOR_KIND`) — an agent row with a
+    ``chain_id`` but no per-call figures used to silently substitute the
+    turn total in the exact same visual slot a genuine per-call figure
+    occupies, which is the ambiguity item ④ closes: a reader could not
+    tell "this call's own tokens" from "the whole turn's total" without
+    already knowing this row's own hidden meta shape. The lookup is
+    present here specifically to prove it is NEVER consulted for an agent
+    row, not merely unconfigured."""
     def _lookup(chain_id: str) -> "dict | None":
-        assert chain_id == "turn-B"
-        return {"chain_id": chain_id, "tokens": 130, "prompt_tokens": 100, "completion_tokens": 30}
+        raise AssertionError(
+            f"an agent row must never consult the turn-total lookup, got "
+            f"chain_id={chain_id!r}"
+        )
 
     gutter = ReynTurnUsageGutter(usage_lookup=_lookup)
     row = OutboxMessage(kind=TURN_ANCHOR_KIND, text="done", meta={"chain_id": "turn-B"})
-    assert _label(gutter, row) == "↑100 ↓30"
+    assert _label(gutter, row) == ""
 
 
 def test_the_owners_originally_reported_symptom_is_closed() -> None:
@@ -133,16 +147,17 @@ def test_the_owners_originally_reported_symptom_is_closed() -> None:
     assert "138" not in _label(gutter, only_row_in_the_turn)
 
 
-def test_a_non_numeric_or_partial_per_call_pair_falls_back_not_crashes() -> None:
+def test_a_non_numeric_or_partial_per_call_pair_renders_empty_not_crashes() -> None:
     """Tier 1: meta carrying only ONE of the two fields (a malformed/partial
-    emit) is not treated as a valid per-call pair — falls through to the
-    turn-total lookup rather than rendering a bogus half-figure or raising."""
+    emit) is not treated as a valid per-call pair — renders an EMPTY cell
+    (#4691 arc item ④: no turn-total fallback exists on an agent row
+    anymore) rather than a bogus half-figure or a raised exception."""
     gutter = ReynTurnUsageGutter(usage_lookup=lambda cid: None)
     row = OutboxMessage(
         kind=TURN_ANCHOR_KIND, text="reply",
         meta={"chain_id": "turn-C", "prompt_tokens": 100},  # completion_tokens missing
     )
-    assert _label(gutter, row) == TURN_USAGE_UNKNOWN
+    assert _label(gutter, row) == ""
 
 
 def test_a_real_per_call_zero_still_renders_as_a_measured_zero() -> None:

--- a/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
+++ b/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
@@ -81,6 +81,7 @@ from reyn.interfaces.inline.textual_chat.gutter import (
     PROMPT_TOKENS_MARKER,
     RIGHT_GUTTER_WIDTH,
     TURN_ANCHOR_KIND,
+    TURN_TOTAL_ANCHOR_KIND,
     TURN_USAGE_UNKNOWN,
     _cell_pad_left,
 )
@@ -106,11 +107,14 @@ _MODEL = "gpt-4o"
 _LEFT_GUTTER_WIDTH = 2
 
 
-def _agent_row(chain_id: "str | None") -> OutboxMessage:
-    """An agent-reply display frame — the turn-figure ANCHOR row. ``chain_id``
-    is the same key ``RouterLoop`` stamps on the real frame's meta."""
+def _user_row(chain_id: "str | None") -> OutboxMessage:
+    """A user-line display frame — the turn TOTAL's own anchor row since
+    #4691 arc item ⑤ (moved off the agent reply, which now shows only its
+    OWN per-call figure, never a turn total). ``chain_id`` is the same key
+    the app's own turn-promotion site (``_handle_turn_started_event``)
+    stamps on the real frame's meta."""
     meta = {"chain_id": chain_id} if chain_id is not None else {}
-    return OutboxMessage(kind=TURN_ANCHOR_KIND, text="done", meta=meta)
+    return OutboxMessage(kind=TURN_TOTAL_ANCHOR_KIND, text="hi", meta=meta)
 
 
 def _entry(item: OutboxMessage):
@@ -286,9 +290,9 @@ def test_gutter_renders_figure_for_known_turn_and_dash_for_unknown_and_evicted()
     evicted, kept = turns[0], turns[-1]
 
     gutter = ReynTurnUsageGutter(usage_lookup=tracker.turn_usage)
-    known_label = _label(gutter, _agent_row(kept))
-    evicted_label = _label(gutter, _agent_row(evicted))
-    unseen_label = _label(gutter, _agent_row("turn-never-seen"))
+    known_label = _label(gutter, _user_row(kept))
+    evicted_label = _label(gutter, _user_row(evicted))
+    unseen_label = _label(gutter, _user_row("turn-never-seen"))
 
     assert known_label not in ("", TURN_USAGE_UNKNOWN), known_label
     assert PROMPT_TOKENS_MARKER in known_label, (
@@ -317,7 +321,7 @@ def test_a_raising_lookup_degrades_to_unknown_rather_than_killing_the_render() -
         raise RuntimeError("tracker exploded")
 
     gutter = ReynTurnUsageGutter(usage_lookup=_boom)
-    assert _label(gutter, _agent_row("turn-A")) == TURN_USAGE_UNKNOWN
+    assert _label(gutter, _user_row("turn-A")) == TURN_USAGE_UNKNOWN
 
 
 def test_no_lookup_wired_still_renders_unknown_not_a_zero() -> None:
@@ -326,7 +330,7 @@ def test_no_lookup_wired_still_renders_unknown_not_a_zero() -> None:
     that NAMES a turn still renders ``—``. The failure mode being closed is a
     silently blank cell, which reads as a free turn."""
     gutter = ReynTurnUsageGutter(usage_lookup=None)
-    assert _label(gutter, _agent_row("turn-somewhere")) == TURN_USAGE_UNKNOWN
+    assert _label(gutter, _user_row("turn-somewhere")) == TURN_USAGE_UNKNOWN
 
 
 def test_remote_snapshot_publishes_no_turn_usage_lookup() -> None:
@@ -361,13 +365,13 @@ def test_zero_token_turn_renders_a_real_zero_distinct_from_unknown() -> None:
     )
 
     gutter = ReynTurnUsageGutter(usage_lookup=tracker.turn_usage)
-    label = _label(gutter, _agent_row("turn-empty"))
+    label = _label(gutter, _user_row("turn-empty"))
     assert label != TURN_USAGE_UNKNOWN, (
         f"a measured zero-token turn must show its real 0, not 'unknown': {label!r}"
     )
     assert label == f"{PROMPT_TOKENS_MARKER}0 {COMPLETION_TOKENS_MARKER}0", label
     # ...and the unknown leg still renders differently, on the same gutter.
-    assert _label(gutter, _agent_row("turn-absent")) == TURN_USAGE_UNKNOWN
+    assert _label(gutter, _user_row("turn-absent")) == TURN_USAGE_UNKNOWN
 
 
 def test_the_smallest_real_token_counts_render_exactly_not_rounded_away() -> None:
@@ -387,7 +391,7 @@ def test_the_smallest_real_token_counts_render_exactly_not_rounded_away() -> Non
             "cost_usd": 0.0,
         }
     )
-    label = _label(gutter, _agent_row("turn-tiny"))
+    label = _label(gutter, _user_row("turn-tiny"))
     assert label != TURN_USAGE_UNKNOWN, label
     assert label == f"{PROMPT_TOKENS_MARKER}1 {COMPLETION_TOKENS_MARKER}1", label
 
@@ -398,24 +402,26 @@ def test_the_smallest_real_token_counts_render_exactly_not_rounded_away() -> Non
 @pytest.mark.parametrize(
     "item",
     [
-        OutboxMessage(kind="user", text="hi", meta={"chain_id": "turn-A"}),
         OutboxMessage(
             kind="tool_call_started",
             text="grep",
             meta={"chain_id": "turn-A", "op_id": "op-1"},
         ),
         OutboxMessage(kind="reasoning", text="thinking", meta={"chain_id": "turn-A"}),
+        OutboxMessage(kind="agent", text="reply", meta={"chain_id": "turn-A"}),
     ],
 )
 def test_non_anchor_rows_of_a_recorded_turn_show_no_token_figure(
     item: OutboxMessage,
 ) -> None:
-    """Tier 1: the turn figure is ANCHORED to the reply row, so the turn's OTHER
-    rows — its user line, its tool calls, its reasoning — render no cost cell
-    even though their frames carry the very same recorded ``chain_id``.
-    Repeating one turn total down every row of the turn, in a column whose
-    other label family (elapsed) IS per-row, would read as N separate per-row
-    figures."""
+    """Tier 1: the turn TOTAL is anchored to the ``user`` row (#4691 arc item
+    ④), so the turn's OTHER rows — its tool calls, its reasoning, and now
+    even its OWN agent reply (which carries no per-call figure of its own
+    here) — render no cost cell even though their frames carry the very
+    same recorded ``chain_id``. An agent row is included deliberately: it
+    used to be the turn-total anchor itself, and now shows nothing rather
+    than the total unless it carries its own per-call figure — the whole
+    point of splitting the two anchors apart."""
     tracker = BudgetTracker(CostConfig())
     _record(tracker, "turn-A", prompt=1000, completion=200)
     gutter = ReynTurnUsageGutter(usage_lookup=tracker.turn_usage)
@@ -428,7 +434,7 @@ def test_non_anchor_rows_of_a_recorded_turn_show_no_token_figure(
     )
     # ...while the anchor row of that SAME turn does — so the empty cells above
     # are the anchoring decision, not a broken lookup.
-    assert _label(gutter, _agent_row("turn-A")) != ""
+    assert _label(gutter, _user_row("turn-A")) != ""
 
 
 def test_a_row_naming_no_turn_renders_an_empty_cell_not_a_dash() -> None:
@@ -437,7 +443,7 @@ def test_a_row_naming_no_turn_renders_an_empty_cell_not_a_dash() -> None:
     renders an empty cell, exactly as #3337's elapsed negative control does.
     ``—`` is reserved for "we know which turn, we do not know the figure"."""
     gutter = ReynTurnUsageGutter(usage_lookup=lambda cid: None)
-    assert _label(gutter, _agent_row(None)) == ""
+    assert _label(gutter, _user_row(None)) == ""
     assert _label(gutter, OutboxMessage(kind="agent", text="hi", meta={})) == ""
 
 
@@ -499,7 +505,7 @@ def test_the_composite_right_gutter_carries_both_label_families() -> None:
     assert _label(gutter, running) == "7s", (
         "the elapsed half must still speak through the composite"
     )
-    reply = _label(gutter, _agent_row("turn-A"))
+    reply = _label(gutter, _user_row("turn-A"))
     assert PROMPT_TOKENS_MARKER in reply and COMPLETION_TOKENS_MARKER in reply, (
         f"the turn-token half is missing: {reply!r}"
     )
@@ -530,7 +536,7 @@ def test_every_label_the_column_can_emit_fits_the_configured_width() -> None:
                 "cost_usd": 0.0,
             }
             gutter = ReynRightGutter(usage_lookup=lambda cid, u=usage: u)
-            label = _label(gutter, _agent_row("t"))
+            label = _label(gutter, _user_row("t"))
             assert cell_len(label) <= RIGHT_GUTTER_WIDTH - 1, (
                 f"{label!r} ({cell_len(label)} cells) leaves no breathing room "
                 f"in RIGHT_GUTTER_WIDTH={RIGHT_GUTTER_WIDTH} "
@@ -589,7 +595,7 @@ def test_the_rendered_gutter_cell_occupies_exactly_the_column_width() -> None:
             "completion_tokens": 1800, "cost_usd": 0.0,
         }
     )
-    padded = gutter.decorate(_entry(_agent_row("t")), RIGHT_GUTTER_WIDTH, 1).plain
+    padded = gutter.decorate(_entry(_user_row("t")), RIGHT_GUTTER_WIDTH, 1).plain
     assert cell_len(padded) == RIGHT_GUTTER_WIDTH, (
         f"{padded!r} occupies {cell_len(padded)} cells, not {RIGHT_GUTTER_WIDTH}"
     )
@@ -752,11 +758,13 @@ def _rendered_lines(flow: "FlowView[OutboxMessage]") -> "list[str]":
 async def test_mounted_app_shows_a_known_turns_split_and_dashes_an_unknown_one() -> None:
     """Tier 2b: end-to-end through the REAL mounted app — the real read-model
     seam, the real ``turn_usage_fn`` publication path, the real
-    ``right_decorator`` wiring — a reply row for a RECORDED turn ends in its
-    real prompt/completion split and a reply row for an unknown turn ends in
-    ``—``, read off the COMPOSED row text rather than a ``decorate()`` call.
-    Both rows are in the same render, so a wiring that fell back to one answer
-    for everything fails on the other row.
+    ``right_decorator`` wiring — a ``user`` row (#4691 arc item ④: the turn
+    total's own anchor, since a per-call agent row cannot answer this
+    ambiguously anymore) for a RECORDED turn ends in its real
+    prompt/completion split and one for an unknown turn ends in ``—``, read
+    off the COMPOSED row text rather than a ``decorate()`` call. Both rows
+    are in the same render, so a wiring that fell back to one answer for
+    everything fails on the other row.
 
     BOTH halves of the split are asserted on the rendered line: an
     implementation that rendered only the total, or only the prompt side, would
@@ -772,12 +780,12 @@ async def test_mounted_app_shows_a_known_turns_split_and_dashes_an_unknown_one()
         await pilot.pause()
         await transport.push(
             OutboxMessage(
-                kind="agent", text="recorded reply", meta={"chain_id": "turn-recorded"}
+                kind="user", text="recorded reply", meta={"chain_id": "turn-recorded"}
             )
         )
         await transport.push(
             OutboxMessage(
-                kind="agent", text="mystery reply", meta={"chain_id": "turn-gone"}
+                kind="user", text="mystery reply", meta={"chain_id": "turn-gone"}
             )
         )
         await pilot.pause()


### PR DESCRIPTION
**[tui-coder]** — the turn-total token figure moves to the user row — #4691 arc, item 4 of 6

## What

Owner ruling (#4691 arc, item ④, from architect's own population census): the SAME visual slot on an agent row answered two different questions depending on an incidental fact — did THIS specific frame happen to carry its own `prompt_tokens`? If yes, "this call's own absolute tokens". If no, silently falls back to the turn-total lookup instead. A reader could not tell which question a number on an agent row was answering without already knowing that frame's own hidden meta shape.

## Changes

`gutter.py` (`ReynTurnUsageGutter`): split into two anchors, not one row wearing two meanings.
- `TURN_ANCHOR_KIND` (`"agent"`) rows now show ONLY their own per-call figure, straight from meta — no `chain_id` fallback. A row with no per-call figure (a restored/legacy frame, a malformed partial emit) renders an empty cell, never a silently-substituted turn total.
- `TURN_TOTAL_ANCHOR_KIND` (`"user"`) rows — the line that OPENS a turn — now show the turn TOTAL via the existing `chain_id`-keyed `usage_lookup`, moved here wholesale from the agent-row fallback it used to be.

`app.py` (`_handle_turn_started_event`): stamps `chain_id` onto the user row's own meta at its one canonical creation site (turn-promotion time — `chain_id` does not exist yet at queue time, so this is the first point it can be threaded through).

## Live-verified

Verified on the real TUI before opening this PR: a simple no-tool-call turn now shows the token split on the USER row (`What's 2+2?...` → `↑1.8k ↓1`), which was **always blank before this change** — `kind="user"` was never handled by this gutter at all. The agent reply row shows the same figure here only because this was a single-call turn — per-call and turn-total coincide numerically for a 1-call turn, from two genuinely different code paths now (meta read vs `chain_id` lookup) — not evidence of the old ambiguity surviving.

## Tests

Renamed/extended the shared test helper (`_agent_row` → `_user_row`, kind flipped to `TURN_TOTAL_ANCHOR_KIND`) across `test_textual_chat_phase4_turn_cost_gutter_3283.py`'s turn-total suite (15 tests, all still Tier-2/2b-appropriate for the SAME behavior, just relocated). `test_4691_gutter_per_call_boundary.py`'s 2 tests that asserted the old agent-row fallback rewritten to assert the new empty-cell behavior instead, including one that **raises from inside the lookup callback** if an agent row ever calls it again (a regression guard, not just an unconfigured lookup — falsifies a future re-introduction of the fallback). `test_non_anchor_rows_of_a_recorded_turn_show_no_token_figure`'s parametrize list swapped its `kind="user"` case (no longer a non-anchor) for `kind="agent"` (which now IS a non-anchor for the turn-total — the whole point of the split).

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/verify_module_docstrings.py <changed files>` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py tests/interfaces/test_4691_gutter_per_call_boundary.py` — 27/27 OK
- [x] Regression sweep: `tests/interfaces/` + `tests/runtime/test_router_loop.py` — 1863 passed, 0 failed, 4 skipped (unrelated optional-extra skips, #4104)
- [x] **Visual: confirmed live on the real TUI before opening this PR** — see above

## Acceptance-criteria table (#4691)

This PR addresses **row ④** (user row = turn total) directly, and removes the agent-row ambiguity architect's population census identified as blocking it. **Not yet addressed**: row ⑤ (highlight B), row ① (turn Group) — both separately scoped, remaining in the arc.

part of #4691

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[lead-coder]** — レビューでの blocking 項:

- [ ] 🔴 削除された Phase A.5 段落のうち、**まだ生きている半分**が失われた。「turn-total lookup に残すと症状が生きる」は構造的に消えたので削除で正しいが、**「終端（no-tool-calls）応答の行にも per-call を打刻する必要がある」は健在**（打刻が無ければその行は空セル）。理由が消えた状態で `router_loop` 側の打刻だけが残っており、次に読む人が冗長と判断して外せる。新 docstring に**「何が壊れるか」の形で 1 行**残すこと。
