### PR TITLE
fix(#4691): a Group parent recedes while expanded (arc item 5, highlight B)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -17,6 +17,7 @@ import time
 from typing import TYPE_CHECKING, Callable
 
 from rich.console import Console, Group, RenderableType
+from rich.styled import Styled
 from rich.text import Text
 from textual.content import Content
 from textual_flowview import Entry, Presentation
@@ -43,6 +44,7 @@ from ._meta_keys import RESULT_KIND_KEY as _RESULT_KIND_KEY
 from ._meta_keys import RESULT_META_KEY as _RESULT_META_KEY
 from ._meta_keys import RUNNING_SINCE_KEY as _RUNNING_SINCE_KEY
 from .gutter import _is_retrieval_tool
+from .palette import TOKENS
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -944,6 +946,31 @@ class ReynPresenter:
         if entry.collapsed and entry.children:
             count_line = Text(f"  ({len(entry.children)} folded)", style=_CC_DIM)
             body = Group(body, count_line)
+        elif entry.children:
+            # #4691 arc item ⑤ (owner ruling — "B で良いよ" + "親に弱い印も
+            # そうだね"): a Group parent's own line recedes while EXPANDED
+            # (children visible) — child = bright (UNCHANGED — the owner's
+            # own ruling is the parent weakening, never the children
+            # strengthening; the reverse would make children stand out
+            # MORE than an ordinary row, changing how the whole
+            # conversation reads), parent = dim, so the reader's eye lands
+            # on the tool rows carrying the actual content rather than the
+            # structural placeholder above them.
+            #
+            # ``palette.TOKENS["@recede@"]`` (``"dim"``, an SGR ATTRIBUTE,
+            # not a colour) — NOT the hex ``_CC_DIM`` this module uses
+            # elsewhere for the plain REPL renderer's own palette. CLAUDE.md's
+            # TUI colour policy requires every value here resolve through a
+            # ``palette.py`` token; ``@recede@`` already carries a measured
+            # justification for exactly this "recede" meaning (#3522/#3528:
+            # ``$text-muted`` resolves to the SAME ``ansi_default`` marker as
+            # ordinary text under the ansi themes, so it recedes by exactly
+            # nothing — ``dim`` is the value that actually changes what is
+            # drawn). Collapsed is excluded (the branch above already owns
+            # that state, and a collapsed parent recedes for a DIFFERENT
+            # reason — it names a hidden count, not a peer of visible
+            # children).
+            body = Styled(body, TOKENS["@recede@"])
         return Presentation(
             height=self._measure(body, width),
             renderable=body,

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -481,7 +481,12 @@ async def test_an_expanded_parent_shows_no_count_line() -> None:
         pres = await app._presenter.present(parent, 80)
         from rich.console import Console
 
-        console = Console(width=80)
+        # no_color=True: an expanded parent recedes (#4691 arc item ⑤) via
+        # a real ANSI colour escape now — a colour-enabled capture would
+        # embed digits from the escape sequence itself (e.g. the "1" in
+        # "38;2;107;114;128") into the plain-text substring check below,
+        # a false positive unrelated to this test's own subject.
+        console = Console(width=80, no_color=True)
         with console.capture() as cap:
             console.print(pres.renderable)
         text = cap.get()
@@ -630,3 +635,90 @@ async def test_space_folds_a_group_parent() -> None:
         while parent.collapsed is False:
             await pilot.pause()
         assert parent.collapsed is True
+
+
+@pytest.mark.asyncio
+async def test_an_expanded_group_parent_recedes() -> None:
+    """Tier 2b: #4691 arc item ⑤ (owner ruling — "B で良いよ" + "親に弱い印
+    もそうだね") — a Group parent's own line dims while EXPANDED (children
+    visible), so the reader's eye lands on the tool rows carrying the
+    actual content. Value comes from ``palette.TOKENS["@recede@"]``
+    (``"dim"``, an SGR attribute with its own measured justification,
+    #3522/#3528) — CLAUDE.md's TUI colour policy requires every value here
+    resolve through a ``palette.py`` token, never a literal."""
+    from rich.styled import Styled
+
+    from reyn.interfaces.inline.textual_chat.palette import TOKENS
+
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        parent = _entries(app)[0]
+        parent.expand()
+        assert parent.collapsed is False, "setup: expanded"
+        assert parent.children, "setup: has a child"
+
+        pres = await app._presenter.present(parent, 80)
+        assert isinstance(pres.renderable, Styled), (
+            "an expanded Group parent's body must be wrapped to recede"
+        )
+        assert pres.renderable.style == TOKENS["@recede@"]
+
+
+@pytest.mark.asyncio
+async def test_a_collapsed_group_parent_does_not_also_recede() -> None:
+    """Tier 2b: accept-side pair — a COLLAPSED parent already recedes via a
+    different mechanism (the "(N folded)" count line, #4750) and is
+    excluded from item ⑤'s own Styled-wrap branch — the two are distinct
+    reasons to dim, not doubled up on the same row."""
+    from rich.styled import Styled
+
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        parent = _entries(app)[0]
+        assert parent.collapsed is True, "setup: defaults collapsed (arc item 3)"
+
+        pres = await app._presenter.present(parent, 80)
+        assert not isinstance(pres.renderable, Styled), (
+            "a collapsed parent's body is a Group (body + count line), "
+            "not item ⑤'s Styled-wrap — the two recede-reasons are "
+            "mutually exclusive by construction"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_leaf_row_never_recedes() -> None:
+    """Tier 2b: accept-side pair — a row with no children at all (an
+    ordinary tool row, or a Group parent before its first child lands) is
+    untouched by item ⑤'s Styled-wrap — receding is a Group-parent-only
+    concept, never applied to a leaf."""
+    from rich.styled import Styled
+
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        parent = _entries(app)[0]
+        parent.expand()
+        (child,) = parent.children
+
+        pres = await app._presenter.present(child, 80)
+        assert not isinstance(pres.renderable, Styled)


### PR DESCRIPTION
**[tui-coder]** — a Group parent recedes while expanded (arc item 5, highlight B) — #4691 arc, item 5 of 6

## What

Owner ruling (#4691 arc, item ⑤ — "B で良いよ" + "親に弱い印もそうだね", direct quotes): child = bright, parent = dim, while a Group is EXPANDED (children visible). Nowhere implemented — architect's own population census found zero style-generating hits across `presenter.py`, `gutter.py`, and flowview 0.21.1 itself for anything touching `depth` alongside style.

## Changes

`presenter.py`'s `present()`: a third branch alongside the existing collapsed-with-count and plain-leaf cases — `entry.children` truthy and NOT collapsed wraps the whole body in `Styled(body, palette.TOKENS["@recede@"])`. The **token**, not a literal or the pre-existing `_CC_DIM` hex constant this file uses elsewhere: CLAUDE.md's TUI colour policy requires every value here resolve through `palette.py`, and `@recede@` already carries a measured justification for exactly this "recede" meaning (#3522/#3528: `$text-muted` resolves to the same `ansi_default` marker as ordinary text under the ansi themes, so it recedes by exactly nothing — `dim` is the value that actually changes what is drawn). Collapsed is excluded (that state already recedes via a DIFFERENT mechanism, #4750's own `(N folded)` count line) — the two are distinct reasons to dim, not doubled on the same row.

**Direction matters**: the owner's own ruling weakens the PARENT, never strengthens the children — the reverse would make a Group's children stand out MORE than an ordinary row, changing how the whole conversation reads.

## Live-verified

Verified on the real TUI before opening this PR (lead-coder's explicit condition — "実機で見てから PR に", this is a face only I can see): a real 2-tool-call turn, expanded via Space, the parent row's own rendered segment carries the raw dim SGR escape (`\x1b[2m`) exactly where `@recede@` resolves; the child rows (`list_directory`, `grep_files`) carry their own pre-existing colour styling unchanged, with no dim attribute added.

## Tests

- `test_an_expanded_group_parent_recedes` — the core claim, asserts the body is `Styled(..., TOKENS["@recede@"])`.
- `test_a_collapsed_group_parent_does_not_also_recede` — accept-side pair, the collapsed count-line branch and this Styled-wrap branch are mutually exclusive.
- `test_a_leaf_row_never_recedes` — accept-side pair, an ordinary tool row (no children) is untouched.

**Falsification**: reverting `presenter.py` alone fails `test_an_expanded_group_parent_recedes` (the body is a plain, unwrapped renderable without the fix) — confirmed, then restored.

One pre-existing test needed a `no_color=True` capture fix: the new `Styled` wrapper introduces real ANSI colour codes into `test_an_expanded_parent_shows_no_count_line`'s captured text, and a digit inside the escape sequence itself (`"1"` in `"38;2;107;114;128"`) was tripping a naive substring check unrelated to that test's own subject.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 203/207 baselined, no new findings
- [x] `python scripts/verify_module_docstrings.py <changed files>` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4691_phase_b_group_construction.py` — 17/17 OK
- [x] `tests/interfaces/test_tui_colour_tokens.py` (CLAUDE.md's colour-token gate) — 6/6 clean
- [x] Regression sweep: `tests/interfaces/` — 1846 passed, 0 failed, 4 skipped (unrelated optional-extra skips, #4104)
- [x] **Visual: confirmed live on the real TUI before opening this PR** — see above

## Acceptance-criteria table (#4691)

This PR addresses **row ⑤** (highlight B) directly. **Not yet addressed**: row ① (turn Group) — the last item remaining in the arc.

part of #4691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
