### PR TITLE
fix(#4788): Esc dismisses an open rewind picker regardless of focus

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2563,6 +2563,22 @@ class TextualChatApp(App):
         ``RECURSIVE`` ``r`` vs. this module's own ``/rewind`` ``r`` handling
         in :meth:`on_key`, only if either were declared priority=True). This
         stays scoped to one key and one widget instead.
+
+        ★Implicit ordering, when BOTH the picker and the intervention panel
+        are open at once: this catch runs first and consumes the Esc press
+        outright (``event.stop()``), so a single Esc closes ONLY the picker
+        — :class:`~.intervention_panel.InterventionPanel`'s own ``escape``
+        Binding (``action_dismiss_panel``) never fires on that same press.
+        No capability is lost: the panel's own Esc is documented as a
+        focus-only escape hatch, not a close ("every pending tab stays
+        exactly as it was" — ``InterventionPanel.Dismissed``'s own
+        docstring), so a SECOND Esc (picker now closed, this branch a no-op)
+        reaches it exactly as before. Picker-first is deliberate — the
+        picker has no other way to close once it has lost focus (that is
+        this fix's whole premise), while the panel already has one. Whether
+        this ordering, or the picker staying open across an intervention at
+        all, is the right UX is a separate, open question (#4788 tracks it;
+        not decided here).
         """
         if isinstance(event, (events.Key, events.MouseScrollDown, events.MouseScrollUp)):
             # ``self._flow`` is created lazily in ``compose()``, not

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2525,7 +2525,8 @@ class TextualChatApp(App):
         )
 
     async def on_event(self, event: events.Event) -> None:
-        """Any key press or scroll dismisses an active text-effect overlay.
+        """Any key press or scroll dismisses an active text-effect overlay;
+        Esc also dismisses an open rewind picker regardless of focus (#4788).
 
         The overlay (:meth:`action_toggle_text_effect`) is a full-viewport
         joke painted OVER the flow view; it should end the instant the reader
@@ -2543,6 +2544,25 @@ class TextualChatApp(App):
         The dismissing press is consumed and does nothing else: Escape while
         the joke plays closes the joke, not the joke AND cancel a text
         selection; a scroll dismisses it without also moving the flow view.
+
+        #4788: the same "sees the raw event first, regardless of focus" seam
+        also closes a real gap in :class:`~.rewind_picker.RewindPicker`'s own
+        ``escape`` Binding. That Binding only participates in Textual's
+        focused-widget-outward walk when the picker (or a descendant) is
+        somewhere in the current focus chain — an intervention arriving while
+        the picker is already open steals focus to its own free-text input,
+        and Esc then resolves against THAT chain instead, leaving the picker
+        visibly open with no way to close it via Esc (found investigating
+        #4761: the picker was never stuck — clicking back into it and Enter
+        still closed it normally — only its own Esc binding was unreachable).
+        Reusing this hook rather than declaring the picker's Binding
+        ``priority=True``: a priority Binding is checked DOM-wide before the
+        normal walk, so its reach crosses every focus boundary, not just this
+        one path — #4751's investigation (architect, same session) flagged a
+        live collision risk for exactly that shape (file_access's
+        ``RECURSIVE`` ``r`` vs. this module's own ``/rewind`` ``r`` handling
+        in :meth:`on_key`, only if either were declared priority=True). This
+        stays scoped to one key and one widget instead.
         """
         if isinstance(event, (events.Key, events.MouseScrollDown, events.MouseScrollUp)):
             # ``self._flow`` is created lazily in ``compose()``, not
@@ -2554,6 +2574,12 @@ class TextualChatApp(App):
             flow = getattr(self, "_flow", None)
             if flow is not None and flow.overlay_active:
                 flow.stop_overlay()
+                event.stop()
+                return
+        if isinstance(event, events.Key) and event.key == "escape":
+            picker = getattr(self, "_rewind_picker", None)
+            if picker is not None and picker.display:
+                picker.action_dismiss()
                 event.stop()
                 return
         await super().on_event(event)

--- a/tests/interfaces/test_4788_rewind_picker_escape_dismiss.py
+++ b/tests/interfaces/test_4788_rewind_picker_escape_dismiss.py
@@ -1,0 +1,217 @@
+"""Tier 2: #4788 — Esc dismisses an open rewind picker regardless of what
+currently holds focus.
+
+Found investigating #4761 (headless repro of a reported TUI freeze — the
+freeze itself did not reproduce, but this real, unrelated defect surfaced
+along the way): :class:`~reyn.interfaces.inline.textual_chat.rewind_picker.
+RewindPicker`'s own ``escape`` Binding only participates in Textual's
+focused-widget-outward walk when the picker (or a descendant) is somewhere
+in the current focus chain. An intervention arriving while the picker is
+already open steals focus to its own free-text ``Input`` — Esc then resolves
+against THAT chain instead, and the picker's own binding never gets
+consulted at all. The picker was never functionally stuck (clicking back
+into it, or Enter on a highlighted row, both still worked) — only Esc's own
+path to it was unreachable, which is the gap this test pins.
+
+Real ``AgentRegistry``/``Session`` (the real ``session.set_pending_command_ui``
++ ``__rewind_list__`` sentinel path a typed ``/rewind`` uses) + a real,
+mounted ``TextualChatApp`` — no mocks, per the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.core.events.events import Event
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
+from reyn.interfaces.inline.textual_chat.rewind_picker import RewindPicker
+from reyn.interfaces.repl.read_model import RegistryReadModel
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` whose ``frames()`` drains an
+    ``asyncio.Queue`` a test pushes onto (mirrors the same harness shape used
+    throughout ``test_3310_n2_reset_hydrate.py``)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue" = asyncio.Queue()
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            yield await self._queue.get()
+
+    def push_display(self, msg: OutboxMessage) -> None:
+        self._queue.put_nowait(DisplayFrame(msg))
+
+    def push_event(self, etype: str, data: dict) -> None:
+        self._queue.put_nowait(EventFrame(Event(type=etype, data=data)))
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return True
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: OutboxMessage) -> None:
+        self.push_display(msg)
+
+    async def cancel_inflight(self) -> None:
+        pass
+
+    async def cancel_queued(self, msg_id: str) -> bool:
+        return False
+
+    async def shutdown(self) -> None:
+        pass
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+async def _settle(pilot, n: int = 3) -> None:
+    for _ in range(n):
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_escape_dismisses_rewind_picker_after_focus_moves_to_intervention(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: picker opens, THEN a pending free-text intervention arrives and
+    steals focus to its own ``Input`` — Esc must still close the picker."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        alpha = reg.get_session("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            # 1) the rewind picker opens first, via the real command-UI path
+            # a typed ``/rewind`` uses.
+            alpha.set_pending_command_ui({
+                "kind": "rewind",
+                "points": [{"seq": 1, "ts": "t1", "kind": "checkpoint"}],
+            })
+            transport.push_display(OutboxMessage(
+                kind="__rewind_list__", text="rewind points", meta={},
+            ))
+            await _settle(pilot)
+            picker = app.query_one(RewindPicker)
+            assert picker.display is True
+            assert app.focused is picker.query_one("#rewind-picker-options")
+
+            # 2) a pending free-text intervention (no "choices" key) arrives
+            # SECOND, while the picker is still open — this is what steals
+            # focus away from the picker.
+            transport.push_display(OutboxMessage(
+                kind="intervention", text="Type an answer",
+                meta={"intervention_id": "iv-1", "prompt": "next step?"},
+            ))
+            await _settle(pilot)
+            iv_panel = app.query_one(InterventionPanel)
+            assert iv_panel.display is True
+            assert picker.display is True, (
+                "the picker must still be open at this point — this test is "
+                "about closing it via Esc, not about it disappearing on its own"
+            )
+            # focus moved off the picker's own OptionList — the discriminator
+            # for this bug: without it, the picker's OWN Binding would still
+            # answer Esc and this test would pass for the wrong reason.
+            assert app.focused is not picker.query_one("#rewind-picker-options")
+
+            # 3) Esc — the picker must close even though it holds no focus.
+            await pilot.press("escape")
+            await _settle(pilot)
+            assert picker.display is False, (
+                "Esc must dismiss an open rewind picker regardless of which "
+                "widget currently holds focus (#4788)"
+            )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_escape_still_dismisses_rewind_picker_when_it_holds_focus(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: accept-side sibling — the ordinary case (picker open, picker
+    holds focus, no intervention involved) must keep working exactly as
+    before; the new app-level Esc catch must not double-fire or otherwise
+    change the plain single-picker path."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        alpha = reg.get_session("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+            alpha.set_pending_command_ui({
+                "kind": "rewind",
+                "points": [{"seq": 1, "ts": "t1", "kind": "checkpoint"}],
+            })
+            transport.push_display(OutboxMessage(
+                kind="__rewind_list__", text="rewind points", meta={},
+            ))
+            await _settle(pilot)
+            picker = app.query_one(RewindPicker)
+            assert picker.display is True
+            assert app.focused is picker.query_one("#rewind-picker-options")
+
+            await pilot.press("escape")
+            await _settle(pilot)
+            assert picker.display is False
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)


### PR DESCRIPTION
**[e2e-coder]** — fixes component **A** (defect) of #4788: `RewindPicker`'s own `escape` `Binding` only participates in Textual's focused-widget-outward walk when the picker (or a descendant) is somewhere in the current focus chain. An intervention arriving while the picker is already open steals focus to its own free-text `Input`, so `Esc` resolves against that chain instead and the picker's own binding never gets consulted — the picker stays visibly open with no way to close it via `Esc`, though it is not otherwise stuck (click-to-refocus + Enter both still worked, per the #4761 headless measurement this was found from).

## Fix

Reuses `TextualChatApp.on_event`'s existing "sees the raw event first, regardless of focus" seam (already used to dismiss the text-effect overlay) instead of declaring the picker's `Binding` `priority=True`. A priority `Binding` is checked DOM-wide before the normal walk, so its reach crosses *every* focus boundary, not just this one path — #4751's investigation (architect) flagged a live collision risk for exactly that shape (`file_access`'s `RECURSIVE` `r` vs. this module's own `/rewind` `r` handling in `on_key`, only if either were declared `priority=True`). The `on_event` catch stays scoped to one key (`escape`) and one widget (the picker, only while `display` is `True`).

## Scope

Only component **A** (defect) of #4788. Component **B** ("should the picker close when an intervention arrives, or stay usable afterward?") is a separate, still-open design/visibility question — explicitly an owner-axis call per lead-coder, untouched here. `part of #4788`, not `Closes` — the issue stays open for B.

## Test plan

- [x] New `tests/interfaces/test_4788_rewind_picker_escape_dismiss.py`, 2 tests:
  - `test_escape_dismisses_rewind_picker_after_focus_moves_to_intervention` — the bug's own repro shape (picker opens, intervention arrives second and steals focus, `Esc` must still close the picker).
  - `test_escape_still_dismisses_rewind_picker_when_it_holds_focus` — accept-side sibling: the ordinary single-picker path (picker holds focus, no intervention) must keep working unchanged.
- [x] Strip-falsified: reverting the `app.py` fix flips the first test red at exactly `assert picker.display is False` — confirmed via `git stash`.
- [x] Existing `tests/interfaces/test_textual_chat_copy_rewind_3362.py` (10 tests) still green — no regression to the picker's ordinary behavior.
- [x] `ruff check .`, `scripts/test_tier_audit.py --strict` (new file), `scripts/verify_module_docstrings.py` (app.py), `scripts/mypy_ratchet.py`, `scripts/check_bare_tests_import_reference.py`, `scripts/check_file_depth_reference.py`, `scripts/flat_tests_ratchet.py` — all green.
- [ ] Visual/TTY (standing waiver applies — merge does not wait on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[lead-coder]** — レビューでの blocking 項:

- [ ] 🔴 Esc の**優先順位を決めている**（picker が開いている間、Esc は他に届かない — 介入パネル等は 2 回目の Esc で閉じる）が、docstring に書かれていない。**順位そのものは妥当**（picker には他に閉じ方が無く、panel には手がある）だが、**B（設計）の領域に半分入る決定**なので、**何をどう決めたか＋なぜ**を 1 文で残すこと。owner が B を判断するときの材料になる。
