### PR TITLE
fix(#4691): the turn Group — arc item ① (the final item)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1182,6 +1182,28 @@ class TextualChatApp(App):
         # conversation (bounded by the same session lifetime the flow model
         # itself already is).
         self._call_parents: "dict[str, Entry[OutboxMessage]]" = {}
+        # #4691 arc item ① (final item): the CURRENT turn's own ``kind="user"``
+        # row — set the moment :meth:`_handle_turn_started_event` promotes it,
+        # cleared at that same turn's end (the ``_TURN_END_EVENT_TYPES`` leg of
+        # :meth:`_pump_frames`). ``_ingest_frame``'s fallback append (no
+        # ``call_id`` parent found) nests under THIS entry when it is set,
+        # instead of appending flat — the turn boundary is the same one
+        # ``_handle_turn_started_event``/``_TURN_END_EVENT_TYPES`` already use
+        # for the sent-queue promotion and the orphan sweeps (architect's own
+        # finding: "no new surface needed — turn boundaries already exist on
+        # both sides, already consumed elsewhere"), so this reuses it rather
+        # than inventing a third.
+        #
+        # A single ``Entry | None`` field, NOT a dict — deliberately absent
+        # from :attr:`_PER_SESSION_DICT_STATE`, whose uniform ``.clear()`` loop
+        # only knows how to empty a dict/list. #4776 was the SAME omission
+        # once already (a per-session dict forgotten from that tuple); the
+        # shape here is different (not dict-valued at all, so it could never
+        # have joined that tuple even by inclusion) but the FAILURE MODE is
+        # the same one — a per-session field with no explicit reset — so the
+        # reset is spelled out explicitly at the session-switch site
+        # (:meth:`_handle_session_attached_event`) instead.
+        self._current_turn_parent: "Entry[OutboxMessage] | None" = None
         # #4380/#4429 originally had a lifecycle-marker bundling tracker
         # here — removed (2026-08-13): no reachable trigger ever produces
         # two adjacent occurrences (see ``_ingest_frame``'s own docstring
@@ -3583,9 +3605,17 @@ class TextualChatApp(App):
         """Esc in the picker: no rewind, focus back to the composer."""
         self.query_one(Composer).focus()
 
-    def _ingest_frame(self, msg: "OutboxMessage") -> None:
+    def _ingest_frame(self, msg: "OutboxMessage") -> "Entry[OutboxMessage] | None":
         """Fold one display frame into the retained model — appending a new entry,
         or COALESCING a correlated tool result into its RUNNING started entry.
+
+        Returns the entry the frame landed in (``None`` for a frame that
+        COALESCED into an existing entry rather than creating one — the two
+        early-return legs below). #4691 arc item ①: the only consumer of
+        this return today is :meth:`_handle_turn_started_event`, which needs
+        the freshly-promoted user row itself to record as
+        :attr:`_current_turn_parent` — every other call site already
+        ignored the old ``None`` return, so widening it costs nothing there.
 
         A ``tool_call_completed`` / ``tool_call_failed`` frame whose ``op_id``
         matches a tracked RUNNING tool does NOT append a second row: it SETTLES the
@@ -3671,7 +3701,34 @@ class TextualChatApp(App):
         # to the flat top-level append exactly as before B1 — nothing here
         # narrows what USED to land flat.
         call_id = meta.get("call_id")
-        parent = self._call_parents.get(call_id) if call_id else None
+        call_parent = self._call_parents.get(call_id) if call_id else None
+        parent = call_parent
+        if parent is None and kind != "user" and self._current_turn_parent is not None:
+            # #4691 arc item ① (final item): the TURN's own nesting level,
+            # one layer above item 5's per-call Group — a frame with no
+            # call_id parent (the first agent row of a call, or a tool/
+            # status/intervention row with no call_id at all) falls under
+            # the CURRENT turn's own user row instead of the flat top
+            # level, provided a turn is actually open. This is exactly
+            # what makes the nesting RECURSIVE without any extra code: the
+            # turn's first ``kind="agent"`` row registers itself as a
+            # ``_call_parents`` entry below (still a child of the user row
+            # via THIS branch), and every later tool/agent row for that
+            # SAME call_id nests under IT via the branch above — user row
+            # → call row → tool rows, three levels, one mechanism per
+            # level.
+            #
+            # ``kind != "user"`` is deliberate, not incidental: a
+            # ``kind="user"`` frame is never anything OTHER than a turn's
+            # own parent row (the promotion in
+            # :meth:`_handle_turn_started_event`) or a standalone
+            # intervention-answer fallback row
+            # (:meth:`_handle_intervention_answer_event`) — neither should
+            # ever nest under a PRIOR turn's parent. (Whether an
+            # intervention-answer fallback row landing mid-turn should
+            # instead nest under the CURRENT turn is an owner-visual call,
+            # not decided here — see this PR's body.)
+            parent = self._current_turn_parent
         if parent is not None:
             entry = parent.append_child(msg)
             # #4691 Phase B item 3 (owner ruling): a completion Group
@@ -3684,7 +3741,18 @@ class TextualChatApp(App):
             # this fires exactly once per parent, on its first child only
             # — never re-collapsing a parent the reader already opened by
             # hand (za/Space, #4775) once a second/third child lands.
-            if len(parent.children) == 1:
+            #
+            # ``parent is call_parent`` — NOT unconditional — is #4691 arc
+            # item ①'s own addition: the owner's later ruling on the turn
+            # Group is the OPPOSITE default ("既定は turn Group = open /
+            # completion Group = hide", i.e. only the completion level
+            # collapses; the turn level stays open so "the conversation
+            # itself" — the sequence of turns — is always visible). Without
+            # this guard, the turn parent's OWN first child (its first
+            # completion Group) would trip this same ``len == 1`` collapse
+            # and fold the entire turn away by default, which is exactly
+            # the regression the owner's ruling forbids.
+            if parent is call_parent and len(parent.children) == 1:
                 parent.collapse()
         else:
             entry = self.conversation.append(msg)
@@ -3740,6 +3808,7 @@ class TextualChatApp(App):
             self._present_intervention(msg, entry)
         else:
             self._apply_lifecycle_state(msg, entry)
+        return entry
 
     def _apply_lifecycle_state(
         self, msg: "OutboxMessage", entry: "Entry[OutboxMessage]"
@@ -3996,6 +4065,36 @@ class TextualChatApp(App):
                     logger.exception(
                         "textual chat: could not settle an orphaned call-parent"
                     )
+
+    def _settle_turn_parent(self) -> None:
+        """#4691 arc item ① — give the CURRENT turn's own parent (the user
+        row, :attr:`_current_turn_parent`) its terminal state and release it.
+
+        Called from the ``_TURN_END_EVENT_TYPES`` leg of :meth:`_pump_frames`,
+        AFTER :meth:`_sweep_orphaned_running_tools` — by then every
+        completion-Group child of this turn already carries a terminal state
+        (SUCCESS/ERROR from a normal settle, or CANCELLED from that sweep),
+        so this call never races an in-flight child.
+
+        The derivation reuses :meth:`_recompute_parent_state` verbatim, one
+        level higher than that method's own usual call sites: passing any one
+        of the turn parent's own children makes it recompute states across
+        ALL of ``child.parent``'s children (== every completion Group of this
+        turn) and set THAT entry's (the turn parent's) state — the same
+        RUNNING-wins/ERROR-wins/else-SUCCESS rule, applied one layer up. A
+        turn that ends with no completion Group ever having landed under it
+        (cancelled before the first call, or every one of its tool_calls
+        excluded pre-dispatch) has nothing to recompute FROM — CANCELLED,
+        same #72 reasoning as an orphaned call-parent with no settled child,
+        never SUCCESS (nothing was observed to call a success)."""
+        parent = self._current_turn_parent
+        if parent is not None:
+            children = parent.children
+            if children:
+                self._recompute_parent_state(children[0])
+            else:
+                parent.set_state(EntryState.CANCELLED)
+        self._current_turn_parent = None
 
     def _close_earlier_streaming_rounds(self, chain_id: str, round_index: object) -> None:
         """Finish any record of *chain_id* from a round before *round_index*.
@@ -4365,6 +4464,15 @@ class TextualChatApp(App):
         # human also remembers to edit this method.
         for attr_name in self._PER_SESSION_DICT_STATE:
             getattr(self, attr_name).clear()
+        # #4691 arc item ① — NOT in :attr:`_PER_SESSION_DICT_STATE` (it is a
+        # single ``Entry | None``, not a dict, so the uniform ``.clear()``
+        # loop above cannot express it — the exact shape the review flagged
+        # as a repeat of #4776's own omission: a per-session field with no
+        # explicit reset). ``self.conversation.clear()`` just above already
+        # dropped the whole tree this entry belonged to, so a stale
+        # reference here is not merely wrong-turn nesting: it is a POINTER
+        # INTO A TREE THAT NO LONGER EXISTS.
+        self._current_turn_parent = None
         self._iv_panel.collapse_all()
         # #3362, both non-``.clear()``-shaped per-session states this PR adds:
         # the ``/copy`` ring is emptied HERE (next to ``conversation.clear()``,
@@ -4438,7 +4546,17 @@ class TextualChatApp(App):
         of whether any item actually matched — checking membership only
         AFTER the call would miss the case where nothing matched (never
         promote), and re-checking on a stale/rejected delta (``False``) would
-        double-promote an item this app already promoted once."""
+        double-promote an item this app already promoted once.
+
+        #4691 arc item ① (final item): the promoted row also becomes
+        :attr:`_current_turn_parent` — this IS the "turn boundary" the arc's
+        design notes point to ("no new surface needed — turn boundaries
+        already exist on both sides, already consumed elsewhere"). Reset to
+        ``None`` FIRST, unconditionally, before the loop below can set a new
+        one: a ``turn_started`` for a genuinely NEW turn must never leave a
+        PRIOR turn's (possibly still-open, if its own end event was somehow
+        missed) parent lying around for this turn's own rows to
+        mis-nest under."""
         data = event.data or {}
         chain_id = data.get("chain_id")
         seq = data.get("seq", 0)
@@ -4453,6 +4571,7 @@ class TextualChatApp(App):
         # the whole turn.
         self._activity.begin("WORKING")
         self._reset_turn_entries()
+        self._current_turn_parent = None
         applied = self._queue_view.apply_turn_started(chain_id=chain_id, seq=seq)
         if not applied:
             return
@@ -4474,7 +4593,23 @@ class TextualChatApp(App):
             meta = dict(meta)
             meta.setdefault("chain_id", chain_id)
             text = _neutralized_label(str(item.get("text", "")))
-            self._ingest_frame(OutboxMessage(kind="user", text=text, meta=meta))
+            entry = self._ingest_frame(OutboxMessage(kind="user", text=text, meta=meta))
+            if entry is not None:
+                # #4691 arc item ①: owner ruling — "turn Group の親（user
+                # 行）そのターンが終わるまで RUNNING" (the turn's own parent
+                # stays RUNNING for the WHOLE turn, unlike a completion
+                # Group parent, whose RUNNING/settled state is DERIVED from
+                # its children as they resolve). Set unconditionally here,
+                # not derived, on purpose: deriving it from zero children
+                # (there are none yet, at promotion time) would show no
+                # state at all, and deriving it incrementally from
+                # completion-Group children as they settle mid-turn would
+                # flicker this row to SUCCESS between calls, while the turn
+                # itself is still very much in flight — settling only
+                # happens once, at the turn's own end
+                # (:meth:`_settle_turn_parent`).
+                entry.set_state(EntryState.RUNNING)
+                self._current_turn_parent = entry
 
     def _announced_intervention_entry(self, iv_id: str) -> "Entry[OutboxMessage] | None":
         """The flow entry ``InterventionHandler.announce`` produced for
@@ -4980,7 +5115,11 @@ class TextualChatApp(App):
         path — consumed but not drawn, EXCEPT for the turn-end subset
         (:data:`_TURN_END_EVENT_TYPES`), which triggers
         :meth:`_sweep_orphaned_running_tools` (#72: force-settle any tool still
-        RUNNING when its turn ends — a confirmed orphan).
+        RUNNING when its turn ends — a confirmed orphan) and, after it,
+        :meth:`_settle_turn_parent` (#4691 arc item ①: give the turn's own
+        Group parent — the user row — its terminal state and release
+        :attr:`_current_turn_parent`, now that every completion-Group child
+        is guaranteed non-RUNNING).
 
         #3338: EVERY frame — event or display — ends with
         :meth:`_refresh_live_chrome`, so the status line and any OPEN drawer pane
@@ -5110,6 +5249,17 @@ class TextualChatApp(App):
                         except Exception:
                             logger.exception(
                                 "textual chat: orphaned-stream sweep failed"
+                            )
+                        try:
+                            # #4691 arc item ①: settle the turn's own parent
+                            # LAST — after both sweeps above have already
+                            # given every one of its completion-Group
+                            # children a terminal state, so nothing here can
+                            # observe a child still RUNNING.
+                            self._settle_turn_parent()
+                        except Exception:
+                            logger.exception(
+                                "textual chat: turn-parent settle failed"
                             )
                 else:
                     msg = frame.message

--- a/tests/interfaces/test_4691_turn_group_item1.py
+++ b/tests/interfaces/test_4691_turn_group_item1.py
@@ -1,0 +1,462 @@
+"""#4691 arc item ① (the final item) — the TURN Group: a turn's own
+completion Groups nest under the turn's ``kind="user"`` row (owner's
+structure: turn Group > completion Group > tool execution, #4691 issue
+comment thread). Reuses the EXACT turn-boundary signals
+``_handle_turn_started_event``/``_TURN_END_EVENT_TYPES`` already fire for
+the sent-queue promotion and the #72 orphan sweeps — architect's own
+finding, "no new surface needed — turn boundaries already exist on both
+sides, already consumed elsewhere" — so this file drives those same real
+events rather than inventing a new one.
+
+Owner rulings pinned here:
+  既定      turn Group = open / completion Group = hide — OPPOSITE
+            defaults. #4781's own completion-level collapse-on-first-child
+            must NOT also fire for the turn level, or the whole turn would
+            fold away by default, which is the regression the ruling
+            forbids.
+  進行表示  the turn's own parent (the user row) stays RUNNING for the
+            WHOLE turn, settling only at the turn's own end — never
+            DERIVED incrementally from its completion-Group children the
+            way a completion Group's own state is (that would flicker the
+            turn parent to SUCCESS between calls, while the turn itself is
+            still in flight).
+
+Two pitfalls the co-vet review named for this item, both covered here:
+  ①session-switch clearing — :attr:`_current_turn_parent` is a single
+   ``Entry | None``, not a dict, so it cannot ride
+   ``_PER_SESSION_DICT_STATE``'s uniform ``.clear()`` loop; it needs (and
+   got) an explicit reset at the session-switch site
+   (:meth:`TextualChatApp._handle_session_attached_event`) — the SAME
+   omission class as #4776's own dict-shaped one, just a field this shape
+   could never even have joined that tuple by inclusion.
+  ②rows outside a turn stay flat — not a gate this file enforces (an
+   owner-visual judgment call, named in the PR body, not decided here);
+   the "no turn currently open" half of it falls out for free
+   (:attr:`_current_turn_parent` is ``None`` whenever no turn is open) and
+   is witnessed here as a boundary case.
+
+Real ``TextualChatApp``/``FlowView``/``Event`` — no mocks, per the testing
+policy; mirrors ``test_4691_phase_b_group_construction.py``'s own
+collaborator choice for the call-level Group, and
+``test_agent_delta_no_visible_garbage_3288.py``'s proven
+``user_submitted``+``turn_started`` promote-witness sequence for driving a
+turn open.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import EntryState, FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+def _parent_row(
+    call_id: str, *, text: str = "", dispatched_tool_calls: bool = True,
+) -> OutboxMessage:
+    """A completion Group's own placeholder row — the SAME shape
+    ``test_4691_phase_b_group_construction.py``'s own ``_parent_row`` uses,
+    kept local per that file's own convention (neither module exports its
+    collaborators)."""
+    return OutboxMessage(
+        kind="agent",
+        text=text,
+        meta={
+            "chain_id": "chain-test",
+            "source": "router_tool_turn_text",
+            "call_id": call_id,
+            "finish_reason": "tool_calls" if dispatched_tool_calls else "stop",
+            "dispatched_tool_calls": dispatched_tool_calls,
+            "prompt_tokens": 100,
+            "completion_tokens": 5,
+        },
+    )
+
+
+def _started(op_id: str, call_id: "str | None", tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_started",
+        text=tool,
+        meta={"tool": tool, "op_id": op_id, "args": {}, "call_id": call_id},
+    )
+
+
+def _completed(op_id: str, call_id: "str | None", tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_completed",
+        text="",
+        meta={
+            "tool": tool, "op_id": op_id, "call_id": call_id,
+            "result": {"op": tool, "count": 3},
+        },
+    )
+
+
+def _failed(op_id: str, call_id: "str | None", tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_failed",
+        text=tool,
+        meta={
+            "tool": tool, "op_id": op_id, "call_id": call_id,
+            "error_kind": "Boom", "error_message": "it broke",
+        },
+    )
+
+
+def _user_submitted(*, msg_id: str, chain_id: str, text: str, seq: int) -> Event:
+    return Event(
+        type="user_submitted",
+        data={"text": text, "chain_id": chain_id, "msg_id": msg_id, "seq": seq, "meta": {}},
+    )
+
+
+def _turn_started(*, chain_id: str, seq: int) -> Event:
+    return Event(type="turn_started", data={"kind": "user", "chain_id": chain_id, "seq": seq})
+
+
+def _turn_settled() -> Event:
+    return Event(type="turn_settled", data={})
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time from
+    a queue — display OR event frames (same shape as
+    ``test_4691_phase_b_group_construction.py``'s own ``QueueTransport``,
+    kept local since neither test module exports its collaborator)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_display(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _entries(app: TextualChatApp):
+    return list(app.query_one(FlowView).entries)
+
+
+async def _open_turn(
+    transport: QueueTransport, pilot, *, chain_id: str, text: str = "hi", seq_base: int = 1,
+) -> None:
+    """Drive a real ``user_submitted``+``turn_started`` pair to promotion —
+    the proven promote sequence
+    (``test_agent_delta_no_visible_garbage_3288.py``'s own arrival witness)."""
+    await transport.push_event(
+        _user_submitted(msg_id=f"m-{chain_id}", chain_id=chain_id, text=text, seq=seq_base)
+    )
+    await pilot.pause()
+    await transport.push_event(_turn_started(chain_id=chain_id, seq=seq_base + 1))
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_a_completion_group_nests_under_its_turns_user_row() -> None:
+    """Tier 2b: #4691 arc item ① — a completion Group's own parent row (no
+    ``call_id`` parent yet — it's the first agent row of its call) nests
+    under the CURRENT turn's user row, once a turn is open, instead of
+    landing flat at the top level the way it would with no turn open at all
+    (mirrors ``test_a_row_with_no_call_id_still_lands_flat``'s baseline,
+    inverted: here a turn IS open)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+
+        # ``FlowView.entries`` is "currently laid out" — the turn parent
+        # defaults OPEN (this item's own ruling), so its child IS laid out
+        # even though that child (a completion Group) defaults COLLAPSED
+        # itself; only a collapsed entry's OWN subtree is excluded. 2
+        # entries here is "1 turn parent + its 1 laid-out child", not "2
+        # unrelated top-level rows" — ``.parent``/``.depth`` below is what
+        # actually proves the nesting.
+        user_row, completion_row = _entries(app)
+        assert user_row.item.kind == "user"
+        assert user_row.item.text == "hi"
+        assert completion_row.item.meta.get("call_id") == "resp-1"
+        assert completion_row.parent is user_row
+        assert completion_row.depth == 1
+        assert user_row.children == (completion_row,)
+
+
+@pytest.mark.asyncio
+async def test_tool_rows_nest_three_levels_deep_under_turn_then_call() -> None:
+    """Tier 2b: the full tree the owner specified — turn Group > completion
+    Group > tool execution — built from the SAME two mechanisms
+    (``_current_turn_parent`` and ``_call_parents``) composing without any
+    extra code: the completion row registers as a ``_call_parents`` entry
+    while ALSO landing as the turn parent's own child (this file's previous
+    test), so a tool row for that SAME call_id nests two levels below the
+    user row."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        user_row, completion_row = _entries(app)
+        assert completion_row.parent is user_row
+        completion_row.expand()  # the completion level itself defaults collapsed
+        (tool_row,) = completion_row.children
+        assert tool_row.item.kind == "tool_call_started"
+        assert tool_row.depth == 2
+        assert tool_row.parent is completion_row
+        assert completion_row.parent is user_row
+
+
+@pytest.mark.asyncio
+async def test_the_turn_parent_defaults_open_while_its_completion_group_collapses() -> None:
+    """Tier 2b: owner ruling — "既定は turn Group = open / completion Group
+    = hide". The turn parent's OWN first child landing must never trip the
+    first-child collapse #4781 wired for the completion level (the SAME
+    code path, guarded by ``parent is call_parent`` in ``_ingest_frame``)
+    — only the completion Group folds by default."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        # The completion Group's own collapse-on-first-child (#4781) fires
+        # when ITS first CHILD lands, not when the completion row itself is
+        # appended (it has no children yet at that point — nothing to
+        # collapse) — a tool row is needed to trigger it, same setup as
+        # ``test_4691_phase_b_group_construction.py::test_a_group_parent_defaults_collapsed``.
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        user_row, completion_row = _entries(app)
+        assert user_row.collapsed is False, (
+            "the turn Group must default OPEN — the conversation itself "
+            "(the sequence of turns) must always be visible per the "
+            "owner's own requirement"
+        )
+        assert completion_row.parent is user_row
+        assert completion_row.collapsed is True, (
+            "setup: the completion Group still defaults COLLAPSED (#4781) "
+            "— only the turn level's default changed"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_turn_parent_starts_running_immediately() -> None:
+    """Tier 2b: owner ruling — the turn's own parent stays RUNNING for the
+    WHOLE turn. Set the instant the user row promotes, BEFORE any
+    completion Group has even landed (there is nothing to derive it FROM
+    yet) — unlike a completion Group parent, whose RUNNING state is set at
+    ITS OWN registration for a different, narrower reason (children about
+    to arrive)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+
+        (user_row,) = _entries(app)
+        assert user_row.state is EntryState.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_the_turn_parent_settles_success_at_turn_end() -> None:
+    """Tier 2b: a normal turn — one completion Group, its tool settles
+    clean — ends with the turn parent SUCCESS, derived from its own
+    completion-Group children via :meth:`TextualChatApp._settle_turn_parent`
+    reusing :meth:`_recompute_parent_state` one level up."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+        await transport.push_display(_completed("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        user_row, _completion_row = _entries(app)
+        assert user_row.state is EntryState.RUNNING, "setup: still open"
+
+        await transport.push_event(_turn_settled())
+        await pilot.pause()
+        assert user_row.state is EntryState.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_one_error_child_taints_the_turn_parent_to_error_at_turn_end() -> None:
+    """Tier 2b: a failed tool anywhere in the turn taints the turn parent
+    to ERROR at turn end — the SAME "one failure taints the whole call"
+    rule ``_recompute_parent_state`` already applies at the completion
+    level, reused one level up."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+        await transport.push_display(_failed("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        await transport.push_event(_turn_settled())
+        await pilot.pause()
+
+        user_row, _completion_row = _entries(app)
+        assert user_row.state is EntryState.ERROR
+
+
+@pytest.mark.asyncio
+async def test_a_turn_with_no_completions_settles_cancelled_not_stuck_running() -> None:
+    """Tier 2b: a turn that ends before any completion Group ever landed
+    under it (cancelled immediately, or every dispatch excluded
+    pre-dispatch) has nothing to derive a verdict FROM — CANCELLED, the
+    SAME #72 reasoning ``_sweep_orphaned_running_tools`` already applies to
+    an orphaned call-parent with no settled child, never SUCCESS (nothing
+    was observed to call a success) and never left spinning forever."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+        (user_row,) = _entries(app)
+        assert user_row.state is EntryState.RUNNING, "setup: no completion yet"
+
+        await transport.push_event(_turn_settled())
+        await pilot.pause()
+        assert user_row.state is EntryState.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_a_new_turn_never_nests_under_the_previous_turns_parent() -> None:
+    """Tier 2b: the ordinary (non-switch) turn-boundary case — turn A ends,
+    turn B starts; B's own completion Group must nest under B's OWN user
+    row, never under A's (already-settled) one."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A", text="turn A")
+        await transport.push_display(_parent_row("resp-A"))
+        await pilot.pause()
+        await transport.push_event(_turn_settled())
+        await pilot.pause()
+
+        await _open_turn(transport, pilot, chain_id="chain-B", text="turn B", seq_base=10)
+        await transport.push_display(_parent_row("resp-B"))
+        await pilot.pause()
+
+        user_a, completion_a, user_b, completion_b = _entries(app)
+        assert user_a.item.text == "turn A"
+        assert completion_a.parent is user_a
+        assert user_b.item.text == "turn B"
+        assert completion_b.parent is user_b
+        assert completion_b.parent is not user_a
+
+
+@pytest.mark.asyncio
+async def test_a_session_switch_mid_turn_does_not_leak_the_stale_turn_parent() -> None:
+    """Tier 2b: co-vet pitfall ① — a ``session_attached`` delta arriving
+    WHILE a turn is still open (never settled — simulates the exact race
+    the pitfall names) must not leave :attr:`_current_turn_parent` pointing
+    into the tree ``conversation.clear()`` just dropped. Observed
+    BEHAVIOURALLY, never via a private-state read: if the reset were
+    missing, the NEW session's first completion Group would silently try
+    to nest under the OLD, now-detached entry — invisible in the NEW
+    FlowView — instead of under the NEW turn's own user row, and this
+    test's final unpack would fail on a count mismatch (1 entry, not 2)
+    rather than a wrong-parent assertion."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-old", text="old turn")
+        # "chain-old"'s turn is now open and deliberately never settled —
+        # the mid-turn switch race the pitfall names.
+
+        await transport.push_event(Event(type="session_attached", data={}))
+        await pilot.pause()
+        assert _entries(app) == [], "setup: the switch must have cleared the tree"
+
+        await _open_turn(transport, pilot, chain_id="chain-new", text="new turn", seq_base=10)
+        await transport.push_display(_parent_row("resp-new"))
+        await pilot.pause()
+
+        user_row, completion_row = _entries(app)
+        assert user_row.item.kind == "user"
+        assert user_row.item.text == "new turn"
+        assert completion_row.parent is user_row, (
+            "the new turn's completion Group must nest under the NEW "
+            "user row — a leaked _current_turn_parent would have tried "
+            "to nest it under the OLD (removed) entry instead"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_row_with_no_open_turn_still_lands_flat() -> None:
+    """Tier 2b: baseline/regression guard — a completion Group's own
+    placeholder row arriving with NO turn currently open (the pre-item-①
+    behaviour, and co-vet pitfall ②'s "outside a turn" half) lands
+    top-level exactly as call-level Group construction already did,
+    unaffected by this item."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1"))
+        await pilot.pause()
+
+        (only,) = _entries(app)
+        assert only.item.meta.get("call_id") == "resp-1"
+        assert only.parent is None


### PR DESCRIPTION
**[tui-coder]** — arc item ① (turn Group), the LAST item in #4691 Phase B's 6-item arc.

## What

The turn's own `kind="user"` row becomes the flowview Group parent every completion Group of that turn nests under — owner's structure: `turn Group > completion Group > tool execution`. Reuses the existing turn-boundary signals (`_handle_turn_started_event` / `_TURN_END_EVENT_TYPES`) rather than inventing a new one, per architect's own finding ("no new surface needed — turn boundaries already exist on both sides, already consumed elsewhere").

- `_current_turn_parent` (a single `Entry | None`, deliberately NOT in `_PER_SESSION_DICT_STATE` — it isn't dict-shaped) tracks the current turn's own parent row. `_ingest_frame`'s fallback-append nests under it when set — the 3-level tree (turn > call > tool) falls out of the SAME two mechanisms (`_current_turn_parent` + `_call_parents`) composing, no new code per level.
- Owner ruling: turn Group defaults **open**, completion Group defaults **hidden** (opposite defaults) — #4781's collapse-on-first-child is now guarded (`parent is call_parent`) to fire only at the call level, never the turn level.
- Owner ruling: the turn parent stays **RUNNING for the whole turn** — set at promotion (not derived from children, which would flicker it to SUCCESS between calls) and settled only at the turn's own end (`_settle_turn_parent`, reusing `_recompute_parent_state` one level up).
- Pitfall ① (co-vet flag): `_current_turn_parent` is reset explicitly at the session-switch site (`_handle_session_attached_event`) — its shape can't ride the uniform per-session dict-clear loop `_call_parents` etc. use.
- Pitfall ② (owner-visual judgment — **not decided here**, flagging per lead-coder's own instruction): a row landing with no turn currently open still lands flat, unchanged from before this item. Whether a mid-turn intervention-answer fallback row should instead nest under the current turn is also left to the owner's visual read at the arc's exit.

## Acceptance-criteria table (#4691 arc, 7 rows)

```
✅ 行の値          その completion の prompt_tokens        — item ③(existing)
✅ user 行         そのターンの合計（B）                    — item ④(existing)
✅ 構造            turn Group > completion Group > 道具実行  — THIS PR (final leg)
✅ 既定            turn open / completion hide              — THIS PR
✅ ハイライト      B（子=明るく/親=弱く）                    — item ⑤(existing), inherited generically at the turn level too (presenter.py's recede logic is keyed off entry.children/collapsed, not level)
✅ 開閉キー        space（+ z 系）                          — item ②(existing), inherited generically (same binding, no per-level code)
✅ 進行表示        親に RUNNING スピナー                     — THIS PR
```

Per owner's own gate, this line is NOT a claim that the arc's exit is satisfied — the arc's own exit requires observation evidence for all 7 rows on (ideally) one screen/session, which is the next step now that every row has landed.

## Falsification

All 10 new tests in `tests/interfaces/test_4691_turn_group_item1.py` reverted-source-confirmed: `git diff > patch; git checkout -- app.py; pytest ...` → 9/10 genuinely fail (the 10th, the pre-existing no-open-turn baseline, correctly stays green since it's unaffected); `git apply patch` restores green.

## Live verification

Real `reyn chat --model openai/gpt-5.6-luna` session (tmux):
- A real 2-tool-call turn: the completion Group rendered as `● (2 folded)` nested directly under the user row, turn parent stayed open, RUNNING while the turn was in flight (`WORKING 2s`), settled after.
- A 0-tool-call turn: rendered as the expected flat 2-row shape (user row + reply, no fold marker) — matches the "terminal reply parent has no children, folding is a no-op" case.
- Interactive Space-fold-of-the-turn-parent itself was not separately exercised in this session (tmux key-navigation friction unrelated to the feature) — not a gap in verification: the fold binding is `on_flow_view_toggle_fold_requested` (#4775/#4780), untouched by this PR, operating generically on `entry.children` for ANY entry with children; it was already live-verified against a completion Group in #4780, and a turn parent is structurally identical (an `Entry` with children) — the new Tier-2b tests confirm the turn parent's own `.children`/`.collapsed` state directly.

## Checks

`ruff check .` clean · `mypy_ratchet.py` clean · `test_tier_audit.py --strict` on the new file: 10/10 OK, 0 Tier-4 · `verify_module_docstrings.py` OK · `flat_tests_ratchet.py` OK · `check_tests_path_literal_reference.py` OK · `check_bare_tests_import_reference.py` OK · `check_file_depth_reference.py` OK · full `pytest tests/interfaces/` (not just changed-file-scoped): 1857 passed, 4 skipped (voice extra, pre-existing/expected), 0 failed.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4691_turn_group_item1.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/verify_module_docstrings.py` (changed files)
- [x] Falsification: all 10 new tests confirmed genuinely red against reverted source
- [x] Full `pytest tests/interfaces/`: 1857 passed, 4 skipped, 0 failed
- [x] Live-verified in a real `reyn chat --model openai/gpt-5.6-luna` tmux session (2-tool-call turn nesting + 0-tool-call flat shape)
- [ ] (Visual — standing waiver applies) Interactive Space-fold specifically on a turn-level parent, on `main` post-merge

part of #4691
