### PR TITLE
test(#4765): drop the now-redundant wait_for(reg.shutdown()) wrapper

### DIFF
--- a/tests/interfaces/test_2280_durability_halt_observability.py
+++ b/tests/interfaces/test_2280_durability_halt_observability.py
@@ -205,7 +205,7 @@ async def test_status_line_text_surfaces_halted_reason(tmp_path) -> None:
         assert "HALTED" in text
         assert "durability_failure" in text
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 def test_status_line_text_healthy_session_shows_no_banner() -> None:
@@ -356,7 +356,7 @@ async def test_idle_operator_sees_halted_status_line_mid_session(tmp_path) -> No
             assert "HALTED" in text_after
             assert "durability_failure" in text_after
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 @pytest.mark.asyncio
@@ -381,4 +381,4 @@ async def test_idle_healthy_session_status_line_shows_no_banner(tmp_path) -> Non
             text = str(app.query_one(StatusLine).render())
             assert "HALTED" not in text
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()

--- a/tests/interfaces/test_3310_n2_reset_hydrate.py
+++ b/tests/interfaces/test_3310_n2_reset_hydrate.py
@@ -280,7 +280,23 @@ async def test_staleness_gate_frames_produced_while_away_are_present(
                 f"cache-as-truth implementation would drop it: {_rows(app)!r}"
             )
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        # No test-owned timeout here (CLAUDE.md/testing.md § Time: tests carry
+        # no wait budget of their own) — this used to be
+        # ``asyncio.wait_for(reg.shutdown(), timeout=5.0)``, a self-timing
+        # wrapper around a call that COULD hang forever before #4765.
+        # #4765 bounded ``AgentRegistry.shutdown()`` itself (an internal
+        # ``asyncio.wait_for(..., timeout=_SHUTDOWN_GRACE_S)`` around
+        # ``session.aclose_background_tasks()``), so the outer wrapper became
+        # redundant, not merely superfluous: measured 2026-08-15, removing it
+        # across this same shape's whole family (5 files, 18 call sites, 23
+        # tests) left every test green with no hang, at ordinary timing. The
+        # one spot this note lives in is deliberate — the other 17 sites (this
+        # file's own siblings below, plus ``test_registry_focus_listener_
+        # rewire.py`` / ``test_4387_tui_paging_extends_from_disk.py`` /
+        # ``test_2280_durability_halt_observability.py`` /
+        # ``test_4788_rewind_picker_escape_dismiss.py``) carry the same bare
+        # ``await reg.shutdown()`` with no repeated comment.
+        await reg.shutdown()
 
 
 # ── 2. orphan gate ────────────────────────────────────────────────────────────
@@ -345,7 +361,7 @@ async def test_orphan_gate_tool_completed_while_away_is_not_running(
             )
             assert all(e.state is not EntryState.RUNNING for e in entries)
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 # ── 3. per-state reset — ONE independent test per state ──────────────────────
@@ -408,7 +424,7 @@ async def test_reset_running_tools_stale_op_id_does_not_silently_coalesce(
                 f"_running_tools entry would swallow it silently: {rows!r}"
             )
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 @pytest.mark.asyncio
@@ -465,7 +481,7 @@ async def test_reset_pending_interventions_closes_all_tabs(tmp_path, monkeypatch
                 "switch must close every pending tab from the OLD session"
             )
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 @pytest.mark.asyncio
@@ -543,7 +559,7 @@ async def test_reset_pending_ivs_stale_key_answer_not_targeted(tmp_path, monkeyp
                 f"transport): {transport.answered_choice_ids!r}"
             )
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 @pytest.mark.asyncio
@@ -590,7 +606,7 @@ async def test_reset_sent_queue_view_and_widget_and_item_meta(tmp_path, monkeypa
             )
             assert sent_queue.rendered_texts() == []
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 @pytest.mark.asyncio
@@ -645,7 +661,7 @@ async def test_reset_streaming_replies_stale_chain_id_does_not_finalize_into_gho
                 f"_streaming_replies entry would swallow it silently: {rows!r}"
             )
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 @pytest.mark.asyncio
@@ -713,7 +729,7 @@ async def test_reset_call_parents_stale_call_id_does_not_nest_into_ghost_parent(
                 f"leftover _call_parents entry would swallow it silently: {rows!r}"
             )
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 def _install_hanging_run_turn(session: Session):
@@ -854,7 +870,7 @@ async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
         release.set()
         await asyncio.wait_for(turn_task, timeout=5)
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 # ── 4. unvisited session ──────────────────────────────────────────────────────
@@ -902,4 +918,4 @@ async def test_unvisited_session_shows_its_history_not_blank(tmp_path, monkeypat
                 f"hydrate from its history, not show blank: {_rows(app)!r}"
             )
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()

--- a/tests/interfaces/test_4387_tui_paging_extends_from_disk.py
+++ b/tests/interfaces/test_4387_tui_paging_extends_from_disk.py
@@ -210,7 +210,7 @@ async def test_scrolling_to_top_extends_from_disk_beyond_the_bounded_load(
                 "'the true start of the conversation'"
             )
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 @pytest.mark.asyncio
@@ -261,4 +261,4 @@ async def test_search_finds_a_match_only_on_disk_beyond_the_bounded_load(
             )
             assert _count_text(app) == "1/1"
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()

--- a/tests/interfaces/test_4788_rewind_picker_escape_dismiss.py
+++ b/tests/interfaces/test_4788_rewind_picker_escape_dismiss.py
@@ -176,7 +176,7 @@ async def test_escape_dismisses_rewind_picker_after_focus_moves_to_intervention(
                 "widget currently holds focus (#4788)"
             )
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()
 
 
 @pytest.mark.asyncio
@@ -214,4 +214,4 @@ async def test_escape_still_dismisses_rewind_picker_when_it_holds_focus(
             await _settle(pilot)
             assert picker.display is False
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()

--- a/tests/runtime/test_registry_focus_listener_rewire.py
+++ b/tests/runtime/test_registry_focus_listener_rewire.py
@@ -12,8 +12,6 @@ Real AgentRegistry + real Sessions (no mocks).
 """
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
@@ -65,4 +63,4 @@ async def test_focus_listeners_follow_agent_switch(tmp_path) -> None:
         reg.unbind_focus_listeners()
         assert not beta.interventions.has_active_listener()
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        await reg.shutdown()


### PR DESCRIPTION
**[e2e-coder]** — measured-then-fixed, per lead-coder's assignment (#4783's non-blocking follow-up).

## Background

18 call sites across 5 files wrapped `reg.shutdown()` in `asyncio.wait_for(..., timeout=5.0)` — a test-owned wait budget CLAUDE.md/testing.md § Time explicitly bans ("tests carry no time limit of their own"). #4765 (merged this session) made `AgentRegistry.shutdown()` itself bounded internally (an `asyncio.wait_for(..., timeout=_SHUTDOWN_GRACE_S)` around `session.aclose_background_tasks()`), which is what made the outer per-test wrapper a candidate for removal.

## What was measured first (reported to lead-coder before this PR)

Replaced all 18 sites with a bare `await reg.shutdown()` and ran the full family: **23 tests, 5 files, all green, no hang, ordinary timing** (6–26s per file). This PR is the fix that measurement earned — not a guess.

## Scope

- 5 files, 18 call sites → bare `await reg.shutdown()`.
- Removed the now-unused `import asyncio` in `tests/runtime/test_registry_focus_listener_rewire.py` (its only `asyncio.` use was the removed wrapper).
- Rationale lives in **exactly one place** — `test_3310_n2_reset_hydrate.py`'s first occurrence (9 of the 18 sites are in this file). The other 17 sites carry the same bare `await reg.shutdown()` with no repeated comment, per lead-coder's explicit "1箇所に残す" instruction.
- **`tests/runtime/test_shutdown_force_cancel.py` is untouched, deliberately.** Its own `wait_for` wrappers are the verification subject for the bounded-shutdown mechanism itself (it patches `_SHUTDOWN_GRACE_S` directly to make termination fast and deterministic) — this is testing the bound, not incidentally wrapping a call for teardown. Family-excluded, not merely skipped.

## Six questions (touches `tests/`)

1. **Tier** — 2 (OS invariant: `registry.shutdown()` terminates within its own internal bound after #4765; removing a test-owned duplicate of that bound, not adding new coverage).
2. **Implementation transcribed?** No — nothing added, only a wrapper removed; the implicit assertion (the `await` returns) is unchanged.
3. **Who would miss it?** Nobody — CI's own `--timeout=120` kill switch is the backstop these tests now rely on, the same shape #4768 (this session, earlier) already relies on for a real termination claim.
4. **Stay green never run?** No — every touched file's suite ran and is asserted against (23/23 passed), not merely collected.
5. **What does it accumulate, who bounds it?** Nothing new; a future regression reintroducing an unbounded hang in `registry.shutdown()` is caught by CI's own `--timeout=120`, not silently masked by a per-test 5.0s timeout as it effectively would have been before (a hang past `_SHUTDOWN_GRACE_S` inside a `wait_for(timeout=5.0)` wrapper would just look like a normal test failure at 5s, not a hang worth investigating).
6. **Declared Tier true?** Yes, per ①.

## Test plan

- [x] `ruff check .`, `scripts/test_tier_audit.py --strict` (all 5 touched files), `scripts/mypy_ratchet.py`, `scripts/check_bare_tests_import_reference.py`, `scripts/check_file_depth_reference.py`, `scripts/flat_tests_ratchet.py` — all green.
- [x] Scoped `pytest` on all 5 touched files: 23/23 passed, ~49s total.
- [ ] Visual/TTY (standing waiver applies — merge does not wait on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)