### PR TITLE
fix(#4691): flowview 0.22.0 bump + close the streaming-bypass Group-nesting class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,7 @@ dependencies = [
     # FlowView's virtualized painting model at all, on the terminals reyn
     # targets — #3970's trade-off no longer applies because the option it
     # was weighing against never actually worked here.
-    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@728eb0070115ddea92153b5b9aca557b92f329b9",
+    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@d90584af11ed89c064cfd796b6bb7e76e27aa2cb",  # v0.22.0
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
     "charset-normalizer>=3.0",  # #1452 read_file encoding detection (MIT, pure-python)

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -3743,8 +3743,7 @@ class TextualChatApp(App):
         # to the flat top-level append exactly as before B1 — nothing here
         # narrows what USED to land flat.
         call_id = meta.get("call_id")
-        call_parent = self._call_parents.get(call_id) if call_id else None
-        parent = call_parent
+        parent = self._call_parents.get(call_id) if call_id else None
         if parent is None and kind != "user" and self._current_turn_parent is not None:
             # #4691 arc item ① (final item): the TURN's own nesting level,
             # one layer above item 5's per-call Group — a frame with no
@@ -3773,29 +3772,6 @@ class TextualChatApp(App):
             parent = self._current_turn_parent
         if parent is not None:
             entry = parent.append_child(msg)
-            # #4691 Phase B item 3 (owner ruling): a completion Group
-            # defaults COLLAPSED — but only from its FIRST child onward.
-            # ``Entry.collapse()`` at registration time (when the parent
-            # is still a leaf) is a documented no-op ("a no-op on a
-            # removed entry, a leaf, or when unchanged") — collapse has to
-            # be re-asserted here, the first moment the parent actually
-            # HAS a subtree to fold. ``len == 1`` (not unconditional) means
-            # this fires exactly once per parent, on its first child only
-            # — never re-collapsing a parent the reader already opened by
-            # hand (za/Space, #4775) once a second/third child lands.
-            #
-            # ``parent is call_parent`` — NOT unconditional — is #4691 arc
-            # item ①'s own addition: the owner's later ruling on the turn
-            # Group is the OPPOSITE default ("既定は turn Group = open /
-            # completion Group = hide", i.e. only the completion level
-            # collapses; the turn level stays open so "the conversation
-            # itself" — the sequence of turns — is always visible). Without
-            # this guard, the turn parent's OWN first child (its first
-            # completion Group) would trip this same ``len == 1`` collapse
-            # and fold the entire turn away by default, which is exactly
-            # the regression the owner's ruling forbids.
-            if parent is call_parent and len(parent.children) == 1:
-                parent.collapse()
         else:
             entry = self.conversation.append(msg)
         # #3712: an entry just arrived. Counted HERE, by the thing that
@@ -3833,17 +3809,34 @@ class TextualChatApp(App):
                 # no tools registers (harmless, above) but never spins —
                 # there is nothing for it to wait on.
                 entry.set_state(EntryState.RUNNING)
-                # #4691 Phase B item 3 (owner ruling via #4691's arc): a
-                # completion Group defaults COLLAPSED — the actual
-                # ``.collapse()`` call is at the ``append_child`` call
-                # site below, not here: this entry is still a LEAF at
-                # this point (no child has arrived yet), and
-                # ``Entry.set_collapsed`` is a documented no-op on a leaf
-                # ("a no-op on a removed entry, a leaf, or when
-                # unchanged") — collapsing here would silently do
-                # nothing. The parent's own RUNNING spinner (just above)
-                # lives on the row's own gutter, independent of the
-                # body-collapse state, so it is unaffected either way.
+                # #4691 Phase B item 3 (owner ruling): a completion Group
+                # defaults COLLAPSED — called HERE, at registration, even
+                # though this entry is still a LEAF (no child has arrived
+                # yet). Before textual-flowview 0.22.0's #14 fix this was a
+                # documented no-op on a leaf ("a no-op on a removed entry,
+                # a leaf, or when unchanged"), which forced the workaround
+                # this comment used to describe: watch the entry's own
+                # ``append_child`` call site and re-assert ``.collapse()``
+                # there, guarded to fire exactly once (``len(children) ==
+                # 1``) so a reader who had already opened the parent by
+                # hand (za/Space, #4775) was never re-folded once a
+                # second/third child landed. #14 fixed the underlying
+                # no-op itself — collapse state is now recorded on ANY
+                # live entry, leaf included, and a child appended later
+                # "walks its ancestors and is born folded" (release notes,
+                # 0.22.0) — so the watch-and-reassert workaround, the
+                # len==1 guard, and the "never re-fold a manually-reopened
+                # parent" guard it existed to give ARE ALL now upstream's
+                # own job, satisfied by this one call. This also removes
+                # #4691 arc item ①'s own guard (``parent is call_parent``)
+                # at the append_child call site below — that guard existed
+                # ONLY to keep this same collapse from also firing on the
+                # TURN parent's first child; with the collapse moved here,
+                # to a call site the turn parent's own registration
+                # (:meth:`_handle_turn_started_event`) never reaches, the
+                # turn parent is never a candidate for it in the first
+                # place, and the guard has nothing left to guard.
+                entry.collapse()
         if kind == "presentation":
             self._begin_image_resolutions(entry, msg)
         if kind == "intervention":

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -3647,6 +3647,142 @@ class TextualChatApp(App):
         """Esc in the picker: no rewind, focus back to the composer."""
         self.query_one(Composer).focus()
 
+    def _resolve_append_parent(
+        self, *, kind: str, meta: dict
+    ) -> "Entry[OutboxMessage] | None":
+        """The ONE decision of where a NEW entry attaches — a registered
+        call_id Group parent, else the current turn's own parent, else
+        flat top-level (``None``). #4691 (owner-observed real-machine
+        contradiction, root-caused by architect via lead-coder): this used
+        to be inlined in :meth:`_ingest_frame` alone, and
+        :meth:`_handle_agent_delta_event`'s first-delta entry creation
+        called ``self.conversation.append(...)`` directly instead —
+        bypassing this decision entirely, so a STREAMED reply (the common
+        case for any provider that streams) never nested under its turn
+        or registered as a call-level Group parent, no matter what
+        :meth:`_ingest_frame` did. Both call sites now go through THIS
+        one method (via :meth:`_append_frame`), so the decision cannot
+        drift between them again — architect's own framing, via
+        lead-coder: "share the PARENT DECISION, not the entry-creation
+        procedure" (a streamed reply's own creation — seeding
+        :class:`_StreamingReply`, registering visibility tracking — stays
+        entirely its own, in :meth:`_handle_agent_delta_event`).
+
+        ① call_id lookup (never "most recently appended" order — see
+        :attr:`_call_parents`'s own docstring) — #4691 Phase B B1.
+        ② the CURRENT turn's own parent, if one is open — #4691 arc item
+        ①, one layer above ①. This is what makes the nesting RECURSIVE
+        without extra code: the turn's first ``kind="agent"`` row lands
+        here (② fires, ① doesn't yet — it has no call_id parent of its
+        OWN), then registers itself as a ``_call_parents`` entry
+        (:meth:`_register_call_parent`), so every LATER row for that same
+        call_id finds it via ① — user row → call row → tool rows, three
+        levels, one mechanism per level.
+        ③ flat top-level (``None``) — a legacy/restored row, an op-loop
+        caller that never threaded a call_id through, or no turn open.
+
+        ``kind != "user"`` in ② is deliberate, not incidental: a
+        ``kind="user"`` frame is never anything OTHER than a turn's own
+        parent row (the promotion in :meth:`_handle_turn_started_event`)
+        or a standalone intervention-answer fallback row
+        (:meth:`_handle_intervention_answer_event`) — neither should ever
+        nest under a PRIOR turn's parent. (Whether an intervention-answer
+        fallback row landing mid-turn should instead nest under the
+        CURRENT turn is an owner-visual call, not decided here.)"""
+        call_id = meta.get("call_id")
+        parent = self._call_parents.get(call_id) if call_id else None
+        if parent is None and kind != "user" and self._current_turn_parent is not None:
+            parent = self._current_turn_parent
+        return parent
+
+    def _append_frame(self, msg: "OutboxMessage") -> "Entry[OutboxMessage]":
+        """Append a NEW entry to the retained model, nested per
+        :meth:`_resolve_append_parent` — the ONLY place ``self.conversation
+        .append(`` is called for a freshly-created entry (#4691's own
+        acceptance line, architect via lead-coder: "zero direct
+        ``self.conversation.append(`` call sites left" outside this
+        method). Every entry-creating call site — :meth:`_ingest_frame`'s
+        normal (non-coalesced) append, and
+        :meth:`_handle_agent_delta_event`'s first-delta entry creation —
+        goes through this, so the nesting decision is made in exactly one
+        place, never two copies that can drift apart."""
+        parent = self._resolve_append_parent(kind=msg.kind, meta=msg.meta or {})
+        if parent is not None:
+            return parent.append_child(msg)
+        return self.conversation.append(msg)
+
+    def _register_call_parent(
+        self, entry: "Entry[OutboxMessage]", kind: str, meta: dict
+    ) -> None:
+        """Register ``entry`` as a call-level Group parent when it carries
+        a ``call_id`` — #4691 Phase B B1/④, #4777, #4691's own
+        streaming-bypass fix (architect via lead-coder). Called from TWO
+        sites: :meth:`_ingest_frame`'s normal (non-streaming) append, and
+        the streaming-settle branch of that same method, once a streamed
+        round's completion frame finally carries its real ``call_id``/
+        ``dispatched_tool_calls`` — neither is known any earlier than
+        that (a round is not classified as tool-dispatching until it
+        actually returns), so the settle leg is the FIRST point
+        registration could happen for a streamed round, not a late
+        correction.
+
+        #4777 (owner-reported, provider-dependence bug): registration no
+        longer gates on ``finish_reason`` — a PROVIDER's own summary
+        string, self-reported at its own discretion (litellm passes it
+        through verbatim, ``llm.py``'s own ``choices[0].finish_reason``).
+        The owner's own provider never returns ``"tool_calls"``, so the
+        old gate here never fired on their screen — #4691 Phase B's
+        entire Group construction was provider-dependent and silently
+        inert for them, despite being green in every test written
+        against a provider that DOES report it correctly.
+
+        Registering unconditionally for every ``call_id``-bearing agent
+        row is harmless even for an ordinary terminal reply that
+        dispatched no tools: nothing ever looks up a call_id belonging
+        to a call that dispatched no tools, so an unused entry here is
+        dead weight, never a wrong nesting (#4776 tracks this dict's
+        own session-lifetime growth separately — not this fix's scope)."""
+        call_id = meta.get("call_id")
+        if kind != "agent" or not call_id:
+            return
+        self._call_parents[call_id] = entry
+        if meta.get("dispatched_tool_calls"):
+            # #4691 Phase B ④: the parent's own spinner starts here — its
+            # children are about to arrive RUNNING too, and
+            # ``_recompute_parent_state`` (called from every child
+            # settle) keeps it RUNNING until every child has settled.
+            #
+            # #4777: gated on ``dispatched_tool_calls`` — a REYN-OBSERVED
+            # fact (router_loop.py stamps it from the LLM result's own
+            # ``tool_calls`` list, non-empty precisely when this round
+            # actually dispatches tools), not the provider's
+            # ``finish_reason`` string. A terminal reply that dispatches
+            # no tools registers (harmless, above) but never spins —
+            # there is nothing for it to wait on.
+            entry.set_state(EntryState.RUNNING)
+            # #4691 Phase B item 3 (owner ruling): a completion Group
+            # defaults COLLAPSED — called HERE, at registration, even
+            # though this entry may still be a LEAF (no child has
+            # arrived yet). Before textual-flowview 0.22.0's #14 fix
+            # this was a documented no-op on a leaf ("a no-op on a
+            # removed entry, a leaf, or when unchanged"), which forced
+            # a workaround this comment used to describe (watch the
+            # entry's own ``append_child`` call site and re-assert
+            # ``.collapse()`` there, guarded to fire exactly once). #14
+            # fixed the underlying no-op itself — collapse state is now
+            # recorded on ANY live entry, leaf included, and a child
+            # appended later "walks its ancestors and is born folded"
+            # (release notes, 0.22.0) — so that workaround is gone;
+            # this one call is upstream's whole job now. This also
+            # means #4691 arc item ①'s own guard (``parent is
+            # call_parent``, once needed to keep this collapse from
+            # ALSO firing on the TURN parent's first child) has nothing
+            # left to guard: the turn parent's own registration
+            # (:meth:`_handle_turn_started_event`) never calls this
+            # method at all (it is not ``kind="agent"``), so it was
+            # never a candidate for this collapse in the first place.
+            entry.collapse()
+
     def _ingest_frame(self, msg: "OutboxMessage") -> "Entry[OutboxMessage] | None":
         """Fold one display frame into the retained model — appending a new entry,
         or COALESCING a correlated tool result into its RUNNING started entry.
@@ -3734,109 +3870,52 @@ class TextualChatApp(App):
                 streaming.entry.set_item(
                     replace(streaming.entry.item, text=msg.text, meta=meta)
                 )
+                # #4691 (owner-observed, real-machine — "folding the turn
+                # group does not hide the final reply"; architect's own
+                # root-cause read, via lead-coder): a STREAMED reply's
+                # entry is created in :meth:`_handle_agent_delta_event`,
+                # not here — this branch only SETTLES it in place. Its
+                # TREE POSITION was already decided at creation time
+                # (:meth:`_append_frame`, the shared seam that call also
+                # goes through now), so nothing here needs to re-parent
+                # it. What DOES still belong here: CALL-LEVEL Group
+                # registration (:meth:`_register_call_parent` —
+                # ``_call_parents[call_id]``, the RUNNING spinner, the
+                # default collapse) was ONLY ever reachable from the
+                # non-streaming leg below, which this early ``return``
+                # never reaches — so a streamed tool round's own agent
+                # row never became a valid Group parent for its OWN tool
+                # rows either. ``meta`` here is the TERMINAL completion's
+                # own meta (call_id/dispatched_tool_calls/finish_reason)
+                # — call_id and dispatched_tool_calls are not known any
+                # earlier than this (a round is not classified as
+                # tool-dispatching until it actually returns), so this is
+                # the first point registration COULD happen, streamed or
+                # not — same call as the non-streaming leg, one shared
+                # method instead of two copies that can drift apart.
+                self._register_call_parent(streaming.entry, kind, meta)
                 return
-        # #4691 Phase B B1: nest under this frame's own litellm CALL, found
-        # by call_id lookup (never by "most recently appended" order — see
-        # ``self._call_parents``'s own docstring). A frame with no call_id,
-        # or one that matches no registered parent (a legacy/restored row,
-        # an op-loop caller that never threaded one through), falls through
-        # to the flat top-level append exactly as before B1 — nothing here
-        # narrows what USED to land flat.
-        call_id = meta.get("call_id")
-        parent = self._call_parents.get(call_id) if call_id else None
-        if parent is None and kind != "user" and self._current_turn_parent is not None:
-            # #4691 arc item ① (final item): the TURN's own nesting level,
-            # one layer above item 5's per-call Group — a frame with no
-            # call_id parent (the first agent row of a call, or a tool/
-            # status/intervention row with no call_id at all) falls under
-            # the CURRENT turn's own user row instead of the flat top
-            # level, provided a turn is actually open. This is exactly
-            # what makes the nesting RECURSIVE without any extra code: the
-            # turn's first ``kind="agent"`` row registers itself as a
-            # ``_call_parents`` entry below (still a child of the user row
-            # via THIS branch), and every later tool/agent row for that
-            # SAME call_id nests under IT via the branch above — user row
-            # → call row → tool rows, three levels, one mechanism per
-            # level.
-            #
-            # ``kind != "user"`` is deliberate, not incidental: a
-            # ``kind="user"`` frame is never anything OTHER than a turn's
-            # own parent row (the promotion in
-            # :meth:`_handle_turn_started_event`) or a standalone
-            # intervention-answer fallback row
-            # (:meth:`_handle_intervention_answer_event`) — neither should
-            # ever nest under a PRIOR turn's parent. (Whether an
-            # intervention-answer fallback row landing mid-turn should
-            # instead nest under the CURRENT turn is an owner-visual call,
-            # not decided here — see this PR's body.)
-            parent = self._current_turn_parent
-        if parent is not None:
-            entry = parent.append_child(msg)
-        else:
-            entry = self.conversation.append(msg)
+        # #4691 Phase B B1 / arc item ① / owner-observed streaming-bypass
+        # fix: nest under this frame's own litellm CALL if one is already
+        # registered, else the CURRENT turn's own parent if one is open,
+        # else flat top-level (:meth:`_append_frame` — the ONE seam every
+        # entry-creating call site in this class goes through, so the
+        # nesting decision can never drift between them; see that
+        # method's own docstring for the 3-tier rule and why it is
+        # shared with :meth:`_handle_agent_delta_event`'s first-delta
+        # creation rather than each having its own copy).
+        entry = self._append_frame(msg)
         # #3712: an entry just arrived. Counted HERE, by the thing that
         # produced it — not reconstructed later from two reads of the model.
         self._note_entry_landed()
-        if kind == "agent" and call_id:
-            # #4777 (owner-reported, provider-dependence bug): registration no
-            # longer gates on ``finish_reason`` — a PROVIDER's own summary
-            # string, self-reported at its own discretion (litellm passes it
-            # through verbatim, ``llm.py``'s own ``choices[0].finish_reason``).
-            # The owner's own provider never returns ``"tool_calls"``, so the
-            # old gate here never fired on their screen — #4691 Phase B's
-            # entire Group construction was provider-dependent and silently
-            # inert for them, despite being green in every test written
-            # against a provider that DOES report it correctly.
-            #
-            # Registering unconditionally for every ``call_id``-bearing agent
-            # row is harmless even for an ordinary terminal reply that
-            # dispatched no tools: nothing ever looks up a call_id belonging
-            # to a call that dispatched no tools, so an unused entry here is
-            # dead weight, never a wrong nesting (#4776 tracks this dict's
-            # own session-lifetime growth separately — not this fix's scope).
-            self._call_parents[call_id] = entry
-            if meta.get("dispatched_tool_calls"):
-                # #4691 Phase B ④: the parent's own spinner starts here — its
-                # children are about to arrive RUNNING too, and
-                # ``_recompute_parent_state`` (called from every child
-                # settle) keeps it RUNNING until every child has settled.
-                #
-                # #4777: gated on ``dispatched_tool_calls`` — a REYN-OBSERVED
-                # fact (router_loop.py stamps it from the LLM result's own
-                # ``tool_calls`` list, non-empty precisely when this round
-                # actually dispatches tools), not the provider's
-                # ``finish_reason`` string. A terminal reply that dispatches
-                # no tools registers (harmless, above) but never spins —
-                # there is nothing for it to wait on.
-                entry.set_state(EntryState.RUNNING)
-                # #4691 Phase B item 3 (owner ruling): a completion Group
-                # defaults COLLAPSED — called HERE, at registration, even
-                # though this entry is still a LEAF (no child has arrived
-                # yet). Before textual-flowview 0.22.0's #14 fix this was a
-                # documented no-op on a leaf ("a no-op on a removed entry,
-                # a leaf, or when unchanged"), which forced the workaround
-                # this comment used to describe: watch the entry's own
-                # ``append_child`` call site and re-assert ``.collapse()``
-                # there, guarded to fire exactly once (``len(children) ==
-                # 1``) so a reader who had already opened the parent by
-                # hand (za/Space, #4775) was never re-folded once a
-                # second/third child landed. #14 fixed the underlying
-                # no-op itself — collapse state is now recorded on ANY
-                # live entry, leaf included, and a child appended later
-                # "walks its ancestors and is born folded" (release notes,
-                # 0.22.0) — so the watch-and-reassert workaround, the
-                # len==1 guard, and the "never re-fold a manually-reopened
-                # parent" guard it existed to give ARE ALL now upstream's
-                # own job, satisfied by this one call. This also removes
-                # #4691 arc item ①'s own guard (``parent is call_parent``)
-                # at the append_child call site below — that guard existed
-                # ONLY to keep this same collapse from also firing on the
-                # TURN parent's first child; with the collapse moved here,
-                # to a call site the turn parent's own registration
-                # (:meth:`_handle_turn_started_event`) never reaches, the
-                # turn parent is never a candidate for it in the first
-                # place, and the guard has nothing left to guard.
-                entry.collapse()
+        # #4777 / #4691 Phase B ④ (owner ruling): register this row as a
+        # Group parent when it carries a call_id — see
+        # :meth:`_register_call_parent`'s own docstring for the full
+        # reasoning (provider-independence, the RUNNING spinner, the
+        # default-collapse timing). Shared with the streaming-settle leg
+        # above, which reaches the SAME call once a streamed round's
+        # call_id is finally known.
+        self._register_call_parent(entry, kind, meta)
         if kind == "presentation":
             self._begin_image_resolutions(entry, msg)
         if kind == "intervention":
@@ -4876,7 +4955,22 @@ class TextualChatApp(App):
             # lands. The 29 deltas that follow fold into it and are not
             # arrivals — one thing arrived, and this is where that is known.
             self._note_entry_landed()
-            entry = self.conversation.append(
+            # #4691 (owner-observed real-machine contradiction, root-caused
+            # by architect via lead-coder): THROUGH :meth:`_append_frame`,
+            # not a direct ``self.conversation.append(...)`` — this used to
+            # append flat, unconditionally, bypassing the SAME nesting
+            # decision every other entry-creating call site now shares
+            # (:meth:`_resolve_append_parent`), so a streamed reply never
+            # nested under its open turn (or, later, under a call-level
+            # Group) no matter what the non-streaming path did. call_id is
+            # not known yet at this point (a round is not classified as
+            # tool-dispatching until it returns), so this lands via the
+            # CURRENT TURN tier of that decision when one is open — the
+            # call-level Group registration itself happens later, at
+            # settle (:meth:`_register_call_parent`, called from
+            # :meth:`_ingest_frame`'s streaming-settle branch once the
+            # terminal frame's real call_id is known).
+            entry = self._append_frame(
                 OutboxMessage(kind="agent", text=text, meta={"chain_id": chain_id})
             )
             # The append already carries this first chunk, so rendered == text —

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -362,15 +362,18 @@ async def test_the_parent_has_no_reactive_watcher_on_its_children() -> None:
 @pytest.mark.asyncio
 async def test_a_group_parent_defaults_collapsed() -> None:
     """Tier 2b: owner ruling (#4691 arc item 3) — a completion Group starts
-    COLLAPSED, not expanded-then-folded. Collapsing is asserted the instant
-    the FIRST child actually lands (never before — ``Entry.collapse()`` is
-    a documented no-op on a leaf, and the parent IS a leaf at registration
-    time, before any tool row has arrived) and never repeated on a second/
-    third child (so a reader who already opened it by hand, za/Space
-    #4775, is not re-folded out from under them). A CHILD's own detail-
-    expand state (the #3508/#4697 Space-toggle axis, unrelated to Group
-    fold) is untouched — only the top-level Group fold defaults to
-    collapsed."""
+    COLLAPSED, not expanded-then-folded. Collapse is asserted at
+    REGISTRATION time — while the parent is still a leaf, no child has
+    landed yet — since textual-flowview 0.22.0's #14 fix: ``.collapse()``
+    now records the state on any live entry (leaf included) rather than
+    silently discarding it, and a child appended later "walks its
+    ancestors and is born folded" (0.22.0 release notes). Before 0.22.0
+    this was a documented no-op on a leaf, which forced reyn to watch its
+    own ``append_child`` and re-assert collapse there, guarded to fire
+    exactly once — that workaround is gone; upstream now does the whole
+    job from one call. A CHILD's own detail-expand state (the #3508/#4697
+    Space-toggle axis, unrelated to Group fold) is untouched — only the
+    top-level Group fold defaults to collapsed."""
     transport = QueueTransport()
     app = TextualChatApp(transport=transport, clock=lambda: 100.0)
     async with app.run_test(size=(100, 30)) as pilot:
@@ -378,15 +381,16 @@ async def test_a_group_parent_defaults_collapsed() -> None:
         await transport.push_display(_parent_row("resp-1"))
         await pilot.pause()
         parent = _entries(app)[0]
-        assert parent.collapsed is False, (
-            "setup: not yet collapsed — no child has landed, the parent "
-            "is still a leaf"
+        assert parent.collapsed is True, (
+            "collapse is asserted at registration — before 0.22.0 this "
+            "had to wait for the first child (a leaf-collapse no-op); "
+            "now it fires immediately"
         )
 
         await transport.push_display(_started("op-1", call_id="resp-1"))
         await pilot.pause()
         assert parent.collapsed is True, (
-            "the FIRST child landing must collapse the parent by default"
+            "still collapsed once the first child actually lands"
         )
         (child,) = parent.children
         assert child.collapsed is False, (
@@ -395,14 +399,15 @@ async def test_a_group_parent_defaults_collapsed() -> None:
         )
 
         # A reader who opens it by hand (za/Space) must not be re-folded
-        # when a SECOND child lands — collapse fires once, on the first
-        # child only.
+        # when a SECOND child lands — reyn's own collapse call fires
+        # exactly once, at registration, and never again.
         parent.expand()
         await transport.push_display(_started("op-2", call_id="resp-1"))
         await pilot.pause()
         assert parent.collapsed is False, (
             "a manually-reopened parent must stay open when a later "
-            "child arrives — collapse-on-first-child fires exactly once"
+            "child arrives — reyn never re-asserts collapse after "
+            "registration"
         )
 
 

--- a/tests/interfaces/test_4691_turn_group_item1.py
+++ b/tests/interfaces/test_4691_turn_group_item1.py
@@ -551,33 +551,28 @@ async def test_turn_settled_arriving_before_the_terminal_reply_leaves_it_flat() 
 
 
 @pytest.mark.asyncio
-async def test_a_streamed_terminal_reply_still_lands_flat_never_nested() -> None:
-    """Tier 2b: 🔴 owner-observed real-machine contradiction — "folding the
-    turn group does not hide the final reply". Every OTHER test in this
-    file drives the terminal reply via ``transport.push_display(...)``, a
-    single non-streamed ``kind="agent"`` frame — the shape a provider
-    returns WITHOUT incremental deltas. A REAL interactive reply is
-    virtually always streamed: its entry is created by
-    :meth:`TextualChatApp._handle_agent_delta_event` on the FIRST
-    ``agent_delta`` audit-event (chain_id-keyed), which appends directly
-    to ``self.conversation`` — bypassing ``_ingest_frame``'s
-    ``_current_turn_parent``/``_call_parents`` nesting decision entirely.
-    The LATER terminal ``kind="agent"`` display frame does not re-parent
-    it either: ``_ingest_frame``'s streaming-settle branch finds the
-    tracked record, calls ``streaming.entry.set_item(...)`` on the
-    ALREADY-FLAT entry, and returns — never touching its parent. This
+async def test_a_streamed_terminal_reply_nests_under_its_turns_user_row() -> None:
+    """Tier 2b: 🔴 owner-observed real-machine contradiction, now CLOSED —
+    "folding the turn group does not hide the final reply". Every OTHER
+    turn-nesting test in this file drives the terminal reply via
+    ``transport.push_display(...)``, a single non-streamed ``kind="agent"``
+    frame — the shape a provider returns WITHOUT incremental deltas. A
+    REAL interactive reply is virtually always streamed: its entry is
+    created by :meth:`TextualChatApp._handle_agent_delta_event` on the
+    FIRST ``agent_delta`` audit-event (chain_id-keyed). Before the fix,
+    that creation appended straight to ``self.conversation`` — bypassing
+    ``_ingest_frame``'s nesting decision entirely — and the LATER terminal
+    ``kind="agent"`` display frame never re-parented it either (the
+    streaming-settle branch only called ``set_item`` and returned). This
     test reproduces that exact two-step production pipeline (an
     ``agent_delta`` event, THEN the terminal display frame for the same
-    chain_id) and pins what actually happens today: the reply's parent is
-    ``None`` — confirming the owner's live observation and CONTRADICTING
-    every other push_display-only nesting test in this file, which never
-    exercises the streaming entry-creation path at all. THIS IS A KNOWN
-    DEFECT, not the desired end state — the fix (routing
-    ``_handle_agent_delta_event``'s entry creation through the same
-    nesting decision) is tracked separately; this test documents today's
-    actual behavior so a fix has something concrete to flip red→green
-    against, and so this gap can never again pass unnoticed under a
-    push_display-only test suite."""
+    chain_id) and pins the FIXED behavior: the reply nests under the
+    turn's own user row, exactly like the non-streamed nesting tests
+    elsewhere in this file. (Architect/lead-coder root-caused this as a
+    CLASS, not an item-①-only gap — see
+    :meth:`TextualChatApp._resolve_append_parent`'s own docstring for the
+    shared seam both the streaming and non-streaming paths now go
+    through.)"""
     from dataclasses import replace as _replace
 
     from reyn.schemas.models import Event as _Event
@@ -608,12 +603,69 @@ async def test_a_streamed_terminal_reply_still_lands_flat_never_nested() -> None
         user_row, reply_row = _entries(app)
         assert user_row.item.kind == "user"
         assert reply_row.item.text == "done"
-        assert reply_row.parent is None, (
-            "KNOWN DEFECT (owner-observed, real machine): a STREAMED "
-            "terminal reply's entry is created flat by "
-            "_handle_agent_delta_event and never re-parented when the "
-            "terminal frame settles it — this is the actual behavior "
-            "today, not the intended one. If this assertion starts "
-            "failing (parent becomes user_row), the fix landed — update "
-            "this test to assert the FIXED behavior instead of deleting it."
+        assert reply_row.parent is user_row, (
+            "a STREAMED terminal reply must nest under its turn's own "
+            "user row — the same shape a non-streamed reply already "
+            "gets (test_a_no_tool_terminal_reply_nests_under_its_turns_"
+            "user_row) — the streaming entry-creation path is no longer "
+            "a second, un-nested code path"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_streamed_tool_round_becomes_a_valid_call_level_group_parent() -> None:
+    """Tier 2b: 🔴 the CALL-level half of the same bypass class (architect's
+    own finding, via lead-coder: "the same early return is also downstream
+    of ``_call_parents[call_id] = entry`` registration — #4779 onward").
+    A streamed tool round's own explanatory-text row used to settle
+    in place (``set_item``) without ever registering itself as a
+    call-level Group parent, since :meth:`_ingest_frame`'s streaming-
+    settle branch returned before reaching that registration block. This
+    reproduces the streamed pipeline for a TOOL-DISPATCHING round (not
+    the terminal no-tool case the sibling test above covers) and asserts
+    a SUBSEQUENT tool row for the SAME call_id nests under the streamed
+    row — proving :meth:`_register_call_parent` now runs from the
+    streaming-settle leg too, once the terminal frame's real call_id is
+    known."""
+    from dataclasses import replace as _replace
+
+    from reyn.schemas.models import Event as _Event
+
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+
+        await transport.push_event(
+            _Event(type="agent_delta", data={"text": "let me check", "chain_id": "chain-A"})
+        )
+        await pilot.pause()
+        completion = _parent_row("resp-1", text="let me check", dispatched_tool_calls=True)
+        completion = _replace(
+            completion, meta={**completion.meta, "chain_id": "chain-A"}
+        )
+        await transport.push_display(completion)
+        await pilot.pause()
+        await transport.push_display(_started("op-1", call_id="resp-1"))
+        await pilot.pause()
+
+        user_row, completion_row = _entries(app)
+        assert completion_row.item.text == "let me check"
+        assert completion_row.parent is user_row
+        assert completion_row.state is EntryState.RUNNING, (
+            "call-level registration (RUNNING spinner) must fire from the "
+            "streaming-settle leg too, not only the non-streaming path"
+        )
+        assert completion_row.collapsed is True, (
+            "the default-collapse-at-registration must also fire from "
+            "the streaming-settle leg"
+        )
+        completion_row.expand()
+        (tool_row,) = completion_row.children
+        assert tool_row.item.kind == "tool_call_started"
+        assert tool_row.parent is completion_row, (
+            "a tool row for the SAME call_id must nest under the "
+            "STREAMED completion row — proving it registered as a "
+            "valid call-level Group parent, not just a turn-nested leaf"
         )

--- a/tests/interfaces/test_4691_turn_group_item1.py
+++ b/tests/interfaces/test_4691_turn_group_item1.py
@@ -548,3 +548,72 @@ async def test_turn_settled_arriving_before_the_terminal_reply_leaves_it_flat() 
             "the turn parent CANCELLED (this file's own "
             "test_a_turn_with_no_completions_settles_cancelled_not_stuck_running)"
         )
+
+
+@pytest.mark.asyncio
+async def test_a_streamed_terminal_reply_still_lands_flat_never_nested() -> None:
+    """Tier 2b: 🔴 owner-observed real-machine contradiction — "folding the
+    turn group does not hide the final reply". Every OTHER test in this
+    file drives the terminal reply via ``transport.push_display(...)``, a
+    single non-streamed ``kind="agent"`` frame — the shape a provider
+    returns WITHOUT incremental deltas. A REAL interactive reply is
+    virtually always streamed: its entry is created by
+    :meth:`TextualChatApp._handle_agent_delta_event` on the FIRST
+    ``agent_delta`` audit-event (chain_id-keyed), which appends directly
+    to ``self.conversation`` — bypassing ``_ingest_frame``'s
+    ``_current_turn_parent``/``_call_parents`` nesting decision entirely.
+    The LATER terminal ``kind="agent"`` display frame does not re-parent
+    it either: ``_ingest_frame``'s streaming-settle branch finds the
+    tracked record, calls ``streaming.entry.set_item(...)`` on the
+    ALREADY-FLAT entry, and returns — never touching its parent. This
+    test reproduces that exact two-step production pipeline (an
+    ``agent_delta`` event, THEN the terminal display frame for the same
+    chain_id) and pins what actually happens today: the reply's parent is
+    ``None`` — confirming the owner's live observation and CONTRADICTING
+    every other push_display-only nesting test in this file, which never
+    exercises the streaming entry-creation path at all. THIS IS A KNOWN
+    DEFECT, not the desired end state — the fix (routing
+    ``_handle_agent_delta_event``'s entry creation through the same
+    nesting decision) is tracked separately; this test documents today's
+    actual behavior so a fix has something concrete to flip red→green
+    against, and so this gap can never again pass unnoticed under a
+    push_display-only test suite."""
+    from dataclasses import replace as _replace
+
+    from reyn.schemas.models import Event as _Event
+
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+
+        # The REAL production shape: content arrives as an agent_delta
+        # BEFORE the terminal completion frame — the streaming path every
+        # other test in this file skips entirely. Both carry the SAME
+        # chain_id (matching production: the correlating id
+        # ``_emit_agent_delta`` stamps IS the round's own chain_id, the
+        # same one the terminal completion frame's meta carries).
+        await transport.push_event(
+            _Event(type="agent_delta", data={"text": "done", "chain_id": "chain-A"})
+        )
+        await pilot.pause()
+        completion = _parent_row("resp-1", text="done", dispatched_tool_calls=False)
+        completion = _replace(
+            completion, meta={**completion.meta, "chain_id": "chain-A"}
+        )
+        await transport.push_display(completion)
+        await pilot.pause()
+
+        user_row, reply_row = _entries(app)
+        assert user_row.item.kind == "user"
+        assert reply_row.item.text == "done"
+        assert reply_row.parent is None, (
+            "KNOWN DEFECT (owner-observed, real machine): a STREAMED "
+            "terminal reply's entry is created flat by "
+            "_handle_agent_delta_event and never re-parented when the "
+            "terminal frame settles it — this is the actual behavior "
+            "today, not the intended one. If this assertion starts "
+            "failing (parent becomes user_row), the fix landed — update "
+            "this test to assert the FIXED behavior instead of deleting it."
+        )

--- a/tests/interfaces/test_4691_turn_group_item1.py
+++ b/tests/interfaces/test_4691_turn_group_item1.py
@@ -460,3 +460,91 @@ async def test_a_row_with_no_open_turn_still_lands_flat() -> None:
         (only,) = _entries(app)
         assert only.item.meta.get("call_id") == "resp-1"
         assert only.parent is None
+
+
+@pytest.mark.asyncio
+async def test_a_no_tool_terminal_reply_nests_under_its_turns_user_row() -> None:
+    """Tier 2b: owner-flagged gap (post-merge review of the arc exit report)
+    — the exit report's live capture described a 0-tool-call turn as
+    rendering a "flat 2-row shape", read from the SCREEN. flowview never
+    indents, so "looks flat" and "IS flat (``parent is None``)" are
+    visually indistinguishable — the screen capture could not actually
+    tell them apart, and no automated test asserted ``.parent`` for this
+    exact shape (every existing nesting test used ``_parent_row``'s
+    ``dispatched_tool_calls=True`` default, a TOOL-dispatching completion,
+    never the true terminal-reply case). This asserts ``.parent`` directly
+    for a call that dispatches NO tools (``dispatched_tool_calls=False``,
+    the #4777 terminal-reply shape) — the SAME registration branch (call_id
+    lookup misses because this row is registering itself, falls through to
+    ``_current_turn_parent``) the tool-dispatching case already goes
+    through, so this closes the untested half rather than a new mechanism."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+        await transport.push_display(_parent_row("resp-1", dispatched_tool_calls=False))
+        await pilot.pause()
+
+        user_row, reply_row = _entries(app)
+        assert user_row.item.kind == "user"
+        assert reply_row.parent is user_row, (
+            "a no-tool-call terminal reply must nest under the turn's own "
+            "user row — an owner-flagged gap: a screen capture alone "
+            "cannot distinguish this from a truly flat, un-nested row, "
+            "since flowview never indents"
+        )
+        assert reply_row.item.meta.get("dispatched_tool_calls") is False
+
+
+@pytest.mark.asyncio
+async def test_turn_settled_arriving_before_the_terminal_reply_leaves_it_flat() -> None:
+    """Tier 2b: owner-flagged ordering question — CAN ``turn_settled``
+    reach this client before the terminal reply's own display frame for
+    the SAME turn, and if it does, what happens?
+
+    Structural reasoning (not a live measurement of the real transport's
+    scheduling): ``Session``'s turn-processing emits ``turn_settled`` from
+    a ``finally:`` block wrapping the whole turn (``session.py`` — "the
+    finally: block always emits ``turn_settled`` once, after all other
+    processing" was true even before this file), so for THIS turn's own
+    two writes, program order guarantees the display frame's ``put_outbox``
+    call has already returned before the event fires — a race is not
+    expected in production. This test is not a check of that guarantee
+    (this file cannot drive the real Session); it measures the OTHER
+    half of the owner's question — what this app's own code does if that
+    order were ever violated, whatever the cause.
+
+    Answer: the reply lands FLAT, never orphaned or crashing.
+    ``_current_turn_parent`` is cleared by ``_settle_turn_parent`` the
+    moment ``turn_settled`` is processed (this file's own
+    ``test_a_turn_with_no_completions_settles_cancelled_not_stuck_running``
+    covers that clearing), so a display frame arriving strictly AFTER it
+    finds no turn parent to nest under and falls through to the same flat
+    top-level append every call-id-less/no-open-turn row already takes —
+    a defined, safe fallback, not a new failure mode this ordering would
+    introduce."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _open_turn(transport, pilot, chain_id="chain-A")
+
+        # Adversarial order: the turn-end EVENT is processed before the
+        # terminal reply's own DISPLAY frame arrives for the same turn.
+        await transport.push_event(_turn_settled())
+        await pilot.pause()
+        await transport.push_display(_parent_row("resp-1", dispatched_tool_calls=False))
+        await pilot.pause()
+
+        user_row, reply_row = _entries(app)
+        assert reply_row.parent is None, (
+            "a reply arriving AFTER turn_settled has already cleared the "
+            "turn parent must land flat, not silently attach to a stale "
+            "or wrong parent"
+        )
+        assert user_row.state is EntryState.CANCELLED, (
+            "setup: turn_settled with zero completions landed yet settles "
+            "the turn parent CANCELLED (this file's own "
+            "test_a_turn_with_no_completions_settles_cancelled_not_stuck_running)"
+        )


### PR DESCRIPTION
**[tui-coder]** — owner-directed: incorporate textual-flowview v0.22.0 (fixes #14, reyn's own upstream report), and — found while verifying it live — close a real, owner-observed streaming-bypass class bug. Held pending review; commits build on each other, see below for the split.

## Commit 1 — flowview 0.22.0 bump + #4781 workaround simplification

- Bumped the pin: `728eb0070115ddea92153b5b9aca557b92f329b9` (v0.21.1) → `d90584af11ed89c064cfd796b6bb7e76e27aa2cb` (v0.22.0).
- **#14 fix taken**: `Entry.collapse()` is no longer a no-op on a leaf. Simplified #4781's own workaround: the completion-Group collapse now fires **once, at registration**, instead of being re-asserted at every `append_child` guarded by `len(children) == 1`. #4790's own `parent is call_parent` guard is also gone (it existed only to keep that append_child-time collapse from firing on the turn parent's first child).
- **#2**/**#3** (parent re-presents on child count change; `update()` no longer blinks a "Loading…" placeholder) are upstream-only fixes.

## Commit 2 — witness-only: pin today's actual streamed-reply behavior

No `src/` change — adds `test_a_streamed_terminal_reply_still_lands_flat_never_nested`, documenting the real bug (see commit 3) as a green pin, per lead-coder's explicit request to separate "measure" from "fix".

## Commit 3 — 🔴 close the streaming-bypass class (the significant part of this PR)

**Owner-observed real-machine contradiction**: folding the turn group did not hide the final reply — meaning item ①'s own turn-nesting appeared broken. Root-caused (architect, via lead-coder) as a CLASS bug, not an item-①-only gap:

`_handle_agent_delta_event`'s first-delta entry creation appended straight to `self.conversation` — bypassing `_ingest_frame`'s ENTIRE nesting decision (both the item ① turn-level nest and the #4779+ call-level Group registration). The terminal completion frame's streaming-settle branch only called `set_item` on the already-flat/unregistered entry and returned. Since virtually every live reply streams, this meant BOTH halves of the arc's Group construction were silently inert for streamed rounds — my own dogfood "(2 folded)" observation earlier tonight was a false positive from an empty-content (never-streamed) tool round; I flagged this myself once I traced it, which is what let the owner's contradiction get root-caused instead of argued past.

**Structural fix** (owner's standing "close the class, no bandaids" directive; architect's framing — share the PARENT DECISION, not the entry-creation procedure):

- `_resolve_append_parent(kind, meta)`: the ONE 3-tier decision (call_id Group parent → current turn parent → flat), extracted from `_ingest_frame`'s old inline block.
- `_append_frame(msg)`: the ONLY place `self.conversation.append(` is called for a freshly-created entry (verified by grep — zero other call sites).
- `_register_call_parent(entry, kind, meta)`: the call-level Group registration, extracted so it runs from BOTH `_ingest_frame`'s normal leg AND the streaming-settle leg, once a streamed round's real `call_id`/`dispatched_tool_calls` are known (settle time — they aren't known any earlier, so this is the FIRST point registration could happen for a streamed round, not a late correction).
- `_handle_agent_delta_event`'s first-delta creation now calls `_append_frame` instead of `self.conversation.append` directly.

**No producer-side change** (`router_loop.py`): `call_id`/`dispatched_tool_calls` aren't known until a round returns, so threading them onto the delta payload gains nothing — registration already happens at the completion frame regardless of whether it streamed.

Two new Tier-2b tests reproduce the real two-step production pipeline (an `agent_delta` event, then the terminal display frame) for BOTH halves:
- `test_a_streamed_terminal_reply_nests_under_its_turns_user_row` (renamed from the commit-2 witness, flipped from asserting the defect to asserting the fix, per its own "if this flips red→green, update don't delete" instruction)
- `test_a_streamed_tool_round_becomes_a_valid_call_level_group_parent`

## Falsification

- Commit 1's `test_a_group_parent_defaults_collapsed`: reverted just that diff → genuinely fails.
- Commit 1's two new ordering/terminal-reply tests: checked out `app.py` at the pre-item-① commit (`8fb063f67`) → both genuinely fail.
- Commit 3's two new streaming tests: reverted just that diff (`git stash`) → both genuinely fail, different failure shapes (flat-count mismatch vs. wrong-parent).

## Checks

`ruff check .` clean · `mypy_ratchet.py` clean · `test_tier_audit.py --strict` on all touched test files: 14/14 OK, 0 Tier-4 · `verify_module_docstrings.py` OK · `flat_tests_ratchet.py` OK · `check_tests_path_literal_reference.py` OK · `check_bare_tests_import_reference.py` OK · `check_file_depth_reference.py` OK · full `pytest tests/interfaces/`: 1863 passed, 4 skipped (voice extra, pre-existing), 0 failed.

## Explicitly NOT in this PR

Per lead-coder's explicit instruction: the arc exit re-observation (a fresh live screen capture on the fixed code, confirming the owner's own contradiction is resolved) is a SEPARATE follow-up, not bundled here — "直した" and "観測し直した" are different things, and mixing them would let a green test stand in for a screen nobody actually looked at again.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` (all touched test files)
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/verify_module_docstrings.py` (changed files)
- [x] Falsification: every new/modified test confirmed genuinely red against the appropriate reverted source
- [x] Full `pytest tests/interfaces/`: 1863 passed, 0 failed
- [ ] (Separate follow-up, not this PR) Arc exit re-observation on the owner's own screen, post-fix

part of #4691
