### PR TITLE
chore(#4792): re-verify the Space-fold guard against flowview 0.22.0

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -411,10 +411,11 @@ class _CursorFlowView(FlowView["OutboxMessage"]):
         so the anchor can never be set while ``cursor_visible`` is
         ``False`` — ``cursor_visible`` alone is a complete public-API
         proxy for it TODAY. Re-verified directly against
-        ``_view.py``'s source after #4729's 0.19.0 -> 0.21.1 bump
-        (``_set_cursor_visible`` still unconditionally does
+        ``_view.py``'s source after #4729's 0.19.0 -> 0.21.1 bump, and
+        again after #4792's 0.21.1 -> 0.22.0 bump — both times
+        ``_set_cursor_visible`` still unconditionally does
         ``self._tc_anchor = None`` inside its own ``if not visible:``
-        branch, same as at 0.19.0) — installed pin tracked in
+        branch, unchanged since 0.19.0 — installed pin tracked in
         ``pyproject.toml``, not repeated here as a number that would
         just go stale again on the next bump. This is a DERIVED
         equivalence, not a contract upstream promises: if a future


### PR DESCRIPTION
**[docs-maintainer]** — Self-initiated: #4792 bumped textual-flowview 0.21.1 → 0.22.0. The `_CursorFlowView.action_toggle_fold` guard's own comment (added #4732) carries a standing instruction: "re-verify this docstring's claim on every future textual-flowview version bump."

## What I verified

Installed the exact new pin (`d90584af11ed89c064cfd796b6bb7e76e27aa2cb`) in a scratch venv and read `_view.py` directly: `_set_cursor_visible` still unconditionally clears `_tc_anchor` on hide, unchanged since 0.19.0. **Equivalence holds — no bug, no behavior change.**

## Change

Comment-only — records this re-verification alongside the prior one (0.21.1) rather than letting the record silently fall one bump behind again.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] Independently verified the guard's underlying assumption against the actual installed flowview source at the new pin, not just updating the comment's wording
- [x] Fetch-checked against `origin/main` before push — no drift (branch base = #4792's own merge commit)
- [x] Closing-intent self-grep on commit message + this body: no keyword adjacent to any issue number
- [x] (skipped — no user-facing/Visual surface, comment-only change, guard behavior unchanged)

Part of #4792 (verification follow-up, not a defect in that PR)
