### PR TITLE
fix(#4737): drop the stale "phase" PyPI discovery keyword

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ keywords = [
     # "phase" removed (#4737): a PyPI discovery keyword for the phase-graph
     # skill engine, removed in #2434/#2438 — "dsl" above still applies (the
     # live pipeline DSL), this one described a feature that no longer
-    # exists. No wording choice here (unlike the `description` field two
-    # PRs up: #4745, owner-blocked) — just a dead entry with nothing left
-    # to point at.
+    # exists.
     "LLM workflow",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,12 @@ keywords = [
     "multi-agent",
     "orchestration",
     "os",
-    "phase",
+    # "phase" removed (#4737): a PyPI discovery keyword for the phase-graph
+    # skill engine, removed in #2434/#2438 — "dsl" above still applies (the
+    # live pipeline DSL), this one described a feature that no longer
+    # exists. No wording choice here (unlike the `description` field two
+    # PRs up: #4745, owner-blocked) — just a dead entry with nothing left
+    # to point at.
     "LLM workflow",
 ]
 classifiers = [


### PR DESCRIPTION
**[e2e-coder]** — assigned #4737, picked up after reading the issue body + all existing PRs (`gh pr list --state all --search "4737 in:body"`): #4744 (merged — REYN.md, facts-only) and #4745 (open — `reyn --help`/`pyproject.toml` `description` wording, owner-blocked, candidate A/B/C).

## What this adds

Swept for the two things architect's issue body flagged as unmeasured: (1) other CLI subcommand `help=`/`description=` strings for the same staleness — checked every file in `interfaces/cli/commands/`, all clean; (2) other "MVP"/phase-engine residue — the overwhelming majority of repo-wide "MVP" hits are legitimate feature-maturity language (Environment ⚗ Stage 2 MVP, A2A `message/send` MVP, historical ADR references) or an unrelated acronym (SVG's "MVP profile" in `smil.py`), not stale identity claims — out of scope, not touched.

One genuine, narrowly-scoped hit outside #4745's diff: `pyproject.toml`'s `keywords` list carried `"phase"` alongside `"dsl"` — both added for the same original (now-being-replaced) description. The phase-graph skill engine that keyword pointed at was removed in #2434/#2438. `"dsl"` stays — the pipeline DSL (`interfaces/cli/commands/pipe.py`) is real and live.

## Why this doesn't need owner sign-off (unlike #4745)

`#4745`'s `description` field needs a REPLACEMENT phrase — a genuine wording/marketing choice. A keyword either points at something real or it doesn't; there's no wording decision in deleting a dead one. Same class as #4744's REYN.md fix (remove a description of something that no longer exists), not the class #4745 is blocked on.

## Test plan

- [x] `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — parses clean, `"phase"` confirmed absent from the loaded list.
- [x] `ruff check .`, `scripts/mypy_ratchet.py` — both green.
- [x] Swept every subcommand's `help=`/`description=` string under `interfaces/cli/commands/` for the same class of staleness — none found.
- [x] Swept `pyproject.toml`'s remaining `keywords`/`classifiers` — no other entries reference anything removed.
- [ ] Visual/TTY — n/a (no user-facing screen surface touched)

`part of #4737` (issue stays open — #4745's owner wording decision is still pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] 🔴 (lead-coder, 確認済み: 該当箇所は削除され、撤去済み機構と "dsl" の理由のみ残存) keywords のコメントから、他 PR の現在状態への参照（"two PRs up"／"owner-blocked"）を落とす — 決着した瞬間に偽になる書き方。撤去された機構（#2434/#2438）と "dsl" が live である理由だけを残す。
