### PR TITLE
fix(#4761): decouple the durable tripwire record from the once-only notice

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -46,6 +46,19 @@ _TRIPWIRE_MS = 250.0
 #: a stall a human would notice cannot hide between two ticks.
 _TICK_SECONDS = 0.05
 
+#: Minimum gap between two durable ``write_record("tripwire", ...)`` calls for
+#: the SAME ongoing stall (#4761 ①). Deliberately independent of the
+#: once-only banner/log notice below — that silence is about not burying a
+#: human-facing reply; this one is about the durable record still being able
+#: to answer "did it recover, or keep getting worse?" while nobody is
+#: watching, which is exactly the question a frozen screen cannot answer on
+#: its own. 2s: short enough that a multi-second stall (#4761's own report)
+#: leaves several data points, long enough that a multi-tick stall spanning
+#: seconds doesn't write one record per :data:`_TICK_SECONDS` (20/s) and
+#: flood ``REYN_PROF_DUMP`` — no config knob added for this one, since it
+#: gates a file that is already opt-in behind ``REYN_PROF_DUMP`` itself.
+_RECORD_INTERVAL_S = 2.0
+
 _DUMP_ENV = "REYN_PROF_DUMP"
 
 
@@ -119,6 +132,10 @@ class LoopTripwire:
         self._threshold_ms = threshold_ms
         self._max_lateness_ms = 0.0
         self._fired = False
+        #: Wall-clock time of the last durable ``write_record`` call, or
+        #: ``None`` before the first one — independent of ``_fired`` (#4761
+        #: ①: one flag was gating two different questions).
+        self._last_recorded_monotonic: "float | None" = None
 
     @property
     def max_lateness_ms(self) -> float:
@@ -142,13 +159,31 @@ class LoopTripwire:
         always-visible chrome row, :func:`stall_log_line` for the durable
         record) — wording either one here would make this the place a caller
         has to work around.
+
+        #4761 ①: the once-only rule above governs the RETURN VALUE (what the
+        human-facing banner/log notice does) — it does not also govern the
+        internal :func:`write_record` call. Those answer different questions:
+        the notice is "tell someone now, once," the durable record is "can a
+        later reader tell whether this recovered or kept getting worse,"
+        which silence cannot answer either way. So ``write_record`` keeps
+        firing at :data:`_RECORD_INTERVAL_S` while ``lateness_ms`` stays
+        above threshold, independently of whether this call also returns a
+        value.
         """
         if lateness_ms > self._max_lateness_ms:
             self._max_lateness_ms = lateness_ms
-        if lateness_ms <= self._threshold_ms or self._fired:
+        if lateness_ms <= self._threshold_ms:
+            return None
+        now = time.monotonic()
+        if (
+            self._last_recorded_monotonic is None
+            or now - self._last_recorded_monotonic >= _RECORD_INTERVAL_S
+        ):
+            write_record("tripwire", lateness_ms=round(lateness_ms, 1))
+            self._last_recorded_monotonic = now
+        if self._fired:
             return None
         self._fired = True
-        write_record("tripwire", lateness_ms=round(lateness_ms, 1))
         return lateness_ms
 
 

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -136,6 +136,11 @@ class LoopTripwire:
         #: ``None`` before the first one — independent of ``_fired`` (#4761
         #: ①: one flag was gating two different questions).
         self._last_recorded_monotonic: "float | None" = None
+        #: Whether the most recent tick was above threshold — lets a healthy
+        #: tick tell "recovered" (this was ``True``) from "was already
+        #: healthy" (this was ``False``) apart, so the durable trace can say
+        #: which one happened instead of just stopping either way.
+        self._in_stall = False
 
     @property
     def max_lateness_ms(self) -> float:
@@ -168,12 +173,20 @@ class LoopTripwire:
         which silence cannot answer either way. So ``write_record`` keeps
         firing at :data:`_RECORD_INTERVAL_S` while ``lateness_ms`` stays
         above threshold, independently of whether this call also returns a
-        value.
+        value — AND a healthy tick that follows a stall writes one
+        ``"tripwire_recovered"`` record, for the same reason: a trace that
+        just stops leaves "it recovered" and "the process died mid-stall"
+        looking identical, the same silence-hides-two-states shape #4761's
+        original defect had, one level up.
         """
         if lateness_ms > self._max_lateness_ms:
             self._max_lateness_ms = lateness_ms
         if lateness_ms <= self._threshold_ms:
+            if self._in_stall:
+                self._in_stall = False
+                write_record("tripwire_recovered", lateness_ms=round(lateness_ms, 1))
             return None
+        self._in_stall = True
         now = time.monotonic()
         if (
             self._last_recorded_monotonic is None

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -21,7 +21,7 @@ import pytest
 from textual.widgets import Tab
 from textual_flowview import FlowView
 
-from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat import TextualChatApp, loop_probe
 from reyn.interfaces.inline.textual_chat.chrome import StatusLine
 from reyn.interfaces.inline.textual_chat.loop_probe import (
     LoopTripwire,
@@ -190,6 +190,55 @@ def test_it_speaks_once_with_a_magnitude_and_a_next_step() -> None:
     assert "1.8s" in stall_log_line(first)
     assert "REYN_PROF_DUMP" in stall_log_line(first), (
         "the durable record must say how to capture the detail next time"
+    )
+
+
+def test_the_durable_record_keeps_landing_while_the_banner_stays_quiet(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Tier 2: #4761 ① — one ``_fired`` flag used to gate BOTH the once-only
+    human notice AND the durable ``write_record`` call, so a stall lasting
+    past the first tick left no durable trace of whether it recovered or
+    kept getting worse — exactly the question a frozen screen cannot answer
+    on its own. The once-only rule stays for the notice (unchanged by this
+    fix — see ``test_it_speaks_once_with_a_magnitude_and_a_next_step``
+    above); the durable record must keep landing independently, at
+    :data:`~reyn.interfaces.inline.textual_chat.loop_probe._RECORD_INTERVAL_S`
+    granularity, for as long as the stall continues.
+    """
+    import json
+
+    target = tmp_path / "probe.jsonl"
+    monkeypatch.setenv("REYN_PROF_DUMP", str(target))
+
+    clock = [1000.0]
+    monkeypatch.setattr(loop_probe.time, "monotonic", lambda: clock[0])
+
+    tripwire = LoopTripwire(threshold_ms=250.0)
+
+    first = tripwire.observe(1800.0)  # crosses — records AND fires the notice
+    clock[0] += 0.5  # inside the interval — still stalled, must NOT record yet
+    still_quiet = tripwire.observe(1900.0)
+    clock[0] += loop_probe._RECORD_INTERVAL_S  # interval elapsed, still stalled
+    still_stalled = tripwire.observe(2000.0)
+    clock[0] += loop_probe._RECORD_INTERVAL_S
+    recovered = tripwire.observe(50.0)  # back under threshold — no record
+
+    assert first is not None, "the first crossing must still fire the notice"
+    assert still_quiet is None, "the once-only notice must not repeat mid-interval"
+    assert still_stalled is None, (
+        "the notice stays quiet after the first crossing regardless of the "
+        "record interval — this fix only changes the durable record's cadence"
+    )
+    assert recovered is None
+
+    records = [
+        json.loads(line) for line in target.read_text(encoding="utf-8").splitlines()
+    ]
+    lateness_values = [r["lateness_ms"] for r in records if r["kind"] == "tripwire"]
+    assert lateness_values == [1800.0, 2000.0], (
+        "expected exactly the first crossing and the one past the interval — "
+        f"the mid-interval tick and the recovered tick must not add entries: {records!r}"
     )
 
 

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -240,6 +240,50 @@ def test_the_durable_record_keeps_landing_while_the_banner_stays_quiet(
         "expected exactly the first crossing and the one past the interval — "
         f"the mid-interval tick and the recovered tick must not add entries: {records!r}"
     )
+    recovered_lateness = [
+        r["lateness_ms"] for r in records if r["kind"] == "tripwire_recovered"
+    ]
+    assert recovered_lateness == [50.0], (
+        "the recovered tick must write exactly ONE tripwire_recovered record — "
+        "without it, a trace that just stops leaves 'it recovered' and 'the "
+        f"process died mid-stall' looking identical: {records!r}"
+    )
+
+
+def test_recovery_is_recorded_only_once_per_episode(monkeypatch, tmp_path: Path) -> None:
+    """Tier 2: #4761 ① follow-up — a SECOND healthy tick after recovery must
+    not write a second ``tripwire_recovered`` record (it was already healthy,
+    nothing changed), and a SECOND stall episode must be able to record its
+    own recovery independently of the first."""
+    import json
+
+    target = tmp_path / "probe.jsonl"
+    monkeypatch.setenv("REYN_PROF_DUMP", str(target))
+
+    clock = [2000.0]
+    monkeypatch.setattr(loop_probe.time, "monotonic", lambda: clock[0])
+
+    tripwire = LoopTripwire(threshold_ms=250.0)
+
+    tripwire.observe(1800.0)  # episode 1: stall
+    clock[0] += 1.0
+    tripwire.observe(50.0)  # episode 1: recovers
+    clock[0] += 1.0
+    tripwire.observe(60.0)  # still healthy — no NEW recovery
+    clock[0] += 1.0
+    tripwire.observe(1700.0)  # episode 2: stall again
+    clock[0] += 1.0
+    tripwire.observe(40.0)  # episode 2: recovers
+
+    records = [
+        json.loads(line) for line in target.read_text(encoding="utf-8").splitlines()
+    ]
+    recovered_lateness = [
+        r["lateness_ms"] for r in records if r["kind"] == "tripwire_recovered"
+    ]
+    assert recovered_lateness == [50.0, 40.0], (
+        f"expected exactly one recovery record per episode: {records!r}"
+    )
 
 
 def test_the_worst_lateness_survives_the_tick_that_saw_it() -> None:


### PR DESCRIPTION
**[e2e-coder]** — #4761 ①, per lead-coder's assignment: `loop_probe.py:147`'s `_fired` flag gated two different things at once.

## The defect

`LoopTripwire.observe()` used ONE `_fired` flag to silence both:
1. The human-facing notice (banner + `logger.warning`, consumed via `observe()`'s return value at the `app.py` call site) — legitimately once-only, per the existing docstring's own reasoning ("repeating the notice per tick would bury the reply").
2. The internal `write_record("tripwire", ...)` call to the `REYN_PROF_DUMP` durable trace — **not** the same reasoning. Silence there during an ongoing stall means a later reader can't tell whether it recovered or kept getting worse, which is exactly the open question in #4761's own report (screen frozen, process alive, low CPU — no further data once the one record lands).

lead-coder's framing (verbatim, relayed): the docstring's reasoning is "人が見る banner の理由であって、`write_record` の durable な記録の理由ではありません."

## Fix

`write_record` now fires on the first crossing AND repeats at `_RECORD_INTERVAL_S` (2.0s, justified in-comment) for as long as `lateness_ms` stays above threshold, tracked by its own `_last_recorded_monotonic` — independent of `_fired`. `observe()`'s **return value** (what the banner/`logger.warning` call site consumes) is unchanged: still `None` on every crossing after the first, per the existing `test_it_speaks_once_with_a_magnitude_and_a_next_step`, which still passes unmodified.

Per lead-coder's instruction ("backoff 定数を足すなら根拠をコメントに書くか config の口を付けるか、必ず一方を"): went with an in-comment rationale rather than a new config knob — `_RECORD_INTERVAL_S` gates a file that is already opt-in behind `REYN_PROF_DUMP` itself, so a second config surface felt like scope creep for an internal diagnostic constant.

## Scope

Only ① (the tripwire single-shot defect). #4761's own mechanism for the reported total-freeze remains unidentified — this doesn't move that forward, it fixes a real, independently-found defect in the diagnostic tooling that would otherwise stay blind during any future occurrence.

## Six questions (touches `tests/`)

1. **Tier** — 2 (OS invariant: the durable record's cadence during an ongoing stall).
2. **Implementation transcribed?** No — the test drives a fake clock through four distinct ticks and asserts on the resulting record COUNT and VALUES, not on re-deriving the interval arithmetic.
3. **Who would miss it?** A future occurrence of #4761 (or any real stall past `_TRIPWIRE_MS`) — currently no test would catch a regression back to the single-write behavior; production's own `REYN_PROF_DUMP` trace is the actual consumer.
4. **Stay green never run?** No — collected and asserted, 10/10 in the file.
5. **What does it accumulate, who bounds it?** The `REYN_PROF_DUMP` file grows at `_RECORD_INTERVAL_S` while a stall persists — bounded by the stall's own duration (a healthy loop writes nothing, per the untouched sibling tests), and the file itself is opt-in.
6. **Declared Tier true?** Yes, per ①.

## Test plan

- [x] New `test_the_durable_record_keeps_landing_while_the_banner_stays_quiet`: fake clock through first-crossing / mid-interval-still-stalled / past-interval-still-stalled / recovered — asserts notice fires once, records land exactly at crossing + past-interval (not mid-interval, not on recovery).
- [x] Strip-falsified: reverting `loop_probe.py` flips the new test red at the missing `_RECORD_INTERVAL_S` — confirmed via `git stash`.
- [x] All 10 tests in `test_loop_probe_3539.py` green, including the untouched once-only-notice test.
- [x] `ruff check .`, `scripts/test_tier_audit.py --strict`, `scripts/verify_module_docstrings.py`, `scripts/mypy_ratchet.py` — all green.
- [ ] Visual/TTY (standing waiver applies — merge does not wait on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] 🔴 (lead-coder、確認済み: _in_stall で episode 化し回復時に 1 回だけ tripwire_recovered を記録) 回復の記録が無い — 閾値を下回った最初の1回だけ「戻った」を書く。無いと、後から読む人には「回復した」と「プロセスが死んだ」が同じ沈黙に見え、#4761 の元の欠陥と同じ形が残る。
