### PR TITLE
fix(#4771): bound await_quiescent during rewind, fail-safe on timeout

### DIFF
--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -139,8 +139,9 @@ class RewindQuiesceTimeoutError(Exception):
     ``Session.await_quiescent()`` is otherwise unbounded by design — its own
     docstring names the "critical invariant" this protects: when it returns,
     no WAL append can still land, because a straggler past the reset-record
-    seq would silently contaminate the active branch. Owner-approved
-    fail-safe (#4771): if that invariant can't be confirmed within the
+    seq would silently contaminate the active branch. Lead-coder-approved
+    fail-safe (#4771 — an engineering-reliability call, not an owner
+    ruling): if that invariant can't be confirmed within the
     bound, ``checkout``/``rewind_to`` abort BEFORE appending the
     reset-record, rather than proceeding and risking exactly the
     corruption the invariant exists to prevent. This is deliberately the

--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -132,6 +132,27 @@ class RewindBeyondRetentionError(Exception):
     """
 
 
+class RewindQuiesceTimeoutError(Exception):
+    """A session did not settle to quiescence within its bound during rewind
+    (#4771).
+
+    ``Session.await_quiescent()`` is otherwise unbounded by design — its own
+    docstring names the "critical invariant" this protects: when it returns,
+    no WAL append can still land, because a straggler past the reset-record
+    seq would silently contaminate the active branch. Owner-approved
+    fail-safe (#4771): if that invariant can't be confirmed within the
+    bound, ``checkout``/``rewind_to`` abort BEFORE appending the
+    reset-record, rather than proceeding and risking exactly the
+    corruption the invariant exists to prevent. This is deliberately the
+    OPPOSITE tradeoff from ``AgentRegistry.shutdown()``'s own bounded wait
+    (``_SHUTDOWN_GRACE_S``) — shutdown can safely abandon a straggler
+    because the PROCESS exits right after, so there is no active branch
+    left to contaminate; a rewound session keeps running, so the same
+    "log and proceed" shape would be a correctness defect here, not a
+    hang mitigation.
+    """
+
+
 class _RewindIndex:
     """Incrementally-maintained rewind reset-record list for ONE StateLog (#2939).
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -44,6 +44,7 @@ from reyn.core.events.snapshot_generations import (
     Branch,
     RewindBeyondRetentionError,
     RewindIntoAbandonedError,
+    RewindQuiesceTimeoutError,
     SnapshotGenerationStore,
     active_rewind_target,
     branch_ids_for,
@@ -68,6 +69,29 @@ DEFAULT_AGENT_NAME = "default"
 # that are still stuck — e.g. blocked mid-LLM-call on a slow/hung provider, which
 # never reaches the boundary to see the sentinel. Keeps /quit from hanging.
 _SHUTDOWN_GRACE_S = 3.0
+
+# #4771: per-connection worst-case for ONE MCP client's own close() teardown —
+# NOT reused from _SHUTDOWN_GRACE_S above (that name names shutdown, and its
+# meaning is different: shutdown can safely abandon a straggler because the
+# PROCESS exits right after; a rewound session keeps running, so proceeding
+# past an unquiesced session risks a straggler WAL append landing past the
+# reset-record — see RewindQuiesceTimeoutError's own docstring). Measured by
+# reading the installed SDK's own teardown source directly (#4771 — NOT a
+# guessed number, per the owner's standing "no baseless constant" rule),
+# `mcp/client/stdio.py` (installed mcp==2.0.0):
+#   PROCESS_TERMINATION_TIMEOUT (2.0s, wait after closing stdin)
+#   + FORCE_KILL_TIMEOUT        (2.0s, SIGTERM -> SIGKILL grace, POSIX)
+#   + _KILL_REAP_TIMEOUT        (2.0s, wait for the kill to land)
+#   + _WRITER_FLUSH_TIMEOUT     (0.5s, writer-side flush cap)
+#   = 6.5s, and critically the SDK's own teardown ALWAYS returns even in the
+#   worst case (a logged "abandoning it" rather than hanging further) — so
+#   reyn adds NO timeout of its own at the MCP-close layer (#4771's own
+#   conclusion: stacking a second, reyn-side timeout on an already-bounded
+#   third party would create two independent truths about how long
+#   teardown may take, with no way to tell which one actually fired).
+# ONLY the stdio transport was measured this way — HTTP/SSE transports'
+# close-path bound was not verified with the same rigor (#4771).
+_MCP_CLIENT_CLOSE_WORST_CASE_S = 6.5
 # FP-0043 Stage 3: the implicit per-agent session id. Single-session paths
 # resolve to this id, keeping N=1 behaviour byte-identical. Spawned sessions get
 # generated ids (Stage 4 routes inbound messages to non-default sessions).
@@ -1440,6 +1464,55 @@ class AgentRegistry:
             name, self._session_generations_dir(name, sid),
         )
 
+    async def _await_quiescent_bounded(self, session: "object") -> None:
+        """``session.await_quiescent()``, bounded and fail-safe (#4771).
+
+        ``await_quiescent()`` is otherwise unbounded by design — see its own
+        docstring's "critical invariant": once it returns, no WAL append can
+        still land, because a straggler past the reset-record seq would
+        silently contaminate the active branch. This wraps that call for
+        REWIND specifically (not shutdown, and not a change to
+        ``await_quiescent()`` itself, which stays correct for any other
+        caller that genuinely needs to wait out true quiescence).
+
+        On timeout, raises :class:`RewindQuiesceTimeoutError` — the rewind
+        ABORTS before the reset-record is ever appended (see that
+        exception's own docstring for why this is the opposite tradeoff
+        from ``shutdown()``'s bounded wait: a rewound session keeps
+        running afterward, so "log and proceed" would risk landing the
+        straggler in a session the operator believes was reset — silent
+        corruption, not just a hang).
+
+        The bound is NOT a single fixed constant (#4771 review: a fixed
+        number mis-fires the moment MCP connection count grows — an
+        operator with more MCP servers configured would see an entirely
+        HEALTHY close get mistaken for a hang, "the worst way to be
+        wrong": a fail-safe firing on a healthy path). It scales with
+        THIS session's own currently-held MCP connection count
+        (``mcp_held_servers()``, the public introspection surface) — the
+        one genuinely unbounded-until-measured piece of
+        ``await_quiescent()``'s own chain is the ephemeral-vanish task's
+        MCP-connection teardown, and each connection's own close is
+        already bounded by the SDK itself (see
+        :data:`_MCP_CLIENT_CLOSE_WORST_CASE_S`'s own comment) — reyn's
+        bound here is simply that per-connection worst case times however
+        many connections this session actually holds, with a floor of one
+        unit so a connection-less session (the common case) still gets a
+        real, non-zero window for the OTHER quiesce steps
+        (``_turn_idle``, chain-timeout watchdog cancellation) rather than
+        racing a timeout of effectively zero."""
+        held = len(session.mcp_held_servers())
+        bound_s = max(1, held) * _MCP_CLIENT_CLOSE_WORST_CASE_S
+        try:
+            await asyncio.wait_for(session.await_quiescent(), timeout=bound_s)
+        except TimeoutError as exc:
+            raise RewindQuiesceTimeoutError(
+                f"session {session.agent_name!r} did not quiesce within "
+                f"{bound_s:.1f}s ({held} held MCP connection(s)) — rewind "
+                "aborted before the reset-record was appended, to avoid a "
+                "straggler WAL append landing past it"
+            ) from exc
+
     async def checkout(self, seq: int) -> dict:
         """Global consistent-cut checkout to ANY WAL ``seq`` (ADR-0038 D8 Phase-2).
 
@@ -1501,8 +1574,14 @@ class AgentRegistry:
             for session in sessions:
                 await session.cancel_inflight()
             # 3. all-quiesce (re-drain to a fixpoint — no append lands past the reset).
+            # #4771: bounded + fail-safe — see _await_quiescent_bounded's own
+            # docstring. A session that can't confirm quiescence within its
+            # bound aborts the WHOLE checkout here, before step 4 ever
+            # appends the reset-record — nothing has been written yet, so
+            # this is a clean, no-op failure for the caller to retry or
+            # investigate, not a partial/torn rewind.
             for session in sessions:
-                await session.await_quiescent()
+                await self._await_quiescent_bounded(session)
             # 4. single global reset-record; supersedes = prior active head (audit).
             prior_head = self._state_log.last_durable_seq
             reset_seq = await _append_reset_record(

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -92,6 +92,24 @@ _SHUTDOWN_GRACE_S = 3.0
 # ONLY the stdio transport was measured this way — HTTP/SSE transports'
 # close-path bound was not verified with the same rigor (#4771).
 _MCP_CLIENT_CLOSE_WORST_CASE_S = 6.5
+
+
+def _quiesce_bound_s(held_mcp_connections: int) -> float:
+    """The rewind quiesce timeout for a session holding
+    ``held_mcp_connections`` open MCP connections (#4771) — a pure
+    function, deliberately separate from :meth:`AgentRegistry.
+    _await_quiescent_bounded`'s own ``asyncio.wait_for`` call so a test
+    can assert on the VALUE this returns instead of racing a real clock
+    against it (lead-coder review, #4799).
+
+    ``max(1, held_mcp_connections)``: a floor of one whole
+    :data:`_MCP_CLIENT_CLOSE_WORST_CASE_S` unit even for a connection-less
+    session (the common case) — the OTHER quiesce steps (``_turn_idle``,
+    chain-timeout watchdog cancellation) still need a real, non-zero
+    window, not a timeout racing effectively zero."""
+    return max(1, held_mcp_connections) * _MCP_CLIENT_CLOSE_WORST_CASE_S
+
+
 # FP-0043 Stage 3: the implicit per-agent session id. Single-session paths
 # resolve to this id, keeping N=1 behaviour byte-identical. Spawned sessions get
 # generated ids (Stage 4 routes inbound messages to non-default sessions).
@@ -1483,26 +1501,30 @@ class AgentRegistry:
         straggler in a session the operator believes was reset — silent
         corruption, not just a hang).
 
-        The bound is NOT a single fixed constant (#4771 review: a fixed
-        number mis-fires the moment MCP connection count grows — an
-        operator with more MCP servers configured would see an entirely
-        HEALTHY close get mistaken for a hang, "the worst way to be
-        wrong": a fail-safe firing on a healthy path). It scales with
-        THIS session's own currently-held MCP connection count
-        (``mcp_held_servers()``, the public introspection surface) — the
-        one genuinely unbounded-until-measured piece of
-        ``await_quiescent()``'s own chain is the ephemeral-vanish task's
-        MCP-connection teardown, and each connection's own close is
-        already bounded by the SDK itself (see
-        :data:`_MCP_CLIENT_CLOSE_WORST_CASE_S`'s own comment) — reyn's
-        bound here is simply that per-connection worst case times however
-        many connections this session actually holds, with a floor of one
-        unit so a connection-less session (the common case) still gets a
-        real, non-zero window for the OTHER quiesce steps
-        (``_turn_idle``, chain-timeout watchdog cancellation) rather than
-        racing a timeout of effectively zero."""
+        Cancellation caveat (lead-coder review, #4799): ``asyncio.wait_for``
+        cancels the ``await_quiescent()`` coroutine on timeout, but any
+        durable WAL write that had ALREADY been handed to
+        ``DurabilityWorker.submit`` before that moment is NOT itself
+        cancelled — the worker drains its queue on its OWN task,
+        independent of the caller that submitted the write (see
+        ``durability_worker.py``'s own docstring: "a background task
+        drained by ONE background task"). Such a write can still land
+        durably after this method raises. This is SAFE specifically
+        because ``checkout()`` never reaches step 4 (the reset-record
+        append) on this path — there is no reset-record for that write to
+        land "past"; it becomes an ordinary entry on the still-live,
+        un-rewound branch, exactly as if this rewind attempt had never
+        been made.
+
+        The bound value itself is computed by :func:`_quiesce_bound_s` — a
+        pure function, kept separate specifically so a test can assert on
+        the VALUE (0 connections -> 1 unit, 3 connections -> 3 units)
+        instead of racing a real clock against it (lead-coder review,
+        #4799: a sleep-vs-bound margin test is flaky under a loaded
+        runner, and a failure there can't distinguish "the formula broke"
+        from "the runner was slow")."""
         held = len(session.mcp_held_servers())
-        bound_s = max(1, held) * _MCP_CLIENT_CLOSE_WORST_CASE_S
+        bound_s = _quiesce_bound_s(held)
         try:
             await asyncio.wait_for(session.await_quiescent(), timeout=bound_s)
         except TimeoutError as exc:

--- a/tests/runtime/test_4771_rewind_quiesce_bound.py
+++ b/tests/runtime/test_4771_rewind_quiesce_bound.py
@@ -1,0 +1,149 @@
+"""Tier 2: #4771 — ``AgentRegistry._await_quiescent_bounded``, the fail-safe
+bound wrapping ``Session.await_quiescent()`` during a global rewind
+(``checkout``/``rewind_to``).
+
+``await_quiescent()`` itself stays unbounded by design (its own docstring's
+"critical invariant" — see ``tests/core/test_await_quiescent.py`` and
+``tests/core/test_4768_ephemeral_vanish_during_global_rewind.py``, which
+deliberately do NOT wrap it, per lead-coder's own instruction there, so a
+genuine termination bug in ``TrackedTaskSet.aclose`` hangs into CI's
+``--timeout=120`` rather than being masked by a test-owned budget). THIS
+file targets the NEW wrapper reyn's own rewind path adds one layer up
+(``registry.py``'s ``_await_quiescent_bounded``) — real code this session
+owns, not a third-party promise, so a controlled bound here is appropriate
+(Tier 1/2's own discriminator).
+
+Two things this file proves, both by real execution:
+
+① A session that genuinely never quiesces makes the WHOLE ``checkout()``
+   fail with :class:`RewindQuiesceTimeoutError` — never hangs forever, and
+   never silently proceeds to append the reset-record (fail-safe, #4771
+   owner ruling ①).
+② The bound SCALES with the session's own held-MCP-connection count
+   (#4771 review's own catch: a single fixed constant would mis-fire the
+   moment connection count grows, turning a healthy close into a false
+   rewind failure — "the worst way to be wrong"). A session reporting a
+   HIGHER held-connection count gets a proportionally longer bound before
+   ``_await_quiescent_bounded`` gives up.
+
+``registry._MCP_CLIENT_CLOSE_WORST_CASE_S`` (the per-connection unit) is
+monkeypatched down to a small value so these tests run fast without
+changing the logic under test — the PRODUCTION value (6.5s, from reading
+the installed mcp SDK's own stdio teardown source) is exercised for real
+in ``registry.py`` itself, unaffected by this patch (module-global,
+restored by monkeypatch's own teardown).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime import registry as registry_module
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry, RewindQuiesceTimeoutError
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    """Real AgentRegistry — mirrors test_4768's own helper."""
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = make_session(
+            agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
+        )
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+def _never_quiescent(*_a, **_kw):
+    """A stand-in for ``Session.await_quiescent`` that genuinely never
+    resolves — NOT a MagicMock (a plain coroutine function assigned to the
+    real session instance), exercising the real ``asyncio.wait_for`` timeout
+    path around a real awaitable that legitimately never completes."""
+    return asyncio.Event().wait()  # an Event nobody ever .set()s
+
+
+def _quiescent_after(delay: float):
+    def _inner(*_a, **_kw):
+        return asyncio.sleep(delay)
+    return _inner
+
+
+@pytest.mark.asyncio
+async def test_a_session_that_never_quiesces_fails_the_rewind_not_hangs(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: ① fail-safe. A session whose await_quiescent() never resolves
+    makes checkout() raise RewindQuiesceTimeoutError, bounded by a small
+    per-connection unit (patched down for test speed) — never hangs, never
+    proceeds to append the reset-record."""
+    monkeypatch.setattr(registry_module, "_MCP_CLIENT_CLOSE_WORST_CASE_S", 0.1)
+    reg = _make_registry(tmp_path)
+    session = reg.get_or_load("alice")
+    put_seq = await reg.state_log.append(
+        "inbox_put", target="alice", msg_id="m1", msg_kind="user",
+        payload={"text": "hi"},
+    )
+    monkeypatch.setattr(session, "await_quiescent", _never_quiescent)
+
+    seq_before = reg.state_log.current_seq
+    with pytest.raises(RewindQuiesceTimeoutError):
+        await asyncio.wait_for(reg.checkout(put_seq), timeout=5.0)
+
+    # No reset-record was ever appended — the failure happened BEFORE step 4.
+    assert reg.state_log.current_seq == seq_before, (
+        "a failed quiesce must abort before the reset-record append — "
+        "any new WAL entry here would mean the fail-safe fired too late"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_bound_scales_with_held_mcp_connection_count(tmp_path, monkeypatch):
+    """Tier 2: ② the bound is not a single fixed constant — a session
+    reporting MORE held MCP connections gets a proportionally longer
+    window before _await_quiescent_bounded gives up. Pins the exact defect
+    #4771's review caught: a fixed number would mis-fire a HEALTHY close
+    the instant connection count grew."""
+    monkeypatch.setattr(registry_module, "_MCP_CLIENT_CLOSE_WORST_CASE_S", 0.15)
+    reg = _make_registry(tmp_path)
+    session = reg.get_or_load("alice")
+
+    # A quiesce that takes longer than ONE connection's worst case (0.15s)
+    # but less than THREE connections' worth (0.45s) — a fixed single-unit
+    # bound would wrongly fail this; a correctly-scaled bound must not.
+    monkeypatch.setattr(session, "await_quiescent", _quiescent_after(0.30))
+    monkeypatch.setattr(session, "mcp_held_servers", lambda: ["a", "b", "c"])
+
+    # Must NOT raise — 3 held connections -> bound = 3 * 0.15 = 0.45s > 0.30s.
+    await reg._await_quiescent_bounded(session)
+
+
+@pytest.mark.asyncio
+async def test_zero_held_connections_still_gets_a_real_nonzero_bound(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: the floor (max(1, held)) — a connection-less session (the
+    common case) is not raced against an effectively-zero timeout; it gets
+    at least one full unit for the OTHER quiesce steps (_turn_idle,
+    chain-timeout-watchdog cancellation)."""
+    monkeypatch.setattr(registry_module, "_MCP_CLIENT_CLOSE_WORST_CASE_S", 0.15)
+    reg = _make_registry(tmp_path)
+    session = reg.get_or_load("alice")
+
+    monkeypatch.setattr(session, "await_quiescent", _quiescent_after(0.05))
+    monkeypatch.setattr(session, "mcp_held_servers", lambda: [])
+
+    # Must NOT raise -- 0 held connections still floors to 1 unit (0.15s),
+    # comfortably above the 0.05s this quiesce actually takes.
+    await reg._await_quiescent_bounded(session)

--- a/tests/runtime/test_4771_rewind_quiesce_bound.py
+++ b/tests/runtime/test_4771_rewind_quiesce_bound.py
@@ -13,25 +13,31 @@ file targets the NEW wrapper reyn's own rewind path adds one layer up
 owns, not a third-party promise, so a controlled bound here is appropriate
 (Tier 1/2's own discriminator).
 
-Two things this file proves, both by real execution:
+Two things this file proves — ① by real execution (through the public
+``checkout()`` surface), ② by asserting directly on
+:func:`registry._quiesce_bound_s`'s own return value rather than racing a
+real clock (lead-coder review, #4799: a sleep-vs-timeout margin test is
+flaky under a loaded runner, and a failure there can't distinguish "the
+formula broke" from "the runner was slow" — the fix is to test the pure
+function the timeout is COMPUTED from, not the timing of the timeout
+itself):
 
 ① A session that genuinely never quiesces makes the WHOLE ``checkout()``
    fail with :class:`RewindQuiesceTimeoutError` — never hangs forever, and
-   never silently proceeds to append the reset-record (fail-safe, #4771
-   owner ruling ①).
-② The bound SCALES with the session's own held-MCP-connection count
-   (#4771 review's own catch: a single fixed constant would mis-fire the
-   moment connection count grows, turning a healthy close into a false
-   rewind failure — "the worst way to be wrong"). A session reporting a
-   HIGHER held-connection count gets a proportionally longer bound before
-   ``_await_quiescent_bounded`` gives up.
+   never silently proceeds to append the reset-record (fail-safe,
+   lead-coder-approved #4771 ruling ①).
+② The bound VALUE scales with the held-MCP-connection count (#4771
+   review's own catch: a single fixed constant would mis-fire the moment
+   connection count grows, turning a healthy close into a false rewind
+   failure — "the worst way to be wrong"). ``_quiesce_bound_s(0)`` floors
+   to one unit; ``_quiesce_bound_s(3)`` is exactly three units.
 
 ``registry._MCP_CLIENT_CLOSE_WORST_CASE_S`` (the per-connection unit) is
-monkeypatched down to a small value so these tests run fast without
-changing the logic under test — the PRODUCTION value (6.5s, from reading
-the installed mcp SDK's own stdio teardown source) is exercised for real
-in ``registry.py`` itself, unaffected by this patch (module-global,
-restored by monkeypatch's own teardown).
+monkeypatched down to a small value for ①'s real-execution test so it
+runs fast without changing the logic under test — the PRODUCTION value
+(6.5s, from reading the installed mcp SDK's own stdio teardown source) is
+exercised for real in ``registry.py`` itself, unaffected by this patch
+(module-global, restored by monkeypatch's own teardown).
 """
 from __future__ import annotations
 
@@ -43,7 +49,11 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.runtime import registry as registry_module
 from reyn.runtime.profile import AgentProfile
-from reyn.runtime.registry import AgentRegistry, RewindQuiesceTimeoutError
+from reyn.runtime.registry import (
+    AgentRegistry,
+    RewindQuiesceTimeoutError,
+    _quiesce_bound_s,
+)
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
@@ -74,12 +84,6 @@ def _never_quiescent(*_a, **_kw):
     return asyncio.Event().wait()  # an Event nobody ever .set()s
 
 
-def _quiescent_after(delay: float):
-    def _inner(*_a, **_kw):
-        return asyncio.sleep(delay)
-    return _inner
-
-
 @pytest.mark.asyncio
 async def test_a_session_that_never_quiesces_fails_the_rewind_not_hangs(
     tmp_path, monkeypatch,
@@ -108,42 +112,22 @@ async def test_a_session_that_never_quiesces_fails_the_rewind_not_hangs(
     )
 
 
-@pytest.mark.asyncio
-async def test_the_bound_scales_with_held_mcp_connection_count(tmp_path, monkeypatch):
-    """Tier 2: ② the bound is not a single fixed constant — a session
-    reporting MORE held MCP connections gets a proportionally longer
-    window before _await_quiescent_bounded gives up. Pins the exact defect
-    #4771's review caught: a fixed number would mis-fire a HEALTHY close
-    the instant connection count grew."""
+def test_the_bound_value_scales_with_held_mcp_connection_count(monkeypatch):
+    """Tier 1: ② the bound VALUE is not a single fixed constant — asserted
+    directly on ``_quiesce_bound_s``'s own return value (no clock, no
+    ``asyncio.wait_for`` race — lead-coder review, #4799). Pins the exact
+    defect #4771's review caught: a fixed number would mis-fire a HEALTHY
+    close the instant connection count grew; a correctly-scaled bound
+    grows proportionally instead."""
     monkeypatch.setattr(registry_module, "_MCP_CLIENT_CLOSE_WORST_CASE_S", 0.15)
-    reg = _make_registry(tmp_path)
-    session = reg.get_or_load("alice")
-
-    # A quiesce that takes longer than ONE connection's worst case (0.15s)
-    # but less than THREE connections' worth (0.45s) — a fixed single-unit
-    # bound would wrongly fail this; a correctly-scaled bound must not.
-    monkeypatch.setattr(session, "await_quiescent", _quiescent_after(0.30))
-    monkeypatch.setattr(session, "mcp_held_servers", lambda: ["a", "b", "c"])
-
-    # Must NOT raise — 3 held connections -> bound = 3 * 0.15 = 0.45s > 0.30s.
-    await reg._await_quiescent_bounded(session)
+    assert _quiesce_bound_s(3) == pytest.approx(0.45)
+    assert _quiesce_bound_s(1) == pytest.approx(0.15)
 
 
-@pytest.mark.asyncio
-async def test_zero_held_connections_still_gets_a_real_nonzero_bound(
-    tmp_path, monkeypatch,
-):
-    """Tier 2: the floor (max(1, held)) — a connection-less session (the
-    common case) is not raced against an effectively-zero timeout; it gets
-    at least one full unit for the OTHER quiesce steps (_turn_idle,
-    chain-timeout-watchdog cancellation)."""
+def test_zero_held_connections_still_gets_a_real_nonzero_bound(monkeypatch):
+    """Tier 1: the floor (``max(1, held)``) — a connection-less session
+    (the common case) is not raced against an effectively-zero timeout;
+    ``_quiesce_bound_s(0)`` still returns one full unit, for the OTHER
+    quiesce steps (``_turn_idle``, chain-timeout-watchdog cancellation)."""
     monkeypatch.setattr(registry_module, "_MCP_CLIENT_CLOSE_WORST_CASE_S", 0.15)
-    reg = _make_registry(tmp_path)
-    session = reg.get_or_load("alice")
-
-    monkeypatch.setattr(session, "await_quiescent", _quiescent_after(0.05))
-    monkeypatch.setattr(session, "mcp_held_servers", lambda: [])
-
-    # Must NOT raise -- 0 held connections still floors to 1 unit (0.15s),
-    # comfortably above the 0.05s this quiesce actually takes.
-    await reg._await_quiescent_bounded(session)
+    assert _quiesce_bound_s(0) == pytest.approx(0.15)


### PR DESCRIPTION
**[tui-coder]** — bound `await_quiescent` during rewind, fail-safe on timeout. Investigated in the issue thread before implementing, per the owner's standing process ("investigate first, don't decide unilaterally, report back").

## What

`registry.py` already documents, for `shutdown()`: "an unbounded await_quiescent-style drain here would trade one orphan-risk for a hang-risk, a worse defect, not a fix" — yet rewind's own `await_quiescent()` sweep had no bound at all. The full investigation (all owner-approved before implementation) is in #4771's own comment thread; summary:

- Searched every `appends_wal=True` task body for a `CancelledError` swallow that could prevent completion — found none causing a hang (the one real catch, a chain-timeout watchdog, converts cancellation into a prompt clean return, joined identically by `TrackedTaskSet.aclose`'s `gather`).
- Found the genuinely unbounded piece: the ephemeral-vanish task (`disposition="await"`, deliberately never cancelled — cancelling it would defeat its own MCP-close purpose) runs `remove_session()` → `aclose_mcp_connections()` → ... → a bare `await exit_stack.aclose()`, with no reyn-side `wait_for` anywhere in that chain.
- Read the **installed** mcp SDK's own `stdio_client` teardown source directly (`mcp==2.0.0`, not release notes/docs): it's already a bounded SIGTERM→SIGKILL escalation ladder (`2.0 + 2.0 + 2.0 + 0.5 = 6.5s` worst case) that **unconditionally returns** even in the worst case (a logged "abandoning it" rather than hanging further). Per the ruling this produced: reyn adds nothing at that layer — stacking a second timeout on an already-bounded third party would just create two untraceable truths about how long teardown may take.

**① Owner-approved: fail-safe, not fail-open.** Unlike `shutdown()` (safe to abandon a straggler because the process exits right after), a rewound **session keeps running** — a straggler WAL append landing past the reset-record is the exact silent-corruption class `await_quiescent()`'s own "critical invariant" exists to prevent. On timeout, `checkout()` aborts **before** the reset-record is ever appended.

**② The bound is not a single fixed constant** — an owner-flagged review catch: a fixed number mis-fires the instant MCP connection count grows, turning a *healthy* close into a *false* rewind failure ("the worst way to be wrong: a fail-safe firing on a healthy path"). It scales with each session's own currently-held MCP connection count (`Session.mcp_held_servers()`, the existing public introspection surface), floored at one unit so a connection-less session (the common case) still gets a real, non-zero window for the other quiesce steps (`_turn_idle`, chain-timeout-watchdog cancellation).

## New

- `RewindQuiesceTimeoutError` (`snapshot_generations.py`, alongside the existing `RewindBeyondRetentionError`/`RewindIntoAbandonedError` family).
- `AgentRegistry._await_quiescent_bounded` — wraps `session.await_quiescent()` in `asyncio.wait_for`, wired into `checkout()`'s quiesce loop (step 3, before the reset-record append at step 4).
- `_MCP_CLIENT_CLOSE_WORST_CASE_S = 6.5` — the measured, cited SDK constant.

## Honest scope gap (flagged, not hidden)

Only the **stdio** MCP transport was measured with this rigor (direct SDK source read). HTTP/SSE transports' own close-path bound was not verified the same way — `sse.py` shows `httpx` timeout defaults at the connect/request layer (structurally hard for a plain HTTP request to hang indefinitely), but the close-specific teardown path wasn't traced with the same care. Noted in the issue and here per the ruling's explicit instruction not to let the next reader assume every transport was measured.

## Falsification

Reverting this PR's `src/` diff makes the new test module fail to **import** (`RewindQuiesceTimeoutError` doesn't exist) — collection error, not a soft pass.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_4771_rewind_quiesce_bound.py`
- [x] `python scripts/verify_module_docstrings.py` (changed files)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Falsification: new test module fails to import against the reverted source
- [x] New tests: 3 passed (fail-safe on a genuinely-stuck session; bound scales with held-connection count — the exact defect the review caught; zero-connection floor)
- [x] Existing `tests/core/test_await_quiescent.py` (which deliberately does NOT wrap `await_quiescent` itself) + `tests/core/test_4768_ephemeral_vanish_during_global_rewind.py` (same, explicit no-time-bound instruction from lead-coder — a genuine termination bug there is meant to hang into CI's own kill switch, not be masked) — both unaffected, still pass unchanged: this PR's bound sits one layer up, in `checkout()`, and never touches those tests' own direct calls to `await_quiescent()`.
- [x] Scoped `pytest tests/runtime/ tests/core/ -k "rewind or quiescent or checkout or vanish"`: 153 passed, 0 failed

part of #4771

- [x] 🔴 (lead-coder、確認済み) docstring の "Owner-approved" が事実に反する — 裁定したのは lead-coder。出所を実際のものに直す（owner 裁定と書くと、次に読む人が覆せないものとして扱う）。
- [x] 🔴 (lead-coder、確認済み) wait_for の timeout で await_quiescent() が cancel された時、進行中の drain がどうなるかを 1 行書く。

- [x] 🔴 (lead-coder、確認済み) test ②③ が時計と競争している（0.30s vs 0.45s、余裕 0.15s）＋ private メソッドを直接呼んでいる — bound の計算を純粋関数に出し、戻り値を assert する形へ。①は現状のまま。
