### PR TITLE
fix(#4761): make the recovery notice visible without arming REYN_PROF_DUMP

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1933,7 +1933,12 @@ class TextualChatApp(App):
         import asyncio  # noqa: PLC0415
         import time  # noqa: PLC0415
 
-        from .loop_probe import _TICK_SECONDS, stall_banner, stall_log_line  # noqa: PLC0415
+        from .loop_probe import (  # noqa: PLC0415
+            _TICK_SECONDS,
+            stall_banner,
+            stall_log_line,
+            stall_recovered_log_line,
+        )
 
         last = time.perf_counter()
         while True:
@@ -1948,6 +1953,14 @@ class TextualChatApp(App):
                     self.notify(stall_banner(fired), severity="warning")
                 except Exception:
                     logger.exception("textual chat: loop tripwire notice failed")
+            elif self._loop_tripwire.consume_recovered():
+                # #4797 follow-up (architect finding): default-visible, no
+                # REYN_PROF_DUMP required — everything else this tripwire
+                # writes goes through write_record, a no-op on the shipped
+                # default. logger.info, not .warning, per lead-coder's
+                # ruling: the stall already used the operator's attention
+                # budget once; recovery is good news, not a second alarm.
+                logger.info("textual chat: %s", stall_recovered_log_line())
 
     def on_mount(self) -> None:
         # #3505: #3504 made ``App``'s own background ``ansi_default`` (the

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -141,6 +141,16 @@ class LoopTripwire:
         #: healthy" (this was ``False``) apart, so the durable trace can say
         #: which one happened instead of just stopping either way.
         self._in_stall = False
+        #: One-shot recovery flag for :meth:`consume_recovered` — separate
+        #: from the ``write_record`` call at the same transition (architect
+        #: finding, #4797 follow-up): ``write_record`` is a no-op on the
+        #: shipped default (``REYN_PROF_DUMP`` unset), so recovery was only
+        #: ever visible to an already-armed session. This lets the CALLER
+        #: (:meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.
+        #: _watch_loop_responsiveness`) put a recovery notice on a surface
+        #: that needs no prior setup — the same "visible with the shipped
+        #: config" bar the once-only stall notice already clears.
+        self._just_recovered = False
 
     @property
     def max_lateness_ms(self) -> float:
@@ -151,6 +161,15 @@ class LoopTripwire:
     def fired(self) -> bool:
         """Whether the threshold has been crossed at least once."""
         return self._fired
+
+    def consume_recovered(self) -> bool:
+        """Whether the loop just recovered from a stall — ``True`` at most
+        once per episode, consumed on read (mirrors :meth:`observe`'s own
+        once-only return for the stall side) so a caller logging this on a
+        default-visible surface doesn't repeat it either."""
+        recovered = self._just_recovered
+        self._just_recovered = False
+        return recovered
 
     def observe(self, lateness_ms: float) -> "float | None":
         """Record one tick's lateness; return it the FIRST time it is bad.
@@ -184,6 +203,7 @@ class LoopTripwire:
         if lateness_ms <= self._threshold_ms:
             if self._in_stall:
                 self._in_stall = False
+                self._just_recovered = True
                 write_record("tripwire_recovered", lateness_ms=round(lateness_ms, 1))
             return None
         self._in_stall = True
@@ -226,3 +246,20 @@ def stall_log_line(lateness_ms: float) -> str:
         f"the interface was unresponsive for {lateness_ms / 1000:.1f}s "
         f"— re-run with {_DUMP_ENV}=<path> to record what it was doing"
     )
+
+
+def stall_recovered_log_line() -> str:
+    """The default-visible recovery notice — no ``REYN_PROF_DUMP`` required.
+
+    architect finding (#4797 follow-up): every OTHER new signal this module
+    gained (the repeated ``"tripwire"`` record, ``"tripwire_recovered"``)
+    goes through :func:`write_record`, a no-op on the shipped default. A
+    session that never armed ``REYN_PROF_DUMP`` before a stall — the exact
+    situation #4761's own report was in — got nothing new from that work.
+    This line is deliberately NOT gated on the env var, so "it fired, then
+    it recovered" is readable from an ordinary, unarmed run's own logs —
+    lead-coder ruling: ``logger.info``, not ``.warning`` — the stall itself
+    already used the operator's attention budget once; recovery is good
+    news, not a second alarm.
+    """
+    return "the interface recovered from the stall reported above"

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -46,6 +46,19 @@ _TRIPWIRE_MS = 250.0
 #: a stall a human would notice cannot hide between two ticks.
 _TICK_SECONDS = 0.05
 
+#: Minimum gap between two durable ``write_record("tripwire", ...)`` calls for
+#: the SAME ongoing stall (#4761 ①). Deliberately independent of the
+#: once-only banner/log notice below — that silence is about not burying a
+#: human-facing reply; this one is about the durable record still being able
+#: to answer "did it recover, or keep getting worse?" while nobody is
+#: watching, which is exactly the question a frozen screen cannot answer on
+#: its own. 2s: short enough that a multi-second stall (#4761's own report)
+#: leaves several data points, long enough that a multi-tick stall spanning
+#: seconds doesn't write one record per :data:`_TICK_SECONDS` (20/s) and
+#: flood ``REYN_PROF_DUMP`` — no config knob added for this one, since it
+#: gates a file that is already opt-in behind ``REYN_PROF_DUMP`` itself.
+_RECORD_INTERVAL_S = 2.0
+
 _DUMP_ENV = "REYN_PROF_DUMP"
 
 
@@ -119,6 +132,10 @@ class LoopTripwire:
         self._threshold_ms = threshold_ms
         self._max_lateness_ms = 0.0
         self._fired = False
+        #: Wall-clock time of the last durable ``write_record`` call, or
+        #: ``None`` before the first one — independent of ``_fired`` (#4761
+        #: ①: one flag was gating two different questions).
+        self._last_recorded_monotonic: "float | None" = None
 
     @property
     def max_lateness_ms(self) -> float:
@@ -142,13 +159,31 @@ class LoopTripwire:
         always-visible chrome row, :func:`stall_log_line` for the durable
         record) — wording either one here would make this the place a caller
         has to work around.
+
+        #4761 ①: the once-only rule above governs the RETURN VALUE (what the
+        human-facing banner/log notice does) — it does not also govern the
+        internal :func:`write_record` call. Those answer different questions:
+        the notice is "tell someone now, once," the durable record is "can a
+        later reader tell whether this recovered or kept getting worse,"
+        which silence cannot answer either way. So ``write_record`` keeps
+        firing at :data:`_RECORD_INTERVAL_S` while ``lateness_ms`` stays
+        above threshold, independently of whether this call also returns a
+        value.
         """
         if lateness_ms > self._max_lateness_ms:
             self._max_lateness_ms = lateness_ms
-        if lateness_ms <= self._threshold_ms or self._fired:
+        if lateness_ms <= self._threshold_ms:
+            return None
+        now = time.monotonic()
+        if (
+            self._last_recorded_monotonic is None
+            or now - self._last_recorded_monotonic >= _RECORD_INTERVAL_S
+        ):
+            write_record("tripwire", lateness_ms=round(lateness_ms, 1))
+            self._last_recorded_monotonic = now
+        if self._fired:
             return None
         self._fired = True
-        write_record("tripwire", lateness_ms=round(lateness_ms, 1))
         return lateness_ms
 
 

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -136,6 +136,11 @@ class LoopTripwire:
         #: ``None`` before the first one — independent of ``_fired`` (#4761
         #: ①: one flag was gating two different questions).
         self._last_recorded_monotonic: "float | None" = None
+        #: Whether the most recent tick was above threshold — lets a healthy
+        #: tick tell "recovered" (this was ``True``) from "was already
+        #: healthy" (this was ``False``) apart, so the durable trace can say
+        #: which one happened instead of just stopping either way.
+        self._in_stall = False
 
     @property
     def max_lateness_ms(self) -> float:
@@ -168,12 +173,20 @@ class LoopTripwire:
         which silence cannot answer either way. So ``write_record`` keeps
         firing at :data:`_RECORD_INTERVAL_S` while ``lateness_ms`` stays
         above threshold, independently of whether this call also returns a
-        value.
+        value — AND a healthy tick that follows a stall writes one
+        ``"tripwire_recovered"`` record, for the same reason: a trace that
+        just stops leaves "it recovered" and "the process died mid-stall"
+        looking identical, the same silence-hides-two-states shape #4761's
+        original defect had, one level up.
         """
         if lateness_ms > self._max_lateness_ms:
             self._max_lateness_ms = lateness_ms
         if lateness_ms <= self._threshold_ms:
+            if self._in_stall:
+                self._in_stall = False
+                write_record("tripwire_recovered", lateness_ms=round(lateness_ms, 1))
             return None
+        self._in_stall = True
         now = time.monotonic()
         if (
             self._last_recorded_monotonic is None

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -21,7 +21,7 @@ import pytest
 from textual.widgets import Tab
 from textual_flowview import FlowView
 
-from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat import TextualChatApp, loop_probe
 from reyn.interfaces.inline.textual_chat.chrome import StatusLine
 from reyn.interfaces.inline.textual_chat.loop_probe import (
     LoopTripwire,
@@ -190,6 +190,55 @@ def test_it_speaks_once_with_a_magnitude_and_a_next_step() -> None:
     assert "1.8s" in stall_log_line(first)
     assert "REYN_PROF_DUMP" in stall_log_line(first), (
         "the durable record must say how to capture the detail next time"
+    )
+
+
+def test_the_durable_record_keeps_landing_while_the_banner_stays_quiet(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Tier 2: #4761 ① — one ``_fired`` flag used to gate BOTH the once-only
+    human notice AND the durable ``write_record`` call, so a stall lasting
+    past the first tick left no durable trace of whether it recovered or
+    kept getting worse — exactly the question a frozen screen cannot answer
+    on its own. The once-only rule stays for the notice (unchanged by this
+    fix — see ``test_it_speaks_once_with_a_magnitude_and_a_next_step``
+    above); the durable record must keep landing independently, at
+    :data:`~reyn.interfaces.inline.textual_chat.loop_probe._RECORD_INTERVAL_S`
+    granularity, for as long as the stall continues.
+    """
+    import json
+
+    target = tmp_path / "probe.jsonl"
+    monkeypatch.setenv("REYN_PROF_DUMP", str(target))
+
+    clock = [1000.0]
+    monkeypatch.setattr(loop_probe.time, "monotonic", lambda: clock[0])
+
+    tripwire = LoopTripwire(threshold_ms=250.0)
+
+    first = tripwire.observe(1800.0)  # crosses — records AND fires the notice
+    clock[0] += 0.5  # inside the interval — still stalled, must NOT record yet
+    still_quiet = tripwire.observe(1900.0)
+    clock[0] += loop_probe._RECORD_INTERVAL_S  # interval elapsed, still stalled
+    still_stalled = tripwire.observe(2000.0)
+    clock[0] += loop_probe._RECORD_INTERVAL_S
+    recovered = tripwire.observe(50.0)  # back under threshold — no record
+
+    assert first is not None, "the first crossing must still fire the notice"
+    assert still_quiet is None, "the once-only notice must not repeat mid-interval"
+    assert still_stalled is None, (
+        "the notice stays quiet after the first crossing regardless of the "
+        "record interval — this fix only changes the durable record's cadence"
+    )
+    assert recovered is None
+
+    records = [
+        json.loads(line) for line in target.read_text(encoding="utf-8").splitlines()
+    ]
+    lateness_values = [r["lateness_ms"] for r in records if r["kind"] == "tripwire"]
+    assert lateness_values == [1800.0, 2000.0], (
+        "expected exactly the first crossing and the one past the interval — "
+        f"the mid-interval tick and the recovered tick must not add entries: {records!r}"
     )
 
 

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -240,6 +240,50 @@ def test_the_durable_record_keeps_landing_while_the_banner_stays_quiet(
         "expected exactly the first crossing and the one past the interval — "
         f"the mid-interval tick and the recovered tick must not add entries: {records!r}"
     )
+    recovered_lateness = [
+        r["lateness_ms"] for r in records if r["kind"] == "tripwire_recovered"
+    ]
+    assert recovered_lateness == [50.0], (
+        "the recovered tick must write exactly ONE tripwire_recovered record — "
+        "without it, a trace that just stops leaves 'it recovered' and 'the "
+        f"process died mid-stall' looking identical: {records!r}"
+    )
+
+
+def test_recovery_is_recorded_only_once_per_episode(monkeypatch, tmp_path: Path) -> None:
+    """Tier 2: #4761 ① follow-up — a SECOND healthy tick after recovery must
+    not write a second ``tripwire_recovered`` record (it was already healthy,
+    nothing changed), and a SECOND stall episode must be able to record its
+    own recovery independently of the first."""
+    import json
+
+    target = tmp_path / "probe.jsonl"
+    monkeypatch.setenv("REYN_PROF_DUMP", str(target))
+
+    clock = [2000.0]
+    monkeypatch.setattr(loop_probe.time, "monotonic", lambda: clock[0])
+
+    tripwire = LoopTripwire(threshold_ms=250.0)
+
+    tripwire.observe(1800.0)  # episode 1: stall
+    clock[0] += 1.0
+    tripwire.observe(50.0)  # episode 1: recovers
+    clock[0] += 1.0
+    tripwire.observe(60.0)  # still healthy — no NEW recovery
+    clock[0] += 1.0
+    tripwire.observe(1700.0)  # episode 2: stall again
+    clock[0] += 1.0
+    tripwire.observe(40.0)  # episode 2: recovers
+
+    records = [
+        json.loads(line) for line in target.read_text(encoding="utf-8").splitlines()
+    ]
+    recovered_lateness = [
+        r["lateness_ms"] for r in records if r["kind"] == "tripwire_recovered"
+    ]
+    assert recovered_lateness == [50.0, 40.0], (
+        f"expected exactly one recovery record per episode: {records!r}"
+    )
 
 
 def test_the_worst_lateness_survives_the_tick_that_saw_it() -> None:

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -29,6 +29,7 @@ from reyn.interfaces.inline.textual_chat.loop_probe import (
     environment_axes,
     stall_banner,
     stall_log_line,
+    stall_recovered_log_line,
     write_record,
 )
 from reyn.interfaces.transport.client_transport import ClientTransport
@@ -283,6 +284,63 @@ def test_recovery_is_recorded_only_once_per_episode(monkeypatch, tmp_path: Path)
     ]
     assert recovered_lateness == [50.0, 40.0], (
         f"expected exactly one recovery record per episode: {records!r}"
+    )
+
+
+def test_consume_recovered_needs_no_dump_env_at_all(monkeypatch) -> None:
+    """Tier 2: #4797 follow-up (architect finding) — ``consume_recovered()``
+    is a plain in-memory flag, reachable with ``REYN_PROF_DUMP`` unset the
+    whole time. Every OTHER new signal added for #4761 ① (the repeated
+    ``"tripwire"`` record, ``"tripwire_recovered"``) goes through
+    :func:`write_record`, a no-op on the shipped default — a session that
+    never armed the dump got nothing new from that work, the exact
+    "visible with the shipped config?" gap CLAUDE.md names. This one does
+    not depend on the file at all.
+    """
+    monkeypatch.delenv("REYN_PROF_DUMP", raising=False)
+    tripwire = LoopTripwire(threshold_ms=250.0)
+
+    assert tripwire.consume_recovered() is False, "nothing has stalled yet"
+    tripwire.observe(1800.0)  # stall
+    assert tripwire.consume_recovered() is False, "still stalled — not recovered"
+    tripwire.observe(50.0)  # recovers
+    assert tripwire.consume_recovered() is True
+    assert tripwire.consume_recovered() is False, (
+        "consuming it must clear the flag — a second read must not repeat it"
+    )
+    assert "recovered" in stall_recovered_log_line()
+
+
+@pytest.mark.asyncio
+async def test_recovery_notice_is_visible_without_arming_the_dump(caplog, monkeypatch) -> None:
+    """Tier 2b: #4797 follow-up (architect finding), REACHED from the running
+    app with REYN_PROF_DUMP deliberately left UNSET — the exact "unarmed
+    session" situation #4761's own report was in. The stall notice already
+    proved reachable in ``test_the_app_actually_shows_the_notice_when_the_
+    loop_stalls`` above; this proves the RECOVERY notice is too, without
+    which "it fired, then went quiet" was indistinguishable from "it fired,
+    then the process died" on a session nobody armed in advance.
+    """
+    import logging
+    import time
+
+    monkeypatch.delenv("REYN_PROF_DUMP", raising=False)
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    logger_name = "reyn.interfaces.inline.textual_chat.app"
+    with caplog.at_level(logging.INFO, logger=logger_name):
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            # A synchronous sleep stalls the loop; the ticks afterward are
+            # healthy again, which is what the recovery notice fires on.
+            time.sleep(0.4)
+            for _ in range(6):
+                await pilot.pause()
+
+    assert "unresponsive" in caplog.text, "the stall itself must still be reported"
+    assert "recovered" in caplog.text, (
+        "the recovery notice must be readable with REYN_PROF_DUMP unset — "
+        f"the exact situation #4761's own report was in: {caplog.text!r}"
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — follow-up to #4797 (merged): architect finding, relayed via lead-coder.

## The gap

Every new signal #4797 added (the repeated `"tripwire"` `write_record` call, `"tripwire_recovered"`) goes through `write_record`, a no-op on the shipped default (`REYN_PROF_DUMP` unset). A session that never armed the dump BEFORE a stall — the exact situation #4761's own report was in, and tui-coder's own verbatim finding on that issue ("would capture what the interface was doing, but only if set BEFORE the hang occurred") — got nothing new from #4797 at all. CLAUDE.md's own second question, named the same night: "Is this visible with the shipped config? If seeing it requires changing a setting, it is not visible."

## Fix (lead-coder's ruling)

Option A of architect's three: log the recovery specifically (not the repeated stall record — that stays `write_record`-only, per-tick during an ongoing stall would be noisy at default visibility), via `logger.info` (not `.warning` — the stall already used the operator's attention budget once).

`LoopTripwire` tracks a one-shot `_just_recovered` flag alongside `_in_stall`, exposed via `consume_recovered()` — a plain in-memory read, no file, no env var involved. The `app.py` call site logs it once via `logger.info` + the new `stall_recovered_log_line()` when `observe()` returns `None` but a recovery just happened.

## Test plan

- [x] `test_consume_recovered_needs_no_dump_env_at_all` — `consume_recovered()`'s own once-per-episode contract, `REYN_PROF_DUMP` deliberately unset throughout.
- [x] `test_recovery_notice_is_visible_without_arming_the_dump` — real `run_test()`, `REYN_PROF_DUMP` unset, `caplog` — proves the notice is actually REACHED from an unarmed running app, not just correct in isolation (mirrors the existing sibling test's own "Tier 2b: REACHED from the running app, not just correct" framing).
- [x] Strip-falsified: removing just the `app.py` call site (leaving `loop_probe.py`'s mechanism intact) flips the integration test red with the real missing-text assertion (`'recovered' in caplog.text` fails, `'unresponsive'` still present) — not an import error, a genuine behavioral miss.
- [x] All 13 tests in `test_loop_probe_3539.py` green.
- [x] `ruff check .`, `scripts/test_tier_audit.py --strict`, `scripts/verify_module_docstrings.py`, `scripts/mypy_ratchet.py` — all green.
- [ ] Visual/TTY (standing waiver applies — merge does not wait on this)

## Noted, not actioned

architect separately flagged that `_RECORD_INTERVAL_S` (added in #4797) is a new constant — my own PR framing at the time said "no backoff constant needed" for choosing face-separation over backoff, which this doesn't quite achieve (the constant governs record CADENCE, not the semantic once-only threshold, so the mismatch is real but low-stakes per architect's own read). Left as-is; recorded here for the trail, not part of this PR's scope.

part of #4761 (② — the App pump heartbeat — is next; unrelated to this default-visibility gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)