### PR TITLE
fix(#4761): make the recovery notice visible without arming REYN_PROF_DUMP

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1933,7 +1933,12 @@ class TextualChatApp(App):
         import asyncio  # noqa: PLC0415
         import time  # noqa: PLC0415
 
-        from .loop_probe import _TICK_SECONDS, stall_banner, stall_log_line  # noqa: PLC0415
+        from .loop_probe import (  # noqa: PLC0415
+            _TICK_SECONDS,
+            stall_banner,
+            stall_log_line,
+            stall_recovered_log_line,
+        )
 
         last = time.perf_counter()
         while True:
@@ -1948,6 +1953,14 @@ class TextualChatApp(App):
                     self.notify(stall_banner(fired), severity="warning")
                 except Exception:
                     logger.exception("textual chat: loop tripwire notice failed")
+            elif self._loop_tripwire.consume_recovered():
+                # #4797 follow-up (architect finding): default-visible, no
+                # REYN_PROF_DUMP required — everything else this tripwire
+                # writes goes through write_record, a no-op on the shipped
+                # default. logger.info, not .warning, per lead-coder's
+                # ruling: the stall already used the operator's attention
+                # budget once; recovery is good news, not a second alarm.
+                logger.info("textual chat: %s", stall_recovered_log_line())
 
     def on_mount(self) -> None:
         # #3505: #3504 made ``App``'s own background ``ansi_default`` (the

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -141,6 +141,16 @@ class LoopTripwire:
         #: healthy" (this was ``False``) apart, so the durable trace can say
         #: which one happened instead of just stopping either way.
         self._in_stall = False
+        #: One-shot recovery flag for :meth:`consume_recovered` — separate
+        #: from the ``write_record`` call at the same transition (architect
+        #: finding, #4797 follow-up): ``write_record`` is a no-op on the
+        #: shipped default (``REYN_PROF_DUMP`` unset), so recovery was only
+        #: ever visible to an already-armed session. This lets the CALLER
+        #: (:meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.
+        #: _watch_loop_responsiveness`) put a recovery notice on a surface
+        #: that needs no prior setup — the same "visible with the shipped
+        #: config" bar the once-only stall notice already clears.
+        self._just_recovered = False
 
     @property
     def max_lateness_ms(self) -> float:
@@ -151,6 +161,15 @@ class LoopTripwire:
     def fired(self) -> bool:
         """Whether the threshold has been crossed at least once."""
         return self._fired
+
+    def consume_recovered(self) -> bool:
+        """Whether the loop just recovered from a stall — ``True`` at most
+        once per episode, consumed on read (mirrors :meth:`observe`'s own
+        once-only return for the stall side) so a caller logging this on a
+        default-visible surface doesn't repeat it either."""
+        recovered = self._just_recovered
+        self._just_recovered = False
+        return recovered
 
     def observe(self, lateness_ms: float) -> "float | None":
         """Record one tick's lateness; return it the FIRST time it is bad.
@@ -184,6 +203,7 @@ class LoopTripwire:
         if lateness_ms <= self._threshold_ms:
             if self._in_stall:
                 self._in_stall = False
+                self._just_recovered = True
                 write_record("tripwire_recovered", lateness_ms=round(lateness_ms, 1))
             return None
         self._in_stall = True
@@ -226,3 +246,20 @@ def stall_log_line(lateness_ms: float) -> str:
         f"the interface was unresponsive for {lateness_ms / 1000:.1f}s "
         f"— re-run with {_DUMP_ENV}=<path> to record what it was doing"
     )
+
+
+def stall_recovered_log_line() -> str:
+    """The default-visible recovery notice — no ``REYN_PROF_DUMP`` required.
+
+    architect finding (#4797 follow-up): every OTHER new signal this module
+    gained (the repeated ``"tripwire"`` record, ``"tripwire_recovered"``)
+    goes through :func:`write_record`, a no-op on the shipped default. A
+    session that never armed ``REYN_PROF_DUMP`` before a stall — the exact
+    situation #4761's own report was in — got nothing new from that work.
+    This line is deliberately NOT gated on the env var, so "it fired, then
+    it recovered" is readable from an ordinary, unarmed run's own logs —
+    lead-coder ruling: ``logger.info``, not ``.warning`` — the stall itself
+    already used the operator's attention budget once; recovery is good
+    news, not a second alarm.
+    """
+    return "the interface recovered from the stall reported above"

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -328,13 +328,21 @@ async def test_recovery_notice_is_visible_without_arming_the_dump(caplog, monkey
     transport = QueueTransport()
     app = TextualChatApp(transport=transport)
     logger_name = "reyn.interfaces.inline.textual_chat.app"
+    # Derived from the real threshold, not a bare literal — a margin large
+    # enough to clear it stays correct if _TRIPWIRE_MS ever moves; 150ms of
+    # headroom mirrors the sibling test's own 250.0 -> 0.4s margin above.
+    stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
     with caplog.at_level(logging.INFO, logger=logger_name):
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()
             # A synchronous sleep stalls the loop; the ticks afterward are
             # healthy again, which is what the recovery notice fires on.
-            time.sleep(0.4)
-            for _ in range(6):
+            time.sleep(stall_seconds)
+            # No test-owned wait budget (CLAUDE.md/testing.md § Time): wait
+            # for the actual condition, unbounded — CI's own --timeout=120
+            # is the kill switch if the wiring is ever broken and this never
+            # arrives.
+            while "recovered" not in caplog.text:
                 await pilot.pause()
 
     assert "unresponsive" in caplog.text, "the stall itself must still be reported"

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -29,6 +29,7 @@ from reyn.interfaces.inline.textual_chat.loop_probe import (
     environment_axes,
     stall_banner,
     stall_log_line,
+    stall_recovered_log_line,
     write_record,
 )
 from reyn.interfaces.transport.client_transport import ClientTransport
@@ -283,6 +284,63 @@ def test_recovery_is_recorded_only_once_per_episode(monkeypatch, tmp_path: Path)
     ]
     assert recovered_lateness == [50.0, 40.0], (
         f"expected exactly one recovery record per episode: {records!r}"
+    )
+
+
+def test_consume_recovered_needs_no_dump_env_at_all(monkeypatch) -> None:
+    """Tier 2: #4797 follow-up (architect finding) — ``consume_recovered()``
+    is a plain in-memory flag, reachable with ``REYN_PROF_DUMP`` unset the
+    whole time. Every OTHER new signal added for #4761 ① (the repeated
+    ``"tripwire"`` record, ``"tripwire_recovered"``) goes through
+    :func:`write_record`, a no-op on the shipped default — a session that
+    never armed the dump got nothing new from that work, the exact
+    "visible with the shipped config?" gap CLAUDE.md names. This one does
+    not depend on the file at all.
+    """
+    monkeypatch.delenv("REYN_PROF_DUMP", raising=False)
+    tripwire = LoopTripwire(threshold_ms=250.0)
+
+    assert tripwire.consume_recovered() is False, "nothing has stalled yet"
+    tripwire.observe(1800.0)  # stall
+    assert tripwire.consume_recovered() is False, "still stalled — not recovered"
+    tripwire.observe(50.0)  # recovers
+    assert tripwire.consume_recovered() is True
+    assert tripwire.consume_recovered() is False, (
+        "consuming it must clear the flag — a second read must not repeat it"
+    )
+    assert "recovered" in stall_recovered_log_line()
+
+
+@pytest.mark.asyncio
+async def test_recovery_notice_is_visible_without_arming_the_dump(caplog, monkeypatch) -> None:
+    """Tier 2b: #4797 follow-up (architect finding), REACHED from the running
+    app with REYN_PROF_DUMP deliberately left UNSET — the exact "unarmed
+    session" situation #4761's own report was in. The stall notice already
+    proved reachable in ``test_the_app_actually_shows_the_notice_when_the_
+    loop_stalls`` above; this proves the RECOVERY notice is too, without
+    which "it fired, then went quiet" was indistinguishable from "it fired,
+    then the process died" on a session nobody armed in advance.
+    """
+    import logging
+    import time
+
+    monkeypatch.delenv("REYN_PROF_DUMP", raising=False)
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    logger_name = "reyn.interfaces.inline.textual_chat.app"
+    with caplog.at_level(logging.INFO, logger=logger_name):
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            # A synchronous sleep stalls the loop; the ticks afterward are
+            # healthy again, which is what the recovery notice fires on.
+            time.sleep(0.4)
+            for _ in range(6):
+                await pilot.pause()
+
+    assert "unresponsive" in caplog.text, "the stall itself must still be reported"
+    assert "recovered" in caplog.text, (
+        "the recovery notice must be readable with REYN_PROF_DUMP unset — "
+        f"the exact situation #4761's own report was in: {caplog.text!r}"
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — replaces #4800 (closed — real merge conflict, see that PR's closing comment for why). Identical diff, rebased onto fresh `main`.

## The gap

Every new signal #4797 added (the repeated `"tripwire"` `write_record` call, `"tripwire_recovered"`) goes through `write_record`, a no-op on the shipped default (`REYN_PROF_DUMP` unset). A session that never armed the dump BEFORE a stall — the exact situation #4761's own report was in, and tui-coder's own verbatim finding on that issue ("would capture what the interface was doing, but only if set BEFORE the hang occurred") — got nothing new from #4797 at all. CLAUDE.md's own second question, named the same night: "Is this visible with the shipped config? If seeing it requires changing a setting, it is not visible."

## Fix (lead-coder's ruling)

Option A of architect's three: log the recovery specifically (not the repeated stall record — that stays `write_record`-only), via `logger.info` (not `.warning` — the stall already used the operator's attention budget once).

`LoopTripwire` tracks a one-shot `_just_recovered` flag alongside `_in_stall`, exposed via `consume_recovered()` — a plain in-memory read, no file, no env var involved. The `app.py` call site logs it once via `logger.info` + the new `stall_recovered_log_line()` when `observe()` returns `None` but a recovery just happened.

## Test plan

- [x] `test_consume_recovered_needs_no_dump_env_at_all` — `consume_recovered()`'s own once-per-episode contract, `REYN_PROF_DUMP` deliberately unset throughout.
- [x] `test_recovery_notice_is_visible_without_arming_the_dump` — real `run_test()`, `REYN_PROF_DUMP` unset, `caplog` — proves the notice is actually REACHED from an unarmed running app.
- [x] Strip-falsified: removing just the `app.py` call site (leaving `loop_probe.py`'s mechanism intact) flips the integration test red with the real missing-text assertion, not an import error.
- [x] All 13 tests in `test_loop_probe_3539.py` green.
- [x] `ruff check .`, `scripts/test_tier_audit.py --strict`, `scripts/verify_module_docstrings.py`, `scripts/mypy_ratchet.py` — all green.
- [x] `git diff origin/main --stat` re-verified clean/isolated after the rebase.
- [ ] Visual/TTY (standing waiver applies — merge does not wait on this)

part of #4761 (② — the App pump heartbeat — is next; unrelated to this default-visibility gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] 🔴 (lead-coder、確認済み) test ② の `range(6)` は body の待ち予算（CLAUDE.md 明文の禁止） — 「recovered が caplog に現れるまで」無界に待つ形へ。併せて `time.sleep(0.4)` の 0.4 を `_TRIPWIRE_MS` から導出する（裸の数だと閾値変更で理由なく壊れる）。
