### PR TITLE
docs(session-construction): document #4771's rewind-path quiesce timeout

### DIFF
--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -231,6 +231,21 @@ Adjacent recovery-adjacent state that stays inline (not builder-owned):
   re-entrancy case (a tracked task itself calling `aclose()`, e.g. the
   ephemeral-vanish task's own `await_quiescent` call) and exactly which
   guarantee that case weakens.
+- **Wall-clock bound on the whole call, rewind-path only** (`#4771`) — the
+  RE-DRAIN LOOP above is bounded by round count, not by time; `await_quiescent()`
+  itself stays unbounded by design (its own docstring's "critical invariant":
+  returning early risks a straggler append landing past the reset-record).
+  `AgentRegistry.checkout`'s step 3 wraps each session's call in
+  `_await_quiescent_bounded`, an `asyncio.wait_for` with a per-session bound
+  (`_quiesce_bound_s` — one `_MCP_CLIENT_CLOSE_WORST_CASE_S` unit, 6.5s, per
+  currently-held MCP connection, floored at one unit for a connection-less
+  session). On timeout it raises `RewindQuiesceTimeoutError` and `checkout`
+  aborts BEFORE the reset-record append (step 4) — fail-safe, not fail-open:
+  unlike `shutdown()` (safe to abandon a straggler because the process exits
+  right after), a rewound session keeps running, so proceeding past an
+  unquiesced session risks the exact silent-corruption class this whole
+  mechanism exists to prevent. Scoped to the rewind/`checkout` call site only
+  — `await_quiescent()` itself is unchanged for every other caller.
 
 ## Family 3 — Hook-event / reactivity
 


### PR DESCRIPTION
**[docs-maintainer]** — part of #4771

## What

`docs/reference/runtime/session-construction.md`'s "RE-DRAIN LOOP" bullet describes `await_quiescent`'s rewind usage in real depth (the round-bounded fixpoint drain, the WAL-appendability filtering axis) but predates #4799 (merged this session), which added a NEW wall-clock bound at the `checkout()` call site: `_await_quiescent_bounded` wraps the whole `await_quiescent()` call in `asyncio.wait_for`, and on timeout raises `RewindQuiesceTimeoutError`, aborting the rewind before the reset-record append — fail-safe, not fail-open.

The doc already goes deep into this exact mechanism's rewind-path behavior, so a reader relying on it now gets an incomplete picture (missing the new abort-on-timeout possibility) without this addition. Added a bullet distinguishing the pre-existing round-bound (inside `TrackedTaskSet.aclose`) from this new, separate time-bound (scoped to the rewind/`checkout` call site only — `await_quiescent()` itself is unchanged for every other caller).

Verified directly against `src/reyn/runtime/registry.py` on `origin/main` (`_await_quiescent_bounded`, `_quiesce_bound_s`, `_MCP_CLIENT_CLOSE_WORST_CASE_S`, `checkout`'s step 3 comment), not against #4799's PR body prose.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no `Aborted` line (pre-existing ja-anchor INFO gaps, unrelated)
- [x] `python scripts/check_doc_anchors.py` — exit 0, no dangling anchors into published pages
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Closing-keyword self-grep on commit message and this PR body — clean
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Visual — N/A, prose-only addition
