### PR TITLE
fix(#4761): correct recovery notice to logger.warning (lead-coder reversal)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1957,10 +1957,19 @@ class TextualChatApp(App):
                 # #4797 follow-up (architect finding): default-visible, no
                 # REYN_PROF_DUMP required — everything else this tripwire
                 # writes goes through write_record, a no-op on the shipped
-                # default. logger.info, not .warning, per lead-coder's
-                # ruling: the stall already used the operator's attention
-                # budget once; recovery is good news, not a second alarm.
-                logger.info("textual chat: %s", stall_recovered_log_line())
+                # default. logger.warning, matching the stall notice above
+                # (revised from an initial logger.info ruling, self-caught
+                # and corrected before landing: the interactive CUI's own
+                # _setup_interactive_logging sets the ROOT logger's level to
+                # WARNING, so an INFO call from a logger with no override of
+                # its own is silently dropped in the real interactive path —
+                # not "quieter", genuinely absent. Raising just this logger's
+                # level was rejected too: it would make "the operator's
+                # chosen floor" mean two different things depending which
+                # module emitted the record. Stall and recovery are the
+                # start and end of ONE episode; one line per episode at the
+                # same severity is not a second alarm).
+                logger.warning("textual chat: %s", stall_recovered_log_line())
 
     def on_mount(self) -> None:
         # #3505: #3504 made ``App``'s own background ``ansi_default`` (the

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -257,9 +257,16 @@ def stall_recovered_log_line() -> str:
     session that never armed ``REYN_PROF_DUMP`` before a stall — the exact
     situation #4761's own report was in — got nothing new from that work.
     This line is deliberately NOT gated on the env var, so "it fired, then
-    it recovered" is readable from an ordinary, unarmed run's own logs —
-    lead-coder ruling: ``logger.info``, not ``.warning`` — the stall itself
-    already used the operator's attention budget once; recovery is good
-    news, not a second alarm.
+    it recovered" is readable from an ordinary, unarmed run's own logs.
+
+    The caller (``app.py``'s ``_watch_loop_responsiveness``) logs this at
+    ``logger.warning`` — same severity as the stall notice, not
+    ``.info``. An initial ``.info`` ruling was self-caught and reverted
+    before landing: the interactive CUI's own ``_setup_interactive_logging``
+    sets the ROOT logger's level to WARNING, so an INFO record from a
+    logger with no override of its own never reaches the file at all —
+    not quieter, genuinely absent. Stall and recovery are the start and
+    end of ONE episode; one WARNING line per episode is not a second
+    alarm.
     """
     return "the interface recovered from the stall reported above"

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -332,7 +332,7 @@ async def test_recovery_notice_is_visible_without_arming_the_dump(caplog, monkey
     # enough to clear it stays correct if _TRIPWIRE_MS ever moves; 150ms of
     # headroom mirrors the sibling test's own 250.0 -> 0.4s margin above.
     stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
-    with caplog.at_level(logging.INFO, logger=logger_name):
+    with caplog.at_level(logging.WARNING, logger=logger_name):
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()
             # A synchronous sleep stalls the loop; the ticks afterward are
@@ -349,6 +349,66 @@ async def test_recovery_notice_is_visible_without_arming_the_dump(caplog, monkey
     assert "recovered" in caplog.text, (
         "the recovery notice must be readable with REYN_PROF_DUMP unset — "
         f"the exact situation #4761's own report was in: {caplog.text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recovery_notice_survives_the_real_interactive_logging_floor(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2b: #4801 follow-up (self-caught, measured, then corrected) —
+    REACHED from the running app under the REAL production logging floor,
+    not a hand-written log call standing in for it.
+
+    The interactive CUI's own startup (``interfaces/cli/commands/chat.py``'s
+    ``_setup_interactive_logging``) calls ``logging.basicConfig(level=
+    logging.WARNING, force=True, ...)``, setting the ROOT logger's level.
+    ``caplog.at_level(...)`` — what the sibling test above uses — overrides
+    exactly that floor FOR THE TEST, which is why an earlier version of
+    this PR's own ``logger.info`` recovery notice passed its own test while
+    being silently dropped in the real interactive path (measured
+    directly). The fix was raising the call site's severity to match the
+    stall notice's ``logger.warning``, not raising this logger's level —
+    so this test drives the SAME ``_watch_loop_responsiveness`` code path
+    the sibling test does, but reads the notice back from a real log FILE
+    under a reconstructed real floor, with no ``caplog`` involved at any
+    point. A test that called ``logger.warning`` directly here would only
+    prove the assertion, not that app.py's own call site still does.
+    """
+    import logging
+    import time
+
+    logfile = tmp_path / "reyn.log"
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    monkeypatch.delenv("REYN_PROF_DUMP", raising=False)
+    try:
+        logging.basicConfig(
+            filename=str(logfile), level=logging.WARNING, force=True,
+        )
+        stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
+        transport = QueueTransport()
+        app = TextualChatApp(transport=transport)
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            time.sleep(stall_seconds)
+            # No test-owned wait budget: wait on the file's actual content,
+            # unbounded — CI's own --timeout=120 is the kill switch.
+            while "recovered" not in logfile.read_text(encoding="utf-8"):
+                await pilot.pause()
+    finally:
+        for handler in root.handlers:
+            if handler not in saved_handlers:
+                handler.close()
+        root.handlers = saved_handlers
+        root.setLevel(saved_level)
+
+    content = logfile.read_text(encoding="utf-8")
+    assert "unresponsive" in content, "the stall notice must reach the file under the real floor"
+    assert "recovered" in content, (
+        "the recovery notice must reach the file under the real floor too — "
+        f"both are logger.warning, the same severity: {content!r}"
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — follow-up to #4801 (merged). Two things landed together: a severity correction, and a fix to the test that let the original miss slip through.

## The mistake and the reversal

#4801's own `logger.info` call for the recovery notice was based on a severity preference ("recovery is good news, not a second alarm") made without knowing `interfaces/cli/commands/chat.py`'s `_setup_interactive_logging` sets the ROOT logger's level to WARNING via `logging.basicConfig(..., force=True)`. Measured directly: under that real floor, `logger.info` from a logger with no override writes nothing to the file at all; `logger.warning` does. #4801's own test passed anyway because `caplog.at_level(logging.INFO, logger=...)` overrides exactly that floor for the test — the test measured a different path than production takes.

lead-coder rejected the first fix I proposed (raising just this logger's own level above the root floor) — "the operator's chosen floor" would mean two different things depending which module emitted the record — and ruled: match the stall notice's `logger.warning`. Stall and recovery are the start and end of ONE episode; one WARNING line per episode at matching severity is not a second alarm.

## The test fix

My own first regression-guard test for this called `logger.warning` directly rather than through the real `_watch_loop_responsiveness` call site — it passed even with the fix reverted locally (a test that proves the assertion, not that the real code still makes it true). Rewritten as a full `app.run_test()` integration test under a reconstructed real logging floor (no `caplog` anywhere), waiting unboundedly on the log FILE's own content.

## Test plan

- [x] Strip-falsified against the REAL `app.py` call site: reverting `.warning` back to `.info` now produces a genuine hang (the wait condition never arrives) — confirmed by direct execution, manually killed after 20s (CI's own `--timeout=120` is the intended backstop, not a test-owned budget).
- [x] All 14 tests in `test_loop_probe_3539.py` green.
- [x] `ruff check .`, `scripts/test_tier_audit.py --strict`, `scripts/verify_module_docstrings.py`, `scripts/mypy_ratchet.py` — all green.
- [x] `git diff origin/main --stat` re-verified clean/isolated after a rebase (this branch was recreated on fresh `main` after #4801/#4799/#4803 landed underneath the working branch).
- [ ] Visual/TTY (standing waiver applies — merge does not wait on this)

part of #4761 (② — the App pump heartbeat — is next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)