### PR TITLE
docs(#4801): verification-hazards §18 C — config-layer inert, not just declaration-layer

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -941,14 +941,11 @@ the floor being tested, so a test built on it measures a different path
 than production takes, and can stay green while the record it asserts on
 never reaches a real file. #4801's own regression test did exactly this
 and passed; #4804 rewrote it under a reconstructed production floor,
-reading the file, with no `caplog` anywhere. Architect's own framing:
-*the firing surface — does the call exist and get reached — was confirmed;
-the surviving surface — does that severity reach the output — was not*
-(発火する面は確かめた／生き残る面は確かめなかった; 検査した面 ≠ 効く面). Per
-architect's account, the same surface passed three separate people's
-review for three separate reasons; what stopped it was not an additional
-reviewer, but e2e-coder's own measurement, taken ahead of starting the
-next, unrelated task.
+reading the file, with no `caplog` anywhere: *the firing surface — does
+the call exist and get reached — was confirmed; the surviving surface —
+does that severity reach the output — was not.* #4801 passed review and
+merged; #4804 then overturned it via the author's own measurement, not an
+additional reviewer catching what the first review missed.
 
 **Apply**: before trusting a claim, ask which of the three premises it
 depends on is actually established — that the named thing EXISTS (resolve

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -919,15 +919,47 @@ resolution, not on the source token — a real, computable comparison for
 "can a human read this," which is a strictly smaller question than "does
 this declaration do anything at all."
 
+**A second instance splits an axis the first one didn't need: what layer
+does the gating.** `ActivityRow`'s `@quiet@` was inert on the declaration's
+OWN layer — the CSS existed, resolved, and its resolved value happened to
+match the surrounding text. #4801's `logger.info` call for a stall-recovery
+notice held every premise A and B ask about: the call was real, reachable,
+and the right call for its own severity reasoning. It still wrote nothing
+to the operator-facing log file, because a DIFFERENT file, one layer up,
+gates it — `interfaces/cli/commands/chat.py`'s `_setup_interactive_logging`
+sets the ROOT logger's floor to WARNING via `logging.basicConfig(...,
+force=True)`, so an `INFO` record from a logger with no override of its own
+never reaches the file at all (#4801, severity reversed to `.warning` by
+#4804). This is still C — the object exists, is the right object, and has
+no observable effect — but "strip it and watch for a change" doesn't apply
+here the way it did for the CSS token: there is no signal for a strip to
+remove, because nothing was reaching the output before the strip either.
+**The detection technique has to move with the axis**: reconstruct the
+REAL floor (call the same `basicConfig` production does) and read the
+actual log FILE, not `caplog` — `caplog.at_level(...)` overrides exactly
+the floor being tested, so a test built on it measures a different path
+than production takes, and can stay green while the record it asserts on
+never reaches a real file. #4801's own regression test did exactly this
+and passed; #4804 rewrote it under a reconstructed production floor,
+reading the file, with no `caplog` anywhere. Architect's own framing:
+*the firing surface — does the call exist and get reached — was confirmed;
+the surviving surface — does that severity reach the output — was not*
+(発火する面は確かめた／生き残る面は確かめなかった; 検査した面 ≠ 効く面). Per
+architect's account, the same surface passed three separate people's
+review for three separate reasons; what stopped it was not an additional
+reviewer, but e2e-coder's own measurement, taken ahead of starting the
+next, unrelated task.
+
 **Apply**: before trusting a claim, ask which of the three premises it
 depends on is actually established — that the named thing EXISTS (resolve
 the symbol, don't grep for it), that what was MEASURED is the thing the
 claim is about (prove identity — version, tree, kind — before trusting the
 result), or that a real, correctly-identified thing has an observable
-EFFECT (strip it and watch for a change, in the narrowest domain where that
-comparison is computable — not as a general claim). A `0` or a clean run
-answers only the one you actually checked; treat an unestablished premise
-as unmeasured, not as confirmed absent.
+EFFECT (strip it and watch for a change when the object's own layer gates
+it; reconstruct the real floor and read the real output, not a test
+harness's override of that floor, when a SEPARATE layer gates it instead).
+A `0` or a clean run answers only the one you actually checked; treat an
+unestablished premise as unmeasured, not as confirmed absent.
 
 ## 19. Documenting an in-flight mechanism as absent invites a same-night rewrite
 


### PR DESCRIPTION
**[docs-maintainer]** — part of #4801, part of #4761

## What

Adds a second instance to `verification-hazards.md` §18 category C (Inert): #4801's `logger.info` recovery-notice call was real, reachable, and the right call for its own severity reasoning — every premise A and B ask about held. It still wrote nothing to the operator-facing log file, because a different file, one layer up, gates it: `chat.py`'s `_setup_interactive_logging` sets the root logger's floor to WARNING via `logging.basicConfig(..., force=True)`.

Still C — the object exists, is the right object, has no observable effect — but "strip it and watch for a change" (the existing technique) doesn't apply the way it did for the existing CSS-token instance: nothing was reaching the output before the strip either. The detection technique has to move with the axis: reconstruct the real floor and read the real log file, not `caplog` (which overrides exactly the floor being tested) — #4804's own fix did precisely this.

## Why this placement

lead-coder dispatched this; architect proposed the placement (an instance within existing §18 C, not a new section) from memory of having opened that section twice tonight, explicitly flagged as unverified. I opened the doc myself and confirmed the placement holds against the actual text (§18 C's verbatim definition — "The right, real object was found, but it has no observable effect" — and its verbatim detection technique — "Strip it and watch for a change" — both match, and the strip-doesn't-apply gap is real). Verified every fact independently against source, not the relayed prose: `chat.py:359`'s `basicConfig` call (read directly), #4801's PR review thread (`caplog.at_level` in the original test), and #4804's PR body (the reconstructed-floor test fix, strip-falsification against the real `app.py` call site).

The "three people passed it, e2e-coder's own pre-work measurement caught it" line is attributed to architect's own broker account — I did not find independent evidence architect reviewed #4801 directly (only lead-coder + e2e-coder appear in that PR's own comment thread), so it's phrased as "per architect's account," not as something I independently confirmed.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no `Aborted` line
- [x] `python scripts/check_doc_anchors.py` — exit 0, no dangling anchors into published pages
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] `src/` / `tests/` unchanged — tier-audit / ratchet scripts N/A
- [x] Closing-keyword self-grep on commit message and this PR body — clean
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Quoted source read directly, not taken from the relayed broker text: `chat.py:359`, #4801's PR comments, #4804's PR body
- [x] Visual — N/A, prose-only doc addition

- [x] 🔴 (lead-coder、確認済み) 帰属 2 点 — (a)「3 人が通した」は architect でなく lead-coder の観察で、出所は broker（恒久面でない）。人に帰属させず PR 履歴から裏が取れる事実として書く。(b) 日本語の逐語併記を落とし、英語 1 文だけ残す（この doc は英語）。
