### PR TITLE
fix(#4761): App pump heartbeat — distinguish H1 from H3/H4

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1946,6 +1946,7 @@ class TextualChatApp(App):
         """
         import asyncio  # noqa: PLC0415
         import time  # noqa: PLC0415
+        from collections import deque  # noqa: PLC0415
 
         from .loop_probe import (  # noqa: PLC0415
             _TICK_SECONDS,
@@ -1954,17 +1955,45 @@ class TextualChatApp(App):
             stall_recovered_log_line,
         )
 
+        # #4761 ② (lead-coder review): a stall that never recovers — #4761's
+        # own report, the operator killed the process rather than waiting —
+        # never reaches stall_recovered_log_line's own comparison, so H1
+        # would be unanswerable on the one occasion it matters most. This
+        # loop already wakes every _TICK_SECONDS regardless of stall state,
+        # so it can track its OWN trailing window of (wall-clock, pump_ticks)
+        # samples and hand the stall notice a self-contained delta — no
+        # second event required. 2.0s window: matches _RECORD_INTERVAL_S's
+        # own magnitude (loop_probe.py), long enough to span several
+        # pump_ticks intervals (1.0s each) so a healthy pump shows a
+        # non-zero delta, short enough that the memory here (at most
+        # 2.0/_TICK_SECONDS ~= 40 tuples of two floats) is negligible and
+        # bounded — old samples are popped every tick, so this deque's own
+        # size never grows past that regardless of session length.
+        _PUMP_WINDOW_S = 2.0
+        pump_history: "deque[tuple[float, int]]" = deque()
+
         last = time.perf_counter()
         while True:
             await asyncio.sleep(_TICK_SECONDS)
             now = time.perf_counter()
             lateness_ms = (now - last - _TICK_SECONDS) * 1000
             last = now
+            pump_history.append((now, self._pump_ticks))
+            while pump_history and now - pump_history[0][0] > _PUMP_WINDOW_S:
+                pump_history.popleft()
             fired = self._loop_tripwire.observe(lateness_ms, pump_ticks=self._pump_ticks)
             if fired is not None:
+                pump_delta = (
+                    self._pump_ticks - pump_history[0][1] if pump_history else 0
+                )
                 logger.warning(
                     "textual chat: %s",
-                    stall_log_line(fired, pump_ticks=self._pump_ticks),
+                    stall_log_line(
+                        fired,
+                        pump_ticks=self._pump_ticks,
+                        pump_delta=pump_delta,
+                        pump_window_s=_PUMP_WINDOW_S,
+                    ),
                 )
                 try:
                     self.notify(stall_banner(fired), severity="warning")

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1230,6 +1230,20 @@ class TextualChatApp(App):
         #: Watches how late the event loop runs (#3539). Always on; see
         #: ``loop_probe`` for why it is not opt-in.
         self._loop_tripwire = LoopTripwire()
+        #: #4761 ②: the App's own message-pump heartbeat — incremented by
+        #: :meth:`on_timer` ONLY for :attr:`_pump_heartbeat_timer`'s own
+        #: ticks, which (no ``callback=`` given to ``set_interval``) post an
+        #: ``events.Timer`` message that only advances this counter once
+        #: Textual's own message-processing loop for THIS App actually
+        #: dequeues and dispatches it — unlike ``self._loop_tripwire``'s
+        #: worker, which is an independent ``asyncio`` task and keeps running
+        #: even if the App's own pump is the thing that's stuck. Silent by
+        #: construction (nothing reads this except the two log lines below,
+        #: which were already once-per-episode before this existed) — see
+        #: :attr:`_pump_heartbeat_timer`'s own start site for why an
+        #: unboundedly-running counter needs no separate bound of its own.
+        self._pump_ticks = 0
+        self._pump_heartbeat_timer: "Timer | None" = None
         #: One row per pipeline RUN, keyed by ``run_id`` — every step frame for
         #: that run folds into it (:meth:`_coalesce_pipeline_step`).
         self._pipeline_runs: "dict[str, Entry[OutboxMessage]]" = {}
@@ -1946,9 +1960,12 @@ class TextualChatApp(App):
             now = time.perf_counter()
             lateness_ms = (now - last - _TICK_SECONDS) * 1000
             last = now
-            fired = self._loop_tripwire.observe(lateness_ms)
+            fired = self._loop_tripwire.observe(lateness_ms, pump_ticks=self._pump_ticks)
             if fired is not None:
-                logger.warning("textual chat: %s", stall_log_line(fired))
+                logger.warning(
+                    "textual chat: %s",
+                    stall_log_line(fired, pump_ticks=self._pump_ticks),
+                )
                 try:
                     self.notify(stall_banner(fired), severity="warning")
                 except Exception:
@@ -1969,7 +1986,10 @@ class TextualChatApp(App):
                 # module emitted the record. Stall and recovery are the
                 # start and end of ONE episode; one line per episode at the
                 # same severity is not a second alarm).
-                logger.warning("textual chat: %s", stall_recovered_log_line())
+                logger.warning(
+                    "textual chat: %s",
+                    stall_recovered_log_line(pump_ticks=self._pump_ticks),
+                )
 
     def on_mount(self) -> None:
         # #3505: #3504 made ``App``'s own background ``ansi_default`` (the
@@ -2050,6 +2070,26 @@ class TextualChatApp(App):
         self.run_worker(
             self._watch_loop_responsiveness(), name="loop-tripwire", exclusive=False
         )
+        # #4761 ②: no ``callback=`` — a Timer with a callback invokes it
+        # directly from the Timer's OWN asyncio task (see textual/timer.py's
+        # ``_tick``), which would make this just as independent of the App's
+        # own message pump as ``_loop_tripwire``'s worker already is. Without
+        # one, each tick instead ``post_message``s an ``events.Timer`` onto
+        # THIS App's own queue, so :meth:`on_timer` only runs — and
+        # ``_pump_ticks`` only advances — when the App's own message-
+        # processing loop is actually dequeuing and dispatching, which is
+        # the one thing this counter needs to be true to answer H1 (#4761's
+        # own architect design: "does the pump keep beating"). 1s: cheap
+        # (an int increment), and short enough that even a several-second
+        # stall — #4761's own report was long enough to screenshot — has
+        # room for multiple ticks if the pump is in fact still alive.
+        # Unbounded FOR THE COUNTER's lifetime is fine: nothing here writes
+        # anything on its own tick, only reads the counter's current value
+        # (see :meth:`_watch_loop_responsiveness`) — the actual OUTPUT stays
+        # exactly as bounded as it already was (silent while healthy, two
+        # lines per stall episode), this just adds one more field to lines
+        # that already exist.
+        self._pump_heartbeat_timer = self.set_interval(1.0, name="pump-heartbeat")
         # Drawer starts collapsed — the default chrome is just the focusable
         # menu row (#3326: which also carries the status-values segment when
         # there's room — see MenuBar._repack). It only becomes visible when a
@@ -2644,6 +2684,42 @@ class TextualChatApp(App):
                 event.stop()
                 return
         await super().on_event(event)
+
+    async def on_timer(self, event: events.Timer) -> None:
+        """#4761 ②: advance the pump heartbeat for OUR OWN timer only, then
+        always delegate to Textual's own base handler.
+
+        ``MessagePump.on_timer`` is what actually invokes a Timer's
+        ``callback`` (see ``self._voice_timeout_timer`` /
+        ``self._streaming_catchup``, both real ``self.set_timer(...,
+        callback=...)`` calls elsewhere in this class) — overriding this
+        method without delegating would silently break both. Checking
+        ``event.timer is self._pump_heartbeat_timer`` rather than reacting
+        to every Timer event keeps this counter meaning ONE specific,
+        known-cheap interval, not "any timer anywhere in the app fired,"
+        which would make its cadence depend on unrelated widgets' own timer
+        churn.
+        """
+        if event.timer is self._pump_heartbeat_timer:
+            self._pump_ticks += 1
+        await super().on_timer(event)
+
+    @property
+    def pump_ticks(self) -> int:
+        """The message-pump heartbeat's current count (#4761 ②) — public
+        read, mirroring :attr:`LoopTripwire.max_lateness_ms`/``.fired``'s
+        own pattern, so a test or a future caller reads this off the same
+        surface the log lines already do rather than the underscore field."""
+        return self._pump_ticks
+
+    @property
+    def pump_heartbeat_timer(self) -> "Timer | None":
+        """The App's own heartbeat :class:`~textual.timer.Timer` — ``None``
+        before :meth:`on_mount` starts it. Public so a test can construct a
+        genuine ``events.Timer(timer=...)`` referencing the SAME object
+        :meth:`on_timer` compares against by identity, without reaching
+        into ``_pump_heartbeat_timer`` directly."""
+        return self._pump_heartbeat_timer
 
     async def on_key(self, event) -> None:
         # #3476 ⑥: 'r' while the cursor has focus is a keyboard shortcut for

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -171,7 +171,9 @@ class LoopTripwire:
         self._just_recovered = False
         return recovered
 
-    def observe(self, lateness_ms: float) -> "float | None":
+    def observe(
+        self, lateness_ms: float, *, pump_ticks: "int | None" = None,
+    ) -> "float | None":
         """Record one tick's lateness; return it the FIRST time it is bad.
 
         Returns ``None`` on every later crossing as well as on healthy ticks: a
@@ -197,6 +199,14 @@ class LoopTripwire:
         just stops leaves "it recovered" and "the process died mid-stall"
         looking identical, the same silence-hides-two-states shape #4761's
         original defect had, one level up.
+
+        ``pump_ticks``, if the caller has one (#4761 ②: ``TextualChatApp``'s
+        own message-pump heartbeat counter), rides along in every
+        ``write_record`` call this method makes — a *comparable* value
+        across the periodic ``"tripwire"`` records lets an armed session
+        see whether the count kept moving DURING an ongoing, not-yet-
+        recovered stall, which the once-per-episode default-visible notice
+        (below) cannot show on its own.
         """
         if lateness_ms > self._max_lateness_ms:
             self._max_lateness_ms = lateness_ms
@@ -204,7 +214,11 @@ class LoopTripwire:
             if self._in_stall:
                 self._in_stall = False
                 self._just_recovered = True
-                write_record("tripwire_recovered", lateness_ms=round(lateness_ms, 1))
+                write_record(
+                    "tripwire_recovered",
+                    lateness_ms=round(lateness_ms, 1),
+                    **({} if pump_ticks is None else {"pump_ticks": pump_ticks}),
+                )
             return None
         self._in_stall = True
         now = time.monotonic()
@@ -212,7 +226,11 @@ class LoopTripwire:
             self._last_recorded_monotonic is None
             or now - self._last_recorded_monotonic >= _RECORD_INTERVAL_S
         ):
-            write_record("tripwire", lateness_ms=round(lateness_ms, 1))
+            write_record(
+                "tripwire",
+                lateness_ms=round(lateness_ms, 1),
+                **({} if pump_ticks is None else {"pump_ticks": pump_ticks}),
+            )
             self._last_recorded_monotonic = now
         if self._fired:
             return None
@@ -232,7 +250,7 @@ def stall_banner(lateness_ms: float) -> str:
     return f"unresponsive {lateness_ms / 1000:.1f}s"
 
 
-def stall_log_line(lateness_ms: float) -> str:
+def stall_log_line(lateness_ms: float, *, pump_ticks: "int | None" = None) -> str:
     """The durable record of a stall — the one that survives the operator
     looking away.
 
@@ -241,14 +259,22 @@ def stall_log_line(lateness_ms: float) -> str:
     diagnosing it later is usually not that person. This line carries the
     magnitude AND how to record the detail on the next occurrence, which the
     short segment has no room for.
+
+    ``pump_ticks`` (#4761 ②), when given, is the App's own message-pump
+    heartbeat counter's value AT THE MOMENT the stall was noticed — the
+    other end of the comparison :func:`stall_recovered_log_line` reports
+    if this episode resolves. On its own it says nothing (there is no
+    prior value to compare it to yet); its purpose is being the FIRST of
+    the pair.
     """
+    ticks_note = "" if pump_ticks is None else f" (pump heartbeat at {pump_ticks})"
     return (
-        f"the interface was unresponsive for {lateness_ms / 1000:.1f}s "
-        f"— re-run with {_DUMP_ENV}=<path> to record what it was doing"
+        f"the interface was unresponsive for {lateness_ms / 1000:.1f}s"
+        f"{ticks_note} — re-run with {_DUMP_ENV}=<path> to record what it was doing"
     )
 
 
-def stall_recovered_log_line() -> str:
+def stall_recovered_log_line(*, pump_ticks: "int | None" = None) -> str:
     """The default-visible recovery notice — no ``REYN_PROF_DUMP`` required.
 
     architect finding (#4797 follow-up): every OTHER new signal this module
@@ -268,5 +294,18 @@ def stall_recovered_log_line() -> str:
     not quieter, genuinely absent. Stall and recovery are the start and
     end of ONE episode; one WARNING line per episode is not a second
     alarm.
+
+    ``pump_ticks`` (#4761 ②), when given, is the App's own message-pump
+    heartbeat counter's value at recovery — held against
+    :func:`stall_log_line`'s own reading from the SAME episode's start.
+    If the two differ, the pump kept dispatching messages throughout the
+    stall (H1 ruled out for this episode); if they're equal, the pump
+    never advanced at all (H1 the leading candidate).
     """
-    return "the interface recovered from the stall reported above"
+    if pump_ticks is None:
+        return "the interface recovered from the stall reported above"
+    return (
+        "the interface recovered from the stall reported above "
+        f"(pump heartbeat at {pump_ticks} — compare against the stall "
+        "notice's own reading)"
+    )

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -250,7 +250,13 @@ def stall_banner(lateness_ms: float) -> str:
     return f"unresponsive {lateness_ms / 1000:.1f}s"
 
 
-def stall_log_line(lateness_ms: float, *, pump_ticks: "int | None" = None) -> str:
+def stall_log_line(
+    lateness_ms: float,
+    *,
+    pump_ticks: "int | None" = None,
+    pump_delta: "int | None" = None,
+    pump_window_s: "float | None" = None,
+) -> str:
     """The durable record of a stall — the one that survives the operator
     looking away.
 
@@ -260,14 +266,29 @@ def stall_log_line(lateness_ms: float, *, pump_ticks: "int | None" = None) -> st
     magnitude AND how to record the detail on the next occurrence, which the
     short segment has no room for.
 
-    ``pump_ticks`` (#4761 ②), when given, is the App's own message-pump
-    heartbeat counter's value AT THE MOMENT the stall was noticed — the
-    other end of the comparison :func:`stall_recovered_log_line` reports
-    if this episode resolves. On its own it says nothing (there is no
-    prior value to compare it to yet); its purpose is being the FIRST of
-    the pair.
+    ``pump_ticks``/``pump_delta``/``pump_window_s`` (#4761 ②, lead-coder
+    review): a FIRST design compared this line's ``pump_ticks`` reading
+    against a SECOND one in :func:`stall_recovered_log_line`, at recovery.
+    That pair never completes for a freeze that never recovers — the exact
+    shape of #4761's own report (the operator killed the process; no
+    recovery line was ever going to fire) — which is precisely the case
+    where knowing whether the pump was still moving matters most.
+    ``pump_delta``, when given, is how much :attr:`TextualChatApp.
+    pump_ticks` changed over the trailing ``pump_window_s`` seconds
+    BEFORE this notice fired — self-contained in ONE line, no second
+    event required. ``0`` here is the H1 signal (pump had already
+    stopped advancing before the stall was even noticed); a positive
+    delta rules H1 out for this episode on its own.
     """
-    ticks_note = "" if pump_ticks is None else f" (pump heartbeat at {pump_ticks})"
+    ticks_note = ""
+    if pump_ticks is not None:
+        if pump_delta is not None and pump_window_s is not None:
+            ticks_note = (
+                f" (pump heartbeat at {pump_ticks}, +{pump_delta} in the "
+                f"last {pump_window_s:.0f}s)"
+            )
+        else:
+            ticks_note = f" (pump heartbeat at {pump_ticks})"
     return (
         f"the interface was unresponsive for {lateness_ms / 1000:.1f}s"
         f"{ticks_note} — re-run with {_DUMP_ENV}=<path> to record what it was doing"

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -556,6 +556,29 @@ def test_stall_and_recovered_lines_carry_pump_ticks_when_given() -> None:
     assert stall_recovered_log_line() == "the interface recovered from the stall reported above"
 
 
+def test_stall_line_carries_a_self_contained_pump_delta() -> None:
+    """Tier 2: #4761 ② follow-up (lead-coder review) — a stall that never
+    recovers (#4761's own report: the operator killed the process rather
+    than waiting) never reaches stall_recovered_log_line's own comparison,
+    so H1 needs to be readable from the STALL line alone. pump_delta/
+    pump_window_s let it say "the pump advanced by D in the trailing W
+    seconds" in the SAME one line — 0 is the H1 signal, a positive delta
+    rules H1 out for this episode without a second event."""
+    frozen_pump = stall_log_line(1800.0, pump_ticks=12, pump_delta=0, pump_window_s=2.0)
+    assert "+0" in frozen_pump
+    assert "2s" in frozen_pump
+
+    live_pump = stall_log_line(1800.0, pump_ticks=12, pump_delta=3, pump_window_s=2.0)
+    assert "+3" in live_pump
+
+    # Partial info (ticks with no delta/window) falls back to the plain
+    # single-value form — a caller that hasn't started tracking a window
+    # yet must not have to supply values it doesn't have.
+    ticks_only = stall_log_line(1800.0, pump_ticks=12)
+    assert "12" in ticks_only
+    assert "+" not in ticks_only
+
+
 def test_observe_threads_pump_ticks_into_both_durable_record_kinds(
     monkeypatch, tmp_path: Path,
 ) -> None:
@@ -660,4 +683,10 @@ async def test_pump_heartbeat_reaches_the_default_visible_notices(
     content = logfile.read_text(encoding="utf-8")
     assert "pump heartbeat" in content, (
         f"the pump-ticks reading must reach the real, default-visible log: {content!r}"
+    )
+    stall_line = next(line for line in content.splitlines() if "unresponsive" in line)
+    assert "+" in stall_line, (
+        "the STALL line itself (not just the recovery line) must carry the "
+        "self-contained trailing-window delta — a freeze that never "
+        f"recovers never reaches the recovery line at all: {stall_line!r}"
     )

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -530,3 +530,134 @@ async def test_a_stall_costs_no_row_of_layout(caplog) -> None:
         "at 80 columns that spends a row of conversation, permanently, on a "
         "momentary hiccup"
     )
+
+
+# ── #4761 ②: the App pump heartbeat ─────────────────────────────────────────
+
+
+def test_stall_and_recovered_lines_carry_pump_ticks_when_given() -> None:
+    """Tier 2: #4761 ② — the two default-visible notices embed the pump
+    heartbeat's value when the caller has one, and stay exactly as they
+    were (#4801/#4804's own wording) when it doesn't — this module has no
+    idea whether a caller tracks pump ticks at all, so the parameter must
+    be fully optional."""
+    with_ticks = stall_log_line(1800.0, pump_ticks=42)
+    assert "1.8s" in with_ticks
+    assert "42" in with_ticks
+    without_ticks = stall_log_line(1800.0)
+    assert "42" not in without_ticks
+    assert without_ticks == (
+        "the interface was unresponsive for 1.8s — re-run with "
+        "REYN_PROF_DUMP=<path> to record what it was doing"
+    )
+
+    recovered_with_ticks = stall_recovered_log_line(pump_ticks=99)
+    assert "99" in recovered_with_ticks
+    assert stall_recovered_log_line() == "the interface recovered from the stall reported above"
+
+
+def test_observe_threads_pump_ticks_into_both_durable_record_kinds(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Tier 2: #4761 ② — an armed session's durable trace carries the SAME
+    pump-ticks value the caller passed, for both the periodic ``"tripwire"``
+    record and the ``"tripwire_recovered"`` one — the comparable pair an
+    operator with detail on would need to see whether the count moved
+    during an ongoing stall."""
+    import json
+
+    target = tmp_path / "probe.jsonl"
+    monkeypatch.setenv("REYN_PROF_DUMP", str(target))
+    tripwire = LoopTripwire(threshold_ms=250.0)
+
+    tripwire.observe(1800.0, pump_ticks=5)
+    tripwire.observe(50.0, pump_ticks=8)
+
+    records = [
+        json.loads(line) for line in target.read_text(encoding="utf-8").splitlines()
+    ]
+    by_kind = {r["kind"]: r for r in records}
+    assert by_kind["tripwire"]["pump_ticks"] == 5
+    assert by_kind["tripwire_recovered"]["pump_ticks"] == 8
+
+
+@pytest.mark.asyncio
+async def test_on_timer_advances_pump_ticks_only_for_its_own_timer() -> None:
+    """Tier 2: #4761 ② — the discriminator this mechanism depends on:
+    ``on_timer`` must advance ``_pump_ticks`` for the App's OWN heartbeat
+    Timer and NOT for an unrelated one, or the counter's meaning drifts
+    from "this app's own message pump is alive" to "some timer somewhere
+    fired," which the docstring explicitly rules out. Delegation to
+    Textual's own base ``on_timer`` (which invokes a Timer's real
+    ``callback``, if any) is also exercised here via the two real
+    ``self.set_timer(..., callback=...)`` sites elsewhere in this class
+    — a broken delegation would leave voice-recording's own timeout or
+    the streamed-reply catch-up silently never firing, not just this
+    counter untested."""
+    from textual import events
+
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        before = app.pump_ticks
+        assert app.pump_heartbeat_timer is not None
+
+        # Our own timer's event: advances the counter.
+        await app.on_timer(events.Timer(timer=app.pump_heartbeat_timer, time=0.0, count=1))
+        assert app.pump_ticks == before + 1
+
+        # A DIFFERENT timer's event: must NOT advance it — the
+        # discriminator itself, not just "some timer event was handled".
+        other_timer = app.set_timer(999.0, name="unrelated-probe-timer")
+        try:
+            await app.on_timer(events.Timer(timer=other_timer, time=0.0, count=1))
+            assert app.pump_ticks == before + 1, (
+                "on_timer must only advance _pump_ticks for its OWN timer"
+            )
+        finally:
+            other_timer.stop()
+
+
+@pytest.mark.asyncio
+async def test_pump_heartbeat_reaches_the_default_visible_notices(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2b: #4761 ② — REACHED end to end: a real stall + recovery,
+    under the reconstructed real logging floor (no ``caplog``, mirroring
+    #4804's own pattern), and the pump-ticks value from the App's real
+    ``_pump_ticks`` counter actually lands in both default-visible notices
+    — not just that the formatting functions accept the parameter in
+    isolation (the sibling unit test above), but that app.py's own call
+    site actually supplies it."""
+    import logging
+    import time
+
+    logfile = tmp_path / "reyn.log"
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    monkeypatch.delenv("REYN_PROF_DUMP", raising=False)
+    try:
+        logging.basicConfig(
+            filename=str(logfile), level=logging.WARNING, force=True,
+        )
+        stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
+        transport = QueueTransport()
+        app = TextualChatApp(transport=transport)
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            time.sleep(stall_seconds)
+            while "recovered" not in logfile.read_text(encoding="utf-8"):
+                await pilot.pause()
+    finally:
+        for handler in root.handlers:
+            if handler not in saved_handlers:
+                handler.close()
+        root.handlers = saved_handlers
+        root.setLevel(saved_level)
+
+    content = logfile.read_text(encoding="utf-8")
+    assert "pump heartbeat" in content, (
+        f"the pump-ticks reading must reach the real, default-visible log: {content!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #4761 ②, per lead-coder's assignment.

## Background

architect's design (#4761 investigation): the existing loop-lateness tripwire runs as an independent `asyncio` worker (`run_worker`), so it keeps reporting fine even if the App's OWN message-processing pump is the thing stuck at an `await` (H1) — it cannot tell that apart from the pump being healthy but input not arriving (H3) or painting not happening (H4). Nothing in the tree observed the pump's own liveness.

## Mechanism

`TextualChatApp.set_interval(1.0, name="pump-heartbeat")` with **no callback** — `Timer._tick` only invokes a callback directly from the Timer's own asyncio task when one is given (`textual/timer.py`); omitting it instead posts an `events.Timer` message through the App's OWN queue, so `on_timer` only fires — and `_pump_ticks` only advances — when this App's own message-processing loop is actually dequeuing and dispatching. That coupling to real pump activity is the whole point; a callback-based timer would be just as independent of pump health as the existing tripwire worker already is.

## Applying ①'s own two-round lesson at design time

- **Visible with shipped config?** The counter itself writes nothing. Its value rides along in the two lines that already exist and are already default-visible (#4804's own `logger.warning` fix) — the stall notice and the recovery notice — plus the periodic `write_record("tripwire", ...)` call for anyone with `REYN_PROF_DUMP` armed. No new `logger.info` trap, no new `write_record`-only surface.
- **Who bounds it?** The Timer runs for the app's lifetime (it must, to catch a freeze whenever it happens) but produces zero output on its own — only an int increment. The actual OUTPUT stays exactly as bounded as ① already made it: silent while healthy, at most 2 lines per stall episode by default, periodic only behind the opt-in dump.

`on_timer` discriminates by identity (`event.timer is self._pump_heartbeat_timer`) rather than reacting to any Timer event, and always delegates to `MessagePump`'s own `on_timer` afterward — two real existing `self.set_timer(..., callback=...)` call sites in this class (voice auto-stop, streamed-reply catch-up) depend on that base handler actually invoking their callbacks; an override that didn't delegate would silently break both.

Added public `pump_ticks` / `pump_heartbeat_timer` read-only properties (mirroring `LoopTripwire.max_lateness_ms`/`.fired`'s own pattern) after `test_tier_audit.py --strict` correctly flagged the first version's direct `_pump_ticks`/`_pump_heartbeat_timer` test assertions as private-state access.

## Test plan

- [x] `test_stall_and_recovered_lines_carry_pump_ticks_when_given` — formatting functions embed the value when given, stay exactly as #4801/#4804 left them when not.
- [x] `test_observe_threads_pump_ticks_into_both_durable_record_kinds` — `observe(..., pump_ticks=N)` reaches both the periodic `"tripwire"` and `"tripwire_recovered"` `write_record` calls.
- [x] `test_on_timer_advances_pump_ticks_only_for_its_own_timer` — the discriminator itself: the app's own timer's event advances the counter, a distinct unrelated timer's event does not.
- [x] `test_pump_heartbeat_reaches_the_default_visible_notices` — end-to-end, real stall+recovery under a reconstructed real logging floor (no `caplog`, mirroring #4804's own pattern), proving `app.py`'s real call site supplies the value.
- [x] All four strip-falsified against the real code path (targeted reverts, not reasoned about) — confirmed red for the right reason each time.
- [x] All 18 tests in `test_loop_probe_3539.py` green, stable across repeated runs; sibling suites (`test_textual_chat_copy_rewind_3362.py`, `test_4788_rewind_picker_escape_dismiss.py`) unaffected.
- [x] `ruff check .`, `scripts/test_tier_audit.py --strict`, `scripts/verify_module_docstrings.py`, `scripts/mypy_ratchet.py` — all green.
- [ ] Visual/TTY (standing waiver applies — merge does not wait on this)

part of #4761 (③ — key-arrival counter — is next per lead-coder's sequencing; not started here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] 🔴 (lead-coder、確認済み) 回復しない凍結（=#4761 の実際の報告）では recovery 行が来ないので対が完成せず H1 が読めない — stall 通知の 1 行目自身に「直前 N 秒の pump 進行数（差分）」を載せる。行数は増やさない。
