### PR TITLE
fix(#4805): raise 2 log sites to WARNING; document message_handler.py's non-fix

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -2487,6 +2487,7 @@ async def recorded_acompletion(
             return _stamp_usage_source(chunk_stream, UsageSource.PROVIDER)
         chunks = []
         _delta_fired = False
+        _tool_calls_seen = False
         async for chunk in chunk_stream:
             chunks.append(chunk)
             if on_content_delta is not None:
@@ -2504,6 +2505,17 @@ async def recorded_acompletion(
                             "recorded_acompletion: on_content_delta callback raised; "
                             "continuing the stream"
                         )
+            # #4805 review (lead-coder catch): a tool-only round's chunks
+            # legitimately never expose delta.content at all (tool_calls is
+            # a SEPARATE field) — this is reyn's most common round shape,
+            # not a defect. Tracked here, alongside _delta_fired, so the
+            # guard below can tell "genuinely dead" apart from "just a
+            # normal tool round."
+            try:
+                if chunk.choices[0].delta.tool_calls:
+                    _tool_calls_seen = True
+            except Exception:  # noqa: BLE001 — malformed/empty chunk shape
+                pass
         # #3288 ③b co-vet fix: a silent functional-dead-mode guard. If the
         # provider streamed at least one chunk AND a callback was supplied,
         # but NOT ONE chunk ever exposed a non-empty delta.content (e.g. a
@@ -2514,14 +2526,23 @@ async def recorded_acompletion(
         # ONE log per STREAM (not per chunk, which would be noise) is cheap
         # and makes that silent mode observable.
         #
-        # #4805: WARNING, not debug — this branch's OWN condition (a
-        # callback was supplied, chunks arrived, none exposed a delta) is
-        # EXCLUSIVELY the defect signal the comment above describes; it
-        # never fires on a normally-working stream (where at least one
-        # chunk exposes a delta). A guard whose firing is invisible under
-        # the interactive CUI's production floor (WARNING) is the same as
-        # having no guard at all — see this issue's own title.
-        if on_content_delta is not None and chunks and not _delta_fired:
+        # #4805: WARNING, not debug — but ONLY when genuinely dead (no text
+        # delta AND no tool_calls either). My first pass raised this to
+        # WARNING gated on `not _delta_fired` alone — lead-coder review
+        # caught that a TOOL-ONLY round (the assistant calls tools with no
+        # accompanying text, reyn's own most common round shape) ALSO never
+        # exposes delta.content, so that gate would have warned on every
+        # ordinary tool call, false-alarming exactly the way I flagged for
+        # message_handler.py's own case and failed to apply here. Excluding
+        # `_tool_calls_seen` restores the guard's own stated property (fires
+        # ONLY on the defect, never on healthy traffic) instead of just
+        # reverting the severity.
+        if (
+            on_content_delta is not None
+            and chunks
+            and not _delta_fired
+            and not _tool_calls_seen
+        ):
             logger.warning(
                 "recorded_acompletion: streamed %d chunk(s) but on_content_delta "
                 "never fired — the provider's chunk shape may not expose "

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -2511,10 +2511,18 @@ async def recorded_acompletion(
         # would silently produce ZERO delta notifications forever — L9 still
         # surfaces the final text via the reconstructed whole response below,
         # so nothing user-visible breaks and nobody would ever notice.
-        # ONE debug log per STREAM (not per chunk, which would be noise) is
-        # cheap and makes that silent mode observable.
+        # ONE log per STREAM (not per chunk, which would be noise) is cheap
+        # and makes that silent mode observable.
+        #
+        # #4805: WARNING, not debug — this branch's OWN condition (a
+        # callback was supplied, chunks arrived, none exposed a delta) is
+        # EXCLUSIVELY the defect signal the comment above describes; it
+        # never fires on a normally-working stream (where at least one
+        # chunk exposes a delta). A guard whose firing is invisible under
+        # the interactive CUI's production floor (WARNING) is the same as
+        # having no guard at all — see this issue's own title.
         if on_content_delta is not None and chunks and not _delta_fired:
-            logger.debug(
+            logger.warning(
                 "recorded_acompletion: streamed %d chunk(s) but on_content_delta "
                 "never fired — the provider's chunk shape may not expose "
                 "delta.content the way this parsing expects",

--- a/src/reyn/llm/model_budget.py
+++ b/src/reyn/llm/model_budget.py
@@ -310,12 +310,24 @@ def get_max_input_tokens(
         # symptom) is wrong specifically for this temporary case — the
         # permanent UNCATALOGED case never reaches here (reason stays
         # UNCATALOGED forever, so the `reason is not None` branch above,
-        # not this one, handles every subsequent call for it). Log only
-        # (info, not warning — this is good news), not a NEW audit event:
-        # `model_budget_fallback`'s own name means "a fallback occurred",
-        # and none is occurring at this call.
+        # not this one, handles every subsequent call for it). Not a NEW
+        # audit event: `model_budget_fallback`'s own name means "a
+        # fallback occurred", and none is occurring at this call.
+        #
+        # #4805: WARNING, not info — the interactive CUI's own root floor
+        # (`interfaces/cli/commands/chat.py`'s `basicConfig(level=WARNING,
+        # force=True)`) discards anything below it, so an `info` call here
+        # was invisible in production regardless of what this comment
+        # claimed. The PAIRED original warning above (NOT_READY fallback)
+        # is `logger.warning(...)` and IS seen; leaving the correction at
+        # `info` reproduced the exact "warned once, never corrected"
+        # failure #4680 exists to close, just moved one level down (the
+        # warning fires, its own resolution silently doesn't) — the
+        # asymmetry this issue's own title names. Raising the CALL's own
+        # severity (never the logger's `setLevel`, which would change what
+        # the floor means for every OTHER call this module makes).
         del _warned_models[model]
-        logger.info(
+        logger.warning(
             f"model_budget: max_input_tokens for model={model!r} is now "
             f"resolved via litellm catalog to {value:,} tokens (previously "
             f"used the temporary NOT_READY fallback of "

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -281,7 +281,30 @@ class ReynMCPMessageHandler:
         handler doesn't act on — distinguishes "processed and silent" (the 5 shapes
         matched above) from "not one of ours, silently ignored" (everything else),
         so a future fastmcp/MCP protocol addition landing here unnoticed is
-        distinguishable in the log from an ordinary quiet run, not identical to it."""
+        distinguishable in the log from an ordinary quiet run, not identical to it.
+
+        #4805: stays at ``debug``, deliberately NOT raised to ``warning`` the
+        way the other two sites in this issue's population were. Those two
+        fire ONLY on a confirmed defect condition (a stream that produced
+        chunks but no delta; a value that never got the correction it was
+        due) — this one does not have that property. Its own call sites
+        (``__call__``'s ``case _:`` branch, and the ``else`` branch for
+        every ``RequestResponder``/transport exception) fire for ANY of the
+        ``ServerNotification`` union's members this handler doesn't act on
+        (only 5 of the union's shapes are matched above) and for EVERY
+        server-initiated request — both are legitimate, protocol-compliant
+        traffic a standards-conforming MCP server can send during entirely
+        normal operation, not just malformed/unexpected input. Raising this
+        to ``warning`` would fire on healthy traffic from a server that
+        simply uses a notification/request shape reyn doesn't act on by
+        design — the opposite of the "defect-only" property #4805's
+        severity-raise fix depends on. The underlying tension (this log
+        line's own stated purpose — "make it observable" — genuinely IS
+        defeated by the production floor for the cases that are actual
+        defects, same as the other two sites) is real but needs a design
+        answer this mechanical fix doesn't have (e.g. distinguishing "an
+        unexpected/never-seen message type" from "a known, legitimate one
+        we just don't act on"), not a blanket severity bump."""
         logger.debug(
             "ReynMCPMessageHandler: no handler for message type %s on server %r",
             type(message).__name__, self._server_name,

--- a/tests/core/test_4680_2_notready_uncataloged.py
+++ b/tests/core/test_4680_2_notready_uncataloged.py
@@ -203,9 +203,21 @@ def test_fallback_event_carries_reason_field() -> None:
 def test_not_ready_then_resolved_emits_a_correction_log(monkeypatch, caplog) -> None:
     """Tier 2: THE mandatory correction witness — a model warned as
     NOT_READY, then called again once litellm is (simulated) ready and
-    resolves to a real catalog value, gets an INFO-level correction log
+    resolves to a real catalog value, gets a WARNING-level correction log
     naming the resolved value. "Warned once, never corrected" (#4680's
-    own reported symptom) is wrong for this temporary case."""
+    own reported symptom) is wrong for this temporary case.
+
+    #4805: the capture floor below is WARNING, not INFO, DELIBERATELY —
+    the interactive CUI's own production floor (`interfaces/cli/commands/
+    chat.py`'s `basicConfig(level=WARNING, force=True)`) discards
+    anything below it, so a test that captured at INFO would stay green
+    even if this correction log were invisible in real production (the
+    exact "green but silent in production" defect #4805 exists to close
+    — this correction log used to be `logger.info(...)`, passing this
+    same test under a `caplog.at_level(logging.INFO)` capture while
+    genuinely emitting nothing under the real WARNING floor). Capturing
+    at WARNING here means this test can only pass if the log actually
+    clears the SAME floor production uses."""
     model = "gemini/gemini-2.5-flash-lite"  # a real, cataloged model
 
     monkeypatch.setattr(
@@ -221,11 +233,15 @@ def test_not_ready_then_resolved_emits_a_correction_log(monkeypatch, caplog) -> 
     from reyn.llm.litellm_bootstrap import ensure_litellm_ready
     ensure_litellm_ready()  # deterministic — real litellm is actually warm
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.WARNING):
         second = get_max_input_tokens(model)
     assert second != _FALLBACK_MAX_INPUT_TOKENS
     assert any(
         "is now resolved via litellm catalog" in r.message for r in caplog.records
+    ), (
+        "the correction must be visible at the interactive CUI's own "
+        "production floor (WARNING) — not merely at a lower capture "
+        "level a real session never uses"
     )
 
 

--- a/tests/llm/test_llm_streaming_delta_emission_3288.py
+++ b/tests/llm/test_llm_streaming_delta_emission_3288.py
@@ -217,10 +217,19 @@ def _make_fake_acompletion_no_content_deltas(chunk_witness: "list[int] | None" =
 def test_silent_zero_delta_stream_logs_once_per_stream(monkeypatch, caplog) -> None:
     """Tier 1: co-vet fix (recommendation (c)) — when a stream produces at
     least one chunk but ``on_content_delta`` never fires (no chunk exposed
-    ``delta.content``), exactly ONE debug log line is emitted for the whole
-    stream (not per chunk) — the cheap observability guard against a silent
-    functional-dead-mode where deltas quietly never happen for a given
-    provider's chunk shape while L9's final text keeps working, masking it."""
+    ``delta.content``), exactly ONE WARNING log line is emitted for the
+    whole stream (not per chunk) — the cheap observability guard against a
+    silent functional-dead-mode where deltas quietly never happen for a
+    given provider's chunk shape while L9's final text keeps working,
+    masking it.
+
+    #4805: captured at WARNING, not DEBUG, deliberately — the interactive
+    CUI's own production floor discards anything below WARNING, so a
+    DEBUG-level capture here would stay green even if this guard were
+    invisible in real production (this guard used to be `logger.debug`,
+    passing this same test under a DEBUG capture while genuinely never
+    reaching a real operator — the exact defect #4805 exists to close).
+    A guard whose firing nobody can see is the same as no guard."""
     import logging
 
     chunk_witness: list[int] = []
@@ -229,7 +238,7 @@ def test_silent_zero_delta_stream_logs_once_per_stream(monkeypatch, caplog) -> N
     )
 
     deltas: list[str] = []
-    with caplog.at_level(logging.DEBUG, logger="reyn.llm.llm"):
+    with caplog.at_level(logging.WARNING, logger="reyn.llm.llm"):
         result = asyncio.run(recorded_acompletion(
             model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=None,

--- a/tests/llm/test_llm_streaming_delta_emission_3288.py
+++ b/tests/llm/test_llm_streaming_delta_emission_3288.py
@@ -332,3 +332,89 @@ def test_silent_zero_delta_guard_does_not_fire_when_deltas_do(monkeypatch, caplo
         if "on_content_delta never fired" in r.message
     ]
     assert guard_records == []
+
+
+def _make_fake_acompletion_tool_calls_only(chunk_witness: "list[int] | None" = None):
+    """#4805 review (lead-coder catch): a real, scripted stand-in whose
+    streaming branch yields chunks carrying ONLY ``delta.tool_calls`` —
+    never ``delta.content`` — reyn's own MOST COMMON round shape (the
+    assistant calls a tool with no accompanying text). This never exposes
+    a content delta either, same surface symptom as the genuine dead-mode
+    case above, but for a completely different (and completely healthy)
+    reason."""
+
+    async def _fake_acompletion(model: str, messages: list, **kw: Any) -> Any:
+        if not kw.get("stream"):
+            return litellm.ModelResponse(
+                id="resp-3", created=1, model=model, object="chat.completion",
+                choices=[{
+                    "index": 0, "finish_reason": "tool_calls",
+                    "message": {"role": "assistant", "content": None, "tool_calls": []},
+                }],
+                usage=dict(_USAGE),
+            )
+
+        def _chunk(delta: Delta, finish_reason: "str | None" = None) -> ModelResponseStream:
+            return ModelResponseStream(
+                id="resp-3", created=1, model=model, object="chat.completion.chunk",
+                choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
+            )
+
+        async def _gen():
+            pieces = [
+                _chunk(Delta(role="assistant", tool_calls=[
+                    {"index": 0, "id": "call_1", "type": "function",
+                     "function": {"name": "read_file", "arguments": '{"path"'}},
+                ])),
+                _chunk(Delta(tool_calls=[
+                    {"index": 0, "function": {"arguments": ': "x"}'}},
+                ])),
+            ]
+            last = _chunk(Delta(), finish_reason="tool_calls")
+            last.usage = Usage(**_USAGE)
+            pieces.append(last)
+            for piece in pieces:
+                if chunk_witness is not None:
+                    chunk_witness.append(1)
+                yield piece
+
+        return _gen()
+
+    return _fake_acompletion
+
+
+def test_a_tool_only_round_never_trips_the_dead_mode_guard(monkeypatch, caplog) -> None:
+    """Tier 1: accept-side — #4805 review's own catch. A tool-only round
+    (the assistant calls a tool with no text — reyn's most common round
+    shape, per lead-coder's live #4691 observation) legitimately never
+    exposes ``delta.content`` on ANY chunk, the exact same surface symptom
+    as the genuine dead-mode case ``test_silent_zero_delta_stream_logs_
+    once_per_stream`` covers. Without excluding a chunk that carried
+    ``tool_calls``, the WARNING-severity guard (#4805) would false-alarm
+    on EVERY ordinary tool call — the same "fires on a healthy path too"
+    defect this PR explicitly avoided for `message_handler.py`'s own
+    case, caught here for `llm.py` on review."""
+    import logging
+
+    chunk_witness: list[int] = []
+    monkeypatch.setattr(
+        litellm, "acompletion", _make_fake_acompletion_tool_calls_only(chunk_witness),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="reyn.llm.llm"):
+        asyncio.run(recorded_acompletion(
+            model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", recorder=None,
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
+            on_content_delta=lambda _t: None,
+        ))
+
+    assert chunk_witness == [1, 1, 1]  # real chunk consumption, not vacuous
+    guard_records = [
+        r for r in caplog.records
+        if "on_content_delta never fired" in r.message
+    ]
+    assert guard_records == [], (
+        "a tool-only round must never trip the dead-mode guard — it is "
+        "reyn's most common round shape, not a defect"
+    )


### PR DESCRIPTION
**[tui-coder]** — raises severity on the 2 confirmed defect-class sites; leaves the 3rd at `debug` with the reasoning documented in the code, per the requested order (population → caplog-overridden subset → necessity judgment → implementation).

## Background

The interactive CUI's own production floor (`interfaces/cli/commands/chat.py`'s `basicConfig(level=WARNING, force=True)`) silently discards anything below `WARNING`. #4801 found one instance of a class: a `logger.info`/`logger.debug` call whose corresponding test used `caplog.at_level(INFO/DEBUG)` to pass — masking that the exact same call never reaches a real operator in production.

## What I did before touching any code

Enumerated the full population (28 `logger.info`/`logger.debug` sites across 17 `src/` files — none override their own logger's level, so all 28 stay in-scope) and cross-referenced against every `caplog.at_level(INFO/DEBUG)` test — 3 sites confirmed in the defect class. Also checked `caplog.set_level(...)` separately (7 hits, all `WARNING` — the floor itself, not below it, so irrelevant). Full detail in issue #4805's own comment thread.

## Classification — by each site's OWN stated intent, not "more logging is nice"

- **`llm/model_budget.py:318`** — literally #4680's own "correction" log. The paired original warning (NOT_READY fallback) is `logger.warning(...)` and IS seen; the correction was `logger.info(...)` and was NOT — an operator sees the warning fire and never sees it resolve, the exact "warned once, never corrected" failure #4680 exists to close, moved one level down. **→ WARNING.**
- **`llm/llm.py:2517`** — the stream dead-mode guard's own comment: "a silent functional-dead-mode guard... makes that silent mode observable." Fires ONLY on the confirmed defect condition (chunks arrived, zero exposed a delta) — never on a healthy stream. A guard whose firing nobody can see is the same as no guard. **→ WARNING.**
- **`mcp/message_handler.py:285`** — **documented but NOT raised.** Its own call sites fire for ANY `ServerNotification`-union member outside the 5 explicitly handled shapes, AND for every server-initiated request — both legitimate, protocol-compliant traffic a standards-conforming MCP server can send during entirely normal operation, not exclusively a defect signal. Raising this to WARNING would false-alarm on a healthy server using MCP features reyn simply doesn't act on by design. The underlying tension (this log's own stated purpose IS defeated by the floor, for the cases that are defects) is real but needs a design answer this mechanical fix doesn't have — left as a documented open question, not silently dropped.

**Never touched `logger.setLevel` or the interactive CUI's own `basicConfig` floor** — only the individual call sites' own severity, so the floor's meaning stays uniform across every other call in these modules (matches #4804's own fix shape).

## Falsification

Two existing tests tightened from `caplog.at_level(INFO/DEBUG)` to `caplog.at_level(WARNING)` — the SAME floor production uses — so they can only pass if the log genuinely clears it, closing the exact gap that let this defect class ship green in the first place. Reverting this PR's `src/` diff (`git stash`) makes both fail correctly (`ValueError: not enough values to unpack` / assertion on the missing correction record).

## Honest remainder

The other 25 `logger.info`/`logger.debug` sites found during enumeration are **not claimed fine-as-is** — they are equally silent in production today, just outside this issue's specific "a green test masks it" signature. Recorded as open in the issue thread, not resolved and not dropped.

## Checks

`ruff check .` clean · `mypy_ratchet.py` clean · `test_tier_audit.py --strict` on the 2 touched test files: 17/17 OK, 0 Tier-4 · `verify_module_docstrings.py` OK · `flat_tests_ratchet.py` OK · `check_tests_path_literal_reference.py` OK · `check_bare_tests_import_reference.py` OK · `check_file_depth_reference.py` OK · full `tests/llm/`: 725 passed · full `tests/core/`: 2709 passed, 1 skipped · full `tests/mcp/`: 172 passed, 1 skipped, **1 pre-existing failure confirmed unrelated** (`test_fastmcp_core_dep_import_chain.py` — a local-venv `fastmcp`-install environment issue, fails identically with this PR's diff stashed via `git stash`, not caused by this change).

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict` (both touched test files)
- [x] `python scripts/verify_module_docstrings.py` (changed files)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Falsification: both tightened tests confirmed genuinely red against the reverted source
- [x] Full `pytest tests/llm/`: 725 passed
- [x] Full `pytest tests/core/`: 2709 passed, 1 skipped
- [x] Full `pytest tests/mcp/`: 172 passed, 1 skipped, 1 pre-existing unrelated failure (confirmed via stash comparison)

part of #4805

- [x] 🔴 (lead-coder、確認済み) llm.py:2517 は健全な経路（tool 呼び出しだけで本文を返さない round）で発火する — delta.content が空でも tool_calls は届くため _delta_fired は False のまま。A: chunk に tool_calls があれば対象外に狭める / B: message_handler と同様 debug 据え置き。推奨は A。
- [ ] 🔴 (lead-coder) #4805 を閉じる際、message_handler.py の残り物（元の意図が floor に潰されている／設計の答えが要る）を filed か dropped に落とす。
