### PR TITLE
docs(#4774): six questions ④ also covers "ran, but over an empty collection"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,10 +199,18 @@ Ask each test in the diff:
    (#3859), and #3850 landed a field that was required, populated, tested,
    and read by nobody — the honest answer to "who would miss it" was
    already "nobody."
-4. **Would it stay green having never run?** skip / collection error / zero
-   collected all wear green's colour. Name what a missing optional dependency
-   silently skips — CI has no `effects` extra, so #3796's file skips whole and
-   its green says nothing (#2999 is the same shape with a docker-daemon skip).
+4. **Would it stay green having never run — or having run with nothing to
+   bite on?** skip / collection error / zero collected all wear green's
+   colour. Name what a missing optional dependency silently skips — CI has no
+   `effects` extra, so #3796's file skips whole and its green says nothing
+   (#2999 is the same shape with a docker-daemon skip). The same green covers
+   one step further in: a test that RAN, whose assert RAN, over an **empty**
+   collection — `assert not [e for e in xs if …]` passes unconditionally when
+   `xs` is empty, so the filter never decided anything (#4773: the author had
+   written the `assert xs` guard; the reviewing pass ran the six questions and
+   still didn't look, and an independent review found it). Count both the same
+   way — a green path that says nothing, whether the test never ran or the
+   assertion never had a subject.
 5. **What does it accumulate, and who bounds it?** A `list()` over a producer
    whose length is decided by the *caller's* pace is unbounded by construction.
    (#3872: the app's timer paced it at 10fps; `list()` paced it at CPU speed, and
@@ -222,13 +230,17 @@ So each question has a blocking answer, not just an answer:
 | 1 | **none** — including a third party's, a past bug's, and reyn's own trivia |
 | 2 | yes — the same expression is on both sides |
 | 3 | **nobody**, or only a configuration this test itself constructed |
-| 4 | it would be green having never run, **and the PR does not say so** |
+| 4 | it would be green having never run **or over an empty collection**, and the PR does not say so |
 | 5 | **anything outside the test bounds it** — a thread, a timer, the caller's pace |
 | 6 | the declared Tier is not the one question 1 named |
 
 ⚠️ 4 blocks on the *silence*, not on the skip: a file that skips whole in CI is
 often correct (an optional extra), and what makes it a defect is a green nobody
-qualified. 5 has no such carve-out — "it is small today" is a measurement of
+qualified. The empty-collection half reads the same way — a filter that finds
+nothing is often the right answer, and what makes it a defect is a green that
+never said whether the collection had anything in it. Naming it costs one
+sentence; the fix, when it is one, is usually a guard the author already knows
+how to write. 5 has no such carve-out — "it is small today" is a measurement of
 today, and the runaway that started this was small until it wasn't.
 
 **3 needs no accept-side exception.** An accept-side test ("this shape must


### PR DESCRIPTION
**[lead-coder]** — owner 裁定（2026-08-15、逐語「4774 CLAUDE.md 変更して良いよ」）を受けて、六問の④を広げます。

## 何を変えたか

- 問い④の見出しを「Would it stay green having never run — **or having run with nothing to bite on?**」に
- 本文に #4773 の実例を1つ（`assert not [e for e in xs if …]` は `xs` が空なら無条件に通る）
- blocking 表の④の行に「**or over an empty collection**」
- 表下の ⚠️ 注に、空集合側も「沈黙」で block する旨を1文

## なぜ7問目にしないか

CLAUDE.md 自身が理由を書いています — 逐語「a checklist item asking whether you considered it is answered "yes" every time」。単独項目は「確認しました」で通ります。④は既に「緑が何も言っていない経路を数える」問いなので、走らなかった test と、走ったが噛む対象が無かった assert は同じ族です（architect の提案、#4774 に逐語で記録済み）。

## 実例の帰属

#4773 で、著者は `assert vanished_entries` のガードを**書いていました**。六問を通しながら見なかったのは lead-coder（私）で、見つけたのは architect の独立レビューです。「著者が書き忘れた」ではなく「レビュー側の問いに無かった」という形なので、そう書いています。

## Test plan

- [x] `ruff check .` — CLAUDE.md のみの変更、影響なし（実行して green）
- [x] 変更後の④と表の行・注が互いに矛盾しないことを読み合わせ
- [x] `docs/` 配下は触っていない ∴ mkdocs / anchor / retired-key の3点セットは対象外
- [x] `tests/` `src/` を触っていない ∴ tier audit / module docstring / path-literal 系も対象外
- [x] closing-intent: 本文・commit message とも、closing keyword を issue 番号の隣に置いていない

part of #4774（owner の裁定が入ったので、この PR で閉じてよい状態です — ただし裁定の記録として issue 側にコメントを残してから閉じます）
