### PR TITLE
docs(#4782): name assignment-delivery in broker rule 3; put the TUI-theme scope test first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,11 +75,28 @@ call sites. That is a habit, not a gate.
 - **Recovery-feature PR gate**: any PR adding recovery / reconstruction functionality (WAL-event-derived state, PITR, rewind/restore paths) MUST include a truncate-falsify test verifying the reconstruction source survives WAL truncation below its source events (set X → truncate past X's events → reconstruct → assert X survives). WAL-event-derived recovery state that isn't snapshot-backed is a silent data-loss vector. Same PR, not a follow-up. (Motivated by #2259/#2260.)
 - **Sandbox axis-witness gate stays 2-layer**: `enforcement_self_test` (`src/reyn/security/sandbox/self_test.py`) is the PRODUCTION gate every real backend resolution calls; its blast radius is every sandboxed op on every host, so it MUST keep witnessing the deny leg only, for the write + spawn axes only. The richer per-axis 3-tuple contract (deny / exception-boundary / workload — `reyn.security.sandbox.axis_contract`) is CI-conformance-only (`tests/security/test_sandbox_axis_contract_2983.py`, mirroring `scripts/sandbox_landlock_deny_gate.py`'s CI-only deny arms). A PR that folds a new axis or leg into `enforcement_self_test` widens the blast radius of a probe bug to every host's sandbox — do not do this without an explicit owner-level design decision (#2983).
 
-- **TUI colour policy: the terminal emulator's theme decides, reyn only names WHICH semantic colour, never WHICH RGB.** Owner ruling (#3525, 2026-07-31): "the terminal emulator's theme should take priority over Textual's own theme." Normative form: use ANSI 16 (`ansi_red` etc. — the terminal resolves it), `ansi_default`, `transparent` (paint nothing), or a `text-style` attribute (`dim`/`bold`/`reverse`) — never a hex literal, and never alpha-composite over `ansi_default` (the blend loses the terminal's own value and becomes hex-equivalent, #3505's `#0c0c0c` residue). Every colour reyn's inline CUI uses lives in one file, `src/reyn/interfaces/inline/textual_chat/palette.py`; every widget stylesheet writes a `@name@` marker instead of a literal value, and `tests/interfaces/test_tui_colour_tokens.py` enumerates every colour-bearing declaration under `interfaces/` and fails on any value named outside the palette — added after two prior greps for an *expected shape* (`$text-muted`, `$var NN%`) each missed a real violation written in a shape nobody searched for (a hex value sitting behind a `border:` keyword). Textual's own `DEFAULT_CSS` is out of scope for this gate — reyn doesn't own it (#3525 tracks where it collides with the ansi themes).
+- **TUI colour policy: the terminal emulator's theme decides, reyn only names WHICH semantic colour, never WHICH RGB.** Owner ruling (#3525, 2026-07-31): "the terminal emulator's theme should take priority over Textual's own theme." Normative form **for a meaning the terminal's theme already has an opinion about** (see the scope test below — this is not every colour in the TUI): use ANSI 16 (`ansi_red` etc. — the terminal resolves it), `ansi_default`, `transparent` (paint nothing), or a `text-style` attribute (`dim`/`bold`/`reverse`) — never a hex literal in a stylesheet, and never alpha-composite over `ansi_default` (the blend loses the terminal's own value and becomes hex-equivalent, #3505's `#0c0c0c` residue). Every colour reyn's inline CUI uses lives in one file, `src/reyn/interfaces/inline/textual_chat/palette.py`; every widget stylesheet writes a `@name@` marker instead of a literal value, and `tests/interfaces/test_tui_colour_tokens.py` enumerates every colour-bearing declaration under `interfaces/` and fails on any value named outside the palette — added after two prior greps for an *expected shape* (`$text-muted`, `$var NN%`) each missed a real violation written in a shape nobody searched for (a hex value sitting behind a `border:` keyword). Textual's own `DEFAULT_CSS` is out of scope for this gate — reyn doesn't own it (#3525 tracks where it collides with the ansi themes).
+
+  **Scope — decide this before choosing any value:**
+
+  1. Does the meaning have a convention a reader already carries (*error*,
+     *success*, *in-flight*)? → name the meaning, let the theme render it
+     (ANSI-16 / `ansi_default` / SGR attribute).
+  2. Is the meaning reyn-specific? → any value that serves the design,
+     full-colour included. The theme has no opinion to defer to here.
+
+  **A colour is not a meaning.** "Error" is the meaning; red is one
+  terminal's rendering of it. Never pick the colour first.
+
+  **This is not an ANSI-16-only policy.** ANSI-16 is how reyn defers on (1);
+  it is not a palette reyn is confined to. Only two things are forbidden, and
+  neither limits expressiveness: a literal in a widget stylesheet (values go
+  through a `palette.py` token), and alpha-compositing over `ansi_default`
+  (the blend destroys the terminal's own value).
 
   **Carve-out (owner, 2026-08-07, extends #3525 rather than replacing it):** a
-  *reyn-specific* meaning — one with no established convention (red = error,
-  etc.) — may use a token value outside ANSI-16. A meaning WITH an
+  *reyn-specific* meaning — one with no established convention the way
+  *error* or *success* has one — may use a token value outside ANSI-16. A meaning WITH an
   established convention still must resolve through ANSI-16 /
   `ansi_default` / an SGR attribute, same as before; "is this meaning
   conventional or reyn-specific" is a judgment call no gate can make, which
@@ -437,7 +454,10 @@ These rules then keep multi-session work coherent:
    a block or revision-ready signal, send a parallel broker message
    (= `post_message(to=<peer>, ...)` with a short summary). Typical
    uses: "revision pushed, ready for re-review", "block raised on
-   #N", "I'm picking up #M, please pause on it". **PR comments
+   #N", "I'm picking up #M, please pause on it", and **delivering a NEW
+   assignment** — no peer polls every issue, so an assignment written only
+   on the issue reaches nobody (#4737 / #4763 / #4776; #4776 idled
+   e2e-coder ~2h while its issue said "assigned"). **PR comments
    remain the authoritative audit trail** — review decisions (block /
    accept / merge), revision rationale, and review evidence all stay
    in PR body / comments / commit messages. Broker is only for


### PR DESCRIPTION
**[lead-coder]** — owner 裁定 2 件を CLAUDE.md に反映します。

## ① broker 規則 3 に「新規割当の配達」を足す（#4782）

> **owner 逐語**:「4782 私の判断必要な理由がわからん」

ご指摘のとおり、これは owner の判断を要しません。私が回した理由は内容ではなく手続きでした（同じ夜に CLAUDE.md を 1 件触っており、2 件目を無断で重ねるのは筋が悪いと考えた）。**トレードオフの無い、純粋な取りこぼしの修正**なので引き取ります。

issue に「X は <peer> に割り当て」と書いても、**どの peer も全 issue を polling していません** — issue にしか載らない割当は誰にも届きません。一晩に 3 度（#4737 / #4763 / #4776）これが起き、#4776 では issue 自身が「割当済み」と言っている間、e2e-coder が約 2 時間空いていました。**PR/issue の面だけでは遅いのではなく無音になる、唯一の broker 用途**なので、他の典型例の隣に名指しします。

## ② TUI テーマの適用範囲を、carve-out の中から前に出す

> **owner 逐語**:「何度も言ってるが、TUI テーマを使うのはそれが一般的な意味である場合に限る。忘れないように TUI テーマについて記載されてるところに追記しておいて」

この判定は 2026-08-07 の carve-out の**中**にありました。carve-out は「例外」として読まれるため、**二方向テストの片側ではなく狭い特殊ケースとして読まれ続けた**のが実態です（owner が「何度も言ってる」と仰るとおり）。前に出しました。

> **owner 逐語（同じやり取り）**:「赤、は意味じゃないからね？」

**色は意味ではありません。**「エラー」が意味で、赤はある端末での描画です。テストは「ここは赤が正しいか」ではなく **「この意味には、読み手が既に持っている慣習があるか」** です。私が最初に書いた「red = error」という並べ方は、reyn が踏まない当のステップ（色を名指しする）を書き戻していたので、直しました。既存の carve-out 側にも同じ表記があったので併せて直しています。

## Test plan

- [x] `ruff check .` — CLAUDE.md のみ、green
- [x] 追記した 2 箇所を前後の文と読み合わせ（規則 3 の典型例の列／colour policy の carve-out との重複なし）
- [x] `docs/` `tests/` `src/` を触っていない ∴ mkdocs / anchor / tier audit / path-literal 系は対象外
- [x] closing-intent: 本文・commit message とも、closing keyword を issue 番号の隣に置いていない

part of #4782（owner の裁定が入ったので、着地後に issue 側へ記録して閉じます）
