### PR TITLE
fix(#4788): an arriving intervention closes an already-open rewind picker

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2678,21 +2678,32 @@ class TextualChatApp(App):
         in :meth:`on_key`, only if either were declared priority=True). This
         stays scoped to one key and one widget instead.
 
+        ★#4788 B (owner-approved, decided after this fix landed): the
+        scenario this fix was written for — an intervention arriving
+        while the picker is already open — can no longer put both modals
+        on screen at once. :meth:`_present_intervention` now closes the
+        picker outright the moment an intervention arrives (``RewindPicker
+        .hide()``, no Esc involved), rather than leaving it open behind
+        the panel. That leaves this Esc branch fully live for one purpose
+        only: the picker's own Esc-to-cancel, same as before this fix, now
+        simply never racing an intervention's arrival.
+
         ★Implicit ordering, when BOTH the picker and the intervention panel
-        are open at once: this catch runs first and consumes the Esc press
-        outright (``event.stop()``), so a single Esc closes ONLY the picker
-        — :class:`~.intervention_panel.InterventionPanel`'s own ``escape``
-        Binding (``action_dismiss_panel``) never fires on that same press.
-        No capability is lost: the panel's own Esc is documented as a
-        focus-only escape hatch, not a close ("every pending tab stays
-        exactly as it was" — ``InterventionPanel.Dismissed``'s own
-        docstring), so a SECOND Esc (picker now closed, this branch a no-op)
-        reaches it exactly as before. Picker-first is deliberate — the
-        picker has no other way to close once it has lost focus (that is
-        this fix's whole premise), while the panel already has one. Whether
-        this ordering, or the picker staying open across an intervention at
-        all, is the right UX is a separate, open question (#4788 tracks it;
-        not decided here).
+        are STILL open at once (the one remaining path: the user opens the
+        picker via ``/rewind`` while an intervention panel is already
+        showing — #4788 B did not touch that direction, only "intervention
+        arrives while picker is open"): this catch runs first and consumes
+        the Esc press outright (``event.stop()``), so a single Esc closes
+        ONLY the picker — :class:`~.intervention_panel.InterventionPanel`'s
+        own ``escape`` Binding (``action_dismiss_panel``) never fires on
+        that same press. No capability is lost: the panel's own Esc is
+        documented as a focus-only escape hatch, not a close ("every
+        pending tab stays exactly as it was" —
+        ``InterventionPanel.Dismissed``'s own docstring), so a SECOND Esc
+        (picker now closed, this branch a no-op) reaches it exactly as
+        before. Picker-first is deliberate — the picker has no other way
+        to close once it has lost focus (that is this fix's whole
+        premise), while the panel already has one.
         """
         if isinstance(event, (events.Key, events.MouseScrollDown, events.MouseScrollUp)):
             # ``self._flow`` is created lazily in ``compose()``, not
@@ -3559,7 +3570,34 @@ class TextualChatApp(App):
         input (:meth:`on_intervention_panel_choice_selected` /
         :meth:`on_intervention_panel_text_submitted`) moved together, so there
         is never a moment where both the panel AND a chip/composer-match path
-        are live for the same intervention."""
+        are live for the same intervention.
+
+        #4788 B (owner-approved, via lead-coder's recommendation — not
+        decided by this session): an arriving intervention closes an
+        already-open rewind picker outright, rather than leaving both
+        modals live behind each other. Three reasons, all lead-coder's:
+        an intervention is the agent BLOCKED and waiting (urgent) while
+        the picker is a look-only browsing surface — different priority;
+        two simultaneous modals make the Esc key's destination ambiguous
+        — exactly the shape #4788 A (fixed in #4789) had to work around
+        for Esc specifically, and there is no reason to leave that
+        ambiguity standing for every OTHER key too; and what's lost is
+        small — the picker holds no state Rewind itself owns, so a single
+        ``r`` reopens it.
+
+        Calls :meth:`~.rewind_picker.RewindPicker.hide` directly, NOT
+        :meth:`~.rewind_picker.RewindPicker.action_dismiss` — the latter
+        posts ``Dismissed``, whose handler (:meth:`on_rewind_picker_
+        dismissed`) unconditionally re-focuses the Composer, which is
+        the right target for a user's own Esc-cancel but would fight
+        this intervention's own focus routing (``InterventionPanel.
+        add_pending`` → ``on_tabbed_content_tab_activated`` on a
+        first-arriving tab). ``hide()`` clears the picker's display and
+        state with no message and no focus side effect, leaving the
+        panel's own routing as the only thing deciding where focus lands."""
+        picker = getattr(self, "_rewind_picker", None)
+        if picker is not None and picker.display:
+            picker.hide()
         meta = msg.meta or {}
         iv_id = meta.get("intervention_id")
         key: object = iv_id if iv_id else id(entry)

--- a/tests/interfaces/test_4788_rewind_picker_escape_dismiss.py
+++ b/tests/interfaces/test_4788_rewind_picker_escape_dismiss.py
@@ -6,12 +6,26 @@ freeze itself did not reproduce, but this real, unrelated defect surfaced
 along the way): :class:`~reyn.interfaces.inline.textual_chat.rewind_picker.
 RewindPicker`'s own ``escape`` Binding only participates in Textual's
 focused-widget-outward walk when the picker (or a descendant) is somewhere
-in the current focus chain. An intervention arriving while the picker is
-already open steals focus to its own free-text ``Input`` — Esc then resolves
-against THAT chain instead, and the picker's own binding never gets
-consulted at all. The picker was never functionally stuck (clicking back
-into it, or Enter on a highlighted row, both still worked) — only Esc's own
-path to it was unreachable, which is the gap this test pins.
+in the current focus chain. Something moving focus away from the picker
+while it stays open — originally observed via an arriving intervention —
+steals focus, and Esc then resolves against the NEW chain instead, so the
+picker's own binding never gets consulted at all. The picker was never
+functionally stuck (clicking back into it, or Enter on a highlighted row,
+both still worked) — only Esc's own path to it was unreachable, which is
+the gap this test pins.
+
+#4788 B (owner-approved, decided AFTER this file's first version landed):
+an arriving intervention now closes the picker outright
+(:meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.
+_present_intervention`), rather than merely stealing its focus — so an
+intervention can no longer produce the "picker open, unfocused" state this
+file's first test used to set up via that specific path. That test is
+rewritten below to move focus away from the picker directly (a plain
+``Composer.focus()``, e.g. the user clicking back into the composer while
+the picker sits open) — a different, still-real way to reach the same
+unfocused-but-open state the Esc catch exists for. #4788 B's OWN new
+behavior (intervention closes the picker) is covered separately, in
+``test_an_arriving_intervention_closes_an_open_rewind_picker`` below.
 
 Real ``AgentRegistry``/``Session`` (the real ``session.set_pending_command_ui``
 + ``__rewind_list__`` sentinel path a typed ``/rewind`` uses) + a real,
@@ -27,6 +41,7 @@ import pytest
 
 from reyn.core.events.events import Event
 from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
 from reyn.interfaces.inline.textual_chat.rewind_picker import RewindPicker
 from reyn.interfaces.repl.read_model import RegistryReadModel
@@ -118,11 +133,14 @@ async def _settle(pilot, n: int = 3) -> None:
 
 
 @pytest.mark.asyncio
-async def test_escape_dismisses_rewind_picker_after_focus_moves_to_intervention(
+async def test_escape_dismisses_rewind_picker_after_focus_moves_elsewhere(
     tmp_path, monkeypatch,
 ) -> None:
-    """Tier 2: picker opens, THEN a pending free-text intervention arrives and
-    steals focus to its own ``Input`` — Esc must still close the picker."""
+    """Tier 2: picker opens, THEN focus moves away from it (a direct
+    ``Composer.focus()`` — the user clicking back into the composer, the
+    same discriminator an arriving intervention used to exercise before
+    #4788 B made intervention arrival close the picker outright instead)
+    — Esc must still close the picker."""
     monkeypatch.chdir(tmp_path)
     reg = _registry(tmp_path)
     try:
@@ -149,16 +167,10 @@ async def test_escape_dismisses_rewind_picker_after_focus_moves_to_intervention(
             assert picker.display is True
             assert app.focused is picker.query_one("#rewind-picker-options")
 
-            # 2) a pending free-text intervention (no "choices" key) arrives
-            # SECOND, while the picker is still open — this is what steals
-            # focus away from the picker.
-            transport.push_display(OutboxMessage(
-                kind="intervention", text="Type an answer",
-                meta={"intervention_id": "iv-1", "prompt": "next step?"},
-            ))
+            # 2) focus moves away from the picker WITHOUT the picker itself
+            # closing — the state Esc's app-level catch exists for.
+            app.query_one(Composer).focus()
             await _settle(pilot)
-            iv_panel = app.query_one(InterventionPanel)
-            assert iv_panel.display is True
             assert picker.display is True, (
                 "the picker must still be open at this point — this test is "
                 "about closing it via Esc, not about it disappearing on its own"
@@ -174,6 +186,58 @@ async def test_escape_dismisses_rewind_picker_after_focus_moves_to_intervention(
             assert picker.display is False, (
                 "Esc must dismiss an open rewind picker regardless of which "
                 "widget currently holds focus (#4788)"
+            )
+    finally:
+        await reg.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_an_arriving_intervention_closes_an_open_rewind_picker(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #4788 B (owner-approved, via lead-coder's recommendation) —
+    an intervention arriving while the rewind picker is open closes the
+    picker outright, rather than leaving both modals live behind each
+    other. Covers the actual owner-decided behavior this issue's B half
+    was about; the escape-reaches-an-unfocused-picker mechanism itself is
+    covered by the sibling tests in this file."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        alpha = reg.get_session("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            # 1) the rewind picker opens first, via the real command-UI path
+            # a typed ``/rewind`` uses.
+            alpha.set_pending_command_ui({
+                "kind": "rewind",
+                "points": [{"seq": 1, "ts": "t1", "kind": "checkpoint"}],
+            })
+            transport.push_display(OutboxMessage(
+                kind="__rewind_list__", text="rewind points", meta={},
+            ))
+            await _settle(pilot)
+            picker = app.query_one(RewindPicker)
+            assert picker.display is True
+
+            # 2) a pending free-text intervention (no "choices" key) arrives
+            # SECOND, while the picker is still open.
+            transport.push_display(OutboxMessage(
+                kind="intervention", text="Type an answer",
+                meta={"intervention_id": "iv-1", "prompt": "next step?"},
+            ))
+            await _settle(pilot)
+            iv_panel = app.query_one(InterventionPanel)
+            assert iv_panel.display is True
+            assert picker.display is False, (
+                "an arriving intervention must close an already-open rewind "
+                "picker outright (#4788 B) — the two are not meant to coexist"
             )
     finally:
         await reg.shutdown()


### PR DESCRIPTION
**[tui-coder]** — #4788 B, owner-approved (via lead-coder's recommendation, not decided by this session). A already landed in #4789.

## Decision (lead-coder, owner-approved)

An intervention arriving while the rewind picker is open closes the picker outright.

- An intervention is the agent BLOCKED and waiting (urgent); the picker is a look-only browsing surface — different priority.
- Two simultaneous modals make the Esc key's destination ambiguous — exactly the shape #4788 A had to work around for Esc specifically; no reason to leave that ambiguity standing for every other key too.
- What's lost is small — the picker holds no state Rewind itself owns, so a single `r` reopens it.

## What I did

`_present_intervention` now calls `RewindPicker.hide()` directly (NOT `action_dismiss()`, which posts a `Dismissed` message whose handler unconditionally re-focuses the Composer — that would fight the intervention panel's own focus routing on a first-arriving tab). `hide()` clears display + state with no message and no focus side effect, so the panel's own routing is the only thing deciding where focus lands.

## Doc-drift fix (same PR, per CLAUDE.md)

`on_event`'s docstring described a "both the picker and intervention panel open at once" scenario reachable via an intervention arriving while the picker is open. That specific path is now impossible — updated the docstring to say so, while noting the OTHER direction (opening the picker via `/rewind` while an intervention panel is already showing) is unchanged and out of #4788 B's scope.

## Tests

`tests/interfaces/test_4788_rewind_picker_escape_dismiss.py`:
- Rewrote the first test — its old setup ("intervention arrives, picker stays open but loses focus") is no longer producible; moved focus via a direct `Composer.focus()` instead, preserving coverage of the underlying Esc-reaches-an-unfocused-picker mechanism.
- Added `test_an_arriving_intervention_closes_an_open_rewind_picker` for the actual #4788 B behavior.
- The accept-side sibling (picker holds focus, Esc closes it) is untouched.

All 3 pass; real `AgentRegistry`/`Session`, no mocks.

## Live verification (real TTY, per lead-coder's note — I'm the only session holding one)

tmux, real `reyn chat`, real LLM turns:
1. Sent a trivial message → created a checkpoint.
2. `/rewind` → picker opened, showing the checkpoint.
3. Tab (focus off the picker, picker stays open) → requested a file write outside the write scope → a real permission intervention arrived.
4. **The picker disappeared from screen the instant the intervention panel appeared** — no leftover picker state.
5. Answered the intervention (No) → resolved cleanly, no residue.

## Checks

`ruff check .` clean · `mypy_ratchet.py` clean · `test_tier_audit.py --strict` on the touched test file: 3/3 OK · `verify_module_docstrings.py` OK · `flat_tests_ratchet.py` OK · `check_tests_path_literal_reference.py` OK · `check_bare_tests_import_reference.py` OK · `check_file_depth_reference.py` OK · full `tests/interfaces/ -k "rewind or intervention"`: 100 passed.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4788_rewind_picker_escape_dismiss.py`
- [x] `python scripts/verify_module_docstrings.py` (changed files)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `pytest tests/interfaces/ -k "rewind or intervention"`: 100 passed
- [x] Live TTY verification (real tmux, real `reyn chat`) — picker closes the instant an intervention arrives

part of #4788