### PR TITLE
fix(#4761): key-arrival counter — distinguish H3 from H1/H2

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1244,6 +1244,28 @@ class TextualChatApp(App):
         #: unboundedly-running counter needs no separate bound of its own.
         self._pump_ticks = 0
         self._pump_heartbeat_timer: "Timer | None" = None
+        #: #4761 ③: total Key events this App has ever received, counted in
+        #: :meth:`on_event` — the earliest, focus-independent seam ②'s own
+        #: docstring already established. Distinguishes H3 (input never
+        #: reaching the App at all) from a live pump that simply has
+        #: nothing to do: ② alone can show the pump is still ticking during
+        #: a stall, but a ticking pump with zero keys arriving despite an
+        #: operator who reports pressing several is H3, not H1/H2. Same
+        #: rolling-window treatment as ②'s ``pump_ticks`` (see
+        #: ``_watch_loop_responsiveness``) — a raw cumulative total alone
+        #: cannot say whether it moved DURING the stall being reported.
+        self._keys_received = 0
+        #: The last ``events.Key`` OBJECT counted, by identity, not value —
+        #: measured directly (not assumed): Textual dispatches the SAME
+        #: Key event object to this App's own ``on_event`` twice for some
+        #: keys (``escape``, confirmed by ``id()``; an ordinary printable
+        #: key consumed by a focused Input along the way did not repeat).
+        #: Without this guard the counter would silently over-count
+        #: exactly the keys most likely to matter for a stall report
+        #: (Esc, an attempt to break out) — dedup by ``is``, not equality,
+        #: since two SEPARATE real presses of the same key are two
+        #: distinct objects and must both count.
+        self._last_counted_key_event: "object | None" = None
         #: One row per pipeline RUN, keyed by ``run_id`` — every step frame for
         #: that run folds into it (:meth:`_coalesce_pipeline_step`).
         self._pipeline_runs: "dict[str, Entry[OutboxMessage]]" = {}
@@ -1969,8 +1991,17 @@ class TextualChatApp(App):
         # 2.0/_TICK_SECONDS ~= 40 tuples of two floats) is negligible and
         # bounded — old samples are popped every tick, so this deque's own
         # size never grows past that regardless of session length.
+        # #4761 ③ reuses this same window (lead-coder: "②で作った形がそのまま
+        # 使える") — self._keys_received is sampled alongside pump_ticks at
+        # the SAME cadence, so one deque of triples covers both rather than
+        # a second, parallel bookkeeping structure. keys_delta lets the
+        # stall notice distinguish H3 (pump ticking, zero keys arriving
+        # despite an operator who reports pressing several) from H1/H2 on
+        # its own, in the same one line — same bound reasoning as ②'s own
+        # pump_delta: old samples popped every tick, size never exceeds
+        # ~2.0/_TICK_SECONDS regardless of session length.
         _PUMP_WINDOW_S = 2.0
-        pump_history: "deque[tuple[float, int]]" = deque()
+        pump_history: "deque[tuple[float, int, int]]" = deque()
 
         last = time.perf_counter()
         while True:
@@ -1978,13 +2009,16 @@ class TextualChatApp(App):
             now = time.perf_counter()
             lateness_ms = (now - last - _TICK_SECONDS) * 1000
             last = now
-            pump_history.append((now, self._pump_ticks))
+            pump_history.append((now, self._pump_ticks, self._keys_received))
             while pump_history and now - pump_history[0][0] > _PUMP_WINDOW_S:
                 pump_history.popleft()
             fired = self._loop_tripwire.observe(lateness_ms, pump_ticks=self._pump_ticks)
             if fired is not None:
                 pump_delta = (
                     self._pump_ticks - pump_history[0][1] if pump_history else 0
+                )
+                keys_delta = (
+                    self._keys_received - pump_history[0][2] if pump_history else 0
                 )
                 logger.warning(
                     "textual chat: %s",
@@ -1993,6 +2027,8 @@ class TextualChatApp(App):
                         pump_ticks=self._pump_ticks,
                         pump_delta=pump_delta,
                         pump_window_s=_PUMP_WINDOW_S,
+                        keys_received=self._keys_received,
+                        keys_delta=keys_delta,
                     ),
                 )
                 try:
@@ -2694,6 +2730,24 @@ class TextualChatApp(App):
         all, is the right UX is a separate, open question (#4788 tracks it;
         not decided here).
         """
+        if isinstance(event, events.Key):
+            # #4761 ③: counted here — the SAME "sees the raw event first,
+            # regardless of focus, regardless of what handling follows"
+            # seam this method's own docstring already relies on — not in
+            # a per-widget on_key, which only sees keys that widget's own
+            # bubble reaches (the composer's Input consumes printable keys
+            # itself, so a per-widget count would silently miss most
+            # keystrokes). Unconditional: every Key event reaching the App
+            # counts, whether it goes on to dismiss an overlay, close the
+            # picker, or fall through to ordinary focused-widget dispatch —
+            # the counter's only job is "did a key reach the App at all,"
+            # not what happened to it next. Deduped by object IDENTITY
+            # (see ``_last_counted_key_event``'s own docstring) — measured
+            # directly that Textual dispatches the SAME Key object to this
+            # method twice for some keys.
+            if event is not self._last_counted_key_event:
+                self._keys_received += 1
+                self._last_counted_key_event = event
         if isinstance(event, (events.Key, events.MouseScrollDown, events.MouseScrollUp)):
             # ``self._flow`` is created lazily in ``compose()``, not
             # ``__init__`` — ``on_event`` fires for every event from the
@@ -2749,6 +2803,12 @@ class TextualChatApp(App):
         :meth:`on_timer` compares against by identity, without reaching
         into ``_pump_heartbeat_timer`` directly."""
         return self._pump_heartbeat_timer
+
+    @property
+    def keys_received(self) -> int:
+        """Total Key events this App has ever received (#4761 ③) — public
+        read, same pattern as :attr:`pump_ticks`."""
+        return self._keys_received
 
     async def on_key(self, event) -> None:
         # #3476 ⑥: 'r' while the cursor has focus is a keyboard shortcut for

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -256,6 +256,8 @@ def stall_log_line(
     pump_ticks: "int | None" = None,
     pump_delta: "int | None" = None,
     pump_window_s: "float | None" = None,
+    keys_received: "int | None" = None,
+    keys_delta: "int | None" = None,
 ) -> str:
     """The durable record of a stall — the one that survives the operator
     looking away.
@@ -279,6 +281,14 @@ def stall_log_line(
     event required. ``0`` here is the H1 signal (pump had already
     stopped advancing before the stall was even noticed); a positive
     delta rules H1 out for this episode on its own.
+
+    ``keys_received``/``keys_delta`` (#4761 ③) follow the SAME
+    self-contained-in-one-line shape, deliberately not a pair with a
+    recovery-side reading, for the same reason: an H3 diagnosis ("keys
+    aren't reaching the App at all") is needed most on a freeze that never
+    resolves. A ticking pump (``pump_delta`` > 0) with ``keys_delta`` at
+    ``0`` despite an operator who reports pressing several keys is H3, not
+    H1/H2 — the pump is fine, input simply never arrived.
     """
     ticks_note = ""
     if pump_ticks is not None:
@@ -289,9 +299,19 @@ def stall_log_line(
             )
         else:
             ticks_note = f" (pump heartbeat at {pump_ticks})"
+    keys_note = ""
+    if keys_received is not None:
+        if keys_delta is not None and pump_window_s is not None:
+            keys_note = (
+                f" (keys received: {keys_received}, +{keys_delta} in the "
+                f"last {pump_window_s:.0f}s)"
+            )
+        else:
+            keys_note = f" (keys received: {keys_received})"
     return (
         f"the interface was unresponsive for {lateness_ms / 1000:.1f}s"
-        f"{ticks_note} — re-run with {_DUMP_ENV}=<path> to record what it was doing"
+        f"{ticks_note}{keys_note} — re-run with {_DUMP_ENV}=<path> to record "
+        "what it was doing"
     )
 
 

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -690,3 +690,107 @@ async def test_pump_heartbeat_reaches_the_default_visible_notices(
         "self-contained trailing-window delta — a freeze that never "
         f"recovers never reaches the recovery line at all: {stall_line!r}"
     )
+
+
+# ── #4761 ③: the key-arrival counter ────────────────────────────────────────
+
+
+def test_stall_line_carries_keys_received_and_delta() -> None:
+    """Tier 2: #4761 ③ — the stall line gains a THIRD, independently-optional
+    field for key arrival, in the same self-contained-in-one-line shape ②'s
+    own lead-coder review established (no pairing with a recovery-side
+    reading — an H3 diagnosis is needed most on a freeze that never
+    resolves)."""
+    with_keys = stall_log_line(
+        1800.0, pump_ticks=5, pump_delta=2, pump_window_s=2.0,
+        keys_received=7, keys_delta=0,
+    )
+    assert "keys received: 7" in with_keys
+    assert "+0" in with_keys  # the H3 signal: pump moved, keys did not
+
+    # keys_received alone (no delta/window) falls back to the bare form —
+    # a caller with a value but no window yet must not have to fabricate one.
+    ticks_only_no_keys = stall_log_line(1800.0, pump_ticks=5)
+    assert "keys received" not in ticks_only_no_keys
+
+    keys_only = stall_log_line(1800.0, keys_received=3)
+    assert "keys received: 3" in keys_only
+    assert "pump heartbeat" not in keys_only
+
+
+@pytest.mark.asyncio
+async def test_on_event_counts_key_events_only() -> None:
+    """Tier 2: #4761 ③ — the discriminator this counter depends on: every
+    real Key event reaching the App counts, and nothing else does (a mouse
+    scroll, in particular, is handled by the SAME isinstance-guarded block
+    in on_event that the overlay-dismiss logic already shares, so this
+    pins that the two checks stayed correctly split apart)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        before = app.keys_received
+
+        await pilot.press("a")
+        assert app.keys_received == before + 1
+
+        await pilot.press("escape")
+        assert app.keys_received == before + 2, (
+            "a key that ALSO triggers other on_event handling (escape) "
+            "must still be counted — the counter's job is arrival, not outcome"
+        )
+
+        from textual import events
+
+        await app.on_event(
+            events.MouseScrollDown(None, 0, 0, 0, 0, 0, False, False, False)
+        )
+        assert app.keys_received == before + 2, (
+            "a non-Key event reaching the same on_event method must NOT "
+            "advance the key counter"
+        )
+
+
+@pytest.mark.asyncio
+async def test_keys_received_reaches_the_default_visible_stall_notice(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2b: #4761 ③ — REACHED end to end: real keypresses, then a real
+    stall, under the reconstructed real logging floor (no ``caplog``,
+    mirroring #4804/②'s own pattern) — the key-arrival count from the
+    App's real ``on_event`` wiring actually lands in the default-visible
+    stall notice, not just that the formatting function accepts the
+    parameter in isolation."""
+    import logging
+    import time
+
+    logfile = tmp_path / "reyn.log"
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    monkeypatch.delenv("REYN_PROF_DUMP", raising=False)
+    try:
+        logging.basicConfig(
+            filename=str(logfile), level=logging.WARNING, force=True,
+        )
+        stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
+        transport = QueueTransport()
+        app = TextualChatApp(transport=transport)
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await pilot.press("a", "b", "c")
+            time.sleep(stall_seconds)
+            while "recovered" not in logfile.read_text(encoding="utf-8"):
+                await pilot.pause()
+    finally:
+        for handler in root.handlers:
+            if handler not in saved_handlers:
+                handler.close()
+        root.handlers = saved_handlers
+        root.setLevel(saved_level)
+
+    content = logfile.read_text(encoding="utf-8")
+    stall_line = next(line for line in content.splitlines() if "unresponsive" in line)
+    assert "keys received: 3" in stall_line, (
+        f"the 3 real keypresses must show up in the stall notice's own count: {stall_line!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #4761 ③, per lead-coder's assignment.

## Background

architect's observation C (#4761 investigation): a ticking pump (②, rules out H1) says nothing about whether input is reaching the App at all. A "pump alive, screen frozen" report couldn't tell H3 (input never reaching the App) apart from H2 (the loop itself starved) or the pump simply having nothing to do.

## Mechanism

Counted in `on_event` — the SAME "sees the raw event first, regardless of focus" seam #4788's own docstring already established for the picker-Esc fix. Not a per-widget `on_key`, which only sees keys that widget's own bubble reaches (the composer's `Input` consumes printable keys itself, so a per-widget count would silently miss most keystrokes).

**Measured, not assumed, before trusting the counter**: Textual dispatches the SAME `Key` event object to this App's own `on_event` **twice** for some keys (`escape`, confirmed by `id()` — an ordinary printable key consumed by the focused `Input` along the way did not repeat). An unguarded counter would have silently over-counted exactly the keys most likely to matter for a stall report (Esc, an attempt to break out). Deduped by object identity (`is`, not `==`) against the last-counted event — two separate real presses of the same key are two distinct objects and both still count.

Reused ②'s own rolling window rather than a second parallel structure — the same `deque` now carries `(timestamp, pump_ticks, keys_received)` triples, sampled at the same cadence, same bound reasoning (old samples popped every tick, size never exceeds ~2.0s/`_TICK_SECONDS` regardless of session length).

## Applying the same two standing questions at design time

- **Visible with shipped config?** `keys_received`/`keys_delta` ride along in the SAME already-default-visible stall line ②'s own lead-coder review corrected — no `write_record`-only path, no `logger.info` trap.
- **Who bounds it?** The counter and the window share ②'s existing bound; nothing new to bound.

Self-contained in the STALL line, not paired with a recovery line — same reasoning ②'s own correction established: a freeze that never recovers (#4761's own report) needs the diagnosis in the one notice guaranteed to fire.

## Test plan

- [x] `test_stall_line_carries_keys_received_and_delta` — formatting, independent of whether `pump_ticks` is also given.
- [x] `test_on_event_counts_key_events_only` — the discriminators: a real keypress counts once (not twice, despite the measured double-dispatch); a non-`Key` event does not count at all.
- [x] `test_keys_received_reaches_the_default_visible_stall_notice` — end-to-end, 3 real keypresses + a real stall under the reconstructed real logging floor (no `caplog`), "keys received: 3" lands via `app.py`'s real call site.
- [x] All three strip-falsified against the real code path — confirmed red for the right reason each time (including the double-dispatch dedup, verified directly via `id()` before trusting the fix).
- [x] All 22 tests in `test_loop_probe_3539.py` green, stable across repeated runs; sibling suites (`test_4788_rewind_picker_escape_dismiss.py`, `test_textual_chat_copy_rewind_3362.py`) unaffected.
- [x] `ruff check .`, `scripts/test_tier_audit.py --strict` (no private-state findings this time — public `keys_received` property used throughout), `scripts/verify_module_docstrings.py`, `scripts/mypy_ratchet.py` — all green.
- [ ] Visual/TTY (standing waiver applies — merge does not wait on this)

part of #4761 (this closes architect's own three "足りないもの" — ①②③ all landed; #4761's own root mechanism remains unidentified, per lead-coder's earlier "機構は依然不明" — this is diagnostic tooling for the NEXT occurrence, not a fix for this one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)