### PR TITLE
fix(#4809): trace records + surfaces prompt_cache_key (#4690 next step)

### DIFF
--- a/scripts/dogfood_trace.py
+++ b/scripts/dogfood_trace.py
@@ -442,9 +442,23 @@ def mode_llm_payloads(records: list[dict], multi_file: bool = False) -> None:
 
         tool_count = len(tools) if tools else 0
         file_tag = f"  [file={req.get('_source_file', '?')}]" if multi_file else ""
+        # #4809: prompt_cache_key printed on every line (not just llm-detail)
+        # so a scan across a session's own request list is enough to answer
+        # #4690's own open question — does the value stay stable turn to
+        # turn, or does it change per call — without opening each request
+        # individually. Three-way, not just "value or (none)": a trace
+        # dumped before #4809 landed never had this key in the record at
+        # all, and reading that the same as an explicit None would silently
+        # misreport "not sent" for a call that simply predates this fix.
+        if "prompt_cache_key" in req:
+            pck = req["prompt_cache_key"]
+            pck_display = "(none)" if pck is None else pck
+        else:
+            pck_display = "(unrecorded, pre-#4809 trace)"
         print(
             f"[{rel_req}] request_id={rid_full}  model={model}  "
-            f"caller={caller}  msgs={len(msgs)}  tools={tool_count}{file_tag}"
+            f"caller={caller}  msgs={len(msgs)}  tools={tool_count}  "
+            f"prompt_cache_key={pck_display}{file_tag}"
         )
 
         if resp is not None:
@@ -496,6 +510,13 @@ def mode_llm_detail(records: list[dict], request_id: str, full: bool = False) ->
     print(f"=== LLM Call Detail: {request_id} ===")
     print(f"  model:       {req.get('model', '?')}")
     print(f"  caller_hint: {req.get('caller_hint', 'unknown')}")
+    # #4809: same three-way distinction as mode_llm_payloads's own summary
+    # line — absent key (pre-#4809 trace) vs explicit None vs a real value.
+    if "prompt_cache_key" in req:
+        _pck = req["prompt_cache_key"]
+        print(f"  prompt_cache_key: {'(none)' if _pck is None else _pck}")
+    else:
+        print("  prompt_cache_key: (unrecorded, pre-#4809 trace)")
     print(f"  timestamp:   {req.get('timestamp', '?')}")
     if req.get("_source_file"):
         print(f"  source_file: {req['_source_file']}")

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -2959,6 +2959,19 @@ async def call_llm_tools(
             "timeout": timeout,
             "max_retries": max_retries,
         },
+        # #4809: #4700/#4704 added this field to the actual call kwargs
+        # (see the ``prompt_cache_key=prompt_cache_key`` forward below) but
+        # never to the trace dump — the one diagnostic surface #4690's own
+        # investigation needed to answer "is it being sent, and is the
+        # value stable across turns" was blind to the exact field in
+        # question. Always present as a key, even when None — a caller
+        # that never set one (every call site pre-#4700) and a caller
+        # that explicitly resolved "no key for this call" must both read
+        # as "not sent" from the trace, distinguishable from a real
+        # non-empty string. Not a secret (router_loop.py's own
+        # ``_prompt_cache_key``: f"{agent_name}:{sid}") — no redaction
+        # concern here, unlike message content.
+        "prompt_cache_key": prompt_cache_key,
     })
 
     async def _tools_call() -> object:

--- a/tests/llm/test_llm_trace_dump.py
+++ b/tests/llm/test_llm_trace_dump.py
@@ -288,6 +288,78 @@ class TestCallerHint:
         assert req["caller_hint"] == "router"
 
 
+class TestPromptCacheKeyInDump:
+    """Tier 2: #4809 — the trace dump reflects prompt_cache_key (#4700),
+    distinguishing a caller that never set one from a caller that
+    explicitly resolved "no key" — #4690's own diagnosis needed exactly
+    this distinction ("is it being sent, and is the value stable") and the
+    trace record had no such field at all before this."""
+
+    def test_prompt_cache_key_recorded_when_given(self, tmp_path: Path, monkeypatch) -> None:
+        """Tier 2: a real prompt_cache_key value lands verbatim in the request record."""
+        import asyncio
+
+        import litellm
+
+        import reyn.llm.llm as llm_mod
+
+        trace_file = tmp_path / "trace_cache_key.jsonl"
+        monkeypatch.setenv("REYN_LLM_TRACE_DUMP", str(trace_file))
+
+        stub = _ScriptedLLM()
+        monkeypatch.setattr(litellm, "acompletion", stub)
+
+        asyncio.run(
+            llm_mod.call_llm_tools(
+                model=MODEL,
+                messages=[{"role": "user", "content": "hi"}],
+                tools=_minimal_tools(),
+                prompt_cache_key="alpha:main",
+            )
+        )
+
+        records = [json.loads(line) for line in trace_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+        req = next(r for r in records if r.get("kind") == "request")
+        assert req["prompt_cache_key"] == "alpha:main"
+
+    def test_prompt_cache_key_present_as_null_when_not_given(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """Tier 2: a caller that never sets prompt_cache_key must still see
+        the KEY in the trace record, with value None — the whole point of
+        #4809 is telling that apart from a trace file dumped before this
+        fix existed (where the key is absent entirely, not present-as-null).
+        A missing key here would silently look identical to the pre-#4809
+        gap this issue exists to close."""
+        import asyncio
+
+        import litellm
+
+        import reyn.llm.llm as llm_mod
+
+        trace_file = tmp_path / "trace_no_cache_key.jsonl"
+        monkeypatch.setenv("REYN_LLM_TRACE_DUMP", str(trace_file))
+
+        stub = _ScriptedLLM()
+        monkeypatch.setattr(litellm, "acompletion", stub)
+
+        asyncio.run(
+            llm_mod.call_llm_tools(
+                model=MODEL,
+                messages=[{"role": "user", "content": "hi"}],
+                tools=_minimal_tools(),
+            )
+        )
+
+        records = [json.loads(line) for line in trace_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+        req = next(r for r in records if r.get("kind") == "request")
+        assert "prompt_cache_key" in req, (
+            "the key must be present even when unset — an absent key is "
+            "indistinguishable from a trace dumped before #4809"
+        )
+        assert req["prompt_cache_key"] is None
+
+
 class TestMultipleCallsAccumulate:
     """Tier 2: consecutive calls append records, request_ids pair correctly."""
 

--- a/tests/scripts/test_dogfood_trace_llm_modes.py
+++ b/tests/scripts/test_dogfood_trace_llm_modes.py
@@ -166,6 +166,63 @@ class TestLlmPayloadsMode:
         assert "no LLM request records" in out
 
 
+class TestPromptCacheKeyDisplay:
+    """Tier 2: #4809 — llm-payloads and llm-detail both surface
+    prompt_cache_key, distinguishing "not recorded at all" (a trace
+    dumped before #4809 landed — SAMPLE_RECORDS has no such field, the
+    realistic pre-fix shape) from an explicit null from from a real
+    value."""
+
+    def test_pre_4809_trace_shows_unrecorded_not_a_crash_or_blank(self, tmp_path: Path) -> None:
+        """Tier 2: SAMPLE_RECORDS predates #4809 (no prompt_cache_key key at
+        all) — llm-payloads must say so explicitly, not silently omit the
+        field or crash on the missing key."""
+        trace = tmp_path / "trace.jsonl"
+        _write_trace(trace, SAMPLE_RECORDS)
+
+        out, rc = _run(["--mode", "llm-payloads", "--trace", str(trace)])
+        assert rc == 0
+        assert "unrecorded" in out
+
+    def test_explicit_none_shown_as_none_not_unrecorded(self, tmp_path: Path) -> None:
+        """Tier 2: a caller that resolved "no key for this call" (key
+        present, value null) must read differently from a pre-#4809 trace
+        that never had the key — the whole distinction #4809 exists for."""
+        records = [dict(r) for r in SAMPLE_RECORDS]
+        records[0]["prompt_cache_key"] = None
+        trace = tmp_path / "trace.jsonl"
+        _write_trace(trace, records)
+
+        out, rc = _run(["--mode", "llm-payloads", "--trace", str(trace)])
+        assert rc == 0
+        assert "prompt_cache_key=(none)" in out
+        assert "unrecorded" not in out.split(REQUEST_ID_A)[1].split("\n")[0], (
+            "the explicit-None request's own line must not say 'unrecorded'"
+        )
+
+    def test_real_value_shown_verbatim_in_payloads_mode(self, tmp_path: Path) -> None:
+        """Tier 2: a real prompt_cache_key value appears in the llm-payloads summary."""
+        records = [dict(r) for r in SAMPLE_RECORDS]
+        records[0]["prompt_cache_key"] = "alpha:main"
+        trace = tmp_path / "trace.jsonl"
+        _write_trace(trace, records)
+
+        out, rc = _run(["--mode", "llm-payloads", "--trace", str(trace)])
+        assert rc == 0
+        assert "prompt_cache_key=alpha:main" in out
+
+    def test_real_value_shown_verbatim_in_detail_mode(self, tmp_path: Path) -> None:
+        """Tier 2: a real prompt_cache_key value appears in the llm-detail view."""
+        records = [dict(r) for r in SAMPLE_RECORDS]
+        records[0]["prompt_cache_key"] = "alpha:main"
+        trace = tmp_path / "trace.jsonl"
+        _write_trace(trace, records)
+
+        out, rc = _run(["--mode", "llm-detail", REQUEST_ID_A, "--trace", str(trace)])
+        assert rc == 0
+        assert "alpha:main" in out
+
+
 class TestLlmDetailMode:
     """Tier 2: llm-detail mode pretty-prints a single request's full payload."""
 


### PR DESCRIPTION
**[e2e-coder]** — #4809, per lead-coder's assignment (next step for #4690).

## Background

#4700/#4704 added `prompt_cache_key` to the actual LLM call kwargs (the routing-affinity hint that lets the same session's calls land on the same backend instance for prefix-cache reuse), but never to the payload trace dump — the one diagnostic surface #4690's own investigation needed to answer "is it being sent, and is the value stable across turns." Owner's own measurement (trace enabled, real payloads captured): a 221,440-char prefix byte-identical across requests, still `cached=0` — ruling out "the content changes" and shifting suspicion to "where the same content is being sent" = affinity, exactly what `prompt_cache_key` exists to control, and exactly the field the trace couldn't show.

## Two parts

1. `llm.py`'s `_dump_llm_request` call site (the single funnel — grepped, only one call site in the file) now always includes `"prompt_cache_key": prompt_cache_key` as a record field, even when `None`. Always-present-as-a-key is the point: a caller that never set one (every pre-#4700 call site) and a caller that explicitly resolved "no key for this call" must both read as an EXPLICIT `None`, distinguishable from a trace dumped before #4809 existed (where the key is absent from the record entirely). Not a secret (`router_loop.py`'s own `_prompt_cache_key`: `f"{agent_name}:{sid}"`) — no redaction concern.
2. `dogfood_trace.py`'s `llm-payloads` (summary line, every request) and `llm-detail` (single-request deep dive) modes now print it, with the same three-way distinction: a real value, `(none)`, or `(unrecorded, pre-#4809 trace)` for old dumps. The summary-line placement matters for #4690's own open question — scanning a session's own request list is enough to see whether the value stays stable turn to turn or changes per call, without opening each request individually.

## Scope

Measurement, not implementation, is step 2 of #4809's own ask — **not done here**. Proxy configuration and API keys are explicitly out of scope per the issue and were not touched or investigated. This PR is the tooling fix only.

## Test plan

- [x] `test_prompt_cache_key_recorded_when_given` / `test_prompt_cache_key_present_as_null_when_not_given` (`tests/llm/test_llm_trace_dump.py`) — real `call_llm_tools` + a real-callable `litellm.acompletion` stub (per this file's own testing-policy note), asserting the record field directly.
- [x] `TestPromptCacheKeyDisplay` (`tests/scripts/test_dogfood_trace_llm_modes.py`, 4 tests) — CLI subprocess + hand-crafted JSONL, covering all three display states in both modes.
- [x] All 6 new tests strip-falsified against the real code path — confirmed red for the right reason each time (including that a neighboring request's own "unrecorded" text doesn't bleed into an explicit-None request's own summary line).
- [x] All 42 tests across both files green.
- [x] `ruff check .`, `scripts/test_tier_audit.py --strict`, `scripts/verify_module_docstrings.py`, `scripts/mypy_ratchet.py` — all green.
- [ ] Visual/TTY — n/a (no UI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)