### PR TITLE
feat(#4761): whether a turn was running at the moment of a stall

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2012,7 +2012,22 @@ class TextualChatApp(App):
             pump_history.append((now, self._pump_ticks, self._keys_received))
             while pump_history and now - pump_history[0][0] > _PUMP_WINDOW_S:
                 pump_history.popleft()
-            fired = self._loop_tripwire.observe(lateness_ms, pump_ticks=self._pump_ticks)
+            # #4761 (architect's outstanding point, unimplemented when
+            # ①②③ landed): whether a turn was running THE INSTANT this tick
+            # was observed. ``ActivityRow.state`` is the app's existing
+            # "is a turn running" surface (already read the same way at the
+            # compact-caps call site, ``turn_active=self._activity.state is
+            # not None``) — reused here rather than adding a second signal
+            # for the same question. ``getattr`` defensively: this loop is
+            # scheduled in ``on_mount``, well after ``self._activity`` is
+            # created in ``compose()``, but matches the defensive idiom this
+            # module already uses for lazily-created widgets read from a
+            # long-lived background loop.
+            activity = getattr(self, "_activity", None)
+            turn_active = None if activity is None else activity.state is not None
+            fired = self._loop_tripwire.observe(
+                lateness_ms, pump_ticks=self._pump_ticks, turn_active=turn_active,
+            )
             if fired is not None:
                 pump_delta = (
                     self._pump_ticks - pump_history[0][1] if pump_history else 0
@@ -2029,6 +2044,7 @@ class TextualChatApp(App):
                         pump_window_s=_PUMP_WINDOW_S,
                         keys_received=self._keys_received,
                         keys_delta=keys_delta,
+                        turn_active=turn_active,
                     ),
                 )
                 try:

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -172,7 +172,11 @@ class LoopTripwire:
         return recovered
 
     def observe(
-        self, lateness_ms: float, *, pump_ticks: "int | None" = None,
+        self,
+        lateness_ms: float,
+        *,
+        pump_ticks: "int | None" = None,
+        turn_active: "bool | None" = None,
     ) -> "float | None":
         """Record one tick's lateness; return it the FIRST time it is bad.
 
@@ -207,17 +211,29 @@ class LoopTripwire:
         see whether the count kept moving DURING an ongoing, not-yet-
         recovered stall, which the once-per-episode default-visible notice
         (below) cannot show on its own.
+
+        ``turn_active``, if the caller has one (#4761: whether a turn was
+        running the instant this tick was observed — see
+        :func:`stall_log_line`'s own docstring for why this matters), rides
+        along the same way for the ARMED trace's own record — this method's
+        own default-visible RETURN VALUE is what :func:`stall_log_line`
+        actually surfaces to an unarmed session; this ``write_record`` call
+        only adds it to the opt-in detail dump for consistency with
+        ``pump_ticks``.
         """
         if lateness_ms > self._max_lateness_ms:
             self._max_lateness_ms = lateness_ms
+        extra: "dict[str, Any]" = {}
+        if pump_ticks is not None:
+            extra["pump_ticks"] = pump_ticks
+        if turn_active is not None:
+            extra["turn_active"] = turn_active
         if lateness_ms <= self._threshold_ms:
             if self._in_stall:
                 self._in_stall = False
                 self._just_recovered = True
                 write_record(
-                    "tripwire_recovered",
-                    lateness_ms=round(lateness_ms, 1),
-                    **({} if pump_ticks is None else {"pump_ticks": pump_ticks}),
+                    "tripwire_recovered", lateness_ms=round(lateness_ms, 1), **extra,
                 )
             return None
         self._in_stall = True
@@ -226,11 +242,7 @@ class LoopTripwire:
             self._last_recorded_monotonic is None
             or now - self._last_recorded_monotonic >= _RECORD_INTERVAL_S
         ):
-            write_record(
-                "tripwire",
-                lateness_ms=round(lateness_ms, 1),
-                **({} if pump_ticks is None else {"pump_ticks": pump_ticks}),
-            )
+            write_record("tripwire", lateness_ms=round(lateness_ms, 1), **extra)
             self._last_recorded_monotonic = now
         if self._fired:
             return None
@@ -258,6 +270,7 @@ def stall_log_line(
     pump_window_s: "float | None" = None,
     keys_received: "int | None" = None,
     keys_delta: "int | None" = None,
+    turn_active: "bool | None" = None,
 ) -> str:
     """The durable record of a stall — the one that survives the operator
     looking away.
@@ -289,6 +302,24 @@ def stall_log_line(
     resolves. A ticking pump (``pump_delta`` > 0) with ``keys_delta`` at
     ``0`` despite an operator who reports pressing several keys is H3, not
     H1/H2 — the pump is fine, input simply never arrived.
+
+    ``turn_active`` (#4761, architect's outstanding point, still unimplemented
+    when ①②③ landed): whether a turn was running AT THE MOMENT this notice
+    fired — the ①②③ trio (tripwire lateness, pump heartbeat, key-arrival
+    count) all discriminate BETWEEN hypotheses for what stopped the interface,
+    but only make sense if the interface was actually being asked to do
+    something. Without this, a byte-identical, unchanging screen is not
+    evidence of a freeze on its own — it is equally consistent with "nothing
+    was happening" (no turn in flight, an idle screen that simply has nothing
+    to redraw). Passes the same two design questions ①②③ already had to pass
+    (lead-coder, tonight, three times): visible with shipped defaults —
+    riding this line's own ``logger.warning`` call, the same always-on
+    surface ①②③'s own notices use, NOT a second ``write_record`` call that
+    would need ``REYN_PROF_DUMP`` armed in advance; and who binds it — the
+    caller (:meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.
+    _watch_loop_responsiveness`) reads its own ``ActivityRow.state`` (already
+    the app's existing "is a turn running" surface — see ``turn_active=`` at
+    the compact-caps call site) at the same instant it reads ``pump_ticks``.
     """
     ticks_note = ""
     if pump_ticks is not None:
@@ -308,10 +339,13 @@ def stall_log_line(
             )
         else:
             keys_note = f" (keys received: {keys_received})"
+    turn_note = ""
+    if turn_active is not None:
+        turn_note = f" (turn {'active' if turn_active else 'idle'} at the time)"
     return (
         f"the interface was unresponsive for {lateness_ms / 1000:.1f}s"
-        f"{ticks_note}{keys_note} — re-run with {_DUMP_ENV}=<path> to record "
-        "what it was doing"
+        f"{ticks_note}{keys_note}{turn_note} — re-run with {_DUMP_ENV}=<path> "
+        "to record what it was doing"
     )
 
 

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -794,3 +794,112 @@ async def test_keys_received_reaches_the_default_visible_stall_notice(
     assert "keys received: 3" in stall_line, (
         f"the 3 real keypresses must show up in the stall notice's own count: {stall_line!r}"
     )
+
+
+# ── #4761: turn_active, whether a turn was running at the moment ──────────
+
+
+def test_stall_line_carries_turn_active_when_given() -> None:
+    """Tier 2: #4761 (architect's outstanding point) — the STALL notice
+    embeds whether a turn was running at the instant it fired, and stays
+    exactly as it was when the caller doesn't have that signal — this
+    module has no idea whether a caller tracks turn activity at all, so the
+    parameter must be fully optional, same discipline as ``pump_ticks``.
+
+    Without this, a byte-identical frozen screen is not evidence of a
+    freeze on its own — it is equally consistent with "nothing was
+    happening" (idle, no turn in flight)."""
+    active = stall_log_line(1800.0, turn_active=True)
+    assert "(turn active at the time)" in active
+    idle = stall_log_line(1800.0, turn_active=False)
+    assert "(turn idle at the time)" in idle
+    assert "(turn active at the time)" not in idle
+    unspecified = stall_log_line(1800.0)
+    assert "turn active" not in unspecified and "turn idle" not in unspecified
+    assert unspecified == (
+        "the interface was unresponsive for 1.8s — re-run with "
+        "REYN_PROF_DUMP=<path> to record what it was doing"
+    )
+
+
+def test_observe_threads_turn_active_into_both_durable_record_kinds(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Tier 2: #4761 — an armed session's durable trace carries the SAME
+    turn-active value the caller passed, for both the periodic
+    ``"tripwire"`` record and the ``"tripwire_recovered"`` one — mirrors
+    ``pump_ticks``'s own coverage above, same reasoning: consistency for
+    the opt-in detail dump, even though the default-visible notice (tested
+    separately below) is what actually matters for an unarmed session."""
+    import json
+
+    target = tmp_path / "probe.jsonl"
+    monkeypatch.setenv("REYN_PROF_DUMP", str(target))
+    tripwire = LoopTripwire(threshold_ms=250.0)
+
+    tripwire.observe(1800.0, turn_active=True)
+    tripwire.observe(50.0, turn_active=False)
+
+    records = [
+        json.loads(line) for line in target.read_text(encoding="utf-8").splitlines()
+    ]
+    by_kind = {r["kind"]: r for r in records}
+    assert by_kind["tripwire"]["turn_active"] is True
+    assert by_kind["tripwire_recovered"]["turn_active"] is False
+
+
+@pytest.mark.asyncio
+async def test_turn_active_reaches_the_default_visible_stall_notice(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2b: #4761 — REACHED end to end, under the reconstructed real
+    logging floor (no ``caplog``, mirroring #4804's own pattern and this
+    file's own ``test_pump_heartbeat_reaches_the_default_visible_notices``):
+    a real stall that happens WHILE a turn is running (a real
+    ``turn_started`` event pushed through the transport — the same public
+    path production uses to set ``ActivityRow``'s state, not a private
+    ``_activity.begin()`` reach-around) shows ``turn active`` in the
+    default-visible log line, not gated behind ``REYN_PROF_DUMP``."""
+    import logging
+    import time
+
+    logfile = tmp_path / "reyn.log"
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    monkeypatch.delenv("REYN_PROF_DUMP", raising=False)
+    try:
+        logging.basicConfig(
+            filename=str(logfile), level=logging.WARNING, force=True,
+        )
+        stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
+        transport = QueueTransport()
+        app = TextualChatApp(transport=transport)
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            # A real turn_started event — the same public path
+            # _handle_turn_started_event uses to call
+            # self._activity.begin("WORKING") in production.
+            await transport.push_event(
+                Event(
+                    type="turn_started",
+                    data={"kind": "user", "chain_id": "chain-1", "seq": 1},
+                )
+            )
+            await pilot.pause()
+            time.sleep(stall_seconds)
+            while "unresponsive" not in logfile.read_text(encoding="utf-8"):
+                await pilot.pause()
+    finally:
+        for handler in root.handlers:
+            if handler not in saved_handlers:
+                handler.close()
+        root.handlers = saved_handlers
+        root.setLevel(saved_level)
+
+    content = logfile.read_text(encoding="utf-8")
+    stall_line = next(line for line in content.splitlines() if "unresponsive" in line)
+    assert "turn active" in stall_line, (
+        "a stall observed while a real turn_started event is in flight must "
+        f"say so in the default-visible notice: {stall_line!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — the unassigned #4761 item lead-coder flagged after #4788's closure.

## What this closes

architect's outstanding point (recorded on #4761, unimplemented when ①②③ landed): "the next occurrence's first line to record — was a turn running at that moment." Without it, the ①②③ trio (tripwire lateness / pump heartbeat / key-arrival count) discriminates BETWEEN hypotheses for what stopped the interface, but a byte-identical unchanging screen is not evidence of a freeze on its own — it's equally consistent with "nothing was happening at all" (idle, no turn in flight).

## Design questions (lead-coder, passed through 3 times tonight on ①②③ — same discipline applied here)

- **Visible with shipped defaults?** Rides `stall_log_line`'s own `logger.warning` call — the same always-on surface ①②③'s own notices use. NOT a second `write_record` call, which would need `REYN_PROF_DUMP` armed in advance (exactly the #4797 mistake that had to be corrected).
- **Who binds it?** The caller (`_watch_loop_responsiveness`) reads `ActivityRow.state` — the app's EXISTING "is a turn running" surface, already used the same way at the compact-caps call site (`turn_active=self._activity.state is not None`). No second signal added for the same question.

Also threads `turn_active` into `LoopTripwire.observe`'s `write_record` calls, for consistency with `pump_ticks` in the opt-in detail dump (secondary — the default-visible line above is what actually matters).

## Merge note

Rebased onto #4816 (key-arrival counter ③, landed mid-work) — resolved a real conflict in `stall_log_line`'s signature/body/docstring and the call site; both features compose cleanly in the same line's output (verified in the falsification run below — `keys received` and would-be `turn active` both present).

## Tests

Mirrors the ①②③ test pattern exactly:
- Unit test on `stall_log_line`'s formatting (optional param, stays byte-identical when omitted).
- `LoopTripwire.observe`'s durable-record test.
- End-to-end: pushes a REAL `turn_started` event through the transport (the same public path `_handle_turn_started_event` uses to call `self._activity.begin("WORKING")` in production — not a private `_activity.begin()` reach-around) and confirms `"turn active"` reaches the real, reconstructed interactive logging floor (`_setup_interactive_logging`'s own WARNING floor, no `caplog` bypass).

Falsified via `git stash` (not `checkout --`): all 3 new tests genuinely red with the fix reverted, green restored.

## Checks

`ruff check .` clean · `mypy_ratchet.py` clean · `test_tier_audit.py --strict`: 25/25 OK · `verify_module_docstrings.py` OK · `flat_tests_ratchet.py` OK · `check_tests_path_literal_reference.py` OK · `check_bare_tests_import_reference.py` OK · `check_file_depth_reference.py` OK · full `tests/interfaces/test_loop_probe_3539.py`: 25 passed.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_loop_probe_3539.py`
- [x] `python scripts/verify_module_docstrings.py` (changed files)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Falsification: all 3 new tests confirmed genuinely red against the reverted source
- [x] Full `pytest tests/interfaces/test_loop_probe_3539.py`: 25 passed

part of #4761