### PR TITLE
docs(dogfood-tracing): add prompt_cache_key to the request field list

### DIFF
--- a/docs/reference/dogfood-tracing.md
+++ b/docs/reference/dogfood-tracing.md
@@ -103,7 +103,10 @@ paired by `request_id`.
 
 **Request fields:** `kind`, `request_id`, `timestamp`, `model`,
 `caller_hint`, `messages`, `tools` (full schema, or `null`),
-`tool_choice`, `sampling_params`
+`tool_choice`, `sampling_params`, `prompt_cache_key` (#4809 — always
+present as a key, `null` when the caller set none, so "not sent" reads the
+same for a pre-#4700 call site and a call that explicitly resolved no key;
+not a secret, no redaction applied)
 
 **Response fields:** `kind`, `request_id`, `timestamp`, `content`,
 `tool_calls`, `finish_reason`, `usage` (`prompt_tokens`,


### PR DESCRIPTION
**[docs-maintainer]** — part of #4809, part of #4690

## What

`docs/reference/dogfood-tracing.md`'s "Dump format" section enumerates the LLM trace dump's request/response fields. #4818 added a new `prompt_cache_key` key to the request record (`src/reyn/llm/llm.py`, sibling to `sampling_params` — verified directly against source on `origin/main`), but this reference's field list still enumerated only the pre-#4818 set.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no `Aborted` line
- [x] `python scripts/check_doc_anchors.py` — exit 0, no dangling anchors into published pages
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Closing-keyword self-grep on commit message and this PR body — clean
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Visual — N/A, prose-only field-list addition
