### PR TITLE
fix(#4824): RegistryReadModel.history_path tolerates an unattached registry

### DIFF
--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -193,8 +193,16 @@ class RegistryReadModel(ChatReadModel):
     """LOCAL read-model — delegates to the same registry/session accessors the
     inline driver called inline before P3 (behavior byte-identical)."""
 
-    def __init__(self, registry) -> None:
+    def __init__(self, registry, *, agent_name: "str | None" = None) -> None:
         self._registry = registry
+        #: #4824: the caller's INTENDED target agent, known before attach can
+        #: possibly succeed (same reasoning ``run_repl``'s own docstring
+        #: already gives for why it no longer waits on attach). Used ONLY as
+        #: :attr:`history_path`'s fallback during the startup race window —
+        #: once the initial (or any later ``/attach``) succeeds, ``_attached()``
+        #: is never ``None`` again for the rest of this read-model's life, so a
+        #: later agent switch never makes this stale value observably wrong.
+        self._agent_name = agent_name
 
     def snapshot(self, config=None):
         return _snapshot(self._registry, config)
@@ -224,13 +232,33 @@ class RegistryReadModel(ChatReadModel):
 
     @property
     def history_path(self) -> Path:
+        """#4824: tolerates an unattached registry, same as every OTHER
+        seam this class's own module docstring claims already does — a
+        piped/non-TTY ``reyn chat`` invocation reaches this property with
+        essentially no yield point since ``attach()`` was scheduled (see
+        ``run_repl``'s own docstring), so it was NOT a slow-WAL-restore
+        race: the background attach task had not ticked even once.
+
+        Falls back to :meth:`AgentRegistry.agent_workspace_dir` (the target
+        agent name this read-model was told about at construction, BEFORE
+        attach could possibly have succeeded) rather than raising. This is
+        the SAME path an attached session's own ``workspace_dir`` would
+        report once attach completes (see that method's own docstring for
+        why) — not a temporary/in-memory stand-in that gets silently
+        replaced later, which would create two truths about where the
+        input-history file lives. Once ``_attached()`` stops returning
+        ``None`` (initial attach, or any later ``/attach``), this fallback
+        is never reached again for the rest of this read-model's life."""
         s = self._attached()
-        if s is None:
-            raise RuntimeError(
-                "RegistryReadModel.history_path: no attached session "
-                "(call registry.attach() before starting the input driver)"
-            )
-        return s.workspace_dir / ".input_history"
+        if s is not None:
+            return s.workspace_dir / ".input_history"
+        if self._agent_name is not None:
+            return self._registry.agent_workspace_dir(self._agent_name) / ".input_history"
+        raise RuntimeError(
+            "RegistryReadModel.history_path: no attached session and no "
+            "target agent_name was given at construction — cannot resolve "
+            "a workspace-independent path either"
+        )
 
     def conversation_history(
         self,

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -45,6 +45,18 @@ async def run_repl(
     now-removed hard requirement that an attached :class:`Session` already
     exist, purely for the banner / Textual app's own display label.
 
+    #4824: this claim was NOT true for one seam — ``RegistryReadModel.
+    history_path`` hard-raised on an unattached registry instead of
+    tolerating it, and a piped/non-TTY ``reyn chat`` invocation reaches it
+    with essentially no ``await`` between ``attach()``'s ``create_task`` and
+    the ``FileHistory(...)`` construction that reads it, so the crash fired
+    on ~every such invocation, not occasionally. Fixed by giving
+    ``RegistryReadModel`` the SAME ``name`` this function already has
+    (below), so ``history_path`` can fall back to
+    :meth:`~reyn.runtime.registry.AgentRegistry.agent_workspace_dir` — a
+    pure path derivation needing no live :class:`Session`, so it costs
+    nothing and races nothing. The claim above is accurate again.
+
     ``config`` is the loaded ReynConfig (or None). When supplied it is threaded
     read-only to the status snapshot (``interfaces/repl/status.py``'s
     ``_snapshot``) so the ``…`` overflow chip can surface cron / mcp / hooks
@@ -80,9 +92,13 @@ async def run_repl(
         transport.start()
 
     # The LOCAL read-model reads status/region/tasks off the attached session —
-    # byte-identical to the pre-P3 inline reads.
+    # byte-identical to the pre-P3 inline reads. ``agent_name=name`` (#4824):
+    # the caller's intended target, known before attach can possibly have
+    # succeeded — lets ``RegistryReadModel.history_path`` tolerate the startup
+    # race window this function's own docstring already promises every OTHER
+    # seam tolerates.
     with stage("client-prep:read-model"):
-        read_model = RegistryReadModel(registry)
+        read_model = RegistryReadModel(registry, agent_name=name)
 
     try:
         await run_chat_client(

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -678,6 +678,22 @@ class AgentRegistry:
     def load_profile(self, name: str) -> AgentProfile:
         return AgentProfile.load(self._dir / name)
 
+    def agent_workspace_dir(self, name: str) -> Path:
+        """The agent's home directory, computed WITHOUT constructing or
+        attaching a :class:`Session` (#4824) — the same ``<state-root>/
+        agents/<name>`` this registry already uses internally for a
+        profile's own path (:meth:`load_profile`/:meth:`exists`/
+        :meth:`create`, all ``self._dir / name``), exposed publicly so a
+        caller that only knows the TARGET agent name — not yet an attached
+        Session, because attach hasn't run — can still resolve the same
+        path an attached ``Session.workspace_dir`` would report (verified:
+        :class:`~reyn.runtime.agent.Agent`'s own ``workspace_dir`` derives
+        from ``workspace_state_dir``, which every registry-constructed
+        agent gets set to this SAME ``project_root / ".reyn"`` at
+        bootstrap — not a re-derivation, the identical value by a
+        different, session-free route)."""
+        return self._dir / name
+
     def exists(self, name: str) -> bool:
         return (self._dir / name / PROFILE_FILENAME).is_file()
 

--- a/tests/interfaces/test_4824_history_path_tolerates_unattached.py
+++ b/tests/interfaces/test_4824_history_path_tolerates_unattached.py
@@ -1,0 +1,130 @@
+"""Tier 2: #4824 — ``RegistryReadModel.history_path`` tolerates an unattached
+registry, closing the one seam ``run_repl``'s own #3671 P2 docstring claimed
+(inaccurately, until this fix) was already covered.
+
+Reproduced via a piped/non-TTY ``echo "..." | reyn chat``: the interactive
+path schedules ``registry.attach(name)`` as a background task and starts the
+REPL immediately, with essentially no ``await`` before
+``FileHistory(str(read_model.history_path))`` runs
+(``interfaces/repl/client_driver.py``) — so the background attach task had
+not ticked even once. Not a slow-WAL-restore race; it fired on ~every such
+invocation.
+
+#3671 P2's own docstring: "Every seam below already tolerated an unattached
+registry" and names three specific accessors it audited
+(``InProcessTransport``'s ``_attached() is None`` guards,
+``_wire_focus_listeners(None)``, ``RegistryReadModel.snapshot`` returning
+``None``) — ``history_path`` was not among them and hard-raised instead.
+Fixed by giving ``RegistryReadModel`` the caller's intended target
+``agent_name`` (known before attach can possibly succeed, same reasoning
+the docstring already uses for ``name`` itself) so ``history_path`` can fall
+back to :meth:`~reyn.runtime.registry.AgentRegistry.agent_workspace_dir` — a
+pure path derivation needing no live :class:`Session`, so it costs nothing
+and races nothing.
+
+Real ``AgentRegistry``/``Session`` — no mocks, per the testing policy.
+Harness mirrors ``test_textual_chat_attach_state_3671_p3.py``'s own
+``_registry`` helper (the sibling #3671 P2/P3 test file).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.repl.read_model import RegistryReadModel
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+def test_history_path_falls_back_when_unattached_with_a_target_name(
+    tmp_path,
+) -> None:
+    """Tier 2: the exact defect — a registry with NOTHING attached yet
+    (``registry.attached_session()`` is ``None``) must not raise when the
+    read-model was given the target agent name at construction."""
+    reg = _registry(tmp_path)
+    read_model = RegistryReadModel(reg, agent_name="alpha")
+
+    path = read_model.history_path
+
+    assert path == reg.agent_workspace_dir("alpha") / ".input_history"
+
+
+def test_history_path_without_a_target_name_still_raises(tmp_path) -> None:
+    """Tier 2: accept-side sibling — a caller that supplies NO agent_name
+    (the pre-#4824 construction shape, still valid for any OTHER caller of
+    this class) must keep the original, honest failure — there is nothing
+    to fall back to."""
+    reg = _registry(tmp_path)
+    read_model = RegistryReadModel(reg)
+
+    with pytest.raises(RuntimeError, match="no attached session"):
+        _ = read_model.history_path
+
+
+@pytest.mark.asyncio
+async def test_the_fallback_path_matches_the_attached_sessions_own_path(
+    tmp_path,
+) -> None:
+    """Tier 2: the fallback must be the SAME path an attached session's own
+    ``workspace_dir`` reports — not a temporary stand-in later silently
+    replaced (lead-coder's own condition: "two truths" is not acceptable).
+    Reads ``history_path`` BEFORE attach, then again AFTER, on the SAME
+    read-model instance."""
+    reg = _registry(tmp_path)
+    read_model = RegistryReadModel(reg, agent_name="alpha")
+
+    before_attach = read_model.history_path
+
+    await reg.attach("alpha")
+    after_attach = read_model.history_path
+
+    assert before_attach == after_attach, (
+        "the unattached fallback and the post-attach real session path "
+        f"must agree: {before_attach!r} != {after_attach!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reproduces_the_original_crash_shape_and_no_longer_raises(
+    tmp_path,
+) -> None:
+    """Tier 2b: reproduces the ACTUAL race from ``chat.py``'s interactive
+    path — ``attach()`` scheduled as a background task via
+    ``asyncio.create_task``, then ``history_path`` read with NO ``await``
+    in between (the exact shape ``run_repl`` → ``run_chat_client`` hits:
+    essentially zero yield points before ``FileHistory(...)`` construction).
+    Before #4824 this raised on ~every piped/non-TTY invocation; must not
+    raise now."""
+    import asyncio
+
+    reg = _registry(tmp_path)
+    read_model = RegistryReadModel(reg, agent_name="alpha")
+
+    attach_task = asyncio.create_task(reg.attach("alpha"))
+    try:
+        # No await here — this is the exact gap that made the crash fire.
+        path = read_model.history_path
+        assert path == reg.agent_workspace_dir("alpha") / ".input_history"
+    finally:
+        await attach_task


### PR DESCRIPTION
**[tui-coder]** — #4824, assigned by lead-coder (未再現・未割当). Reproduced, root-caused, and fixed per lead-coder's own ruling (measure whether `workspace_dir` is knowable before attach → decide A/B).

## ① Reproduced

Deterministically, 100% of the time, first attempt, fresh empty workspace:
```
echo "say hello in one word" | reyn chat
```
```
RuntimeError: RegistryReadModel.history_path: no attached session
(call registry.attach() before starting the input driver)
```

## ② Root cause — genuine oversight, not intentional

`chat.py`'s interactive path schedules `registry.attach(name)` as a background task and starts `run_repl` immediately, with essentially no `await` before `FileHistory(str(read_model.history_path))` runs (`client_driver.py`). **Not a slow-WAL-restore race** — the background attach task hadn't ticked even once. Fires ~always for piped/non-TTY, not occasionally.

`run_repl`'s own #3671 P2 docstring claims *"every seam below already tolerated an unattached registry"* and names 3 specific audited accessors — `history_path` wasn't among them and still hard-raised, contradicting the docstring's own claim.

## Lead-coder's decision point: is `workspace_dir` knowable before attach?

**Yes** — measured directly. `Agent.workspace_dir` is a pure derivation (`workspace_state_dir / "agents" / name`), and `AgentRegistry` already computes the identical path internally (`self._dir / name`, used by `load_profile`/`exists`/`create`) with no Session construction and no WAL restore. → **Option A**: make `history_path` tolerate, using this SAME pre-existing computation — not a workaround, makes the docstring's claim literally true.

## Fix

- `AgentRegistry.agent_workspace_dir(name)` — new public accessor, exposes the registry's existing `self._dir / name` (no new derivation, no behavior change for any existing caller).
- `RegistryReadModel.__init__` accepts the caller's intended `agent_name` (same reasoning `run_repl`'s docstring already gives for why `name` itself doesn't need attach to have succeeded).
- `history_path` falls back to `registry.agent_workspace_dir(agent_name)` when unattached — verified to be the SAME path an attached session's own `workspace_dir` reports (not a temporary stand-in swapped out later — lead-coder's explicit "two truths" prohibition).
- `run_repl`'s own #3671 P2 docstring corrected in this PR, per lead-coder's explicit condition regardless of A or B — its claim is accurate again.

## Tests

4 new tests, real `AgentRegistry`/`Session`, no mocks:
- Fallback path matches `agent_workspace_dir()`.
- Accept-side sibling: no `agent_name` given → still raises (unchanged safety for any other caller).
- Fallback and post-attach path agree (no "two truths").
- Direct reproduction of the actual race shape (`asyncio.create_task` + zero-`await` read) — no longer raises.

Falsified via `git stash`: 3 of 4 genuinely red without the fix (the accept-side one correctly stays green either way).

Live-verified twice: the original `echo "..." | reyn chat` reproduction now completes cleanly end-to-end, both during development and again on this exact final branch/commit.

## Checks

`ruff check .` clean · `mypy_ratchet.py` clean · `test_tier_audit.py --strict`: 4/4 OK · `verify_module_docstrings.py` OK · `flat_tests_ratchet.py` OK · `check_tests_path_literal_reference.py` OK · `check_bare_tests_import_reference.py` OK · `check_file_depth_reference.py` OK · broader `tests/interfaces/ -k "repl or read_model or history"`: 132 passed, no regressions.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4824_history_path_tolerates_unattached.py`
- [x] `python scripts/verify_module_docstrings.py` (changed files)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Falsification: 3/4 new tests confirmed genuinely red against the reverted source
- [x] `pytest tests/interfaces/ -k "repl or read_model or history"`: 132 passed
- [x] Live reproduction: `echo "..." | reyn chat` completes cleanly (verified twice, incl. on final branch)

Closes #4824