### PR TITLE
fix(#4827①): wait for the real key-arrival count before the stall phase

### DIFF
--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -452,19 +452,19 @@ async def test_the_app_actually_shows_the_notice_when_the_loop_stalls(caplog) ->
             time.sleep(0.4)
             # #4827 (same class, lead-coder's re-read caught what I missed):
             # a fixed range(6) was trusted as "enough pauses for the stall
-            # notice to have been logged" before the POSITIVE assert below
-            # (`"unresponsive" in caplog.text`) — under real CI-host
-            # contention that assert can starve exactly like :794/:902 did.
-            # My own first pass wrongly called this a different, no-change-
-            # only concern; it is not — wait on the real condition instead,
-            # unbounded (CLAUDE.md testing policy).
+            # notice to have been logged" before a positive assert — under
+            # real CI-host contention that assert can starve exactly like
+            # :794/:902 did. Wait on the real condition instead, unbounded
+            # (CLAUDE.md testing policy): if the stall never trips the
+            # wire, this waits forever and CI's own --timeout=120 kills
+            # it — the detector moved from a separate assert (now removed,
+            # six-questions ②: it would have been the same expression on
+            # both sides of this loop, unable to ever fail) to that
+            # timeout; detection isn't lost, only where it lands.
             while "unresponsive" not in caplog.text:
                 await pilot.pause()
             status_after = str(app.query_one(StatusLine).render())
 
-    assert "unresponsive" in caplog.text, (
-        f"the loop stalled and nothing recorded it: {caplog.text!r}"
-    )
     assert "REYN_PROF_DUMP" in caplog.text, (
         "the record must say how to capture the detail next time"
     )
@@ -511,8 +511,12 @@ async def test_a_stall_costs_no_row_of_layout(caplog) -> None:
 
             time.sleep(0.4)
             # #4827 (same class as the sibling test above): wait on the
-            # real condition the positive assert below depends on, not a
-            # fixed pause count.
+            # real condition, unbounded — if the stall never trips the
+            # wire, this waits forever and CI's own --timeout=120 kills
+            # it. The separate post-loop assert this replaced would have
+            # been the same expression on both sides of this loop
+            # (six-questions ②, unable to ever fail) — the detector moved
+            # to that timeout, not lost.
             while "unresponsive" not in caplog.text:
                 await pilot.pause()
 
@@ -524,12 +528,6 @@ async def test_a_stall_costs_no_row_of_layout(caplog) -> None:
             # this asserts the packing outcome itself.
             merged_after = bool(app.query_one(StatusLine).parent.query(Tab))
 
-    # Non-vacuity: without a stall, "nothing moved" is true for the
-    # uninteresting reason and this test asserts nothing.
-    assert "unresponsive" in caplog.text, (
-        "non-vacuity: the wait loop above only exits once this is true, but "
-        "an empty caplog here would mean the stall never tripped the wire at all"
-    )
     assert rows_after == rows_before, (
         "the stall added a conversation row"
     )

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -450,7 +450,15 @@ async def test_the_app_actually_shows_the_notice_when_the_loop_stalls(caplog) ->
             # holds it, which is exactly the condition being detected.
             status_before = str(app.query_one(StatusLine).render())
             time.sleep(0.4)
-            for _ in range(6):
+            # #4827 (same class, lead-coder's re-read caught what I missed):
+            # a fixed range(6) was trusted as "enough pauses for the stall
+            # notice to have been logged" before the POSITIVE assert below
+            # (`"unresponsive" in caplog.text`) — under real CI-host
+            # contention that assert can starve exactly like :794/:902 did.
+            # My own first pass wrongly called this a different, no-change-
+            # only concern; it is not — wait on the real condition instead,
+            # unbounded (CLAUDE.md testing policy).
+            while "unresponsive" not in caplog.text:
                 await pilot.pause()
             status_after = str(app.query_one(StatusLine).render())
 
@@ -502,7 +510,10 @@ async def test_a_stall_costs_no_row_of_layout(caplog) -> None:
             merged_before = bool(app.query_one(StatusLine).parent.query(Tab))
 
             time.sleep(0.4)
-            for _ in range(6):
+            # #4827 (same class as the sibling test above): wait on the
+            # real condition the positive assert below depends on, not a
+            # fixed pause count.
+            while "unresponsive" not in caplog.text:
                 await pilot.pause()
 
             rows_after = len(app.query_one(FlowView).entries)
@@ -516,7 +527,8 @@ async def test_a_stall_costs_no_row_of_layout(caplog) -> None:
     # Non-vacuity: without a stall, "nothing moved" is true for the
     # uninteresting reason and this test asserts nothing.
     assert "unresponsive" in caplog.text, (
-        "the stall did not trip the wire — raise the sleep or lower the threshold"
+        "non-vacuity: the wait loop above only exits once this is true, but "
+        "an empty caplog here would mean the stall never tripped the wire at all"
     )
     assert rows_after == rows_before, (
         "the stall added a conversation row"

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -779,6 +779,19 @@ async def test_keys_received_reaches_the_default_visible_stall_notice(
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()
             await pilot.press("a", "b", "c")
+            # #4827①: pilot.press() awaits Textual's own message-queue-drain
+            # marker (Pilot._wait_for_screen), which is robust — but under
+            # real CI-host CPU contention the WHOLE process (this one, not
+            # just key dispatch) can be starved long enough that press()'s
+            # return is not yet followed by the counter's own read being
+            # observed consistent with it on this exact interpreter turn.
+            # Rather than trust press()'s return as an implicit guarantee,
+            # wait on the actual fact the rest of this test depends on
+            # before entering the timing-sensitive stall phase below — an
+            # unbounded condition wait (CLAUDE.md testing policy: no
+            # attempts=N / time-bound), never a race the test itself builds.
+            while app.keys_received < 3:
+                await pilot.pause()
             time.sleep(stall_seconds)
             while "recovered" not in logfile.read_text(encoding="utf-8"):
                 await pilot.pause()

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -899,7 +899,23 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
                     data={"kind": "user", "chain_id": "chain-1", "seq": 1},
                 )
             )
-            await pilot.pause()
+            # #4827 (same class as ①, folded here): a single pilot.pause()
+            # was trusted as "the pushed event has been processed", before
+            # immediately entering the real, blocking time.sleep() stall
+            # phase below — under real CI-host contention that trust can be
+            # wrong (measured: this exact assert failed in CI with
+            # "turn idle" instead of "turn active", same run that also hit
+            # ①'s failure). Wait on the real fact this test depends on — the
+            # App's own turn-activity surface, the same one
+            # ``_watch_loop_responsiveness`` reads (``self._activity.state
+            # is not None``) — via Textual's public widget query rather
+            # than reaching into the private attribute. Unbounded (CLAUDE.md
+            # testing policy: no attempts=N / time-bound); CI's own
+            # --timeout=120 is the kill switch if the wiring is ever
+            # actually broken and this never arrives.
+            from reyn.interfaces.inline.textual_chat.activity_row import ActivityRow
+            while app.query_one(ActivityRow).state is None:
+                await pilot.pause()
             time.sleep(stall_seconds)
             while "unresponsive" not in logfile.read_text(encoding="utf-8"):
                 await pilot.pause()


### PR DESCRIPTION
**[e2e-coder]** — #4827① only (per assignment; ② is separate/optional, not included here).

## Decision: "should this exist" before "how to make it green"

CI evidence: 3 occurrences (`#4826`, an earlier PR, `#4831`), all unrelated diffs, always the same symptom — `keys received: 0` AND `pump heartbeat at 0` together in the stall notice. Local: 0/72 (but the "CPU-load-simulated" runs in that earlier measurement were later found inert — a `multiprocessing` pickling failure on macOS silently no-opped the stress — so local testing never actually replicated real CI-host CPU contention).

Per assignment: decide keys-not-arriving vs counter-not-counting before touching anything.

- **Counter side** (`#4816`'s src, `on_event`'s `self._keys_received += 1`): a plain synchronous increment, no `await` inside it, independently pinned green by `test_on_event_counts_key_events_only`. Not the defect.
- **Delivery side**: falsified my first hypothesis directly — `Pilot.press()`'s internal `wait_for_idle()` (a CPU-time-vs-wall-clock heuristic) racing ahead of actual Key dispatch under contention. Stubbed `wait_for_idle` AND `Animator.wait_until_complete` to no-ops and re-ran `press()`: keys still landed 3/3, because `Pilot._wait_for_screen()` (`call_later` markers + `asyncio.wait(timeout=30.0)`) is a real completion guarantee, not a heuristic, and I hadn't touched it. That mechanism is robust to contention within its own 30s window — so it's not a simple "the heuristic misfires" story.

Both counters reading 0 together in the real CI failure is consistent with the whole process being CPU-starved by the host for the entire press-to-stall-check window (nothing ran at all, not a partial/selective dispatch miss) — something I could not genuinely reproduce locally. But regardless of the exact host mechanism, the test's own structural defect is the same: it trusts `press()`'s return as an implicit "the 3 keys are already counted" guarantee under all host conditions, then immediately blocks the event loop with a real `time.sleep()` for the timing-sensitive stall phase. This is a race **the test itself builds** (CLAUDE.md six-questions ③) — not a production defect: a production freeze-detector legitimately wants to know keys DID arrive before the stall it's now measuring.

## Fix

An explicit, **unbounded** condition wait (`while app.keys_received < 3: await pilot.pause()`, no `attempts=N` / time-bound, per CLAUDE.md testing policy) between `press()` and the stall phase, replacing implicit trust with a wait on the actual fact the assertion depends on. `#4816`'s src instrumentation and the assertion itself (`assert "keys received: 3" in stall_line`) are untouched — no guard loosened, nothing weakened.

## Six questions (touches `tests/`)

1. **Tier**: Tier 2 (matches the file's declared Tier), real `TextualChatApp`/`Pilot`, no mocks — a named behavioral contract (keypresses reaching the stall notice's count), not a third party's property (I traced Textual's own `Pilot` internals to RULE THIS OUT as the fault, not to pin it) or a past bug's fingerprint.
2. **Implementation transcribed?** No — the wait loop reads `app.keys_received`, a public counter; the assertion still checks the formatted log line, an independent surface.
3. **Who'd miss it?** A production consumer: the stall notice is what an operator/architect reads to diagnose a real freeze; this end-to-end wiring (counter → formatted notice) has no other test.
4. **Stay green never-run?** No — ran directly, 25/25 pass in the full file, isolated run passes too.
5. **Accumulation bound?** The new `while` loop is unbounded by design per CLAUDE.md (CI's own timeout is the backstop) — bounded by the real condition it's waiting on (Textual's own event loop always eventually runs), not a caller-paced producer.
6. **Declared Tier is true Tier?** Yes — Tier 2, unchanged from the file's existing convention.

## Test plan
- [x] `ruff check .`
- [x] `scripts/test_tier_audit.py --strict tests/interfaces/test_loop_probe_3539.py`
- [x] `scripts/mypy_ratchet.py`
- [x] Full file: `pytest tests/interfaces/test_loop_probe_3539.py` — 25 passed
- [ ] (no `docs/`/`src/reyn/mcp/`/`tests/`-path-literal gate triggers beyond tier-audit, already run)

part of #4827

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: folded per lead-coder's ruling — class, not 2 point patches

The same #4831 CI re-run also failed a sibling assert (`test_turn_active_reaches_the_default_visible_stall_notice`, line 902) in this same file, same shape: a single `pilot.pause()` trusted as "the pushed `turn_started` event has been processed" before the real blocking stall phase. Folded in with the same technique (wait on `ActivityRow.state is not None`, the same surface `_watch_loop_responsiveness` itself reads, via Textual's public widget query, unbounded).

**Enumerated the whole file** (not just a grep on `time.sleep`) for every `push_event`/`press`/`post_message`/`on_event` call site paired with a following stall — exactly these 2 share the class; the other `time.sleep()` sites (recovery-notice tests, layout-preservation tests, the pump-heartbeat test) have no preceding event-delivery step to race against, so they're untouched.

**Correction relayed to lead-coder**: "pump heartbeat: 0" in both failing log lines is not evidence of a stalled event loop — the heartbeat timer ticks once per 1.0s, these tests' `stall_seconds` is 0.4s (well under one interval), so `pump_ticks==0` is mathematically expected regardless of loop health. `test_pump_heartbeat_reaches_the_default_visible_notices` only asserts the label is present, never a tick count, for the same reason. The two informative signals were `keys_received` and `turn_active`, not the heartbeat.

---

## Full 18-site classification (lead-coder's request)

Every `await pilot.pause()` in this file, classified A (single call trusted as "event processed" — defect) / B (already condition-gated or has nothing async to wait for — healthy) / C (different concern, named):

| Line | Context | Class | Why |
|---|---|---|---|
| 337 | startup pause, before `time.sleep` | B | no preceding event push to race — mount-settle only |
| 346 | inside `while "recovered" not in caplog.text:` | B | already condition-gated |
| 394 | startup pause, before `time.sleep` | B | mount-settle only |
| 399 | inside `while "recovered" not in ...:` | B | already condition-gated |
| 447 | startup pause, before `time.sleep(0.4)` | B | mount-settle only (captures `status_before`, nothing pending) |
| 454 | `for _ in range(6): await pilot.pause()` | **C** | a bounded loop, not single-call-trusted NOR condition-gated — but the assertion it feeds is `status_after == status_before` (a **no-change** invariant); under-waiting can't flip a no-change assertion to a false failure the way an increment-target wait can, so it isn't the same race class. It IS a `range(N)`-shaped bounded loop, which CLAUDE.md's testing policy generally disallows — flagging as a **separate**, out-of-class concern, not silently left unclassified |
| 499 | startup pause, before `time.sleep(0.4)` | B | mount-settle only |
| 506 | `for _ in range(6): await pilot.pause()` | **C** | same as 454 (sibling test, same no-change invariant) |
| 625 | startup pause, then a **direct** `await app.on_timer(...)` call, asserted immediately | B | synchronous coroutine call, not queued via transport — no dispatch lag to race |
| 672 | startup pause, before `time.sleep(stall_seconds)` | B | no preceding event push (pump-heartbeat test asserts only the label is present, never a tick count) |
| 675 | inside `while "recovered" not in logfile...:` | B | already condition-gated |
| 731 | startup pause, then `pilot.press("a")` asserted immediately (no intervening blocking sleep) | B | no real `time.sleep()` gap between confirmed-delivered and checked — the race class needs that gap |
| 780 | startup pause, before `pilot.press(...)` | B | mount-settle only |
| 794 | `while app.keys_received < 3: await pilot.pause()` | B | **the ① fix** — was A before this PR |
| 797 | inside `while "recovered" not in logfile...:` | B | already condition-gated |
| 892 | startup pause, before `push_event` | B | mount-settle only |
| 918 | `while app.query_one(ActivityRow).state is None: await pilot.pause()` | B | **the folded fix** — was A before this PR |
| 921 | inside `while "unresponsive" not in logfile...:` | B | already condition-gated |

**Non-grep sweep**: also searched for `asyncio.sleep(`, `wait_for(`, `await asyncio.wait` beyond the literal `pilot.pause()` grep — no additional sites found (0 hits, searched).

**Result: 0 remaining A-class sites in this file.** 2 C-class sites named (454, 506) — real but a different, non-racing concern; not fixed in this PR (would be a second, separate structural change to a different invariant-test family, not folded into this one without confirming that's wanted).

---

## Correction: 454/506 were misclassified as C — they are A

lead-coder's re-read caught it: both `for _ in range(6)` sites are immediately followed by a POSITIVE assert, `"unresponsive" in caplog.text`, which only becomes true once the tripwire-detection loop has actually run and logged the notice — if `range(6)` isn't enough pauses under real CI-host contention, that assert starves exactly like ①/turn_active did. My original "C" reasoning covered only the OTHER assert in each test (the no-change ones), and missed the positive assert sitting right next to it with the same exposure. Fixed both to `while "unresponsive" not in caplog.text: await pilot.pause()`; reworded the now-stale "raise the sleep or lower the threshold" message.

**Final result: 0 A, 0 C.** All 4 same-class sites in this file now wait on the real condition, unbounded, no time-bound, no guard loosened.

- [x] 🔴 (lead-coder) :454/:506 の `assert "unresponsive" in caplog.text` を削除（while の脱出条件と同じ式で、もう落ちない＝六問②）。代わりに loop 直上に「起きなければ CI timeout が落とす」と 1 行。no-change assert は残す。

