### PR TITLE
test(#4827②): enrich the vacuity assert's failure message, no new gate

### DIFF
--- a/tests/runtime/test_fp0063_arc_witness.py
+++ b/tests/runtime/test_fp0063_arc_witness.py
@@ -606,6 +606,26 @@ def _pid_is_alive(pid: int) -> bool:
     return True
 
 
+def _ps_snapshot_or_reason() -> str:
+    """#4827②: best-effort ``ps -ef`` for a failing assert's diagnostic
+    message. Must NEVER raise -- this only runs inside that assert's
+    message expression (Python evaluates it exclusively on the falsy
+    path), so an exception here would replace the real AssertionError
+    with an unrelated one, hiding the very failure this diagnostic
+    exists to explain (lead-coder's review point). ``ps`` is POSIX and
+    already assumed available by this file's own ``_child_pids`` (a
+    plain, unguarded ``pgrep`` call on every run, not just on failure) --
+    but this string is built ONLY on an already-rare failure path, so
+    the extra defensiveness costs nothing and closes the hole rather
+    than merely documenting a judgment call."""
+    try:
+        return subprocess.run(
+            ["ps", "-ef"], capture_output=True, text=True, check=False,
+        ).stdout
+    except Exception as exc:  # noqa: BLE001 -- diagnostic-only, must degrade not raise
+        return f"(ps unavailable: {exc!r})"
+
+
 async def _drive_one_turn(registry, prompt: str, timeout: float) -> str:
     """The SAME two primitives ``run_agent_step`` composes
     (``spawn_ephemeral_session`` + ``MessageBus.request``), called directly
@@ -989,7 +1009,7 @@ async def test_llm_driven_install_ingest_query_arc_reaches_the_ingested_chunk(
             "witness below would vacuously pass. "
             f"os.getpid()={os.getpid()!r} baseline_children={_baseline_children!r}. "
             "Full OS process table at the moment of failure:\n"
-            f"{subprocess.run(['ps', '-ef'], capture_output=True, text=True).stdout}"
+            f"{_ps_snapshot_or_reason()}"
         )
         assert all(_pid_is_alive(pid) for pid in _arc_children), (
             f"one or more of the arc's own captured child pids {_arc_children} "

--- a/tests/runtime/test_fp0063_arc_witness.py
+++ b/tests/runtime/test_fp0063_arc_witness.py
@@ -965,11 +965,31 @@ async def test_llm_driven_install_ingest_query_arc_reaches_the_ingested_chunk(
         # witness has nothing to observe -- fail loudly rather than let part 2
         # vacuously pass.
         _arc_children = _child_pids(os.getpid()) - _baseline_children
+        # #4827②: this assert's failure message is enriched (NOT its truth
+        # condition — no wait/sync/new gate added; lead-coder's explicit
+        # instruction after two independently-refuted hypotheses on my own
+        # part: local reproduction is 0/1 and every further theory is
+        # speculation without a repro to iterate against). The enrichment
+        # itself is what makes the NEXT CI occurrence a usable n=2 instead
+        # of a repeat of the same bare "assert set()" — it captures exactly
+        # the two things this investigation needed and didn't have: the
+        # baseline set this diffed against, and the full OS process table
+        # at the moment of failure (mirrors the diagnostic I ran by hand
+        # locally, ``ps -ef``, under a real 3.11 venv -- on that PASSING
+        # run the vector-store server showed up as a genuine direct child,
+        # so "categorically not a direct child" is refuted; what's
+        # different in the CI-3.11-only failure remains open). ``ps -ef``
+        # is only invoked in the message expression itself, so it is NEVER
+        # run on a passing test (Python only evaluates an ``assert``'s
+        # message when the condition is falsy) -- zero cost on green.
         assert _arc_children, (
             "expected the rag plugin's real chunker/vector-store MCP server "
             "subprocess(es) to be running as direct children of this process "
             "at this point in the arc -- found none, so the #4759 structural "
-            "witness below would vacuously pass"
+            "witness below would vacuously pass. "
+            f"os.getpid()={os.getpid()!r} baseline_children={_baseline_children!r}. "
+            "Full OS process table at the moment of failure:\n"
+            f"{subprocess.run(['ps', '-ef'], capture_output=True, text=True).stdout}"
         )
         assert all(_pid_is_alive(pid) for pid in _arc_children), (
             f"one or more of the arc's own captured child pids {_arc_children} "


### PR DESCRIPTION
**[e2e-coder]** — #4827② (`tests/runtime/test_fp0063_arc_witness.py:968`). Not a fix — the assert's failure message is enriched, per lead-coder's explicit call to stop the causal investigation and instead make the NEXT occurrence usable.

## Why this shape, not a fix

CI hit `assert _arc_children` empty on the SAME commit, Python 3.11 only, passing on 3.12 in the same attempt (lead-coder recovered the actual CI logs). Investigated independently of ①'s cause, as instructed (① is an asyncio-dispatch-confirmation race inside one process; ② is an OS process-table read via `pgrep -P` of a genuinely separate subprocess — different layer, no assumption carried over):

- Confirmed turn 1's install-probe subprocess is explicitly `kill_process_tree`'d by design (`mcp_install.py`'s `probe_mcp_server` docstring) — not expected to survive to this check regardless of anything else.
- Built a real Python 3.11 venv (`uv`) and ran the test with a temporary diagnostic (removed before this commit) printing the full OS process table at the check point. On a passing local run, the vector-store MCP server genuinely showed up as a **direct child** of `os.getpid()` — this **refutes** my own working hypothesis that the expected subprocess structurally belongs to a different session/process and could never be a direct child.

Local reproduction: 0/1 under 3.11 (this run), consistent with lead-coder's earlier 0/9 under a different environment. Every further theory beyond this point is speculation with no repro to iterate against.

## What this PR does

Per lead-coder's explicit instruction: enrich ONLY the existing assert's failure **message** — not its truth condition, no wait/sync added, no new test, no new gate — with exactly what this investigation needed and didn't have: `_baseline_children`'s contents and the full `ps -ef` process table at the moment of failure. The next CI occurrence becomes a usable n=2 with enough detail to actually decide the cause, instead of repeating the same bare `assert set()`.

**Zero cost on green**: Python only evaluates an `assert` statement's message expression when the condition is falsy (verified directly with a standalone repro). Confirmed no runtime change on the actual passing test (36.22s, same ballpark as before the edit).

## Six questions (touches `tests/`, message-only change to an existing assert)

1. **Tier**: unchanged — Tier 3a, the file's own declared tier. This change touches only a message string, not the test's classification.
2. **Implementation transcribed?** No — the message reads real OS state (`ps -ef`, `os.getpid()`, `_baseline_children`) independently of the code under test.
3. **Who'd miss it?** The next person triaging this exact assert's next CI failure — currently they'd get `assert set()` and nothing else; this is the entire point of the change.
4. **Stay green never-run?** N/A — no new assert, no new test; the enrichment only fires on the failure path, verified it doesn't fire on green (confirmed no perf change) and does render correctly when simulated failing (standalone repro, no crash, ~110KB message).
5. **Accumulation bound?** N/A — one `ps -ef` call, only on failure, once.
6. **Declared Tier is true Tier?** Yes — unchanged.

## Test plan
- [x] `ruff check .`
- [x] `scripts/test_tier_audit.py --strict tests/runtime/test_fp0063_arc_witness.py`
- [x] `scripts/mypy_ratchet.py`
- [x] Ran the actual test (3.11 venv, `uv`) — passes, 36.22s, no runtime regression
- [x] Standalone repro confirming the message expression renders without error when the assert would fail, and is never evaluated when it passes

part of #4827

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review point addressed: diagnostic must never mask the real AssertionError

lead-coder's TESTS-READ caught it: since the `ps -ef` call runs only inside the assert's message expression (evaluated exclusively on the falsy path), a `FileNotFoundError` from `ps` being unavailable would replace the real `AssertionError` with an unrelated one — hiding the very failure this diagnostic exists to explain. I hadn't considered this before it was raised.

`ps` is POSIX and already assumed available by this file's own `_child_pids` (an unguarded `pgrep` call on every run, not just on failure), so the realistic risk on CI Linux/macOS is effectively zero — but since guarding costs nothing on an already-rare failure path, added `_ps_snapshot_or_reason()`: wraps the call in try/except, falling back to a plain string naming the exception instead of raising. Verified both paths directly (normal: full process table; simulated ps-missing: the fallback string, no crash). Closes the hole rather than only documenting the judgment call.
