### PR TITLE
fix(#4836): restore ReynMCPMessageHandler.bind_client, re-targeted at the official SDK's Client

### DIFF
--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -1229,6 +1229,15 @@ class MCPClient:
                 # this PR's own port closes).
                 mode=_resolve_client_mode(self._config),
             )
+            # #4836: complete the message handler's weakref binding to THIS
+            # client now that it exists (constructor kwarg above required
+            # the handler to exist first, so it couldn't bind to a client
+            # that wasn't there yet) — must run before `client.__aenter__()`
+            # opens the transport, since no message can arrive before that.
+            # See reyn/mcp/message_handler.py's module docstring "Two-phase
+            # client binding" section for the full reasoning.
+            if self._message_handler is not None:
+                self._message_handler.bind_client(client)
             # #3028/#3698 stage 1 — PR-1 REVERSES this bound's mechanism
             # (live-verified, not assumed): `anyio.fail_after` around
             # `Client.__aenter__()` raises "Attempted to exit a cancel scope
@@ -1437,6 +1446,10 @@ class MCPClient:
                 # full PR-1/PR-2 history.
                 mode=_resolve_client_mode(self._config),
             )
+            # #4836: see _initialize_stdio's matching comment — complete the
+            # weakref binding now that `client` exists, before `__aenter__`.
+            if self._message_handler is not None:
+                self._message_handler.bind_client(client)
             # PR-1: `asyncio.wait_for`, not `anyio.fail_after` — see
             # _initialize_stdio's matching comment for the full live-verified
             # root-cause (an anyio LIFO cancel-scope-nesting violation

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -1,10 +1,12 @@
 """ReynMCPMessageHandler — server->client notifications bridge (#2597 S2b).
 
-S2a (``MCPConnectionService``) holds one ``fastmcp.Client`` open per server for the
-whole session lifetime. Because the connection stays open, FastMCP's ``session_task``
-keeps its receive loop running — so server-pushed notifications (``tools/list_changed``,
-``prompts/list_changed``, ``notifications/progress``) ARRIVE on the wire, but nothing
-consumed them before S2b. This module installs the consumer.
+S2a (``MCPConnectionService``) holds one ``mcp.Client`` open per server for the whole
+session lifetime (was ``fastmcp.Client`` pre-#4282; fastmcp is retired from the client
+path, this module now binds to the official SDK's own ``Client``). Because the
+connection stays open, the client's own session task keeps its receive loop running —
+so server-pushed notifications (``tools/list_changed``, ``prompts/list_changed``,
+``notifications/progress``) ARRIVE on the wire, but nothing consumed them before S2b.
+This module installs the consumer.
 
 ## Composition, not inheritance (#3698 P3)
 
@@ -34,18 +36,28 @@ What the inheritance used to provide, and how this class now provides it itself:
     rather than silently reaching nothing (see below — this is a DELIBERATE behavior
     addition, not a byte-identical port).
 
-  - **Two-phase client binding** (unchanged mechanism, no longer inherited): the owning
-    ``fastmcp.Client`` does not exist yet when this handler must be constructed (FastMCP's
-    own ``Client(transport, message_handler=...)`` takes the handler as a constructor
-    argument, so the handler must exist first) — :meth:`bind_client`, called by
-    :class:`~reyn.mcp.client.MCPClient` immediately after constructing the ``fastmcp.Client``
-    and before ``__aenter__()`` opens the transport, completes a weakref binding
-    (``self._client_ref``) that :meth:`__call__` reads for task-status forwarding. No
-    message can be dispatched before ``__aenter__()`` completes the handshake, so
-    ``bind_client`` always runs before the first ``__call__``.
+  - **Two-phase client binding** (unchanged mechanism, no longer inherited; #4836
+    restated for the official SDK — fastmcp is retired from the client path, #4282):
+    the owning ``mcp.Client`` does not exist yet when this handler must be
+    constructed — the official SDK's own ``Client(transport, message_handler=...)``
+    takes the handler as a constructor argument (same contract fastmcp's ``Client``
+    had), so the handler must exist first. The reason THIS class needed a two-phase
+    bind rather than a single-shot constructor argument was never fastmcp-specific
+    (that constraint transferred unchanged to the official SDK's ``Client`` — same
+    "handler exists before client" ordering); what fastmcp genuinely provided that
+    the official SDK does not is a matching ``_handle_task_status_notification``
+    method (#4457: task-status notifications don't currently reach this handler at
+    all on mcp 2.0, so that forwarding call is presently dead code either way) —
+    :meth:`bind_client`, called by :class:`~reyn.mcp.client.MCPClient` immediately
+    after constructing the ``mcp.Client`` and before ``__aenter__()`` opens the
+    transport, completes a weakref binding (``self._client_ref``) that
+    :meth:`__call__` reads for task-status forwarding. No message can be dispatched
+    before ``__aenter__()`` completes the handshake, so ``bind_client`` always runs
+    before the first ``__call__``.
 
-  - **Synchronous hook bodies**: the handler runs on FastMCP's ``session_task`` (not the
-    agent turn task), but ``EventLog.emit()`` is fully synchronous and asyncio is
+  - **Synchronous hook bodies**: the handler runs on the client's own receive-loop task
+    (the ``mcp`` SDK's ``ClientSession``/``BaseSession`` machinery — not the agent turn
+    task), but ``EventLog.emit()`` is fully synchronous and asyncio is
     single-loop with no preemption mid-sync-call, so calling ``emit_sink(...)`` directly
     from a hook is safe — no marshalling, no ``call_soon``, no queue (verified against the
     WAL's lock-free design — see S2-pre spike / connection_service.py's Option C
@@ -99,10 +111,10 @@ OnExternalEvent = Callable[[str | None, bool], None]
 
 
 class ReynMCPMessageHandler:
-    """Bridges FastMCP server-pushed notifications on a held connection to reyn's
+    """Bridges MCP server-pushed notifications on a held connection to reyn's
     ``EventLog`` (#2597 S2b). One instance per held server connection.
 
-    Composes, does not inherit, fastmcp's message-handling contract — see module
+    Composes, does not inherit, the underlying message-handling contract — see module
     docstring's "#3698 P3" section for the full design and what changed.
 
     Scope (S2b): ``tools/list_changed``, ``prompts/list_changed``. ``resources/
@@ -183,10 +195,20 @@ class ReynMCPMessageHandler:
         self._listen_honors_resources = False
 
     def bind_client(self, client: Any) -> None:
-        """Complete the weakref binding once the owning ``fastmcp.Client`` exists.
-        MUST run before the first message is dispatched — see module docstring's
-        "two-phase client binding"."""
+        """Complete the weakref binding once the owning ``mcp.Client`` (the
+        official SDK's, since #4282/#4836 — was fastmcp's ``Client`` pre-#4282,
+        same constructor-ordering contract either way) exists. MUST run before
+        the first message is dispatched — see module docstring's "two-phase
+        client binding"."""
         self._client_ref = weakref.ref(client)
+
+    def is_bound(self) -> bool:
+        """#4836: True once :meth:`bind_client` has run and its weakref target
+        is still alive. The public surface a caller (or a test) checks for
+        "has the two-phase binding completed" — reads the same
+        ``self._client_ref`` :meth:`__call__` uses for task-status forwarding,
+        without exposing that private attribute itself."""
+        return self._client_ref() is not None
 
     def set_listen_honored(self, *, tools: bool, prompts: bool, resources: bool) -> None:
         """Called by :class:`~reyn.mcp.subscription_port.ListenSubscriptionAdapter`

--- a/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
@@ -18,6 +18,7 @@ import pytest
 
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
+from reyn.mcp.client import MCPClient
 from reyn.mcp.connection_service import MCPConnectionService
 from reyn.mcp.message_handler import ReynMCPMessageHandler
 from reyn.runtime.services import (
@@ -287,6 +288,41 @@ async def test_task_status_routing_via_composed_call():
 
     (routed,) = fake_client.routed  # exactly one status notification was dispatched
     assert routed.params.taskId == "task-1"
+
+
+@pytest.mark.asyncio
+async def test_initialize_stdio_actually_binds_the_message_handler_to_the_real_client():
+    """Tier 2: #4836 — ``MCPClient._initialize_stdio``'s production call site
+    actually invokes ``bind_client(client)`` with the REAL ``mcp.Client`` it
+    just constructed, not merely that :meth:`ReynMCPMessageHandler.bind_client`
+    works in isolation when called directly (the sibling tests in this file,
+    and #4457's own skipped test, only ever call it by hand against a fake).
+    #4282 retired fastmcp from the client path and, with it, the ONE call site
+    that used to invoke ``bind_client`` at all — restored here targeting the
+    official SDK's ``Client`` instead. Real stdio connection (the same echo
+    server this file's other tests use), real ``MCPClient.initialize()`` —
+    the same production entrypoint ``MCPConnectionService``/every live chat
+    turn goes through — asserted via the handler's own public
+    :meth:`~reyn.mcp.message_handler.ReynMCPMessageHandler.is_bound`, not a
+    reach into either object's private state.
+
+    Falsify (owner-instructed weak-witness shape, mcp 2.0 doesn't currently
+    deliver ``TaskStatusNotification`` at all — #4457 — so the binding's
+    actual CONSUMER can't be witnessed end-to-end today): stripping the
+    restored ``bind_client`` call from ``_initialize_stdio`` flips this test
+    red (``is_bound()`` stays False, the weakref target is never set) while
+    every other test in this file's own bucket stays green — confirmed by
+    hand before landing."""
+    handler = ReynMCPMessageHandler(lambda *a, **k: None, "srv")
+    assert not handler.is_bound(), "unbound until a real client actually binds"
+
+    async with MCPClient(_CFG, message_handler=handler) as client:
+        assert client.is_initialized()
+        assert handler.is_bound(), (
+            "the real production init path must call bind_client() with the "
+            "client it just constructed, not leave the two-phase binding "
+            "incomplete"
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — Restores `ReynMCPMessageHandler.bind_client`'s call site, dropped by #4282's fastmcp retirement, per owner ruling ("standard feature support is the ask" — restore, don't retire).

## What

`#4282` fully retired fastmcp from the client path and, in the same sweep, dropped the ONE call site that ever invoked `bind_client(client)` — the method, its docstring, and its tests all survived (tests bind a Fake directly, so they stayed green), but nothing in production called it anymore.

**Not a verbatim restore** — the old call site constructed fastmcp's `Client` immediately before binding; that constructor path is gone. The underlying reason for a two-phase bind (the handler must exist before the client, because the client's constructor takes `message_handler=` as a kwarg) is **unchanged** for the official SDK's `Client` — same ordering constraint, different class. Restored at both `_initialize_stdio`'s and `_initialize_http_or_sse`'s own `Client(...)` construction sites (the old code was one shared method PR-1 later split into these two), right after construction and before `__aenter__`.

## Docstrings

`client.py`'s own `initialize()` docstring was already accurate — the false claims were all in `message_handler.py`:
- Module docstring's "Two-phase client binding" section rewritten to name the official SDK's `Client` and state the ordering constraint transferred unchanged (never fastmcp-specific).
- `bind_client`'s own docstring, the class docstring's opening line, and the "Synchronous hook bodies" bullet (still said "FastMCP's session_task") — updated in the same sweep (re-read the whole section, not just the one line the issue named).

## New finding, reported separately, NOT fixed here

`message_handler.py`'s `__call__` forwards a routed `TaskStatusNotification` to `client._handle_task_status_notification` — a method that exists on fastmcp's OLD `Client` but **not** on the official SDK's `mcp.Client` (checked directly: absent from `dir(Client)`). Currently inert for the same reason #4457 already tracks: mcp 2.0's `ServerNotification` union excludes `TaskStatusNotification` entirely, so this branch is presently unreachable (Pyright independently flags it as statically unreachable under the installed stubs). A latent `AttributeError` waiting for the day the SDK adds the notification back — belongs to #4457's scope, not restated here.

## Falsify

Per the issue's own caution: mcp 2.0 can't deliver the notification that would end-to-end-witness this wiring today, and faking one would create a codepath the real protocol doesn't have — avoided. New Tier 2 test `test_initialize_stdio_actually_binds_the_message_handler_to_the_real_client` drives a **real** stdio `MCPClient.initialize()` against the file's existing real echo server and asserts a real handler's own new public `is_bound()` (`self._client_ref() is not None`, replacing a private-state reach) flips True — proving the **production call site** invokes `bind_client`, not just that the method works when called directly (every existing test in this bucket, including #4457's skipped one, only ever calls it by hand against a fake).

Strip-falsified by hand: removed the restored call from `_initialize_stdio`, confirmed this exact test goes RED (`is_bound()` stays False) while the rest of the bucket stays green, then restored.

## Test plan
- [x] `ruff check .`
- [x] `scripts/test_tier_audit.py --strict tests/mcp/test_2597_s2b_mcp_notifications_bridge.py`
- [x] `scripts/verify_module_docstrings.py src/reyn/mcp/client.py src/reyn/mcp/message_handler.py`
- [x] `scripts/mypy_ratchet.py`
- [x] Full `tests/mcp/` bucket: 174 passed, 1 skipped (pre-existing #4457 skip, untouched) — re-run after the fix, not just once
- [x] Strip-falsify: RED for the right reason, confirmed by hand
- [x] Repo-wide sweep for `bind_client`/`ReynMCPMessageHandler` consumers — no other call sites needed changes

Closes #4836

🤖 Generated with [Claude Code](https://claude.com/claude-code)
