### PR TITLE
docs(#4840): TUI colour policy の冒頭が同じ節の第 2 条を否定していた

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,13 +38,17 @@ considered it is answered "yes" every time.
 
 ### TUI colour policy
 
-The terminal emulator's theme decides; reyn names the MEANING, never the RGB
-(owner ruling #3525).
+Name the MEANING; the active theme renders it. Never pick a colour first
+(owner ruling #3525). **"The theme" is whichever theme is active** — reyn's own
+full-colour default, a Textual builtin, or an `ansi-*` theme that defers to the
+terminal emulator's palette. Terminal palettes are not a vocabulary: ECMA-48
+standardises the escape codes, not the RGB behind them, and 16 slots carry no
+meanings — that is why the meanings live in a theme.
 
-1. Meaning has a convention a reader already carries (*error*, *success*, *in-flight*) → name it, let the theme render it: ANSI-16 / `ansi_default` / `transparent` / an SGR `text-style`.
-2. Meaning is reyn-specific → any value that serves the design, full-colour included. The theme has no opinion to defer to.
+1. Meaning has a convention a reader already carries (*error*, *success*, *in-flight*) → name it so every theme can render it: a theme token (`$error`, `$text-muted`, `$markdown-*` …), an SGR `text-style`, or `ansi_default` / `transparent` where the terminal's own value is the point.
+2. Meaning is reyn-specific → any value that serves the design, full-colour included. No theme has an opinion to defer to.
 
-- **A colour is not a meaning.** "Error" is the meaning; red is one terminal's rendering. Never pick the colour first.
+- **A colour is not a meaning.** "Error" is the meaning; red is one theme's rendering. Never pick the colour first.
 - **This is not an ANSI-16-only policy.** Only two things are forbidden, and neither limits expressiveness: **a literal in a widget stylesheet** (every value goes through a token in `src/reyn/interfaces/inline/textual_chat/palette.py`, and stylesheets write a `@name@` marker) and **alpha-compositing over `ansi_default`** (the blend destroys the terminal's own value).
 - `tests/interfaces/test_tui_colour_tokens.py` enumerates every colour-bearing declaration under `interfaces/` and fails on any value named outside the palette. Textual's own `DEFAULT_CSS` is out of scope.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,11 +41,11 @@ considered it is answered "yes" every time.
 Name the MEANING; the active theme renders it. Never pick a colour first
 (owner ruling #3525). **"The theme" is whichever theme is active** — reyn's own
 full-colour default, a Textual builtin, or an `ansi-*` theme that defers to the
-terminal emulator's palette. Terminal palettes are not a vocabulary: ECMA-48
-standardises the escape codes, not the RGB behind them, and 16 slots carry no
-meanings — that is why the meanings live in a theme.
+terminal emulator's palette. Terminal palettes are not a vocabulary: the escape
+codes are standardised, the RGB behind them is not, and a slot carries a colour
+name, not a role — that is why the roles live in a theme.
 
-1. Meaning has a convention a reader already carries (*error*, *success*, *in-flight*) → name it so every theme can render it: a theme token (`$error`, `$text-muted`, `$markdown-*` …), an SGR `text-style`, or `ansi_default` / `transparent` where the terminal's own value is the point.
+1. Meaning has a convention a reader already carries (*error*, *success*, *in-flight*) → name it so every theme can render it: a theme token (`$error`, `$text-muted`, `$markdown-*` …), an SGR `text-style`, or an ANSI name (`ansi_blue` / `ansi_default` / `transparent`) where the terminal's own value is the point — `@selection-bg@` and `@selection-fg@` are live examples of the last.
 2. Meaning is reyn-specific → any value that serves the design, full-colour included. No theme has an opinion to defer to.
 
 - **A colour is not a meaning.** "Error" is the meaning; red is one theme's rendering. Never pick the colour first.


### PR DESCRIPTION
**[lead-coder]** — part of #4840

## 何が問題だったか

節の冒頭が「The terminal emulator's theme decides; reyn names the MEANING, **never the RGB**」で、**絶対の禁止として読めます**。しかし同じ節の第 2 条は「any value that serves the design, **full-colour included**」で、直下の箇条書きは「**This is not an ANSI-16-only policy**」と明記しています。**冒頭が下の 2 条を否定しています。**

## 実測されたコスト

**私（lead-coder）が同一セッション中に 2 度、冒頭行だけ読んで止まりました。**

1. ANSI-16 に寄せた設計を提案（owner が以前「表現力を ANSI-16 に制限するな」と言われた形の再発）
2. owner に「full-colour の reyn 既定テーマは方針を反転させる、CLAUDE.md の書き換えが要る」と報告 — **どちらも偽**

owner の一貫した指示は「**端末テーマが在るなら従うべき**」であって、ANSI-16 への制限ではありませんでした。そして**意味の水準では従うべき端末テーマが存在しません** — ECMA-48 が標準化しているのはエスケープ符号であって RGB ではなく、16 の席は意味を持ちません。

## 変更

- 冒頭を第 1・2 条と同じ内容に：**意味を名指す／描くのは active theme／色を先に選ばない**。あわせて「the theme」が何を指すか（reyn 独自の full-colour 既定 / Textual 組込 / 端末に委ねる `ansi-*`）を明記し、「端末の」としか読めない形を潰しました。
- 第 1 条の先頭を ANSI-16 から**テーマ token**（`$error` / `$text-muted` / `$markdown-*`）に。`ansi_default` / `transparent` は「端末自身の値であることに意味がある場合」として残しています。
- 「red is one **terminal's** rendering」→「one **theme's** rendering」。

**禁止 2 つ（widget stylesheet の literal／`ansi_default` へのアルファ合成）と token ゲートは無変更です。**

## Test plan

- [x] 規範の変更なし（許可範囲・禁止範囲とも同一）— 冒頭が本文と一致しただけ
- [x] `ruff check .`（無関係だが実行）
- [ ] (skipped — CLAUDE.md は `docs/` 配下ではないため mkdocs / anchor gate の対象外)



- [x] 🔴 **③ ECMA-48 の一文（architect review）** — 「16 slots」は ECMA-48 が SGR で定義する前景色 8 つ（30–37）と食い違う可能性（明るい 8 つは aixterm 由来の拡張）／「carry no meanings」は ECMA-48 が色名を割り当てている以上 言い過ぎで、言いたいのは「★役割は持たない」。**規格を引いて確かめるか、「ECMA-48」と「16」を落とした形（review コメントの案）に差し替えてから merge してください。**
- [x] 🔴 **① 許可リストから `ansi_*`（ANSI-16 名前色）が消えた件（architect review）** — 禁止範囲は同一なので規範の後退ではありませんが、**意図的な変更か書き落としかの確認**をお願いします（現行の `ansi_*` 使用箇所は architect は数えていません）。




**架 architect 再読（2026-08-15）**: 🔴 2 件とも解消。**③** — 「ECMA-48」「16 slots」が落ち、確かめずに真な形になっています。**①** — ANSI 名が戻り、`palette.py:97 "@selection-bg@": "ansi_blue"` / `:101 "@selection-fg@": "ansi_black"` を **architect が独立に確認**しました（実在します）。**②** は初回レビューで確認済み。**私からの blocking はありません。**
