### PR TITLE
test(#4827①): enrich the recurrence's failure message, no new gate

### DIFF
--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -926,9 +926,25 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
             from reyn.interfaces.inline.textual_chat.activity_row import ActivityRow
             while app.query_one(ActivityRow).state is None:
                 await pilot.pause()
+            # #4827① recurrence diagnostic (lead-coder): the wait loop above
+            # reads `query_one(ActivityRow)`; the tripwire's own tick reads
+            # `self._activity` directly (app.py's `getattr(self, "_activity",
+            # None)`). "Same object" was only verified structurally
+            # (compose() assigns self._activity exactly once, the same
+            # object it yields into the tree) — never empirically, on a
+            # CI host, at the moment a real failure happened. Captured here,
+            # while the app is still alive/mounted (post-teardown queries
+            # are unreliable) — used only in the enriched assert message
+            # below, so this costs nothing on a passing run.
+            _diag_activity_obj_id = id(app._activity)
+            _diag_query_obj_id = id(app.query_one(ActivityRow))
+            _diag_state_at_confirm = app._activity.state
             time.sleep(stall_seconds)
             while "unresponsive" not in logfile.read_text(encoding="utf-8"):
                 await pilot.pause()
+            _diag_pump_ticks_at_notice = app.pump_ticks
+            _diag_keys_received_at_notice = app.keys_received
+            _diag_state_at_notice = app._activity.state
     finally:
         for handler in root.handlers:
             if handler not in saved_handlers:
@@ -940,5 +956,13 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
     stall_line = next(line for line in content.splitlines() if "unresponsive" in line)
     assert "turn active" in stall_line, (
         "a stall observed while a real turn_started event is in flight must "
-        f"say so in the default-visible notice: {stall_line!r}"
+        f"say so in the default-visible notice: {stall_line!r}. "
+        "#4827① recurrence diagnostic — "
+        f"id(self._activity) at confirm-time={_diag_activity_obj_id!r} "
+        f"id(query_one(ActivityRow)) at confirm-time={_diag_query_obj_id!r} "
+        f"(same object: {_diag_activity_obj_id == _diag_query_obj_id}); "
+        f"activity.state at confirm-time={_diag_state_at_confirm!r} "
+        f"activity.state at notice-time={_diag_state_at_notice!r}; "
+        f"pump_ticks at notice-time={_diag_pump_ticks_at_notice!r} "
+        f"keys_received at notice-time={_diag_keys_received_at_notice!r}"
     )

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -942,9 +942,18 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
             time.sleep(stall_seconds)
             while "unresponsive" not in logfile.read_text(encoding="utf-8"):
                 await pilot.pause()
-            _diag_pump_ticks_at_notice = app.pump_ticks
-            _diag_keys_received_at_notice = app.keys_received
-            _diag_state_at_notice = app._activity.state
+            # lead-coder's TESTS-READ (#4842): these 3 are read AFTER this
+            # test's OWN loop above observes "unresponsive" in the logfile —
+            # not synchronized with the tripwire's own tick that actually
+            # WROTE the line. By the time this runs, further ticks may have
+            # already advanced pump_ticks/keys_received past what the
+            # tripwire itself saw, and activity.state could in principle
+            # have moved again too. Still useful (a divergence AT LEAST this
+            # late is still a divergence), but "at observation-time" is the
+            # honest name — not "at the tripwire's own read".
+            _diag_pump_ticks_after_notice_observed = app.pump_ticks
+            _diag_keys_received_after_notice_observed = app.keys_received
+            _diag_state_after_notice_observed = app._activity.state
     finally:
         for handler in root.handlers:
             if handler not in saved_handlers:
@@ -962,7 +971,7 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
         f"id(query_one(ActivityRow)) at confirm-time={_diag_query_obj_id!r} "
         f"(same object: {_diag_activity_obj_id == _diag_query_obj_id}); "
         f"activity.state at confirm-time={_diag_state_at_confirm!r} "
-        f"activity.state at notice-time={_diag_state_at_notice!r}; "
-        f"pump_ticks at notice-time={_diag_pump_ticks_at_notice!r} "
-        f"keys_received at notice-time={_diag_keys_received_at_notice!r}"
+        f"activity.state after this test observed the notice={_diag_state_after_notice_observed!r}; "
+        f"pump_ticks after this test observed the notice={_diag_pump_ticks_after_notice_observed!r} "
+        f"keys_received after this test observed the notice={_diag_keys_received_after_notice_observed!r}"
     )


### PR DESCRIPTION
**[e2e-coder]** — #4827① recurred (test_turn_active_reaches_the_default_visible_stall_notice, the exact assert #4833 fixed once) on #4767 (docs-only PR, both 3.11 and 3.12). Message-only enrichment, matching #4827②'s precedent — no local repro, no blind fix.

## What happened

The wait loop #4833 added (`while app.query_one(ActivityRow).state is None: await pilot.pause()`) DID confirm `state is not None` before the stall — yet the notice again said "turn idle", with `pump heartbeat` and `keys_received` both 0, the same whole-process-starvation signature as ①'s earlier failures.

## Investigated before touching anything

- lead-coder's "the turn ends during `time.sleep()`" hypothesis: `ActivityRow.state` has exactly two mutators (`begin`/`end`, `activity_row.py`) and this test never triggers `end()` — structurally, nothing should clear it.
- Local reproduction under **real** CPU contention (10 parallel busy-loop subprocesses, not the earlier inert `multiprocessing.Process` attempt from tonight's ① investigation) — 0/19, no reproduction. Same pattern as every other CI-only occurrence in this arc.

## What this PR does

Per lead-coder's explicit instruction: enrich the failure message only, no truth-condition change, no new test, no new gate. Captures — while the app is still alive/mounted (post-teardown widget queries are unreliable) — exactly what's needed to decide the mechanism on the next occurrence:

- `id(self._activity)` vs `id(query_one(ActivityRow))` at confirm-time — the wait loop reads the latter, the tripwire's own tick reads the former directly (`app.py`'s `getattr(self, "_activity", None)`). "Same object" was only ever verified **structurally** (`compose()` assigns `self._activity` exactly once, the same object it yields into the tree) — never **empirically**, on a CI host, at the moment of a real failure.
- `activity.state` at confirm-time vs at notice-time — direct evidence of whether it flipped between the two windows.
- `pump_ticks` / `keys_received` at notice-time — same "whole process stalled" signature check ① already established.

**Zero cost on green**: captures are cheap (`id()`/attribute reads, no I/O), and Python only evaluates an `assert`'s message expression when the condition is falsy — same discipline as #4827②. Verified the enriched message renders correctly under a direct simulated-failure check; the full test file (25 tests) still passes.

## Test plan
- [x] `ruff check .`
- [x] `scripts/test_tier_audit.py --strict tests/interfaces/test_loop_probe_3539.py`
- [x] `scripts/mypy_ratchet.py`
- [x] Full test file: 25 passed
- [x] Direct simulated-failure check confirming the enriched message renders without error
- [x] 19 local runs (4 baseline + 15 under real CPU contention) — 0 reproductions, consistent with CI-only

part of #4827

🤖 Generated with [Claude Code](https://claude.com/claude-code)
