### PR TITLE
docs(#4844): 時間の規則が「上限」しか名指しておらず、「下限」がその横を素通りした

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ observation does not name its own referent**.
 - **No snapshot/golden-file tests** outside `tests/scaffold/`.
 - **A test writes no duration, in EITHER direction.** A duration is never the property under test; it is a stand-in for an observation nobody exposed — so reaching for one says the seam is missing, not that the test needs a clock. Both shapes fail the same way: the machine that runs it decides whether the assert passes.
   - **Ceiling** (how long we will wait): no `@pytest.mark.timeout`, no `attempts=200`, no `range(N)` wrapping a wait. Wait on the condition unboundedly; CI's `--timeout=120` is the kill switch.
-  - **Floor** (how long something must take): no `sleep(N)` sized to outrun a threshold — `(_TRIPWIRE_MS + 150) / 1000` is the shape. Inject the threshold or the clock. `LoopProbe(threshold_ms=…)` has been injectable all along and no test used it; 4 unrelated PRs were reddened before anyone read the sleep (#4844).
+  - **Floor** (how long something must take): **no `sleep(N)` the assertion depends on** — sized to outrun a threshold (`(_TRIPWIRE_MS + 150) / 1000` is the shape), to let a task settle, or to let a clock tick (an mtime, a TTL). Inject the threshold or the clock. `LoopProbe(threshold_ms=…)` has been injectable all along and no test used it; 4 unrelated PRs were reddened before anyone read the sleep (#4844). Splitting the decision out as a pure function removes the place a duration could be written at all (#4847).
 - Tests for an extracted refactor live in `tests/scaffold/` with `triggered_by`/`removed_by`, and are **deleted in the PR that lands the refactor**.
 
 ## Comment policy (READ BEFORE WRITING OR MOVING A COMMENT)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ observation does not name its own referent**.
 - Each test belongs to exactly one Tier (1 Contract / 2 OS invariant / 3 LLM-replay). Anything else is **Tier 4 — do not write**.
 - First docstring line declares the Tier: `"""Tier 3a: ..."""`.
 - Declaring a Tier presupposes a named behaviour that exists **outside the test's own docstring**.
-- **Never fake a collaborator** when a real instance is cheaply constructible — no `MagicMock`/`AsyncMock`/`patch`, no hand-rolled stand-in. Use real instances or the `LLMReplay` Fake (#3037).
+- **Never fake a collaborator** when a real instance is cheaply constructible — no `MagicMock`/`AsyncMock`/`patch`, no hand-rolled stand-in. Use real instances or the `LLMReplay` Fake (#3037). **Cheap to construct is not the same as drivable**: a collaborator whose only trigger is its own timer (a watcher on an mtime) leaves a test that may not fake it and may not wait for it — the repair is to give it an external drive (`check()` you can call), not a fake and not a `sleep` (#4847).
 - **Never assert on private state.** Use the public surface or a `snapshot()`-style read.
 - **Never pin algorithm-level behaviour** — sort order, dict iteration order, cache structure, exact whitespace.
 - **No snapshot/golden-file tests** outside `tests/scaffold/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,13 +38,17 @@ considered it is answered "yes" every time.
 
 ### TUI colour policy
 
-The terminal emulator's theme decides; reyn names the MEANING, never the RGB
-(owner ruling #3525).
+Name the MEANING; the active theme renders it. Never pick a colour first
+(owner ruling #3525). **"The theme" is whichever theme is active** — reyn's own
+full-colour default, a Textual builtin, or an `ansi-*` theme that defers to the
+terminal emulator's palette. Terminal palettes are not a vocabulary: ECMA-48
+standardises the escape codes, not the RGB behind them, and 16 slots carry no
+meanings — that is why the meanings live in a theme.
 
-1. Meaning has a convention a reader already carries (*error*, *success*, *in-flight*) → name it, let the theme render it: ANSI-16 / `ansi_default` / `transparent` / an SGR `text-style`.
-2. Meaning is reyn-specific → any value that serves the design, full-colour included. The theme has no opinion to defer to.
+1. Meaning has a convention a reader already carries (*error*, *success*, *in-flight*) → name it so every theme can render it: a theme token (`$error`, `$text-muted`, `$markdown-*` …), an SGR `text-style`, or `ansi_default` / `transparent` where the terminal's own value is the point.
+2. Meaning is reyn-specific → any value that serves the design, full-colour included. No theme has an opinion to defer to.
 
-- **A colour is not a meaning.** "Error" is the meaning; red is one terminal's rendering. Never pick the colour first.
+- **A colour is not a meaning.** "Error" is the meaning; red is one theme's rendering. Never pick the colour first.
 - **This is not an ANSI-16-only policy.** Only two things are forbidden, and neither limits expressiveness: **a literal in a widget stylesheet** (every value goes through a token in `src/reyn/interfaces/inline/textual_chat/palette.py`, and stylesheets write a `@name@` marker) and **alpha-compositing over `ansi_default`** (the blend destroys the terminal's own value).
 - `tests/interfaces/test_tui_colour_tokens.py` enumerates every colour-bearing declaration under `interfaces/` and fails on any value named outside the palette. Textual's own `DEFAULT_CSS` is out of scope.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,11 +41,11 @@ considered it is answered "yes" every time.
 Name the MEANING; the active theme renders it. Never pick a colour first
 (owner ruling #3525). **"The theme" is whichever theme is active** — reyn's own
 full-colour default, a Textual builtin, or an `ansi-*` theme that defers to the
-terminal emulator's palette. Terminal palettes are not a vocabulary: ECMA-48
-standardises the escape codes, not the RGB behind them, and 16 slots carry no
-meanings — that is why the meanings live in a theme.
+terminal emulator's palette. Terminal palettes are not a vocabulary: the escape
+codes are standardised, the RGB behind them is not, and a slot carries a colour
+name, not a role — that is why the roles live in a theme.
 
-1. Meaning has a convention a reader already carries (*error*, *success*, *in-flight*) → name it so every theme can render it: a theme token (`$error`, `$text-muted`, `$markdown-*` …), an SGR `text-style`, or `ansi_default` / `transparent` where the terminal's own value is the point.
+1. Meaning has a convention a reader already carries (*error*, *success*, *in-flight*) → name it so every theme can render it: a theme token (`$error`, `$text-muted`, `$markdown-*` …), an SGR `text-style`, or an ANSI name (`ansi_blue` / `ansi_default` / `transparent`) where the terminal's own value is the point — `@selection-bg@` and `@selection-fg@` are live examples of the last.
 2. Meaning is reyn-specific → any value that serves the design, full-colour included. No theme has an opinion to defer to.
 
 - **A colour is not a meaning.** "Error" is the meaning; red is one theme's rendering. Never pick the colour first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,9 @@ observation does not name its own referent**.
 - **Never assert on private state.** Use the public surface or a `snapshot()`-style read.
 - **Never pin algorithm-level behaviour** — sort order, dict iteration order, cache structure, exact whitespace.
 - **No snapshot/golden-file tests** outside `tests/scaffold/`.
-- **Tests carry no time limit of their own** — no `@pytest.mark.timeout`, no wait-budget in the body (`attempts=200`, `range(N)`). Wait on the condition unboundedly; CI's `--timeout=120` is the kill switch. Straight-line `sleep(N)` as the thing that makes an assertion pass stays banned.
+- **A test writes no duration, in EITHER direction** — both shapes fail the same way: the machine that runs it decides whether the assert passes.
+  - **Ceiling** (how long we will wait): no `@pytest.mark.timeout`, no `attempts=200`, no `range(N)` wrapping a wait. Wait on the condition unboundedly; CI's `--timeout=120` is the kill switch.
+  - **Floor** (how long something must take): no `sleep(N)` sized to outrun a threshold — `(_TRIPWIRE_MS + 150) / 1000` is the shape. Inject the threshold or the clock. `LoopProbe(threshold_ms=…)` has been injectable all along and no test used it; 4 unrelated PRs were reddened before anyone read the sleep (#4844).
 - Tests for an extracted refactor live in `tests/scaffold/` with `triggered_by`/`removed_by`, and are **deleted in the PR that lands the refactor**.
 
 ## Comment policy (READ BEFORE WRITING OR MOVING A COMMENT)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ observation does not name its own referent**.
 - **Never assert on private state.** Use the public surface or a `snapshot()`-style read.
 - **Never pin algorithm-level behaviour** — sort order, dict iteration order, cache structure, exact whitespace.
 - **No snapshot/golden-file tests** outside `tests/scaffold/`.
-- **A test writes no duration, in EITHER direction** — both shapes fail the same way: the machine that runs it decides whether the assert passes.
+- **A test writes no duration, in EITHER direction.** A duration is never the property under test; it is a stand-in for an observation nobody exposed — so reaching for one says the seam is missing, not that the test needs a clock. Both shapes fail the same way: the machine that runs it decides whether the assert passes.
   - **Ceiling** (how long we will wait): no `@pytest.mark.timeout`, no `attempts=200`, no `range(N)` wrapping a wait. Wait on the condition unboundedly; CI's `--timeout=120` is the kill switch.
   - **Floor** (how long something must take): no `sleep(N)` sized to outrun a threshold — `(_TRIPWIRE_MS + 150) / 1000` is the shape. Inject the threshold or the clock. `LoopProbe(threshold_ms=…)` has been injectable all along and no test used it; 4 unrelated PRs were reddened before anyone read the sleep (#4844).
 - Tests for an extracted refactor live in `tests/scaffold/` with `triggered_by`/`removed_by`, and are **deleted in the PR that lands the refactor**.


### PR DESCRIPTION
**[lead-coder]** — part of #4844

## owner の指摘

> **「規則があるのに見逃したのは規則の書き方が悪いんじゃないの？」**

**そのとおりでした。診断は具体的です。**

## 何が悪かったか

見出しは「Tests carry no time **LIMIT** of their own」で、例は 3 つとも **上限**（timeout / attempts=200 / range(N)）＝「これ以上は待たない」。**`sleep(N)` は逆向きの形**（**下限** ＝「これだけの時間を必ず使う」）で、**例も理由もない末尾の 1 節**として、**片方向しか名指していない見出しの下に**置かれていました。

さらにその末尾節は **自前の逃げ道**を持っていました — 「as the thing that **makes an assertion pass**」。`test_loop_probe_3539.py` をレビューしたとき、私は「sleep は stall を**作る**だけで、assert は通知を読んでいる」と自分に言って通しました。**sleep 7 箇所、うち 4 箇所が `(_TRIPWIRE_MS + 150) / 1000`** — **150ms の余裕**に対し、**CI の飢餓は実測 2 秒**（#4834）。

## 変更

- **両方向を 1 つの規則**として名指し、**壊れ方が共通である**ことを書きました（走らせた機械が assert の成否を決める）。
- **下限側に固有の形と処方**を与えました — `(_TRIPWIRE_MS + 150) / 1000` という形／閾値か時計を注入する。
- **`LoopProbe(threshold_ms=…)` は最初から注入可能で、どの test も渡していなかった**という実測を添えました。

## Test plan

- [x] 規範の緩和なし（禁止範囲は同一 — 下限側が明示されただけ）
- [x] 母集団の実測を添付（下記）
- [ ] (skipped — CLAUDE.md は `docs/` 配下ではないため mkdocs / anchor gate の対象外)

**AST 実測（tests/ 全体）**: 疑わしい **347 箇所** — `range(N)` で待つ **155** / `asyncio.sleep(>0)` **137** / `time.sleep(>0)` **55**。無害と分類: `range(N)` のデータ反復 133 / `sleep(0)` の譲渡 114。**規則だけでは 347 件は止まりません** — ratchet を #4844 の続きとして起票します。



- [x] 🔴 **① floor 側の禁止範囲が狭まっている（architect review）** — 旧「`sleep(N)` **as the thing that makes an assertion pass**」⊃ 新「`sleep(N)` **sized to outrun a threshold**」。タスクが落ち着くのを待つ `sleep(0.1)`／mtime が進むのを待つ `sleep(1)` は新文の名指しから外れる。**この PR が直している構図（広い見出し × 狭い例）が新文で再発**しています。review コメントの案（「the assertion depends on」＋例 3 つ）に差し替えてから merge してください。




**architect 再読（2026-08-15）**: 🔴 解消。`no `sleep(N)` the assertion depends on` ＋ 例 3 つ（threshold / task settle / clock tick）＋ #4847 参照を確認。**force-push 後の健全性も architect が独立に確認**しました — CLAUDE.md に競合マーカー 0、`ECMA-48`/`16 slots` の復活 0、`ansi_blue`/`@selection-bg@` 現存、colour 段落は `origin/main` と byte 一致。**私からの blocking はありません。**
