### PR TITLE
fix(#4787): relocate palette.py outside textual_chat's TTY-only import boundary

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/activity_row.py
+++ b/src/reyn/interfaces/inline/textual_chat/activity_row.py
@@ -71,7 +71,7 @@ from textual.widgets import Static
 if TYPE_CHECKING:
     from textual.timer import Timer
 
-from reyn.interfaces.inline.textual_chat import palette
+from reyn.interfaces import palette
 from reyn.interfaces.inline.textual_chat.sent_queue import ROW_TEXT_COLUMN
 
 #: The cancel affordance shown while a turn runs. Plain ASCII: the key it names

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -53,7 +53,7 @@ from textual_flowview import (
     FlowView,
 )
 
-from reyn.interfaces.inline.textual_chat import palette
+from reyn.interfaces import palette
 from reyn.interfaces.repl._clipboard import (
     copy_to_clipboard,
     copy_to_clipboard_async,

--- a/src/reyn/interfaces/inline/textual_chat/completion.py
+++ b/src/reyn/interfaces/inline/textual_chat/completion.py
@@ -143,7 +143,7 @@ from typing import TYPE_CHECKING
 from rich.cells import cell_len, set_cell_size
 from textual.widgets import OptionList
 
-from reyn.interfaces.inline.textual_chat import palette
+from reyn.interfaces import palette
 
 from .presenter import _neutralized_label, option_content_rows
 

--- a/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
+++ b/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
@@ -108,7 +108,7 @@ from textual.widgets import (
     Tabs,
 )
 
-from reyn.interfaces.inline.textual_chat import palette
+from reyn.interfaces import palette
 
 from .presenter import _neutralized_label
 

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -22,6 +22,7 @@ from rich.text import Text
 from textual.content import Content
 from textual_flowview import Entry, Presentation
 
+from reyn.interfaces.palette import TOKENS
 from reyn.interfaces.repl.renderer import (
     _CC_ACCENT,
     _CC_DIM,
@@ -44,7 +45,6 @@ from ._meta_keys import RESULT_KIND_KEY as _RESULT_KIND_KEY
 from ._meta_keys import RESULT_META_KEY as _RESULT_META_KEY
 from ._meta_keys import RUNNING_SINCE_KEY as _RUNNING_SINCE_KEY
 from .gutter import _is_retrieval_tool
-from .palette import TOKENS
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/reyn/interfaces/inline/textual_chat/rewind_picker.py
+++ b/src/reyn/interfaces/inline/textual_chat/rewind_picker.py
@@ -37,7 +37,7 @@ from textual.content import Content
 from textual.message import Message
 from textual.widgets import OptionList, Static
 
-from reyn.interfaces.inline.textual_chat import palette
+from reyn.interfaces import palette
 
 #: Max characters of a point's ``ts`` shown in a row — the WAL timestamp is a
 #: free-form string read straight off the WAL entry, so it is truncated rather

--- a/src/reyn/interfaces/inline/textual_chat/search_bar.py
+++ b/src/reyn/interfaces/inline/textual_chat/search_bar.py
@@ -40,7 +40,7 @@ from textual.containers import Horizontal
 from textual.message import Message
 from textual.widgets import Input, Static
 
-from reyn.interfaces.inline.textual_chat import palette
+from reyn.interfaces import palette
 
 
 class SearchBar(Horizontal):

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -84,7 +84,7 @@ from textual.content import Content
 from textual.message import Message
 from textual.widgets import Static
 
-from reyn.interfaces.inline.textual_chat import palette
+from reyn.interfaces import palette
 
 from .presenter import _neutralized_label
 

--- a/src/reyn/interfaces/inline/textual_chat/text_effect.py
+++ b/src/reyn/interfaces/inline/textual_chat/text_effect.py
@@ -187,7 +187,7 @@ def _pulse_colours(dark: bool) -> "tuple[str, ...]":
     """
     from rich.color import Color, blend_rgb
 
-    from reyn.interfaces.inline.textual_chat import palette
+    from reyn.interfaces import palette
 
     peak = Color.parse(
         palette.BLINK_PEAK_DARK if dark else palette.BLINK_PEAK_LIGHT

--- a/src/reyn/interfaces/palette.py
+++ b/src/reyn/interfaces/palette.py
@@ -1,4 +1,4 @@
-"""The single place the inline CUI names a colour.
+"""The single place ``interfaces/`` names a colour.
 
 Every colour and emphasis decision the TUI makes is a token here, and every
 widget's ``DEFAULT_CSS`` interpolates one rather than writing a value. Checking
@@ -23,6 +23,22 @@ carried by SGR attributes (``dim``, ``bold``) for the same reason: under the
 ``$text 40%`` and ``$accent 30%`` do not fade anything, they either do nothing
 or paint a solid colour. An attribute leaves the hue to the terminal and
 survives the merge.
+
+**Location (#4787, lead-coder ruling):** lives directly under
+``interfaces/``, not inside ``interfaces/inline/textual_chat/`` where it
+started — that package's own ``__init__.py`` eagerly imports ``textual``/
+``textual_flowview`` through its submodules ("must only ever be imported on
+the TTY path", its own docstring), and Python always runs a package's
+``__init__.py`` before any of its submodules, so ANY import of
+``textual_chat.palette`` — even a direct one, even though this module itself
+has zero framework imports — paid that cost regardless. Verified directly:
+``'textual' in sys.modules`` was ``False`` after importing
+``interfaces.repl.renderer`` alone, ``True`` the moment
+``textual_chat.palette`` was imported. ``interfaces/repl/renderer.py`` (the
+plain/``--cui``/non-TTY chat path, which must stay usable without
+``flowview`` installed) needs these same token values without paying that
+cost — this module has none of its own for the SAME reason it never did:
+``interfaces/__init__.py`` is docstring-only.
 """
 from __future__ import annotations
 

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -653,7 +653,7 @@ async def test_an_expanded_group_parent_recedes() -> None:
     resolve through a ``palette.py`` token, never a literal."""
     from rich.styled import Styled
 
-    from reyn.interfaces.inline.textual_chat.palette import TOKENS
+    from reyn.interfaces.palette import TOKENS
 
     transport = QueueTransport()
     app = TextualChatApp(transport=transport, clock=lambda: 100.0)

--- a/tests/interfaces/test_activity_row_3693.py
+++ b/tests/interfaces/test_activity_row_3693.py
@@ -27,7 +27,8 @@ from typing import AsyncIterator
 
 import pytest
 
-from reyn.interfaces.inline.textual_chat import TextualChatApp, palette
+from reyn.interfaces import palette
+from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.activity_row import (
     _CANCEL_HINT,
     LATEST_HINT,

--- a/tests/interfaces/test_recede_dim_3523.py
+++ b/tests/interfaces/test_recede_dim_3523.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import pytest
 from textual.app import App, ComposeResult
 
-from reyn.interfaces.inline.textual_chat.palette import TOKENS
 from reyn.interfaces.inline.textual_chat.rewind_picker import RewindPicker
 from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
+from reyn.interfaces.palette import TOKENS
 
 
 class _Probe(App):

--- a/tests/interfaces/test_selection_not_bright_3542.py
+++ b/tests/interfaces/test_selection_not_bright_3542.py
@@ -23,7 +23,7 @@ import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import Static
 
-from reyn.interfaces.inline.textual_chat import palette
+from reyn.interfaces import palette
 
 #: ANSI slot numbers, named so the assertions below read as intent rather than
 #: as magic numbers. 4 is blue; 12 is its bright counterpart.

--- a/tests/interfaces/test_tui_colour_tokens.py
+++ b/tests/interfaces/test_tui_colour_tokens.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from reyn.interfaces.inline.textual_chat import palette
+from reyn.interfaces import palette
 from tests._support.paths import REPO_ROOT
 
 _INTERFACES = REPO_ROOT / "src" / "reyn" / "interfaces"


### PR DESCRIPTION
**[tui-coder]** — lead-coder's structural ruling, implementing.

## The finding (verified empirically before shipping)

`textual_chat/__init__.py`'s own docstring: "must only ever be imported on the TTY path" — eagerly imports `textual`/`textual_flowview` through its submodules. Python always runs a package's `__init__.py` before any of its submodules, so ANY import of `textual_chat.palette` — even a direct one, even though `palette.py` itself has zero framework imports — paid that cost regardless:

```python
>>> import sys; import reyn.interfaces.repl.renderer
>>> 'textual' in sys.modules
False
>>> from reyn.interfaces.inline.textual_chat import palette
>>> 'textual' in sys.modules
True
```

This blocked `renderer.py` (the plain/`--cui`/non-TTY chat path, which must stay usable without `flowview` installed) from ever reading these tokens without breaking that invariant.

## The ruling

Relocate to `src/reyn/interfaces/palette.py` — verified `interfaces/__init__.py` is docstring-only (zero imports), a safe target. Not lazy-importing inside `textual_chat`'s own `__init__` — moving palette out is the narrower change, and the eager import is an intentional invariant, not a bug to route around.

## Consumers (14, not the 3 first estimated)

Found via `git grep` for every import FORM — package-level, relative, function-local — not trusting one pattern. The 14th (`test_activity_row_3693.py`'s `from ... import TextualChatApp, palette` on one line) only surfaced by actually running the test suite, not by grep alone — recorded as a real gap in my own initial measurement, caught before merge.

All 14 updated to import from the new location directly. **No re-export shim** — per lead-coder's explicit instruction.

## Falsification

- Confirmed the OLD import path worked before the move (`git stash`).
- Confirmed `renderer.py` alone still pulls in zero Textual modules after the move (unaffected — it doesn't import palette yet, that's future work once #4840's mechanism question resolves).
- Confirmed the NEW location (`reyn.interfaces.palette`) is import-cheap — zero Textual modules pulled in.

## Tests

209 tests in the scoped area (every file touched, plus related keyword matches) pass, no regressions. 55 tests in the directly-touched files individually verified + tier-audited.

## Time-dependency check (#4845/#4847)

**0 instances** — no test in this diff writes a time bound in either direction.

## Checks

`ruff check .` clean · `mypy_ratchet.py` clean · `test_tier_audit.py --strict`: 55/55 OK · `verify_module_docstrings.py` OK · `flat_tests_ratchet.py` OK · `check_tests_path_literal_reference.py` OK · `check_bare_tests_import_reference.py` OK · `check_file_depth_reference.py` OK.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict` (5 touched test files)
- [x] `python scripts/verify_module_docstrings.py` (changed files)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Falsification: old path pre-move, new path import-cheap, renderer.py unaffected
- [x] Scoped `pytest tests/interfaces/ -k "palette or colour or ..."`: 209 passed
- [x] Time-dependency check: 0 instances

part of #4787