### PR TITLE
feat(#4787): renderer.py sources its 5 reusable colour constants from palette.py

### DIFF
--- a/src/reyn/interfaces/palette.py
+++ b/src/reyn/interfaces/palette.py
@@ -115,6 +115,41 @@ TOKENS: "dict[str, str]" = {
     #: here so the pair is legible in one place: a background chosen without
     #: its foreground beside it is how contrast regressions happen.
     "@selection-fg@": "ansi_black",
+    #: #4787: the first 5 of ``interfaces/repl/renderer.py``'s 8 former
+    #: ``_CC_*`` hex constants — the ones whose value #4787's own
+    #: classification found reusable AS-IS (no new colour chosen; the
+    #: MEANING decision was the whole exercise, per CLAUDE.md's "Never pick
+    #: a colour first"). Consumed DIRECTLY as Python values
+    #: (``palette.TOKENS["@success@"]``) by both ``renderer.py`` (the plain
+    #: REPL, ``rich.Text(style=...)``, no live Textual App to resolve a
+    #: ``$token`` against — #4840's own open question) and
+    #: ``presenter.py``/``gutter.py`` (the TUI, same values, same reason: no
+    #: reyn Textual theme exists yet to resolve ``$success`` etc. against).
+    #: NOT yet ``@name@``-embedded in any stylesheet string — these values
+    #: are plain dict lookups here, the marker-in-CSS mechanism above
+    #: doesn't apply to this batch.
+    #:
+    #: Each is expected to become a Textual token reference (``$success``,
+    #: ``$error``, ``$warning``, ``$accent``, ``$secondary``) once #4840's
+    #: reyn theme module exists — this is the meaning-assignment half of
+    #: that migration, landing first per lead-coder's own ordering (①
+    #: classify+move, ② broaden the gate — #4851, ③ relocate palette out
+    #: of textual_chat's TTY-only import boundary — #4857, ④ the colour
+    #: direction itself, on hold for the owner).
+    "@success@": "#7ee787",     # green — completion (was _CC_DONE)
+    "@error@": "#f97066",       # red — failure (was _CC_ERR)
+    #: Textual's own state-palette meaning (gutter.py's own comment: "RUNNING
+    #: amber, SUCCESS green, ERROR coral"), covering BOTH "in progress" and
+    #: "needs you" — broader in scope than @attention@ above, which stays
+    #: scoped to its own one widget (the intervention panel's border/prompt)
+    #: and is UNCHANGED by this addition. Textual's own vocabulary has one
+    #: amber-family token (``$warning``) for both meanings, so the two reyn
+    #: tokens are expected to converge on the SAME eventual Textual value
+    #: without being the same token — they answer different "why is this
+    #: amber" questions even when the colour ends up equal.
+    "@warning@": "#e3b341",     # amber — state-palette + SESSION HALTED (was _CC_WARN)
+    "@accent@": "#d97757",      # terracotta — primary interactive accent (was _CC_ACCENT)
+    "@secondary@": "#6cb6ff",   # blue — secondary/markdown accent (was _CC_COOL)
 }
 
 #: The NOW row's travelling shine (#3777), as a GROUND and a PEAK per terminal

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -8,6 +8,7 @@ from io import StringIO
 
 from prompt_toolkit.formatted_text import HTML, AnyFormattedText
 
+from reyn.interfaces import palette
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.outbox import OutboxMessage
 
@@ -379,11 +380,21 @@ _CC_DIM = "#6b7280"     # low-importance / ambient, as a COLOUR (see _CC_AMBIENT
 # ``tool_call_started`` rows have ``background=None``, and those are exactly the
 # rows the right gutter's token / elapsed labels ride on.
 _CC_AMBIENT = "dim"
-_CC_DONE = "#7ee787"    # green — completion
-_CC_ERR = "#f97066"     # red — failure
-_CC_WARN = "#e3b341"    # amber — an intervention that needs the user to act
-_CC_ACCENT = "#d97757"  # terracotta — spinner / accents
-_CC_COOL = "#6cb6ff"    # cool blue — a secondary accent (status-bar agent value)
+# #4787: these 5 no longer declare their own hex literal — they read the
+# SAME value from ``interfaces/palette.py``'s ``TOKENS`` dict, the one
+# place ``interfaces/`` names a colour (this file's own module-level
+# import: ``from reyn.interfaces import palette``, safe — palette.py has
+# zero framework imports, so this pulls in no Textual dependency, verified
+# directly). Each is expected to become a Textual token reference
+# (``$success``/``$error``/``$warning``/``$accent``/``$secondary``) once
+# #4840's reyn theme module exists; for now the VALUE is unchanged, only
+# WHERE it is declared moved — see palette.py's own comment on this batch
+# for the full reasoning.
+_CC_DONE = palette.TOKENS["@success@"]    # green — completion
+_CC_ERR = palette.TOKENS["@error@"]       # red — failure
+_CC_WARN = palette.TOKENS["@warning@"]    # amber — an intervention that needs the user to act
+_CC_ACCENT = palette.TOKENS["@accent@"]   # terracotta — spinner / accents
+_CC_COOL = palette.TOKENS["@secondary@"]  # cool blue — a secondary accent (status-bar agent value)
 # Row-TINT backgrounds. The convention (established by _CC_USER_BG, extended to
 # _CC_ERR_BG by #3367): a row tint is a FAINT DARK block that the row's normal
 # foreground colour stays legible against — never a saturated foreground colour

--- a/tests/interfaces/test_tui_colour_tokens.py
+++ b/tests/interfaces/test_tui_colour_tokens.py
@@ -138,8 +138,15 @@ _HEX_LITERAL_EXEMPT_DIRS = frozenset({"web"})
 #: whole point. Remove entries as each constant actually moves; the file
 #: drops out entirely once all 8 do.
 _PY_HEX_LITERAL_TRACKED = {
-    "repl/renderer.py": "#4787 — 8 constants, meaning-classification done, "
-                        "migration to palette.py in progress",
+    # lead-coder review (#4861): no count here — a written number goes
+    # stale the moment a migration commit lands (measured: this said "8
+    # constants" after #4861 had already moved 5 of them to palette.py,
+    # and the staleness test below cannot catch a wrong COUNT — it only
+    # fires when the file stops holding ANY hex literal at all, existence
+    # not quantity). The remaining sites are whatever _python_hex_literals()
+    # finds for this file right now — read that, not this string.
+    "repl/renderer.py": "#4787 — meaning-classification done, migration to "
+                        "palette.py in progress",
 }
 
 


### PR DESCRIPTION
**[tui-coder]** — the second half of #4787①, now that #4857 (relocation) is merged. Closes the cross-boundary architect flagged on #4857 ("越境（TUI が repl の hex を import して使う）はまだそのまま") for 5 of the 8 constants — **CORRECTION** (architect catch, post-merge): the *specific* example architect quoted, `_CC_DIM = "#6b7280"`, is NOT one of the 5 — see the "What's still open" section below, which correctly lists it among the 3 remaining. The opening sentence originally implied otherwise; fixing that claim here since GitHub doesn't let a merged PR's body silently misstate what landed.

## What changed

`renderer.py` imports `reyn.interfaces.palette` at module level — verified to pull in zero Textual modules, same guarantee #4857 established for the location itself. 5 constants (whose meaning-classification, my earlier #4787 comment, found reusable as-is) now read their value from `palette.TOKENS` instead of declaring their own hex literal:

```
_CC_DONE   -> palette.TOKENS["@success@"]
_CC_ERR    -> palette.TOKENS["@error@"]
_CC_WARN   -> palette.TOKENS["@warning@"]
_CC_ACCENT -> palette.TOKENS["@accent@"]
_CC_COOL   -> palette.TOKENS["@secondary@"]
```

Values are **byte-identical** to before — verified directly (equality assertion, not visual comparison) — only where they're declared moved, no colour re-picked, matching CLAUDE.md's own "never pick a colour first" and lead-coder's explicit instruction that this half needs no owner input.

## What's still open

The remaining 3 (`_CC_DIM`/`_CC_USER_BG`/`_CC_ERR_BG`) stay untouched — their WCAG-measured-contrast-pair blocker (my earlier #4787 comment) is unaffected by this and still needs the colour-direction question (#4840, owner-pending) resolved first. The gate's own tracked allowance for `renderer.py` correctly stays non-stale — the file still holds these 3 real hex literals, so `test_the_tracked_hex_literal_allowance_stays_current` keeps passing for the right reason.

## Falsification

`git stash`: pre-change state shows the plain hex literal (`_CC_DONE = "#7ee787"`); post-change value confirmed byte-identical via the new indirection.

## Tests

143 renderer/chat-render-scoped tests pass, no regressions. Gate's own 8 tests still pass (tracked allowance correctly non-stale).

## Time-dependency check (#4845/#4847)

**0 instances** — no new tests in this diff.

## Checks

`ruff check .` clean · `mypy_ratchet.py` clean · `test_tier_audit.py --strict tests/interfaces/test_tui_colour_tokens.py`: 8/8 OK · `verify_module_docstrings.py` OK.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_tui_colour_tokens.py`
- [x] `python scripts/verify_module_docstrings.py` (changed files)
- [x] Falsification: `git stash` confirms pre-change plain hex, post-change byte-identical value
- [x] Scoped renderer-related tests: 143 passed
- [x] Time-dependency check: 0 instances

part of #4787

- [x] 🔴 (lead-coder) `_PY_HEX_LITERAL_TRACKED` の文言が「8 constants」のままで偽（実測: 残り 3）。staleness test は存在しか見ないので 8→3 を検知しません。数を書かない形（②）を推奨。


