### PR TITLE
feat(#4787): renderer.py's _CC_DIM sources from palette.py (6th of 8)

### DIFF
--- a/src/reyn/interfaces/palette.py
+++ b/src/reyn/interfaces/palette.py
@@ -150,6 +150,36 @@ TOKENS: "dict[str, str]" = {
     "@warning@": "#e3b341",     # amber — state-palette + SESSION HALTED (was _CC_WARN)
     "@accent@": "#d97757",      # terracotta — primary interactive accent (was _CC_ACCENT)
     "@secondary@": "#6cb6ff",   # blue — secondary/markdown accent (was _CC_COOL)
+    #: The 6th of the 8 — moved alone, NOT together with ``_CC_USER_BG``/
+    #: ``_CC_ERR_BG`` (renderer.py's own remaining two), which stay blocked
+    #: on #4840's colour-direction question. Safe to move independently:
+    #: this changes WHERE the value is declared, never the value itself
+    #: (``#6b7280``, unchanged) — renderer.py's own comment on the
+    #: constant this replaces documents a WCAG-measured contrast PAIRING
+    #: against ``_CC_USER_BG`` (#3371: 3.30 at this exact value, below WCAG
+    #: AA-large's 3.0 threshold at the prior one); since neither value
+    #: changes, only the declaration site, that measured pairing is
+    #: untouched. Low-importance/ambient is its own clear meaning (unlike
+    #: the backgrounds, which double as candidates for #4840's
+    #: still-undecided ``background``/``panel`` — see #4787's own comment
+    #: thread), so this one didn't need to wait for that ruling.
+    #:
+    #: **★changing this value breaks renderer.py's own measured 3.30
+    #: contrast ratio against ``_CC_USER_BG`` there** (architect finding,
+    #: #4787) — the two halves of that ONE measurement now live in
+    #: different files, since ``_CC_USER_BG`` itself stays put pending
+    #: #4840. Re-measure BOTH sides together, not just this one, if either
+    #: changes.
+    #:
+    #: **Unlike the 5 above, this one does NOT become a Textual token
+    #: reference once #4840's theme exists** — it stays a permanently
+    #: CONCRETE value. renderer.py's own comment on the constant this
+    #: replaces documents two independent reasons: ``prompt_toolkit``
+    #: rejects an SGR-only style outright (``fg:dim`` raises
+    #: ``ValueError``, measured), and #3367's contrast gate "skips any
+    #: segment whose foreground is not concrete" — a ``$token`` reference
+    #: resolved at Textual-theme time would be invisible to both.
+    "@dim@": "#6b7280",  # low-importance / ambient, as a COLOUR (was _CC_DIM)
 }
 
 #: The NOW row's travelling shine (#3777), as a GROUND and a PEAK per terminal

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -355,7 +355,11 @@ class RichChatRenderer(ChatRenderer):
 # to signal STATE — error (red), needs-action (amber), done (green), ambient/low
 # (dim) — so a coloured glyph always means "something to notice".
 _CC_TEXT = "default"    # terminal default fg — normal text + markers (no forced colour)
-_CC_DIM = "#6b7280"     # low-importance / ambient, as a COLOUR (see _CC_AMBIENT)
+# #4787: moved alone, not with _CC_USER_BG/_CC_ERR_BG below (still blocked
+# on #4840's colour direction) — safe independently because the VALUE is
+# unchanged, only where it's declared; the WCAG-measured contrast pairing
+# against those two backgrounds (#3371, unmoved) is therefore untouched.
+_CC_DIM = palette.TOKENS["@dim@"]  # low-importance / ambient, as a COLOUR (see _CC_AMBIENT)
 # The same "low-importance" role expressed as an ATTRIBUTE rather than a colour
 # (#3536). ``dim`` emits SGR 2 and forces no colour, so the terminal's own theme
 # decides the shade — the owner's standing direction (#3525) and the only form
@@ -410,6 +414,12 @@ _CC_COOL = palette.TOKENS["@secondary@"]  # cool blue — a secondary accent (st
 # (still reads as "a faint dark block", not a new hue) to raise every
 # foreground's contrast against it, _CC_DIM's included — measured 3.30 at
 # this value. Not a new color: the same named constant, same design role.
+#
+# #4787 (architect finding): _CC_DIM's own value now lives in
+# interfaces/palette.py (TOKENS["@dim@"]), a DIFFERENT file from this one —
+# changing @dim@ there breaks this 3.30 measurement here, and re-measuring
+# only one side leaves the pairing's real number unknown. Re-measure BOTH
+# _CC_USER_BG and palette.TOKENS["@dim@"] together if either changes.
 _CC_USER_BG = "#1e222a"
 # Failure block-tint behind a failed tool call / error row. A desaturated dark
 # coral: it reads unmistakably as "the red row" edge to edge (CC's block-tint of


### PR DESCRIPTION
**[tui-coder]** — part of #4787 (colour-token migration arc; not the closing PR)

## What changed

`_CC_DIM = "#6b7280"` (`interfaces/repl/renderer.py`) now sources from
`palette.TOKENS["@dim@"]` in `interfaces/palette.py` — the 6th of the
original 8 hex constants named in #4787, moved alone rather than together
with #4861's 5.

Moving this one independently (not waiting on #4840's still-open colour
direction) was judged safe because:
- It changes only WHERE the value is declared, never the value itself
  (`#6b7280` unchanged).
- `_CC_DIM`'s meaning (low-importance/ambient) is unambiguous — unlike
  `_CC_USER_BG`/`_CC_ERR_BG`, which double as candidates for #4840's
  still-undecided `background`/`panel` tokens.
- `renderer.py` documents a WCAG-measured contrast pairing between
  `_CC_DIM` and `_CC_USER_BG` (#3371: 3.30, above WCAG AA-large's 3.0
  threshold). Since neither value changes, only the declaration site,
  that pairing's number is untouched — but the two halves of the ONE
  measurement now live in different files, so this PR adds an explicit
  cross-file "X breaks" note on both sides (`comments.md`'s convention),
  per architect's pre-land review.

Also per architect's review: `_CC_DIM` does NOT follow the same
"eventually becomes a Textual `$token`" trajectory as the 5 constants
moved in #4861 — it stays permanently concrete. Two independent reasons,
both already documented on the constant it replaces: `prompt_toolkit`
rejects an SGR-only style outright (`fg:dim` raises `ValueError`,
measured), and #3367's contrast gate skips any segment whose foreground
isn't concrete. Both points are now called out explicitly in the new
comment blocks in `palette.py` and `renderer.py`.

## What's still open

`_CC_USER_BG` / `_CC_ERR_BG` (2 of the original 8) — blocked on #4840's
owner-pending colour-direction ruling. No action pending from this PR on
those.

## Falsification

`git stash` of both changed files reproduced the pre-migration literal
(`_CC_DIM = "#6b7280"` in `renderer.py`, un-tokenized) and confirmed
`renderer._CC_DIM` printed the plain hex string; `git stash pop` restored
the change and re-verified `renderer._CC_DIM == palette.TOKENS["@dim@"]
== "#6b7280"`.

## Time-dependency check

0 instances — no new tests in this diff.

## Test plan

- [x] `pytest tests/interfaces/test_tui_colour_tokens.py -q` — 8 passed
- [x] `ruff check .` — all checks passed
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/palette.py src/reyn/interfaces/repl/renderer.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] Falsification via `git stash`/`git stash pop` (see above)
- [ ] Visual — n/a (no rendering-behaviour change; declaration-site move only)
