### PR TITLE
test(#4862): rescue family3 inv5/inv6 at the public surface

### DIFF
--- a/tests/core/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/core/test_2761_pr2_hotreload_immediate_apply.py
@@ -262,65 +262,27 @@ async def test_operator_reload_still_runs_all_seams(tmp_path: Path) -> None:
 
 
 # ===========================================================================
-# A2. #4862 rescue — session.hot_reloader IS wired to session.audit_events,
-# and get_active_hot_reloader() IS this session's own reloader
+# A2. #4862 rescue — get_active_hot_reloader() IS this session's own reloader
 # ===========================================================================
 #
 # Replaces tests/scaffold/test_family3_hook_event_bundle_byte_identical.py's
-# test_hot_reloader_events_is_the_family_audit_events (invariant 5) and
-# test_get_active_hot_reloader_is_this_sessions_reloader (invariant 6),
-# which pinned both via private-attribute identity (`session._hot_reloader`
-# / `session._audit_events`, a scaffold-only exception). Rescued at the
-# public surface via the new `session.hot_reloader` / `session.audit_events`
-# accessors (#4862 step ②).
-
-
-@pytest.mark.asyncio
-async def test_session_hot_reloader_reload_lands_in_session_audit_events(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Tier 2: a reload run through ``session.hot_reloader`` emits
-    ``config_reloaded`` that lands in ``session.audit_events`` specifically
-    — witnessed via effect (real reload + real subscriber), not a private
-    ``hot_reloader.events is audit_events`` identity peek. If the two were
-    wired to DIFFERENT EventLogs, this reload's event would never reach
-    ``session.audit_events``'s subscribers."""
-    monkeypatch.chdir(tmp_path)
-    session = _make_session(tmp_path)
-    collected = collect_events(session.audit_events)
-
-    await session.hot_reloader.apply_all(exclude=frozenset())
-
-    types = [e.type for e in collected]
-    assert "config_reloaded" in types, (
-        f"a reload through session.hot_reloader must emit config_reloaded "
-        f"onto session.audit_events; observed types={types}"
-    )
-
-
-@pytest.mark.asyncio
-async def test_strip_falsify_hot_reloader_events_wiring_is_live(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Tier 2: strip-falsify — a reload run on a FRESH, independently-wired
-    ``HotReloader`` (events=a different EventLog, never ``session.
-    audit_events``) must NOT land its ``config_reloaded`` event on
-    ``session.audit_events``'s subscribers, proving the positive test
-    above is genuinely reading session.hot_reloader's OWN wiring, not a
-    check that would trivially pass for any reload anywhere."""
-    monkeypatch.chdir(tmp_path)
-    session = _make_session(tmp_path)
-    collected = collect_events(session.audit_events)
-
-    poisoned = HotReloader(project_root=tmp_path, events=EventLog())
-    await poisoned.apply_all(exclude=frozenset())
-
-    types = [e.type for e in collected]
-    assert "config_reloaded" not in types, (
-        "a reload on an INDEPENDENT HotReloader must not land on "
-        "session.audit_events — otherwise the positive test's assertion "
-        "would be vacuous"
-    )
+# test_get_active_hot_reloader_is_this_sessions_reloader (invariant 6) at
+# the public surface, via the new session.hot_reloader accessor (#4862
+# step ②).
+#
+# invariant 5 (test_hot_reloader_events_is_the_family_audit_events —
+# hot_reloader.events IS audit_events) has NO rescue here: #4866 decided
+# NOT to add a public session.audit_events accessor (it answered no
+# question nothing else could — a plain rename of already-private state,
+# the exact "publishing _x as x ratifies the encapsulation break instead
+# of closing it" failure mode the ceiling gate exists to catch). Without
+# that accessor there is no public route left to witness the wiring — the
+# effect-based design used here for invariant 6 needed BOTH sides public
+# (hot_reloader AND audit_events); only one landed. Per this arc's own
+# rule (a rescue is either A: add a public read-hook, or B: delete — never
+# a private-state compromise), invariant 5 falls into the same
+# genuinely-unrescuable bucket as family7's test 3 (#4862) and is dropped
+# with the scaffold, not rescued.
 
 
 def test_get_active_hot_reloader_is_this_sessions_reloader(

--- a/tests/core/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/core/test_2761_pr2_hotreload_immediate_apply.py
@@ -262,27 +262,70 @@ async def test_operator_reload_still_runs_all_seams(tmp_path: Path) -> None:
 
 
 # ===========================================================================
-# A2. #4862 rescue — get_active_hot_reloader() IS this session's own reloader
+# A2. #4862 rescue — session.hot_reloader IS wired to session's own audit
+# trail, and get_active_hot_reloader() IS this session's own reloader
 # ===========================================================================
 #
 # Replaces tests/scaffold/test_family3_hook_event_bundle_byte_identical.py's
-# test_get_active_hot_reloader_is_this_sessions_reloader (invariant 6) at
-# the public surface, via the new session.hot_reloader accessor (#4862
-# step ②).
-#
-# invariant 5 (test_hot_reloader_events_is_the_family_audit_events —
-# hot_reloader.events IS audit_events) has NO rescue here: #4866 decided
-# NOT to add a public session.audit_events accessor (it answered no
-# question nothing else could — a plain rename of already-private state,
-# the exact "publishing _x as x ratifies the encapsulation break instead
-# of closing it" failure mode the ceiling gate exists to catch). Without
-# that accessor there is no public route left to witness the wiring — the
-# effect-based design used here for invariant 6 needed BOTH sides public
-# (hot_reloader AND audit_events); only one landed. Per this arc's own
-# rule (a rescue is either A: add a public read-hook, or B: delete — never
-# a private-state compromise), invariant 5 falls into the same
-# genuinely-unrescuable bucket as family7's test 3 (#4862) and is dropped
-# with the scaffold, not rescued.
+# test_hot_reloader_events_is_the_family_audit_events (invariant 5) and
+# test_get_active_hot_reloader_is_this_sessions_reloader (invariant 6),
+# which pinned both via private-attribute identity (a scaffold-only
+# exception). session.audit_events (a raw-property rescue) was considered
+# and dropped (#4866) — it answered no question nothing else could. But
+# `Session.subscribe_audit_events`/`unsubscribe_audit_events`
+# (session.py, "narrow public API... so UI callers subscribe without
+# reaching into `_audit_events`") were already there, missed in an
+# earlier pass of this same investigation — invariant 5 IS rescuable,
+# via subscription (an effect witness), not a property (an identity
+# witness).
+
+
+@pytest.mark.asyncio
+async def test_session_hot_reloader_reload_reaches_session_audit_subscribers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: a reload run through ``session.hot_reloader`` reaches a
+    callback registered via ``session.subscribe_audit_events`` — witnessed
+    via effect (real reload + a real subscriber on the session's own
+    public subscription seam), not a private ``hot_reloader.events is
+    audit_events`` identity peek. If the two were wired to DIFFERENT
+    EventLogs, this reload's event would never reach this subscriber."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    received: list[str] = []
+    session.subscribe_audit_events(lambda e: received.append(e.type))
+
+    await session.hot_reloader.apply_all(exclude=frozenset())
+
+    assert "config_reloaded" in received, (
+        f"a reload through session.hot_reloader must reach a subscriber "
+        f"registered via session.subscribe_audit_events; observed={received!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strip_falsify_hot_reloader_audit_wiring_is_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: strip-falsify — a reload run on a FRESH, independently-wired
+    ``HotReloader`` (events=a different EventLog, never this session's
+    own) must NOT reach a callback subscribed via ``session.
+    subscribe_audit_events``, proving the positive test above is
+    genuinely reading session.hot_reloader's OWN wiring, not a check
+    that would trivially pass for any reload anywhere."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    received: list[str] = []
+    session.subscribe_audit_events(lambda e: received.append(e.type))
+
+    poisoned = HotReloader(project_root=tmp_path, events=EventLog())
+    await poisoned.apply_all(exclude=frozenset())
+
+    assert "config_reloaded" not in received, (
+        "a reload on an INDEPENDENT HotReloader must not reach this "
+        "session's own audit subscribers — otherwise the positive test's "
+        "assertion would be vacuous"
+    )
 
 
 def test_get_active_hot_reloader_is_this_sessions_reloader(

--- a/tests/core/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/core/test_2761_pr2_hotreload_immediate_apply.py
@@ -39,6 +39,7 @@ from reyn.data.workspace.workspace import Workspace
 from reyn.runtime.hot_reload import (
     HotReloader,
     dispatch_install_reload,
+    get_active_hot_reloader,
     is_pure_addition,
     set_active_hot_reloader,
 )
@@ -258,6 +259,81 @@ async def test_operator_reload_still_runs_all_seams(tmp_path: Path) -> None:
 
     assert set(summary["applied"]) == {"skills", "pipelines"}
     assert ran == {"skills": 1, "pipelines": 1}
+
+
+# ===========================================================================
+# A2. #4862 rescue — session.hot_reloader IS wired to session.audit_events,
+# and get_active_hot_reloader() IS this session's own reloader
+# ===========================================================================
+#
+# Replaces tests/scaffold/test_family3_hook_event_bundle_byte_identical.py's
+# test_hot_reloader_events_is_the_family_audit_events (invariant 5) and
+# test_get_active_hot_reloader_is_this_sessions_reloader (invariant 6),
+# which pinned both via private-attribute identity (`session._hot_reloader`
+# / `session._audit_events`, a scaffold-only exception). Rescued at the
+# public surface via the new `session.hot_reloader` / `session.audit_events`
+# accessors (#4862 step ②).
+
+
+@pytest.mark.asyncio
+async def test_session_hot_reloader_reload_lands_in_session_audit_events(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: a reload run through ``session.hot_reloader`` emits
+    ``config_reloaded`` that lands in ``session.audit_events`` specifically
+    — witnessed via effect (real reload + real subscriber), not a private
+    ``hot_reloader.events is audit_events`` identity peek. If the two were
+    wired to DIFFERENT EventLogs, this reload's event would never reach
+    ``session.audit_events``'s subscribers."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    collected = collect_events(session.audit_events)
+
+    await session.hot_reloader.apply_all(exclude=frozenset())
+
+    types = [e.type for e in collected]
+    assert "config_reloaded" in types, (
+        f"a reload through session.hot_reloader must emit config_reloaded "
+        f"onto session.audit_events; observed types={types}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strip_falsify_hot_reloader_events_wiring_is_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: strip-falsify — a reload run on a FRESH, independently-wired
+    ``HotReloader`` (events=a different EventLog, never ``session.
+    audit_events``) must NOT land its ``config_reloaded`` event on
+    ``session.audit_events``'s subscribers, proving the positive test
+    above is genuinely reading session.hot_reloader's OWN wiring, not a
+    check that would trivially pass for any reload anywhere."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    collected = collect_events(session.audit_events)
+
+    poisoned = HotReloader(project_root=tmp_path, events=EventLog())
+    await poisoned.apply_all(exclude=frozenset())
+
+    types = [e.type for e in collected]
+    assert "config_reloaded" not in types, (
+        "a reload on an INDEPENDENT HotReloader must not land on "
+        "session.audit_events — otherwise the positive test's assertion "
+        "would be vacuous"
+    )
+
+
+def test_get_active_hot_reloader_is_this_sessions_reloader(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: ``get_active_hot_reloader()`` (the process-wide registration
+    every Session performs at construction) returns THIS session's own
+    ``hot_reloader`` — both sides now public (`get_active_hot_reloader`
+    always was; `session.hot_reloader` since #4862 step ②), so this is a
+    direct identity check, not an indirect effect."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    assert get_active_hot_reloader() is session.hot_reloader
 
 
 # ===========================================================================


### PR DESCRIPTION
**[e2e-coder]** — Step 3 of #4862's scaffold rescue. Rebased onto main (includes #4866/#4882).

## What

Rescues both invariants from `tests/scaffold/test_family3_hook_event_bundle_byte_identical.py` into `tests/core/test_2761_pr2_hotreload_immediate_apply.py`:

- **inv5** (`hot_reloader.events IS audit_events`): rescued via EFFECT, not identity -- subscribe a callback via `session.subscribe_audit_events` (a narrow public API that already existed, missed in an earlier pass of this investigation -- see history below), trigger a real reload through `session.hot_reloader`, assert the callback received `config_reloaded`. Paired with a strip-falsify (an independently-wired `HotReloader`'s reload must NOT reach this session's own subscriber).
- **inv6** (`get_active_hot_reloader() is session._hot_reloader`): rescued as a direct identity check -- both sides are public now, no behavioral workaround needed.

### History on inv5 (kept for the next reader)

`session.audit_events` (a raw property) was considered and dropped in #4866 -- it answered no question nothing else could, a plain rename of already-private state. At that point both I and lead-coder read "no property" as "no public route" and I dropped inv5's rescue entirely (a prior revision of this PR). That was wrong: `Session.subscribe_audit_events`/`unsubscribe_audit_events` were already there (docstring: "so UI callers subscribe without reaching into `_audit_events`") -- a property (identity witness) and a subscription (effect witness) are different rescue shapes for the same claim; dropping one doesn't mean the other is unavailable.

## Test plan

- [x] `pytest tests/core/test_2761_pr2_hotreload_immediate_apply.py -q` -- 19/19 passed
- [x] `pytest tests/interfaces/test_3595_s4_slash_handler_seam.py -q` (ceiling gate) -- 9/9 passed
- [x] `ruff check` -- clean
- [x] `python scripts/test_tier_audit.py --strict <file>` -- 0 errors
- [x] `python scripts/mypy_ratchet.py` -- baselined, no new findings
- [x] Strip-falsify verified by hand against real production code: patched `Session._build_hook_event_bundle`'s `HotReloader` construction to use an independent `EventLog` -- positive test went RED (`observed=[]`), then reverted (`git checkout --`), confirmed green again.

⚠️ Non-blocking, flagged not fixed here: `set_active_hot_reloader` (the process-wide registration every `Session` performs at construction, session.py:1271) is never reset/cleared on session teardown anywhere in `src/` (confirmed via grep) -- nobody currently owns that cleanup. Separate from this PR's scope.

Full context: #4862, #4847, #4866, #4864.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

