### PR TITLE
feat(#4840): @app-background@ maps to Textual's $background, not the terminal

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -824,18 +824,21 @@ class TextualChatApp(App):
     ]
 
     CSS = palette.css("""
-    /* #3503: the app paints NO ground of its own — the terminal's background
-       shows through. Measured before this: ``#inputrow`` / ``#inputgutter`` /
-       ``SentQueue`` / ``MenuBar`` all declare ``transparent`` already, yet all
-       painted ``#121212``, because "transparent" means "show what is behind"
-       and what was behind is the SCREEN's own ``#121212`` (Textual's dark
-       theme). So this could not be fixed per widget — the Screen is the source,
-       which is why the fix reaches the whole surface rather than just the two
-       regions the report named. Regions that are meant to stand OUT keep
-       declaring ``$panel`` explicitly (drawer, completion popup, search bar,
-       rewind picker), and the presenter's deliberate ROW TINTS
-       (``_CC_USER_BG`` / ``_CC_ERR_BG``) are unaffected — those are content,
-       not ground. */
+    /* #3503: the App declares its own ground explicitly (``@app-background@``,
+       #4840's owner ruling: the active THEME's ``$background``, not "no
+       ground of its own" deferring to the terminal — that deferral made
+       sense only before reyn had a theme to defer to instead). #3503's own
+       original measurement still explains why this rule exists at the App
+       level rather than per-widget: ``#inputrow`` / ``#inputgutter`` /
+       ``SentQueue`` / ``MenuBar`` all declared ``transparent`` already, yet
+       all painted ``#121212``, because "transparent" means "show what is
+       behind" and what was behind was the SCREEN's own ``#121212`` (Textual's
+       built-in dark theme, before reyn had one) — the Screen was the source,
+       not any one widget, so the fix has to reach the whole surface. Regions
+       that are meant to stand OUT keep declaring ``$panel`` explicitly
+       (drawer, completion popup, search bar, rewind picker), and the
+       presenter's deliberate ROW TINTS (``_CC_USER_BG`` / ``_CC_ERR_BG``) are
+       unaffected — those are content, not ground. */
     App { background: @app-background@; }
     Screen { layout: vertical; background: transparent; }
     /* #3542: the drag-selection band. Textual's ansi-dark defaults to
@@ -847,7 +850,15 @@ class TextualChatApp(App):
        Textual COMPOSES the selection style onto each cell, so reverse would
        let every coloured run (tool rows, amber intervention headings, dim
        chrome) become its own background and the band would fragment — which
-       is a different complaint than "too loud". */
+       is a different complaint than "too loud".
+
+       #4840 (owner ruling, 2026-08-16) retires the "ask the terminal for a
+       slot" premise in principle, but NOT here yet — mapping to Textual's own
+       ``$screen-selection-background`` would regress this fix under the
+       CURRENT default theme (``ansi-dark``'s own value for that token is the
+       loud ``ansi_bright_blue`` this comment describes moving away from,
+       measured). Sequenced after reyn's own default theme exists (#4840);
+       see ``@selection-bg@``'s own comment in ``palette.py``. */
     Screen > .screen--selection {
         background: @selection-bg@;
         color: @selection-fg@;

--- a/src/reyn/interfaces/palette.py
+++ b/src/reyn/interfaces/palette.py
@@ -14,15 +14,34 @@ of matching an expectation about their shape. Enumerating them is what this
 module makes unnecessary: ``test_tui_colour_tokens.py`` fails if any colour is
 written outside it.
 
-**Terminal-owned meanings stay with the terminal.** Where the terminal already
-has a meaning — its default foreground and background — the token names that
-rather than pinning a value the user's theme is entitled to choose. Emphasis is
-carried by SGR attributes (``dim``, ``bold``) for the same reason: under the
-``ansi-*`` themes ``$text`` and ``$text-muted`` both resolve to the
-``ansi_default`` marker, and alpha compositing DROPS that marker — so
-``$text 40%`` and ``$accent 30%`` do not fade anything, they either do nothing
-or paint a solid colour. An attribute leaves the hue to the terminal and
-survives the merge.
+**Colour meanings map to the Textual theme, not the terminal (owner ruling,
+#4840, 2026-08-16).** Deferring to the terminal's own default colours — an
+``ansi_default``/``ansi_blue``/``ansi_black`` marker naming one of its
+sixteen slots rather than an RGB value — made sense only while reyn had no
+theme of its own to defer to instead: "端末の既定色に従う意味は、テーマを
+採用した時点で消えます" (owner, verbatim). ``@app-background@`` maps to
+Textual's own ``$background`` under this ruling — the active theme decides
+the RGB, not the terminal. ``@selection-bg@``/``@selection-fg@`` name the
+SAME retired premise but are NOT remapped yet — landing them ahead of reyn's
+own default theme would regress #3542 (measured: ``ansi-dark``'s own
+``$screen-selection-background`` is the loud ``ansi_bright_blue`` #3542
+moved away from), so lead-coder's ruling sequences them after that theme
+exists (see the tokens' own comments below). ``@rule@`` stays a literal hex
+for an unrelated reason (documented on the token itself): it must read as a
+divider against both of the app's OWN light/dark grounds, which a theme
+variable would just vanish into on one of them — that is a THEME question,
+never a terminal one, and was never in this paragraph's scope.
+
+Emphasis is still carried by SGR attributes (``dim``, ``bold``), which this
+ruling does not reach — ``dim``/``bold`` are not colours, ANSI or otherwise,
+they are text-style attributes the terminal (or Textual's own ANSI-to-
+truecolor filter) applies on top of whatever colour is already chosen. Under
+a full-colour theme, ``$text``/``$text-muted`` resolve to concrete RGB, so
+``$text-muted`` alone is no longer the "recedes by exactly nothing" case
+#3522/#3528 measured under the ``ansi-*`` themes — but ``@recede@``/
+``@telemetry@`` stay ``dim`` regardless, because an attribute still changes
+what is drawn on top of a concrete colour the same way it always did, and
+introduces no new failure mode by staying.
 
 **Location (#4787, lead-coder ruling):** lives directly under
 ``interfaces/``, not inside ``interfaces/inline/textual_chat/`` where it
@@ -63,9 +82,13 @@ TOKENS: "dict[str, str]" = {
     #: and its prompt). The only semantic colour the CUI claims; anything else
     #: that must stand out uses an attribute instead.
     "@attention@": "$warning",
-    #: The app's ground. ``ansi_default`` is the marker meaning "whatever the
-    #: terminal's background is" — not a colour, deliberately.
-    "@app-background@": "ansi_default",
+    #: The app's ground. Was ``ansi_default`` ("whatever the terminal's
+    #: background is") until #4840's owner ruling retired that deferral —
+    #: reyn now has its own theme to defer to instead, so this maps to
+    #: Textual's own semantic token for exactly this role (``Screen``'s own
+    #: ``DEFAULT_CSS`` uses the identical ``background: $background;``).
+    #: The active theme's RGB shows through; no terminal slot is named.
+    "@app-background@": "$background",
     #: Hairline rules around the input row. A concrete value because it must
     #: read as a divider against BOTH terminal grounds; a theme variable would
     #: follow the theme and vanish into one of them.
@@ -110,10 +133,24 @@ TOKENS: "dict[str, str]" = {
     #: against the conversation (#3542). Both are ANSI FRAMES, not colours —
     #: what blue looks like is the terminal theme's decision and stays that
     #: way; this only chooses which of the sixteen slots to ask for.
+    #:
+    #: #4840 (owner ruling, 2026-08-16) retires this deferral in principle —
+    #: see ``@app-background@`` above, mapped already — but NOT here yet.
+    #: Mapping straight to Textual's own ``$screen-selection-background``
+    #: would regress #3542 under the CURRENT default theme: ``ansi-dark``'s
+    #: own value for that token is ``ansi_bright_blue`` (measured), the exact
+    #: loud one #3542 moved away from. lead-coder's ruling (#4840): land
+    #: ``@app-background@`` now (no such regression there — measured), build
+    #: reyn's own default theme next, and land this token + #3542's test
+    #: THEN — a theme `variables` shim on `ansi-dark` was explicitly rejected
+    #: ("1つのテーマの欠点を、全テーマに効く層で埋める" — the opposite of
+    #: mapping to theme meaning). Whether reyn's own theme preserves #3542's
+    #: quiet choice is undecided — read #3542 when that theme is designed.
     "@selection-bg@": "ansi_blue",
     #: The text inside that band. Unchanged from Textual's default, and named
     #: here so the pair is legible in one place: a background chosen without
-    #: its foreground beside it is how contrast regressions happen.
+    #: its foreground beside it is how contrast regressions happen. Same
+    #: #4840 deferral as ``@selection-bg@`` above — not mapped yet.
     "@selection-fg@": "ansi_black",
     #: #4787: the first 5 of ``interfaces/repl/renderer.py``'s 8 former
     #: ``_CC_*`` hex constants — the ones whose value #4787's own


### PR DESCRIPTION
**[tui-coder]** — part of #4840 (owner colour-direction ruling, not the closing PR)

## What changed

`@app-background@` (`palette.py`) maps from a hardcoded `"ansi_default"` to
Textual's own `$background` — 1 of the 3 tokens named in the owner's ruling
(verbatim): "Textual テーマ採用時点で端末の規定色に従う意味は無くなって
るでしょ。そこ修正して" / "そこは Textual のテーマから意味にマッピング
すべき。reyn の問題。"

`app.py`'s `#3503`/`#3542` CSS comments updated in the same PR — the old
"the app paints no ground, terminal shows through" framing is now false for
`@app-background@` (same-PR doc-sync per CLAUDE.md's hard rule).

## Scope — 1 of 3 tokens, by design

`@selection-bg@`/`@selection-fg@` (the other 2 tokens in the owner's ruling)
are **not** touched here. Measured: mapping them to Textual's own
`$screen-selection-background`/`$screen-selection-foreground` would regress
owner-adjudicated #3542 under the CURRENT default theme — `ansi-dark`'s own
value for `screen-selection-background` is `ansi_bright_blue`, the exact
loud one #3542 moved away from (the old code hardcoded the quieter
`ansi_blue` directly, overriding ansi-dark's own default).

Reported this to lead-coder before proceeding rather than silently updating
#3542's test assertions to absorb the regression. Ruling (③, sequencing):
land `@app-background@` now (no regression there — measured: `ansi-dark`'s
own `background` was already `ansi_default`, so old-literal and
new-`$background`-resolved values are identical), build reyn's own default
theme next (#4840 main body), land the 2 selection tokens + #3542's test
update after that theme exists. A `variables=` shim injecting `ansi_blue`
into `ansi-dark` specifically was explicitly rejected as the wrong layer —
"1つのテーマの欠点を、全テーマに効く層で埋める" is the opposite of
mapping to theme meaning.

## CLAUDE.md — not touched here

PR #4869 (lead-coder, open) already owns the `:48`/`:52` colour-policy text
change this ruling implies. Touching it here would conflict; my own earlier
local edit was reverted before this commit.

## #4850 relevance (hypothesis, not a confirmed fix)

The crash's precondition was `background.triplet is None` reaching
Textual's `ANSIToTruecolor.dim_color()`. Measured: under `rose-pine` (the
owner's active theme in the #4850 crash traceback, `ansi=False`), the OLD
hardcoded literal `"ansi_default"` had `.triplet is None`; the NEW
`$background` resolves through rose-pine's own theme definition to a
concrete `#191724` (`.triplet` populated). This closes the App/Screen-
background axis of that precondition under any non-`ansi-*` theme, but is
**not** a full live reproduction of the exact crash (`presenter.py:973`'s
dim+truecolor combination) before/after this change — flagging as a
hypothesis per #4840's own comment thread, not claiming the fix.

## Falsification

`git stash` of both changed files reproduced the pre-change literal
(`@app-background@ == "ansi_default"`); `git stash pop` restored and
re-verified `== "$background"`.

## Time-dependency check

0 instances — no new tests in this diff.

## Test plan

- [x] `pytest tests/interfaces/test_tui_colour_tokens.py tests/interfaces/test_selection_not_bright_3542.py tests/interfaces/test_chrome_uses_the_terminal_background_3503.py -q` — 14 passed
- [x] `ruff check .` — all checks passed
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/palette.py src/reyn/interfaces/inline/textual_chat/app.py` — OK
- [x] Falsification via `git stash`/`git stash pop` (see above)
- [ ] Visual — n/a (identical resolved value under the current default theme `ansi-dark`, measured; no visible change today)
