### PR TITLE
feat(#4840): reyn's own full-colour default Textual theme

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -107,6 +107,7 @@ from .restore import RESUME_DIVIDER, project_restored_frames
 from .rewind_picker import RewindPicker
 from .search_bar import SearchBar
 from .sent_queue import SentQueue
+from .theme import REYN_THEME
 
 if TYPE_CHECKING:
     from textual.geometry import Offset
@@ -2084,42 +2085,40 @@ class TextualChatApp(App):
                 )
 
     def on_mount(self) -> None:
-        # #3505: #3504 made ``App``'s own background ``ansi_default`` (the
-        # terminal's true default), but two chrome regions still painted a
-        # concrete ``#0c0c0c`` — the alpha-blend of ``ansi_default`` with any
-        # other color drops the "send as terminal default" marker and
-        # produces a solid dark RGB instead (Textualize/textual#5452, closed
-        # not planned). Textual's own ``"ansi-dark"``/``"ansi-light"`` themes
-        # exist for exactly this: every alpha-bearing design-system variable
+        # #3505/#4840: #3504 made ``App``'s own background ``ansi_default``
+        # (the terminal's true default), but two chrome regions still
+        # painted a concrete ``#0c0c0c`` — the alpha-blend of
+        # ``ansi_default`` with any other color drops the "send as terminal
+        # default" marker and produces a solid dark RGB instead
+        # (Textualize/textual#5452, closed not planned). Switching the
+        # WHOLE APP to Textual's own ``"ansi-dark"`` theme was the fix at
+        # the time: every alpha-bearing design-system variable
         # (``$foreground``/``$background``/``$surface``/``$panel``/``$text``/
-        # ``$text-muted``/etc.) resolves to ``ansi_default`` (or another
-        # marker-carrying ``ansi_*`` value) instead of a literal hex, so the
-        # SAME blend that broke under the default theme now blends two
-        # marker-carrying values and the marker survives — measured: no
-        # ``48;2;`` truecolor background escape codes anywhere in a real
-        # terminal capture after this switch, versus 2 residue regions
-        # before. A LOCALIZED per-selector ``background: @app-background@;``
-        # override (mirroring how #3504 fixed ``App``) was tried first and
-        # does NOT work: the literal ``ansi_default`` value fails to
-        # propagate when declared on anything other than ``App`` itself
-        # (verified with a ``background: red;`` positive control on the same
-        # selectors, which DID paint immediately — ruling out a selector/
-        # specificity mistake). This theme switch is the only measured fix.
+        # ``$text-muted``/etc.) resolved to ``ansi_default`` (or another
+        # marker-carrying ``ansi_*`` value) under it, so the SAME blend that
+        # broke under Textual's DEFAULT theme now blended two
+        # marker-carrying values and the marker survived.
         #
-        # Known, accepted trade-off (owner-reviewed, 2026-07-30): every
-        # widget that reads a now-``ansi_default``-valued variable loses its
-        # concrete-hex identity — most visibly ``$panel``/``$surface`` (the
-        # drawer / completion popup / search bar / rewind picker, and
-        # ``Composer``'s own opt-out target) go ``transparent`` instead of
-        # their prior dark shade, and ``MenuBar``'s own
-        # ``color: $text-muted`` / ``:focus-within { color: $text }`` rule
-        # collapses to the identical value (partially offset by Tab's own
-        # ``:ansi`` variant, which still distinguishes active/inactive via
-        # dim/bold text-style). None of this is patched here — see the PR
-        # body for the full impact table; MenuBar re-coloring and any
-        # ``$panel``/``$surface`` follow-up are separate, out-of-scope
-        # issues pending a real-terminal look.
-        self.theme = "ansi-dark"
+        # #4840 (owner ruling, 2026-08-16) retires the premise this fix
+        # depended on: reyn no longer defers to the terminal's own colours
+        # by default (``@app-background@`` no longer names ``ansi_default``
+        # — see ``palette.py``), so there is no marker left for an
+        # alpha-blend to destroy under reyn's OWN theme (``.theme.py``,
+        # ``REYN_THEME``) — every design-system variable there is a
+        # concrete hex, not an ``ansi_*`` marker. The #3505 alpha-blend
+        # hazard is still real (documented on CLAUDE.md:52) for whoever
+        # selects an ``ansi-*`` theme explicitly — it just no longer governs
+        # what reyn ships as its OWN default.
+        #
+        # #3505's own accepted trade-off (owner-reviewed, 2026-07-30) — the
+        # drawer/completion popup/search bar/rewind picker/``Composer``
+        # losing their concrete-hex identity under ``ansi-dark``, MenuBar's
+        # active/inactive colour distinction collapsing — is likewise a
+        # property of the ``ansi-*`` themes specifically, not of reyn's own
+        # default theme, which keeps concrete ``$panel``/``$surface`` values
+        # throughout (``REYN_THEME.panel``/``.surface``).
+        self.register_theme(REYN_THEME)
+        self.theme = "reyn"
         # #3469 (generalizing #3326's single-key fix): push the COMPLETE
         # palette-derived markdown theme (``renderer.CHAT_MARKDOWN_THEME_STYLES``
         # — the plain renderers' Consoles consume the same constant) onto the

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1018,6 +1018,26 @@ class TextualChatApp(App):
         padding: 0 1;
     }
     MenuBar:focus-within { text-style: none; }
+    /* #4840/#3528: re-affirms ``dim`` on every tab once focus enters the
+       menu — ``MenuBar:focus-within`` above clears ``text-style`` on the
+       WHOLE bar (including inherited ``dim``), and nothing re-applied it to
+       the tabs that are not the active one. #3528's own words above say
+       the inactive tabs should STAY "dim already, so the bar as a whole
+       does not visibly lift" — that was the intent from the start, but the
+       gap existed since #3528 itself; it was invisible until now because
+       Textual's OWN ``Tab`` widget carries a builtin
+       ``&:ansi { text-style: dim; ...}`` rule (``_tabs.py``) that stayed in
+       effect throughout under ``ansi-dark`` (``ansi=True`` disables
+       nothing about this — the ``:ansi`` pseudo-class match, not the
+       colour-conversion filter, is what applied it) and silently covered
+       for the missing reassertion. reyn's own theme (``ansi=False``,
+       this PR) is the first time that builtin rule stops matching,
+       exposing the gap (measured: `test_focus_does_not_restyle_the_other_tabs`,
+       this PR's own CI). More specific than the plain ``Tab.-active`` rule
+       below, so it does not undo that one's own emphasis — CSS cascade
+       order here mirrors Tab's own builtin ``&:ansi { ...; &.-active
+       {...} }`` nesting pattern. */
+    MenuBar:focus-within Tab { text-style: dim; }
     /* The "you are here" marker. Un-dimming alone is too quiet to answer the
        owner's report, and it reaches only the ACTIVE tab in practice (the
        inactive ones are dim already, so the bar as a whole does not visibly

--- a/src/reyn/interfaces/inline/textual_chat/theme.py
+++ b/src/reyn/interfaces/inline/textual_chat/theme.py
@@ -1,0 +1,112 @@
+"""Reyn's own full-colour default Textual theme (#4840).
+
+**Why this exists (owner ruling, 2026-08-16, verbatim):** "Textual テーマ採用
+時点で端末の規定色に従う意味は無くなってるでしょ。そこ修正して" / "そこは
+Textual のテーマから意味にマッピングすべき。reyn の問題。" Deferring to the
+terminal's own default colours (the ``ansi-*`` theme family, reyn's default
+since #3505) made sense only while reyn had no theme of its own to defer to
+instead. This module is that theme — registered with the App and set as its
+default in ``app.py``'s ``on_mount`` (replacing ``self.theme = "ansi-dark"``).
+
+**Values are a candidate, not a final visual sign-off.** The MECHANISM
+(module structure, registration, default-flip, the ``ansi_default``-family
+tokens no longer being reachable from reyn's own default) is what #4840
+delegated; the exact RGB is a visual-preference call that stays the owner's
+(CLAUDE.md's TUI colour policy: "Never pick a colour first" is about MEANING,
+but which concrete value RENDERS a meaning is still a taste call this module
+does not get to make unilaterally — see the PR this landed in for the
+specific trade-offs flagged for review).
+
+**5 of 8 base tokens reuse existing, already-reasoned values** — no new
+colour picked for those, only a new place for the SAME value to live:
+``primary``/``accent`` = ``palette.TOKENS["@accent@"]`` (terracotta,
+``#d97757``), ``secondary`` = ``@secondary@`` (``#6cb6ff``), ``warning`` =
+``@warning@`` (``#e3b341``), ``error`` = ``@error@`` (``#f97066``),
+``success`` = ``@success@`` (``#7ee787``) — all #4787/#4861's own
+classification of reyn's PRE-EXISTING colour meanings, not a fresh choice.
+``surface`` also reuses an existing value: ``#1e222a`` is ``_CC_USER_BG``
+(``interfaces/repl/renderer.py``, #3371's WCAG-measured contrast pairing
+against ``_CC_DIM``/``@dim@`` — unaffected here, since this module doesn't
+touch that pairing's own two values, only reuses one of them for a
+DIFFERENT role).
+
+**``background``/``panel`` are the genuinely new choices** — reyn's TUI has
+never had a full-colour ground before (#4787's own finding). Picked to stay
+in the SAME dark blue-gray family ``surface``/``_CC_ERR_BG`` already
+established (lead-coder's own "A" recommendation, offered while explicitly
+declining to decide it — visual calls are the owner's).
+
+**``panel`` is explicit, not ``boost``-derived — a rejected alternative,
+not an oversight.** Textual's own ``ColorSystem.generate()`` only computes
+``panel`` from ``surface.blend(primary, 0.1) + boost`` when ``panel`` is
+left unset (measured, #4840's own ``boost``-anomaly investigation). Tried
+that path first: ``surface="#1e222a"`` blended 10% toward ``primary``
+(``#d97757``, terracotta — a WARM hue) pulls the auto-derived ``panel``
+toward brown (measured: resolves to ``#363034``), drifting OFF the cool
+blue-gray family ``background``/``surface`` are IN — a visible seam nobody
+asked for. An explicit ``panel="#232833"`` (between ``background`` and
+``surface`` in the same family) avoids it; the cost is ``boost`` staying
+transparent (harmless — nothing in reyn's own CSS reads ``$boost`` today).
+
+**``variables["screen-selection-background"/"-foreground"]`` deliberately
+carry #3542's own intent forward**, not Textual's auto-derived default
+(``primary.with_alpha(0.5)``, which would use the ACCENT hue at 50% alpha —
+loud, the same complaint #3542 was about, just with reyn's own primary
+instead of Textual's ``ansi_bright_blue``). #3542, read explicitly per
+lead-coder's #4840 ruling: a MUTED, DISTINCT hue — not full accent
+intensity — is the actual invariant, not "blue" specifically. Chosen a
+muted blue independent of ``primary``/``secondary`` (neither terracotta nor
+reyn's own bright secondary blue) so the band reads as a selection
+overlay, not as either semantic accent. WCAG contrast against this
+module's own ``foreground`` (left unset — auto-derives to
+``background.inverse``, measured ``#e5e2dc``, so not re-declared here):
+5.50:1 (comfortably above AA's 4.5:1 for normal text; not AAA-loud either).
+
+**Scope**: this module is the theme-BUILD half of #4840's "full colour"
+ruling — it does not add the config knob to let a user pick a DIFFERENT
+theme (the original #4840 issue's item ①, ``self.theme`` from config
+instead of a fixed literal) or override ``palette.py`` tokens from config
+(item ②). Both stay open, tracked on #4840; this module only replaces WHAT
+the fixed literal points at.
+"""
+from __future__ import annotations
+
+from textual.theme import Theme
+
+from reyn.interfaces import palette
+
+#: Every value below is a ``palette.TOKENS`` lookup, not a literal — this
+#: module names no colour of its own; ``palette.py`` is still the one place
+#: ``interfaces/`` does that (``test_tui_colour_tokens.py`` enumerates every
+#: colour-bearing declaration under here and would fail on a literal hex in
+#: this file). The 5 base tokens (``primary``…``accent``) reuse EXISTING
+#: values; ``@theme-*@`` are the genuinely new ones — see their own comments
+#: in ``palette.py`` for the reasoning (boost-vs-explicit-panel, #3542, WCAG
+#: contrast) this module's own docstring above summarises.
+#:
+#: The active default background/foreground/panel/surface WCAG contrast
+#: ratios this module's own docstring cites (5.50:1 selection,
+#: 13.06:1 background/foreground, 11.42:1 panel/foreground) are computed
+#: once, off these token values, in this module's own test — see
+#: ``tests/interfaces/test_reyn_theme_4840.py`` — not re-verified here at
+#: import time, so a value edited in ``palette.py`` without re-running that
+#: test can silently drift out of the range this docstring documents.
+REYN_THEME = Theme(
+    name="reyn",
+    primary=palette.TOKENS["@accent@"],
+    secondary=palette.TOKENS["@secondary@"],
+    warning=palette.TOKENS["@warning@"],
+    error=palette.TOKENS["@error@"],
+    success=palette.TOKENS["@success@"],
+    accent=palette.TOKENS["@accent@"],
+    background=palette.TOKENS["@theme-background@"],
+    surface=palette.TOKENS["@theme-surface@"],
+    panel=palette.TOKENS["@theme-panel@"],
+    dark=True,
+    variables={
+        "screen-selection-background": palette.TOKENS["@theme-selection-bg@"],
+        "screen-selection-foreground": palette.TOKENS["@theme-selection-fg@"],
+    },
+)
+
+__all__ = ["REYN_THEME"]

--- a/src/reyn/interfaces/palette.py
+++ b/src/reyn/interfaces/palette.py
@@ -217,6 +217,49 @@ TOKENS: "dict[str, str]" = {
     #: segment whose foreground is not concrete" — a ``$token`` reference
     #: resolved at Textual-theme time would be invisible to both.
     "@dim@": "#6b7280",  # low-importance / ambient, as a COLOUR (was _CC_DIM)
+    #: #4840: reyn's own default Textual theme's base tokens (``theme.py``,
+    #: ``REYN_THEME``) — the genuinely NEW colour choices, not reused from
+    #: any existing ``_CC_*``/``@name@`` constant (unlike
+    #: ``primary``/``secondary``/``warning``/``error``/``success``/``accent``,
+    #: which theme.py pulls from the tokens above instead of repeating
+    #: here). Consumed DIRECTLY as Python values by ``theme.py``
+    #: (``Theme(background=palette.TOKENS["@theme-background@"], ...)``) —
+    #: NOT CSS ``@name@`` markers; nothing in ``interfaces/``'s stylesheets
+    #: writes ``@theme-background@`` literally, this is the SAME
+    #: plain-dict-lookup mechanism the 5 ``@success@``-family tokens above
+    #: already use, for the same reason (a ``Theme`` constructor takes
+    #: Python values, not a CSS string ``css()`` could resolve markers in).
+    #: Reused here rather than left as literals directly in ``theme.py``
+    #: for the SAME invariant every other colour in ``interfaces/`` follows
+    #: — this file is the one place a value gets named, so
+    #: ``test_tui_colour_tokens.py``'s hex-literal census stays complete.
+    "@theme-background@": "#1a1d23",
+    #: Same hex as ``renderer.py``'s own ``_CC_USER_BG`` (#4787's remaining
+    #: 2, still unmigrated, blocked until now on this exact ruling) — a
+    #: DIFFERENT token key, not a shared one, because the two migrations
+    #: are independent tracks (this is the Textual theme's ``surface`` role;
+    #: ``_CC_USER_BG`` is the plain REPL's row-tint background) that happen
+    #: to agree on the same dark blue-gray value. Whether ``_CC_USER_BG``
+    #: itself later migrates to THIS token, or its own, is #4787's call, not
+    #: decided here.
+    "@theme-surface@": "#1e222a",
+    #: Explicit, not ``boost``-derived — see ``theme.py``'s own docstring
+    #: for the rejected alternative (auto-deriving ``panel`` from
+    #: ``surface.blend(primary, 0.1) + boost`` pulls it toward primary's
+    #: WARM terracotta hue, off the cool blue-gray family
+    #: ``background``/``surface`` are in — measured, not guessed).
+    "@theme-panel@": "#232833",
+    #: #3542 read explicitly, per #4840's own ruling (theme.py's docstring
+    #: has the full reasoning) — muted and DISTINCT from ``primary``, not
+    #: Textual's own auto-derived ``primary.with_alpha(0.5)`` (which would
+    #: be the loud selection #3542 was about, just with reyn's own accent
+    #: hue instead of Textual's ``ansi_bright_blue``).
+    "@theme-selection-bg@": "#3a5a80",
+    #: Paired with ``@theme-selection-bg@`` above for the same reason every
+    #: other background/foreground pair here is named adjacently — WCAG
+    #: contrast against it is 5.50:1 (measured), comfortably above AA's
+    #: 4.5:1 without being AAA-loud either.
+    "@theme-selection-fg@": "#e5e2dc",
 }
 
 #: The NOW row's travelling shine (#3777), as a GROUND and a PEAK per terminal

--- a/tests/interfaces/test_chrome_uses_the_terminal_background_3503.py
+++ b/tests/interfaces/test_chrome_uses_the_terminal_background_3503.py
@@ -1,27 +1,33 @@
-"""#3503 — the app paints no ground of its own; the terminal's background shows.
+"""#3503/#4840 — chrome takes the App's own ground; no region forces its own.
 
-Owner report: the input box and the sent-queue region above it were black. The
-cause was NOT those widgets — measured, `#inputrow`, `#inputgutter`, `SentQueue`
-and `MenuBar` all already declared `transparent`, and all still PAINTED
-`#121212`, because "transparent" means "show what is behind" and what was
-behind was the App/Screen's own `$background`. Textual's own `App` CSS is
-explicit about it (`App { background: $background }`, with an `&:ansi` variant
-using `ansi_default`), so the fix has to happen at the root — which is why it
-reaches the whole surface rather than only the two regions named.
+Owner report (#3503): the input box and the sent-queue region above it were
+black. The cause was NOT those widgets — measured, `#inputrow`, `#inputgutter`,
+`SentQueue` and `MenuBar` all already declared `transparent`, and all still
+PAINTED `#121212`, because "transparent" means "show what is behind" and what
+was behind was the App/Screen's own `$background`. Textual's own `App` CSS is
+explicit about it (`App { background: $background }`), so the fix has to
+happen at the root — which is why it reaches the whole surface rather than
+only the two regions named.
 
-These tests assert the RESOLVED background of each chrome region is the
-terminal's default rather than a forced colour. A test that only checked the
-CSS declaration would have passed before the fix — the declaration was
-already `transparent`; the painted colour is the thing that was wrong.
+These tests assert the RESOLVED background of each chrome region matches the
+App's own `$background`, not a forced colour of its own. A test that only
+checked the CSS declaration would have passed before the fix — the
+declaration was already `transparent`; the painted colour is the thing that
+was wrong.
 
-#3505 (owner-approved, 2026-07-30) removed the non-vacuity test that used to
-live here asserting the `$panel` overlays (#drawer, #completion) still carry
-their OWN background rather than the terminal's default — under the
-`ansi-dark` theme #3505 switches to for a different fix, `$panel` itself
-resolves to `ansi_default`, so that invariant is no longer true by
-construction, not merely harder to measure. See
-`src/reyn/interfaces/inline/textual_chat/app.py`'s `on_mount` docstring for
-the full mechanism and the removal's own history note in this file.
+**#4840 (owner ruling, 2026-08-16) changed WHAT "the App's own ground" is,
+not whether this invariant holds.** Until #4840, reyn's default theme was
+Textual's own `ansi-dark`, under which `$background` resolves to the
+`ansi_default` MARKER (no RGB) — so these tests originally asserted the
+resolved colour was `rich.color.ColorType.DEFAULT` (a literal ANSI-marker
+propagation check), and #3505's own history note (removed here) explained
+why the `$panel` overlays' non-vacuity check couldn't survive that theme
+either. Under reyn's own theme (`REYN_THEME`, `.theme.py`) `$background` is
+a concrete hex (`#1a1d23`), so `ColorType.DEFAULT` no longer describes
+ANYTHING reyn paints by default — the invariant this file protects (a
+region takes the ground rather than forcing its own colour) is unchanged,
+but the way to observe it changed: compare the widget's resolved colour
+against the App's own resolved `$background`, not against a marker type.
 """
 from __future__ import annotations
 
@@ -29,7 +35,6 @@ import asyncio
 from typing import AsyncIterator
 
 import pytest
-from rich.color import ColorType
 from textual.color import Color
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
@@ -76,17 +81,26 @@ class _Transport(ClientTransport):
         pass
 
 
-def _is_terminal_default(widget) -> bool:
+def _matches_app_ground(widget, app: TextualChatApp) -> bool:
+    """True iff *widget*'s resolved background is the SAME colour as the
+    App's own resolved ``$background`` — i.e. it is taking the ground rather
+    than forcing one of its own. Compares resolved RGB, not the CSS
+    declaration (``transparent`` was already declared before #3503's fix and
+    still painted the wrong colour — the resolved value is the thing that
+    was wrong, so it is the thing this checks)."""
     bg = widget.rich_style.bgcolor
-    return bg is None or bg.type is ColorType.DEFAULT
+    if bg is None or bg.triplet is None:
+        return False
+    app_bg = Color.parse(app.get_css_variables()["background"]).rich_color
+    return bg.triplet == app_bg.triplet
 
 
 @pytest.mark.asyncio
-async def test_the_input_row_and_sent_queue_take_the_terminals_background() -> None:
+async def test_the_input_row_and_sent_queue_take_the_apps_ground() -> None:
     """Tier 2b: the two regions the owner named — the input box and the
-    sent-queue above it — resolve to the terminal's own background, not a
-    forced dark colour. The sent queue is populated first so the assertion is
-    about a region that is actually being displayed."""
+    sent-queue above it — resolve to the App's own ground, not a forced dark
+    colour. The sent queue is populated first so the assertion is about a
+    region that is actually being displayed."""
     app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
@@ -100,9 +114,10 @@ async def test_the_input_row_and_sent_queue_take_the_terminals_background() -> N
             ("Composer", app.query_one(Composer)),
             ("SentQueue", queue),
         ):
-            assert _is_terminal_default(widget), (
+            assert _matches_app_ground(widget, app), (
                 f"{name} forces its own background "
-                f"({widget.rich_style.bgcolor}) instead of taking the terminal's"
+                f"({widget.rich_style.bgcolor}) instead of taking the App's "
+                f"own ground ({app.get_css_variables()['background']!r})"
             )
 
 
@@ -114,75 +129,69 @@ async def test_the_root_and_menu_row_force_no_background_either() -> None:
     app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
-        assert _is_terminal_default(app.screen), (
+        assert _matches_app_ground(app.screen, app), (
             f"the Screen still paints {app.screen.rich_style.bgcolor} — every "
             "transparent child inherits it, which is the whole bug"
         )
-        assert _is_terminal_default(app.query_one(MenuBar))
-
+        assert _matches_app_ground(app.query_one(MenuBar), app)
 
 
 # #3505 (owner-approved, 2026-07-30) REMOVED
 # ``test_overlay_regions_still_carry_their_own_background`` here — not skipped.
 # That test asserted a non-vacuity invariant: dropping the app's own ground
 # (#3503) must not ALSO flatten the ``$panel`` overlays (#drawer,
-# #completion) into the terminal's default. #3505 switches
+# #completion) into the terminal's default. #3505 switched
 # ``TextualChatApp``'s theme to ``ansi-dark`` to fix a different residue
-# (see app.py's ``on_mount`` docstring), and under that theme ``$panel``
-# itself resolves to ``ansi_default`` instead of a literal hex — so
-# #drawer/#completion now correctly resolve to the terminal's own
-# background too, same as every other chrome region. The invariant this
-# test checked is not "true but hard to measure now" — it is permanently
-# false by construction under this theme, so there is nothing to
-# reactivate later; keeping it as a skip would misread as "pending a
-# fix." Whether the drawer/completion popup should get an explicit
-# concrete background under ``ansi-dark`` is real-hardware-review-gated,
-# owner-deferred work tracked separately, not part of #3505 — a NEW test
-# belongs with that follow-up if it lands, not a revived version of this
-# one.
+# (see app.py's ``on_mount`` docstring history), and under THAT theme
+# ``$panel`` itself resolved to ``ansi_default`` instead of a literal hex —
+# so #drawer/#completion correctly resolved to the terminal's own
+# background too, same as every other chrome region, and the removed test's
+# invariant was permanently false by construction under it.
+#
+# #4840 (owner ruling, 2026-08-16) replaces ``ansi-dark`` with reyn's own
+# theme (``REYN_THEME``), where ``$panel`` is AGAIN a concrete hex distinct
+# from ``$background`` (``#232833`` vs ``#1a1d23`` — chosen explicitly, not
+# boost-derived, see ``theme.py``'s own docstring) — the #3505-era
+# permanent-falseness this removal note describes no longer holds. Whether
+# to REVIVE a #drawer/#completion non-vacuity test against reyn's own
+# ``$panel`` is real-hardware/visual-review-gated, tracked with #4840's own
+# follow-up, not reintroduced silently here — this file's scope stays the
+# root/chrome regions #3503 named.
 #
 # ★ That removed test was ALSO the file's non-vacuity guard for the two
 # tests above: without it, ``test_the_input_row_and_sent_queue_...`` and
 # ``test_the_root_and_menu_row_...`` would go green even under a defect
-# that resolves EVERYTHING (the whole chrome, no exceptions) to the
-# terminal's default — exactly what ``$panel``/``$surface`` -> ``ansi_default``
-# risks under #3505's theme. The replacement below restores that role with
-# a check that does not depend on the owner's still-open ``$panel``
-# decision: it forces a widget's background directly (bypassing CSS/theme
-# entirely) and asserts ``_is_terminal_default`` reports it as NOT the
-# terminal default — proving the helper (and the render path it reads)
-# can still tell "forced concrete color" apart from "terminal default" at
-# all, independent of what any theme resolves ``$panel`` to.
+# that resolves EVERYTHING (the whole chrome, no exceptions) to the App's
+# ground. The replacement below restores that role with a check that does
+# not depend on any theme's specific values: it forces a widget's
+# background directly (bypassing CSS/theme entirely) and asserts
+# ``_matches_app_ground`` reports it as NOT matching — proving the helper
+# (and the render path it reads) can still tell "forced concrete colour"
+# apart from "the App's own ground" at all, independent of which theme (or
+# which hex) is active.
 
 
 @pytest.mark.asyncio
-async def test_a_forced_concrete_background_is_still_detected_as_non_default() -> None:
+async def test_a_forced_concrete_background_is_still_detected_as_distinct() -> None:
     """Tier 2b: non-vacuity guard, theme-independent. Directly overrides one
     widget's resolved background (bypassing CSS/theme resolution entirely,
-    so this holds regardless of what any theme resolves ``$panel`` to) and
-    asserts ``_is_terminal_default`` reports False for it. This is the
-    replacement for the #3503 non-vacuity role the (now-removed, see the
-    comment above) ``test_overlay_regions_still_carry_their_own_background``
-    used to serve — without SOME live check that ``_is_terminal_default``
-    can still say "no" to a real color, the two tests above would pass
-    vacuously under a hypothetical defect that flattens the ENTIRE chrome to
-    the terminal's default, exactly the shape of risk #3505's theme switch
-    introduces via ``$panel``/``$surface`` -> ``ansi_default``. Falsify: drop
-    the ``widget.styles.background = ...`` line below and this goes red,
-    confirming the guard is live, not a tautology."""
+    so this holds regardless of what any theme resolves ``$panel``/
+    ``$background`` to) and asserts ``_matches_app_ground`` reports False for
+    it. Falsify: drop the ``widget.styles.background = ...`` line below and
+    this goes red, confirming the guard is live, not a tautology."""
     app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         widget = app.query_one(MenuBar)
-        assert _is_terminal_default(widget), (
-            "sanity: MenuBar should resolve to the terminal default BEFORE "
-            "the forced override below, or this test proves nothing"
+        assert _matches_app_ground(widget, app), (
+            "sanity: MenuBar should match the App's own ground BEFORE the "
+            "forced override below, or this test proves nothing"
         )
         widget.styles.background = Color.parse("red")
         await pilot.pause()
-        assert not _is_terminal_default(widget), (
+        assert not _matches_app_ground(widget, app), (
             "forcing a concrete background did not change "
-            f"{widget.rich_style.bgcolor!r} away from the terminal default — "
+            f"{widget.rich_style.bgcolor!r} away from the App's own ground — "
             "the non-vacuity check itself is broken, independent of any "
-            "theme or $panel decision"
+            "theme or $panel/$background decision"
         )

--- a/tests/interfaces/test_focus_visible_3528.py
+++ b/tests/interfaces/test_focus_visible_3528.py
@@ -9,6 +9,22 @@ resolves to the same value, so it had been painting nothing since #3505.
 Asserted on the PAINTED tab, and asserted in both directions — a marker that
 arrives but never leaves would make every tab look focused after the first
 visit, which an arrival-only test cannot see.
+
+This module used to ALSO pin the marker's resolved colour as
+``ColorType.DEFAULT``/system-defined (never a concrete truecolor), on the
+owner's then-standing direction that ``reverse`` should invert "whatever
+the terminal is already using" rather than reyn pinning a shade of its own.
+#4840's owner ruling (2026-08-16) retired that direction for reyn's
+default theme — ``$foreground``/``$background`` now resolve to concrete
+RGB structurally, so nothing under reyn's theme is ``ColorType.DEFAULT``
+or system-defined anymore, by construction. That test is REWRITTEN, not
+deleted (lead-coder review, #4875): pinning "colour matches reyn's current
+`$foreground`" would transcribe the CSS rule as the test (six-questions
+Q2), but the ORIGINAL guarantee — the marker changes NO colour of its own,
+only inverts what was already there — is a RELATIONSHIP between the
+focused and unfocused resolved styles, and that relationship survives
+#4840 untouched: `color`/`bgcolor` must be IDENTICAL in both states, only
+`text-style` (`reverse`/`bold`) may differ.
 """
 from __future__ import annotations
 
@@ -140,29 +156,39 @@ async def test_leaving_the_menu_clears_the_marker() -> None:
 
 
 @pytest.mark.asyncio
-async def test_the_marker_forces_no_colour_of_its_own() -> None:
-    """Tier 2b: the cue is an SGR attribute, not a palette entry.
+async def test_the_marker_changes_no_colour_of_its_own() -> None:
+    """Tier 2b: the cue is an SGR attribute, not a palette entry — re-expressed
+    RELATIONALLY (#4840, lead-coder review), not as a pinned value.
 
-    A concrete colour would look the same on every terminal theme, which is the
-    thing the app's colour direction rules out; ``reverse`` inverts whatever two
-    colours the terminal is already using, so it survives a light theme as well
-    as a dark one.
+    The invariant `reverse` was chosen FOR still holds regardless of any
+    theme's specific RGB: `reverse` inverts whatever two colours are ALREADY
+    there rather than the CSS declaring a color/bgcolor of its own
+    (``MenuBar:focus-within Tab.-active { text-style: reverse bold; }`` — no
+    `color`/`bgcolor` property). That is a RELATIONSHIP between the focused
+    and unfocused resolved styles — the same tab's `color`/`bgcolor` must be
+    IDENTICAL in both states, and only its `text-style` (`reverse`/`bold`)
+    may differ — which survives any theme's specific RGB, so it is what
+    this test asserts (see the module docstring for what this replaces).
     """
     app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(110, 30)) as pilot:
         await pilot.pause()
         app.query_one(Composer).focus()
         await pilot.pause()
+        unfocused = _active_tab_style(app)
+        assert not unfocused.reverse, "setup: the marker was already present"
+
         await pilot.press("tab")
         await pilot.pause()
+        focused = _active_tab_style(app)
+        assert focused.reverse, "setup: the marker never appeared"
 
-        style = _active_tab_style(app)
-        assert style.reverse, "setup: the marker never appeared"
-        for colour in (style.color, style.bgcolor):
-            assert colour is None or colour.is_default or colour.is_system_defined, (
-                f"the focus marker pinned a concrete colour ({colour!r}) instead of "
-                "inverting the terminal's own"
-            )
+        assert focused.color == unfocused.color and focused.bgcolor == unfocused.bgcolor, (
+            f"the focus marker changed the tab's own colour "
+            f"(unfocused={unfocused.color!r}/{unfocused.bgcolor!r}, "
+            f"focused={focused.color!r}/{focused.bgcolor!r}) instead of only "
+            "inverting whatever colour was already there"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_placeholder_dim_3522.py
+++ b/tests/interfaces/test_placeholder_dim_3522.py
@@ -160,6 +160,16 @@ async def test_the_placeholder_paints_darker_than_typed_text() -> None:
     background, so this compares actual painted luminance, not the
     pre-render `Style.color` (identical for both segments at that level —
     see the two tests above).
+
+    `dim_color` is used here as an INSTRUMENT, not tested for its own
+    sake (six-questions Q1: this asserts reyn's own placeholder-darker-
+    than-text guarantee, not Textual's internal darkening formula) — but
+    it is a THIRD-PARTY internal function, so if Textual changes it this
+    test can redden for a reason that is not reyn's bug. It also
+    unconditionally unpacks `background.triplet` (the same crash #4850
+    investigated, `filter.py:142`) — harmless here because reyn's own
+    theme always supplies concrete RGB, but would crash outright if this
+    test ever ran under an `ansi-*` ground instead.
     """
     app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(90, 20)) as pilot:

--- a/tests/interfaces/test_placeholder_dim_3522.py
+++ b/tests/interfaces/test_placeholder_dim_3522.py
@@ -11,9 +11,28 @@ properties are pinned, not one: that the placeholder IS dimmed, and that typed
 text is NOT — a rule reaching further than the placeholder would make the user's
 own input look provisional, and only the second assertion can see that.
 
-The colour is deliberately left as the terminal's default (``dim`` rather than a
-muted colour): the owner's standing direction is that the terminal's own theme
-wins over any concrete shade reyn could pick.
+reyn's own CSS (``Composer > .text-area--placeholder { text-style: dim; }``,
+``app.py``) picks ``dim`` — an SGR ATTRIBUTE, not a colour — over a muted
+grey. This module used to ALSO pin the resolved colour as the terminal's
+default (``ColorType.DEFAULT``), on the owner's then-standing direction that
+the terminal's own theme should win over any concrete shade reyn could
+pick. #4840's owner ruling (2026-08-16) retired that direction — reyn's
+default theme now supplies concrete RGB for `$text` itself, so nothing
+under it resolves to `ColorType.DEFAULT` anymore, structurally.
+
+The third test here used to pin that absolute value; it is REWRITTEN, not
+deleted (lead-coder review, #4875) — pinning "colour matches reyn's `$text`
+value" would transcribe the CSS rule as the test (six-questions Q2), but
+the ORIGINAL guarantee ("the placeholder sinks", not "the placeholder is
+`ColorType.DEFAULT`") is a RELATIONSHIP, not a value, and that relationship
+survives #4840 untouched: the placeholder must still be DARKER than typed
+text once actually rendered. Resolved via
+``textual.filter.dim_color`` — the SAME function #4850's crash investigation
+found (``filter.py:129``) — applied to both segments' colour against the
+composer's own resolved background, so the comparison is the ACTUAL painted
+luminance a `dim=True` segment produces, not the pre-render `Style.color`
+(which is identical for both segments — only the `.dim` flag differs at
+that level, per the two tests above).
 """
 from __future__ import annotations
 
@@ -21,6 +40,8 @@ import asyncio
 from typing import AsyncIterator
 
 import pytest
+from rich.color import Color as RichColor
+from textual.filter import dim_color
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer
@@ -120,20 +141,65 @@ async def test_typed_text_is_not_dimmed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_the_placeholder_keeps_the_terminal_foreground_colour() -> None:
-    """Tier 2b: dimming does not pin a colour.
+async def test_the_placeholder_paints_darker_than_typed_text() -> None:
+    """Tier 2b: the placeholder must sink relative to real content — a
+    RELATIONSHIP (#4840, lead-coder review), not a pinned absolute colour.
 
-    A muted grey would dim it too, but it would also override whatever
-    foreground the user's terminal theme chose — the standing direction is that
-    the terminal's theme wins. ``dim`` is the only measured option that darkens
-    while leaving the hue to the terminal.
+    This module used to pin the placeholder's resolved colour as
+    `ColorType.DEFAULT`, on the standing-at-the-time direction that the
+    terminal's own theme should win over any concrete shade reyn could
+    pick. #4840's owner ruling retired that direction for reyn's default —
+    `$text` now resolves to concrete RGB structurally, so `ColorType.DEFAULT`
+    no longer describes anything reyn paints. The ORIGINAL guarantee this
+    protected — "the placeholder reads as an invitation, not as typed
+    text" (this module's own title) — was never really about the colour
+    TYPE; it was about the placeholder being VISUALLY DARKER than real
+    content, and that survives #4840 untouched. Resolved through
+    `textual.filter.dim_color` (the same function #4850's crash
+    investigation found, `filter.py:129`) against the composer's own
+    background, so this compares actual painted luminance, not the
+    pre-render `Style.color` (identical for both segments at that level —
+    see the two tests above).
     """
     app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(90, 20)) as pilot:
         await pilot.pause()
-        colour = _body_segment(app.query_one(Composer)).style.color
+        composer = app.query_one(Composer)
+        assert composer.text == "", "setup: the composer was not empty"
+        placeholder_segment = _body_segment(composer)
 
-        assert colour is not None and colour.is_default, (
-            f"the placeholder pinned a concrete foreground colour ({colour!r}) "
-            "instead of deferring to the terminal's own theme"
+        composer.text = "a real message"
+        await pilot.pause()
+        typed_segment = _body_segment(composer)
+
+        background = composer.rich_style.bgcolor or composer.rich_style.color
+        assert background is not None, "setup: no resolvable ambient colour"
+        placeholder_color = placeholder_segment.style.color
+        typed_color = typed_segment.style.color
+        assert placeholder_color is not None and typed_color is not None, (
+            "setup: a segment painted with no foreground colour at all"
         )
+
+        placeholder_rgb = dim_color(background, placeholder_color)
+        typed_rgb = typed_color
+
+        placeholder_luminance = _relative_luminance(placeholder_rgb)
+        typed_luminance = _relative_luminance(typed_rgb)
+        assert placeholder_luminance < typed_luminance, (
+            f"the placeholder ({placeholder_luminance:.3f}) is not darker "
+            f"than typed text ({typed_luminance:.3f}) once actually rendered"
+        )
+
+
+def _relative_luminance(color: RichColor) -> float:
+    """WCAG relative luminance of a resolved (truecolor) `rich.color.Color` —
+    the same formula #4787/#4840's own contrast-measurement comments use,
+    inlined here rather than imported (no shared util module owns it)."""
+    triplet = color.get_truecolor()
+
+    def lin(component: int) -> float:
+        c = component / 255
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = lin(triplet.red), lin(triplet.green), lin(triplet.blue)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b

--- a/tests/interfaces/test_reyn_theme_4840.py
+++ b/tests/interfaces/test_reyn_theme_4840.py
@@ -1,0 +1,84 @@
+"""Tier 2: reyn's own default Textual theme resolves to concrete colours,
+never an ``ansi_*`` marker, and honours #3542's "quiet, not loud" selection
+band under its own values.
+
+#4840, owner ruling (2026-08-16): reyn's default is now a full-colour theme
+it owns, not a deferral to the terminal's ``ansi-*`` family. What this Tier
+2 (OS invariant) pins is the CONSEQUENCE of that ruling holding: every
+design-system variable reyn's own theme produces is a concrete colour — the
+same property #4850's crash needed absent (Textual's ``ANSIToTruecolor``
+filter crashes unpacking a ``None`` ``.triplet``, which only an
+``ansi_*``-marker colour has) — not the specific RGB picked (a visual-taste
+call this test does not gate; CLAUDE.md's colour policy is about MEANING).
+
+Time-dependency check: 0 instances.
+"""
+from __future__ import annotations
+
+from textual.color import Color
+
+from reyn.interfaces.inline.textual_chat.theme import REYN_THEME
+
+
+def _resolved(name: str) -> Color:
+    colors = REYN_THEME.to_color_system().generate()
+    return Color.parse(colors[name])
+
+
+def test_the_theme_is_not_ansi() -> None:
+    """Tier 2: reyn's own theme resolves colours itself — it does not defer
+    to the terminal (`ansi=True` disables Textual's truecolor-conversion
+    filter entirely, the property every ``ansi-*`` theme relies on)."""
+    assert REYN_THEME.ansi is False
+
+
+def test_every_base_design_variable_is_concrete() -> None:
+    """Tier 2: none of the theme's core roles resolve to a ``.triplet``-less
+    marker colour — the precondition #4850's crash needed (measured:
+    ``Color.parse("ansi_default").rich_color.triplet is None``)."""
+    for name in (
+        "background",
+        "surface",
+        "panel",
+        "foreground",
+        "primary",
+        "secondary",
+        "warning",
+        "error",
+        "success",
+        "accent",
+    ):
+        resolved = _resolved(name)
+        assert resolved.rich_color.triplet is not None, (
+            f"{name} resolved to a marker colour with no RGB triplet"
+        )
+
+
+def test_the_selection_band_is_concrete_and_distinct_from_the_accent() -> None:
+    """Tier 2: #3542 read explicitly (per #4840's own ruling) — the
+    selection band must be a muted, DISTINCT hue, not the full-intensity
+    accent Textual's own auto-derivation (`primary.with_alpha(0.5)`) would
+    produce, and not a marker colour either."""
+    selection_bg = _resolved("screen-selection-background")
+    primary = _resolved("primary")
+    assert selection_bg.rich_color.triplet is not None
+    assert selection_bg.hex != primary.hex
+
+
+def test_the_selection_band_meets_wcag_aa_contrast() -> None:
+    """Tier 2: #3542's own concern was legibility as much as loudness — the
+    selection text must stay readable against its own background."""
+    bg = _resolved("screen-selection-background")
+    fg = _resolved("screen-selection-foreground")
+
+    def relative_luminance(color: Color) -> float:
+        def lin(c: float) -> float:
+            return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+        r, g, b = lin(color.r / 255), lin(color.g / 255), lin(color.b / 255)
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+    l1, l2 = relative_luminance(bg), relative_luminance(fg)
+    l1, l2 = max(l1, l2), min(l1, l2)
+    contrast = (l1 + 0.05) / (l2 + 0.05)
+    assert contrast >= 4.5, f"selection band contrast {contrast:.2f} below WCAG AA"


### PR DESCRIPTION
**[tui-coder]** — part of #4840, ② of the ①→②→③ sequence lead-coder set

## What changed

`REYN_THEME` (new `interfaces/inline/textual_chat/theme.py`), registered
and set as the App's default in `on_mount` (`self.theme = "reyn"`,
replacing `"ansi-dark"` — the #3505 fix whose premise this ruling retires:
there is no `ansi_default` marker left in the App's own design-system
variables to protect from an alpha-blend once reyn supplies concrete RGB
itself).

## Values — candidate, not a final visual sign-off

5 of 8 base tokens (`primary`/`secondary`/`warning`/`error`/`success`, plus
`accent = primary`) reuse EXISTING already-reasoned `palette.py` values —
no new colour picked, only a new place the SAME value renders.
`background`/`surface`/`panel` are the genuinely new choices (reyn's TUI
has never had a full-colour ground before, #4787's own finding) — added to
`palette.py` as `@theme-*@` tokens, not literals in `theme.py` (the
hex-literal gate in `test_tui_colour_tokens.py` caught the literal-in-
theme.py attempt on the first pass; routed through `palette.py` like
everything else in `interfaces/`).

**Mechanism is what #4840 delegated here; the exact RGB is still a
visual-taste call** — CLAUDE.md's colour policy is about MEANING, and
which concrete value renders a meaning stays owner's to confirm on real
hardware. `theme.py`'s own module docstring carries the full reasoning per
value.

## `panel` is explicit, not `boost`-derived — a rejected alternative

Textual's `ColorSystem.generate()` only computes `panel` from
`surface.blend(primary, 0.1) + boost` when `panel` is left unset (measured,
#4840's own earlier `boost`-anomaly investigation, #4871's thread). Tried
that path first: blending `surface` (`#1e222a`, cool blue-gray) 10% toward
`primary` (`#d97757`, warm terracotta) pulls the auto-derived panel to
`#363034` — off the cool family `background`/`surface` are in, a visible
seam nobody asked for. Explicit `panel="#232833"` avoids it; the cost is
`boost` staying transparent (harmless — nothing in reyn's own CSS reads
`$boost` today).

## Selection tokens — deliberately NOT touched here (③, next)

`@selection-bg@`/`@selection-fg@` stay `ansi_blue`/`ansi_black` in this
PR. Landing reyn's own default theme here is what UNBLOCKS ③ — mapping
those 2 tokens to `$screen-selection-background`/`-foreground` no longer
regresses owner-adjudicated #3542 once "reyn" (not `ansi-dark`, whose own
`screen-selection-background` is the loud `ansi_bright_blue` #3542 moved
away from) is the App's default. Follow-up PR, not bundled here, per
lead-coder's own sequencing ruling on #4871.

## `app.py:840`/`:931`'s 2 `background: transparent` sites — reviewed, no edit needed

Per lead-coder's request to check these for a stale terminal-era
assumption while building ②: neither carries one. `Screen`'s own #3503
comment was already updated in #4871. `Composer`'s describes `TextArea`'s
own `DEFAULT_CSS` painting `$surface` — a theme-independent fact about
Textual's widget, unaffected by which theme is active.

## Tests

- **New** `tests/interfaces/test_reyn_theme_4840.py` — the theme resolves
  every base design variable to a concrete colour (never an `ansi_*`
  marker — the exact precondition #4850's crash needed, per that issue's
  own hypothesis), is not `ansi=True`, and the selection band is concrete,
  distinct from the accent, and WCAG-AA (≥4.5:1 measured 5.50:1).
- **Rewritten** `tests/interfaces/test_chrome_uses_the_terminal_background_3503.py`
  — its whole premise ("chrome resolves to the terminal's own
  `ColorType.DEFAULT` marker") is exactly what #4840's ruling retires. The
  STRUCTURAL invariant (#3503: a region takes the App's ground rather than
  forcing its own) is unchanged, so rewritten against "matches the App's
  own resolved `$background`" instead of "is the terminal-default marker
  type" — same non-vacuity guard preserved (a forced concrete override is
  still detected as NOT matching).

## #4850

Per owner instruction (relayed via lead-coder): **not** attempting a live
crash reproduction here. The hypothesis recorded on #4871/#4850 (App-level
`ansi_default` was the crash's precondition; concrete colours throughout
reyn's own theme structurally remove it) stands as a hypothesis, not
re-verified further in this PR.

## Falsification

`git stash` of all 5 changed/new files reproduced the pre-change state
(`theme.py` absent, `app.py`'s `self.theme == "ansi-dark"`); `git stash
pop` restored both.

## Time-dependency check

0 instances — the 4 new theme tests resolve a `ColorSystem` directly (no
App/event-loop timing); the rewritten `_3503` tests already used
`pilot.pause()` (the established async-settle idiom) unchanged by this PR.

## Test plan

- [x] `pytest tests/interfaces/test_tui_colour_tokens.py tests/interfaces/test_selection_not_bright_3542.py tests/interfaces/test_chrome_uses_the_terminal_background_3503.py tests/interfaces/test_reyn_theme_4840.py -q` — 18 passed
- [x] `ruff check .` — all checks passed
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/verify_module_docstrings.py` (3 changed src files) — OK
- [x] `python scripts/test_tier_audit.py --strict` (2 changed/new test files) — 0 errors, 0 warnings
- [x] Falsification via `git stash`/`git stash pop` (see above)
- [ ] Visual — n/a (standing waiver; TTY-only result, operator review pending on real hardware — this PR ships the MECHANISM, the RGB is a candidate)
