### PR TITLE
docs(verification-hazards): a second, larger-scale git grep -E \b instance

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -86,6 +86,21 @@ ERE, which does not understand `\s` — so even a known hit
 Neither zero was distinguishable from a real zero without recognizing the
 query itself was narrow, then broken.
 
+**`\b` fails the identical way, and the same night reproduced it at a scale
+`\s` didn't.** `git grep -E` is POSIX ERE for both metacharacters — no error,
+just a silent zero — but `\b` is far more commonly reached for than `\s`, so
+the same broken instrument did more damage before anything caught it:
+`\bsetattr\(` counted 0 "non-monkeypatch" call sites where the true count was
+23, and a separate private-attribute-read census counted 158 where the true
+count was 3,727 — both undercounts by roughly two orders of magnitude,
+neither flagged by the check itself, only by disagreeing with a different
+count taken later. The same session measured the boundary precisely: on this
+machine, plain `grep -E` is shell-aliased to `ugrep`, which DOES understand
+`\b` — so the identical `-E` flag is two different regex languages depending
+on which binary answers it, and "I used `-E`" is not enough provenance to
+trust a result. **Measured on Darwin with `ugrep` only — CI's GNU/Linux
+`grep` was not tested, and this doc does not claim its behavior.**
+
 The other side of the same coin: **a nonzero hit is not itself an answer
 either** — it's a classification that isn't decided until the hit is opened.
 Auditing whether two issues were already landed, one search returned zero
@@ -104,10 +119,19 @@ checking for would leave a positive trace if present, or only an absence —
 only the first kind makes zero a real answer. Then calibrate the instrument
 itself: run the same query against one KNOWN hit before trusting a null
 result on the rest, and prefer `-P`/PCRE or a portable class like
-`[[:space:]]` over ERE metacharacters that vary by grep flavor. And when the
-count comes back nonzero, don't stop at the count — open every hit and read
-it before classifying it as "just a mention"; the classification isn't
-decided by the search, only by what's actually in the hit.
+`[[:space:]]` over ERE metacharacters that vary by grep flavor — `\b` and
+`\s` both silently return zero under `git grep -E`, not an error, so nothing
+in the output distinguishes "checked, absent" from "the tool didn't
+understand the pattern." A zero that matters is worth one extra move: drop
+one metacharacter and re-run — if the count jumps, the first zero was the
+tool, not the world. Note which binary actually answered the query (`git
+grep`, this shell's own `grep` alias, plain `/usr/bin/grep`) next to the
+count; the same `-E` flag is not the same regex language across them, so a
+number without its tool is not reproducible by a reader who tries to check
+it. And when the count comes back nonzero, don't stop at the count — open
+every hit and read it before classifying it as "just a mention"; the
+classification isn't decided by the search, only by what's actually in the
+hit.
 
 ## 4. Census vs. structure — extrapolation dies on use, not on review
 


### PR DESCRIPTION
**[docs-maintainer]** — cross-ref audit follow-up, not tied to a specific reyn issue

## What

lead-coder dispatched a judgment call: does the fresh `git grep -E '\b'`/`\s` silent-no-match measurement (memory pin `feedback_git_grep_e_silently_no_matches_b_and_s`, shared across all sessions) belong in `verification-hazards.md`? §3 ("Two zeros: one settles it, one says nothing") already records the `\s` instance from the 2026-07-31 colour census — this extends it with a second, same-mechanism, much larger-scale `\b` instance measured the same night: a non-monkeypatch census undercounted 23 as 0, a private-attribute-read census undercounted 3,727 as 158.

## Why this placement (not a new section)

Same mechanism (`git grep -E` is POSIX ERE, silently swallows an unsupported metacharacter rather than erroring), same "zero can lie" root §3 already states. A new top-level section would duplicate the framing; extending §3's existing paragraph and its Apply prescription keeps the doc's own convention (multiple instances accumulate under one mechanism, per §18 C earlier this session).

## Verification (not just relayed)

Independently re-ran the exact commands before writing anything: `git grep -E '\bsetattr\(' -- tests/` → 0 on this machine; this shell's own `grep -E` (aliased to `ugrep`) → 971 for the identical pattern. Confirms the claim directly rather than trusting the relayed measurement — same `-E` flag, two different regex languages depending on which binary answers it.

## Scope honesty

Measured **Darwin with `ugrep` only** — lead-coder's own caveat, carried into the doc verbatim: CI's GNU/Linux `grep` was not tested, and the addition does not claim its behavior.

## Cross-ref audits done in parallel

Also audited memory-curator's fold (`feedback_git_grep_e_silently_no_matches_b_and_s` → `feedback_verification_blind_spot_family`, 4 wikilinks) and lead-coder's own memory-index line for the same pin — both clean, no dangling links.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no `Aborted` line
- [x] `python scripts/check_doc_anchors.py` — exit 0, no dangling anchors into published pages
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Closing-keyword self-grep on commit message and this PR body — clean
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Independently re-verified the core claim against real command output before writing (not just relaying the peer measurement)
- [x] Time-dependency check (#4845/#4847): 0 instances — prose-only doc edit, no tests touched
- [x] Owner veto window — this doc is normative; opened as a PR, not a direct edit
- [x] Visual — N/A, prose-only addition
