### PR TITLE
fix(#4855): select the notice line this test itself caused, not the first one

### DIFF
--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -761,6 +761,10 @@ async def test_pump_heartbeat_reaches_the_default_visible_notices(
             await app.on_timer(
                 events.Timer(timer=app.pump_heartbeat_timer, time=0.0, count=1),
             )
+            # #4855: mark where THIS test's own content begins — see the
+            # sibling test_keys_received_... 's comment for why (an earlier,
+            # unrelated stall's "unresponsive" line is not this test's own).
+            pre_jump_len = len(logfile.read_text(encoding="utf-8"))
             clock.jump(stall_seconds)
             while "recovered" not in logfile.read_text(encoding="utf-8"):
                 await pilot.pause()
@@ -771,7 +775,7 @@ async def test_pump_heartbeat_reaches_the_default_visible_notices(
         root.handlers = saved_handlers
         root.setLevel(saved_level)
 
-    content = logfile.read_text(encoding="utf-8")
+    content = logfile.read_text(encoding="utf-8")[pre_jump_len:]
     assert "pump heartbeat" in content, (
         f"the pump-ticks reading must reach the real, default-visible log: {content!r}"
     )
@@ -885,6 +889,14 @@ async def test_keys_received_reaches_the_default_visible_stall_notice(
             # attempts=N / time-bound), never a race the test itself builds.
             while app.keys_received < 3:
                 await pilot.pause()
+            # #4855: the "unresponsive" line this test reads must be the ONE
+            # ITS OWN clock.jump caused — not the first "unresponsive" line
+            # anywhere in the file (an unrelated stall during app mount can
+            # log one earlier, e.g. real CI-host contention). Position in
+            # the file is not identity; what this test itself caused is —
+            # so the offset right before the jump marks where THIS test's
+            # own content begins. No time is written in either direction.
+            pre_jump_len = len(logfile.read_text(encoding="utf-8"))
             clock.jump(stall_seconds)
             while "recovered" not in logfile.read_text(encoding="utf-8"):
                 await pilot.pause()
@@ -895,7 +907,7 @@ async def test_keys_received_reaches_the_default_visible_stall_notice(
         root.handlers = saved_handlers
         root.setLevel(saved_level)
 
-    content = logfile.read_text(encoding="utf-8")
+    content = logfile.read_text(encoding="utf-8")[pre_jump_len:]
     stall_line = next(line for line in content.splitlines() if "unresponsive" in line)
     assert "keys received: 3" in stall_line, (
         f"the 3 real keypresses must show up in the stall notice's own count: {stall_line!r}"
@@ -974,14 +986,6 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
     saved_level = root.level
     monkeypatch.delenv("REYN_PROF_DUMP", raising=False)
     # #4844: virtual clock, no real sleep — see _VirtualClock's docstring.
-    # As a side effect this also narrows #4827①'s own recurring window: the
-    # tripwire's very next tick (a real, but tiny, _TICK_SECONDS=50ms
-    # asyncio.sleep) observes the jump immediately, instead of racing a
-    # real multi-hundred-ms time.sleep() during which CI-host starvation
-    # had room to disturb state between "confirmed active" and "observed".
-    # #4827's own "why does starvation happen at all" question stays open
-    # (tracked separately) — this only removes the real-time WINDOW the
-    # test itself used to hold open for it.
     clock = _VirtualClock()
     monkeypatch.setattr(time, "perf_counter", clock)
     try:
@@ -1032,8 +1036,12 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
             _diag_activity_obj_id = id(app._activity)
             _diag_query_obj_id = id(app.query_one(ActivityRow))
             _diag_state_at_confirm = app._activity.state
+            # #4855: mark where THIS test's own content begins — see
+            # test_keys_received_...'s comment for why (an earlier,
+            # unrelated stall's "unresponsive" line is not this test's own).
+            pre_jump_len = len(logfile.read_text(encoding="utf-8"))
             clock.jump(stall_seconds)
-            while "unresponsive" not in logfile.read_text(encoding="utf-8"):
+            while "unresponsive" not in logfile.read_text(encoding="utf-8")[pre_jump_len:]:
                 await pilot.pause()
             # lead-coder's TESTS-READ (#4842): these 3 are read AFTER this
             # test's OWN loop above observes "unresponsive" in the logfile —
@@ -1054,7 +1062,7 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
         root.handlers = saved_handlers
         root.setLevel(saved_level)
 
-    content = logfile.read_text(encoding="utf-8")
+    content = logfile.read_text(encoding="utf-8")[pre_jump_len:]
     stall_line = next(line for line in content.splitlines() if "unresponsive" in line)
     assert "turn active" in stall_line, (
         "a stall observed while a real turn_started event is in flight must "

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -766,7 +766,14 @@ async def test_pump_heartbeat_reaches_the_default_visible_notices(
             # unrelated stall's "unresponsive" line is not this test's own).
             pre_jump_len = len(logfile.read_text(encoding="utf-8"))
             clock.jump(stall_seconds)
-            while "recovered" not in logfile.read_text(encoding="utf-8"):
+            # #4855 (same defect, same function, 2 lines up): waiting on
+            # "recovered" ANYWHERE in the file — not sliced to what THIS
+            # test's own jump caused — lets an earlier, unrelated
+            # recovery already in the file satisfy the wait before this
+            # test's own stall has even been logged, racing the read
+            # below against a "unresponsive" line that has not landed
+            # yet.
+            while "recovered" not in logfile.read_text(encoding="utf-8")[pre_jump_len:]:
                 await pilot.pause()
     finally:
         for handler in root.handlers:
@@ -779,7 +786,12 @@ async def test_pump_heartbeat_reaches_the_default_visible_notices(
     assert "pump heartbeat" in content, (
         f"the pump-ticks reading must reach the real, default-visible log: {content!r}"
     )
-    stall_line = next(line for line in content.splitlines() if "unresponsive" in line)
+    stall_line = next(
+        (line for line in content.splitlines() if "unresponsive" in line), None,
+    )
+    assert stall_line is not None, (
+        f"no 'unresponsive' line in this test's own content: {content!r}"
+    )
     assert "+" in stall_line, (
         "the STALL line itself (not just the recovery line) must carry the "
         "self-contained trailing-window delta — a freeze that never "
@@ -898,7 +910,12 @@ async def test_keys_received_reaches_the_default_visible_stall_notice(
             # own content begins. No time is written in either direction.
             pre_jump_len = len(logfile.read_text(encoding="utf-8"))
             clock.jump(stall_seconds)
-            while "recovered" not in logfile.read_text(encoding="utf-8"):
+            # #4855 (same defect, same function, 2 lines up): sliced to
+            # THIS test's own content — see
+            # test_pump_heartbeat_reaches_the_default_visible_notices's
+            # sibling comment for why an unsliced wait races an
+            # unrelated recovery already in the file.
+            while "recovered" not in logfile.read_text(encoding="utf-8")[pre_jump_len:]:
                 await pilot.pause()
     finally:
         for handler in root.handlers:
@@ -908,7 +925,12 @@ async def test_keys_received_reaches_the_default_visible_stall_notice(
         root.setLevel(saved_level)
 
     content = logfile.read_text(encoding="utf-8")[pre_jump_len:]
-    stall_line = next(line for line in content.splitlines() if "unresponsive" in line)
+    stall_line = next(
+        (line for line in content.splitlines() if "unresponsive" in line), None,
+    )
+    assert stall_line is not None, (
+        f"no 'unresponsive' line in this test's own content: {content!r}"
+    )
     assert "keys received: 3" in stall_line, (
         f"the 3 real keypresses must show up in the stall notice's own count: {stall_line!r}"
     )
@@ -1063,7 +1085,12 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
         root.setLevel(saved_level)
 
     content = logfile.read_text(encoding="utf-8")[pre_jump_len:]
-    stall_line = next(line for line in content.splitlines() if "unresponsive" in line)
+    stall_line = next(
+        (line for line in content.splitlines() if "unresponsive" in line), None,
+    )
+    assert stall_line is not None, (
+        f"no 'unresponsive' line in this test's own content: {content!r}"
+    )
     assert "turn active" in stall_line, (
         "a stall observed while a real turn_started event is in flight must "
         f"say so in the default-visible notice: {stall_line!r}. "


### PR DESCRIPTION
- [x] 🔴 **待ち側が 2 箇所、元のままです**（lead-coder TESTS-READ）— `pump_heartbeat` と `keys_received` の `while "recovered" not in logfile.read_text(...)` にスライスが無く、先行する停止の "recovered" で即座に抜け得ます。3 箇所目（`turn_active`）では待ち側も直っているので形は既にあります。
- [x] ⚪ 非 blocking: `next()` が裸 — スライス後に通知が無いと `StopIteration` で「何が無かったか」が出ません。
- [x] ⚪ 非 blocking: `test_turn_active_...` から消した #4827① の 8 行について、「`_VirtualClock` になった今もう偽か」を 1 行で。

---

**[e2e-coder]** — Fixes #4855's "which notice is mine" half (position-based line selection).

## What

3 sites in `tests/interfaces/test_loop_probe_3539.py` read the FIRST "unresponsive" line anywhere in the logfile, not necessarily the one this test's own `clock.jump` caused. An earlier, unrelated stall (real CI-host contention during app mount) can log one first. Fixed by marking the logfile's length right before `clock.jump`, then only searching content written after that offset -- what the test itself caused, not position. No time written in either direction.

Also removed a stale comment (in `test_turn_active_...`) claiming the virtual clock "narrows #4827①'s own recurring window" -- disproven earlier this session (the CI failure that motivated it ran on a branch predating #4844's merge).

## Test plan

- [x] `pytest tests/interfaces/test_loop_probe_3539.py -k "..."` (the 3 touched tests, individually) -- green, multiple runs
- [x] `ruff check` / `test_tier_audit.py --strict` / `mypy_ratchet.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `verify_module_docstrings.py` -- all clean
- [x] Synthetic demonstration: reproduced the exact `next(line for line in content...)` selection mechanism with an earlier unrelated "unresponsive" line before the offset -- old logic selects the wrong line, new logic selects the right one.
- [x] **Full-run comparison**: 20 runs of the whole file on unpatched `main` (0 failures) and 20 runs on this patch (0 failures) -- **no difference observed between the two at this sample size**. An earlier, smaller sample (2/5 failures under the patch) did not reproduce across the larger run; the cause of that earlier observation is **not identified** -- could be noise, or an environmental change between observations (`main` moved during this investigation: #4848/#4869/#4871 landed). Not claiming the patch caused or fixed that specific instance.

Full context: #4855, #4827①, #4844.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


