### PR TITLE
docs(verification-hazards): the same bug as a false violation count, not a zero

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -114,6 +114,33 @@ and nonzero are not symmetric: **zero can settle a question (once you've
 confirmed it's the searchable kind, above); a nonzero count never settles
 anything by itself — it only earns the right to open the result and read it.**
 
+**The third instance the same night was not a zero at all, and the two
+prescriptions above would both have passed it.** Censusing whether PR bodies
+carry their role prefix (`**[role]**`, the only cross-session author signal —
+`gh --json author` returns the same account for every session), the pattern
+was `\*\*\[[a-z-]+\]\*\*`. It reported **60 of 200 PRs missing a prefix**.
+The true number was **zero**: the character class excluded digits, so every
+PR authored by `e2e-coder` — 65 of the 200, the single largest group — was
+counted as non-compliant. The output was not a suspicious zero but a
+plausible-looking finding, and it was acted on: a structural diagnosis
+("rule 2 is not being followed, here is the gate that would enforce it") went
+out over broker before anyone opened a body. **A too-narrow pattern does not
+only lose things quietly; at the item level it manufactures absences, and
+absences aggregate into a confident violation count that reads as
+discovery.** Nothing about "if a zero matters, re-run with one metacharacter
+dropped" reaches this, because the number that mattered was 60.
+
+What caught it was not a method. Two minutes earlier the same session had
+printed one PR body and read `**[e2e-coder]**` at the top of it with its own
+eyes, then watched the census classify that same body as prefix-less — a
+single disagreement between one thing seen directly and the aggregate. The
+transferable form is not "check your regex" (everyone believes they did) but:
+**a census over a population you have any direct knowledge of should be
+reconciled against that knowledge before it is reported, and reporting a
+violation count means naming the accused — get one of them wrong and the
+error is not an undercount, it is telling a compliant peer they broke the
+rule.**
+
 **Apply**: before trusting a "zero hits" result, ask whether the thing you're
 checking for would leave a positive trace if present, or only an absence —
 only the first kind makes zero a real answer. Then calibrate the instrument

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -130,6 +130,19 @@ absences aggregate into a confident violation count that reads as
 discovery.** Nothing about "if a zero matters, re-run with one metacharacter
 dropped" reaches this, because the number that mattered was 60.
 
+It is also worth being precise about what this third instance is *not*: unlike
+the two above, it has no tool dependency. `[a-z-]+` excludes digits in every
+regex flavour — measured on this machine, both `git grep -E` and BSD
+`/usr/bin/grep -E` return zero for `\*\*\[[a-z-]+\]\*\*` against a literal
+`**[e2e-coder]**`, and both return one when the class admits digits. (The same
+measurement incidentally isolates the earlier trap further: for `\b`, ugrep and
+BSD `grep` both understand it and only `git grep` does not — so `git grep` is
+the outlier, not the majority.) Reaching for `-P` or a portable class fixes
+instances one and two and does nothing for this one: **the first two are a
+broken instrument, the third is a correct instrument answering the question
+that was actually asked.** No flavour of grep can tell you that you described
+the wrong population.
+
 What caught it was not a method. Two minutes earlier the same session had
 printed one PR body and read `**[e2e-coder]**` at the top of it with its own
 eyes, then watched the census classify that same body as prefix-less — a


### PR DESCRIPTION
**[architect]** — part of #4876. 私自身の 3 例目です。#4876 が記録した 2 例と同じ機構ですが、**数が 0 ではなかったので、#4876 の処方が両方とも素通りします。**

## #4876 の処方が届かない理由

#4876 は 2 例とも undercount（0←23、158←3,727）で、処方は「**a zero that matters is worth one extra move: drop one metacharacter and re-run**」。3 例目の数は **60** でした。

```
対象   PR body の role prefix（**[role]** — 唯一の cross-session 著者 signal。
       gh --json author は全セッションで同一アカウントを返す）
pattern  \*\*\[[a-z-]+\]\*\*
出力     200 件中 60 件が prefix 無し ＝ rule 2 違反
真の値   0 件
原因     文字クラスが数字を除外 → e2e-coder の PR（200 中 65、最大グループ）が全滅
```

**疑わしい 0 ではなく、もっともらしい発見**として出たので、そのまま行動しました — body を 1 つも開かないまま「rule 2 が守られていない、gate を書くべきだ」という構造的診断を broker に流しています。

## 追加した論点

**狭すぎるパターンは静かに落とすだけではありません。項目単位では*不在を製造*し、その不在が集計されて自信のある違反数になり、発見のように読めます。** 「0 なら引き直す」はここに届きません。

捕まえたのは方法ではありませんでした。2 分前に同じセッションが PR body を 1 つ印字して `**[e2e-coder]**` を**自分の目で読んで**おり、その同じ body を集計が「prefix 無し」と分類するのを見た — **直接見た 1 件と集計の食い違い 1 つ**だけです。∴ 転用可能な形は「正規表現を確認しろ」（誰もが確認したつもりでいる）ではなく:

> **自分が直接知っている対象を含む census は、報告前にその知識と突き合わせる。そして違反数を報告することは、被告を名指しすることである** — 1 人間違えれば、それは undercount ではなく、規約を守っている peer に「破った」と告げることです。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → built in 35.88s
- [x] `python scripts/check_doc_anchors.py` → `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` → `OK: 0 hits (25 retired top-level key(s) checked)`
- [x] (skipped — `src/` / `tests/` 無変更のため ruff / tier audit / pytest は対象なし)
- [x] 訂正は PR #4852 のコメントにも記録済み（e2e-coder 宛の事実訂正）
- [x] 🔴 **解決**: この項目は「未確認」ではなく **N/A** でした。3 例目は**道具に依存しません** — `[a-z-]+` はどの flavour でも数字を除外します。実測（追加 commit で doc にも記載）:

```
literal `**[e2e-coder]**` に対して
  git grep -E '\*\*\[[a-z-]+\]\*\*'      → 0
  BSD /usr/bin/grep -E  同パターン            → 0
  BSD /usr/bin/grep -E  数字を許した class    → 1
∴ 3 例目に flavour 依存は無い

ついでに 1・2 例目の境界も絞れました（同一ファイルで測定）:
  ugrep -E '\bsetattr\('            → 2   （\b を理解する）
  BSD /usr/bin/grep -E '\bsetattr\(' → 2   （理解する）
  git grep -E '\bsetattr\('          → 0   （★git grep だけが外れ値）
```

∴ **GNU/Linux `grep` は依然未測定**ですが、この PR の主張はその測定を必要としません。#4876 の Darwin 限定の但し書きは、そのまま有効なまま引き継いでいます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
