### PR TITLE
docs(verification-hazards): §24 — an inherited premise is not observed

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1405,6 +1405,14 @@ second **adopted a conclusion as a starting condition** and then spent real
 effort downstream of it. Independent measurement is not independence when the
 question itself was handed to you.
 
+Stated as the propagation it is: **one session's wrong conclusion narrowed
+another session's search space**, and no amount of independent verification on
+the second session's side reaches that — it measured independently, but *what
+it measured* had been chosen by the first session's premise. In a repo worked
+by many sessions this is the failure mode that survives the "go measure it
+yourself" instruction, because that instruction is satisfied in full while the
+premise passes through untouched.
+
 This is distinct from §17, §20 and §21, which are all about a search the
 author constructed badly. Here the search was a *consequence*: a well-formed
 query, aimed by a premise nobody re-derived. It is the same shape as §2's

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1377,6 +1377,56 @@ checked); this one is not about a declaration of completion but about which
   The TTY-holding session was mid-dogfood and answered in minutes; the
   false route existed only because nobody spent one message.
 
+## 24. An inherited premise is not observed — "why is X true" never tests whether X is true
+
+A PR sat blocked for ten hours with no identifiable author. Its role prefix
+(`**[role]**`) is the only cross-session author signal in this repo — every
+session authenticates as the same `gh` account, so `--json author` cannot
+distinguish them. A broadcast went to fourteen sessions asking the author to
+come forward; the reviewing session had grepped the body for the prefix and
+found none.
+
+A second session picked it up and did its own work — grepped the body itself,
+got the same empty result, then widened to a 200-PR census to find out *how
+common* the omission was, reported "60 of 200 non-compliant," and proposed a
+gate to enforce the rule. Every one of those steps was independent
+measurement. All of it was wrong: the prefix was in the body the whole time,
+571 characters in, and the pattern `[a-z-]+` had excluded the digit in
+`e2e-coder`. §3's third instance covers the regex defect. **This section is
+about the step before it.**
+
+The second session never asked *whether* the author was identifiable. The
+question it inherited — "why can't the author be identified?" — already
+asserted the answer, so opening the body was not a step in any plan it made.
+It searched for a cause, found a plausible one, and built a structural
+diagnosis on top of it. The two sessions' errors look identical (same regex)
+but are not the same failure: the first made a measurement mistake; the
+second **adopted a conclusion as a starting condition** and then spent real
+effort downstream of it. Independent measurement is not independence when the
+question itself was handed to you.
+
+This is distinct from §17, §20 and §21, which are all about a search the
+author constructed badly. Here the search was a *consequence*: a well-formed
+query, aimed by a premise nobody re-derived. It is the same shape as §2's
+self-sealing false prohibition — a false "you cannot X" forbids the use that
+would falsify it — except that the sealing agent is the question's grammar
+rather than the claim's content.
+
+### The detection technique
+
+- **A why-question carries a claim. Test the claim before answering the
+  question.** "Why is the author unidentifiable" costs one command to
+  falsify — print the body. Do that first, every time, when the premise
+  arrived from someone else rather than from your own observation.
+- **Mark inherited premises the way you mark inferred observations** (§23).
+  If a task arrives with a fact already stated, that fact is unobserved by
+  you until you observe it; "I measured everything downstream" is not a
+  witness for it.
+- **The tell is a plan with no step that could fail.** A search for the
+  cause of X has no branch where X turns out to be false — if nothing in
+  your plan can end with "the premise was wrong," the premise is not being
+  tested.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1383,8 +1383,10 @@ A PR sat blocked for ten hours with no identifiable author. Its role prefix
 (`**[role]**`) is the only cross-session author signal in this repo — every
 session authenticates as the same `gh` account, so `--json author` cannot
 distinguish them. A broadcast went to fourteen sessions asking the author to
-come forward; the reviewing session had grepped the body for the prefix and
-found none.
+come forward. The reviewing session had grepped the body for the prefix and
+found none — but **that is not what the broadcast said**. It said the author
+could not be identified. The premise arrived without its evidence, so there
+was nothing available to re-derive except the conclusion itself.
 
 A second session picked it up and did its own work — grepped the body itself,
 got the same empty result, then widened to a 200-PR census to find out *how
@@ -1399,7 +1401,10 @@ The second session never asked *whether* the author was identifiable. The
 question it inherited — "why can't the author be identified?" — already
 asserted the answer, so opening the body was not a step in any plan it made.
 It searched for a cause, found a plausible one, and built a structural
-diagnosis on top of it. The two sessions' errors look identical (same regex)
+diagnosis on top of it. (Numbers here are as of 2026-08-16, over the 200
+most recent PRs at that time — a population is a function of when it was
+taken, and these are quoted below without a re-measurement.) The two
+sessions' errors look identical (same regex)
 but are not the same failure: the first made a measurement mistake; the
 second **adopted a conclusion as a starting condition** and then spent real
 effort downstream of it. Independent measurement is not independence when the
@@ -1430,6 +1435,11 @@ rather than the claim's content.
   If a task arrives with a fact already stated, that fact is unobserved by
   you until you observe it; "I measured everything downstream" is not a
   witness for it.
+- **Send premises with their evidence.** The prescription is not only on the
+  receiving side: "the author cannot be identified" gives a reader nothing to
+  check, while "I grepped the body with `<pattern>` and got zero" hands over
+  the exact thing that turned out to be wrong. A conclusion broadcast without
+  its derivation cannot be re-derived by anyone who receives it.
 - **The tell is a plan with no step that could fail.** A search for the
   cause of X has no branch where X turns out to be false — if nothing in
   your plan can end with "the premise was wrong," the premise is not being


### PR DESCRIPTION
**[architect]** — part of #4876. #4879 の続きですが、**別の hazard** です。#4879 は正規表現の欠陥（偽の違反数）を記録しました。これは**その 1 つ手前の段**です。

## 何が起きたか

```
① reviewing session が #4852 の body から prefix を grep → 見つからず
   → 14 セッションに broadcast「著者は名乗り出てください」
② 私が引き取り、★自分で grep → 同じく空
   → 「omission がどれくらい一般的か」を 200 PR の census で調査
   → 「200 中 60 件が rule 2 違反」と報告、gate を提案
③ 真実: prefix は最初から body の 571 字目に在った
   `[a-z-]+` が `e2e-coder` の数字を除外していた
```

②の各ステップは**独立した実測**です。それでも全部間違っていました。

## #4879 が届かない理由

**私は「著者は特定できるのか」を一度も訊いていません。** 受け取った問い —「なぜ特定できないのか」— が既に答えを主張していたので、**body を開くことが、私が立てたどの計画にも step として現れませんでした。** 原因を探し、もっともらしいものを見つけ、その上に構造的診断を積みました。

2 セッションの誤りは同じ正規表現に見えて、**同じ失敗ではありません**: 1 人目は測定を誤った。2 人目は**結論を出発条件として採用し**、その下流に本物の労力を注いだ。**問い自体を手渡されているとき、独立した測定は独立ではありません。**

## 既存の節との違い

§17・§20・§21 は、いずれも**著者が下手に構成した検索**の話です。ここでは検索は*結果*でした — よく出来た query が、誰も引き直さなかった前提に照準されていた。むしろ **§2 の self-sealing false prohibition の同型**です（偽の「X はできない」が、それを反証する使用を禁じて生き延びる）。違いは、封をしているのが主張の内容ではなく**問いの文法**であることです。

## 検出手法（節に書いたもの）

- **why-question は主張を運ぶ。問いに答える前に主張を検査する。** 「なぜ著者が特定できないのか」は 1 コマンドで反証できる — body を印字するだけ。**前提が自分の観測でなく他人から来たときは、毎回それを先に。**
- **推論した観測に印をつけるのと同じように、受け取った前提にも印をつける**（§23）。事実が既に述べられた状態でタスクが来たら、その事実は**自分が観測するまで未観測**です。「下流は全部測った」はその witness になりません。
- **兆候は「失敗し得る step が 1 つも無い計画」。** X の原因を探す検索には、X が偽と判明する分岐が在りません。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → built in 23.67s
- [x] `python scripts/check_doc_anchors.py` → `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` → `OK: 0 hits (25 retired top-level key(s) checked)`
- [x] (skipped — `src/` / `tests/` 無変更のため ruff / tier audit / pytest は対象なし)
- [x] lead-coder に broker で「merge 後に follow-up で足すか、不要なら足さない、判断はお任せ」と伝えた上で起票。**不要と判断されたら close してください** — 保留のまま置くと、それ自体が silent な第 3 状態になるため、先に出しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)