### PR TITLE
feat(#4840): @selection-bg@/@selection-fg@ map to reyn's own theme (③)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -842,24 +842,26 @@ class TextualChatApp(App):
        unaffected — those are content, not ground. */
     App { background: @app-background@; }
     Screen { layout: vertical; background: transparent; }
-    /* #3542: the drag-selection band. Textual's ansi-dark defaults to
-       `ansi_bright_blue`, which the operator found too loud against the
-       conversation. Dropping to `ansi_blue` asks the terminal for a different
-       one of its sixteen slots — reyn is not overriding the user's colours
-       here and never was, it only picks which frame to request. Declared as an
-       explicit background/foreground PAIR rather than `text-style: reverse`:
-       Textual COMPOSES the selection style onto each cell, so reverse would
-       let every coloured run (tool rows, amber intervention headings, dim
-       chrome) become its own background and the band would fragment — which
-       is a different complaint than "too loud".
-
-       #4840 (owner ruling, 2026-08-16) retires the "ask the terminal for a
-       slot" premise in principle, but NOT here yet — mapping to Textual's own
-       ``$screen-selection-background`` would regress this fix under the
-       CURRENT default theme (``ansi-dark``'s own value for that token is the
-       loud ``ansi_bright_blue`` this comment describes moving away from,
-       measured). Sequenced after reyn's own default theme exists (#4840);
-       see ``@selection-bg@``'s own comment in ``palette.py``. */
+    /* #3542: the drag-selection band. Until #4840's owner ruling this asked
+       the terminal for one of its sixteen ANSI slots (`ansi_blue`, dropped
+       from Textual's louder default `ansi_bright_blue` because the operator
+       found that too loud against the conversation) — reyn was not
+       overriding the user's colours, it only picked which frame to request.
+       Now maps to `$screen-selection-background`/`$screen-selection-foreground`
+       — Textual's own tokens for exactly this role — so reyn's OWN default
+       theme (`REYN_THEME`, `.theme.py`) supplies the RGB via its own
+       `variables` override, chosen explicitly to read #3542 forward (a
+       muted, distinct hue — see `theme.py`'s own docstring). This landed
+       ONLY after reyn's own theme became the default (#4875): mapping to
+       the generic token any earlier, while `ansi-dark` was still default,
+       would have regressed this fix — `ansi-dark`'s own value for that
+       token is the loud `ansi_bright_blue` this comment describes moving
+       away from (measured). Declared as an explicit background/foreground
+       PAIR rather than `text-style: reverse`: Textual COMPOSES the
+       selection style onto each cell, so reverse would let every coloured
+       run (tool rows, amber intervention headings, dim chrome) become its
+       own background and the band would fragment — which is a different
+       complaint than "too loud". */
     Screen > .screen--selection {
         background: @selection-bg@;
         color: @selection-fg@;

--- a/src/reyn/interfaces/palette.py
+++ b/src/reyn/interfaces/palette.py
@@ -20,14 +20,18 @@ written outside it.
 sixteen slots rather than an RGB value — made sense only while reyn had no
 theme of its own to defer to instead: "端末の既定色に従う意味は、テーマを
 採用した時点で消えます" (owner, verbatim). ``@app-background@`` maps to
-Textual's own ``$background`` under this ruling — the active theme decides
-the RGB, not the terminal. ``@selection-bg@``/``@selection-fg@`` name the
-SAME retired premise but are NOT remapped yet — landing them ahead of reyn's
-own default theme would regress #3542 (measured: ``ansi-dark``'s own
-``$screen-selection-background`` is the loud ``ansi_bright_blue`` #3542
-moved away from), so lead-coder's ruling sequences them after that theme
-exists (see the tokens' own comments below). ``@rule@`` stays a literal hex
-for an unrelated reason (documented on the token itself): it must read as a
+Textual's own ``$background`` under this ruling (#4871), and
+``@selection-bg@``/``@selection-fg@`` map to ``$screen-selection-background``/
+``$screen-selection-foreground`` (#4875's own follow-up) — the active theme
+decides every one of these, not the terminal. The selection pair was
+sequenced AFTER reyn's own default theme existed (#4875), not landed
+alongside ``@app-background@``: mapping straight to Textual's generic
+token while ``ansi-dark`` was still the default would have regressed #3542
+(measured: ``ansi-dark``'s own ``$screen-selection-background`` is the loud
+``ansi_bright_blue`` #3542 moved away from) — reyn's own theme supplies a
+muted value instead (see the tokens' own comments below). ``@rule@`` stays
+a literal hex for an unrelated reason (documented on the token itself): it
+must read as a
 divider against both of the app's OWN light/dark grounds, which a theme
 variable would just vanish into on one of them — that is a THEME question,
 never a terminal one, and was never in this paragraph's scope.
@@ -128,30 +132,31 @@ TOKENS: "dict[str, str]" = {
     #: it. Pairing an attribute with SOMETHING in the text is the invariant —
     #: this token alone is not a selection mark.
     "@selected-style@": "bold",
-    #: The drag-selection band. ``ansi_blue`` rather than Textual's default
-    #: ``ansi_bright_blue``: the operator found the bright frame too loud
-    #: against the conversation (#3542). Both are ANSI FRAMES, not colours —
-    #: what blue looks like is the terminal theme's decision and stays that
-    #: way; this only chooses which of the sixteen slots to ask for.
-    #:
-    #: #4840 (owner ruling, 2026-08-16) retires this deferral in principle —
-    #: see ``@app-background@`` above, mapped already — but NOT here yet.
-    #: Mapping straight to Textual's own ``$screen-selection-background``
-    #: would regress #3542 under the CURRENT default theme: ``ansi-dark``'s
-    #: own value for that token is ``ansi_bright_blue`` (measured), the exact
-    #: loud one #3542 moved away from. lead-coder's ruling (#4840): land
-    #: ``@app-background@`` now (no such regression there — measured), build
-    #: reyn's own default theme next, and land this token + #3542's test
-    #: THEN — a theme `variables` shim on `ansi-dark` was explicitly rejected
-    #: ("1つのテーマの欠点を、全テーマに効く層で埋める" — the opposite of
-    #: mapping to theme meaning). Whether reyn's own theme preserves #3542's
-    #: quiet choice is undecided — read #3542 when that theme is designed.
-    "@selection-bg@": "ansi_blue",
-    #: The text inside that band. Unchanged from Textual's default, and named
-    #: here so the pair is legible in one place: a background chosen without
-    #: its foreground beside it is how contrast regressions happen. Same
-    #: #4840 deferral as ``@selection-bg@`` above — not mapped yet.
-    "@selection-fg@": "ansi_black",
+    #: The drag-selection band. Was ``ansi_blue`` (one of the terminal's
+    #: sixteen slots, chosen over Textual's louder default
+    #: ``ansi_bright_blue`` because the operator found that too loud against
+    #: the conversation — #3542) until #4840's owner ruling and its own
+    #: 3-step sequencing (① ``@app-background@`` -> ``$background``, #4871;
+    #: ② reyn's own default theme, #4875; ③ this token, here). Blocked on
+    #: ② specifically: mapping straight to Textual's own
+    #: ``$screen-selection-background`` under ``ansi-dark`` (the default
+    #: before ②) would have regressed #3542 — ``ansi-dark``'s own value for
+    #: that token is ``ansi_bright_blue``, the exact loud one #3542 moved
+    #: away from (measured). Now that "reyn" is the default (②), the same
+    #: mapping resolves through ``REYN_THEME``'s own
+    #: ``variables["screen-selection-background"]`` instead — a muted,
+    #: DISTINCT hue chosen explicitly to read #3542 forward (``theme.py``'s
+    #: own docstring has the full reasoning: NOT Textual's auto-derived
+    #: ``primary.with_alpha(0.5)`` either, which would be #3542's same
+    #: complaint with reyn's own accent hue in place of
+    #: ``ansi_bright_blue``).
+    "@selection-bg@": "$screen-selection-background",
+    #: The text inside that band. Was ``ansi_black``; now
+    #: ``$screen-selection-foreground``, the token this pairs with above —
+    #: kept adjacent here for the same reason as before: a background chosen
+    #: without its foreground beside it is how contrast regressions happen.
+    #: Same ② dependency as ``@selection-bg@`` above.
+    "@selection-fg@": "$screen-selection-foreground",
     #: #4787: the first 5 of ``interfaces/repl/renderer.py``'s 8 former
     #: ``_CC_*`` hex constants — the ones whose value #4787's own
     #: classification found reusable AS-IS (no new colour chosen; the

--- a/tests/interfaces/test_conversation_pane_boundary_3692.py
+++ b/tests/interfaces/test_conversation_pane_boundary_3692.py
@@ -122,15 +122,28 @@ async def test_ctrl_o_is_not_reyns_only_route_shift_tab_still_reaches_the_pane()
 
 
 def _cursor_col(flow: FlowView, row: int) -> "int | None":
-    """The column of flowview's own reverse-video text-cursor glyph on content
-    row ``row`` (``None`` if the cursor is not on this row) — read from
+    """The column of flowview's own text-cursor glyph on content row ``row``
+    (``None`` if the cursor is not on this row) — read from
     :meth:`FlowView.render_line`'s PUBLIC per-segment ``style``, not any
-    private cursor-position field. The cursor renders as a ``… on color(4)``
-    segment (measured against 0.13.1, re-verified against 0.14.0) regardless
-    of the surrounding theme."""
+    private cursor-position field.
+
+    Compares against the app's OWN LIVE ``screen--selection`` component
+    style, resolved dynamically, not a literal colour string. flowview's own
+    docstring (``_view.py``, ``COMPONENT_CLASSES``) states the cursor "defers
+    to Textual's ``screen--selection``" — that component's resolved
+    background is what the cursor glyph actually paints, and #4840's owner
+    ruling (mapping ``@selection-bg@`` to reyn's own theme, #4881) changed
+    that resolved value from an ANSI-numbered colour (which Rich's ``Style``
+    repr rendered as the literal substring ``"on color(4)"``, this helper's
+    PRIOR check) to a concrete truecolor hex. A hardcoded string match
+    encoded an incidental detail of ONE specific token value, not the actual
+    invariant (the cursor renders with `.screen--selection`'s own
+    background) — comparing against the live resolved style survives any
+    future value that component resolves to, ANSI-numbered or concrete."""
+    selection_bg = flow.screen.get_component_styles("screen--selection").background
     x = 0
     for seg in flow.render_line(row):
-        if "on color(4)" in str(seg.style):
+        if seg.style is not None and seg.style.bgcolor == selection_bg.rich_color:
             return x
         x += len(seg.text)
     return None

--- a/tests/interfaces/test_selection_not_bright_3542.py
+++ b/tests/interfaces/test_selection_not_bright_3542.py
@@ -1,91 +1,137 @@
-"""Tier 2: the drag-selection band asks for plain blue, not bright blue.
+"""Tier 2: the drag-selection band, as the live App resolves it, is muted —
+not the loud default.
 
 #3542, owner-adjudicated: the selection read as too loud against the
-conversation. Textual's `ansi-dark` defaults `screen-selection-background` to
-`ansi_bright_blue` (slot 12); reyn now asks for `ansi_blue` (slot 4).
+conversation. Originally fixed by asking the terminal for a quieter ANSI
+slot (`ansi_blue`, not Textual's default `ansi_bright_blue`) — #4840's owner
+ruling (2026-08-16) retired that mechanism (reyn no longer defers to the
+terminal for any colour it names), but not the INVARIANT: #3542's own
+complaint was loudness, and that is still real under reyn's own theme.
+Landed as ③ of #4840's own ①→②→③ sequence — only after reyn's own default
+theme (②, #4875) existed to supply a value, since mapping straight to
+Textual's generic `$screen-selection-background` any earlier (while
+`ansi-dark` was still default) would have regressed this fix: `ansi-dark`'s
+own value for that token is the loud `ansi_bright_blue` #3542 moved away
+from (measured, #4840's own comment thread).
 
-Both are ANSI FRAMES, not colours. What blue actually looks like is the
-terminal theme's decision, and it stays that way — reyn was never overriding
-the operator's palette here, it only chooses which of the sixteen slots to
-request. That distinction is what these tests pin: the assertions are on the
-`ansi` slot number, not on RGB, because an RGB assertion would pass while
-quietly meaning reyn had started dictating the colour.
+What "loud" means under a full-colour theme changed too. Textual's own
+auto-derived default for an unset `screen-selection-background` is
+`primary.with_alpha(0.5)` — reyn's own ACCENT at 50% alpha, which is
+`ansi_bright_blue`'s exact complaint with a different hue: full intensity,
+not muted. So these tests assert the LIVE, App-resolved selection colour is
+BOTH distinct from reyn's own `primary` (not the loud auto-derived default)
+and legible against its own paired foreground — the same two properties
+`ansi_blue`/`ansi_black` used to guarantee via a slot pick, now guaranteed
+by `REYN_THEME`'s own `variables` override (`theme.py`).
 
-`text-style: reverse` was considered and rejected. Textual COMPOSES the
-selection style onto each cell, so reverse would let every coloured run — tool
-rows, amber intervention headings, dim chrome — become its own background, and
-the band would fragment. That answers a complaint nobody made; the complaint
-was loudness, not uniformity.
+`text-style: reverse` was considered and rejected (unchanged from #3542's
+original reasoning). Textual COMPOSES the selection style onto each cell, so
+reverse would let every coloured run — tool rows, amber intervention
+headings, dim chrome — become its own background, and the band would
+fragment. That answers a complaint nobody made; the complaint was loudness,
+not uniformity.
 """
 from __future__ import annotations
 
+import asyncio
+from typing import AsyncIterator
+
 import pytest
-from textual.app import App, ComposeResult
-from textual.widgets import Static
 
-from reyn.interfaces import palette
-
-#: ANSI slot numbers, named so the assertions below read as intent rather than
-#: as magic numbers. 4 is blue; 12 is its bright counterpart.
-_ANSI_BLUE = 4
-_ANSI_BRIGHT_BLUE = 12
-_ANSI_BLACK = 0
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.theme import REYN_THEME
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
 
 
-class _Probe(App):
-    CSS = palette.css(
-        """
-Screen > .screen--selection {
-    background: @selection-bg@;
-    color: @selection-fg@;
-}
-"""
-    )
+class _Transport(ClientTransport):
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
 
-    def compose(self) -> ComposeResult:
-        yield Static("x")
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
 
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-def test_the_tokens_name_ansi_frames_not_colours() -> None:
-    """Tier 2: the palette asks for slots, so the terminal keeps deciding.
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
 
-    A hex value here would look equivalent and would take the choice away from
-    the operator's theme — the thing this change is careful NOT to do.
-    """
-    assert palette.TOKENS["@selection-bg@"] == "ansi_blue"
-    assert palette.TOKENS["@selection-fg@"] == "ansi_black"
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
 
 
 @pytest.mark.asyncio
-async def test_the_selection_resolves_to_plain_blue_under_ansi_dark() -> None:
-    """Tier 2: the band lands on slot 4, not Textual's default slot 12.
+async def test_the_running_app_uses_reyns_own_theme() -> None:
+    """Tier 2: non-vacuity — the two tests below only mean something if the
+    App actually resolves the selection style through `REYN_THEME`'s own
+    override, not Textual's built-in default for an unset token."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(40, 10)) as pilot:
+        await pilot.pause()
+        assert app.theme == "reyn"
+
+
+@pytest.mark.asyncio
+async def test_the_selection_is_not_the_loud_auto_derived_default() -> None:
+    """Tier 2: the band lands on reyn's own muted `variables` override, not
+    Textual's auto-derived `primary.with_alpha(0.5)` — which would be
+    #3542's exact complaint (full accent intensity) with a different hue.
 
     Asserted on the resolved component style rather than on the stylesheet
     text: a rule can be present and lose to something later in the cascade,
     which is the failure mode this repo keeps finding.
     """
-    app = _Probe()
+    app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(40, 10)) as pilot:
-        app.theme = "ansi-dark"
         await pilot.pause()
 
         styles = app.screen.get_component_styles("screen--selection")
+        resolved_bg = styles.background
 
-        assert styles.background.ansi == _ANSI_BLUE
-        assert styles.background.ansi != _ANSI_BRIGHT_BLUE
+        primary = app.get_css_variables()["primary"]
+        assert resolved_bg.hex.lower() != primary.lower(), (
+            "the selection band resolved to reyn's own primary — the "
+            "auto-derived Textual default (primary at 50% alpha) leaking "
+            "through, which is #3542's original complaint with a new hue"
+        )
+        assert resolved_bg.a == 1.0, (
+            "the selection band is alpha-blended rather than a fully opaque "
+            "override — REYN_THEME.variables['screen-selection-background'] "
+            "is meant to replace Textual's own alpha-derived default"
+        )
 
 
 @pytest.mark.asyncio
-async def test_the_text_inside_the_band_is_unchanged() -> None:
-    """Tier 2: only the background moved.
-
-    Pinned because changing a background without its foreground is how a
-    readable pair turns into an unreadable one — and the fix for "too loud"
-    must not become "now I cannot read it".
-    """
-    app = _Probe()
+async def test_the_text_inside_the_band_stays_legible() -> None:
+    """Tier 2: only the background changed intent; the pairing invariant
+    from #3542 stays — a background chosen without its foreground beside it
+    is how a readable pair turns into an unreadable one, and the fix for
+    "too loud" must not become "now I cannot read it"."""
+    app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(40, 10)) as pilot:
-        app.theme = "ansi-dark"
         await pilot.pause()
 
-        assert app.screen.get_component_styles("screen--selection").color.ansi == _ANSI_BLACK
+        styles = app.screen.get_component_styles("screen--selection")
+        expected_fg = REYN_THEME.variables["screen-selection-foreground"]
+        assert styles.color.hex.lower() == expected_fg.lower()


### PR DESCRIPTION
**[tui-coder]** — part of #4840, ③ (final step) of the ①→②→③ sequence

## What changed

`@selection-bg@`/`@selection-fg@` (`palette.py`) map from `ansi_blue`/
`ansi_black` to Textual's own `$screen-selection-background`/
`$screen-selection-foreground`. ① (#4871) and ② (#4875) both merged; this
is what they unblocked — safe now because reyn's own theme (not
`ansi-dark`) is the App's default, so the mapping no longer regresses
owner-adjudicated #3542 (measured: `ansi-dark`'s own value for that token
is the loud `ansi_bright_blue` #3542 moved away from).

`REYN_THEME.variables["screen-selection-background"]` (landed in ②,
`theme.py`) was chosen explicitly to read #3542 forward — not Textual's
auto-derived default (`primary.with_alpha(0.5)`, which would be #3542's
same complaint with reyn's own accent hue instead of `ansi_bright_blue`),
but a muted, distinct value.

## Tests

`test_selection_not_bright_3542.py` rewritten — its whole premise
(asserting an ANSI slot NUMBER, "the terminal decides") is exactly what
#4840's ruling retires. Asserts the LIVE App resolves the selection band
through reyn's own theme (non-vacuity: `app.theme == "reyn"`), that the
resolved colour is NOT the loud auto-derived default (distinct from
`primary`, fully opaque), and that the foreground pairing stays legible
(matches `REYN_THEME`'s own value) — the same 2 properties the old
ANSI-slot assertions guaranteed, re-expressed against what's actually true
now.

## Falsification

`git stash` of the 3 changed files reproduced the pre-③ literal
(`@selection-bg@ == "ansi_blue"`); `stash pop` restored
`== "$screen-selection-background"`.

## Time-dependency check

0 instances.

## Test plan

- [x] `pytest tests/interfaces/test_tui_colour_tokens.py tests/interfaces/test_selection_not_bright_3542.py tests/interfaces/test_chrome_uses_the_terminal_background_3503.py tests/interfaces/test_reyn_theme_4840.py tests/interfaces/test_placeholder_dim_3522.py tests/interfaces/test_focus_visible_3528.py -q` — 25 passed
- [x] `ruff check .` — all checks passed
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/verify_module_docstrings.py` (3 changed files) — OK
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_selection_not_bright_3542.py` — 0 errors, 0 warnings
- [x] Falsification via `git stash`/`git stash pop`
- [ ] Visual — n/a (standing waiver; operator review on real hardware pending)

Depends on #4875 (② — merge that first; this branch is based on it).
