### PR TITLE
fix(#4884): _ErrorWatchingTransport was silently missing 4 delegations

### DIFF
--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -180,6 +180,9 @@ class _ErrorWatchingTransport(ClientTransport):
     def has_session(self) -> bool:
         return self._inner.has_session()
 
+    def attach_failed(self) -> bool:
+        return self._inner.attach_failed()
+
     def pending_intervention_head(self) -> "object | None":
         return self._inner.pending_intervention_head()
 
@@ -208,6 +211,17 @@ class _ErrorWatchingTransport(ClientTransport):
 
     async def cancel_queued(self, msg_id: str) -> bool:
         return await self._inner.cancel_queued(msg_id)
+
+    async def request_attach(self, agent_name: str) -> bool:
+        return await self._inner.request_attach(agent_name)
+
+    async def request_session_switch(self, session_id: str) -> bool:
+        return await self._inner.request_session_switch(session_id)
+
+    async def request_artifact_list(
+        self, *, agent: str
+    ) -> "tuple[list[dict], int]":
+        return await self._inner.request_artifact_list(agent=agent)
 
     async def run_slash_command(self, name: str, args: str) -> bool:
         return await self._inner.run_slash_command(name, args)

--- a/tests/interfaces/test_error_watching_transport_total_delegation_4884.py
+++ b/tests/interfaces/test_error_watching_transport_total_delegation_4884.py
@@ -1,0 +1,69 @@
+"""Tier 2: #4884 — _ErrorWatchingTransport's own class docstring claims total,
+explicit delegation ("Delegation is total and explicit: every method
+forwards, so a handler that reaches for any other part of the seam reaches
+the real one") — this test is what makes that claim true rather than
+aspirational.
+
+#4884: 4 ClientTransport methods (attach_failed / request_attach /
+request_session_switch / request_artifact_list) were silently missing from
+_ErrorWatchingTransport's own class body. A caller going through the
+wrapper (every slash handler does, via execute_slash_command) fell through
+to ClientTransport's own base-class default instead of the wrapped
+transport's real value — not a crash, a silently WRONG answer. `/agent
+new`'s `request_attach` always read False through this wrapper, even when
+the real attach genuinely succeeded (reproduced directly against a fake
+inner transport whose real request_attach returns True).
+
+Reyn-reviewer + lead-coder's initial pass named 2 of the 4 (grep-checking
+only the names already handed to them, #4880/§24's own "independent
+measurement is not independence when the question was handed to you") — a
+full AST/reflection diff against every ClientTransport member found the
+other 2. This test is that diff, kept live so a future method added to
+ClientTransport that this wrapper forgets to delegate is caught
+immediately, not discovered by a silent-failure bug report.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.slash.dispatch import _ErrorWatchingTransport
+from reyn.interfaces.transport.client_transport import ClientTransport
+
+
+def _own_public_methods(cls: type) -> "set[str]":
+    """Names of public callables defined directly on ``cls``'s own class
+    body (``vars(cls)``, NOT ``dir(cls)`` — the latter includes inherited
+    members, which is exactly the silent-fallback shape under test)."""
+    return {
+        name for name, member in vars(cls).items()
+        if not name.startswith("_") and callable(member)
+    }
+
+
+def test_error_watching_transport_overrides_every_client_transport_method() -> None:
+    """Tier 2: every PUBLIC ClientTransport method must be defined directly
+    on _ErrorWatchingTransport's own class body, not silently inherited
+    from ClientTransport's own (deliberate, for OTHER narrow-purpose test
+    stubs — see request_attach's own docstring) default. A member missing
+    here means a caller reaching through this specific wrapper gets
+    ClientTransport's fallback value instead of the wrapped transport's
+    real one."""
+    base_public = _own_public_methods(ClientTransport)
+    own_public = _own_public_methods(_ErrorWatchingTransport)
+    missing = base_public - own_public
+    assert not missing, (
+        f"_ErrorWatchingTransport's own class body does not define "
+        f"{sorted(missing)} — it silently falls through to "
+        f"ClientTransport's own base default for these, contradicting "
+        f"its own docstring's total-delegation claim."
+    )
+
+
+def test_positive_control_the_walk_actually_sees_client_transport_methods() -> None:
+    """Tier 2: positive control (per this repo's own testing policy —
+    a broken enumeration passes the ceiling above trivially) — confirms
+    ``_own_public_methods`` genuinely finds real members, not an empty
+    set that would make the assertion above vacuous."""
+    base_public = _own_public_methods(ClientTransport)
+    assert {"request_attach", "request_session_switch", "shutdown"} <= base_public, (
+        f"the member-enumeration is broken — it produced {base_public!r}, "
+        "which does not contain methods ClientTransport certainly has."
+    )

--- a/tests/interfaces/test_slash_agent.py
+++ b/tests/interfaces/test_slash_agent.py
@@ -112,6 +112,44 @@ async def test_agent_new_creates_and_requests_attach(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_agent_new_through_execute_slash_command_confirms_the_attach(tmp_path):
+    """Tier 2: #4884 — driven through the REAL public entrypoint
+    (``execute_slash_command``, what every client actually calls), not
+    ``_create_agent`` directly. Production wraps ``ctx.transport`` in
+    ``_ErrorWatchingTransport`` for the duration of the handler
+    (``dispatch.py``'s ``execute_slash_command``); the test above never
+    goes through that wrapper, which is exactly why 4 missing
+    delegations (including ``request_attach``) went undetected — a
+    genuinely successful attach still read back ``False`` through the
+    wrapper, and ``/agent new`` always replied "could not confirm the
+    attach" even though it happened."""
+    from reyn.interfaces.slash.dispatch import execute_slash_command
+
+    registry = _build_real_registry(tmp_path)
+    session = _FakeSession(registry)
+    ctx = _ctx(session)
+
+    ran = await execute_slash_command(ctx, "agent", "new gamma")
+
+    assert ran is True
+    assert registry.exists("gamma"), "agent profile must persist on disk"
+    assert ctx.transport.attach_requests == ["gamma"], (
+        "the handler must still ask the (wrapped) transport to attach"
+    )
+    texts = [m.text for m in ctx.transport.displayed]
+    assert any("attaching…" in t for t in texts), (
+        f"a genuinely successful attach (RecordingTransport.request_attach "
+        f"always returns True) must produce the confirming reply, not "
+        f"'could not confirm the attach' — the silent-failure shape #4884 "
+        f"exists to close: {texts!r}"
+    )
+    assert not any("could not confirm" in t for t in texts), (
+        f"attach was NOT actually unconfirmed here, so this wording must "
+        f"not appear: {texts!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_agent_new_rejects_duplicate(tmp_path):
     """Tier 2: creating an existing agent surfaces a recoverable error,
     NOT a Python stack trace."""


### PR DESCRIPTION
**[e2e-coder]** — Fixes #4884 (roi:high) — `/agent new`'s attach silently fails.

## What

`_ErrorWatchingTransport` (the pass-through wrapper `execute_slash_command` puts around `ctx.transport` for the duration of every slash handler) was silently missing 4 of `ClientTransport`'s public methods, falling through to the base class's own defaults instead of delegating to the wrapped real transport. Its own class docstring claims "Delegation is total and explicit: every method forwards" — false.

- `request_attach` — `/agent new`'s actual bug: `_create_agent` calls `ctx.transport.request_attach(name)`; through the wrapper this always read `False`, even when the real attach genuinely succeeded, so `/agent new` always replied "could not confirm the attach — try /attach <name>" instead of confirming.
- `request_session_switch` — same shape, `/session switch`'s seam.
- `attach_failed` / `request_artifact_list` — found via a full AST/reflection diff against every `ClientTransport` member (the initial pass named only the first 2, grep-checked against names already handed to it — a full diff was needed to find the other 2).

## Fix (2 parts, as prescribed)

1. Added the 4 missing delegations directly to `_ErrorWatchingTransport`.
2. Added `test_error_watching_transport_overrides_every_client_transport_method` — reflects on `ClientTransport` vs `_ErrorWatchingTransport` and fails if ANY future method added to the base isn't defined on this subclass's own class body, so the next omission is caught immediately rather than discovered as a bug report.

Also added a behavioral regression test driven through the REAL public entrypoint (`execute_slash_command`, not `_create_agent` directly) — the existing `/agent new` test bypassed the exact wrapper that had the bug, which is why it went undetected in the first place.

## Test plan

- [x] Reproduced directly before fixing: a fake inner transport whose real `request_attach` returns `True` still read `False` through the unfixed wrapper.
- [x] `pytest tests/interfaces/test_slash_agent.py tests/interfaces/test_error_watching_transport_total_delegation_4884.py -q` — 13/13 passed
- [x] Strip-falsified both new tests by hand: reverted the production fix, confirmed both go RED for the right reason (`attach_requests == []` — proves the real transport was never even reached), restored, confirmed green again.
- [x] `ruff check` / `python scripts/test_tier_audit.py --strict <files>` / `python scripts/mypy_ratchet.py` / `verify_module_docstrings.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all clean

Full context: #4884.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
