### PR TITLE
docs(#4787/#4840): cross-file same-value notes + stale ansi-dark comments

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -945,14 +945,28 @@ class TextualChatApp(App):
         background: transparent;
     }
     /* The placeholder must read as an invitation, not as typed text. Textual's
-       own rule is ``color: $text 40%``, which under ``ansi-dark`` resolves
-       ``$text`` to the ansi_default MARKER — and alpha compositing DROPS the
-       marker, so the 40% never applies and it painted at the terminal's full
-       default foreground (measured: ``Color('default')``, no dim). ``dim``
-       is used instead of a muted colour because it leaves the HUE to the
-       terminal, which is what a themed default is for; ``$text-muted`` hits
-       the identical trap, and a concrete grey would pin a colour the user's
-       theme is entitled to choose. */
+       own rule is ``color: $text 40%``, which under ``ansi-dark`` (reyn's
+       DEFAULT until #4875) resolved ``$text`` to the ansi_default MARKER —
+       alpha compositing DROPS that marker, so the 40% never applied and it
+       painted at the terminal's full default foreground (measured:
+       ``Color('default')``, no dim). ``dim`` was picked over a muted colour
+       for that reason: it leaves the HUE to the terminal, which is what a
+       themed default is for; ``$text-muted`` hit the identical trap under
+       ``ansi-dark``, and a concrete grey would pin a colour the user's
+       theme is entitled to choose.
+       #4840 (owner ruling): ``ansi-dark`` is no longer reyn's default —
+       under ``REYN_THEME`` (#4875), ``$text``/``$text-muted`` resolve to
+       Textual's own contrast-derived ``auto 87%``/``auto 60%`` (measured),
+       concrete values with no marker to drop, so the alpha-compositing
+       trap this comment describes no longer applies to reyn's shipped
+       default. ``dim`` is NOT re-justified by that trap here anymore —
+       it stays for OTHER reasons (an SGR attribute needs no palette
+       entry, and survives any ``ansi-*`` theme a user selects later, #3522
+       being about the CUI's own choice, not merely a workaround for one
+       theme's marker behaviour) — but whether ``$text-muted`` alone would
+       now serve just as well under reyn's own theme is a design question
+       this comment does not settle; not changed here without a fuller
+       repaint review (reported to lead-coder, #4840's own follow-up). */
     Composer > .text-area--placeholder {
         text-style: dim;
     }
@@ -1008,14 +1022,27 @@ class TextualChatApp(App):
         height: auto;
         /* #3528: ``text-style``, not ``color``. The pair this replaces was
            ``color: $text-muted`` here and ``color: $text`` on
-           ``:focus-within`` — a brightness step that has been INERT since
-           #3505 adopted ``ansi-dark``, where both variables resolve to the
-           same ``ansi_default`` marker. Measured: moving focus from the
-           composer into the menu changed exactly ONE cell on the whole
-           screen, and it was the composer's own text cursor vanishing — a
-           cue you only notice by its absence. ``dim`` survives that theme
-           (it is an SGR attribute, not a colour) and is the mechanism the
-           tabs' own active/inactive distinction already relies on. */
+           ``:focus-within`` — a brightness step that WAS INERT under
+           ``ansi-dark`` (reyn's default until #4875), where both variables
+           resolved to the same ``ansi_default`` marker. Measured at the
+           time: moving focus from the composer into the menu changed
+           exactly ONE cell on the whole screen, and it was the composer's
+           own text cursor vanishing — a cue you only notice by its
+           absence. ``dim`` survived that theme (it is an SGR attribute,
+           not a colour) and is the mechanism the tabs' own active/inactive
+           distinction already relies on.
+           #4840 (owner ruling): under ``REYN_THEME`` (#4875, reyn's
+           default since), ``$text``/``$text-muted`` resolve to Textual's
+           own ``auto 87%``/``auto 60%`` (measured) — concrete, DISTINCT
+           values, not the same marker — so a ``color:`` brightness step
+           here would no longer be inert. That does not retroactively make
+           ``dim`` the wrong choice (#3528's own reasoning — a single
+           reusable SGR mechanism the tabs' active/inactive split already
+           depends on — stands independent of the ansi_default trap), but
+           this comment's OWN cited justification for picking it (the
+           trap) no longer describes reyn's shipped default; whether a
+           colour-based step now serves as well is a design question left
+           open here (reported to lead-coder, #4840's own follow-up). */
         text-style: dim;
         padding: 0 1;
     }

--- a/src/reyn/interfaces/palette.py
+++ b/src/reyn/interfaces/palette.py
@@ -247,6 +247,13 @@ TOKENS: "dict[str, str]" = {
     #: to agree on the same dark blue-gray value. Whether ``_CC_USER_BG``
     #: itself later migrates to THIS token, or its own, is #4787's call, not
     #: decided here.
+    #:
+    #: **This value carries NO WCAG contrast obligation of its own** —
+    #: ``_CC_USER_BG``'s own comment (``renderer.py``) documents a
+    #: measured 3.30 contrast ratio against ``palette.TOKENS["@dim@"]``
+    #: (#3371), but that pairing is with ``_CC_USER_BG``, not this token.
+    #: Changing ``@theme-surface@`` alone does not break that measurement;
+    #: consolidating the two constants into one WOULD need it re-verified.
     "@theme-surface@": "#1e222a",
     #: Explicit, not ``boost``-derived — see ``theme.py``'s own docstring
     #: for the rejected alternative (auto-deriving ``panel`` from

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -420,6 +420,16 @@ _CC_COOL = palette.TOKENS["@secondary@"]  # cool blue — a secondary accent (st
 # changing @dim@ there breaks this 3.30 measurement here, and re-measuring
 # only one side leaves the pairing's real number unknown. Re-measure BOTH
 # _CC_USER_BG and palette.TOKENS["@dim@"] together if either changes.
+#
+# #4840/#4787 (lead-coder, post-arc note): interfaces/palette.py's
+# TOKENS["@theme-surface@"] (REYN_THEME's `surface` role, #4875) is the
+# SAME hex, "#1e222a", but a DIFFERENT token for a DIFFERENT role — this
+# constant is the plain REPL's row-tint background, @theme-surface@ is the
+# Textual theme's generic raised-surface colour. Same value, unrelated
+# migration tracks; changing @theme-surface@ does NOT touch the 3.30
+# measurement above (that pairing is with palette.TOKENS["@dim@"] only) —
+# but if the two are ever consolidated into one token, the 3.30 measurement
+# needs re-verifying against whatever value survives.
 _CC_USER_BG = "#1e222a"
 # Failure block-tint behind a failed tool call / error row. A desaturated dark
 # coral: it reads unmistakably as "the red row" edge to edge (CC's block-tint of


### PR DESCRIPTION
**[tui-coder]** — part of #4787/#4840, follow-up requested after ①②③ landed

## What changed

**Cross-file "same value, different token" notes** (#4787): `_CC_USER_BG`
(renderer.py) and `@theme-surface@` (palette.py) share the hex `#1e222a`
but are independent migration tracks. Added the reciprocal note (matching
the existing `_CC_DIM`/`@dim@` precedent): changing `@theme-surface@`
alone does not touch `_CC_USER_BG`'s own measured 3.30 WCAG pairing
against `@dim@` (#3371) — but consolidating the two would need that
re-verified.

**2 stale ansi-dark-as-default comments** (#4840): app.py's placeholder
and MenuBar comments both stated in the present tense that `ansi-dark`
is reyn's default and that `$text`/`$text-muted` resolve to the shared
`ansi_default` marker — both true when written, false since #4875.

Rendered and measured before touching either, per lead-coder's request:
under `REYN_THEME`, `$text`/`$text-muted` resolve to `auto 87%`/`auto 60%`
(Textual's own contrast-derived tokens) — concrete, distinct values, not
a shared marker. This means the alpha-compositing trap that originally
justified picking `dim` over a colour-based step no longer applies to
reyn's shipped default. Both comments now speak of `ansi-dark` in the
past tense, cite the actual current resolution, and explicitly flag that
whether `dim` should be replaced by a colour step now is an OPEN design
question — **not decided in this PR**, since that's a design call beyond
what was asked (comment accuracy, not a behaviour change).

## Verified, not changed

The 2 `background: transparent;` sites (`app.py:844`/`:945`) lead-coder
flagged as "intent or oversight, unclear." Verified: both intentional —
"transparent" now shows reyn's own theme background through, exactly
what #4840 intends. No code change.

## Deferred

11 `ansi_` mentions in `palette.py`'s own comments — lead-coder's own
triage: history, not necessarily false. Lower priority, not touched here.

## Time-dependency check

0 instances — comment-only.

## Test plan

- [x] `pytest tests/interfaces/test_placeholder_dim_3522.py tests/interfaces/test_focus_visible_3528.py tests/interfaces/test_tui_colour_tokens.py -q` — 15 passed
- [x] `ruff check .` — all checks passed
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/verify_module_docstrings.py` (3 changed files) — OK
- [ ] Visual — n/a (comment-only change, no rendering behaviour touched)
