### PR TITLE
docs: ADR-0043 (Proposed) + proposal 0068 — generic SecretProvider seam

### DIFF
--- a/docs/deep-dives/decisions/0043-generic-secret-provider-seam.md
+++ b/docs/deep-dives/decisions/0043-generic-secret-provider-seam.md
@@ -1,0 +1,72 @@
+# ADR-0043: A generic `SecretProvider` seam — new consumers only, and the capability gate that already exists gets wired
+
+**Status**: Proposed (2026-08-19) — owner interest relayed via `reyn-reviewer`; **not** confirmed by the owner directly to the author of this ADR. Do not read `Proposed` as `Accepted`.
+**Track**: Architecture — credential lookup, extending ADR-0030 (universal secret handling) and FP-0016 (OAuth lifecycle + scoped store).
+**Supersedes**: nothing. See §5.
+
+---
+
+## 1. Context
+
+Reyn can read credentials from the shell environment and from `~/.reyn/secrets.env`. It cannot read a credential a developer has already stored in the host's native store (macOS Keychain, Linux Secret Service, Windows Credential Manager), so a workstation login that other tools reuse is invisible to Reyn.
+
+A design document (`SECRET_PROVIDER_PROPOSAL.md`, authored outside version control in the `reyn-self` workspace) proposed a generic `SecretProvider` abstraction to close that gap. This ADR records the decisions taken after reviewing it against what is actually in the tree (review: #4890).
+
+Three measurements shaped these decisions; each is stated with its own limit.
+
+**M1 — the current model is eager, not lazy.** `src/reyn/security/secrets/loader.py`'s own docstring: *"Called once at Reyn process startup (from `config.load_config()`) so that all components can read secrets via `os.environ.get()` without any knowledge of the dotenv file."* Secrets are pushed into `os.environ` at startup; components read the process environment, not a lookup API.
+
+**M2 — the scale of converting that model.** `os.environ` is read at **133 lines across 60 files** under `src/reyn/`. *Limit: none of the 133 were opened; the figure includes non-secret configuration flags (e.g. `REYN_PROF_DUMP`), so it is an upper bound on the conversion surface, not a count of credential reads.*
+
+**M3 — the capability gate exists as code and is not connected.** `ScopedSecretStore` (`src/reyn/security/secrets/store.py:115`) implements `allowed_keys`, `is_unrestricted`, a `_check` that raises `CredentialScopeError`, and `list_visible_keys`. It is constructed **0 times** under `src/reyn/` and 8 times inside `tests/core/test_fp0016_d_e2e_confused_deputy.py`. `OpContext.secret_store` (`src/reyn/core/op_runtime/context.py:273`) is the single occurrence of the name in `src/`: a type declaration with no assignment and no reader. *Limit: why it was never wired is not established — a deliberate staging or a dropped remainder are both consistent with what was measured.*
+
+## 2. Decision
+
+1. **Introduce a `SecretProvider` / `SecretReference` / `SecretResolver` seam** as the single lookup boundary for credentials obtained by *new* consumers.
+
+2. **Do not migrate the existing `os.environ` reads.** The seam is a branch, not a replacement: existing components keep reading the process environment exactly as ADR-0030 specified. M2 is why — a "wrap the current paths as providers" phase that actually re-routes call sites is a 133-site change and cannot also be the "no behaviour change" phase it is usually described as. A façade nobody calls and a migration of every caller are different projects; this ADR chooses neither by conflation and picks the branch explicitly.
+
+3. **Wire `ScopedSecretStore` at the resolver, rather than designing a second capability gate.** Per M3 the class is dormant, so this is *connecting an existing dormant gate*, not *reusing a working one*. Any text that says the capability layer "already exists" is false in the sense that matters: nothing in production can be denied by it today.
+
+4. **OAuth stays in its own lifecycle.** `src/reyn/security/secrets/oauth.py` records the reason: *"`secrets.env` is a flat dotenv text file used for static keys … OAuth tokens have multiple fields plus a refresh lifecycle, which fits a structured [store]."* That is a decision already taken under FP-0016 Component B, not an open question. Re-unifying the backends would require a superseding ADR and a migration story for expiry semantics; neither is proposed here.
+
+5. **Native backends are demand-gated.** Ship the seam, the reference type, and a value-free readiness probe first. Add a native backend when a named consumer needs it — not as a completeness exercise across three platforms.
+
+6. **No Git- or GitHub-specific code in Reyn core.** Git credential-helper compatibility is a validation target: either a generic reference satisfies a standard credential request or it does not. Either answer is information; neither justifies a Git subsystem.
+
+7. **Reports distinguish five states, and "unknown" is one of them**: `declared` (a reference exists in configuration), `resolved` (a provider returned a usable handle internally), `injected` (a consumer accepted it at its transport seam), `used` (the consumer completed an authenticated operation), `unknown` (that step was not measured). A provider declaration, a name in documentation, and a peer's summary are none of the first four.
+
+## 3. Consequences
+
+**Desirable.** New consumers get one lookup boundary instead of each inventing its own environment read. The readiness probe becomes possible before any credential is injected anywhere, which is the cheapest half of the value. Wiring `ScopedSecretStore` turns a tested-but-inert deny path into a live one — the confused-deputy scenario its tests already describe becomes something production can actually refuse.
+
+**Undesirable, and accepted.** Two lookup paths coexist indefinitely: the ADR-0030 environment path and the provider seam. That is a real cost — a reader must ask which path a given credential took, and the answer will not be uniform. The alternative (converting 133 sites) buys uniformity at a price this ADR judges higher than the confusion it prevents. If a later measurement shows the split causing incidents rather than merely inelegance, that is grounds for a superseding ADR, and this paragraph is the record that the split was chosen rather than overlooked.
+
+**Also accepted.** Environment-variable injection is not a secrecy boundary — child inheritance, debuggers, and process inspection all remain. The seam must document that where it offers env injection, rather than implying that routing through a provider makes the value safe.
+
+## 4. Alternatives considered
+
+- **Convert every `os.environ` read to the provider (M2's 133 sites).** Rejected for this ADR: it is a large behaviour-affecting change to a path ADR-0030 accepted, and it delivers nothing a new-consumer branch does not, until a second backend actually exists.
+- **Design a fresh capability gate alongside `ScopedSecretStore`.** Rejected: two gates over one resource is the failure this repo keeps re-encountering, and the dormant one already carries the semantics (`allowed_keys`, `CredentialScopeError`) plus tests describing the attack it prevents.
+- **Extract the provider as a standalone OSS project.** Rejected for now: the parts worth reusing (binding, permission, audit, injection) are the parts entangled with Reyn's runtime, and platform access is already covered by existing libraries.
+- **Ship all three native backends up front.** Rejected: each adds optional dependencies, packaging matrix, and CI surface, and none has a named consumer yet.
+
+## 5. Relationship to existing records
+
+- **ADR-0030** (universal secret handling — `${VAR}`, `~/.reyn/secrets.env`, `reyn secret set/list/clear/rotate`) is **extended, not superseded**. Every string it names keeps its meaning: `${VAR}` interpolation is untouched, `secrets.env` remains the portable file path, and `reyn secret` remains the value-entry surface. A credential-reference syntax, if one is ever added, takes a separate namespace (e.g. `${credential:…}`) so that no sentence in ADR-0030 becomes false.
+- **FP-0016** (OAuth lifecycle, Component B; scoped store, Component D) is **extended, not superseded**. Decision 4 preserves Component B's separation; decision 3 finally connects Component D's class.
+- `reyn credential add` is proposed as an **additional** command, not a rename of `reyn secret set`. Renaming a string an accepted ADR names would itself require a superseding ADR (`docs/deep-dives/decisions/README.md`).
+
+## 6. Open questions this ADR does not decide
+
+- Deterministic precedence for `provider: auto`, and the behaviour when two providers can both satisfy a reference.
+- Whether resolved values are returned as opaque handles only, and what the trusted injection seams are.
+- Whether native backends ship as optional extras or as plugins.
+- How operator approval for a binding is persisted, and which operations may reference credentials at all.
+- Why `ScopedSecretStore` was never wired (M3's limit) — worth establishing before assuming the wiring is simply missing rather than blocked.
+
+## 7. References
+
+- Review and measurements: #4890.
+- Source design document: `SECRET_PROVIDER_PROPOSAL.md` (reyn-self workspace; **not under version control** — its contents are summarised here rather than linked).
+- Implementation plan: `docs/deep-dives/proposals/0068-secret-provider-seam.md`.

--- a/docs/deep-dives/proposals/0068-secret-provider-seam.md
+++ b/docs/deep-dives/proposals/0068-secret-provider-seam.md
@@ -1,0 +1,71 @@
+# 0068 — `SecretProvider` seam: implementation plan
+
+**Status**: proposal (2026-08-19). Decisions it implements: [ADR-0043](../decisions/0043-generic-secret-provider-seam.md) (**Proposed**, not accepted — this plan is contingent on that ADR being ratified).
+**Review it came from**: #4890.
+
+**One line:** add a credential lookup boundary that only *new* consumers use, wire the dormant `ScopedSecretStore` to it, and ship a value-free readiness probe before any native backend exists.
+
+## 0. What this is not
+
+It is not a migration. `os.environ` is read at 133 lines across 60 files under `src/reyn/` (upper bound — includes non-secret flags like `REYN_PROF_DUMP`; none were opened). ADR-0043 §2.2 decides those stay as they are. A reviewer who sees "provider" and expects existing call sites to change is reading the wrong plan.
+
+It is also not an OAuth change. FP-0016 Component B's separation stands (ADR-0043 §2.4).
+
+## 1. Phases
+
+Each phase names what would make it *not* done, because "the class exists" has already proven insufficient once here — see Phase 2's own subject.
+
+### Phase 1 — the seam, reachable by nobody yet
+
+- `SecretReference` — a value type: `provider` (`env` | `file` | `os` | `auto`), `service`, `account | None`.
+- `SecretProvider` — a `Protocol` with a single lookup returning a handle or metadata, never a bare value into caller scope.
+- `EnvSecretProvider`, `FileSecretProvider` — adapters over the two sources that exist today. They read the same places `loader.py` already reads; they do not change what `loader.py` does at startup.
+- `SecretResolver` — picks a provider for a reference; `auto` order is explicit and refuses ambiguity rather than guessing.
+
+**Not done if**: the resolver can return a value that a tool result or audit payload could serialise; `auto` silently picks when two providers both match; any existing component's behaviour changed.
+
+### Phase 2 — wire the dormant capability gate
+
+`ScopedSecretStore` is constructed 0 times under `src/reyn/` today and 8 times in `tests/core/test_fp0016_d_e2e_confused_deputy.py`; `OpContext.secret_store` (`context.py:273`) is a declaration with no assignment and no reader. Phase 2 connects it at the resolver so a reference outside `allowed_keys` raises `CredentialScopeError` on a real path.
+
+**Not done if**: production still constructs it zero times; or the deny path is only reachable from tests. The falsification is direct — remove the wiring and a production-shaped denial must stop happening.
+
+**Before writing code**: establish *why* it was never wired (ADR-0043 §6). A dropped remainder and a deliberate block look identical from the call-site count alone, and only one of them is safe to simply finish.
+
+### Phase 3 — readiness, without values
+
+`reyn doctor` reports, per declared reference: which provider would serve it, whether the store is reachable, whether the reference resolves. It prints no secret value and no evidence of one.
+
+Reports use ADR-0043 §2.7's five states — `declared` / `resolved` / `injected` / `used` / `unknown` — and `unknown` is printed as `unknown`, not omitted and not rendered as a failure.
+
+**Not done if**: a probe's output lets a reader distinguish two different secret values; or an unmeasured step renders as anything other than `unknown`.
+
+### Phase 4 — one native backend, when a consumer names it
+
+`keyring` is the candidate (it fronts macOS Keychain, Linux backends, and the Windows store). Do not add all three platforms; add the one a named consumer needs, behind an optional dependency.
+
+**Not done if**: it ships without a named consumer; or an unlocked-store assumption is made from a successful import (importability is not availability, and the probe must distinguish them).
+
+### Phase 5 — bindings and scoped injection (separate security review)
+
+Operator-authored binding of a reference to a consumer, with narrowly scoped injection. This phase, not Phase 1, is where agent exposure is decided. It should not begin while Phase 2's question (why the gate was dormant) is unanswered.
+
+## 2. Surfaces
+
+`reyn credential add <name> --provider … --service … --account …` stores reference metadata only, never a value. `reyn credential verify <name>` resolves without printing. `reyn secret set` is unchanged and remains the value-entry surface for the file provider (ADR-0030's string, untouched — see ADR-0043 §5).
+
+## 3. Risks this plan carries deliberately
+
+- **Two lookup paths coexist.** Accepted in ADR-0043 §3, recorded here so the plan does not read as if uniformity were coming later by default.
+- **Env injection is not a boundary.** Where the seam offers env injection it must say so at the point of offering, not in a distant document.
+- **`auto` is the sharp edge.** Ambiguity handling is unspecified in ADR-0043 §6 and must be settled before `auto` ships, not after.
+
+## 4. Open — carried from ADR-0043 §6
+
+`auto` precedence; opaque-handle-only or not; extras vs plugins for native backends; how approval is persisted; and why `ScopedSecretStore` was never wired.
+
+## 5. Measurement limits in this document
+
+- The 133/60 figure is an upper bound; no line was opened, and non-secret `os.environ` reads are included.
+- `ScopedSecretStore`'s dormancy is established by construction-site and name-occurrence counts, not by running anything.
+- No claim here is based on executing Reyn; the author has no environment in which to exercise a credential store.


### PR DESCRIPTION
**[architect]** — part of #4890. owner 依頼（reyn-reviewer 経由）の 3〜4 番目: 設計を正式化する ADR と実装 proposal。

## 作成物

| ファイル | 中身 |
|---|---|
| `docs/deep-dives/decisions/0043-generic-secret-provider-seam.md` | ADR、**Status: Proposed** |
| `docs/deep-dives/proposals/0068-secret-provider-seam.md` | 実装計画 |

## 決めたこと（ADR §2）

1. `SecretProvider` / `SecretReference` / `SecretResolver` の seam を入れる
2. **既存の `os.environ` 読みは移行しない** — seam は置換ではなく分岐
3. **休眠している `ScopedSecretStore` を resolver に配線する**（2 つ目の gate を設計しない）
4. OAuth は FP-0016 のライフサイクルに残す
5. native backend は需要が名指しされてから
6. Git/GitHub 固有コードは core に入れない
7. 報告は `declared` / `resolved` / `injected` / `used` / **`unknown`** を区別する

## 決定を形づくった 3 つの実測

```
M1 loader.py 逐語 ──「Called once at Reyn process startup … read secrets via
   os.environ.get() without any knowledge of the dotenv file」
   ＝ 現行は eager load、lazy lookup ではない

M2 os.environ 直読み ── 133 行 / 60 ファイル（src/reyn）
   ∴「現行 path を provider で wrap」は no-behaviour-change phase と両立しない
   ⚠️ 上限の目安 — 1 件も開いておらず REYN_PROF_DUMP 等の非 secret を含む

M3 ScopedSecretStore ── src/ での構築 0 件 / tests で 8 件
   OpContext.secret_store（context.py:273）は宣言のみ、代入も読取もなし
   ∴ capability gate は「コード」であって「生きた gate」ではない
```

M3 は当初の私のレビュー所見 A を**逆転**させました（#4890 のコメントで訂正済み）。「既存 gate が在るから重複を避けよ」ではなく「休眠 gate をどう起こすか」が論点で、提案の価値は当初評価より**高い**です。

## ADR-0030 / FP-0016 との関係

**どちらも extends、supersede なし。** ADR-0030 が名指しする文字列（`${VAR}` / `~/.reyn/secrets.env` / `reyn secret set/list/clear/rotate`）はすべて意味が変わりません。`reyn credential add` は改名ではなく追加です。`decisions/README.md` の「an ADR that names a string makes renaming that string an ADR decision」に照らして確認しました。

## Status を `Proposed` にした理由

owner の関心は **reyn-reviewer 経由の中継**でのみ私に届いており、私の側で裏が取れていません。`Accepted` を私が付けると私が決めたことになります。前例あり（既存 ADR に `Proposed` / `Pending User Confirmation`）。

## 未解決事項（ADR §6 / proposal §4）

- `provider: auto` の決定的な優先順位と曖昧時の挙動
- 値を opaque handle のみで返すか、信頼できる injection seam はどこか
- native backend は optional extra か plugin か
- binding の承認をどう永続化し、どの操作が credential を参照してよいか
- **`ScopedSecretStore` がなぜ配線されなかったか** — 意図的な段階分けか落ちた残件かは未確定。**Phase 2 はこれを先に確かめてから**（#4381 と同じ形の可能性）

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → built in 21.34s
- [x] `python scripts/check_doc_anchors.py` → `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` → `OK: 0 hits (25 retired top-level key(s) checked)`
- [x] (skipped — `src/` / `tests/` 無変更のため ruff / tier audit / pytest は対象なし)
- [x] ADR 番号 0043・proposal 番号 0068 は既存最大（0042 / 0067）の次を実測で確認
- [ ] 🔴 owner による直接確認 — `Proposed` のまま。**この PR は設計を記録するもので、ratify するものではありません**

## 元文書について

`SECRET_PROVIDER_PROPOSAL.md` は `~/Workspace/reyn_dev/reyn-self/` にあり、**git repo ではありません**（`git rev-parse` → `fatal: not a git repository`）。そのため「元文書の commit hash」は存在しません。内容はリンクではなく ADR 本文に要約して取り込んでいます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)