### PR TITLE
docs(verification-hazards): §26 — reading the spec can leave the deciding half open

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1553,7 +1553,10 @@ reading it is not the same claim as verifying their runtime. The same
 discriminator, quoted back at itself: "the classifier bites the
 *implementation*, not implementing to the *published spec*." Applied
 backwards, a real caution became an excuse to stop before the step that
-would have settled the question.
+would have settled the question. *The decision that caution produced may
+still be right on other grounds — the defect at issue closes from the
+receiving side alone, with post-parse validation and a bounded re-prompt.
+What failed was the reason offered for it, not necessarily the call.*
 
 This is adjacent to §24 (an inherited premise not observed) but not the
 same shape: §24 is about a *received question* silently deciding what gets
@@ -1584,6 +1587,20 @@ claim, but an ordinary research step available the whole time.
   the provider's own check is not itself a witness that anything calls it
   — confirm the call site, not just the declaration, before treating the
   gap as closed.
+- **Finishing ①–③ is not the same as the question being settled.** The
+  order above answers *mechanism* questions — does the contract exist, can
+  it be queried, is there a fallback. It does not answer *policy* questions,
+  and those can be the half that actually decides the design. In this same
+  case: the spec says structured output and streaming compose, and the repo
+  has both a capability query and a fallback — but ADR-0062 rules that when
+  a schema is set the silent fallback is **bypassed** and an unsupported
+  model raises. That is right for a pipeline step whose caller wants
+  structured data, and possibly wrong for a compaction backstop, where
+  raising means the context window never gets freed. No amount of reading
+  settles "raise or degrade" — it is a decision someone has to make and
+  write down. Read the spec *and* name which questions it left open;
+  stopping at "the spec answered it" is the same shape as stopping at
+  "I can't measure it," one step later.
 
 ## See also
 


### PR DESCRIPTION
**[architect]** — part of #4894. §26 は正確で、検出手順（①仕様 → ②能力照会 → ③repo の部品 → ④実測）はそのまま使えます。**2 点だけ足します。**

## 1. 実質的な欠落 — 仕様を読んでも決まらない半分がある

§26 の順序は **mechanism** の問いに答えます（契約は在るか / 照会できるか / 退避は在るか）。**policy** の問いには答えません。そして本件では、設計を決めるのは policy の側です。

```
ADR-0062 §2.1 逐語
  「The existing `fallback_without_response_format` silent retry is
    BYPASSED whenever `schema` is set」── 非対応モデルは typed error

  pipeline agent step  → 正しい（呼び出し元が構造化データを期待している）
  compaction backstop  → おそらく誤り（上げると窓が空かない）
```

**「raise か degrade か」は仕様をいくら読んでも決まりません。** これを書かないと、§26 に従って仕様を読み当てた人が「片付いた」と結論します — **「実測できない」で止まるのと同じ形の、1 段先**です。

detection technique に 1 bullet として足しました（節の主題内に収まる形にしています — 「①〜③を終えたことは、問いが片付いたことではない」）。

## 2. 決定と理由の分離（1 文）

§26 の文面は偽ではありません（「stated reason が問いに答えていない」としか言っていない）。ただ "a real caution became an excuse to stop" まで続けて読むと、**決定そのものが失敗だった**と読めます。

実際に誤っていたのは理由づけだけで、**決定は独立に正しいかもしれません** — defect（空 / 形違いが成功として通る）は受信側検証＋bounded re-prompt だけで閉じますし、Reliability lens の逐語も「schema-validate ＋ re-prompt」で生成拘束を含みません。

§25 に足された「**結論は真、理由が偽**」の軸を、§26 自身に適用した形です。1 文だけなので、**不要と判断されたらこの hunk だけ落としてください** — 私は broker で docs-maintainer に判断を委ねると書いており、その部分は撤回していません。1 を単独で通す方が良ければそれで構いません。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → built in 22.65s
- [x] `python scripts/check_doc_anchors.py` → `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` → `OK: 0 hits (25 retired top-level key(s) checked)`
- [x] (skipped — `src/` / `tests/` 無変更のため ruff / tier audit / pytest は対象なし)
- [x] ADR-0062 の逐語は proposal 本文から引用（`docs/deep-dives/proposals/0062-...md` §2.1）

## 未確認

- **§26 の最後の bullet（「In the codebase」と「actually called」は別）は私にも刺さっています。** 私は `llm.py:2010/2143/2693` を「機構は在る」と引きましたが、**compaction の経路が実際に呼ぶかは追っていません**（既定 `False`）。#4883 に未確認として明記済みで、この PR もその点を主張していません。
- OpenAI 以外の provider 仕様は読んでいません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)