### PR TITLE
docs(verification-hazards): §26 overclaimed — the reason failed, not necessarily the decision

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1543,6 +1543,24 @@ OpenAI's own docs already state structured outputs support streaming; the
 project's own `llm.py` already has a per-model capability query
 (`supports_response_schema`, mirroring litellm's) AND a fallback path for
 models that fail it. None of this was hidden — it was two greps away.
+**The decision that came out of this may still turn out right on other
+grounds — a "conclusion true, reasoning false" instance in its own right
+(a same-night sibling pin's own axis): what failed here was specifically
+the REASON given, not necessarily the withdrawal itself.**
+
+Reading the spec settles the capability question — streaming and schema
+DO compose, providers document it — but not the whole design question. The
+switch's real caller is compaction, which uses schema output as a
+**backstop**: proposal 0062's own §2.1 states the `fallback_without_
+response_format` silent retry is BYPASSED whenever `schema` is set, so an
+unsupported model gets a typed error instead of silent degrade — the
+correct choice for most callers, but for compaction specifically, raising
+an error is compaction *failing to run*, not compaction degrading, and
+compaction exists as the backstop for a context window with nowhere else
+to go. Whether an unsupported model should raise or fall back **for this
+one caller** is a real design call the published spec cannot make for you
+— reading it closes the capability half of the question, not the policy
+half.
 
 **The discriminator that was misapplied**: "a third party's behavior is not
 ours to verify" governs *taking over the third party's own implementation*
@@ -1583,7 +1601,18 @@ claim, but an ordinary research step available the whole time.
   A capability-query function existing with a comment saying it mirrors
   the provider's own check is not itself a witness that anything calls it
   — confirm the call site, not just the declaration, before treating the
-  gap as closed.
+  gap as closed. This bullet caught its own reviewer: a review of this
+  section cited `llm.py`'s capability-query and fallback lines as
+  evidence "the mechanism exists," without separately confirming
+  compaction's own call path actually reaches them (the parameter
+  defaults `False`) — flagged as unconfirmed in the tracking issue, not
+  silently assumed.
+- **Reading the spec answers what a provider supports, not what reyn
+  should do about a caller-specific failure mode.** Settle the capability
+  question first, then ask separately whether the caller in front of you
+  (here: a backstop with nowhere else to go) changes the answer — a spec
+  that says "this works" does not say "raise here" or "degrade here" for
+  every caller alike.
 
 ## See also
 


### PR DESCRIPTION
**[docs-maintainer]** — follow-up to #4894, per architect review

## What

Architect flagged two precision issues in §26 (both accurate on re-reading):

1. **Overclaim**: §26 read as "the withdrawal decision was wrong," when only the *stated reason* was shown wrong. Compaction uses schema output as a backstop; proposal 0062's own §2.1 states `fallback_without_response_format` is bypassed whenever `schema` is set — an unsupported model raises a typed error rather than silently degrading. Correct for most callers, but for compaction specifically, raising IS compaction failing to run, and compaction exists as the last resort when context has nowhere else to go. Whether to raise or degrade for this one caller is a real design call the spec doesn't settle.
2. **Self-check**: architect's own review cited `llm.py`'s capability-query/fallback lines as "the mechanism exists" without separately confirming compaction's own call path reaches them — a live instance of the section's own closing bullet, added as an example rather than left implicit.

## Verification

Independently re-grepped `docs/deep-dives/proposals/0062-structured-output-ephemeral-sessions-agent-steps.md` before writing: confirmed the "BYPASSED whenever `schema` is set" language verbatim.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no `Aborted` line
- [x] `python scripts/check_doc_anchors.py` — exit 0, no dangling anchors into published pages
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Closing-keyword self-grep on commit message and this PR body — clean
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Independently re-verified the 0062 quote against source before writing
- [x] Time-dependency check (#4845/#4847): 0 instances — prose-only doc edit, no tests touched
- [x] Owner veto window — this doc is normative; opened as a PR, not a direct edit
- [x] Visual — N/A, prose-only addition
