### PR TITLE
docs(verification-hazards): §26 — name who ratified the rule before carving an exception

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1560,7 +1560,7 @@ compaction exists as the backstop for a context window with nowhere else
 to go. Whether an unsupported model should raise or fall back **for this
 one caller** is a real design call the published spec cannot make for you
 — reading it closes the capability half of the question, not the policy
-half.
+half. **And that the spec cannot make the call does not mean the person reading the spec may.** That policy is owner-ratified, not a default someone chose: proposal 0062's own front matter reads *"owner-intent: ratified direction (owner GO 2026-07-13) … unsupported model errors, no silent degrade"*. So degrading for one caller is a departure from a ratified position — an owner decision, not a designer's discretion. The question has three steps, not two: what the spec permits, what this caller needs, and **who ratified the rule you are about to carve an exception out of**. Skipping the third turns a correct observation about specs into an unauthorised exception.
 
 **The discriminator that was misapplied**: "a third party's behavior is not
 ours to verify" governs *taking over the third party's own implementation*


### PR DESCRIPTION
**[architect]** — part of #4894. lead-coder の依頼（#4897 着地後）。**節を弱めず、強めます。**

## 何が変わったか

lead-coder が **0062 の原文を開きました**。私も引き直しています:

```
docs/deep-dives/proposals/0062-…md front matter 逐語
  owner-intent: ratified direction (owner GO 2026-07-13) — … 
                unsupported model errors, no silent degrade
```

§26 は raise-or-degrade を「**a real design call the published spec cannot make for you**」と書いています。**真ですが不完全**でした — 仕様が決めないことは、**仕様を読んだ人が決めてよいこと**を意味しません。この規則については、決めた主体が記録に残っています。

∴ 「compaction では degrade する」は**批准済み方針からの逸脱**であり、設計者の裁量ではなく **owner 判断**です。

## 足した中身

問いを 2 段から 3 段にしました:

```
① 仕様は何を許すか
② この caller は何を要るか
③ ★これから例外を切り出そうとしている規則を、誰が批准したか
```

③ を飛ばすと、**仕様についての正しい観察が、無許可の例外に化けます。**

## 補足（節には書いていない）

0062 は実装の形も決めています — `:35` 逐語「`litellm.supports_response_schema(model)` … **Do NOT catch-classify a provider rejection**」。∴ fallback 頼みではなく**事前照会**です。lead-coder は当初「fallback を渡せ」と指示し、既に訂正済みとのことです。これは §26 の主題（仕様と policy）から外れるので節には入れていません。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → built in 16.47s
- [x] `python scripts/check_doc_anchors.py` → `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` → `OK: 0 hits (25 retired top-level key(s) checked)`
- [x] (skipped — `src/` / `tests/` 無変更のため ruff / tier audit / pytest は対象なし)
- [x] 0062 の逐語は front matter と `:35` を自分で引き直して確認（lead-coder の引用と一致）
- [x] **1 回目の patch は Python の SyntaxError で適用されておらず、その状態でも 3 ゲートは緑を出しました。** `git diff --stat` で 1 insertion を確認してから再実行しています（緑は「変更が正しい」ではなく「壊れていない」しか言いません）

🤖 Generated with [Claude Code](https://claude.com/claude-code)