### PR TITLE
feat(#4864): gate — private read with a same-class public @property, whole-file not assert-scoped

### DIFF
--- a/scripts/test_tier_audit.py
+++ b/scripts/test_tier_audit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Test policy compliance auditor — Reyn testing.ja.md automated linter.
 
-Detects 7 categories of Tier 4 violations and policy warnings in test files:
+Detects 8 categories of Tier 4 violations and policy warnings in test files:
   1. Missing Tier docstring (ERROR)
   2. Format pinning via len(...) < N (ERROR)
   3. Private state assertion via obj._attr (ERROR)
@@ -9,6 +9,8 @@ Detects 7 categories of Tier 4 violations and policy warnings in test files:
   5. Bounded-life test outside tests/scaffold/ (WARNING)
   6. Snapshot/golden test outside tests/scaffold/ (ERROR)
   7. Fake attribute on a real object, suppressed via type: ignore (ERROR)
+  8. Private read (obj._x, not just assert obj._x) with a same-class
+     public @property alternative (ERROR)
 
 Usage:
     python scripts/test_tier_audit.py tests/
@@ -225,6 +227,7 @@ RULE_NAMES = {
     "bounded-life",
     "snapshot",
     "fake-attr",
+    "private-read-public-alt",
 }
 
 # ---------------------------------------------------------------------------
@@ -680,6 +683,288 @@ def _check_fake_attr_assignments(source: str, tree: ast.Module) -> list[Finding]
     return findings
 
 
+def _annotation_class_names(node: ast.AST | None) -> set[str]:
+    """Every candidate class name spelled by an annotation node — ``Session``
+    from ``x: Session``, ``"Session"`` from a quoted forward-reference,
+    ``Session`` from ``x: module.Session``, and (load-bearing, not a nicety
+    — see below) BOTH names from a union: ``x: "Session | None"`` and
+    ``x: Optional[Session]`` alike.
+
+    The union case is not speculative completeness: it's the exact shape
+    that made this rule MISS one of architect's own 4 named positive
+    controls on its first pass (#4864 thread) —
+    ``def _op_ctx(tmp_path, session: "Session | None") -> OpContext:`` in
+    ``tests/core/test_2761_pr2_hotreload_immediate_apply.py`` — caught only
+    by re-checking each of the 4 named sites individually against this
+    PR's own findings before writing the PR body, not by any corpus-wide
+    measurement (only that one file was checked this way)."""
+    if node is None:
+        return set()
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, ast.Attribute):
+        return {node.attr}
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        try:
+            inner = ast.parse(node.value, mode="eval").body
+        except SyntaxError:
+            return set()
+        return _annotation_class_names(inner)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return _annotation_class_names(node.left) | _annotation_class_names(
+            node.right
+        )
+    if isinstance(node, ast.Subscript):
+        return _annotation_class_names(node.slice)  # Optional[X] / Union[X, Y]
+    if isinstance(node, ast.Tuple):
+        out: set[str] = set()
+        for elt in node.elts:
+            out |= _annotation_class_names(elt)
+        return out
+    return set()
+
+
+def _annotation_class_name(node: ast.AST | None, class_names: set[str]) -> str | None:
+    """The single name from ``_annotation_class_names(node)`` that is
+    actually one of *class_names* — resolves ``"Session | None"`` to
+    ``"Session"`` (``"None"`` is never a tracked class) without the caller
+    needing to know about unions at all. None if no candidate matches."""
+    candidates = _annotation_class_names(node) & class_names
+    if not candidates:
+        return None
+    return sorted(candidates)[0]
+
+
+def _build_class_property_index(src_root: Path) -> dict[str, tuple[set[str], str]]:
+    """Rule 8 (#4864): for every class in *src_root*, the private attribute
+    names it assigns via ``self._x = ...`` that are ALSO published by a
+    same-class ``@property def x``. Keyed by class name; whole ``src/``
+    scanned ONCE (mirrors #3670's single-index-build precedent — this is
+    shared across every test file the caller audits, not rebuilt per-file).
+
+    Class-SCOPED intersection is load-bearing, not a stylistic choice.
+    architect's own #4864-thread pitfall: ``self._chains = chains`` is
+    assigned in FIVE different classes (SpawnTracker/RouterHostAdapter/
+    ChainTimeoutGlue/InterAgentMessaging/Session), but only ``Session``
+    ALSO defines ``@property def chains``. A global (does this attr name
+    exist as a property ANYWHERE) index would wrongly flag ``_chains``
+    reads on the other four classes too — keying by class name here, and
+    requiring the caller to prove the read's object is THAT SPECIFIC class
+    (see ``_build_function_return_types`` / ``_infer_local_types`` below)
+    is what keeps the false-positive rate at the 0 architect's spec
+    requires.
+
+    Known gap (disclosed, not measured): two classes sharing a bare name
+    in different files collide in this dict (last one scanned wins) —
+    unmeasured corpus-wide, same caveat class as #4873's own disclosed
+    dynamic-``setattr`` gap.
+    """
+    index: dict[str, tuple[set[str], str]] = {}
+    for path in sorted(src_root.rglob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(path))
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            private_assigned: set[str] = set()
+            property_names: set[str] = set()
+            for inner in ast.walk(node):
+                if isinstance(inner, (ast.Assign, ast.AnnAssign)):
+                    targets = (
+                        inner.targets
+                        if isinstance(inner, ast.Assign)
+                        else [inner.target]
+                    )
+                    for t in targets:
+                        if (
+                            isinstance(t, ast.Attribute)
+                            and isinstance(t.value, ast.Name)
+                            and t.value.id == "self"
+                            and t.attr.startswith("_")
+                            and not t.attr.startswith("__")
+                        ):
+                            private_assigned.add(t.attr)
+                elif isinstance(inner, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    for dec in inner.decorator_list:
+                        if isinstance(dec, ast.Name) and dec.id == "property":
+                            property_names.add(inner.name)
+            backed = {a for a in private_assigned if a[1:] in property_names}
+            if backed:
+                index[node.name] = (backed, str(path))
+    return index
+
+
+def _build_function_return_types(
+    tree: ast.Module, class_names: set[str]
+) -> dict[str, str]:
+    """Same-file function/fixture defs whose return annotation names one of
+    *class_names* — e.g. ``def _make_session(...) -> Session:``. This is
+    how the rule sees through the dominant test-corpus construction idiom
+    (a local ``_make_x`` factory, not a bare ``Session(...)`` call) without
+    ever assuming a naming convention: the evidence is the annotation, not
+    the function's name."""
+    out: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            name = _annotation_class_name(node.returns, class_names)
+            if name is not None:
+                out[node.name] = name
+    return out
+
+
+def _infer_local_types(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    class_names: set[str],
+    function_return_types: dict[str, str],
+) -> dict[str, str]:
+    """Best-effort local-variable-name -> class-name map for *func*,
+    evidence-only (never inferred from a variable's own name — a param
+    called ``session`` proves nothing by itself). Accepted evidence:
+
+      - parameter annotation:        def test_x(s: Session): ...
+      - parameter name matches a same-file factory/fixture def whose
+        return annotation names a known class (covers the ``s =`` idiom
+        AND the pytest fixture-injection idiom in one pass, since both
+        are "a same-file def with a typed return, referenced by name")
+      - local annotated assignment:  s: Session = ...
+      - local assignment from a direct constructor or factory call:
+        s = Session(...)  /  s = _make_session(...)  /  s = await _make_session(...)
+    """
+    types: dict[str, str] = {}
+    all_args = list(func.args.args) + list(func.args.kwonlyargs)
+    if func.args.posonlyargs:
+        all_args = list(func.args.posonlyargs) + all_args
+    for arg in all_args:
+        name = _annotation_class_name(arg.annotation, class_names)
+        if name is not None:
+            types[arg.arg] = name
+        elif arg.arg in function_return_types:
+            types[arg.arg] = function_return_types[arg.arg]
+    for stmt in ast.walk(func):
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            name = _annotation_class_name(stmt.annotation, class_names)
+            if name is not None:
+                types[stmt.target.id] = name
+        elif (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+        ):
+            value = stmt.value
+            if isinstance(value, ast.Await):
+                value = value.value
+            if isinstance(value, ast.Call):
+                callee = value.func
+                callee_name = None
+                if isinstance(callee, ast.Name):
+                    callee_name = callee.id
+                elif isinstance(callee, ast.Attribute):
+                    callee_name = callee.attr
+                if callee_name in class_names:
+                    types[stmt.targets[0].id] = callee_name
+                elif callee_name in function_return_types:
+                    types[stmt.targets[0].id] = function_return_types[callee_name]
+    return types
+
+
+def _check_private_read_with_public_alt(
+    source: str,
+    tree: ast.Module,
+    class_index: dict[str, tuple[set[str], str]],
+) -> list[Finding]:
+    """Rule 8 (#4864): ``obj._x`` READ anywhere (not only inside an
+    ``assert`` — the whole point per the issue's own measurement: routing
+    the private read through a local var one line before the assert made
+    126 sites invisible to Rule 3's assert-scoped AST walk) where *obj* is
+    type-evident (see ``_infer_local_types``) as a class that ALSO
+    publishes ``x`` via ``@property``.
+
+    Repair-obligation, not bare detector (architect, #4864 thread): the
+    message must not stop at "use .x instead" — #4866 is the concrete
+    instance where a fail was closed by ADDING a same-named ``@property``
+    that just republished the private field, "ratif[ying] the
+    encapsulation break instead of closing it" (#4866's own diff wording).
+    So the suggestion also tells the fixer: if no public alternative
+    already answers what the test is actually asking, don't manufacture
+    one to satisfy the gate.
+
+    ``obj`` is restricted to a bare ``ast.Name`` (not ``a.b._x`` chains) —
+    a deliberately narrower net than Rule 3's, since this rule's
+    precondition is TYPE evidence on the base, not just syntactic shape;
+    disclosed gap, not claimed as covering every real violation."""
+    findings: list[Finding] = []
+    ast_lines = _split_source_lines(source)
+    class_names = set(class_index)
+    function_return_types = _build_function_return_types(tree, class_names)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        local_types = _infer_local_types(node, class_names, function_return_types)
+        if not local_types:
+            continue
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Attribute):
+                continue
+            # Store context (`client._x = value`) is a WRITE to private
+            # state, not the READ this rule is scoped to — a direct
+            # assignment target is #4873's territory (a different rule),
+            # not this one. A nested Load (`client._x.y = value`, where
+            # `client._x` is READ to reach `.y`) still matches: only the
+            # OUTERMOST node of a chain carries Store, per ast's own ctx
+            # assignment, so this filter affects only the direct-target
+            # case.
+            if not isinstance(inner.ctx, ast.Load):
+                continue
+            attr = inner.attr
+            if not (attr.startswith("_") and not attr.startswith("__")):
+                continue
+            base = inner.value
+            if not isinstance(base, ast.Name) or base.id == "self":
+                continue
+            class_name = local_types.get(base.id)
+            if class_name is None:
+                continue
+            backed, class_file = class_index.get(class_name, (set(), ""))
+            if attr not in backed:
+                continue
+            public_name = attr[1:]
+            line_src = (
+                ast_lines[inner.lineno - 1]
+                if inner.lineno - 1 < len(ast_lines)
+                else ""
+            )
+            findings.append(
+                Finding(
+                    rule="private-read-public-alt",
+                    level="ERROR",
+                    line=inner.lineno,
+                    message=(
+                        f"private read (.{attr}) has a public alternative "
+                        f"— {class_name}.{public_name} is a @property "
+                        f"({_rel_path(Path(class_file))}): "
+                        f"{line_src.strip()[:80]}"
+                    ),
+                    suggestion=(
+                        f"Use .{public_name} instead of .{attr}. If no "
+                        f"public alternative actually answers what this "
+                        f"test is asking, do not add a @property just to "
+                        f"silence this gate — that ratifies the "
+                        f"encapsulation break instead of closing it "
+                        f"(#4866); re-examine what the test is asking "
+                        f"instead."
+                    ),
+                    policy_ref=(
+                        "CLAUDE.md: must not depend on private state — "
+                        "use the public surface or a snapshot()-style read"
+                    ),
+                )
+            )
+    return findings
+
+
 # ---------------------------------------------------------------------------
 # File collection
 # ---------------------------------------------------------------------------
@@ -840,7 +1125,16 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Only check one rule: "
             "tier-docstring / format-pinning / private-state / mock / bounded-life / "
-            "snapshot / fake-attr"
+            "snapshot / fake-attr / private-read-public-alt"
+        ),
+    )
+    parser.add_argument(
+        "--src-root",
+        metavar="DIR",
+        default="src",
+        help=(
+            "Root to scan for Rule 8's class/@property index "
+            "(default: src). Only read when private-read-public-alt runs."
         ),
     )
     parser.add_argument(
@@ -900,6 +1194,15 @@ def main(argv: list[str] | None = None) -> int:
     auditor = TestAuditor(check_rules=check_rules)
     reports: list[FileReport] = []
 
+    # Rule 8 (#4864): the class/@property index is built ONCE against
+    # --src-root, shared across every test file below — same
+    # single-build-not-per-file precedent as #3670's ``_split_source_lines``.
+    # Only built when the rule is actually active: it's a whole-src-tree
+    # scan, and every other rule here is test-file-only.
+    class_property_index: dict[str, tuple[set[str], str]] = {}
+    if check_rules is None or "private-read-public-alt" in check_rules:
+        class_property_index = _build_class_property_index(Path(args.src_root))
+
     for f in files:
         report = auditor.audit_file(f)
 
@@ -933,6 +1236,24 @@ def main(argv: list[str] | None = None) -> int:
                 if fake_attr_findings:
                     synthetic = TestResult(name="<module-level>")
                     synthetic.findings.extend(fake_attr_findings)
+                    report.results.insert(0, synthetic)
+            except (OSError, SyntaxError):
+                pass
+
+        # Rule 8 (#4864): whole-file, same reason as Rule 7 — the reads
+        # this rule targets aren't confined to ``assert`` bodies.
+        if not report.parse_error and (
+            check_rules is None or "private-read-public-alt" in check_rules
+        ):
+            try:
+                source = f.read_text(encoding="utf-8")
+                tree = ast.parse(source, filename=str(f))
+                private_read_findings = _check_private_read_with_public_alt(
+                    source, tree, class_property_index
+                )
+                if private_read_findings:
+                    synthetic = TestResult(name="<module-level>")
+                    synthetic.findings.extend(private_read_findings)
                     report.results.insert(0, synthetic)
             except (OSError, SyntaxError):
                 pass

--- a/tests/core/test_1503_mcp_install_error_surface.py
+++ b/tests/core/test_1503_mcp_install_error_surface.py
@@ -56,7 +56,7 @@ def _make_resolver(tmp_path: Path) -> PermissionResolver:
 
 
 def _make_source_decl(resolver: PermissionResolver) -> PermissionDecl:
-    canonical_config = str(resolver._project_root / ".reyn" / "config" / "mcp.yaml")
+    canonical_config = str(resolver.project_root / ".reyn" / "config" / "mcp.yaml")
     resolver.session_approve_path(canonical_config, "mcp_install_test", "file.write")
     return PermissionDecl(
         file_write=[{"path": canonical_config, "scope": "just_path"}],

--- a/tests/core/test_1800_c_staging.py
+++ b/tests/core/test_1800_c_staging.py
@@ -120,7 +120,7 @@ async def _run_n_turns_then_shutdown(session: Session, n: int) -> None:
     except asyncio.TimeoutError:
         run_task.cancel()
         await asyncio.gather(run_task, return_exceptions=True)
-    await session._journal.flush()  # #2259 PR-2b: drain async WAL+snapshot before the sync read
+    await session.journal.flush()  # #2259 PR-2b: drain async WAL+snapshot before the sync read
 
 
 # ---------------------------------------------------------------------------
@@ -291,13 +291,13 @@ async def test_c_staging_persist_and_restore(tmp_path) -> None:
     session = _make_session(tmp_path)
 
     # Directly call the journal method to stage a ride-along entry.
-    await session._journal.record_next_turn_context_staged(
+    await session.journal.record_next_turn_context_staged(
         kind="hook",
         payload={"name": "hook_a", "text": "ride-along context"},
     )
 
     # Verify the snapshot file contains the staged entry.
-    await session._journal.flush()  # #2259 PR-2b: drain async snapshot write before the load
+    await session.journal.flush()  # #2259 PR-2b: drain async snapshot write before the load
     snapshot_on_disk = AgentSnapshot.load(
         session.agent_name, session._snapshot_path,
     )

--- a/tests/core/test_1800_wake_drain.py
+++ b/tests/core/test_1800_wake_drain.py
@@ -92,7 +92,7 @@ async def _run_n_turns_then_shutdown(session: Session, n: int) -> None:
     except asyncio.TimeoutError:
         run_task.cancel()
         await asyncio.gather(run_task, return_exceptions=True)
-    await session._journal.flush()  # #2259 PR-2b: drain async WAL+snapshot before the sync read
+    await session.journal.flush()  # #2259 PR-2b: drain async WAL+snapshot before the sync read
 
 
 # ---------------------------------------------------------------------------
@@ -321,7 +321,7 @@ async def test_drain_to_wake_inbox_consume_per_message(tmp_path) -> None:
 
     assert trigger is not None
 
-    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes before the read
+    await session.journal.flush()  # #2259 PR-2b: drain async WAL writes before the read
     events = _wal_events(tmp_path)
     consume_events = [e for e in events if e.get("kind") == "inbox_consume"]
 
@@ -383,7 +383,7 @@ async def test_drain_to_wake_only_wake_false_then_trigger_arrives(
     )
 
     # WAL must record inbox_consume for all 3 messages (2 ride-alongs + 1 trigger).
-    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes before the read
+    await session.journal.flush()  # #2259 PR-2b: drain async WAL writes before the read
     events = _wal_events(tmp_path)
     consume_events = [e for e in events if e.get("kind") == "inbox_consume"]
     n_consume = len(consume_events)

--- a/tests/core/test_2581_pipeline_hotreload.py
+++ b/tests/core/test_2581_pipeline_hotreload.py
@@ -185,8 +185,8 @@ async def test_hotreload_via_apply_pending_dual_write(
     _write_pipeline(tmp_path, "hello.yaml", _HELLO_V1)
     _write_dynamic_entries(tmp_path, ("hello", "pipelines/hello.yaml"))
 
-    session._hot_reloader.request_reload(source="operator")
-    summary = await session._hot_reloader.apply_pending()
+    session.hot_reloader.request_reload(source="operator")
+    summary = await session.hot_reloader.apply_pending()
 
     assert summary is not None
     assert "pipelines" in summary["applied"]
@@ -244,9 +244,9 @@ async def test_hotreload_malformed_pipeline_observable_via_warning_and_noop_appl
     session = _make_session(tmp_path)
 
     _write_pipeline(tmp_path, "hello.yaml", "pipeline: hello\nsteps: not-a-list\n")
-    session._hot_reloader.request_reload(source="operator")
+    session.hot_reloader.request_reload(source="operator")
     with caplog.at_level("WARNING", logger="reyn.runtime.session"):
-        summary = await session._hot_reloader.apply_pending()
+        summary = await session.hot_reloader.apply_pending()
 
     assert summary is not None
     assert "pipelines" not in summary["applied"]

--- a/tests/core/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/core/test_2761_pr2_hotreload_immediate_apply.py
@@ -98,7 +98,7 @@ def _op_ctx(tmp_path: Path, session: "Session | None") -> OpContext:
         events=EventLog(),
         permission_decl=PermissionDecl(),
         permission_resolver=None,
-        hot_reloader=(session._hot_reloader if session is not None else None),
+        hot_reloader=(session.hot_reloader if session is not None else None),
     )
 
 
@@ -124,12 +124,12 @@ def _write_pipeline(tmp_path: Path, filename: str, *, name: str, description: st
 
 
 def _skill_names(session: Session) -> list[str]:
-    skills = session._router_host.get_available_skills()
+    skills = session.router_host.get_available_skills()
     return [s.name for s in skills] if skills else []
 
 
 def _skill_desc(session: Session, name: str) -> "str | None":
-    for s in session._router_host.get_available_skills() or []:
+    for s in session.router_host.get_available_skills() or []:
         if s.name == name:
             return s.description
     return None
@@ -137,11 +137,11 @@ def _skill_desc(session: Session, name: str) -> "str | None":
 
 def _pipeline_names(session: Session) -> tuple[str, ...]:
     """Names in the LIVE pipeline registry (the one run_pipeline resolves against)."""
-    return session._router_host.get_pipeline_registry().names()
+    return session.router_host.get_pipeline_registry().names()
 
 
 def _pipeline_desc(session: Session, name: str) -> "str | None":
-    reg = session._router_host.get_pipeline_registry()
+    reg = session.router_host.get_pipeline_registry()
     return reg.get(name).description if name in reg.names() else None
 
 
@@ -434,7 +434,7 @@ async def test_skill_install_new_name_is_live_same_turn(
     )
     # The immediate path fully handled it — nothing was left pending for the turn
     # boundary (apply_pending is a no-op → None when nothing is scheduled).
-    residual = await session._hot_reloader.apply_pending()
+    residual = await session.hot_reloader.apply_pending()
     assert residual is None, (
         "the immediate addition path must not ALSO schedule a deferred reload"
     )
@@ -475,7 +475,7 @@ async def test_skill_install_same_name_overwrite_defers_but_lands(
 
     # It lands at the next turn boundary (the deferred turn-end apply) — proving the
     # overwrite scheduled the deferred path, and clobber-update still works.
-    await session._hot_reloader.apply_pending()
+    await session.hot_reloader.apply_pending()
     assert _skill_desc(session, "greet-skill") == "v2", (
         "the clobber-update must land at the turn boundary (applies next turn)"
     )
@@ -503,7 +503,7 @@ async def test_pipeline_install_new_name_is_resolvable_same_turn(
     assert "greet.greet" in _pipeline_names(session), (
         "a NEW pipeline must be resolvable the same turn (immediate mid-turn apply)"
     )
-    residual = await session._hot_reloader.apply_pending()
+    residual = await session.hot_reloader.apply_pending()
     assert residual is None, (
         "the immediate addition path must not ALSO schedule a deferred reload"
     )
@@ -540,7 +540,7 @@ async def test_pipeline_install_same_name_overwrite_defers_but_lands(
         "a same-name overwrite must NOT be applied mid-turn (deferred)"
     )
 
-    await session._hot_reloader.apply_pending()
+    await session.hot_reloader.apply_pending()
     assert _pipeline_desc(session, "greet.greet") == "v2", (
         "the clobber-update must land at the turn boundary (applies next turn)"
     )
@@ -559,7 +559,7 @@ async def test_skill_install_no_per_session_reloader_defers(
 
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    set_active_hot_reloader(session._hot_reloader)
+    set_active_hot_reloader(session.hot_reloader)
     try:
         skill_dir = _write_skill(tmp_path, "solo", name="solo-skill", description="v1")
         result = await skill_install_handle(
@@ -574,7 +574,7 @@ async def test_skill_install_no_per_session_reloader_defers(
         "with no per-session reloader the install must NOT apply mid-turn"
     )
     # It fell back to the deferred path — applying at the turn boundary makes it live.
-    await session._hot_reloader.apply_pending()
+    await session.hot_reloader.apply_pending()
     assert "solo-skill" in _skill_names(session), (
         "the deferred fallback lands the install at the turn boundary"
     )

--- a/tests/core/test_2761_pr3_mcp_immediate_probe.py
+++ b/tests/core/test_2761_pr3_mcp_immediate_probe.py
@@ -114,7 +114,7 @@ def _session_ctx(session: Session, tmp: Path) -> ToolContext:
     """A ctx whose op-context factory is the session's REAL make_router_op_context (so
     ctx.hot_reloader is the session's per-session reloader). resolver=None → the
     install_local file-write gate is skipped (not under test)."""
-    return _Ctx(tmp, _RS(session._router_host.make_router_op_context))
+    return _Ctx(tmp, _RS(session.router_host.make_router_op_context))
 
 
 def _reloader_ctx(
@@ -144,7 +144,7 @@ def _servers_on_disk(tmp: Path) -> dict:
 
 
 def _roster_names(session: Session) -> list[str]:
-    return [s["name"] for s in session._router_host.get_mcp_servers()]
+    return [s["name"] for s in session.router_host.get_mcp_servers()]
 
 
 # ===========================================================================
@@ -254,10 +254,10 @@ async def test_local_install_new_reachable_is_live_same_turn(
         assert "pidsrv" in _roster_names(session), (
             "a NEW reachable server must be resolvable the same turn (immediate probe-commit)"
         )
-        snap = session._router_host.mcp_tools_cache_snapshot
+        snap = session.router_host.mcp_tools_cache_snapshot
         assert snap is not None and "pidsrv" in snap, "its tools must be live-cached same turn"
         # Immediate path — nothing left pending for the turn boundary.
-        residual = await session._hot_reloader.apply_pending()
+        residual = await session.hot_reloader.apply_pending()
         assert residual is None, "the immediate probe-commit must not ALSO defer a reload"
     finally:
         await session.aclose_mcp_connections()
@@ -314,7 +314,7 @@ async def test_local_install_same_name_overwrite_defers_and_skips_probe(
         )
 
         assert result["status"] == "ok", "an overwrite must NOT be probe-gated (re-install preserved)"
-        pending = session._hot_reloader.pending
+        pending = session.hot_reloader.pending
         assert pending is True, "an overwrite schedules the deferred turn-boundary reload"
         assert _servers_on_disk(tmp_path)["srv"]["command"] == "/nonexistent/reyn-xyz", (
             "the overwrite is written to config (clobber-update), applied at the turn boundary"

--- a/tests/core/test_await_quiescent.py
+++ b/tests/core/test_await_quiescent.py
@@ -57,7 +57,7 @@ async def test_await_quiescent_cancels_chain_timeout_timer_no_append(tmp_path):
 
     # The chain must be registered so the watchdog's "still pending?" check passes
     # and on_fire would actually run (otherwise the fire short-circuits).
-    await session._chains.register(
+    await session.chains.register(
         chain_id="c1", depth=0, original_text="q", sender=None,
     )
 
@@ -66,8 +66,8 @@ async def test_await_quiescent_cancels_chain_timeout_timer_no_append(tmp_path):
         await log.append("chain_timeout_fired", agent="alpha", chain_id=chain_id)
 
     # Short timeout so the watchdog WOULD fire almost immediately if not cancelled.
-    session._chains._chain_timeout_seconds = 0.05
-    await session._chains.arm_timeout("c1", on_fire=_on_fire)
+    session.chains._chain_timeout_seconds = 0.05
+    await session.chains.arm_timeout("c1", on_fire=_on_fire)
     # proposal 0067 P8 (#3978): arm_timeout() now persists arm_at via a
     # fire-and-forget WAL append (append_nowait — the worker assigns the
     # seq off-loop, not synchronously when record_chain_update() returns).
@@ -104,7 +104,7 @@ async def test_await_quiescent_cancels_intervention_dispatch_no_append(tmp_path)
     iv = UserIntervention(kind="ask_user", prompt="Q?")
     # Seed the stalled queue directly (test precedent: test_pending_intervention_268)
     # so claim re-dispatches through the real path.
-    session._interventions._stalled[iv.id] = iv
+    session.interventions._stalled[iv.id] = iv
 
     view = await session.claim_pending_intervention(iv.id, "new-channel")
     assert view is not None
@@ -166,7 +166,7 @@ async def test_await_quiescent_settles_intervention_answer_consumed_no_append(tm
     log = StateLog(tmp_path / "state.wal")
     session = _session(tmp_path, log)
 
-    session._buffered_intervention_answers["run-1"] = InterventionAnswer(text="ok")
+    session.buffered_intervention_answers["run-1"] = InterventionAnswer(text="ok")
     answer = session.consume_buffered_intervention_answer("run-1")
     assert answer is not None and answer.text == "ok"
 

--- a/tests/core/test_context_auto_producer_consumer_1827.py
+++ b/tests/core/test_context_auto_producer_consumer_1827.py
@@ -56,7 +56,7 @@ async def test_external_answer_narrows_next_turn_end_to_end(tmp_path):
     iv = UserIntervention(kind="ask_user", prompt="name?", run_id="r1")
     iv.future = asyncio.get_running_loop().create_future()
     task = asyncio.ensure_future(s._dispatch_intervention(iv))
-    await wait_until(lambda: bool(s._interventions.list_active()))
+    await wait_until(lambda: bool(s.interventions.list_active()))
     delivered = await s._deliver_answer_to(iv, "Mallory", external_source=True)
     await asyncio.gather(task, return_exceptions=True)
     assert delivered is True
@@ -80,7 +80,7 @@ async def test_local_answer_does_not_narrow(tmp_path):
     iv = UserIntervention(kind="ask_user", prompt="?", run_id="r1")
     iv.future = asyncio.get_running_loop().create_future()
     task = asyncio.ensure_future(s._dispatch_intervention(iv))
-    await wait_until(lambda: bool(s._interventions.list_active()))
+    await wait_until(lambda: bool(s.interventions.list_active()))
     await s._deliver_answer_to(iv, "local user input", external_source=False)
     await asyncio.gather(task, return_exceptions=True)
 

--- a/tests/core/test_context_inbound_fence_1822.py
+++ b/tests/core/test_context_inbound_fence_1822.py
@@ -56,7 +56,7 @@ def test_ep3_project_context_passes_through_unfenced(tmp_path):
     only the wrapping is gone (see the byte-identical-across-turns test
     below for why the wrapping itself was the defect)."""
     s = _make_session(tmp_path, project_context=_INJECTION)
-    out = s._router_host.get_project_context()
+    out = s.router_host.get_project_context()
     assert out == _INJECTION                    # passthrough, no fence markers
     assert "EXTERNAL_UNTRUSTED" not in out
 
@@ -64,7 +64,7 @@ def test_ep3_project_context_passes_through_unfenced(tmp_path):
 def test_ep3_empty_project_context_returns_empty(tmp_path):
     """Tier 3: empty project_context stays empty (no markers) — §6 skip-render."""
     s = _make_session(tmp_path, project_context="")
-    out = s._router_host.get_project_context()
+    out = s.router_host.get_project_context()
     assert out == ""
 
 
@@ -83,8 +83,8 @@ def test_ep3_project_context_repeated_calls_match(tmp_path):
     permission gate, not a per-turn marker.
     """
     s = _make_session(tmp_path, project_context="stable project context, unchanged between turns")
-    first = s._router_host.get_project_context()
-    second = s._router_host.get_project_context()
+    first = s.router_host.get_project_context()
+    second = s.router_host.get_project_context()
     assert first == second, (
         "project_context must be byte-identical across turns when the "
         f"underlying content hasn't changed: {first!r} != {second!r}"

--- a/tests/core/test_emit_hook_event_0059_phase5_part2.py
+++ b/tests/core/test_emit_hook_event_0059_phase5_part2.py
@@ -420,7 +420,7 @@ async def test_emit_origin_self_stimulating_chain_force_closes_at_cap(tmp_path):
         # handler — the self-stimulating step of the chain.
         ctx = OpContext(
             workspace=None, events=session._audit_events, permission_decl=PermissionDecl(),
-            session_id=session._session_id, hook_bus=session._hook_bus,
+            session_id=session.session_id, hook_bus=session._hook_bus,
         )
         op = EmitHookEventIROp(kind="emit_hook_event", event_name="ping")
         await emit_handle(op, ctx)

--- a/tests/core/test_mcp_hot_reload_2372.py
+++ b/tests/core/test_mcp_hot_reload_2372.py
@@ -47,7 +47,7 @@ def _install_server_in_config(tmp_path: Path, name: str) -> None:
 
 
 def _server_names(session: Session) -> list[str]:
-    return [s["name"] for s in session._router_host.get_mcp_servers()]
+    return [s["name"] for s in session.router_host.get_mcp_servers()]
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_mcp_install_op.py
+++ b/tests/core/test_mcp_install_op.py
@@ -150,7 +150,7 @@ def _phase5_install_decl(resolver: PermissionResolver) -> PermissionDecl:
     the registry response). Session-approves the file path so the
     ``require_file_write`` check passes without an interactive prompt.
     """
-    canonical_config = str(resolver._project_root / ".reyn" / "config" / "mcp.yaml")
+    canonical_config = str(resolver.project_root / ".reyn" / "config" / "mcp.yaml")
     resolver.session_approve_path(canonical_config, "mcp_install_test", "file.write")
     return PermissionDecl(
         file_write=[{"path": canonical_config, "scope": "just_path"}],
@@ -342,7 +342,7 @@ def test_save_secret_blocked_when_secret_write_not_declared(tmp_path, monkeypatc
     """
     monkeypatch.setattr("shutil.which", lambda _cmd: "/usr/bin/npx")
     resolver = _make_resolver(tmp_path)
-    canonical_config = str(resolver._project_root / ".reyn" / "config" / "mcp.yaml")
+    canonical_config = str(resolver.project_root / ".reyn" / "config" / "mcp.yaml")
     resolver.session_approve_path(canonical_config, "mcp_install_test", "file.write")
     decl = PermissionDecl(
         file_write=[{"path": canonical_config, "scope": "just_path"}],

--- a/tests/core/test_mcp_source_install.py
+++ b/tests/core/test_mcp_source_install.py
@@ -219,7 +219,7 @@ def _phase5_source_install_decl(resolver: PermissionResolver) -> PermissionDecl:
     secret.write (= #571 Phase 6) covers any isSecret env vars the
     source resolver surfaces.
     """
-    canonical_config = str(resolver._project_root / ".reyn" / "config" / "mcp.yaml")
+    canonical_config = str(resolver.project_root / ".reyn" / "config" / "mcp.yaml")
     resolver.session_approve_path(canonical_config, "mcp_install_source_test", "file.write")
     return PermissionDecl(
         file_write=[{"path": canonical_config, "scope": "just_path"}],

--- a/tests/core/test_pipeline_is4_inline.py
+++ b/tests/core/test_pipeline_is4_inline.py
@@ -151,13 +151,13 @@ def _ctx(
     PipelineRegistry. ``wired=False`` drops agent_registry/host to exercise the
     wiring-error path."""
     return ToolContext(
-        events=caller._router_host.events,
+        events=caller.router_host.events,
         permission_resolver=None,
         workspace=None,
         caller_kind="router",
         router_state=RouterCallerState(
             agent_registry=reg if wired else None,
-            host=caller._router_host if wired else None,
+            host=caller.router_host if wired else None,
         ),
         state_log=state_log,
     )

--- a/tests/core/test_present_registry_fp0054_prc.py
+++ b/tests/core/test_present_registry_fp0054_prc.py
@@ -379,7 +379,7 @@ def _write_dynamic_template(tmp_path: Path, name: str, blueprint) -> None:
 async def test_hotreload_seam_registered(tmp_path: Path) -> None:
     """Tier 2: the Session registers the presentations seam on the HotReloader."""
     session = _make_session(tmp_path)
-    seam_names = [name for (name, _fn) in session._hot_reloader._seams]
+    seam_names = [name for (name, _fn) in session.hot_reloader._seams]
     assert "presentations" in seam_names
 
 
@@ -416,8 +416,8 @@ async def test_hotreload_via_apply_pending(
     session = _make_session(tmp_path)
     _write_dynamic_template(tmp_path, "authors", _AUTHORS_TEMPLATE)
 
-    session._hot_reloader.request_reload(source="operator")
-    summary = await session._hot_reloader.apply_pending()
+    session.hot_reloader.request_reload(source="operator")
+    summary = await session.hot_reloader.apply_pending()
 
     assert summary is not None
     assert "presentations" in summary["applied"]

--- a/tests/core/test_reset_for_rewind.py
+++ b/tests/core/test_reset_for_rewind.py
@@ -43,13 +43,13 @@ async def test_reset_for_rewind_then_restore_state_zero_residue(tmp_path):
 
     # ── populate pre-rewind live state (OLD markers) ──
     session.inbox.put_nowait(("user", {"text": "OLD"}))
-    await session._chains.register(
+    await session.chains.register(
         chain_id="OLD-chain", depth=0,
         original_text="old", sender=None,
     )
-    session._buffered_intervention_answers["OLD-run"] = InterventionAnswer(text="OLD")
+    session.buffered_intervention_answers["OLD-run"] = InterventionAnswer(text="OLD")
     old_iv = UserIntervention(kind="ask_user", prompt="OLD?")
-    session._interventions._stalled[old_iv.id] = old_iv
+    session.interventions._stalled[old_iv.id] = old_iv
     await asyncio.sleep(0)
 
     # ── reset, then adopt a reconstructed snapshot carrying only NEW state ──
@@ -60,7 +60,7 @@ async def test_reset_for_rewind_then_restore_state_zero_residue(tmp_path):
     session.restore_state(new_snap)
 
     # ── public views reflect ONLY the new snapshot — zero OLD residue ──
-    chain_ids = session._chains.all_chain_ids()
+    chain_ids = session.chains.all_chain_ids()
     assert chain_ids == []                                  # OLD-chain cleared
     assert session.list_stalled_interventions() == []       # OLD iv cleared
     assert session.buffered_intervention_answers == {}       # OLD buffered cleared
@@ -143,7 +143,7 @@ async def test_reset_for_rewind_is_idempotent_on_clean_session(tmp_path):
 
     await session.reset_for_rewind()  # nothing populated — must not raise
 
-    chain_ids = session._chains.all_chain_ids()
+    chain_ids = session.chains.all_chain_ids()
     assert chain_ids == []
     assert session.list_stalled_interventions() == []
     assert session.buffered_intervention_answers == {}

--- a/tests/core/test_session_intervention_persistence.py
+++ b/tests/core/test_session_intervention_persistence.py
@@ -135,7 +135,7 @@ async def test_deliver_answer_appends_intervention_resolved(tmp_path, monkeypatc
     # pre-existing ``wait_until`` polls the IN-MEMORY pending state, NOT the resolved WAL event, so
     # it is a FALSE barrier here; ``flush()`` is the bounded-by-construction one (root of the 3.12
     # flake: the read raced the append's durability).
-    await session._journal.flush()
+    await session.journal.flush()
     events = _wal_events(tmp_path)
     resolved = [e for e in events if e["kind"] == "intervention_resolved"]
     assert resolved, "intervention_resolved must be emitted after successful answer"
@@ -164,7 +164,7 @@ async def test_unknown_choice_does_not_emit_resolved(tmp_path, monkeypatch):
 
     # #2279: the ``wait_until`` above polled IN-MEMORY pending, not the WAL — so drain the worker
     # before the raw read to make ``intervention_dispatched`` durability deterministic (else racy).
-    await session._journal.flush()
+    await session.journal.flush()
     events = _wal_events(tmp_path)
     dispatched = [e for e in events if e["kind"] == "intervention_dispatched"]
     resolved = [e for e in events if e["kind"] == "intervention_resolved"]
@@ -230,13 +230,13 @@ async def test_wal_read_without_flush_races_durability_the_root(tmp_path, monkey
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
     # Fire-and-forget the exact append the flaky test asserts on.
-    session._journal._wal_append_nowait(
+    session.journal._wal_append_nowait(
         "intervention_resolved", target="alpha", intervention_id="iv-x",
     )
     # RAW read with no await / no flush → the worker has not drained → NOT durable yet (the race).
     before = [e for e in _wal_events(tmp_path) if e["kind"] == "intervention_resolved"]
     assert before == [], "read-before-flush: a fire-and-forget append is not yet durable (the race root)"
     # The flush barrier → drain → durable → deterministic read.
-    await session._journal.flush()
+    await session.journal.flush()
     after = [e for e in _wal_events(tmp_path) if e["kind"] == "intervention_resolved"]
     assert after and after[0]["intervention_id"] == "iv-x", "flush() makes the append durable"

--- a/tests/core/test_spawn_routing_detached_fail_mode_2708.py
+++ b/tests/core/test_spawn_routing_detached_fail_mode_2708.py
@@ -383,7 +383,7 @@ async def _spawn_from(
 ) -> "tuple[Session, str]":
     """Spawn a child session from ``spawner`` via the LLM session_spawn adapter path (so the child
     gets the adapter's BridgeToParent routing), returning ``(child_session, child_sid)``."""
-    host = spawner._router_host
+    host = spawner.router_host
     host._live_sid_in = LiveSessionIdInputs(
         session_id=host._live_sid_in.session_id, live_session_id_fn=lambda: spawner_sid,
     )

--- a/tests/interfaces/test_user_submitted_render_3300.py
+++ b/tests/interfaces/test_user_submitted_render_3300.py
@@ -305,7 +305,7 @@ async def test_user_submitted_precedes_turn_started(tmp_path, monkeypatch) -> No
 
     await session.submit_user_text("hello")
     await _run_n_turns_then_shutdown(session, n=1)
-    await session._journal.flush()
+    await session.journal.flush()
 
     types = [e.type for e in sink.events]
     assert "user_submitted" in types
@@ -333,7 +333,7 @@ async def test_history_persistence_unaffected_by_the_echo_move(tmp_path, monkeyp
 
     await session.submit_user_text("persist me")
     await _run_n_turns_then_shutdown(session, n=1)
-    await session._journal.flush()
+    await session.journal.flush()
 
     texts = [m.content for m in session.history if m.role == "user"]
     assert any("persist me" in str(t) for t in texts)

--- a/tests/llm/test_4381_pr2_stage3_in_flight_untrusted_flag.py
+++ b/tests/llm/test_4381_pr2_stage3_in_flight_untrusted_flag.py
@@ -92,14 +92,14 @@ def _simulate_deferred_commit(session: Session) -> None:
     construction, so patching the instance attribute after the fact would
     not be observed by the callback the adapter already holds.
     """
-    real_cb = session._router_host._append_history_cb
+    real_cb = session.router_host._append_history_cb
 
     def _drop_untrusted_tool_result(msg: Any) -> None:
         if msg.role == "tool" and (msg.meta or {}).get("external_source"):
             return
         real_cb(msg)
 
-    session._router_host._append_history_cb = _drop_untrusted_tool_result
+    session.router_host._append_history_cb = _drop_untrusted_tool_result
 
 
 @pytest.mark.asyncio
@@ -146,7 +146,7 @@ async def test_falsify_without_the_flag_the_same_window_is_open(tmp_path, monkey
     # Neutralize ONLY the flag-setting path — RouterHostAdapter.
     # mark_untrusted_in_flight forwards to this callback; a no-op leaves the
     # gate with nothing but the (deliberately blinded) history scan.
-    session._router_host._mark_untrusted_in_flight_cb = None
+    session.router_host._mark_untrusted_in_flight_cb = None
     monkeypatch.setattr(
         "reyn.runtime.router_loop.call_llm_tools",
         _scripted_llm([

--- a/tests/mcp/test_mcp_client_stderr_capture.py
+++ b/tests/mcp/test_mcp_client_stderr_capture.py
@@ -104,7 +104,7 @@ def test_close_stderr_capture_clears_attribute() -> None:
     """Tier 2: after close, ``_stderr_capture`` is None and tail is empty."""
     client = _client()
     client._stderr_capture = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
-    client._stderr_capture.write("anything")
+    client.stderr_capture.write("anything")
     client.close_stderr_capture()
     assert client.stderr_capture is None
     assert client.read_stderr_tail() == ""

--- a/tests/runtime/test_2103_C1_topology_create_tool_1953.py
+++ b/tests/runtime/test_2103_C1_topology_create_tool_1953.py
@@ -111,7 +111,7 @@ async def test_create_topology_accepts_subtree_members_and_routes_through_emit_s
     assert res["status"] == "created"
     assert reg.get_topology("myteam") is not None  # persisted
     # routed through the emit seam → topology_created landed in the WAL
-    events = list(reg._state_log.iter_from(0))
+    events = list(reg.state_log.iter_from(0))
     assert any(e.get("kind") == "topology_created" for e in events)
 
 
@@ -138,7 +138,7 @@ async def test_create_topology_rejects_non_subtree_member(tmp_path):
     import pytest as _pytest
     with _pytest.raises(Exception):
         reg.get_topology("grab")
-    events = list(reg._state_log.iter_from(0))
+    events = list(reg.state_log.iter_from(0))
     assert not any(
         e.get("kind") == "topology_created" and e.get("name") == "grab" for e in events
     )

--- a/tests/runtime/test_2548_skill_hotreload_toggle_pr_b.py
+++ b/tests/runtime/test_2548_skill_hotreload_toggle_pr_b.py
@@ -72,7 +72,7 @@ def _write_skills(tmp_path: Path, entries: dict) -> None:
 
 def _skill_names(session: Session) -> "list[str]":
     """Read skill names via the LIVE public surface (RouterHostAdapter)."""
-    skills = session._router_host.get_available_skills()
+    skills = session.router_host.get_available_skills()
     if not skills:
         return []
     return [s.name for s in skills]

--- a/tests/runtime/test_2946_item2_restore_all_bucketing.py
+++ b/tests/runtime/test_2946_item2_restore_all_bucketing.py
@@ -120,7 +120,7 @@ async def test_restore_all_buckets_by_agent_session_and_survives_truncation(tmp_
     # re-enqueues for the user to answer, unlike a restored inbox message
     # (which can trigger a LIVE LLM turn on `ensure_running`, per
     # `test_multi_session_restore.py`'s docstring on this same hazard).
-    state_log1 = reg1._state_log
+    state_log1 = reg1.state_log
     assert state_log1 is not None
     await state_log1.append(
         "intervention_dispatched", target=AGENT,
@@ -147,7 +147,7 @@ async def test_restore_all_buckets_by_agent_session_and_survives_truncation(tmp_
         "sanity: the legacy entry must NOT leak into the spawned bucket"
     )
 
-    state_log2 = reg2._state_log
+    state_log2 = reg2.state_log
     assert state_log2 is not None
 
     # the source events (iv_main / iv_spawn / iv_legacy dispatch) are durable
@@ -208,6 +208,6 @@ async def test_restore_all_buckets_by_agent_session_and_survives_truncation(tmp_
     assert "iv_main" not in _active_iv_ids(spawned3)
     assert "iv_legacy" not in _active_iv_ids(spawned3)
 
-    reg3_state_log = reg3._state_log
+    reg3_state_log = reg3.state_log
     assert reg3_state_log is not None
     await reg3_state_log.aclose()

--- a/tests/runtime/test_3036_spawned_session_mcp_refresh.py
+++ b/tests/runtime/test_3036_spawned_session_mcp_refresh.py
@@ -85,7 +85,7 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
 
 
 def _server_names(session: Session) -> list[str]:
-    return [s["name"] for s in session._router_host.get_mcp_servers()]
+    return [s["name"] for s in session.router_host.get_mcp_servers()]
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_3137_cold_start_history_completeness_sweep.py
+++ b/tests/runtime/test_3137_cold_start_history_completeness_sweep.py
@@ -153,7 +153,7 @@ async def test_restore_all_constructed_session_has_complete_history(tmp_path, mo
         intervention_id="iv1", iv_dict=_iv_dict("iv1"),
     )
     await s1.journal.flush()
-    state_log1 = reg1._state_log
+    state_log1 = reg1.state_log
     assert state_log1 is not None
     await state_log1.aclose()
 
@@ -183,4 +183,4 @@ async def test_restore_all_constructed_session_has_complete_history(tmp_path, mo
         "transcript, not a partial/empty one"
     )
 
-    await reg2._state_log.aclose()
+    await reg2.state_log.aclose()

--- a/tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -263,14 +263,14 @@ async def _narrowed_invoker(reg: AgentRegistry) -> "tuple[Session, str]":
 
 def _tool_ctx(session: Session, reg: AgentRegistry, state_log: StateLog) -> ToolContext:
     return ToolContext(
-        events=session._router_host.events,
+        events=session.router_host.events,
         permission_resolver=None,
         workspace=None,
         caller_kind="router",
         router_state=RouterCallerState(
             pipeline_registry=session.pipeline_registry,
             agent_registry=reg,
-            host=session._router_host,
+            host=session.router_host,
         ),
         state_log=state_log,
     )

--- a/tests/runtime/test_3556_session_spawn_narrowing_inheritance.py
+++ b/tests/runtime/test_3556_session_spawn_narrowing_inheritance.py
@@ -201,7 +201,7 @@ def _spawn_ctx(spawner: Session, reg: AgentRegistry, state_log: StateLog) -> Too
     ``spawn_session_fn`` is the spawner's own ``RouterHostAdapter.spawn_session`` with
     ``chain_id`` pre-bound (``router_loop._spawn_session_bound_impl``). The tool handler
     and the adapter method — the site under test — are both the production objects."""
-    host = spawner._router_host
+    host = spawner.router_host
 
     async def _spawn_session_bound(
         *, request: str, mode: str, narrowing: "dict | None" = None,

--- a/tests/runtime/test_4244_pipeline_hooks_add_denied.py
+++ b/tests/runtime/test_4244_pipeline_hooks_add_denied.py
@@ -84,7 +84,7 @@ def _bound_driver(reg: AgentRegistry, session: Session) -> PipelineExecutorDrive
         driver_agent=session.agent_name, driver_sid="main",
     )
     driver = PipelineExecutorDriver(work_order, registry=reg, state_log=reg.state_log)
-    driver.bind_session(session, session._router_host)
+    driver.bind_session(session, session.router_host)
     return driver
 
 

--- a/tests/runtime/test_agent_lifecycle_emit_2103_s2b.py
+++ b/tests/runtime/test_agent_lifecycle_emit_2103_s2b.py
@@ -54,7 +54,7 @@ async def test_create_agent_emits_agent_created_with_config(tmp_path):
     carrying the profile config — the record rewind re-materialises from."""
     reg = _make_registry(tmp_path)
     await reg.create_agent("helper", role="my role")
-    await reg._state_log.flush()  # #2259 PR-2b: create_agent's agent_created append is async
+    await reg.state_log.flush()  # #2259 PR-2b: create_agent's agent_created append is async
 
     assert _agent_dir(tmp_path, "helper").is_dir()
     created = _events(reg, "agent_created")

--- a/tests/runtime/test_embed_cost_wiring_live_path.py
+++ b/tests/runtime/test_embed_cost_wiring_live_path.py
@@ -89,7 +89,7 @@ async def _run_embed_tool_via_live_path(session: Session) -> dict:
     `op_context_factory` resolution a live chat turn performs."""
     from reyn.tools.embed import _handle_embed
 
-    router_state = await build_resource_caller_state(session._router_host)
+    router_state = await build_resource_caller_state(session.router_host)
     tool_ctx = ToolContext(
         events=session._audit_events,
         permission_resolver=None,

--- a/tests/runtime/test_list_mcp_servers_canonical_shape.py
+++ b/tests/runtime/test_list_mcp_servers_canonical_shape.py
@@ -67,7 +67,7 @@ def test_end_to_end_list_mcp_servers_matches_conversation_and_llm_text(tmp_path)
     forwarder = ChatLifecycleForwarder(outbox)
     session._audit_events.add_subscriber(forwarder)
 
-    loop = RouterLoop(host=session._router_host, chain_id="c1", router_model="gpt-4o")
+    loop = RouterLoop(host=session.router_host, chain_id="c1", router_model="gpt-4o")
     catalog = {"list_mcp_servers": {"function": {"name": "list_mcp_servers", "parameters": {}}}}
     ctx = DispatchContext(
         caller_kind="router", caller_id="alice", chain_id="c1",

--- a/tests/runtime/test_mcp_list_tools_finally_close.py
+++ b/tests/runtime/test_mcp_list_tools_finally_close.py
@@ -116,7 +116,7 @@ async def test_list_tools_error_path_still_closes_same_task(tmp_path, monkeypatc
     _install_fake(monkeypatch, sess, raises=True)
 
     with pytest.raises(MCPFault) as excinfo:
-        await sess._router_host.mcp_list_tools("srv")
+        await sess.router_host.mcp_list_tools("srv")
     assert "boom from list_tools" in str(excinfo.value), (
         "the fault propagates as MCPFault (#3447: the catch moved to tools/mcp.py's "
         "_handle_list_mcp_tools, not raised here)"
@@ -134,7 +134,7 @@ async def test_list_tools_success_path_closes_and_returns(tmp_path, monkeypatch)
     sess = await _session(tmp_path)
     _install_fake(monkeypatch, sess, raises=False)
 
-    result = await sess._router_host.mcp_list_tools("srv")
+    result = await sess.router_host.mcp_list_tools("srv")
 
     assert result == [{"name": "some_tool"}]
     client = _FakeMCPClient.instances[-1]

--- a/tests/runtime/test_registry_wal_size_safety_net.py
+++ b/tests/runtime/test_registry_wal_size_safety_net.py
@@ -177,7 +177,7 @@ def test_maybe_truncate_for_size_fires_when_wal_large(tmp_path: Path):
 
     async def go():
         # Inflate WAL above the small threshold (50 KB to keep test fast)
-        await _inflate_wal(registry._state_log, target_bytes=51_200)
+        await _inflate_wal(registry.state_log, target_bytes=51_200)
         result = await registry.maybe_truncate_for_size(threshold_bytes=50_000)
         assert result is not None, (
             "WAL size > threshold must trigger truncate"
@@ -202,7 +202,7 @@ def test_maybe_truncate_for_size_bypasses_throttle(tmp_path: Path):
         await registry.truncate_wal_if_eligible()
         ts1 = registry.last_truncation_ts
         # Inflate
-        await _inflate_wal(registry._state_log, target_bytes=51_200)
+        await _inflate_wal(registry.state_log, target_bytes=51_200)
         # Size-triggered call should proceed even within throttle window
         result = await registry.maybe_truncate_for_size(threshold_bytes=50_000)
         assert result is not None
@@ -231,14 +231,14 @@ def test_size_safety_net_protects_active_skill_events(tmp_path: Path):
     _seed_skill(registry, "alpha", "run_active", last_phase_applied_seq=50)
 
     async def go():
-        await _inflate_wal(registry._state_log, target_bytes=51_200)
+        await _inflate_wal(registry.state_log, target_bytes=51_200)
         # Size-triggered truncate
         result = await registry.maybe_truncate_for_size(threshold_bytes=50_000)
         assert result is not None, "expected size-triggered truncate to run"
-        await registry._state_log.flush()  # #2259 PR-2b: truncate is fire-and-forget
+        await registry.state_log.flush()  # #2259 PR-2b: truncate is fire-and-forget
         # Floor = min(10_000, 50) + 1 = 51. Events with seq < 51 dropped,
         # seq >= 51 kept (active skill protection).
-        events = list(registry._state_log.iter_from(0))
+        events = list(registry.state_log.iter_from(0))
         kept_seqs = [e["seq"] for e in events]
         assert kept_seqs, "expected some events to be kept"
         assert min(kept_seqs) >= 51, (
@@ -247,7 +247,7 @@ def test_size_safety_net_protects_active_skill_events(tmp_path: Path):
         # And events below the floor really were dropped (= we inflated way more
         # than 50 entries, so dropping below 51 must have removed dozens). #2259 PR-2b:
         # truncate is fire-and-forget, so read the stats from last_truncate_stats post-flush.
-        stats = registry._state_log.last_truncate_stats
+        stats = registry.state_log.last_truncate_stats
         assert stats["dropped"] > 0, (
             f"expected drops below floor; stats={stats}"
         )

--- a/tests/runtime/test_send_to_session_3978_p5.py
+++ b/tests/runtime/test_send_to_session_3978_p5.py
@@ -51,7 +51,7 @@ def _seed(tmp_path: Path, name: str) -> None:
 def _ctx_for(caller: Session, reg: AgentRegistry) -> ToolContext:
     """A ToolContext wired the way RouterLoop wires one for this tool
     (router_loop._send_to_session_bound_impl's exact shape)."""
-    host = caller._router_host
+    host = caller.router_host
 
     async def _send_to_session_bound(
         *, agent: str, session: str, text: str, wake: bool = False,

--- a/tests/runtime/test_session_invariants.py
+++ b/tests/runtime/test_session_invariants.py
@@ -252,7 +252,7 @@ async def test_chain_register_emits_wal_event(tmp_path, monkeypatch):
         origin_depth=1,
     )
 
-    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
+    await session.journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = _wal_events(tmp_path)
     register_events = [e for e in events if e.get("kind") == "chain_register"]
 
@@ -331,7 +331,7 @@ async def test_chain_resolve_clears_snapshot_and_emits_resolve(tmp_path, monkeyp
     )
 
     # WAL must have register before resolve (intermediate updates are OK).
-    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
+    await session.journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = _wal_events(tmp_path)
     kinds = [e.get("kind") for e in events if e.get("chain_id") == "chain-res-001"]
     assert "chain_register" in kinds, f"chain_register missing from WAL: {kinds}"
@@ -528,7 +528,7 @@ async def test_chain_timeout_fires_upstream_error_and_emits_event(tmp_path, monk
     await wait_until(lambda: bool(upstream_received))
 
     # WAL must contain chain_register → chain_timeout_fired.
-    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
+    await session.journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = _wal_events(tmp_path)
     chain_events = [
         e for e in events if e.get("chain_id") == "chain-timeout-001"
@@ -662,7 +662,7 @@ async def test_inbox_put_consume_emits_wal_events_with_monotonic_seq(tmp_path, m
 
     await _run_one_turn()
 
-    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
+    await session.journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = _wal_events(tmp_path)
     put_events = [e for e in events if e.get("kind") == "inbox_put"]
     consume_events = [e for e in events if e.get("kind") == "inbox_consume"]
@@ -717,7 +717,7 @@ async def test_shutdown_signal_bypasses_wal(tmp_path, monkeypatch):
 
     await _run_with_shutdown()
 
-    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
+    await session.journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = _wal_events(tmp_path)
     shutdown_put = [
         e for e in events
@@ -955,7 +955,7 @@ async def test_p6_chain_state_changes_emit_events(tmp_path, monkeypatch):
     assert resolved_chain is not None, "resolve must return the chain"
 
     # ── WAL read: verify P6 invariant ─────────────────────────────────────
-    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
+    await session.journal.flush()  # #2259 PR-2b: drain async WAL writes
     wal_entries = _wal_events(tmp_path)
     kinds_present = {e["kind"] for e in wal_entries}
     required_kinds = {"inbox_put", "inbox_consume", "chain_register", "chain_resolve"}

--- a/tests/runtime/test_slash_model.py
+++ b/tests/runtime/test_slash_model.py
@@ -321,12 +321,12 @@ async def test_turn_budget_engine_rebuilt_on_model_switch(tmp_path):
     """
     session = _make_session(tmp_path, model="standard")
     session._resolver = _make_resolver()
-    before = session._router_host._turn_budget_engine
+    before = session.router_host._turn_budget_engine
 
     ctx = _ctx(session)
     await model_cmd(ctx, "strong")
 
-    after = session._router_host._turn_budget_engine
+    after = session.router_host._turn_budget_engine
     assert after is not before  # rebuilt (or explicitly re-evaluated) for the new model
 
 
@@ -405,7 +405,7 @@ async def test_turn_budget_engine_rebuild_does_not_raise_for_a_bare_model_name(t
     ctx = _ctx(session)
     await model_cmd(ctx, "terra")  # must not raise
 
-    engine = session._router_host._turn_budget_engine
+    engine = session.router_host._turn_budget_engine
     assert engine is not None, "a viable model must produce a real engine, not None"
 
 
@@ -428,5 +428,5 @@ def test_lazy_startup_turn_budget_engine_does_not_raise_for_a_bare_model_name(tm
     session._resolver = _make_resolver({"terra": {"model": "gpt-5.6-terra"}})
     session._model_override = "terra"
 
-    engine = session._router_host._ensure_turn_budget_engine()  # must not raise
+    engine = session.router_host._ensure_turn_budget_engine()  # must not raise
     assert engine is not None

--- a/tests/runtime/test_teardown_completeness_2783.py
+++ b/tests/runtime/test_teardown_completeness_2783.py
@@ -90,7 +90,7 @@ async def test_shutdown_drains_state_log(tmp_path, monkeypatch):
     reg = _make_registry(tmp_path)
     reg.get_or_load("owner")
 
-    reg._state_log.append_nowait("agent_archived", entity_kind="agent", name="owner")
+    reg.state_log.append_nowait("agent_archived", entity_kind="agent", name="owner")
     await reg.shutdown()
 
     wal_path = tmp_path / "wal.jsonl"

--- a/tests/scaffold/test_family3_hook_event_bundle_byte_identical.py
+++ b/tests/scaffold/test_family3_hook_event_bundle_byte_identical.py
@@ -121,7 +121,7 @@ class TestFamily3HookEventBundleByteIdentical:
         is_fs_watcher = isinstance(s._fs_watcher, FsWatcher)
         is_composer_registry = isinstance(s._composer_registry, ComposerRegistry)
         is_composed_consumer = isinstance(s._composed_consumer, ComposedEventConsumer)
-        is_hot_reloader = isinstance(s._hot_reloader, HotReloader)
+        is_hot_reloader = isinstance(s.hot_reloader, HotReloader)
         assert is_hook_bus
         assert is_dispatcher
         assert is_fs_watcher
@@ -264,7 +264,7 @@ class TestFamily3HookEventBundleByteIdentical:
         s = _make_session(tmp_path)
         collected = collect_events(s._audit_events)
         before = len(collected)
-        await s._hot_reloader.apply_all(exclude=frozenset({"cron"}))
+        await s.hot_reloader.apply_all(exclude=frozenset({"cron"}))
         after = [e.type for e in collected]
         assert len(after) > before
         assert "config_reloaded" in after
@@ -275,7 +275,7 @@ class TestFamily3HookEventBundleByteIdentical:
         that moved WITH the family to after the builder call), so
         ``get_active_hot_reloader()`` returns THIS session's instance."""
         s = _make_session(tmp_path)
-        this_sessions_reloader = s._hot_reloader
+        this_sessions_reloader = s.hot_reloader
         assert get_active_hot_reloader() is this_sessions_reloader
 
     @pytest.mark.asyncio

--- a/tests/scaffold/test_family6b_history_compaction_bundle_byte_identical.py
+++ b/tests/scaffold/test_family6b_history_compaction_bundle_byte_identical.py
@@ -242,9 +242,9 @@ class TestFamily6bHistoryCompactionBundleByteIdentical:
             model_fn=lambda: session._resolver.resolve(session.model).model,
             events=session._audit_events,
             media_store=session._media_store,
-            router_host=session._router_host,
+            router_host=session.router_host,
             universal_wrappers_enabled=session._universal_wrappers_enabled,  # #4552 PR-3
-            non_interactive=session._non_interactive,
+            non_interactive=session.non_interactive,
             reasoning=session._reasoning,
         )
         fresh_patched_controller = fresh_history_buffer._compaction_controller

--- a/tests/scaffold/test_family7_intervention_bundle_byte_identical.py
+++ b/tests/scaffold/test_family7_intervention_bundle_byte_identical.py
@@ -91,8 +91,8 @@ class TestFamily7InterventionBundleByteIdentical:
         ``InterventionRegistry`` / ``InterventionHandler`` /
         ``InterventionCoordinator`` / ``ChainTimeoutGlue`` instances onto
         Session — the extraction's core contract."""
-        chains = session._chains
-        interventions = session._interventions
+        chains = session.chains
+        interventions = session.interventions
         intervention_handler = session._intervention_handler
         intervention_coordinator = session._intervention_coordinator
         chain_timeout_glue = session._chain_timeout_glue
@@ -183,7 +183,7 @@ class TestFamily7InterventionBundleByteIdentical:
         inter_agent_messaging = session._inter_agent_messaging
         assert isinstance(inter_agent_messaging, InterAgentMessaging)
         wired_chains = inter_agent_messaging._chains
-        session_chains = session._chains
+        session_chains = session.chains
         assert wired_chains is session_chains
 
     # ── deferred: chains → chain_timeout_glue resolves only via a bound method, at CALL time ──
@@ -244,14 +244,14 @@ class TestFamily7InterventionBundleByteIdentical:
         instance ``InterAgentMessaging`` actually holds — proving that
         pin is genuinely reading the live cross-family wiring."""
         fresh_chains = ChainManager(
-            journal=session._journal,
+            journal=session.journal,
             events=session._audit_events,
             chain_timeout_seconds=session._chain_timeout_seconds,
             max_hop_depth=session._max_hop_depth,
         )
 
         wired_chains = session._inter_agent_messaging._chains
-        session_chains = session._chains
+        session_chains = session.chains
 
         assert fresh_chains is not session_chains
         assert wired_chains is session_chains

--- a/tests/scripts/test_tier_audit_private_read_public_alt_4864.py
+++ b/tests/scripts/test_tier_audit_private_read_public_alt_4864.py
@@ -1,0 +1,276 @@
+"""Tier 1: Rule 8 (#4864) — obj._x READ with a same-class public @property.
+
+Pins the mechanism the #4864 thread specified: Rule 3 (private-state) only
+walks ``ast.Assert`` test expressions, so the corpus's dominant evasion —
+route the private read through a local var one line before the assert —
+is invisible to it (126 sites, per the issue's own measurement). This rule
+is a whole-file scan (#4900's own lesson: per-test walk drops 9/10 real
+violations) that fires on ANY private read, not only inside ``assert``.
+
+The class-scoped, type-evidence-gated design is the load-bearing part,
+not incidental: architect's own #4864-thread pitfall is ``self._chains =
+chains``, assigned in FIVE different classes in this repo, where only ONE
+of them also defines ``@property def chains``. A global (does this attr
+name exist as a property ANYWHERE) index would misfire on the other four.
+These tests pin that a same-named-but-unbacked class does NOT cross-fire,
+and that firing requires actual local type evidence (a param annotation
+or a same-file factory/fixture def with a typed return) — never a bare
+variable-name guess.
+
+Tier 1 because this is the audit script's own contract surface, same
+justification as ``test_tier_audit_private_state_ast.py``.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+
+import pytest
+
+from tests._support.paths import REPO_ROOT
+
+
+def _load_audit_module():
+    """Import ``scripts/test_tier_audit.py`` without pytest collecting it
+    as a test module (same rationale as the sibling private-state test)."""
+    import sys
+    script = REPO_ROOT / "scripts" / "test_tier_audit.py"
+    spec = importlib.util.spec_from_file_location("_audit_tier_audit_script_4864", script)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def audit_mod():
+    return _load_audit_module()
+
+
+def _findings_for(audit_mod, source: str, class_index: dict) -> list:
+    tree = ast.parse(source)
+    return audit_mod._check_private_read_with_public_alt(source, tree, class_index)
+
+
+# ── Positive cases: detection MUST fire ─────────────────────────────────────
+
+
+def test_factory_typed_return_makes_the_read_type_evident(audit_mod) -> None:
+    """Tier 1: ``x = _make_foo()`` where ``_make_foo() -> Foo`` is a
+    same-file def gives the rule its type evidence — the dominant
+    corpus idiom (a local ``_make_x`` factory, not ``Foo(...)`` inline)."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        "def _make_foo() -> Foo:\n"
+        "    return Foo()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    foo = _make_foo()\n"
+        "    assert foo._router_host is not None\n"
+    )
+    (only,) = _findings_for(audit_mod, src, class_index)
+    assert "_router_host" in only.message
+    assert "Foo.router_host" in only.message
+
+
+def test_param_annotation_makes_the_read_type_evident(audit_mod) -> None:
+    """Tier 1: ``def test_x(foo: Foo)`` — annotation is direct evidence,
+    no factory needed."""
+    class_index = {"Foo": ({"_state_log"}, "src/foo.py")}
+    src = (
+        "def test_thing(foo: Foo):\n"
+        '    """Tier 2: example."""\n'
+        "    assert foo._state_log is None\n"
+    )
+    (only,) = _findings_for(audit_mod, src, class_index)
+    assert "_state_log" in only.message
+
+
+def test_quoted_union_annotation_makes_the_read_type_evident(audit_mod) -> None:
+    """Tier 1: ``def f(x: "Foo | None")`` — a quoted forward-ref union.
+
+    Not a hypothetical: this is the exact shape that made the FIRST
+    version of this rule miss one of architect's own 4 named positive
+    controls (#4864 thread) —
+    ``def _op_ctx(tmp_path, session: "Session | None") -> OpContext:``
+    in ``tests/core/test_2761_pr2_hotreload_immediate_apply.py:101``.
+    ``_annotation_class_name`` originally treated the whole quoted string
+    as one opaque candidate name (``"Session | None"``, matching nothing);
+    fixed by re-parsing the string and unioning both branches."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        "def test_thing(foo: \"Foo | None\"):\n"
+        '    """Tier 2: example."""\n'
+        "    assert (foo._router_host if foo is not None else None) is None\n"
+    )
+    (only,) = _findings_for(audit_mod, src, class_index)
+    assert "_router_host" in only.message
+
+
+def test_fires_outside_assert_too(audit_mod) -> None:
+    """Tier 1: the whole point of this rule — a private read that never
+    reaches an ``assert`` (routed through a local var, or read for a
+    side effect) still fires. Rule 3 cannot see this by construction."""
+    class_index = {"Foo": ({"_hot_reloader"}, "src/foo.py")}
+    src = (
+        "def _make_foo() -> Foo:\n"
+        "    return Foo()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    foo = _make_foo()\n"
+        "    foo._hot_reloader.request_reload(source='test')\n"
+    )
+    (only,) = _findings_for(audit_mod, src, class_index)
+    assert "_hot_reloader" in only.message
+
+
+# ── Negative cases: detection MUST NOT fire ─────────────────────────────────
+
+
+def test_same_attr_name_unbacked_on_this_class_does_not_fire(audit_mod) -> None:
+    """Tier 1: the ``_chains`` pitfall, reproduced directly. ``Bar`` assigns
+    ``self._chains`` too (per the class index, mirroring the real repo's
+    SpawnTracker/RouterHostAdapter/ChainTimeoutGlue/InterAgentMessaging)
+    but does NOT publish a ``chains`` @property — only some OTHER class
+    (``Foo``, standing in for ``Session``) does. A global name-only index
+    would misfire here; the class-scoped index must not."""
+    class_index = {
+        "Foo": ({"_chains"}, "src/foo.py"),  # backed: has @property chains
+        "Bar": (set(), "src/bar.py"),  # self._chains assigned, no @property
+    }
+    src = (
+        "def _make_bar() -> Bar:\n"
+        "    return Bar()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    bar = _make_bar()\n"
+        "    assert bar._chains is not None\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index)
+    assert findings == []
+
+
+def test_no_public_alternative_anywhere_does_not_fire(audit_mod) -> None:
+    """Tier 1: an attribute name absent from the index entirely (the
+    ``_audit_events`` case — #4866 dropped that half of its own title)
+    never fires, regardless of local type evidence."""
+    class_index = {"Foo": (set(), "src/foo.py")}
+    src = (
+        "def _make_foo() -> Foo:\n"
+        "    return Foo()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    foo = _make_foo()\n"
+        "    assert foo._audit_events is not None\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index)
+    assert findings == []
+
+
+def test_no_type_evidence_does_not_fire(audit_mod) -> None:
+    """Tier 1: a bare, unannotated variable from an untyped call gives NO
+    evidence — the rule must not guess from the variable's own name
+    (``foo`` looking like it should be a ``Foo``)."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    foo = get_thing()\n"
+        "    assert foo._router_host is not None\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index)
+    assert findings == []
+
+
+def test_own_private_state_self_dot_x_not_flagged(audit_mod) -> None:
+    """Tier 1: ``self._x`` inside the test's own helper class is the
+    test's own private state, not a collaborator's — architect's own
+    explicit exclusion in the #4864 thread."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        "class _Helper:\n"
+        "    def check(self):\n"
+        "        assert self._router_host is None\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    _Helper().check()\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index)
+    assert findings == []
+
+
+def test_direct_assignment_write_not_flagged(audit_mod) -> None:
+    """Tier 1: ``client._x = value`` is a WRITE (Store context), not the
+    READ this rule targets — that's #4873's territory (a real object
+    mock-ified in place), a different rule. Must not double-fire here."""
+    class_index = {"Foo": ({"_negotiated_version"}, "src/foo.py")}
+    src = (
+        "def _make_foo() -> Foo:\n"
+        "    return Foo()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    foo = _make_foo()\n"
+        "    foo._negotiated_version = '2025-11-25'\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index)
+    assert findings == []
+
+
+def test_dunder_excluded(audit_mod) -> None:
+    """Tier 1: dunder attributes are language-level surfaces, not private
+    state — same exclusion as Rule 3."""
+    class_index = {"Foo": ({"__class__"}, "src/foo.py")}
+    src = (
+        "def _make_foo() -> Foo:\n"
+        "    return Foo()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    foo = _make_foo()\n"
+        "    assert foo.__class__.__name__ == 'Foo'\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index)
+    assert findings == []
+
+
+# ── Regression pin: the real Session.hot_reloader / router_host sites ───────
+
+
+def test_real_corpus_class_property_index_backs_session_hot_reloader(audit_mod) -> None:
+    """Tier 1: against the REAL ``src/`` tree, ``Session`` must be indexed
+    with ``_hot_reloader`` backed by ``@property def hot_reloader`` — the
+    exact positive control architect named in the #4864 thread (#4868 left
+    4 raw ``session._hot_reloader`` sites in the very file meant to repair
+    them). A regression here means the index-builder stopped seeing a
+    property it used to see, silently turning the gate into a no-op."""
+    index = audit_mod._build_class_property_index(REPO_ROOT / "src")
+    assert "Session" in index
+    backed, _file = index["Session"]
+    assert "_hot_reloader" in backed
+    assert "_router_host" in backed
+
+
+def test_real_corpus_chains_is_not_a_global_name_match(audit_mod) -> None:
+    """Tier 1: ``RouterHostAdapter`` assigns ``self._chains = chains`` (the
+    exact pitfall architect named in the #4864 thread) but does not
+    publish a ``chains`` @property. If the index degenerated into a
+    global (does ``_chains`` exist as a property SOMEWHERE) match, a
+    read on a ``RouterHostAdapter`` instance would wrongly fire the gate
+    just because ``Session`` — a different class — happens to publish
+    ``chains``. This proves the index stays class-scoped against the
+    real source tree, not just the synthetic classes above."""
+    index = audit_mod._build_class_property_index(REPO_ROOT / "src")
+    assert "Session" in index
+    session_backed, _file = index["Session"]
+    assert "_chains" in session_backed  # sanity: Session really is backed
+
+    assert "RouterHostAdapter" in index
+    adapter_backed, _adapter_file = index["RouterHostAdapter"]
+    assert "_chains" not in adapter_backed


### PR DESCRIPTION
**[tui-coder]** — closes #4864 (architect's spec, self-assigned when idle per lead-coder's standing invitation)

## What changed

**Rule 8** in `scripts/test_tier_audit.py`: `obj._x` READ anywhere in a
test file — not only inside `assert`. Rule 3 (private-state) only walks
`ast.Assert` test expressions, so the issue's own measurement (126
sites) is exactly what that scoping misses: route the private read
through a local var one line before the `assert` and it's invisible.
Whole-file scan (same lesson #4900 already paid for: per-test walk drops
9/10 real violations).

**Fires only when the read is type-evident** as a class that ALSO
publishes the same name via `@property` — never from the variable's own
name. Evidence accepted: a parameter annotation, a local annotated
assignment, or (the corpus's dominant idiom) a same-file factory/fixture
def with a typed return, e.g. `def _make_session(...) -> Session:`.

## The pitfall architect named, reproduced as a test

`self._chains = chains` is assigned in **5 different classes** in this
repo (`SpawnTracker`/`RouterHostAdapter`/`ChainTimeoutGlue`/
`InterAgentMessaging`/`Session`) — only `Session` also defines
`@property def chains`. A global (does this attr name exist as a
property *anywhere*) index would misfire on the other four. The index is
keyed **by class name**, and firing requires the read's own object to be
evidently that specific class — pinned both against synthetic classes
and directly against the real `src/` tree (`RouterHostAdapter` indexed,
`_chains` absent from its backed set) in
`tests/scripts/test_tier_audit_private_read_public_alt_4864.py`.

`_audit_events` (no `@property` anywhere — #4866 dropped that half of
its own title) and a direct assignment `client._x = value` (a WRITE,
Store context — that's #4873's territory, a different rule) are also
pinned as non-firing.

## Repair obligation, not bare detector

Per architect's #4864-thread spec: the message doesn't stop at "use .x
instead". #4866 is the concrete instance where a fail was closed by
*adding* a same-named `@property` that just republished the private
field — "ratif[ying] the encapsulation break instead of closing it"
(#4866's own diff wording). The suggestion text says so explicitly: if
no public alternative already answers what the test is asking, don't
manufacture one to silence this gate.

## Corpus fix — 109 real sites, 41 files

Running the new rule against the full `tests/` tree found 109 real
sites (not enumerated by hand — the gate found them). All fixed
mechanically (verified: each replacement targets the exact flagged
`file:line`, not a blanket rename):
`._router_host` / `._hot_reloader` / `._chains` / `._journal` /
`._state_log` / `._interventions` / `._buffered_intervention_answers` /
`._project_root` / `._session_id` / `._stderr_capture` /
`._non_interactive` → their public `@property` equivalents.

Includes the exact positive control architect named: the 4 residual
`._hot_reloader` sites `#4868` itself left unrepaired in
`tests/core/test_2761_pr2_hotreload_immediate_apply.py` — but only 3 of
the 4 (`:437/478/506`) fired on the first pass. The 4th (`:101`) uses a
quoted union annotation, `session: "Session | None"`, which the first
version of `_annotation_class_name` treated as one opaque string
(matching nothing). Caught by individually re-checking architect's 4
named line numbers against this PR's own findings before writing this
body — not by a corpus-wide re-measurement, and the gap that let it
through in the first place is now closed generally (unions resolve via
re-parse-and-union, not special-cased to this one site), with a
regression test (`test_quoted_union_annotation_makes_the_read_type_
evident`) and falsification.

## Disclosed, not claimed away

- Two classes sharing a bare name in different files collide in the
  index (last-scanned wins) — unmeasured corpus-wide, same caveat class
  as #4873's own disclosed dynamic-`setattr` gap.
- Type inference is local-function-scoped only: a fixture defined in
  `conftest.py` and injected by pytest into a test in a different file
  gives no evidence here (no cross-file fixture resolution). This is a
  deliberately conservative, zero-false-positive bias, not an attempt at
  general type inference — it under-detects rather than over-fires.
- The base object is restricted to a bare `ast.Name` (not `a.b._x`
  chains) — narrower than Rule 3's own AST walk, for the same
  type-evidence reason.
- A=25/B=1/C=68's individual classification (architect, #4864 thread)
  was never opened site-by-site by architect or by me; this PR's 109
  found-and-fixed sites are the gate's own output, not a transcription
  of that classification.

## Falsification

Reverting the class-scoping (making the lookup a global name-only
union) reproduces a false fire on the reproduced `_chains` pitfall test.
Reverting the `ast.Load`-only filter reproduces a false fire on the
direct-assignment-write test. Reverting the union-annotation handling
reproduces the exact miss on `:101` (test fails: `not enough values to
unpack`, 0 findings instead of 1). All three verified before landing.

## Time-dependency check

0 instances.

## Test plan

- [x] `python scripts/test_tier_audit.py --check private-read-public-alt tests/` — 10,626 tests, 0 errors (real zero baseline after the corpus fix, including the `:101` union-annotation site)
- [x] Falsification (see above) — the class-scoping guard, the Store-context exclusion, and the union-annotation fix, all verified
- [x] `pytest` on all 42 changed test files + the new test file — 362 passed (full diff), re-verified incrementally after the union-annotation fix — 31 passed
- [x] `ruff check .` (full diff scope) — all checks passed
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/verify_module_docstrings.py scripts/test_tier_audit.py tests/scripts/test_tier_audit_private_read_public_alt_4864.py` — OK
- [x] `python scripts/test_tier_audit.py --strict` (changed test files) — 0 errors, 0 warnings
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [ ] Visual — n/a (no TUI/rendering surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
