### PR TITLE
fix(#4893): dogfood judge — supports_response_schema precheck, json_schema strict, no more silent score=0.0

### DIFF
--- a/src/reyn/dev/dogfood/verifiers/reply.py
+++ b/src/reyn/dev/dogfood/verifiers/reply.py
@@ -8,6 +8,7 @@ Supports four kinds:
 """
 from __future__ import annotations
 
+import asyncio
 import re
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
@@ -24,18 +25,156 @@ if TYPE_CHECKING:
 # Default LLM judge backend
 # ---------------------------------------------------------------------------
 
+# #4893: hand-written, not routed through core.pipeline.schema's
+# SchemaRegistry/to_json_schema (0062's own generator) — that registry
+# exists to validate named, cross-referencing pipeline field schemas; this
+# is 3 flat fields with no refs, and #4883/#4899 (compaction's own
+# equivalent, _CHAT_SUMMARY_JSON_SCHEMA) set the precedent of a small
+# literal dict for exactly this shape rather than standing up a registry
+# for one ad hoc verdict schema.
+_JUDGE_JSON_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "passed": {"type": "boolean"},
+        "score": {"type": "number"},
+        "reason": {"type": "string"},
+    },
+    "required": ["passed", "score", "reason"],
+    "additionalProperties": False,
+}
+
+_JUDGE_MODEL = "gemini-2.5-flash-lite"
+
+
+async def _supports_structured_output(model: str) -> bool:
+    """#4893: whether *model* supports schema-constrained JSON generation
+    (``litellm.supports_response_schema``) — the SAME capability precheck
+    0062's ``AgentStep.schema`` path uses in production
+    (``router_loop.py``'s precheck) and #4883/#4899 already ported to
+    compaction (``services/compaction/engine.py``'s own
+    ``_supports_structured_output``). A third local copy rather than an
+    import: both existing copies are module-private (a leading
+    underscore), and #4883's own precheck additionally resolves a
+    ``ModelSpec`` via ``host.resolve_model_spec`` — machinery this call
+    site has no use for, since :data:`_JUDGE_MODEL` is a fixed literal
+    string, never resolved via ``class_for_purpose`` (#4206 T1).
+
+    Routed through ``ensure_litellm_ready`` — the sole chokepoint for a
+    not-yet-warm or persistently-broken environment (cooldown, the
+    background warming thread) — never a second, independent
+    ``import litellm`` (CI's ``test_4421_litellm_import_seam.py``
+    enforces this repo-wide).
+
+    Never raises: any failure (litellm not importable/not ready yet, the
+    capability query itself erroring) degrades to ``False``, which
+    :func:`_default_judge_fn` below turns into a
+    ``StructuredOutputUnsupportedModelError`` — the SAME outcome as a
+    real "not supported" answer. That's deliberate, not an oversight:
+    unlike compaction (a context-window backstop — raising there means
+    the conversation itself cannot continue), this verifier isn't one.
+    ``verify_reply``'s own ``except Exception`` around the judge call
+    already turns any raise into ``outcome="inconclusive"``, which ranks
+    ABOVE ``"refuted"`` (``runner.py``'s ``OUTCOME_ORDER``) — strictly
+    safer than the bug this fixes (a missing/malformed score silently
+    defaulting to 0.0, read as a DEFINITIVE false "refuted").
+    """
+    try:
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+        litellm = await asyncio.to_thread(ensure_litellm_ready)
+    except Exception:  # noqa: BLE001 — capability probe, never the caller's failure
+        return False
+    if litellm is None or not hasattr(litellm, "supports_response_schema"):
+        return False
+    try:
+        from reyn.llm.llm import proxy_kwargs
+        extra = proxy_kwargs()
+        precheck_model = (
+            model.split("/", 1)[1] if extra.get("api_base") and "/" in model else model
+        )
+        return bool(litellm.supports_response_schema(precheck_model))
+    except Exception:  # noqa: BLE001 — capability probe, never the caller's failure
+        return False
+
+
+def _parse_judge_response(raw: str) -> dict:
+    """#4893: parse + validate a judge completion's raw text into the
+    ``{"passed": bool, "score": float, "reason": str}`` contract
+    ``verify_reply`` consumes. Extracted as a pure function (mirrors
+    #4883's own ``_validate_chat_summary_fields`` split) so the parsing
+    and the validation floor are each independently testable without a
+    real or replayed LLM call.
+
+    Post-parse validation floor even though the primary path requests
+    ``json_schema`` (strict): schema-constrained generation guarantees
+    the response IS the declared shape when the call succeeds, but never
+    that the call reaches this function with strict enforcement actually
+    in effect — a stale/incorrect capability-table entry, a provider that
+    accepts the request but doesn't fully honor ``strict``, or (on any
+    future fallback leg) plain ``json_object`` mode all reach here with
+    no such guarantee. The one thing this function must never do is what
+    the bug it replaces did: let a missing/malformed ``score`` silently
+    become ``0.0`` — that reads to ``verify_reply`` as a definitive
+    "refuted", when the true state is "the judge didn't actually answer".
+    ``score: None`` in the return routes into ``verify_reply``'s existing
+    "judge returned no score" -> ``inconclusive`` branch, unchanged.
+    """
+    import json
+
+    if raw.startswith("```"):
+        m = re.match(r"^```(?:json)?\s*(.*?)```\s*$", raw, re.DOTALL)
+        if m:
+            raw = m.group(1).strip()
+
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        return {
+            "passed": False,
+            "score": None,
+            "reason": f"LLM response not valid JSON: {raw[:200]}",
+        }
+    if not isinstance(parsed, dict):
+        return {
+            "passed": False,
+            "score": None,
+            "reason": f"LLM response JSON is not an object: {raw[:200]}",
+        }
+
+    try:
+        score = float(parsed["score"])
+    except (KeyError, TypeError, ValueError):
+        return {
+            "passed": False,
+            "score": None,
+            "reason": f"LLM response missing/invalid score field: {parsed!r}",
+        }
+    if not (0.0 <= score <= 1.0):
+        return {
+            "passed": False,
+            "score": None,
+            "reason": f"LLM response score out of [0,1] range: {score!r}",
+        }
+
+    threshold = 0.7
+    return {
+        "passed": score >= threshold,
+        "score": score,
+        "reason": str(parsed.get("reason", "")),
+    }
+
 
 async def _default_judge_fn(rubric: list[str], reply_text: str) -> dict:
     """Invoke litellm directly with the rubric and reply text.
 
-    Returns: {"passed": bool, "score": float, "reason": str}
+    Returns: {"passed": bool, "score": float | None, "reason": str}
+    (``score`` is ``None`` only on a validation failure — see
+    :func:`_parse_judge_response`, which routes it into ``verify_reply``'s
+    existing "no score" -> ``inconclusive`` handling.)
 
     Isolated here so tests can inject a stub without touching litellm.
     Contract: score 0.0-1.0, threshold 0.7. This is an independent
     dev-harness scorer (a direct litellm call).
     """
-    import json
-
     rubric_text = "\n".join(f"- {item}" for item in rubric)
     # reyn.prompt.dogfood (SP prompt-package, Phase 3 §H) owns the static
     # header + "Rubric:" label; this reassembles them exactly as before.
@@ -46,14 +185,40 @@ async def _default_judge_fn(rubric: list[str], reply_text: str) -> dict:
         {"role": "user", "content": user_text},
     ]
 
+    # #4893: raise on an unsupported model — DELIBERATELY the same policy
+    # as 0062 (router_loop.py §2.1's StructuredOutputUnsupportedModelError)
+    # and the OPPOSITE of compaction's #4883/#4899 degrade-to-json_object.
+    # These aren't the same decision wearing two names: compaction is a
+    # context-window backstop (raising means the conversation itself gets
+    # stuck), so it degrades. This verifier has no such backstop role —
+    # verify_reply's own except-Exception around the judge call already
+    # turns a raise into outcome="inconclusive", ranked ABOVE "refuted" in
+    # runner.py's OUTCOME_ORDER. So raising here doesn't cost anything a
+    # degrade path would have bought, and it rides 0062's already-ratified
+    # policy instead of inventing a second one (lead-coder/#4893 thread).
+    if not await _supports_structured_output(_JUDGE_MODEL):
+        from reyn.runtime.errors import StructuredOutputUnsupportedModelError
+        raise StructuredOutputUnsupportedModelError(
+            f"dogfood judge model {_JUDGE_MODEL!r} does not support "
+            "structured output (litellm.supports_response_schema "
+            "returned False) — verify_reply's own except-Exception turns "
+            "this into an inconclusive verdict, never a false refutation."
+        )
+
     # #1190 stage (ii): route through the cost chokepoint (purpose=dogfood,
-    # recorder=None — eval verifier surface). The response_format fallback is
-    # absorbed by the chokepoint. Stub-injection still intercepts at
-    # litellm.acompletion underneath.
+    # recorder=None — eval verifier surface). Stub-injection still
+    # intercepts at litellm.acompletion underneath.
+    #
+    # fallback_without_response_format=False (0062's own text, quoted in
+    # engine.py's #4883 comment): "Do NOT catch-classify a provider
+    # rejection for this — a raw 400 can't be reliably told apart from
+    # transient/other errors." The degrade decision (raise, above) is
+    # already made BEFORE this call, based on the precheck, not by
+    # catching a rejection and silently retrying differently-shaped.
     from reyn.llm.llm import recorded_acompletion
 
     response = await recorded_acompletion(
-        model="gemini-2.5-flash-lite",
+        model=_JUDGE_MODEL,
         messages=messages,
         purpose="dogfood",
         # #4206 T1: a fixed literal model string, never resolved via
@@ -61,29 +226,22 @@ async def _default_judge_fn(rubric: list[str], reply_text: str) -> dict:
         # ceiling axis.
         model_class=None,
         recorder=None,
-        response_format={"type": "json_object"},
-        fallback_without_response_format=True,
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "dogfood_judge_verdict",
+                "schema": _JUDGE_JSON_SCHEMA,
+                "strict": True,
+            },
+        },
+        fallback_without_response_format=False,
         extra_kwargs={"timeout": 30.0, "num_retries": 2},
     )
 
     raw: str = (response.choices[0].message.content or "").strip()
-    if raw.startswith("```"):
-        m = re.match(r"^```(?:json)?\s*(.*?)```\s*$", raw, re.DOTALL)
-        if m:
-            raw = m.group(1).strip()
-
-    try:
-        parsed = json.loads(raw)
-    except Exception:
-        return {"passed": False, "score": 0.0, "reason": f"LLM response not valid JSON: {raw[:200]}"}
-
-    score = float(parsed.get("score", 0.0))
-    threshold = 0.7
-    return {
-        "passed": score >= threshold,
-        "score": score,
-        "reason": str(parsed.get("reason", "")),
-    }
+    if not raw:
+        return {"passed": False, "score": None, "reason": "LLM response was empty"}
+    return _parse_judge_response(raw)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dev/test_fp0036_default_judge_fn_4893.py
+++ b/tests/dev/test_fp0036_default_judge_fn_4893.py
@@ -1,0 +1,168 @@
+"""Tier 1: ``_default_judge_fn``'s own contract (#4893).
+
+#4893 (owner-directed, mirroring #4883/#4899's structured-output pattern
+onto the LAST literal ``json_object`` call site outside compaction):
+schema-constrained generation (``json_schema``, strict) when the model
+supports it, and a post-parse validation floor that never lets a
+missing/malformed ``score`` silently become ``0.0`` — that read as a
+DEFINITIVE false "refuted" to ``verify_reply``'s consumer
+(``runner.py``'s ``OUTCOME_ORDER`` ranks ``refuted`` below
+``inconclusive``), which is exactly the bug this closes.
+
+Deliberately the OPPOSITE policy from compaction's #4883/#4899 on an
+unsupported model: compaction degrades to ``json_object`` (a
+context-window backstop — raising would leave the conversation stuck).
+This verifier raises ``StructuredOutputUnsupportedModelError``, mirroring
+0062's own ratified policy (``router_loop.py`` §2.1) directly, because
+``verify_reply``'s own ``except Exception`` around the judge call already
+turns any raise into ``outcome="inconclusive"`` — there is no backstop
+role here for a degrade path to protect.
+
+``_supports_structured_output`` and ``_parse_judge_response`` are tested
+directly against real litellm (no mock/patch — module-level capability
+lookups and pure JSON parsing, not a network call) and real JSON strings,
+per CLAUDE.md's real-instances-or-Fake rule.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.dev.dogfood.verifiers.reply import (
+    _default_judge_fn,
+    _parse_judge_response,
+    _supports_structured_output,
+)
+from reyn.runtime.errors import StructuredOutputUnsupportedModelError
+
+# ===========================================================================
+# _supports_structured_output — real litellm capability table, no mocking
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_known_supported_model_returns_true() -> None:
+    """Tier 1: the dogfood judge's own fixed model
+    (gemini-2.5-flash-lite) is a real, currently-supported model in
+    litellm's capability table — the primary path this verifier takes on
+    every call in a healthy environment."""
+    assert await _supports_structured_output("gemini-2.5-flash-lite") is True
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_model_returns_false_not_raise() -> None:
+    """Tier 1: an unrecognized model name returns False (litellm's own
+    real answer for a model it has no capability entry for), never
+    raises — the precheck itself must never be the caller's failure."""
+    assert await _supports_structured_output("not-a-real-model-xyz-12345") is False
+
+
+# ===========================================================================
+# _parse_judge_response — pure function, real JSON strings, no LLM call
+# ===========================================================================
+
+
+def test_well_formed_response_parses() -> None:
+    """Tier 1: a valid {passed, score, reason} object parses through
+    unchanged, threshold applied."""
+    result = _parse_judge_response('{"passed": true, "score": 0.9, "reason": "good"}')
+    assert result == {"passed": True, "score": 0.9, "reason": "good"}
+
+
+def test_score_below_threshold_is_not_passed() -> None:
+    """Tier 1: score below 0.7 threshold -> passed=False, score preserved
+    (not coerced to None — this is a real, valid, low score)."""
+    result = _parse_judge_response('{"passed": false, "score": 0.2, "reason": "bad"}')
+    assert result["passed"] is False
+    assert result["score"] == 0.2
+
+
+def test_fenced_code_block_is_stripped() -> None:
+    """Tier 1: a ```json ... ``` fence around the JSON is stripped before
+    parsing — matches models that ignore the "no markdown" instruction."""
+    raw = '```json\n{"passed": true, "score": 1.0, "reason": "ok"}\n```'
+    result = _parse_judge_response(raw)
+    assert result == {"passed": True, "score": 1.0, "reason": "ok"}
+
+
+def test_missing_score_field_is_inconclusive_not_refuted() -> None:
+    """Tier 1: THE bug this PR fixes. A missing ``score`` key must not
+    silently become 0.0 (= definitively refuted). ``score: None`` routes
+    into ``verify_reply``'s existing "judge returned no score" ->
+    inconclusive branch."""
+    result = _parse_judge_response('{"passed": false, "reason": "no score field"}')
+    assert result["score"] is None
+
+
+def test_malformed_json_is_inconclusive_not_refuted() -> None:
+    """Tier 1: unparseable JSON must not silently become a 0.0/refuted
+    verdict either — same inconclusive routing as a missing field."""
+    result = _parse_judge_response("not json at all")
+    assert result["score"] is None
+
+
+def test_non_numeric_score_is_inconclusive_not_refuted() -> None:
+    """Tier 1: a score field present but not coercible to a number
+    (the type: ignore-style "silently becomes 0.0" trap) must also route
+    to inconclusive, not a false refutation."""
+    result = _parse_judge_response('{"passed": false, "score": "not a number", "reason": "x"}')
+    assert result["score"] is None
+
+
+def test_out_of_range_score_is_inconclusive_not_refuted() -> None:
+    """Tier 1: a syntactically valid but out-of-contract score (the
+    contract is 0.0-1.0, per this module's own docstring) is also not a
+    trustworthy verdict — routes to inconclusive rather than being taken
+    at face value."""
+    result = _parse_judge_response('{"passed": true, "score": 5.0, "reason": "x"}')
+    assert result["score"] is None
+
+
+def test_response_is_not_a_json_object() -> None:
+    """Tier 1: valid JSON that isn't an object (e.g. a bare array) must
+    not crash on ``.get`` / ``[...]`` access — routes to inconclusive."""
+    result = _parse_judge_response("[1, 2, 3]")
+    assert result["score"] is None
+
+
+# ===========================================================================
+# _default_judge_fn — raise-on-unsupported-model policy (real function,
+# monkeypatching only the model-capability precheck it calls — the LLM
+# completion call itself is never reached on this path, so nothing about
+# litellm needs faking here).
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_unsupported_model_raises_structured_output_error(monkeypatch) -> None:
+    """Tier 1: the raise-on-unsupported policy itself — #4893's actual
+    design decision, mirroring 0062 rather than compaction's #4883/#4899
+    degrade. Verified by forcing the real precheck function to return
+    False (a legitimate real return value of that function, not a faked
+    collaborator) and asserting the specific exception type."""
+    import reyn.dev.dogfood.verifiers.reply as reply_mod
+
+    async def _always_unsupported(model: str) -> bool:
+        return False
+
+    monkeypatch.setattr(reply_mod, "_supports_structured_output", _always_unsupported)
+
+    with pytest.raises(StructuredOutputUnsupportedModelError):
+        await _default_judge_fn(["some rubric item"], "some reply")
+
+
+@pytest.mark.asyncio
+async def test_verify_reply_turns_the_raise_into_inconclusive_not_refuted() -> None:
+    """Tier 1: the end-to-end contract this whole design leans on —
+    ``verify_reply``'s own ``except Exception`` around the judge call
+    already exists (pre-#4893) and must turn ANY judge_fn raise into
+    outcome="inconclusive", never "refuted". This is what makes
+    raise-on-unsupported safe instead of a regression."""
+    from reyn.dev.dogfood.scenarios import ExpectedReply
+    from reyn.dev.dogfood.verifiers import verify_reply
+
+    async def _raising_judge(rubric: list[str], reply_text: str) -> dict:
+        raise StructuredOutputUnsupportedModelError("model doesn't support it")
+
+    expected = ExpectedReply(kind="judge", rubric=["x"])
+    result = await verify_reply(expected, "some reply", judge_fn=_raising_judge)
+    assert result.outcome == "inconclusive"


### PR DESCRIPTION
**[tui-coder]** — closes #4893

## What changed

`dev/dogfood/verifiers/reply.py:64` was the LAST literal `json_object`
`response_format=` site outside compaction (the issue's own `grep`
measurement). `_default_judge_fn` now:

1. **Precheck**: `_supports_structured_output(model)` — a local copy of
   the SAME `litellm.supports_response_schema` capability check 0062's
   `router_loop.py` precheck uses in production and #4883/#4899 already
   ported to compaction, adapted for a fixed literal model (`#4206 T1` —
   `gemini-2.5-flash-lite`, never resolved via `class_for_purpose`, so no
   `ModelSpec` resolution is needed here unlike the other two copies).
2. **Supported → `json_schema` (strict)** against a small hand-written
   3-field schema (`passed`/`score`/`reason`). Not routed through
   `core.pipeline.schema`'s `SchemaRegistry`/`to_json_schema` (flagged as
   available in the issue) — that registry is for named, cross-referencing
   pipeline field schemas; #4883/#4899 already set the precedent of a
   small literal dict for exactly this shape (`_CHAT_SUMMARY_JSON_SCHEMA`)
   rather than standing up a registry for one ad hoc verdict.
3. **Unsupported → raise**, not degrade. This is the one deliberate
   deviation from the issue's own original step ②
   ("非対応なら現状どおり json_object + 既存の fallback"): lead-coder's
   later revision asked me to read what `verify_reply`'s judge branch
   actually does with the result before deciding raise-vs-degrade. It
   already wraps the judge call in `except Exception` →
   `outcome="inconclusive"`, and `runner.py`'s `OUTCOME_ORDER` ranks
   `inconclusive` ABOVE `refuted`. So raising
   `StructuredOutputUnsupportedModelError` (0062's own type,
   `router_loop.py` §2.1's ratified policy) costs nothing a degrade path
   would have bought — there's no backstop role here for a degrade to
   protect, unlike compaction (a context-window backstop, where raising
   would leave the conversation stuck).
4. **Post-parse validation floor** (`_parse_judge_response`, extracted
   as a pure function — mirrors #4883's own `_validate_chat_summary_fields`
   split): a missing, non-numeric, or out-of-`[0,1]`-range `score` now
   returns `score: None`, routing into `verify_reply`'s EXISTING "judge
   returned no score" → inconclusive branch (no change needed there).
   Replaces `float(parsed.get("score", 0.0))`, which silently turned any
   of those into a **definitive false "refuted"** — the same defect
   class as #4883/#4899's own bug, in the sibling call site.

No new config knob — nothing to wire through `load_config` (lead-coder's
#4899-derived lesson doesn't apply here; noting it was checked, not
skipped).

## Falsification

- Reverting the score-validation floor to `float(parsed.get("score",
  0.0))` reproduces exactly 3 test failures (missing/non-numeric/
  out-of-range score all silently pass through as a numeric 0.0 or the
  literal out-of-range value instead of `None`).
- Removing the raise-on-unsupported block reproduces a test failure —
  the call falls through to the real `recorded_acompletion`, caught
  instead by the repo's own network gate (`UnpinnedNetworkReach`) since
  the test has no `@pytest.mark.replay` pin, confirming the raise is
  actually load-bearing (removing it changes behavior, just not into the
  form I originally guessed — reported as observed, not assumed).

## Test plan

- [x] `python3 scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `ruff check src/reyn/dev/dogfood/verifiers/reply.py tests/dev/test_fp0036_default_judge_fn_4893.py` — all checks passed
- [x] `python scripts/verify_module_docstrings.py` (both files) — OK
- [x] `python scripts/test_tier_audit.py --strict tests/dev/test_fp0036_default_judge_fn_4893.py` — 12 tests, 0 errors
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/dev/test_fp0036_default_judge_fn_4893.py tests/dev/test_fp0036_verifiers.py tests/dev/test_fp0036_runner_and_compare.py` — 83 passed (existing `verify_reply` judge-kind tests use a fully injected stub, unaffected by `_default_judge_fn`'s internals)
- [x] Falsification (see above) — both the validation-floor fix and the raise-on-unsupported policy, verified
- [ ] Visual — n/a (no TUI/rendering surface touched)

## Time-dependency check

0 instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
