### PR TITLE
fix(#4906): close 2 disclosed false-negatives — tuple-unpack, chained-access base

### DIFF
--- a/scripts/test_tier_audit.py
+++ b/scripts/test_tier_audit.py
@@ -797,6 +797,82 @@ def _build_class_property_index(src_root: Path) -> dict[str, tuple[set[str], str
     return index
 
 
+def _build_class_property_return_types(src_root: Path) -> dict[tuple[str, str], str]:
+    """#4906 (false-negative ① of #4864/#4905's gate): ``(class_name,
+    public_property_name) -> the class the property's getter return
+    annotation names`` — resolves ONE LINK of a chained read
+    (``w.f._router_host``, where ``f`` is itself a ``@property`` returning
+    another tracked class, e.g. ``Widget.f -> Session``) so
+    ``_resolve_base_class`` below can walk an attribute chain instead of
+    being restricted to a bare local ``ast.Name`` base.
+
+    tui-coder's own #4905 PR body already disclosed this restriction
+    verbatim: "base object restricted to a bare `ast.Name` … narrower than
+    Rule 3's own walk" — architect reproduced it live afterward
+    (``w.f._router_host`` → 0 findings, real violation). This index is
+    the evidence source that removes the restriction: an entry only exists
+    when the getter's OWN return annotation names a tracked class — never
+    guessed from the property's name.
+
+    Never claims completeness beyond one link at a time: a chain of
+    ``a.b.c._x`` resolves iff EVERY link (``a``'s local type, ``b``'s
+    return annotation, ``c``'s return annotation) is independently
+    evidence-backed; any unresolvable link anywhere in the chain returns
+    ``None`` for the whole chain (see ``_resolve_base_class``), never a
+    partial guess.
+    """
+    class_names: set[str] = set()
+    class_defs: list[tuple[str, ast.ClassDef]] = []
+    for path in sorted(src_root.rglob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(path))
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                class_names.add(node.name)
+                class_defs.append((node.name, node))
+
+    index: dict[tuple[str, str], str] = {}
+    for cls_name, node in class_defs:
+        for inner in ast.walk(node):
+            if not isinstance(inner, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not any(
+                isinstance(d, ast.Name) and d.id == "property"
+                for d in inner.decorator_list
+            ):
+                continue
+            ret_cls = _annotation_class_name(inner.returns, class_names)
+            if ret_cls is not None:
+                index[(cls_name, inner.name)] = ret_cls
+    return index
+
+
+def _resolve_base_class(
+    node: ast.expr,
+    local_types: dict[str, str],
+    property_return_types: dict[tuple[str, str], str],
+) -> str | None:
+    """#4906: the class of an expression used as an ``ast.Attribute``
+    BASE — a bare local ``ast.Name`` (resolved via ``local_types``, the
+    original #4864/#4905 scope) or a CHAIN of public-property reads, each
+    link resolved via ``property_return_types``. Recurses on ``node.value``
+    (strictly smaller each call — terminates at a ``Name`` or an
+    unresolvable node), so a chain of any length works, not just depth 1.
+    Any unresolvable link anywhere returns ``None`` for the whole
+    expression — never a guessed/partial answer."""
+    if isinstance(node, ast.Name):
+        return local_types.get(node.id)
+    if isinstance(node, ast.Attribute):
+        base_class = _resolve_base_class(node.value, local_types, property_return_types)
+        if base_class is None:
+            return None
+        return property_return_types.get((base_class, node.attr))
+    return None
+
+
 def _build_function_return_types(
     tree: ast.Module, class_names: set[str]
 ) -> dict[str, str]:
@@ -815,10 +891,65 @@ def _build_function_return_types(
     return out
 
 
+def _tuple_return_class_names(
+    node: ast.expr | None, class_names: set[str],
+) -> list[str | None] | None:
+    """#4906 (false-negative ②): the POSITIONAL class list from a
+    subscripted tuple return annotation — ``-> tuple[Session, StateLog]``
+    or ``-> Tuple[Session, StateLog]`` — one entry per element (``None``
+    where that position's own annotation doesn't resolve to a tracked
+    class), or ``None`` entirely when *node* isn't a tuple-shaped
+    subscript at all (a single-class return stays ``_annotation_class_
+    name``'s job, unchanged).
+
+    A quoted forward-ref (``-> "tuple[Session, StateLog]"``) is parsed
+    into its expression tree first — the dominant real-corpus shape (this
+    file's own return annotations are quoted throughout), not an edge
+    case."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        try:
+            node = ast.parse(node.value, mode="eval").body
+        except SyntaxError:
+            return None
+    if not isinstance(node, ast.Subscript):
+        return None
+    base = node.value
+    base_name = base.id if isinstance(base, ast.Name) else (
+        base.attr if isinstance(base, ast.Attribute) else None
+    )
+    if base_name not in ("tuple", "Tuple"):
+        return None
+    elts = node.slice.elts if isinstance(node.slice, ast.Tuple) else [node.slice]
+    return [_annotation_class_name(e, class_names) for e in elts]
+
+
+def _build_function_tuple_return_types(
+    tree: ast.Module, class_names: set[str],
+) -> dict[str, list[str | None]]:
+    """#4906 (false-negative ①): same-file function defs whose return
+    annotation is a tuple shape (``-> tuple[Session, StateLog]``) — the
+    evidence source ``_infer_local_types`` needs to bind ``a, b =
+    _make_pair()`` (tuple-UNPACKING assignment), which #4864/#4905's
+    original ``_infer_local_types`` could not see at all: its Assign
+    branch only handled ``len(stmt.targets) == 1 and isinstance(stmt.
+    targets[0], ast.Name)``, so an ``ast.Tuple`` target was skipped
+    entirely — tui-coder's own #4905 PR reproduced this live: ``a, b =
+    _make_pair()`` then ``a._router_host`` produced ZERO findings despite
+    ``a`` genuinely being a ``Session``."""
+    out: dict[str, list[str | None]] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            names = _tuple_return_class_names(node.returns, class_names)
+            if names is not None:
+                out[node.name] = names
+    return out
+
+
 def _infer_local_types(
     func: ast.FunctionDef | ast.AsyncFunctionDef,
     class_names: set[str],
     function_return_types: dict[str, str],
+    function_tuple_return_types: dict[str, list[str | None]] | None = None,
 ) -> dict[str, str]:
     """Best-effort local-variable-name -> class-name map for *func*,
     evidence-only (never inferred from a variable's own name — a param
@@ -832,8 +963,15 @@ def _infer_local_types(
       - local annotated assignment:  s: Session = ...
       - local assignment from a direct constructor or factory call:
         s = Session(...)  /  s = _make_session(...)  /  s = await _make_session(...)
+      - #4906: TUPLE-UNPACKING assignment from a factory whose return
+        annotation is itself a tuple shape: ``a, b = _make_pair()`` where
+        ``_make_pair() -> tuple[Session, StateLog]`` binds ``a -> Session``,
+        ``b -> StateLog`` positionally. A ``Starred`` element anywhere in
+        the target, or an arity mismatch between target and annotation
+        length, skips the WHOLE assignment (never a partial/guessed bind).
     """
     types: dict[str, str] = {}
+    tuple_return_types = function_tuple_return_types or {}
     all_args = list(func.args.args) + list(func.args.kwonlyargs)
     if func.args.posonlyargs:
         all_args = list(func.args.posonlyargs) + all_args
@@ -848,25 +986,38 @@ def _infer_local_types(
             name = _annotation_class_name(stmt.annotation, class_names)
             if name is not None:
                 types[stmt.target.id] = name
-        elif (
-            isinstance(stmt, ast.Assign)
-            and len(stmt.targets) == 1
-            and isinstance(stmt.targets[0], ast.Name)
-        ):
-            value = stmt.value
-            if isinstance(value, ast.Await):
-                value = value.value
-            if isinstance(value, ast.Call):
-                callee = value.func
-                callee_name = None
-                if isinstance(callee, ast.Name):
-                    callee_name = callee.id
-                elif isinstance(callee, ast.Attribute):
-                    callee_name = callee.attr
-                if callee_name in class_names:
-                    types[stmt.targets[0].id] = callee_name
-                elif callee_name in function_return_types:
-                    types[stmt.targets[0].id] = function_return_types[callee_name]
+            continue
+        if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+            continue
+        target = stmt.targets[0]
+        value = stmt.value
+        if isinstance(value, ast.Await):
+            value = value.value
+        if not isinstance(value, ast.Call):
+            continue
+        callee = value.func
+        callee_name = None
+        if isinstance(callee, ast.Name):
+            callee_name = callee.id
+        elif isinstance(callee, ast.Attribute):
+            callee_name = callee.attr
+        if isinstance(target, ast.Name):
+            if callee_name in class_names:
+                types[target.id] = callee_name
+            elif callee_name in function_return_types:
+                types[target.id] = function_return_types[callee_name]
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            if callee_name is None or callee_name not in tuple_return_types:
+                continue
+            positions = tuple_return_types[callee_name]
+            elts = target.elts
+            if len(elts) != len(positions) or any(
+                isinstance(e, ast.Starred) for e in elts
+            ):
+                continue  # arity mismatch or *rest — never a partial bind
+            for elt, cls in zip(elts, positions):
+                if isinstance(elt, ast.Name) and cls is not None:
+                    types[elt.id] = cls
     return types
 
 
@@ -874,6 +1025,7 @@ def _check_private_read_with_public_alt(
     source: str,
     tree: ast.Module,
     class_index: dict[str, tuple[set[str], str]],
+    property_return_types: dict[tuple[str, str], str] | None = None,
 ) -> list[Finding]:
     """Rule 8 (#4864): ``obj._x`` READ anywhere (not only inside an
     ``assert`` — the whole point per the issue's own measurement: routing
@@ -891,18 +1043,38 @@ def _check_private_read_with_public_alt(
     already answers what the test is actually asking, don't manufacture
     one to satisfy the gate.
 
-    ``obj`` is restricted to a bare ``ast.Name`` (not ``a.b._x`` chains) —
-    a deliberately narrower net than Rule 3's, since this rule's
-    precondition is TYPE evidence on the base, not just syntactic shape;
-    disclosed gap, not claimed as covering every real violation."""
+    ``obj`` may be a bare ``ast.Name`` OR a chain of public-property reads
+    (``w.f._router_host`` — #4906, false-negative ②: the original #4864/
+    #4905 restriction to a bare Name was narrower than Rule 3's own walk,
+    reproduced live by architect after tui-coder disclosed it in the #4905
+    PR body). Each link beyond the first needs its OWN evidence
+    (``property_return_types``); an unresolvable link anywhere still
+    yields no finding — the net widens, the zero-false-positive bar does
+    not move."""
     findings: list[Finding] = []
     ast_lines = _split_source_lines(source)
-    class_names = set(class_index)
+    prop_return_types = property_return_types or {}
+    # #4906: "known classes" (the set a parameter/assignment annotation
+    # must name to bind a local var) can't be JUST class_index's own keys
+    # (classes with a directly-backed private attr) — a class that only
+    # participates as an intermediate CHAIN LINK (e.g. `Widget`, which owns
+    # `.f` but never itself reads a backed private attr) would otherwise
+    # never resolve as a parameter/assignment annotation target, silently
+    # keeping the chained-access fix inert for exactly the shape it exists
+    # to catch (`w.f._router_host` needs `w: Widget` to bind first).
+    class_names = (
+        set(class_index)
+        | {cls for cls, _ in prop_return_types}
+        | set(prop_return_types.values())
+    )
     function_return_types = _build_function_return_types(tree, class_names)
+    function_tuple_return_types = _build_function_tuple_return_types(tree, class_names)
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        local_types = _infer_local_types(node, class_names, function_return_types)
+        local_types = _infer_local_types(
+            node, class_names, function_return_types, function_tuple_return_types
+        )
         if not local_types:
             continue
         for inner in ast.walk(node):
@@ -922,9 +1094,9 @@ def _check_private_read_with_public_alt(
             if not (attr.startswith("_") and not attr.startswith("__")):
                 continue
             base = inner.value
-            if not isinstance(base, ast.Name) or base.id == "self":
+            if isinstance(base, ast.Name) and base.id == "self":
                 continue
-            class_name = local_types.get(base.id)
+            class_name = _resolve_base_class(base, local_types, prop_return_types)
             if class_name is None:
                 continue
             backed, class_file = class_index.get(class_name, (set(), ""))
@@ -1200,8 +1372,14 @@ def main(argv: list[str] | None = None) -> int:
     # Only built when the rule is actually active: it's a whole-src-tree
     # scan, and every other rule here is test-file-only.
     class_property_index: dict[str, tuple[set[str], str]] = {}
+    class_property_return_types: dict[tuple[str, str], str] = {}
     if check_rules is None or "private-read-public-alt" in check_rules:
         class_property_index = _build_class_property_index(Path(args.src_root))
+        # #4906: chained-access evidence (`w.f._router_host`) — see
+        # _build_class_property_return_types's own docstring.
+        class_property_return_types = _build_class_property_return_types(
+            Path(args.src_root)
+        )
 
     for f in files:
         report = auditor.audit_file(f)
@@ -1249,7 +1427,7 @@ def main(argv: list[str] | None = None) -> int:
                 source = f.read_text(encoding="utf-8")
                 tree = ast.parse(source, filename=str(f))
                 private_read_findings = _check_private_read_with_public_alt(
-                    source, tree, class_property_index
+                    source, tree, class_property_index, class_property_return_types
                 )
                 if private_read_findings:
                     synthetic = TestResult(name="<module-level>")

--- a/tests/runtime/test_chain_peer_discarded_notify.py
+++ b/tests/runtime/test_chain_peer_discarded_notify.py
@@ -112,7 +112,7 @@ def test_handler_resolves_chain_and_emits_audit_event(tmp_path: Path):
             reason="user_discarded_skill_run",
         )
 
-        await sess_a._journal.flush()  # #2259 PR-2b: drain async WAL in-context
+        await sess_a.journal.flush()  # #2259 PR-2b: drain async WAL in-context
     asyncio.run(go())
     # Chain is gone
     assert sess_a.chains.find_chain("X-001") is None
@@ -136,7 +136,7 @@ def test_handler_is_idempotent_when_chain_already_resolved(tmp_path: Path):
             chain_id="never_registered", peer="B", reason="x",
         )
 
-        await sess_a._journal.flush()  # #2259 PR-2b: drain async WAL in-context
+        await sess_a.journal.flush()  # #2259 PR-2b: drain async WAL in-context
     asyncio.run(go())  # No exception is the assertion
 
 

--- a/tests/scripts/test_tier_audit_private_read_public_alt_4906.py
+++ b/tests/scripts/test_tier_audit_private_read_public_alt_4906.py
@@ -1,0 +1,264 @@
+"""Tier 1: #4906 — 2 false-negative forms in Rule 8 (#4864/#4905)'s gate.
+
+tui-coder's own #4905 PR body disclosed a real restriction verbatim: the
+attribute BASE is a bare ``ast.Name`` only, and ``_infer_local_types``'s
+Assign branch only binds a single-``Name`` target. Both restrictions are
+real corpus false negatives — architect reproduced them live against the
+merged gate (a synthetic ``class_index``, zero findings, despite a genuine
+violation):
+
+  ① tuple-unpack: ``a, b = _make_pair()`` where ``_make_pair() -> tuple[A,
+     B]`` — the Assign branch required ``len(stmt.targets) == 1 and
+     isinstance(stmt.targets[0], ast.Name)``, so an ``ast.Tuple`` target
+     was skipped entirely; ``a``'s type had zero evidence afterward.
+  ② chained access: ``w.f._router_host`` — the attribute-base check was
+     ``isinstance(base, ast.Name)``, excluding ``w.f`` (an ``ast.Attribute``
+     chain) even when ``f`` is itself a ``@property`` returning a tracked
+     class.
+
+Both fixes stay evidence-only (never a guessed binding) and class-scoped
+(never a bare attribute-name match) — the same zero-false-positive bar
+#4864's own design set. This file pins both fixes AND their own negative
+controls (an unresolvable link anywhere must still yield nothing), mirroring
+the sibling ``test_tier_audit_private_read_public_alt_4864.py``'s structure.
+
+Tier 1 because this is the audit script's own contract surface.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+
+import pytest
+
+from tests._support.paths import REPO_ROOT
+
+
+def _load_audit_module():
+    import sys
+    script = REPO_ROOT / "scripts" / "test_tier_audit.py"
+    spec = importlib.util.spec_from_file_location("_audit_tier_audit_script_4906", script)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def audit_mod():
+    return _load_audit_module()
+
+
+def _findings_for(
+    audit_mod, source: str, class_index: dict, property_return_types: dict | None = None,
+) -> list:
+    tree = ast.parse(source)
+    return audit_mod._check_private_read_with_public_alt(
+        source, tree, class_index, property_return_types,
+    )
+
+
+# ── ① tuple-unpack: positive cases ──────────────────────────────────────────
+
+
+def test_tuple_unpack_from_a_typed_factory_fires(audit_mod) -> None:
+    """Tier 1: ``a, b = _make_pair()`` where ``_make_pair() -> tuple[Foo,
+    Bar]`` binds ``a -> Foo`` positionally — the exact shape architect
+    reproduced live (``a, b = _make_pair()`` then ``a._router_host``,
+    zero findings pre-fix)."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        'def _make_pair() -> "tuple[Foo, Bar]":\n'
+        "    return Foo(), Bar()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    a, b = _make_pair()\n"
+        "    assert a._router_host is not None\n"
+    )
+    (only,) = _findings_for(audit_mod, src, class_index)
+    assert "_router_host" in only.message
+    assert "Foo.router_host" in only.message
+
+
+def test_tuple_unpack_second_position_also_binds(audit_mod) -> None:
+    """Tier 1: positional binding is not accidentally first-element-only —
+    the SECOND unpacked name resolves too."""
+    class_index = {"Bar": ({"_state_log"}, "src/bar.py")}
+    src = (
+        'def _make_pair() -> "tuple[Foo, Bar]":\n'
+        "    return Foo(), Bar()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    a, b = _make_pair()\n"
+        "    assert b._state_log is not None\n"
+    )
+    (only,) = _findings_for(audit_mod, src, class_index)
+    assert "_state_log" in only.message
+
+
+def test_tuple_unpack_via_await_still_binds(audit_mod) -> None:
+    """Tier 1: ``a, b = await _make_pair()`` — the ``ast.Await`` unwrap
+    already covered the single-Name case; must still apply to tuple
+    targets."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        'async def _make_pair() -> "tuple[Foo, Bar]":\n'
+        "    return Foo(), Bar()\n"
+        "\n"
+        "async def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    a, b = await _make_pair()\n"
+        "    assert a._router_host is not None\n"
+    )
+    (only,) = _findings_for(audit_mod, src, class_index)
+    assert "_router_host" in only.message
+
+
+# ── ① tuple-unpack: negative cases (must NOT fire / must NOT crash) ────────
+
+
+def test_tuple_unpack_arity_mismatch_does_not_bind(audit_mod) -> None:
+    """Tier 1: 2 targets against a 3-element tuple annotation — never a
+    partial/guessed bind. Must not fire (and must not raise)."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        'def _make_triple() -> "tuple[Foo, Bar, Baz]":\n'
+        "    return Foo(), Bar(), Baz()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    a, b = _make_triple()\n"
+        "    assert a._router_host is not None\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index)
+    assert findings == []
+
+
+def test_tuple_unpack_with_starred_target_does_not_bind(audit_mod) -> None:
+    """Tier 1: ``a, *rest = _make_pair()`` — a ``Starred`` element in the
+    target skips the whole assignment, never a partial bind for the
+    non-starred names."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        'def _make_pair() -> "tuple[Foo, Bar]":\n'
+        "    return Foo(), Bar()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    a, *rest = _make_pair()\n"
+        "    assert a._router_host is not None\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index)
+    assert findings == []
+
+
+def test_tuple_unpack_from_an_untyped_factory_does_not_fire(audit_mod) -> None:
+    """Tier 1: ``a, b = _make_pair()`` with NO return annotation at all
+    stays unresolvable — never a guess from the unpacking shape alone."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        "def _make_pair():\n"
+        "    return Foo(), Bar()\n"
+        "\n"
+        "def test_thing():\n"
+        '    """Tier 2: example."""\n'
+        "    a, b = _make_pair()\n"
+        "    assert a._router_host is not None\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index)
+    assert findings == []
+
+
+# ── ② chained access: positive case ─────────────────────────────────────────
+
+
+def test_chained_property_access_fires(audit_mod) -> None:
+    """Tier 1: ``w.f._router_host`` — ``f`` is a ``@property`` on
+    ``Widget`` returning ``Foo`` (evidenced via ``property_return_types``);
+    ``w``'s own type comes from its parameter annotation. The exact shape
+    #4905's own PR body disclosed as out of scope (base restricted to a
+    bare Name) and architect reproduced live."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    property_return_types = {("Widget", "f"): "Foo"}
+    src = (
+        "def test_thing(w: Widget):\n"
+        '    """Tier 2: example."""\n'
+        "    x = w.f._router_host\n"
+        "    assert x is not None\n"
+    )
+    (only,) = _findings_for(audit_mod, src, class_index, property_return_types)
+    assert "_router_host" in only.message
+    assert "Foo.router_host" in only.message
+
+
+def test_two_link_chain_also_resolves(audit_mod) -> None:
+    """Tier 1: recursion isn't accidentally depth-1-only — ``w.g.f.
+    _router_host`` (2 property links before the private read) still
+    resolves when EVERY link has evidence."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    property_return_types = {
+        ("Widget", "g"): "Gadget",
+        ("Gadget", "f"): "Foo",
+    }
+    src = (
+        "def test_thing(w: Widget):\n"
+        '    """Tier 2: example."""\n'
+        "    x = w.g.f._router_host\n"
+        "    assert x is not None\n"
+    )
+    (only,) = _findings_for(audit_mod, src, class_index, property_return_types)
+    assert "_router_host" in only.message
+
+
+# ── ② chained access: negative cases (same-class-scoping, unresolvable) ────
+
+
+def test_chained_access_with_no_return_type_evidence_does_not_fire(audit_mod) -> None:
+    """Tier 1: ``w.f._router_host`` where ``f``'s return type is NOT in
+    ``property_return_types`` (no evidence) — must not fire; the chain
+    resolver returns None for the whole expression, never a guess."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        "def test_thing(w: Widget):\n"
+        '    """Tier 2: example."""\n'
+        "    x = w.f._router_host\n"
+        "    assert x is not None\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index, {})
+    assert findings == []
+
+
+def test_chained_access_resolves_to_an_unbacked_class_does_not_fire(audit_mod) -> None:
+    """Tier 1: architect's own #4864 pitfall, replayed through the chain
+    path — ``w.f`` resolves to a REAL class (``Gadget``), but ``Gadget``
+    has no backed private attr matching ``._router_host`` (it's backed
+    only on the unrelated ``Foo``). Same-class scoping must hold for the
+    chain resolver too, not just the direct-Name path."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    property_return_types = {("Widget", "f"): "Gadget"}
+    src = (
+        "def test_thing(w: Widget):\n"
+        '    """Tier 2: example."""\n'
+        "    x = w.f._router_host\n"
+        "    assert x is not None\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index, property_return_types)
+    assert findings == []
+
+
+def test_self_base_still_excluded_through_the_new_resolver(audit_mod) -> None:
+    """Tier 1: regression sanity — ``self._x`` inside a method must still
+    never fire (deliberately out of scope), now that the base check no
+    longer short-circuits on ``isinstance(base, ast.Name)`` first."""
+    class_index = {"Foo": ({"_router_host"}, "src/foo.py")}
+    src = (
+        "class Foo:\n"
+        "    def test_thing(self):\n"
+        '        """Tier 2: example."""\n'
+        "        assert self._router_host is not None\n"
+    )
+    findings = _findings_for(audit_mod, src, class_index)
+    assert findings == []


### PR DESCRIPTION
**[e2e-coder]** — closes #4906: 2 disclosed false-negatives in #4864/#4905's private-read-public-alt gate

## Defect

Both restrictions were already disclosed (tui-coder's #4905 PR body; architect reproduced live afterward):

1. **tuple-unpack**: `_infer_local_types`'s `Assign` branch only handled `len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name)` — `a, b = _make_pair()` (an `ast.Tuple` target) was skipped entirely, so `a` had zero type evidence and `a._router_host` produced no finding.
2. **chained access**: the attribute base was restricted to a bare `ast.Name` — `w.f._router_host` never matched, only `w._router_host` did.

## Fix

1. New positional tuple-return-type index (`_build_function_tuple_return_types` / `_tuple_return_class_names`, handling both bare and quoted-forward-ref `-> tuple[A, B]` annotations) + a `Tuple`/`List`-target branch in `_infer_local_types`. Arity mismatch or a `Starred` element skips the whole assignment — never a partial/guessed bind.
2. New `(class, property_name) -> return_class` index (`_build_class_property_return_types`) + a recursive `_resolve_base_class` that walks a chain of property reads, each link independently evidence-gated. An unresolvable link anywhere yields nothing for the whole expression.
3. `class_names` (the "known classes" set for local-variable binding) had to widen to include classes that only participate as intermediate chain LINKS (e.g. `Widget`, which owns `.f` but never itself reads a backed private attr) — otherwise `w: Widget` could never bind in the first place, silently keeping fix ② inert even after landing it.

Both fixes stay evidence-only and class-scoped — the same zero-false-positive bar #4864's own design set (verified: `RouterHostAdapter._chains`-style negative controls, "unresolvable chain link", and "chain resolves to a real but UNBACKED class" all still correctly produce nothing).

## Corpus impact

0 hits before this fix (post-#4905's own 109-violation cleanup) → **2 real hits surfaced**: `tests/runtime/test_chain_peer_discarded_notify.py:115,139` — `sess_a` is bound via tuple-unpacking (`_registry, sess_a, _sess_b, _log = _make_registry_with_two_agents(...)`), then reads `._journal` directly, where `Session.journal` is a real, pre-existing `@property`. Fixed in this PR (`sess_a.journal.flush()`) — back to 0 corpus-wide.

## Testing

New file: `tests/scripts/test_tier_audit_private_read_public_alt_4906.py` — 11 tests (3 tuple-unpack positive, 3 tuple-unpack negative, 2 chained-access positive, 3 chained-access negative including the `_chains`-style same-class-scoping replay and the `self`-still-excluded regression sanity).

Strip-falsified by hand: reverting fix 1 flips exactly the 3 tuple-unpack positive tests (8 others stay green); reverting fix 2 flips exactly the 2 chained-access positive tests (9 others stay green). Restored to real production code and confirmed green after each.

Full local gate suite: `ruff check .`, `test_tier_audit.py --strict` (self-referential, 11/11 OK), `verify_module_docstrings.py`, `mypy_ratchet.py` (203/207 baselined, unchanged), `flat_tests_ratchet.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_tests_path_literal_reference.py` — all green. `tests/scripts/` full sweep (827 tests) green, no regressions. Sibling `test_tier_audit_private_read_public_alt_4864.py` (22 tests) unaffected.

## Test plan

- [x] `pytest tests/scripts/test_tier_audit_private_read_public_alt_4906.py` — 11/11 green
- [x] Strip-falsify each fix against real production code
- [x] `pytest tests/scripts/` full sweep — 827/827 green
- [x] `pytest tests/runtime/test_chain_peer_discarded_notify.py` (corpus fix) — 5/5 green
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict`
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_tests_path_literal_reference.py`
- [x] (skipped — no docs/ paths touched) mkdocs gates

part of #4906

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
