### PR TITLE
test(#4910): accept-side witness for Rule 7's # requirement

### DIFF
--- a/tests/scripts/test_tier_audit_fake_attr_self_test_4904.py
+++ b/tests/scripts/test_tier_audit_fake_attr_self_test_4904.py
@@ -188,6 +188,36 @@ def test_assignment_with_a_different_ignore_code_not_flagged() -> None:
     assert findings == []
 
 
+def test_hashless_string_literal_containing_the_phrase_not_flagged() -> None:
+    """Tier 1: #4910 — an ATTRIBUTE assignment whose VALUE is a string
+    literal that happens to contain the text ``type: ignore[attr-defined]``
+    (no leading ``#`` anywhere on the source line, so it is DATA, not a
+    real suppression comment) must not fire.
+
+    Real-corpus-inspired (architect, #4910): ``tests/scripts/
+    test_3726_mypy_ratchet.py`` builds a string mimicking mypy stdout that
+    quotes the phrase ``"type: ignore[assignment]"`` as data — but that
+    file's own assignment target is a plain NAME (``text = (...)``), which
+    the rule already excludes by construction (only Attribute-target
+    assignments are even considered) regardless of the ``#`` requirement,
+    so it is not itself a witness for the ``#`` requirement specifically.
+    THIS test puts the same shape of string value on an Attribute-target
+    assignment instead — the one case that actually reaches
+    ``_ignore_codes`` — so a future regex change that dropped the literal
+    ``#`` requirement (matching the phrase anywhere on the line, comment
+    or not) would flip this test red without dropping the target-type
+    filter at the same time."""
+    audit = _load_audit_module()
+    source = (
+        "def _helper(obj):\n"
+        '    """Fixture helper."""\n'
+        '    obj.injected = \'Error code not covered by "type: ignore[attr-defined]" comment\'\n'
+        "    return obj\n"
+    )
+    findings = _fake_attr_findings(audit, source)
+    assert findings == []
+
+
 def test_ordinary_self_attribute_assignment_not_flagged() -> None:
     """Tier 1: sanity — a normal, unsuppressed ``self.x = value`` inside a
     real class (the overwhelming majority of assignments in any file) must


### PR DESCRIPTION
**[e2e-coder]** — closes #4910: accept-side witness for Rule 7's `#` requirement

## Gap

`_check_fake_attr_assignments`'s ignore-comment regex (`_TYPE_IGNORE_RE`) correctly requires a literal `#` before `type: ignore[attr-defined]`. Real behavior is correct — verified against `tests/scripts/test_3726_mypy_ratchet.py`, which builds a string mimicking mypy stdout that quotes the phrase as data — but that file's own assignment target is a plain `Name` (`text = (...)`), which the rule already excludes by construction (only `Attribute`-target assignments are even considered), independent of the `#` requirement. So it isn't actually a witness for the `#` requirement specifically — a future change that dropped the literal-`#` requirement (matching the phrase anywhere on the line) would flag that file and nothing in the corpus would catch it.

## Fix

One test using an `Attribute`-target assignment whose value is a hash-less string containing the phrase — the one shape that actually reaches `_ignore_codes`, so it's a real witness for the requirement rather than an accidental pass via the target-type filter.

## Testing

Strip-falsified: relaxing `_TYPE_IGNORE_RE` to make `#` optional (`#?\s*type:...`) flips exactly the new test red; the other 10 in the same file stay green. Restored, confirmed green.

Full local gate suite: `ruff check .`, `test_tier_audit.py --strict` (11/11 OK), `verify_module_docstrings.py`, `mypy_ratchet.py` (unchanged), `pytest tests/scripts/` (817/817 green, no regressions).

## Test plan

- [x] `pytest tests/scripts/test_tier_audit_fake_attr_self_test_4904.py` — 11/11 green
- [x] Strip-falsify against the real `#`-requirement regex
- [x] `pytest tests/scripts/` full sweep — 817/817 green
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict`
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] (skipped — no docs/ paths touched) mkdocs gates

part of #4910

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
