### PR TITLE
docs(0068): sync the M3 test-side count the ADR fix left behind

### DIFF
--- a/docs/deep-dives/proposals/0068-secret-provider-seam.md
+++ b/docs/deep-dives/proposals/0068-secret-provider-seam.md
@@ -26,7 +26,7 @@ Each phase names what would make it *not* done, because "the class exists" has a
 
 ### Phase 2 — wire the dormant capability gate
 
-`ScopedSecretStore` is constructed 0 times under `src/reyn/` today and 8 times in `tests/core/test_fp0016_d_e2e_confused_deputy.py`; `OpContext.secret_store` (`context.py:273`) is a declaration with no assignment and no reader. Phase 2 connects it at the resolver so a reference outside `allowed_keys` raises `CredentialScopeError` on a real path.
+`ScopedSecretStore` is constructed 0 times under `src/reyn/` today and 27 times across three test files (`tests/security/test_fp0016_d_scoped_store.py` 15, `tests/core/test_fp0016_d_e2e_confused_deputy.py` 9, `tests/core/test_fp0016_d_opcontext_field.py` 3); `OpContext.secret_store` (`context.py:273`) is a declaration with no assignment and no reader. Phase 2 connects it at the resolver so a reference outside `allowed_keys` raises `CredentialScopeError` on a real path.
 
 **Not done if**: production still constructs it zero times; or the deny path is only reachable from tests. The falsification is direct — remove the wiring and a production-shaped denial must stop happening.
 
@@ -68,4 +68,5 @@ Operator-authored binding of a reference to a consumer, with narrowly scoped inj
 
 - The 133/60 figure is an upper bound; no line was opened, and non-secret `os.environ` reads are included.
 - `ScopedSecretStore`'s dormancy is established by construction-site and name-occurrence counts, not by running anything.
+- The test-side figure above shipped wrong ("8 times in" one file) and was corrected in ADR-0043 by #4892 without this document being updated in the same change — the two files landed together in #4891, and only one of them was fixed. It is corrected here. The count that matters to the plan is the `src/` zero; the test-side figure matters because Phase 2 has to move that surface, and one file versus three is a different job.
 - No claim here is based on executing Reyn; the author has no environment in which to exercise a credential store.


### PR DESCRIPTION
**[architect]** — part of #4890. **私自身が、memory-curator の pin が名指しした形をやっていました。**

## 何が偽だったか

```
#4892 ── ADR-0043 の M3 を訂正（1 ファイル 8 件 → 3 ファイル 27 件）
🔴 proposal 0068:29 ── 同じ測定を書いており、★訂正されていなかった
   逐語（訂正前）「constructed 0 times under `src/reyn/` today and
                  ★8 times in `tests/core/test_fp0016_d_e2e_confused_deputy.py`」
∴ 2 つは #4891 で★一緒に着地したのに、★片方だけ直した
```

## どう見つけたか

memory-curator の pin（`feedback_my_approval_procedure_has_no_what_does_this_make_false_step`）の処方をそのまま自分に当てました:

> そのPRが触った識別子・issue番号・件数を doc 側で grep

**1 コマンドで出ました。そして、pin が言うまで私は引いていません。** lead-coder の 2 件（#4900 / #4911）を「他人が捕まえた」と読んだ直後に、自分の 1 件が同じ形で残っていた、という並びです。

## 影響

**計画の根拠は `src/` の 0 件**で、そちらは一度も疑われていません。test 側の数が効くのは **Phase 2 がその面を動かす**からで、**1 ファイルと 3 ファイルでは仕事が違います**。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → built in 24.34s
- [x] `python scripts/check_doc_anchors.py` → `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` → `OK: 0 hits (25 retired top-level key(s) checked)`
- [x] (skipped — `src/` / `tests/` 無変更のため ruff / tier audit / pytest は対象なし)
- [x] `git diff --stat` で 2 insertions / 1 deletion を確認してからゲートを走らせた（緑は「変更が正しい」ではなく「壊れていない」しか言わないため）
- [x] 同じ grep を ADR-0043 側にも掛け、そちらは 27 件表記で正しいことを確認

## 未確認

- **他に同じ数字を持つ面が無いか** — `docs/` 配下の 2 ファイルしか引いていません。issue コメント側（#4890 の私の訂正コメント）は正しい数字ですが、**#4890 の本文に畳んだ内容は再確認していません**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)