### PR TITLE
docs(#4886): note the in-flight untrusted-taint latch is currently redundant, not dead

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -961,6 +961,18 @@ class Session:
         # turn's own remaining iterations, matching the existing
         # `_untrusted_latched` per-iteration latch's own "narrows, never
         # un-narrows mid-turn" discipline.
+        #
+        # #4886 (measured, kept — not removed): under the CURRENT wiring
+        # `_append_entry` for the same tool result runs synchronously right
+        # after the stamp (router_loop.py), so whenever this flag is True
+        # the plain history scan is independently also True at that same
+        # moment — this OR-term is currently redundant, never the deciding
+        # factor. Kept anyway: it is a NARROWING mechanism (safety
+        # tightens, never loosens), so removing a currently-redundant term
+        # would silently reopen the gap the moment the deferred-commit PR
+        # above actually lands — "reachable, correct, currently redundant"
+        # is not the same failure class as "unreachable," and redundant
+        # safety is not grounds for removal.
         self._in_flight_untrusted_this_turn: bool = False
         # excluded_categories (#1667) + the visibility override (#2285) are owned by
         # CapabilityVisibility, constructed below (see #3121 step3 Extract Class).

--- a/tests/llm/test_4381_pr2_stage3_in_flight_untrusted_flag.py
+++ b/tests/llm/test_4381_pr2_stage3_in_flight_untrusted_flag.py
@@ -26,6 +26,15 @@ not a departure from this suite's established idiom.
 Real ``Session`` + real history + real tool registry + scripted
 ``call_llm_tools`` throughout — no ``_FakeMessage``/hand-rolled host
 stand-in (#2957 PR-A precedent, same as this file's sibling).
+
+#4886 (measured, kept — not removed): under CURRENT wiring, ① still does
+not exist, so ``_simulate_deferred_commit`` below is the ONLY way this
+file's own precondition ("history has not landed") can be constructed —
+real code paths append synchronously today, and this scenario cannot
+occur through them. Once ① lands and defers the commit for real, this
+file's own scripted flow starts exercising a genuinely reachable state
+instead of a monkeypatched stand-in for one — same test, same witness,
+different status of the thing it's watching.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[e2e-coder]** — closes #4886: annotate the in-flight untrusted-taint latch as currently-redundant-but-kept

## Ruling (lead-coder)

Keep `_in_flight_untrusted_this_turn`, do not remove. It's a narrowing (safety-tightening) mechanism — under current wiring it's never the deciding factor (measured), but removing a currently-redundant safety term would silently reopen a gap the instant the deferred-commit PR it exists for (`#4381 ①`, never landed) actually ships. "Reachable, correct, currently redundant" ≠ "unreachable" — redundant safety isn't grounds for removal.

## Measurement (posted to #4886 first, restated here)

- 1 real reader (`session.py`'s `_ephemeral_contextual_for_turn` OR-guard), 1 real writer path (`router_loop.py:3641`), fully wired end-to-end — not test-only.
- Never the deciding factor under current wiring: `_append_entry` for the same tool result runs synchronously right after the flag is set, so the plain history scan is independently also True at that same moment whenever the flag is.
- The flag's own test (`test_4381_pr2_stage3_in_flight_untrusted_flag.py`) already had to monkeypatch the append callback to construct the "not yet landed" precondition — confirms the scenario cannot occur via real code paths today.
- Checked convergence with #4885 (merged as #4895): none — that PR's scope was entirely compaction's 413-byte-limit shrink classification, zero overlap with this code.

## Changes (per lead-coder's 3-item instruction)

1. `session.py`'s own `__init__` comment — 1 paragraph explaining why the term is currently redundant and why that's not grounds for removal.
2. The test file's own module docstring — 1 paragraph explaining why `_simulate_deferred_commit` is the only way to construct the precondition today, and what changes once ① lands.
3. Test NOT deleted — the mechanism stays, so the witness stays (six-questions #3: "removable" ≠ "should be removed").

## Testing

`pytest tests/llm/test_4381_pr2_stage3_in_flight_untrusted_flag.py` — 2/2 green. Broader sweep (`-k "untrusted_narrow or 1909 or 4468 or 4381"`) — 43/43 green, no regressions. `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py` — all green.

## Test plan

- [x] `pytest tests/llm/test_4381_pr2_stage3_in_flight_untrusted_flag.py` — 2/2 green
- [x] Broader untrusted-narrowing sweep — 43/43 green
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict`
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] (skipped — docs-only comment changes, no docs/ path touched, no TESTS-READ trigger beyond the existing test file)

part of #4886

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
