### PR TITLE
fix(loop_probe): recovery notice reported without a corresponding onset (part of #4855)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1308,7 +1308,17 @@ class TextualChatApp(App):
         #: see :meth:`_voice_cancel_timeout_timer`).
         self._voice_timeout_timer: "Timer | None" = None
         #: Watches how late the event loop runs (#3539). Always on; see
-        #: ``loop_probe`` for why it is not opt-in.
+        #: ``loop_probe`` for why it is not opt-in. Reset via
+        #: :meth:`reset_loop_tripwire`, not a constructor parameter —
+        #: #4855 follow-up (lead-coder's own retraction, round 3): a
+        #: test needing a CLEAN tripwire is reacting to contamination
+        #: that happens DURING mount (a real, unrelated stall consuming
+        #: the one-shot notice before the test's own intentional stall
+        #: runs), which is AFTER construction — a fresh instance handed
+        #: in at construction time would be contaminated by that same
+        #: mount-time stall just the same, making a constructor seam
+        #: unreachable dead code for the actual failure mode it would
+        #: exist to fix.
         self._loop_tripwire = LoopTripwire()
         #: #4761 ②: the App's own message-pump heartbeat — incremented by
         #: :meth:`on_timer` ONLY for :attr:`_pump_heartbeat_timer`'s own
@@ -2891,6 +2901,27 @@ class TextualChatApp(App):
         if event.timer is self._pump_heartbeat_timer:
             self._pump_ticks += 1
         await super().on_timer(event)
+
+    def reset_loop_tripwire(self) -> None:
+        """Replace :attr:`_loop_tripwire` with a fresh, never-fired
+        instance — #4855 follow-up (lead-coder's TESTS-READ, #4920).
+
+        Public so a test that needs a CLEAN tripwire mid-run (its own
+        intentional stall/recovery must be deterministic regardless of
+        what a real, unrelated stall during mount already did to the
+        original instance's one-shot state) does not have to write
+        ``app._loop_tripwire = LoopTripwire()`` directly from outside the
+        class. That direct write is worse than a private READ: if
+        ``_loop_tripwire`` is ever renamed, Python does not raise — it
+        silently creates a new, never-read attribute on the instance, the
+        app keeps using the OLD (still-consumed) tripwire internally, and
+        every test using the old write-around stays green with zero
+        actual protection. Routing through this method means the SAME
+        rename that would need to touch this method's own body (both in
+        app.py) also touches every caller — a compile-time-visible
+        breakage, not a silent no-op one file away.
+        """
+        self._loop_tripwire = LoopTripwire()
 
     @property
     def pump_ticks(self) -> int:

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -151,6 +151,21 @@ class LoopTripwire:
         #: that needs no prior setup — the same "visible with the shipped
         #: config" bar the once-only stall notice already clears.
         self._just_recovered = False
+        #: #4855: whether the CURRENT (still-ongoing) stall episode's onset
+        #: was itself returned to the caller — i.e. whether ``observe()``'s
+        #: ``self._fired`` gate let this specific episode's stall notice
+        #: through, as opposed to being silently swallowed by an EARLIER
+        #: episode having already consumed the session's one-shot notice.
+        #: Set True only at the exact point ``observe()`` returns a stall
+        #: magnitude; read (and reset) at the matching recovery transition.
+        #: Without this, ``_just_recovered`` fired on EVERY recovery
+        #: regardless of whether its own episode's onset was ever told to
+        #: anyone — the user-facing text is literally "recovered from the
+        #: stall reported above," and a session whose FIRST stall happened
+        #: during app-mount startup jitter (consuming ``_fired``) could
+        #: recover from every SUBSEQUENT episode with no "reported above"
+        #: to point at (#4855's root cause).
+        self._current_stall_reported = False
 
     @property
     def max_lateness_ms(self) -> float:
@@ -231,7 +246,15 @@ class LoopTripwire:
         if lateness_ms <= self._threshold_ms:
             if self._in_stall:
                 self._in_stall = False
-                self._just_recovered = True
+                # #4855: report a recovery only for the episode whose OWN
+                # onset was told to the caller — write_record stays
+                # unconditional (#4761 ①'s durable-record guarantee is
+                # untouched), but _just_recovered must not fire for an
+                # episode that was silently swallowed below because an
+                # earlier episode already consumed the one-shot notice.
+                if self._current_stall_reported:
+                    self._just_recovered = True
+                    self._current_stall_reported = False
                 write_record(
                     "tripwire_recovered", lateness_ms=round(lateness_ms, 1), **extra,
                 )
@@ -247,6 +270,7 @@ class LoopTripwire:
         if self._fired:
             return None
         self._fired = True
+        self._current_stall_reported = True
         return lateness_ms
 
 

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -339,6 +339,51 @@ def test_recovery_is_recorded_only_once_per_episode(monkeypatch, tmp_path: Path)
     )
 
 
+def test_consume_recovered_stays_false_when_the_stalls_own_onset_was_never_reported() -> None:
+    """Tier 2: #4855's root cause, reproduced directly against the unit
+    under test (no dump file, no real/virtual clock — ``_fired`` is a
+    permanent one-shot latch and needs no time to consume: a SECOND stall
+    episode alone is enough).
+
+    Mechanism (confirmed by reading ``observe()``'s two branches):
+    ``self._fired`` silently swallows the ONSET return value for every
+    episode after the first (``if self._fired: return None`` — no notice
+    reaches the caller), but the pre-fix recovery branch set
+    ``self._just_recovered = True`` UNCONDITIONALLY on every recovery,
+    regardless of whether the episode it was "recovering from" ever had
+    its onset reported. In production this surfaces as
+    ``stall_recovered_log_line``'s literal text — "the interface recovered
+    from the stall reported above" — with no stall ever reported above,
+    exactly the CI-observed ``assert None is not None`` signature
+    (#4855's own PR-thread investigation: waiting for "recovered" then
+    asserting "unresponsive" never finds it, because episode 2's onset
+    line was never written).
+
+    A real host can reach episode 2's onset going unreported without any
+    injected delay at all: an unrelated stall during app-mount startup
+    jitter consumes ``_fired`` before the test's own intentional stall
+    ever runs — #4855's own root-cause comment traces exactly this path.
+    This test skips the mount-jitter framing and drives ``LoopTripwire``
+    directly through two consecutive episodes, which is sufficient to
+    exercise the same ``_fired``-already-True branch."""
+    tripwire = LoopTripwire(threshold_ms=250.0)
+
+    tripwire.observe(1800.0)  # episode 1: stall — onset REPORTED (fired False -> True)
+    tripwire.observe(50.0)  # episode 1: recovers
+    assert tripwire.consume_recovered() is True, (
+        "episode 1's own onset was reported, so its recovery must be too"
+    )
+
+    tripwire.observe(1700.0)  # episode 2: stall — onset SWALLOWED (fired already True)
+    tripwire.observe(40.0)  # episode 2: recovers
+    assert tripwire.consume_recovered() is False, (
+        "episode 2's own onset was never reported (fired already True, "
+        "observe() returned None) — reporting its recovery would read as "
+        "\"recovered from the stall reported above\" with nothing ever "
+        "reported above, the exact #4855 defect"
+    )
+
+
 def test_consume_recovered_needs_no_dump_env_at_all(monkeypatch) -> None:
     """Tier 2: #4797 follow-up (architect finding) — ``consume_recovered()``
     is a plain in-memory flag, reachable with ``REYN_PROF_DUMP`` unset the
@@ -389,6 +434,22 @@ async def test_recovery_notice_is_visible_without_arming_the_dump(caplog, monkey
     with caplog.at_level(logging.WARNING, logger=logger_name):
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()
+            # #4855 follow-up (lead-coder's TESTS-READ, two rounds on this
+            # same PR): the App's own, session-lifetime LoopTripwire —
+            # an unrelated real stall during mount (real CI-host
+            # contention, before this line ever runs) can already have
+            # consumed its one-shot _fired latch. Post-fix, THIS test's
+            # own jump below would then have its onset silently
+            # swallowed, so its recovery is correctly NOT reported — and
+            # the "recovered" wait below hangs until CI's own
+            # --timeout=120 kills it, not a fast, readable assert.
+            # app.reset_loop_tripwire() (public — round 2 of review:
+            # directly assigning app._loop_tripwire from a test is a
+            # private WRITE a future rename would silently stop
+            # protecting, worse than a private read) gives this test's
+            # own stall/recovery pair a clean instance, deterministic
+            # regardless of what happened during mount.
+            app.reset_loop_tripwire()
             # No real delay: the tripwire's own tick reads this jump on its
             # next wake, exactly as if the loop had actually gone
             # unresponsive for stall_seconds — the ticks afterward are
@@ -451,6 +512,12 @@ async def test_recovery_notice_survives_the_real_interactive_logging_floor(
         app = TextualChatApp(transport=transport)
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()
+            # #4855 follow-up — see the sibling test above's identical
+            # comment: a fresh LoopTripwire makes this test's own
+            # stall/recovery pair deterministic regardless of a real,
+            # unrelated stall during mount having already consumed the
+            # App's session-lifetime one-shot notice.
+            app.reset_loop_tripwire()
             clock.jump(stall_seconds)
             # No test-owned wait budget: wait on the file's actual content,
             # unbounded — CI's own --timeout=120 is the kill switch.
@@ -511,6 +578,13 @@ async def test_the_app_actually_shows_the_notice_when_the_loop_stalls(caplog, mo
             # — the loop appearing unable to run the watcher — with no real
             # delay.
             status_before = str(app.query_one(StatusLine).render())
+            # #4855 follow-up — same determinism fix as the sibling
+            # default-visible tests: a real, unrelated stall during mount
+            # can already have consumed the App's own tripwire's one-shot
+            # _fired latch before this line runs, leaving the
+            # "unresponsive" wait below unbounded-hanging instead of
+            # observing this test's own stall.
+            app.reset_loop_tripwire()
             clock.jump(0.4)
             # #4827 (same class, lead-coder's re-read caught what I missed):
             # a fixed range(6) was trusted as "enough pauses for the stall
@@ -573,6 +647,10 @@ async def test_a_stall_costs_no_row_of_layout(caplog, monkeypatch) -> None:
             status_before = str(app.query_one(StatusLine).render())
             merged_before = bool(app.query_one(StatusLine).parent.query(Tab))
 
+            # #4855 follow-up — same determinism fix as the sibling tests
+            # in this file: an unrelated real stall during mount can
+            # already have consumed the one-shot notice.
+            app.reset_loop_tripwire()
             clock.jump(0.4)
             # #4827 (same class as the sibling test above): wait on the
             # real condition, unbounded — if the stall never trips the
@@ -765,6 +843,14 @@ async def test_pump_heartbeat_reaches_the_default_visible_notices(
             # sibling test_keys_received_... 's comment for why (an earlier,
             # unrelated stall's "unresponsive" line is not this test's own).
             pre_jump_len = len(logfile.read_text(encoding="utf-8"))
+            # #4855 follow-up (lead-coder's TESTS-READ, same PR): slicing
+            # to pre_jump_len (above) fixed WHICH line this test reads —
+            # it does not fix whether a "recovered" line for THIS test's
+            # own stall gets written at all. A real mount-time stall can
+            # already have consumed the App's own tripwire's one-shot _fired
+            # latch before this line runs; a fresh instance makes this
+            # test's own stall/recovery pair deterministic regardless.
+            app.reset_loop_tripwire()
             clock.jump(stall_seconds)
             # #4855 (same defect, same function, 2 lines up): waiting on
             # "recovered" ANYWHERE in the file — not sliced to what THIS
@@ -909,6 +995,12 @@ async def test_keys_received_reaches_the_default_visible_stall_notice(
             # so the offset right before the jump marks where THIS test's
             # own content begins. No time is written in either direction.
             pre_jump_len = len(logfile.read_text(encoding="utf-8"))
+            # #4855 follow-up — see
+            # test_pump_heartbeat_reaches_the_default_visible_notices's
+            # identical comment: a fresh LoopTripwire makes this test's
+            # own stall/recovery pair deterministic regardless of an
+            # unrelated real stall during mount.
+            app.reset_loop_tripwire()
             clock.jump(stall_seconds)
             # #4855 (same defect, same function, 2 lines up): sliced to
             # THIS test's own content — see
@@ -1062,6 +1154,15 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
             # test_keys_received_...'s comment for why (an earlier,
             # unrelated stall's "unresponsive" line is not this test's own).
             pre_jump_len = len(logfile.read_text(encoding="utf-8"))
+            # #4855 follow-up (same determinism fix as the sibling
+            # default-visible tests, applied here too — this wait targets
+            # "unresponsive", not "recovered", but is exposed to the SAME
+            # pre-existing hazard: a real, unrelated stall during mount can
+            # already have consumed the App's own tripwire's one-shot _fired
+            # latch, silently swallowing THIS test's own onset and leaving
+            # the wait below unbounded-hanging instead of reading its own
+            # stall line).
+            app.reset_loop_tripwire()
             clock.jump(stall_seconds)
             while "unresponsive" not in logfile.read_text(encoding="utf-8")[pre_jump_len:]:
                 await pilot.pause()


### PR DESCRIPTION
**[tui-coder]** — part of #4855 (lead-coder's root-cause finding;
assigned to me for implementation). This fixes the flake mechanism
only; the issue itself stays open, since its own A/B/C owner-judgment
question (`blocked:external`, should a 2nd+ stall notify the user at
all) is untouched.

## What changed

`LoopTripwire.observe()` had an asymmetry: the STOP notice is gated by
the session-lifetime one-shot `_fired` latch (silent after episode 1),
but the RECOVERY notice (`_just_recovered` / `consume_recovered()`)
fired unconditionally on every recovery — regardless of whether the
episode it was "recovering from" ever had its own onset actually
reported to the caller.

**Real path** (lead-coder's own trace, confirmed against the code):
a stall during app-mount startup jitter consumes `_fired` before any
later, intentional stall runs. From then on every recovery still
reports (`stall_recovered_log_line`'s literal text: "the interface
recovered from the stall reported above"), with nothing ever reported
above. This is the CI-flake signature #4855's own comment thread
tracked as it recurred (`assert None is not None` — waits for
"recovered", asserts "unresponsive", never finds it) — a running
tally lead-coder kept updating (23-29% of that night's PRs, by their
own count) as PRs kept hitting it. I have not independently re-opened
and re-verified each one myself; citing the thread's own tally, not
re-deriving a number of my own. Not CI noise either way — the assert-
message signature is identical across every instance either of us has
actually opened, and the mechanism above explains it exactly.

**Fix**: a new per-episode `_current_stall_reported` flag, set `True`
only at the exact point `observe()` returns a stall magnitude to the
caller (the `_fired` gate having let it through this time), read and
cleared at the matching recovery transition. `_just_recovered` now
fires only when `_current_stall_reported` is `True`.

`write_record` (the durable, opt-in-`REYN_PROF_DUMP` record) stays
**completely unconditional** on both sides — #4761 ①'s own guarantee
("a trace that just stops leaves 'it recovered' and 'the process died
mid-stall' looking identical") is untouched. This only changes the
user-facing, default-visible notice `consume_recovered()` exposes.

## Scope — what this does NOT decide

#4855's own open question (options A/B/C in its thread: should a 2nd+
stall notify the user at all, independent of this bug) is untouched
and stays `blocked:external`. This fix holds regardless of which of
those three the owner eventually picks — reporting a recovery for an
episode nobody was ever told started is wrong under all three options.

## Test-suite determinism (2 lead-coder TESTS-READ rounds)

**Round 1 — the hang risk.** The production fix, correctly applied,
exposed a pre-existing hazard: every test in `test_loop_probe_3539.py`
that drives a real `TextualChatApp` through a virtual-clock
stall/recovery and waits on `"recovered"`/`"unresponsive"` in the
log is reading the App's single, session-lifetime `LoopTripwire`
instance. A real, unrelated stall during app-mount startup jitter can
consume that instance's one-shot state before the test's own
intentional stall ever runs — turning a fast, readable assert into a
120s CI timeout, the flake's trigger otherwise untouched. Re-grepping
found **7 call sites needing a fix, not the 3 originally flagged**
(2 of the 7 didn't even have the `pre_jump_len` slicing the other 5
already carried). 4 were newly exposed by this PR's own change (the
`"recovered"`-wait sites); 3 had the identical hazard against the
pre-existing `_fired` onset-gate, unrelated to this PR, fixed while
here rather than left as a second landmine.

**Round 2 — the fix itself was a private write.** The first pass fixed
this with `app._loop_tripwire = LoopTripwire()` directly from the
test file — lead-coder's second TESTS-READ round caught that this is
WORSE than a private read: if `_loop_tripwire` is ever renamed,
Python does not raise, it silently creates a new, never-read attribute
on the instance; the app keeps using the OLD (already-consumed)
tripwire; every one of these tests stays green with **zero actual
coverage**, invisibly. Fixed by adding
`TextualChatApp.reset_loop_tripwire()` (a public method). All 7
test-file call sites now route through `app.reset_loop_tripwire()`
instead of the private attribute — a future rename breaks this
method's own body (same file, compile-time-visible) rather than
silently orphaning 7 tests one file away.

**Round 3** (lead-coder retracting their own round-2 prescription, not
my mistake): the round-2 fix also added a `loop_tripwire` constructor
parameter, mirroring the existing `clock`/`presenter` injection
pattern in `__init__`. Removed — it was unreachable dead code. The
contamination this whole fix chases happens DURING mount (a real,
unrelated stall consuming the one-shot notice before a test's own
intentional stall runs), which is AFTER construction; a fresh instance
handed in at construction time would be contaminated by that same
mount-time stall just the same. `reset_loop_tripwire()`, called
post-mount right before each test's own stall, was always the correct
seam — the constructor parameter never had a reachable use case for
this specific failure mode.

## Falsification

Reverting `_current_stall_reported` (recovery fires unconditionally
again, matching pre-fix behavior) reproduces the new test's exact
failure — `consume_recovered()` returns `True` for episode 2's recovery
when it must be `False`. Verified before landing, then restored.

## Test plan

- [x] `pytest tests/interfaces/test_loop_probe_3539.py` — 26 passed (25 pre-existing + 1 new); re-run after the 7 determinism fixes — still 26 passed; re-run again after `reset_loop_tripwire()` — still 26 passed, all fast (~5-14s total), no hangs
- [x] Falsification (see above) — verified; also confirmed `reset_loop_tripwire()` exists and produces a fresh, never-fired `LoopTripwire` against a standalone-constructed `TextualChatApp`
- [x] `ruff check` (all 3 changed files: `app.py`, `loop_probe.py`, `test_loop_probe_3539.py`) — all checks passed
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/verify_module_docstrings.py` (all 3 files) — OK
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_loop_probe_3539.py` — 26 tests, 0 errors, 0 warnings
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Confirmed no docs reference this mechanism (`grep -rl consume_recovered docs/` — empty) — nothing to update
- [ ] Visual — n/a (no TUI/rendering surface touched; loop_probe.py is instrumentation)

## Time-dependency check

0 instances (the new test drives `LoopTripwire` directly through two
consecutive episodes — no clock, real or virtual, needed; `_fired` is a
permanent in-memory latch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Reviewer's blocking points (lead-coder)

- [x] 🔴 **Fixed, and the actual scope was wider than 3.** Re-grepped every `while "recovered"`/`while "unresponsive"` wait against a real `TextualChatApp` in this file — found **6** sites exposed to the mount-jitter hazard, not 3 (`test_recovery_notice_is_visible_without_arming_the_dump` and `test_recovery_notice_survives_the_real_interactive_logging_floor` don't even have the `pre_jump_len` slicing the other 4 do). Fixed all 6 the same way: `app._loop_tripwire = LoopTripwire()` right before each test's own intentional `clock.jump(...)` — a fresh instance of the SAME real class, definitionally `_fired=False`/`_current_stall_reported=False` regardless of what happened to the OLD instance during mount, so each test's own stall/recovery pair is deterministic no matter what a real host did before that line ran. 3 of the 6 (`test_the_app_actually_shows_the_notice_when_the_loop_stalls`, `test_a_stall_costs_no_row_of_layout`, and the `test_turn_active_...` unresponsive wait) were a PRE-EXISTING hazard (the `_fired` onset-gate itself, unrelated to this PR's own change) — fixed while here since it's the same root cause and the same one-line remedy, not left as a second landmine.
- [x] 🔴 Title changed to avoid the `fix(#NNNN)`-adjacent-to-`#NNNN` shape `_CLOSING_RE` matches (verified against `scripts/check_pr_closing_intent.py`'s own regex before renaming, not by guessing a shape that looks safer).
- [x] 🔴 Rewritten — the count is #4855's own comment-thread tally (a running count lead-coder updated as PRs kept hitting it, 23-29% by their own math), not something I re-derived or verified PR-by-PR myself. Said so directly in the body now instead of presenting it as this session's own confirmed figure.


- [x] 🔴 **Fixed.** Added `TextualChatApp.reset_loop_tripwire()` (public method) — a rename of `_loop_tripwire` now breaks this method's own body (same file, compile-time-visible), not a silent no-op 7 tests away. Also added the `loop_tripwire: LoopTripwire | None = None` constructor parameter you specified (default `None` — construction is byte-identical to today), mirroring the existing `clock`/`presenter` seams already in `__init__`, for the general injection case. My own count was 7 sites, not 8 (re-grepped `app._loop_tripwire = LoopTripwire()` in the test file directly rather than estimating) — all 7 now call `app.reset_loop_tripwire()`. Falsified: constructed a real `TextualChatApp` standalone, confirmed `reset_loop_tripwire()` exists and produces a fresh, never-fired instance.


- [x] 🔴 **Fixed.** Removed the `loop_tripwire` constructor parameter entirely (0 callers, confirmed unreachable for the reason you gave — mount-time contamination happens after construction). `reset_loop_tripwire()` is now the only seam; its own docstring and the `self._loop_tripwire` assignment site's comment both updated to explain why a constructor parameter would not have worked, not just that it was removed.

  **7 vs 8**: my own recount is 7 real call sites (`app.reset_loop_tripwire()` at 7 distinct lines). The 8th string match was my own explanatory comment mentioning `reset_loop_tripwire()` in prose (`grep -c` counts a comment the same as a call) — not a test calling it twice. Confirmed by listing the actual call-site line numbers, not just the count.

