### PR TITLE
docs: voice config and AG-UI N3 remote-parity claims went stale

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -336,7 +336,7 @@ whose turn the runtime holds no figure for renders `—`, never `0`.
 | Local client reset + rehydrate on switch | `TextualChatApp` treats the barrier as a reconnect: clears every per-session client state (retained `FlowModel`, running-tool tracking, pending-intervention tabs, sent-queue view/widget + item-meta, in-flight streamed-reply tracking) and rehydrates from the NEW session's `history.jsonl` — never from a client-side cache, which is stale-by-construction while a session is detached (the forwarder drops its frames entirely) | [AG-UI transport § The session-switch barrier](reference/runtime/agui-transport.md) |
 | Targeted hydrate seam | `ChatReadModel.conversation_history` accepts an optional `(agent, session_id)` — omitted hydrates the currently attached session (pre-N2 behavior unchanged); given, hydrates that specific session (possibly never attached in this client run) via `AgentRegistry.get_session`, no duplicated `history.jsonl` path literal | [AG-UI transport § The session-switch barrier](reference/runtime/agui-transport.md) |
 
-> **Remote parity gap (N3, open):** the AG-UI/SSE remote transport does not yet re-emit `session_attached` on the wire, so a remote client's switch-hydrate is unimplemented today (`RemoteReadModel.conversation_history` degrades to empty regardless of a targeted session — the same frame-sufficiency boundary this arc follows throughout).
+> **Remote parity landed (N3, #3310, closed via #3322, further ported off the sentinel by #4548):** the AG-UI/SSE remote transport re-emits `session_attached` on the wire on a session switch. `RemoteReadModel.conversation_history` still degrades to empty regardless of a targeted session — by design, not a gap: a remote client holds no session, and the past-turn `ChatMessage` log is deliberately never projected onto the wire (the same frame-sufficiency boundary this arc follows throughout).
 
 ---
 
@@ -445,7 +445,7 @@ Main reference: **[`reyn.yaml`](reference/config/reyn-yaml.md)**
 | `web_fetch` | SSL `verify_ssl` and `ca_bundle` override | [reyn-yaml § web_fetch](reference/config/reyn-yaml.md#web_fetch-block) |
 | `chat` | Compaction trigger / head+tail retention / section token caps | [Chat Compaction](concepts/data-retrieval/chat-compaction.md) |
 | `embedding` | Model classes / batch_size / cost_warn_threshold | [RAG concepts](concepts/data-retrieval/rag.md) |
-| `voice` ⚠️ | Whisper model / language / device config still parses, but has no consumer since the Textual TUI it was built for was deleted (replaced by the inline CUI) — currently unavailable | [Voice concepts](concepts/tools-integrations/voice.md) |
+| `voice` | Whisper model / language / device config for the inline CUI's F2 dictation binding — revived (#4187/#4249) after the original binding was deleted along with the retired Textual TUI it was built for | [Voice concepts](concepts/tools-integrations/voice.md) |
 | `events` | Rotation size/age + cleanup_period_days | [Events reference](reference/runtime/events.md) |
 | `models` | Class → LiteLLM model string with `extends` chain | [reyn-yaml § llm.models](reference/config/reyn-yaml.md#llmmodels-block) |
 | `permissions` | Project-wide default capability policy | [Permissions config](reference/config/permissions.md) |

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -75,7 +75,7 @@ aren't.
 | `hooks` | list | both (`.reyn/config/hooks.yaml` side is **hot-reloaded**) | Agent-lifecycle hooks. Four action schemes: `template_push` / `exec` / `exec_capture` / `pipeline_launch`. See below. |
 | `embedding` | map | PRJ only · **restart** | RAG embedding: the master switch (`enabled`), model classes, batch sizing and concurrency, retry / backoff / timeout, tokenizer, and a cost-warning threshold. See below. |
 | `chat` | map | PRJ only · **restart** | Chat-session runtime knobs: history compaction, reasoning/"thinking" text handling, the interactive renderer (`render_mode`), TUI gutters, body neutralization, and permitted image-URL schemes. See below. |
-| `voice` | map | PRJ only · **restart** | ⚠️ Currently unavailable (no consumer). See below. |
+| `voice` | map | PRJ only · **restart** | Whisper model/language/device settings for F2 dictation in the inline CUI (revived #4187/#4249). See below. |
 | `audit_events` | map | PRJ only · **restart** | Rotation policy (size / age / cleanup period) for the P6 **audit-event** files under `.reyn/events`. Not WAL-events, not hook-events. See below. |
 | `artifacts` | map | PRJ only · **restart** | The artifact-ref table fallback's own row cap (`remote_fallback_limit`, #4601) — used by a remote client's (and a post-restart local client's) Artifacts pane. See below. |
 | `observability` | map | PRJ only · **restart** | Opt-in OpenTelemetry (OTLP) export of P6 audit-events. Off by default. See below. |
@@ -2244,13 +2244,11 @@ artifacts:
 
 ## `voice` block
 
-**⚠️ Currently unavailable.** The block still parses (no error if set), but has no consumer — it was built for the Ctrl+R Whisper binding in the old Textual TUI, which was deleted and replaced by the inline CUI (no voice-input binding). Kept for schema completeness only. See [concepts: voice](../../concepts/tools-integrations/voice.md).
-
-Voice-input (Whisper) settings, when a consumer exists. Optional — requires `pip install 'reyn[voice]'` (`sounddevice` + `faster-whisper`). The block is lazy-loaded; a missing `[voice]` extra silently disables the record key.
+Voice-input (Whisper) settings for the inline CUI's F2 dictation binding — revived (#4187/#4249) as a reimplementation against the current CUI, after the original Ctrl+R binding was deleted along with the retired Textual TUI it was built for. See [concepts: voice](../../concepts/tools-integrations/voice.md). Optional — requires `pip install 'reyn[voice]'` (`sounddevice` + `faster-whisper`). The block is lazy-loaded; a missing `[voice]` extra silently disables the record key.
 
 ```yaml
 voice:
-  enabled: true           # set false to disable Ctrl+R even if deps are installed
+  enabled: true           # set false to disable F2 dictation even if deps are installed
   model: small            # tiny | base | small | medium | large-v3
   language: ja            # ISO 639-1 code; "" or null = auto-detect
   device: cpu             # cpu | cuda
@@ -2263,7 +2261,7 @@ voice:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | bool | `true` | Set `false` to hard-disable Ctrl+R even when deps are installed. |
+| `enabled` | bool | `true` | Set `false` to hard-disable F2 dictation even when deps are installed. |
 | `model` | string | `small` | Whisper model size: `tiny` / `base` / `small` / `medium` / `large-v3`. |
 | `language` | string \| null | `ja` | ISO 639-1 language code. `""` or `null` enables auto-detection (less reliable for short clips). |
 | `device` | string | `cpu` | Inference device: `cpu` or `cuda`. `auto` is not supported — it picks the wrong device on some Mac setups. |


### PR DESCRIPTION
**[docs-maintainer]** — part of #4187, part of #4249, part of #3310

## What

Per lead-coder's dispatched sweep (architect's own measurement: drift hides in current-tense state claims, not issue-number citations). Scoped to the 7 highest-churn `docs/` files from tonight, using a delegated agent to review every state-word hit's surrounding context against current `src/`, then independently re-verified every finding myself before writing anything.

Two independent, unrelated drift clusters:

1. **Voice config** (`reyn-yaml.md` 2 spots, `feature-map.md` 1 spot) — said the `voice:` block "has no consumer" / "currently unavailable." False since `#4187`/`#4249` revived it as F2 dictation in the inline CUI. A prior follow-up commit (`239295b43`) fixed `voice.md`/`chat-and-web-ui.md` but never touched these two files. Also fixed 2 stale "Ctrl+R" binding-name references (the binding is F2 now) left over from the same drift.
2. **AG-UI N3 remote parity** (`feature-map.md`) — said "gap... open... does not yet re-emit `session_attached`... unimplemented today." `#3310` is closed, its N3 fix merged as `#3322` (2026-07-26), further ported by `#4548`. Kept the still-true, by-design `conversation_history`-degrades-to-empty note, removed only the false "gap"/"open" framing.

## Verification

Independently re-verified every claim against source before writing, not the sweep's own report alone: confirmed `voice.py` exists and the F2 binding (`app.py:824`, `action_voice_toggle` at `:3356`); confirmed `#3310`/`#3322`'s closed/merged state via `gh issue view`/`gh pr view`; confirmed `session_attached` is actually emitted at `endpoint.py:423`; confirmed `RemoteReadModel.conversation_history`'s current degrade-to-empty behavior directly in `read_model.py`.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no `Aborted` line
- [x] `python scripts/check_doc_anchors.py` — exit 0, no dangling anchors into published pages
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Closing-keyword self-grep on commit message and this PR body — clean
- [x] Fetch-checked against `origin/main` before push — no drift
- [x] Every claim independently re-verified against source (not just the sweep's own report)
- [x] Time-dependency check (#4845/#4847): 0 instances — prose-only doc edit, no tests touched
- [x] Visual — N/A, prose-only edit


## Reviewer's blocking point (lead-coder)

- [x] ⚪ (was 🔴, **withdrawn by the reviewer**) The same claim survives in `docs/reference/config/reyn-yaml.ja.md`. CLAUDE.md rule 5 says a `.ja.md` is fixed **only when the PR falsifies something it asserts** — this PR does not; #4187/#4249 did, months ago. Blocking on it exceeded the rule and was holding the en-side fix off main, where the claim is currently false in **both** languages. Split out as #4929.

