### PR TITLE
fix(#4847): remove the 0.3s sleep floor from CodeActRunner's cancel test

### DIFF
--- a/tests/security/test_codeact_cancel_4166.py
+++ b/tests/security/test_codeact_cancel_4166.py
@@ -37,7 +37,18 @@ async def test_cancel_event_kills_a_running_snippet_promptly() -> None:
     ``asyncio.wait({comm_future, cancel_task}, ...)`` race begins
     (``codeact_runner.py``), so the event being pre-set doesn't make this
     vacuous — it still proves an ALREADY-RUNNING process gets killed, just
-    without a sleep-based sender racing against it."""
+    without a sleep-based sender racing against it.
+
+    #4847 (lead-coder review): the FLOOR duration is gone, but the CEILING
+    (``elapsed < 5.0``, below) is still a duration standing in for an
+    observation nothing public exposes — ``run()``'s cancelled-result dict
+    (``{"ok": False, "status": "cancelled", ...}``) carries no pid /
+    returncode / kill-confirmation field, so there is no non-timing seam
+    to assert on from outside the function today. Elapsed-time is a
+    disclosed proxy for that missing seam, not a hidden one — tracked as
+    #4924, not silently left (real seam: expose the killed process's
+    returncode in the result so a future version of this test can assert
+    on that instead of timing)."""
     runner = CodeActRunner()
     cancel_event = asyncio.Event()
     cancel_event.set()  # pre-set: cancel fires as soon as the run's own race begins

--- a/tests/security/test_codeact_cancel_4166.py
+++ b/tests/security/test_codeact_cancel_4166.py
@@ -25,36 +25,40 @@ async def _dispatch(name: str, args: dict) -> dict:
 
 @pytest.mark.asyncio
 async def test_cancel_event_kills_a_running_snippet_promptly() -> None:
-    """Tier 2: cancel_event.set() during a long-running snippet returns
+    """Tier 2: cancel_event, pre-set before ``run()`` is even called, returns
     status='cancelled' well before the snippet's own sleep would finish —
     the process was actually killed, not merely marked cancelled while
-    left running to completion."""
+    left running to completion.
+
+    Pre-set (mirrors ``test_subprocess_cancel_1470.py``'s own idiom, e.g.
+    ``test_noop_cancel_event_set_kills_subprocess``), not a background task
+    racing a fixed sleep against the run: the subprocess is already spawned
+    and running the snippet by the time ``run()``'s internal
+    ``asyncio.wait({comm_future, cancel_task}, ...)`` race begins
+    (``codeact_runner.py``), so the event being pre-set doesn't make this
+    vacuous — it still proves an ALREADY-RUNNING process gets killed, just
+    without a sleep-based sender racing against it."""
     runner = CodeActRunner()
     cancel_event = asyncio.Event()
+    cancel_event.set()  # pre-set: cancel fires as soon as the run's own race begins
     code = "import time\ntime.sleep(30)\nresult = 'never gets here'"
 
-    async def _cancel_soon() -> None:
-        await asyncio.sleep(0.3)
-        cancel_event.set()
-
-    canceller = asyncio.create_task(_cancel_soon())
     start = time.monotonic()
     out = await runner.run(
         code=code, dispatch=_dispatch, allow_unsandboxed=True,
         timeout=30.0, cancel_event=cancel_event,
     )
     elapsed = time.monotonic() - start
-    await canceller
 
     assert out["status"] == "cancelled", out
     assert out["ok"] is False, out
     # The falsifying witness: if kill_process_tree did NOT actually run,
     # the 30s sleep would have to complete (or the 30s timeout would fire)
-    # before this returns. Cancelling within 0.3s must not cost anywhere
+    # before this returns. A pre-set cancel_event must not cost anywhere
     # near that — generous margin, not pinning exact timing.
     assert elapsed < 5.0, (
-        f"took {elapsed:.1f}s after a 0.3s cancel — the subprocess was not "
-        "actually killed, only marked cancelled while left running"
+        f"took {elapsed:.1f}s with a pre-set cancel_event — the subprocess "
+        "was not actually killed, only marked cancelled while left running"
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — closes #4847's remaining site: `tests/security/test_codeact_cancel_4166.py:37`

## Defect

The cancel-sender ran on a fixed `asyncio.sleep(0.3)` before setting `cancel_event` — a floor duration the assertion depended on (CLAUDE.md hard rule: "no `sleep(N)` the assertion depends on").

## Fix

Pre-set `cancel_event` **before** calling `run()`, mirroring `test_subprocess_cancel_1470.py`'s own established idiom (`test_noop_cancel_event_set_kills_subprocess`: `event.set()  # pre-set: cancel fires immediately`).

Not vacuous: `CodeActRunner.run()`'s cancel-vs-completion race begins **after** the subprocess is already spawned and running the snippet (`codeact_runner.py`'s `asyncio.wait({comm_future, cancel_task}, ...)`), so a pre-set event still proves an already-running process gets killed — it just removes the sleep-based race entirely instead of picking a smaller one.

## Testing

Strip-falsified: removed the `kill_process_tree(proc)` call from the cancel branch — the test correctly waited the full 30s sleep and failed with `"took 30.3s with a pre-set cancel_event — the subprocess was not actually killed"`, proving the assertion isn't vacuous. Restored, confirmed green.

`pytest tests/security/test_codeact_cancel_4166.py` — 3/3 green (now 0.88s, down from the prior 0.3s-floor-plus-overhead run). `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py` — all green.

## Test plan

- [x] `pytest tests/security/test_codeact_cancel_4166.py` — 3/3 green
- [x] Strip-falsify (removed the real kill, confirmed RED for the right reason)
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict`
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] (skipped — no docs/ paths touched) mkdocs gates

part of #4847

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


## Reviewer's blocking point (lead-coder)

- [x] 🔴 `assert elapsed < 5.0` (and the `time.monotonic()` around it) survives — the floor (`sleep(0.3)`) is gone but the ceiling is not, and #4847's whole thesis is that a duration stands in for an observation nobody exposed. Either observe the kill directly, or state in the docstring that no seam exists and file the absence. Leaving it silent is the one option that's out.
  Resolved: no non-timing seam exists (CodeActRunner.run()'s cancelled-result dict has no pid/returncode field) — disclosed in the test's own docstring and filed #4924 for the real fix (expose returncode).

