### PR TITLE
fix(#4924): expose CodeActRunner's killed:bool seam, replacing the elapsed-time proxy

### DIFF
--- a/src/reyn/core/kernel/codeact_runner.py
+++ b/src/reyn/core/kernel/codeact_runner.py
@@ -242,6 +242,17 @@ class CodeActRunner:
         timed_out = False
         cancelled = False
         truncated = False
+        # #4924: tied to actual EXECUTION of the kill call (set only on the
+        # line immediately after `kill_process_tree(proc)` returns), never a
+        # hardcoded literal in the return dict below — a literal would be
+        # tautological with `cancelled` itself (true on every path that
+        # reaches the `if cancelled:` return, including a future regression
+        # that reaches it WITHOUT ever calling kill_process_tree at all),
+        # closing zero of the gaps #4923's disclosed elapsed-time proxy was
+        # standing in for. This variable is what makes `killed` in the
+        # return dict a real signal instead of restating `status ==
+        # "cancelled"` under a different name.
+        killed = False
         # #4166: cancel_event=None is the byte-identical original path
         # (asyncio.wait_for against the wall-clock timeout alone). When
         # provided, race BOTH the timeout and the event — mirrors
@@ -279,6 +290,7 @@ class CodeActRunner:
                     cancelled = True
                     service_task.cancel()
                     await kill_process_tree(proc)
+                    killed = True
                     stdout_b, stderr_b = b"", b""
                 elif not done:
                     timed_out = True
@@ -302,9 +314,36 @@ class CodeActRunner:
                 cleanup()
 
         if cancelled:
+            # #4924 (architect ruling): a discriminated-union-safe seam for a
+            # consumer that needs to know kill_process_tree was actually
+            # invoked for this cancellation, not just that this call
+            # returned — a real alternative to the elapsed-time proxy
+            # #4923 was left disclosing. `killed` is ALWAYS present when
+            # `status == "cancelled"` (never conditionally added only when
+            # a kill "worked") — presence must never carry information in
+            # an envelope that already has discriminators (`status`/
+            # `kind`); `status == "cancelled"` is what a consumer branches
+            # on, `killed` is data attached to that branch, not a second
+            # discriminator.
+            #
+            # `killed: bool`, not `returncode: int` — kill_process_tree()
+            # (the shared reaper _subprocess_io.py:284) has no return value
+            # today, and its own docstring is explicit that graceful
+            # (SIGTERM, reaped) vs. forced (SIGKILL after grace_seconds)
+            # produce DIFFERENT returncodes; exposing a real returncode
+            # here would need extending that SHARED helper's contract
+            # (used by every sandbox backend, not just CodeAct) — out of
+            # #4924's scope, which is "stop using a duration as this
+            # test's proxy," not "add OS-level kill-signal fidelity."
+            # `killed` reports the information this call site ALREADY has
+            # (kill_process_tree was invoked for this cancellation) rather
+            # than reaching for new information — if a real returncode
+            # signal is needed later, `killed` can be replaced by it
+            # without a second migration of THIS envelope's shape.
             return {
                 "ok": False, "status": "cancelled",
                 "kind": "Cancelled", "error": "codeact run was cancelled",
+                "killed": killed,
             }
         if timed_out:
             return {

--- a/tests/security/test_codeact_cancel_4166.py
+++ b/tests/security/test_codeact_cancel_4166.py
@@ -1,18 +1,37 @@
-"""Tier 2: #4166 — CodeActRunner.run(cancel_event=...) actually kills a
-running snippet's subprocess, mirroring the cancel-aware race
+"""Tier 2: #4166 — CodeActRunner.run(cancel_event=...) invokes the kill path
+on a running snippet's subprocess, mirroring the cancel-aware race
 ``noop_backend``/``landlock`` already carry for the sibling (non-CodeAct)
 sandboxed_exec op since #1470.
 
-Real subprocess, real asyncio.Event, real wall-clock — no fakes of the
-process or the race. The falsifying witness is elapsed time: the snippet
-sleeps far longer than the test waits before cancelling, so if the kill
-did NOT happen the run would take (and this test would observe) the full
-sleep duration instead of returning promptly.
+Real subprocess, real asyncio.Event — no fakes of the process or the race.
+The witness is ``out["killed"]`` (#4924), not elapsed time: #4923 removed
+the sleep-based FLOOR this file used to have and disclosed that the
+CEILING (an ``elapsed < N`` assertion) was still standing in for an
+observation nothing public exposed. #4924 closed that by adding a real
+non-timing signal to ``run()``'s cancelled-result envelope — see
+``codeact_runner.py``'s own comment on the ``killed`` field for the
+discriminated-union design (``killed`` is data attached to the existing
+``status == "cancelled"`` branch, never a second discriminator a consumer
+would need to probe for presence).
+
+Scope, precisely (lead-coder review — the test docstring below originally
+overclaimed this): ``killed=True`` witnesses that ``kill_process_tree(proc)``
+was CALLED and RETURNED for this cancellation — not that the OS process is
+CONFIRMED dead. ``kill_process_tree()`` has no return value today (#4924's
+own reasoning for choosing this field over a real ``returncode``), so
+whether the graceful (SIGTERM) or forced (SIGKILL-after-grace) path fired,
+and whether the process actually exited, is not observable from this seam.
+The elapsed-time witness this replaces used to ALSO indirectly cover "the
+process was not left running to completion" (an unrelated snippet, if left
+alive past this call, would still be consuming CPU/holding resources even
+though ``run()`` itself returned) — this new witness does not cover that
+either. Both gaps are ``kill_process_tree()``'s own responsibility to close
+(a future OS-level confirmation, #4924's disclosed "option ① later" path),
+not something a caller-side test can currently verify.
 """
 from __future__ import annotations
 
 import asyncio
-import time
 
 import pytest
 
@@ -26,9 +45,14 @@ async def _dispatch(name: str, args: dict) -> dict:
 @pytest.mark.asyncio
 async def test_cancel_event_kills_a_running_snippet_promptly() -> None:
     """Tier 2: cancel_event, pre-set before ``run()`` is even called, returns
-    status='cancelled' well before the snippet's own sleep would finish —
-    the process was actually killed, not merely marked cancelled while
-    left running to completion.
+    status='cancelled' with ``killed=True`` — ``kill_process_tree`` was
+    genuinely invoked (and returned) for this cancellation, not merely
+    marked cancelled while the subprocess was left running from this
+    call's own perspective. See the module docstring's own "Scope,
+    precisely" section for what this does NOT claim (OS-level death
+    confirmation, or that the process wasn't left running past this
+    call — both are ``kill_process_tree()``'s own unclosed gap, not this
+    test's).
 
     Pre-set (mirrors ``test_subprocess_cancel_1470.py``'s own idiom, e.g.
     ``test_noop_cancel_event_set_kills_subprocess``), not a background task
@@ -36,40 +60,37 @@ async def test_cancel_event_kills_a_running_snippet_promptly() -> None:
     and running the snippet by the time ``run()``'s internal
     ``asyncio.wait({comm_future, cancel_task}, ...)`` race begins
     (``codeact_runner.py``), so the event being pre-set doesn't make this
-    vacuous — it still proves an ALREADY-RUNNING process gets killed, just
-    without a sleep-based sender racing against it.
+    vacuous — it still proves the kill path fires against an
+    ALREADY-RUNNING process, just without a sleep-based sender racing
+    against it.
 
-    #4847 (lead-coder review): the FLOOR duration is gone, but the CEILING
-    (``elapsed < 5.0``, below) is still a duration standing in for an
-    observation nothing public exposes — ``run()``'s cancelled-result dict
-    (``{"ok": False, "status": "cancelled", ...}``) carries no pid /
-    returncode / kill-confirmation field, so there is no non-timing seam
-    to assert on from outside the function today. Elapsed-time is a
-    disclosed proxy for that missing seam, not a hidden one — tracked as
-    #4924, not silently left (real seam: expose the killed process's
-    returncode in the result so a future version of this test can assert
-    on that instead of timing)."""
+    ``killed`` is tied to the LINE right after ``kill_process_tree(proc)``
+    returns (``codeact_runner.py``'s own comment on the ``killed`` local),
+    not a literal baked into the return dict — a hardcoded ``True`` there
+    would be tautological with ``status == "cancelled"`` (true on every
+    path reaching that return, including a hypothetical future regression
+    that reaches it WITHOUT ever calling ``kill_process_tree`` at all),
+    closing none of the gap #4923 disclosed. This PR's own strip-falsify
+    (removing the ``kill_process_tree(proc)`` call entirely — see the PR
+    body, not a permanent sibling test) confirmed a naive literal would
+    NOT have caught that regression, which is why the field is wired to
+    real execution instead."""
     runner = CodeActRunner()
     cancel_event = asyncio.Event()
     cancel_event.set()  # pre-set: cancel fires as soon as the run's own race begins
     code = "import time\ntime.sleep(30)\nresult = 'never gets here'"
 
-    start = time.monotonic()
     out = await runner.run(
         code=code, dispatch=_dispatch, allow_unsandboxed=True,
         timeout=30.0, cancel_event=cancel_event,
     )
-    elapsed = time.monotonic() - start
 
     assert out["status"] == "cancelled", out
     assert out["ok"] is False, out
-    # The falsifying witness: if kill_process_tree did NOT actually run,
-    # the 30s sleep would have to complete (or the 30s timeout would fire)
-    # before this returns. A pre-set cancel_event must not cost anywhere
-    # near that — generous margin, not pinning exact timing.
-    assert elapsed < 5.0, (
-        f"took {elapsed:.1f}s with a pre-set cancel_event — the subprocess "
-        "was not actually killed, only marked cancelled while left running"
+    assert out["killed"] is True, (
+        "cancelled but killed=False — kill_process_tree was not invoked "
+        "for this cancellation (the subprocess was marked cancelled without "
+        "the kill path ever firing)"
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — closes #4924: expose a real `killed: bool` seam, replacing the elapsed-time proxy #4923 disclosed

## Design (architect ruling — option ②, not ①)

`killed: bool`, always present when `status == "cancelled"` (never conditionally added only when a kill "worked" — presence must never carry information in an envelope that already has discriminators, `status`/`kind`; a consumer branches on `status`, never on key-presence).

Not `returncode: int` (option ①): `kill_process_tree()` — the shared reaper `security/sandbox/_subprocess_io.py:284` uses across noop_backend/seatbelt/landlock/CodeAct, not just CodeAct — has no return value today, and its own docstring is explicit that graceful (SIGTERM) vs. forced (SIGKILL after `grace_seconds`) termination produce *different* returncodes. Exposing a real returncode would mean extending that **shared** helper's contract — out of #4924's scope (this issue is "stop using a duration as a test's proxy," not "add OS-level kill-signal fidelity").

## Implementation detail (found during implementation, not part of architect's original text)

`killed` is tied to the **line right after** `kill_process_tree(proc)` returns — not a literal baked into the return dict. A hardcoded `killed: True` in the return statement would be **tautological with `cancelled` itself** (true on every code path reaching that return, including a hypothetical future regression that reaches it *without ever calling* `kill_process_tree` at all) — closing none of the gap #4923 disclosed. Confirmed via strip-falsify (below): removing the `kill_process_tree(proc)` call entirely still reaches the exact same return statement, so a hardcoded literal would have stayed green through that regression.

## Test update

`test_codeact_cancel_4166.py::test_cancel_event_kills_a_running_snippet_promptly` now asserts `out["killed"] is True` instead of `elapsed < 5.0` — the gap #4923 disclosed is now closed, in the same file it was disclosed in. `time`/`time.monotonic()` removed (now unused).

## Consumer sweep (per lead-coder's assignment)

- `CodeActRunner.run()`'s only production consumer is `_content_fence_cell.py:191` (`_format_codeact_observation`) — reads `ok`/`result`/`stdout`/`stderr`/`kind`/`error`, never reads `status` directly. Unaffected by the new additive `killed` key.
- `kill_process_tree()` itself is **untouched** — 9 total call sites (3 CodeActRunner, 2 noop_backend, 2 seatbelt, 2 landlock), none affected since its signature didn't change (this is exactly why option ② was chosen over ①).
- Success-path harness contract (architect's :457-458, corrected to :460-461): `payload["status"] = "ok" if payload.get("ok") else "error"; return payload` — the success path returns the harness's own dict verbatim, so a uniform `killed` key across *every* status branch isn't achievable without changing the harness's own contract — out of scope, confirmed by both architect and lead-coder independently.

## Testing

Strip-falsified: removed the `kill_process_tree(proc)` call from the cancel branch (leaving `killed` unset/`False`) — the test correctly failed with `killed=False`. Restored, confirmed green. No orphaned subprocess left behind after the strip run (verified via `ps`).

`pytest tests/security/test_codeact_cancel_4166.py` — 3/3 green (2.6s). Broader CodeAct sweep (10 files) — 54/54 green, no regressions. `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py` — all green.

## Test plan

- [x] `pytest tests/security/test_codeact_cancel_4166.py` — 3/3 green
- [x] Strip-falsify (removed the kill call, confirmed RED for the right reason; confirmed no orphaned subprocess)
- [x] Broader CodeAct sweep (10 files) — 54/54 green
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict`
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] (skipped — no docs/ paths touched) mkdocs gates

closes #4924, follows #4847/#4923

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


## Reviewer's blocking points (lead-coder)

- [x] 🔴 Docstring overclaims: "with `killed=True` — the subprocess **was actually killed**". `killed` witnesses that `kill_process_tree(proc)` was *invoked and returned*, not that the process died — the production comment says this precisely ("was invoked for this cancellation"); the test docstring is one notch stronger. Also state what the witness *stopped* covering: `elapsed < 5.0` caught "left running to completion", `killed` does not (correctly so — whether the shared reaper works is its own responsibility — but the next reader cannot infer that).
  Resolved: reworded both the module and test docstrings (+ the assertion's own failure message) to the precise claim — "kill_process_tree was invoked and returned", not "the process died" — and added a "Scope, precisely" section naming both gaps this witness does NOT cover (OS-level death confirmation; "left running to completion", which the old elapsed-time proxy used to also catch).
- [x] 🔴 `closing-intent contradiction check` was red: the body declared closing intent on line 1 and a non-closing trailer on line 40 for the same issue. Closing is the correct intent; the trailer was dropped. (Phrasing here deliberately avoids repeating the trailer keyword — the gate strips backticks before matching, so quoting it re-triggers the check.)
  Resolved: line 40 now reads `closes #4924, follows #4847/#4923`.




