### PR TITLE
docs(#4858): dedup CLAUDE.md<->docs verbatim overlap found by the 7-surface re-measurement

### DIFF
--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -280,8 +280,8 @@ These rules then keep multi-session work coherent:
    pairs the keyword with a number gets copied faithfully by whoever
    receives it, and the trap fires on THEIR PR, not the sender's. Check
    phrasing you're about to hand off the same way you'd check your own.
-8. **A PR touching `tests/` does not self-merge until a reviewer's
-   TESTS-READ note lands on the PR.** "A lead-coder merge train refuses
+8. **The TESTS-READ rule (`CLAUDE.md`'s own rule 8) has a gap instance
+   here.** "A lead-coder merge train refuses
    any PR touching `tests/` without one" (Test review, above) describes
    what *that train's own script* does — it is not a rule that reaches a
    session merging directly. `#3916` (75 files, 31 under `tests/`) merged

--- a/docs/deep-dives/contributing/test-review-six-questions.md
+++ b/docs/deep-dives/contributing/test-review-six-questions.md
@@ -49,8 +49,8 @@ Ask each test in the diff:
    (#3859), and #3850 landed a field that was required, populated, tested,
    and read by nobody — the honest answer to "who would miss it" was
    already "nobody."
-4. **Would it stay green having never run — or having run with nothing to
-   bite on?** skip / collection error / zero collected all wear green's
+4. **The never-ran/nothing-to-bite-on question (full wording in `CLAUDE.md`).**
+   skip / collection error / zero collected all wear green's
    colour. Name what a missing optional dependency silently skips — CI has no
    `effects` extra, so #3796's file skips whole and its green says nothing
    (#2999 is the same shape with a docker-daemon skip). The same green covers
@@ -73,16 +73,10 @@ first use and the PR merged anyway: #3876's ⑤ answer was "bounded only by the
 thread scheduler, not by the test" — written down, measured at 413 MB, and let
 through as a note. The operator had to ask why. **An answer recorded is not an
 answer acted on**, which is the same gap as an audit that reads a Tier string.
-So each question has a blocking answer, not just an answer:
-
-| | blocks when the answer is |
-|---|---|
-| 1 | **none** — including a third party's, a past bug's, and reyn's own trivia |
-| 2 | yes — the same expression is on both sides |
-| 3 | **nobody**, or only a configuration this test itself constructed |
-| 4 | it would be green having never run **or over an empty collection**, and the PR does not say so |
-| 5 | **anything outside the test bounds it** — a thread, a timer, the caller's pace |
-| 6 | the declared Tier is not the one question 1 named |
+So each question has a blocking answer, not just an answer — the table is in
+`CLAUDE.md` § "Test review" (this file's own opening line already says so;
+the table itself belongs there once, not twice — #4858 found this copy had
+already drifted one word from that one).
 
 ⚠️ 4 blocks on the *silence*, not on the skip: a file that skips whole in CI is
 often correct (an optional extra), and what makes it a defect is a green nobody
@@ -109,8 +103,8 @@ it instead of whether it's green resolves this without a special case.
 lead-coder merge train refuses any PR touching `tests/` without one — the promise
 "I will open the tests next time" is exactly the shape this replaces.
 
-**When something forces you to touch a test — a dependency bump, a rebase, a CI
-failure — ask "should this exist" before "how do I make it pass again."** A
+**The "why did I have to touch this test" rule (verbatim in `CLAUDE.md`) has
+its own instance here.** A
 flowview pin bump (0.16.0 → 0.16.1, #3886) broke one test's premise ("a fresh
 session is a blank screen" — it never quite was; reyn's own welcome placeholder
 was always painted, just invisible to the older, narrower capture). The first

--- a/scripts/check_claude_md_doc_overlap.py
+++ b/scripts/check_claude_md_doc_overlap.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Measure verbatim-span overlap between every ``CLAUDE.md`` file and the
+``docs/`` corpus — the re-runnable form of #4858/#4860's measurement.
+
+#4858: 3/3 same-day mirror-drift misses (`#4841→#4843`, `#4851→#4853`,
+`#4854`'s own bullet) all landed inside a ~10%-of-CLAUDE.md verbatim overlap
+with ``tier1-rationale.md`` — a normative rule restated in a second place
+that could (and did) go stale independently. #4860 fixed that ONE pair to
+0 words of overlap (word-tokenized ``difflib.SequenceMatcher``, blocks
+``>= 15`` words — the method this script keeps).
+
+Deliberately NOT a hard CI gate (owner/lead-coder ruling still stands: gate
+design has open questions — front-matter vs. naming-convention pairing,
+false-positive handling, whether a restated table is ever legitimate). This
+script is the reusable MEASUREMENT — "what is the current value" — kept so
+re-measuring after the next ``CLAUDE.md`` edit is one command, not a fresh
+investigation. Whoever eventually designs the gate reads this file for the
+population definition, per lead-coder's own #4858 comment.
+
+Population, derived from the filesystem, not hardcoded (#4858 follow-up,
+2026-08-19 measurement): every ``CLAUDE.md`` found under the repo root,
+excluding ``.venv``/``.claude/worktrees``/``node_modules`` — this is the
+CANONICAL way to answer "how many surfaces are there right now" so this
+script does not silently go stale the next time a module gains or loses
+its own ``CLAUDE.md`` (as happened between #4860's 1-doc-pair design and
+this file's own 7-surface reality, per #4867/#4869/#4918's split).
+
+Known accepted exemptions (NOT flagged as findings, ruled acceptable —
+#4858 2026-08-19): a short, stable, intentionally-repeated epigraph/tagline
+(the Constitution one-liner in ``CLAUDE.md``, ``docs/index.md``, and
+``docs/start.md``) is a citation, not a restated rule — #4860's own
+precedent ("pointed to CLAUDE.md's own quote instead of repeating it") is
+about restated PROSE, not a single stable headline meant to read the same
+everywhere. This script does NOT auto-exempt such spans (no reliable way
+to tell a legitimate short quote from an accidental one by shape alone);
+it reports every span >=15 words and leaves severity judgment to the
+reader, per #4858's own explicit warning that "always require both" is
+the wrong rule for this population.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from difflib import SequenceMatcher
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EXCLUDED_DIR_PARTS = {".venv", ".venv311", "node_modules", "worktrees"}
+_MIN_OVERLAP_WORDS = 15
+
+
+def _tokenize(text: str) -> list[str]:
+    return re.findall(r"\S+", text)
+
+
+def discover_claude_md_files(root: Path) -> list[Path]:
+    """Every ``CLAUDE.md`` under *root*, excluding vendored/worktree copies
+    — the population this measurement checks. Filesystem-derived (not a
+    hardcoded list) so it tracks the module-CLAUDE.md set as it evolves."""
+    found = []
+    for p in sorted(root.rglob("CLAUDE.md")):
+        if any(part in _EXCLUDED_DIR_PARTS for part in p.parts):
+            continue
+        found.append(p)
+    return found
+
+
+def find_overlap_blocks(
+    a_words: list[str], b_words: list[str], min_len: int = _MIN_OVERLAP_WORDS,
+) -> list:
+    sm = SequenceMatcher(None, a_words, b_words, autojunk=False)
+    return [b for b in sm.get_matching_blocks() if b.size >= min_len]
+
+
+def measure(root: Path) -> list[tuple[Path, Path, list, list[str]]]:
+    """Every (claude_file, doc_file, blocks, claude_words) with >=1
+    matching span of >= _MIN_OVERLAP_WORDS words."""
+    claude_files = discover_claude_md_files(root)
+    docs_files = sorted((root / "docs").glob("**/*.md"))
+
+    results = []
+    for cf in claude_files:
+        a_words = _tokenize(cf.read_text(encoding="utf-8"))
+        for df in docs_files:
+            b_words = _tokenize(df.read_text(encoding="utf-8"))
+            blocks = find_overlap_blocks(a_words, b_words)
+            if blocks:
+                results.append((cf, df, blocks, a_words))
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(__doc__ or "").splitlines()[0]
+    )
+    parser.add_argument(
+        "--root", default=str(_REPO_ROOT), help="Repo root (default: this script's own repo)"
+    )
+    args = parser.parse_args(argv)
+    root = Path(args.root)
+
+    claude_files = discover_claude_md_files(root)
+    results = measure(root)
+
+    print(f"Population: {len(claude_files)} CLAUDE.md file(s):")
+    for cf in claude_files:
+        print(f"  {cf.relative_to(root)}")
+    print()
+
+    total_words = sum(sum(b.size for b in blocks) for _, _, blocks, _ in results)
+    print(
+        f"Found {len(results)} (CLAUDE.md, docs-file) pair(s) with "
+        f">= {_MIN_OVERLAP_WORDS}-word overlap, {total_words} words total\n"
+    )
+    for cf, df, blocks, a_words in results:
+        span_words = sum(b.size for b in blocks)
+        print(
+            f"{cf.relative_to(root)}  <->  {df.relative_to(root)}: "
+            f"{len(blocks)} span(s), {span_words} words"
+        )
+        for b in blocks:
+            snippet = " ".join(a_words[b.a : b.a + min(b.size, 20)])
+            print(f"    size={b.size}: {snippet!r}{'...' if b.size > 20 else ''}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**[e2e-coder]** — part of #4858 (discussing, not closing — gate design stays open)

<!-- closing-check: discussing #4858 -->

## What

Re-measured #4860's "0 verbatim spans >=15 words" claim against the current 7-surface CLAUDE.md population (root split into 7 by #4867/#4869/#4918 since #4860's design). Result: not zero.

## Found

- **CLAUDE.md ↔ `test-review-six-questions.md`: 4 spans, 138 words.** The "blocks when the answer is" table restated near-verbatim in a doc whose own opening line already says the table lives in CLAUDE.md. #4858's exact root-cause pattern, and it had already drifted (row 4's wording differed by one clause between copies). Verified via `git log -S` which wording is authoritative (CLAUDE.md's, from owner-approved #4811 — the doc's copy was never synced to that edit). Fixed: removed the table + 2 smaller residual spans, paraphrased to point at CLAUDE.md, kept every unique instance/essay intact.
- **CLAUDE.md ↔ `pr-workflow.md`: 1 span, 17 words.** Rule 8 restated verbatim as the doc's own numbered item. Same treatment.
- **CLAUDE.md ↔ `docs/index.md`/`docs/start.md`: 17 words each.** The Constitution epigraph, intentionally repeated as a landing-page tagline. Ruled acceptable (lead-coder) — left untouched.

## Added

`scripts/check_claude_md_doc_overlap.py` — the reusable form of this measurement. Population derived from the filesystem (glob for every `CLAUDE.md`, excluding vendored/worktree copies) rather than hardcoded, so it tracks the module-CLAUDE.md set as it evolves. **Not wired into CI** — gate design stays an open question (#4858's own list: pairing representation, false-positive handling, whether a gate is even the right shape). Kept so the next re-measurement is one command.

## Verification

Re-measured after all edits: 0 spans against `tier1-rationale.md` (holds, #4860 unaffected by this PR), 0 against `test-review-six-questions.md`/`pr-workflow.md` (fixed here), 2 remaining (the ruled-acceptable epigraph).

`mkdocs build --strict`, `check_doc_anchors.py`, `check_retired_config_keys_denylist.py` — all green. `ruff check` on the new script — clean.

## Test plan

- [x] `python scripts/check_claude_md_doc_overlap.py` — 2 remaining pairs, both the ruled-acceptable epigraph
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml`
- [x] `check_doc_anchors.py`
- [x] `check_retired_config_keys_denylist.py`
- [x] `ruff check scripts/check_claude_md_doc_overlap.py`
- [x] Closing-keyword self-check on commit message + this PR body (both use `<!-- closing-check: discussing #4858 -->`, per this session's own #4923/#4924/#4925 lessons)
- [x] (skipped — no TESTS-READ needed, no tests/ touched)

part of #4858

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
