### PR TITLE
fix(#4927): strip markdown decoration before tokenizing in check_claude_md_doc_overlap.py

### DIFF
--- a/scripts/check_claude_md_doc_overlap.py
+++ b/scripts/check_claude_md_doc_overlap.py
@@ -49,8 +49,27 @@ _EXCLUDED_DIR_PARTS = {".venv", ".venv311", "node_modules", "worktrees"}
 _MIN_OVERLAP_WORDS = 15
 
 
+# #4927: markdown decoration (backtick / `*` / `#`) is stripped BEFORE
+# tokenizing, not just whitespace/newlines — the un-fixed version
+# (`re.findall(r"\S+", text)` alone) let a decoration character glued to a
+# word boundary at a DIFFERENT line-wrap point in the two files split the
+# SAME text into a different token sequence, undercounting overlap (real
+# instance, architect: a shared pre-push command list in `CLAUDE.md` and
+# `pr-workflow.md` wrapped its backtick-fenced inline code at different
+# points, so this tool's own pre-fix measurement missed it entirely — 0
+# words where a real, current duplication exists).
+#
+# `-` is included in the strip set (matching the reproducing shape found)
+# — verified corpus-wide (not assumed) that this does not introduce any
+# NEW (CLAUDE.md, docs-file) pair that wasn't already flagged without it;
+# splitting a hyphenated compound word into two tokens did not, in this
+# corpus, produce a spurious new pair, only shifted a couple of existing
+# spans' sizes by 1-2 words (case-lowering resolving one word's casing).
+_DECORATION_RE = re.compile(r"[`*#\-]")
+
+
 def _tokenize(text: str) -> list[str]:
-    return re.findall(r"\S+", text)
+    return _DECORATION_RE.sub(" ", text.lower()).split()
 
 
 def discover_claude_md_files(root: Path) -> list[Path]:

--- a/scripts/check_claude_md_doc_overlap.py
+++ b/scripts/check_claude_md_doc_overlap.py
@@ -119,6 +119,21 @@ def main(argv: list[str] | None = None) -> int:
     root = Path(args.root)
 
     claude_files = discover_claude_md_files(root)
+
+    # #4927 blocking point ①: an empty population (wrong --root, or a repo
+    # that genuinely lost every CLAUDE.md) must NOT print "Found 0 pairs, 0
+    # words total" and exit 0 — that output is byte-identical to "population
+    # is real and has zero overlap", so a typo'd --root reads as a clean
+    # result. This tool's only value IS the population (six-questions ④: a
+    # green over an EMPTY collection wears the same colour as a real green).
+    # Fail loudly instead of measuring nothing.
+    if not claude_files:
+        print(
+            f"error: no CLAUDE.md found under {root} — refusing to report "
+            f"'0 pairs found' as if that were a measurement. Check --root.",
+        )
+        return 1
+
     results = measure(root)
 
     print(f"Population: {len(claude_files)} CLAUDE.md file(s):")

--- a/tests/scripts/test_claude_md_doc_overlap_4927.py
+++ b/tests/scripts/test_claude_md_doc_overlap_4927.py
@@ -1,0 +1,89 @@
+"""Tier 1: #4927 — ``check_claude_md_doc_overlap.py``'s tokenizer must strip
+markdown decoration before splitting on whitespace, not just whitespace.
+
+The un-fixed tokenizer (``re.findall(r"\\S+", text)`` alone) let a decoration
+character (backtick / ``*`` / ``#`` / ``-``) glued to a word at a DIFFERENT
+line-wrap point in two files split the SAME text into a different token
+sequence — undercounting real overlap. Real instance (architect, #4927): the
+pre-push command list is duplicated between ``CLAUDE.md`` and
+``docs/deep-dives/contributing/pr-workflow.md``, wrapped at different points
+inside backtick-fenced inline code; the un-fixed tool measured 0 words of
+overlap for this pair where real, current duplication exists.
+
+Real files, not a synthetic fixture (lead-coder's explicit #4927
+instruction, following #4858's own principle: the reproducing command
+sequence itself is not a defect to paraphrase away — rewording it would
+stop demonstrating the bug this test pins). If either file's wording
+changes enough that this specific span no longer exists, that is new
+information for whoever touches those files next, not a reason to weaken
+this test's own assertion.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+from tests._support.paths import REPO_ROOT
+
+_SCRIPT = REPO_ROOT / "scripts" / "check_claude_md_doc_overlap.py"
+_CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+_PR_WORKFLOW = REPO_ROOT / "docs" / "deep-dives" / "contributing" / "pr-workflow.md"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("_claude_md_doc_overlap_4927", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _pair_overlap_words(mod, a_text: str, b_text: str) -> int:
+    a_words = mod._tokenize(a_text)
+    b_words = mod._tokenize(b_text)
+    blocks = mod.find_overlap_blocks(a_words, b_words)
+    return sum(b.size for b in blocks)
+
+
+def test_decoration_stripped_tokenizer_finds_the_real_command_list_overlap() -> None:
+    """Tier 1: the fixed tokenizer finds >= 15 words of overlap between
+    CLAUDE.md and pr-workflow.md's shared pre-push command list — asserting
+    a VALUE (a floor), not an exact match against this test's own
+    computation, so a future edit narrowing (but not eliminating) the
+    overlap doesn't silently pass a test that no longer checks anything
+    (the same "declared vs. actual" gap #4858 was about)."""
+    mod = _load_module()
+    claude_text = _CLAUDE_MD.read_text(encoding="utf-8")
+    pr_workflow_text = _PR_WORKFLOW.read_text(encoding="utf-8")
+
+    words = _pair_overlap_words(mod, claude_text, pr_workflow_text)
+    assert words >= 15, (
+        f"expected >= 15 words of overlap on the known command-list span "
+        f"between CLAUDE.md and pr-workflow.md; got {words}. If this "
+        f"legitimately dropped to 0, the shared command list itself "
+        f"changed — that's real news, not a reason to lower this bound."
+    )
+
+
+def test_strip_falsify_undecorated_tokenizer_misses_the_same_pair() -> None:
+    """Tier 1: strip-falsify — the PRE-#4927 tokenizer shape (whitespace
+    split only, no decoration stripped) finds 0 words on the SAME pair,
+    proving the fix in the test above is genuinely load-bearing and not
+    something the old code already caught."""
+    import re
+
+    def _old_tokenize(text: str) -> list[str]:
+        return re.findall(r"\S+", text)
+
+    mod = _load_module()
+    claude_words = _old_tokenize(_CLAUDE_MD.read_text(encoding="utf-8"))
+    pr_words = _old_tokenize(_PR_WORKFLOW.read_text(encoding="utf-8"))
+    blocks = mod.find_overlap_blocks(claude_words, pr_words)
+    total = sum(b.size for b in blocks)
+    assert total == 0, (
+        f"expected the OLD (undecorated) tokenizer to miss this pair "
+        f"entirely (0 words) — got {total}. If this is no longer 0, the "
+        f"files changed in a way that makes this strip-falsify stale; it "
+        f"no longer proves the fix is load-bearing and needs a fresh pair."
+    )

--- a/tests/scripts/test_claude_md_doc_overlap_4927.py
+++ b/tests/scripts/test_claude_md_doc_overlap_4927.py
@@ -1,5 +1,6 @@
 """Tier 1: #4927 — ``check_claude_md_doc_overlap.py``'s tokenizer must strip
-markdown decoration before splitting on whitespace, not just whitespace.
+markdown decoration before splitting on whitespace, not just whitespace; and
+``main()`` must fail loudly, not report "0 pairs", on an empty population.
 
 The un-fixed tokenizer (``re.findall(r"\\S+", text)`` alone) let a decoration
 character (backtick / ``*`` / ``#`` / ``-``) glued to a word at a DIFFERENT
@@ -17,6 +18,13 @@ stop demonstrating the bug this test pins). If either file's wording
 changes enough that this specific span no longer exists, that is new
 information for whoever touches those files next, not a reason to weaken
 this test's own assertion.
+
+Second bug in the same PR (lead-coder's review, blocking point ①): a
+mistyped ``--root`` producing zero discovered ``CLAUDE.md`` files printed
+"Found 0 pairs ... 0 words total" and exited 0 — indistinguishable from a
+real population that genuinely has no overlap. Six-questions ④: a green
+over an EMPTY collection wears the same colour as a real green. ``main()``
+now exits 1 on an empty population instead of measuring nothing.
 """
 from __future__ import annotations
 
@@ -87,3 +95,46 @@ def test_strip_falsify_undecorated_tokenizer_misses_the_same_pair() -> None:
         f"files changed in a way that makes this strip-falsify stale; it "
         f"no longer proves the fix is load-bearing and needs a fresh pair."
     )
+
+
+def test_empty_population_fails_loudly_instead_of_reporting_zero_pairs(tmp_path, capsys) -> None:
+    """Tier 1: an empty CLAUDE.md population (wrong --root, or a repo that
+    genuinely has none) must exit non-zero, not print "Found 0 pairs, 0
+    words total" and exit 0 — that output is indistinguishable from "the
+    population is real and has zero overlap" (lead-coder #4927 blocking
+    point ①; real repro: running a copy of this script from outside the
+    repo silently reported Population: 0 / 0 words total / exit 0)."""
+    mod = _load_module()
+
+    exit_code = mod.main(["--root", str(tmp_path)])
+
+    assert exit_code != 0, (
+        "an empty population must not exit 0 — that reads as a clean "
+        "measurement instead of a broken --root or a lost population"
+    )
+    captured = capsys.readouterr()
+    assert "0 CLAUDE.md" not in captured.out, (
+        "must not print a 'Population: 0' success-shaped line at all — "
+        f"got stdout: {captured.out!r}"
+    )
+
+
+def test_strip_falsify_empty_population_check_is_load_bearing() -> None:
+    """Tier 1: strip-falsify — with the loud-failure check removed,
+    ``discover_claude_md_files`` + ``measure`` on an empty root DOES return
+    an empty result silently (0 files, 0 pairs), proving the check in the
+    test above is the thing doing the work, not something else already
+    catching it."""
+    import tempfile
+    from pathlib import Path
+
+    mod = _load_module()
+    with tempfile.TemporaryDirectory() as empty_root:
+        root = Path(empty_root)
+        claude_files = mod.discover_claude_md_files(root)
+        results = mod.measure(root)
+        assert claude_files == [] and results == [], (
+            "expected an empty root to silently produce 0 files / 0 results "
+            "at the discover/measure layer — this is exactly the silent "
+            "shape main() must refuse to report as if it were a measurement"
+        )


### PR DESCRIPTION
**[e2e-coder]** — part of #4927

## What

`check_claude_md_doc_overlap.py`'s `_tokenize` split on whitespace only
(`re.findall(r"\S+", text)`), leaving backtick/`*`/`#`/`-` decoration glued to
the adjacent word. When the same text is line-wrapped differently inside
backtick-fenced inline code across two files, that decoration lands at a
different word boundary in each file, so the two files' word-token sequences
diverge for text that is otherwise identical — undercounting overlap.

Real instance (architect, #4927): the pre-push command list is duplicated
between `CLAUDE.md` and `docs/deep-dives/contributing/pr-workflow.md`,
wrapped at different points inside backtick-fenced inline code. The pre-fix
tool measured **0 words** of overlap for this pair, where real, current
duplication exists.

## Fix

Lowercase + strip `` ` ``/`*`/`#`/`-` before whitespace-splitting. `-` is
included in the strip set (matches the reproducing shape); verified
corpus-wide this introduces no NEW (CLAUDE.md, docs-file) pair that wasn't
already flagged without it — splitting a hyphenated compound word only
shifted a couple of existing spans' sizes by 1-2 words.

Post-fix measurement: **3 pairs, 66 words total** (was 2 pairs, **34** words
— corrected from an earlier, unverified "48"; the real pre-fix baseline,
re-run against landed `main`, is 2 pairs / 34 words, 17+17, both epigraph
citations). The previously-invisible CLAUDE.md↔pr-workflow.md pair now
measures **18 words / 1 span**, so 66 − 34 = 32 words of newly-caught
overlap: 18 (the pr-workflow pair) + 14 (the two epigraph spans grew by
7 words each once `-`/`*`/`#` decoration inside them stopped splitting a
token).

## Disclosed discrepancy (not silently resolved)

Architect's independently-cited figure for this same pair was **42
words**. My own measurement is 18. I traced the gap: `CLAUDE.md`'s own
`(the same command CI runs, not a narrower one)` parenthetical breaks span
contiguity right after `ruff check .`, so this tool's `>=15`-word matching
block starts at `python scripts/test_tier_audit.py` rather than including
the `ruff check .` prefix — a genuine, corpus-derived difference, not a bug
in either measurement I could find. Reporting my own tool's empirical
number rather than force-matching architect's, per "assert a value, not a
match against someone else's figure."

## Not touched

Per lead-coder's explicit #4927 instruction, the reproducing command list
itself is unchanged in both `CLAUDE.md` and `pr-workflow.md` — only the
measurement script's tokenizer changed.

## Tests

`tests/scripts/test_claude_md_doc_overlap_4927.py`:
- `test_decoration_stripped_tokenizer_finds_the_real_command_list_overlap`:
  fixed tokenizer finds `>= 15` words on the real CLAUDE.md↔pr-workflow.md
  pair (a floor, not an exact match — a future edit narrowing but not
  eliminating the overlap shouldn't silently pass a test that no longer
  checks anything).
- `test_strip_falsify_undecorated_tokenizer_misses_the_same_pair`: the
  pre-fix tokenizer shape gets exactly 0 words on the same real pair,
  proving the fix is load-bearing.

Both strip-falsified against the real committed file (reverted `_tokenize`
to the old shape, confirmed the first test goes RED with `got 0`, restored).

## Test plan

- [x] `ruff check scripts/check_claude_md_doc_overlap.py tests/scripts/test_claude_md_doc_overlap_4927.py`
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_claude_md_doc_overlap_4927.py`
- [x] `python scripts/verify_module_docstrings.py scripts/check_claude_md_doc_overlap.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `.venv/bin/python -m pytest tests/scripts/test_claude_md_doc_overlap_4927.py -v` — 2 passed
- [x] Strip-falsify against the real committed `_tokenize` — RED for the right reason, restored, GREEN again
- [x] (skipped — no `docs/` files touched, no `tests/` path-conditional gate triggered beyond the standard 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Reviewer's blocking points (lead-coder)

- [x] 🔴 An empty discovered population prints `Population: 0 CLAUDE.md file(s)` and then `Found 0 pair(s) … 0 words total` — indistinguishable from "no duplication", exit code included. A mistyped `--root` therefore reads as a clean result. Fail loudly when the population is empty: the population IS this tool's only value, and a zero-sized one is not an answer (six-questions #4 — an assert over an empty collection wears green's colour).
  **Resolved:** `main()` now returns 1 with an explicit error message on an empty population. Repro'd independently first (copy of the script run from `/tmp` gave `Population: 0` / `0 words total` / exit 0), then fixed, then strip-falsified against the real committed file (removed the check → RED with `0 != 0` → restored → GREEN). New tests: `test_empty_population_fails_loudly_instead_of_reporting_zero_pairs`, `test_strip_falsify_empty_population_check_is_load_bearing`.
- [x] ⚠️ The "was 2 pairs, 48 words" baseline does not reproduce: running the pre-fix script on landed `main` gives 2 pairs, **34** words (17 + 17, both epigraph). Post-fix (66) matches independently. State where 48 was measured (branch / main / intermediate) or re-measure it — as written, "66 − 48 = 18" is not derivable.
  **Resolved:** re-measured against landed `origin/main`'s pre-fix script (`git show origin/main:scripts/check_claude_md_doc_overlap.py`, run with the correct `--root`): confirmed 2 pairs / 34 words, not 48. "48" had no verified source and is dropped; PR text above now says 34 throughout. No code was wrong — only my own unverified claim in this PR's prose.

