### PR TITLE
fix(#4932): exec visibility no longer gated on sandbox backend

### DIFF
--- a/docs/concepts/tools-integrations/universal-catalog.ja.md
+++ b/docs/concepts/tools-integrations/universal-catalog.ja.md
@@ -59,9 +59,13 @@ hallucination 0/35)。
 | `rag_operation` | RAG op | `list_sources` / multi-source semantic_search / drop source |
 | `exec` | sandboxed argv 実行 | sandbox backend 下で argv 実行 |
 
-`exec` は `is_exec_available()` で gate される — 本物の sandbox backend
-(= `"noop"` 以外) が configure されている場合のみ surface に出る。 残り
-は常に visible。
+`exec` は常に visible — 他の全 category と同じ permission 軸
+（`gates.router` + `exec: allow`）で決まる（#4932、owner 裁定
+2026-08-19 — 本物の sandbox backend が configure されていない場合に
+`exec` 全体を隠していた `is_exec_available()` gate を撤回）。本物の
+backend が configure されていない場合は、category が黙って消える代わ
+りに、tool の description が「隔離なしで実行される」ことを開示する —
+開示 predicate は下の [Visibility gating](#visibility-gating-d14) 参照。
 
 **どの category も列挙する action は固定 verb 集合**。 resource (保存済み
 memory / indexed corpus / install 済 MCP tool / 登録済 pipeline) は verb の
@@ -235,16 +239,27 @@ availability を反映した action 集合から `difflib`-ranked suggestions �
 
 ## Visibility gating (§D14)
 
-一部の category は runtime 環境で visibility-gate される:
+本物の runtime VISIBILITY gate が残っているのは `knowledge`
+（`search_actions` 経由）だけ:
 
 | Predicate | 効果 |
 |---|---|
 | `is_search_available(embedding_enabled)` | `search_actions` が tools= に出るか (Phase 2) |
-| `is_exec_available(sandbox_backend)` | `exec` が `list_actions` 列挙に出るか |
 
-gate は pure function; runtime は `embedding.enabled`(FP-0066 §7)
-と resolved sandbox backend から configuration を渡す。 hidden category
-は `list_actions` の `category=` enum にも列挙結果にも現れない。
+gate は pure function; runtime は `embedding.enabled`(FP-0066 §7) から
+configuration を渡す。hidden category は `list_actions` の `category=`
+enum にも列挙結果にも現れない。
+
+`exec` にも同等の gate があった（`is_exec_available`、§D14-ext）—
+#4932（owner 裁定、2026-08-19）で撤回済み。`exec` は常に visible;
+`is_exec_isolated(sandbox_backend)` は開示専用の predicate で、tool
+自身の description text から consume される（本物の backend が
+configure されていない場合、「隔離なしで実行される」旨の平文 notice
+を追記する）— visibility の判断には二度と使わない。残る違いはこう:
+`knowledge` は本当に機能しない tool（問い合わせる index が無い）を隠す
+のに対し、`exec` は隔離の有無にかかわらず常に動く — ∴ 隠すのは
+functional-availability の gate では元々なく、security-posture の問い
+だった。owner 裁定は「黙って隠すのではなく開示する」だった。
 
 ## System prompt placement (§D9)
 

--- a/docs/concepts/tools-integrations/universal-catalog.md
+++ b/docs/concepts/tools-integrations/universal-catalog.md
@@ -95,9 +95,14 @@ The `mcp` category provides six verb_object actions that cover the LLM-visible s
 | `mcp_call_tool`      | Call a tool by `<server>__<tool>` id with `tool_args` |
 | `mcp_drop_server`    | Remove an installed server |
 
-`exec` is gated by `is_exec_available()` — it only appears when a real
-sandbox backend (= not `"noop"`) is configured. The rest are always
-visible.
+`exec` is always visible, on the same permission axis (`gates.router` +
+`exec: allow`) as every other category (#4932, owner ruling
+2026-08-19 — reverses the earlier `is_exec_available()` gate that hid
+`exec` entirely when no real sandbox backend was configured). When no
+real backend is configured, the tool's description discloses that
+commands run without isolation, instead of the category disappearing
+silently — see [Visibility gating](#visibility-gating-d14) below for
+the disclosure predicate.
 
 **Every category enumerates a fixed set of verbs.** A resource — a stored
 memory, an indexed corpus, an installed MCP tool, a registered pipeline — is an
@@ -264,17 +269,29 @@ obvious recovery move.
 
 ## Visibility gating (§D14)
 
-Some categories are visibility-gated by the runtime environment:
+`knowledge` (via `search_actions`) is the only category left with a
+genuine runtime VISIBILITY gate:
 
 | Predicate | Effect |
 |---|---|
 | `is_search_available(embedding_enabled)` | Whether `search_actions` appears in tools= (Phase 2) |
-| `is_exec_available(sandbox_backend)` | Whether `exec` appears in `list_actions` enumeration |
 
-The gates are pure functions; the runtime supplies the configuration
-values from `embedding.enabled` (FP-0066 §7) and the resolved
-sandbox backend. Hidden categories appear neither in the
-`list_actions` `category=` enum nor in any enumeration result.
+The gate is a pure function; the runtime supplies the configuration
+value from `embedding.enabled` (FP-0066 §7). A hidden category appears
+neither in the `list_actions` `category=` enum nor in any enumeration
+result.
+
+`exec` used to have an equivalent gate (`is_exec_available`, §D14-ext) —
+retired by #4932 (owner ruling, 2026-08-19). `exec` is now always
+visible; `is_exec_isolated(sandbox_backend)` is a DISCLOSURE-only
+predicate consumed by the tool's own description text (appends a
+plain-language "no sandbox isolation is applied" notice when no real
+backend is configured), never a visibility decision. The distinction
+that survives: `knowledge` hides a genuinely non-functional tool (no
+index to query); `exec` always works, with or without isolation, so
+hiding it was never a functional-availability gate — it was a
+security-posture question, which the owner ruled must be disclosed,
+not silently enforced by omission.
 
 ## System prompt placement (§D9)
 

--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -817,10 +817,13 @@ already set earlier in `__init__`.
 
 ### sandbox_backend gate reads the injected instance, not the config string (#1417 / FP-0034)
 
-The exec D14 visibility gate — whether `exec`/`sandboxed_exec` appears as an
-available capability in the universal catalog — must gate on the INJECTED
-backend's real capability, not the `reyn.yaml` `sandbox.backend` config
-STRING.
+`exec`/`sandboxed_exec` is always discoverable in the universal catalog
+(#4932, owner ruling 2026-08-19 — the earlier D14-ext visibility gate
+that could hide it entirely is retired). What still must read the
+INJECTED backend's real identity, not the `reyn.yaml` `sandbox.backend`
+config STRING, is the ISOLATION-DISCLOSURE text the tool's description
+carries: it must name the backend that will actually run the command,
+not the config value that may no longer match it.
 
 `sandbox_backend=_exec_gate_backend_name(self._sandbox_backend,
 self._sandbox_config)` reads `self._sandbox_backend` — the SAME object used
@@ -831,12 +834,12 @@ expose `.name`.
 
 **The construction-forwarding-gap this closes**: without reading the
 injected instance, `sandbox.backend=noop` config plus an injected exec
-backend (e.g. `--env-backend=docker`) would HIDE exec from discovery even
-though `sandboxed_exec` is functionally available through the injected
-backend. The mismatch produces no error — the capability is simply absent
-from the catalog the LLM sees, indistinguishable from an operator who
-deliberately disabled exec. No injected instance → falls back to the config
-string (auto / host-default behaviour unchanged).
+backend (e.g. `--env-backend=docker`) would (pre-#4932) HIDE exec from
+discovery, or (post-#4932) wrongly disclose "no isolation" even though
+`sandboxed_exec` is functionally isolated through the injected backend —
+either way the mismatch is silent, indistinguishable from an operator who
+deliberately configured `noop`. No injected instance → falls back to the
+config string (auto / host-default behaviour unchanged).
 
 ### available_skills_fn reads the BASE set, not the UX-filtered copy (#3196)
 

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -622,12 +622,13 @@ class RouterLoopHost(RouterLoopCore, Protocol):
 
         FP-0034 Phase 2.  Mirror of ``sandbox.backend`` from reyn.yaml
         (resolved from ``session._sandbox_config.backend``).  RouterLoop
-        forwards this into ``RouterCallerState.sandbox_backend`` so the
-        ``exec`` category D14 visibility gate in
-        ``universal_catalog._enumerate_category`` can decide whether to
-        expose ``exec``.  ``None`` and ``"noop"`` both
-        hide the category; any other value (``"seatbelt"`` /
-        ``"landlock"`` / ``"auto"``) makes it visible.
+        forwards this into ``RouterCallerState.sandbox_backend``, consumed
+        by ``universal_catalog._enumerate_category``'s ``exec`` branch.
+        #4932 (owner ruling, 2026-08-19): the ``exec`` category is ALWAYS
+        exposed now, regardless of this value — ``None``/``"noop"`` only
+        make the ``exec`` tool's own description disclose that no sandbox
+        isolation applies (``is_exec_isolated``); any other value
+        (``"seatbelt"`` / ``"landlock"`` / ``"auto"``) omits that notice.
         """
         ...
 

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -358,17 +358,19 @@ class RouterHostAdapter:
         # tools/types.py) — i.e. the live interactive path. Without it the
         # user-facing embed is billed but recorded nowhere ($0.00), the exact
         # bug FP-0063 closes.
-        # FP-0034 Phase 2: sandbox backend name for exec D14 visibility
-        # gate. Passed from ``session._sandbox_config.backend`` so the
-        # universal catalog ``_enumerate_category("exec")`` can decide
-        # whether to expose ``exec``. Default None hides
-        # the exec category (= noop / no sandbox configured).
+        # FP-0034 Phase 2: sandbox backend name, passed from
+        # ``session._sandbox_config.backend``. #4932 (owner ruling,
+        # 2026-08-19): the universal catalog ``_enumerate_category("exec")``
+        # no longer gates VISIBILITY on this value — ``exec`` is always
+        # exposed. Default None only means the ``exec`` description
+        # discloses "no sandbox isolation is applied" (noop / no sandbox
+        # configured), never that the category disappears.
         sandbox_backend: str | None = None,
         # #187: the FS EnvironmentBackend INSTANCE (docker for in-container repos)
         # for the router OpContext Workspace. Distinct from ``sandbox_backend``
-        # (a STRING for the exec D14 gate). Without this the LIVE file-op
-        # dispatch built a host-cwd Workspace (the #187 wrong-FS defect: file
-        # ops on the reyn repo, not /testbed).
+        # (a STRING feeding exec's isolation-disclosure text, #4932). Without
+        # this the LIVE file-op dispatch built a host-cwd Workspace (the #187
+        # wrong-FS defect: file ops on the reyn repo, not /testbed).
         environment_backend: Any = None,
         # #2548 PR-A: enabled skill registry snapshot (list[SkillEntry]).
         # Session builds it via build_skill_registry(config.skills) and passes
@@ -1212,12 +1214,13 @@ class RouterHostAdapter:
 
         FP-0034 Phase 2.  Mirror of ``sandbox.backend`` from reyn.yaml
         (resolved via ``session._sandbox_config.backend``).  RouterLoop
-        forwards this into ``RouterCallerState.sandbox_backend`` so the
-        exec category D14 visibility gate in
-        ``universal_catalog._enumerate_category`` can decide whether to
-        expose ``exec``.  ``None`` and ``"noop"`` both
-        hide the exec category; any other value (``"seatbelt"`` /
-        ``"landlock"`` / ``"auto"``) makes it visible.
+        forwards this into ``RouterCallerState.sandbox_backend``, consumed
+        by ``universal_catalog._enumerate_category``'s ``exec`` branch.
+        #4932 (owner ruling, 2026-08-19): the ``exec`` category is ALWAYS
+        exposed now, regardless of this value — ``None``/``"noop"`` only
+        make the ``exec`` tool's own description disclose that no sandbox
+        isolation applies (``is_exec_isolated``); any other value
+        (``"seatbelt"`` / ``"landlock"`` / ``"auto"``) omits that notice.
         """
         return self._sandbox_backend
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -211,19 +211,24 @@ _PEER_REPLY_FAILED_MSG: dict[str, str] = {
 
 
 def _exec_gate_backend_name(sandbox_backend: Any, sandbox_config: Any) -> str | None:
-    """#1417: resolve the ``exec`` D14 visibility-gate backend name.
+    """#1417: resolve the ``exec`` isolation-disclosure backend name.
 
-    The ``exec`` category is gated on the ACTUAL exec backend, not the reyn.yaml
-    config string. When a sandbox backend INSTANCE is injected (e.g.
-    ``--env-backend=docker`` → ``DockerEnvironmentBackend.name == "docker"``),
-    its ``.name`` is the gate value — so ``exec`` stays discoverable even with a
-    ``sandbox.backend = noop`` config (the construction-forwarding-gap: the
-    config string is NOT the live injected instance, and the instance is what
-    actually executes via ``sandboxed_exec``). With no injected instance, fall
-    back to the config string (``auto`` / host-default behaviour unchanged).
+    #4932 (owner ruling, 2026-08-19): ``exec`` is no longer gated on the
+    ACTUAL exec backend (it is always visible) — this value now feeds the
+    ISOLATION-DISCLOSURE text instead (``universal_catalog.
+    is_exec_isolated``), so it must still be the ACTUAL backend, not the
+    reyn.yaml config string. When a sandbox backend INSTANCE is injected
+    (e.g. ``--env-backend=docker`` → ``DockerEnvironmentBackend.name ==
+    "docker"``), its ``.name`` is the value used — so the disclosure text
+    correctly reports "isolated" even with a ``sandbox.backend = noop``
+    config (the construction-forwarding-gap: the config string is NOT the
+    live injected instance, and the instance is what actually executes
+    via ``sandboxed_exec``). With no injected instance, fall back to the
+    config string (``auto`` / host-default behaviour unchanged).
 
-    A defensive ``getattr`` keeps an instance without a ``name`` from raising
-    (degrades to None → exec hidden, the safe direction).
+    A defensive ``getattr`` keeps an instance without a ``name`` from
+    raising (degrades to None → disclosed as not-isolated, the safe
+    direction — never a crash, and never silence either).
     """
     if sandbox_backend is not None:
         return getattr(sandbox_backend, "name", None)

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -202,13 +202,17 @@ def get_default_registry() -> ToolRegistry:
     registry.register(LIST_AGENTS)
     registry.register(DESCRIBE_AGENT)
     # ── Exec / lint / ask_user (gates declared per-tool) ──
-    # #1352-D: EXEC is router="allow" (chat-reachable; the exec
-    # category is additionally gated by is_exec_available = a real sandbox
-    # backend, not by gates.router) — it was previously mis-grouped under a
-    # "gates.router=deny" comment alongside the now-removed `shell` op (the only
-    # true router=deny here was ask_user). #3226 Phase 1: the #2593 pipeline
-    # DSL `shell` tool (thin sugar building `/bin/sh -c <command>` over this
-    # same EXEC, then named `sandboxed_exec`) is removed outright — the sole
+    # #1352-D: EXEC is router="allow" (chat-reachable) — it was previously
+    # mis-grouped under a "gates.router=deny" comment alongside the
+    # now-removed `shell` op (the only true router=deny here was ask_user).
+    # #4932 (owner ruling, 2026-08-19): the exec category used to be
+    # ADDITIONALLY gated by is_exec_available (= a real sandbox backend,
+    # not gates.router) — that gate is retired; exec is always visible on
+    # gates.router alone now, same as every other category, and the former
+    # gate value (renamed is_exec_isolated) only composes an isolation-
+    # disclosure text suffix. #3226 Phase 1: the #2593 pipeline DSL `shell`
+    # tool (thin sugar building `/bin/sh -c <command>` over this same EXEC,
+    # then named `sandboxed_exec`) is removed outright — the sole
     # `/bin/sh -c <str>` injection surface in the codebase. #3226 Phase 3
     # renamed the tool `sandboxed_exec` -> `exec`. ASK_USER=router="deny".
     registry.register(EXEC)

--- a/src/reyn/tools/descriptions/execution.py
+++ b/src/reyn/tools/descriptions/execution.py
@@ -23,8 +23,10 @@ from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 exec_ = ToolDescription(
     tool_name="exec",
     surfaced=(
-        "router (gates.router=allow) — FP-0034 "
-        "exec category, visibility-gated on a configured sandbox backend"
+        "router (gates.router=allow) — FP-0034 exec category, always "
+        "visible (#4932: no longer visibility-gated on a configured "
+        "sandbox backend; isolation state is disclosed in the "
+        "description text instead)"
     ),
     purpose=(
         "Execute a command in a sandboxed environment (FP-0017), with the "

--- a/src/reyn/tools/exec.py
+++ b/src/reyn/tools/exec.py
@@ -10,11 +10,23 @@ primitive, collapsed to the owner-directed name); the op_runtime layer
 is UNCHANGED — only the tool/qualified name + the ``permissions.exec``
 key moved.
 
-D14-ext visibility gating: the ``exec`` category is only shown to the
-LLM when a real sandbox backend is configured (= not "noop" / not None).
-The ToolDefinition is always in the registry; the catalog enumeration
-layer (``universal_catalog._enumerate_category``) performs the gate
-check using ``RouterCallerState.sandbox_backend``.
+#4932 (owner ruling, 2026-08-19): the ``exec`` category is ALWAYS visible
+to the LLM — it is no longer hidden when no real sandbox backend is
+configured (the retired FP-0034 §D14-ext visibility gate). Switching
+``sandbox.backend`` to ``"noop"`` for an unrelated reason (#4932's own
+repro: probing Keychain reachability) used to make ``exec`` silently
+vanish from the catalog with no error and no notice — unpredictable
+capability loss the owner ruled against ("UX/predictability outrank
+security; security should be opt-in [a real backend], not silently
+enforced by hiding a working tool"). ``exec`` still WORKS under
+``"noop"``, just without OS-level isolation, so hiding it was never a
+security control — the real command still ran, or didn't, on the SAME
+permission axis (``gates.router`` + ``exec: allow``) every other
+category uses. The catalog enumeration layer
+(``universal_catalog._enumerate_category`` / ``_describe_one``) now
+DISCLOSES the isolation state in the description text instead
+(``universal_catalog.is_exec_isolated`` + ``_EXEC_NO_ISOLATION_NOTICE``)
+— never by omission.
 """
 from __future__ import annotations
 

--- a/src/reyn/tools/knowledge.py
+++ b/src/reyn/tools/knowledge.py
@@ -54,9 +54,16 @@ pins the classification.
 ``invoke_action``) is enumerated only when ``embedding.enabled:
 true`` — ``universal_catalog._enumerate_category``'s ``"knowledge"``
 branch calls the SAME ``is_search_available`` predicate ``search_actions``
-already uses (shared helper, not a duplicated embedding-config re-check —
-mirrors how the pre-existing ``"exec"`` branch shares ``is_exec_available``
-with ``visible_categories``).
+already uses (shared helper, not a duplicated embedding-config re-check).
+#4932 (2026-08-19): this is now the ONLY category-level availability gate
+left — the ``"exec"`` branch's equivalent (``is_exec_available``, which
+this docstring used to say ``knowledge`` mirrored) was removed by owner
+ruling; ``exec`` is always enumerated, and its former gate value now only
+composes a disclosure suffix (``is_exec_isolated``), never an
+availability decision. ``knowledge``'s gate is a different SHAPE by
+design — a genuinely non-functional tool (no index) versus exec's
+merely-less-isolated one — see ``is_exec_isolated``'s own docstring for
+why that distinction is what changed.
 """
 from __future__ import annotations
 

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -233,13 +233,13 @@ class RouterCallerState:
     embedding_provider: Any = None
     embedding_model_class: str | None = None
 
-    # FP-0034 Phase 2: sandbox backend name for the exec category
-    # D14 visibility gate.  RouterLoop binds this from
-    # ``session._sandbox_config.backend`` so ``list_actions(category=
-    # ["exec"])`` returns ``exec`` (#3226 Phase 3 qualified name)
-    # when a real backend is configured (= not "noop" / not None).
-    # ``None`` = sandbox not configured or noop backend; exec category
-    # stays hidden.
+    # FP-0034 Phase 2: sandbox backend name, threaded from
+    # ``session._sandbox_config.backend``. #4932 (owner ruling,
+    # 2026-08-19): no longer a VISIBILITY gate — the exec category is
+    # always in ``list_actions(category=["exec"])`` regardless of this
+    # value (#3226 Phase 3 qualified name). ``None``/``"noop"`` now only
+    # decides whether exec's own description discloses "no sandbox
+    # isolation is applied" (``universal_catalog.is_exec_isolated``).
     sandbox_backend: str | None = None
 
     # #2548 PR-A: skill registry snapshot — enabled skills available at

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -237,36 +237,60 @@ def is_search_available(*, embedding_enabled: bool) -> bool:
     return bool(embedding_enabled)
 
 
-def is_exec_available(*, sandbox_backend: str | None) -> bool:
-    """Return True iff the ``exec`` category should be exposed.
+def is_exec_isolated(*, sandbox_backend: str | None) -> bool:
+    """Return True iff ``exec`` runs under a real sandbox backend (isolation
+    actually applies) — False when ``sandbox_backend`` is ``None``/``"noop"``.
 
-    Per FP-0034 §D14-ext, the ``exec`` category (and the ``exec`` action
-    it contains) is only visible when a real sandbox
-    backend is configured. ``sandbox_backend`` of ``"noop"`` or None
-    keeps the category hidden so list_actions(category=["exec"])
-    returns empty and the schema enum can also drop ``"exec"``.
+    #4932 (owner ruling, 2026-08-19, reverses FP-0034 §D14-ext): this
+    predicate is DISCLOSURE-ONLY now — it composes the ``exec`` tool's
+    per-request isolation notice (``_enumerate_category``'s and
+    ``_describe_one``'s ``"exec"`` special-cases), never a VISIBILITY
+    decision. D14-ext's original shape (``is_exec_available`` — hide the
+    category entirely when noop) borrowed D14's "hide a functionally-dead
+    tool" pattern (``search_actions`` with no embedding index configured,
+    see ``is_search_available``) and misapplied it to a SECURITY-posture
+    question: ``exec`` still WORKS under ``noop``, just without OS-level
+    isolation — hiding it produced silent, unpredictable capability loss
+    (an operator who switched to ``noop`` for an unrelated reason, e.g.
+    #4932's own repro: probing Keychain reachability, lost ``exec``
+    entirely with no error, no notice) instead of a disclosed tradeoff.
+    Owner ruling (#4932, verbatim): "UX and predictability outrank
+    security; security should be opt-in [via a real sandbox backend], not
+    silently enforced by hiding a working tool." See
+    ``visible_categories`` for the visibility-side reversal.
     """
     if not sandbox_backend:
         return False
     return sandbox_backend != "noop"
 
 
-def visible_categories(
-    *,
-    sandbox_backend: str | None = None,
-) -> tuple[str, ...]:
+# #4932: the notice appended to `exec`'s description (both the
+# `_enumerate_category` short form and `_describe_one`'s full form) when
+# `is_exec_isolated` is False — the disclosure that REPLACES hiding the
+# category. Static text (not backend-name-specific): the LLM needs to know
+# isolation is absent, not which specific backend string produced that
+# state (`None` vs `"noop"` carry the same operational meaning here).
+_EXEC_NO_ISOLATION_NOTICE: Final[str] = (
+    " In THIS environment, no sandbox isolation is applied (no sandbox "
+    "backend is configured, or it is set to \"noop\") — the command runs "
+    "with the operator's own OS-level permissions, unconfined."
+)
+
+
+def visible_categories() -> tuple[str, ...]:
     """Return the categories that should be visible given the current env.
 
-    Drops ``exec`` when ``is_exec_available`` is False. Other categories
-    are always visible (search_actions visibility is a tool-level
-    decision, not a category-level one).
+    #4932 (owner ruling, 2026-08-19): ALL categories are always visible —
+    ``exec`` no longer has a category-level visibility gate (it used to
+    drop out entirely when ``sandbox_backend`` was ``"noop"``/``None``,
+    FP-0034 §D14-ext; see ``is_exec_isolated``'s own docstring for why
+    that was reversed). This function keeps its own identity (a named,
+    testable "what's visible" surface, referenced from
+    ``docs/deep-dives/research/fp-0035-permission-communication-analysis.md``)
+    even though it is now a constant — a future category-level gate has
+    a place to attach without re-inventing this function's name/shape.
     """
-    visible: list[str] = []
-    for cat in CATEGORIES:
-        if cat == "exec" and not is_exec_available(sandbox_backend=sandbox_backend):
-            continue
-        visible.append(cat)
-    return tuple(visible)
+    return CATEGORIES
 
 
 # ── 4 Universal wrapper ToolDefinitions ────────────────────────────────────
@@ -479,8 +503,11 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
     ``ctx.router_state`` is consulted, but only ever to decide whether a FIXED
     verb is AVAILABLE this session — never to invent one:
       - ``excluded_categories`` (#1667) — the caller drops a whole category.
-      - ``sandbox_backend`` (D14-ext) — ``exec`` enumerates its single verb only
-        when a real backend is configured, and nothing otherwise.
+      - ``sandbox_backend`` — #4932 (owner ruling, 2026-08-19): no longer an
+        availability gate for ``exec`` (see ``is_exec_isolated``'s own
+        docstring for the reversal). Still consulted here, but only to
+        compose ``exec``'s isolation-disclosure text — the category itself
+        is always enumerated.
 
     The output items each carry ``action_name`` (= what
     invoke_action / describe_action expects) and ``short_description``
@@ -502,10 +529,11 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
     (a category is *listed*), never enumeration REACHABILITY (a category's
     verbs actually come back non-empty) — so ``task`` passed that gate while
     still being invisible. Closing the class instead of the 7th instance:
-    ``knowledge``/``exec`` are the only two categories with a genuine runtime
-    availability gate (embedding / sandbox backend); every other category —
-    present or future — falls through to the unconditional static branch at
-    the bottom with nothing left to remember to wire in.
+    ``knowledge`` is the only category left with a genuine runtime
+    availability gate (embedding configured or not — #4932 removed
+    ``exec``'s own equivalent gate, see ``is_exec_isolated``); every other
+    category — present or future — falls through to the unconditional
+    static branch at the bottom with nothing left to remember to wire in.
     """
     rs = ctx.router_state
 
@@ -545,23 +573,17 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
         return _enumerate_static_category("knowledge")
 
     # exec category — the `exec` tool (FP-0017; renamed from `sandboxed_exec`
-    # #3226 Phase 3). Visible only when a real sandbox backend is configured
-    # (D14-ext). RouterCallerState.sandbox_backend carries the backend name
-    # (None = noop).
+    # #3226 Phase 3). #4932 (owner ruling, 2026-08-19): ALWAYS enumerated,
+    # same as every other category below — no runtime availability gate any
+    # more (FP-0034 §D14-ext's "hide when noop" reversed; is_exec_isolated's
+    # own docstring has the full rationale). RouterCallerState.sandbox_backend
+    # still feeds the isolation-disclosure text (None = noop = no isolation).
     if category == "exec":
-        if rs is None:
-            return []
-        backend = getattr(rs, "sandbox_backend", None)
-        if not is_exec_available(sandbox_backend=backend):
-            return []
-        return [
-            {
-                "action_name": "exec",
-                "short_description": (
-                    "Execute a command in a sandboxed environment."
-                ),
-            }
-        ]
+        backend = getattr(rs, "sandbox_backend", None) if rs is not None else None
+        short_desc = "Execute a command in a sandboxed environment."
+        if not is_exec_isolated(sandbox_backend=backend):
+            short_desc += _EXEC_NO_ISOLATION_NOTICE
+        return [{"action_name": "exec", "short_description": short_desc}]
 
     # Every other category (file / web / memory_operation / reyn_repo /
     # multi_agent / mcp / pipeline / skill_management / pipeline_management /
@@ -976,7 +998,12 @@ def _describe_one(
     resource categories collapsed there is no such action left, so the override
     seam is gone rather than kept as an unused hook. ``ctx`` stays in the
     signature: it is what ``list_actions`` / ``catalog_entries`` already thread,
-    and removing it would churn both call sites for nothing.
+    and removing it would churn both call sites for nothing — and (#4932) it is
+    now genuinely read: ``exec``'s description gets an isolation-disclosure
+    suffix derived from ``ctx.router_state.sandbox_backend``, the SAME source
+    ``_enumerate_category``'s ``"exec"`` branch reads for its own
+    ``short_description`` suffix — one signal, two call sites, list ≡ describe
+    still holds because both derive from the same ``ctx``.
     """
     from reyn.tools.universal_dispatch import is_known_action
 
@@ -986,8 +1013,19 @@ def _describe_one(
     if target is None:
         return None
 
+    description = target.description
+    if action_name == "exec":
+        # #4932: same isolation-disclosure suffix _enumerate_category's exec
+        # branch appends to short_description — kept here too so
+        # describe_action's full description (this function, not the
+        # enumeration layer) also discloses it, not just the browse view.
+        rs = ctx.router_state
+        backend = getattr(rs, "sandbox_backend", None) if rs is not None else None
+        if not is_exec_isolated(sandbox_backend=backend):
+            description = description + _EXEC_NO_ISOLATION_NOTICE
+
     return {
-        "description": target.description,
+        "description": description,
         # #3383: a LIVE LLM-payload seam, not just a tool-result one —
         # ``catalog_entries`` below reuses this ``input_schema`` as an entry's
         # ``parameters``, and the DEFAULT ``enumerate-all`` scheme concatenates
@@ -1020,10 +1058,12 @@ def catalog_entries(ctx: ToolContext) -> list[dict[str, Any]]:
     Deterministic ``name`` sort (stable ``tools=`` ordering → replay-fixture
     stability). **Pass a ``ToolContext`` with ``router_state`` populated**: no
     category needs it to produce names any more (#3026), but it still gates
-    AVAILABILITY — ``excluded_categories`` and ``exec``'s sandbox backend — so a
-    None ``router_state`` yields a superset-shaped list that is not the "usable
-    this session" set. Note the count does NOT depend on how much the operator
-    has accumulated; that invariant is pinned in
+    AVAILABILITY via ``excluded_categories`` (#4932: ``exec``'s sandbox
+    backend no longer gates availability, only its description text — see
+    ``is_exec_isolated``) — so a None ``router_state`` yields a
+    superset-shaped list that is not the "usable this session" set. Note the
+    count does NOT depend on how much the operator has accumulated; that
+    invariant is pinned in
     ``tests/tools/test_resource_collapse_invariant_3026.py``.
     """
     from reyn.tools import get_default_registry
@@ -1303,6 +1343,6 @@ __all__ = [
     "_DESCRIBE_ACTION_DESCRIPTION",
     "_INVOKE_ACTION_DESCRIPTION",
     "is_search_available",
-    "is_exec_available",
+    "is_exec_isolated",
     "visible_categories",
 ]

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -157,8 +157,12 @@ _CATEGORY_ACTIONS: Final[dict[str, tuple[str, ...]]] = {
         "reyn_repo_glob",
         "reyn_repo_grep",
     ),
-    # FP-0017 sandboxed_exec, tool renamed ``exec`` in #3226 Phase 3. D14
-    # visibility gating lives in ``_enumerate_category`` (sandbox backend).
+    # FP-0017 sandboxed_exec, tool renamed ``exec`` in #3226 Phase 3.
+    # #4932 (owner ruling, 2026-08-19): the D14-ext visibility gate that
+    # used to live in ``_enumerate_category`` (sandbox backend) is
+    # retired — ``exec`` always enumerates; the same sandbox_backend
+    # value now only composes an isolation-disclosure text suffix
+    # (``is_exec_isolated``).
     "exec": ("exec",),
     # #2548 PR-C/PR-D skill directory install verbs; #2971 added ``skill_list``
     # (without it a skill outside the L1 menu had no surface naming it, so it

--- a/tests/tools/test_alias_spelling_dedup_3428.py
+++ b/tests/tools/test_alias_spelling_dedup_3428.py
@@ -35,6 +35,7 @@ import pytest
 
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.router_loop import RouterLoop
+from reyn.tools.encoders import sanitize_identifier
 from reyn.tools.exposure import without_duplicate_names
 from reyn.tools.scheme import advertised_entries, get_scheme
 from reyn.tools.schemes._enumerate_exposure import (
@@ -337,10 +338,23 @@ async def test_the_two_enumerate_all_cells_still_show_the_same_set() -> None:
     """Tier 2: production-reaches — deduplicating did not re-split the populations
     #3381 joined.
 
-    The #3419 invariant is that ``enumerate-all``'s two cells expose the same set;
-    a dedup applied at one composition site and not the other would satisfy this
-    file's other arm while quietly restoring exactly the asymmetry #3381 was
-    about."""
+    The #3419 invariant is that ``enumerate-all``'s two cells expose the SAME
+    ACTIONS; a dedup applied at one composition site and not the other would
+    satisfy this file's other arm while quietly restoring exactly the
+    asymmetry #3381 was about.
+
+    #4932 (2026-08-19): with ``exec``'s own visibility gate retired, ``exec``
+    is now unconditionally in this comparison for the first time — surfacing
+    a PRE-EXISTING, legitimate spelling difference this test never had cause
+    to normalize before: the code-API cell (``Transport.CONTENT_FENCE``)
+    renders every name through ``sanitize_identifier`` (``reyn.tools.
+    encoders``), which suffixes ``exec`` to ``exec_`` because it collides
+    with BOTH the Python keyword and safe-mode's banned-builtin AST check
+    (that module's own docstring, #3429). Comparing the RAW ``tool_calls``
+    names against ``sanitize_identifier``-mapped names is the correct
+    "same actions" check — a literal-string comparison was never actually
+    the invariant's intent, it simply never had a keyword-colliding name to
+    expose the gap until ``exec`` became unconditionally visible."""
     session = make_session(
         agent_name="dedup-3428-parity",
         state_log=StateLog(_tmpdir() / "state.wal"),
@@ -350,8 +364,11 @@ async def test_the_two_enumerate_all_cells_still_show_the_same_set() -> None:
     calls = set(await _exposed_names(host, "enumerate-all", Transport.TOOL_CALLS, _LAYER_CTX))
     fence = set(await _exposed_names(host, "enumerate-all", Transport.CONTENT_FENCE, _LAYER_CTX))
     assert calls, "the tool_calls cell advertised nothing — nothing to compare"
-    assert calls == fence, (
-        "the two enumerate-all cells no longer show the same set: "
-        f"only in tool_calls {sorted(calls - fence)}, only in the code-API "
-        f"{sorted(fence - calls)}"
+    calls_as_identifiers = {sanitize_identifier(name) for name in calls}
+    assert calls_as_identifiers == fence, (
+        "the two enumerate-all cells no longer show the same ACTIONS (after "
+        "mapping tool_calls names through the SAME sanitize_identifier the "
+        "code-API cell itself uses): "
+        f"only in tool_calls (mapped) {sorted(calls_as_identifiers - fence)}, "
+        f"only in the code-API {sorted(fence - calls_as_identifiers)}"
     )

--- a/tests/tools/test_exec_gate_injected_backend_1417.py
+++ b/tests/tools/test_exec_gate_injected_backend_1417.py
@@ -1,11 +1,19 @@
-"""Tier 2: #1417 — the exec D14 visibility gate keys off the INJECTED sandbox
-backend instance, not the reyn.yaml config string.
+"""Tier 2: #1417 — the exec isolation-disclosure value keys off the INJECTED
+sandbox backend instance, not the reyn.yaml config string.
 
 Construction-forwarding-gap fix: ``sandbox.backend=noop`` config + an injected
-exec backend (``--env-backend=docker``) must still expose ``exec`` in
-``list_actions(category=["exec"])`` because ``exec`` is functionally
-available via the injected instance. Pins ``_exec_gate_backend_name`` (the
-derivation) + ``visible_categories`` (the gate consuming it).
+exec backend (``--env-backend=docker``) must still be treated as ISOLATED
+(disclosure text absent) because ``exec`` actually runs via the injected
+instance, not the config string. Pins ``_exec_gate_backend_name`` (the
+derivation) + ``is_exec_isolated``/``_enumerate_category`` (the consumers).
+
+#4932 (owner ruling, 2026-08-19): exec's VISIBILITY no longer depends on
+this value at all — ``exec`` is always enumerated (see
+``test_universal_catalog.py``'s own #4932 tests for that side). This file
+narrows to what #1417 was actually about: the derived backend NAME must be
+the injected instance's, not the config string's, because that name is
+what feeds the isolation-disclosure text now (get the wrong name here and
+the disclosure lies about which backend is really running commands).
 """
 from __future__ import annotations
 
@@ -15,13 +23,12 @@ from reyn.runtime.session import _exec_gate_backend_name
 from reyn.tools.types import RouterCallerState, ToolContext
 from reyn.tools.universal_catalog import (
     _enumerate_category,
-    is_exec_available,
-    visible_categories,
+    is_exec_isolated,
 )
 
 
 def _router_ctx(sandbox_backend: str | None) -> ToolContext:
-    """A minimal router ToolContext carrying the exec D14 gate value (the value
+    """A minimal router ToolContext carrying the exec gate value (the value
     session threads via _exec_gate_backend_name → RouterCallerState.sandbox_backend)."""
     return ToolContext(
         events=None,
@@ -53,17 +60,15 @@ def test_injected_instance_wins_over_noop_config() -> None:
     instance ('docker'), not the config string ('noop'). The filed bug."""
     val = _exec_gate_backend_name(_FakeBackend(name="docker"), _FakeSandboxConfig(backend="noop"))
     assert val == "docker"
-    assert is_exec_available(sandbox_backend=val) is True
-    assert "exec" in visible_categories(sandbox_backend=val)
+    assert is_exec_isolated(sandbox_backend=val) is True
 
 
-def test_injected_noop_instance_hidden() -> None:
-    """Tier 2: #1417 — an injected noop backend → 'noop' → exec hidden, even if
+def test_injected_noop_instance_not_isolated() -> None:
+    """Tier 2: #1417 — an injected noop backend → 'noop' → not isolated, even if
     the config string says otherwise (instance is the truth)."""
     val = _exec_gate_backend_name(_FakeBackend(name="noop"), _FakeSandboxConfig(backend="docker"))
     assert val == "noop"
-    assert is_exec_available(sandbox_backend=val) is False
-    assert "exec" not in visible_categories(sandbox_backend=val)
+    assert is_exec_isolated(sandbox_backend=val) is False
 
 
 def test_no_instance_falls_back_to_config() -> None:
@@ -75,40 +80,47 @@ def test_no_instance_falls_back_to_config() -> None:
     assert _exec_gate_backend_name(None, None) is None
 
 
-def test_no_instance_noop_config_hidden_and_auto_visible() -> None:
-    """Tier 2: #1417 — config-only path: noop hidden, auto visible (unchanged)."""
+def test_no_instance_noop_config_not_isolated_and_auto_isolated() -> None:
+    """Tier 2: #1417 — config-only path: noop not isolated, auto isolated
+    (unchanged derivation; only the CONSUMER — availability vs disclosure —
+    changed in #4932)."""
     noop_val = _exec_gate_backend_name(None, _FakeSandboxConfig(backend="noop"))
     auto_val = _exec_gate_backend_name(None, _FakeSandboxConfig(backend="auto"))
-    assert "exec" not in visible_categories(sandbox_backend=noop_val)
-    assert "exec" in visible_categories(sandbox_backend=auto_val)
+    assert is_exec_isolated(sandbox_backend=noop_val) is False
+    assert is_exec_isolated(sandbox_backend=auto_val) is True
 
 
-def test_instance_without_name_degrades_to_hidden() -> None:
+def test_instance_without_name_degrades_to_not_isolated() -> None:
     """Tier 2: #1417 — a defensive: an injected instance lacking ``.name`` →
-    None → exec hidden (the safe direction), never an AttributeError."""
+    None → not isolated (the safe direction for the disclosure text), never
+    an AttributeError."""
     class _NoName:
         pass
 
     val = _exec_gate_backend_name(_NoName(), _FakeSandboxConfig(backend="noop"))
     assert val is None
-    assert is_exec_available(sandbox_backend=val) is False
+    assert is_exec_isolated(sandbox_backend=val) is False
 
 
 # ─── integration: the real list_actions exec-gate handler honors the value ────
 
 
-def test_enumerate_exec_visible_with_docker_gate() -> None:
-    """Tier 2: #1417 — the real `_enumerate_category('exec', ...)` handler returns
-    exec when the threaded gate value is a real backend ('docker',
-    the value _exec_gate_backend_name derives from an injected docker instance even
-    under noop config). Exercises the actual list_actions exec-gate path."""
+def test_enumerate_exec_no_disclosure_with_docker_gate() -> None:
+    """Tier 2: #1417 — the real `_enumerate_category('exec', ...)` handler
+    returns exec with NO isolation-disclosure suffix when the threaded gate
+    value is a real backend ('docker', the value _exec_gate_backend_name
+    derives from an injected docker instance even under noop config)."""
     gate = _exec_gate_backend_name(_FakeBackend(name="docker"), _FakeSandboxConfig(backend="noop"))
     actions = _enumerate_category("exec", _router_ctx(gate))
     assert [a["action_name"] for a in actions] == ["exec"]
+    assert "no sandbox isolation" not in actions[0]["short_description"]
 
 
-def test_enumerate_exec_hidden_with_noop_gate() -> None:
-    """Tier 2: #1417 — the handler returns [] (exec hidden) when the gate is noop
-    (no injected instance + noop config)."""
+def test_enumerate_exec_discloses_no_isolation_with_noop_gate() -> None:
+    """Tier 2: #1417/#4932 — exec is still enumerated (never hidden) when the
+    gate is noop (no injected instance + noop config), but its description
+    discloses the absence of isolation instead."""
     gate = _exec_gate_backend_name(None, _FakeSandboxConfig(backend="noop"))
-    assert _enumerate_category("exec", _router_ctx(gate)) == []
+    actions = _enumerate_category("exec", _router_ctx(gate))
+    assert [a["action_name"] for a in actions] == ["exec"]
+    assert "no sandbox isolation" in actions[0]["short_description"]

--- a/tests/tools/test_universal_catalog.py
+++ b/tests/tools/test_universal_catalog.py
@@ -9,9 +9,11 @@ Tests for ``src/reyn/tools/universal_catalog.py`` covering:
      category, empty entry_name.
   4. 4 ToolDefinitions (LIST_ACTIONS / SEARCH_ACTIONS / DESCRIBE_ACTION /
      INVOKE_ACTION) shape — name, gates, render_for_router schema.
-  5. D14 visibility gating predicates (is_search_available /
-     is_exec_available / visible_categories) behave per §D14 /
-     §D14-ext.
+  5. D14 visibility gating predicate (is_search_available) behaves per
+     §D14; #4932 (2026-08-19, owner ruling): exec's own former gate
+     (is_exec_available / D14-ext) is retired — exec is now ALWAYS
+     enumerated, and is_exec_isolated (renamed, same value semantics)
+     only composes an isolation-disclosure text suffix.
   6. search_actions handler degrades gracefully when no router_state
      (= real impl since Phase 2 step 1; deeper invariants in
      test_universal_handlers.py).
@@ -26,7 +28,7 @@ import asyncio
 import pytest
 
 from reyn.core.events.events import EventLog
-from reyn.tools.types import ToolContext, ToolDefinition, ToolGates
+from reyn.tools.types import RouterCallerState, ToolContext, ToolDefinition, ToolGates
 from reyn.tools.universal_catalog import (
     CATEGORIES,
     DESCRIBE_ACTION,
@@ -34,7 +36,7 @@ from reyn.tools.universal_catalog import (
     LIST_ACTIONS,
     SEARCH_ACTIONS,
     _enumerate_category,
-    is_exec_available,
+    is_exec_isolated,
     is_search_available,
     visible_categories,
 )
@@ -491,32 +493,83 @@ def test_is_search_available_predicate(
         ("", False),
     ],
 )
-def test_is_exec_available_predicate(
+def test_is_exec_isolated_predicate(
     backend: str | None, expected: bool,
 ) -> None:
-    """Tier 2: exec category visibility per §D14-ext.
+    """Tier 2: #4932 — is_exec_isolated (renamed from is_exec_available,
+    same value semantics) reports whether real isolation applies.
 
-    `noop` and None/empty both mean "no real sandbox backend".
+    `noop` and None/empty both mean "no real sandbox backend" (= not
+    isolated). Since #4932 this is DISCLOSURE-only — it no longer gates
+    exec's visibility (see the visible_categories/enumerate tests below).
     """
-    assert is_exec_available(sandbox_backend=backend) is expected
+    assert is_exec_isolated(sandbox_backend=backend) is expected
 
 
-def test_visible_categories_drops_exec_when_sandbox_noop() -> None:
-    """Tier 2: visible_categories excludes 'exec' when sandbox=noop."""
-    vis = visible_categories(sandbox_backend="noop")
-    assert "exec" not in vis
+def test_visible_categories_always_includes_exec() -> None:
+    """Tier 2: #4932 (owner ruling, 2026-08-19) — visible_categories no
+    longer drops 'exec' for any sandbox_backend value; category
+    visibility follows the same permission axis every other category
+    uses (gates.router + exec: allow), never sandbox posture. Strip-
+    falsify note: this test would have failed under the pre-#4932 gate
+    for every value below except a real backend."""
+    for backend in ("seatbelt", "landlock", "noop", None, ""):
+        assert "exec" in visible_categories(), (
+            f"exec must be visible regardless of sandbox_backend "
+            f"(checked implicitly for {backend!r} — visible_categories "
+            f"no longer takes a sandbox_backend argument at all)"
+        )
 
 
-def test_visible_categories_includes_exec_when_sandbox_real() -> None:
-    """Tier 2: visible_categories includes 'exec' when real backend present."""
-    vis = visible_categories(sandbox_backend="seatbelt")
-    assert "exec" in vis
+def test_enumerate_exec_always_returns_the_action_regardless_of_backend() -> None:
+    """Tier 2: #4932 — _enumerate_category('exec', ...) returns the exec
+    action for every sandbox_backend value, including noop/None (the
+    exact cases D14-ext used to hide it for)."""
+    for backend in ("seatbelt", "noop", None):
+        ctx = ToolContext(
+            events=None,
+            permission_resolver=None,
+            workspace=None,
+            caller_kind="router",
+            router_state=RouterCallerState(sandbox_backend=backend),
+        )
+        actions = _enumerate_category("exec", ctx)
+        assert [a["action_name"] for a in actions] == ["exec"], (
+            f"exec must always enumerate, got {actions!r} for backend={backend!r}"
+        )
 
 
-def test_visible_categories_drops_exec_when_sandbox_none() -> None:
-    """Tier 2: visible_categories excludes 'exec' when sandbox unset."""
-    vis = visible_categories(sandbox_backend=None)
-    assert "exec" not in vis
+def test_enumerate_exec_discloses_no_isolation_when_noop_or_none() -> None:
+    """Tier 2: #4932 — when isolation does not apply, the short_description
+    the LLM sees names it explicitly (never silence — the replacement for
+    hiding the category)."""
+    for backend in ("noop", None):
+        ctx = ToolContext(
+            events=None,
+            permission_resolver=None,
+            workspace=None,
+            caller_kind="router",
+            router_state=RouterCallerState(sandbox_backend=backend),
+        )
+        actions = _enumerate_category("exec", ctx)
+        assert "no sandbox isolation is applied" in actions[0]["short_description"], (
+            f"expected an explicit isolation-disclosure notice for "
+            f"backend={backend!r}, got {actions[0]['short_description']!r}"
+        )
+
+
+def test_enumerate_exec_no_disclosure_when_real_backend() -> None:
+    """Tier 2: #4932 — with a real sandbox backend, no isolation-disclosure
+    suffix is appended (nothing to disclose)."""
+    ctx = ToolContext(
+        events=None,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(sandbox_backend="seatbelt"),
+    )
+    actions = _enumerate_category("exec", ctx)
+    assert "no sandbox isolation" not in actions[0]["short_description"]
 
 
 # ── 6. search_actions Phase 2 step 1 — handler is real, not a stub ───────

--- a/tests/tools/test_universal_dispatch.py
+++ b/tests/tools/test_universal_dispatch.py
@@ -187,9 +187,11 @@ def test_action_names_for_category_mcp() -> None:
 
 
 def test_action_names_for_category_exec_is_single_entry() -> None:
-    """Tier 2: exec is a single-entry category. D14 visibility gating (hide
-    when sandbox_backend is None/noop) happens at the enumeration layer, not
-    here."""
+    """Tier 2: exec is a single-entry category. #4932 (2026-08-19): the
+    former D14-ext visibility gate (hide when sandbox_backend is
+    None/noop) is retired — exec always enumerates now; what the
+    enumeration layer still derives from sandbox_backend is an
+    isolation-disclosure text suffix, not a hide/show decision."""
     assert action_names_for_category("exec") == ("exec",)
 
 

--- a/tests/tools/test_universal_handlers.py
+++ b/tests/tools/test_universal_handlers.py
@@ -706,12 +706,11 @@ def test_describe_action_via_registry_returns_tool_meta() -> None:
 
 
 def test_exec_enumerable_when_sandbox_configured() -> None:
-    """Tier 2: exec appears in list_actions when sandbox backend is set.
-
-    D14-ext visibility gate: when RouterCallerState.sandbox_backend is a
-    real backend name (not 'noop' / None), the exec category returns
-    exec in list_actions output.
-    """
+    """Tier 2: exec appears in list_actions with a real sandbox backend set
+    (#4932, 2026-08-19: it appears UNCONDITIONALLY now — see the
+    test_exec_discloses_* trio below for the noop/None cases the retired
+    D14-ext gate used to hide). No isolation-disclosure suffix is appended
+    here since a real backend IS configured."""
     rs = RouterCallerState(sandbox_backend="seatbelt")
     result = _run(LIST_ACTIONS.handler(
         {"category": ["exec"]}, _make_ctx(rs),
@@ -719,17 +718,17 @@ def test_exec_enumerable_when_sandbox_configured() -> None:
     qns = {it["action_name"] for it in result["items"]}
     assert "exec" in qns
     assert result["total"] == 1
-    # short_description must be a non-empty string
     for item in result["items"]:
         assert isinstance(item["short_description"], str)
         assert item["short_description"]
+        assert "no sandbox isolation" not in item["short_description"]
 
 
 def test_exec_enumerable_when_sandbox_landlock() -> None:
-    """Tier 2: exec category is visible with any real backend name.
-
-    Both 'seatbelt' and 'landlock' are real backends per §D14-ext.
-    """
+    """Tier 2: exec category enumerates with any real backend name — both
+    'seatbelt' and 'landlock' omit the isolation-disclosure suffix
+    (#4932; formerly both were "real backends per §D14-ext" for a
+    visibility gate that no longer exists)."""
     rs = RouterCallerState(sandbox_backend="landlock")
     result = _run(LIST_ACTIONS.handler(
         {"category": ["exec"]}, _make_ctx(rs),
@@ -738,44 +737,42 @@ def test_exec_enumerable_when_sandbox_landlock() -> None:
     assert result["items"][0]["action_name"] == "exec"
 
 
-def test_exec_hidden_when_sandbox_noop() -> None:
-    """Tier 2: exec category returns empty when sandbox_backend is 'noop'.
-
-    D14-ext: noop backend means no real enforcement; exec stays hidden
-    so the LLM does not attempt exec without isolation.
-    """
+def test_exec_discloses_no_isolation_when_sandbox_noop() -> None:
+    """Tier 2: #4932 (owner ruling, 2026-08-19) — exec category is NEVER
+    hidden any more when sandbox_backend is 'noop'; the retired D14-ext
+    gate used to hide it here. It stays visible with an isolation-
+    disclosure notice in its description instead."""
     rs = RouterCallerState(sandbox_backend="noop")
     result = _run(LIST_ACTIONS.handler(
         {"category": ["exec"]}, _make_ctx(rs),
     ))
-    assert result["items"] == []
-    assert result["total"] == 0
+    assert result["total"] == 1
+    assert result["items"][0]["action_name"] == "exec"
+    assert "no sandbox isolation" in result["items"][0]["short_description"]
 
 
-def test_exec_hidden_when_sandbox_backend_none() -> None:
-    """Tier 2: exec category returns empty when sandbox_backend is None.
-
-    D14-ext: None = not configured; exec stays hidden.
-    """
+def test_exec_discloses_no_isolation_when_sandbox_backend_none() -> None:
+    """Tier 2: #4932 — same as the noop case, for sandbox_backend=None
+    (not configured)."""
     rs = RouterCallerState(sandbox_backend=None)
     result = _run(LIST_ACTIONS.handler(
         {"category": ["exec"]}, _make_ctx(rs),
     ))
-    assert result["items"] == []
-    assert result["total"] == 0
+    assert result["total"] == 1
+    assert result["items"][0]["action_name"] == "exec"
+    assert "no sandbox isolation" in result["items"][0]["short_description"]
 
 
-def test_exec_hidden_when_no_router_state() -> None:
-    """Tier 2: exec category returns empty without router_state.
-
-    When ctx.router_state is None, exec category defaults to empty
-    (= cannot determine sandbox backend = treat as noop).
-    """
+def test_exec_discloses_no_isolation_when_no_router_state() -> None:
+    """Tier 2: #4932 — exec category is visible even without router_state
+    (backend can't be determined → treated as not isolated → disclosed,
+    never hidden)."""
     result = _run(LIST_ACTIONS.handler(
         {"category": ["exec"]}, _make_ctx(),
     ))
-    assert result["items"] == []
-    assert result["total"] == 0
+    assert result["total"] == 1
+    assert result["items"][0]["action_name"] == "exec"
+    assert "no sandbox isolation" in result["items"][0]["short_description"]
 
 
 def test_exec_is_the_exec_categorys_only_action() -> None:
@@ -823,27 +820,34 @@ def test_exec_describe_action_returns_exec_schema() -> None:
     assert "argv" in required
 
 
-def test_list_actions_all_categories_exec_hidden_by_default() -> None:
-    """Tier 2: list_actions() with no category filter hides exec without sandbox.
+def test_list_actions_all_categories_exec_discloses_no_isolation_by_default() -> None:
+    """Tier 2: #4932 (owner ruling, 2026-08-19) — list_actions() with no
+    category filter includes exec even without a sandbox backend; the
+    former "hidden by default" behavior is retired, disclosed instead.
 
-    The exec category should NOT appear in the default (no-sandbox)
-    enumeration because RouterCallerState has sandbox_backend=None.
+    Pre-#4932 this test asserted no ``exec__``-prefixed entry appeared —
+    a qualified-name form #3429 retired well before #4932 (the tool has
+    been named bare ``exec`` since), so that assertion bit on nothing
+    regardless of visibility. Fixed alongside the real behavior change
+    since it lived directly in this PR's blast radius: assert on the
+    CURRENT name (``exec``) and the disclosure text, not a naming
+    pattern that no longer exists anywhere in the system.
     """
     rs = RouterCallerState(sandbox_backend=None)
     result = _run(LIST_ACTIONS.handler({}, _make_ctx(rs)))
-    qns = [it["action_name"] for it in result["items"]]
-    assert not any(qn.startswith("exec__") for qn in qns), (
-        f"exec__ entries should be hidden when sandbox_backend=None; got {qns}"
+    items_by_name = {it["action_name"]: it for it in result["items"]}
+    assert "exec" in items_by_name, (
+        f"exec must be present even with sandbox_backend=None; got "
+        f"{sorted(items_by_name)}"
     )
+    assert "no sandbox isolation" in items_by_name["exec"]["short_description"]
 
 
-def test_list_actions_all_categories_exec_visible_with_sandbox() -> None:
-    """Tier 2: list_actions() with no filter includes exec when sandbox is real.
-
-    When RouterCallerState.sandbox_backend is a real backend, the exec
-    category is included in the unrestricted enumeration.
-    """
+def test_list_actions_all_categories_exec_no_disclosure_with_sandbox() -> None:
+    """Tier 2: list_actions() with no filter includes exec when sandbox is
+    real, with no isolation-disclosure suffix (nothing to disclose)."""
     rs = RouterCallerState(sandbox_backend="seatbelt")
     result = _run(LIST_ACTIONS.handler({}, _make_ctx(rs)))
-    qns = [it["action_name"] for it in result["items"]]
-    assert "exec" in qns
+    items_by_name = {it["action_name"]: it for it in result["items"]}
+    assert "exec" in items_by_name
+    assert "no sandbox isolation" not in items_by_name["exec"]["short_description"]


### PR DESCRIPTION
**[e2e-coder]** — part of #4932

## What

Owner ruling (2026-08-19): "UX/predictability outrank security; security should be opt-in, not silently enforced by hiding a working tool." `exec`'s FP-0034 §D14-ext visibility gate (`is_exec_available` — hid the whole `exec` category when `sandbox.backend` was `"noop"`/`None`) is retired.

Root cause: switching `sandbox.backend` to `noop` for an unrelated reason (the filed repro: probing Keychain reachability) silently dropped `exec` from the catalog with no error, no notice. `exec` still WORKS under `noop`, just without OS-level isolation — hiding it was never a real security control, since the command still runs (or doesn't) on the same permission axis (`gates.router` + `exec: allow`) every other category uses.

## Fix

1. **Visibility**: `exec` is always enumerated now — same permission axis as every other category, no special-case gate.
2. **Disclosure, not omission**: `is_exec_isolated` (renamed from `is_exec_available`, identical value semantics) now composes a plain-language notice appended to `exec`'s description when no real sandbox backend is configured — surfaced in both `list_actions`/`catalog_entries`'s `short_description` and `describe_action`'s full `description` (same `ctx`, same signal — `list ≡ describe` still holds by construction).
3. **Design record updated in this PR** (owner's requirement): §D14-ext's rationale lived only in code docstrings (no separate ADR exists) — updated in `universal_catalog.py`, `exec.py`, `knowledge.py` (draws the D14 vs D14-ext distinction explicitly), `types.py`, `session.py`, `router_loop.py`, `router_host_adapter.py`, `universal_dispatch.py`, plus the 2 live docs describing this mechanism (`universal-catalog.md` + its `.ja.md` mirror, `session-construction.md`).

## The 3 holes I was asked to close

- **All `is_exec_available` call sites, not just the 2 architect found**: both real ones (`visible_categories`, `_enumerate_category`) fixed, plus `_describe_one` gained a new exec-specific disclosure branch (it's the shared list≡describe core, so it needed the same signal).
- **Checked for a similarly-shaped "environment infers a capability drop" predicate elsewhere**: `is_search_available` (embedding-gated `knowledge`/`search_actions`) is a genuinely different shape — it hides a functionally non-functional tool (no index to query), not a security-posture question. No new issue filed; nothing else of this shape exists.
- **No `exec` command text changed** — only the measurement/visibility script (well, the actual production gate) changed.

## Side discoveries, fixed since they're in this diff's direct blast radius

- `test_alias_spelling_dedup_3428.py`: `exec` becoming unconditionally visible surfaced a pre-existing, legitimate spelling difference (`exec` → `exec_` on the code-API cell, keyword-safety rename via `reyn.tools.encoders.sanitize_identifier`, #3429) this test never had cause to normalize before. Fixed the comparison to go through that SAME production mapping — the invariant was always "same actions", never "same literal spelling".
- `test_list_actions_all_categories_exec_hidden_by_default`: checked for an `exec__`-prefixed name, a qualified-name form #3429 retired well before #4932 — so it never bit on anything regardless of visibility, pre-existing and unrelated to #4932's root cause but directly in this diff's area. Renamed/rewritten to assert on the current name and disclosure behavior.

## Not in this PR

PR-2 (seatbelt Keychain `mach-lookup` fix) is a separate PR, currently on hold pending #4935 (a larger sandbox-default-posture reversal that may make PR-2 moot).

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 108 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py` (docs/ touched)
- [x] `pytest tests/tools/` — 915 passed
- [x] Strip-falsify against the real committed file (reverted the exec branch to the old gate shape, confirmed 7 tests go RED for the right reason, restored, GREEN again)
- [x] (skipped — no PR/issue closing-intent-gate conflict; verified with `check_pr_closing_intent.py` before push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)