### PR TITLE
fix(#4932,#4933): grant com.apple.SecurityServer mach-lookup in Seatbelt

### DIFF
--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -80,6 +80,22 @@ def _build_sbpl_profile(policy: SandboxPolicy) -> str:
         "; binary under (deny default). Without it, even /bin/echo aborts at",
         "; libc init (SIGABRT) on macOS 26+.",
         '(import "bsd.sb")',
+        "",
+        "; #4932/#4933 (owner ruling, 2026-08-19): a real command that works",
+        "; OUTSIDE the sandbox (e.g. `gh auth status`) failed silently inside it",
+        "; because nobody had enumerated `security`/`gh`'s one required",
+        "; mach-lookup service — a capability #3901's ratified posture (\"the",
+        "; sandbox no longer re-decides what the launching shell could already",
+        "; do\") already covers in INTENT but SandboxPolicy has no axis for.",
+        "; Confirmed by direct measurement (architect, #4932/#4935): the",
+        "; `security`/Keychain failure and `gh auth status`'s token-invalid",
+        "; failure share this ONE root cause; adding this single, `global-name`-",
+        "; scoped grant (not a blanket `(allow mach-lookup)`) fixes both. Owner:",
+        "; \"if this makes `gh` work under the default config, go ahead.\" On by",
+        "; default (not gated by a policy field) — a future STRICT/opt-in mode",
+        "; that wants to close this is a separate, deliberate decision (#4935),",
+        "; not something this fix pre-empts.",
+        '(allow mach-lookup (global-name "com.apple.SecurityServer"))',
     ]
 
     # process-exec* is always allowed: without it sandbox-exec cannot even

--- a/tests/security/test_sandbox_seatbelt.py
+++ b/tests/security/test_sandbox_seatbelt.py
@@ -202,6 +202,28 @@ def test_sbpl_profile_loopback_bind_always_allowed():
     assert expected in profile_on
 
 
+def test_sbpl_profile_security_server_mach_lookup_always_allowed():
+    """Tier 2: #4932/#4933 — the `com.apple.SecurityServer` mach-lookup grant
+    is emitted regardless of policy (default-on, not gated by any
+    SandboxPolicy field — owner ruling: "if this makes `gh` work under the
+    default config, go ahead"). It is `global-name`-scoped, not a blanket
+    `(allow mach-lookup)` — real measurement (architect, #4932) found this
+    ONE service is what both `security`/Keychain and `gh auth status`
+    (which shells out to `security` for its stored token) need and nothing
+    else in the 9 candidate SBPL classes was required."""
+    expected = '(allow mach-lookup (global-name "com.apple.SecurityServer"))'
+
+    # Present under a bare-default policy...
+    assert expected in _build_sbpl_profile(SandboxPolicy())
+    # ...and under a maximally-restrictive policy (deny_subprocess + no
+    # network) — this grant is NOT gated by any policy field.
+    assert expected in _build_sbpl_profile(
+        SandboxPolicy(deny_subprocess=True, network=False)
+    )
+    # Never a blanket grant — the exact global-name form only.
+    assert "(allow mach-lookup)" not in _build_sbpl_profile(SandboxPolicy()).splitlines()
+
+
 # ─── 3. _sbpl_quote ──────────────────────────────────────────────────────────
 
 
@@ -318,6 +340,37 @@ async def test_seatbelt_allows_socketpair_sendto_but_denies_addressed_sendto_whe
     assert b"ADDRESSED_SENDTO_DENIED" in result.stdout, (
         f"addressed UDP sendto (real egress) must stay denied under network=False; "
         f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="sandbox-exec is macOS-only")
+@pytest.mark.asyncio
+async def test_seatbelt_security_command_succeeds_under_default_policy():
+    """Tier 2: #4932/#4933 — `security list-keychains` (which needs the
+    `com.apple.SecurityServer` mach-lookup service this profile now always
+    grants) succeeds through the REAL SeatbeltBackend.run() path under a
+    bare-default SandboxPolicy — not a raw `sandbox-exec` invocation
+    (architect's own #4932 measurement used the latter; lead-coder's
+    review explicitly asked for reproduction through the real backend +
+    its full deny-list-included profile). `security` (not the personal
+    `gh` CLI, whose success depends on this machine's own stored OAuth
+    token) is the CI-portable witness for the underlying capability: it
+    only needs to enumerate the machine's own keychain search list, not
+    a specific credential.
+
+    Strip-falsify: this test fails (returncode != 0, "One or more
+    parameters passed to a function were not valid" — the exact error
+    architect measured before the fix) if the mach-lookup grant this PR
+    adds is removed from ``_build_sbpl_profile``."""
+    backend = SeatbeltBackend()
+    if not backend.available():
+        pytest.skip("sandbox-exec not available on this machine")
+
+    policy = SandboxPolicy(timeout_seconds=10)
+    result = await backend.run(["security", "list-keychains"], policy)
+    assert result.returncode == 0, (
+        f"security list-keychains must succeed under the default policy "
+        f"(#4932/#4933); stdout={result.stdout!r} stderr={result.stderr!r}"
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — part of #4932, part of #4933

## What

Owner ruling (verbatim, relayed 2026-08-19/20): "if this makes `gh` work under the default config, go ahead." Landed standalone, ahead of #4935 (lead-coder's decision: "small, certain fix, not tied to a large, uncertain one" — #4935 is a much bigger arc and Landlock likely can't carry the same argument since it's allowlist-only and structurally cannot carve a deny out of an allowed parent).

## Root cause

`security`/`gh auth status` both fail under the default sandbox policy because nobody had enumerated the ONE mach-lookup service (`com.apple.SecurityServer`) they need. #3901's already-ratified posture ("the sandbox no longer re-decides what the launching shell could already do") already covers this in intent, but `SandboxPolicy` has no axis for services outside the 4 named ones (write/read/network/subprocess) — so this capability silently fell through to `(import "bsd.sb")`'s narrower default regardless of compat/strict mode. Same "enumeration gap reads as capability loss, with no error anywhere" shape as #4932's own root cause.

## Fix

One `global-name`-scoped grant in `_build_sbpl_profile`, unconditional (not gated by any `SandboxPolicy` field) — on by default, matching the "every other axis is compat by default" posture #3901 already ratified. **Not** a blanket `(allow mach-lookup)`.

## The 3 verification items lead-coder flagged as open — closed here

1. **Reproduced through the REAL `SeatbeltBackend.run()` path** (a full profile with every deny-list rule included), not architect's raw `sandbox-exec` probe — `gh auth status` and `security list-keychains` both succeed under `SandboxPolicy()`'s default. Measured directly, not inferred from a green test.
2. **`process-fork` dependency confirmed and characterized**: the fix works under the DEFAULT policy (`deny_subprocess=False`, #3901's compat default). It does **not** work if `deny_subprocess=True` is explicitly set — verified this is expected/consistent (an operator who opted into stricter isolation gets stricter isolation), not a new gap this PR introduces.
3. **Pass-line**: `gh auth status` measured directly — returncode 0, matches the unsandboxed output exactly. `security list-keychains` (same fix, closes #4933) also verified directly.

## Strip-falsify

Removed the grant from the real committed file, confirmed both new tests + the live `gh`/`security` probes fail with the EXACT error architect originally measured (`SecKeychainCopySearchList: One or more parameters passed to a function were not valid`), restored, green again.

## Tests

- A deterministic profile-content test: the grant is present regardless of policy (even under `deny_subprocess=True, network=False`), and never the blanket `(allow mach-lookup)` form.
- A darwin-only live-execution test via `security list-keychains` — CI-portable, unlike a live `gh auth status` test which depends on this machine's personal OAuth token; exercises the SAME underlying capability without an environment-specific dependency a CI runner can't satisfy.

## Not in this PR

#4935 (extending #3901's ratified posture to every axis-less capability, not just this one) is a separate, larger, still-evolving design question. This PR does not pre-empt it — a future stricter opt-in mode that wants to close this specific grant is #4935's call, not this fix's.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_sandbox_seatbelt.py` — 24 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/security/sandbox/backends/seatbelt.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `pytest tests/security/ tests/tools/` — 1675 passed, 26 skipped
- [x] Strip-falsify against the real committed file (removed the grant, confirmed RED with the exact original error, restored, GREEN)
- [x] Live-measured `gh auth status` and `security list-keychains` through the real `SeatbeltBackend.run()` path, both before (RED) and after (GREEN) the fix
- [x] (skipped — Landlock/Linux side explicitly out of scope, macOS-only fix per architect's own #4935 caveat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)