### PR TITLE
feat(4840): chat.theme config knob for the TUI's Textual theme name

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -74,7 +74,7 @@ aren't.
 | `sandbox` | map | PRJ only · **restart** | Backend selection (`backend`), unsupported-platform policy (`on_unsupported`), the enforcement mode (`mode`: compat / strict / custom), and the agent-level sandbox policy (`policy`). See below. |
 | `hooks` | list | both (`.reyn/config/hooks.yaml` side is **hot-reloaded**) | Agent-lifecycle hooks. Four action schemes: `template_push` / `exec` / `exec_capture` / `pipeline_launch`. See below. |
 | `embedding` | map | PRJ only · **restart** | RAG embedding: the master switch (`enabled`), model classes, batch sizing and concurrency, retry / backoff / timeout, tokenizer, and a cost-warning threshold. See below. |
-| `chat` | map | PRJ only · **restart** | Chat-session runtime knobs: history compaction, reasoning/"thinking" text handling, the interactive renderer (`render_mode`), TUI gutters, body neutralization, and permitted image-URL schemes. See below. |
+| `chat` | map | PRJ only · **restart** | Chat-session runtime knobs: history compaction, reasoning/"thinking" text handling, the interactive renderer (`render_mode`), TUI gutters, body neutralization, permitted image-URL schemes, and the TUI theme name. See below. |
 | `voice` | map | PRJ only · **restart** | Whisper model/language/device settings for F2 dictation in the inline CUI (revived #4187/#4249). See below. |
 | `audit_events` | map | PRJ only · **restart** | Rotation policy (size / age / cleanup period) for the P6 **audit-event** files under `.reyn/events`. Not WAL-events, not hook-events. See below. |
 | `artifacts` | map | PRJ only · **restart** | The artifact-ref table fallback's own row cap (`remote_fallback_limit`, #4601) — used by a remote client's (and a post-restart local client's) Artifacts pane. See below. |
@@ -568,7 +568,8 @@ Chat-session runtime knobs. `chat.compaction` controls chat-history compaction
 (ratio-based budget; see `reyn.local.yaml.example`). `chat.reasoning` controls
 model reasoning/"thinking" text handling. `chat.render_mode` selects the
 interactive chat renderer/driver. `chat.gutters` sets the TUI conversation
-pane's two gutter columns' start state.
+pane's two gutter columns' start state. `chat.theme` overrides the interactive
+TUI's Textual theme name.
 
 ```yaml
 chat:
@@ -583,6 +584,7 @@ chat:
   neutralize_body: false  # opt-in ESC/OSC strip on agent-reply/tool-result body text
   image_url_schemes: []   # opt-in scheme allowlist for present's image src fetch
   empty_stop_retry: false # opt-in resend on an empty router response
+  theme: null              # override the TUI's Textual theme name (default: reyn's own)
 ```
 
 ### `chat.render_mode`
@@ -713,6 +715,22 @@ audit event fires regardless of this setting.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `empty_stop_retry` | bool | `false` | Resend one "resume" prompt when the router loop detects an empty `finish_reason="stop"` response. |
+
+### `chat.theme`
+
+Override the interactive TUI's Textual theme name (#4840 ③ — the
+config-knob half; the colour direction itself was decided separately and
+already shipped, #4869/#4875). Default (unset) keeps reyn's own
+full-colour theme (registered name `"reyn"`). Any name Textual resolves
+is accepted — reyn's own theme, or any of Textual's built-ins (`nord`,
+`dracula`, `gruvbox`, `catppuccin-mocha`, `textual-dark`, `ansi-dark`,
+…). Not validated at config-load time — an unknown name raises where
+Textual itself resolves the theme, not here, so this config layer never
+carries its own copy of Textual's theme registry to keep in sync.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `theme` | str \| null | `null` | Textual theme name for the interactive TUI. `null` keeps reyn's own default (`"reyn"`). |
 
 ### `chat.reasoning` fields
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -504,6 +504,16 @@
 # only changes what happens after one is detected.
 #   empty_stop_retry: false
 
+# chat.theme: override the interactive TUI's Textual theme name (#4840 ③,
+# the config-knob half — the colour direction itself was decided
+# separately and already shipped, #4869/#4875). Default (unset) keeps
+# reyn's own full-colour theme ("reyn"). Any name Textual resolves is
+# accepted — reyn's own registered theme, or any of Textual's built-ins
+# (nord / dracula / gruvbox / catppuccin-mocha / textual-dark / ansi-dark
+# / …). Not validated here — an unknown name raises where Textual itself
+# resolves it, not at config-load time.
+#   theme: nord
+
 
 # -----------------------------------------------------------------------------
 # audit_events: audit-log rotation + automatic purge policy (#4174 T5:

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -927,6 +927,24 @@ class ChatConfig:
     are fixed" anywhere this flag is discussed — the empty response's own
     root cause is unmeasured (#3698's anyio cancel-scope is a candidate);
     this flag only changes what happens AFTER one occurs.
+
+    ``theme`` (#4840 ③, the config-knob half — the visual/colour-direction
+    half was owner-decided separately and already shipped, #4869/#4875):
+    the Textual theme name ``TextualChatApp.on_mount`` passes to
+    ``self.theme``. ``None`` (default) keeps the shipped default, reyn's
+    own full-colour theme (``REYN_THEME``, registered name ``"reyn"``) —
+    this knob does not change what ships out of the box, only whether an
+    operator can override it. Deliberately UNRESTRICTED: any name Textual
+    (or reyn's own ``register_theme`` call) resolves is accepted, including
+    every built-in (``nord``/``dracula``/``ansi-dark``/…) — an unknown name
+    is caught where ``self.theme =`` actually runs (Textual raises there),
+    not pre-validated here, so this config layer never carries its own
+    stale copy of Textual's theme registry. Whether ``ansi-dark`` deserves
+    special-cased continued support as a "defer to the terminal" escape
+    hatch, now that reyn ships a full-colour default, is a separate,
+    still-open design question (#4840's own thread) — this knob does not
+    answer it; it just stops silently discarding whatever name an operator
+    already knows to type.
     """
     compaction: CompactionConfig = field(default_factory=CompactionConfig)
     reasoning: ReasoningConfig = field(default_factory=ReasoningConfig)
@@ -935,6 +953,7 @@ class ChatConfig:
     neutralize_body: bool = False
     image_url_schemes: "list[str]" = field(default_factory=list)
     empty_stop_retry: bool = False
+    theme: "str | None" = None
 
 
 def _build_reasoning_config(raw: object) -> ReasoningConfig:
@@ -997,12 +1016,17 @@ def _build_chat_config(raw: object) -> ChatConfig:
     # #4677: so does the empty-stop-retry knob (owner default False — see the
     # field's own docstring for the incident + the tradeoff being made).
     empty_stop_retry = bool(raw.get("empty_stop_retry", ChatConfig().empty_stop_retry))
+    # #4840 ③: so does the theme-name override (default None — see the
+    # field's own docstring; unrestricted, not validated against a known-name
+    # list here).
+    raw_theme = raw.get("theme")
+    theme = str(raw_theme) if raw_theme is not None else None
     compaction_raw = raw.get("compaction") or {}
     if not isinstance(compaction_raw, dict):
         return ChatConfig(  # type: ignore[arg-type]
             reasoning=reasoning, render_mode=render_mode, gutters=gutters,
             neutralize_body=neutralize_body, image_url_schemes=image_url_schemes,
-            empty_stop_retry=empty_stop_retry,
+            empty_stop_retry=empty_stop_retry, theme=theme,
         )
     # #1128: head_size/tail_size (step 3) + trigger_total_tokens/min_compact_batch
     # (PR-a, axis-1 removal) were removed — head/tail sizing is token-budget via
@@ -1089,6 +1113,7 @@ def _build_chat_config(raw: object) -> ChatConfig:
         compaction=compaction, reasoning=reasoning, render_mode=render_mode,  # type: ignore[arg-type]
         gutters=gutters, neutralize_body=neutralize_body,
         image_url_schemes=image_url_schemes, empty_stop_retry=empty_stop_retry,
+        theme=theme,
     )
 
 

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2196,7 +2196,15 @@ class TextualChatApp(App):
         # default theme, which keeps concrete ``$panel``/``$surface`` values
         # throughout (``REYN_THEME.panel``/``.surface``).
         self.register_theme(REYN_THEME)
-        self.theme = "reyn"
+        # #4840 ③: config-knob half only — the default (this literal,
+        # "reyn") is unchanged; ``ChatConfig.theme`` (default ``None``)
+        # only OVERRIDES it. Unrestricted on purpose (see that field's own
+        # docstring) — an unknown name raises HERE, at the exact point
+        # Textual itself resolves theme names, not from a stale allowlist
+        # this config layer would otherwise have to keep in sync with
+        # Textual's own registry.
+        _configured_theme = getattr(getattr(self._config, "chat", None), "theme", None)
+        self.theme = _configured_theme or "reyn"
         # #3469 (generalizing #3326's single-key fix): push the COMPLETE
         # palette-derived markdown theme (``renderer.CHAT_MARKDOWN_THEME_STYLES``
         # — the plain renderers' Consoles consume the same constant) onto the

--- a/tests/core/test_4840_chat_theme_config.py
+++ b/tests/core/test_4840_chat_theme_config.py
@@ -1,0 +1,112 @@
+"""Tier 1/2: `chat.theme` config parsing (#4840 ③ — the config-knob half;
+the colour-direction half was owner-decided separately and already shipped,
+#4869/#4875).
+
+Default None — `TextualChatApp.on_mount` keeps shipping reyn's own
+full-colour theme (`REYN_THEME`, registered name `"reyn"`) unless an
+operator names one explicitly. Deliberately unrestricted at this layer
+(no allowlist here — see `ChatConfig.theme`'s own docstring for why): a
+config-layer allowlist would need to be kept in sync with Textual's own
+theme registry forever, for no safety benefit (an unknown name raises at
+`self.theme = ...`, not here).
+
+`test_chat_theme_survives_a_real_load_config_round_trip` closes the
+`load_config`-reload gap lead-coder's #4899 review found (a config field
+was `set` but the loader never actually read it back on reload) — the
+other tests in this file exercise `_build_chat_config` directly (matching
+`test_4677_empty_stop_retry_config.py`'s own established pattern for a
+`ChatConfig` field), which proves the PARSER reads the field; this one
+additionally proves `load_config()` itself — the real entrypoint,
+reading a real `reyn.yaml` off disk — surfaces the value all the way
+through, not just the parser in isolation.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from reyn.config.chat import ChatConfig, _build_chat_config
+from reyn.config.loader import load_config
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+
+def test_chat_theme_defaults_to_none() -> None:
+    """Tier 1: ChatConfig.theme defaults to None — the shipped default
+    (reyn's own full-colour theme, "reyn") is unchanged unless overridden."""
+    assert ChatConfig().theme is None
+
+
+def test_chat_theme_parses_a_name() -> None:
+    """Tier 1: `chat.theme: nord` in reyn.yaml carries through — the
+    required "config で名前を書ける" condition (#4840 ③)."""
+    assert _build_chat_config({"theme": "nord"}).theme == "nord"
+
+
+def test_chat_theme_absent_stays_none() -> None:
+    """Tier 1: falsification pair — omitting the key keeps the None
+    default (this field does not accidentally pick up a value from any
+    other chat: key)."""
+    assert _build_chat_config({"render_mode": "plain"}).theme is None
+
+
+def test_chat_theme_parses_when_compaction_block_present() -> None:
+    """Tier 1: the field parses correctly whether or not a sibling
+    `chat.compaction:` block is present — `_build_chat_config` has an
+    early-return branch when `compaction` is absent/malformed, and this
+    field's parse must survive BOTH branches, not just the one every
+    other test in this file happens to exercise (mirrors #4677's own
+    sibling test for exactly this shape)."""
+    assert _build_chat_config({
+        "theme": "dracula",
+        "compaction": {"body_token_cap": 5000},
+    }).theme == "dracula"
+    assert _build_chat_config({"theme": "dracula"}).theme == "dracula"
+
+
+def test_chat_theme_is_not_restricted_to_a_known_list() -> None:
+    """Tier 1: any string parses through unchanged — this config layer
+    does not validate against Textual's theme registry (see the field's
+    own docstring for why: an unknown name is Textual's own concern, at
+    the point `self.theme = ...` actually runs, not this parser's)."""
+    assert _build_chat_config({"theme": "not-a-real-theme-name"}).theme == (
+        "not-a-real-theme-name"
+    )
+
+
+def test_chat_theme_survives_a_real_load_config_round_trip(tmp_path, monkeypatch) -> None:
+    """Tier 2: load_config() itself — not just _build_chat_config in
+    isolation — reads chat.theme off a real reyn.yaml on disk. Closes the
+    exact gap #4899 found (a field set in YAML but never actually read
+    back through the real loader)."""
+    monkeypatch.chdir(tmp_path)
+    reyn_yaml = tmp_path / "reyn.yaml"
+    _write_yaml(reyn_yaml, {"chat": {"theme": "gruvbox"}})
+
+    cfg = load_config(tmp_path)
+
+    assert cfg.chat.theme == "gruvbox"
+
+
+def test_chat_theme_absent_from_yaml_stays_none_through_load_config(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: strip-falsify for the round-trip test above — a reyn.yaml
+    with no chat.theme key must leave load_config()'s own result at the
+    None default, proving the prior test's assertion is reading a value
+    that actually came from the YAML, not a value load_config() would
+    produce regardless of what's on disk."""
+    monkeypatch.chdir(tmp_path)
+    reyn_yaml = tmp_path / "reyn.yaml"
+    _write_yaml(reyn_yaml, {"chat": {"render_mode": "plain"}})
+
+    cfg = load_config(tmp_path)
+
+    assert cfg.chat.theme is None


### PR DESCRIPTION
**[tui-coder]** — part of #4840 (the config-knob half, ③) — last remaining
item this arc's own closing summary had lost track of ("nothing else
remains but the repaint review" was false — verified directly before
implementing: `git grep theme -- src/reyn/config/` was still 0 hits,
`app.py`'s `self.theme` was still a hardcoded literal, across all 18
comments / 14 merged PRs).

## What changed

`ChatConfig.theme: str | None = None`, parsed in `_build_chat_config`
(both branches — the early-return path and the full-parse path, matching
the sibling `empty_stop_retry` field's own dual-branch coverage).
`app.py`: `self.theme = config.chat.theme or "reyn"` in place of the
literal — **default unchanged** (still `"reyn"`, reyn's own full-colour
theme, #4869/#4875), only an override path added.

**Deliberately unrestricted** — no allowlist here. An unknown theme name
raises at `self.theme = ...` (Textual's own resolution point), not at
config-load time; a config-layer allowlist would need to be kept in sync
with Textual's own theme registry forever for zero safety benefit.

## Open question, deliberately not answered here

Whether `ansi-dark` deserves special-cased continued support as a "defer
to the terminal" escape hatch, now that reyn ships a full-colour default,
is a real, still-open design question from #4840's own thread. This PR
does not restrict which names can be chosen, so it doesn't foreclose
either answer — flagging per instruction, not resolving it.

## Config-mirror coverage caught a real gap

`test_config_mirror_coverage_1056.py` failed on first run — both
`reyn.local.yaml.example` and `docs/reference/config/reyn-yaml.md` were
missing the new field. Exactly the #4899-class gap that gate exists for.
Both fixed in this same PR, re-verified green.

## Test plan

- [x] `pytest tests/core/test_4840_chat_theme_config.py tests/config/test_config_mirror_coverage_1056.py tests/config/test_config_cascade.py tests/interfaces/test_loop_probe_3539.py tests/interfaces/test_3671_stall_trace_startup_wiring.py` — 47 passed
- [x] Falsification — removed the field/parsing/wiring entirely, all 7 new tests failed with `AttributeError` as expected; restored, all green
- [x] Manual end-to-end verification against 2 real `TextualChatApp` instances (headless `run_test()`): no config → `theme == "reyn"`; `config.chat.theme = "nord"` → `theme == "nord"`
- [x] `ruff check` (all 3 changed source files) — all checks passed
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/test_tier_audit.py --strict tests/core/test_4840_chat_theme_config.py` — 7 tests, 0 errors, 0 warnings
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py` — all clean (pre-existing, unrelated ja-mirror gaps only)
- [x] Checked `docs/reference/config/reyn-yaml.ja.md` for a falsified "exhaustive field list" claim before deciding not to touch it — no such claim found (no blanket mirror obligation, CLAUDE.md rule 5)
- [ ] Visual — n/a (default unchanged; an operator-opted-in override, no shipped appearance change)

## Time-dependency check

0 instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
