### PR TITLE
fix(#4812): split message_handler.py's unhandled-message log into a real classifier

### DIFF
--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -72,12 +72,25 @@ For every message shape the real MCP protocol produces TODAY, observable behavio
 identical: the 4 acted-on notification types still trigger the same hook bodies
 (unchanged), task-status still routes to the client, and every other shape still
 produces no ``EventLog``/hook-trigger side effect. **One deliberate addition**: an
-unrecognized message shape now emits a DEBUG log line (:meth:`_log_unhandled`) instead
-of silently reaching an inherited no-op — lead-coder's P3 review condition: a closed
-match-list must not silently drop an "unknown to us" shape the same way it silently
-finishes handling a KNOWN one; the day fastmcp/MCP adds a new notification type this
-class doesn't yet act on, that day is now distinguishable in the log from an ordinary
-quiet run, rather than reading identical to one.
+unrecognized message shape now emits a log line (:meth:`_log_unhandled` /
+:meth:`_log_unknown_shape`) instead of silently reaching an inherited no-op —
+lead-coder's P3 review condition: a closed match-list must not silently drop an
+"unknown to us" shape the same way it silently finishes handling a KNOWN one; the day
+fastmcp/MCP adds a new notification type this class doesn't yet act on, that day is
+now distinguishable in the log from an ordinary quiet run, rather than reading
+identical to one.
+
+**#4812 (classifier, not just a severity bump)**: the original single DEBUG line
+covered two genuinely different populations under one severity — "a real,
+protocol-compliant ``ServerNotification`` variant reyn has no behavior for" (still
+DEBUG, :meth:`_log_unhandled`) and "a shape this handler cannot classify at all"
+(now WARNING, :meth:`_log_unknown_shape`: a future SDK-added notification variant, a
+non-conforming server, or a real transport-level ``Exception``). Every currently-known
+``ServerNotification`` union member (per the installed SDK's own
+``typing.get_args(mcp.types.ServerNotification)``) now has an explicit named ``case``
+in :meth:`__call__` — see that method's own comments for the exhaustiveness this split
+depends on, and for the (already-known, #4457-tracked) ``TaskStatusNotification`` case
+that stays unreachable on the pinned SDK without being deleted.
 """
 from __future__ import annotations
 
@@ -290,45 +303,107 @@ class ReynMCPMessageHandler:
                     # exact class of bug this handler's module docstring
                     # exists to make un-silent.
                     await self.on_progress(root)
-                case _:
+                # #4812: the remaining KNOWN-BUT-UNACTED-ON ServerNotification
+                # union members, named explicitly (not left to the wildcard
+                # below). Each is real, protocol-compliant traffic a
+                # standards-conforming server can send during entirely
+                # normal operation — reyn simply has no behavior for it, by
+                # design, same as the 5 shapes matched above. Enumerating
+                # them BY NAME is what makes the wildcard's own severity
+                # meaningful: see `_log_unknown_shape`'s docstring.
+                case mcp.types.LoggingMessageNotification():
                     self._log_unhandled(root)
+                case mcp.types.ResourceListChangedNotification():
+                    self._log_unhandled(root)
+                case mcp.types.ElicitCompleteNotification():
+                    self._log_unhandled(root)
+                case mcp.types.SubscriptionsAcknowledgedNotification():
+                    # Reachable only when NO live listen() stream is
+                    # consuming this ack for the relevant subscription (the
+                    # installed SDK's own `_on_notify` routes an
+                    # in-flight-listen ack to that stream directly instead
+                    # of here — see this handler's module docstring on
+                    # listen-honored suppression for the analogous
+                    # tools/prompts/resources gating).
+                    self._log_unhandled(root)
+                # `CancelledNotification` (also a ServerNotification member)
+                # is EXCLUDED here, not silently missing: the installed
+                # SDK's own dispatcher (`ClientSession._on_notify`)
+                # intercepts and returns before ever calling
+                # `message_handler` for it (verified live,
+                # `.venv/lib/.../mcp/client/session.py`) — it structurally
+                # cannot reach this match statement, so there is no case
+                # arm for it to fall into.
+                case _:
+                    # A genuinely UNCLASSIFIED ServerNotification shape — every
+                    # currently-known union member (per `typing.get_args
+                    # (mcp.types.ServerNotification)`, the installed SDK pin)
+                    # has its own named `case` above; reaching this arm means
+                    # the connected server sent something outside that set —
+                    # either a FUTURE mcp-SDK-added variant this match hasn't
+                    # been updated for, or a non-conforming server. #4812:
+                    # THIS is the "unexpected/never-seen message type" #4805's
+                    # own discriminator (fires only on the defect, not on
+                    # healthy paths) asks for — unlike the named cases above,
+                    # nothing legitimate is expected to land here.
+                    self._log_unknown_shape(root)
         else:
-            # A request (RequestResponder) or a transport-level Exception — reyn
-            # never acted on either (no on_request/on_ping/on_exception override
-            # existed even in the inherited version) — see module docstring.
-            self._log_unhandled(message)
+            # #4812 correction: the installed SDK's own `IncomingMessage`
+            # TypeAlias (`mcp/client/session.py`) is
+            # `ServerNotification | Exception` — NOT `ServerNotification |
+            # RequestResponder` as this branch's comment used to claim.
+            # `message_handler` never receives a request in this SDK
+            # version (sampling/roots/elicitation requests route through
+            # their OWN dedicated callbacks, not this one) — the prior
+            # "RequestResponder" wording described an API shape that does
+            # not exist on the pinned SDK. Since `isinstance(message,
+            # mcp.types.ServerNotification)` was False to reach this
+            # branch, `message` here is ALWAYS an Exception: a real
+            # transport-level fault (`ClientSession._on_stream_exception`),
+            # never "legitimate expected traffic" the way an unacted-on
+            # notification variant is — #4805's own discriminator (fires
+            # only on the defect, never on a healthy path) applies
+            # directly, unlike the notification branch above.
+            self._log_unknown_shape(message)
 
     def _log_unhandled(self, message: Any) -> None:
-        """#3698 P3 review condition: an OBSERVABLE trace for a message shape this
-        handler doesn't act on — distinguishes "processed and silent" (the 5 shapes
-        matched above) from "not one of ours, silently ignored" (everything else),
-        so a future fastmcp/MCP protocol addition landing here unnoticed is
-        distinguishable in the log from an ordinary quiet run, not identical to it.
+        """#3698 P3 review condition: an OBSERVABLE trace for a KNOWN
+        ``ServerNotification`` variant this handler doesn't act on by design
+        (the ``case`` arms in ``__call__`` that route here) — legitimate,
+        protocol-compliant traffic a standards-conforming server sends during
+        entirely normal operation. Stays at ``debug`` (#4805): raising it
+        would false-alarm on healthy traffic from a server that simply uses a
+        notification shape reyn doesn't act on, the opposite of the
+        "defect-only" property #4805's severity-raise fix depends on.
 
-        #4805: stays at ``debug``, deliberately NOT raised to ``warning`` the
-        way the other two sites in this issue's population were. Those two
-        fire ONLY on a confirmed defect condition (a stream that produced
-        chunks but no delta; a value that never got the correction it was
-        due) — this one does not have that property. Its own call sites
-        (``__call__``'s ``case _:`` branch, and the ``else`` branch for
-        every ``RequestResponder``/transport exception) fire for ANY of the
-        ``ServerNotification`` union's members this handler doesn't act on
-        (only 5 of the union's shapes are matched above) and for EVERY
-        server-initiated request — both are legitimate, protocol-compliant
-        traffic a standards-conforming MCP server can send during entirely
-        normal operation, not just malformed/unexpected input. Raising this
-        to ``warning`` would fire on healthy traffic from a server that
-        simply uses a notification/request shape reyn doesn't act on by
-        design — the opposite of the "defect-only" property #4805's
-        severity-raise fix depends on. The underlying tension (this log
-        line's own stated purpose — "make it observable" — genuinely IS
-        defeated by the production floor for the cases that are actual
-        defects, same as the other two sites) is real but needs a design
-        answer this mechanical fix doesn't have (e.g. distinguishing "an
-        unexpected/never-seen message type" from "a known, legitimate one
-        we just don't act on"), not a blanket severity bump."""
+        #4812 split this method's OLD, wider job in two: this half keeps the
+        original "known, unacted-on, not a defect" case; the genuinely
+        unclassified case (a future/unknown shape, or a transport Exception)
+        now routes to :meth:`_log_unknown_shape` instead — see that method
+        and ``__call__``'s own comments for the enumerated population this
+        split rests on."""
         logger.debug(
             "ReynMCPMessageHandler: no handler for message type %s on server %r",
+            type(message).__name__, self._server_name,
+        )
+
+    def _log_unknown_shape(self, message: Any) -> None:
+        """#4812: an OBSERVABLE, ``warning``-level trace for a message this
+        handler cannot classify as a known, legitimate shape — the population
+        __call__ routes here is EITHER a ``ServerNotification`` outside every
+        named ``case`` in the match statement above (a future SDK-added
+        variant, or a non-conforming server — see the match's own ``case _:``
+        comment for the exhaustiveness argument this rests on) OR a real
+        transport-level ``Exception`` (the ``else`` branch — never "expected
+        traffic" the way a known-but-unacted-on notification is).
+
+        This is the design #4812 itself asked for (quoting the issue): "a way
+        to split the two populations ... so only the [actual anomaly] could
+        reasonably raise severity without false-alarming on normal MCP
+        servers." Distinct from :meth:`_log_unhandled` (stays at ``debug`` —
+        that method's own docstring covers the KNOWN, non-anomalous half)."""
+        logger.warning(
+            "ReynMCPMessageHandler: unclassified message type %s on server %r",
             type(message).__name__, self._server_name,
         )
 

--- a/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
@@ -354,12 +354,17 @@ async def test_unrecognized_notification_is_logged_not_silently_dropped(caplog) 
 
 @pytest.mark.asyncio
 async def test_a_non_notification_message_is_also_logged_not_silently_dropped(caplog) -> None:
-    """Tier 1: same condition as above, for the OTHER branch of __call__ — a
-    non-ServerNotification message (a request or a transport-level Exception,
-    per ``mcp.types``' own ``Message`` union) also reaches _log_unhandled
-    rather than nothing, since reyn has never acted on either shape (no
-    on_request/on_ping/on_exception override existed even in the inherited
-    version)."""
+    """Tier 1: same OBSERVABLE-not-silent condition as above, for the OTHER
+    branch of __call__. #4812 (classifier split): the installed SDK's own
+    ``IncomingMessage`` TypeAlias is ``ServerNotification | Exception`` — no
+    request ever reaches this branch on the pinned SDK (sampling/roots/
+    elicitation requests route through their own dedicated callbacks) — so
+    this branch's ONLY population is a real transport-level Exception, which
+    is never "expected, healthy" traffic the way an unacted-on notification
+    variant is. It therefore now routes to ``_log_unknown_shape`` at
+    ``warning``, not ``_log_unhandled`` at ``debug`` — see
+    ``test_unrecognized_notification_is_logged_not_silently_dropped`` above
+    for the sibling KNOWN-variant case that stays at ``debug``."""
     import logging
 
     handler = ReynMCPMessageHandler(lambda *a, **k: None, "srv")
@@ -368,7 +373,115 @@ async def test_a_non_notification_message_is_also_logged_not_silently_dropped(ca
     with caplog.at_level(logging.DEBUG, logger="reyn.mcp.message_handler"):
         await handler(RuntimeError("not a ServerNotification"))
 
-    assert any("no handler for message type" in r.message for r in caplog.records)
+    matches = [r for r in caplog.records if "unclassified message type" in r.message]
+    assert matches, f"expected an observable unclassified-message log line; got: {[r.message for r in caplog.records]}"
+    assert matches[0].levelname == "WARNING", (
+        f"a transport-level Exception is never expected/healthy traffic — "
+        f"#4805's own discriminator applies directly; got {matches[0].levelname}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "notification",
+    [
+        pytest.param(
+            types.LoggingMessageNotification(
+                params=types.LoggingMessageNotificationParams(level="info", data="x"),
+            ),
+            id="LoggingMessageNotification",
+        ),
+        pytest.param(
+            types.ElicitCompleteNotification(
+                params=types.ElicitCompleteNotificationParams(elicitationId="e1"),
+            ),
+            id="ElicitCompleteNotification",
+        ),
+        pytest.param(
+            types.SubscriptionsAcknowledgedNotification(
+                params=types.SubscriptionsAcknowledgedNotificationParams(
+                    notifications=types.SubscriptionFilter(),
+                ),
+            ),
+            id="SubscriptionsAcknowledgedNotification",
+        ),
+    ],
+)
+async def test_other_known_notification_variants_stay_at_debug(caplog, notification) -> None:
+    """Tier 1: #4812 — the OTHER 3 real ``ServerNotification`` union members
+    this handler has never acted on (beyond ``ResourceListChangedNotification``,
+    already pinned above) are each now named explicitly in ``__call__``'s
+    ``match`` — and all 3 stay at ``debug`` via ``_log_unhandled``, same as
+    before #4812, because they are legitimate protocol traffic, not an
+    anomaly. This is the "known, not acted on" half of #4812's classifier;
+    the sibling test above pins the "genuinely unclassified" half."""
+    import logging
+
+    handler = ReynMCPMessageHandler(lambda *a, **k: None, "srv")
+    handler.bind_client(_FakeClient())
+
+    with caplog.at_level(logging.DEBUG, logger="reyn.mcp.message_handler"):
+        await handler(notification)
+
+    matches = [r for r in caplog.records if "no handler for message type" in r.message]
+    assert matches, (
+        f"expected the KNOWN-variant debug log for {type(notification).__name__}; "
+        f"got: {[r.message for r in caplog.records]}"
+    )
+    assert matches[0].levelname == "DEBUG", (
+        f"a known, legitimate-but-unacted-on notification must stay at debug "
+        f"(#4805's own discriminator); got {matches[0].levelname}"
+    )
+
+
+def test_every_current_servernotification_member_has_a_named_case_or_is_disclosed() -> None:
+    """Tier 1: #4812 — population-completeness pin. Enumerates the INSTALLED
+    SDK's own ``mcp.types.ServerNotification`` union (via ``typing.get_args``,
+    not a hand-copied list this repo could forget to update) and asserts
+    every member is one of:
+      - one of the 5 ACTED-ON shapes (unchanged since before #4812), or
+      - one of the 4 KNOWN-but-unacted-on shapes #4812 just named explicitly
+        (debug, ``_log_unhandled``), or
+      - ``CancelledNotification`` — the ONE member structurally excluded
+        because the installed SDK's own dispatcher intercepts and never
+        surfaces it to ``message_handler`` at all (verified live against
+        ``mcp/client/session.py``'s ``_on_notify`` — see ``__call__``'s own
+        comment).
+
+    If a future ``mcp`` SDK bump adds a 10th member, THIS test fails —
+    forcing whoever bumps the pin to look at it and decide whether it's
+    acted-on, known-but-silent, or should reach ``_log_unknown_shape``'s
+    warning — rather than it silently falling through to the wildcard with
+    nobody having looked at it. This is the population-side half of the
+    classifier #4812 asked for; the routing-side half is pinned by the
+    handler tests above."""
+    import typing
+
+    acted_on = {
+        "ToolListChangedNotification",
+        "PromptListChangedNotification",
+        "ResourceUpdatedNotification",
+        "ProgressNotification",
+    }
+    known_but_unacted_on = {
+        "LoggingMessageNotification",
+        "ResourceListChangedNotification",
+        "ElicitCompleteNotification",
+        "SubscriptionsAcknowledgedNotification",
+    }
+    structurally_excluded = {"CancelledNotification"}
+
+    accounted_for = acted_on | known_but_unacted_on | structurally_excluded
+    actual_members = {cls.__name__ for cls in typing.get_args(types.ServerNotification)}
+
+    assert actual_members == accounted_for, (
+        f"mcp.types.ServerNotification's membership changed — a member is "
+        f"either new (not yet classified: "
+        f"{actual_members - accounted_for}) or was removed (stale in this "
+        f"test's own bookkeeping: {accounted_for - actual_members}). "
+        f"Either way, #4812's classifier needs a human to look at this "
+        f"before it's silently correct or silently wrong."
+    )
 
 
 # ── (d) synchronous handler body — sink faults never escape __call__ ──────────────


### PR DESCRIPTION
**[e2e-coder]** — part of #4812

## What

#4805/#4808 raised 2 of 3 candidate log sites to WARNING; the 3rd (`_log_unhandled`, `message_handler.py:285`) was deliberately left at DEBUG because it fires on legitimate protocol traffic as much as on real anomalies — a blanket raise would false-alarm on every ordinary session using an MCP feature reyn doesn't implement. #4812 asked for a classifier that splits the two populations, not a severity bump.

## Measured the reachable population precisely (not guessed at it)

- `mcp.types.ServerNotification` is a 9-member union (`typing.get_args`, installed SDK pin). 4 are acted on (unchanged). `CancelledNotification` is intercepted by the SDK's own dispatcher (`ClientSession._on_notify`) and **never** reaches `message_handler` at all — verified live against `mcp/client/session.py`, not assumed. The remaining 4 (`LoggingMessageNotification` / `ResourceListChangedNotification` / `ElicitCompleteNotification` / `SubscriptionsAcknowledgedNotification`) are real, legitimate, unacted-on protocol traffic — exactly the "known variant we don't act on" case that must stay DEBUG.
- The `else` branch's own comment claimed it handled "a request (RequestResponder) or a transport-level Exception" — checked against the installed SDK's own `IncomingMessage` TypeAlias (`ServerNotification | Exception`, `mcp/client/session.py`) and found this **stale**: no request has ever reached this branch on the pinned SDK (sampling/roots/elicitation route through their own dedicated callbacks). This branch's ONLY population is a real transport-level Exception — never "expected, healthy" traffic the way an unacted-on notification is, so #4805's own discriminator (fires only on the defect, never a healthy path) applies to it directly.

## Fix

Named every currently-reachable `ServerNotification` member explicitly in `__call__`'s `match` (the 4 unacted-on ones now route to `_log_unhandled`, unchanged DEBUG severity), which makes the match's own wildcard genuinely mean "a future SDK-added variant, or a non-conforming server" — a real anomaly, not routine traffic. Split `_log_unhandled` into two methods: `_log_unhandled` (DEBUG, known variants) and a new `_log_unknown_shape` (WARNING, the wildcard AND the Exception branch). Corrected the stale `RequestResponder` claim in both the inline comment and the class docstring.

`TaskStatusNotification`'s own `case` arm is **untouched** — it is NOT a member of `ServerNotification`'s union on this SDK pin (confirmed: `TaskStatusNotification.__mro__` shares no base with any of the 9 members) and is structurally unreachable through this match today, same finding this repo's own #4457-tracked skipped test already disclosed. Per lead-coder's explicit "unreachable population = report only, never delete" instruction, this PR does not touch it — cited, not silently dropped.

## Tests

`tests/mcp/test_2597_s2b_mcp_notifications_bridge.py`:
- Fixed the one stale assertion (an Exception used to assert DEBUG + "no handler for message type"; now asserts WARNING + "unclassified message type").
- 3 new parametrized cases pin each of the other known-but-unacted-on notification variants stays at DEBUG.
- A population-completeness test enumerates `typing.get_args(mcp.types.ServerNotification)` LIVE (not a hand-copied list) and asserts every member is accounted for by name — fails the day a future mcp SDK bump adds a 10th member, forcing a human decision instead of a silent fall-through to the wildcard.

## Strip-falsify

Reverted `_log_unknown_shape`'s severity to debug, confirmed the Exception test goes RED for the right reason ("got DEBUG" where WARNING was expected), restored, green again.

## Not in scope

Per the issue's own non-goals: the `logger.setLevel`/interactive-CUI production floor itself, and a wholesale severity raise for `message_handler.py:285` (already ruled wrong by #4805/#4808).

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/mcp/test_2597_s2b_mcp_notifications_bridge.py` — 10 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/mcp/message_handler.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_fastmcp_import_boundary.py` (`src/reyn/mcp/` path-conditional gate)
- [x] `pytest tests/mcp/` — 178 passed, 1 skipped (pre-existing, #4457)
- [x] Strip-falsify against the real committed file (reverted severity, confirmed RED for the right reason, restored, GREEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)