### PR TITLE
docs(#4935): disambiguate 0017's never-implemented SandboxCapability from CapabilitySupport

### DIFF
--- a/docs/deep-dives/proposals/0017-sandboxed-execution.ja.md
+++ b/docs/deep-dives/proposals/0017-sandboxed-execution.ja.md
@@ -224,6 +224,8 @@ class SandboxBackend(Protocol):
     def apply(self, policy: SandboxPolicy) -> None: ...
 ```
 
+> ⚠️ **この `SandboxCapability` は実装されませんでした**（`src/reyn/sandbox/` 自体、下の Landing notes が示すとおり現存しません）。**同じ語で別のもの**が #4935 で新設されています — `src/reyn/security/sandbox/capability.py` の `CapabilitySupport`（named-service 単位の申告、"grant" 概念）。混同を避けるため、この提案文書自体は経緯の記録として残し、この 1 行だけ添えます。
+
 **`sandboxed_exec` op**: `SandboxPolicy` を必須とする新しい Control IR op。
 OS は適切なバックエンドを選択し、`backend.apply(policy)` を呼び出したあと、
 制限された環境内でサブプロセスを起動する。

--- a/docs/deep-dives/proposals/0017-sandboxed-execution.md
+++ b/docs/deep-dives/proposals/0017-sandboxed-execution.md
@@ -228,6 +228,13 @@ class SandboxBackend(Protocol):
     def apply(self, policy: SandboxPolicy) -> None: ...
 ```
 
+> ⚠️ **This `SandboxCapability` was never implemented** (`src/reyn/sandbox/` itself
+> does not exist today, per the Landing notes below). A DIFFERENT thing with the
+> SAME name was introduced by #4935 — `CapabilitySupport` in
+> `src/reyn/security/sandbox/capability.py` (a named-service-level declaration,
+> the "grant" concept). This proposal document stays as the historical record —
+> only this one disambiguating line is added.
+
 **`sandboxed_exec` op**: a new Control IR op that requires a `SandboxPolicy`. The OS
 selects the appropriate backend, calls `backend.apply(policy)`, then spawns the subprocess
 inside the restricted environment. P6 events emitted: `sandbox_applied` (on successful


### PR DESCRIPTION
**[e2e-coder]** — part of #4935

## What

Lead-coder's finding (post-#4941 merge, non-blocking): `docs/deep-dives/proposals/0017-sandboxed-execution.{md,ja.md}` sketches a `SandboxCapability(Enum)` (`FS_RESTRICT`/`NET_RESTRICT`/`RESOURCE_LIMITS`) in its original 2026-05-10 design section — never implemented (the Landing notes right above it describe what actually landed, no `SandboxCapability` anywhere in it; `src/reyn/sandbox/` itself does not exist today). #4935 introduces an unrelated, real `CapabilitySupport` in `src/reyn/security/sandbox/capability.py` — same word, structurally different concept (named-service grant declaration, not a coarse axis-restriction enum). Not false, but a `grep` hit on "capability" here lands a reader on the wrong thing — the 4th same-word-different-thing instance this session hit in one night.

## Fix

One disambiguating line in each file, directly under the stale sketch — states it was never implemented, points to the real `CapabilitySupport` by name and path. The proposal document itself stays as the historical record (deleting it would lose "why this design wasn't chosen") — only this one line is added.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py` (docs/ touched)
- [x] (skipped — docs-only, no code/test to run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)