### PR TITLE
fix(#4935): NoopBackend's ipc_named_service was SUPPORTED under the wrong reading

### DIFF
--- a/docs/concepts/runtime/sandbox.md
+++ b/docs/concepts/runtime/sandbox.md
@@ -215,9 +215,16 @@ not a claim that nothing else is missing). Seatbelt declares `SUPPORTED`
 not a gap, a structural fact (Landlock's kernel-documented model is
 restrict-only, with no "grant" operation at all, so the #4932-class
 enumeration-gap failure cannot occur there in the first place); Noop
-declares `SUPPORTED` trivially (nothing is restricted to begin with);
-Docker declares `NOT_SUPPORTED` (the concept is macOS-specific, no
-Linux/container equivalent exists).
+ALSO declares `NOT_SUPPORTED` (corrected post-#4941 review, architect +
+lead-coder: `CapabilitySupport` asks whether a backend can EXPRESS a
+capability, a mechanism question — Noop has no grant mechanism either,
+it simply never needed one because it restricts nothing; an earlier
+version of this declaration answered a DIFFERENT question, "is a
+required capability reachable under this backend" — true by
+construction, but not what the field means, and it had a real
+operator-visible consequence, see below); Docker declares
+`NOT_SUPPORTED` (the concept is macOS-specific, no Linux/container
+equivalent exists).
 
 **Declaration ≠ guarantee — the property an operator must read correctly.**
 `SUPPORTED` means "this backend HAS the mechanism," never "every named
@@ -228,9 +235,14 @@ category (`opendirectoryd`, `com.apple.SystemConfiguration`) that are
 **not yet granted** — a disclosed, open gap, not silently implied closed.
 Declaring `require_capabilities: [ipc_named_service]` therefore does two
 different things depending on WHY a backend fails a required capability:
-against Landlock/Docker/Noop-fallback (genuinely `NOT_SUPPORTED`, no
-mechanism at all) it correctly refuses per `on_unsupported`; against
-Seatbelt it never fires at all — the category-level declaration cannot
+against Landlock/Docker/Noop (all genuinely `NOT_SUPPORTED`, no
+mechanism at all) it correctly refuses per `on_unsupported` — and a
+desirable side effect of Noop's own correction above: `on_unsupported:
+error` now refuses a run that resolved to NO enforcement at all, exactly
+the predictability the owner's ruling prioritises (the earlier,
+inverted version would have refused the genuinely-enforcing Landlock
+while accepting the fully-unenforced Noop); against Seatbelt it never
+fires at all — the category-level declaration cannot
 distinguish "granted" from "declared-supported-but-this-particular-service-
 isn't," so a `dscl` failure under Seatbelt is invisible to this mechanism.
 The mechanism's real value is closing the class of "silent capability loss

--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -88,14 +88,23 @@ class NoopBackend:
         allow_env_names=AxisEnforcement.ENFORCES,
     )
 
-    # #4935: SUPPORTED — trivially, not because Noop has a grant mechanism,
-    # but because it restricts NOTHING (enforced_axes above, all
-    # DOES_NOT_ENFORCE): there is no default it needs a named-service
-    # exception to widen. A required capability under Noop is reachable by
-    # construction, same reasoning `probe_argv`'s own Noop exemption uses
-    # for "nothing to differentiate on".
+    # #4935 (corrected, architect + lead-coder, post-merge review of #4941):
+    # NOT_SUPPORTED. `CapabilitySupport`'s own docstring defines the axis as
+    # "whether a backend can EXPRESS one named-capability class" — a
+    # mechanism question, not a reachability one. Noop has no grant
+    # mechanism at all (it restricts nothing, so it never needed one) —
+    # the FIRST version of this declaration wrongly answered a different
+    # question ("is a required capability reachable under this backend",
+    # true by construction since nothing is denied) than the one the enum
+    # actually asks. Getting this wrong here had a real, disclosed,
+    # operator-visible consequence: `require_capabilities` +
+    # `on_unsupported: error` would have REJECTED Landlock (genuinely
+    # enforcing) while ACCEPTING Noop (enforcing nothing) — inverted
+    # predictability, the opposite of what strict opt-in is for. This
+    # value now rejects Noop under that same combination, the behavior a
+    # predictability-first reading of the mechanism actually wants.
     supported_capabilities: CapabilityDeclaration = CapabilityDeclaration(
-        ipc_named_service=CapabilitySupport.SUPPORTED,
+        ipc_named_service=CapabilitySupport.NOT_SUPPORTED,
     )
 
     def available(self) -> bool:

--- a/tests/security/test_sandbox_capability_declaration_4935.py
+++ b/tests/security/test_sandbox_capability_declaration_4935.py
@@ -69,7 +69,7 @@ def test_declaration_has_no_default_for_the_field() -> None:
     [
         pytest.param(SeatbeltBackend, CapabilitySupport.SUPPORTED, id="seatbelt"),
         pytest.param(LandlockBackend, CapabilitySupport.NOT_SUPPORTED, id="landlock"),
-        pytest.param(NoopBackend, CapabilitySupport.SUPPORTED, id="noop"),
+        pytest.param(NoopBackend, CapabilitySupport.NOT_SUPPORTED, id="noop"),
         pytest.param(DockerEnvironmentBackend, CapabilitySupport.NOT_SUPPORTED, id="docker"),
     ],
 )
@@ -79,9 +79,23 @@ def test_every_shipped_backend_declares_ipc_named_service(backend_cls, expected)
     shape as #4039's own per-backend enforced_axes checks) — Seatbelt
     SUPPORTED (proven by #4937's own grant working through the real
     backend), Landlock NOT_SUPPORTED (architect's kernel-doc research:
-    restrict-only, no grant operation exists), Noop SUPPORTED (nothing is
-    restricted in the first place), Docker NOT_SUPPORTED (macOS-only
-    concept, no Linux/container equivalent)."""
+    restrict-only, no grant operation exists), Docker NOT_SUPPORTED
+    (macOS-only concept, no Linux/container equivalent).
+
+    Noop NOT_SUPPORTED (corrected, architect + lead-coder post-merge
+    review of #4941 — a real defect this test's own FIRST version pinned
+    the WRONG value for): ``CapabilitySupport`` asks whether a backend can
+    EXPRESS a named-capability class, a mechanism question — Noop has no
+    grant mechanism, full stop, it simply never needed one because it
+    restricts nothing. The original SUPPORTED answered a DIFFERENT
+    question ("is a required capability reachable under this backend",
+    trivially true by construction) that is not what the field means, and
+    it had a disclosed, real operator-visible consequence:
+    ``require_capabilities`` + ``on_unsupported: error`` used to REJECT
+    the genuinely-enforcing Landlock while ACCEPTING the fully-unenforced
+    Noop — inverted predictability. See
+    ``test_error_now_rejects_unenforced_noop_not_enforced_landlock``
+    below for that exact scenario, fixed."""
     assert backend_cls.supported_capabilities.ipc_named_service is expected
 
 
@@ -189,6 +203,21 @@ def test_apply_required_capabilities_ignore_is_silent(caplog) -> None:
     with caplog.at_level(logging.DEBUG, logger="reyn.security.sandbox"):
         _apply_required_capabilities(LandlockBackend(), ["ipc_named_service"], "ignore")
     assert not caplog.records
+
+
+def test_error_now_rejects_unenforced_noop_not_enforced_landlock() -> None:
+    """Tier 1: #4935 — the exact predictability-inversion scenario architect
+    found (post-merge review of #4941), now fixed. Before this correction:
+    ``require_capabilities: [ipc_named_service]`` + ``on_unsupported:
+    error`` REJECTED Landlock (genuinely enforcing every other axis) while
+    ACCEPTING Noop (enforcing nothing) — backwards from what a strict
+    opt-in refusal is supposed to protect against. Both backends now
+    declare NOT_SUPPORTED for the SAME reason (no grant mechanism exists),
+    so ``error`` rejects both uniformly — no capability-declaration axis
+    treats the unenforced backend as the SAFER one to accept."""
+    for backend in (NoopBackend(), LandlockBackend()):
+        with pytest.raises(RuntimeError, match="ipc_named_service"):
+            _apply_required_capabilities(backend, ["ipc_named_service"], "error")
 
 
 # ─── 6. Strip-falsify witness for the empty-default no-op guarantee ───────


### PR DESCRIPTION
**[e2e-coder]** — part of #4935

## What

Architect's post-merge review of #4941: `CapabilitySupport`'s own docstring defines the axis as "whether a backend can EXPRESS one named-capability class" — a mechanism question. Landlock correctly answers that question (`NOT_SUPPORTED` — restrict-only, no grant operation exists at all). NoopBackend answered a DIFFERENT question instead: "is a required capability reachable under this backend" (`SUPPORTED` — trivially true by construction, since nothing is restricted). Two different readings of the same field, landed inconsistently because the #4941 review checked the declaration DISCIPLINE (no default, 2 values only) but never re-asked "does the mechanism exist" for each backend individually — lead-coder's own self-identified review gap.

## Real, disclosed operator-visible consequence

Declaring `sandbox.require_capabilities: [ipc_named_service]` with `on_unsupported: error` **REJECTED Landlock** (genuinely enforcing every other axis) **while ACCEPTING Noop** (enforcing nothing at all) — inverted predictability, the opposite of what a strict opt-in refusal exists to protect against.

## Fix

Noop → `NOT_SUPPORTED`, unifying every backend on the mechanism reading. Architect and lead-coder jointly ruled out fixing the OTHER direction (Landlock → `SUPPORTED`, unifying on the reachability reading instead): that would need real Linux measurement (does Landlock's seccomp-BPF companion treat `AF_UNIX`-class syscalls the same way `_NETWORK_SYSCALLS` does) that nobody on this arc has access to (macOS-only session, same constraint as #4935's own premise measurement). Never resolve an inconsistency toward the direction nobody can verify.

**Desirable side effect** (lead-coder): `require_capabilities` + `on_unsupported: error` now correctly refuses a run that resolved to NO enforcement at all — exactly the predictability the owner's ruling prioritises, previously backwards.

## Docs

- `noop_backend.py`'s own declaration + comment.
- `docs/concepts/runtime/sandbox.md` — both the per-backend rationale paragraph AND the "declaration ≠ guarantee" paragraph, which had ALREADY described Noop as `NOT_SUPPORTED` — an internal inconsistency within that same doc, now resolved by fixing the code to match rather than the doc to match the code.
- `docs/reference/config/reyn-yaml.md` already said "noop/landlock resolve to `NOT_SUPPORTED`" (from #4943) — already correct, no change needed there.

## Tests

Flipped the population test's noop case, added a new test pinning the exact fixed scenario (`error` now rejects BOTH Noop and Landlock uniformly, neither treated as the safer one to accept). Strip-falsified against the real committed file (reverted Noop to `SUPPORTED`, confirmed 2 tests go RED for the right reason, restored, green again). 1090 related tests pass.

## Test plan

- [x] `ruff check src/reyn/security/sandbox/noop_backend.py tests/security/test_sandbox_capability_declaration_4935.py`
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_sandbox_capability_declaration_4935.py` — 15 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/security/sandbox/noop_backend.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py` (docs/ touched)
- [x] `pytest tests/security/ tests/config/ tests/environment/ tests/interfaces/test_4364_c5_sandbox_posture.py` — 1090 passed, 37 skipped
- [x] Strip-falsify against the real committed file (reverted Noop to `SUPPORTED`, confirmed RED for the right reason, restored, GREEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)