### PR TITLE
fix(4947): name the HTTP 413 when max_iterations exhausts on a byte-limit cause

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -2042,6 +2042,21 @@ async def retry_loop(
                 "SP + head_min + summary + tail_min + new_msg exceeds T_max"
             )
 
+    # #4947 ②: name the byte limit when it was the LAST recovered cause —
+    # a compact()-origin 413 is currently exempt from the same-cause cap
+    # above (see the #4885 comment on that skip) and from every shrink
+    # step in this ladder (all token-measured; a byte limit says nothing
+    # about them), so it can ride every iteration to here unchanged. The
+    # generic message below said nothing about WHY nothing converged;
+    # this branch reports the actual last-known cause instead of leaving
+    # an operator to re-derive "413" from event-log archaeology.
+    if _last_recover_is_byte_limit:
+        raise UnrecoveredError(
+            f"retry_loop exceeded max_iterations={max_iterations} without "
+            "convergence — the last recovered cause was an HTTP 413 "
+            "(a request-BODY-BYTE limit), which this ladder's token-only "
+            "shrink steps cannot resolve on their own."
+        )
     raise UnrecoveredError(
         f"retry_loop exceeded max_iterations={max_iterations} without convergence"
     )

--- a/tests/services/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/services/test_pr_n6_compaction_overflow_retry.py
@@ -991,3 +991,55 @@ def test_413_recovery_same_cause_cap_does_not_cut_off_the_binary_search() -> Non
     assert "consecutive times" not in message, (
         f"the same-cause cap fired instead of the binary-search floor: {message!r}"
     )
+
+
+def test_max_iterations_exhaustion_names_413_when_last_cause_was_byte_limit() -> None:
+    """Tier 2: #4947 ② — when retry_loop exhausts max_iterations, the
+    generic "without convergence" message must name the byte limit if the
+    LAST recovered cause was one, instead of leaving an operator to
+    re-derive "413" from the event log. #4947's own repro is a
+    compact()-origin 413 riding the same-cause cap's existing exemption
+    (unconditional on ``_last_recover_is_byte_limit``, unchanged here —
+    whether that exemption's PREDICATE should instead key on binary-search
+    progress is ①, still under architect review) all the way to
+    max_iterations; this test exercises only the message this PR actually
+    changes, via a main_call-origin 413 (the predicate ② reads from is
+    origin-agnostic — same field, same message, either origin), and a
+    ``max_iterations`` small enough that the byte-limit binary-search floor
+    (already covered, named 413, by ``test_413_recovery_does_not_claim_exceeds_t_max``)
+    is never reached.
+
+    Falsification (performed during review): with the new branch removed,
+    this test goes RED — the generic message contains no "413".
+    """
+    cfg = _make_cfg()
+    engine = _OverflowingEngine(fail_compact=False)
+    learner = TokenMultiplierLearner(storage_path=Path(tempfile.mkdtemp()) / "m.json")
+
+    # Large enough that 3 iterations of tail-halving never reaches
+    # tail_min_tokens (1500) or the SP+new_msg floor — this test wants
+    # max_iterations exhaustion, not the binary-search floor raise the
+    # other #4885 tests already cover.
+    head = _turns(["h" * 4000] * 20)
+    tail = _turns(["t" * 4000] * 20)
+    raw_middle: list[dict] = []
+    new_msg = {"role": "user", "content": "q", "seq": 99}
+
+    async def _always_413(**kwargs):
+        raise ContextOverflowError("simulated 413") from _FakeStatusError(
+            "Request Entity Too Large", status_code=413,
+        )
+
+    with pytest.raises(UnrecoveredError) as excinfo:
+        asyncio.run(retry_loop(
+            SP="sp", head=head, summary=None, raw_middle=raw_middle,
+            tail=tail, new_msg=new_msg, cfg=cfg, model="test-model",
+            engine=engine,  # type: ignore[arg-type]
+            learner=learner,
+            main_call=_always_413,
+            max_iterations=3,
+        ))
+
+    message = str(excinfo.value)
+    assert "max_iterations" in message
+    assert "413" in message


### PR DESCRIPTION
**[tui-coder]** — part of #4947 (②) — the max_iterations-exhaustion
message named no cause at all, leaving an operator to re-derive "413"
from event-log archaeology.

## What changed

`retry_loop`'s final `UnrecoveredError` (max_iterations exhausted
without convergence) now names the HTTP 413 byte limit when
`_last_recover_is_byte_limit` was true at the last recovery — the same
field the existing binary-search-floor message already names 413 from.

**Deliberately independent of #4947's other, still-open questions**:
- Whether the same-cause cap's exemption predicate itself should key on
  binary-search progress instead of the raw cause (①) — unchanged here.
- Stage 1's mid→tail direction redesign (③, architect-ruled, separate
  PR to follow) — this fix reads `_last_recover_is_byte_limit`
  regardless of origin (`main_call` or `compact()`), so it holds under
  either design.

## Test plan

- [x] `pytest tests/services/test_pr_n6_compaction_overflow_retry.py` — 35 passed
- [x] Falsification — removed the new branch, new test goes RED (message has no "413"); restored, all green
- [x] `ruff check` (both changed files) — all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/services/test_pr_n6_compaction_overflow_retry.py` — 35 tests, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/services/compaction/engine.py` — OK
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [ ] Visual — n/a (no UI surface)

## Time-dependency check

0 instances — new test uses a small `max_iterations` bound, not a sleep/timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
