### PR TITLE
fix(#4949): restore an overall-decrease witness (architect follow-up)

### DIFF
--- a/tests/services/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/services/test_pr_n6_compaction_overflow_retry.py
@@ -1226,3 +1226,19 @@ def test_413_recovery_succeeds_once_binary_search_lowers_t_max_enough() -> None:
         f"first (the binary search only ever halves the ceiling, never "
         f"raises it); got {overrides!r}"
     )
+    # Architect's follow-up (non-blocking, on the merged version of this
+    # test): non-increasing alone is true even of a CONSTANT sequence —
+    # weakening away "strictly decreasing" also weakened away "the ceiling
+    # was actually lowered at all". Restore that witness at the ENDPOINTS
+    # only (first vs last), which #4885's own contract (still-413 -> halve)
+    # guarantees over a run this long, while still permitting the
+    # documented mid-search repeats the assertion above already allows. A
+    # single-element ``later_overrides`` compares its one value to ITSELF
+    # here (``x < x`` is always False) and correctly fails this assertion
+    # too — no separate length precondition needed.
+    assert later_overrides[-1] < later_overrides[0], (
+        f"the ceiling must have been strictly lower by the LAST recovery "
+        f"than the FIRST overridden one — real, overall search progress, "
+        f"not merely non-increasing (which a constant sequence would also "
+        f"satisfy); got {overrides!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — Non-blocking follow-up to #4953 (merged), per architect's next comment on that PR.

part of #4944

## What
Weakening the `t_max_override` sequence check from strictly-decreasing to non-increasing (#4953) also weakened away "the ceiling was actually lowered at all" — a constant sequence satisfies non-increasing too.

## Fix
One endpoint check: `later_overrides[-1] < later_overrides[0]`. Restores the "the binary search made real progress overall" witness (guaranteed by #4885's own still-413-recovers-by-halving contract over a run this long) while still permitting the documented mid-search repeats the non-increasing assertion already allows.

A single-element `later_overrides` compares its one value to itself here (`x < x` is always `False`) and correctly fails too — no separate length precondition needed (dropped an explicit `len(...) >= 2` after `test_tier_audit.py --strict` flagged it as format-pinning-shaped).

## Testing
36/36 green. All local gates green (ruff, tier_audit --strict, mypy_ratchet, flat_tests_ratchet, check_tests_path_literal_reference, check_bare_tests_import_reference, check_file_depth_reference).

Not self-merging — holding for TESTS-READ.