### PR TITLE
feat(4957): chat.compaction.max_shrink_iterations config knob

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -2145,6 +2145,7 @@ chat:
     body_token_cap: 1500               # hard cap on summary body tokens (post-truncation)
     resummarize_passes: 1              # LLM re-compression passes before hard_truncate floor
     max_schema_reprompt_attempts: 1    # bounded re-prompt budget on invalid compaction JSON
+    max_shrink_iterations: 8           # retry_loop's overflow-recovery safety cap (escape valve, not a cure)
     # Section budget weights within body, normalised at runtime.
     section_weights:
       topic_arc:            5
@@ -2170,6 +2171,7 @@ chat:
 | `body_token_cap` | int | `1500` | Hard cap on summary body tokens after post-truncation. |
 | `resummarize_passes` | int | `1` | Max LLM re-compression passes when a produced `topic_arc` overshoots its body budget, before the deterministic `hard_truncate` floor. `0` = skip re-summary (straight to the floor). |
 | `max_schema_reprompt_attempts` | int | `1` | #4883: bounded re-prompt budget when the compaction LLM's JSON response has an empty/missing `topic_arc` (whose emptiness can't be told apart from a dead response). Exhausting the budget raises rather than silently accepting an empty summary. `0` = raise on the first invalid response, no re-prompt. `new_turn_seqs` no longer gates this (#4951-A) — `covers_through_seq` is derived from `compact()`'s own input, not read from the LLM's echo of it. |
+| `max_shrink_iterations` | int | `8` | #4957: `retry_loop`'s own safety cap on overflow-recovery iterations. **This is an escape valve, not a cure** — raising it only delays exhaustion if the underlying cause (a persistent HTTP 413, a 5xx, a rate limit) never resolves on its own; it does not fix that cause. Must be `>= 1` (`0` would never run the shrink loop at all, raising immediately on the first overflow). Distinct from `RouterLoop`'s own unrelated `max_iterations` (the tool-call loop bound) — do not confuse the two. |
 | `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out for large deployments). |
 
 ### `chat.compaction.section_token_caps` fields

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -432,6 +432,12 @@
 #     max_schema_reprompt_attempts: 1  # #4883: bounded re-prompt budget when the
 #                                      # compaction JSON response is missing/empty
 #                                      # new_turn_seqs/topic_arc (0 = raise immediately)
+#     max_shrink_iterations: 8         # #4957: retry_loop's own safety cap — an
+#                                      # ESCAPE VALVE for a slow-to-converge overflow
+#                                      # recovery, not a cure. Raising it only delays
+#                                      # exhaustion if the underlying cause (a
+#                                      # persistent 413/5xx/rate-limit) never
+#                                      # resolves; it does not fix that cause.
 #     section_token_caps:
 #       topic_arc: 200
 #       decisions: 400

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -800,7 +800,30 @@ class CompactionConfig:
     # a silently-accepted empty summary) — operator-tunable via this field
     # if a specific deployment's models warrant a different budget.
     max_schema_reprompt_attempts: int = 1
+    # #4957 (owner: "max iterations は config ノブにしておいた方が良いね") —
+    # retry_loop's own `max_iterations` safety cap, previously a signature
+    # default only (8) with no operator-facing knob: router_loop_driver.py
+    # never passed it, so production always ran at 8 with no way to raise
+    # it. Owner's own real machine hits an HTTP 413 EVERY turn (#4954);
+    # #4947 ③'s mid-split floor means a persistent 413 now fails fast
+    # rather than cycling, but a persistent NON-byte-limit failure (a
+    # flaky provider, a rate limit) can still exhaust this cap before the
+    # conversation would have otherwise converged. This is an ESCAPE
+    # VALVE, not a cure: raising it just delays exhaustion if the
+    # underlying cause never resolves (#4954's own persistent-compaction
+    # fix, once landed, reduces how many shrink steps are needed per turn
+    # in the first place — this knob does not substitute for that).
+    max_shrink_iterations: int = 8
     section_token_caps: CompactionSectionCaps = field(default_factory=CompactionSectionCaps)
+
+    def __post_init__(self) -> None:
+        if self.max_shrink_iterations < 1:
+            raise ValueError(
+                "chat.compaction.max_shrink_iterations must be >= 1 (0 would "
+                "never run the shrink loop at all, immediately raising on "
+                "the first overflow); got "
+                f"{self.max_shrink_iterations!r}"
+            )
 
 
 @dataclass
@@ -1106,6 +1129,9 @@ def _build_chat_config(raw: object) -> ChatConfig:
             compaction_raw.get(
                 "max_schema_reprompt_attempts", defaults.max_schema_reprompt_attempts
             )
+        ),
+        max_shrink_iterations=int(
+            compaction_raw.get("max_shrink_iterations", defaults.max_shrink_iterations)
         ),
         section_token_caps=section,
     )

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -316,6 +316,14 @@ class RouterLoopDriver:
                 engine=engine,
                 learner=self._token_learner,
                 main_call=_router_main_call,
+                max_iterations=self._compaction.max_shrink_iterations,
+                # #4957: operator-tunable escape valve (chat.compaction.
+                # max_shrink_iterations) — was previously always the
+                # signature default (8) here, with no way to raise it.
+                # Distinct from this class's own `_router_max_iterations`
+                # (RouterLoop's tool-call loop bound, unrelated) —
+                # `self._compaction` is retry_loop's OWN config, not
+                # this driver's.
             )
             return _shim.usage
 

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -2359,15 +2359,25 @@ async def retry_loop(
     # generic message below said nothing about WHY nothing converged;
     # this branch reports the actual last-known cause instead of leaving
     # an operator to re-derive "413" from event-log archaeology.
+    # #4957: name the config key an operator can actually change here — not
+    # just the bare number this call happened to be given. This is an
+    # ESCAPE VALVE message, not a diagnosis: raising the cap only delays
+    # exhaustion if the underlying cause never resolves (a persistent
+    # 413/5xx/rate-limit keeps failing regardless of how many attempts are
+    # allowed) — it does not mean the cap itself was the wrong size.
     if _last_recover_is_byte_limit:
         raise UnrecoveredError(
-            f"retry_loop exceeded max_iterations={max_iterations} without "
-            "convergence — the last recovered cause was an HTTP 413 "
-            "(a request-BODY-BYTE limit), which this ladder's token-only "
-            "shrink steps cannot resolve on their own."
+            f"retry_loop exceeded max_iterations={max_iterations} "
+            "(chat.compaction.max_shrink_iterations) without convergence — "
+            "the last recovered cause was an HTTP 413 (a request-BODY-BYTE "
+            "limit), which this ladder's token-only shrink steps cannot "
+            "resolve on their own. Raising this config value is an escape "
+            "valve, not a cure: if the same 413 recurs every turn, it will "
+            "only delay exhaustion, not prevent it."
         )
     raise UnrecoveredError(
-        f"retry_loop exceeded max_iterations={max_iterations} without convergence"
+        f"retry_loop exceeded max_iterations={max_iterations} "
+        "(chat.compaction.max_shrink_iterations) without convergence"
     )
 
 

--- a/tests/core/test_4957_max_shrink_iterations_config.py
+++ b/tests/core/test_4957_max_shrink_iterations_config.py
@@ -1,0 +1,70 @@
+"""Tier 1: `chat.compaction.max_shrink_iterations` config parsing (#4957,
+owner: "max iterations は config ノブにしておいた方が良いね").
+
+Before this, `retry_loop`'s `max_iterations` safety cap was a signature
+default only (8) — `router_loop_driver.py` never passed it, so production
+always ran at 8 with no operator-facing knob at all. Owner's own real
+machine hits an HTTP 413 every turn (#4954); this is an ESCAPE VALVE for
+that (see `CompactionConfig.max_shrink_iterations`'s own docstring), not a
+cure — the field itself does not change #4947's shrink mechanics.
+
+Named `max_shrink_iterations`, not `max_iterations` — `RouterLoop` has its
+own unrelated `max_iterations` (the tool-call loop bound,
+`router_loop_driver.py`'s `_router_max_iterations`); the same spelling
+already caused one same-name-different-meaning confusion this session
+(#4942). The wiring itself (config value reaching retry_loop's actual
+bound) is proven in
+tests/runtime/test_retry_loop_chat_wiring_1125.py::test_max_shrink_iterations_config_value_bounds_the_real_driver_call
+— this file covers only the config-parsing layer.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config.chat import CompactionConfig, _build_chat_config
+
+
+def test_max_shrink_iterations_defaults_to_8() -> None:
+    """Tier 1: default is 8 — the retry_loop signature default this knob
+    exposes, unchanged behavior for every deployment that never sets it."""
+    assert CompactionConfig().max_shrink_iterations == 8
+
+
+def test_chat_compaction_max_shrink_iterations_parses() -> None:
+    """Tier 1: `chat.compaction.max_shrink_iterations: N` in reyn.yaml
+    sets the field — the required "config で変更できる" condition."""
+    cfg = _build_chat_config({"compaction": {"max_shrink_iterations": 20}})
+    assert cfg.compaction.max_shrink_iterations == 20
+
+
+def test_chat_compaction_max_shrink_iterations_absent_stays_default() -> None:
+    """Tier 1: falsification pair — omitting the key keeps the default
+    (this field does not accidentally pick up an unrelated value)."""
+    cfg = _build_chat_config({"compaction": {"body_token_cap": 5000}})
+    assert cfg.compaction.max_shrink_iterations == 8
+
+
+def test_chat_compaction_max_shrink_iterations_absent_compaction_block_stays_default() -> None:
+    """Tier 1: the field parses correctly (falls back to its default) even
+    when the whole `chat.compaction:` block is absent, not just when it is
+    present but missing this one key."""
+    cfg = _build_chat_config({"render_mode": "plain"})
+    assert cfg.compaction.max_shrink_iterations == 8
+
+
+def test_max_shrink_iterations_below_1_raises_at_construction() -> None:
+    """Tier 1: `__post_init__` rejects < 1 — 0 would never run the shrink
+    loop at all (retry_loop's own `for _iteration in range(max_iterations)`
+    body never executes), so the first overflow would raise immediately
+    with zero chance to shrink, defeating the entire mechanism silently
+    rather than failing fast at config-load time."""
+    with pytest.raises(ValueError, match="max_shrink_iterations must be >= 1"):
+        CompactionConfig(max_shrink_iterations=0)
+    with pytest.raises(ValueError, match="max_shrink_iterations must be >= 1"):
+        CompactionConfig(max_shrink_iterations=-1)
+
+
+def test_max_shrink_iterations_of_1_is_the_valid_floor() -> None:
+    """Tier 1: falsification pair for the floor check itself — 1 (the
+    boundary) must NOT raise, only values below it."""
+    assert CompactionConfig(max_shrink_iterations=1).max_shrink_iterations == 1

--- a/tests/runtime/test_retry_loop_chat_wiring_1125.py
+++ b/tests/runtime/test_retry_loop_chat_wiring_1125.py
@@ -310,3 +310,64 @@ def test_router_usage_shim_exposes_usage(tmp_path) -> None:
     shim = _RouterUsageShim(usage)
     assert shim.usage is usage
     assert shim.usage.prompt_tokens == 42
+
+
+# ── #4957: chat.compaction.max_shrink_iterations reaches retry_loop's OWN bound ──
+
+
+def test_max_shrink_iterations_config_value_bounds_the_real_driver_call(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 1: RouterLoopDriver._run_with_shrink passes
+    ``self._compaction.max_shrink_iterations`` — NOT the retry_loop
+    signature default (8) — as retry_loop's ``max_iterations``. Uses a
+    non-default value (3) per the issue's own explicit requirement: the
+    same value as the signature default would prove nothing (the wiring
+    could be entirely absent and this would still pass).
+
+    Drives the REAL ``RouterLoopDriver._run_with_shrink`` (the literal
+    production call site #4957 changed), not a re-implementation of it —
+    only ``loop.run`` is a scripted async fn (a ``_run_with_shrink``
+    parameter, the same shape ``main_call`` is a ``retry_loop`` parameter
+    in the sibling tests above), since a real ``RouterLoop`` LLM call
+    cannot run offline.
+    """
+    from reyn.services.compaction.engine import UnrecoveredError
+
+    class _FakeStatusError(Exception):
+        def __init__(self, message: str, *, status_code: int) -> None:
+            super().__init__(message)
+            self.status_code = status_code
+
+    cfg = CompactionConfig(
+        body_token_cap=1500,
+        use_chars4_estimate=True,
+        section_caps_spec_tokens=0,
+        max_shrink_iterations=3,  # non-default — see docstring
+    )
+    state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    bt = BudgetTracker(CostConfig())
+    session = make_session(
+        agent_name="default",
+        agent_role="",
+        output_language="en",
+        budget_tracker=bt,
+        state_log=state_log,
+        compaction_config=cfg,
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
+    _push(session, "user", "hi")
+
+    class _AlwaysOverflowLoop:
+        async def run(self, *, user_text: str, history: list) -> None:
+            raise _FakeStatusError("request too large", status_code=413)
+
+    with pytest.raises(UnrecoveredError) as excinfo:
+        asyncio.run(
+            session._loop_driver._run_with_shrink(_AlwaysOverflowLoop(), "hi again")
+        )
+
+    # Names the ACTUAL config value (3), proving it reached retry_loop —
+    # the signature default (8) appearing here instead would mean the
+    # wiring silently regressed back to always-8.
+    assert "max_iterations=3" in str(excinfo.value)


### PR DESCRIPTION
**[tui-coder]** — part of #4957 — owner ruling (direct, relayed by
architect): "max iterations は config ノブにしておいた方が良いね". A
mitigation companion to #4954 (persistent-compaction fix) — see the
"escape valve, not a cure" framing below.

## Why

`retry_loop`'s own `max_iterations` safety cap was a signature default
only (8) — `router_loop_driver.py` never passed it, so production
always ran at 8 with no operator-facing knob at all. Owner's own real
machine hits an HTTP 413 every turn (#4954); #4947 ③'s mid-split floor
means a persistent 413 now fails fast rather than cycling, but a
persistent NON-byte-limit failure (a flaky provider, a rate limit) can
still exhaust this cap before the conversation would otherwise have
converged.

## What changed

- `CompactionConfig.max_shrink_iterations: int = 8` (behavior-unchanged
  default), `__post_init__` validates `>= 1` (`0` would never run the
  shrink loop at all, raising immediately on the first overflow rather
  than failing fast at config-load time).
- `_build_chat_config` wires `chat.compaction.max_shrink_iterations`
  through — same pattern as the sibling `max_schema_reprompt_attempts`.
- `router_loop_driver.py`'s `_run_with_shrink` now passes
  `max_iterations=self._compaction.max_shrink_iterations` to
  `retry_loop` — the one line that was previously always defaulting to
  8.
- Both `max_iterations`-exhaustion messages in `engine.py` now name the
  config key (`chat.compaction.max_shrink_iterations`), not just the
  bare number, and state explicitly that raising it is an **escape
  valve, not a cure**: it only delays exhaustion if the underlying
  cause never resolves — #4954's own persistent-compaction fix, once
  landed, reduces how many shrink steps are needed per turn in the
  first place; this knob does not substitute for that.

**Deliberately named `max_shrink_iterations`, not `max_iterations`** —
`RouterLoop` has its own unrelated `max_iterations` (the tool-call loop
bound, `router_loop_driver.py`'s `_router_max_iterations`); the same
spelling already caused one same-name-different-meaning confusion this
session (#4942).

## Tests

Per the issue's own explicit requirement — the signature default value
(8) would prove nothing, since the wiring could be entirely absent and
it would still pass:

- `tests/core/test_4957_max_shrink_iterations_config.py`: config-parsing
  layer (default, parses, absent-key/absent-block fallback,
  `__post_init__` floor validation) — mirrors
  `test_4677_empty_stop_retry_config.py`'s own established shape.
- `tests/runtime/test_retry_loop_chat_wiring_1125.py`: a new Tier-1 test
  drives the **real** `RouterLoopDriver._run_with_shrink` (the literal
  production call site this PR changed) with a **non-default value (3,
  not 8)** and an always-413 scripted `loop.run`, asserting the
  resulting `UnrecoveredError` names `max_iterations=3` — proving the
  config value reached `retry_loop`'s actual bound, not just that
  `retry_loop` respects its own parameter (already covered elsewhere).

## Test plan

- [x] `pytest tests/services/test_pr_n6_compaction_overflow_retry.py tests/services/test_wire_byte_estimate_4944.py tests/core/test_3783_stage3_invert_default_to_recover.py tests/core/test_4883_compaction_schema_validation.py tests/core/test_4951_local_covers_derivation.py tests/core/test_4957_max_shrink_iterations_config.py tests/runtime/test_retry_loop_chat_wiring_1125.py tests/config/test_config_mirror_coverage_1056.py` — 87 passed
- [x] Falsification — removed the `max_iterations=` kwarg from the driver's `_retry_loop` call, the wiring test goes RED (loop runs to the signature default of 8, hitting the T_max binary-search floor instead of the `max_iterations=3` message); restored, green.
- [x] `ruff check` (all changed files) — all checks passed
- [x] `python scripts/test_tier_audit.py --strict` (both new/changed test files) — 14 tests, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py` (all 3 changed src files) — OK
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py` — all clean
- [x] `test_config_mirror_coverage_1056.py` — passed on first run (both `reyn.local.yaml.example` and `docs/reference/config/reyn-yaml.md` kept in sync while implementing, not caught red after the fact)
- [x] Checked `docs/reference/config/reyn-yaml.ja.md` for a falsified "exhaustive field list" claim before deciding not to touch it — no such claim found (no blanket mirror obligation, CLAUDE.md rule 5; same precedent as #4840/#4899's own PRs this session)
- [ ] Visual — n/a (no UI surface)

## Time-dependency check

0 instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
