### PR TITLE
feat(4954): a byte-limit exhaustion triggers a real compaction (b)

### DIFF
--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -245,11 +245,17 @@ class RouterLoopDriver:
             ContextOverflowError as _ContextOverflowError,
         )
         from reyn.services.compaction.engine import (
+            UnrecoveredError as _UnrecoveredError,
+        )
+        from reyn.services.compaction.engine import (
             is_context_overflow_error as _is_context_overflow_error,
         )
-        # `UnrecoveredError` is not imported here — it is no longer caught
-        # in this function (#4885: propagates unwrapped, see the comment
-        # below); `run_turn`'s own scope imports it for its widened except.
+        # #4954 (b): `UnrecoveredError` IS caught here now, but only to
+        # read `.saw_byte_limit` and trigger a real compaction as a side
+        # effect (see the except block below) — it is always re-raised
+        # unchanged, so it still propagates unwrapped to `run_turn`'s own
+        # widened except exactly as #4885 established. This is not a
+        # reversion of that fix.
 
         history = self._history_buffer.build_history()
         try:
@@ -304,27 +310,68 @@ class RouterLoopDriver:
             # widened to catch both (same audit event, same `repr(exc)`
             # field — which now correctly names `UnrecoveredError` instead
             # of always `ContextOverflowError`, no new event kind needed).
-            _shim = await _retry_loop(
-                SP=self._history_buffer.build_system_prompt(),
-                head=_head,
-                summary=_summary_dict,
-                raw_middle=_raw_middle,
-                tail=_tail,
-                new_msg=_new_msg,
-                cfg=self._compaction,
-                model=self._effective_router_model_class(),
-                engine=engine,
-                learner=self._token_learner,
-                main_call=_router_main_call,
-                max_iterations=self._compaction.max_shrink_iterations,
-                # #4957: operator-tunable escape valve (chat.compaction.
-                # max_shrink_iterations) — was previously always the
-                # signature default (8) here, with no way to raise it.
-                # Distinct from this class's own `_router_max_iterations`
-                # (RouterLoop's tool-call loop bound, unrelated) —
-                # `self._compaction` is retry_loop's OWN config, not
-                # this driver's.
-            )
+            try:
+                _shim = await _retry_loop(
+                    SP=self._history_buffer.build_system_prompt(),
+                    head=_head,
+                    summary=_summary_dict,
+                    raw_middle=_raw_middle,
+                    tail=_tail,
+                    new_msg=_new_msg,
+                    cfg=self._compaction,
+                    model=self._effective_router_model_class(),
+                    engine=engine,
+                    learner=self._token_learner,
+                    main_call=_router_main_call,
+                    max_iterations=self._compaction.max_shrink_iterations,
+                    # #4957: operator-tunable escape valve (chat.compaction.
+                    # max_shrink_iterations) — was previously always the
+                    # signature default (8) here, with no way to raise it.
+                    # Distinct from this class's own `_router_max_iterations`
+                    # (RouterLoop's tool-call loop bound, unrelated) —
+                    # `self._compaction` is retry_loop's OWN config, not
+                    # this driver's.
+                )
+            except _UnrecoveredError as _unrecovered:
+                # #4954 (b), architect-ruled: on a BYTE-limit exhaustion
+                # (an HTTP 413 that recurred all the way to retry_loop's
+                # own terminal condition), trigger a REAL compaction here
+                # — in the driver's except block, not inside retry_loop
+                # itself (retry_loop stays a pure TRANSPORT operation;
+                # compaction is the SEMANTIC operation that actually
+                # retires history entries, Session's own docstring:
+                # "the only operation meant to retire an entry"). Routed
+                # through `force_compact_now` — the SAME durable-watermark
+                # path `ContextBudgetAdvisor`'s pre-frame guard already
+                # uses (`_durable_active_history_after`-backed,
+                # continuous from the last real `covers_through_seq`) —
+                # deliberately NOT `retry_loop`'s own compaction result:
+                # its `covers` can cover only `raw_middle` while skipping
+                # `head` entirely, which is not continuous from the
+                # previous watermark and would silently mark the OLDEST
+                # unsummarized part of history "covered" without ever
+                # summarizing it (exactly owner's own real-machine shape).
+                #
+                # This turn still fails — re-raised below unchanged. What
+                # this buys is the NEXT turn: a real compaction now
+                # advances the watermark, so a persistent 413 becomes "one
+                # turn fails, not every turn" once paired with #4958 (the
+                # projection that reads the advanced watermark back). No
+                # new infinite-loop guard needed — force_compact_now
+                # already returns immediately on `self._compacting` (a
+                # concurrent pass) or zero candidates (nothing left to
+                # compact = terminal), and this except fires at most once
+                # per turn.
+                #
+                # #4885's own token-overflow pre-trigger already covers
+                # non-byte-limit overflow before it would ever reach here
+                # — a token overflow that STILL reaches this point means
+                # the pre-trigger's own estimate was wrong, which the
+                # existing adaptive learner (not a second compaction
+                # trigger here) is the correct fix for.
+                if _unrecovered.saw_byte_limit:
+                    await self._compaction_controller.force_compact_now()
+                raise
             return _shim.usage
 
     # ── Main turn entry point ─────────────────────────────────────────────────

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -883,10 +883,44 @@ class UnrecoveredError(Exception):
     ----------
     reason:
         Human-readable description of the terminal condition.
+    saw_byte_limit:
+        #4954 (b), architect finding: whether an HTTP 413 (a
+        request-BODY-BYTE limit) was observed during this call's shrink
+        attempts — a real structured field, not something a caller
+        should re-derive by string-matching ``reason`` (message wording
+        is not a stable API; #4948/#4957 named the byte limit in prose
+        for a HUMAN operator, not for a caller to parse).
+
+        Deliberately named ``saw_byte_limit``, not ``is_byte_limit`` (or
+        anything implying "this raise's own root cause"): at some raise
+        sites (the same-cause cap, the generic "all shrink paths
+        exhausted", max_iterations exhaustion) the branch taken does
+        NOT itself determine the cause — the value here is the LAST
+        recovered cause observed before this raise, which is correct
+        for those sites but is a genuinely different claim from "this
+        specific raise IS a byte-limit raise" (true only at the 3 sites
+        where the branch itself is byte-limit-gated: the mid-split
+        floor's byte-limit arm, the T_max binary-search floor, and the
+        max_iterations byte-limit branch). A name like ``is_byte_limit``
+        invites a future reader to assume the stronger claim at every
+        site — the exact "same spelling, different meaning" trap this
+        session hit repeatedly elsewhere tonight.
+
+        "Last observed", not "sticky" (was a byte limit EVER seen this
+        call, even if a later non-byte cause is what actually
+        terminated it) — architect ruling: sufficient for the one
+        measured symptom (owner's real machine always terminates ON the
+        413, never past it to a different cause), and a "seen at all"
+        version would require deliberately widening scope with no
+        measured need for it yet. A caller that needs to react to a
+        byte-limit exhaustion (#4954 (b): triggering a real compaction
+        so the NEXT turn doesn't repeat the same overflow) reads this
+        attribute.
     """
 
-    def __init__(self, reason: str) -> None:
+    def __init__(self, reason: str, *, saw_byte_limit: bool = False) -> None:
         self.reason = reason
+        self.saw_byte_limit = saw_byte_limit
         super().__init__(reason)
 
 
@@ -2192,6 +2226,12 @@ async def retry_loop(
                 _consecutive_same_cause > _MAX_CONSECUTIVE_SAME_CAUSE_RECOVERS
                 and not _last_recover_is_byte_limit
             ):
+                # #4954 (b): ``saw_byte_limit`` defaults to False here, and
+                # this site is REACHABLE — its own guard clause
+                # (``and not _last_recover_is_byte_limit``) is what makes
+                # False the only value this raise can ever carry, not an
+                # unreachable branch where the default happens not to
+                # matter.
                 raise UnrecoveredError(
                     f"retry_loop: cause {_cause!r} recovered "
                     f"{_consecutive_same_cause} consecutive times (limit "
@@ -2257,7 +2297,8 @@ async def retry_loop(
                         "recurred compacting a single raw_middle turn "
                         "alone — mid cannot be split any further; this is "
                         "not a token-shrink problem, shrinking it further "
-                        "is not possible."
+                        "is not possible.",
+                        saw_byte_limit=True,
                     )
                 # Defer: move ONLY the one turn that was just attempted
                 # (not the rest of raw_middle, which may still hold more
@@ -2313,7 +2354,8 @@ async def retry_loop(
                     "BYTE limit, not a token-count one — shrinking the "
                     "token-count representation further cannot resolve it "
                     "(most likely: the newest message alone exceeds the "
-                    "upstream byte limit)."
+                    "upstream byte limit).",
+                    saw_byte_limit=True,
                 )
             _t_max_override = _candidate
             bg = compute_budgets(
@@ -2346,6 +2388,12 @@ async def retry_loop(
             # 413 (same content, same call) halves the ceiling again on its
             # own next pass through this branch, continuing the search.
         else:
+            # #4954 (b): ``saw_byte_limit`` defaults to False here, and
+            # this ``else`` is REACHABLE — the ``elif _last_recover_is_
+            # byte_limit:`` branch above it already claims the True case,
+            # so False is the only value execution can reach this point
+            # carrying, not an unreachable branch where the default
+            # happens not to matter.
             raise UnrecoveredError(
                 "retry_loop: all shrink paths exhausted — "
                 "SP + head_min + summary + tail_min + new_msg exceeds T_max"
@@ -2373,7 +2421,8 @@ async def retry_loop(
             "limit), which this ladder's token-only shrink steps cannot "
             "resolve on their own. Raising this config value is an escape "
             "valve, not a cure: if the same 413 recurs every turn, it will "
-            "only delay exhaustion, not prevent it."
+            "only delay exhaustion, not prevent it.",
+            saw_byte_limit=True,
         )
     raise UnrecoveredError(
         f"retry_loop exceeded max_iterations={max_iterations} "

--- a/tests/runtime/test_retry_loop_chat_wiring_1125.py
+++ b/tests/runtime/test_retry_loop_chat_wiring_1125.py
@@ -371,3 +371,119 @@ def test_max_shrink_iterations_config_value_bounds_the_real_driver_call(
     # the signature default (8) appearing here instead would mean the
     # wiring silently regressed back to always-8.
     assert "max_iterations=3" in str(excinfo.value)
+
+
+# ── #4954 (b): a byte-limit exhaustion triggers a real compaction ────────────
+
+
+def test_byte_limit_exhaustion_triggers_a_real_compaction(tmp_path, monkeypatch) -> None:
+    """Tier 1: architect-ruled (b) — when `_run_with_shrink` exhausts with
+    `UnrecoveredError(saw_byte_limit=True)`, the driver's except block
+    triggers `CompactionController.force_compact_now()` (the SAME
+    durable-watermark path the pre-frame guard already uses — not
+    retry_loop's own non-continuous `covers`). This turn still fails
+    (`UnrecoveredError` still propagates) — the trigger only helps the
+    NEXT turn.
+
+    Real effect observed, not a mock call-count: `force_compact_now`
+    emits a real `compaction_check` audit-event on the controller's own
+    EventLog — subscribed to directly, the same public observable an
+    operator's own event tooling would see.
+    """
+    from reyn.services.compaction.engine import UnrecoveredError
+
+    class _FakeStatusError(Exception):
+        def __init__(self, message: str, *, status_code: int) -> None:
+            super().__init__(message)
+            self.status_code = status_code
+
+    cfg = CompactionConfig(
+        body_token_cap=1500,
+        use_chars4_estimate=True,
+        section_caps_spec_tokens=0,
+        max_shrink_iterations=3,
+    )
+    state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    bt = BudgetTracker(CostConfig())
+    session = make_session(
+        agent_name="default",
+        agent_role="",
+        output_language="en",
+        budget_tracker=bt,
+        state_log=state_log,
+        compaction_config=cfg,
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
+    _push(session, "user", "hi")
+
+    events: list = []
+    session._compaction_controller._events.add_subscriber(lambda e: events.append(e))
+
+    class _AlwaysOverflowLoop:
+        async def run(self, *, user_text: str, history: list) -> None:
+            raise _FakeStatusError("request too large", status_code=413)
+
+    with pytest.raises(UnrecoveredError) as excinfo:
+        asyncio.run(
+            session._loop_driver._run_with_shrink(_AlwaysOverflowLoop(), "hi again")
+        )
+
+    assert excinfo.value.saw_byte_limit is True
+    checks = [e for e in events if e.type == "compaction_check"]
+    assert checks, (
+        "expected force_compact_now to emit compaction_check on a "
+        "byte-limit exhaustion — none observed"
+    )
+
+
+def test_non_byte_limit_exhaustion_does_not_trigger_compaction(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 1: falsification pair — a NON-byte-limit exhaustion
+    (`saw_byte_limit=False`) must NOT trigger `force_compact_now`.
+    #4885's own token-overflow pre-trigger already handles that axis; a
+    non-byte-limit failure reaching here means the pre-trigger's estimate
+    was wrong, which the adaptive learner fixes, not a second compaction
+    trigger here (architect ruling ④)."""
+    from reyn.services.compaction.engine import UnrecoveredError
+
+    cfg = CompactionConfig(
+        body_token_cap=1500,
+        use_chars4_estimate=True,
+        section_caps_spec_tokens=0,
+        max_shrink_iterations=3,
+    )
+    state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    bt = BudgetTracker(CostConfig())
+    session = make_session(
+        agent_name="default",
+        agent_role="",
+        output_language="en",
+        budget_tracker=bt,
+        state_log=state_log,
+        compaction_config=cfg,
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
+    _push(session, "user", "hi")
+
+    events: list = []
+    session._compaction_controller._events.add_subscriber(lambda e: events.append(e))
+
+    class _AlwaysNonByteOverflowLoop:
+        async def run(self, *, user_text: str, history: list) -> None:
+            # No status_code — a plain context-length overflow, not a 413.
+            raise RuntimeError("context_length_exceeded: too many tokens")
+
+    with pytest.raises(UnrecoveredError) as excinfo:
+        asyncio.run(
+            session._loop_driver._run_with_shrink(
+                _AlwaysNonByteOverflowLoop(), "hi again",
+            )
+        )
+
+    assert excinfo.value.saw_byte_limit is False
+    checks = [e for e in events if e.type == "compaction_check"]
+    assert not checks, (
+        f"force_compact_now must not fire on a non-byte-limit exhaustion; "
+        f"observed: {[e.data for e in checks]!r}"
+    )

--- a/tests/services/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/services/test_pr_n6_compaction_overflow_retry.py
@@ -534,7 +534,7 @@ def test_retry_loop_raises_unrecovered_when_all_at_min() -> None:
     async def _always_overflow(**kwargs):
         raise ContextOverflowError("always overflow")
 
-    with pytest.raises(UnrecoveredError):
+    with pytest.raises(UnrecoveredError) as excinfo:
         asyncio.run(retry_loop(
             SP="sp",
             head=head,
@@ -549,6 +549,10 @@ def test_retry_loop_raises_unrecovered_when_all_at_min() -> None:
             main_call=_always_overflow,
             max_iterations=8,
         ))
+    # #4954 (b): a plain overflow (no status_code) — the "all shrink paths
+    # exhausted" raise site's saw_byte_limit is reachable-and-False here,
+    # not merely unreached.
+    assert excinfo.value.saw_byte_limit is False
 
 
 def test_retry_loop_max_iterations_raises_unrecovered() -> None:
@@ -761,6 +765,10 @@ def test_retry_loop_same_cause_cap_raises_before_shrink_paths_exhausted() -> Non
         ))
 
     assert "consecutive times" in str(excinfo.value)
+    # #4954 (b): the cap's own guard (`and not _last_recover_is_byte_limit`)
+    # is what makes this raise reachable at all — saw_byte_limit is False
+    # here by construction, not by an unreached default.
+    assert excinfo.value.saw_byte_limit is False
     recovered = [e for e in events if e.type == "compaction_shrink_recovered"]
     # Cap is > 2, so exactly 3 consecutive same-cause recovers happen before
     # the 3rd one raises — the loop must not have run all 8 iterations.
@@ -931,6 +939,10 @@ def test_413_recovery_does_not_claim_exceeds_t_max() -> None:
     message = str(excinfo.value)
     assert "413" in message
     assert "exceeds T_max" not in message
+    # #4954 (b): the T_max binary-search floor is one of the 3 sites whose
+    # OWN branch is byte-limit-gated (`elif _last_recover_is_byte_limit:`)
+    # — saw_byte_limit must be True here, not merely mentioned in prose.
+    assert excinfo.value.saw_byte_limit is True
 
 
 def test_413_recovery_emits_t_max_override_in_the_audit_event() -> None:
@@ -1068,6 +1080,12 @@ def test_max_iterations_exhaustion_names_413_when_last_cause_was_byte_limit() ->
     message = str(excinfo.value)
     assert "max_iterations" in message
     assert "413" in message
+    # #4954 (b): "last observed cause" semantics — this raise site's own
+    # branch does NOT determine the cause (it fires after the loop's
+    # `for` completes regardless of what the last iteration's cause was),
+    # so saw_byte_limit here reflects `_last_recover_is_byte_limit` at
+    # loop-exit time, which this fixture's always-413 main_call makes True.
+    assert excinfo.value.saw_byte_limit is True
 
 
 def _make_payload_threshold_main_call(
@@ -1363,6 +1381,10 @@ def test_4947_stage1_mid_split_terminates_instead_of_reproducing_old_state() -> 
     assert "mid cannot be split any further" in message
     assert "consecutive times" not in message
     assert "max_iterations" not in message
+    # #4954 (b): the mid-split floor's byte-limit arm is one of the 3
+    # sites whose OWN branch is byte-limit-gated — saw_byte_limit must be
+    # True here.
+    assert excinfo.value.saw_byte_limit is True
 
     recovered = [e for e in events if e.type == "compaction_shrink_recovered"]
     # The OLD cycle recovered on EVERY one of the 20 iterations (compact


### PR DESCRIPTION
**[tui-coder]** — part of #4954's arc — the last remaining piece, per
lead-coder: "(b) 413 を `CompactionController` の compaction の起動信号
に". Landing order respected (#4958's projection landed first, so this
piece's watermark advance is now actually consumed).

## Why

`retry_loop`'s own `UnrecoveredError` exhaustion previously just failed
the turn with no side effect — a persistent 413 meant every subsequent
turn re-attempted the exact same overflow recovery from the exact same
starting point, with no progress made. This wires a real compaction
trigger into the driver's except block on a byte-limit exhaustion, so
the **NEXT turn** benefits from an advanced watermark (#4958's own
projection then reads that watermark back).

**Remainder, deliberately not addressed here** (explicit per architect
+ lead-coder): "compact and retry THIS turn" is not implemented — a new
retry loop is a new upper-bound problem. **This turn still fails**
(`UnrecoveredError` still propagates unchanged); what changes is the
next turn, which now starts from an advanced watermark. A persistent
413 becomes "one turn fails, not every turn," not "no turns fail."

## Design questions resolved with architect first (issue #4954)

- **Trigger point**: the driver's except block, NOT inside `retry_loop`
  itself — `retry_loop` is a pure TRANSPORT operation; compaction is
  the SEMANTIC operation that actually retires history entries
  (`Session`'s own docstring: "the only operation meant to retire an
  entry"). `retry_loop` is also re-exported from the package (an API
  surface) — injecting a controller dependency into it would widen
  that contract for no benefit.
- **Infinite-loop prevention**: none needed. `force_compact_now`
  already returns immediately on `self._compacting` (a concurrent
  pass) or zero candidates (nothing left to compact = terminal); this
  except fires at most once per turn.
- **Sync/async**: `force_compact_now` is already `async def` — its
  docstring's "Synchronous force-trigger" means "not a background
  task, a single pass in place," not "a sync function."
- **Scope**: byte-limit (413) only. Token overflow already has an
  existing pre-trigger (`ContextBudgetAdvisor.maybe_force_compact`); a
  token overflow that still reaches this point means the pre-trigger's
  own estimate was wrong, which the existing adaptive learner is the
  correct fix for.

Routed through `CompactionController.force_compact_now()` — the SAME
durable-watermark path (`_durable_active_history_after`-backed,
continuous from the last real `covers_through_seq`) the pre-frame
guard already uses. **Deliberately NOT** `retry_loop`'s own compaction
result: its `covers` can cover only `raw_middle` while skipping `head`
entirely, which is not continuous from the previous watermark and
would silently mark the OLDEST unsummarized part of history "covered"
without ever summarizing it — exactly owner's own real-machine shape,
lead-coder's own blocking finding on this issue.

## Structural finding along the way

`UnrecoveredError` carried no structured field for whether its cause
was a byte limit — the only way to tell was string-matching `reason`
(message wording is not a stable API, and #4381 had already moved
AWAY from that for the underlying 413 classification itself). Added
`UnrecoveredError(reason, *, saw_byte_limit: bool = False)`, set
explicitly `True` at exactly the 3 raise sites whose own branch is
byte-limit-gated. Deliberately named `saw_byte_limit`, not
`is_byte_limit`: at 2 sites (the same-cause cap, "all shrink paths
exhausted") the branch taken does NOT itself determine the cause, so
the value there is the LAST recovered cause observed before that
raise — a different claim from "this raise IS a byte-limit raise,"
which the stronger-sounding name would invite a future reader to
assume everywhere (the "same spelling, different meaning" trap this
session hit repeatedly tonight). "Last observed", not "sticky" — per
architect ruling, sufficient for the one measured symptom, with a
1-line disclosure for a future widening. No `from`-chain needed:
Python deletes `except X as e:`'s `e` when the block exits, so the
raise sites that matter (outside any active except, including the one
owner hits) have no chain to read from anyway — each raise site
already has the correct boolean in scope locally, passed directly.

## Test plan

- [x] `pytest tests/services/test_pr_n6_compaction_overflow_retry.py tests/services/test_wire_byte_estimate_4944.py tests/core/test_3783_stage3_invert_default_to_recover.py tests/core/test_4883_compaction_schema_validation.py tests/core/test_4951_local_covers_derivation.py tests/core/test_4957_max_shrink_iterations_config.py tests/runtime/test_retry_loop_chat_wiring_1125.py tests/config/test_config_mirror_coverage_1056.py` — 89 passed
- [x] Falsification (driver wiring) — reverted `if _unrecovered.saw_byte_limit:` to `if False:`, the byte-limit trigger test goes RED (no `compaction_check` event observed); restored, green.
- [x] Falsification (`saw_byte_limit` itself) — pinned assertions on all 6 raise sites (3 True, 3 False-and-reachable, each distinguished from "False-by-default-and-unreached" with an explicit comment)
- [x] `ruff check` (all changed files) — all checks passed
- [x] `python scripts/test_tier_audit.py --strict` (both changed test files) — 51 tests, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py` (both changed src files) — OK
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] No `docs/` changes — no doc path gates apply
- [ ] Visual — n/a (no UI surface)

## Time-dependency check

0 instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
