### PR TITLE
fix(#4961): per-subscriber isolation in EventLog's dispatch loop

### DIFF
--- a/src/reyn/core/events/backend.py
+++ b/src/reyn/core/events/backend.py
@@ -28,16 +28,20 @@ guarantee `emit()` already provides for free — so backends never touch it.
 try/except — BEFORE it loops over `self._subscribers` (#4496 PR-2). This
 is deliberate, not incidental:
 
-    - the subscriber loop (`for sub in self._subscribers: sub(event)`) has
-      no per-subscriber try/except (`events.py`, measured) — a raising
-      subscriber aborts the loop and every LATER subscriber in the list is
-      silently skipped. Inserting a backend as JUST ANOTHER subscriber
-      would inherit this hazard: a raising backend (e.g. a future network
-      backend hitting a connection error) would abort delivery to every
-      subscriber registered after it — including the CUI/AG-UI forwarders
-      session.py wires — the exact "discard silences the UI" failure mode
-      the owner's #4496 ruling forbids ("emit は抽象に対して必ず行う、
-      Backend 側で破棄するだけ").
+    - the subscriber loop (`for sub in self._subscribers: sub(event)`) now
+      HAS per-subscriber try/except (#4961 A — this used to be a real gap:
+      a raising subscriber aborted the loop and every LATER subscriber in
+      the list was silently skipped, `events.py`, measured). That fix
+      isolates one subscriber's failure from the NEXT ones, but it does
+      NOT make position in `self._subscribers` a safe place for the
+      backend: inserting a backend as JUST ANOTHER subscriber would still
+      make it position-dependent (registered early enough to run before
+      whatever fills the list — including a future backend that changes
+      registration order) instead of unconditional — the exact "discard
+      silences the UI" failure mode the owner's #4496 ruling forbids
+      ("emit は抽象に対して必ず行う、Backend 側で破棄するだけ") demands
+      the backend write happen NO MATTER what's registered or in what
+      order, not merely "isolated from subscribers that happen to raise".
     - calling the backend FIRST, outside the subscriber loop, with its own
       try/except, gets both halves of prohibition ③ (backend failure must
       not reach subscribers, and vice versa) from ORDERING alone: the

--- a/src/reyn/core/events/events.py
+++ b/src/reyn/core/events/events.py
@@ -253,8 +253,30 @@ class EventLog:
                     "continuing to subscriber dispatch",
                     self._emitter, type,
                 )
+        # #4961 A: per-subscriber isolation. Before this, a raising
+        # subscriber aborted the WHOLE loop — every LATER subscriber in
+        # ``self._subscribers`` (registration order) was silently skipped,
+        # and the exception propagated all the way to `emit()`'s own
+        # caller (an op/tool's execution path). Registration order is not
+        # under this method's control, and transport forwarders (AG-UI,
+        # A2A, MCP) share this exact list with the OTEL exporter
+        # (session.py) — a raising transport could silently blind
+        # observability with no exception anywhere to notice by (#4961's
+        # own "silent" framing). Failure is logged, never swallowed —
+        # same posture ``self._backend.write`` above already takes for its
+        # own failure, and NOT a change to registration semantics
+        # (``add_subscriber`` stays synchronous — #3310 N3(a)'s barrier
+        # ordering is untouched; this is purely a dispatch-loop isolation,
+        # per-subscriber, sequential and in the SAME order as before).
         for sub in self._subscribers:
-            sub(event)
+            try:
+                sub(event)
+            except Exception:
+                logger.exception(
+                    "event subscriber failed (emitter=%s type=%s) — "
+                    "continuing to the next subscriber",
+                    self._emitter, type,
+                )
         return event
 
     def compute_ingested(self, data_ref: str, resolved: str) -> str:

--- a/tests/core/test_4496_pr2_event_backend.py
+++ b/tests/core/test_4496_pr2_event_backend.py
@@ -25,8 +25,6 @@ EventLog that bypasses the real construction path.
 """
 from __future__ import annotations
 
-import pytest
-
 from reyn.config import AuditEventsConfig
 from reyn.core.events.backend import DiscardEventBackend, LocalEventBackend
 from reyn.core.events.events import EventLog
@@ -100,9 +98,12 @@ def test_a_raising_backend_does_not_stop_subscriber_delivery() -> None:
     """Tier 2: witness ③ / falsify ④ — a backend that raises on write()
     must not prevent subscribers from receiving the event. This is the
     test that goes RED if a future edit ever makes the backend "just
-    another subscriber" with no isolating try/except (see backend.py's
-    module docstring for the measured mechanism: the current subscriber
-    loop has none, so a raising list entry aborts every later one)."""
+    another subscriber" — inserted somewhere in ``self._subscribers``
+    instead of called separately, BEFORE that loop, with its own
+    try/except (see backend.py's module docstring: #4961 A gave the
+    subscriber loop its own per-subscriber isolation too, but that does
+    NOT make position in the list a safe substitute for the backend's
+    unconditional, order-independent guarantee)."""
     log = EventLog(backend=_RaisingBackend())
     received = []
     log.add_subscriber(received.append)
@@ -131,13 +132,14 @@ def test_a_raising_subscriber_does_not_stop_the_backend_from_having_written() ->
     log = EventLog(backend=_RecordingBackend())
     log.add_subscriber(_raising_subscriber)
 
-    # The subscriber loop itself has no isolating try/except (a pre-existing,
-    # separately-flagged fact — see backend.py's module docstring), so the
-    # raise propagates out of emit(). What matters here is that the
-    # backend, called BEFORE the subscriber loop, has already written by
-    # the time that happens.
-    with pytest.raises(RuntimeError, match="subscriber failed"):
-        log.emit("tool_executed", op="read")
+    # #4961 A: the subscriber loop now isolates each subscriber's own
+    # failure (previously it did not, and the raise propagated all the
+    # way out of emit() — this test used to assert exactly that
+    # propagation; #4961 A closed it, so this test's OWN premise changed).
+    # What still matters here, unaffected by #4961 A: the backend, called
+    # BEFORE the subscriber loop, has already written regardless of
+    # whether a later subscriber raises OR that raise is now caught.
+    log.emit("tool_executed", op="read")
 
     assert written and written[0].type == "tool_executed"
 
@@ -229,3 +231,58 @@ def test_session_with_discard_backend_still_delivers_to_real_subscribers(
 
     assert received == [emitted]
     assert emitted.data.get("foo") == "bar"
+
+
+# ── 5. #4961 A — per-subscriber isolation in the dispatch loop ───────────
+
+
+def test_a_raising_subscriber_does_not_skip_a_later_subscriber(caplog) -> None:
+    """Tier 1: #4961 A — the actual gap this fix closes. Before it, a
+    raising subscriber aborted the ENTIRE dispatch loop, silently
+    skipping every subscriber registered AFTER it (registration order is
+    not under the caller's control at the emit() call site — e.g. the
+    OTEL exporter could sit after a raising transport forwarder). The
+    witness is the LATER subscriber's own received list — "no exception
+    escaped" is NOT sufficient (that would also be true of a loop that
+    quietly skipped it), so this asserts actual delivery. Also witnesses
+    lead-coder's second acceptance condition in the same test: the
+    failure is LOGGED, not silently swallowed (#4961's own framing is
+    "silent" — closing delivery while going quiet would trade one
+    unobservable gap for another)."""
+    import logging
+
+    log = EventLog()
+    later_received = []
+
+    def _raising_subscriber(_event) -> None:
+        raise RuntimeError("earlier subscriber failed")
+
+    log.add_subscriber(_raising_subscriber)
+    log.add_subscriber(later_received.append)
+
+    with caplog.at_level(logging.ERROR, logger="reyn.core.events.events"):
+        emitted = log.emit("tool_executed", op="read")
+
+    assert later_received == [emitted], (
+        "the subscriber registered AFTER the raising one must still "
+        "receive the event — this is #4961 A's own gap, closed"
+    )
+    assert any(
+        "event subscriber failed" in r.getMessage() for r in caplog.records
+    ), "a raising subscriber's failure must be logged, not silently discarded"
+
+
+def test_subscribers_are_still_dispatched_in_registration_order() -> None:
+    """Tier 1: #4961 A's other acceptance condition (lead-coder) —
+    per-subscriber isolation must not reorder dispatch. agui/endpoint.py's
+    own barrier ordering (co-vet #3310 N3(a)) depends on `add_subscriber`
+    staying synchronous and subscribers firing in registration order."""
+    log = EventLog()
+    order: list[str] = []
+    log.add_subscriber(lambda _e: order.append("first"))
+    log.add_subscriber(lambda _e: order.append("second"))
+    log.add_subscriber(lambda _e: order.append("third"))
+
+    log.emit("tool_executed", op="read")
+
+    assert order == ["first", "second", "third"]


### PR DESCRIPTION
**[e2e-coder]** — #4961 A (per-subscriber isolation) only — B (worker delegation) and A' (AG-UI queue maxsize, endpoint.py) explicitly excluded, both held back per lead-coder/architect.

part of #4961

<!-- closing-check: discussing #4961 -->

## What
Transport forwarders (AG-UI, A2A, MCP) and the OTEL exporter share one `EventLog` subscriber list. The dispatch loop had no per-subscriber try/except — a raising subscriber aborted the whole loop, silently skipping every LATER subscriber (registration order isn't under `emit()`'s control), and propagated all the way to `emit()`'s own caller (an op/tool's execution path).

**Severity note** (lead-coder/architect re-measure — please read this as-written): none of the 5 subscribers checked today have a known raise path. This closes a **class** of defect ("the day a raising subscriber is added, delivery silently breaks for everyone after it"), not a currently-observed failure.

## Fix
Per-subscriber try/except inside the existing loop, log the failure (never swallow — this issue's own framing is "silent"), continue to the next subscriber. Registration order/synchronicity untouched (`agui/endpoint.py`'s barrier ordering, co-vet #3310 N3(a), depends on `add_subscriber` staying synchronous — not touched here).

`backend.py`'s module docstring corrected — it asserted "no per-subscriber try/except" as part of the reason the backend runs separately/first; that's now false, so the paragraph states the surviving reason instead (backend write must be unconditional/order-independent, not merely isolated-from-subscribers-that-raise).

## Testing
Updated a pre-existing test whose premise (the raise propagates out of `emit()`) was exactly the gap this PR closes. New tests: a subscriber registered AFTER a raising one still receives the event (not just "no exception escaped" — a silent skip would also pass that weaker check) + the failure is logged; dispatch order preserved. Strip-falsified, restored green.

14/14 in the directly affected file, 247/247 across the broader `core/events` surface, 26/26 across the #3310 barrier-ordering suite (untouched, confirmed still green). All local gates green.

Not self-merging — holding for TESTS-READ.