### PR TITLE
fix(#4946): gate MCP-sourced images through the shared media-size check

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -117,6 +117,7 @@ mcp_install_cancelled
 mcp_install_probe_failed
 mcp_install_threat_blocked
 mcp_install_threat_match
+mcp_media_denied
 mcp_progress
 mcp_prompt_get
 mcp_prompt_get_cancelled
@@ -381,6 +382,7 @@ Each Control IR op kind emits its own event:
 | `read_file`, `write_file`, `edit_file`, `delete_file`, `glob_files`, `grep`, `regenerate_index` | `file` op variants — all via `tool_executed` with `op=<sub_op>` |
 | `sandboxed_exec_started`, `sandboxed_exec_completed` | `sandboxed_exec` op — `started`: `argv`, `argv0_resolved`, `backend`; `completed`: `argv`, `argv0_resolved`, `backend`, `returncode`, `denial_class`. `argv0_resolved` (#2820) is the absolute path actually executed: a version-manager shim (`~/.pyenv/shims/python3`) is resolved to its real binary by reading the manager's on-disk layout (part A — filesystem-only, no subprocess) so the sandbox runs the real binary directly instead of the shim, whose launch-`fork()` would die under `(deny process-fork)`; equals the plain PATH resolution for a non-shim command, or the unchanged `argv[0]` when resolution is unavailable (fail-open). `denial_class` is `"fork_denied"` when the sandbox blocked `fork()` at a PATH launcher/shim (pyenv/asdf/mise/npx/uvx) under `(deny process-fork)`, else `null` — an environment/config condition, not a tool failure |
 | `mcp_called`, `mcp_completed`, `mcp_failed`, `mcp_cancelled` | MCP tool ops — `mcp_cancelled` (#2813) fires instead of `mcp_completed`/`mcp_failed` when a Ctrl-C `cancel_event` interrupts an in-flight call before it completes |
+| `mcp_media_denied` | #4946 — an MCP tool response carried an image whose byte size the multi-modal gate (`require_media_load`, same shared gate as `file_read_media_denied`/`web_fetch_media_denied`) rejected under `multimodal.on_oversize=deny` (or an `ask` prompt the operator declined). Gated PER IMAGE, not per call — an MCP tool can return several images in one response, and one oversized image is dropped (replaced with a text denial note) without discarding the rest of the result. `server`, `tool`, `size_bytes`, `mime_type` |
 | `mcp_server_installed` | `mcp_install` op — `name`, key names only (no values) |
 | `mcp_install_cancelled`, `mcp_prompt_get_cancelled`, `mcp_resource_read_cancelled`, `mcp_resource_subscribe_cancelled`, `mcp_resource_unsubscribe_cancelled` | #2813 — a Ctrl-C `cancel_event` interrupted the corresponding op (install probe / get-prompt / read-resource / subscribe / unsubscribe) before it completed; the op returns `status:"cancelled"` and nothing is committed |
 | `plugin_install_started`, `plugin_install_copied`, `plugin_install_registered`, `plugin_install_completed` | `plugin_install` op's own main-flow milestones — `started`: `name`, `source_kind`; `copied`: `name`, `plugin_root`; `registered`: `name`, `registered` (the per-capability-kind registration result); `completed`: `name` |

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -296,6 +296,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "mcp_install_probe_failed",
     "mcp_install_threat_blocked",
     "mcp_install_threat_match",
+    "mcp_media_denied",
     "mcp_progress",
     "mcp_prompt_get",
     "mcp_prompt_get_cancelled",

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -124,11 +124,40 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
     # blocks as flat files under ``.reyn/media/`` and emit path-ref blocks
     # instead of inline base64. Non-image media blocks (= resource, etc.)
     # pass through unchanged for now (= future #385 scope expansion).
+    #
+    # #4946: apply the SAME multi-modal size gate (``require_media_load``)
+    # web_fetch (web.py) / read_file (file.py) / user `/image` (image.py)
+    # already apply before persisting any image bytes — MCP was the one
+    # producer named in the gate's own docstring that never actually
+    # called it (measured, #4944's Angle 3 byproduct: 0 call sites). An
+    # MCP tool response is UNTRUSTED input reaching this exact same
+    # ingest boundary; skipping the gate here left it as a second,
+    # unguarded entry point alongside the missing-aggregate-byte-check
+    # #4944 found — this closes the per-item one.
+    #
+    # Gated PER IMAGE, not per op-call: unlike the other 3 producers
+    # (always exactly one image), one MCP tool call can return several.
+    # Rejecting the WHOLE result (including any text and every other,
+    # correctly-sized image) for one oversized image among many would be
+    # a strictly worse outcome than the other 3 producers' single-image
+    # case ever has to consider — so an oversized image is dropped
+    # individually (replaced with a denial note, the same "surface the
+    # loss, never hide it" shape ``router_loop.py``'s own
+    # ``_overflow_ref_text``/tail-preview machinery already uses for a
+    # DIFFERENT over-budget reason), while the rest of the result
+    # (text + correctly-sized images) still reaches the caller.
     media_blocks: list[dict] = []
+    # #4946: a denied image is dropped from `media_blocks` (that list's own
+    # consumer, router_loop.py's `_build_media_followup_message`, filters
+    # to `type == "image"` ONLY — a text block placed there would be
+    # silently discarded, the exact "model sees one fewer image with no
+    # sign anything was lost" shape lead-coder's review flagged). Fold the
+    # denial into `text` (== `out["content"]`, the ONE field guaranteed to
+    # reach the model) instead, appended after the join below.
+    denial_notes: list[str] = []
     for idx, item in enumerate(raw_media_blocks, start=1):
         if (
-            ctx.media_store is not None
-            and isinstance(item, dict)
+            isinstance(item, dict)
             and item.get("type") == "image"
             and isinstance(item.get("data"), str)
         ):
@@ -140,6 +169,32 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
                 media_blocks.append(item)
                 continue
             mime = item.get("mimeType") or item.get("mime_type") or "image/png"
+            if ctx.permission_resolver is not None and ctx.multimodal_config is not None:
+                if ctx.intervention_bus is None:
+                    raise RuntimeError(
+                        "mcp op requires intervention_bus when loading "
+                        "binary media (multimodal gate)"
+                    )
+                try:
+                    await ctx.permission_resolver.require_media_load(
+                        size_bytes=len(raw_bytes),
+                        source=f"mcp {op.server}.{op.tool}",
+                        mime_type=mime,
+                        max_bytes=ctx.multimodal_config.max_bytes,
+                        on_oversize=ctx.multimodal_config.on_oversize,
+                        bus=ctx.intervention_bus,
+                    )
+                except PermissionError as exc:
+                    ctx.events.emit(
+                        "mcp_media_denied",
+                        server=op.server, tool=op.tool,
+                        size_bytes=len(raw_bytes), mime_type=mime,
+                    )
+                    denial_notes.append(f"[image {idx}: {exc}]")
+                    continue
+            if ctx.media_store is None:
+                media_blocks.append(item)
+                continue
             media_blocks.append(ctx.media_store.save_image(
                 raw_bytes, mime_type=mime,
                 chain_id=ctx.run_id or "",
@@ -148,6 +203,8 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
             ))
         else:
             media_blocks.append(item)
+    if denial_notes:
+        text = "\n".join([text, *denial_notes]) if text else "\n".join(denial_notes)
 
     is_error = bool(result.get("isError"))
     # #3070: an errored tool call previously logged ONLY the boolean — the tool's

--- a/tests/core/test_4946_mcp_media_gate.py
+++ b/tests/core/test_4946_mcp_media_gate.py
@@ -1,0 +1,251 @@
+"""Tier 2: #4946 — MCP-sourced images must pass the shared multi-modal
+size gate (``PermissionResolver.require_media_load``), the same gate
+web_fetch (web.py) / read_file (file.py) / user ``/image`` (image.py)
+already apply before persisting any image bytes.
+
+Measured before this fix (issue #4944's Angle 3 byproduct): the gate's
+own docstring named MCP as one of its 4 producers, but `require_media_load`
+had ZERO call sites reached from ``op_runtime/mcp.py`` — an oversized MCP
+image bypassed the 5MB cap entirely.
+
+Gated PER IMAGE (lead-coder's explicit ruling, not a mirrored-without-
+thought copy of the other 3 producers' shape): a single MCP tool call can
+return several images, unlike the other 3 producers (always exactly one).
+Rejecting the whole result for one oversized image among several would
+lose correctly-sized images and text unnecessarily.
+
+Real ``PermissionResolver`` + ``OpContext``, no collaborator mocks — same
+convention as ``test_web_fetch_binary_media_gate.py`` and
+``test_mcp_multimodal_forwarding.py``, which this file is a sibling of.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+from pathlib import Path
+from typing import Any
+
+from reyn.config import MultimodalConfig
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+
+class _FakeBus:
+    """Drop-in for RequestBus that pre-answers the prompt with `answer`
+    (same shape as test_web_fetch_binary_media_gate.py's own fake)."""
+
+    def __init__(self, answer: str) -> None:
+        self._answer = answer
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        return InterventionAnswer(text="", choice_id=self._answer)
+
+
+class _FakeMCPClient:
+    """Stand-in for reyn.mcp.client.MCPClient — returns a canned
+    call_tool result without spawning a subprocess (mirrors
+    test_mcp_multimodal_forwarding.py's own fake)."""
+
+    def __init__(self, content: list[dict], *, is_error: bool = False) -> None:
+        self._content = content
+        self._is_error = is_error
+
+    async def call_tool(
+        self, name: str, args: dict, *,
+        progress_callback: Any = None, timeout_seconds: Any = None,
+    ) -> dict:
+        return {"content": self._content, "isError": self._is_error, "structuredContent": None}
+
+
+class _StubPool:
+    def __init__(self, client) -> None:
+        self._client = client
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    @property
+    def owner_task(self):
+        return None
+
+    async def get(self, server, config, *, agent_id=None):
+        return self._client
+
+
+def _make_gated_ctx(
+    tmp_path: Path, mcp_client: _FakeMCPClient, *,
+    multimodal: MultimodalConfig, bus_answer: str = "yes",
+) -> Any:
+    from reyn.core.events.events import EventLog
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.data.workspace.workspace import Workspace
+
+    events = EventLog()
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=True)
+    return OpContext(
+        workspace=Workspace(events=events, permission_resolver=resolver),
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=resolver,
+        intervention_bus=_FakeBus(bus_answer),  # type: ignore[arg-type]
+        multimodal_config=multimodal,
+        mcp_servers={"testsrv": {"type": "stdio", "command": "fake"}},
+        mcp_pool=_StubPool(mcp_client),
+    )
+
+
+def _image_block(size_bytes: int, *, mime: str = "image/png") -> dict:
+    return {
+        "type": "image",
+        "data": base64.b64encode(b"x" * size_bytes).decode("ascii"),
+        "mimeType": mime,
+    }
+
+
+def test_oversize_mcp_image_is_actually_rejected(tmp_path, monkeypatch) -> None:
+    """Tier 2: #4946 acceptance ① — a real oversized (>5MB) MCP image is
+    NOT persisted via media_store and does NOT appear in media_blocks.
+    "no exception raised" is not the witness — the ABSENCE of the block
+    (and the media_store file it would have created) is."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    big_image = _image_block(6_000_000)  # over the 5MB default cap
+    client = _FakeMCPClient(content=[big_image])
+    ctx = _make_gated_ctx(
+        tmp_path, client,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="deny"),
+    )
+
+    op = MCPIROp(kind="mcp", server="testsrv", tool="screenshot", args={})
+    result = asyncio.run(_execute(op, ctx))
+
+    assert result["status"] == "ok", "the OP itself still succeeds — only the image is dropped"
+    assert result["media_blocks"] == [], (
+        f"an oversized image must never reach media_blocks; got {result['media_blocks']!r}"
+    )
+
+
+def test_oversized_image_among_normal_ones_drops_only_the_oversized_one(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #4946 acceptance ② — the per-image witness. One oversized
+    image among 2 correctly-sized ones + text: the 2 normal images and
+    the text must still reach the caller. Rejecting the WHOLE result for
+    one oversized image would lose content the gate has no reason to
+    touch."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    small_1 = _image_block(1_000)
+    big = _image_block(6_000_000)
+    small_2 = _image_block(2_000)
+    text_block = {"type": "text", "text": "here are the screenshots"}
+    client = _FakeMCPClient(content=[text_block, small_1, big, small_2])
+    ctx = _make_gated_ctx(
+        tmp_path, client,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="deny"),
+    )
+
+    op = MCPIROp(kind="mcp", server="testsrv", tool="screenshots", args={})
+    result = asyncio.run(_execute(op, ctx))
+
+    assert result["status"] == "ok"
+    surviving_data = {b.get("data") for b in result["media_blocks"] if isinstance(b, dict)}
+    assert small_1["data"] in surviving_data, "the first correctly-sized image must survive"
+    assert small_2["data"] in surviving_data, "the second correctly-sized image must survive"
+    assert big["data"] not in surviving_data, "the oversized image must not survive"
+    assert "here are the screenshots" in result["content"], (
+        "the original text must still reach the caller unchanged"
+    )
+
+
+def test_mcp_media_denied_event_emitted(tmp_path, monkeypatch) -> None:
+    """Tier 2: #4946 acceptance ③ — a real audit-event witness, not just
+    an assertion about the return value."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    big_image = _image_block(6_000_000)
+    client = _FakeMCPClient(content=[big_image])
+    ctx = _make_gated_ctx(
+        tmp_path, client,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="deny"),
+    )
+
+    seen: list = []
+    ctx.events.add_subscriber(seen.append)
+
+    op = MCPIROp(kind="mcp", server="testsrv", tool="screenshot", args={})
+    asyncio.run(_execute(op, ctx))
+
+    denied = [e for e in seen if e.type == "mcp_media_denied"]
+    assert denied, "expected an mcp_media_denied audit-event"
+    assert denied[0].data.get("server") == "testsrv"
+    assert denied[0].data.get("tool") == "screenshot"
+    assert denied[0].data.get("size_bytes") == 6_000_000
+
+
+def test_denial_is_visible_in_the_tool_result_text_not_just_the_event(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #4946 acceptance ④ (lead-coder, explicit) — the audit-event
+    alone is not enough. The dropped image must be named in the tool
+    result's own `content` text, the field the MODEL actually reads —
+    `media_blocks` is filtered to `type == "image"` by its own consumer
+    (router_loop.py's `_build_media_followup_message`), so a text note
+    placed THERE would be silently discarded, leaving the model with "one
+    fewer image, no sign anything was lost" — the exact silent-loss shape
+    this session's #4961/#4954 arcs closed elsewhere tonight."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    big_image = _image_block(6_000_000)
+    client = _FakeMCPClient(content=[big_image])
+    ctx = _make_gated_ctx(
+        tmp_path, client,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="deny"),
+    )
+
+    op = MCPIROp(kind="mcp", server="testsrv", tool="screenshot", args={})
+    result = asyncio.run(_execute(op, ctx))
+
+    assert result["content"], "expected a denial note in the tool result's text content"
+    assert "not loaded" in result["content"] or "denied" in result["content"].lower(), (
+        f"the tool result text must name the drop, not just describe it "
+        f"implicitly; got {result['content']!r}"
+    )
+
+
+def test_under_limit_mcp_image_still_persists_normally(tmp_path, monkeypatch) -> None:
+    """Tier 2: regression control — a correctly-sized MCP image still
+    reaches media_blocks via media_store when a real gate is wired in
+    (not just when permission_resolver=None bypasses it, as the sibling
+    file's existing tests use)."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    small_image = _image_block(1_000)
+    client = _FakeMCPClient(content=[small_image])
+    ctx = _make_gated_ctx(
+        tmp_path, client,
+        multimodal=MultimodalConfig(max_bytes=5_000_000, on_oversize="deny"),
+    )
+
+    op = MCPIROp(kind="mcp", server="testsrv", tool="screenshot", args={})
+    result = asyncio.run(_execute(op, ctx))
+
+    assert result["status"] == "ok"
+    surviving_data = {b.get("data") for b in result["media_blocks"] if isinstance(b, dict)}
+    assert small_image["data"] in surviving_data, (
+        f"the correctly-sized image must still reach media_blocks; got "
+        f"{result['media_blocks']!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — B confirmed (implementation gap, not stale doc) — severity raised to high per lead-coder.

Closes #4946

## What
`require_media_load`'s docstring names 4 producers (web_fetch / read_file / MCP / user input) — measured 0 call sites reached from `op_runtime/mcp.py`. An MCP tool response is UNTRUSTED input reaching the exact same image-ingest boundary the other 3 producers already gate; an oversized MCP image bypassed the 5MB cap (and `on_oversize` policy) entirely, landing in `media_store` unconditionally.

## Design decision — per-image gating (lead-coder's explicit ruling)
A single MCP tool call can return several images, unlike the other 3 producers (always exactly one) — so "reject the whole op" isn't the established convention to mirror, it's just what a single-image producer's only option looks like. Gated per image instead; one oversized image among several drops only that image, not the correctly-sized ones or the text.

New event `mcp_media_denied` (same shape as existing `file_read_media_denied`/`web_fetch_media_denied`).

## Critical fix during implementation (lead-coder review)
The denial note must NOT go into `media_blocks` as a `type="text"` item — that list's own consumer (`router_loop.py`'s `_build_media_followup_message`) filters to `type=="image"` only, so a text block placed there is silently discarded, leaving the model with "one fewer image, no sign anything was lost." Denial notes are folded into the tool result's `content` (text) field instead — the one field guaranteed to reach the model.

## Testing
New file `tests/core/test_4946_mcp_media_gate.py`, driving the real op handler with a REAL `PermissionResolver`/`MultimodalConfig`/intervention bus (not `permission_resolver=None`, which the sibling test file's existing tests use to bypass the gate). Covers: actual rejection (absence, not "no exception"); one-oversized-among-several drops only that one; `mcp_media_denied` fires with real fields; denial visible in tool result text; correctly-sized image still persists through a real wired gate.

Strip-falsified 2 mechanisms independently (gate disabled → 4/5 red; text-fold reverted → visibility test red, for the right reasons in each case). Both restored green.

5/5 new, 29/29 sibling files, 403/404 broader mcp/media surface (the 1 failure is a pre-existing, unrelated environment flake — confirmed identical on main). All local + docs-path gates green.

Not self-merging — holding for TESTS-READ.