### PR TITLE
docs(#4966): events.md's "dispatches to every subscriber, and returns" claim went stale

### DIFF
--- a/docs/concepts/runtime/events.md
+++ b/docs/concepts/runtime/events.md
@@ -89,10 +89,10 @@ Stable shape makes the log machine-readable without a custom parser per consumer
 
 Where an audit-event lands on disk (or doesn't) is a separate axis from
 whether it fires and reaches subscribers. `EventLog.emit()` always: stamps
-`agent_id`/`run_id`/`emitter`/`audit_seq`, dispatches to every subscriber
-(console reporters, the TUI/AG-UI forwarders, hooks, OTEL), and returns —
-regardless of the write-side backend `reyn.yaml`'s `audit_events.backend`
-selects (see [config reference](../../reference/config/reyn-yaml.md#audit_events-block)):
+`agent_id`/`run_id`/`emitter`/`audit_seq`, hands the event off for
+subscriber delivery, and returns — regardless of the write-side backend
+`reyn.yaml`'s `audit_events.backend` selects (see [config
+reference](../../reference/config/reyn-yaml.md#audit_events-block)):
 
 - **`local`** (default) — writes to `.reyn/events`, unchanged from before
   this abstraction existed.
@@ -102,13 +102,25 @@ selects (see [config reference](../../reference/config/reyn-yaml.md#audit_events
   read for a `discard` run — this is a real trade-off (support-bundle in
   particular is the tool operators use to report bugs), not a free lunch.
 
-The backend is called from inside `emit()`, before the subscriber loop
-runs, wrapped in its own try/except — never inserted as just another
+The backend is called from inside `emit()`, before subscriber dispatch,
+wrapped in its own try/except — never inserted as just another
 subscriber. That ordering is what guarantees a backend failure (or a
 future network backend's connection error) can never silence a
 subscriber, and a raising subscriber can never stop the backend from
 having already written. See `src/reyn/core/events/backend.py`'s module
 docstring for the full mechanism.
+
+**Dispatch timing is NOT uniform (#4966).** `emit()` branches on whether a
+running event loop exists at call time: with one, the event is queued and
+a background consumer task delivers it to every subscriber — `emit()` can
+return BEFORE that delivery happens, not after. Without one (no running
+loop — e.g. a synchronous CLI path), dispatch runs inline, synchronously,
+before `emit()` returns. Both branches share the same per-subscriber
+try/except isolation (#4963) — one subscriber's failure never blocks the
+next, in either branch — but "emit() returned" is a delivery guarantee
+only in the no-loop case. A caller that needs delivery to have actually
+happened before proceeding awaits `EventLog.drain()` explicitly (see its
+own docstring for the queue/consumer race it resolves).
 
 ### `agent_delta` durable-write coalescing (#4960)
 

--- a/src/reyn/core/events/backend.py
+++ b/src/reyn/core/events/backend.py
@@ -17,31 +17,42 @@ so a subscriber can detect a gap — is NOT a backend responsibility. It is
 already implemented in `EventLog.emit()` itself (#4496 PR-1): `audit_seq`
 is stamped on every event regardless of backend, including `discard`
 (measured: `emit()` does agent_id/run_id stamp -> emitter+audit_seq stamp
--> subscriber dispatch -> return; no file I/O happens inside `emit()` at
-all — see `EventLog.emit`'s own docstring). A backend that skipped seq
-under its own logic would be reimplementing (and could diverge from) a
-guarantee `emit()` already provides for free — so backends never touch it.
+-> hand off for subscriber dispatch -> return; no file I/O happens inside
+`emit()` at all — see `EventLog.emit`'s own docstring). Stamping always
+precedes hand-off, in either dispatch branch #4966 introduced (queued to
+a background consumer when a running loop exists, inline when it doesn't)
+— #4966 changed WHEN dispatch happens relative to `emit()` returning, not
+this stamp-before-dispatch ordering. A backend that skipped seq under its
+own logic would be reimplementing (and could diverge from) a guarantee
+`emit()` already provides for free — so backends never touch it.
 
 ## Not a subscriber (the structural guarantee this module exists for)
 
 `EventLog.emit()` calls `self._backend.write(event)` directly — wrapped in
-try/except — BEFORE it loops over `self._subscribers` (#4496 PR-2). This
-is deliberate, not incidental:
+try/except — BEFORE handing the event off for subscriber dispatch (#4496
+PR-2). This is deliberate, not incidental:
 
-    - the subscriber loop (`for sub in self._subscribers: sub(event)`) now
-      HAS per-subscriber try/except (#4961 A — this used to be a real gap:
-      a raising subscriber aborted the loop and every LATER subscriber in
-      the list was silently skipped, `events.py`, measured). That fix
-      isolates one subscriber's failure from the NEXT ones, but it does
-      NOT make position in `self._subscribers` a safe place for the
-      backend: inserting a backend as JUST ANOTHER subscriber would still
-      make it position-dependent (registered early enough to run before
-      whatever fills the list — including a future backend that changes
-      registration order) instead of unconditional — the exact "discard
-      silences the UI" failure mode the owner's #4496 ruling forbids
-      ("emit は抽象に対して必ず行う、Backend 側で破棄するだけ") demands
-      the backend write happen NO MATTER what's registered or in what
-      order, not merely "isolated from subscribers that happen to raise".
+    - the subscriber dispatch loop (`for sub in self._subscribers:
+      sub(event)`) HAS per-subscriber try/except (#4961 A — this used to
+      be a real gap: a raising subscriber aborted the loop and every
+      LATER subscriber in the list was silently skipped, `events.py`,
+      measured). #4966 split this single loop into two call sites that
+      must stay in sync — `_dispatch_inline` (no running loop, runs
+      synchronously inside `emit()`) and `_dispatch_consumer` (running
+      loop present, runs later on the background consumer task) — both
+      preserve the same per-subscriber isolation, just at different call
+      sites and different times relative to `emit()` returning. That
+      isolation isolates one subscriber's failure from the NEXT ones, but
+      it does NOT make position in `self._subscribers` a safe place for
+      the backend: inserting a backend as JUST ANOTHER subscriber would
+      still make it position-dependent (registered early enough to run
+      before whatever fills the list — including a future backend that
+      changes registration order) instead of unconditional — the exact
+      "discard silences the UI" failure mode the owner's #4496 ruling
+      forbids ("emit は抽象に対して必ず行う、Backend 側で破棄するだけ")
+      demands the backend write happen NO MATTER what's registered or in
+      what order, not merely "isolated from subscribers that happen to
+      raise".
     - calling the backend FIRST, outside the subscriber loop, with its own
       try/except, gets both halves of prohibition ③ (backend failure must
       not reach subscribers, and vice versa) from ORDERING alone: the


### PR DESCRIPTION
**[docs-maintainer]** — part of #4966

## What

Lead-coder's dispatch flagged exactly this claim as a likely stale spot
after #4966 landed. Confirmed by reading `EventLog.emit()`'s actual
branching (`src/reyn/core/events/events.py`): with a running event loop,
the event is queued and a background consumer delivers it — `emit()` can
return before that delivery happens. Without a running loop, dispatch is
still inline/synchronous before `emit()` returns (the architect-ruled
correction #4966 made to #4961 C's original always-queue design).

`docs/concepts/runtime/events.md`'s "Write-side backend" section
described this as one synchronous sequence — "dispatches to every
subscriber ..., and returns" — which no longer holds in the loop-present
case.

## Fixed

Reworded to name both branches explicitly (queued+background-consumer
when a loop is running, inline+synchronous when not), state which one is
a delivery guarantee at return time and which isn't, and point at
`EventLog.drain()` for a caller that needs delivery to have actually
completed. Left the backend-ordering paragraph (backend write happens
before dispatch in EITHER branch) untouched — still accurate.

## Update — `backend.py`'s module docstring (lead-coder's request, 2nd commit)

Lead-coder independently measured the SAME falsification inside
`src/reyn/core/events/backend.py`'s own module docstring (2 spots quoting
the identical stale synchronous sequence) and asked it be folded into
this PR rather than split off — same falsification, same CI run, avoids
leaving the src/ side of a doc/src pair stale after the docs/ side lands
(which happened tonight with a different pair). Reworded both spots to
name the #4966 branch split (`_dispatch_inline`/`_dispatch_consumer`)
without changing either paragraph's actual point (audit_seq stamped
before dispatch either way; per-subscriber isolation holds at both call
sites). `ruff check`, `verify_module_docstrings.py`, `mypy_ratchet.py` —
all green on the changed file.

## Checked, not touched

- `docs/reference/runtime/events.md` — grepped for the same claim shape
  (`dispatches to every subscriber`, `subscriber loop`), 0 hits — no
  parallel stale claim there.
- No existing "CI gate list" doc found to add `check_collect_events_settle.py`
  to (gates are referenced ad hoc from testing.md/pr-workflow.md/sandbox.md
  as relevant, no single enumeration doc exists) — noted, not actioned
  (lead-coder confirmed: not creating one, not needed yet).

## Test plan

- [x] Read `EventLog.emit()`'s real branching logic (`events.py`) before
      writing the fix, not just the PR description
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no `Aborted`/`WARNING`
- [x] `python scripts/check_doc_anchors.py` — "no dangling anchors into published pages"
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] `ruff check src/reyn/core/events/backend.py` — all checks passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/events/backend.py` — OK
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] Closing-keyword self-check on both commit messages + this PR body — 0 hits
- [x] (skipped — docstring-only src/ change, no tests/ paths touched, no TESTS-READ needed)

part of #4966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
