### PR TITLE
fix(#4978): retire maybe_compact_messages — 0 production implementations

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -31,10 +31,7 @@ from reyn.runtime.router_tools import (
     build_tools,
     get_dispatch_kind,
 )
-from reyn.services.compaction.engine import (
-    _IMAGE_FIXED_TOKEN_COST,
-    is_context_overflow_error,
-)
+from reyn.services.compaction.engine import _IMAGE_FIXED_TOKEN_COST
 from reyn.services.turn_budget import wrap_up_system_prompt
 
 if TYPE_CHECKING:
@@ -1802,16 +1799,7 @@ class RouterLoop:
             else:
                 from reyn.llm.model_resolver import ModelSpec
                 resolved_spec = ModelSpec(model=resolved_model, kwargs={})
-            # #1092 PR-C-4b: per-turn in-loop message-history compaction. A phase
-            # host implements ``maybe_compact_messages`` to proactively bound the
-            # converged op-loop's growing native tool-message history (json-mode
-            # parity). Chat hosts don't implement it (getattr → None) → no-op, so
-            # the chat loop is byte-identical.
-            _compact_fn = getattr(self.host, "maybe_compact_messages", None)
-            if _compact_fn is not None:
-                messages = await _compact_fn(messages, model=resolved_model)
-            # #1092 PR-C: layer-1 force-close trigger — checked AFTER compaction
-            # (so it sees the shrunk content). A host implements
+            # #1092 PR-C: layer-1 force-close trigger. A host implements
             # ``should_force_close`` to decide, from the current accumulated turn
             # content, whether the CUMULATIVE budget is reached; if so this turn is
             # force-closed (a clean wrap-up finish) instead of risking overflow.
@@ -2884,49 +2872,21 @@ class RouterLoop:
         resolved_model: str,
         reason: "str | None" = None,
     ) -> "LLMToolCallResult":
-        """#1092 PR-B layer-2 (PHASE axis): the force-close call, made robust to
-        its OWN overflow via overflow → host shrink → retry, monotonic to the
-        floor (§5 layer-2 retry-guarantee).
+        """#1092 PR-B: the force-close call. An overflow raised by the call
+        itself is never retried in-loop here — it propagates to the caller
+        (the session's existing outer ``retry_loop``, the proven
+        head/middle/tail shrink).
 
-        Axis split (B′, lead-coder confirmed): the CHAT axis does NOT use this —
-        a chat force-close overflow propagates to the session's existing outer
-        ``retry_loop`` (the proven head/middle/tail shrink), so the shrink hook
-        is phase-host-only and ``getattr``-guarded; when absent (chat host) the
-        overflow is re-raised to that outer loop. The PHASE host drives
-        ``run_loop`` directly with no such wrapper, so it shrinks in-loop here via
-        ``maybe_compact_messages`` (the SAME hook json-mode parity uses).
-
-        Monotonic termination: each shrink that changes the messages strictly
-        reduces them; when the host can shrink no further it returns the
-        messages unchanged (identity) = the FLOOR, which RAISES (floor-abort).
-        This used to be a placeholder — "PR-D"/"PR-E", a planned
-        consolidate+hand-off that would replace the raise — but #4381 PR-4
-        (owner ruling: "２の force close 廃止して spill にしよう") undid that
-        plan permanently: the floor-abort is the real terminal now, not a
-        pre-handoff stopgap. The #4381 family (tool-result spill) is what
-        keeps an oversized single result from reaching this floor at all.
+        #4978: this used to also try an in-loop shrink-and-retry via a
+        ``maybe_compact_messages`` host hook (the layer-2 PHASE-axis path,
+        #1092 PR-B). Removed — 0 production hosts ever implemented that
+        hook (measured; the only implementation was a test Fake), so the
+        shrink branch was permanently dead code: every real host took the
+        immediate re-raise path this function now takes unconditionally.
         """
-        shrink = getattr(self.host, "maybe_compact_messages", None)
-        cur = messages
-        while True:
-            try:
-                return await self._force_close_call(
-                    cur, resolved_model=resolved_model, reason=reason,
-                )
-            except Exception as exc:  # noqa: BLE001
-                if not is_context_overflow_error(exc):
-                    raise
-                if shrink is None:
-                    # Chat host: no in-loop shrink — propagate to the outer
-                    # session retry_loop (B′ axis-inherited path).
-                    raise
-                shrunk = await shrink(cur, model=resolved_model)
-                if shrunk is cur or shrunk == cur:
-                    # Floor: the host can shrink no further — genuine
-                    # terminal, re-raise (floor-abort). #4381 PR-4: no
-                    # handoff-and-retry replaces this anymore.
-                    raise
-                cur = shrunk
+        return await self._force_close_call(
+            messages, resolved_model=resolved_model, reason=reason,
+        )
 
     async def _execute_tool(self, tc: dict, *, call_id: "str | None" = None) -> dict:
         """Dispatch one tool call via dispatch_tool (cross-cutting concerns).

--- a/tests/llm/test_force_close_call_1092.py
+++ b/tests/llm/test_force_close_call_1092.py
@@ -121,22 +121,19 @@ async def test_force_close_drops_extra_system_turns() -> None:
     assert systems == [{"role": "system", "content": wrap_up_system_prompt()}]
 
 
-# ── layer-2 phase shrink-retry (#1092 PR-B 2/2) ──────────────────────────────
-
-
-class _ShrinkHost(FakeRouterHost):
-    """FakeRouterHost + a phase-style maybe_compact_messages that drops the
-    oldest tool message each call, and returns the messages UNCHANGED once there
-    are no tool messages left (= the floor)."""
-
-    async def maybe_compact_messages(
-        self, messages: list[dict], *, model: str
-    ) -> list[dict]:
-        tool_idxs = [i for i, m in enumerate(messages) if m.get("role") == "tool"]
-        if not tool_idxs:
-            return messages  # floor — nothing left to shrink
-        drop = tool_idxs[0]
-        return [m for i, m in enumerate(messages) if i != drop]
+# ── layer-2 force-close retry (#1092 PR-B 2/2) ───────────────────────────────
+#
+# #4978: the shrink-and-retry branch these tests used to exercise
+# (`maybe_compact_messages`, a "PHASE host" getattr-optional hook) is
+# removed — 0 production hosts ever implemented it (the only
+# implementation was this file's own `_ShrinkHost` test double, now
+# deleted along with it). `_force_close_call_with_retry` no longer
+# branches on host capability at all: EVERY host now takes the
+# immediate re-raise path the tests below were already covering for
+# the "no shrink hook" case — that behavior survives unchanged; the
+# shrink-recovery and floor-abort tests that only exercised the dead
+# branch do not (removed, not adapted — see #4978's own PR body for
+# the per-assert accounting this section's tests underwent).
 
 
 class _OverflowThenFinishLLM:
@@ -170,41 +167,13 @@ def _msgs_with_tools(n: int) -> list[dict]:
 
 
 @pytest.mark.asyncio
-async def test_phase_shrink_retry_recovers_after_overflow() -> None:
-    """Tier 2: a phase force-close call that overflows once is recovered by one
-    host shrink + retry, returning the finish — the layer-2 guarantee in action."""
-    llm = _OverflowThenFinishLLM(overflow_count=1, result=_finish("HANDOFF"))
-    loop = _retry_loop(_ShrinkHost(), llm)
-    result = await loop._force_close_call_with_retry(
-        _msgs_with_tools(3), resolved_model="gpt-4o-mini"
-    )
-    assert result.content == "HANDOFF"
-    assert llm.call_count == 2  # initial overflow + one successful retry
-
-
-@pytest.mark.asyncio
-async def test_phase_shrink_retry_floor_aborts() -> None:
-    """Tier 2: when the call keeps overflowing, the host shrinks monotonically to
-    the floor (no tool messages → identity); at the floor the overflow re-raises
-    (floor-abort, pre-PR-D). Bounded by construction — the shrink strictly
-    reduces each step, so the loop cannot spin."""
-    llm = _OverflowThenFinishLLM(overflow_count=99, result=_finish())
-    loop = _retry_loop(_ShrinkHost(), llm)
-    with pytest.raises(RuntimeError):
-        await loop._force_close_call_with_retry(
-            _msgs_with_tools(2), resolved_model="gpt-4o-mini"
-        )
-    # 2 tool messages → 2 successful shrinks + the floor attempt = 3 LLM calls.
-    assert llm.call_count == 3
-
-
-@pytest.mark.asyncio
-async def test_chat_host_without_shrink_reraises_overflow() -> None:
-    """Tier 2: (B′ axis split) a host with NO maybe_compact_messages (= chat)
-    re-raises the overflow immediately — it propagates to the session's outer
-    retry_loop, NOT an in-loop shrink. No retry here."""
+async def test_force_close_retry_reraises_overflow_immediately() -> None:
+    """Tier 2: a force-close call that overflows re-raises immediately —
+    it propagates to the session's outer retry_loop, no in-loop retry
+    (#4978: this is now the ONLY behavior, not one side of a host-capability
+    axis — see this section's own header comment)."""
     llm = _OverflowThenFinishLLM(overflow_count=1, result=_finish())
-    loop = _retry_loop(FakeRouterHost(), llm)  # no maybe_compact_messages
+    loop = _retry_loop(FakeRouterHost(), llm)
     with pytest.raises(RuntimeError):
         await loop._force_close_call_with_retry(
             _msgs_with_tools(2), resolved_model="gpt-4o-mini"
@@ -213,9 +182,9 @@ async def test_chat_host_without_shrink_reraises_overflow() -> None:
 
 
 @pytest.mark.asyncio
-async def test_non_overflow_error_is_not_retried() -> None:
-    """Tier 2: a non-overflow exception is re-raised immediately — the shrink
-    path is ONLY for context-overflow, never a blanket retry."""
+async def test_non_overflow_error_is_also_reraised_immediately() -> None:
+    """Tier 2: a non-overflow exception is re-raised immediately too — same
+    single-call, no-retry behavior regardless of the exception's shape."""
     class _BoomLLM:
         def __init__(self) -> None:
             self.calls = 0
@@ -225,9 +194,9 @@ async def test_non_overflow_error_is_not_retried() -> None:
             raise ValueError("unrelated boom")
 
     llm = _BoomLLM()
-    loop = _retry_loop(_ShrinkHost(), llm)
+    loop = _retry_loop(FakeRouterHost(), llm)
     with pytest.raises(ValueError):
         await loop._force_close_call_with_retry(
             _msgs_with_tools(3), resolved_model="gpt-4o-mini"
         )
-    assert llm.calls == 1  # no shrink, no retry
+    assert llm.calls == 1  # no retry


### PR DESCRIPTION
**[e2e-coder]** — Closes #4978 (`maybe_compact_messages` removal).

## What

`maybe_compact_messages` is a `getattr`-optional host hook in `router_loop.py` with **0 production implementations** (measured) — every real call site (2) resolved `getattr(self.host, "maybe_compact_messages", None)` → `None` → no-op. The only implementation anywhere in the tree was a test double (`_ShrinkHost` in `tests/llm/test_force_close_call_1092.py`).

Its sibling `should_force_close` has 1 real implementation and stays alive — **not touched by this PR**.

## Removed

- **Site 1** (proactive in-loop compaction, `#1092 PR-C-4b`): the `getattr`/conditional-call block is deleted entirely — this was dead weight on every real turn regardless of host.
- **Site 2** (`_force_close_call_with_retry`, `#1092 PR-B` layer-2): the shrink-and-retry branch (`getattr` → shrink → monotonic-floor loop) is deleted. Since `shrink` was *always* `None` in production, the loop's only reachable path was the immediate `raise` on overflow — the function now does exactly that, unconditionally, with no branching on host capability.

## Tests — decided per-assert (architect's ruling), not per-file

`tests/llm/test_force_close_call_1092.py`'s "layer-2 phase shrink-retry" section had 4 tests:

- `test_phase_shrink_retry_recovers_after_overflow`, `test_phase_shrink_retry_floor_aborts` — named behavior that **only existed when a host implemented the hook**. No host ever did; **removed**, not adapted.
- `test_chat_host_without_shrink_reraises_overflow` → renamed `test_force_close_retry_reraises_overflow_immediately` — this asserted the real, universal production behavior (immediate re-raise, no in-loop retry) under a "chat vs phase axis" framing that no longer exists (there's only one behavior now). **Kept**, reworded to drop the now-false axis framing.
- `test_non_overflow_error_is_not_retried` → renamed `test_non_overflow_error_is_also_reraised_immediately`, switched from `_ShrinkHost()` to plain `FakeRouterHost()`. **Kept**.
- `_ShrinkHost` (the Fake implementing `maybe_compact_messages`) — **deleted**, per architect's required condition for keeping any test in this section: a Fake must never stay more capable than every real host, or "Fake passes but nothing real has that door" becomes a standing false-green.

## Scope note (required by architect + lead-coder ruling)

**Same-shaped `getattr`-optional hooks elsewhere were NOT counted in this PR.** The census tool used to estimate a candidate count is confirmed broken (a positive control — `workspace`, a core concept that's obviously non-zero — came back 0 hits), so any number it produced would be a candidate wearing a number's face, not a finding. `getattr`-optional is also a legitimate, intentional shape for a hook a host may deliberately not implement — "0 implementations" alone doesn't distinguish "dead" from "optional," so a discriminator is needed before counting, and none exists yet (architect: it arrives with a 2nd concrete example, same shape as `content_declarations`'s own "a second one is the trigger to re-open the question," #4974). This PR's scope is `maybe_compact_messages` only.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/llm/test_force_close_call_1092.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/router_loop.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `pytest` scoped to diff + `tests/llm/` (729 passed) + `tests/runtime/` regression sweep
- [x] (skipped — Visual, standing waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

