### PR TITLE
docs: reyn.local.yaml.example still listed new_turn_seqs as gating the reprompt

### DIFF
--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -430,8 +430,9 @@
 #     resummarize_passes: 1            # #271: LLM re-compression passes on topic_arc
 #                                      # overshoot before the hard_truncate floor (0 = skip)
 #     max_schema_reprompt_attempts: 1  # #4883: bounded re-prompt budget when the
-#                                      # compaction JSON response is missing/empty
-#                                      # new_turn_seqs/topic_arc (0 = raise immediately)
+#                                      # compaction JSON response has a missing/empty
+#                                      # topic_arc (0 = raise immediately). new_turn_seqs
+#                                      # no longer gates this (#4951-A).
 #     max_shrink_iterations: 8         # #4957: retry_loop's own safety cap — an
 #                                      # ESCAPE VALVE for a slow-to-converge overflow
 #                                      # recovery, not a cure. Raising it only delays


### PR DESCRIPTION
**[docs-maintainer]** — found during lead-coder's falsify-sweep assignment for 3 retired identifiers

## What

Lead-coder asked me to independently re-check (different method: `git
grep -lF`, not `-E`) whether `new_turn_seqs`/`elide_evaluated`/
`maybe_compact_messages` leave stale traces in `docs/`/`*.example`.
`elide_evaluated` and `maybe_compact_messages`: 0 hits, both confirmed
clean. `new_turn_seqs`: 3 hits — but that field genuinely still exists
today (its removal, PR #4981, hasn't landed yet), so those hits
themselves are not the finding.

Reading the 3 hits surfaced a DIFFERENT, pre-existing drift instead:
`reyn.local.yaml.example`'s `max_schema_reprompt_attempts` comment said
the reprompt triggers on a missing/empty `new_turn_seqs`**/**`topic_arc`
— but #4951-A (already landed, unrelated to the pending #4981) made
`new_turn_seqs` stop gating this entirely. Both `docs/reference/config/
reyn-yaml.md` and `docs/reference/runtime/events.md` already say so
correctly ("`new_turn_seqs` no longer gates this (#4951-A)") — this
`.example` comment was the one surface that never got the same fix.

## Fixed

Reworded the comment to name only `topic_arc` as the trigger and cite
`#4951-A` for why `new_turn_seqs` doesn't gate it, matching the wording
already established in the other 2 docs.

## Not touched

The other 2 `new_turn_seqs` mentions (in `reyn-yaml.md`/`events.md`)
were already correct — no change needed there. Nothing done for the
pending #4981 removal itself — not landed yet, per lead-coder's explicit
"don't get ahead of the landing PR" instruction from the earlier
`elide_evaluated` case tonight.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no `Aborted`/`WARNING`
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Closing-keyword self-check on commit message + this PR body — 0 hits
- [x] (skipped — no `tests/` paths touched, no TESTS-READ needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
