### PR TITLE
fix(#4983): mount no longer makes a synchronous history.jsonl read

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1216,12 +1216,29 @@ class TextualChatApp(App):
         config=None,
         clock: "Callable[[], float]" = time.monotonic,
         presenter: "ReynPresenter | None" = None,
+        initial_history_messages: "list | None" = None,
     ) -> None:
         super().__init__()
         self._transport = transport
         self._read_model = read_model
         self._agent_name = agent_name
         self._config = config
+        # #4983: the CURRENTLY-ATTACHED session's conversation history,
+        # read BEFORE this App was constructed (the caller — normally
+        # ``run_textual_chat``'s own pre-``run_async`` step — reads it off
+        # the event loop, e.g. via ``asyncio.to_thread``) so ``on_mount``
+        # never has to make its own synchronous disk read to hydrate the
+        # first frame. ``None`` means "no pre-fetched history was given" —
+        # a real caller that just has nothing to restore passes ``[]``,
+        # not ``None`` (``ChatReadModel.conversation_history`` never
+        # returns ``None`` on success) — so ``on_mount`` can tell "read
+        # for me already" apart from "read it yourself" and fall back to
+        # the old synchronous :meth:`_hydrate_from_history` call for any
+        # caller (most existing tests included) that constructs this App
+        # directly without threading this parameter through. See
+        # :meth:`on_mount`'s own docstring for the full mount-vs-session-
+        # switch split this parameter exists for.
+        self._initial_history_messages = initial_history_messages
         # App-side monotonic clock for the RUNNING-tool elapsed timer: tool frames
         # carry no RUNNING-start timestamp (ADR finding D2), so elapsed is computed
         # from when the started frame arrived here. Injectable so a test drives the
@@ -2225,7 +2242,18 @@ class TextualChatApp(App):
         from reyn.runtime.startup_timing import stage  # noqa: PLC0415
 
         with stage("tui-boot:hydrate"):
-            self._hydrate_from_history()
+            # #4983: prefer the history this App was CONSTRUCTED with (the
+            # caller already read it OFF the event loop — see
+            # ``__init__``'s own ``initial_history_messages`` docstring) —
+            # step ② only, no new disk read here. ``None`` (nothing was
+            # pre-fetched — most existing construction sites, tests
+            # included) falls back to the old synchronous do-both call,
+            # unchanged: this method must still hydrate correctly for a
+            # caller that never opted into the split.
+            if self._initial_history_messages is not None:
+                self._apply_hydrated_messages(self._initial_history_messages)
+            else:
+                self._hydrate_from_history()
         # The running-blink gutter animates off FlowView's NATIVE animation clock
         # (``animation_fps`` wired in :meth:`compose`), not an app-side timer — so
         # there is nothing to start/pause here. The blink is ADDITIVE: a frozen
@@ -2285,24 +2313,52 @@ class TextualChatApp(App):
         self.query_one("#drawer", ContentSwitcher).display = False
         self.query_one(Composer).focus()
 
-    def _hydrate_from_history(
+    def _read_conversation_history(
         self, *, agent: "str | None" = None, session_id: "str | None" = None
-    ) -> None:
-        """Restore-on-restart (#3273 Phase 5) AND session-switch reset+rehydrate
-        (#3310 N2): project a persisted conversation log into the retained
-        model so the pane shows that session's PREVIOUS conversation instead
-        of whatever was left over from before.
+    ) -> "list | None":
+        """#4983 step ① — the actual disk read (``history.jsonl`` via
+        :meth:`~reyn.interfaces.repl.read_model.ChatReadModel.
+        conversation_history`), split out of :meth:`_hydrate_from_history`
+        so a caller can choose HOW this specific step runs without also
+        touching step ② (:meth:`_apply_hydrated_messages`, pure in-memory
+        projection). Deliberately still a PLAIN synchronous method, not
+        ``async def`` — architect ruling (#4983): the two call sites need
+        DIFFERENT answers for "run this off the event loop or not" (mount
+        reads before the loop's own ``run_async`` even starts; a live
+        session-switch would need ``asyncio.to_thread``), and forcing one
+        ``async`` shape onto both would make the axis that actually
+        differs between them (WHEN/HOW step ① runs) invisible at the call
+        site. Each caller decides that for itself — this method only does
+        the read.
 
-        Two call shapes:
+        Returns ``None`` on `self._read_model` being unset OR the read
+        raising (already logged here) — the caller's :meth:`_apply_
+        hydrated_messages` treats ``None`` as "nothing to hydrate", same
+        behavior as the pre-split method's own early-return did."""
+        if self._read_model is None:
+            return None
+        try:
+            if agent is not None or session_id is not None:
+                return self._read_model.conversation_history(
+                    agent=agent, session_id=session_id
+                )
+            return self._read_model.conversation_history()
+        except Exception:
+            logger.exception("textual chat: conversation-history read failed")
+            return None
 
-        - No args (:meth:`on_mount`'s original Phase-5 call): hydrates the
-          CURRENTLY ATTACHED session, byte-identical to pre-N2 behavior.
-        - ``agent``/``session_id`` given (:meth:`_handle_session_attached_event`,
-          called AFTER :meth:`self.conversation`'s ``clear()``): hydrates that
-          SPECIFIC (possibly never-before-attached-in-this-client-run) session
-          instead — the same read-model seam
-          (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.conversation_history`
-          — ``history.jsonl``, NOT the P6 audit-event log), just targeted.
+    def _apply_hydrated_messages(self, messages: "list | None") -> None:
+        """#4983 step ② — project *messages* (already read by :meth:`_read_
+        conversation_history`, step ①) into the retained model so the pane
+        shows that session's PREVIOUS conversation instead of whatever was
+        left over from before. Pure in-memory work — deliberately left ON
+        the event loop at both call sites (architect ruling, #4983): this
+        is cheap (projection + a batched ``FlowView.extend``, no I/O), and
+        splitting it further would buy nothing while adding a second
+        cross-thread handoff for no reason.
+
+        A no-op when *messages* is ``None`` (step ① found nothing to read,
+        or failed — already logged there).
 
         Appends each projected frame to ``self.conversation``
         (:func:`.restore.project_restored_frames`). Every restored entry is
@@ -2323,17 +2379,7 @@ class TextualChatApp(App):
         either way, and the pane starts/stays blank (remote switch-rehydrate is
         #3310 N3's job). Fully guarded — a restore failure must never stop the
         app from mounting/resetting and pumping live frames."""
-        if self._read_model is None:
-            return
-        try:
-            if agent is not None or session_id is not None:
-                messages = self._read_model.conversation_history(
-                    agent=agent, session_id=session_id
-                )
-            else:
-                messages = self._read_model.conversation_history()
-        except Exception:
-            logger.exception("textual chat: conversation-history read failed")
+        if messages is None:
             return
         try:
             frames = project_restored_frames(messages)
@@ -2382,6 +2428,40 @@ class TextualChatApp(App):
         for msg in frames:
             if msg.kind == "agent":
                 self._recent_replies.appendleft(msg.text)
+
+    def _hydrate_from_history(
+        self, *, agent: "str | None" = None, session_id: "str | None" = None
+    ) -> None:
+        """Restore-on-restart (#3273 Phase 5) AND session-switch reset+rehydrate
+        (#3310 N2): the SYNCHRONOUS do-both convenience — runs step ①
+        (:meth:`_read_conversation_history`) then step ② (:meth:`_apply_
+        hydrated_messages`) back to back, on whatever thread/task calls
+        this. #4983: mount (:meth:`on_mount`) no longer calls this when a
+        pre-fetched history is available (see that method's own docstring
+        for why it reads BEFORE the app is even constructed instead) —
+        this wrapper remains for :meth:`_handle_session_attached_event`
+        (the live session-switch rehydrate, #3310 N2), which #4983
+        deliberately did NOT touch: that call site's own event-loop-block
+        question is a separate, still-open UX question (does the
+        conversation pane briefly go blank on switch, in exchange for the
+        TUI no longer freezing?) requiring its own owner-facing ruling —
+        see #4983's own issue thread. Do not read "mount is fixed" as
+        "this method is fixed" — it is the SAME synchronous shape it
+        always was, on this call path.
+
+        Two call shapes:
+
+        - No args: hydrates the CURRENTLY ATTACHED session, byte-identical
+          to pre-N2/pre-#4983 behavior.
+        - ``agent``/``session_id`` given (:meth:`_handle_session_attached_event`,
+          called AFTER :meth:`self.conversation`'s ``clear()``): hydrates that
+          SPECIFIC (possibly never-before-attached-in-this-client-run) session
+          instead — the same read-model seam
+          (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.conversation_history`
+          — ``history.jsonl``, NOT the P6 audit-event log), just targeted."""
+        self._apply_hydrated_messages(
+            self._read_conversation_history(agent=agent, session_id=session_id)
+        )
 
     def _extend_older_frames_from_disk(self) -> bool:
         """#4387 Phase B ② (remaining consumers): when ``self._older_frames``
@@ -6084,10 +6164,50 @@ async def run_textual_chat(
     # outlives this call regardless of which path it takes.
     # ``disarm()`` is idempotent (its own docstring), so both firing on
     # the ordinary path is harmless.
+    import asyncio  # noqa: PLC0415
+
     from reyn.runtime.stall_trace import arm as _arm_stall_trace
     from reyn.runtime.stall_trace import disarm as _disarm_stall_trace
     from reyn.runtime.stall_trace import stall_trace_seconds_from_env
     from reyn.runtime.startup_timing import mark_app_constructed, stage  # noqa: PLC0415
+
+    # #4983 (architect design (c)): read the CURRENTLY-ATTACHED session's
+    # history OFF the event loop, BEFORE the App (and its own event loop)
+    # even exist — closes the measured defect (``on_mount`` used to make
+    # this exact read synchronously, ON the loop, via
+    # ``TextualChatApp._hydrate_from_history``) WITHOUT changing what the
+    # first frame shows: the read still completes before ``run_async``
+    # starts, so first paint has the same populated pane it always did.
+    # ``None`` when there is no read model at all (a caller with nothing
+    # to restore) — ``TextualChatApp.__init__``'s own ``initial_history_
+    # messages`` docstring explains why that must stay ``None``, not
+    # ``[]``, in that case (``on_mount`` needs to tell "nothing to read"
+    # apart from "read it yourself").
+    #
+    # Deliberately does NOT touch the session-switch rehydrate path
+    # (``TextualChatApp._handle_session_attached_event``, live, mid-
+    # session) — that call site still makes the SAME synchronous read it
+    # always did. Its own event-loop-block question is a separate,
+    # still-open UX question (a live switch would trade "TUI freezes
+    # briefly" for "the pane goes blank for a beat, then refills") that
+    # needs its own owner-facing ruling before it changes — see #4983's
+    # own issue thread. Do not read this fix as covering that path too.
+    _initial_history_messages = None
+    if read_model is not None:
+        try:
+            _initial_history_messages = await asyncio.to_thread(
+                read_model.conversation_history
+            )
+        except Exception:
+            # Fully guarded, same discipline as the pre-#4983 synchronous
+            # read this replaces (``TextualChatApp._read_conversation_
+            # history``'s own docstring) — a restore failure must never
+            # stop the app from mounting; ``None`` here makes ``on_mount``
+            # fall back to its own (also-guarded) synchronous retry rather
+            # than silently mounting with an empty pane no one decided on.
+            logger.exception(
+                "textual chat: pre-fetching conversation history failed"
+            )
 
     _stall_seconds = stall_trace_seconds_from_env()
     if _stall_seconds is not None:
@@ -6100,6 +6220,7 @@ async def run_textual_chat(
                 read_model=read_model,
                 agent_name=agent_name,
                 config=config,
+                initial_history_messages=_initial_history_messages,
             )
         await app.run_async(inline=inline)
     finally:

--- a/tests/interfaces/test_4983_mount_hydrate_off_loop.py
+++ b/tests/interfaces/test_4983_mount_hydrate_off_loop.py
@@ -1,0 +1,220 @@
+"""Tier 2: #4983 — ``on_mount()`` no longer makes its own synchronous
+``history.jsonl`` disk read.
+
+Root cause: ``TextualChatApp.on_mount()`` is not ``async def``, and used to
+call ``self._hydrate_from_history()`` unconditionally, which synchronously
+called ``self._read_model.conversation_history()`` — real disk I/O, directly
+on the event loop, with no ``await`` anywhere in the chain. Found while
+investigating #4834's CI `pump heartbeat +0` stalls; confirmed as a real
+defect independent of that investigation's own open question (whether it
+explains CI's specific 2-second symptom — it may not, given CI's own small
+test fixtures — see #4834's own thread).
+
+Architect's design (c), issue #4983: read the CURRENTLY-ATTACHED session's
+history OFF the event loop, BEFORE the App exists at all (``run_textual_
+chat``, via ``asyncio.to_thread``), then hand the result to the App at
+construction — ``on_mount()`` applies it (pure in-memory projection, no I/O)
+instead of reading it itself. First paint is UNCHANGED (still populated,
+never blank-then-fills) because the read completes before ``run_async``
+starts. Scope: MOUNT ONLY — the session-switch rehydrate path
+(``_handle_session_attached_event``) is deliberately untouched here (a
+separate, still-open UX question; see that method's own docstring).
+
+Real ``TextualChatApp`` + a real ``ChatReadModel`` seam impl throughout
+(mirrors ``tests/runtime/test_textual_chat_phase5_3273.py``'s own
+``_HistoryReadModel``) — no mocks.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.app import run_textual_chat
+from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.runtime import stall_trace
+from reyn.runtime.chat_message import ChatMessage
+from tests._support.textual_chat_test_helpers import QueueTransport
+
+
+class _CountingReadModel(ChatReadModel):
+    """A real :class:`ChatReadModel` seam impl (like
+    ``test_textual_chat_phase5_3273.py``'s own ``_HistoryReadModel``) that
+    additionally counts ``conversation_history`` calls — the observable
+    this file's tests need (whether ``on_mount`` reads for itself)."""
+
+    def __init__(self, messages: "list[ChatMessage]") -> None:
+        self.messages = list(messages)
+        self.call_count = 0
+
+    def snapshot(self, config=None):
+        return None
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    @property
+    def history_path(self) -> Path:
+        return Path("/tmp/reyn_4983_input_history")
+
+    def conversation_history(self, *, limit=None, agent=None, session_id=None):
+        self.call_count += 1
+        return list(self.messages)
+
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
+
+def _fixture_messages() -> "list[ChatMessage]":
+    return [
+        ChatMessage(role="user", content="hello", seq=1),
+        ChatMessage(role="assistant", content="hi there", seq=2),
+    ]
+
+
+# ── mount with a pre-fetched history: no read, first paint still populated ──
+
+
+@pytest.mark.asyncio
+async def test_mount_with_prefetched_history_never_calls_conversation_history() -> None:
+    """Tier 2: the measured defect's own falsifier — with ``initial_history_
+    messages`` given, ``on_mount`` must not touch ``self._read_model`` at
+    all. Reverting ``on_mount``'s own branch (always calling
+    ``_hydrate_from_history()``) turns this red — confirmed by reading the
+    diff, not asserted blind."""
+    messages = _fixture_messages()
+    read_model = _CountingReadModel(messages)
+    app = TextualChatApp(
+        transport=QueueTransport(),
+        read_model=read_model,
+        initial_history_messages=messages,
+    )
+    async with app.run_test(size=(80, 24)):
+        pass
+
+    assert read_model.call_count == 0, (
+        "on_mount must use the pre-fetched history, not read it again itself"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mount_with_prefetched_history_populates_first_paint() -> None:
+    """Tier 2: the UX invariant architect's design (c) exists to preserve —
+    pre-fetched history must still reach the conversation model (no
+    blank-then-fills regression from this refactor)."""
+    messages = _fixture_messages()
+    read_model = _CountingReadModel(messages)
+    app = TextualChatApp(
+        transport=QueueTransport(),
+        read_model=read_model,
+        initial_history_messages=messages,
+    )
+    async with app.run_test(size=(80, 24)):
+        assert len(app.conversation) > 0, (
+            "pre-fetched history must be applied to the retained model"
+        )
+
+
+# ── backward compat: no pre-fetch given → old synchronous path still works ──
+
+
+@pytest.mark.asyncio
+async def test_mount_without_prefetch_falls_back_to_the_synchronous_read() -> None:
+    """Tier 2: accept-side — a caller that constructs ``TextualChatApp``
+    directly without ``initial_history_messages`` (every pre-#4983 call
+    site, most existing tests) must still hydrate correctly: ``None`` is
+    read as "read it yourself," not "there is nothing to restore.\""""
+    read_model = _CountingReadModel(_fixture_messages())
+    app = TextualChatApp(transport=QueueTransport(), read_model=read_model)
+    async with app.run_test(size=(80, 24)):
+        assert read_model.call_count == 1, (
+            "no initial_history_messages given: on_mount must still read once, "
+            "exactly like before this issue"
+        )
+        assert len(app.conversation) > 0
+
+
+# ── run_textual_chat: the actual pre-fetch wiring ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_textual_chat_prefetches_off_thread_before_construction(
+    monkeypatch,
+) -> None:
+    """Tier 2: ``run_textual_chat`` itself must call ``conversation_history``
+    BEFORE constructing the App (mirrors ``test_3671_stall_trace_startup_
+    wiring.py``'s own technique — stub ``TextualChatApp.run_async`` to raise
+    immediately, so only pre-construction wiring is observed).
+
+    Also confirms the read runs OFF the calling task via a real
+    ``asyncio.to_thread``: records the thread identity ``conversation_
+    history`` was called from and asserts it differs from the main
+    event-loop thread's own identity."""
+    main_thread = threading.current_thread()
+    call_threads: "list[threading.Thread]" = []
+    messages = _fixture_messages()
+    read_model = _CountingReadModel(messages)
+    real_conversation_history = read_model.conversation_history
+
+    def _recording(*args, **kwargs):
+        call_threads.append(threading.current_thread())
+        return real_conversation_history(*args, **kwargs)
+
+    monkeypatch.setattr(read_model, "conversation_history", _recording)
+
+    construct_order: "list[str]" = []
+    real_init = TextualChatApp.__init__
+
+    def _recording_init(self, *args, **kwargs):
+        construct_order.append("construct")
+        assert kwargs.get("initial_history_messages") == messages, (
+            "the App must be constructed WITH the pre-fetched history"
+        )
+        return real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(TextualChatApp, "__init__", _recording_init)
+
+    async def _raising_run_async(self, *args, **kwargs):
+        raise RuntimeError("simulated: app never reached first frame")
+
+    monkeypatch.setattr(TextualChatApp, "run_async", _raising_run_async)
+    monkeypatch.setattr(stall_trace, "arm", lambda seconds: None)
+    monkeypatch.setattr(stall_trace, "disarm", lambda: None)
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        await run_textual_chat(transport=QueueTransport(), read_model=read_model)
+
+    assert read_model.call_count == 1
+    assert construct_order == ["construct"], "the App must have been constructed"
+    assert call_threads, "conversation_history must have been called"
+    assert call_threads[0] is not main_thread, (
+        "the read must run off the event-loop thread (asyncio.to_thread), "
+        "not inline on the same thread run_textual_chat itself runs on"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_textual_chat_with_no_read_model_prefetches_nothing(monkeypatch) -> None:
+    """Tier 2: accept-side — ``read_model=None`` (a caller with nothing to
+    restore) must not attempt a read at all, and the App must still
+    construct (with ``initial_history_messages=None``, on_mount's own
+    fallback path — covered by the mount-side tests above)."""
+    async def _raising_run_async(self, *args, **kwargs):
+        raise RuntimeError("simulated: app never reached first frame")
+
+    monkeypatch.setattr(TextualChatApp, "run_async", _raising_run_async)
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        await run_textual_chat(transport=QueueTransport(), read_model=None)


### PR DESCRIPTION
**[tui-coder]** — part of #4983 (MOUNT SIDE ONLY — architect design (c), lead-coder-approved scope split; found while investigating #4834).

## What

`TextualChatApp.on_mount()` is not `async def`, and used to call `self._hydrate_from_history()` unconditionally, which synchronously called `self._read_model.conversation_history()` — real `history.jsonl` disk I/O directly on the event loop, no `await` anywhere in the chain. Confirmed independently of #4834's own open discriminator (whether this explains CI's specific 2s symptom — it may not, given CI's small test fixtures).

## Design (architect ruling on #4983)

The UX axis is **"does the first painted frame have history in it"**, not "async vs deferred" — a naive `async def` on `_hydrate_from_history` would still let Textual paint an empty frame the instant the first real `await` is reached, which is itself a regression. Design (c) sidesteps that: read the currently-attached session's history **OFF the event loop, BEFORE the App even exists** (`asyncio.to_thread` in `run_textual_chat`), hand the result to the App at construction. First paint is unchanged — still populated, never blank-then-fills. No owner consult needed (no visible UX change).

## Explicit scope boundary

This PR does **not** touch the session-switch rehydrate path (`_handle_session_attached_event`) — that call site keeps making the exact same synchronous read it always did. Its own event-loop-block question is separate and still open (a live switch would trade "TUI freezes" for "pane briefly blanks, then refills"), needs its own owner-facing UX ruling, and is tracked in #4983's own issue thread. Do not read this PR as closing #4983 in full — `#4983`'s own session-switch item stays open. `#4834` also stays open — its own discriminator is unresolved and untouched by this PR.

## Changes

- `TextualChatApp._hydrate_from_history` split into two steps so the "run this off-thread or not" axis lives at the call site, not inside a shared function architect ruled must stay one synchronous shape:
  - `_read_conversation_history` — the I/O (still plain, sync)
  - `_apply_hydrated_messages` — projection + apply to the retained model (pure in-memory, stays on the loop everywhere)
  - `_hydrate_from_history` itself remains the synchronous do-both convenience, **unchanged**, still used by the untouched session-switch path.
- `TextualChatApp.__init__` gains `initial_history_messages` (default `None` = "read it yourself" — every existing construction site's unchanged behavior).
- `run_textual_chat` pre-fetches via `asyncio.to_thread` before constructing the App, fully guarded (a read failure logs and falls through to `on_mount`'s own synchronous retry — same discipline the pre-fix code already had).

## Test plan

- [x] 5 new tests (`tests/interfaces/test_4983_mount_hydrate_off_loop.py`): the measured defect's own falsifier (mount must not call `conversation_history` when pre-fetched — **strip-falsified**, confirmed red on revert), first-paint population, backward-compat fallback, `run_textual_chat`'s own pre-construction + off-thread wiring (real thread-identity check), `read_model=None` accept-side
- [x] `ast.parse` — valid
- [x] `ruff check` — clean
- [x] `pytest tests/interfaces/` (full sweep) — **1906/1906 passed**, 4 skipped (unrelated optional-extras)
- [x] `pytest tests/runtime -k "textual or hydrate or mount"` — 25/25 passed
- [x] `scripts/test_tier_audit.py --strict` on the new test file — 5/5 OK
- [x] `scripts/verify_module_docstrings.py` — OK
- [x] `scripts/mypy_ratchet.py` — OK (203, all baselined, unchanged)
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_file_depth_reference.py` / `check_bare_tests_import_reference.py` — all OK
- [ ] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
