### PR TITLE
fix(#4988): cancel-then-await-then-swallow class, 8 sites

### DIFF
--- a/.github/workflows/cancel-swallow-gate.yml
+++ b/.github/workflows/cancel-swallow-gate.yml
@@ -1,0 +1,44 @@
+name: cancel-swallow gate
+
+# #4986/#4988: reject any "cancel a task/future this code owns, await it,
+# catch the resulting CancelledError unconditionally" site with no
+# Task.cancelling() check. `await some_task` raises CancelledError for two
+# indistinguishable reasons — that task's own cancellation outcome (the
+# intended target) or the CURRENT coroutine's own task being
+# independently, externally cancelled at the same await — and an
+# unconditional swallow absorbs both, letting a genuine external
+# cancellation (e.g. a shutdown sweep, asyncio.run()'s / pytest-asyncio's
+# own end-of-loop _cancel_all_tasks) appear to have completed when it did
+# not. See scripts/check_cancel_swallow.py's module docstring for the full
+# design rationale (#4986/#4988).
+#
+# No diff/base-ref needed — a whole-tree scan against a baseline of zero,
+# same shape as collect-events-settle-gate.yml. A shallow checkout is
+# enough.
+on:
+  pull_request:
+    paths:
+      - "src/reyn/**"
+
+permissions:
+  contents: read
+
+jobs:
+  cancel-swallow:
+    name: cancel-swallow gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_cancel_swallow.py is stdlib-only (ast / pathlib /
+      # sys). No pip install needed.
+      - name: Check no cancel-then-await-then-swallow site is missing a cancelling() check
+        run: |
+          python scripts/check_cancel_swallow.py

--- a/.github/workflows/main-hourly-gate-sweep.yml
+++ b/.github/workflows/main-hourly-gate-sweep.yml
@@ -99,3 +99,7 @@ jobs:
       - name: collect-events-settle
         if: ${{ !cancelled() }}
         run: python scripts/check_collect_events_settle.py
+
+      - name: cancel-swallow
+        if: ${{ !cancelled() }}
+        run: python scripts/check_cancel_swallow.py

--- a/scripts/check_cancel_swallow.py
+++ b/scripts/check_cancel_swallow.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""#4988 — a static gate against the "cancel-then-await-then-swallow"
+class: a coroutine cancels a task/future it owns, awaits it, and catches
+the resulting ``CancelledError`` unconditionally — with no check for
+whether the CATCHING coroutine's own task was ALSO, independently,
+externally cancelled at that exact same await.
+
+## The failure this closes
+
+    some_task.cancel()
+    try:
+        await some_task
+    except asyncio.CancelledError:
+        pass          # <-- swallows BOTH cases below, indistinguishably
+
+``await some_task`` raises ``CancelledError`` for two different reasons
+that are, at the `except` clause, indistinguishable by the exception
+alone:
+
+  (a) ``some_task``'s own cancellation outcome — the ``.cancel()`` call
+      two lines up, exactly what this pattern exists to absorb.
+  (b) the CURRENT coroutine's own task being independently, externally
+      cancelled (e.g. a shutdown sweep, `asyncio.run()`'s / pytest-
+      asyncio's own end-of-loop `_cancel_all_tasks`, which cancels every
+      task in `asyncio.all_tasks()` with no ordering guarantee) while
+      suspended at this exact await.
+
+An unconditional ``pass`` treats both the same: case (b) is silently
+absorbed, and the enclosing function returns NORMALLY instead of letting
+a genuine external cancellation propagate — the caller's own shutdown/
+teardown appears to have completed when it did not. Found in
+``events.py``'s ``drain()``/``stop_dispatch()`` (#4986/#4988) and,
+census'd from there, 4 more sites with the identical shape.
+
+## The fix this gate accepts (already applied at every site above)
+
+Python 3.11+ (this repo's own floor — ``pyproject.toml``'s
+``requires-python = ">=3.11"``) added ``Task.cancelling()`` for exactly
+this: the number of pending cancellation requests against the CURRENT
+task. Checking it in the ``except`` handler tells (a) apart from (b):
+
+    some_task.cancel()
+    try:
+        await some_task
+    except asyncio.CancelledError:
+        if asyncio.current_task().cancelling() > 0:
+            raise
+
+reyn already had this exact pattern before #4988 — ``session.py``'s own
+#3377 precedent (``_driver.cancelling() > 0``) — this gate's fix mirrors
+it, not a new invention. Python's own docs (asyncio-task.html): "Should
+the coroutine nevertheless decide to suppress the cancellation, it needs
+to call Task.uncancel() in addition to catching the exception" —
+checking ``cancelling()`` before deciding to swallow is the read-side of
+that same discipline.
+
+## Scope and known gap (disclosed, not silently narrowed)
+
+This gate is a STRUCTURAL pattern match (AST), not a semantic proof: it
+flags a `try: await <name> / except CancelledError:` handler with no
+`raise` anywhere in it, PRECEDED in the same function by `<name>.cancel()`
+on that exact name, and no `.cancelling()` call anywhere in the handler.
+A site that legitimately does not need the check (e.g. it can prove by
+construction that its own task is never independently cancellable at
+that point) has no way to declare that here — the only escape is to
+restructure the code so the pattern's own shape (cancel-a-name, await
+that SAME name, catch-and-swallow) doesn't match, same as
+`check_collect_events_settle.py`'s own precedent for this repo's static
+gates. A hand-rolled indirection (cancelling through a wrapper function
+whose name this gate can't trace back to the literal `.cancel()` call)
+is a disclosed blind spot, not a claim of exhaustive coverage — mirrors
+that same gate's own "not every hand-rolled shape is traceable" caveat.
+
+This gate only scans ``src/`` (production code) — the failure mode is a
+production defect (a real shutdown silently appearing to complete), not
+a test-authoring one.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC_DIR = _ROOT / "src" / "reyn"
+
+
+def _is_cancelled_error_handler(handler: ast.ExceptHandler) -> bool:
+    """True if *handler* catches ``asyncio.CancelledError`` or a bare
+    ``CancelledError`` (either import shape this codebase uses)."""
+    node = handler.type
+    if node is None:
+        return False
+    names = [node] if not isinstance(node, ast.Tuple) else list(node.elts)
+    for n in names:
+        if isinstance(n, ast.Attribute) and n.attr == "CancelledError":
+            return True
+        if isinstance(n, ast.Name) and n.id == "CancelledError":
+            return True
+    return False
+
+
+def _handler_has_raise(handler: ast.ExceptHandler) -> bool:
+    """True if any ``raise`` statement (bare or with an exception)
+    appears anywhere in *handler*'s own body — the handler already
+    propagates, at least on some path, so it is not a silent swallow."""
+    return any(isinstance(n, ast.Raise) for stmt in handler.body for n in ast.walk(stmt))
+
+
+def _handler_checks_cancelling(handler: ast.ExceptHandler) -> bool:
+    """True if *handler* calls ``.cancelling()`` anywhere in its own
+    body — the discriminator this gate exists to require (session.py's
+    own #3377 precedent; see this module's own docstring)."""
+    return any(
+        isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "cancelling"
+        for stmt in handler.body
+        for n in ast.walk(stmt)
+    )
+
+
+def _awaited_name(try_node: ast.Try) -> "str | None":
+    """The bare name being awaited, if *try_node*'s body is (or starts
+    with) a single ``await <Name>`` — the shape every known instance of
+    this class uses (``await task`` / ``await join_future`` / ``await
+    self._drain_task``, never a compound expression). Returns the
+    dotted-attribute path as a string (e.g. ``self._drain_task``) or a
+    bare name, so it can be compared against a preceding ``<same>.cancel()``
+    call textually."""
+    for stmt in try_node.body:
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Await):
+            awaited = stmt.value.value
+        elif isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Await):
+            awaited = stmt.value.value
+        else:
+            continue
+        return _dotted_name(awaited)
+    return None
+
+
+def _dotted_name(node: ast.AST) -> "str | None":
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted_name(node.value)
+        return f"{base}.{node.attr}" if base is not None else None
+    return None
+
+
+def _has_preceding_cancel_call(func_body_root: ast.AST, try_node: ast.Try, name: str) -> bool:
+    """True if ``<name>.cancel()`` is called anywhere in *func_body_root*
+    at a line number BEFORE *try_node*'s own line — the "this code owns
+    and just told this task to cancel" signal that makes the awaited
+    name's own cancellation the EXPECTED outcome (case (a) in this
+    module's own docstring)."""
+    for node in ast.walk(func_body_root):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "cancel"
+            and _dotted_name(node.func.value) == name
+            and node.lineno < try_node.lineno
+        ):
+            return True
+    return False
+
+
+def _check_function(func: "ast.FunctionDef | ast.AsyncFunctionDef") -> "list[tuple[int, str]]":
+    """Return ``[(lineno, awaited_name), ...]`` for every cancel-then-
+    await-then-swallow site found in *func*'s own body."""
+    hits: "list[tuple[int, str]]" = []
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Try):
+            continue
+        name = _awaited_name(node)
+        if name is None:
+            continue
+        for handler in node.handlers:
+            if not _is_cancelled_error_handler(handler):
+                continue
+            if _handler_has_raise(handler):
+                continue  # propagates on at least one path — not a swallow
+            if _handler_checks_cancelling(handler):
+                continue  # already discriminates — the accepted fix shape
+            if not _has_preceding_cancel_call(func, node, name):
+                continue  # not "this code's own cancel" — different shape
+            hits.append((node.lineno, name))
+    return hits
+
+
+def offending_files(src_dir: Path) -> "list[tuple[Path, list[tuple[int, str]]]]":
+    """The gate's whole decision, isolated from CLI/printing — directly
+    testable, mirrors ``check_collect_events_settle.py``'s own split."""
+    offenders: "list[tuple[Path, list[tuple[int, str]]]]" = []
+    for path in sorted(src_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, SyntaxError):
+            continue
+        hits: "list[tuple[int, str]]" = []
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                hits.extend(_check_function(node))
+        if hits:
+            offenders.append((path, sorted(hits)))
+    return offenders
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options — a whole-tree scan against a baseline of zero
+    offenders = offending_files(_SRC_DIR)
+
+    if not offenders:
+        print(
+            "OK: no cancel-then-await-then-swallow site found without a "
+            "Task.cancelling() check in the except handler."
+        )
+        return 0
+
+    print("cancel-swallow gate FAILED:\n", file=sys.stderr)
+    print(
+        f"{len(offenders)} file(s) cancel a task/future they own, await "
+        "it, and catch the resulting CancelledError unconditionally "
+        "(#4986/#4988) — this cannot tell 'that task's own cancellation' "
+        "apart from 'my OWN task was independently, externally cancelled "
+        "at this same await', so the second case is silently absorbed "
+        "instead of propagating:",
+        file=sys.stderr,
+    )
+    for path, hits in offenders:
+        rel = path.relative_to(_ROOT)
+        for line, name in hits:
+            print(f"  {rel}:{line}: cancel-then-await-swallow of {name!r}", file=sys.stderr)
+
+    print(
+        "\nFix: check `asyncio.current_task().cancelling() > 0` in the "
+        "except handler and `raise` when true (session.py's own #3377 "
+        "precedent; see events.py's drain()/stop_dispatch() for the "
+        "worked example, #4988).\n"
+        "\nThis gate's own starting population is zero, so any hit here "
+        "is a new regression, not inherited debt.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/reyn/core/cancellable.py
+++ b/src/reyn/core/cancellable.py
@@ -110,7 +110,23 @@ async def race_cancellable(
             try:
                 await watcher
             except asyncio.CancelledError:
-                pass
+                # #4988: `await watcher` raises CancelledError either as (a)
+                # `watcher`'s own outcome (this method's `watcher.cancel()`
+                # two lines up — the case this except exists to absorb), or
+                # (b) `host_task` (the CURRENT task, running this very
+                # `finally`) being independently, externally cancelled AGAIN
+                # while suspended at this specific await. `pass`-ing
+                # unconditionally used to treat both the same, silently
+                # completing this function instead of letting (b) propagate.
+                # Same discriminator as this module's own `except
+                # asyncio.CancelledError:` a few lines up (`host_task.
+                # cancelling()` vs `baseline_cancelling`) and as session.py's
+                # #3377 precedent: `> baseline_cancelling` means a
+                # cancellation request against `host_task` is still
+                # outstanding beyond what this function already accounted
+                # for, so it must be re-raised rather than absorbed here.
+                if host_task.cancelling() > baseline_cancelling:
+                    raise
         elif fired and not already_uncancelled:
             # The watcher fired but coro did NOT raise CancelledError (it returned
             # normally, or raised a different exception, before our cancel() was

--- a/src/reyn/core/events/durability_worker.py
+++ b/src/reyn/core/events/durability_worker.py
@@ -234,4 +234,15 @@ class DurabilityWorker:
             try:
                 await self._drainer
             except asyncio.CancelledError:
-                pass
+                # #4988: `await self._drainer` raises CancelledError either
+                # as the drainer task's own outcome (this method's own
+                # `.cancel()` two lines up — what this except exists to
+                # absorb) or as an independent, external cancellation of
+                # THIS coroutine's own task landing at the same await.
+                # `pass`-ing unconditionally used to treat both the same,
+                # letting `aclose()` return normally even when its own
+                # caller was being cancelled. Same discriminator as
+                # session.py's #3377 precedent (`_driver.cancelling() > 0`).
+                _current = asyncio.current_task()
+                if _current is not None and _current.cancelling() > 0:
+                    raise

--- a/src/reyn/core/events/events.py
+++ b/src/reyn/core/events/events.py
@@ -325,7 +325,33 @@ class EventLog:
         try:
             await join_future
         except asyncio.CancelledError:
-            pass
+            # #4986: `await join_future` raises CancelledError for TWO
+            # possible reasons, indistinguishable by the exception alone —
+            # (a) `join_future.cancel()` two lines up, its own outcome,
+            # exactly what this except exists to absorb; (b) THIS
+            # coroutine's OWN task was independently, externally cancelled
+            # (e.g. pytest-asyncio's/`asyncio.run()`'s end-of-loop
+            # `_cancel_all_tasks`, which cancels every task in
+            # `asyncio.all_tasks()` — including whatever task is running
+            # `drain()` right now — with no ordering guarantee relative to
+            # this await). Swallowing unconditionally used to treat both
+            # the same: (b) would silently continue past this method
+            # (logging a "some events undelivered" warning, then
+            # RETURNING NORMALLY) instead of propagating — the exact
+            # cancel-swallow session.py's own #3377 precedent
+            # (`_driver.cancelling() > 0`) already exists to prevent, not
+            # applied here. `Task.cancelling()` (Python 3.11+, this repo's
+            # own floor — pyproject.toml `requires-python = ">=3.11"`)
+            # answers which case this is: >0 means a cancellation request
+            # against THIS task is still outstanding (case (b)) and must
+            # be re-raised so the caller's own teardown/shutdown actually
+            # happens instead of appearing to complete; 0 means this
+            # task's own cancel count nets to zero, so the CancelledError
+            # just seen can only have come from `join_future` itself
+            # (case (a)) and is safe to absorb, unchanged from before.
+            _current = asyncio.current_task()
+            if _current is not None and _current.cancelling() > 0:
+                raise
         remaining = self._dispatch_queue.qsize()
         if remaining:
             logger.warning(
@@ -387,7 +413,23 @@ class EventLog:
         try:
             await task
         except asyncio.CancelledError:
-            pass
+            # #4986: same ambiguity as `drain()`'s own identical shape a
+            # few lines up this file (see that except block's own
+            # docstring-length comment for the full reasoning) —
+            # `await task` raising CancelledError here could be `task`'s
+            # own cancellation outcome (this method's own `task.cancel()`
+            # two lines up) OR THIS coroutine's own task being
+            # independently, externally cancelled at the same await. The
+            # unconditional `pass` this replaces could not tell them
+            # apart, so an external cancel landing here used to be
+            # silently absorbed — `self._consumer_task = None` would run
+            # and this method would return normally, instead of the
+            # caller's own cancellation actually propagating. Checked the
+            # same way session.py's own #3377 precedent
+            # (`_driver.cancelling() > 0`) already does.
+            _current = asyncio.current_task()
+            if _current is not None and _current.cancelling() > 0:
+                raise
         self._consumer_task = None
 
     def set_backend(self, backend: "EventBackend | None") -> None:

--- a/src/reyn/hooks/ingress.py
+++ b/src/reyn/hooks/ingress.py
@@ -161,7 +161,21 @@ class _BoundedEventBridge:
             try:
                 await self._drain_task
             except asyncio.CancelledError:
-                pass
+                # #4988: `await self._drain_task` raises CancelledError
+                # either as the drain task's own outcome (this method's own
+                # `.cancel()` two lines up — what this except exists to
+                # absorb) or as an independent, external cancellation of
+                # THIS coroutine's own task landing at the same await.
+                # `pass`-ing unconditionally used to treat both the same,
+                # letting `aclose()` return normally even when its own
+                # caller was being cancelled. Same discriminator as
+                # session.py's #3377 precedent (`_driver.cancelling() > 0`).
+                # Shared by every subclass that inherits this `aclose()`
+                # (McpIngressAdapter / FsIngressAdapter — see this class's
+                # own docstring), so one fix covers both.
+                _current = asyncio.current_task()
+                if _current is not None and _current.cancelling() > 0:
+                    raise
         self._drain_task = None
 
 

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -281,7 +281,21 @@ async def _lifespan(app: FastAPI):
         sweep_task.cancel()
         try:
             await sweep_task
-        except (asyncio.CancelledError, Exception):  # noqa: BLE001 — defensive shutdown
+        except asyncio.CancelledError:
+            # #4988: `await sweep_task` raises CancelledError either as
+            # that task's own outcome (this block's own `.cancel()` two
+            # lines up — what this except exists to absorb) or as an
+            # independent, external cancellation of THIS coroutine's own
+            # task landing at the same await. Catching it unconditionally
+            # (formerly folded into the broad `Exception` tuple below)
+            # used to treat both the same, letting shutdown continue as
+            # if it had completed even when its own caller was being
+            # cancelled. Same discriminator as session.py's #3377
+            # precedent (`_driver.cancelling() > 0`).
+            _current = asyncio.current_task()
+            if _current is not None and _current.cancelling() > 0:
+                raise
+        except Exception:  # noqa: BLE001 — defensive shutdown
             pass
 
     sched = getattr(app.state, "cron_scheduler", None)

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -762,7 +762,24 @@ class MCPConnectionService:
             try:
                 await task
             except asyncio.CancelledError:
-                pass
+                # #4988: `await task` raises CancelledError either as that
+                # task's own outcome (the `.cancel()` loop just above —
+                # what this except exists to absorb) or as an independent,
+                # external cancellation of THIS coroutine's own task
+                # landing at the same await. `pass`-ing unconditionally
+                # used to treat both the same, letting `aclose()` continue
+                # (and return normally) even when its own caller was being
+                # cancelled. Same discriminator as session.py's #3377
+                # precedent (`_driver.cancelling() > 0`). Every task in
+                # `background_tasks` already had `.cancel()` called on it
+                # in the loop above, so re-raising here (stopping short of
+                # awaiting the rest) does not leave any of them un-asked-
+                # to-cancel — only un-joined, the same trade-off structured
+                # concurrency already accepts when a caller's own task is
+                # cancelled mid-cleanup elsewhere in this codebase.
+                _current = asyncio.current_task()
+                if _current is not None and _current.cancelling() > 0:
+                    raise
 
         # #3698 PR-2: close every subscription adapter's own background
         # delivery machinery (a ListenSubscriptionAdapter's consumer task)

--- a/src/reyn/mcp/subscription_port.py
+++ b/src/reyn/mcp/subscription_port.py
@@ -349,7 +349,22 @@ class ListenSubscriptionAdapter:
             self._task.cancel()
             try:
                 await self._task
-            except (asyncio.CancelledError, SubscriptionLost):
+            except asyncio.CancelledError:
+                # #4988: `await self._task` raises CancelledError either
+                # as that task's own outcome (this block's own `.cancel()`
+                # two lines up — what this except exists to absorb) or as
+                # an independent, external cancellation of THIS
+                # coroutine's own task landing at the same await.
+                # Catching it unconditionally (formerly folded into the
+                # `SubscriptionLost` tuple below) used to treat both the
+                # same, letting `close()` continue as if it had completed
+                # even when its own caller was being cancelled. Same
+                # discriminator as session.py's #3377 precedent
+                # (`_driver.cancelling() > 0`).
+                _current = asyncio.current_task()
+                if _current is not None and _current.cancelling() > 0:
+                    raise
+            except SubscriptionLost:
                 pass
             self._task = None
         if self._cm is not None:

--- a/tests/core/test_4988_cancel_swallow.py
+++ b/tests/core/test_4988_cancel_swallow.py
@@ -1,0 +1,93 @@
+"""Tier 1/2: #4986/#4988 — the "cancel-then-await-then-swallow" class.
+
+``EventLog.stop_dispatch()``/``drain()`` (and 6 more sites, census'd from
+there — ``cancellable.py``, ``durability_worker.py``,
+``connection_service.py``, ``hooks/ingress.py``, ``interfaces/web/
+server.py``, ``mcp/subscription_port.py``) used to cancel a task/future
+they own, await it, and catch the resulting ``CancelledError``
+unconditionally:
+
+    some_task.cancel()
+    try:
+        await some_task
+    except asyncio.CancelledError:
+        pass
+
+``await some_task`` raises ``CancelledError`` for two indistinguishable
+reasons: (a) ``some_task``'s own cancellation outcome (the intended
+target), or (b) the CURRENT coroutine's own task being independently,
+externally cancelled at the same await. An unconditional ``pass``
+absorbs both — case (b) makes the enclosing function return NORMALLY
+instead of letting a genuine external cancellation propagate, exactly
+the shape a generic shutdown sweep (`asyncio.run()`'s / pytest-asyncio's
+own end-of-loop `_cancel_all_tasks`) can trigger.
+
+Fixed with the SAME discriminator session.py's own #3377 precedent
+already uses: ``asyncio.current_task().cancelling() > 0`` in the except
+handler, re-raising when true (Python 3.11+, this repo's own floor).
+
+Witness here is "does the cancellation propagate", per CLAUDE.md's own
+floor/ceiling rule — no test in this file writes a duration; every
+suspension point is landed via ``await asyncio.sleep(0)``'s documented
+"yield exactly once" semantics (zero real time, not a wait), the same
+idiom this repo's own asyncio tests already use for this purpose.
+
+Real ``EventLog`` + real ``asyncio.Task`` throughout — no fakes.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.events.events import EventLog
+
+
+@pytest.mark.asyncio
+async def test_stop_dispatch_propagates_an_external_cancel_of_its_own_caller() -> None:
+    """Tier 2: the measured defect's own falsifier. ``stop_dispatch()``'s
+    OWN calling task is externally cancelled while suspended exactly at
+    its internal ``await task`` (awaiting the consumer task it just told
+    to cancel) — the fix must let that propagate, not swallow it.
+
+    Reverting the fix (bare ``except asyncio.CancelledError: pass``, no
+    ``cancelling()`` check) turns this red: ``stop_dispatch()`` catches
+    BOTH the consumer's own cancellation outcome AND the external cancel
+    of its own wrapping task, and returns normally either way — so
+    ``await wrapper`` below would return ``None`` instead of raising,
+    because a task whose own coroutine swallows an external cancel and
+    returns normally is NOT ``cancelled()`` (a real, documented asyncio
+    property, not a guess) — confirmed by reverting the fix locally
+    before landing this test."""
+    events = EventLog()
+    events.emit("warmup")
+    await events.drain()  # real consumer running, suspended at queue.get()
+
+    wrapper = asyncio.create_task(events.stop_dispatch())
+    await asyncio.sleep(0)  # let wrapper run up to its own `await task` and suspend
+    wrapper.cancel()  # external cancel of stop_dispatch()'s OWN calling task
+
+    with pytest.raises(asyncio.CancelledError):
+        await wrapper
+
+
+@pytest.mark.asyncio
+async def test_stop_dispatch_still_absorbs_the_consumers_own_cancellation() -> None:
+    """Tier 2: accept-side — the ORIGINAL, intended case (no external
+    cancel of the caller) must still work exactly as before: calling
+    ``stop_dispatch()`` normally (not wrapped, not externally cancelled)
+    returns cleanly (does not raise), and — #4966's own "stop is not
+    never again" guarantee — a LATER ``emit()`` still gets delivered via
+    a fresh consumer, all through the public surface, no private-state
+    read."""
+    events = EventLog()
+    delivered: list = []
+    events.add_subscriber(lambda e: delivered.append(e.type))
+    events.emit("warmup")
+    await events.drain()
+
+    await events.stop_dispatch()  # must return cleanly, not raise
+
+    events.emit("after-stop")
+    await events.drain()
+    assert delivered == ["warmup", "after-stop"]

--- a/tests/scripts/test_check_cancel_swallow_4988.py
+++ b/tests/scripts/test_check_cancel_swallow_4988.py
@@ -1,0 +1,145 @@
+"""Tier 2: #4986/#4988 — the cancel-swallow gate itself.
+
+7 of the 8 real sites #4988 fixed have no dedicated behavioral test (a
+per-site test transcribing the same fix 8 times would be six-questions
+②: the implementation, transcribed) — the gate IS the mechanism that
+protects them. A "0 hits against the real tree" result alone cannot tell
+"the pattern genuinely doesn't exist" apart from "the gate detects
+nothing, ever" — this file is the fixture-based proof that the gate's
+own detection actually fires, per this repo's own established
+convention (mirrors ``tests/scripts/test_check_fastmcp_import_boundary_
+3698.py``).
+
+Real filesystem fixtures throughout (a real `tmp_path` tree of `.py`
+files) — the function under test reads real file content and parses
+real ASTs, so faking the filesystem would test nothing real.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_cancel_swallow import offending_files
+
+
+def test_cancel_then_await_then_swallow_with_no_cancelling_check_is_flagged(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: THE case #4986/#4988 exists for — a task this code owns is
+    cancelled, awaited, and the resulting CancelledError is swallowed
+    unconditionally, with no check for whether the CURRENT task was ALSO
+    independently, externally cancelled at the same await."""
+    (tmp_path / "worker.py").write_text(
+        "import asyncio\n"
+        "\n"
+        "async def aclose(self):\n"
+        "    self._task.cancel()\n"
+        "    try:\n"
+        "        await self._task\n"
+        "    except asyncio.CancelledError:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == [(tmp_path / "worker.py", [(5, "self._task")])]
+
+
+def test_the_fixed_shape_with_a_cancelling_check_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: accept-side — the ACTUAL fix #4988 applied at all 8 real
+    sites (session.py's own #3377 precedent) must not itself be flagged;
+    a gate that flags its own prescribed fix would be self-defeating."""
+    (tmp_path / "worker.py").write_text(
+        "import asyncio\n"
+        "\n"
+        "async def aclose(self):\n"
+        "    self._task.cancel()\n"
+        "    try:\n"
+        "        await self._task\n"
+        "    except asyncio.CancelledError:\n"
+        "        current = asyncio.current_task()\n"
+        "        if current is not None and current.cancelling() > 0:\n"
+        "            raise\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_an_unconditional_reraise_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: a handler that re-raises unconditionally already
+    propagates on every path — not a swallow, regardless of whether it
+    also checks ``cancelling()``."""
+    (tmp_path / "worker.py").write_text(
+        "import asyncio\n"
+        "\n"
+        "async def aclose(self):\n"
+        "    self._task.cancel()\n"
+        "    try:\n"
+        "        await self._task\n"
+        "    except asyncio.CancelledError:\n"
+        "        raise\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_awaiting_ones_own_body_without_a_preceding_cancel_is_not_flagged(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: non-vacuity — a coroutine's own ordinary try/except around
+    ITS OWN body (no ``.cancel()`` call on the awaited name anywhere
+    first) is a completely different, common, and correct shape (e.g.
+    ``session.py``'s own ``run()`` loop swallowing its own cancellation
+    to log and re-raise) — must not false-positive just because SOME
+    name is awaited inside a CancelledError-catching try block."""
+    (tmp_path / "session.py").write_text(
+        "import asyncio\n"
+        "\n"
+        "async def run(self):\n"
+        "    try:\n"
+        "        await self.run_one_iteration()\n"
+        "    except asyncio.CancelledError:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_a_tuple_form_handler_is_also_flagged(tmp_path: Path) -> None:
+    """Tier 2: #4988's own falsifier for the census's own miss — a grep
+    for the literal single-exception-type line misses ``except
+    (asyncio.CancelledError, SomeOtherError):`` (2 real sites,
+    ``interfaces/web/server.py`` / ``mcp/subscription_port.py``, found
+    only once the AST gate existed). This fixture pins that the AST
+    match still catches the tuple form."""
+    (tmp_path / "worker.py").write_text(
+        "import asyncio\n"
+        "\n"
+        "class Lost(Exception):\n"
+        "    pass\n"
+        "\n"
+        "async def aclose(self):\n"
+        "    self._task.cancel()\n"
+        "    try:\n"
+        "        await self._task\n"
+        "    except (asyncio.CancelledError, Lost):\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == [(tmp_path / "worker.py", [(8, "self._task")])]
+
+
+def test_the_real_repo_tree_is_currently_clean() -> None:
+    """Tier 2: the gate's own starting population — verified against the
+    real, current tree (not assumed), matching the sibling gates' own
+    "run it before shipping it" discipline. #4988 fixed all 8 real sites
+    this gate's own census found; this asserts it stayed fixed."""
+    from scripts.check_cancel_swallow import _SRC_DIR
+
+    offenders = offending_files(_SRC_DIR)
+    assert offenders == [], (
+        f"real regression(s) found: {offenders} — this gate's baseline is "
+        "zero, so any hit here is new, not inherited debt"
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #4988 (found while investigating #4986's CI teardown hangs). This fix's justification is independent of that symptom — the corresponding CI signature predates this class of code by 8-10 days (lead-coder's own measurement) — `#4986` stays out of scope for this PR, per the standing house rule "if CI can catch the violation, write the gate" and the owner's own "measurement is only a counterexample" doctrine.

## The defect

```python
some_task.cancel()
try:
    await some_task
except asyncio.CancelledError:
    pass
```

`await some_task` raises `CancelledError` for two indistinguishable reasons: (a) `some_task`'s own cancellation outcome (the intended target), or (b) the CURRENT coroutine's own task being independently, externally cancelled at the same await (e.g. a shutdown sweep, `asyncio.run()`'s / pytest-asyncio's own end-of-loop `_cancel_all_tasks`, which cancels every task in `asyncio.all_tasks()` with no ordering guarantee). An unconditional `pass` absorbs both — case (b) makes the enclosing function return NORMALLY instead of letting a genuine external cancellation propagate.

Fixed with the discriminator reyn already carries elsewhere — `session.py`'s own #3377 precedent (`_driver.cancelling() > 0`), not a new invention: Python 3.11+'s `Task.cancelling()` (this repo's own floor) tells (a) apart from (b). Python's own docs, quoted verbatim on the issue: *"Should the coroutine nevertheless decide to suppress the cancellation, it needs to call `Task.uncancel()` in addition to catching the exception."*

## 8 sites, not 6 — why the gate is the real population

A manual grep-based census found 6 sites. Writing the actual AST gate (`scripts/check_cancel_swallow.py`) found **2 more** the grep missed — both **tuple-form** handlers (`except (asyncio.CancelledError, Exception):` / `except (asyncio.CancelledError, SubscriptionLost):`), a shape the grep's single-line pattern never matched:

- `interfaces/web/server.py:281-285`, `mcp/subscription_port.py:348-354`

Both needed extra care to keep the OTHER exception class's handling (`Exception` / `SubscriptionLost`) completely unchanged — split into a separate `except` clause each. lead-coder's own ruling: "gate is clean" defines "the class is closed", not the census — **the gate is the population, not a one-time count of it**.

Full list: `events.py` (`drain()`, `stop_dispatch()` — where this was first found), `cancellable.py` (`race_cancellable`'s watcher cleanup — most delicate, inside existing `baseline_cancelling` bookkeeping, applied conservatively), `durability_worker.py`, `connection_service.py`, `hooks/ingress.py` (shared `aclose()`, covers both `McpIngressAdapter`/`FsIngressAdapter`), `interfaces/web/server.py`, `mcp/subscription_port.py`.

## The gate

AST-based, `src/reyn/` only (a production defect, not test-authoring), zero-baseline — mirrors `check_collect_events_settle.py`'s structure and self-disclosed-gap discipline (a hand-rolled indirection this gate can't trace back to a literal `.cancel()` call is a known blind spot, not claimed exhaustive coverage — see the gate's own module docstring).

## Test plan

- [x] 2 new tests (`tests/core/test_4988_cancel_swallow.py`) — **no duration in either** (CLAUDE.md's floor/ceiling rule): witness is "does the cancellation propagate", landed via `await asyncio.sleep(0)`'s documented "yield exactly once" semantics, not a wait
  - `test_stop_dispatch_propagates_an_external_cancel_of_its_own_caller` — the defect's own falsifier, **strip-falsified** (reverted locally, confirmed red for the right reason)
  - `test_stop_dispatch_still_absorbs_the_consumers_own_cancellation` — accept-side, entirely through the public surface (no private-state read)
- [x] Gate: 0 hits against the fixed tree; found all 8 real sites when run before the fix
- [x] `ruff check` on all 9 changed files — clean
- [x] `scripts/test_tier_audit.py --strict` on the new test file — 2/2 OK
- [x] `scripts/verify_module_docstrings.py` — OK
- [x] `scripts/mypy_ratchet.py` — OK (203, all baselined, unchanged)
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_file_depth_reference.py` / `check_bare_tests_import_reference.py` — all OK
- [x] `scripts/check_fastmcp_import_boundary.py` (this dir's own `CLAUDE.md` gate) — OK
- [x] **Full regression sweep** (`tests/core/` + `tests/mcp/` + `tests/hooks/` + `tests/web/`, 3414 tests): **3413 passed**. The 1 failure (`test_fastmcp_core_dep_import_chain.py`) is confirmed **pre-existing and unrelated** — fails identically on unmodified `main` (a local-venv artifact, fastmcp happens to be installed here; nothing this PR touches)
- [x] **"Does the repair destroy evidence" (CLAUDE.md's 3rd question)**: no test anywhere in the 3414-test sweep newly failed — fixing the swallow did not surface any previously-hidden `CancelledError` in this sweep's own coverage. If CI (a broader population) surfaces one, that is a **newly visible** defect this fix uncovered, not a new one it introduced.
- [ ] (skipped — Visual, standing waiver)

## Explicit scope boundaries

- `#4986` stays out of scope for this PR — that signature predates this code by 8-10 days; it needs its own, separate `asyncio.all_tasks()`-dump investigation.
- The candidate count (8) is not a claim of exhaustive coverage — see the gate's own disclosed blind spot (indirected/wrapped `.cancel()` calls this AST match can't trace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 🔴 lead-coder のブロッキング点（規則 7）

- [x] 🔴 ~~**`scripts/check_cancel_swallow.py` が CI に配線されていません。**~~ ✅ `e38635160` で解消（2 箇所とも実測確認: `cancel-swallow-gate.yml:44` / `main-hourly-gate-sweep.yml:105`）

```
git grep -n "check_cancel_swallow" <this branch> -- .github/   → ★0 件
```

★ **走らない gate は ★gate ではありません。**⚪ **本 PR の file list に `.github/workflows/` が 1 つも在りません。**

**前例が repo に在ります**（`scripts/check_collect_events_settle.py`、#4966）── ★ **2 箇所に配線されています**:

```
.github/workflows/collect-events-settle-gate.yml:46   python scripts/check_collect_events_settle.py
.github/workflows/main-hourly-gate-sweep.yml:101      python scripts/check_collect_events_settle.py
```

★ **同じ 2 箇所に配線してください。**⚠️ **専用 workflow だけでは、★main が緑のまま腐る経路が残ります** ── **hourly sweep は「PR を通らずに main が壊れる」を捕まえるためのものです。**

⚪ **これは #4988 の着手内容②（「gate を書く」）の ★残り半分**です ── ★ **「スクリプトを書いた」と「gate になった」は別**で、**今夜私が閉じてきたクラスそのもの**です（宣言・実装・通るテストは、★呼ばれていなくても同じに見える）。

---

## ⚪ lead-coder の doc 面検査（★ブロックしません）

```
check_cancel_swallow ── 0 面
uncancel             ── 0 面
cancelling           ── 4 面 ── ★読みました ── ★偽になりません
   0018-cross-agent-discard-notify.md:10 / 0034-a2a-task-lifecycle.md:28
   claude-design-prompt.md:184 / session-construction.md:206,212,229
   ── ★いずれも 普通の英語の散文（"cancelling the asyncio task" 等）であって
      ★`Task.cancelling()` API を指していません
```



- [x] 🔴 ~~**gate 自身の検出能力に witness がありません。**~~ ✅ `1876537ce` で解消（`tests/scripts/test_check_cancel_swallow_4988.py`、実測確認）

```
本 PR の枝 ── `git grep -lF check_cancel_swallow <枝> -- tests/`  → ★0 件
追加された 2 本は ★`stop_dispatch()`（修正側）を縛っており ★gate を縛っていません
```

★ **repo の慣例は `tests/scripts/test_check_<名>_<issue>.py`** で、**★gate スクリプト 10 本中 ★9 本が持っています**（実測。例は `tests/scripts/test_check_fastmcp_import_boundary_3698.py`）。

🔴 **本 PR で ★とくに重い理由**: reyn-reviewer の所見のとおり **8 箇所のうち test が直接 witness するのは 1 箇所で、★残り 7 箇所は この gate だけが守ります。**★ **その gate が ★空虚に緑になれる**なら、**7/8 は ★何にも守られていません。**

**お願い**: **gate が ★必ず flag する fixture**（`except (asyncio.CancelledError, X): pass` を含む小さなソース断片）を置き、**gate がそれを検出することを assert** してください。★ **「0 件だった」ではなく「★この形は検出する」を assert** ── ★ **0 件は「無い」と「検出できていない」を区別しません。**

⚪ **例外の 1 本（`check_collect_events_settle`）は ★私が #4966 で入れたもの**です。★ **私の分は別途起票します** ── **本 PR に背負わせません。**


