### PR TITLE
test(#4990): cover check_collect_events_settle.py (the #4966 gate)

### DIFF
--- a/tests/scripts/test_check_collect_events_settle_4966.py
+++ b/tests/scripts/test_check_collect_events_settle_4966.py
@@ -1,0 +1,121 @@
+"""Tier 2: #4966 — the collect-events-without-settle gate.
+
+Real filesystem fixtures throughout (a real `tmp_path` tree of `.py`
+files) — the function under test reads real file content and parses real
+ASTs, so faking the filesystem would test nothing real. Mirrors
+`tests/scripts/test_check_fastmcp_import_boundary_3698.py`'s own shape
+(reject variants / accept variants / a final "real tree is currently
+clean" check against the gate's own live scope).
+
+#4990: this gate's own starting population was zero (all 31 found
+instances were fixed in the same PR that added it, #4966) but had NO
+covering test of its own — "0 hits" cannot distinguish "nothing to find"
+from "the gate never actually runs its detection logic" (CLAUDE.md's
+pre-conclusion checklist: an absence needs a positive witness, not a
+green run). Every fixture below asserts a SHAPE the gate must detect (or
+must NOT), never a bare hit-count.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_collect_events_settle import offending_files
+
+
+def test_a_read_with_no_settle_before_it_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: the exact class #4965/#4966 exists to close — an `async
+    def` test binds `collect_events(log)`'s result and reads it back with
+    no yield point (settle/drain/polling helper) anywhere earlier in the
+    same function, so the read can race the background consumer."""
+    (tmp_path / "test_x.py").write_text(
+        "async def test_something(log):\n"
+        "    collected = collect_events(log)\n"
+        "    await trigger(log)\n"
+        "    assert not any(e.type == 'denied' for e in collected)\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert [p for p, _hits in offenders] == [tmp_path / "test_x.py"]
+    assert offenders[0][1] == [(4, "collected")]
+
+
+def test_a_one_level_derived_name_is_also_flagged(tmp_path: Path) -> None:
+    """Tier 2: a name derived one level from an already-tracked name
+    (a comprehension filtering `collected`) is tracked too — the real
+    shape most of the 31-site audit's instances used (`blocked =
+    [e for e in collected if ...]`, not a bare re-read of `collected`
+    itself)."""
+    (tmp_path / "test_y.py").write_text(
+        "async def test_something(log):\n"
+        "    collected = collect_events(log)\n"
+        "    await trigger(log)\n"
+        "    denied = [e for e in collected if e.type == 'denied']\n"
+        "    assert denied == []\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert [p for p, _hits in offenders] == [tmp_path / "test_y.py"]
+
+
+def test_a_hand_rolled_add_subscriber_read_is_also_flagged(tmp_path: Path) -> None:
+    """Tier 2: the SECOND discriminator this gate closes (found the same
+    night, #4966's own docstring) — a hand-rolled
+    `log.add_subscriber(collected.append)` list, never touching
+    `collect_events()` at all, needs the identical settle()-before-read
+    treatment and must be tracked the same way."""
+    (tmp_path / "test_z.py").write_text(
+        "async def test_something(log):\n"
+        "    collected = []\n"
+        "    log.add_subscriber(collected.append)\n"
+        "    await trigger(log)\n"
+        "    assert not any(e.type == 'denied' for e in collected)\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert [p for p, _hits in offenders] == [tmp_path / "test_z.py"]
+
+
+def test_a_settle_before_the_read_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: accept side — the actual fix (`await settle(log)`
+    immediately before the read) must not false-positive. This is the
+    consumer #4990 itself names: an author who did the fix correctly
+    must never see this gate fire on them (six-questions ③)."""
+    (tmp_path / "test_ok.py").write_text(
+        "async def test_something(log):\n"
+        "    collected = collect_events(log)\n"
+        "    await trigger(log)\n"
+        "    await settle(log)\n"
+        "    assert not any(e.type == 'denied' for e in collected)\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_unrelated_code_with_no_tracked_name_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: non-vacuity — an ordinary async test with no
+    `collect_events()`/`add_subscriber()` anywhere must not be touched by
+    this gate at all."""
+    (tmp_path / "test_unrelated.py").write_text(
+        "async def test_something():\n"
+        "    result = await do_a_thing()\n"
+        "    assert result == 'ok'\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_the_real_repo_tree_is_currently_clean() -> None:
+    """Tier 2: the gate's own starting population — verified against the
+    real, current `tests/` tree (not assumed), matching the sibling
+    gates' own "run it before shipping it" discipline. #4966 fixed every
+    found instance in the same PR that added this gate, so this asserts
+    it stayed at zero, not that it started there."""
+    from scripts.check_collect_events_settle import _TESTS_DIR
+
+    offenders = offending_files(_TESTS_DIR)
+    assert offenders == [], (
+        f"real regression(s) found: {offenders} — this gate's baseline is "
+        "zero, so any hit here is new, not inherited debt"
+    )


### PR DESCRIPTION
**[e2e-coder]** — Closes #4990 (`check_collect_events_settle.py`, the one gate of 10 with zero test coverage).

## What

lead-coder's own finding: `scripts/check_*.py` has 10 gates, 9 referenced from `tests/`. `check_collect_events_settle` (added in #4966) had zero — a gap in lead-coder's own PR. "0 hits" against a real tree cannot distinguish "nothing to find" from "the gate's detection logic never actually runs" — this repo's own pre-conclusion checklist names exactly that trap.

Mirrors `tests/scripts/test_check_fastmcp_import_boundary_3698.py`'s shape rather than inventing a new pattern: real `tmp_path` fixtures, reject variants, accept variants, a final "real tree is currently clean" check against the gate's own live scope.

## Tests

- **3 reject-side** (must be flagged): a bare `collect_events()`-derived read with no yield point; a one-level-derived name via comprehension (the shape most of the original 31-site audit actually used); the gate's SECOND discriminator — a hand-rolled `log.add_subscriber(collected.append)` list that never touches `collect_events()` at all.
- **2 accept-side** (must NOT be flagged): a `settle()`-before-read (the real fix — six-questions ③'s consumer is "the author who did it correctly and must never see a false-positive"); unrelated code with no tracked name (non-vacuity).
- **1 real-tree-clean** test, same discipline as the fastmcp precedent.

**Strip-falsified**: with the gate's own `_check_function` neutered (forced `return []`), all 3 reject-side tests correctly reddened; restored, all 6 green.

Deliberately **not** `tests/scaffold/`  — permanent gate coverage, not extraction-refactor scaffolding. No duration/sleep anywhere.

## Out of scope (explicit, per lead-coder's instruction)

Whether `scripts/**` belongs in `check_tests_path_literal_reference.py`'s `paths` list is a separate decision — none of the 10 `check_*.py` scripts currently have it, not specific to this one gate. Not touched here.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_collect_events_settle_4966.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `pytest tests/scripts/` (840 passed) + strip-falsify
- [x] (skipped — Visual, standing waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

