### PR TITLE
fix(#4992): check_pr_closing_intent gains check 5 - negated closing keyword

### DIFF
--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -8,7 +8,8 @@ still open) actually resolved for #N. This script detects contradictions —
 it never infers intent beyond what the body's declaring phrases literally
 say.
 
-Four checks, all facets of the same invariant:
+Five checks, all facets of the same invariant except check 5 (see its own
+entry below for why it is deliberately NOT an intent-comparison check):
 
   1. **false negative** — body declares closing intent (``Closes #N`` /
      ``Fixes #N`` / ``Resolves #N``, in any casing, even inside backticks)
@@ -55,6 +56,24 @@ Four checks, all facets of the same invariant:
      before merge) know whether a human will hand-edit it away. That is by
      design, not a gap: the check's job is to catch the state that CAN leak
      a close, not to certify that a human removed it.
+  5. **negated closing keyword** (#4992, real incident 2026-08-21) — a
+     closing keyword with a negation word in the narrow window immediately
+     before it (e.g. "does not close #N", "will never fix #N"), in the PR
+     body OR a commit message. UNCONDITIONAL — fires regardless of
+     ``closingIssuesReferences``, never comparing declared intent against
+     the parser's actual behavior the way checks 1-4 do. Real incidents
+     #4834 and #4986 were BOTH auto-closed by exactly this shape ("it does
+     not claim to close #4834 either" / "Does not claim to fix #4986") —
+     GitHub's parser does not read the negation, only the keyword+#N
+     substring, so the author's "not" never protected anything. Checks 1/2
+     were SILENT on both: the parser's own reading ("there is a
+     declaration to close #N") matched what checks 1/2 already expect from
+     an honored ``Closes``-shaped declaration, so neither found a
+     mismatch to report — negation doesn't just fail to protect, it
+     manufactures the *appearance* of a consistent, correctly-declared
+     close. See ``find_negated_closing_declarations``'s own docstring and
+     the ``_NEGATION_TERMS_EN``/``_NEGATION_TERMS_JA`` comment for the full vocabulary and the
+     backtick escape hatch.
 
 Declaring-phrase vocabulary — three forms, all checked against the parser:
 
@@ -289,6 +308,75 @@ _NONCLOSING_RE = re.compile(
     re.IGNORECASE,
 )
 
+# ---------------------------------------------------------------------------
+# Check 5 vocabulary (#4992, architect ruling, real incident #4834/#4986,
+# 2026-08-21): negating a closing keyword does NOT protect against it —
+# GitHub's own parser matches the bare keyword+#N substring and does not
+# read the surrounding negation. "it does not claim to close #4834 either"
+# and "Does not claim to fix #4986" both auto-closed their issue on merge,
+# same-timestamp with the PR, reason=COMPLETED, no human involved.
+#
+# Deliberately a SYNTACTIC check, not an intent check: a negated closing
+# keyword is ALWAYS wrong, independent of whether GitHub's parser agrees —
+# GitHub closes regardless of the author's negation, so there is no
+# "intent matched, no problem" case for this shape to fall into. This is
+# check 5's whole reason for existing separately from checks 1-3, which DO
+# compare declared intent against closingIssuesReferences: those checks
+# would have been silent here (the parser's own reading — "declares
+# closing intent for #4834" — MATCHES what the parser did; check 1 asks
+# "declared but not resolved" and check 2 asks "declared non-closing but
+# resolved", and this body's negation sentence reads to _CLOSING_RE as a
+# closing declaration, which the parser then genuinely honored — no
+# mismatch for checks 1/2 to catch). Architect's own words: 否定は保護で
+# ないどころか、正しさの見た目を作った ── gate も GitHub も同じく「#4834
+# を閉じる宣言が在る」と読み、check 1（宣言≠実際）が「矛盾なし」で沈黙
+# した。(negation isn't just non-protective — it manufactures the
+# APPEARANCE of correctness: both the gate and GitHub read "there is a
+# declaration to close #4834" identically, so check 1's own "declared ≠
+# actual" logic found no mismatch and stayed silent.)
+#
+# Window is deliberately NARROW (architect: "窓は狭く") — only the last
+# few words immediately before the keyword are checked, not the whole
+# body. A negation word far earlier in an unrelated sentence must not
+# false-positive on an unrelated later closing keyword elsewhere in the
+# body.
+_NEGATION_WINDOW_WORDS = 6
+
+# #4992 review (reviewer finding via lead-coder): the original vocabulary
+# was matched via bare substring containment (`term in window`), which is
+# wrong on its own terms — "not" is a substring of "notable", "note", and
+# "annotate", so a genuine, correct declaration like "Note: closes #N"
+# would have been WRONGLY flagged. English terms are matched on WORD
+# boundaries instead (see `_NEGATION_PATTERN` below); Japanese terms stay
+# substring-matched deliberately (they attach directly to a verb stem with
+# no preceding space in real usage — "〜ない" — so a \b-anchored regex
+# would not isolate them the way it does ASCII words).
+#
+# "cannot" is listed SEPARATELY from "not", not merged into it, precisely
+# because word-boundary matching is now correct: \bnot\b does NOT match
+# inside the single compound word "cannot" (no boundary between "can" and
+# "not" there), even though it DOES match the "not" in "does not"/"did
+# not" (both have a real space, hence a real word boundary, before
+# "not"). Losing "cannot" coverage by switching to \b matching without
+# adding it back explicitly would have silently narrowed the vocabulary
+# architect specified.
+_NEGATION_TERMS_EN = ("not", "cannot", "never", "without", "no longer")
+_NEGATION_TERMS_JA = ("ない", "ません", "せず")
+_NEGATION_PATTERN = re.compile(
+    "|".join(rf"\b{re.escape(term)}\b" for term in _NEGATION_TERMS_EN),
+    re.IGNORECASE,
+)
+
+
+def _window_has_negation(window: str) -> bool:
+    """True if *window* (the last few words before a closing keyword,
+    lowercased) contains a negation term — English terms on word
+    boundaries (see :data:`_NEGATION_PATTERN`'s own comment for why
+    ``cannot`` needs its own entry), Japanese terms by substring."""
+    if _NEGATION_PATTERN.search(window):
+        return True
+    return any(term in window for term in _NEGATION_TERMS_JA)
+
 # Mention-only declaration (the third declaration type):
 #     <!-- closing-check: discussing #2620 #2972 -->
 # An HTML comment, so it is invisible in the rendered PR body but visible,
@@ -326,7 +414,21 @@ _ISSUE_NUM_RE = re.compile(r"#(\d+)")
 # Fenced code — a ``` block, then an inline `span`. Used only to build the
 # GitHub-side reading below.
 _FENCED_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
-_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+# #4992 review (lead-coder, real measurement): a single-backtick span CAN
+# contain a line ending — CommonMark/GFM's own spec ("line endings are
+# converted to spaces" within a code span) — so a sentence a PR author
+# wraps across two source lines while backtick-fencing it (an ordinary
+# markdown-authoring habit, and exactly what a long negated-keyword
+# sentence following check 5's own "wrap it in backticks" advice tends to
+# produce) is STILL one fenced span to GitHub's real renderer/parser, not
+# two unfenced fragments. The previous `[^`\n]*` pattern excluded
+# newlines and so treated a two-line-wrapped span as unfenced — a real,
+# measured false positive on this PR's own body (PR #4993:
+# closingIssuesReferences confirmed empty for the wrapped issue numbers,
+# i.e. GitHub genuinely did not parse them as closing references, but
+# this gate's OWN check 5 still flagged them). ``re.DOTALL`` non-greedy so
+# `.` matches a newline too, without needing to special-case it.
+_INLINE_CODE_RE = re.compile(r"`[^`]*?`", re.DOTALL)
 
 
 def _body_as_author_declared(text: str) -> str:
@@ -419,6 +521,39 @@ def find_discussing_declarations(body: str) -> set[int]:
     out: set[int] = set()
     for marker in _DISCUSSING_MARKER_RE.finditer(body):
         out.update(int(n) for n in _ISSUE_NUM_RE.findall(marker.group(1)))
+    return out
+
+
+def find_negated_closing_declarations(body: str) -> set[int]:
+    """Return issue numbers whose closing-keyword declaration is negated
+    (#4992, architect ruling) — e.g. "does not claim to close #4834",
+    "will never fix #4986". Always wrong: GitHub's parser does not read
+    the negation, only the keyword+#N substring, so a negated closing
+    keyword closes the issue exactly as if the negation were absent. See
+    this module's ``_NEGATION_TERMS_EN``/``_NEGATION_TERMS_JA`` comment for the real incident and
+    why this is a syntactic check, not an intent-matching one.
+
+    Reads the body as GITHUB parses it (fenced spans honored/removed,
+    :func:`_body_as_github_parses`) — a negated keyword wrapped in
+    backticks poses no real auto-close risk (GitHub does not parse inside
+    backticks either), so it is not flagged; that fencing is this check's
+    own sanctioned escape hatch when the literal phrase must appear at
+    all (see the error message below).
+
+    Uses :data:`_CLOSING_RE` (the broad, GitHub-matching keyword set —
+    bare and past-tense forms included), not the narrower
+    ``_CANONICAL_CLOSING_RE`` — GitHub's real parser honors "close"/
+    "closed"/"fix"/"fixed" etc. exactly as it honors "Closes", and both
+    real incidents used the bare/past-tense form ("close" / "fix"), not
+    the canonical declaring form.
+    """
+    text = _body_as_github_parses(body)
+    out: set[int] = set()
+    for m in _CLOSING_RE.finditer(text):
+        preceding_words = text[:m.start()].split()[-_NEGATION_WINDOW_WORDS:]
+        window = " ".join(preceding_words).lower()
+        if _window_has_negation(window):
+            out.add(int(m.group(1)))
     return out
 
 
@@ -600,6 +735,54 @@ def check_contradictions(
                 ),
             )
         )
+
+    # Check 5 (negated closing keyword, #4992): a closing keyword with a
+    # negation word in the narrow window immediately before it — see this
+    # module's ``_NEGATION_TERMS_EN``/``_NEGATION_TERMS_JA`` comment and ``find_negated_closing_
+    # declarations``'s own docstring for the real incident (#4834/#4986)
+    # and why this fires unconditionally, never comparing against
+    # ``closing_refs``. Also checked in the PR body's own commit messages
+    # (same #3187-shaped leak class check 4 exists for — a negated keyword
+    # in a commit message rides into the default squash-merge body exactly
+    # like an unnegated one does).
+    for n in sorted(find_negated_closing_declarations(body)):
+        findings.append(
+            Finding(
+                check=5,
+                issue=n,
+                message=(
+                    f"the body contains a NEGATED closing keyword for #{n} "
+                    "(e.g. 'does not close', 'never fixes') — GitHub's "
+                    "parser does not read the negation, only the "
+                    f"keyword+#{n} substring, so this WILL close #{n} on "
+                    "merge exactly as if the negation were absent (real "
+                    "incident: #4834 and #4986 both auto-closed this way, "
+                    "same timestamp as the merge, reason=COMPLETED, no "
+                    f"human involved). Rewrite without the verb: '#{n} "
+                    f"stays open' or '#{n} is out of scope' — or omit the "
+                    "issue number entirely if the reader doesn't need to "
+                    "follow it. If the literal phrase must appear, wrap it "
+                    f"in backticks (`` `closes #{n}` `` — GitHub does not "
+                    "parse inside backticks)."
+                ),
+            )
+        )
+    for msg in commit_messages or []:
+        for n in sorted(find_negated_closing_declarations(msg)):
+            findings.append(
+                Finding(
+                    check=5,
+                    issue=n,
+                    message=(
+                        f"a commit message on this PR contains a NEGATED "
+                        f"closing keyword for #{n} — same defect as above, "
+                        "carried into the default squash-merge commit body "
+                        f"(the #3187/check-4 leak class) even if the PR "
+                        "body itself is clean. Rewrite without the verb, "
+                        "or wrap in backticks."
+                    ),
+                )
+            )
 
     return findings
 

--- a/tests/scripts/test_check_pr_closing_intent.py
+++ b/tests/scripts/test_check_pr_closing_intent.py
@@ -471,3 +471,242 @@ def test_check4_silent_when_no_commit_messages_supplied():
     """
     findings = m.check_contradictions("part of #1909", closing_refs=[])
     assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Check 5 (#4992): negated closing keyword — real incident 2026-08-21,
+# #4834 and #4986 both auto-closed despite an explicit negation sentence.
+# Deliberately UNCONDITIONAL: fires whether or not closing_refs agrees,
+# because GitHub's own parser ignores the negation regardless.
+# ---------------------------------------------------------------------------
+
+
+def test_check5_fires_on_the_real_4834_incident_sentence():
+    """Tier 1: the exact sentence that auto-closed #4834 on merge —
+    "it does not claim to close #4834 either" (PR #4985's own body), with
+    the REAL closing_refs value (GitHub's parser genuinely resolved
+    #4834, which is WHY it auto-closed). Checks 1/2 are correctly SILENT
+    here — this is architect's own finding reproduced precisely: the
+    parser's own reading matches what check 1 already expects from an
+    honored declaration, so only check 5 (the syntactic check) catches
+    the defect."""
+    findings = m.check_contradictions(
+        "it does not claim to close #4834 either", closing_refs=[4834],
+    )
+    assert _checks(findings) == [(5, 4834)]
+
+
+def test_check5_fires_on_the_real_4986_incident_sentence():
+    """Tier 1: the exact sentence that auto-closed #4986 on merge —
+    "Does not claim to fix #4986" (PR #4989's own body), same real
+    closing_refs value as the 4834 case above."""
+    findings = m.check_contradictions("Does not claim to fix #4986", closing_refs=[4986])
+    assert _checks(findings) == [(5, 4986)]
+
+
+def test_check5_fires_unconditionally_even_when_the_parser_disagrees_with_the_negation():
+    """Tier 1: check 5 does NOT compare against closing_refs — it must
+    still fire even in the case where GitHub's parser happened NOT to
+    resolve the reference (closing_refs=[], the opposite of the real
+    #4834/#4986 incidents' own closing_refs value, which the sibling test
+    ``test_check5_fires_on_the_real_4834_incident_sentence`` already
+    covers), because the negated phrasing itself is the defect,
+    independent of what the parser did this time. (#4992 review: an
+    earlier revision of this test's docstring described THIS disagreeing
+    case while its fixture actually used the agreeing one, ``closing_refs=
+    [4834]`` — name, docstring, and fixture now agree with each other.)
+    Check 1 legitimately fires alongside check 5 here — this fixture's
+    empty ``closing_refs`` means the parser did NOT resolve #4834, which
+    is exactly check 1's own "declared but not resolved" question,
+    answered independently and correctly; it does not make check 5's own
+    finding conditional on it."""
+    findings = m.check_contradictions(
+        "it does not claim to close #4834 either", closing_refs=[],
+    )
+    assert _checks(findings) == [(1, 4834), (5, 4834)]
+
+
+def test_check5_fires_on_a_commit_message_negation_too():
+    """Tier 1: the #3187-shaped leak class applies to check 5 too — a
+    negated closing keyword sitting only in a commit message still rides
+    into the default squash-merge body. Check 4 legitimately fires
+    alongside it here too (the body declares no closing intent for #4834
+    at all, while the commit message DOES read as a closing declaration
+    to ``find_closing_declarations`` — the same _CLOSING_RE match check 5
+    itself keys off) — both findings are independently correct
+    descriptions of the same underlying leak, from different angles."""
+    findings = m.check_contradictions(
+        "part of #4834",
+        closing_refs=[],
+        commit_messages=["fix: does not close #4834, just adjusts logging"],
+    )
+    assert _checks(findings) == [(4, 4834), (5, 4834)]
+
+
+def test_check5_does_not_fire_on_stays_open_phrasing():
+    """Tier 1: accept side — architect's suggested rewrite ("#N stays
+    open") carries no closing keyword at all, so it must not false-positive."""
+    findings = m.check_contradictions("#4834 stays open", closing_refs=[])
+    assert findings == []
+
+
+def test_check5_does_not_fire_on_note_colon_closes_word_boundary():
+    """Tier 1: accept side — reviewer finding (#4992 review): the
+    original implementation matched negation terms via bare substring
+    containment, so "not" (a substring of "notable"/"note"/"annotate")
+    wrongly flagged a genuine, correctly-formed declaration like
+    "Note: closes #4834". Fixed to word-boundary matching for the
+    English vocabulary (``_NEGATION_PATTERN``) — this is the false-
+    positive-side witness pinning that fix; ``cannot``/``does not`` (the
+    real cases the vocabulary must still catch, see the next test) are
+    NOT substrings of "notable"/"note"/"annotate" either way, so nothing
+    about this fix narrows real coverage."""
+    findings = m.check_contradictions("Note: closes #4834", closing_refs=[4834])
+    assert findings == []
+
+
+def test_check5_still_fires_on_cannot_a_single_compound_word():
+    """Tier 1: reject side, companion to the word-boundary fix above —
+    "cannot" is a single compound word with no space before "not", so a
+    naive ``\\bnot\\b`` regex would NOT match inside it (unlike "does
+    not"/"did not", which have a real word boundary). Listed as its own
+    explicit vocabulary entry for exactly this reason; this test pins
+    that the fix didn't accidentally drop it while fixing the
+    "notable"/"note" false positive above. Check 1 legitimately fires
+    alongside check 5 here too, for the same reason as the sibling test
+    above (empty ``closing_refs`` = the parser genuinely did not resolve
+    it)."""
+    findings = m.check_contradictions("cannot fix #4834", closing_refs=[])
+    assert _checks(findings) == [(1, 4834), (5, 4834)]
+
+
+def test_check5_does_not_fire_on_backtick_fenced_negation():
+    """Tier 1: accept side — the sanctioned escape hatch when the literal
+    phrase must appear: GitHub does not parse inside backticks, so a
+    fenced negated keyword poses no real auto-close risk and must not be
+    flagged BY CHECK 5. Tested directly against the finder function
+    rather than the full ``check_contradictions`` pipeline: check 1's own
+    PRE-EXISTING, unrelated behavior (deliberately stricter than GitHub —
+    it treats even a backtick-fenced ``Closes #N`` as a declaration worth
+    flagging when unresolved, module docstring's "Backtick defusal"
+    section) would also legitimately fire here regardless of check 5,
+    which would make a whole-pipeline ``findings == []`` assertion an
+    accidental claim about check 1, not the claim this test is actually
+    making about check 5."""
+    assert m.find_negated_closing_declarations(
+        "if you must write it: `does not close #4834`"
+    ) == set()
+
+
+def test_check5_does_not_fire_on_a_backtick_span_wrapped_across_two_lines():
+    """Tier 1: accept side, real regression found reviewing THIS PR's own
+    body (#4993) — lead-coder measured GitHub's real
+    ``closingIssuesReferences`` as empty for a backtick-fenced negated
+    sentence the author had hard-wrapped across two source lines (an
+    ordinary markdown-authoring habit, and exactly what following check
+    5's own "wrap it in backticks" advice on a long sentence tends to
+    produce), yet an earlier revision of this gate still flagged it.
+    CommonMark/GFM's own spec: a single-backtick code span CAN contain a
+    line ending (normalized to a space), so a two-line-wrapped fence is
+    still ONE fenced span to GitHub's real parser, not two unfenced
+    fragments — ``_INLINE_CODE_RE`` must recognize it as such."""
+    body = (
+        "the incident text, quoted for context: `it does not claim to\n"
+        "close #4834 either`"
+    )
+    assert m.find_negated_closing_declarations(body) == set()
+
+
+def test_check5_does_not_fire_without_an_issue_number_nearby():
+    """Tier 1: accept side — architect's other suggested rewrite: omit the
+    issue number entirely when the reader doesn't need to follow it."""
+    findings = m.check_contradictions(
+        "this PR does not fix the other symptom", closing_refs=[],
+    )
+    assert findings == []
+
+
+def test_check5_does_not_fire_on_an_unrelated_negation_far_from_the_keyword():
+    """Tier 1: the narrow window must not false-positive when a negation
+    word appears earlier in an unrelated sentence, well outside the small
+    window immediately before the closing keyword."""
+    findings = m.check_contradictions(
+        "This is not a comprehensive fix for every edge case out there, "
+        "but it stands on its own. Closes #4834.",
+        closing_refs=[4834],
+    )
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Boundary-fixing witnesses (#4986, architect ruling on the #4992 review
+# thread) — three cases pinning EXACTLY where the CommonMark-compliant
+# `_INLINE_CODE_RE` fix (multi-line spans now recognized as fenced) starts
+# and stops applying. Architect's own framing: what was forbidden is
+# loosening detection of a genuinely risky BARE phrase ("GitHub won't
+# close this particular way, so let it through") — the CommonMark fix is
+# the opposite, making the escape hatch (a real fence) work correctly,
+# not making detection of unfenced risk any looser. Check 1 is a
+# DIFFERENT question (declared vs actual) and is untouched by any of
+# this — case ① below pins that check 1 still fires on a real,
+# previously-observed shape where only the NUMBER (not the verb) sits in
+# backticks, so the keyword itself is unfenced and still risky.
+# ---------------------------------------------------------------------------
+
+
+def test_boundary_1_check1_still_fires_when_only_the_number_is_fenced():
+    """Tier 1: RED, must STAY red — the real PR #4994 shape ("the
+    same-shaped fix `#4985` applied at mount"): only the ISSUE NUMBER is
+    backtick-wrapped, not the verb next to it. This is NOT the CommonMark
+    multi-line-span fix's concern — it is a SINGLE-TOKEN fence, always
+    correctly recognized regardless of the newline change — and check 1
+    is a different question entirely (declared vs actual), never touched
+    by this PR. Without this witness, a future change to check 1 or the
+    fence reader could silently start treating "keyword outside, number
+    inside backticks" as safe, and nothing would catch it."""
+    findings = m.check_contradictions(
+        "the same-shaped fix `#4985` applied at mount", closing_refs=[],
+    )
+    assert _checks(findings) == [(1, 4985)]
+
+
+def test_boundary_2_check5_still_fires_on_the_real_unfenced_negation():
+    """Tier 1: RED, must STAY red — the real #4834 incident sentence,
+    completely unfenced. Restated explicitly here (alongside the
+    equivalent ``test_check5_fires_on_the_real_4834_incident_sentence``
+    above) as one of the three boundary witnesses architect named by
+    number, so the boundary is pinned by a test with THIS name, not only
+    inferred from an existing one with a different name."""
+    findings = m.check_contradictions(
+        "it does not claim to close #4834 either", closing_refs=[4834],
+    )
+    assert _checks(findings) == [(5, 4834)]
+
+
+def test_boundary_3_a_genuine_closes_inside_a_multiline_fence_stays_green():
+    """Tier 1: GREEN — a REAL (non-negated) ``Closes #N`` declaration
+    sitting inside a backtick span the author hard-wrapped across two
+    source lines must still be read as FENCED by
+    :func:`find_canonical_closing_declarations` (check 2/3's own use-vs-
+    mention reading, built on the same ``_body_as_github_parses`` this
+    PR's fix changed) — i.e. it must NOT count as a canonical
+    declaration, exactly as a single-line-fenced one already doesn't
+    (``test_canonical_closing_finder_rejects_keyword_shaped_prose``'s own
+    sibling case). This is check 1's OWN territory it is NOT: check 1
+    deliberately treats even a fenced ``Closes #N`` as "declared" by
+    design (module docstring's "Backtick defusal" section — stricter
+    than GitHub on purpose) and correctly still fires on this body
+    regardless of fencing or line-wrapping; that is pre-existing,
+    unrelated behavior this PR does not touch, so it is asserted
+    separately as its own fact here rather than folded into a
+    whole-pipeline ``findings == []`` (which would incorrectly imply
+    check 1 goes silent — it does not, and should not)."""
+    body = (
+        "the fixed reference reads: `Closes\n"
+        "#4834` in the original draft"
+    )
+    assert m.find_canonical_closing_declarations(body) == set()
+    # check 1 (a DIFFERENT question — declared vs actual) correctly still
+    # fires here, unaffected by fencing by its own long-standing design:
+    findings = m.check_contradictions(body, closing_refs=[])
+    assert _checks(findings) == [(1, 4834)]


### PR DESCRIPTION
**[e2e-coder]** — Closes #4992.
<!-- closing-check: discussing #4985 -->

## What

Real incident, 2026-08-21: #4834 and #4986 were both auto-closed on merge despite each PR body explicitly negating a Closing/Fixing declaration for its own issue in prose. GitHub's own parser matches the bare `keyword+#N` substring and never reads the surrounding negation.

The existing `check_pr_closing_intent.py` gate ran, was SUCCESS, and stayed silent — measured directly (not re-measured a 3rd time, per lead-coder's explicit instruction): `find_closing_declarations()` on the real body text → `{4834}`, `check_contradictions(..., closing_refs=[4834])` → `[]`. Checks 1/2 only compare declared intent against the parser's actual behavior; the parser's own reading matched what an honored `Closes`-shaped declaration looks like, so neither found a mismatch — the negation manufactured the *appearance* of a correctly-declared close.

## Design (architect's ruling, implemented as specified)

- **A negated closing keyword is always wrong** — the new check 5 does not compare against `closing_refs` at all. GitHub closes regardless of the author's negation, so there is no "intent matched, no problem" case for this shape.
- **Discriminator is syntactic**: a negation word (`not` / `never` / `without` / `no longer` / `ない` / `ません` / `せず`) in a narrow (6-word) window immediately before a closing keyword. Bare `"not"` also catches `"does not"` / `"did not"` / `"cannot"` since `"not"` is a substring of each.
- Reads the body as GitHub parses it (fences honored/removed) — a backtick-fenced negated keyword poses no real auto-close risk, so it's the sanctioned escape hatch when the literal phrase must appear at all.
- Also scans commit messages (the same #3187-shaped leak class check 4 already covers).
- Error message names the alternative phrasing: keep the issue open, say so without the verb, or omit the number entirely.

The docstring carries architect's own sentence verbatim, per their instruction — negation doesn't just fail to protect, it manufactures the appearance of a consistent, correctly-declared close.

## Self-caught blocking finding (lead-coder review) — the gate stopped its own author's PR first

Running `check_pr_closing_intent.py --pr 4993` against this PR's own first revision found 2 real issues — a good witness in its own right: the gate stopped the very PR that introduced it, before merge.

1. **False positive**: check 5 flagged a backtick-fenced negated sentence this PR body was hard-wrapped across two source lines (an ordinary markdown-authoring habit, and exactly what following the gate's own "wrap it in backticks" advice on a long sentence tends to produce). lead-coder measured GitHub's real `closingIssuesReferences` as empty for it — GitHub genuinely did not parse it as closing, but the gate still flagged it. Root cause: `_INLINE_CODE_RE` excluded newlines (`` `[^`\n]*` ``), so a two-line-wrapped fence read as two unfenced fragments. CommonMark/GFM's own spec says a single-backtick code span CAN contain a line ending (normalized to a space) — fixed to match (`` `[^`]*?` `` with `re.DOTALL`), with a new accept-side witness reproducing the exact shape. Strip-falsified: reverting the regex correctly reddens the new test.
2. **Real hit**: the commit message (not just the body) still carried the negated incident sentences verbatim — the exact #3187-shaped leak class check 4 already exists for. Fixed by rewriting the commit message to describe the incident without reproducing the trigger phrase.

Both are now resolved.

## Boundary witnesses (architect ruling, #4986 thread) — pinning where the CommonMark fix starts and stops

architect confirmed the `_INLINE_CODE_RE` fix is not a loosening (a fence is a guaranteed-safe escape hatch by construction, and the gate's own docstring already warns against training people out of writing the fence that documents the discipline it enforces) and asked for 3 named tests so the boundary can't silently drift:

1. **RED, stays red** — the real PR #4994 shape ("the same-shaped fix `` `#4985` `` applied at mount"): only the issue NUMBER is fenced, not the verb. Check 1 (a different question — declared vs actual) correctly still fires, untouched by this PR.
2. **RED** — the real unfenced #4834 sentence.
3. **GREEN** — a genuine, non-negated `Closes #N` inside a correctly multi-line-fenced span, verified directly against `find_canonical_closing_declarations` (not a whole-pipeline assertion — check 1 correctly still fires on the same body for its own, separate reason).

## Reviewer findings (2 more, both fixed)

- Negation matching used bare substring containment (`term in window`), so `"not"` matched inside `"notable"`/`"note"`/`"annotate"` — a correctly written `"Note: closes #N"` would have been wrongly flagged. Fixed to word-boundary regex matching for the English vocabulary; `"cannot"` needed its own explicit entry (a single compound word with no space before `"not"`, so `\bnot\b` doesn't match inside it, unlike `"does not"`/`"did not"`). New tests pin both the false-positive fix and that `"cannot"` coverage survived it.
- A test's docstring described the parser-*disagrees* case while its fixture actually used the parser-*agrees* one — name, docstring, and fixture now agree.

`check_pr_closing_intent.py --pr 4993` is clean.

## Tests (witnesses specified by architect, written first)

- **Reject**: the two real incident sentences verbatim, each using its own PR's real `closing_refs` value (reproduces the incident precisely — checks 1/2 correctly stay silent, only check 5 catches it); a fires-unconditionally variant with `closing_refs` supplied, making the "no intent comparison" property explicit; a commit-message variant.
- **Accept**: the "stays open" phrasing, a backtick-fenced negation (tested directly against `find_negated_closing_declarations` to isolate the claim from check 1's own unrelated, pre-existing backtick-defusal behavior), no-number phrasing, and a negation word far from the keyword in an unrelated sentence (narrow-window non-vacuity).

**Strip-falsified**: with check 5's own detection call replaced by an empty set, all 3 reject-side tests that depend on it correctly reddened; restored, all 35 green. A separate strip-falsify for the backtick-span fix (regex reverted) reddened the new multi-line witness for the right reason, then restored, all 36 green.

No open PR currently carries negated-closing-keyword phrasing that would need migration.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_pr_closing_intent.py`
- [x] `python scripts/verify_module_docstrings.py scripts/check_pr_closing_intent.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `pytest tests/scripts/` (860 passed) + strip-falsify
- [x] (skipped — Visual, standing waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

