### PR TITLE
feat(#4983): session-switch rehydrate off the event loop

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1404,6 +1404,13 @@ class TextualChatApp(App):
         # early seed is harmless there.
         self._queue_view = RemoteQueueView()
         self._queue_seeded = False
+        # #4983 (architect co-vet on #4994): a monotonic switch generation.
+        # ``_handle_session_attached_event`` claims one at entry and, after
+        # its off-thread history read returns, applies the result only if
+        # this is still the LATEST claimed generation — a newer switch that
+        # started (and possibly finished) while this one's read was still
+        # in flight off-thread must win. See that method's own docstring.
+        self._session_switch_generation = 0
         # A queued item's ``meta`` (ADR-0039 attribution) — ``apply_user_submitted``
         # deliberately stores only msg_id/chain_id/text on
         # ``RemoteQueueView.items`` (P2a's delta contract, reused unmodified,
@@ -5044,8 +5051,26 @@ class TextualChatApp(App):
 
         Runs the reset UNGUARDED (a `try`/`except` around clearing plain
         dicts/lists would only hide a real bug) but the follow-on hydrate
-        call is internally guarded, same as the mount-time call."""
+        call is internally guarded, same as the mount-time call.
+
+        #4983 supersede guard (architect co-vet on #4994, self-flagged as
+        "my own design's residue" — the shape was handed over, the fact
+        that an ``await`` in between lets the TARGET change was not): step
+        ①'s off-thread read has no ordering guarantee against a LATER
+        switch that starts while it is still in flight — switch A begins
+        its (slow) read, switch B arrives and finishes first, THEN A's
+        read returns; applying it unconditionally would silently overwrite
+        B's just-hydrated conversation with A's stale one. Guarded with a
+        monotonic :attr:`_session_switch_generation`, claimed at entry:
+        step ②'s apply only happens if this call still holds the latest
+        generation when the read comes back. Otherwise it is exactly what
+        :meth:`_handle_user_submitted_event`'s own docstring already calls
+        "a stale/already-superseded delta" — "a no-op", same words, not a
+        new concept."""
         import asyncio  # noqa: PLC0415
+
+        self._session_switch_generation += 1
+        my_switch_generation = self._session_switch_generation
 
         data = event.data or {}
         agent = data.get("agent")
@@ -5119,6 +5144,13 @@ class TextualChatApp(App):
         messages = await asyncio.to_thread(
             self._read_conversation_history, agent=agent, session_id=session_id,
         )
+        # #4983 supersede guard — see this method's own docstring. A LATER
+        # switch may have claimed a newer generation (and already applied
+        # its own hydrate) while the read above was still in flight; this
+        # read is then a stale/already-superseded delta, so applying it now
+        # is a no-op, not an overwrite.
+        if self._session_switch_generation != my_switch_generation:
+            return
         self._apply_hydrated_messages(messages)
 
     def _handle_user_submitted_event(self, event) -> None:

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -4918,9 +4918,25 @@ class TextualChatApp(App):
                 # a late-joining client).
                 self._queue_item_meta[msg_id] = dict(item.get("meta") or {})
 
-    def _handle_session_attached_event(self, event) -> None:
+    async def _handle_session_attached_event(self, event) -> None:
         """The session-switch reset barrier (#3310 N2, consuming N1's
         ``session_attached`` ``EventFrame``, ``{agent, session_id}``).
+
+        #4983 (owner ruling, 2026-08-21: "セッション切り替えの見た目許容" —
+        a brief blank-then-refill on switch is accepted; NOT "history
+        never arrives" or "order changes"): ``async def``, not ``def``,
+        so the NEW session's ``conversation_history()`` disk read
+        (:meth:`_read_conversation_history`, step ①) can run OFF the
+        event loop via ``asyncio.to_thread`` — see this method's own
+        tail for where. Deliberately does NOT make :meth:`_hydrate_from_
+        history` itself async (architect ruling, #4983: that would push
+        the SAME "off-thread or not" axis onto BOTH call sites — mount
+        (:meth:`on_mount`, #4985) does NOT want to ``await`` here, this
+        one does) — the split is by WORK (I/O vs UI), not by function:
+        :meth:`_read_conversation_history` (I/O) runs off-thread ONLY at
+        this call site; :meth:`_apply_hydrated_messages` (projection +
+        apply, pure in-memory) stays on the loop exactly as it always
+        has, at both call sites.
 
         ★Design thesis (architect deep-dive, issue #3310 §1): a cached
         FlowView cannot be the source of truth after a switch — while THIS
@@ -5029,6 +5045,8 @@ class TextualChatApp(App):
         Runs the reset UNGUARDED (a `try`/`except` around clearing plain
         dicts/lists would only hide a real bug) but the follow-on hydrate
         call is internally guarded, same as the mount-time call."""
+        import asyncio  # noqa: PLC0415
+
         data = event.data or {}
         agent = data.get("agent")
         session_id = data.get("session_id")
@@ -5091,7 +5109,17 @@ class TextualChatApp(App):
         except Exception:
             logger.exception("textual chat: switch queue-view reseed failed")
         self._queue_seeded = True
-        self._hydrate_from_history(agent=agent, session_id=session_id)
+        # #4983: step ① (the disk read) runs OFF the event loop — the
+        # measured defect this issue exists for (a synchronous
+        # `conversation_history()` call blocking the TUI's own event
+        # loop, here on every session switch, not just at mount) —
+        # step ② (projection + apply) stays on the loop, unchanged. See
+        # this method's own docstring for why `_hydrate_from_history`
+        # itself is not what's called here.
+        messages = await asyncio.to_thread(
+            self._read_conversation_history, agent=agent, session_id=session_id,
+        )
+        self._apply_hydrated_messages(messages)
 
     def _handle_user_submitted_event(self, event) -> None:
         """MATERIALIZE exit (#3300 P2b, sent-queue exit contract §6a): a
@@ -5790,7 +5818,7 @@ class TextualChatApp(App):
                     etype = getattr(frame.event, "type", None)
                     if etype == "session_attached":
                         try:
-                            self._handle_session_attached_event(frame.event)
+                            await self._handle_session_attached_event(frame.event)
                         except Exception:
                             logger.exception(
                                 "textual chat: session_attached reset+hydrate failed"

--- a/tests/interfaces/test_4983_session_switch_off_thread.py
+++ b/tests/interfaces/test_4983_session_switch_off_thread.py
@@ -106,6 +106,7 @@ def _registry(tmp_path: Path) -> AgentRegistry:
     reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
     reg.create("alpha")
     reg.create("beta")
+    reg.create("gamma")
     return reg
 
 
@@ -204,5 +205,108 @@ async def test_session_switch_still_hydrates_the_new_sessions_history(
                 if e.item.kind != "system"
             ]
             assert rows == [("user", "turn while away")]
+    finally:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_session_switch_supersede_guard_lets_the_later_switch_win(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #4983 supersede guard (architect co-vet on #4994, self-
+    flagged as their own design's residue).
+
+    Moving step ①'s read off the event loop opens a window an ``await``
+    didn't have before: switch A's read can still be in flight when switch
+    B arrives, and if B finishes first, A returning later must NOT
+    overwrite B's already-applied hydrate. Witness ① from the co-vet:
+    2 switches in a row, the FIRST one's read held open — final display
+    is the SECOND switch's history; reverting the guard (always applying)
+    turns this red because A's stale read lands last.
+
+    No duration anywhere (CLAUDE.md floor/ceiling rule): ordering is
+    forced with a ``threading.Event`` gate — a controllable seam the test
+    releases explicitly — never a sleep. Calls
+    ``_handle_session_attached_event`` directly (real method, real app,
+    real registry/session — no mock) rather than through the transport
+    frame pump, because ``_pump_frames``'s ``async for`` only ever awaits
+    one frame's handler to completion before requesting the next: the
+    pump itself cannot interleave two ``session_attached`` frames, so
+    exercising the guard's own contract needs to invoke the coroutine the
+    way a second concurrent caller would.
+
+    Witness ② (a single switch still hydrates normally, so an "always
+    discard" implementation cannot pass vacuously) is
+    ``test_session_switch_still_hydrates_the_new_sessions_history`` above
+    — both are required together per the co-vet note."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        from reyn.runtime.chat_message import ChatMessage
+
+        await reg.attach("beta")
+        reg.get_session("beta")._append_history(
+            ChatMessage(role="user", content="beta's own turn"),
+        )
+        await reg.attach("gamma")
+        reg.get_session("gamma")._append_history(
+            ChatMessage(role="user", content="gamma's own turn"),
+        )
+        await reg.attach("alpha")
+
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            loop = asyncio.get_running_loop()
+            release_beta_read = threading.Event()
+            beta_read_started = asyncio.Event()
+            real_read = app._read_conversation_history
+
+            def _gated_read(*, agent=None, session_id=None):
+                if agent == "beta":
+                    loop.call_soon_threadsafe(beta_read_started.set)
+                    release_beta_read.wait()
+                return real_read(agent=agent, session_id=session_id)
+
+            monkeypatch.setattr(app, "_read_conversation_history", _gated_read)
+
+            await reg.attach("beta")
+            beta_task = asyncio.create_task(
+                app._handle_session_attached_event(
+                    Event(
+                        type="session_attached",
+                        data={"agent": "beta", "session_id": _DEFAULT_SID},
+                    )
+                )
+            )
+            await beta_read_started.wait()  # beta's read is now held open
+
+            # gamma's switch starts AFTER beta's and, being ungated, finishes
+            # (including its own apply) BEFORE beta's held-open read returns.
+            await reg.attach("gamma")
+            await app._handle_session_attached_event(
+                Event(
+                    type="session_attached",
+                    data={"agent": "gamma", "session_id": _DEFAULT_SID},
+                )
+            )
+
+            release_beta_read.set()
+            await beta_task
+            await _settle(pilot)
+
+            rows = [
+                (e.item.kind, e.item.text)
+                for e in app.query_one(FlowView).entries
+                if e.item.kind != "system"
+            ]
+            assert rows == [("user", "gamma's own turn")], (
+                "the LATER switch (gamma) must win — beta's stale, "
+                "later-arriving read must be a no-op, not an overwrite"
+            )
     finally:
         pass

--- a/tests/interfaces/test_4983_session_switch_off_thread.py
+++ b/tests/interfaces/test_4983_session_switch_off_thread.py
@@ -1,0 +1,208 @@
+"""Tier 2: #4983 — the session-switch rehydrate no longer makes its
+synchronous ``history.jsonl`` disk read on the event loop.
+
+Owner ruling (2026-08-21, "セッション切り替えの見た目許容"): a brief
+blank-then-refill on switch is the ACCEPTED trade — NOT "history never
+arrives" or "order changes" (both still forbidden), and NOT a change to
+mount's own first-paint behavior (#4985 already keeps that unchanged).
+
+Architect's design: split by WORK, not by function — ``_hydrate_from_
+history`` itself stays synchronous (mount, #4985's own untouched
+fallback path, still uses it byte-identically); ONLY
+``_handle_session_attached_event`` (the live switch barrier) is now
+``async def`` and runs step ① (``_read_conversation_history``, the I/O)
+via ``asyncio.to_thread`` before applying step ② (``_apply_hydrated_
+messages``, pure in-memory) on the loop, exactly as it always has.
+
+Witness is "does the I/O run off the event loop" (real thread-identity
+check, mirroring ``test_4983_mount_hydrate_off_loop.py``'s own
+technique for the mount side) — no duration anywhere (CLAUDE.md's
+floor/ceiling rule).
+
+Real ``AgentRegistry`` + real ``Session`` + real ``RegistryReadModel`` +
+the real mounted ``TextualChatApp``, driven through a real queue-backed
+``ClientTransport`` — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.core.events.events import Event
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.repl.read_model import RegistryReadModel
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` whose ``frames()`` drains
+    an ``asyncio.Queue`` the test pushes onto (mirrors ``test_3310_n2_
+    reset_hydrate.py``'s own helper of the same name/shape)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue" = asyncio.Queue()
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            yield await self._queue.get()
+
+    def push_event(self, etype: str, data: dict) -> None:
+        self._queue.put_nowait(EventFrame(Event(type=etype, data=data)))
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self):
+        return None
+
+    def put_display(self, msg: OutboxMessage) -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    reg.create("beta")
+    return reg
+
+
+async def _settle(pilot, n: int = 2) -> None:
+    for _ in range(n):
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_session_switch_reads_conversation_history_off_the_event_loop(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: the measured defect's own falsifier. The switch barrier's
+    ``conversation_history()`` call must run on a DIFFERENT thread than
+    the event loop's own main thread — reverting the fix (calling
+    ``_hydrate_from_history`` synchronously again, as it did before this
+    PR) turns this red: the call lands on the SAME thread the test
+    itself runs on."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        read_model = RegistryReadModel(reg)
+        main_thread = threading.current_thread()
+        call_threads: "list[threading.Thread]" = []
+        real_conversation_history = read_model.conversation_history
+
+        def _recording(*args, **kwargs):
+            call_threads.append(threading.current_thread())
+            return real_conversation_history(*args, **kwargs)
+
+        monkeypatch.setattr(read_model, "conversation_history", _recording)
+
+        transport = QueueTransport()
+        app = TextualChatApp(transport=transport, read_model=read_model, agent_name="alpha")
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+            calls_at_mount = len(call_threads)
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID},
+            )
+            await _settle(pilot)
+
+        switch_calls = call_threads[calls_at_mount:]
+        assert switch_calls, "the switch must have read conversation_history"
+        assert all(t is not main_thread for t in switch_calls), (
+            "the session-switch read must run off the event-loop thread "
+            "(asyncio.to_thread), not inline on the test's own thread"
+        )
+    finally:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_session_switch_still_hydrates_the_new_sessions_history(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: accept-side — moving the read off-thread must not change
+    WHAT ends up on screen. Same staleness-gate shape ``test_3310_n2_
+    reset_hydrate.py`` already established, reconfirmed after the split:
+    a turn produced on alpha while this client is on beta (durably
+    persisted only, never delivered live) is present after switching
+    back to alpha."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        alpha = reg.get_session("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID},
+            )
+            await _settle(pilot)
+
+            from reyn.runtime.chat_message import ChatMessage
+            alpha._append_history(ChatMessage(role="user", content="turn while away"))
+
+            await reg.attach("alpha")
+            transport.push_event(
+                "session_attached", {"agent": "alpha", "session_id": _DEFAULT_SID},
+            )
+            await _settle(pilot)
+
+            rows = [
+                (e.item.kind, e.item.text)
+                for e in app.query_one(FlowView).entries
+                if e.item.kind != "system"
+            ]
+            assert rows == [("user", "turn while away")]
+    finally:
+        pass


### PR DESCRIPTION
**[tui-coder]** — session-switch half of `#4983` (the mount half already landed via `#4985`/`aa32b67dd`). `#4834` stays open — its own discriminator is a separate, unresolved investigation this PR does not touch.

## What

Owner ruling (2026-08-21, "セッション切り替えの見た目許容"): a brief blank-then-refill on session switch is the **accepted** trade — **not** accepted: "history never arrives" or "order changes". Mount's own first-paint is unchanged (`#4985` already solved that).

Architect's design — split by WORK, not by function:

- `_hydrate_from_history` itself stays **synchronous** — mount's own untouched fallback path (`on_mount`, `#4985`) still calls it byte-identically.
- Only `_handle_session_attached_event` (the live switch barrier) becomes `async def`, so its own `conversation_history()` disk read (`_read_conversation_history`, step ①) runs **off** the event loop via `asyncio.to_thread`.
- `_apply_hydrated_messages` (step ②, pure in-memory projection + apply) stays **on** the loop exactly as it always has, at both call sites.

This is the same shape `#4985` already applied at mount, pushed onto the session-switch path, where the identical synchronous `history.jsonl` read was blocking the TUI's own event loop on every switch, not just at startup.

## Test plan

- [x] `tests/interfaces/test_4983_session_switch_off_thread.py` — 2 new tests, no duration anywhere (CLAUDE.md floor/ceiling rule)
  - `test_session_switch_reads_conversation_history_off_the_event_loop` — the defect's own falsifier via real thread-identity check, **strip-falsified** (reverted locally, confirmed red for the stated reason)
  - `test_session_switch_still_hydrates_the_new_sessions_history` — accept-side: moving the read off-thread does not change what ends up on screen
- [x] `ruff check` on both changed files — clean
- [x] `scripts/test_tier_audit.py --strict` on the new test file — OK
- [x] `scripts/mypy_ratchet.py` — OK, unchanged baseline
- [x] `scripts/verify_module_docstrings.py` — OK
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_file_depth_reference.py` / `check_bare_tests_import_reference.py` — all OK
- [x] Full `tests/interfaces/` regression sweep (re-run after the race fix): **1909 passed, 4 skipped** (skips are the pre-existing `#4104` optional `reyn[voice]` extra, unrelated to this change)
- [ ] (skipped — Visual, standing waiver)

## Scope boundaries

- `#4834`'s own discriminator is untouched by this PR — that investigation stays where lead-coder left it, parked pending its next occurrence.
- Mount's own hydrate path (`#4985`) is not modified here beyond what's needed to keep `_hydrate_from_history`'s shared helpers (`_read_conversation_history`/`_apply_hydrated_messages`) reusable by both call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔴 lead-coder のブロッキング点（規則 7）

- [x] 🔴 ~~**`await` を挟んだことで ★切替の race が生まれています。**~~ ✅ `168457c3c` で解消（`_session_switch_generation` という単調カウンタを entry で claim し、await 後に一致確認 → 不一致は no-op。witness 2 本追加、`test_session_switch_supersede_guard_lets_the_later_switch_win`（strip-falsify 済み）と既存 `test_session_switch_still_hydrates_the_new_sessions_history`。architect 確認・ブロック解除済み。

```
★app.py:5119-5122（この枝で実測）
    messages = await asyncio.to_thread(
        self._read_conversation_history, agent=agent, session_id=session_id,
    )
    self._apply_hydrated_messages(messages)
🔴 ★間に 何も在りません
```

**起きること**:

```
★switch A →（読み中）→ ★switch B 到着 → ★B を表示 → ★A の読みが戻り ★A を上書き
∴ ★★利用者は B に切り替えたのに ★A の会話を見ます
🔴 ★この race は ★本 PR が 作りました（★以前は同期で、間に何も挟まりませんでした）
🔴 ★窓の広さは ★off-thread にしたぶん ★長く開きます
∴ ★★「UI を固めない」ための変更が ★「間違った会話を出す」を 生んでいます
```

## ✅ 処方（architect）

> **`await` の前に対象（`agent` / `session_id`）を控え、★後に「今の対象」と一致するか見る。★一致→適用／★不一致→捨てる（新しい切替が勝つ）。**

⚪ **語彙は ★このファイルに既に在ります**（`app.py:5130` 逐語、私が確認しました）:

> **a stale/already-superseded delta is a no-op**

★ **同じ言葉で書いてください** ── **新しい語を作らないでください。**

## ✅ witness 2 本（architect 指定 ── ★①だけでは足りません）

```
★① 2 回続けて切替 ＋ 1 回目の読みを遅く → ★最終表示は 2 回目
   ── ★guard を外すと RED
★② 1 回だけの切替 → ★従来どおり適用（★guard が 過剰に捨てない）
🔴 ★①だけだと ★「常に捨てる」実装でも ★緑になります
```

⚠️ **test に時間を書かないでください**（家則）── ★ **「1 回目の読みを遅く」は ★clock でなく ★制御可能な seam で**（★読みを差し替えられる形にする、など）。

---

⚪ **architect の自己申告を記録します**: > **これは私の裁定の残渣です ──「①を off-thread、②は loop 上」と ★形は渡して、★「await を挟むと対象が変わり得る」を渡しませんでした。**★ **今夜 3 件目の同型**（#4989 / #4991 / 本件）。

