### PR TITLE
docs(#4992): record the n=1 measurement caveat and confirm check 2's scope

### DIFF
--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -428,6 +428,31 @@ _FENCED_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
 # i.e. GitHub genuinely did not parse them as closing references, but
 # this gate's OWN check 5 still flagged them). ``re.DOTALL`` non-greedy so
 # `.` matches a newline too, without needing to special-case it.
+#
+# #4992 post-merge review (architect): the discriminator this fix rests
+# on is the OBSERVATION above (GitHub genuinely did not parse the wrapped
+# span as closing), not "because CommonMark says so" — a spec citation
+# alone would NOT have been accepted as sufficient grounds for widening a
+# gate whose whole job is stopping risky bare phrasing; what makes this
+# an acceptable widening is that it only recognizes spans GitHub itself
+# already treats as safe, never loosens detection of anything GitHub
+# would actually act on. Disclosed explicitly, per the same discipline
+# this repo's own pre-conclusion checklist requires: that observation is
+# n=1 (this PR's own body, one wrapped span) — supported by CommonMark's
+# spec as the reason to expect it generalizes, but not independently
+# re-measured against a second real body.
+#
+# Also flagged (not a defect, a scope note): `_body_as_github_parses`
+# feeds check 2's own use-vs-mention reading too
+# (`find_canonical_closing_declarations`), so this same widening — a
+# span that spans a line break is now recognized as fenced — applies
+# there as well, not only to check 5. This is the CORRECT, intended
+# consequence of the two checks sharing one "what does GitHub actually
+# see as fenced" primitive, not an accidental side effect: check 2 asks
+# "did the author canonically declare a close GitHub will act on", and a
+# multi-line-fenced `Closes #N` is exactly as GitHub-inert as a
+# single-line-fenced one, so it must be excluded from check 2's
+# corroboration the same way.
 _INLINE_CODE_RE = re.compile(r"`[^`]*?`", re.DOTALL)
 
 


### PR DESCRIPTION
part of #4992.

## What

architect's post-merge review of landed PR #4993 approved the `_INLINE_CODE_RE` fix but named two non-blocking follow-ups to record in the code itself:

1. **The measurement is n=1**: the fix's actual discriminator is the observation that GitHub genuinely did not parse the wrapped span as closing (measured once, on PR #4993's own body) — CommonMark's spec is why that generalizes, but it wasn't independently re-measured a second time. architect's own words: a spec citation alone would not have been sufficient grounds — the gate's job is stopping risky bare phrasing, and "matched the spec, not the observed behavior" is exactly the gap this repo's own pre-conclusion checklist warns about.
2. **Check 2's scope also widened**: `_body_as_github_parses` feeds check 2's own use-vs-mention reading (`find_canonical_closing_declarations`), not just check 5 — confirmed as the intended, correct consequence of both checks sharing one "what does GitHub actually see as fenced" primitive, not an accidental side effect.

Comment-only change, recording both in `_INLINE_CODE_RE`'s own comment (the durable record future readers see, not just a PR thread). No behavior/test change — same 41 tests pass unchanged.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `pytest tests/scripts/test_check_pr_closing_intent.py` (41 passed, unchanged)
- [x] (skipped — Visual, standing waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
