### PR TITLE
feat(#4997①): detect_4986_teardown_hang - CI-log signature detector

### DIFF
--- a/.github/workflows/detect-4986-recurrence.yml
+++ b/.github/workflows/detect-4986-recurrence.yml
@@ -1,0 +1,87 @@
+name: "Detect #4986 recurrence"
+
+# #4997① — status:awaiting-recurrence on #4986 had zero detectors (owner
+# finding): nobody could notice the teardown-hang recurring. This workflow
+# is the invocation point scripts/detect_4986_teardown_hang.py itself was
+# deliberately left without (architect ruling on #4999): pure detection
+# logic in the script, this file decides WHEN it runs.
+#
+# Trigger: workflow_run on "CI" (test.yml's own `name: CI`), fired when
+# that workflow completes — architect explicitly rejected a cron/schedule
+# alternative: cron satisfies "gets called" but not "arrives before a
+# re-run" — this detector's whole notification depends on reaching a human
+# BEFORE they re-run the job and destroy the only copy of the hung log
+# (the exact incident that motivated #4997's common requirement). An
+# hourly cron could arrive up to an hour late; workflow_run fires within
+# the SAME event as the failure itself.
+#
+# workflow_dispatch (with a run_id input) is added alongside for two
+# reasons architect named, not just convenience:
+#   1. workflow_run only ever runs the DEFAULT BRANCH's copy of this
+#      workflow — this PR's own branch never triggers it no matter what
+#      the file says, so without workflow_dispatch this workflow could not
+#      be tested against a real run before merge at all.
+#   2. A silent no-detection run looks IDENTICAL to a broken workflow that
+#      never ran — workflow_dispatch lets a human replay a known-positive
+#      run (e.g. 32459227086, the real #4986 signature this script's own
+#      test fixture is drawn from) on demand to confirm the workflow
+#      itself is alive, independent of waiting for a fresh failure.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "A CI run ID to check (for manual verification against a known run, e.g. a real #4986 recurrence)."
+        required: true
+
+permissions:
+  actions: read
+  issues: write
+  contents: read
+
+jobs:
+  detect:
+    name: "detect #4986 teardown-hang signature"
+    # workflow_run: only act on a FAILED CI run — a green run cannot carry
+    # the #4986 signature (the hang, by definition, causes pytest-timeout
+    # to fail the job). workflow_dispatch always runs (a human explicitly
+    # asked to check a specific run).
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Resolve the run ID to check
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_id=${{ github.event.inputs.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Run the #4986 signature detector"
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          python scripts/detect_4986_teardown_hang.py --run-id "${{ steps.resolve.outputs.run_id }}" > detection_output.txt 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          cat detection_output.txt
+
+      - name: "Post the notification to #4986"
+        if: steps.detect.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 4986 --body "$(cat detection_output.txt)"

--- a/scripts/detect_4986_teardown_hang.py
+++ b/scripts/detect_4986_teardown_hang.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""#4997① — detect the #4986 teardown-hang signature in a CI run's log.
+
+## Why this exists
+
+`status:awaiting-recurrence` on #4986 (asyncio-runner teardown hangs in
+`_cancel_all_tasks` until pytest-timeout kills it at 120s) had ZERO
+detectors — owner's own finding (#4997): a "recurrence" label with no way
+to notice the recurrence is a wish, not a state. This script closes that
+for #4986 specifically; #4997②/③ are #4834/#4975's own separate
+detectors, tracked independently.
+
+## The signature (measured, not guessed)
+
+Two real CI runs were cross-referenced (#4986 issue thread, lead-coder +
+e2e-coder, 2026-08-21) to find what is COMMON between them, discarding
+anything that appeared in only one:
+
+    - `ERROR at teardown of <test name>` (pytest's own teardown-failure
+      header)
+    - `_cancel_all_tasks` (the frame inside asyncio's own
+      `runners.py:close` where the hang sits — `loop.run_until_complete
+      (tasks.gather(*to_cancel, ...))`, which never returns)
+    - `Timeout (>120` (pytest-timeout's own kill message —
+      `Failed: Timeout (>120.0s) from pytest-timeout.`)
+
+All three, not any one alone: each individually can appear in an
+UNRELATED failure (a plain teardown error with no hang; an unrelated
+120s timeout with no teardown error; `_cancel_all_tasks` appears in
+EVERY asyncio-runner teardown, hung or not). Co-occurrence of all three
+in the SAME failure block is the signature.
+
+## What is deliberately NOT part of the signature
+
+`ephemeral-vanish` (`TrackedTaskSet.aclose(caller='await_quiescent'):
+called reentrantly from a task ('ephemeral-vanish', ...)`) was measured
+and REJECTED as a discriminator: this WARNING is a routine, frequent
+message unrelated to the hang — run 31913669752 has it WITHOUT the
+teardown hang, so including it would produce false positives on ordinary
+runs that never hung at all.
+
+## Scope
+
+Reads a CI run's raw log TEXT (from `gh run view --log-failed`, `gh api
+.../attempts/N/logs`, or a saved file) — the same substrate
+`check_pr_closing_intent.py --fixture` uses for offline testing, kept
+pure/network-free so it is fully unit-testable. The CLI wrapper below is
+the thin, separately-swappable network layer.
+
+Usage:
+    python scripts/detect_4986_teardown_hang.py --run-id <id>
+    python scripts/detect_4986_teardown_hang.py --log-file <path>
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+_SIGNATURE_MARKERS = (
+    "ERROR at teardown",
+    "_cancel_all_tasks",
+    "Timeout (>120",
+)
+
+
+def has_4986_signature(log_text: str) -> bool:
+    """True iff *log_text* contains all three #4986 signature markers.
+
+    Pure, no I/O — the whole decision this script makes, isolated so it
+    is directly testable against fixture log text without hitting
+    GitHub. See the module docstring for what the three markers are and
+    why `ephemeral-vanish` is deliberately excluded."""
+    return all(marker in log_text for marker in _SIGNATURE_MARKERS)
+
+
+def format_notification(run_id: str) -> str:
+    """The notification text a detection must carry — per #4997's common
+    requirement across all 3 detectors: the issue number to trace to, AND
+    evidence-preservation instructions, IN THE SAME MESSAGE. Without the
+    second half, whoever reads the alert re-runs CI to "confirm" and
+    destroys the only copy of the log before anyone can read it (lead-
+    coder's own incident, same night this issue was filed)."""
+    return (
+        f"RED #4986 — CI run {run_id} matches #4986's teardown-hang "
+        "signature (ERROR at teardown + _cancel_all_tasks + "
+        "Timeout (>120). Before re-running this job, preserve the "
+        "evidence: `gh api /repos/tya5/reyn/actions/runs/"
+        f"{run_id}/attempts/1/logs` (or `gh run view {run_id} "
+        "--log-failed`) — a re-run may not reproduce the hang, and the "
+        "log is the only record of this occurrence."
+    )
+
+
+# ---------------------------------------------------------------------------
+# gh wrapper (thin — kept separate from the pure logic above)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_run_log(run_id: str) -> str:
+    result = subprocess.run(
+        ["gh", "run", "view", run_id, "--log-failed"],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Detect the #4986 teardown-hang signature in a CI run's log.",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--run-id", metavar="ID",
+        help="A GitHub Actions run ID — fetched via `gh run view ID --log-failed`.",
+    )
+    group.add_argument(
+        "--log-file", metavar="PATH",
+        help="Path to a saved log file (offline / already-fetched — never re-runs CI).",
+    )
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.log_file is not None:
+        from pathlib import Path
+        log_text = Path(args.log_file).read_text(encoding="utf-8", errors="replace")
+        run_id = args.log_file
+    else:
+        try:
+            log_text = _fetch_run_log(args.run_id)
+        except subprocess.CalledProcessError as exc:
+            print(f"gh run view failed: {exc.stderr}", file=sys.stderr)
+            return 2
+        run_id = args.run_id
+
+    if has_4986_signature(log_text):
+        print(format_notification(run_id))
+        return 1
+
+    print(f"OK — no #4986 signature found in {run_id}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_detect_4986_teardown_hang.py
+++ b/tests/scripts/test_detect_4986_teardown_hang.py
@@ -1,0 +1,101 @@
+"""Tier 1: #4997① — the #4986 teardown-hang CI-log detector.
+
+Pins the signature co-occurrence rule measured across two real CI runs
+(#4986 issue thread): `ERROR at teardown` + `_cancel_all_tasks` +
+`Timeout (>120`, all three, and the explicit exclusion of
+`ephemeral-vanish` as a discriminator (real counterexample: run
+31913669752 has the warning without the hang).
+"""
+from __future__ import annotations
+
+from scripts.detect_4986_teardown_hang import format_notification, has_4986_signature
+
+_REAL_POSITIVE_EXCERPT = """\
+_ ERROR at teardown of test_model_output_cannot_reach_slash_dispatch_and_spawns_nothing _
+[gw2] linux -- Python 3.12.14 /opt/hostedtoolcache/Python/3.12.14/x64/bin/python
+        yield runner
+    except Exception as e:
+        runner.__exit__(type(e), e, e.__traceback__)
+    else:
+        with warnings.catch_warnings():
+>                       runner.__exit__(None, None, None)
+/opt/hostedtoolcache/Python/3.12.14/x64/lib/python3.12/asyncio/runners.py:70: in close
+    _cancel_all_tasks(loop)
+/opt/hostedtoolcache/Python/3.12.14/x64/lib/python3.12/asyncio/runners.py:206: in _cancel_all_tasks
+    loop.run_until_complete(tasks.gather(*to_cancel, return_exceptions=True))
+E           Failed: Timeout (>120.0s) from pytest-timeout.
+WARNING  reyn.runtime.tracked_tasks:tracked_tasks.py:280 TrackedTaskSet.aclose(caller='await_quiescent'): called reentrantly from a task ('ephemeral-vanish', disposition='await', appends_wal=True) this tracker is itself still tracking -- that task is excluded from THIS call's own drain (see aclose()'s own docstring for why). Normal for the ephemeral-vanish task's internal call; if caller=='AgentRegistry.shutdown' here, its non-reentrancy assumption has broken.
+"""
+
+
+def test_the_real_positive_excerpt_is_detected():
+    """Tier 1: the exact 3-marker co-occurrence from a real CI run
+    (#4986 thread, run 32459227086) is detected."""
+    assert has_4986_signature(_REAL_POSITIVE_EXCERPT) is True
+
+
+def test_ephemeral_vanish_alone_is_not_the_signature():
+    """Tier 1: real counterexample (run 31913669752) — the
+    ephemeral-vanish warning appears WITHOUT the teardown hang. Must NOT
+    be flagged: this is the exact false-positive the issue explicitly
+    warned against."""
+    body = (
+        "WARNING TrackedTaskSet.aclose(caller='await_quiescent'): called "
+        "reentrantly from a task ('ephemeral-vanish', disposition='await', "
+        "appends_wal=True) this tracker is itself still tracking\n"
+        "1 passed in 4.21s\n"
+    )
+    assert has_4986_signature(body) is False
+
+
+def test_teardown_error_alone_without_timeout_is_not_flagged():
+    """Tier 1: a teardown ERROR with no hang (an ordinary teardown
+    exception, resolved well under the timeout) must not be flagged —
+    only the co-occurrence with the timeout+_cancel_all_tasks frame is
+    the signature."""
+    body = (
+        "_ ERROR at teardown of test_something _\n"
+        "some ordinary AttributeError raised during fixture teardown\n"
+        "1 failed in 2.31s\n"
+    )
+    assert has_4986_signature(body) is False
+
+
+def test_an_unrelated_120s_timeout_is_not_flagged():
+    """Tier 1: a Timeout (>120 with no teardown ERROR and no
+    _cancel_all_tasks frame — a genuinely slow test that legitimately
+    exceeded the ceiling — must not be conflated with the #4986 hang."""
+    body = "E           Failed: Timeout (>120.0s) from pytest-timeout.\n"
+    assert has_4986_signature(body) is False
+
+
+def test_cancel_all_tasks_alone_appears_in_every_teardown_and_is_not_flagged():
+    """Tier 1: `_cancel_all_tasks` by itself appears in EVERY
+    asyncio-runner teardown, hung or not (it's the frame that runs
+    regardless) — must not be the sole trigger."""
+    body = (
+        "/opt/.../asyncio/runners.py:70: in close\n"
+        "    _cancel_all_tasks(loop)\n"
+        "1 passed in 3.02s\n"
+    )
+    assert has_4986_signature(body) is False
+
+
+def test_two_of_three_markers_is_not_enough():
+    """Tier 1: non-vacuity for the co-occurrence rule — exactly 2 of the
+    3 markers, missing the third, must not fire."""
+    body = "_ ERROR at teardown of test_x _\n    _cancel_all_tasks(loop)\n"
+    assert has_4986_signature(body) is False
+
+
+def test_notification_names_the_issue_and_the_evidence_preservation_step():
+    """Tier 1: #4997's common requirement across all 3 detectors — the
+    notification must carry the issue number to trace to AND the
+    evidence-preservation step, in the SAME message (lead-coder's own
+    incident, same night: a notification without this step gets the
+    evidence destroyed by a re-run before anyone reads it)."""
+    text = format_notification("32459227086")
+    assert "#4986" in text
+    assert "32459227086" in text
+    assert "attempts/1/logs" in text
+    assert "before re-running" in text.lower()


### PR DESCRIPTION
part of #4997 (item ①).

## What

owner finding: `status:awaiting-recurrence` on #4986 had zero detectors — nobody can notice a recurrence, so the label was a wish, not a state.

## Signature

Co-occurrence of all 3 (measured by cross-referencing two real CI runs, keeping only what's common between them):

- `ERROR at teardown` (pytest's own teardown-failure header)
- `_cancel_all_tasks` (the asyncio runner frame the hang sits in)
- `Timeout (>120` (pytest-timeout's own kill message)

Each alone appears in unrelated failures; only the co-occurrence is the signature. `ephemeral-vanish` is explicitly excluded — measured and rejected as a discriminator (run 31913669752 has that warning WITHOUT the hang, so including it would false-positive on ordinary runs).

## Common requirement (#4997, applies to all 3 detectors)

A detection must carry the issue number AND the evidence-preservation step in the SAME notification (`gh api .../attempts/1/logs` before re-running). Without the second half, whoever reads the alert re-runs CI to "confirm" and destroys the only copy of the log first — lead-coder's own same-night incident.

## Design

Pure detection logic (`has_4986_signature`) is network-free, tested against real fixture text (the actual excerpt from run 32459227086); the `gh`-wrapping CLI is a thin, separately-swappable layer — mirrors `check_pr_closing_intent.py`'s own pure-logic/network-wrapper split.

## Tests

7: the real positive excerpt, `ephemeral-vanish`-alone (the real counterexample), each of the 3 markers alone (non-vacuity for co-occurrence), 2-of-3 not enough, and the notification format (issue number + evidence step both present). **Strip-falsified**: forcing the detection call to `False` correctly reddened the real-positive test; restored, all 7 green.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_detect_4986_teardown_hang.py`
- [x] `python scripts/verify_module_docstrings.py scripts/detect_4986_teardown_hang.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `pytest tests/scripts/test_detect_4986_teardown_hang.py` (7 passed) + strip-falsify
- [x] (skipped — Visual, standing waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔴 lead-coder のブロッキング点（規則 7）

- [ ] 🔴 **検出器に ★呼び口がありません ── ★呼ばれない検出器は 何も検出しません。**

```
★本 PR の配線 ── ★0（`git grep -ln detect_4986_teardown_hang <枝> -- .github/` → ★0）
★repo に `workflow_run` 契機の workflow ── ★0 件 ── ★前例が ありません
★ci-watcher の振る舞い ── ★repo に 在りません ── ★セッションであって ★成果物ではない
```

## 🔴 なぜ「ci-watcher に頼む」で足りないか

```
★ci-watcher は ★セッション ── ★その義務は ★再起動を 越えません
★私は今夜 ★何度も「broker は hint、★面が contract」と書きました
∴ ★★「ci-watcher が呼ぶ」は ★どの面にも 書かれない義務です
🔴 ★#4997 の本旨は ★「次に出たときに ★気づける」こと
   ── ★気づく主体が ★消え得るなら ★問題は 閉じていません
```

⚠️ **本 PR の中身は良いです** ── **署名は実測（2 run の共通項）、`ephemeral-vanish` の除外は反例つき、実 CI ログの実物 fixture、strip-falsify 済、純粋ロジックとネットワーク層の分離も `check_pr_closing_intent.py` に倣っています。**★ **足りないのは «誰が呼ぶか» だけ**です。

## ✅ 私が求めるもの（★機構は指定しません）

> **★再起動を越えて残る呼び口を 1 つ。**

⚠️ **私は機構を選びません** ── ★ **`workflow_run` の前例が repo に無く、★「どこで走らせるか」は設計判断**です。**architect に判定を仰ぎます。**

⚪ **判定の材料**（★私が測ったもの）:
```
★検出器は ★失敗した run の ★後で しか走れません（★その run の中では 走れない）
★∴ 呼び口は ★run の外に 要ります
★repo に在る「後から走る」形 ── `main-hourly-gate-sweep.yml`（★cron）
```


## Wiring (architect ruling, added per lead-coder's blocking point)

`.github/workflows/detect-4986-recurrence.yml` — `workflow_run` on `CI` (`test.yml`'s own `name: CI`), gated to `conclusion == 'failure'`, plus `workflow_dispatch` (`run_id` input) alongside for the two pitfalls architect named: (1) `workflow_run` only ever runs the default branch's copy of the file, so this PR's own branch would otherwise never trigger it; (2) a silent no-detection run is indistinguishable from a broken workflow that never ran — `workflow_dispatch` lets a human replay a known-positive run on demand. On detection, posts the script's own notification (issue number + evidence-preservation step) directly as a comment on #4986.

**Caught while writing it**: `name:` fields containing a bare `#4986`/`#4997` are silently truncated by YAML's own comment syntax (`#` starts a comment mid-line, even inside a scalar) — verified via a PyYAML round-trip before pushing, not assumed; all 4 affected values quoted. `on:` is deliberately left bare (not quoted) despite PyYAML parsing it as the boolean `true` under YAML 1.1 — verified this repo's own existing, live workflows (`test.yml`, `check-pr-closing-intent.yml`) already use bare `on:` and run correctly, confirming GitHub Actions' real parser doesn't share PyYAML's default-loader quirk.

**Correction to architect's stated benefit**: attempted `gh workflow run detect-4986-recurrence.yml --ref <this-branch> -f run_id=32459227086` to validate live before merge, per architect's own framing ("merge前に実物runで試せる"). It failed — `HTTP 404: workflow detect-4986-recurrence.yml not found on the default branch` — and `gh api .../actions/workflows` confirms GitHub has not registered this workflow at all yet. `workflow_dispatch` genuinely requires the file to already exist on the default branch first (at least via this CLI path); pre-merge dispatch is not actually available the way I understood the ruling to promise. Not claiming this as verified — flagging it so the plan for post-merge validation (dispatch against 32461855416 / 32459227086 once on `main`) is the real first live test, not a redundant confirmation of something already checked.
