### PR TITLE
feat(#4996): ChatReadModel implementations declare their read capabilities

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -212,6 +212,15 @@ def empty_state_hint() -> "object":
 #: (so a single page-in absorbs several screens of scrolling before the next).
 _HYDRATE_PAGE_FRAMES = 200
 
+#: #4996 witness② marker — appended in :meth:`TextualChatApp.
+#: _apply_hydrated_messages` when a read model DECLARES it can never
+#: produce conversation history (:attr:`~reyn.interfaces.repl.read_model.
+#: ChatReadModelCapabilities.conversation_history` is ``False``) and this
+#: particular read came back empty. Distinguishes that case from a
+#: genuinely new, capable session with nothing to restore yet, which stays
+#: silent exactly as it always has.
+HISTORY_UNAVAILABLE_MARKER = "conversation history isn't available on this connection"
+
 
 def _apply_restored_state(msg: "OutboxMessage", entry: "Entry[OutboxMessage]") -> None:
     """The restored-frame state transition, shared by initial hydration and
@@ -2382,11 +2391,39 @@ class TextualChatApp(App):
         resolve correctly rather than replaying as RUNNING: the completion
         already landed in ``history.jsonl`` before this read, so it projects
         straight to its settled state. A REMOTE read model returns an empty log
-        (frame-sufficiency: past turns are not on the wire) → this is a no-op
-        either way, and the pane starts/stays blank (remote switch-rehydrate is
-        #3310 N3's job). Fully guarded — a restore failure must never stop the
-        app from mounting/resetting and pumping live frames."""
+        (frame-sufficiency: past turns are not on the wire) — this is still a
+        no-op for PROJECTION (there is nothing to project), but #4996's own
+        witness② lives right here: an empty ``messages`` list is ambiguous on
+        its own (a genuinely NEW session and "this read model can never
+        produce history" both return ``[]``), so
+        :attr:`~reyn.interfaces.repl.read_model.ChatReadModel.capabilities`
+        is consulted to tell them apart — see the ``not messages`` branch
+        below. Fully guarded — a restore failure must never stop the app
+        from mounting/resetting and pumping live frames."""
         if messages is None:
+            return
+        if not messages:
+            # #4996: without the declared capability, a remote client whose
+            # conversation history is never on the wire (frame-sufficiency)
+            # looks IDENTICAL to a genuinely new local session — both leave
+            # this pane silently blank. That conflation is #4996's own
+            # motivating case (the owner-reviewed one, most likely to read
+            # as "my history is gone" rather than "this connection can't
+            # show it"). A capability-declared-unsupported empty read gets
+            # ONE explicit marker row instead; a genuinely empty capable
+            # read (the common, correct "new session" case) stays exactly
+            # as silent as before this issue.
+            caps = getattr(self._read_model, "capabilities", None)
+            if caps is not None and not caps.conversation_history:
+                from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
+
+                self._append_frame(
+                    OutboxMessage(
+                        kind="system",
+                        text=HISTORY_UNAVAILABLE_MARKER,
+                        meta={"history_unavailable": True},
+                    )
+                )
             return
         try:
             frames = project_restored_frames(messages)

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -219,6 +219,10 @@ _HYDRATE_PAGE_FRAMES = 200
 #: particular read came back empty. Distinguishes that case from a
 #: genuinely new, capable session with nothing to restore yet, which stays
 #: silent exactly as it always has.
+#:
+#: PROVISIONAL wording (#5000): making this distinction visible at all is
+#: the owner's own direction; this exact phrasing is the author's and is
+#: freely revisable — not a design decision to defend.
 HISTORY_UNAVAILABLE_MARKER = "conversation history isn't available on this connection"
 
 

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -92,6 +92,16 @@ class ChatReadModelCapabilities:
     THIS dataclass will not fail to construct until a human also adds a
     field for it here; that step is not, and cannot be, machine-enforced by
     this class alone.
+
+    **A declaration is an assertion, not an observation** (architect
+    co-vet, #5000 — the same limitation ``AxisEnforcementDeclaration``
+    already carries, not new here): nothing checks that
+    :class:`RegistryReadModel` returning ``LOCAL_CHAT_READ_CAPABILITIES``
+    stays TRUE of its actual accessors. If a future edit made
+    ``completion_session()`` start returning ``None`` under some new local
+    condition without updating this declaration, the declared/actual gap
+    this class exists to prevent would reopen silently, on the LOCAL side
+    this time. Follow-up, not a defect in this class.
     """
 
     completion_session: bool

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -40,6 +40,7 @@ value.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -50,6 +51,83 @@ if TYPE_CHECKING:
     from reyn.runtime.chat_message import ChatMessage
 
 
+@dataclass(frozen=True)
+class ChatReadModelCapabilities:
+    """A :class:`ChatReadModel` implementation's declared support for its own
+    degradable reads (#4996, architect design, owner-directed: "capability
+    declaration → issue → leader").
+
+    ``None``/``[]``/``0``/``False`` are the CORRECT graceful-degrade answer
+    for every read below when a caller genuinely has nothing to show — this
+    declaration does not change any of those return values. What it fixes is
+    the caller's side: a bare ``None`` is used identically for "nothing to
+    show right now" and "this client can never show this", and the two read
+    as the same thing to the TUI. This is the DECLARATION half of making
+    that distinction askable, exactly the same discipline
+    :class:`~reyn.security.sandbox.backend.AxisEnforcementDeclaration` and
+    :mod:`~reyn.core.dispatch.content_declarations` already use — a 3rd
+    example, not a new concept.
+
+    Every field is REQUIRED, no defaults anywhere — mirrors
+    ``AxisEnforcementDeclaration``'s own discipline verbatim: a NEW
+    :class:`ChatReadModel` implementation that forgets a field fails to
+    CONSTRUCT its declaration, a ``TypeError`` at the module's own
+    construction site, not a silent "unsupported" nobody chose.
+
+    One field per degradable read, named identically to the method it
+    describes. ``True`` = this implementation can genuinely produce a
+    non-degraded answer; ``False`` = every call always degrades, regardless
+    of underlying state (the wire-frame-sufficiency boundary those methods'
+    own docstrings already document).
+
+    **Witness① scope, stated honestly (lead-coder/architect co-vet on
+    #4996):** this dataclass's "forgets a field fails to construct"
+    guarantee covers exactly ONE failure mode — a NEW
+    :class:`ChatReadModel` implementation that omits one of these 6 already-
+    declared fields. It is NOT a 1:1 gate over every :class:`ChatReadModel`
+    method: ``snapshot()`` and ``history_path()`` work identically on a
+    remote client and correctly have NO field here — a mechanical "one field
+    per abstract method" mapping would be a false invariant, not a stronger
+    one. If a 7th degradable method is ever added to :class:`ChatReadModel`,
+    THIS dataclass will not fail to construct until a human also adds a
+    field for it here; that step is not, and cannot be, machine-enforced by
+    this class alone.
+    """
+
+    completion_session: bool
+    intervention_head: bool
+    pending_command_ui: bool
+    has_command_ui_region: bool
+    conversation_history: bool
+    load_older_conversation_history: bool
+
+
+#: :class:`RegistryReadModel` is local — every degradable read reflects real,
+#: current state; ``None``/``[]``/``0`` from it always means "genuinely
+#: nothing", never "unsupported here".
+LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
+    completion_session=True,
+    intervention_head=True,
+    pending_command_ui=True,
+    has_command_ui_region=True,
+    conversation_history=True,
+    load_older_conversation_history=True,
+)
+
+#: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these 6
+#: methods' own docstrings already document (session-local state the AG-UI
+#: wire does not project): every one of them always degrades, independent of
+#: server-side state. See the module docstring's "Frame-sufficiency" section.
+REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
+    completion_session=False,
+    intervention_head=False,
+    pending_command_ui=False,
+    has_command_ui_region=False,
+    conversation_history=False,
+    load_older_conversation_history=False,
+)
+
+
 class ChatReadModel(ABC):
     """The inline CUI's sole READ seam: status snapshot + region + history.
 
@@ -58,6 +136,15 @@ class ChatReadModel(ABC):
     Protocol) so a partial implementation fails at construction, not first use —
     the same completeness-by-construction discipline ``ClientTransport`` uses.
     """
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> ChatReadModelCapabilities:
+        """This implementation's :class:`ChatReadModelCapabilities` — see
+        that class's own docstring (#4996). Abstract for the same reason
+        every OTHER accessor here is: a new implementation that forgets to
+        declare fails to construct, rather than silently reading every
+        capability as unsupported."""
 
     @abstractmethod
     def snapshot(self, config=None) -> "dict | None":
@@ -203,6 +290,10 @@ class RegistryReadModel(ChatReadModel):
         #: is never ``None`` again for the rest of this read-model's life, so a
         #: later agent switch never makes this stale value observably wrong.
         self._agent_name = agent_name
+
+    @property
+    def capabilities(self) -> ChatReadModelCapabilities:
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def snapshot(self, config=None):
         return _snapshot(self._registry, config)
@@ -412,6 +503,10 @@ class RemoteReadModel(ChatReadModel):
     def __init__(self, transport: "ClientTransport") -> None:
         self._transport = transport
 
+    @property
+    def capabilities(self) -> ChatReadModelCapabilities:
+        return REMOTE_CHAT_READ_CAPABILITIES
+
     def snapshot(self, config=None):
         # ``transport.status`` is the RemoteStatusView the AgUiTransport updates as
         # it decodes STATE_* frames; read it live each render tick.
@@ -476,6 +571,9 @@ class RemoteReadModel(ChatReadModel):
 
 __all__ = [
     "ChatReadModel",
+    "ChatReadModelCapabilities",
+    "LOCAL_CHAT_READ_CAPABILITIES",
+    "REMOTE_CHAT_READ_CAPABILITIES",
     "RegistryReadModel",
     "RemoteReadModel",
     "project_remote_snapshot",

--- a/tests/interfaces/test_3300_p2b_sentqueue_render.py
+++ b/tests/interfaces/test_3300_p2b_sentqueue_render.py
@@ -56,7 +56,7 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.sent_queue import ROW_TEXT_COLUMN, SentQueue
-from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.transport.agui.state import RemoteQueueView
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import EventFrame
@@ -138,6 +138,14 @@ class _SnapshotSeededReadModel(ChatReadModel):
     remote transport. Every other accessor degrades to the same graceful
     empty/None ``RemoteReadModel`` uses — this read-model's only job is the
     ``queue``/``turn_active``/``queue_seq`` snapshot shape."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def __init__(self, queue_item: dict) -> None:
         self._queue_item = queue_item

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -63,7 +63,7 @@ from reyn.interfaces.inline.textual_chat.chrome import (
     pane_payload,
     status_line_text,
 )
-from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.repl.status import _snapshot
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import EventFrame
@@ -695,6 +695,14 @@ class _MutableSnapshotReadModel(ChatReadModel):
     frames — standing in for a live session whose cost/ctx move as a turn runs,
     without needing a real LLM call. The dict itself is produced by the real
     ``_snapshot()``."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def __init__(self, snap: dict) -> None:
         self.snap = snap

--- a/tests/interfaces/test_3354_composer_completion.py
+++ b/tests/interfaces/test_3354_composer_completion.py
@@ -70,7 +70,7 @@ from reyn.interfaces.inline.textual_chat.completion import (
     CompletionPopup,
     compute_completion,
 )
-from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.slash import REGISTRY
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import EventFrame
@@ -141,6 +141,14 @@ class SessionReadModel(ChatReadModel):
     ``test_3338``'s ``_MutableSnapshotReadModel``) whose
     :meth:`completion_session` returns a REAL ``Session`` — the seam the app
     resolves both completion sources through."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def __init__(self, session=None) -> None:
         self._session = session

--- a/tests/interfaces/test_4983_mount_hydrate_off_loop.py
+++ b/tests/interfaces/test_4983_mount_hydrate_off_loop.py
@@ -33,7 +33,7 @@ import pytest
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.app import run_textual_chat
-from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.runtime import stall_trace
 from reyn.runtime.chat_message import ChatMessage
 from tests._support.textual_chat_test_helpers import QueueTransport
@@ -44,6 +44,14 @@ class _CountingReadModel(ChatReadModel):
     ``test_textual_chat_phase5_3273.py``'s own ``_HistoryReadModel``) that
     additionally counts ``conversation_history`` calls — the observable
     this file's tests need (whether ``on_mount`` reads for itself)."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def __init__(self, messages: "list[ChatMessage]") -> None:
         self.messages = list(messages)

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -1,0 +1,267 @@
+"""Tier 1/2: #4996 — ``ChatReadModel`` implementations declare which of
+their degradable reads they actually support, so a caller can tell "nothing
+to show" apart from "this client can never show this".
+
+Owner-directed via architect ("capability declaration → issue → leader"),
+same discipline as :class:`~reyn.security.sandbox.backend.
+AxisEnforcementDeclaration` and :mod:`~reyn.core.dispatch.
+content_declarations` — a 3rd example, not a new concept. ``None``/``[]``/
+``0``/``False`` remain the correct graceful-degrade return values; this
+declaration changes nothing about them.
+
+Two witnesses (both required — lead-coder/architect co-vet: ①alone would
+pass an "declared but nobody reads it" implementation, the #4991 shape):
+
+①  A new :class:`~reyn.interfaces.repl.read_model.ChatReadModel`
+   implementation that omits one of :class:`~reyn.interfaces.repl.
+   read_model.ChatReadModelCapabilities`'s 6 required fields fails to
+   CONSTRUCT — a bare dataclass-completeness check, scoped exactly as
+   ``ChatReadModelCapabilities``'s own docstring discloses (catches a
+   missing FIELD among the 6 already declared, not a missing declaration
+   for some 7th method that might be added later).
+②  The one real call site architect/lead-coder picked (most user-visible
+   harm): :meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.
+   _apply_hydrated_messages`. An empty ``conversation_history()`` read
+   renders DIFFERENTLY depending on the declaration — unsupported gets an
+   explicit marker row, a genuinely empty but CAPABLE read stays exactly as
+   silent as it always has (the accept-side half of the same test family,
+   so an "always show the marker" implementation cannot pass vacuously
+   either).
+
+Real ``AgentRegistry`` + real ``Session`` + real ``RegistryReadModel`` +
+real ``RemoteReadModel`` (backed by a real, minimal ``ClientTransport``) +
+the real mounted ``TextualChatApp`` — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import fields
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.app import HISTORY_UNAVAILABLE_MARKER
+from reyn.interfaces.repl.read_model import (
+    ChatReadModel,
+    ChatReadModelCapabilities,
+    RegistryReadModel,
+    RemoteReadModel,
+)
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` whose ``frames()`` drains
+    an ``asyncio.Queue`` the test pushes onto (mirrors ``test_4983_
+    session_switch_off_thread.py``'s own helper of the same name/shape).
+    Not exercised for its frame stream here — only as the real collaborator
+    :class:`RemoteReadModel` is constructed with."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue" = asyncio.Queue()
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self):
+        return None
+
+    def put_display(self, msg: OutboxMessage) -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> str:  # pragma: no cover - trivial
+        return ""
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+# ── witness① — dataclass completeness ───────────────────────────────────
+
+
+def test_capabilities_dataclass_rejects_a_missing_field():
+    """Tier 1: omitting any one of the 6 required fields fails to
+    CONSTRUCT — a ``TypeError``, not a silently-defaulted ``False``. Mirrors
+    ``AxisEnforcementDeclaration``'s own witness verbatim."""
+    with pytest.raises(TypeError):
+        ChatReadModelCapabilities(  # type: ignore[call-arg]
+            completion_session=True,
+            intervention_head=True,
+            pending_command_ui=True,
+            has_command_ui_region=True,
+            conversation_history=True,
+            # load_older_conversation_history omitted
+        )
+
+
+def test_capabilities_dataclass_has_exactly_the_6_declared_fields():
+    """Tier 1: pins the declared vocabulary itself — the 6 names #4996's
+    own issue enumerated, no more, no fewer. A regression here is a
+    silent widening/narrowing of what's declared, not a missing-field bug
+    (that's the test above)."""
+    names = {f.name for f in fields(ChatReadModelCapabilities)}
+    assert names == {
+        "completion_session",
+        "intervention_head",
+        "pending_command_ui",
+        "has_command_ui_region",
+        "conversation_history",
+        "load_older_conversation_history",
+    }
+
+
+def test_a_new_chat_read_model_that_omits_capabilities_fails_to_construct():
+    """Tier 1: the OTHER half of witness① — a new ``ChatReadModel``
+    subclass that forgets to implement the abstract ``capabilities``
+    property fails at construction (Python's own ABC mechanism), not at
+    first use. Mirrors the class docstring's own "abstract so a partial
+    implementation fails at construction" rule, extended to this new
+    property exactly like every other accessor on the class."""
+
+    class _IncompleteReadModel(ChatReadModel):
+        def snapshot(self, config=None):
+            return None
+
+        def intervention_head(self):
+            return None
+
+        def pending_command_ui(self):
+            return None
+
+        def clear_pending_command_ui(self) -> None:
+            return None
+
+        @property
+        def has_command_ui_region(self) -> bool:
+            return False
+
+        @property
+        def history_path(self) -> Path:
+            return Path("/tmp/unused")
+
+        def conversation_history(self, *, limit=None, agent=None, session_id=None):
+            return []
+
+        def load_older_conversation_history(self, *, agent=None, session_id=None) -> int:
+            return 0
+
+        # ``capabilities`` deliberately NOT implemented.
+
+    with pytest.raises(TypeError):
+        _IncompleteReadModel()  # type: ignore[abstract]
+
+
+# ── witness② — the actual render site ───────────────────────────────────
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+async def _settle(pilot, n: int = 2) -> None:
+    for _ in range(n):
+        await pilot.pause()
+
+
+def _flow_rows(app: TextualChatApp) -> "list[tuple[str, str]]":
+    return [(e.item.kind, e.item.text) for e in app.query_one(FlowView).entries]
+
+
+@pytest.mark.asyncio
+async def test_capability_declared_unsupported_and_empty_shows_the_marker(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: witness②'s own falsifier. A read model that DECLARES it can
+    never produce conversation history (``RemoteReadModel`` — a real
+    instance, frame-sufficiency boundary) and whose read comes back empty
+    gets an explicit marker row, not silence — reverting the
+    ``capabilities`` check in ``_apply_hydrated_messages`` (leaving the pane
+    silently blank) turns this red."""
+    monkeypatch.chdir(tmp_path)
+    transport = QueueTransport()
+    read_model = RemoteReadModel(transport)
+    assert read_model.capabilities.conversation_history is False
+    assert read_model.conversation_history() == []
+
+    app = TextualChatApp(transport=transport, read_model=read_model, agent_name="alpha")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _settle(pilot)
+        rows = _flow_rows(app)
+
+    assert (
+        "system",
+        HISTORY_UNAVAILABLE_MARKER,
+    ) in rows, "an unsupported+empty read must render the marker, not silence"
+
+
+@pytest.mark.asyncio
+async def test_capability_declared_supported_and_empty_stays_silent(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: accept-side — the OTHER required direction (co-vet note: ①
+    alone would pass an "always show the marker" implementation too). A
+    genuinely NEW, fully-capable local session with no history yet must NOT
+    show the marker: an empty conversation pane at first mount is the
+    correct, ordinary "nothing to restore" case, unchanged by #4996."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    await reg.attach("alpha")
+    read_model = RegistryReadModel(reg)
+    assert read_model.capabilities.conversation_history is True
+    assert read_model.conversation_history() == []
+
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, read_model=read_model, agent_name="alpha")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _settle(pilot)
+        rows = _flow_rows(app)
+
+    assert HISTORY_UNAVAILABLE_MARKER not in [text for _, text in rows], (
+        "a genuinely empty but CAPABLE read must stay silent, unchanged "
+        "from pre-#4996 behavior"
+    )

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -114,7 +114,22 @@ class QueueTransport(ClientTransport):
 def test_capabilities_dataclass_rejects_a_missing_field():
     """Tier 1: omitting any one of the 6 required fields fails to
     CONSTRUCT — a ``TypeError``, not a silently-defaulted ``False``. Mirrors
-    ``AxisEnforcementDeclaration``'s own witness verbatim."""
+    ``AxisEnforcementDeclaration``'s own witness verbatim.
+
+    Positive control (architect co-vet on #5000): without it, this test
+    alone would ALSO go green after a field is renamed or deleted — an
+    unknown ``kwarg`` raises the identical ``TypeError``, same red, wrong
+    reason. Constructing with all 6 fields present, right here, is what
+    lets this test claim the ``TypeError`` above is caused by the MISSING
+    field specifically, not by some other construction failure."""
+    ChatReadModelCapabilities(
+        completion_session=True,
+        intervention_head=True,
+        pending_command_ui=True,
+        has_command_ui_region=True,
+        conversation_history=True,
+        load_older_conversation_history=True,
+    )
     with pytest.raises(TypeError):
         ChatReadModelCapabilities(  # type: ignore[call-arg]
             completion_session=True,
@@ -130,7 +145,14 @@ def test_capabilities_dataclass_has_exactly_the_6_declared_fields():
     """Tier 1: pins the declared vocabulary itself — the 6 names #4996's
     own issue enumerated, no more, no fewer. A regression here is a
     silent widening/narrowing of what's declared, not a missing-field bug
-    (that's the test above)."""
+    (that's the test above).
+
+    Not load-bearing for witness① (the positive control added to the test
+    above already makes that claim on its own) — this one is a plain
+    transcription of the field list and would need editing in the SAME PR
+    as any real rename anyway (CLAUDE.md's 6-questions, #2: "is it the
+    implementation, transcribed?"). Kept as an explicit, readable pin of
+    the vocabulary itself, not as a second guard."""
     names = {f.name for f in fields(ChatReadModelCapabilities)}
     assert names == {
         "completion_session",

--- a/tests/interfaces/test_lazy_history_paging_3476.py
+++ b/tests/interfaces/test_lazy_history_paging_3476.py
@@ -36,7 +36,7 @@ from textual_flowview import EntryState, FlowView
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.app import _HYDRATE_PAGE_FRAMES
 from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
-from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
@@ -86,6 +86,14 @@ class _HistoryReadModel(ChatReadModel):
     """A real :class:`ChatReadModel` seam impl (the phase-5 suite's shape):
     ``conversation_history`` serves a synthetic persisted log, so the REAL
     hydrate + projector run end to end."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def __init__(self, messages: "list[ChatMessage]") -> None:
         self._messages = messages

--- a/tests/interfaces/test_search_bar_3476.py
+++ b/tests/interfaces/test_search_bar_3476.py
@@ -31,7 +31,7 @@ from reyn.interfaces.inline.textual_chat.app import _HYDRATE_PAGE_FRAMES
 from reyn.interfaces.inline.textual_chat.chrome import Composer
 from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
 from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
-from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
@@ -79,6 +79,14 @@ class _Transport(ClientTransport):
 
 class _HistoryReadModel(ChatReadModel):
     """A real :class:`ChatReadModel` seam impl (the phase-5 suite's shape)."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def __init__(self, messages: "list[ChatMessage]") -> None:
         self._messages = messages

--- a/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
+++ b/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
@@ -46,7 +46,7 @@ from typing import AsyncIterator
 import pytest
 
 from reyn.interfaces.inline.textual_chat.chrome import Composer, status_line_text
-from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
@@ -201,6 +201,14 @@ class _AttachStateTransport(ClientTransport):
 class _NoneReadModel(ChatReadModel):
     """Mirrors what `RegistryReadModel.snapshot()` genuinely returns
     pre-attach — `None` (see `status._snapshot`)."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def snapshot(self, config=None):
         return None

--- a/tests/interfaces/test_textual_chat_copy_rewind_3362.py
+++ b/tests/interfaces/test_textual_chat_copy_rewind_3362.py
@@ -58,7 +58,7 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.rewind_picker import RewindPicker
-from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
@@ -71,6 +71,14 @@ class _PickerReadModel(ChatReadModel):
     """A real :class:`ChatReadModel` seam impl (the shape ``RegistryReadModel``
     has) that hosts a command-UI region and serves one pending request plus an
     optional persisted history — exactly the two reads the app makes here."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def __init__(
         self,

--- a/tests/interfaces/test_textual_chat_phase1_3273.py
+++ b/tests/interfaces/test_textual_chat_phase1_3273.py
@@ -176,7 +176,7 @@ assert "textual" not in sys.modules, "textual imported at module load"
 
 # (2) functional: a real non-TTY plain run completes without touching flowview.
 from reyn.interfaces.repl.client_driver import run_chat_client  # noqa: E402
-from reyn.interfaces.repl.read_model import ChatReadModel  # noqa: E402
+from reyn.interfaces.repl.read_model import ChatReadModel, LOCAL_CHAT_READ_CAPABILITIES  # noqa: E402
 from reyn.interfaces.repl.renderer import ChatRenderer  # noqa: E402
 from reyn.interfaces.transport.client_transport import ClientTransport  # noqa: E402
 from reyn.interfaces.transport.frames import DisplayFrame  # noqa: E402
@@ -203,6 +203,14 @@ class T(ClientTransport):
 
 
 class RM(ChatReadModel):
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
     def snapshot(self, config=None): return None
     def intervention_head(self): return None
     def pending_command_ui(self): return None

--- a/tests/interfaces/test_textual_chat_phase4_3273.py
+++ b/tests/interfaces/test_textual_chat_phase4_3273.py
@@ -42,7 +42,7 @@ from reyn.interfaces.inline.textual_chat.chrome import (
     pane_payload,
     status_line_text,
 )
-from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.slash import REGISTRY, SlashCommand, SlashRegistry
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
@@ -205,6 +205,14 @@ class _SnapshotReadModel(ChatReadModel):
     """A real :class:`ChatReadModel` seam impl (like ``RegistryReadModel`` /
     ``RemoteReadModel``) returning a fixed real-shaped snapshot — the app reads
     model/agent/cost/ctx off this same seam the plain status bar uses."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def __init__(self, snap: "dict | None") -> None:
         self._snap = snap

--- a/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
+++ b/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
@@ -86,7 +86,11 @@ from reyn.interfaces.inline.textual_chat.gutter import (
     _cell_pad_left,
 )
 from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
-from reyn.interfaces.repl.read_model import ChatReadModel, project_remote_snapshot
+from reyn.interfaces.repl.read_model import (
+    LOCAL_CHAT_READ_CAPABILITIES,
+    ChatReadModel,
+    project_remote_snapshot,
+)
 from reyn.interfaces.repl.status import _snapshot
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
@@ -664,6 +668,14 @@ class _TurnUsageReadModel(ChatReadModel):
     ``status.py``'s ``_snapshot()`` publishes as ``turn_usage_fn`` in
     production. Nothing about the lookup is simulated; only the surrounding
     session/registry is skipped."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def __init__(self, tracker: BudgetTracker) -> None:
         self._tracker = tracker

--- a/tests/runtime/test_textual_chat_phase5_3273.py
+++ b/tests/runtime/test_textual_chat_phase5_3273.py
@@ -46,7 +46,12 @@ from reyn.interfaces.inline.textual_chat.restore import (
     RESTORED_META_KEY,
     project_restored_frames,
 )
-from reyn.interfaces.repl.read_model import ChatReadModel, RegistryReadModel, RemoteReadModel
+from reyn.interfaces.repl.read_model import (
+    LOCAL_CHAT_READ_CAPABILITIES,
+    ChatReadModel,
+    RegistryReadModel,
+    RemoteReadModel,
+)
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
@@ -67,6 +72,14 @@ class _HistoryReadModel(ChatReadModel):
     """A real :class:`ChatReadModel` seam impl (like ``RegistryReadModel``)
     returning a fixed persisted ``ChatMessage`` log — the app hydrates its model
     off ``conversation_history`` exactly as it would off the local registry."""
+
+    @property
+    def capabilities(self):
+        # #4996: a test double simulating a fully-capable (local-shaped)
+        # read model — every accessor above is a REAL, non-degraded
+        # implementation for this test's own purposes, not a stand-in for
+        # RemoteReadModel's frame-sufficiency boundary.
+        return LOCAL_CHAT_READ_CAPABILITIES
 
     def __init__(self, messages: "list[ChatMessage]") -> None:
         self._messages = list(messages)


### PR DESCRIPTION
**[tui-coder]** — part of `#4996`, owner-directed via architect ("capability declaration → issue → leader"). Read-model side only — `ClientTransport`'s own two degraded methods (`put_display`/`cancel_inflight`) stay out of scope for this PR, per architect's own ordering: read-model first, transport one item at a time, later.

## What

`None`/`[]`/`0`/`False` is the correct graceful-degrade answer for every `ChatReadModel` accessor when there's genuinely nothing to show — that doesn't change here. What changes is the caller's side: a bare `None` currently means BOTH "nothing to show right now" and "this client can never show this", and a caller can't tell them apart. This PR adds the declaration half of making that distinction askable — the same discipline `AxisEnforcementDeclaration` (`security/sandbox/backend.py`) and `content_declarations.py` already use in this repo, a 3rd example, not a new concept.

- `ChatReadModelCapabilities`: frozen dataclass, 6 required fields (no defaults), one per degradable `ChatReadModel` read. A new implementation that forgets a field fails to **construct** — a `TypeError`, not a silent "unsupported" nobody chose.
- `ChatReadModel.capabilities`: new abstract property. `RegistryReadModel` declares full support (`LOCAL_CHAT_READ_CAPABILITIES`); `RemoteReadModel` declares all 6 unsupported (`REMOTE_CHAT_READ_CAPABILITIES`), matching the frame-sufficiency boundary those methods' own docstrings already document.
- `_apply_hydrated_messages` (`TextualChatApp`): the one real call site architect/lead-coder picked as highest-impact — an empty `conversation_history()` read now renders a distinct marker row when the read model declares it unsupported, instead of leaving the pane silently blank (which today is indistinguishable from a genuinely new session — the exact conflation this issue exists to fix).

`ChatReadModelCapabilities`'s own docstring is explicit about witness①'s real scope (lead-coder/architect co-vet point): the dataclass only catches a missing FIELD among the 6 already declared. It's deliberately not a 1:1 gate over every `ChatReadModel` method — `snapshot()`/`history_path()` work fine on a remote client and correctly have no field here; a mechanical "one field per abstract method" mapping would be a false invariant.

Every existing test-double `ChatReadModel` subclass across 11 test files gained the same `LOCAL_CHAT_READ_CAPABILITIES` declaration — they simulate a fully-capable local read model, not `RemoteReadModel`'s boundary.

**UX note (not blocking, just flagging):** the marker text itself — "conversation history isn't available on this connection" — is my own wording. Making the empty/unsupported distinction visible at all is the owner's own direction via this issue; the exact phrasing is mine and freely revisable if the owner wants different wording.

## Test plan

- [x] `tests/interfaces/test_4996_read_model_capabilities.py` — 5 new tests, no duration anywhere
  - witness① (2): a missing dataclass field fails to construct, WITH a positive control constructing all 6 fields successfully first (architect co-vet: without it, a renamed/deleted field would raise the identical `TypeError` for the wrong reason, and this test couldn't tell the two apart); a new `ChatReadModel` subclass omitting `capabilities` fails to construct (Python's own ABC mechanism)
  - witness② (2): a declared-unsupported+empty read shows the marker — **strip-falsified** (reverted, confirmed red for the stated reason); a declared-supported+empty read stays silent, unchanged from before this issue
  - non-vacuity, confirmed by hand: an "always show the marker" stub fails only the second witness②test; an "always discard" stub fails only the first — the pair only passes together when the declaration is actually consulted
  - 1 pinning test: the declared vocabulary itself (the 6 field names) — not load-bearing for witness① once the positive control above exists; kept as a readable pin
- [x] `ruff check` on all 15 changed files — clean
- [x] `scripts/test_tier_audit.py --strict` on the new test file — OK
- [x] `scripts/mypy_ratchet.py` — OK, unchanged baseline
- [x] `scripts/verify_module_docstrings.py` — OK
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_file_depth_reference.py` / `check_bare_tests_import_reference.py` — all OK
- [x] Full `tests/interfaces/` + `tests/runtime/` regression sweep: **3771 passed, 5 skipped**. The 1 failure (`test_plain_path_survives_flowview_absence`) reproduces identically with this diff stashed on the same tree — deterministic, pre-existing, caused by a stray editable `reyn` install this local venv resolves to (an unrelated repo checkout), not by this PR. What this tree can show is that much; whether CI's own checkout is clear of it is CI's own result to demonstrate, not something claimed here in advance.
- [ ] (skipped — Visual, standing waiver)

## Scope boundaries

- `ClientTransport`'s own two degraded methods (`put_display` no-op, `cancel_inflight` fire-and-forget) are a separate PR, per architect's explicit ordering (read-model declared and actually consumed FIRST, transport one item at a time after).
- `STATE_SNAPSHOT`/`STATE_DELTA` wire extension (actually projecting completion/intervention data onto the wire) is out of scope — this issue is "make the gap visible", not "close the gap".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


