### PR TITLE
fix(#5001): stop routing client-authored notices through put_display

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6102,14 +6102,31 @@ class TextualChatApp(App):
         """#3671 P3: tell the operator WHY their Enter did nothing, matching
         the header's connecting/failed distinction (owner ruling: a genuine
         failure must never be papered over as an indefinite "still loading")
-        rather than silently dropping the keystroke."""
+        rather than silently dropping the keystroke.
+
+        #5001: appends directly via :meth:`_ingest_frame`, NOT ``self.
+        _transport.put_display(...)``. This is a client-authored notice
+        ABOUT this client's own composer state — it was never something the
+        server's outbox needed to carry, and routing it through the
+        transport seam meant ``AgUiTransport.put_display``'s no-op (a
+        CORRECT no-op — a remote client cannot inject into the server's
+        outbox) silently dropped this specific sentence on a remote client,
+        while the header's own connecting/failed STATE (read straight off
+        ``has_session()``/``attach_failed()``, independent of this method)
+        kept rendering — which is exactly why the gap went unnoticed: the
+        state looked fine. ``_ingest_frame`` is the SAME local-model append
+        both an in-process AND a remote client already use elsewhere for
+        purely client-side notices, so this now takes one path regardless
+        of transport, matching what ``AgUiTransport.put_display``'s own
+        docstring already claims for "client-authored echoes" — which
+        wasn't true for this call site until now."""
         if self._transport.attach_failed():
             text = "attach failed (see log) — your message was kept; retry once resolved"
         else:
             text = "still connecting — your message will send once ready"
         from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
         try:
-            self._transport.put_display(OutboxMessage(kind="status", text=text))
+            self._ingest_frame(OutboxMessage(kind="status", text=text))
         except Exception:
             pass
 
@@ -6145,7 +6162,16 @@ class TextualChatApp(App):
         highlighted row to cancel) — rather than losing it. That is the
         invariant #3300 protects, and slash leaving the queue does not touch
         it. Errors are contained and surfaced as an error frame the pump
-        renders — a silent input drop is the worst failure for a chat box."""
+        renders — a silent input drop is the worst failure for a chat box.
+
+        #5001: this error notice appends via :meth:`_ingest_frame`, not
+        ``self._transport.put_display(...)`` — see
+        :meth:`_notify_blocked_on_attach`'s own docstring for why (same
+        fix, same reasoning: a client-authored notice about THIS client's
+        own submit attempt, never something the server's outbox needed to
+        carry, so routing it through the transport seam meant a remote
+        client silently lost it to ``AgUiTransport.put_display``'s
+        no-op)."""
         try:
             from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
             if await maybe_dispatch_slash(self._transport, text):
@@ -6156,7 +6182,7 @@ class TextualChatApp(App):
             from reyn.runtime.outbox import OutboxMessage
             detail = f"{type(exc).__name__}: {exc}"
             try:
-                self._transport.put_display(
+                self._ingest_frame(
                     OutboxMessage(
                         kind="error", text=f"input could not be submitted: {detail}"
                     )

--- a/tests/interfaces/test_5001_remote_notice_delivery.py
+++ b/tests/interfaces/test_5001_remote_notice_delivery.py
@@ -1,0 +1,112 @@
+"""Tier 2: #5001 — two client-authored notices that used to vanish on a
+REAL remote (AG-UI) connection.
+
+Both ``TextualChatApp._notify_blocked_on_attach`` (the "still connecting" /
+"attach failed" detail sentence shown when Enter is blocked) and
+``TextualChatApp._submit``'s exception path (the "input could not be
+submitted: ..." error) used to route through ``self._transport.
+put_display(...)``. ``AgUiTransport.put_display`` is a CORRECT no-op — a
+remote client cannot inject into the server's outbox (#4996③'s own
+falsified design attempt tried to declare this as a "capability" and was
+rejected: nobody read the declaration, since both call sites discarded
+their own outcome already). The real defect was the CALL, not the no-op:
+both notices are entirely CLIENT-SIDE — about THIS client's own composer/
+submit attempt — and never needed the server's outbox at all. The fix
+(architect, #5001) routes them through ``_ingest_frame`` instead, the SAME
+local-model append both an in-process and a remote client already use for
+other purely client-side rows — one path, no transport branch.
+
+**Why the header's own "connecting"/"failed" STATE is not enough to catch
+this bug** (architect's own framing): the header reads ``has_session()``/
+``attach_failed()`` directly, independent of ``put_display`` — so it kept
+rendering FINE on a remote client throughout this bug's whole lifetime,
+masking the DETAIL sentence's disappearance. A witness that only asserts
+the header's state (or the STATE half of these two notices) would stay
+green with the bug still present — the DETAIL TEXT itself must be
+asserted, over a REAL ``AgUiTransport``, not a hand-rolled stand-in whose
+own ``put_display`` isn't the no-op in question.
+
+Real ``AgUiTransport`` (constructed directly with a real, minimal
+``sse_lines``/``send`` pair — the same shape ``test_3310_n3_remote_switch_
+parity.py`` already uses) + the real mounted ``TextualChatApp`` — no mocks.
+Both witnesses are strip-falsified below (reverting the fix in ``app.py``
+turns them red for the stated reason: the detail text goes missing while
+the app otherwise runs normally).
+"""
+from __future__ import annotations
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.transport.agui.client import AgUiTransport
+
+
+async def _empty_sse_lines():
+    return
+    yield  # pragma: no cover - makes this an async generator, never reached
+
+
+async def _noop_send(_payload):
+    return None
+
+
+def _flow_texts(app: TextualChatApp) -> "list[str]":
+    return [e.item.text or "" for e in app.query_one(FlowView).entries]
+
+
+@pytest.mark.asyncio
+async def test_blocked_on_attach_detail_reaches_a_real_remote_transport() -> None:
+    """Tier 2: #5001's own falsifier, path ①. A REAL ``AgUiTransport`` with
+    ``connected=False`` (still attaching) — pressing Enter must show the
+    "still connecting" DETAIL sentence in the flow, not just leave the
+    header's own state rendering while this specific notice silently
+    vanishes into ``AgUiTransport.put_display``'s no-op."""
+    transport = AgUiTransport(_empty_sse_lines(), _noop_send, connected=False)
+    app = TextualChatApp(transport=transport, read_model=None)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        composer.text = "hello, are you there"
+        await pilot.pause()
+        await app.on_composer_submitted(Composer.Submitted("hello, are you there"))
+        await pilot.pause()
+
+        rows = _flow_texts(app)
+        assert any("still connecting" in t.lower() for t in rows), (
+            f"the connecting-detail sentence must reach the flow over a real "
+            f"AgUiTransport; rows={rows!r}"
+        )
+        # The composer text itself is untouched by this fix (decision 4B,
+        # #3671 P3) — re-asserted here as a sanity check that this test's
+        # own real transport didn't accidentally let the submission through.
+        assert composer.text == "hello, are you there"
+
+
+@pytest.mark.asyncio
+async def test_submit_failure_detail_reaches_a_real_remote_transport() -> None:
+    """Tier 2: #5001's own falsifier, path ②. A REAL ``AgUiTransport`` whose
+    ``send`` callable raises for real (its own documented extension point,
+    not a patched internal — ``AgUiTransport.submit_user_text`` has no
+    try/except of its own, so this propagates exactly like a genuine bug
+    would) — the resulting error notice must reach the flow, not vanish
+    into the same no-op."""
+    async def _raising_send(_payload):
+        raise RuntimeError("boom")
+
+    transport = AgUiTransport(_empty_sse_lines(), _raising_send, connected=True)
+    app = TextualChatApp(transport=transport, read_model=None)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        composer.text = "go ahead"
+        await pilot.pause()
+        await app.on_composer_submitted(Composer.Submitted("go ahead"))
+        await pilot.pause()
+
+        rows = _flow_texts(app)
+        assert any("input could not be submitted" in t.lower() for t in rows), (
+            f"the submit-failure detail must reach the flow over a real "
+            f"AgUiTransport; rows={rows!r}"
+        )

--- a/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
+++ b/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import AsyncIterator
 
 import pytest
+from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat.chrome import Composer, status_line_text
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
@@ -259,7 +260,15 @@ async def test_submit_blocked_while_unattached_preserves_typed_text():
         assert composer.text == "hello, are you there", (
             "typed text must survive a blocked submission (decision 4B)"
         )
-        assert any("connecting" in m.text.lower() for m in transport.displayed), (
+        # #5001: this notice is a client-authored one about THIS client's
+        # own composer state — it now appends directly via `_ingest_frame`
+        # rather than `transport.put_display` (a remote client's
+        # `AgUiTransport.put_display` is a correct no-op; routing this
+        # notice through it silently dropped it there). Assert on the
+        # FlowView the operator actually sees, not the transport's own
+        # `displayed` list, which this notice no longer reaches.
+        rows = [e.item.text or "" for e in app.query_one(FlowView).entries]
+        assert any("connecting" in t.lower() for t in rows), (
             "operator must be told WHY nothing happened"
         )
 
@@ -284,7 +293,9 @@ async def test_submit_blocked_message_distinguishes_failed_from_connecting():
 
         assert transport.submitted == []
         assert composer.text == "still there?"
-        assert any("fail" in m.text.lower() for m in transport.displayed)
+        # #5001: same rerouting as above — see that test's own comment.
+        rows = [e.item.text or "" for e in app.query_one(FlowView).entries]
+        assert any("fail" in t.lower() for t in rows)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** — part of `#5001`. Architect design, root-caused from my own #4996③ measurement, which falsified architect's original plan there (a declared capability would have gone unread — neither degraded method had a reader, both call sites already discarded their own outcome, exactly the shape #4996② forbade). `#4996` stays closed on ①② — this is a separate, follow-up fix, not a re-opening of it.

## What

`TextualChatApp._notify_blocked_on_attach` (the "still connecting"/"attach failed" DETAIL sentence) and `_submit`'s exception path (the "input could not be submitted: ..." error) both routed through `self._transport.put_display(...)`. `AgUiTransport.put_display`'s no-op is **correct** — a remote client cannot inject into the server's outbox — but the **call** was wrong: both notices are entirely client-side, about this client's own composer/submit attempt, and never needed the server's outbox at all.

Routing them through the transport seam meant this specific sentence silently vanished on a real remote connection. The header's own connecting/failed **state** (read independently off `has_session()`/`attach_failed()`) kept rendering fine throughout — which is exactly why the gap went unnoticed: the header looked fine, so nobody had a reason to look closer at the detail line.

Fix: both now append directly via `_ingest_frame`, the same local-model append an in-process and a remote client already use for other purely client-side rows — one path, no transport branch. This makes `AgUiTransport.put_display`'s own docstring claim ("client-authored echoes render locally through the renderer, not this seam") actually true for these two call sites, rather than narrowing the claim to exclude them.

**UX-visible change, flagged explicitly (per architect):** a sentence that never appeared on a remote connection before will now appear there — the "still connecting"/"attach failed"/"input could not be submitted" detail lines a local client already saw.

**Scope, evaluated and explicitly not pursued this PR** (per architect's own #4996③ close-out):
- A `ChatReadModelCapabilities`-style declaration for `put_display`/`cancel_inflight` — rejected, no reader existed for either.
- Deciding not to emit the sentence at all instead — reduces UX, needs an owner call, not mine to make here.
- `cancel_inflight`'s own fixed `"cancel requested"` string, which names an unobserved outcome — harmless today since `action_cancel_turn` discards the return value entirely (nobody reads the lie). Held as an explicit conditional deferral on `#4996`'s own thread: fix the value FIRST, once a reason to display it exists — not before.

## Test plan

- [x] `tests/interfaces/test_5001_remote_notice_delivery.py` (new, 2 tests, no duration) — drives a **real** `AgUiTransport` (constructed directly with a real `sse_lines`/`send` pair, the same shape `test_3310_n3_remote_switch_parity.py` already uses — not a hand-rolled stand-in whose own `put_display` isn't the no-op in question) through both notice paths and asserts the **detail text itself** reaches the flow, not just the header's independently-rendering state (which is why a state-only witness would have missed this bug for as long as it's apparently existed). Both **strip-falsified**: reverted to `put_display`, confirmed red for the stated reason (rows empty; the underlying exception is logged, confirming the code path ran but the notice itself vanished).
- [x] `tests/interfaces/test_textual_chat_attach_state_3671_p3.py` — 2 existing tests updated: the notice text no longer reaches `transport.displayed` (this fix's whole point), re-pointed at the `FlowView` the operator actually sees — same named behavior, corrected location, not weakened.
- [x] `ruff check` on all 3 changed files — clean
- [x] `scripts/test_tier_audit.py --strict` on both changed/new test files — OK
- [x] `scripts/mypy_ratchet.py` — OK, unchanged baseline
- [x] `scripts/verify_module_docstrings.py` — OK
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_file_depth_reference.py` / `check_bare_tests_import_reference.py` — all OK
- [x] Full `tests/interfaces/` regression sweep: **1915 passed, 4 skipped**. The 1 failure (`test_plain_path_survives_flowview_absence`) is the same known pre-existing local-environment artifact confirmed on the #4996/#5000 PR (a stray editable `reyn` install this venv resolves to) — unrelated to this diff.
- [ ] (skipped — Visual, standing waiver)

## Disclosed limits (per lead-coder's explicit request on this issue)

- "Vanishes on remote" is a **reading-based** finding, corroborated by a real `AgUiTransport` collaborator in the new test — not confirmed on a live server + real remote screen. "No other render path was found" means exactly that: not found in the code I read, not proven absent.
- `_submit`'s exception path's real-world reachability is **narrow and unconfirmed**: `AgUiTransport.submit_user_text` itself never raises for an ordinary failed POST (`_send` is documented to swallow that to `""`), so this branch fires only for some OTHER, unexpected exception — not the common remote-submit-failure case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

