### PR TITLE
docs(#5001): name the FIFO-position trade _ingest_frame made on purpose

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6119,7 +6119,19 @@ class TextualChatApp(App):
         purely client-side notices, so this now takes one path regardless
         of transport, matching what ``AgUiTransport.put_display``'s own
         docstring already claims for "client-authored echoes" — which
-        wasn't true for this call site until now."""
+        wasn't true for this call site until now.
+
+        ★Ordering trade, stated on purpose (architect co-vet on #5004): the
+        OLD ``put_display`` path queued this notice on ``repl_outbox``,
+        landing "in FIFO order with the session's own output" (that
+        method's own docstring, verbatim). Appending via ``_ingest_frame``
+        is IMMEDIATE — it can now land ahead of any session output already
+        sitting in that outbox at the moment Enter was blocked. Deliberate:
+        this notice is about THIS client's own composer state right now,
+        not a delta from the session, so immediate is the right answer,
+        not a regression to paper over — but it IS a real position change,
+        named here so a future ordering-bug hunt doesn't rule this call
+        site out."""
         if self._transport.attach_failed():
             text = "attach failed (see log) — your message was kept; retry once resolved"
         else:

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6121,7 +6121,7 @@ class TextualChatApp(App):
         docstring already claims for "client-authored echoes" — which
         wasn't true for this call site until now.
 
-        ★Ordering trade, stated on purpose (architect co-vet on #5004): the
+        Ordering trade, stated on purpose (architect co-vet on #5004): the
         OLD ``put_display`` path queued this notice on ``repl_outbox``,
         landing "in FIFO order with the session's own output" (that
         method's own docstring, verbatim). Appending via ``_ingest_frame``


### PR DESCRIPTION
**[tui-coder]** — follow-up to `#5001`/`#5004` (merged as `024bd7138`). In-PR-required from architect's co-vet on that PR — the requesting comment landed 1 second after the merge (a near-miss architect has already owned as their own process gap, not a violation on my end), so the line never actually made it into the merged PR. Comment-only.

## What

`_notify_blocked_on_attach`'s docstring now names the ordering trade `_ingest_frame` made on purpose: the old `self._transport.put_display(...)` path queued this notice on `repl_outbox`, landing "in FIFO order with the session's own output" (that method's own docstring, verbatim). Appending via `_ingest_frame` is immediate — it can land ahead of any session output already queued at the moment the notice fires.

Deliberate, not a regression: this notice is about this client's own composer/submit state right now, not a delta from the session, so immediate is the right answer. But it's a real position change, and left unnamed it would read as "same append, no behavior difference" to whoever investigates an ordering bug later — this documents it so that call site stays a candidate instead of being silently ruled out.

No behavior change. No tests touched (architect: a comment-only PR doesn't need TESTS-READ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
