### PR TITLE
feat(#5003): doc-drift gate — ask the PR, not the doc

### DIFF
--- a/.github/workflows/check-doc-drift.yml
+++ b/.github/workflows/check-doc-drift.yml
@@ -1,0 +1,62 @@
+name: Doc-drift check
+
+# #5003: flag a PR that removes an identifier from src/ without touching
+# any docs/ file that still names it. See
+# scripts/check_doc_drift.py's module docstring for the discriminator
+# (asks the PR, not the doc) and the two structural exclusions.
+#
+# WARN-ONLY (architect condition, #5003 / PR #5007): the false-positive
+# rate was measured against the 15 most-recently-merged PRs at review
+# time (see PR #5007's body for the count and the one caught-and-fixed
+# false positive), not against a large enough or long enough sample to
+# justify a required, merge-blocking check yet. This job therefore never
+# fails the run — a finding is surfaced as a workflow ANNOTATION only
+# (`::warning::`), visible on the PR without gating it. Flip to a
+# required check (script's own `main()` already prints a nonzero-shaped
+# WARN banner) only after a larger calibration pass, per architect
+# ruling.
+#
+# Trigger scoped to `paths: ["src/**"]` — the discriminator only ever
+# considers identifiers removed from src/, so a PR that never touches
+# src/ cannot produce a finding; running the job anyway would just be a
+# nonzero-cost no-op every time.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - "src/**"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  doc-drift:
+    name: doc-drift check (warn-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      # scripts/check_doc_drift.py is stdlib-only (argparse / re /
+      # subprocess, `git`/`gh` as external tools). No pip install needed.
+      - name: Check for src/ identifiers removed without a docs/ touch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          python scripts/check_doc_drift.py --pr "${{ github.event.pull_request.number }}" > doc_drift_output.txt 2>&1
+          cat doc_drift_output.txt
+          if grep -q "^WARN" doc_drift_output.txt; then
+            while IFS= read -r line; do
+              echo "::warning::${line}"
+            done < <(grep "^  '" doc_drift_output.txt)
+          fi
+          exit 0

--- a/.github/workflows/check-doc-drift.yml
+++ b/.github/workflows/check-doc-drift.yml
@@ -5,16 +5,22 @@ name: Doc-drift check
 # scripts/check_doc_drift.py's module docstring for the discriminator
 # (asks the PR, not the doc) and the two structural exclusions.
 #
-# WARN-ONLY (architect condition, #5003 / PR #5007): the false-positive
-# rate was measured against the 15 most-recently-merged PRs at review
-# time (see PR #5007's body for the count and the one caught-and-fixed
-# false positive), not against a large enough or long enough sample to
-# justify a required, merge-blocking check yet. This job therefore never
-# fails the run — a finding is surfaced as a workflow ANNOTATION only
-# (`::warning::`), visible on the PR without gating it. Flip to a
-# required check (script's own `main()` already prints a nonzero-shaped
-# WARN banner) only after a larger calibration pass, per architect
-# ruling.
+# WARN-ONLY (architect condition, #5003 / PR #5007): a dry-run against
+# the 15 most-recently-merged PRs at review time found 0 findings, but
+# only 1/15 had a gone-from-src identifier at all (#4980's `_compact_fn`)
+# and that one is not named in any docs/ file — so the discriminator's
+# "touched the doc?" branch was never actually exercised by that sample.
+# The false-positive rate is therefore STILL UNMEASURED, not "measured
+# and clean". The one real firing during development (PR #4981) WAS a
+# true false positive (a word inside a removed Python comment), since
+# fixed — see PR #5007's body for the full account. This job therefore
+# never fails the run — a finding is surfaced as a workflow ANNOTATION
+# only (`::warning::`), visible on the PR without gating it. Flip to a
+# required check only once a calibration pass produces a concrete count:
+# N PRs where a gone-from-src identifier IS named in some docs/ file
+# (i.e. the "touched the doc?" branch actually ran), with 0 false
+# positives among them — not "a larger sample" in the abstract, which no
+# one could ever satisfy.
 #
 # Trigger scoped to `paths: ["src/**"]` — the discriminator only ever
 # considers identifiers removed from src/, so a PR that never touches

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""#5003 — flag a PR that removes an identifier from ``src/`` without
+touching any ``docs/`` file that still names it.
+
+## The question this asks, and the one it deliberately does NOT ask
+
+The first form tried (lead-coder, #4997 doc-drift candidate) asked the DOC:
+"are you a removal record?" — a natural-language judgment a machine cannot
+make (this codebase deliberately writes phrases like "now-retired" / "#4951-B
+で削除" — a naive "does this doc still mention a name that's gone from src"
+scan flags every one of those *on-purpose* removal records as a violation).
+Per CLAUDE.md's own rule, a mechanism that has to guess is a mechanism that
+stays silent and gets removed — see `find_negated_closing_declarations` in
+`check_pr_closing_intent.py` for the sibling case (negation-detection stayed
+UNCONDITIONAL specifically because it never had to guess intent).
+
+The question this script asks instead is put to the PR, not the doc:
+
+    "Of the identifiers this diff removed from src/, is there any docs/
+    file that still contains one of them, that this PR did NOT touch?"
+
+Not touched -> flag. Touched -> pass, unconditionally, with no attempt to
+read what the touch says. This is why the false-positive class collapses:
+whoever writes a removal record ("X is now retired, see #N") touches that
+doc IN THE SAME PR that removes X — the two edits are the same commit action
+by construction, not two independent choices that might drift apart. And a
+PRE-EXISTING removal record (some earlier PR's own "X, removed in #N" note)
+never enters this PR's candidate set at all, because X was not removed BY
+THIS diff — it was already gone from src/ before this diff started.
+
+## Structural exclusions (syntax only, never semantic judgment)
+
+1. **History-class docs are exempt directories, not a semantic read.**
+   `docs/deep-dives/decisions/` and `docs/deep-dives/journal/` are the
+   places CLAUDE.md's own rules say a name is deliberately preserved after
+   removal (an ADR records what a design USED to be; a journal entry records
+   what happened, and rewriting it changes the record). Exclusion is by
+   DIRECTORY PREFIX — never by asking whether a given file "is" a record.
+2. **Identifier salience floor** (the one tunable knob — see
+   `_MIN_IDENTIFIER_LENGTH`). A short, common bare word ("run", "Session")
+   removed from one src/ call site is not a distinctive enough token to
+   search docs/ for without drowning in coincidental prose matches. An
+   identifier passes the floor if it has ANY of: contains `_` (snake_case
+   symbols are not English words), is dotted (`module.symbol` /
+   `Class.method` shape), or is at least `_MIN_IDENTIFIER_LENGTH` characters
+   long. All three tests are syntactic — none of them reads what the
+   identifier means.
+
+## Not yet blocking (architect ruling, #5003)
+
+The false-positive rate of this discriminator is UNMEASURED beyond
+lead-coder's own "caught it by hand twice" instances (true-positive side
+only). Per the architect's explicit condition, this check ships in **warn
+mode** (`main` always returns 0) until a calibration pass — `--calibrate`
+below — has been run against a batch of recently-merged PRs and each red
+hit inspected by hand. Flip to blocking only after that count exists; an
+untallied "0 false positives" is indistinguishable from "flags nothing"
+(CLAUDE.md's pre-conclusion checklist, item 5).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Structural exclusions
+# ---------------------------------------------------------------------------
+
+# Directory prefixes (relative to repo root) exempt from drift-flagging:
+# a name preserved here on purpose is the documented PRODUCT of this
+# directory, not drift. See module docstring, exclusion 1.
+_HISTORY_CLASS_DOC_PREFIXES = (
+    "docs/deep-dives/decisions/",
+    "docs/deep-dives/journal/",
+)
+
+# The one tunable knob (architect ruling, #5003) — see module docstring,
+# exclusion 2. Not yet calibrated against a measured false-positive rate;
+# revisit via `--calibrate` before this check goes blocking.
+_MIN_IDENTIFIER_LENGTH = 8
+
+_IDENTIFIER_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
+
+
+def is_salient_identifier(name: str) -> bool:
+    """True iff *name* clears the identifier-salience floor — see module
+    docstring, exclusion 2. Purely syntactic: never reads what the token
+    means, only its shape."""
+    if "_" in name:
+        return True
+    if "." in name:
+        return True
+    return len(name) >= _MIN_IDENTIFIER_LENGTH
+
+
+def is_history_class_doc(path: str) -> bool:
+    """True iff *path* (repo-relative, forward-slash) sits under a
+    directory this repo's own rules designate as a preserved record — see
+    module docstring, exclusion 1. Directory-prefix test only."""
+    return any(path.startswith(prefix) for prefix in _HISTORY_CLASS_DOC_PREFIXES)
+
+
+# ---------------------------------------------------------------------------
+# Pure diff parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FileDiff:
+    path: str
+    removed_lines: "tuple[str, ...]"
+    added_lines: "tuple[str, ...]"
+
+
+def _iter_file_diffs(diff_text: str) -> "list[_FileDiff]":
+    """Split a unified ``git diff`` / ``gh pr diff`` text into per-file
+    removed/added line buckets. Only the ``+``/``-`` content lines are kept
+    (not the file-header ``+++``/``---`` lines, which this regex excludes
+    by requiring the line not start with ``+++``/``---``)."""
+    files: "list[_FileDiff]" = []
+    current_path: "str | None" = None
+    removed: "list[str]" = []
+    added: "list[str]" = []
+
+    def _flush() -> None:
+        if current_path is not None:
+            files.append(_FileDiff(current_path, tuple(removed), tuple(added)))
+
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            _flush()
+            removed = []
+            added = []
+            # "diff --git a/path b/path" — take the b/ side (post-image path,
+            # which is what a rename/new-file case still resolves to).
+            match = re.match(r"diff --git a/(.+) b/(.+)$", line)
+            current_path = match.group(2) if match else None
+        elif line.startswith("+++") or line.startswith("---"):
+            continue
+        elif line.startswith("+"):
+            added.append(line[1:])
+        elif line.startswith("-"):
+            removed.append(line[1:])
+    _flush()
+    return files
+
+
+def find_touched_files(diff_text: str) -> "set[str]":
+    """Every file path this diff touches at all (added, removed, or
+    modified) — repo-relative, forward-slash. Used to test whether a docs/
+    file the identifier appears in was edited by THIS PR."""
+    return {fd.path for fd in _iter_file_diffs(diff_text)}
+
+
+def _strip_python_comment(line: str) -> str:
+    """Drop everything from the first ``#`` onward, for ``.py`` source
+    lines only — a syntactic rule (Python's own comment marker), not a
+    semantic read of what the comment says. Real incident (#5003
+    calibration, PR #4981): a prose word ("scaffolding") inside a REMOVED
+    comment line was extracted as if it were a removed code identifier,
+    then matched against docs/ using its ordinary-English sense — a false
+    positive that had nothing to do with a removed src/ symbol. Disclosed
+    limitation: a ``#`` inside a string literal is also stripped past
+    (e.g. ``"a # b"``) — accepted because the alternative (a full Python
+    tokenizer) is a much larger surface for a diff-line heuristic, and an
+    inline ``#`` inside a string literal removed alongside real code is
+    rare enough not to have shown up in the #5003 calibration sample.
+    """
+    idx = line.find("#")
+    return line if idx == -1 else line[:idx]
+
+
+def find_removed_identifiers(diff_text: str, *, src_prefix: str = "src/") -> "set[str]":
+    """Identifiers this diff removed from ``src/``: tokens present on a
+    removed (``-``) line of a ``src/``-prefixed file, salient (see
+    :func:`is_salient_identifier`), and NOT also present on any added
+    (``+``) line of the SAME file in this diff (a token that moved within
+    the same file's diff was not removed, just relocated). Comment text is
+    stripped first for ``.py`` files (see :func:`_strip_python_comment`) —
+    a comment's prose is not a code identifier."""
+    removed_ids: "set[str]" = set()
+    for fd in _iter_file_diffs(diff_text):
+        if not fd.path.startswith(src_prefix):
+            continue
+        is_py = fd.path.endswith(".py")
+        strip = _strip_python_comment if is_py else (lambda line: line)
+        removed_tokens = {
+            tok for line in fd.removed_lines for tok in _IDENTIFIER_RE.findall(strip(line))
+        }
+        added_tokens = {
+            tok for line in fd.added_lines for tok in _IDENTIFIER_RE.findall(strip(line))
+        }
+        for tok in removed_tokens - added_tokens:
+            if is_salient_identifier(tok):
+                removed_ids.add(tok)
+    return removed_ids
+
+
+def identifier_survives_in_src(identifier: str, src_root: Path) -> bool:
+    """True iff *identifier* still appears anywhere in the CURRENT (post-
+    diff) ``src/`` tree — i.e. this diff moved it rather than deleting it
+    from the codebase. Uses `git grep` scoped to the working tree so this
+    reads the checked-out post-diff state, not history."""
+    result = subprocess.run(
+        ["git", "grep", "-lF", "--", identifier, "--", "src"],
+        cwd=src_root,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def find_doc_files_containing(identifier: str, docs_root: Path) -> "set[str]":
+    """Every ``docs/`` file (repo-relative path) that contains *identifier*
+    as a whole word, excluding history-class directories (exclusion 1)."""
+    result = subprocess.run(
+        ["git", "grep", "-lF", "--", identifier, "--", "docs"],
+        cwd=docs_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return set()
+    return {
+        path
+        for path in result.stdout.splitlines()
+        if path and not is_history_class_doc(path)
+    }
+
+
+# ---------------------------------------------------------------------------
+# The check
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Finding:
+    identifier: str
+    doc_path: str
+
+
+def check_doc_drift_pure(
+    gone_identifiers: "set[str]",
+    doc_files_by_identifier: "dict[str, set[str]]",
+    touched_files: "set[str]",
+) -> "list[Finding]":
+    """The discriminator itself (architect ruling, #5003), as a PURE
+    function over already-resolved data — no subprocess, no filesystem —
+    so this is the Tier 1 contract surface (mirrors
+    ``check_pr_closing_intent.check_contradictions``).
+
+    *gone_identifiers*: identifiers this diff removed from ``src/`` that do
+    not survive anywhere else in the current ``src/`` tree (the network
+    wrapper, :func:`resolve_gone_identifiers`, computes this).
+    *doc_files_by_identifier*: identifier -> the non-history docs/ files
+    that still name it (the network wrapper,
+    :func:`resolve_doc_files_by_identifier`, computes this).
+    *touched_files*: every file path this diff touched at all.
+
+    For every gone identifier, for every doc file that still names it,
+    flag it UNLESS this diff also touched that doc file.
+    """
+    findings: "list[Finding]" = []
+    for identifier in sorted(gone_identifiers):
+        for doc_path in sorted(doc_files_by_identifier.get(identifier, ())):
+            if doc_path in touched_files:
+                continue
+            findings.append(Finding(identifier=identifier, doc_path=doc_path))
+    return findings
+
+
+def resolve_gone_identifiers(diff_text: str, repo_root: Path) -> "set[str]":
+    """Network/filesystem wrapper: identifiers removed from ``src/`` by this
+    diff (:func:`find_removed_identifiers`, pure) that also do not survive
+    anywhere else in the current ``src/`` tree (``git grep``)."""
+    return {
+        identifier
+        for identifier in find_removed_identifiers(diff_text)
+        if not identifier_survives_in_src(identifier, repo_root)
+    }
+
+
+def resolve_doc_files_by_identifier(
+    identifiers: "set[str]", repo_root: Path,
+) -> "dict[str, set[str]]":
+    """Network/filesystem wrapper: for each identifier, the non-history
+    docs/ files that still name it (``git grep``, one call per identifier —
+    see :func:`find_doc_files_containing`)."""
+    return {
+        identifier: find_doc_files_containing(identifier, repo_root)
+        for identifier in identifiers
+    }
+
+
+def check_doc_drift(
+    diff_text: str,
+    *,
+    repo_root: Path = _ROOT,
+) -> "list[Finding]":
+    """End-to-end: wires the network/filesystem wrappers into
+    :func:`check_doc_drift_pure`. This is the impure entry point — tests
+    exercise :func:`check_doc_drift_pure` directly with fixture data."""
+    touched = find_touched_files(diff_text)
+    gone = resolve_gone_identifiers(diff_text, repo_root)
+    doc_files_by_identifier = resolve_doc_files_by_identifier(gone, repo_root)
+    return check_doc_drift_pure(gone, doc_files_by_identifier, touched)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def fetch_pr_diff(pr_number: int) -> str:
+    result = subprocess.run(
+        ["gh", "pr", "diff", str(pr_number)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Flag a PR that removes an identifier from src/ without "
+            "touching any docs/ file that still names it. Warn-only until "
+            "calibrated — see module docstring."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pr", type=int, metavar="N", help="Live PR number (via `gh pr diff`).")
+    group.add_argument("--fixture", metavar="PATH", help="Path to a unified-diff text file.")
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.pr is not None:
+        try:
+            diff_text = fetch_pr_diff(args.pr)
+        except subprocess.CalledProcessError as exc:
+            print(f"gh pr diff failed: {exc.stderr}", file=sys.stderr)
+            return 2
+        source = f"PR #{args.pr}"
+    else:
+        diff_text = Path(args.fixture).read_text(encoding="utf-8")
+        source = args.fixture
+
+    findings = check_doc_drift(diff_text)
+
+    if not findings:
+        print(f"OK — no doc-drift findings ({source}).")
+        return 0
+
+    print(f"WARN — doc-drift findings ({source}), NOT YET BLOCKING (see module docstring):\n")
+    for f in findings:
+        print(f"  {f.identifier!r} removed from src/, still named in {f.doc_path} (untouched by this PR)")
+    print(f"\nTotal: {len(findings)} finding(s).")
+    return 0  # warn-only — see module docstring "Not yet blocking"
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_doc_drift_5003.py
+++ b/tests/scripts/test_check_doc_drift_5003.py
@@ -1,0 +1,304 @@
+"""Tier 1: scripts/check_doc_drift.py doc-drift discriminator contract.
+
+Pins the invariant #5003 ratified: a PR that removes an identifier from
+src/ is only flagged if some non-history docs/ file still names that
+identifier AND this PR did not touch that doc file. The discriminator
+asks the PR ("did you touch the doc"), never the doc ("are you a removal
+record") — see the module docstring's own account of why the first form
+(asking the doc) was rejected as an unmakeable natural-language judgment.
+
+``check_doc_drift_pure`` is a pure function over already-resolved data
+(gone identifiers, doc-files-by-identifier, touched files) — no
+subprocess, no filesystem — mirroring
+``check_pr_closing_intent.check_contradictions``. The diff-parsing helpers
+(``find_removed_identifiers``, ``find_touched_files``) are also pure over
+diff text. Only the ``git grep``-based resolvers
+(``identifier_survives_in_src``, ``find_doc_files_containing``) touch the
+filesystem, and are exercised separately against a real temp git repo.
+
+Public surface only (no MagicMock, no private-state asserts).
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+
+from tests._support.paths import REPO_ROOT
+
+
+def _load_module():
+    repo_root = REPO_ROOT
+    path = repo_root / "scripts" / "check_doc_drift.py"
+    spec = importlib.util.spec_from_file_location("check_doc_drift", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_doc_drift"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+m = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# is_salient_identifier — the one tunable knob (purely syntactic)
+# ---------------------------------------------------------------------------
+
+
+def test_salient_identifier_passes_on_underscore():
+    """Tier 1: snake_case (contains `_`) is salient regardless of length."""
+    assert m.is_salient_identifier("go")  is False  # sanity: bare short word alone fails
+    assert m.is_salient_identifier("go_x") is True
+
+
+def test_salient_identifier_passes_on_dotted_form():
+    """Tier 1: `module.symbol` shape is salient regardless of length."""
+    assert m.is_salient_identifier("a.b") is True
+
+
+def test_salient_identifier_passes_on_length_floor():
+    """Tier 1: a bare word with no `_`/`.` still passes at/above the floor."""
+    long_bare_word = "x" * m._MIN_IDENTIFIER_LENGTH
+    short_bare_word = "x" * (m._MIN_IDENTIFIER_LENGTH - 1)
+    assert m.is_salient_identifier(long_bare_word) is True
+    assert m.is_salient_identifier(short_bare_word) is False
+
+
+def test_salient_identifier_excludes_short_common_words():
+    """Tier 1: the real motivating examples ("run", "Session") — the
+    architect's own witness for why the floor exists at all."""
+    assert m.is_salient_identifier("run") is False
+    assert m.is_salient_identifier("Session") is False
+
+
+# ---------------------------------------------------------------------------
+# is_history_class_doc — directory-prefix exclusion, not semantic
+# ---------------------------------------------------------------------------
+
+
+def test_history_class_doc_excludes_decisions_dir():
+    """Tier 1: docs/deep-dives/decisions/ is an exempt directory (exclusion 1)."""
+    assert m.is_history_class_doc("docs/deep-dives/decisions/0027-foo.md") is True
+
+
+def test_history_class_doc_excludes_journal_dir():
+    """Tier 1: docs/deep-dives/journal/ is an exempt directory (exclusion 1)."""
+    assert m.is_history_class_doc("docs/deep-dives/journal/2026-01-01-foo.md") is True
+
+
+def test_history_class_doc_does_not_exclude_ordinary_docs():
+    """Tier 1: a doc outside both exempt directories is not excluded."""
+    assert m.is_history_class_doc("docs/reference/config/reyn-yaml.md") is False
+
+
+# ---------------------------------------------------------------------------
+# find_removed_identifiers / find_touched_files — pure diff parsing
+# ---------------------------------------------------------------------------
+
+_DIFF_REMOVES_MAYBE_COMPACT = """\
+diff --git a/src/reyn/core/pipeline/executor.py b/src/reyn/core/pipeline/executor.py
+index abc123..def456 100644
+--- a/src/reyn/core/pipeline/executor.py
++++ b/src/reyn/core/pipeline/executor.py
+@@ -10,7 +10,6 @@ class Executor:
+     def run(self):
+-        maybe_compact_messages(self.state)
+         return self.state
+"""
+
+
+def test_find_removed_identifiers_finds_a_removed_salient_symbol():
+    """Tier 1: a `-` line in src/ carrying a salient identifier not present
+    on any `+` line of the same file is a removed identifier."""
+    ids = m.find_removed_identifiers(_DIFF_REMOVES_MAYBE_COMPACT)
+    assert "maybe_compact_messages" in ids
+
+
+def test_find_removed_identifiers_ignores_non_src_paths():
+    """Tier 1: the same removal, but outside src/, does not count — this
+    check's whole premise is "removed from src/"."""
+    diff = _DIFF_REMOVES_MAYBE_COMPACT.replace("src/reyn", "tests/reyn")
+    ids = m.find_removed_identifiers(diff)
+    assert "maybe_compact_messages" not in ids
+
+
+def test_find_removed_identifiers_excludes_a_token_also_added_same_file():
+    """Tier 1: a token present on both a `-` and a `+` line of the same
+    file was relocated within the diff, not removed."""
+    diff = """\
+diff --git a/src/reyn/core/x.py b/src/reyn/core/x.py
+--- a/src/reyn/core/x.py
++++ b/src/reyn/core/x.py
+@@ -1,3 +1,3 @@
+-    do_the_thing()
++    # moved below
++    do_the_thing()
+"""
+    ids = m.find_removed_identifiers(diff)
+    assert "do_the_thing" not in ids
+
+
+def test_find_removed_identifiers_ignores_words_inside_a_removed_comment():
+    """Tier 1: real incident (#5003 calibration, PR #4981) — a prose word
+    ("scaffolding") inside a removed Python comment line must not be
+    extracted as a removed identifier; it names nothing in src/."""
+    diff = """\
+diff --git a/src/reyn/core/x.py b/src/reyn/core/x.py
+--- a/src/reyn/core/x.py
++++ b/src/reyn/core/x.py
+@@ -1,2 +1,1 @@
+-        # working-attention scaffolding for the model
+"""
+    ids = m.find_removed_identifiers(diff)
+    assert "scaffolding" not in ids
+
+
+def test_find_removed_identifiers_still_finds_code_before_an_inline_comment():
+    """Tier 1: an inline comment does not blind the scan to real code on
+    the same removed line — only text from `#` onward is dropped."""
+    diff = """\
+diff --git a/src/reyn/core/x.py b/src/reyn/core/x.py
+--- a/src/reyn/core/x.py
++++ b/src/reyn/core/x.py
+@@ -1,2 +1,1 @@
+-        maybe_compact_messages(state)  # scaffolding note
+"""
+    ids = m.find_removed_identifiers(diff)
+    assert "maybe_compact_messages" in ids
+    assert "scaffolding" not in ids
+
+
+def test_find_removed_identifiers_excludes_non_salient_short_word():
+    """Tier 1: a removed bare short word ("run") never enters the
+    candidate set at all — filtered at the salience floor, not later."""
+    diff = """\
+diff --git a/src/reyn/core/x.py b/src/reyn/core/x.py
+--- a/src/reyn/core/x.py
++++ b/src/reyn/core/x.py
+@@ -1,2 +1,1 @@
+-    run()
+"""
+    ids = m.find_removed_identifiers(diff)
+    assert "run" not in ids
+
+
+def test_find_touched_files_lists_every_changed_path():
+    """Tier 1: every file path present as a `diff --git` header in the
+    diff text is returned, regardless of src/ vs docs/."""
+    diff = """\
+diff --git a/docs/reference/config/reyn-yaml.md b/docs/reference/config/reyn-yaml.md
+--- a/docs/reference/config/reyn-yaml.md
++++ b/docs/reference/config/reyn-yaml.md
+@@ -1 +1 @@
+-old
++new
+diff --git a/src/reyn/core/x.py b/src/reyn/core/x.py
+--- a/src/reyn/core/x.py
++++ b/src/reyn/core/x.py
+@@ -1 +1 @@
+-old
++new
+"""
+    touched = m.find_touched_files(diff)
+    assert touched == {"docs/reference/config/reyn-yaml.md", "src/reyn/core/x.py"}
+
+
+# ---------------------------------------------------------------------------
+# check_doc_drift_pure — the discriminator itself, over resolved fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_pure_flags_when_doc_file_untouched():
+    """Tier 1: boundary witness ① (architect-required) — a gone identifier
+    named in an untouched doc file is flagged."""
+    findings = m.check_doc_drift_pure(
+        gone_identifiers={"maybe_compact_messages"},
+        doc_files_by_identifier={"maybe_compact_messages": {"docs/reference/pipeline.md"}},
+        touched_files=set(),
+    )
+    assert [(f.identifier, f.doc_path) for f in findings] == [
+        ("maybe_compact_messages", "docs/reference/pipeline.md"),
+    ]
+
+
+def test_pure_passes_when_the_same_pr_touches_the_doc():
+    """Tier 1: boundary witness ② (architect-required) — the SAME PR that
+    removes the identifier also edits the doc that named it (e.g. to write
+    a removal record) → no finding. Without this witness, "always flags"
+    would still pass witness ①."""
+    findings = m.check_doc_drift_pure(
+        gone_identifiers={"maybe_compact_messages"},
+        doc_files_by_identifier={"maybe_compact_messages": {"docs/reference/pipeline.md"}},
+        touched_files={"docs/reference/pipeline.md"},
+    )
+    assert findings == []
+
+
+def test_pure_is_silent_when_no_doc_names_the_identifier():
+    """Tier 1: a gone identifier with no entry in doc_files_by_identifier
+    produces no finding — nothing to flag against."""
+    findings = m.check_doc_drift_pure(
+        gone_identifiers={"some_internal_helper"},
+        doc_files_by_identifier={},
+        touched_files=set(),
+    )
+    assert findings == []
+
+
+def test_pure_only_flags_the_untouched_doc_among_several():
+    """Tier 1: an identifier named in two docs, one touched one not — only
+    the untouched one is flagged."""
+    findings = m.check_doc_drift_pure(
+        gone_identifiers={"foo_bar_baz"},
+        doc_files_by_identifier={"foo_bar_baz": {"docs/a.md", "docs/b.md"}},
+        touched_files={"docs/a.md"},
+    )
+    assert [(f.identifier, f.doc_path) for f in findings] == [("foo_bar_baz", "docs/b.md")]
+
+
+# ---------------------------------------------------------------------------
+# git-grep-backed resolvers — exercised against a real temp git repo
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(tmp_path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+def test_identifier_survives_in_src_true_when_present(tmp_path):
+    """Tier 1: git-grep resolver finds a symbol still present in src/."""
+    repo = _init_repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / "src" / "x.py").write_text("def foo_bar_baz(): pass\n")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    assert m.identifier_survives_in_src("foo_bar_baz", repo) is True
+
+
+def test_identifier_survives_in_src_false_when_absent(tmp_path):
+    """Tier 1: git-grep resolver finds nothing when the symbol is gone."""
+    repo = _init_repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / "src" / "x.py").write_text("def other_name(): pass\n")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    assert m.identifier_survives_in_src("foo_bar_baz", repo) is False
+
+
+def test_find_doc_files_containing_excludes_history_class_dir(tmp_path):
+    """Tier 1: the git-grep resolver itself applies exclusion 1 — a
+    journal entry naming the identifier is not returned."""
+    repo = _init_repo(tmp_path)
+    (repo / "docs" / "reference").mkdir(parents=True)
+    (repo / "docs" / "deep-dives" / "journal").mkdir(parents=True)
+    (repo / "docs" / "reference" / "pipeline.md").write_text("uses maybe_compact_messages\n")
+    (repo / "docs" / "deep-dives" / "journal" / "2026-01-01.md").write_text(
+        "maybe_compact_messages was removed in #4978\n",
+    )
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    found = m.find_doc_files_containing("maybe_compact_messages", repo)
+    assert found == {"docs/reference/pipeline.md"}


### PR DESCRIPTION
**[e2e-coder]** — part of #5003

## What / Why

doc-drift gate: flags a PR that removes an identifier from `src/` without
touching any `docs/` file that still names it. Motivation (#5003, owner
finding): `.example` was stale for 5 days after #4951-A; the only reason
it was caught was lead-coder's own memory, not a gate.

## The discriminator (architect ruling — full text on #5003)

The first form tried asked the **doc**: "are you a removal record?" — a
natural-language judgment a machine can't make (this repo deliberately
writes phrases like "now-retired" / "#4951-B で削除", so a naive scan
flags every intentional removal record).

This version asks the **PR** instead: *"of the identifiers this diff
removed from `src/`, is there a `docs/` file still naming one, that this
PR did not touch?"* Untouched → flag. Touched → pass, unconditionally,
no reading of what the touch says. FPs collapse structurally: writing a
removal record means touching that doc in the SAME PR that removes the
symbol.

Two structural (syntax-only) exclusions:
1. History-class doc directories — `docs/deep-dives/decisions/`,
   `docs/deep-dives/journal/` — by directory prefix, never semantic.
2. Identifier-salience floor (the one tunable knob) — an identifier
   passes if it contains `_`, is dotted (`module.symbol`), or is
   `>= 8` chars. Excludes generic short words ("run", "Session").

`check_doc_drift_pure` is the pure Tier 1 contract surface (mirrors
`check_pr_closing_intent.check_contradictions`); the `git grep`-backed
resolvers are exercised against a real temp git repo.

## Ships warn-only (architect condition)

`main()` always returns `0`. The false-positive rate was unmeasured
beyond lead-coder's own two hand-caught instances (true-positive side
only) — going blocking on that is not warranted (CLAUDE.md
pre-conclusion checklist item 5: an unmeasured "0 FP" reads the same as
"never fires").

## Wired (architect finding ①) — `pull_request`, `paths: ["src/**"]`, annotation-only

`.github/workflows/check-doc-drift.yml` — same trigger family as
`check-pr-closing-intent.yml`, scoped to `paths: ["src/**"]` since the
discriminator only ever considers identifiers removed from `src/`. The
job always exits 0 (warn-only, not a required check) and surfaces a
finding as a GitHub Actions **annotation** (`::warning::`) rather than a
failed run — visible on the PR without gating it.

## Calibration: 15 most-recently-merged PRs, dry-run + hand-inspected

```
gh pr list --state merged --limit 15
→ #5004 #5000 #4999 #4998 #4994 #4993 #4991 #4989 #4985 #4984
  #4981 #4980 #4979 #4976 #4974
```

**Denominator, precisely (architect finding ②)** — of the 15, only
**1/15** (#4980) removed an identifier from `src/` that no longer
survives *anywhere* in the current `src/` tree (`_compact_fn`,
`identifier_survives_in_src` confirmed absent). And that one candidate
is **not named anywhere in `docs/`** at all
(`git grep -l "_compact_fn" -- docs` → empty) — so the 0-findings result
on that PR is explained by "no doc names it", not by the discriminator
declining a real match. **The other 14/15 never removed a gone-from-src
identifier in the first place** (several PRs, e.g. #4985/#4979/#4981,
did remove other tokens, but each one either survives elsewhere in
`src/` — a rename, not a removal — or the specific identifier removed
was not itself docs-mentioned).

**First pass** (before the fix below): 14/15 clean, 1/15 (#4981) fired —
5 findings, all the same identifier: `scaffolding`.

**Inspected #4981 by hand**: `scaffolding` was inside a **removed Python
comment** ("...working-attention scaffolding for the model)..."), not a
code identifier at all — a false positive from scanning comment text as
if it were code. **Fixed**: `_strip_python_comment` drops everything
from the first `#` onward on `.py`-file diff lines before tokenizing
(disclosed limitation: also strips past a `#` inside a string literal —
accepted, a full tokenizer is a much larger surface for a diff-line
heuristic, and this didn't show up in the 15-PR sample). Pinned by
`test_find_removed_identifiers_ignores_words_inside_a_removed_comment`
and `test_find_removed_identifiers_still_finds_code_before_an_inline_comment`.

**Re-run after the fix**: **0/15 findings**, with the denominator above
disclosed — this sample did not contain a real drift instance to catch,
only the one false positive (now fixed).

## Not-toothless witness (CLAUDE.md six-questions item 4 — a green over
an untallied/empty set wears green's color too)

- **PR #4981 itself, pre-fix, is direct proof the pipeline fires on
  real PR data** — it caught something (wrongly, which is exactly what
  got fixed), not nothing.
- Unit-level witness pair (architect-required): `test_pure_flags_when_doc_file_untouched`
  (① doesn't touch the doc → flagged) and
  `test_pure_passes_when_the_same_pr_touches_the_doc` (② same PR touches
  the doc → clean; "always flags" would still pass witness ① alone).
  Strip-falsified: reverting the "touched → pass" branch turns both red
  for the expected reason (confirmed locally, restored).
- `identifier_survives_in_src` / `find_doc_files_containing` exercised
  against a real temp git repo (not fixture data), confirming the
  `git grep` resolvers actually read the filesystem they claim to.

**Reading of the result, precisely**: 15 recently-merged PRs contained
exactly 1 real "identifier gone from src/" candidate, and that candidate
had no docs/ mention to flag against — so this sample cannot yet
distinguish "the discriminator is correct" from "this sample never
exercised it on a true positive". Not overclaimed as "0 false
positives" or "proven correct"; a larger/longer calibration window is
still needed before any blocking decision.

## Test plan

- [x] `pytest tests/scripts/test_check_doc_drift_5003.py` — 21/21 green
- [x] Strip-falsify: reverted `check_doc_drift_pure`'s touched-file
      check → 2 tests red for the right reason → restored → green
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_doc_drift_5003.py` — 21/21 OK
- [x] `python scripts/verify_module_docstrings.py scripts/check_doc_drift.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (203 findings, all baselined)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] 15-PR calibration dry-run + hand inspection + precise denominator (above)
- [x] Workflow YAML round-tripped through PyYAML before push (no `#`-in-`name:` truncation; bare `on:` confirmed harmless, matches existing live workflows)
- [ ] (skipped — no docs/ changes in this PR; doc gates not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔴 lead-coder のブロッキング点（規則 7）── 2 件（★architect の指摘、★私も同意）

- [x] 🔴 ~~**① ★呼び口がありません。**~~ ✅ 解消（`.github/workflows/check-doc-drift.yml` が入りました）

```
★実測 ── `gh pr diff 5007 | grep -c "^+++ b/.github"` → ★0
★他の gate は ★全て workflow から呼ばれています
🔴 ★warn-only ＋ ★呼び口なし ＝ ★★何も起きません
⚠️ ★「まだ blocking にしない」と ★「まだ走らせない」は ★★別の判断です
   ── ★条件にしたのは ★前者だけ
✅ ★同 PR に ── ★pull_request 契機・★`paths: ["src/**"]`
   ⚠️ ★warn-only なので ★required check にはしない（★annotation で足ります）
```

★ **今夜 ★3 度目**です（#4989 の gate ／ #4999 の検出器 ／ 本 PR）── ★ **「スクリプトを書いた」と「★gate になった」は 別**です。

- [x] 🔴 ~~**② ★母数 15 の中身が書かれていません。**~~ ✅ 解消 ── ★答えが ★本 PR でいちばん価値ある行になりました（下記）

```
★「直近 merge 済 ★15 本に空回し → ★0/15」
🔴 ★15 本のうち ★何本が ★実際に `src/` から識別子を ★消したのか
   ── ★1 本も消していなければ ── ★★0/15 は「★噛む対象が 無かった」です
⚪ ★#4981 が fire した ∴ ★全部が空では ありません ── ★★ですが 数は 言えていません
✅ ★1 行 ──「★15 本中 ★N 本が `src/` 由来の gone identifier を持ち、★その N 本で 0 findings」
```

★ **これは ★あなた自身が gate に要求したものと ★同じ規律**です ── ★ **「0 件」は「無い」と「検出できていない」を区別しない**を、★ **FP 較正そのものに 当てた形**です。

---

## ⚪ ブロックしない点（★記録・★私と reviewer が確認）

```
✅ ★純粋関数が ★判別子そのもの ／ ★warn-only 維持 ／ ★accept 側 15 PR の実測
✅ ★`identifier_survives_in_src` ── ★architect が求めていないのに ★足されている
   ── ★rename が 誤検出されない ── ★良い追加
✅ ★0/15 の ★読み方が正しい ── 逐語「not proof this repo never drifts … not overclaimed」
✅ ★witness② の理由も正しい ──「'always flags' would still pass witness ①」
✅ ★comment-strip の修正 ── ★FP を 1 件 実測で見つけて 直し、★pin test を足している
   ── ★「0 件を鵜呑みにせず ★#4981 自体を『発火する』の証拠として明記」も 正しい
```



---

## 🔴 lead-coder のブロッキング点 ③（★最後の 1 件 ── architect の指摘、★私も同意）

- [ ] 🔴 **`yml` のコメントが ★過大です。**

```
★現在の逐語 ──「the false-positive rate ★WAS MEASURED against the 15 most-recently-merged PRs」
🔴 ★★「測ろうとした」が正しい ── ★★測れていません
   ── ★本 PR 自身が そう書いています:
      逐語「of the 15, ★only 1/15 (#4980) removed an identifier …
            ★And that one candidate is ★not named anywhere in docs/ at all」
   ∴ ★★判別子が「触ったか」を判定した回数は ★★0 回
   ── ★★`0/15` は「誤検出しなかった」でなく ★「★噛む対象が 無かった」
🔴 ★yml は ★PR 本文より 長生きします ── ★blocking に上げるか判断する人が読むのは ★yml です
   ── ★「measured」と書いてあれば ★測定が在ると 読みます（★#4991 と 同じ形）
```

✅ **書き換え**:
> **0 findings だが ★15 本中 ★1 本しか gone-from-src identifier を持たず、★その 1 本は ★どの doc にも出現しない ∴ ★★FP rate は ★STILL UNMEASURED。★唯一の実発火（#4981）は ★真の FP で ★修正済。**

✅ **flip の条件も ★数で**:
> **「doc に名前が載っている gone identifier を ★N 件 通し、★FP 0」** ── ⚠️ **「★もっと大きなサンプル」は ★誰も満たせません。**

---

⚪ **★②の答えは ★本 PR の最良の成果**です ── ★ **自分の較正が空虚だったことを ★自分で測って 書いた**形です。⚪ **`_strip_python_comment` の限界（★文字列中の `#` も落とす）の開示も 良い。**
