### PR TITLE
docs: document the ★ source-comment marker

### DIFF
--- a/docs/deep-dives/contributing/comments.md
+++ b/docs/deep-dives/contributing/comments.md
@@ -132,7 +132,7 @@ condition that would make it non-zero, which the detection question above
 lets you do. Never write "class C is empty" — write "class C is 0 *in this
 file*, and here is what a positive instance would look like."
 
-## 4. The shape of a residue (the load-bearing section)
+## 5. The shape of a residue (the load-bearing section)
 
 **Write what BREAKS, never "do not change this."**
 
@@ -152,7 +152,7 @@ The strongest instance from #3404: *"Sink closure resolves
 break was **silent**, not merely possible — which is exactly what stops the
 next person from "fixing" it back to eager capture.
 
-## 5. Conditions for moving a comment to a doc
+## 6. Conditions for moving a comment to a doc
 
 A comment may move to a doc only if BOTH hold:
 
@@ -187,7 +187,7 @@ away from the punctuation a gate keys on. (Swept for this specific risk on
 `\bMCPGateway\s*\(` — a future sweep can start from that count rather than
 re-deriving it.)
 
-## 6. Do not set a numeric target
+## 7. Do not set a numeric target
 
 **Never set "reduce N lines" as a goal.** A line-count target creates
 pressure to misclassify a Class C or K-inline comment as movable just to hit
@@ -201,7 +201,7 @@ negative finding — "most of what looked like bloat wasn't" — would not have
 surfaced under a numeric target, because a target rewards moving things,
 not correctly leaving them alone.
 
-## 7. A "never do this in the future" comment owns its own update
+## 8. A "never do this in the future" comment owns its own update
 
 A comment of the form *"do not make this change until X"* takes on an
 obligation: when X actually happens, THAT change must update the comment
@@ -214,7 +214,7 @@ drive-by."* #3401 (the PR that WAS #3371 landing) raised the value to `3.0`
 **and rewrote that same comment in the same commit** to describe the new
 value's own margin — the prohibition did not outlive its own trigger.
 
-## 8. Rejected arguments (record these, or the same ground gets re-litigated)
+## 9. Rejected arguments (record these, or the same ground gets re-litigated)
 
 The #3082 discussion converged by eliminating arguments, not by starting
 from a blank page. Recording only the conclusion would let a future
@@ -239,12 +239,12 @@ scratch:
   degrade too, and faster, by the same #2884 measurement. This is the
   "inline resists drift better than docs" argument returning under a
   different name (caught mid-thread as exactly that re-introduction). The
-  actual answer to degradation is already in §4: don't try to PREVENT it,
+  actual answer to degradation is already in §5: don't try to PREVENT it,
   make it DETECTABLE (a falsifiable "X breaks" claim goes stale visibly;
   "do not change this" does not).
 - ❌ **"Keep important comments inline."** Not decidable as stated —
   importance depends on which question the reader currently holds, which
-  this document cannot know in advance. Replaced entirely by §3's
+  this document cannot know in advance. Replaced entirely by §4's
   mechanical test: relational, or not.
 
 ---

--- a/docs/deep-dives/contributing/comments.md
+++ b/docs/deep-dives/contributing/comments.md
@@ -63,7 +63,37 @@ with how you count cannot be an acceptance gate. Demotions (a comment that
 looks safe to move) are named explicitly, one at a time, never swept by a
 size rule.
 
-## 3. The test for Class C (one question, answerable by inspection)
+## 3. The `★` marker in source comments
+
+The `★` is an editorial attention marker used in source comments. It is not
+Python syntax, a runtime annotation, or a machine-readable severity level.
+Its purpose is to tell a future reader that the surrounding claim deserves
+careful reading because it records a decision, a measured boundary, a known
+failure mode, or an explicit scope limit.
+
+Use it in either of these forms:
+
+- **Line-leading marker:** put `★` at the start of the comment text when the
+  whole line carries the attention signal, for example `# ★ the event is
+  client-authored` or a doc-comment equivalent.
+- **Inline marker:** put `★` immediately before the particular sentence or
+  clause that needs attention when the rest of the comment is ordinary
+  explanation, for example `# the value is ★bounded by the caller`.
+
+Place the marker next to the claim it qualifies. Do not use it as decoration,
+as a substitute for explaining what breaks, or as a promise that a claim has
+been independently measured. A marker does not change the comment's Class A,
+B, C, or K-inline classification; classify the content first, then choose the
+marker placement that keeps the claim's scope visible.
+
+Existing source comments use both line-leading and inline forms. This is a
+descriptive convention, not a migration target: do not rewrite existing
+comments merely to normalize marker placement. When adding or editing a
+comment, preserve the surrounding comment's form unless the new claim has a
+clearer local placement. If the claim is historical or measured, state the
+source and confidence separately; `★` alone is not evidence.
+
+## 4. The test for Class C (one question, answerable by inspection)
 
 > **Does this line assert something about a SECOND location? Does another
 > symbol's / file's / field's correctness depend on what this line says?**

--- a/docs/deep-dives/contributing/comments.md
+++ b/docs/deep-dives/contributing/comments.md
@@ -86,6 +86,14 @@ been independently measured. A marker does not change the comment's Class A,
 B, C, or K-inline classification; classify the content first, then choose the
 marker placement that keeps the claim's scope visible.
 
+A full pass over `src/` found `★` in 44 files: 101 lines containing the
+marker and 105 marker occurrences. The counts differ because 4 lines contain
+more than one marker. For a reproducible shape count, this section uses
+"line-leading" when the first non-comment character of the comment text is
+`★`; all other occurrences are "inline". That pass classified 78 lines as
+line-leading and 23 as inline. These are descriptive measurements, not a
+migration target.
+
 Existing source comments use both line-leading and inline forms. This is a
 descriptive convention, not a migration target: do not rewrite existing
 comments merely to normalize marker placement. When adding or editing a


### PR DESCRIPTION
**[reyn-self]** — part of #5006

## What

Add a normative section to `docs/deep-dives/contributing/comments.md` documenting the `★` marker used in `src/` comments:

- meaning and limits (editorial attention marker, not evidence or severity)
- line-leading and inline forms
- placement next to the claim it qualifies
- no drive-by migration of the existing 101 measured lines / 44 files

## Scope

- Existing source comments were read in full before writing the section: `rg -n '★' src` found 101 lines across 44 files; the requested 105 differs by an unresolved counting definition, so I do not claim equivalence.
- No existing source comment was changed.
- No gate was added: marker meaning is editorial and not a low-FP syntactic invariant.

## Verification

- `./.venv/bin/mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- `./.venv/bin/python scripts/check_doc_anchors.py` — exit 0
- `./.venv/bin/python scripts/check_retired_config_keys_denylist.py` — exit 0

All verification was run from `repo/.venv`; tests were not run because this PR changes documentation only.


---

## 🔴 lead-coder のブロッキング点（規則 7）── 1 件

- [x] 🔴 ~~**`## 4.` が ★2 つあります ── ★節番号が ★1 本しか繰り上がっていません。**~~ ✅ `3ad419987` で解消（★私も実測: 1〜9 が連番・重複 0・範囲は 1 ファイルのまま）

```
★実測（`git show <this branch>:docs/deep-dives/contributing/comments.md | grep -E '^## '`）
   1. Premise
   2. Classification
   ★3. The `★` marker in source comments      ← ★新規（ここは正しい）
   ★4. The test for Class C …                  ← ★元 3 から 繰り上げ（正しい）
   🔴 ★4. The shape of a residue …             ← ★★元 4 のまま ── ★★重複
   5. Conditions for moving …                  ← ★元 5 のまま（★以降 全部 ずれ）
   6. / 7. / 8. …                              ← ★同上
```

★ **新しい節を ★2 番目と 3 番目の間に入れたので、★それ以降は ★全部 1 つずつ 繰り上がるべき**でした ── ★ **直後の 1 本だけが 繰り上がっています。**

## 🔴 ★どの gate も これを捕まえません（★実測に基づく指摘）

```
★`check_doc_anchors.py` ── ★捕まえません
   ── ★anchor は ★見出しの ★文字列から作られます
   ── ★`#4-the-test-for-class-c…` と ★`#4-the-shape-of-a-residue…` は ★別の slug
   ∴ ★★衝突しない ── ★★番号の重複は anchor の問題ではない
★`mkdocs build --strict` ── ★同上（★見出しの番号は ★ただの本文）
∴ ★★「3 gate すべて exit 0」は ★真 ── ★★それでも この欠陥は 通ります
```

⚠️ **∴ これは ★あなたの gate の回し方の誤りでは ありません** ── ★ **gate が見ない面**です。

## ✅ 直し方

**`## 4. The shape of a residue …` 以降を ★1 つずつ繰り上げてください**（★4→5, 5→6, 6→7, 7→8, 8→9）。⚠️ **`## Sources` は番号無しなので そのまま。**

⚠️ **本文中に「§N」形式の相互参照が在れば ★そちらも**（★私は `comments.md#` の外部参照を引きましたが ★0 件でした ── ★ **本文内の参照は ★あなたが確かめてください**）。

---

## ⚪ ブロックしない点（★私が実測したもの）

```
✅ ★範囲 ── ★src/ ★0 ファイル ／ ★scripts+.github ★0 ファイル
   ── ★「既存 105 箇所を触らない」「gate を作らない」── ★★両方 守られています
✅ ★規則 4 ── ★body 0 hits ／ ★commit 0 hits ／ ★closingIssuesReferences ★空
   ── ★`part of #5006` ── ★closing keyword を 番号の隣に置いていません
✅ ★本文先頭 ── `**[reyn-self]** — `
✅ ★全数を ★自分で測っている ── ★101 行 / 44 ファイル
   ── ★★私の 105 との差 4 を ★断定せず「定義差があり得る」と 記録した
   ── ★★正しい扱いです（★下記に答えを書きます）
```

## ⚪ 105 と 101 の差 ── ★解けました（★私が測りました）

```
★出現回数（★を1つずつ）── ★105  ← ★私と architect の数え方
★行数（★を含む行）      ── ★101  ← ★あなたの数え方（rg -n）
★★を2つ以上含む行      ── ★★4  ← ★★105 − 101 = 4 ── ★一致
★ファイル数 ── ★44（★両者一致）
```

✅ **節に書くなら ★両方**: 「**44 ファイル・★101 行・★105 箇所**（★2 つ以上を含む行が 4 行 ── ★数え方で数が変わる）」

## ⚪ 節の内容について（★評価）

★ **とくに良い 3 行**:
> **not Python syntax, a runtime annotation, or a machine-readable severity level**
> **Do not use it … as a promise that a claim has ★been independently measured**
> **This is a ★descriptive convention, not a migration target**

⚪ **既存の Class A/B/C/K-inline 分類に ★接続した**（★並行する分類を 作らなかった）のも 良いです。



---

## ⚪ ★この欠陥を機械で捕まえられるか ── ★測りました。★私の判別子は 使えません

**私は「gate が見ない面だ」と書きました。**★ **では gate を作れるか**を、★ **提案する前に 測りました。**

```
★番号付き見出し（`## N.`）を使う doc ── ★126 本
★素朴な判別子「同じ `## N.` が 2 回出たら flag」で main を走らせた
   → ★4 本 hit（dogfood-discipline ja/en ／ dogfood-reporting ja/en）
🔴 ★4 本とも ★★誤検出でした
   ★dogfood-reporting ── ★H1 が 4 つ（`# Batch N — Findings` 等）
      ── ★★各 H1 の下で ★1. から 振り直している ── ★★正当
   ★dogfood-discipline ── ★私の grep が ★★コードフェンス内の `# …` を ★H1 と誤認
∴ ★★FP 4/4 ── ★★私の判別子は 使えません
```

✅ **正しい形にするには 2 つ 要ります**: ★ **①H1 単位でスコープを切る ②コードフェンスを剥がす。**⚠️ **どちらも構文で書けますが、★FP 率は ★未測定**です。

⚪ **∴ 私は ★gate を提案しません**（★今夜 architect が #5003 で出した裁定と同じ ── **accept 側を数えるまで blocking にしない／★判別子が言えるまで作らない**）。★ **「クラスは在る・私の最初の判別子は 4/4 で誤検出・正しい形には追加の 2 条件が要る」までが ★今 言えることです。**
