### PR TITLE
feat(#5010): promote doc-drift gate to blocking

### DIFF
--- a/.github/workflows/check-doc-drift.yml
+++ b/.github/workflows/check-doc-drift.yml
@@ -3,27 +3,42 @@ name: Doc-drift check
 # #5003: flag a PR that removes an identifier from src/ without touching
 # any docs/ file that still names it. See
 # scripts/check_doc_drift.py's module docstring for the discriminator
-# (asks the PR, not the doc) and the two structural exclusions.
+# (asks the PR, not the doc) and the structural exclusions.
 #
-# WARN-ONLY (architect condition, #5003 / #5010). Calibration history:
-#   - PR #5007's 15-PR sample: 0 findings, but only 1/15 had a
-#     gone-from-src identifier at all, and it was not doc-named — the
-#     "touched the doc?" branch never actually ran. FP rate: unmeasured.
-#   - #5010 round 1: a ~400-PR backward scan found 9 real candidates
-#     (the branch DID run). 2 true positives, 7 false positives —
-#     mostly docstring-prose words the line-heuristic extraction
-#     couldn't distinguish from real code.
-#   - #5010 round 2 (this file's current shape): rewrote extraction to
-#     read real pre/post file content (`git show`) and tokenize it
-#     (scripts/check_doc_drift.py's `find_removed_identifiers_precise`)
-#     instead of guessing from diff-line text. Re-run on the same 9
-#     candidates: 3 true positives (a 3rd surfaced), 0 false positives.
-# "0 FP among N=9" is the architect's stated promotion bar — met. Still
-# warn-only: whether N=9 is ENOUGH is a separate decision the architect
-# has explicitly not made yet — see #5010 for the ruling when it lands.
-# This job therefore never fails the run — a finding is surfaced as a
-# workflow ANNOTATION only (`::warning::`), visible on the PR without
-# gating it.
+# BLOCKING (promoted #5010, architect ruling 2026-08-21). Calibration
+# history — full account in scripts/check_doc_drift.py's module
+# docstring, "Blocking" section:
+#   - PR #5007's 15-PR sample: 0 findings, but the "touched the doc?"
+#     branch never actually ran (no doc-named gone-from-src candidate).
+#   - #5010 round 1 (line-heuristic extraction): a ~400-PR backward
+#     scan found 9 real candidates. 2 true positives, 7 false
+#     positives — mostly docstring-prose words a diff-line-text-only
+#     heuristic couldn't distinguish from real code.
+#   - #5010 round 2 (this file's current shape): extraction rewritten
+#     to read real pre/post file content (`git show`) and tokenize it
+#     (find_removed_identifiers_precise) instead of guessing from
+#     diff-line text. Re-run on the same 9 candidates: 3 true positives
+#     (a 3rd surfaced), 0 false positives.
+#
+# Promotion does NOT rest on "0/9" as a statistic (9 trials barely
+# bounds a rate at all) — it rests on three structural points: (1) the
+# false-positive CLASS was eliminated, not merely unobserved — a NAME
+# token structurally cannot come from inside a STRING/COMMENT token,
+# (2) every fallback to the weaker line heuristic prints to stderr,
+# never silent, verified against two real triggers, (3) the PASSING
+# action (touch the doc file in the same PR) is always the correct
+# action even in a false-positive world — no dead end a false positive
+# can walk an author into. See the module docstring for the full
+# argument.
+#
+# REVERT CONDITION (required for a promotion to not be one-way): if a
+# genuine false positive is found in production use, change the final
+# step back to `set +e` / always `exit 0` / `::warning::` annotations
+# (the shape this file had before #5010's promotion — see git history)
+# until the new false-positive class is closed the same STRUCTURAL way
+# as the first two (never by loosening _MIN_IDENTIFIER_LENGTH or adding
+# another marker-guessing heuristic — that regresses past what this
+# promotion earned).
 #
 # Trigger scoped to `paths: ["src/**"]` — the discriminator only ever
 # considers identifiers removed from src/, so a PR that never touches
@@ -41,18 +56,18 @@ permissions:
 
 jobs:
   doc-drift:
-    name: doc-drift check (warn-only)
+    name: doc-drift check
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      # fetch-depth: 0 (full history) — #5010 round 2's precise
-      # extraction path reads real pre/post file content via
-      # `git show <sha>:<path>`, which needs the base ref's commit
-      # present locally; the default shallow (depth 1) checkout would
-      # only have the PR's own tip commit and make every file fall back
-      # to the line heuristic (logged, not silent, but pointless to pay
-      # for every run when a full checkout avoids it).
+      # fetch-depth: 0 (full history) — the precise extraction path
+      # reads real pre/post file content via `git show <sha>:<path>`,
+      # which needs the base ref's commit present locally; the default
+      # shallow (depth 1) checkout would only have the PR's own tip
+      # commit and make every file fall back to the line heuristic
+      # (logged, not silent, but pointless to pay for every run when a
+      # full checkout avoids it).
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -71,10 +86,11 @@ jobs:
         run: |
           set +e
           python scripts/check_doc_drift.py --pr "${{ github.event.pull_request.number }}" > doc_drift_output.txt 2>&1
+          exit_code=$?
           cat doc_drift_output.txt
-          if grep -q "^WARN" doc_drift_output.txt; then
+          if [ "$exit_code" -ne 0 ]; then
             while IFS= read -r line; do
-              echo "::warning::${line}"
+              echo "::error::${line}"
             done < <(grep "^  '" doc_drift_output.txt)
           fi
-          exit 0
+          exit "$exit_code"

--- a/.github/workflows/check-doc-drift.yml
+++ b/.github/workflows/check-doc-drift.yml
@@ -5,22 +5,25 @@ name: Doc-drift check
 # scripts/check_doc_drift.py's module docstring for the discriminator
 # (asks the PR, not the doc) and the two structural exclusions.
 #
-# WARN-ONLY (architect condition, #5003 / PR #5007): a dry-run against
-# the 15 most-recently-merged PRs at review time found 0 findings, but
-# only 1/15 had a gone-from-src identifier at all (#4980's `_compact_fn`)
-# and that one is not named in any docs/ file — so the discriminator's
-# "touched the doc?" branch was never actually exercised by that sample.
-# The false-positive rate is therefore STILL UNMEASURED, not "measured
-# and clean". The one real firing during development (PR #4981) WAS a
-# true false positive (a word inside a removed Python comment), since
-# fixed — see PR #5007's body for the full account. This job therefore
-# never fails the run — a finding is surfaced as a workflow ANNOTATION
-# only (`::warning::`), visible on the PR without gating it. Flip to a
-# required check only once a calibration pass produces a concrete count:
-# N PRs where a gone-from-src identifier IS named in some docs/ file
-# (i.e. the "touched the doc?" branch actually ran), with 0 false
-# positives among them — not "a larger sample" in the abstract, which no
-# one could ever satisfy.
+# WARN-ONLY (architect condition, #5003 / #5010). Calibration history:
+#   - PR #5007's 15-PR sample: 0 findings, but only 1/15 had a
+#     gone-from-src identifier at all, and it was not doc-named — the
+#     "touched the doc?" branch never actually ran. FP rate: unmeasured.
+#   - #5010 round 1: a ~400-PR backward scan found 9 real candidates
+#     (the branch DID run). 2 true positives, 7 false positives —
+#     mostly docstring-prose words the line-heuristic extraction
+#     couldn't distinguish from real code.
+#   - #5010 round 2 (this file's current shape): rewrote extraction to
+#     read real pre/post file content (`git show`) and tokenize it
+#     (scripts/check_doc_drift.py's `find_removed_identifiers_precise`)
+#     instead of guessing from diff-line text. Re-run on the same 9
+#     candidates: 3 true positives (a 3rd surfaced), 0 false positives.
+# "0 FP among N=9" is the architect's stated promotion bar — met. Still
+# warn-only: whether N=9 is ENOUGH is a separate decision the architect
+# has explicitly not made yet — see #5010 for the ruling when it lands.
+# This job therefore never fails the run — a finding is surfaced as a
+# workflow ANNOTATION only (`::warning::`), visible on the PR without
+# gating it.
 #
 # Trigger scoped to `paths: ["src/**"]` — the discriminator only ever
 # considers identifiers removed from src/, so a PR that never touches
@@ -43,7 +46,16 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      # fetch-depth: 0 (full history) — #5010 round 2's precise
+      # extraction path reads real pre/post file content via
+      # `git show <sha>:<path>`, which needs the base ref's commit
+      # present locally; the default shallow (depth 1) checkout would
+      # only have the PR's own tip commit and make every file fall back
+      # to the line heuristic (logged, not silent, but pointless to pay
+      # for every run when a full checkout avoids it).
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -75,9 +75,20 @@ _ROOT = Path(__file__).resolve().parent.parent
 # Directory prefixes (relative to repo root) exempt from drift-flagging:
 # a name preserved here on purpose is the documented PRODUCT of this
 # directory, not drift. See module docstring, exclusion 1.
+#
+# docs/deep-dives/proposals/ added after #5010 calibration (PR #4454):
+# every proposal in this directory carries its own **Status** field
+# (README.md: "cut, landed" / etc.) — the directory's own README states
+# the split explicitly: decisions/ records "why chosen", proposals/
+# records "what should be implemented", and both are point-in-time
+# design records, not living reference docs that track current src/
+# identifier names. #4454's `_force_close_wrap_up` false-fire (named in
+# two `Status: cut, landed`-flagged proposals neither touched by the PR
+# that removed it) is the real incident this exclusion closes.
 _HISTORY_CLASS_DOC_PREFIXES = (
     "docs/deep-dives/decisions/",
     "docs/deep-dives/journal/",
+    "docs/deep-dives/proposals/",
 )
 
 # The one tunable knob (architect ruling, #5003) — see module docstring,
@@ -158,22 +169,76 @@ def find_touched_files(diff_text: str) -> "set[str]":
     return {fd.path for fd in _iter_file_diffs(diff_text)}
 
 
-def _strip_python_comment(line: str) -> str:
-    """Drop everything from the first ``#`` onward, for ``.py`` source
-    lines only — a syntactic rule (Python's own comment marker), not a
-    semantic read of what the comment says. Real incident (#5003
-    calibration, PR #4981): a prose word ("scaffolding") inside a REMOVED
-    comment line was extracted as if it were a removed code identifier,
-    then matched against docs/ using its ordinary-English sense — a false
-    positive that had nothing to do with a removed src/ symbol. Disclosed
-    limitation: a ``#`` inside a string literal is also stripped past
-    (e.g. ``"a # b"``) — accepted because the alternative (a full Python
-    tokenizer) is a much larger surface for a diff-line heuristic, and an
-    inline ``#`` inside a string literal removed alongside real code is
-    rare enough not to have shown up in the #5003 calibration sample.
+_TRIPLE_QUOTES = ('"""', "'''")
+
+
+def _strip_comments_and_docstrings(lines: "tuple[str, ...]") -> "list[str]":
+    """Best-effort, line-oriented removal of ``#``-comment text AND
+    triple-quoted docstring bodies from a sequence of ``.py`` source
+    lines — a syntactic rule (Python's own comment/string-literal
+    markers), not a semantic read of what the text says.
+
+    Real incidents this closes (#5010 calibration, backward scan past
+    PR #5007's own 15-PR sample): a `#`-comment prose word
+    ("scaffolding", PR #4981, fixed in #5007) and SIX docstring-prose
+    words ("Operational" PR #4563, "affordances" PR #4560, "resumption"
+    PR #4545, "surprised" PR #4504, "normalises" PR #4459, "Compares"
+    PR #4458) were each extracted as if they were removed code
+    identifiers and matched against docs/ using their ordinary-English
+    sense — false positives with nothing to do with a removed src/
+    symbol. The original ``#``-only stripper (PR #5007) caught the first
+    class but not the second; this closes both with one state machine.
+
+    Disclosed limitations (same shape as the original's): a ``#`` or
+    triple-quote marker inside a single/double-quoted string literal is
+    not distinguished from a real marker; and this operates only on the
+    given (possibly non-contiguous — a diff hunk may omit context lines)
+    line sequence, so a docstring opened on a line NOT included here
+    (e.g. an unchanged line the hunk didn't carry) is not recognized as
+    already-open when this sequence starts. A full Python tokenizer
+    would close both gaps but needs the complete pre/post file content,
+    not just a diff's changed-line text — a larger surface than this
+    diff-line-only module takes on elsewhere; accepted as a known gap,
+    not silently assumed away.
     """
-    idx = line.find("#")
-    return line if idx == -1 else line[:idx]
+    out: "list[str]" = []
+    in_docstring = False
+    quote = ""
+    for raw in lines:
+        line = raw
+        if in_docstring:
+            idx = line.find(quote)
+            if idx == -1:
+                out.append("")
+                continue
+            line = line[idx + 3:]
+            in_docstring = False
+        piece = ""
+        while True:
+            hash_idx = line.find("#")
+            markers = [(hash_idx, "#")] if hash_idx != -1 else []
+            for q in _TRIPLE_QUOTES:
+                q_idx = line.find(q)
+                if q_idx != -1:
+                    markers.append((q_idx, q))
+            if not markers:
+                piece += line
+                break
+            idx, marker = min(markers, key=lambda pair: pair[0])
+            if marker == "#":
+                piece += line[:idx]
+                break
+            prefix = line[:idx]
+            rest = line[idx + 3:]
+            close_idx = rest.find(marker)
+            if close_idx == -1:
+                piece += prefix
+                in_docstring = True
+                quote = marker
+                break
+            line = prefix + rest[close_idx + 3:]
+        out.append(piece)
+    return out
 
 
 def find_removed_identifiers(diff_text: str, *, src_prefix: str = "src/") -> "set[str]":
@@ -181,21 +246,19 @@ def find_removed_identifiers(diff_text: str, *, src_prefix: str = "src/") -> "se
     removed (``-``) line of a ``src/``-prefixed file, salient (see
     :func:`is_salient_identifier`), and NOT also present on any added
     (``+``) line of the SAME file in this diff (a token that moved within
-    the same file's diff was not removed, just relocated). Comment text is
-    stripped first for ``.py`` files (see :func:`_strip_python_comment`) —
-    a comment's prose is not a code identifier."""
+    the same file's diff was not removed, just relocated). ``#``-comment
+    and docstring text is stripped first for ``.py`` files (see
+    :func:`_strip_comments_and_docstrings`) — prose is not a code
+    identifier."""
     removed_ids: "set[str]" = set()
     for fd in _iter_file_diffs(diff_text):
         if not fd.path.startswith(src_prefix):
             continue
         is_py = fd.path.endswith(".py")
-        strip = _strip_python_comment if is_py else (lambda line: line)
-        removed_tokens = {
-            tok for line in fd.removed_lines for tok in _IDENTIFIER_RE.findall(strip(line))
-        }
-        added_tokens = {
-            tok for line in fd.added_lines for tok in _IDENTIFIER_RE.findall(strip(line))
-        }
+        removed_lines = _strip_comments_and_docstrings(fd.removed_lines) if is_py else list(fd.removed_lines)
+        added_lines = _strip_comments_and_docstrings(fd.added_lines) if is_py else list(fd.added_lines)
+        removed_tokens = {tok for line in removed_lines for tok in _IDENTIFIER_RE.findall(line)}
+        added_tokens = {tok for line in added_lines for tok in _IDENTIFIER_RE.findall(line)}
         for tok in removed_tokens - added_tokens:
             if is_salient_identifier(tok):
                 removed_ids.add(tok)

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -70,7 +70,7 @@ file" exist in this module, and calibration (#5010) is why both do:
   no post-image; unparseable content) — every fallback is printed to
   stderr, never silently taken.
 
-## Calibration status (#5010) — after the round-2 (precise) rewrite
+## Blocking (promoted #5010, architect ruling 2026-08-21)
 
 A backward scan of ~400 merged PRs found 9 real candidates (PRs where
 this discriminator's "touched the doc?" branch actually ran). Hand-
@@ -78,11 +78,41 @@ inspection: 3 CONFIRMED TRUE POSITIVES (`_action_retrieval`, PRs
 #4572/#4567/#4563 — PR #4582's own title: "sweep stale
 action_retrieval.universal_wrappers_enabled refs #4572's own fix scope
 missed", direct evidence a human had to notice and fix what this gate
-would have flagged), 0 false positives after the round-2 rewrite (was
-7/9 with the line-heuristic-only round 1). Still **warn-only**
-(`main` always returns 0) — architect's explicit ruling that "9 is
-enough" or not is a SEPARATE decision from "0 FP among 9", not made
-here. See #5010 for the full writeup and promotion decision.
+would have flagged), 0 false positives after the round-2 (tokenizer)
+rewrite (was 7/9 with the line-heuristic-only round 1).
+
+**"0 FP among 9" is NOT why this is blocking** — with only 9 trials,
+0/9 barely bounds the true rate at all (roughly "under ~30%", a loose
+statistical read, not a safety argument). The promotion rests on three
+STRUCTURAL points instead, none of them a count:
+
+1. **The false-positive CLASS was eliminated, not merely unobserved.**
+   Both real FP classes found in calibration (`#`-comment prose,
+   docstring prose) tokenize as impossible-to-confuse with a NAME token
+   once the extractor reads real pre-image file content instead of
+   guessing from diff-line text — see `find_removed_identifiers_precise`.
+   The disclosed line-heuristic limitation (a `#`/quote inside a string
+   literal) disappears the same way, for the same reason.
+2. **The fallback speaks up.** Every time the precise path can't run
+   for a file (no pre/post image; unparseable content), it prints to
+   stderr and falls back to the weaker line heuristic FOR THAT FILE
+   ONLY — never silently. Verified against two real triggers
+   (#4560/#4454, both files deleted entirely by their PR), with a test
+   that asserts the fallback message itself, not just the result.
+3. **The decisive point: the PASSING action is always the correct
+   action.** This gate's pass condition is "touch the doc file in the
+   SAME PR" — even in a false-positive world, the only thing an author
+   does in response is open that doc and confirm it's still accurate.
+   There is no dead end a false positive can walk someone into. Staying
+   warn-only despite that would return to #5003's own founding problem
+   ("the prescription exists, but firing depends on someone's memory").
+
+**Revert condition** (required — a promotion with no way back is a
+one-way door): if a genuine false positive is found in production use,
+`.github/workflows/check-doc-drift.yml`'s job reverts to warn-only
+(annotation, `main()`'s exit code ignored) until the new FP class is
+closed the same structural way as the first two — never by loosening
+`_MIN_IDENTIFIER_LENGTH` or adding another marker-guessing heuristic.
 """
 from __future__ import annotations
 
@@ -616,6 +646,29 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _print_findings_and_exit_code(findings: "list[Finding]", source: str) -> int:
+    """The blocking-gate contract, pulled out as its own small pure-ish
+    function so the exit code — the actual thing a required CI check
+    reads — is directly testable without needing real PR/repo access
+    (see tests/scripts/test_check_doc_drift_5003.py's `test_main_*`
+    cases). 0 clean, 1 on any finding — see module docstring,
+    "Blocking" (promoted #5010)."""
+    if not findings:
+        print(f"OK — no doc-drift findings ({source}).")
+        return 0
+
+    print(f"FAIL — doc-drift findings ({source}):\n")
+    for f in findings:
+        print(f"  {f.identifier!r} removed from src/, still named in {f.doc_path} (untouched by this PR)")
+    print(
+        f"\nTotal: {len(findings)} finding(s). Fix: touch the doc file listed above in "
+        "THIS PR (a removal note, or an update) — that is the correct action whether "
+        "this is a real drift or a coincidental identifier match; see the module "
+        "docstring's 'Blocking' section for why.",
+    )
+    return 1
+
+
 def main(argv: "list[str] | None" = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -634,16 +687,7 @@ def main(argv: "list[str] | None" = None) -> int:
         source = args.fixture
 
     findings = check_doc_drift(diff_text, pr_number=pr_number)
-
-    if not findings:
-        print(f"OK — no doc-drift findings ({source}).")
-        return 0
-
-    print(f"WARN — doc-drift findings ({source}), NOT YET BLOCKING (see module docstring):\n")
-    for f in findings:
-        print(f"  {f.identifier!r} removed from src/, still named in {f.doc_path} (untouched by this PR)")
-    print(f"\nTotal: {len(findings)} finding(s).")
-    return 0  # warn-only — see module docstring "Not yet blocking"
+    return _print_findings_and_exit_code(findings, source)
 
 
 if __name__ == "__main__":

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -31,11 +31,14 @@ THIS diff — it was already gone from src/ before this diff started.
 ## Structural exclusions (syntax only, never semantic judgment)
 
 1. **History-class docs are exempt directories, not a semantic read.**
-   `docs/deep-dives/decisions/` and `docs/deep-dives/journal/` are the
-   places CLAUDE.md's own rules say a name is deliberately preserved after
-   removal (an ADR records what a design USED to be; a journal entry records
-   what happened, and rewriting it changes the record). Exclusion is by
-   DIRECTORY PREFIX — never by asking whether a given file "is" a record.
+   `docs/deep-dives/decisions/`, `docs/deep-dives/journal/`, and
+   `docs/deep-dives/proposals/` are the places CLAUDE.md's own rules (and,
+   for proposals/, that directory's own README) say a name is deliberately
+   preserved after removal (an ADR/proposal records what a design USED to
+   be — every proposal carries its own `Status:` field — and a journal
+   entry records what happened; rewriting any of them changes the record).
+   Exclusion is by DIRECTORY PREFIX — never by asking whether a given file
+   "is" a record.
 2. **Identifier salience floor** (the one tunable knob — see
    `_MIN_IDENTIFIER_LENGTH`). A short, common bare word ("run", "Session")
    removed from one src/ call site is not a distinctive enough token to
@@ -46,24 +49,52 @@ THIS diff — it was already gone from src/ before this diff started.
    long. All three tests are syntactic — none of them reads what the
    identifier means.
 
-## Not yet blocking (architect ruling, #5003)
+## Extraction: precise (tokenizer) path vs line-heuristic fallback
 
-The false-positive rate of this discriminator is UNMEASURED beyond
-lead-coder's own "caught it by hand twice" instances (true-positive side
-only). Per the architect's explicit condition, this check ships in **warn
-mode** (`main` always returns 0) until a calibration pass — `--calibrate`
-below — has been run against a batch of recently-merged PRs and each red
-hit inspected by hand. Flip to blocking only after that count exists; an
-untallied "0 false positives" is indistinguishable from "flags nothing"
-(CLAUDE.md's pre-conclusion checklist, item 5).
+Two ways to decide "what identifiers did this diff remove from a `.py`
+file" exist in this module, and calibration (#5010) is why both do:
+
+- **`find_removed_identifiers_precise`** (architect ruling, #5010 round
+  2) — reads the REAL pre/post file content (`git show <sha>:<path>`)
+  and tokenizes it with Python's own `tokenize` module. A NAME token
+  structurally cannot come from inside a STRING (docstring) or COMMENT
+  token, so this closes the false-positive class calibration actually
+  measured (6 of 9 real-world candidates were docstring-prose words —
+  see git history for the full writeup) with ZERO marker-guessing. Used
+  whenever a PR number is available (`--pr`, or CI).
+- **`find_removed_identifiers`** (the original #5007/#5010-round-1
+  line-heuristic: comment/docstring-marker stripping + regex) — pure
+  over diff TEXT alone, no repository access. Used for `--fixture` mode
+  (no PR to resolve real file content from), and as the PER-FILE
+  FALLBACK when the precise path can't run (a deleted/renamed file has
+  no post-image; unparseable content) — every fallback is printed to
+  stderr, never silently taken.
+
+## Calibration status (#5010) — after the round-2 (precise) rewrite
+
+A backward scan of ~400 merged PRs found 9 real candidates (PRs where
+this discriminator's "touched the doc?" branch actually ran). Hand-
+inspection: 3 CONFIRMED TRUE POSITIVES (`_action_retrieval`, PRs
+#4572/#4567/#4563 — PR #4582's own title: "sweep stale
+action_retrieval.universal_wrappers_enabled refs #4572's own fix scope
+missed", direct evidence a human had to notice and fix what this gate
+would have flagged), 0 false positives after the round-2 rewrite (was
+7/9 with the line-heuristic-only round 1). Still **warn-only**
+(`main` always returns 0) — architect's explicit ruling that "9 is
+enough" or not is a SEPARATE decision from "0 FP among 9", not made
+here. See #5010 for the full writeup and promotion decision.
 """
 from __future__ import annotations
 
 import argparse
+import json
+import keyword
 import re
 import subprocess
 import sys
+import tokenize
 from dataclasses import dataclass
+from io import StringIO
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
@@ -127,37 +158,71 @@ class _FileDiff:
     path: str
     removed_lines: "tuple[str, ...]"
     added_lines: "tuple[str, ...]"
+    # 1-indexed line numbers in the PRE-image (removed) / POST-image
+    # (added) file content — same length/order as removed_lines/
+    # added_lines respectively. Added for #5010 round 2 (the precise,
+    # tokenizer-backed extraction path needs to know which real file
+    # line a removed/added token sits on; see find_removed_identifiers_precise).
+    removed_line_nos: "tuple[int, ...]"
+    added_line_nos: "tuple[int, ...]"
+
+
+_HUNK_HEADER_RE = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 
 
 def _iter_file_diffs(diff_text: str) -> "list[_FileDiff]":
     """Split a unified ``git diff`` / ``gh pr diff`` text into per-file
-    removed/added line buckets. Only the ``+``/``-`` content lines are kept
-    (not the file-header ``+++``/``---`` lines, which this regex excludes
-    by requiring the line not start with ``+++``/``---``)."""
+    removed/added line buckets, tracking each line's real 1-indexed
+    pre-/post-image line number from the hunk headers (``@@ -a,b +c,d @@``).
+    Only the ``+``/``-`` content lines are kept (not the file-header
+    ``+++``/``---`` lines, which this regex excludes by requiring the line
+    not start with ``+++``/``---``)."""
     files: "list[_FileDiff]" = []
     current_path: "str | None" = None
     removed: "list[str]" = []
     added: "list[str]" = []
+    removed_nos: "list[int]" = []
+    added_nos: "list[int]" = []
+    old_line = 0
+    new_line = 0
 
     def _flush() -> None:
         if current_path is not None:
-            files.append(_FileDiff(current_path, tuple(removed), tuple(added)))
+            files.append(_FileDiff(
+                current_path, tuple(removed), tuple(added),
+                tuple(removed_nos), tuple(added_nos),
+            ))
 
     for line in diff_text.splitlines():
         if line.startswith("diff --git "):
             _flush()
-            removed = []
-            added = []
+            removed, added, removed_nos, added_nos = [], [], [], []
+            old_line = new_line = 0
             # "diff --git a/path b/path" — take the b/ side (post-image path,
             # which is what a rename/new-file case still resolves to).
             match = re.match(r"diff --git a/(.+) b/(.+)$", line)
             current_path = match.group(2) if match else None
         elif line.startswith("+++") or line.startswith("---"):
             continue
+        elif line.startswith("\\"):
+            continue  # "\ No newline at end of file" — not a real line
+        elif line.startswith("@@"):
+            hunk = _HUNK_HEADER_RE.match(line)
+            if hunk:
+                old_line = int(hunk.group(1))
+                new_line = int(hunk.group(2))
         elif line.startswith("+"):
             added.append(line[1:])
+            added_nos.append(new_line)
+            new_line += 1
         elif line.startswith("-"):
             removed.append(line[1:])
+            removed_nos.append(old_line)
+            old_line += 1
+        else:
+            # context line — present in both images, advance both counters.
+            old_line += 1
+            new_line += 1
     _flush()
     return files
 
@@ -241,28 +306,145 @@ def _strip_comments_and_docstrings(lines: "tuple[str, ...]") -> "list[str]":
     return out
 
 
+def _removed_identifiers_in_file(fd: "_FileDiff") -> "set[str]":
+    """The LINE-HEURISTIC path (comment/docstring line-stripping + regex)
+    for one file — the #5007 / #5010-round-1 approach. Kept as the
+    FALLBACK for when the precise, tokenizer-backed path
+    (:func:`find_removed_identifiers_precise`) can't run for a file (no
+    pre-image available, or the content doesn't tokenize as valid
+    Python) — never silently dropped, see that function's docstring."""
+    is_py = fd.path.endswith(".py")
+    removed_lines = _strip_comments_and_docstrings(fd.removed_lines) if is_py else list(fd.removed_lines)
+    added_lines = _strip_comments_and_docstrings(fd.added_lines) if is_py else list(fd.added_lines)
+    removed_tokens = {tok for line in removed_lines for tok in _IDENTIFIER_RE.findall(line)}
+    added_tokens = {tok for line in added_lines for tok in _IDENTIFIER_RE.findall(line)}
+    return {tok for tok in removed_tokens - added_tokens if is_salient_identifier(tok)}
+
+
 def find_removed_identifiers(diff_text: str, *, src_prefix: str = "src/") -> "set[str]":
-    """Identifiers this diff removed from ``src/``: tokens present on a
-    removed (``-``) line of a ``src/``-prefixed file, salient (see
-    :func:`is_salient_identifier`), and NOT also present on any added
-    (``+``) line of the SAME file in this diff (a token that moved within
-    the same file's diff was not removed, just relocated). ``#``-comment
-    and docstring text is stripped first for ``.py`` files (see
-    :func:`_strip_comments_and_docstrings`) — prose is not a code
-    identifier."""
+    """Identifiers this diff removed from ``src/``, via the LINE-HEURISTIC
+    path only (:func:`_removed_identifiers_in_file`) — pure over diff text,
+    no repository access. This is what ``--fixture`` mode uses (no PR
+    number to resolve real file content from), and the fallback
+    :func:`find_removed_identifiers_precise` reaches for per-file when the
+    precise path can't run. Prefer :func:`find_removed_identifiers_precise`
+    when a PR number is available — it does not share this function's
+    known false-positive class (docstring/comment prose)."""
     removed_ids: "set[str]" = set()
     for fd in _iter_file_diffs(diff_text):
         if not fd.path.startswith(src_prefix):
             continue
-        is_py = fd.path.endswith(".py")
-        removed_lines = _strip_comments_and_docstrings(fd.removed_lines) if is_py else list(fd.removed_lines)
-        added_lines = _strip_comments_and_docstrings(fd.added_lines) if is_py else list(fd.added_lines)
-        removed_tokens = {tok for line in removed_lines for tok in _IDENTIFIER_RE.findall(line)}
-        added_tokens = {tok for line in added_lines for tok in _IDENTIFIER_RE.findall(line)}
-        for tok in removed_tokens - added_tokens:
+        removed_ids |= _removed_identifiers_in_file(fd)
+    return removed_ids
+
+
+def _name_tokens_by_line(source: str) -> "dict[str, set[int]]":
+    """Pure: map each NAME token (identifier) in *source* to the set of
+    1-indexed line numbers it starts on, via Python's own ``tokenize``
+    module. A NAME token structurally cannot come from inside a STRING
+    (docstring or otherwise) or COMMENT token — the tokenizer resolves
+    quoting correctly by construction, so this closes BOTH gaps the
+    line-heuristic path only approximated: docstring prose (never
+    tokenizes as NAME) and the disclosed ``#``/quote-inside-a-string-
+    literal limitation (no marker-guessing needed at all). Python
+    keywords (``def``, ``class``, ``return``, ...) are excluded — never
+    real removed/added identifiers. Returns ``{}`` if *source* does not
+    tokenize as valid Python (a caller falls back to the line heuristic
+    and logs it — see :func:`find_removed_identifiers_precise`)."""
+    result: "dict[str, set[int]]" = {}
+    try:
+        for tok in tokenize.generate_tokens(StringIO(source).readline):
+            if tok.type == tokenize.NAME and not keyword.iskeyword(tok.string):
+                result.setdefault(tok.string, set()).add(tok.start[0])
+    except (tokenize.TokenError, IndentationError, SyntaxError, OSError):
+        return {}
+    return result
+
+
+def find_removed_identifiers_precise(
+    diff_text: str, repo_root: Path, pre_sha: str, post_sha: str,
+    *, src_prefix: str = "src/",
+) -> "set[str]":
+    """The precise identifier-removal extractor (architect ruling, #5010
+    round 2): for each ``src/`` ``.py`` file in the diff, tokenizes the
+    REAL pre-image and post-image file content (:func:`_file_content_at`,
+    via ``git show``) instead of guessing from diff-line text — the diff
+    only tells us WHICH LINES changed; the real file tells us what those
+    lines actually ARE (code vs. comment vs. docstring), which is what
+    was structurally missing from the line-heuristic path (#5010
+    calibration: 6 of 9 real-world false positives were docstring prose,
+    since #5007's ``#``-only stripper never covered triple-quoted text).
+
+    Falls back to :func:`_removed_identifiers_in_file` (the line
+    heuristic), restricted to one file at a time, when the precise path
+    can't run for that file — no pre-image (e.g. a newly added file has
+    no prior content to diff against) or content that fails to tokenize.
+    Every fallback is printed to stderr; never silently dropped."""
+    removed_ids: "set[str]" = set()
+    for fd in _iter_file_diffs(diff_text):
+        if not fd.path.startswith(src_prefix) or not fd.path.endswith(".py"):
+            continue
+        pre_content = _file_content_at(pre_sha, fd.path, repo_root)
+        post_content = _file_content_at(post_sha, fd.path, repo_root)
+        if pre_content is None or post_content is None:
+            print(
+                f"WARN check_doc_drift: falling back to line heuristic for "
+                f"{fd.path!r} — pre/post file content unavailable at "
+                f"{pre_sha}/{post_sha}",
+                file=sys.stderr,
+            )
+            removed_ids |= _removed_identifiers_in_file(fd)
+            continue
+        pre_tokens = _name_tokens_by_line(pre_content)
+        post_tokens = _name_tokens_by_line(post_content)
+        if not pre_tokens and pre_content.strip():
+            print(
+                f"WARN check_doc_drift: falling back to line heuristic for "
+                f"{fd.path!r} — pre-image did not tokenize as valid Python",
+                file=sys.stderr,
+            )
+            removed_ids |= _removed_identifiers_in_file(fd)
+            continue
+        removed_line_nos = set(fd.removed_line_nos)
+        added_line_nos = set(fd.added_line_nos)
+        removed_here = {name for name, lines in pre_tokens.items() if lines & removed_line_nos}
+        added_here = {name for name, lines in post_tokens.items() if lines & added_line_nos}
+        for tok in removed_here - added_here:
             if is_salient_identifier(tok):
                 removed_ids.add(tok)
     return removed_ids
+
+
+def _file_content_at(sha: str, path: str, repo_root: Path) -> "str | None":
+    """``git show <sha>:<path>`` — the real file content at a specific
+    ref. Returns ``None`` if the ref/path doesn't resolve (most commonly:
+    a newly-added file has no pre-image, so ``pre_sha`` never contained
+    it) rather than raising — the caller treats ``None`` as "fall back to
+    the line heuristic for this file", never as an error to propagate."""
+    result = subprocess.run(
+        ["git", "show", f"{sha}:{path}"], cwd=repo_root, capture_output=True, text=True,
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def resolve_pr_shas(pr_number: int) -> "tuple[str, str]":
+    """(pre_sha, post_sha) — the two refs :func:`find_removed_identifiers_precise`
+    reads real file content from. Prefers the merge commit
+    (``gh pr view --json mergeCommit``): pre = the merge commit's first
+    parent, post = the merge commit itself — the most robust choice for
+    an already-merged PR, since both are guaranteed present in this
+    repo's own local git history (no extra fetch needed). Falls back to
+    ``baseRefOid``/``headRefOid`` for an OPEN PR (no ``mergeCommit`` yet —
+    the live-CI case, where the PR branch is what's checked out)."""
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "mergeCommit,baseRefOid,headRefOid"],
+        capture_output=True, text=True, check=True,
+    )
+    data = json.loads(result.stdout)
+    merge = data.get("mergeCommit")
+    if merge and merge.get("oid"):
+        return f"{merge['oid']}^", merge["oid"]
+    return data["baseRefOid"], data["headRefOid"]
 
 
 def identifier_survives_in_src(identifier: str, src_root: Path) -> bool:
@@ -340,11 +522,27 @@ def check_doc_drift_pure(
 
 def resolve_gone_identifiers(diff_text: str, repo_root: Path) -> "set[str]":
     """Network/filesystem wrapper: identifiers removed from ``src/`` by this
-    diff (:func:`find_removed_identifiers`, pure) that also do not survive
-    anywhere else in the current ``src/`` tree (``git grep``)."""
+    diff, via the LINE-HEURISTIC path (:func:`find_removed_identifiers`),
+    that also do not survive anywhere else in the current ``src/`` tree
+    (``git grep``). Used only when no PR number is available (``--fixture``
+    mode) — prefer :func:`resolve_gone_identifiers_precise` otherwise."""
     return {
         identifier
         for identifier in find_removed_identifiers(diff_text)
+        if not identifier_survives_in_src(identifier, repo_root)
+    }
+
+
+def resolve_gone_identifiers_precise(
+    diff_text: str, repo_root: Path, pre_sha: str, post_sha: str,
+) -> "set[str]":
+    """Network/filesystem wrapper: identifiers removed from ``src/`` by
+    this diff, via the PRECISE (tokenizer-backed) path
+    (:func:`find_removed_identifiers_precise`), that also do not survive
+    anywhere else in the current ``src/`` tree (``git grep``)."""
+    return {
+        identifier
+        for identifier in find_removed_identifiers_precise(diff_text, repo_root, pre_sha, post_sha)
         if not identifier_survives_in_src(identifier, repo_root)
     }
 
@@ -365,12 +563,26 @@ def check_doc_drift(
     diff_text: str,
     *,
     repo_root: Path = _ROOT,
+    pr_number: "int | None" = None,
 ) -> "list[Finding]":
     """End-to-end: wires the network/filesystem wrappers into
     :func:`check_doc_drift_pure`. This is the impure entry point — tests
-    exercise :func:`check_doc_drift_pure` directly with fixture data."""
+    exercise :func:`check_doc_drift_pure` directly with fixture data.
+
+    *pr_number*, when given, resolves real pre/post file content
+    (:func:`resolve_pr_shas`) and uses the PRECISE, tokenizer-backed
+    extraction path (:func:`resolve_gone_identifiers_precise`) — the
+    #5010-round-2 architect ruling: guessing from diff-line text alone
+    (comment/docstring line-stripping) has a real, measured
+    false-positive class the tokenizer path structurally does not.
+    ``None`` (``--fixture`` mode, no PR to resolve shas from) falls back
+    to the line-heuristic path (:func:`resolve_gone_identifiers`)."""
     touched = find_touched_files(diff_text)
-    gone = resolve_gone_identifiers(diff_text, repo_root)
+    if pr_number is not None:
+        pre_sha, post_sha = resolve_pr_shas(pr_number)
+        gone = resolve_gone_identifiers_precise(diff_text, repo_root, pre_sha, post_sha)
+    else:
+        gone = resolve_gone_identifiers(diff_text, repo_root)
     doc_files_by_identifier = resolve_doc_files_by_identifier(gone, repo_root)
     return check_doc_drift_pure(gone, doc_files_by_identifier, touched)
 
@@ -408,6 +620,7 @@ def main(argv: "list[str] | None" = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
+    pr_number = None
     if args.pr is not None:
         try:
             diff_text = fetch_pr_diff(args.pr)
@@ -415,11 +628,12 @@ def main(argv: "list[str] | None" = None) -> int:
             print(f"gh pr diff failed: {exc.stderr}", file=sys.stderr)
             return 2
         source = f"PR #{args.pr}"
+        pr_number = args.pr
     else:
         diff_text = Path(args.fixture).read_text(encoding="utf-8")
         source = args.fixture
 
-    findings = check_doc_drift(diff_text)
+    findings = check_doc_drift(diff_text, pr_number=pr_number)
 
     if not findings:
         print(f"OK — no doc-drift findings ({source}).")

--- a/tests/scripts/test_check_doc_drift_5003.py
+++ b/tests/scripts/test_check_doc_drift_5003.py
@@ -86,8 +86,17 @@ def test_history_class_doc_excludes_journal_dir():
     assert m.is_history_class_doc("docs/deep-dives/journal/2026-01-01-foo.md") is True
 
 
+def test_history_class_doc_excludes_proposals_dir():
+    """Tier 1: real incident (#5010 calibration, PR #4454) — a REAL
+    removed identifier (`_force_close_wrap_up`) was still named in two
+    `docs/deep-dives/proposals/` docs, both carrying their own `Status:
+    cut, landed` field (the directory's own README: proposals are
+    point-in-time design records, same rationale as decisions/)."""
+    assert m.is_history_class_doc("docs/deep-dives/proposals/0045-foo.md") is True
+
+
 def test_history_class_doc_does_not_exclude_ordinary_docs():
-    """Tier 1: a doc outside both exempt directories is not excluded."""
+    """Tier 1: a doc outside all three exempt directories is not excluded."""
     assert m.is_history_class_doc("docs/reference/config/reyn-yaml.md") is False
 
 
@@ -166,6 +175,42 @@ diff --git a/src/reyn/core/x.py b/src/reyn/core/x.py
     ids = m.find_removed_identifiers(diff)
     assert "maybe_compact_messages" in ids
     assert "scaffolding" not in ids
+
+
+def test_find_removed_identifiers_ignores_words_inside_a_removed_docstring():
+    """Tier 1: real incident (#5010 calibration, PR #4459) — a prose word
+    ("normalises") inside a removed multi-line DOCSTRING (not a
+    `#`-comment) must not be extracted as a removed identifier. The
+    original `#`-only stripper (#5007) did not catch this class."""
+    diff = """\
+diff --git a/src/reyn/mcp/adapter.py b/src/reyn/mcp/adapter.py
+--- a/src/reyn/mcp/adapter.py
++++ b/src/reyn/mcp/adapter.py
+@@ -1,5 +1,1 @@
+-    \"\"\"Handler bodies are written against the 2.0
+-    shape (dict-style ``.get(...)``, snake_case), so :class:`_CtxAdapter`
+-    normalises a 1.x pydantic ``Meta`` into a plain dict with the SAME
+-    snake_case keys at adaptation time.
+-    \"\"\"
+"""
+    ids = m.find_removed_identifiers(diff)
+    assert "normalises" not in ids
+    assert "_CtxAdapter" not in ids
+
+
+def test_find_removed_identifiers_still_finds_code_inside_a_docstring_boundary_line():
+    """Tier 1: the docstring stripper only drops TEXT inside the
+    triple-quote span — real code on the opening/closing line itself
+    (before the opening `\"\"\"` or after the closing one) still counts."""
+    diff = """\
+diff --git a/src/reyn/mcp/adapter.py b/src/reyn/mcp/adapter.py
+--- a/src/reyn/mcp/adapter.py
++++ b/src/reyn/mcp/adapter.py
+@@ -1,2 +1,1 @@
+-    maybe_compact_messages(state)  \"\"\"trailing docstring-shaped text\"\"\"
+"""
+    ids = m.find_removed_identifiers(diff)
+    assert "maybe_compact_messages" in ids
 
 
 def test_find_removed_identifiers_excludes_non_salient_short_word():

--- a/tests/scripts/test_check_doc_drift_5003.py
+++ b/tests/scripts/test_check_doc_drift_5003.py
@@ -292,6 +292,23 @@ def test_pure_is_silent_when_no_doc_names_the_identifier():
     assert findings == []
 
 
+def test_exit_code_is_1_on_a_finding():
+    """Tier 1: the blocking-gate contract (#5010 promotion, architect
+    ruling) — a required CI check reads the process exit code, so THIS
+    is the line that actually gates a merge. 0 (warn-only) would let a
+    real drift instance land silently again, #5003's founding problem."""
+    exit_code = m._print_findings_and_exit_code(
+        [m.Finding(identifier="foo_bar_baz", doc_path="docs/x.md")], "test-source",
+    )
+    assert exit_code == 1
+
+
+def test_exit_code_is_0_when_clean():
+    """Tier 1: no findings → exit 0, the merge is not blocked."""
+    exit_code = m._print_findings_and_exit_code([], "test-source")
+    assert exit_code == 0
+
+
 def test_pure_only_flags_the_untouched_doc_among_several():
     """Tier 1: an identifier named in two docs, one touched one not — only
     the untouched one is flagged."""

--- a/tests/scripts/test_check_doc_drift_5003.py
+++ b/tests/scripts/test_check_doc_drift_5003.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import importlib.util
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
 from tests._support.paths import REPO_ROOT
 
@@ -347,3 +349,157 @@ def test_find_doc_files_containing_excludes_history_class_dir(tmp_path):
     subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
     found = m.find_doc_files_containing("maybe_compact_messages", repo)
     assert found == {"docs/reference/pipeline.md"}
+
+
+# ---------------------------------------------------------------------------
+# _name_tokens_by_line — pure, tokenizer-backed identifier extraction
+# (#5010 round 2, architect ruling)
+# ---------------------------------------------------------------------------
+
+
+def test_name_tokens_by_line_finds_real_code_names():
+    """Tier 1: a NAME token (def/assignment) is captured with its line."""
+    source = "def foo_bar_baz():\n    x = 1\n"
+    tokens = m._name_tokens_by_line(source)
+    assert 1 in tokens["foo_bar_baz"]
+    assert 2 in tokens["x"]
+
+
+def test_name_tokens_by_line_ignores_docstring_prose():
+    """Tier 1: the central #5010-round-2 fix — a word inside a triple-
+    quoted docstring is NEVER a NAME token, unlike the line-heuristic
+    path which could only approximate this with marker-toggling."""
+    source = '"""This word normalises the input."""\n'
+    tokens = m._name_tokens_by_line(source)
+    assert "normalises" not in tokens
+
+
+def test_name_tokens_by_line_ignores_comment_prose():
+    """Tier 1: a `#`-comment word is never a NAME token either."""
+    source = "x = 1  # scaffolding note\n"
+    tokens = m._name_tokens_by_line(source)
+    assert "scaffolding" not in tokens
+    assert 1 in tokens["x"]
+
+
+def test_name_tokens_by_line_ignores_keywords():
+    """Tier 1: `def`/`return`/`None` are Python keywords, never real
+    removed/added identifiers — excluded even though they tokenize as
+    NAME-shaped."""
+    source = "def foo():\n    return None\n"
+    tokens = m._name_tokens_by_line(source)
+    assert "def" not in tokens
+    assert "return" not in tokens
+    assert "None" not in tokens  # a keyword since Python 3
+
+
+def test_name_tokens_by_line_returns_empty_on_invalid_python():
+    """Tier 1: unparseable content is a disclosed no-signal case, not a
+    crash — the caller falls back to the line heuristic."""
+    tokens = m._name_tokens_by_line("def (:::\n")
+    assert tokens == {}
+
+
+# ---------------------------------------------------------------------------
+# find_removed_identifiers_precise — the precise, git-show + tokenize path
+# (#5010 round 2). Real temp git repo with 2 commits (pre/post), exercising
+# the actual mechanism this PR adds, not a mocked stand-in.
+# ---------------------------------------------------------------------------
+
+
+def _commit_file(repo, rel_path, content, message):
+    path = repo / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", message], cwd=repo, check=True)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def test_find_removed_identifiers_precise_resolves_the_docstring_boundary_case():
+    """Tier 1: the REAL regression this round fixes — a docstring word
+    ("normalises") whose OPENING `\"\"\"` sits on a line the diff hunk
+    didn't carry (so the line-heuristic path, operating on diff text
+    alone, cannot see it's inside a docstring) is correctly excluded by
+    the precise path, because it reads the real pre-image file and
+    tokenizes it directly — no hunk-boundary blind spot is possible."""
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        _init_repo(repo)
+        pre_sha = _commit_file(
+            repo, "src/reyn/mcp/adapter.py",
+            '"""Docstring intro paragraph that stays.\n\n'
+            'Handler bodies are written against 2.0, so _CtxAdapter\n'
+            'normalises the input at adaptation time.\n"""\n'
+            'def real_fn():\n    pass\n',
+            "pre",
+        )
+        post_sha = _commit_file(
+            repo, "src/reyn/mcp/adapter.py",
+            '"""Docstring intro paragraph that stays.\n"""\n'
+            'def real_fn():\n    pass\n',
+            "post",
+        )
+        diff = subprocess.run(
+            ["git", "diff", pre_sha, post_sha], cwd=repo, capture_output=True, text=True, check=True,
+        ).stdout
+        gone = m.find_removed_identifiers_precise(diff, repo, pre_sha, post_sha)
+        assert "normalises" not in gone
+        assert "_CtxAdapter" not in gone
+
+
+def test_find_removed_identifiers_precise_still_finds_a_real_removed_function():
+    """Tier 1: a genuinely removed function definition IS found by the
+    precise path (not just "everything gets excluded")."""
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        _init_repo(repo)
+        pre_sha = _commit_file(
+            repo, "src/reyn/core/x.py",
+            "def action_retrieval_helper():\n    pass\n\n\ndef stays():\n    pass\n",
+            "pre",
+        )
+        post_sha = _commit_file(
+            repo, "src/reyn/core/x.py",
+            "def stays():\n    pass\n",
+            "post",
+        )
+        diff = subprocess.run(
+            ["git", "diff", pre_sha, post_sha], cwd=repo, capture_output=True, text=True, check=True,
+        ).stdout
+        gone = m.find_removed_identifiers_precise(diff, repo, pre_sha, post_sha)
+        assert "action_retrieval_helper" in gone
+
+
+def test_find_removed_identifiers_precise_falls_back_and_logs_when_file_deleted(capsys):
+    """Tier 1: real incident (#5010 round 2, PR #4560/#4454) — a file
+    deleted entirely by the diff has no post-image; the precise path
+    must fall back to the line heuristic for that file AND print a
+    fallback warning (never silently drop to a weaker path)."""
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        _init_repo(repo)
+        pre_sha = _commit_file(
+            repo, "src/reyn/tools/gone_file.py",
+            "def deleted_entirely_marker_fn():\n    pass\n",
+            "pre",
+        )
+        (repo / "src/reyn/tools/gone_file.py").unlink()
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "delete file"], cwd=repo, check=True)
+        post_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        diff = subprocess.run(
+            ["git", "diff", pre_sha, post_sha], cwd=repo, capture_output=True, text=True, check=True,
+        ).stdout
+        gone = m.find_removed_identifiers_precise(diff, repo, pre_sha, post_sha)
+        assert "deleted_entirely_marker_fn" in gone  # fallback path still finds it
+        captured = capsys.readouterr()
+        assert "falling back to line heuristic" in captured.err
+        assert "gone_file.py" in captured.err


### PR DESCRIPTION
> 🔴🔴 **訂正 v2（lead-coder、2026-08-21、★merge 後）**
> ★ **── ★★私が 先に貼った 訂正 v1 は ★★偽でした。★v1 を 撤回し、★これに 置き換えます。**
>
> ```
> 🔴 ★v1 で 私が 書いたこと ──「`_action_retrieval` の 1 件は ★FALSE POSITIVE」
>    ── ★★偽です ── ★★#4572 は ★真の TRUE POSITIVE
> ✅ ★実測（architect、★merge commit `46a8bf1c3`）
>    ★`git grep -c "_action_retrieval" 46a8bf1c3^ -- src/` → ★★10
>    ★`git grep -c "_action_retrieval" 46a8bf1c3  -- src/` → ★★0
>    ★`git show --stat 46a8bf1c3 | grep -c session-construction.md` → ★★0
>    ★その時点の doc:313 ──「… ★★DRIVES whether … ★★IS preserved」── ★★現在形
>    ∴ ★★当時 doc は ★偽 ── ★★TRUE POSITIVE
> 🔴 ★私の誤りの 形 ── ★★時制と 時点の 混同
>    ── ★今の doc が 正確なのは ★★#4582 が ★後から 直したから
>    ── ★★「今 正確」を「★当時も 正確」と 読みました
> ```
>
> ★ **✅ ★★それでも ★昇格の撤回は ★正しく、★変わりません。**
>
> ```
> ★撤回の理由は ★★数では ありません
>    ──「★★もう直っている doc に ★編集を 要求する」★構造
>    ── ★★TP が 何件 あっても ★変わりません
> ⚠️ ★FP は ★較正集合の中の 実例では なく ── ★★構造から 導かれる ★将来の 1 例:
>    ★「★今日 merge される PR が ★★既に歴史的な 識別子を 消したとき
>      ★★有効な直し方が 無い」── ★★それが 行き止まり
> ★較正集合の 3 件 ── ★#4572 は ★実測で TP／★#4567・#4563 は ★★未測定
> ```
>
> ✅ **★昇格は `5020` で 取り消され、★warn-only に 戻っています（★main で 実測済）。**
> ⚪ **★下記の本文は ★当時の判断の記録として ★そのまま 残します。**

---

**[e2e-coder]** — part of #5010

## Promoted to blocking (architect ruling, 2026-08-21)

**This is not "0/9 → safe."** With only 9 real-world trials, 0 observed
false positives barely constrains the true rate at all (a loose read:
"probably under ~30%" — treating 0/9 as a safety guarantee would be a
counting-error, the exact shape CLAUDE.md's pre-conclusion checklist
warns against). The promotion rests on three STRUCTURAL points instead,
none of them a count:

1. **The false-positive CLASS was eliminated, not merely unobserved.**
   Round 2's rewrite (`find_removed_identifiers_precise`) reads real
   pre/post file content and tokenizes it — a NAME token structurally
   cannot come from inside a STRING (docstring) or COMMENT token, so
   both real FP classes calibration found (comment prose, docstring
   prose) are impossible by construction, not just unlucky-not-to-hit.
2. **The fallback speaks up.** Every time the precise path can't run
   for a file, it prints to stderr and falls back to the line heuristic
   for THAT FILE ONLY — never silent. Verified against two real
   triggers (#4560/#4454, both files deleted entirely by their PR), and
   the test (`test_find_removed_identifiers_precise_falls_back_and_logs_when_file_deleted`)
   asserts the fallback MESSAGE itself, not just the downstream result
   — the shape #4991's own incident (a silent fallback) needed and
   didn't have.
3. **The decisive point: the passing action is always the correct
   action.** This gate's pass condition is "touch the doc file in the
   SAME PR" — even in a false-positive world, the only thing an author
   does in response is open that doc and confirm it still holds. There
   is no dead end a false positive can walk someone into. Staying
   warn-only despite that returns to #5003's own founding problem: "the
   prescription exists, but firing depends on someone's memory."

## What changed in this PR (mechanical)

- `main()`'s finding-branch (extracted to `_print_findings_and_exit_code`
  for direct testability) now returns **1** on any finding, not 0.
- `check-doc-drift.yml`: the job now propagates the script's real exit
  code instead of always `exit 0`; findings surface as `::error::`
  annotations (was `::warning::`); job name drops "(warn-only)".
- **Revert condition, written into the yml itself** (a promotion with
  no way back is one-way): if a genuine false positive is found in
  production, revert the final step to `set +e` / always `exit 0` /
  `::warning::` (git history has the prior shape) until the new FP
  class is closed the same STRUCTURAL way as the first two — never by
  loosening `_MIN_IDENTIFIER_LENGTH` or another marker-guessing
  heuristic.
- Module docstring's "Not yet blocking" section rewritten to "Blocking"
  with the three-point argument above and the revert condition.

## Test plan

- [x] `pytest tests/scripts/test_check_doc_drift_5003.py` — 34/34 green
      (2 new: `test_exit_code_is_1_on_a_finding` /
      `test_exit_code_is_0_when_clean`, pinning the actual gate contract)
- [x] Strip-falsify the exit-code change (reverted to `return 0`) — red
      for the right reason, restored green
- [x] Manually verified end-to-end against real PRs: `--pr 4572` (a
      confirmed true positive still present in current docs) → exit 1;
      `--pr 5014` (this PR itself, clean) → exit 0
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict ...` — 34/34 OK
- [x] `python scripts/verify_module_docstrings.py scripts/check_doc_drift.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (203 findings, all baselined)
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] Workflow YAML round-tripped through PyYAML before push
- [ ] (skipped — no docs/ changes in this PR; doc gates not applicable)

---

<details>
<summary>Round 1 + round 2 history (collapsed, unchanged from before promotion)</summary>

Backward scan of ~400 merged PRs found 9 real candidates (PRs where the
"touched the doc?" branch actually ran). Round 1 (line-heuristic
comment/docstring stripping + a 3rd structural exclusion for
`docs/deep-dives/proposals/`) resolved 4/7 false positives. Round 2
(precise, tokenizer-backed extraction reading real pre/post file
content via `git show`) resolved the remaining 3/9 and surfaced a 3rd
true positive. Full detail in this PR's earlier revisions / #5010's
comment history.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


