### PR TITLE
feat(#5009): declare whether cache-hit accounting is actually reported

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1387,7 +1387,7 @@ def cost_pane_lines(snap: "dict | None") -> list[str]:
         f"tokens   prompt {p:,} · completion {c:,} · total {agent_tokens:,}",
         _cache_hit_line(
             "cache", cached, p, note="cumulative",
-            reported=snap.get("cache_usage_reported", True),
+            reported=snap.get("cache_usage_reported", False),
         ),
     ]
     # #3695: the status row can only afford a mark; this pane has room to say
@@ -1457,7 +1457,7 @@ def ctx_pane_lines(snap: "dict | None") -> list[str]:
         # started in a different place from the five around it.
         _cache_hit_line(
             f"{'cache':<{_CTX_LABEL_W}}", recent_cached, recent_prompt,
-            reported=snap.get("cache_usage_reported", True),
+            reported=snap.get("cache_usage_reported", False),
         ),
         f"compaction   {comp_est:,} / {comp_trigger:,} tokens est.  ({comp_pct}% to trigger)",
     ]

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1149,10 +1149,21 @@ def _ctx_bar(used: int, window: int, *, cells: int = 24) -> str:
     return "▓" * filled + "░" * (cells - filled)
 
 
-def _cache_hit_line(label: str, cached: int, prompt: int, *, note: str = "") -> str:
+def _cache_hit_line(
+    label: str, cached: int, prompt: int, *, note: str = "", reported: bool = True,
+) -> str:
     """One ``cache X% hit (a / b prompt tokens)`` line, label padded to the same
     9-char column every other cost/ctx line uses (it was misaligned when the label
-    itself carried the qualifier, e.g. ``"cache (cumulative)"``)."""
+    itself carried the qualifier, e.g. ``"cache (cumulative)"``).
+
+    ``reported`` (#5009, ``snap["cache_usage_reported"]``): a REMOTE client's
+    ``cached``/``prompt`` are always ``0`` (cache-hit accounting is
+    session-local, never on the AG-UI wire) — indistinguishable on their own
+    from a genuine 0% hit rate. ``False`` here renders an explicit "not
+    reported" line instead of computing a percentage off zeros, so this
+    reads as "unavailable", never as a fabricated real 0%."""
+    if not reported:
+        return f"{label:<9}not reported on this connection"
     pct = round(100 * cached / prompt) if prompt > 0 else 0
     tail = f", {note}" if note else ""
     return f"{label:<9}{pct}% hit ({cached:,} / {prompt:,} prompt tokens{tail})"
@@ -1374,7 +1385,10 @@ def cost_pane_lines(snap: "dict | None") -> list[str]:
     rows = [
         *_cost_breakdown_table(snap),
         f"tokens   prompt {p:,} · completion {c:,} · total {agent_tokens:,}",
-        _cache_hit_line("cache", cached, p, note="cumulative"),
+        _cache_hit_line(
+            "cache", cached, p, note="cumulative",
+            reported=snap.get("cache_usage_reported", True),
+        ),
     ]
     # #3695: the status row can only afford a mark; this pane has room to say
     # what the mark means and how much of the total is unaccounted for. Absent
@@ -1441,7 +1455,10 @@ def ctx_pane_lines(snap: "dict | None") -> list[str]:
         # Label column widened to match its neighbours — it was four spaces
         # where every other label is seven, so the one line about the cache
         # started in a different place from the five around it.
-        _cache_hit_line(f"{'cache':<{_CTX_LABEL_W}}", recent_cached, recent_prompt),
+        _cache_hit_line(
+            f"{'cache':<{_CTX_LABEL_W}}", recent_cached, recent_prompt,
+            reported=snap.get("cache_usage_reported", True),
+        ),
         f"compaction   {comp_est:,} / {comp_trigger:,} tokens est.  ({comp_pct}% to trigger)",
     ]
 

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -80,18 +80,48 @@ class ChatReadModelCapabilities:
     of underlying state (the wire-frame-sufficiency boundary those methods'
     own docstrings already document).
 
+    ``cache_usage_reported`` (#5009, architect co-vet) is the one field
+    NOT named after a :class:`ChatReadModel` method — it covers two
+    ``snapshot()`` dict KEYS instead (``session_cached_tokens`` /
+    ``ctx_recent_usage``), which carry the identical undeclared-``0``
+    conflation this class exists to close, just one level down (inside
+    the dict a supported METHOD returns, rather than the method itself).
+    First tried as a hand-typed literal directly in the two ``snapshot()``
+    producers (``status.py`` / ``project_remote_snapshot``) — measured to
+    be the WRONG container: a hand-typed literal can be forgotten
+    silently, with no construction-time failure to catch it, exactly the
+    defect this class exists to prevent. Declaring it HERE instead means
+    a producer that forgets it fails to construct, like every other
+    field — see :func:`project_remote_snapshot` and ``status.py``'s
+    ``_snapshot()`` for how each producer reads its own value from here
+    rather than typing the literal a second time.
+
     **Witness① scope, stated honestly (lead-coder/architect co-vet on
     #4996):** this dataclass's "forgets a field fails to construct"
     guarantee covers exactly ONE failure mode — a NEW
-    :class:`ChatReadModel` implementation that omits one of these 6 already-
-    declared fields. It is NOT a 1:1 gate over every :class:`ChatReadModel`
-    method: ``snapshot()`` and ``history_path()`` work identically on a
-    remote client and correctly have NO field here — a mechanical "one field
-    per abstract method" mapping would be a false invariant, not a stronger
-    one. If a 7th degradable method is ever added to :class:`ChatReadModel`,
-    THIS dataclass will not fail to construct until a human also adds a
-    field for it here; that step is not, and cannot be, machine-enforced by
-    this class alone.
+    :class:`ChatReadModel` implementation that omits one of these
+    already-declared fields. It is NOT a 1:1 gate over every
+    :class:`ChatReadModel` method: ``snapshot()`` and ``history_path()``
+    work identically on a remote client and correctly have NO field
+    here — a mechanical "one field per abstract method" mapping would be
+    a false invariant, not a stronger one. If a further degradable
+    method or snapshot key is ever added, THIS dataclass will not fail
+    to construct until a human also adds a field for it here; that step
+    is not, and cannot be, machine-enforced by this class alone.
+
+    **A DIFFERENT gap this class does NOT close** (#5009's own
+    falsified first attempt, kept here as the record): a *snapshot dict*
+    that is genuinely ``None``/``{}`` (no read yet — e.g. before mount's
+    first frame) and a *snapshot dict missing a declared key* both
+    normalize to the same empty shape at a naive consumer that does
+    ``snap = snap or {}`` before indexing — bare-indexing the resulting
+    dict cannot tell "nothing to show yet" from "an implementation
+    forgot to populate this key from its own declaration". This
+    dataclass closes the SECOND gap (a producer that forgets to consult
+    its own declaration now fails to construct); the FIRST is a
+    consumer-side concern the reading pane itself must still handle
+    (``snap.get(key, False)`` — false, never true, is the safe direction
+    when there is nothing to consult at all).
 
     **A declaration is an assertion, not an observation** (architect
     co-vet, #5000 — the same limitation ``AxisEnforcementDeclaration``
@@ -110,6 +140,21 @@ class ChatReadModelCapabilities:
     has_command_ui_region: bool
     conversation_history: bool
     load_older_conversation_history: bool
+    cache_usage_reported: bool
+
+
+def cache_usage_reported_snapshot_key(
+    capabilities: ChatReadModelCapabilities,
+) -> "dict[str, bool]":
+    """The ``snapshot()`` dict fragment for :attr:`ChatReadModelCapabilities.
+    cache_usage_reported` — the ONE source both ``snapshot()`` producers
+    (``status.py``'s ``_snapshot()`` and :func:`project_remote_snapshot`)
+    merge in, instead of each hand-typing the literal a second time (#5009,
+    architect co-vet: two producers hand-typing the same bit independently
+    is exactly one more way to silently diverge — one helper, called from
+    both, is the #4996-family fix: derive from the SSoT, don't duplicate
+    the literal)."""
+    return {"cache_usage_reported": capabilities.cache_usage_reported}
 
 
 #: :class:`RegistryReadModel` is local — every degradable read reflects real,
@@ -122,6 +167,7 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     has_command_ui_region=True,
     conversation_history=True,
     load_older_conversation_history=True,
+    cache_usage_reported=True,
 )
 
 #: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these 6
@@ -135,6 +181,7 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     has_command_ui_region=False,
     conversation_history=False,
     load_older_conversation_history=False,
+    cache_usage_reported=False,
 )
 
 
@@ -453,21 +500,22 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # #5009: `0` above is the correct graceful-degrade VALUE for both cache
         # figures (neither is projected onto the AG-UI wire — cache-hit
         # accounting is session-local, like the other keys in this block) —
-        # this key is the missing DECLARATION half: `0` is indistinguishable
-        # from a genuine 0% cache-hit rate on its own (#4996's own conflation,
-        # re-opened on the KEY axis rather than the METHOD axis #4996 covered
-        # — architect's own design gap, not a new bug class). Consulted by
-        # `chrome.py`'s `_cache_hit_line` so BOTH panes reading these 2 keys
-        # (Cost pane's cumulative line, Ctx pane's recent-call line) render a
-        # "not reported" line instead of a fabricated "0% hit (0 / 0)" — the
-        # same wording that would come from a real, empty session.
+        # the missing DECLARATION half lives on REMOTE_CHAT_READ_CAPABILITIES
+        # itself (derived here via cache_usage_reported_snapshot_key, never
+        # hand-typed a second time — architect co-vet: two producers
+        # hand-typing the same bit independently is one more way to
+        # silently diverge). Consulted by `chrome.py`'s `_cache_hit_line`
+        # so BOTH panes reading these 2 keys (Cost pane's cumulative line,
+        # Ctx pane's recent-call line) render a "not reported" line instead
+        # of a fabricated "0% hit (0 / 0)" — the same wording that would
+        # come from a real, empty session.
         #
         # Scope, explicit (architect, #5009): this is NOT the owner's actual
         # "cache stuck at 0%" observation — that was measured on a LOCAL
         # session (owner-confirmed) and is a separate, still-unresolved
         # symptom this key does not touch. This key only makes the REMOTE
         # "0 could mean unsupported" case honestly say so.
-        "cache_usage_reported": False,
+        **cache_usage_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES),
         "ctx_source": "remote",
         "ctx_compaction_status_fn": None,
         # #3283 ④: the keyed per-turn cost/token lookup is a SESSION-local read

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -450,6 +450,24 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         "usage": (0, 0, v.get("agent_tokens", 0)),
         "session_cached_tokens": 0,
         "ctx_recent_usage": (0, 0),
+        # #5009: `0` above is the correct graceful-degrade VALUE for both cache
+        # figures (neither is projected onto the AG-UI wire — cache-hit
+        # accounting is session-local, like the other keys in this block) —
+        # this key is the missing DECLARATION half: `0` is indistinguishable
+        # from a genuine 0% cache-hit rate on its own (#4996's own conflation,
+        # re-opened on the KEY axis rather than the METHOD axis #4996 covered
+        # — architect's own design gap, not a new bug class). Consulted by
+        # `chrome.py`'s `_cache_hit_line` so BOTH panes reading these 2 keys
+        # (Cost pane's cumulative line, Ctx pane's recent-call line) render a
+        # "not reported" line instead of a fabricated "0% hit (0 / 0)" — the
+        # same wording that would come from a real, empty session.
+        #
+        # Scope, explicit (architect, #5009): this is NOT the owner's actual
+        # "cache stuck at 0%" observation — that was measured on a LOCAL
+        # session (owner-confirmed) and is a separate, still-unresolved
+        # symptom this key does not touch. This key only makes the REMOTE
+        # "0 could mean unsupported" case honestly say so.
+        "cache_usage_reported": False,
         "ctx_source": "remote",
         "ctx_compaction_status_fn": None,
         # #3283 ④: the keyed per-turn cost/token lookup is a SESSION-local read

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -467,6 +467,11 @@ def _snapshot(registry, config=None):
         "ctx_source": ctx_source,
         "session_cached_tokens": u.cached_tokens,
         "ctx_recent_usage": (recent.prompt_tokens, recent.cached_tokens),
+        # #5009: LOCAL genuinely measures both cache figures above (the
+        # `u`/`recent` reads are real Session state) — see
+        # ``project_remote_snapshot``'s own comment for the key this pairs
+        # with on the remote side.
+        "cache_usage_reported": True,
         "ctx_compaction_status_fn": ctx_compaction_status_fn,
         "cron_jobs": _extract_cron_jobs(config) if config is not None else [],
         "mcp_servers": _extract_mcp_servers(config) if config is not None else [],

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -351,6 +351,20 @@ def _session_pipelines(session) -> list[dict]:
         return []
 
 
+def _cache_usage_reported_key() -> "dict[str, bool]":
+    """LOCAL's own `{"cache_usage_reported": True}` — a thin wrapper around
+    ``read_model.py``'s ``cache_usage_reported_snapshot_key`` (#5009) that
+    carries the LAZY import (see the call site's own comment for why: this
+    module is imported BY ``read_model.py``'s own top level, so the reverse
+    reference must not be)."""
+    from reyn.interfaces.repl.read_model import (  # noqa: PLC0415
+        LOCAL_CHAT_READ_CAPABILITIES,
+        cache_usage_reported_snapshot_key,
+    )
+
+    return cache_usage_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES)
+
+
 def _snapshot(registry, config=None):
     """Read live status values off the attached session via sync accessors."""
     s = registry.attached_session()
@@ -468,10 +482,14 @@ def _snapshot(registry, config=None):
         "session_cached_tokens": u.cached_tokens,
         "ctx_recent_usage": (recent.prompt_tokens, recent.cached_tokens),
         # #5009: LOCAL genuinely measures both cache figures above (the
-        # `u`/`recent` reads are real Session state) — see
-        # ``project_remote_snapshot``'s own comment for the key this pairs
-        # with on the remote side.
-        "cache_usage_reported": True,
+        # `u`/`recent` reads are real Session state). Derived from
+        # LOCAL_CHAT_READ_CAPABILITIES via cache_usage_reported_snapshot_key,
+        # never hand-typed here directly — see that helper's own docstring
+        # for why (two producers hand-typing the same bit independently is
+        # one more way to silently diverge). Local import: read_model.py
+        # imports `_snapshot` from this module at its own top level, so the
+        # reverse import must stay lazy to avoid a cycle.
+        **_cache_usage_reported_key(),
         "ctx_compaction_status_fn": ctx_compaction_status_fn,
         "cron_jobs": _extract_cron_jobs(config) if config is not None else [],
         "mcp_servers": _extract_mcp_servers(config) if config is not None else [],

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -112,14 +112,14 @@ class QueueTransport(ClientTransport):
 
 
 def test_capabilities_dataclass_rejects_a_missing_field():
-    """Tier 1: omitting any one of the 6 required fields fails to
+    """Tier 1: omitting any one of the required fields fails to
     CONSTRUCT — a ``TypeError``, not a silently-defaulted ``False``. Mirrors
     ``AxisEnforcementDeclaration``'s own witness verbatim.
 
     Positive control (architect co-vet on #5000): without it, this test
     alone would ALSO go green after a field is renamed or deleted — an
     unknown ``kwarg`` raises the identical ``TypeError``, same red, wrong
-    reason. Constructing with all 6 fields present, right here, is what
+    reason. Constructing with every field present, right here, is what
     lets this test claim the ``TypeError`` above is caused by the MISSING
     field specifically, not by some other construction failure."""
     ChatReadModelCapabilities(
@@ -129,6 +129,7 @@ def test_capabilities_dataclass_rejects_a_missing_field():
         has_command_ui_region=True,
         conversation_history=True,
         load_older_conversation_history=True,
+        cache_usage_reported=True,
     )
     with pytest.raises(TypeError):
         ChatReadModelCapabilities(  # type: ignore[call-arg]
@@ -137,13 +138,14 @@ def test_capabilities_dataclass_rejects_a_missing_field():
             pending_command_ui=True,
             has_command_ui_region=True,
             conversation_history=True,
-            # load_older_conversation_history omitted
+            load_older_conversation_history=True,
+            # cache_usage_reported omitted
         )
 
 
-def test_capabilities_dataclass_has_exactly_the_6_declared_fields():
-    """Tier 1: pins the declared vocabulary itself — the 6 names #4996's
-    own issue enumerated, no more, no fewer. A regression here is a
+def test_capabilities_dataclass_has_exactly_the_declared_fields():
+    """Tier 1: pins the declared vocabulary itself — the field names #4996
+    and #5009 enumerated, no more, no fewer. A regression here is a
     silent widening/narrowing of what's declared, not a missing-field bug
     (that's the test above).
 
@@ -152,7 +154,11 @@ def test_capabilities_dataclass_has_exactly_the_6_declared_fields():
     transcription of the field list and would need editing in the SAME PR
     as any real rename anyway (CLAUDE.md's 6-questions, #2: "is it the
     implementation, transcribed?"). Kept as an explicit, readable pin of
-    the vocabulary itself, not as a second guard."""
+    the vocabulary itself, not as a second guard.
+
+    ``cache_usage_reported`` (#5009) is the one field NOT named after a
+    ``ChatReadModel`` method — see the class's own docstring for why it
+    lives here anyway."""
     names = {f.name for f in fields(ChatReadModelCapabilities)}
     assert names == {
         "completion_session",
@@ -161,6 +167,7 @@ def test_capabilities_dataclass_has_exactly_the_6_declared_fields():
         "has_command_ui_region",
         "conversation_history",
         "load_older_conversation_history",
+        "cache_usage_reported",
     }
 
 

--- a/tests/interfaces/test_5009_cache_reported_declaration.py
+++ b/tests/interfaces/test_5009_cache_reported_declaration.py
@@ -1,0 +1,142 @@
+"""Tier 1/2: #5009 — cache-hit accounting declares WHETHER it is reported,
+so ``0`` on a remote client can't be misread as a real 0% hit rate.
+
+Re-opens #4996's own conflation on a DIFFERENT axis. #4996 declared
+whether a whole `ChatReadModel` METHOD is supported; this issue is about
+two SNAPSHOT KEYS (`session_cached_tokens` / `ctx_recent_usage`) inside
+`snapshot()`'s own dict — a `RemoteReadModel` always returns `0`/`(0, 0)`
+for both (cache-hit accounting is session-local, never on the AG-UI wire),
+indistinguishable on their own from a genuine empty/zero session.
+
+Architect's ruling (co-vet on this issue, in response to a scope question
+asked before implementing): fix the KEY, not the PANE — splitting the fix
+by which pane reads the key would repeat the exact mistake this issue
+names (declaring by implementation/render boundary instead of by the
+actual shared fact). `session_cached_tokens` and `ctx_recent_usage` are
+ONE fact (cache accounting is or isn't reported on this connection) read
+by TWO panes (Cost pane's cumulative line, Ctx pane's last-call line) —
+one declaration, `snap["cache_usage_reported"]`, both consumers.
+
+Explicit scope (architect): only these 2 keys. The other 9 session-local
+`project_remote_snapshot` keys stay undeclared, filed on #5009 itself for
+later, not folded in here. This PR also does NOT touch the owner's
+actual "cache stuck at 0%" report — that was measured on a LOCAL session
+(owner-confirmed) and turned out to be a separate, since-resolved
+display issue (#5011, the single-sample-as-percentage shape), not this
+one.
+
+Witness② (lead-coder/architect: "at least 1 location draws differently,
+2 is even better; splitting into a pane-scoped fix would leave the OTHER
+pane still lying") — both consuming panes are tested, each with the
+unreported (marker, not a fabricated 0%) and the reported (accept-side,
+unchanged real percentage) case.
+
+Real `RegistryReadModel`/`RemoteReadModel`-shaped snapshot construction
+(`project_remote_snapshot` directly, and a real local snapshot via
+`test_3338`'s own `_real_snapshot` helper) — no mocks.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.chrome import cost_pane_lines, ctx_pane_lines
+from reyn.interfaces.repl.read_model import (
+    LOCAL_CHAT_READ_CAPABILITIES,
+    REMOTE_CHAT_READ_CAPABILITIES,
+    project_remote_snapshot,
+)
+
+
+def test_remote_snapshot_declares_cache_usage_unreported():
+    """Tier 1: the declaration itself — a remote snapshot always says
+    `cache_usage_reported: False`, paired with the graceful `0`/`(0, 0)`
+    values those same 2 keys already carried."""
+    snap = project_remote_snapshot({})
+    assert snap["cache_usage_reported"] is False
+    assert snap["session_cached_tokens"] == 0
+    assert snap["ctx_recent_usage"] == (0, 0)
+
+
+def test_capabilities_declarations_are_unaffected_by_this_key():
+    """Tier 1: pins that #5009 is a SNAPSHOT-key declaration, layered
+    alongside #4996's METHOD-level `ChatReadModelCapabilities` — not a
+    replacement for it. Both declarations exist independently on their
+    respective read models."""
+    assert LOCAL_CHAT_READ_CAPABILITIES.conversation_history is True
+    assert REMOTE_CHAT_READ_CAPABILITIES.conversation_history is False
+
+
+def test_cost_pane_shows_not_reported_instead_of_a_fabricated_zero_percent():
+    """Tier 2: witness② path ① (Cost pane). Strip-falsifier: reverting
+    `_cache_hit_line`'s `reported` gate turns this red — the pane would
+    show `0% hit (0 / 0 prompt tokens, cumulative)`, indistinguishable
+    from a genuine empty session."""
+    snap = {
+        "usage": (0, 0, 0),
+        "agent_tokens": 0,
+        "session_cached_tokens": 0,
+        "cache_usage_reported": False,
+    }
+    blob = "\n".join(cost_pane_lines(snap))
+    assert "not reported on this connection" in blob, blob
+    assert "0% hit" not in blob, (
+        f"a fabricated 0% must not appear when reporting is declared "
+        f"unavailable:\n{blob}"
+    )
+
+
+def test_cost_pane_still_shows_a_real_percentage_when_reported():
+    """Tier 2: accept-side for the Cost pane — a genuinely reported,
+    non-zero cache figure renders exactly as before this issue. Without
+    this, an "always show not-reported" implementation would pass the
+    test above vacuously."""
+    snap = {
+        "usage": (12345, 6789, 19134),
+        "agent_tokens": 19134,
+        "session_cached_tokens": 5180,
+        "cache_usage_reported": True,
+    }
+    blob = "\n".join(cost_pane_lines(snap))
+    assert "42% hit" in blob, blob
+    assert "not reported" not in blob, blob
+
+
+def test_ctx_pane_shows_not_reported_instead_of_a_fabricated_zero_percent():
+    """Tier 2: witness② path ② (Ctx pane) — the SAME declaration consulted
+    by a SECOND, independent consumer. Strip-falsified the same way as
+    the Cost pane test above."""
+    snap = {
+        "ctx_window": 200000,
+        "ctx_used": 48120,
+        "ctx_recent_usage": (0, 0),
+        "cache_usage_reported": False,
+    }
+    blob = "\n".join(ctx_pane_lines(snap))
+    assert "not reported on this connection" in blob, blob
+    assert "0% hit" not in blob, blob
+
+
+def test_ctx_pane_still_shows_a_real_percentage_when_reported():
+    """Tier 2: accept-side for the Ctx pane."""
+    snap = {
+        "ctx_window": 200000,
+        "ctx_used": 48120,
+        "ctx_recent_usage": (48120, 14900),
+        "cache_usage_reported": True,
+    }
+    blob = "\n".join(ctx_pane_lines(snap))
+    assert "31% hit" in blob, blob
+    assert "not reported" not in blob, blob
+
+
+def test_a_read_model_that_omits_the_key_defaults_to_reported():
+    """Tier 2: backward compatibility — a snapshot dict that predates this
+    key (any 3rd-party or test-double `ChatReadModel` that hasn't been
+    updated) defaults to `reported=True`, preserving the pre-#5009
+    rendering rather than newly hiding a real figure."""
+    snap = {
+        "usage": (100, 50, 150),
+        "agent_tokens": 150,
+        "session_cached_tokens": 30,
+    }
+    blob = "\n".join(cost_pane_lines(snap))
+    assert "not reported" not in blob, blob
+    assert "% hit" in blob, blob

--- a/tests/interfaces/test_5009_cache_reported_declaration.py
+++ b/tests/interfaces/test_5009_cache_reported_declaration.py
@@ -3,21 +3,50 @@ so ``0`` on a remote client can't be misread as a real 0% hit rate.
 
 Re-opens #4996's own conflation on a DIFFERENT axis. #4996 declared
 whether a whole `ChatReadModel` METHOD is supported; this issue is about
-two SNAPSHOT KEYS (`session_cached_tokens` / `ctx_recent_usage`) inside
-`snapshot()`'s own dict — a `RemoteReadModel` always returns `0`/`(0, 0)`
-for both (cache-hit accounting is session-local, never on the AG-UI wire),
-indistinguishable on their own from a genuine empty/zero session.
+two `snapshot()` dict KEYS (`session_cached_tokens` / `ctx_recent_usage`)
+— a `RemoteReadModel` always returns `0`/`(0, 0)` for both (cache-hit
+accounting is session-local, never on the AG-UI wire), indistinguishable
+on their own from a genuine empty/zero session.
 
-Architect's ruling (co-vet on this issue, in response to a scope question
-asked before implementing): fix the KEY, not the PANE — splitting the fix
-by which pane reads the key would repeat the exact mistake this issue
-names (declaring by implementation/render boundary instead of by the
-actual shared fact). `session_cached_tokens` and `ctx_recent_usage` are
-ONE fact (cache accounting is or isn't reported on this connection) read
-by TWO panes (Cost pane's cumulative line, Ctx pane's last-call line) —
-one declaration, `snap["cache_usage_reported"]`, both consumers.
+**Design history, kept honest** (this issue went through 2 falsified
+attempts before settling — both measured, not guessed):
 
-Explicit scope (architect): only these 2 keys. The other 9 session-local
+1. Fix the KEY, not the pane (architect, in response to a scope question
+   asked before implementing): `session_cached_tokens`/`ctx_recent_usage`
+   are ONE fact read by TWO panes (Cost pane's cumulative line, Ctx
+   pane's last-call line) — splitting the fix by pane would repeat this
+   issue's own named mistake. Settled, still true.
+2. First container tried: a hand-typed `"cache_usage_reported": True/False`
+   literal directly in each `snapshot()` producer, with panes reading
+   `snap.get(key, True)`. FALSIFIED by running the actual test suite: a
+   `True` default lets a producer that forgot the key silently CLAIM
+   "I report" while returning a fabricated `0`% — the exact conflation
+   this issue exists to close, just moved one level down.
+3. Second attempt: flip the default to `snap.get(key, False)`. Also
+   FALSIFIED, on measurement: "snapshot not built yet" (`None`/`{}`,
+   the genuine pre-attach case `cost_pane_lines(None)`/`ctx_pane_lines
+   (None)` already have a Tier 1 contract for — see
+   `test_no_placeholder_residue_pickers_empty_readouts_zero`) and
+   "snapshot built but this ONE key forgotten" both normalize to the
+   same `{}` shape at `snap = snap or {}` — no default value, in either
+   direction, can tell them apart. The conflation this issue exists to
+   close cannot be fixed by choosing a default; it needs a DIFFERENT
+   container for the declaration.
+4. Settled: the declaration moves INTO `ChatReadModelCapabilities`
+   itself (#4996's own container, already disciplined for exactly this:
+   frozen, all fields required, no defaults — a producer that forgets
+   the field fails to CONSTRUCT, at import time, not at render time).
+   Each `snapshot()` producer derives its own key from ITS OWN
+   capabilities constant via `cache_usage_reported_snapshot_key(...)` —
+   never hand-typed a second time, so the two producers cannot silently
+   diverge from each other. The pane's own `snap.get(key, False)`
+   default is now correct and UNREACHABLE for any real, complete read
+   model: it fires only for the genuine `None`/`{}` pre-attach case,
+   where `False` (never claim reporting with nothing to consult) is the
+   right answer.
+
+Explicit scope (architect): only these 2 keys folded into
+`ChatReadModelCapabilities`. The other 9 session-local
 `project_remote_snapshot` keys stay undeclared, filed on #5009 itself for
 later, not folded in here. This PR also does NOT touch the owner's
 actual "cache stuck at 0%" report — that was measured on a LOCAL session
@@ -29,11 +58,13 @@ Witness② (lead-coder/architect: "at least 1 location draws differently,
 2 is even better; splitting into a pane-scoped fix would leave the OTHER
 pane still lying") — both consuming panes are tested, each with the
 unreported (marker, not a fabricated 0%) and the reported (accept-side,
-unchanged real percentage) case.
+unchanged real percentage) case. Witness① (a producer that forgets the
+field fails to construct) is covered generically by
+``test_4996_read_model_capabilities.py``'s own witness① tests, extended
+to this field rather than duplicated here — one dataclass, one guard.
 
-Real `RegistryReadModel`/`RemoteReadModel`-shaped snapshot construction
-(`project_remote_snapshot` directly, and a real local snapshot via
-`test_3338`'s own `_real_snapshot` helper) — no mocks.
+Real `project_remote_snapshot` / `LOCAL_CHAT_READ_CAPABILITIES` /
+`REMOTE_CHAT_READ_CAPABILITIES` — no mocks.
 """
 from __future__ import annotations
 
@@ -41,27 +72,40 @@ from reyn.interfaces.inline.textual_chat.chrome import cost_pane_lines, ctx_pane
 from reyn.interfaces.repl.read_model import (
     LOCAL_CHAT_READ_CAPABILITIES,
     REMOTE_CHAT_READ_CAPABILITIES,
+    cache_usage_reported_snapshot_key,
     project_remote_snapshot,
 )
 
 
+def test_capabilities_declare_cache_usage_reported():
+    """Tier 1: the declaration itself, on both constants — the SSoT every
+    `snapshot()` producer must derive from rather than hand-type."""
+    assert LOCAL_CHAT_READ_CAPABILITIES.cache_usage_reported is True
+    assert REMOTE_CHAT_READ_CAPABILITIES.cache_usage_reported is False
+
+
+def test_the_snapshot_key_helper_derives_from_the_capabilities_it_is_given():
+    """Tier 1: `cache_usage_reported_snapshot_key` is a pure projection —
+    it returns exactly `{"cache_usage_reported": capabilities.
+    cache_usage_reported}`, nothing hand-typed alongside it. Both real
+    producers call this (see the tests below), so this pins the ONE
+    function they both depend on."""
+    assert cache_usage_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES) == {
+        "cache_usage_reported": True,
+    }
+    assert cache_usage_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES) == {
+        "cache_usage_reported": False,
+    }
+
+
 def test_remote_snapshot_declares_cache_usage_unreported():
-    """Tier 1: the declaration itself — a remote snapshot always says
-    `cache_usage_reported: False`, paired with the graceful `0`/`(0, 0)`
-    values those same 2 keys already carried."""
+    """Tier 1: the REAL producer — `project_remote_snapshot` — carries the
+    declaration through to its own output, paired with the graceful
+    `0`/`(0, 0)` values those same 2 keys already carried."""
     snap = project_remote_snapshot({})
     assert snap["cache_usage_reported"] is False
     assert snap["session_cached_tokens"] == 0
     assert snap["ctx_recent_usage"] == (0, 0)
-
-
-def test_capabilities_declarations_are_unaffected_by_this_key():
-    """Tier 1: pins that #5009 is a SNAPSHOT-key declaration, layered
-    alongside #4996's METHOD-level `ChatReadModelCapabilities` — not a
-    replacement for it. Both declarations exist independently on their
-    respective read models."""
-    assert LOCAL_CHAT_READ_CAPABILITIES.conversation_history is True
-    assert REMOTE_CHAT_READ_CAPABILITIES.conversation_history is False
 
 
 def test_cost_pane_shows_not_reported_instead_of_a_fabricated_zero_percent():
@@ -127,16 +171,21 @@ def test_ctx_pane_still_shows_a_real_percentage_when_reported():
     assert "not reported" not in blob, blob
 
 
-def test_a_read_model_that_omits_the_key_defaults_to_reported():
-    """Tier 2: backward compatibility — a snapshot dict that predates this
-    key (any 3rd-party or test-double `ChatReadModel` that hasn't been
-    updated) defaults to `reported=True`, preserving the pre-#5009
-    rendering rather than newly hiding a real figure."""
-    snap = {
-        "usage": (100, 50, 150),
-        "agent_tokens": 150,
-        "session_cached_tokens": 30,
-    }
-    blob = "\n".join(cost_pane_lines(snap))
-    assert "not reported" not in blob, blob
-    assert "% hit" in blob, blob
+def test_a_pre_attach_snapshot_defaults_to_not_reported_not_a_crash():
+    """Tier 2: the genuinely empty `None`/`{}` pre-attach case (an
+    existing Tier 1 contract — `test_no_placeholder_residue_pickers_
+    empty_readouts_zero` calls `cost_pane_lines(None)`/`ctx_pane_lines
+    (None)` directly and requires graceful zero output, never a crash).
+    `snap.get("cache_usage_reported", False)` is what makes this
+    reachable at all WITHOUT lying: `False` here never claims a real
+    percentage — it is the safe direction, distinct from (and no longer
+    confused with) a real read model that forgot to declare, which now
+    fails to CONSTRUCT instead (`ChatReadModelCapabilities`'s own
+    witness①, `test_4996_read_model_capabilities.py`)."""
+    assert cost_pane_lines(None) is not None  # does not raise
+    blob = "\n".join(cost_pane_lines(None))
+    assert "not reported on this connection" in blob, blob
+    assert "% hit" not in blob, blob
+
+    ctx_blob = "\n".join(ctx_pane_lines(None))
+    assert "not reported on this connection" in ctx_blob, ctx_blob


### PR DESCRIPTION
**[tui-coder]** — part of `#5009`, architect design (in response to a scope question I asked before implementing — full thread on the issue).

## Owner-symptom scope, stated up front (important, per architect's explicit request)

This PR does **not** fix the owner's own "cache stuck at 0%" report. That was measured on a **local** session (owner-confirmed) and turned out to be a separate, since-understood display issue — a single-sample cache figure rendered as a percentage with no note saying so (filed as `#5011`, reserved as my next task after this one, sequenced to avoid a same-line edit conflict — both touch the same 2 `_cache_hit_line` call sites in `chrome.py`, for unrelated reasons). This PR only fixes: **remote returns `0` for cache-hit accounting, and that `0` used to render identically to a genuine 0% hit rate.**

## What (final settled shape — see the PR's own comment history below for the 2 falsified attempts that got here)

Re-opens `#4996`'s own conflation on a different axis: `#4996` declared whether a whole `ChatReadModel` **method** is supported. `snapshot()`'s own `session_cached_tokens` / `ctx_recent_usage` **keys** carry the identical "`0` could mean unsupported OR genuinely zero" ambiguity, undeclared. `RemoteReadModel` always returns `0`/`(0, 0)` for both (cache-hit accounting is session-local, never on the AG-UI wire) — indistinguishable on its own from a real empty session's genuine `0%`.

**Fix the KEY, not the pane** (settled first, unchanged): `session_cached_tokens` and `ctx_recent_usage` are ONE fact read by TWO panes (Cost pane's cumulative line, Ctx pane's last-call line) — one declaration, both consumers fixed together.

**Where the declaration lives — 2 measured-wrong attempts, then the container that actually closes the gap:**

1. A hand-typed `"cache_usage_reported": True/False"` literal in each `snapshot()` producer, panes reading `snap.get(key, True)`. Blocked: a `True` default lets a producer that forgot the key silently claim "I report" while returning a fabricated `0%` — the exact conflation this issue exists to close, moved one level down.
2. Flip the pane default to `snap.get(key, False)`. Also wrong, measured by running the suite: `cost_pane_lines(None)`/`ctx_pane_lines(None)` is a genuine, existing Tier 1 contract (`test_no_placeholder_residue_pickers_empty_readouts_zero`) — "snapshot not built yet" and "snapshot built but this key forgotten" both normalize to the same `{}`, so no default in either direction can distinguish them.
3. **Settled:** the declaration moves INTO `ChatReadModelCapabilities` itself (`#4996`'s own container — frozen, all fields required, no defaults). A producer that forgets the field now fails to **construct**, at import time, not at render time.
   - `ChatReadModelCapabilities` gains `cache_usage_reported: bool`.
   - `cache_usage_reported_snapshot_key(capabilities)` — the ONE helper both `snapshot()` producers (`status.py`'s `_snapshot()`, `read_model.py`'s `project_remote_snapshot()`) call, so neither can hand-type the literal and silently diverge from the other.
   - `LOCAL_CHAT_READ_CAPABILITIES` declares `True`; `REMOTE_CHAT_READ_CAPABILITIES` declares `False`.
   - `chrome.py`'s pane call sites keep `snap.get("cache_usage_reported", False)` — now correct and **unreachable** for any real, complete read model; it fires only for the genuine `None`/`{}` pre-attach case, where `False` (never claim reporting with nothing to consult) is the right answer.

## Scope, explicit (architect)

- Only these 2 keys. The other 9 session-local `project_remote_snapshot` keys (`model_active_class` / `model_classes` / `agent_names` / `session_tree` / `usage` / `ctx_compaction_status_fn` / `turn_usage_fn` / `cron_jobs` / `mcp_servers`) stay undeclared — filed on `#5009` itself for a later PR, `#5009` stays open.
- `#5011`'s own fix (the un-noted single-sample-as-percentage shape) is a separate PR, next.

## Test plan

- [x] `tests/interfaces/test_5009_cache_reported_declaration.py` (8 tests) + `tests/interfaces/test_4996_read_model_capabilities.py` (updated for the 7th field) — no duration
  - the declaration constants + the shared `cache_usage_reported_snapshot_key` helper, pinned directly
  - the real `project_remote_snapshot` producer's own output
  - witness② at BOTH consumers (Cost pane, Ctx pane), each **strip-falsified** (reverting `_cache_hit_line`'s `reported` gate turns both red for the stated reason: `"0% hit (0 / 0 ...)"` instead of the marker), paired with an accept-side test confirming a genuinely reported figure still renders its real percentage unchanged
  - the genuine pre-attach `None`/`{}` case (`cost_pane_lines(None)`/`ctx_pane_lines(None)`) renders "not reported", never crashes, never fabricates a percentage — **strip-falsified twice**: once against the pane-level `reported=True` stub, once against a hand-typed literal bypassing the shared helper in `project_remote_snapshot` (confirmed red for the stated reason in each case)
  - witness① (a producer that forgets the field fails to construct) is covered generically by `test_4996_read_model_capabilities.py`'s own witness① tests, extended to this field — not duplicated
- [x] `ruff check` on all 4 changed files — clean
- [x] `scripts/test_tier_audit.py --strict` on the new test file — OK
- [x] `scripts/mypy_ratchet.py` — OK, unchanged baseline
- [x] `scripts/verify_module_docstrings.py` — OK
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_file_depth_reference.py` / `check_bare_tests_import_reference.py` — all OK
- [x] Full `tests/interfaces/` regression sweep: **1923 passed, 4 skipped**. The 1 failure (`test_plain_path_survives_flowview_absence`) reproduces identically with this diff stashed on the same tree — the same pre-existing, deterministic stray-editable-install artifact already documented on #4996/#5000/#5001, unrelated to this change.
- [ ] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔴 lead-coder のブロッキング点（規則 7）── 1 件（★architect の指摘、★私も同意）

- [x] 🔴 ~~**`snap.get("cache_usage_reported", ★True)` の ★既定値を 消してください。**~~ ⚠️ **★この直し方は 誤りでした（architect が取り下げ）** ── ★下記の 3 段に 置き換えます

```
★実測 ── ★2 箇所
🔴 ★★宣言を忘れた read model が ★★「私は cache を報告します」と 名乗り ★0 を返します
   ── ★★#5009 が ★まさに これを直しに来ました
```

★ **前例が ★逆を言っています** ── `AxisEnforcementDeclaration` 逐語:
> **a backend that ★FORGETS an axis ★fails to CONSTRUCT … ★NOT a ★silent 'not reported'**

⚪ **#5000 の witness① は ★その「忘れたら落ちる」を守る test** です ── 🔴 **同じ PR 族で ★逆向きの既定を 入れないでください。**

★ **家則も同じ側**です: > **reyn CORE: root/ideal fix, ★no backward-compat, ★no debt**
⚪ **互換の相手が居ません** ── ★ **`ChatReadModel` の実装は ★repo 内が全部**で、★ **#5000 で ★11 の test double も ★あなたが更新済**です。

✅ **直し**: ★ **既定を消す** ── ★ **`snap["cache_usage_reported"]`（★KeyError で落ちる）で十分。**

---

## ⚪ ブロックしない点（★architect と 私が確認）

```
✅ ★key 単位で ★1 宣言・★両 pane ── ★裁定どおり（★pane で分けていない）
✅ ★witness② を ★両 pane で strip-falsify
   ── 逐語「★捏造された『0% hit (0/0)』が出る」＝ ★正しい理由で赤
✅ ★accept 側（★実値があれば 従来どおり % 表示）も ★両 pane で確認
   ── ★これが無いと「★常に利用不可」でも 通ります
✅ ★規則 4 ★2 面 ── ★closingIssuesReferences ★空 ／ ★body・commit とも clean
```



---

## 🔴 ★直し方を 差し替えます（architect 裁定・★懸念は維持、★容れ物を変える）

### ★実測が 処方を falsify しました（★実施者）

```
★`cost_pane_lines(None)` / `ctx_pane_lines(None)` は ★正当な pre-attach 経路
   ── ★`snap = snap or {}` の ★既存 Tier 1 契約
🔴 ★bare indexing は ★それを 巻き込みます ── ★architect「★私は 測らずに書きました」
```

### 🔴 ★核心 ── ★既定値の議論では 決着しません

```
★「snapshot が まだ無い」と ★「キーが 欠けている」が ★★どちらも `{}` になる
🔴 ★★これは ★この arc が 閉じようとしている ★conflation そのもの
∴ ★★既定を True にしても False にしても ★区別は 戻りません
```

### ✅ ★容れ物が違う

```
★能力は ★frame の性質では なく ★★read model の性質
   ── ★毎フレーム変わる dict に載せたのが 誤り
   ── ★architect「★#5009 に『snapshot() のキー軸』と書いた ── ★軸は正しく ★容れ物が誤り」
✅ ★#5000 が ★既に 正しい容れ物を 作っています ── ★`ChatReadModelCapabilities`
   ── ★frozen / ★全必須 / ★デフォルト無し / ★abstract property
   ── ★★起動時に 1 度 ＝ ★前例の規律（忘れたら構築失敗）が ★効く場所
```

### ✅ ★形 ── ★3 段

```
★① ★`ChatReadModelCapabilities` に ★`cache_usage_reported: bool` を足す
   ── ★忘れたら ★構築で TypeError ── ★#5000 の witness① が ★守ります
★② ★snapshot への設定は ★★その宣言から 行う
   ── ★`status.py` / ★`project_remote_snapshot` ★両方 ── ★★手打ちしない
★③ ★pane 側は ★`.get("cache_usage_reported", ★False)`
   ── ★①があるので ★実在の read model が この既定に落ちることは ★ありません
   ── ★落ちるのは ★`snap is None`（pre-attach）だけ ── ★そこでは ★False が 正しい
```

⚪ **実施者の ★False 案は ★③として 正しい**でした ── ★ **①と組んで 初めて 穴が閉じます。**

---

⚪ **記録**: ★ **architect の BLOCK の ★懸念（捏造しない）は 維持**、★ **示された 直しは 誤り**でした。⚪ **実施者が ★実装して テストを回してから 返した** ── ★ **それが 正しい順序**です。



---

## ✅ lead-coder ── ★ブロッキング点 解消（★私が実測しました）

```
✅ ★① ★宣言に足した ── `read_model.py:143` ── ★`cache_usage_reported: bool`
   ── ★frozen dataclass の必須フィールド ∴ ★忘れたら ★構築で TypeError
   ── ★#5000 の witness① が ★守ります
✅ ★② ★宣言から設定 ── `status.py:354` ── `_cache_usage_reported_key()`
   ── 逐語「LOCAL's own `{"cache_usage_reported": True}` — ★a thin wrapper …」
   ── ★★手打ちしていません
✅ ★③ ★pane 側の既定 ── ★`snap.get("cache_usage_reported", ★False)` ── ★2 箇所とも
   ── ★実測: ★`True` 既定は ★0 件 ／ ★`False` 既定が ★2 件
   ── ★①があるので ★実在の read model が この既定に落ちることは ★なく、
      ★落ちるのは ★`snap is None`（pre-attach）だけ ── ★そこでは ★False が 正しい
```

⚪ **経緯を 1 行残します**: ★ **最初の処方（bare indexing）は ★実施者が ★実装してテストを回して falsify しました。**★ **「snapshot がまだ無い」と「キーが欠けている」が ★どちらも `{}` になる** ── ★ **この arc が閉じようとしている conflation そのもの**で、★ **既定値では決着せず、★容れ物（`ChatReadModelCapabilities`）を変えて 閉じました。**

