### PR TITLE
revert(#5010): doc-drift gate back to warn-only — promotion falsified

### DIFF
--- a/.github/workflows/check-doc-drift.yml
+++ b/.github/workflows/check-doc-drift.yml
@@ -5,40 +5,32 @@ name: Doc-drift check
 # scripts/check_doc_drift.py's module docstring for the discriminator
 # (asks the PR, not the doc) and the structural exclusions.
 #
-# BLOCKING (promoted #5010, architect ruling 2026-08-21). Calibration
-# history — full account in scripts/check_doc_drift.py's module
-# docstring, "Blocking" section:
-#   - PR #5007's 15-PR sample: 0 findings, but the "touched the doc?"
-#     branch never actually ran (no doc-named gone-from-src candidate).
-#   - #5010 round 1 (line-heuristic extraction): a ~400-PR backward
-#     scan found 9 real candidates. 2 true positives, 7 false
-#     positives — mostly docstring-prose words a diff-line-text-only
-#     heuristic couldn't distinguish from real code.
-#   - #5010 round 2 (this file's current shape): extraction rewritten
-#     to read real pre/post file content (`git show`) and tokenize it
-#     (find_removed_identifiers_precise) instead of guessing from
-#     diff-line text. Re-run on the same 9 candidates: 3 true positives
-#     (a 3rd surfaced), 0 false positives.
+# WARN-ONLY (architect ruling 2026-08-21, REVERTING the same day's
+# earlier promotion — #5010). Full account in
+# scripts/check_doc_drift.py's module docstring, "Blocking" section
+# (kept, corrected in place — do not re-derive from PR history alone).
 #
-# Promotion does NOT rest on "0/9" as a statistic (9 trials barely
-# bounds a rate at all) — it rests on three structural points: (1) the
-# false-positive CLASS was eliminated, not merely unobserved — a NAME
-# token structurally cannot come from inside a STRING/COMMENT token,
-# (2) every fallback to the weaker line heuristic prints to stderr,
-# never silent, verified against two real triggers, (3) the PASSING
-# action (touch the doc file in the same PR) is always the correct
-# action even in a false-positive world — no dead end a false positive
-# can walk an author into. See the module docstring for the full
-# argument.
-#
-# REVERT CONDITION (required for a promotion to not be one-way): if a
-# genuine false positive is found in production use, change the final
-# step back to `set +e` / always `exit 0` / `::warning::` annotations
-# (the shape this file had before #5010's promotion — see git history)
-# until the new false-positive class is closed the same STRUCTURAL way
-# as the first two (never by loosening _MIN_IDENTIFIER_LENGTH or adding
-# another marker-guessing heuristic — that regresses past what this
-# promotion earned).
+# The promotion's decisive point ("the passing action is always
+# correct — no dead end") was falsified within hours: one of the 3
+# "true positives" in the #5010 calibration set (`_action_retrieval`,
+# PR #4572/#4567/#4563) turned out to be a FALSE POSITIVE on
+# independent re-measurement — `docs/reference/runtime/session-
+# construction.md` is CURRENTLY ACCURATE (correctly phrased as a
+# historical rename note; #5016, closed). The doc WAS stale right
+# after #4572 merged, but a LATER PR (#4582) already fixed it into
+# permanently-correct historical prose — a case the discriminator
+# structurally cannot see, because it only asks "did THIS removing PR
+# touch the doc", never "has ANY later PR already fixed it since". A
+# PR merged today that happens to remove another already-historical
+# `_action_retrieval`-shaped identifier gets flagged with NO valid
+# fix — touching the doc again would mean writing something false,
+# since it is already correct. That is the dead end promotion assumed
+# could not exist. Corrected calibration count: **1 FP / 9** in this
+# family (was reported as 0/9) — the naive "staged, multi-PR removal"
+# case is a DIFFERENT false-positive class than the two (comment
+# prose, docstring prose) round 2 actually closed; re-promotion needs
+# its own structural discriminator for THIS class, not another metric
+# push. See #5010 for the corrected record and re-promotion status.
 #
 # Trigger scoped to `paths: ["src/**"]` — the discriminator only ever
 # considers identifiers removed from src/, so a PR that never touches
@@ -56,7 +48,7 @@ permissions:
 
 jobs:
   doc-drift:
-    name: doc-drift check
+    name: doc-drift check (warn-only)
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -90,7 +82,7 @@ jobs:
           cat doc_drift_output.txt
           if [ "$exit_code" -ne 0 ]; then
             while IFS= read -r line; do
-              echo "::error::${line}"
+              echo "::warning::${line}"
             done < <(grep "^  '" doc_drift_output.txt)
           fi
-          exit "$exit_code"
+          exit 0

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -70,49 +70,54 @@ file" exist in this module, and calibration (#5010) is why both do:
   no post-image; unparseable content) — every fallback is printed to
   stderr, never silently taken.
 
-## Blocking (promoted #5010, architect ruling 2026-08-21)
+## Not blocking — promoted then REVERTED same day (#5010, 2026-08-21)
 
 A backward scan of ~400 merged PRs found 9 real candidates (PRs where
 this discriminator's "touched the doc?" branch actually ran). Hand-
-inspection: 3 CONFIRMED TRUE POSITIVES (`_action_retrieval`, PRs
-#4572/#4567/#4563 — PR #4582's own title: "sweep stale
-action_retrieval.universal_wrappers_enabled refs #4572's own fix scope
-missed", direct evidence a human had to notice and fix what this gate
-would have flagged), 0 false positives after the round-2 (tokenizer)
-rewrite (was 7/9 with the line-heuristic-only round 1).
+inspection first read 3 as TRUE POSITIVES (`_action_retrieval`, PRs
+#4572/#4567/#4563) and 0 as false positives, and the gate was promoted
+to blocking on that basis. **Corrected within hours, on independent
+re-measurement**: `docs/reference/runtime/session-construction.md` is
+CURRENTLY ACCURATE — correctly phrased as a historical rename note
+(`renamed from _action_retrieval`, `the now-deleted action_retrieval:
+block`, `retired ... on/off gate`; #5016, closed). The doc WAS stale
+right after PR #4572 merged, but PR #4582 (a LATER, separate PR)
+already fixed it permanently. **Corrected calibration count: 1 FP / 9**
+in this identifier's family, not 0/9.
 
-**"0 FP among 9" is NOT why this is blocking** — with only 9 trials,
-0/9 barely bounds the true rate at all (roughly "under ~30%", a loose
-statistical read, not a safety argument). The promotion rests on three
-STRUCTURAL points instead, none of them a count:
+**Why this falsified the promotion, not just the count.** The
+discriminator only asks "did THIS removing PR touch the doc" — it has
+no way to see that some OTHER, later PR already fixed the doc since.
+A staged, multi-PR removal (rename recorded in one PR, deletion
+completed in a second, doc genuinely fixed in a third) breaks the
+"whoever writes a removal record touches the doc in the SAME PR" premise
+the whole discriminator design rests on (see this docstring's opening
+section) — the premise was written as a description of THIS repo's
+practice, and it does not hold for a staged removal. The promotion's
+decisive point — "the passing action (touch the doc) is always
+correct, no dead end" — is FALSE for this case: the doc is already
+accurate, so touching it again means writing something false. That is
+the dead end the promotion assumed could not exist.
 
-1. **The false-positive CLASS was eliminated, not merely unobserved.**
-   Both real FP classes found in calibration (`#`-comment prose,
-   docstring prose) tokenize as impossible-to-confuse with a NAME token
-   once the extractor reads real pre-image file content instead of
-   guessing from diff-line text — see `find_removed_identifiers_precise`.
-   The disclosed line-heuristic limitation (a `#`/quote inside a string
-   literal) disappears the same way, for the same reason.
-2. **The fallback speaks up.** Every time the precise path can't run
-   for a file (no pre/post image; unparseable content), it prints to
-   stderr and falls back to the weaker line heuristic FOR THAT FILE
-   ONLY — never silently. Verified against two real triggers
-   (#4560/#4454, both files deleted entirely by their PR), with a test
-   that asserts the fallback message itself, not just the result.
-3. **The decisive point: the PASSING action is always the correct
-   action.** This gate's pass condition is "touch the doc file in the
-   SAME PR" — even in a false-positive world, the only thing an author
-   does in response is open that doc and confirm it's still accurate.
-   There is no dead end a false positive can walk someone into. Staying
-   warn-only despite that would return to #5003's own founding problem
-   ("the prescription exists, but firing depends on someone's memory").
+**Structural, not statistical, in both directions**: promotion rested
+on eliminating false-positive CLASSES (comment prose, docstring prose —
+both genuinely closed by the tokenizer rewrite, kept, still correct),
+and reversion rests on finding a THIRD class the tokenizer rewrite does
+not touch (a doc that is accurate today about an identifier removed in
+a PAST, different PR). Re-promotion needs its own structural
+discriminator for this class — e.g. some way to tell "records a past
+rename/removal" apart from "still describes current behavior" without
+reading the doc's own natural language (the very judgment #5003's
+original design rejected as unmakeable) — not another push on N. If no
+such discriminator is found, staying warn-only permanently is a valid,
+final answer (architect: "それも答え").
 
-**Revert condition** (required — a promotion with no way back is a
-one-way door): if a genuine false positive is found in production use,
-`.github/workflows/check-doc-drift.yml`'s job reverts to warn-only
-(annotation, `main()`'s exit code ignored) until the new FP class is
-closed the same structural way as the first two — never by loosening
-`_MIN_IDENTIFIER_LENGTH` or adding another marker-guessing heuristic.
+**What's still kept, unchanged, still correct**: the tokenizer-backed
+extraction (`find_removed_identifiers_precise`), its stderr-logged
+fallback, `_print_findings_and_exit_code` (still returns 1 on a
+finding — useful for a human running `--pr N` by hand; only the CI
+workflow ignores it now), and every existing test. None of that was
+what broke.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[e2e-coder]** — part of #5010

## URGENT — reverts today's promotion; blocking has been live on main since #5014 merged

Architect's decisive promotion point ("the passing action is always
correct — no dead end") was falsified within hours, on independent
re-measurement, matching what I'd separately found and closed at
#5016: `docs/reference/runtime/session-construction.md` is **currently
accurate** — correctly phrased as a historical rename note. It WAS
stale right after PR #4572 merged (the actual removal), but PR #4582
(a later, separate PR) already fixed it permanently.

**Why this broke the promotion, not just the count**: the discriminator
only asks "did THIS removing PR touch the doc" — it has no way to see
that a LATER PR already fixed the doc since. A staged, multi-PR removal
(rename recorded in one PR, deletion completed in a second, doc
genuinely fixed in a third) breaks the "whoever writes a removal record
touches the doc in the SAME PR" premise the whole discriminator design
rests on. Re-running `check_doc_drift.py --pr 4572` today still fires,
because the doc's current text still literally contains the substring
`_action_retrieval` — even though it's now accurate, historical prose.
Touching the doc again in response would mean writing something FALSE.
That is the dead end the promotion assumed could not exist.

**Corrected calibration count: 1 FP / 9**, not 0/9.

## What this PR does

- `.github/workflows/check-doc-drift.yml`: reverts the final step to
  always `exit 0` (`::warning::` annotations, not `::error::`); job
  name regains "(warn-only)"; header comment corrected in place with
  the falsification account and the corrected count.
- `scripts/check_doc_drift.py`'s module docstring: "Blocking" section
  rewritten to record the promotion-then-revert, why it broke, and
  what's needed for a valid re-promotion (a structural discriminator
  for THIS false-positive class — "doc accurate today about an
  identifier removed by a past, different PR" — not another push on N;
  staying warn-only permanently is an acceptable final answer if none
  is found).

**Explicitly NOT reverted** (still correct, still kept): the
tokenizer-backed extraction (`find_removed_identifiers_precise`), its
stderr-logged fallback (verified against 2 real triggers), the
`_print_findings_and_exit_code` exit-code contract (still returns 1 —
useful for a human running `--pr N` locally; only the CI *workflow* now
ignores it), and all 34 existing tests. None of that was what broke —
only the promotion decision itself.

## Test plan

- [x] `pytest tests/scripts/test_check_doc_drift_5003.py` — 34/34 green, unchanged
- [x] `ruff check scripts/check_doc_drift.py` — clean
- [x] YAML round-tripped through PyYAML before push
- [x] `python scripts/test_tier_audit.py --strict ...` — 34/34 OK
- [x] `python scripts/verify_module_docstrings.py scripts/check_doc_drift.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (203 findings, all baselined)
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [ ] (skipped — no docs/ changes in this PR; doc gates not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
