### PR TITLE
fix(#5010): #4572 is a confirmed TP — retracts this PR's own earlier '0 TP' claim

### DIFF
--- a/.github/workflows/check-doc-drift.yml
+++ b/.github/workflows/check-doc-drift.yml
@@ -10,27 +10,27 @@ name: Doc-drift check
 # scripts/check_doc_drift.py's module docstring, "Blocking" section
 # (kept, corrected in place — do not re-derive from PR history alone).
 #
-# The promotion's decisive point ("the passing action is always
-# correct — no dead end") was falsified within hours: one of the 3
-# "true positives" in the #5010 calibration set (`_action_retrieval`,
-# PR #4572/#4567/#4563) turned out to be a FALSE POSITIVE on
-# independent re-measurement — `docs/reference/runtime/session-
-# construction.md` is CURRENTLY ACCURATE (correctly phrased as a
-# historical rename note; #5016, closed). The doc WAS stale right
-# after #4572 merged, but a LATER PR (#4582) already fixed it into
-# permanently-correct historical prose — a case the discriminator
-# structurally cannot see, because it only asks "did THIS removing PR
-# touch the doc", never "has ANY later PR already fixed it since". A
-# PR merged today that happens to remove another already-historical
-# `_action_retrieval`-shaped identifier gets flagged with NO valid
-# fix — touching the doc again would mean writing something false,
-# since it is already correct. That is the dead end promotion assumed
-# could not exist. Corrected calibration count: **1 FP / 9** in this
-# family (was reported as 0/9) — the naive "staged, multi-PR removal"
-# case is a DIFFERENT false-positive class than the two (comment
-# prose, docstring prose) round 2 actually closed; re-promotion needs
-# its own structural discriminator for THIS class, not another metric
-# push. See #5010 for the corrected record and re-promotion status.
+# The promotion's structural premise was falsified within hours — NOT
+# its TP/FP count (see scripts/check_doc_drift.py's module docstring
+# for the full, corrected account, including a RETRACTED "0 TP" claim
+# an earlier revision of this file made without doing the verification
+# it asserted). `docs/reference/runtime/session-construction.md` is
+# CURRENTLY ACCURATE (a correctly-phrased historical rename note;
+# #5016, closed). PR #4572 — independently re-verified against its own
+# merge commit — genuinely removed `_action_retrieval` from src/
+# without touching this doc, and the doc's text at that exact point was
+# present-tense, describing then-live behavior: a real, confirmed true
+# positive at the time. It only became accurate LATER, when PR #4582 (a
+# separate, later PR) fixed it. The discriminator structurally cannot
+# see that a later PR already fixed a doc some earlier PR should have
+# — it only asks "did THIS removing PR touch the doc", re-evaluated
+# against TODAY's doc content on every run. Re-running `--pr 4572`
+# TODAY still fires, even though flagging it back then was correct,
+# because today's doc is already accurate and touching it again would
+# mean writing something false. That dead end — not any specific FP
+# count — is why this reverted. Re-promotion needs its own structural
+# discriminator for this class, not another metric push. See #5010
+# for the corrected record and re-promotion status.
 #
 # Trigger scoped to `paths: ["src/**"]` — the discriminator only ever
 # considers identifiers removed from src/, so a PR that never touches

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -76,28 +76,41 @@ A backward scan of ~400 merged PRs found 9 real candidates (PRs where
 this discriminator's "touched the doc?" branch actually ran). Hand-
 inspection first read 3 as TRUE POSITIVES (`_action_retrieval`, PRs
 #4572/#4567/#4563) and 0 as false positives, and the gate was promoted
-to blocking on that basis. **Corrected within hours, on independent
-re-measurement**: `docs/reference/runtime/session-construction.md` is
-CURRENTLY ACCURATE — correctly phrased as a historical rename note
-(`renamed from _action_retrieval`, `the now-deleted action_retrieval:
-block`, `retired ... on/off gate`; #5016, closed). The doc WAS stale
-right after PR #4572 merged, but PR #4582 (a LATER, separate PR)
-already fixed it permanently. **Corrected calibration count: 1 FP / 9**
-in this identifier's family, not 0/9.
+to blocking on that basis.
 
-**Why this falsified the promotion, not just the count.** The
-discriminator only asks "did THIS removing PR touch the doc" — it has
-no way to see that some OTHER, later PR already fixed the doc since.
-A staged, multi-PR removal (rename recorded in one PR, deletion
-completed in a second, doc genuinely fixed in a third) breaks the
-"whoever writes a removal record touches the doc in the SAME PR" premise
-the whole discriminator design rests on (see this docstring's opening
-section) — the premise was written as a description of THIS repo's
-practice, and it does not hold for a staged removal. The promotion's
-decisive point — "the passing action (touch the doc) is always
-correct, no dead end" — is FALSE for this case: the doc is already
-accurate, so touching it again means writing something false. That is
-the dead end the promotion assumed could not exist.
+**#4572 is a CONFIRMED true positive** — verified independently, twice,
+against the actual merge commit (`46a8bf1c3`): `_action_retrieval` had
+10 occurrences in `src/` at the commit immediately before the merge,
+0 immediately after (confirming #4572 fully removed it); the merge
+commit's own diffstat shows 0 changes to
+`docs/reference/runtime/session-construction.md` (confirming it was
+never touched); and the doc's text AT THAT POINT read, present tense,
+"`_action_retrieval` ... DRIVES whether the universal catalog wrappers
+appear ... Default constructs an off-flag `ActionRetrievalConfig` so
+existing chat behaviour IS preserved" — describing then-current
+behavior, not history. The doc only became accurate LATER, when PR
+#4582 (a separate, later PR) fixed it into the historical-rename-note
+form it has today. **#4567 and #4563 are UNMEASURED** — the same
+verification (occurrence count at `<merge>^` vs `<merge>`, diffstat,
+and the doc's own tense at that point) has not been run against either
+of their individual merge commits; an earlier revision of this
+docstring asserted "0 TP, all 3 the same false positive" without
+having done that verification — that claim is retracted here, not
+repeated.
+
+**Why the promotion was still correctly reverted — not because of the
+TP/FP count.** The structural problem stands regardless of how many of
+the 3 are eventually confirmed TP: the discriminator only asks "did
+THIS removing PR touch the doc" — it cannot see that some OTHER, later
+PR (#4582) already fixed the doc since. Re-running `--pr 4572` TODAY
+still fires, even though #4572 was genuinely correct to flag AT THE
+TIME — because the check re-evaluates against the CURRENT doc content
+on every run, and today's doc is accurate, so touching it again in
+response would mean writing something false. That is a real dead end a
+future, different PR (one that also removes an `_action_retrieval`-
+shaped identifier no longer present anywhere) could walk into, even
+though #4572 itself was never a case where the gate had nothing valid
+to ask for.
 
 **Structural, not statistical, in both directions**: promotion rested
 on eliminating false-positive CLASSES (comment prose, docstring prose —


### PR DESCRIPTION
**[e2e-coder]** — part of #5010

## Retraction — this PR's own earlier revision was wrong

This PR originally claimed "3 FP / 9, 0 TP remaining" (a correction of
#5020's "1 FP / 9"). **That claim itself was wrong and is retracted.**
Architect independently re-measured PR #4572 against its actual merge
commit and found it IS a confirmed true positive; I independently
re-verified the same three facts myself:

```
git grep -c "_action_retrieval" 46a8bf1c3^ -- src   → 10 occurrences (pre-merge)
git grep -c "_action_retrieval" 46a8bf1c3  -- src   → 0 occurrences  (post-merge — #4572 removed it)
git show --stat 46a8bf1c3 | grep -c session-construction.md   → 0   (doc never touched)
docs/.../session-construction.md at that point (46a8bf1c3^): present-tense,
  "`_action_retrieval` ... DRIVES whether the universal catalog wrappers
   appear ... existing chat behaviour IS preserved" — describing THEN-live
   behavior, not history.
```

**#4572 was correctly flagged at the time.** It only became accurate
LATER when PR #4582 (a separate, later PR) fixed the doc. #4567/#4563
remain **UNMEASURED** — my earlier "same FP cited 3 times" claim
asserted this without doing the same verification for either; that
claim is retracted, not repeated here.

## What this PR now does

- Corrects `scripts/check_doc_drift.py`'s module docstring and
  `check-doc-drift.yml`'s header comment to state: #4572 is a
  CONFIRMED true positive (with the verification above cited in the
  docstring itself); #4567/#4563 are unmeasured; the earlier "0 TP"
  claim is explicitly retracted rather than silently dropped.
- Makes clear the revert of #5020's promotion stands for a STRUCTURAL
  reason independent of the TP/FP count: the discriminator cannot see
  that a later PR (#4582) already fixed what #4572 should have —
  re-running `--pr 4572` today still fires even though flagging it
  back then was correct, because today's doc is already accurate and
  touching it again would mean writing something false.

Root cause of my own error: conflating "the doc is accurate TODAY"
with "the doc was accurate AT THE TIME PR #4572 merged" — a
time-point/tense confusion. #5020's own docstring (which I also wrote)
got this right the first time; this PR's now-retracted second commit
overwrote that correct statement with a wrong one before self-catching
it too late to stop #5020's auto-merge, then over-corrected further in
the wrong direction. This commit is the third correction; verified via
independent re-measurement (not by retracing anyone else's method) this
time.

## Test plan

- [x] `pytest tests/scripts/test_check_doc_drift_5003.py` — 34/34 green, unchanged (docs/comments only)
- [x] `ruff check scripts/check_doc_drift.py` — clean
- [x] YAML round-tripped through PyYAML before push
- [x] `python scripts/test_tier_audit.py --strict ...` — 34/34 OK
- [x] `python scripts/verify_module_docstrings.py scripts/check_doc_drift.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (203 findings, all baselined)
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [ ] (skipped — no docs/ changes in this PR; doc gates not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
