### PR TITLE
fix(#5013): reyn_repo's "does not exist" error names its own reachable scope

### DIFF
--- a/docs/concepts/agent-engineering/tool-contract-design.md
+++ b/docs/concepts/agent-engineering/tool-contract-design.md
@@ -43,6 +43,10 @@ Two properties fall out of "every op has a schema":
 - **Reject early.** Malformed output triggers a validation error before any side effect runs.
 - **Replay safely.** A saved event log can be re-rendered without re-invoking the LLM, because every op was validated at write-time.
 
+## Denial messages name a permitted alternative
+
+A tool that returns a refusal should name at least one thing that IS allowed — a different path, a different scope, where to find the right argument shape — not just say "no" and stop (#5013). "No" alone leaves the caller re-guessing at the boundary instead of acting on it.
+
 ## See also
 
 - [Reference: control-ir](../../reference/runtime/control-ir.md)

--- a/src/reyn/runtime/reyn_repo.py
+++ b/src/reyn/runtime/reyn_repo.py
@@ -239,7 +239,10 @@ def safe_resolve_inside(root: Path, rel_path: str) -> Path:
     if not candidate.exists():
         raise ValueError(
             f"reyn_repo: path {rel_path!r} does not exist in the Reyn "
-            "repository."
+            "repository. This tool reads only THIS checkout, under "
+            f"{REACHABLE_TOP_LEVEL_ENTRIES} (proposal 0061 §3.3) — a path "
+            "that exists in a different checkout/worktree is out of this "
+            "tool's read scope, not a Reyn-repo file at all."
         )
     return candidate
 

--- a/tests/runtime/test_reyn_repo_resolver.py
+++ b/tests/runtime/test_reyn_repo_resolver.py
@@ -119,10 +119,18 @@ def test_safe_resolve_inside_missing_path_errors():
     ``test_safe_resolve_inside_rejects_non_declared_top_level`` below
     (a bare non-declared top-level segment like ``no-such-file.xyz`` is
     refused for a DIFFERENT reason — not in the declared set at all).
+
+    #5013: the message must also name a permitted alternative (this
+    tool's own reachable scope), not just say "no" — asserted on the
+    exact wording, not just "an error occurred" (lead-coder's own
+    witness standard, #5011).
     """
     root = resolve_reyn_root()
-    with pytest.raises(ValueError, match="does not exist"):
+    with pytest.raises(ValueError, match="does not exist") as excinfo:
         safe_resolve_inside(root, "docs/no-such-file.xyz")
+    message = str(excinfo.value)
+    assert "This tool reads only THIS checkout" in message
+    assert "README.md" in message and "src" in message  # the reachable set, named
 
 
 def test_safe_resolve_inside_rejects_non_declared_top_level():


### PR DESCRIPTION
**[docs-maintainer]** — part of #5013

## What

reyn-self hit 4 examples of a denial message that didn't name a
permitted alternative — just "no". Fixed the one reyn owns the text
for; the other 3 are reported not-fixable-in-scope (acceptance
criterion explicitly allows this: "直せないものは「直せない・理由」で
構いません（それも答えです）").

## ① `reyn_repo`'s "does not exist in the Reyn repository" — FIXED

`src/reyn/runtime/reyn_repo.py`'s `safe_resolve_inside`: a path that
resolves inside the reachable set but doesn't exist on disk used to
just say "does not exist" with no further guidance. Now names this
tool's own reachable set (`README.md`/`CHANGELOG.md`/`docs`/`src`) and
states explicitly that a path from a different checkout/worktree is
out of this tool's read scope entirely, not a typo to retry here —
answering the exact two questions the issue named ("別checkoutか" /
"read scope外か").

Witness (`tests/runtime/test_reyn_repo_resolver.py`): strengthened the
existing `test_safe_resolve_inside_missing_path_errors` to assert the
new guidance text verbatim, not just the pre-existing "does not exist"
substring — per lead-coder's own witness standard (#5011: assert what
it says, not just that it errors). Strip-falsified: reverted the
addition, confirmed the test fails for the stated reason, restored.

## ②③④ — investigated, not fixable in this repo's own text

- **② MCP `subscriber_id`/`session_id` "Field required"**: grepped
  `src/reyn/` for both field names — 0 hits. The text lives in the
  `broker` MCP server (`~/Workspace/reyn_dev/broker/server.py`), a
  separate project entirely outside this repo's `src/`. Reyn has no
  control over that error text.
- **③ `git show`'s "fatal: not a git repository"**: git's own native
  CLI stderr, surfaced verbatim through reyn-self's generic shell-exec
  tool. Grepped `src/reyn/` for any existing site that wraps or
  postprocesses `git`/`gh` subprocess output — 0 hits anywhere. Adding
  one now would mean building new output-interception infrastructure,
  explicitly out of this issue's scope ("gate も作らない・広げない").
- **④ `gh`'s "HTTP 401 ... Try authenticating with: gh auth login"**:
  same shape and same conclusion as ③ — gh's own native output, no
  existing reyn wrapping site to extend.

## Doc line (acceptance criterion ③)

Added to `docs/concepts/agent-engineering/tool-contract-design.md` — a
new small section, "Denial messages name a permitted alternative",
citing #5013.

## Scope discipline

Touched only the 4 named examples (well, the 1 fixable one) — no
sweep of other denial-returning tools, no new gate/linter for this
pattern, per the issue's explicit "広げない・gate も作らない".

## Test plan

- [x] `.venv/bin/python -m pytest tests/runtime/test_reyn_repo_resolver.py` — 14/14 passed
- [x] Strip-falsify — reverted the message addition, confirmed the
      strengthened test fails for the stated reason, restored, green
- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_reyn_repo_resolver.py` — 14 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/reyn_repo.py` — OK
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no `Aborted`/`WARNING`
- [x] `python scripts/check_doc_anchors.py` — "no dangling anchors into published pages"
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Closing-keyword self-check on commit message + this PR body — 0 hits
- [x] TESTS-READ: this PR touches `tests/` — holding for a reviewer's TESTS-READ note per CLAUDE.md rule 8, not self-merging

part of #5013

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
