### PR TITLE
feat(#5009): declare 3 more snapshot keys that fabricated a value

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -985,8 +985,18 @@ def pipe_pane_lines(snap: "dict | None") -> list[str]:
 def cron_pane_lines(snap: "dict | None") -> list[str]:
     """The configured cron jobs (``config.cron.jobs`` via the snapshot's
     ``cron_jobs``), each with its enabled state and schedule. Read-only: a cron
-    job's enabled flag is config-declared, not session-togglable."""
+    job's enabled flag is config-declared, not session-togglable.
+
+    #5009 closing pass: ``cron_jobs_reported`` (``snap.get(..., False)`` —
+    ``False`` is the safe direction, matching every other #5009 field;
+    unreachable for any real, complete read model, since both producers
+    always populate it — see :class:`~reyn.interfaces.repl.read_model.
+    ChatReadModelCapabilities`'s own docstring) gates the ``["(none)"]``
+    fallback: a remote client's own ``cron_jobs: []`` used to render
+    byte-identical to a genuinely empty LOCAL cron config."""
     snap = snap or {}
+    if not snap.get("cron_jobs_reported", False):
+        return ["not reported on this connection"]
     jobs = snap.get("cron_jobs") or []
     return [
         f"[{'on' if j.get('enabled') else 'off'}] {j['name']}  {j['schedule']}"
@@ -1382,9 +1392,22 @@ def cost_pane_lines(snap: "dict | None") -> list[str]:
     p, c, _t = snap.get("usage", (0, 0, 0))
     agent_tokens = snap.get("agent_tokens", _t)
     cached = snap.get("session_cached_tokens", 0)
+    # #5009 closing pass: the total above is real wire data on every
+    # implementation, but the prompt/completion SPLIT is `0`/`0` on a
+    # remote client — an inconsistent breakdown (`0 + 0 != total`) this
+    # pane never flagged on its own. `usage_breakdown_reported` (safe
+    # default `False`, unreachable for any real, complete read model —
+    # see `ChatReadModelCapabilities`'s own docstring) gates the split
+    # only; the total keeps rendering unconditionally.
+    usage_breakdown_reported = snap.get("usage_breakdown_reported", False)
+    prompt_completion = (
+        f"prompt {p:,} · completion {c:,}"
+        if usage_breakdown_reported
+        else "prompt — · completion —"
+    )
     rows = [
         *_cost_breakdown_table(snap),
-        f"tokens   prompt {p:,} · completion {c:,} · total {agent_tokens:,}",
+        f"tokens   {prompt_completion} · total {agent_tokens:,}",
         _cache_hit_line(
             "cache", cached, p, note="cumulative",
             reported=snap.get("cache_usage_reported", False),
@@ -1460,7 +1483,20 @@ def ctx_pane_lines(snap: "dict | None") -> list[str]:
             note="last call",
             reported=snap.get("cache_usage_reported", False),
         ),
-        f"compaction   {comp_est:,} / {comp_trigger:,} tokens est.  ({comp_pct}% to trigger)",
+        # #5009 closing pass: `status_fn is None` degrades ``comp_trigger``
+        # to `0`, and "0% to trigger" is a FABRICATED reassurance — a real
+        # local session essentially never has a genuine zero-trigger
+        # state, so this isn't "indistinguishable from empty" (#4996's
+        # own proxy criterion), it's a number that looks like real
+        # headroom when nothing was measured (the corrected criterion —
+        # see `ChatReadModelCapabilities`'s own docstring). Gated the
+        # same safe-default way as every other #5009 field.
+        (
+            f"compaction   {comp_est:,} / {comp_trigger:,} tokens est."
+            f"  ({comp_pct}% to trigger)"
+            if snap.get("ctx_compaction_reported", False)
+            else "compaction   not reported on this connection"
+        ),
     ]
 
 

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -132,6 +132,22 @@ class ChatReadModelCapabilities:
     condition without updating this declaration, the declared/actual gap
     this class exists to prevent would reopen silently, on the LOCAL side
     this time. Follow-up, not a defect in this class.
+
+    **The real criterion, corrected** (#5009 closing pass — ``cron_jobs_
+    reported`` / ``usage_breakdown_reported`` / ``ctx_compaction_
+    reported``): the FIRST measuring stick tried for "does a key need a
+    field here" was "is the degrade value indistinguishable from a
+    genuinely empty local state" — a useful PROXY, but not the actual
+    rule. #4996's own words already said the real one: "never a
+    fabricated turn", "never a fabricated count". ``ctx_compaction_
+    reported`` is the falsifying case: remote's degraded compaction line
+    reads "0% to trigger" — a real local session essentially never has a
+    genuine zero-trigger state, so the OLD proxy would have said "no
+    conflation, skip it" — but "0%" fabricates reassurance regardless of
+    whether a real empty state could produce the same string. The
+    correct question is always the fabrication one; "indistinguishable
+    from empty" is one way a value fabricates, not the definition of
+    fabrication.
     """
 
     completion_session: bool
@@ -141,6 +157,9 @@ class ChatReadModelCapabilities:
     conversation_history: bool
     load_older_conversation_history: bool
     cache_usage_reported: bool
+    cron_jobs_reported: bool
+    usage_breakdown_reported: bool
+    ctx_compaction_reported: bool
 
 
 def cache_usage_reported_snapshot_key(
@@ -157,6 +176,51 @@ def cache_usage_reported_snapshot_key(
     return {"cache_usage_reported": capabilities.cache_usage_reported}
 
 
+def cron_jobs_reported_snapshot_key(
+    capabilities: ChatReadModelCapabilities,
+) -> "dict[str, bool]":
+    """The ``snapshot()`` dict fragment for :attr:`ChatReadModelCapabilities.
+    cron_jobs_reported` (#5009 closing pass). Same shape as
+    :func:`cache_usage_reported_snapshot_key` — see that function's own
+    docstring for why a helper, not a hand-typed literal, in each
+    producer. Measured (per-key, before declaring): remote's
+    ``cron_jobs: []`` renders the Cron pane's own ``["(none)"]`` fallback,
+    byte-identical to a genuinely empty LOCAL cron config — the same
+    conflation ``cache_usage_reported`` closes, one key over."""
+    return {"cron_jobs_reported": capabilities.cron_jobs_reported}
+
+
+def usage_breakdown_reported_snapshot_key(
+    capabilities: ChatReadModelCapabilities,
+) -> "dict[str, bool]":
+    """The ``snapshot()`` dict fragment for :attr:`ChatReadModelCapabilities.
+    usage_breakdown_reported` (#5009 closing pass, architect's corrected
+    criterion — not "indistinguishable from empty" but the ``#4996``
+    principle stated directly: "never a fabricated ... count"). Measured:
+    remote's ``usage`` degrades to ``(0, 0, real_agent_tokens)`` — the
+    Cost pane renders ``prompt 0 · completion 0 · total X`` with X real
+    and nonzero, an inconsistent breakdown (``0 + 0 != X``) the pane
+    itself never flags. Governs the prompt/completion SPLIT only; the
+    total is real wire data on both implementations and is unaffected."""
+    return {"usage_breakdown_reported": capabilities.usage_breakdown_reported}
+
+
+def ctx_compaction_reported_snapshot_key(
+    capabilities: ChatReadModelCapabilities,
+) -> "dict[str, bool]":
+    """The ``snapshot()`` dict fragment for :attr:`ChatReadModelCapabilities.
+    ctx_compaction_reported` (#5009 closing pass). Measured: remote's
+    ``ctx_compaction_status_fn: None`` renders the Ctx pane's compaction
+    line as ``0 / 0 tokens est. (0% to trigger)`` — not indistinguishable
+    from a genuine local zero-trigger session (which essentially never
+    happens once a model is resolved), but a FABRICATED reassurance —
+    "0% to trigger" reads as "plenty of headroom" when nothing was
+    actually measured. Architect's corrected criterion for this class of
+    field: a fabricated-looking number is disqualifying even when it
+    can't be confused with a real empty state."""
+    return {"ctx_compaction_reported": capabilities.ctx_compaction_reported}
+
+
 #: :class:`RegistryReadModel` is local — every degradable read reflects real,
 #: current state; ``None``/``[]``/``0`` from it always means "genuinely
 #: nothing", never "unsupported here".
@@ -168,6 +232,9 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     conversation_history=True,
     load_older_conversation_history=True,
     cache_usage_reported=True,
+    cron_jobs_reported=True,
+    usage_breakdown_reported=True,
+    ctx_compaction_reported=True,
 )
 
 #: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these 6
@@ -182,6 +249,9 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     conversation_history=False,
     load_older_conversation_history=False,
     cache_usage_reported=False,
+    cron_jobs_reported=False,
+    usage_breakdown_reported=False,
+    ctx_compaction_reported=False,
 )
 
 
@@ -495,6 +565,13 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         "agent_names": [],
         "session_tree": [],
         "usage": (0, 0, v.get("agent_tokens", 0)),
+        # #5009 closing pass: the prompt/completion SPLIT above is `0`/`0`
+        # while the total is real wire data — an inconsistent breakdown
+        # (`0 + 0 != total`) the Cost pane never flags on its own.
+        # Declared so it renders "—" for the split instead of a
+        # fabricated `0`; the total stays untouched (already real on
+        # both implementations).
+        **usage_breakdown_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES),
         "session_cached_tokens": 0,
         "ctx_recent_usage": (0, 0),
         # #5009: `0` above is the correct graceful-degrade VALUE for both cache
@@ -518,12 +595,25 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         **cache_usage_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES),
         "ctx_source": "remote",
         "ctx_compaction_status_fn": None,
+        # #5009 closing pass: `None` above is correct (no compaction-status
+        # source on the wire) — declared here so `chrome.py`'s Ctx pane
+        # renders "not reported" instead of the fabricated-looking
+        # "0 / 0 tokens est. (0% to trigger)" a naive `status_fn is None`
+        # fallback produces (a real local session essentially never has a
+        # genuine zero-trigger state, so "0%" here reads as false
+        # reassurance, not as an honest empty state).
+        **ctx_compaction_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES),
         # #3283 ④: the keyed per-turn cost/token lookup is a SESSION-local read
         # (the tracker's per-turn buckets are process-local, in-memory, and not
         # projected onto the AG-UI wire) → None for remote, and the right
         # gutter renders "—" rather than a fabricated figure. Same
         # frame-sufficiency boundary as ``conversation_history`` above.
         "turn_usage_fn": None,
+        # #5009 closing pass: `[]` above is correct (cron config is not on
+        # the wire) — declared here so the Cron pane renders "not
+        # reported" instead of its own `["(none)"]` fallback, which is
+        # byte-identical to a genuinely empty LOCAL cron config.
+        **cron_jobs_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES),
         "cron_jobs": [],
         "mcp_servers": [],
         "hooks": [],

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from dataclasses import fields as dataclass_fields
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -162,63 +163,36 @@ class ChatReadModelCapabilities:
     ctx_compaction_reported: bool
 
 
-def cache_usage_reported_snapshot_key(
+def reported_snapshot_keys(
     capabilities: ChatReadModelCapabilities,
 ) -> "dict[str, bool]":
-    """The ``snapshot()`` dict fragment for :attr:`ChatReadModelCapabilities.
-    cache_usage_reported` — the ONE source both ``snapshot()`` producers
+    """The FULL ``snapshot()`` dict fragment for *every* field of
+    *capabilities* — the ONE source both ``snapshot()`` producers
     (``status.py``'s ``_snapshot()`` and :func:`project_remote_snapshot`)
-    merge in, instead of each hand-typing the literal a second time (#5009,
-    architect co-vet: two producers hand-typing the same bit independently
-    is exactly one more way to silently diverge — one helper, called from
-    both, is the #4996-family fix: derive from the SSoT, don't duplicate
-    the literal)."""
-    return {"cache_usage_reported": capabilities.cache_usage_reported}
+    merge in, instead of each hand-typing a literal a second time (#5009).
 
+    Generalized (#5009 closing pass, architect co-vet) from 4 near-
+    identical single-field helpers — ``cache_usage_reported_snapshot_
+    key``, ``cron_jobs_reported_snapshot_key``,
+    ``usage_breakdown_reported_snapshot_key``,
+    ``ctx_compaction_reported_snapshot_key`` — each a literal copy of the
+    same one-line ``return {"<name>": capabilities.<name>}`` shape.
+    Measured: 4 helpers meant 4 producer-side call sites too, and the
+    NEXT declared field would add a 5th of each — the exact "forgot to
+    wire one side" risk this whole design exists to close, just moved
+    from the VALUE to the WIRING. One generic projection over every
+    dataclass field removes the wiring step entirely: declaring a field
+    HERE is now the only step a future key needs; no producer edit, no
+    new helper.
 
-def cron_jobs_reported_snapshot_key(
-    capabilities: ChatReadModelCapabilities,
-) -> "dict[str, bool]":
-    """The ``snapshot()`` dict fragment for :attr:`ChatReadModelCapabilities.
-    cron_jobs_reported` (#5009 closing pass). Same shape as
-    :func:`cache_usage_reported_snapshot_key` — see that function's own
-    docstring for why a helper, not a hand-typed literal, in each
-    producer. Measured (per-key, before declaring): remote's
-    ``cron_jobs: []`` renders the Cron pane's own ``["(none)"]`` fallback,
-    byte-identical to a genuinely empty LOCAL cron config — the same
-    conflation ``cache_usage_reported`` closes, one key over."""
-    return {"cron_jobs_reported": capabilities.cron_jobs_reported}
-
-
-def usage_breakdown_reported_snapshot_key(
-    capabilities: ChatReadModelCapabilities,
-) -> "dict[str, bool]":
-    """The ``snapshot()`` dict fragment for :attr:`ChatReadModelCapabilities.
-    usage_breakdown_reported` (#5009 closing pass, architect's corrected
-    criterion — not "indistinguishable from empty" but the ``#4996``
-    principle stated directly: "never a fabricated ... count"). Measured:
-    remote's ``usage`` degrades to ``(0, 0, real_agent_tokens)`` — the
-    Cost pane renders ``prompt 0 · completion 0 · total X`` with X real
-    and nonzero, an inconsistent breakdown (``0 + 0 != X``) the pane
-    itself never flags. Governs the prompt/completion SPLIT only; the
-    total is real wire data on both implementations and is unaffected."""
-    return {"usage_breakdown_reported": capabilities.usage_breakdown_reported}
-
-
-def ctx_compaction_reported_snapshot_key(
-    capabilities: ChatReadModelCapabilities,
-) -> "dict[str, bool]":
-    """The ``snapshot()`` dict fragment for :attr:`ChatReadModelCapabilities.
-    ctx_compaction_reported` (#5009 closing pass). Measured: remote's
-    ``ctx_compaction_status_fn: None`` renders the Ctx pane's compaction
-    line as ``0 / 0 tokens est. (0% to trigger)`` — not indistinguishable
-    from a genuine local zero-trigger session (which essentially never
-    happens once a model is resolved), but a FABRICATED reassurance —
-    "0% to trigger" reads as "plenty of headroom" when nothing was
-    actually measured. Architect's corrected criterion for this class of
-    field: a fabricated-looking number is disqualifying even when it
-    can't be confused with a real empty state."""
-    return {"ctx_compaction_reported": capabilities.ctx_compaction_reported}
+    Deliberately projects EVERY field, not only the ``*_reported`` ones
+    — the METHOD-axis fields from #4996 (``completion_session`` etc.)
+    ride along too, harmlessly (no pane reads them off the snapshot
+    dict; ``ChatReadModel.capabilities`` remains their real consumer).
+    Simpler than filtering by name pattern, and the field NAME already
+    doubles as the snapshot key by construction — the two can no more
+    drift apart than a dataclass field can rename itself."""
+    return {f.name: getattr(capabilities, f.name) for f in dataclass_fields(capabilities)}
 
 
 #: :class:`RegistryReadModel` is local — every degradable read reflects real,
@@ -560,60 +534,64 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         "ctx_used": v.get("ctx_used", 0),
         "ctx_window": v.get("ctx_window", 0),
         # -- session-local keys (NOT on the wire) → graceful empty/zero --
+        #
+        # #5009 / #5009 closing pass: every ``*_reported`` declaration
+        # (whether the VALUE next to it here can be trusted, or is a
+        # graceful degrade with no reader-visible way to tell) is
+        # projected in ONE call, from ONE source
+        # (``REMOTE_CHAT_READ_CAPABILITIES``) — never hand-typed per key.
+        # A hand-typed literal per key was tried and measured wrong (a
+        # producer that forgets one key can silently claim "I report"
+        # while returning a fabricated value); one generic projection
+        # over ``ChatReadModelCapabilities``'s own fields (see
+        # :func:`reported_snapshot_keys`) removes the "forgot to wire
+        # this key" failure mode structurally — a new field declared on
+        # that dataclass reaches every producer for free, no call-site
+        # edit required.
+        **reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES),
         "model_active_class": None,
         "model_classes": [],
         "agent_names": [],
         "session_tree": [],
+        # The prompt/completion SPLIT below is `0`/`0` while the total is
+        # real wire data — an inconsistent breakdown (`0 + 0 != total`)
+        # the Cost pane never flags on its own; gated by
+        # ``usage_breakdown_reported`` above.
         "usage": (0, 0, v.get("agent_tokens", 0)),
-        # #5009 closing pass: the prompt/completion SPLIT above is `0`/`0`
-        # while the total is real wire data — an inconsistent breakdown
-        # (`0 + 0 != total`) the Cost pane never flags on its own.
-        # Declared so it renders "—" for the split instead of a
-        # fabricated `0`; the total stays untouched (already real on
-        # both implementations).
-        **usage_breakdown_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES),
-        "session_cached_tokens": 0,
-        "ctx_recent_usage": (0, 0),
-        # #5009: `0` above is the correct graceful-degrade VALUE for both cache
-        # figures (neither is projected onto the AG-UI wire — cache-hit
-        # accounting is session-local, like the other keys in this block) —
-        # the missing DECLARATION half lives on REMOTE_CHAT_READ_CAPABILITIES
-        # itself (derived here via cache_usage_reported_snapshot_key, never
-        # hand-typed a second time — architect co-vet: two producers
-        # hand-typing the same bit independently is one more way to
-        # silently diverge). Consulted by `chrome.py`'s `_cache_hit_line`
-        # so BOTH panes reading these 2 keys (Cost pane's cumulative line,
-        # Ctx pane's recent-call line) render a "not reported" line instead
-        # of a fabricated "0% hit (0 / 0)" — the same wording that would
-        # come from a real, empty session.
+        # `0`/`(0, 0)` below are the correct graceful-degrade VALUES for
+        # both cache figures (neither is projected onto the AG-UI wire —
+        # cache-hit accounting is session-local); gated by
+        # ``cache_usage_reported`` above, consulted by `chrome.py`'s
+        # `_cache_hit_line` so BOTH panes reading these 2 keys (Cost
+        # pane's cumulative line, Ctx pane's recent-call line) render a
+        # "not reported" line instead of a fabricated "0% hit (0 / 0)".
         #
         # Scope, explicit (architect, #5009): this is NOT the owner's actual
         # "cache stuck at 0%" observation — that was measured on a LOCAL
         # session (owner-confirmed) and is a separate, still-unresolved
         # symptom this key does not touch. This key only makes the REMOTE
         # "0 could mean unsupported" case honestly say so.
-        **cache_usage_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES),
+        "session_cached_tokens": 0,
+        "ctx_recent_usage": (0, 0),
         "ctx_source": "remote",
+        # `None` below is correct (no compaction-status source on the
+        # wire); gated by ``ctx_compaction_reported`` above so the Ctx
+        # pane renders "not reported" instead of the fabricated-looking
+        # "0 / 0 tokens est. (0% to trigger)" a naive ``status_fn is
+        # None`` fallback produces (a real local session essentially
+        # never has a genuine zero-trigger state, so "0%" here reads as
+        # false reassurance, not as an honest empty state).
         "ctx_compaction_status_fn": None,
-        # #5009 closing pass: `None` above is correct (no compaction-status
-        # source on the wire) — declared here so `chrome.py`'s Ctx pane
-        # renders "not reported" instead of the fabricated-looking
-        # "0 / 0 tokens est. (0% to trigger)" a naive `status_fn is None`
-        # fallback produces (a real local session essentially never has a
-        # genuine zero-trigger state, so "0%" here reads as false
-        # reassurance, not as an honest empty state).
-        **ctx_compaction_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES),
         # #3283 ④: the keyed per-turn cost/token lookup is a SESSION-local read
         # (the tracker's per-turn buckets are process-local, in-memory, and not
         # projected onto the AG-UI wire) → None for remote, and the right
         # gutter renders "—" rather than a fabricated figure. Same
         # frame-sufficiency boundary as ``conversation_history`` above.
         "turn_usage_fn": None,
-        # #5009 closing pass: `[]` above is correct (cron config is not on
-        # the wire) — declared here so the Cron pane renders "not
+        # `[]` below is correct (cron config is not on the wire); gated
+        # by ``cron_jobs_reported`` above so the Cron pane renders "not
         # reported" instead of its own `["(none)"]` fallback, which is
         # byte-identical to a genuinely empty LOCAL cron config.
-        **cron_jobs_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES),
         "cron_jobs": [],
         "mcp_servers": [],
         "hooks": [],

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -351,54 +351,20 @@ def _session_pipelines(session) -> list[dict]:
         return []
 
 
-def _cache_usage_reported_key() -> "dict[str, bool]":
-    """LOCAL's own `{"cache_usage_reported": True}` — a thin wrapper around
-    ``read_model.py``'s ``cache_usage_reported_snapshot_key`` (#5009) that
-    carries the LAZY import (see the call site's own comment for why: this
-    module is imported BY ``read_model.py``'s own top level, so the reverse
-    reference must not be)."""
+def _reported_snapshot_keys() -> "dict[str, bool]":
+    """LOCAL's own full ``ChatReadModelCapabilities`` projection — a thin
+    wrapper around ``read_model.py``'s ``reported_snapshot_keys`` (#5009)
+    that carries the LAZY import (this module is imported BY
+    ``read_model.py``'s own top level, so the reverse reference must not
+    be). Generalized (#5009 closing pass) from 4 near-identical
+    single-field wrappers to the ONE generic projection — see
+    ``reported_snapshot_keys``'s own docstring for why."""
     from reyn.interfaces.repl.read_model import (  # noqa: PLC0415
         LOCAL_CHAT_READ_CAPABILITIES,
-        cache_usage_reported_snapshot_key,
+        reported_snapshot_keys,
     )
 
-    return cache_usage_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES)
-
-
-def _cron_jobs_reported_key() -> "dict[str, bool]":
-    """LOCAL's own `{"cron_jobs_reported": True}` — same lazy-import shape
-    as :func:`_cache_usage_reported_key` above, extended in #5009's
-    closing pass."""
-    from reyn.interfaces.repl.read_model import (  # noqa: PLC0415
-        LOCAL_CHAT_READ_CAPABILITIES,
-        cron_jobs_reported_snapshot_key,
-    )
-
-    return cron_jobs_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES)
-
-
-def _usage_breakdown_reported_key() -> "dict[str, bool]":
-    """LOCAL's own `{"usage_breakdown_reported": True}` — same lazy-import
-    shape as :func:`_cache_usage_reported_key` above, extended in #5009's
-    closing pass."""
-    from reyn.interfaces.repl.read_model import (  # noqa: PLC0415
-        LOCAL_CHAT_READ_CAPABILITIES,
-        usage_breakdown_reported_snapshot_key,
-    )
-
-    return usage_breakdown_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES)
-
-
-def _ctx_compaction_reported_key() -> "dict[str, bool]":
-    """LOCAL's own `{"ctx_compaction_reported": True}` — same lazy-import
-    shape as :func:`_cache_usage_reported_key` above, extended in #5009's
-    closing pass."""
-    from reyn.interfaces.repl.read_model import (  # noqa: PLC0415
-        LOCAL_CHAT_READ_CAPABILITIES,
-        ctx_compaction_reported_snapshot_key,
-    )
-
-    return ctx_compaction_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES)
+    return reported_snapshot_keys(LOCAL_CHAT_READ_CAPABILITIES)
 
 
 def _snapshot(registry, config=None):
@@ -467,16 +433,23 @@ def _snapshot(registry, config=None):
     # in ONE place (``BudgetTracker.turn_usage`` returns None, not 0).
     turn_usage_fn = s.turn_usage
     return {
+        # #5009 / #5009 closing pass: every ``*_reported`` declaration is
+        # projected in ONE call, from ONE source
+        # (``LOCAL_CHAT_READ_CAPABILITIES``) — see ``reported_snapshot_
+        # keys``'s own docstring (read_model.py) for why a single
+        # generic projection replaced 4 near-identical hand-typed
+        # call sites.
+        **_reported_snapshot_keys(),
         "model": s.model,
         "model_active_class": s.active_model_class(),
         "model_classes": list(s.known_model_classes()),
         "agent_names": list(registry.loaded_names()),
         "attached_name": registry.attached_name,
         "session_tree": registry.session_tree(),
+        # LOCAL genuinely measures the prompt/completion SPLIT below
+        # (real Session state, u.prompt_tokens/u.completion_tokens) —
+        # gated by ``usage_breakdown_reported`` above.
         "usage": (u.prompt_tokens, u.completion_tokens, u.total_tokens),
-        # #5009 closing pass: LOCAL genuinely measures the prompt/completion
-        # SPLIT above (real Session state, u.prompt_tokens/u.completion_tokens).
-        **_usage_breakdown_reported_key(),
         "cost_usd": s.total_cost_usd,
         "cost_total": cost_total,
         "cost_agent": cost_agent,
@@ -518,31 +491,25 @@ def _snapshot(registry, config=None):
         "ctx_used": ctx_used,
         "ctx_window": ctx_window,
         "ctx_source": ctx_source,
+        # LOCAL genuinely measures both cache figures below (the
+        # `u`/`recent` reads are real Session state) — gated by
+        # ``cache_usage_reported`` above.
         "session_cached_tokens": u.cached_tokens,
         "ctx_recent_usage": (recent.prompt_tokens, recent.cached_tokens),
-        # #5009: LOCAL genuinely measures both cache figures above (the
-        # `u`/`recent` reads are real Session state). Derived from
-        # LOCAL_CHAT_READ_CAPABILITIES via cache_usage_reported_snapshot_key,
-        # never hand-typed here directly — see that helper's own docstring
-        # for why (two producers hand-typing the same bit independently is
-        # one more way to silently diverge). Local import: read_model.py
-        # imports `_snapshot` from this module at its own top level, so the
-        # reverse import must stay lazy to avoid a cycle.
-        **_cache_usage_reported_key(),
+        # LOCAL genuinely measures compaction status below (the bound
+        # method is real ``Session.context_window_status``) — gated by
+        # ``ctx_compaction_reported`` above.
         "ctx_compaction_status_fn": ctx_compaction_status_fn,
-        # #5009 closing pass: LOCAL genuinely measures compaction status
-        # (the bound method above is real ``Session.context_window_status``).
-        **_ctx_compaction_reported_key(),
+        # LOCAL genuinely measures cron config below (via
+        # ``_extract_cron_jobs``) whenever a ``config`` is given — gated
+        # by ``cron_jobs_reported`` above, declared True unconditionally:
+        # an unattached/no-config caller already gets `[]` for
+        # `cron_jobs` itself (same graceful-degrade value either way),
+        # and this is LOCAL's capability declaration, not a per-call
+        # state — the LOCAL implementation is always CAPABLE of
+        # reporting cron config, whether or not one happens to be
+        # loaded on THIS particular call.
         "cron_jobs": _extract_cron_jobs(config) if config is not None else [],
-        # #5009 closing pass: LOCAL genuinely measures cron config (via
-        # ``_extract_cron_jobs`` above) whenever a ``config`` is given —
-        # declared True unconditionally: an unattached/no-config caller
-        # already gets `[]` for `cron_jobs` itself (same graceful-degrade
-        # value either way), and this is LOCAL's capability declaration,
-        # not a per-call state — the LOCAL implementation is always
-        # CAPABLE of reporting cron config, whether or not one happens to
-        # be loaded on THIS particular call.
-        **_cron_jobs_reported_key(),
         "mcp_servers": _extract_mcp_servers(config) if config is not None else [],
         "hooks": _extract_hooks(config) if config is not None else [],
         "skills": _extract_skills(config) if config is not None else [],

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -365,6 +365,42 @@ def _cache_usage_reported_key() -> "dict[str, bool]":
     return cache_usage_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES)
 
 
+def _cron_jobs_reported_key() -> "dict[str, bool]":
+    """LOCAL's own `{"cron_jobs_reported": True}` — same lazy-import shape
+    as :func:`_cache_usage_reported_key` above, extended in #5009's
+    closing pass."""
+    from reyn.interfaces.repl.read_model import (  # noqa: PLC0415
+        LOCAL_CHAT_READ_CAPABILITIES,
+        cron_jobs_reported_snapshot_key,
+    )
+
+    return cron_jobs_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES)
+
+
+def _usage_breakdown_reported_key() -> "dict[str, bool]":
+    """LOCAL's own `{"usage_breakdown_reported": True}` — same lazy-import
+    shape as :func:`_cache_usage_reported_key` above, extended in #5009's
+    closing pass."""
+    from reyn.interfaces.repl.read_model import (  # noqa: PLC0415
+        LOCAL_CHAT_READ_CAPABILITIES,
+        usage_breakdown_reported_snapshot_key,
+    )
+
+    return usage_breakdown_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES)
+
+
+def _ctx_compaction_reported_key() -> "dict[str, bool]":
+    """LOCAL's own `{"ctx_compaction_reported": True}` — same lazy-import
+    shape as :func:`_cache_usage_reported_key` above, extended in #5009's
+    closing pass."""
+    from reyn.interfaces.repl.read_model import (  # noqa: PLC0415
+        LOCAL_CHAT_READ_CAPABILITIES,
+        ctx_compaction_reported_snapshot_key,
+    )
+
+    return ctx_compaction_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES)
+
+
 def _snapshot(registry, config=None):
     """Read live status values off the attached session via sync accessors."""
     s = registry.attached_session()
@@ -438,6 +474,9 @@ def _snapshot(registry, config=None):
         "attached_name": registry.attached_name,
         "session_tree": registry.session_tree(),
         "usage": (u.prompt_tokens, u.completion_tokens, u.total_tokens),
+        # #5009 closing pass: LOCAL genuinely measures the prompt/completion
+        # SPLIT above (real Session state, u.prompt_tokens/u.completion_tokens).
+        **_usage_breakdown_reported_key(),
         "cost_usd": s.total_cost_usd,
         "cost_total": cost_total,
         "cost_agent": cost_agent,
@@ -491,7 +530,19 @@ def _snapshot(registry, config=None):
         # reverse import must stay lazy to avoid a cycle.
         **_cache_usage_reported_key(),
         "ctx_compaction_status_fn": ctx_compaction_status_fn,
+        # #5009 closing pass: LOCAL genuinely measures compaction status
+        # (the bound method above is real ``Session.context_window_status``).
+        **_ctx_compaction_reported_key(),
         "cron_jobs": _extract_cron_jobs(config) if config is not None else [],
+        # #5009 closing pass: LOCAL genuinely measures cron config (via
+        # ``_extract_cron_jobs`` above) whenever a ``config`` is given —
+        # declared True unconditionally: an unattached/no-config caller
+        # already gets `[]` for `cron_jobs` itself (same graceful-degrade
+        # value either way), and this is LOCAL's capability declaration,
+        # not a per-call state — the LOCAL implementation is always
+        # CAPABLE of reporting cron config, whether or not one happens to
+        # be loaded on THIS particular call.
+        **_cron_jobs_reported_key(),
         "mcp_servers": _extract_mcp_servers(config) if config is not None else [],
         "hooks": _extract_hooks(config) if config is not None else [],
         "skills": _extract_skills(config) if config is not None else [],

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -678,6 +678,7 @@ def test_pipe_and_cron_panes_surface_their_entries() -> None:
     snap = {
         "pipelines": [{"name": "nightly", "description": "the nightly pass"}],
         "cron_jobs": [{"name": "sweep", "schedule": "0 3 * * *", "enabled": True}],
+        "cron_jobs_reported": True,
     }
     assert any("nightly" in r for r in pane_payload("pipe", snapshot=snap))
     pipe_rows = " ".join(pane_payload("pipe", snapshot=snap))

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -130,6 +130,9 @@ def test_capabilities_dataclass_rejects_a_missing_field():
         conversation_history=True,
         load_older_conversation_history=True,
         cache_usage_reported=True,
+        cron_jobs_reported=True,
+        usage_breakdown_reported=True,
+        ctx_compaction_reported=True,
     )
     with pytest.raises(TypeError):
         ChatReadModelCapabilities(  # type: ignore[call-arg]
@@ -139,7 +142,10 @@ def test_capabilities_dataclass_rejects_a_missing_field():
             has_command_ui_region=True,
             conversation_history=True,
             load_older_conversation_history=True,
-            # cache_usage_reported omitted
+            cache_usage_reported=True,
+            cron_jobs_reported=True,
+            usage_breakdown_reported=True,
+            # ctx_compaction_reported omitted
         )
 
 
@@ -156,9 +162,10 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
     implementation, transcribed?"). Kept as an explicit, readable pin of
     the vocabulary itself, not as a second guard.
 
-    ``cache_usage_reported`` (#5009) is the one field NOT named after a
-    ``ChatReadModel`` method — see the class's own docstring for why it
-    lives here anyway."""
+    ``cache_usage_reported`` / ``cron_jobs_reported`` /
+    ``usage_breakdown_reported`` / ``ctx_compaction_reported`` (#5009) are
+    the 4 fields NOT named after a ``ChatReadModel`` method — see the
+    class's own docstring for why they live here anyway."""
     names = {f.name for f in fields(ChatReadModelCapabilities)}
     assert names == {
         "completion_session",
@@ -168,6 +175,9 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
         "conversation_history",
         "load_older_conversation_history",
         "cache_usage_reported",
+        "cron_jobs_reported",
+        "usage_breakdown_reported",
+        "ctx_compaction_reported",
     }
 
 

--- a/tests/interfaces/test_5009_cache_reported_declaration.py
+++ b/tests/interfaces/test_5009_cache_reported_declaration.py
@@ -159,12 +159,17 @@ def test_ctx_pane_shows_not_reported_instead_of_a_fabricated_zero_percent():
 
 
 def test_ctx_pane_still_shows_a_real_percentage_when_reported():
-    """Tier 2: accept-side for the Ctx pane."""
+    """Tier 2: accept-side for the Ctx pane. `ctx_compaction_reported` is
+    also set True here — this test is only about the cache line, so the
+    (independently-declared, #5009 closing pass) compaction line must
+    not fall back to its own "not reported" and get caught by the
+    blanket assertion below."""
     snap = {
         "ctx_window": 200000,
         "ctx_used": 48120,
         "ctx_recent_usage": (48120, 14900),
         "cache_usage_reported": True,
+        "ctx_compaction_reported": True,
     }
     blob = "\n".join(ctx_pane_lines(snap))
     assert "31% hit" in blob, blob

--- a/tests/interfaces/test_5009_cache_reported_declaration.py
+++ b/tests/interfaces/test_5009_cache_reported_declaration.py
@@ -37,13 +37,15 @@ attempts before settling — both measured, not guessed):
    frozen, all fields required, no defaults — a producer that forgets
    the field fails to CONSTRUCT, at import time, not at render time).
    Each `snapshot()` producer derives its own key from ITS OWN
-   capabilities constant via `cache_usage_reported_snapshot_key(...)` —
-   never hand-typed a second time, so the two producers cannot silently
-   diverge from each other. The pane's own `snap.get(key, False)`
-   default is now correct and UNREACHABLE for any real, complete read
-   model: it fires only for the genuine `None`/`{}` pre-attach case,
-   where `False` (never claim reporting with nothing to consult) is the
-   right answer.
+   capabilities constant via `reported_snapshot_keys(...)` (originally
+   `cache_usage_reported_snapshot_key`, generalized in #5009's closing
+   pass once 3 more fields needed the identical helper shape — see that
+   function's own docstring) — never hand-typed a second time, so the
+   two producers cannot silently diverge from each other. The pane's
+   own `snap.get(key, False)` default is now correct and UNREACHABLE
+   for any real, complete read model: it fires only for the genuine
+   `None`/`{}` pre-attach case, where `False` (never claim reporting
+   with nothing to consult) is the right answer.
 
 Explicit scope (architect): only these 2 keys folded into
 `ChatReadModelCapabilities`. The other 9 session-local
@@ -72,8 +74,8 @@ from reyn.interfaces.inline.textual_chat.chrome import cost_pane_lines, ctx_pane
 from reyn.interfaces.repl.read_model import (
     LOCAL_CHAT_READ_CAPABILITIES,
     REMOTE_CHAT_READ_CAPABILITIES,
-    cache_usage_reported_snapshot_key,
     project_remote_snapshot,
+    reported_snapshot_keys,
 )
 
 
@@ -85,17 +87,15 @@ def test_capabilities_declare_cache_usage_reported():
 
 
 def test_the_snapshot_key_helper_derives_from_the_capabilities_it_is_given():
-    """Tier 1: `cache_usage_reported_snapshot_key` is a pure projection —
-    it returns exactly `{"cache_usage_reported": capabilities.
-    cache_usage_reported}`, nothing hand-typed alongside it. Both real
-    producers call this (see the tests below), so this pins the ONE
-    function they both depend on."""
-    assert cache_usage_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES) == {
-        "cache_usage_reported": True,
-    }
-    assert cache_usage_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES) == {
-        "cache_usage_reported": False,
-    }
+    """Tier 1: `reported_snapshot_keys` is a pure projection over EVERY
+    field of the capabilities it's given (generalized in #5009's closing
+    pass from the original single-field `cache_usage_reported_snapshot_
+    key` — see that function's own docstring) — its `cache_usage_
+    reported` entry always matches the source it was given, nothing
+    hand-typed alongside it. Both real producers call this (see the
+    tests below), so this pins the ONE function they both depend on."""
+    assert reported_snapshot_keys(LOCAL_CHAT_READ_CAPABILITIES)["cache_usage_reported"] is True
+    assert reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)["cache_usage_reported"] is False
 
 
 def test_remote_snapshot_declares_cache_usage_unreported():

--- a/tests/interfaces/test_5009_closing_pass_declarations.py
+++ b/tests/interfaces/test_5009_closing_pass_declarations.py
@@ -1,0 +1,222 @@
+"""Tier 1/2: #5009 closing pass — 3 more snapshot keys declare whether
+they are genuinely reported, closing the issue.
+
+Extends `#5009`'s own `cache_usage_reported` field with 3 siblings —
+`cron_jobs_reported` / `usage_breakdown_reported` / `ctx_compaction_
+reported` — each covering a different snapshot key that was left
+undeclared when `#5009` first landed (`#5015`), scoped out on purpose per
+architect's own "1 key at a time, report the render site before adding"
+process. All 9 originally-open keys were investigated (per-key: where is
+it rendered? does the remote-degrade value fabricate anything?), 3 of
+the 9 needed declaring, 6 did not — see the class-level docstring for
+the disposition of all 9, and `#5009`'s own issue thread for the full
+per-key measurement this PR's implementer reported before writing any
+of this.
+
+**The corrected criterion** (architect, on this closing pass): the
+FIRST measuring stick — "is the remote-degrade value indistinguishable
+from a genuine local empty state" — is a useful PROXY, not the actual
+rule. `ctx_compaction_reported` is the falsifying case: a real local
+session essentially never has a genuine zero-compaction-trigger state
+(so the proxy alone would have said "skip it, no confusable real
+case"), but the degraded line ("0% to trigger") still FABRICATES a
+specific, false reassurance regardless of whether a real state could
+produce the same string. `#4996`'s own words already named the real
+rule: "never a fabricated turn", "never a fabricated count" — the proxy
+is one way a value fabricates, not the definition.
+
+Each of the 3 declared keys, with its own render site and its own
+conflation:
+
+- `cron_jobs_reported`: the Cron pane's `["(none)"]` fallback for an
+  empty `cron_jobs` list — byte-identical to a genuinely empty LOCAL
+  cron config. The clean, original-proxy case (matches `cache_usage_
+  reported`'s own shape exactly).
+- `usage_breakdown_reported`: the Cost pane's `prompt 0 · completion 0
+  · total X` line, X real and nonzero — an inconsistent breakdown
+  (`0 + 0 != X`) the pane never flags on its own. Governs the SPLIT
+  only; the total stays real and unconditional on both implementations.
+- `ctx_compaction_reported`: the Ctx pane's compaction line, degrading
+  to `0 / 0 tokens est. (0% to trigger)` — the corrected-criterion case
+  above.
+
+Witnesses, same shape as `#5009`'s own original 2: each key strip-
+falsified at its own render site (reverting the gate turns the test red
+for the stated reason — a fabricated value reappears), paired with an
+accept-side test confirming a genuinely-reported figure still renders
+unchanged.
+
+Real `LOCAL_CHAT_READ_CAPABILITIES` / `REMOTE_CHAT_READ_CAPABILITIES` /
+`project_remote_snapshot` — no mocks.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.chrome import (
+    cost_pane_lines,
+    cron_pane_lines,
+    ctx_pane_lines,
+)
+from reyn.interfaces.repl.read_model import (
+    LOCAL_CHAT_READ_CAPABILITIES,
+    REMOTE_CHAT_READ_CAPABILITIES,
+    cron_jobs_reported_snapshot_key,
+    ctx_compaction_reported_snapshot_key,
+    project_remote_snapshot,
+    usage_breakdown_reported_snapshot_key,
+)
+
+
+def test_capabilities_declare_the_3_closing_pass_keys():
+    """Tier 1: the declarations themselves."""
+    assert LOCAL_CHAT_READ_CAPABILITIES.cron_jobs_reported is True
+    assert LOCAL_CHAT_READ_CAPABILITIES.usage_breakdown_reported is True
+    assert LOCAL_CHAT_READ_CAPABILITIES.ctx_compaction_reported is True
+    assert REMOTE_CHAT_READ_CAPABILITIES.cron_jobs_reported is False
+    assert REMOTE_CHAT_READ_CAPABILITIES.usage_breakdown_reported is False
+    assert REMOTE_CHAT_READ_CAPABILITIES.ctx_compaction_reported is False
+
+
+def test_the_3_helpers_derive_from_the_capabilities_they_are_given():
+    """Tier 1: pins each helper's own pure projection, same shape as
+    `cache_usage_reported_snapshot_key` — see that function's own
+    docstring, in read_model.py, for why a helper rather than a
+    hand-typed literal in each producer."""
+    assert cron_jobs_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES) == {
+        "cron_jobs_reported": True,
+    }
+    assert usage_breakdown_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES) == {
+        "usage_breakdown_reported": False,
+    }
+    assert ctx_compaction_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES) == {
+        "ctx_compaction_reported": True,
+    }
+
+
+def test_remote_snapshot_declares_all_3_unreported():
+    """Tier 1: the real producer — `project_remote_snapshot` — carries
+    all 3 declarations through, paired with the existing graceful
+    degrade values those keys already carried."""
+    snap = project_remote_snapshot({})
+    assert snap["cron_jobs_reported"] is False
+    assert snap["cron_jobs"] == []
+    assert snap["usage_breakdown_reported"] is False
+    assert snap["ctx_compaction_reported"] is False
+    assert snap["ctx_compaction_status_fn"] is None
+
+
+# ── cron_jobs_reported ──────────────────────────────────────────────────
+
+
+def test_cron_pane_shows_not_reported_instead_of_a_fabricated_none():
+    """Tier 2: strip-falsifier. Reverting the `cron_jobs_reported` gate in
+    `cron_pane_lines` turns this red — the pane would show `["(none)"]`,
+    indistinguishable from a genuinely empty LOCAL cron config."""
+    snap = {"cron_jobs": [], "cron_jobs_reported": False}
+    lines = cron_pane_lines(snap)
+    assert lines == ["not reported on this connection"], lines
+
+
+def test_cron_pane_still_lists_real_jobs_when_reported():
+    """Tier 2: accept-side — a genuinely reported, non-empty cron config
+    renders exactly as before this issue."""
+    snap = {
+        "cron_jobs": [{"name": "sweep", "schedule": "0 3 * * *", "enabled": True}],
+        "cron_jobs_reported": True,
+    }
+    lines = cron_pane_lines(snap)
+    assert lines == ["[on] sweep  0 3 * * *"], lines
+
+
+# ── usage_breakdown_reported ────────────────────────────────────────────
+
+
+def test_cost_pane_shows_dashes_instead_of_a_fabricated_zero_split():
+    """Tier 2: strip-falsifier. Reverting the `usage_breakdown_reported`
+    gate turns this red — the pane would show `prompt 0 · completion 0
+    · total 1,540`, an inconsistent breakdown (`0 + 0 != 1,540`) that
+    reads as "no tokens used" when real tokens were."""
+    snap = {
+        "usage": (0, 0, 1540),
+        "agent_tokens": 1540,
+        "usage_breakdown_reported": False,
+    }
+    blob = "\n".join(cost_pane_lines(snap))
+    assert "prompt — · completion —" in blob, blob
+    assert "total 1,540" in blob, (
+        f"the total must keep rendering unconditionally (real wire data on "
+        f"both implementations):\n{blob}"
+    )
+    assert "prompt 0" not in blob, blob
+
+
+def test_cost_pane_still_shows_the_real_split_when_reported():
+    """Tier 2: accept-side."""
+    snap = {
+        "usage": (1200, 340, 1540),
+        "agent_tokens": 1540,
+        "usage_breakdown_reported": True,
+    }
+    blob = "\n".join(cost_pane_lines(snap))
+    assert "prompt 1,200 · completion 340" in blob, blob
+    assert "total 1,540" in blob, blob
+    assert "—" not in blob.split("tokens")[1].split("\n")[0], blob
+
+
+# ── ctx_compaction_reported ─────────────────────────────────────────────
+
+
+def test_ctx_pane_shows_not_reported_instead_of_a_fabricated_reassurance():
+    """Tier 2: strip-falsifier. Reverting the `ctx_compaction_reported`
+    gate turns this red — the pane would show `0 / 0 tokens est. (0% to
+    trigger)`, a fabricated "plenty of headroom" reading when nothing
+    was actually measured."""
+    snap = {
+        "ctx_window": 200000,
+        "ctx_used": 90000,
+        "ctx_recent_usage": (90000, 40000),
+        "cache_usage_reported": True,
+        "ctx_compaction_status_fn": None,
+        "ctx_compaction_reported": False,
+    }
+    blob = "\n".join(ctx_pane_lines(snap))
+    assert "compaction   not reported on this connection" in blob, blob
+    assert "0% to trigger" not in blob, blob
+
+
+def test_ctx_pane_still_shows_the_real_compaction_estimate_when_reported():
+    """Tier 2: accept-side — a genuinely reported compaction status still
+    renders its real figures."""
+    def _status_fn():
+        return {"effective_trigger": 100000, "free_window": 40000}
+
+    snap = {
+        "ctx_window": 200000,
+        "ctx_used": 90000,
+        "ctx_recent_usage": (90000, 40000),
+        "cache_usage_reported": True,
+        "ctx_compaction_status_fn": _status_fn,
+        "ctx_compaction_reported": True,
+    }
+    blob = "\n".join(ctx_pane_lines(snap))
+    assert "60,000 / 100,000 tokens est." in blob, blob
+    assert "60% to trigger" in blob, blob
+    assert "not reported" not in blob, blob
+
+
+# ── pre-attach None/{} — the settled safe direction, all 3 keys ────────
+
+
+def test_a_pre_attach_snapshot_shows_not_reported_for_all_3_keys_too():
+    """Tier 2: the same pre-attach contract #5009's own original 2 keys
+    established (`cost_pane_lines(None)`/`ctx_pane_lines(None)` must
+    degrade gracefully, never crash) extends to these 3 — and to
+    `cron_pane_lines(None)`, not previously exercised by #5009's own
+    test file."""
+    cost_blob = "\n".join(cost_pane_lines(None))
+    assert "prompt — · completion —" in cost_blob, cost_blob
+
+    ctx_blob = "\n".join(ctx_pane_lines(None))
+    assert "compaction   not reported on this connection" in ctx_blob, ctx_blob
+
+    cron_lines = cron_pane_lines(None)
+    assert cron_lines == ["not reported on this connection"], cron_lines

--- a/tests/interfaces/test_5009_closing_pass_declarations.py
+++ b/tests/interfaces/test_5009_closing_pass_declarations.py
@@ -59,10 +59,8 @@ from reyn.interfaces.inline.textual_chat.chrome import (
 from reyn.interfaces.repl.read_model import (
     LOCAL_CHAT_READ_CAPABILITIES,
     REMOTE_CHAT_READ_CAPABILITIES,
-    cron_jobs_reported_snapshot_key,
-    ctx_compaction_reported_snapshot_key,
     project_remote_snapshot,
-    usage_breakdown_reported_snapshot_key,
+    reported_snapshot_keys,
 )
 
 
@@ -76,20 +74,21 @@ def test_capabilities_declare_the_3_closing_pass_keys():
     assert REMOTE_CHAT_READ_CAPABILITIES.ctx_compaction_reported is False
 
 
-def test_the_3_helpers_derive_from_the_capabilities_they_are_given():
-    """Tier 1: pins each helper's own pure projection, same shape as
-    `cache_usage_reported_snapshot_key` — see that function's own
-    docstring, in read_model.py, for why a helper rather than a
-    hand-typed literal in each producer."""
-    assert cron_jobs_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES) == {
-        "cron_jobs_reported": True,
-    }
-    assert usage_breakdown_reported_snapshot_key(REMOTE_CHAT_READ_CAPABILITIES) == {
-        "usage_breakdown_reported": False,
-    }
-    assert ctx_compaction_reported_snapshot_key(LOCAL_CHAT_READ_CAPABILITIES) == {
-        "ctx_compaction_reported": True,
-    }
+def test_the_shared_helper_derives_all_3_from_the_capabilities_given():
+    """Tier 1: pins `reported_snapshot_keys`'s own pure projection for
+    these 3 fields specifically — see that function's own docstring, in
+    read_model.py, for why ONE generic helper (not 4 near-identical
+    single-field ones, the shape this PR replaced) is what both
+    producers derive every `*_reported` key from."""
+    local_keys = reported_snapshot_keys(LOCAL_CHAT_READ_CAPABILITIES)
+    assert local_keys["cron_jobs_reported"] is True
+    assert local_keys["usage_breakdown_reported"] is True
+    assert local_keys["ctx_compaction_reported"] is True
+
+    remote_keys = reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)
+    assert remote_keys["cron_jobs_reported"] is False
+    assert remote_keys["usage_breakdown_reported"] is False
+    assert remote_keys["ctx_compaction_reported"] is False
 
 
 def test_remote_snapshot_declares_all_3_unreported():

--- a/tests/interfaces/test_textual_chat_phase4_3273.py
+++ b/tests/interfaces/test_textual_chat_phase4_3273.py
@@ -69,6 +69,8 @@ _SNAP = {
     "ctx_window": 200000,
     "ctx_source": "model",
     "ctx_recent_usage": (90000, 40000),
+    "cache_usage_reported": True,
+    "usage_breakdown_reported": True,
 }
 
 


### PR DESCRIPTION
**[tui-coder]** — closing pass on `#5009`. Architect's explicit process for this pass: 1 key at a time, report the render site before adding — full per-key measurement posted on the issue thread before this diff started.

## What

Extends `cache_usage_reported` with 3 siblings, same shape throughout:

- `cron_jobs_reported` — the Cron pane's `["(none)"]` fallback for an empty `cron_jobs` list, byte-identical to a genuinely empty LOCAL cron config. The clean, original-criterion case.
- `usage_breakdown_reported` — the Cost pane's `prompt 0 · completion 0 · total X` line, X real and nonzero — an inconsistent breakdown (`0 + 0 != X`) the pane never flags on its own. Governs the split only; the total is real wire data on both implementations and stays unconditional.
- `ctx_compaction_reported` — the Ctx pane's compaction line, degrading to `0 / 0 tokens est. (0% to trigger)`.

**Corrected criterion (architect, mid-pass):** the first measuring stick tried — "is the degrade value indistinguishable from a genuine local empty state" — is a useful *proxy*, not the actual rule. `ctx_compaction_reported` is the falsifying case: a real local session essentially never has a genuine zero-compaction-trigger state, so the proxy alone would say "skip it, no confusable real case" — but `"0% to trigger"` still fabricates a specific, false reassurance regardless of whether a real state could produce the same string. `#4996`'s own words already named the real rule directly: "never a fabricated turn", "never a fabricated count".

`ChatReadModelCapabilities` gains the 3 fields (frozen, required, no defaults — a producer that forgets one fails to construct). **In-PR-required (architect co-vet):** the 3 new fields were first wired through 3 near-identical single-field helper functions (matching `#5015`'s own `cache_usage_reported_snapshot_key` shape) — measured to be 4 near-identical functions total once counted alongside the original, each with its own producer-side call site, meaning the NEXT declared field would add a 5th of each: the exact "forgot to wire one side" risk `#5015` introduced a helper to prevent, just diluted across 4 call sites instead of 1. Collapsed into ONE generic `reported_snapshot_keys(capabilities)`, which projects every field of the dataclass it's given; both `status.py`'s `_snapshot()` and `project_remote_snapshot()` now merge in a single call each, derived from the SAME `LOCAL_CHAT_READ_CAPABILITIES`/`REMOTE_CHAT_READ_CAPABILITIES` constant. A future declared key now reaches every producer for free — no new helper, no new call site. `chrome.py`'s 3 render sites keep the safe `snap.get(key, False)` default, unreachable for any real complete read model.

## Per-key disposition of the other 6 originally-open keys (not declared)

Posted on `#5009`'s own thread with reasons, per house rule — filed or explicitly dropped, never silently lost:

- `model_active_class`/`model_classes`: no fabrication (real wire model name always shown) — a separate wording issue split out to `#5025` (the "(current, not a configured class)" label misleads on remote, but names no fabricated *value*).
- `agent_names`/`session_tree`: a real local session always has ≥1 loaded agent, so the empty-degrade state never occurs locally — no plausible confusable case.
- `turn_usage_fn`: already solved — renders `—` by design (`gutter.py`'s own docstring documents this).
- `mcp_servers`: never the actual decider — a different key (`visibility_items`) already gates this rendering correctly.

This PR closes the remaining scope on `#5009`; `#5009` itself stays open until this merges.

## Test plan

- [x] `tests/interfaces/test_5009_closing_pass_declarations.py` (new, 10 tests, no duration) — declarations + helpers + the real producer's output, then each of the 3 keys' own render site **strip-falsified** (reverting the gate turns the test red for the stated reason — a fabricated value reappears), paired with an accept-side test, plus the pre-attach `None`/`{}` contract extended to all 3 (and to `cron_pane_lines`, not previously exercised by `#5009`'s own original test file)
- [x] Existing snap-literal test fixtures updated for the 3 new keys: `test_3338_tui_status_chrome_liveness.py`'s cron test, `test_textual_chat_phase4_3273.py`'s shared `_SNAP`, `test_5009_cache_reported_declaration.py`'s ctx accept-side test
- [x] `ruff check` on all 8 changed files — clean
- [x] `scripts/test_tier_audit.py --strict` on the new test file — OK
- [x] `scripts/mypy_ratchet.py` — OK, unchanged baseline
- [x] `scripts/verify_module_docstrings.py` — OK
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_file_depth_reference.py` / `check_bare_tests_import_reference.py` — all OK
- [x] Full `tests/interfaces/` regression sweep, via `.venv/bin/python -m pytest` (not bare `python -m pytest` — see `#5028`: a bare interpreter silently bypasses this repo's venv and resolves an unrelated stray sandbox editable install for any test that shells out a subprocess, the actual cause behind the single failure earlier PRs in this arc, including my own, imprecisely reported as "known pre-existing" without naming it): **1937 passed, 4 skipped, 0 failures**.
- [ ] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

