### PR TITLE
fix(#5028): pin out_of_process_reyn's src root as PYTHONPATH for the flowview isolation subprocess

### DIFF
--- a/tests/interfaces/test_textual_chat_phase1_3273.py
+++ b/tests/interfaces/test_textual_chat_phase1_3273.py
@@ -243,21 +243,35 @@ print("ISOLATION_OK")
 '''
 
 
-def test_plain_path_survives_flowview_absence() -> None:
+def test_plain_path_survives_flowview_absence(out_of_process_reyn) -> None:
     """Tier 2c: with ``textual`` / ``textual_flowview`` unimportable from a clean
     interpreter, the plain / non-TTY path imports and runs green — the flowview
     import is lazy and TTY-only. Runs the strip in a subprocess (see the module
     comment for why in-process would be a false witness) and asserts it reaches
-    the ``ISOLATION_OK`` sentinel."""
+    the ``ISOLATION_OK`` sentinel.
+
+    ``out_of_process_reyn`` (#5028): a subprocess gets no benefit from pytest's
+    own ``pythonpath = ["src"]`` — it re-resolves ``reyn`` from whatever the
+    venv's own editable install (or, in a git worktree, the ambient shell's)
+    points at, which can be a DIFFERENT checkout's ``src`` entirely. Pinning
+    the in-process-derived root as ``PYTHONPATH`` makes the subprocess read the
+    SAME ``reyn`` this test imported, rather than trusting the ambient
+    environment to agree. This does not widen what the subprocess can import —
+    its own ``sys.meta_path`` blocker (above) still blocks ``textual``/
+    ``textual_flowview`` regardless of ``PYTHONPATH``, since that block is a
+    finder installed by the script itself, not a path-visibility question."""
+    import os
     import subprocess
     import sys
 
+    env = {**os.environ, "PYTHONPATH": out_of_process_reyn}
     # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     proc = subprocess.run(
         [sys.executable, "-c", _ISOLATION_SUBPROCESS],
         cwd=str(_REPO_ROOT),
         capture_output=True,
         text=True,
+        env=env,
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
     assert "ISOLATION_OK" in proc.stdout, f"stdout={proc.stdout}\nstderr={proc.stderr}"


### PR DESCRIPTION
**[e2e-coder]** — part of #5028

## What / Why

`test_plain_path_survives_flowview_absence` spawns
`sys.executable -c ...` with no `env=` override, so the subprocess
inherits ambient `sys.path` resolution instead of pytest's own
`pythonpath = ["src"]` (which is in-process only). On a machine whose
ambient interpreter/venv carries a foreign editable `.pth` — this
repo's own real incident (#5028): `sandbox_2`'s install shadows
`reyn.interfaces.repl.read_model`, `ImportError: cannot import name
'LOCAL_CHAT_READ_CAPABILITIES'` — the subprocess silently reads a
DIFFERENT checkout's `reyn`.

This is exactly the class `out_of_process_reyn` (`tests/conftest.py`,
already an established fixture used by 20 files — verified, not
assumed after an earlier wrong "unused" claim of mine on the issue)
exists to close. Fix: request the fixture, pin its returned src root
as `PYTHONPATH` in the subprocess's env — the same pattern already
used by `tests/llm/test_llm_run_async_client_cache_scope_3434.py` and
others.

## Scope

- **This one test only** — #5028's own instruction was not to sweep
  other files.
- **Does not touch `./conftest.py`'s #3233 in-process guard** — a
  separate, already-correct mechanism for a different half of the same
  divergence class (in-process is protected by `pythonpath`; a
  subprocess is not, which is exactly why this fixture exists).

## Witnessed both directions on real contamination (not "should")

My own machine independently carries the identical contamination
lead-coder found (same `sandbox_2` `.pth` in pyenv global
site-packages) — used it directly rather than constructing a synthetic
repro:

```
① RED, before the fix:
   python3 -m pytest tests/interfaces/test_textual_chat_phase1_3273.py::test_plain_path_survives_flowview_absence
   (bare pyenv global, no venv)
   -> ImportError: cannot import name 'LOCAL_CHAT_READ_CAPABILITIES'
      from 'reyn.interfaces.repl.read_model'
      (.../sandbox_2/src/reyn/interfaces/repl/read_model.py)
   — same shape as the incident report, reproduced independently.

② GREEN, after the fix, same invocation, same machine:
   python3 -m pytest tests/interfaces/test_textual_chat_phase1_3273.py::test_plain_path_survives_flowview_absence
   -> 1 passed

   GREEN, unchanged, under .venv/bin/python -m pytest (no regression) —
   also confirmed the file's other 4 tests still pass.

③ Test's own purpose preserved (its clean-interpreter isolation guarantee
   is unaffected by PYTHONPATH): the subprocess installs its OWN
   sys.meta_path blocker before importing anything (`_Block`, raises
   ModuleNotFoundError for textual/textual_flowview by name) — that's a
   FINDER, evaluated at import time regardless of what's on sys.path,
   not a path-visibility question. Pinning the src root cannot widen
   what the subprocess can import; it only fixes WHICH reyn checkout it
   reads. The test's own internal assertions
   ("flowview imported at module load" / "flowview imported during
   plain run") still ran and still passed in both ① and ② above.
```

## Test plan

- [x] `python3 -m pytest tests/interfaces/test_textual_chat_phase1_3273.py::test_plain_path_survives_flowview_absence` (contaminated env) — RED before, GREEN after (shown above)
- [x] `.venv/bin/python -m pytest tests/interfaces/test_textual_chat_phase1_3273.py` — 5/5 green, no regression
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_textual_chat_phase1_3273.py` — 5/5 OK
- [x] `python scripts/check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (203 findings, all baselined)
- [ ] (skipped — no docs/ changes in this PR; doc gates not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
