### PR TITLE
fix(#5025): model picker's passthrough row asserts a weaker, always-true claim

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -679,12 +679,30 @@ def _model_pane_entries(
     That string never equals any class name, so the ``· active`` marker
     silently appeared nowhere. Prepended here as its own informational row
     (empty command = inert, the same convention read-only panes use) rather
-    than left unmarked."""
+    than left unmarked.
+
+    #5025: the prepended row's own wording, ``"(current model, not in the
+    class list below)"``, is deliberately WEAKER than an earlier
+    ``"(current, not a configured class)"``. ``classes`` is the snapshot's
+    ``model_classes`` — on a remote connection that key is unconditionally
+    ``[]`` (never reported over the wire, #5009's own conflation, this time
+    on a VALUE the caller passes in rather than a declared key), so the old
+    wording asserted "nothing is configured" when the true state is simply
+    unknown here. The new wording is true in BOTH cases it actually covers
+    — genuine local #3324 passthrough (nothing below really is configured)
+    and remote (the list below is empty because it is never populated,
+    configured or not) — without claiming to tell them apart, which this
+    function cannot do from ``classes`` alone. PROVISIONAL, same footing as
+    #5011's own ``note="last call"``: the exact string is the author's,
+    freely revisable by the owner without touching this function's logic.
+    """
     entries = [
         (f"{c}  · active" if c == active else c, f"/model {c}") for c in classes
     ]
     if active is not None and active not in classes:
-        entries.insert(0, (f"(current, not a configured class)  {active}", ""))
+        entries.insert(
+            0, (f"(current model, not in the class list below)  {active}", "")
+        )
     return entries
 
 

--- a/tests/interfaces/test_5025_model_pane_passthrough_wording.py
+++ b/tests/interfaces/test_5025_model_pane_passthrough_wording.py
@@ -1,0 +1,81 @@
+"""Tier 2: #5025 — the model picker's "current, not in the class list"
+row asserts a weaker, always-true claim instead of a false one.
+
+The old wording, ``"(current, not a configured class)"``, was FALSE on a
+remote connection: the snapshot's ``model_classes`` is unconditionally
+``[]`` there (never reported over the wire — the same #5009 conflation,
+here on a VALUE `_model_pane_entries` is handed rather than a declared
+capability key), so the row asserted "nothing is configured" regardless
+of what the operator actually configured server-side.
+
+Settled (architect + lead-coder, issuecomment-5374381732): wording only,
+no new `ChatReadModelCapabilities` field — `classes`/`active` never
+fabricate a VALUE here, only the accompanying claim overreached. New
+wording: ``"(current model, not in the class list below)"`` — literally
+true in BOTH cases this function actually distinguishes:
+
+- genuine local #3324 passthrough — nothing below really IS configured.
+- remote — the list below is empty because it is never populated,
+  configured or not.
+
+PROVISIONAL (same footing as #5011's ``note="last call"``): the exact
+string is the author's, freely revisable by the owner without touching
+`_model_pane_entries`'s logic. Scope, per lead-coder's own sign-off: THIS
+row only — no declaration added, no other pane swept.
+
+Witness ①② (lead-coder, stated before implementation): the new string
+itself must be asserted (not just "a row exists") in BOTH the local-
+passthrough case and the remote-shaped case (`classes == []`) — without
+both, a "remote-only" branch would still pass the local case vacuously,
+and vice versa. Neither case is told apart by the function — that is the
+point of the weaker claim, not a gap in this test.
+
+Real `_model_pane_entries` / `model_pane_options` — no mocks.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.chrome import (
+    _model_pane_entries,
+    model_pane_options,
+)
+
+_NEW_WORDING = "(current model, not in the class list below)"
+_OLD_WORDING = "(current, not a configured class)"
+
+
+def test_local_passthrough_shows_the_weaker_wording():
+    """Tier 2: #3324's own local case — a raw model string active, real
+    configured classes present, none matching it."""
+    entries = _model_pane_entries(["fast", "careful"], "openrouter/some-raw-id")
+    rows = [row for row, _cmd in entries]
+    assert f"{_NEW_WORDING}  openrouter/some-raw-id" in rows, rows
+    assert not any(_OLD_WORDING in row for row in rows), rows
+
+
+def test_remote_shaped_classes_show_the_same_weaker_wording():
+    """Tier 2: the remote shape — `classes == []` (never reported over the
+    wire), active still a real model name. The row must not claim "not
+    configured" when nothing here can tell configured-but-unreported
+    apart from genuinely unconfigured."""
+    entries = _model_pane_entries([], "claude-sonnet-5")
+    rows = [row for row, _cmd in entries]
+    assert f"{_NEW_WORDING}  claude-sonnet-5" in rows, rows
+    assert not any(_OLD_WORDING in row for row in rows), rows
+
+
+def test_the_row_is_inert_same_as_before():
+    """Tier 2: unchanged behaviour check — the prepended row's command
+    stays empty (informational only), only the label text moved."""
+    entries = _model_pane_entries([], "claude-sonnet-5")
+    row, cmd = entries[0]
+    assert row.startswith(_NEW_WORDING)
+    assert cmd == ""
+
+
+def test_a_matching_active_class_shows_no_prepended_row_at_all():
+    """Tier 2: accept-side — when `active` genuinely IS one of `classes`,
+    no informational row is prepended in either case; this issue only
+    touches the mismatched-active row's own wording."""
+    rows = model_pane_options(["fast", "careful"], "fast")
+    assert not any("not in the class list below" in row for row in rows), rows
+    assert rows == ["fast  · active", "careful"], rows


### PR DESCRIPTION
**[tui-coder]** — #5025: the model picker's passthrough row asserted a false claim on remote.

## What
`_model_pane_entries`'s prepended informational row for an `active` model
that doesn't match any configured class read:

```
(current, not a configured class)  <model>
```

False on a remote connection: the snapshot's `model_classes` is
unconditionally `[]` there (never reported over the wire — #5009's own
conflation, this time on a VALUE the function is handed rather than a
declared capability key), so the row asserted "nothing is configured"
regardless of what the operator actually configured server-side.

New wording:

```
(current model, not in the class list below)  <model>
```

Literally true in both cases this function actually distinguishes:
local #3324 passthrough (nothing below really is configured) and remote
(the list below is empty because it's never populated, configured or
not) — without claiming to tell them apart, which `_model_pane_entries`
cannot do from `classes` alone.

## Why wording, not a declaration
Investigated per lead-coder's explicit question ("declaration or
wording — pick the cheaper"): `classes`/`active` never fabricate a
VALUE here (the real model string is always shown), only the
accompanying claim overreached. No new `ChatReadModelCapabilities`
field warranted. Settled with architect + lead-coder:
issuecomment-5374381732.

## Scope
Wording only, one call site (`chrome.py`, `_model_pane_entries`'s
prepended-row branch). No declaration added, no other pane touched.

## PROVISIONAL — owner may revise the string
Same footing as #5011's own `note="last call"`: the exact string is
the author's, freely revisable by the owner without touching this
function's logic.

## Test plan
- [x] `tests/interfaces/test_5025_model_pane_passthrough_wording.py` —
  4 new tests, both witness cases required by lead-coder's sign-off:
  the new wording asserted verbatim for local-passthrough AND for
  remote-shaped (`classes == []`) input, plus an inert-row check and
  an accept-side "no row at all when active matches a class" case.
  Strip-falsified (reverted the wording locally, confirmed 3 of the 4
  tests go red for the stated reason).
- [x] `ruff check .`
- [x] `scripts/test_tier_audit.py --strict` on the new test file
- [x] `scripts/verify_module_docstrings.py` on `chrome.py`
- [x] `scripts/mypy_ratchet.py`
- [x] `scripts/flat_tests_ratchet.py`
- [x] `scripts/check_tests_path_literal_reference.py`
- [x] `scripts/check_bare_tests_import_reference.py`
- [x] `scripts/check_file_depth_reference.py`
- [x] `.venv/bin/python -m pytest tests/interfaces/ -k "chrome or model_pane or 3338 or phase4_3273 or 5025"` — 76 passed
- [ ] (skipped — Visual; standing waiver, owner 2026-08-08)

Closes #5025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
