### PR TITLE
fix(#5034): hook/pipeline panes declare whether they are genuinely reported

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -971,7 +971,16 @@ def _mcp_pane_entries(snap: dict) -> "list[tuple[str, str]]":
 def _hook_pane_entries(snap: dict) -> "list[tuple[str, str]]":
     """``(row, slash)`` for the hook-applicability toggles — session-backed
     ``hook_items`` (each row's slash flips it via ``/hook on|off <name>``), else the
-    config-derived hook labels as a read-only listing."""
+    config-derived hook labels as a read-only listing.
+
+    #5034: gated by ``hooks_reported`` — a remote connection's ``hook_items``/
+    ``hooks`` are both unconditionally ``[]`` (never on the wire), and the old
+    unconditional ``["(none)"]`` fallback was byte-identical to a genuine local
+    zero-hooks config. Same shape ``cron_jobs_reported`` (#5027) already closed
+    for the Cron pane; missed by #5009's original hand-enumerated key list,
+    found via #5034's mechanical re-derivation."""
+    if not snap.get("hooks_reported", False):
+        return [DrawerRow(label="not reported on this connection").as_entry()]
     items = snap.get("hook_items") or []
     if items:
         return [
@@ -991,8 +1000,16 @@ def _hook_pane_entries(snap: dict) -> "list[tuple[str, str]]":
 
 def pipe_pane_lines(snap: "dict | None") -> list[str]:
     """The registered pipelines (``PipelineRegistry.entries()`` via the snapshot's
-    ``pipelines``). Read-only: pipelines have no on/off toggle mechanism."""
+    ``pipelines``). Read-only: pipelines have no on/off toggle mechanism.
+
+    #5034: gated by ``pipelines_reported`` — same fabrication shape as
+    ``hooks_reported`` above; a remote connection's ``pipelines`` is
+    unconditionally ``[]`` (never on the wire), and the old unconditional
+    ``["(none)"]`` fallback was byte-identical to a genuine local empty
+    pipeline registry."""
     snap = snap or {}
+    if not snap.get("pipelines_reported", False):
+        return ["not reported on this connection"]
     pipelines = snap.get("pipelines") or []
     return [
         f"{p['name']}  {p['description']}" if p.get("description") else f"{p['name']}"

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -149,6 +149,22 @@ class ChatReadModelCapabilities:
     correct question is always the fabrication one; "indistinguishable
     from empty" is one way a value fabricates, not the definition of
     fabrication.
+
+    ``hooks_reported``/``pipelines_reported`` (#5034): found while working
+    #5025's own thread, in the same file. #5009's original 9-key list was
+    HAND-enumerated by architect and missed both — confirmed on #5034 by
+    mechanically AST-walking :func:`project_remote_snapshot`'s own return
+    dict for every literal (non-wire-sourced) entry, rather than trusting
+    the earlier hand count a second time. ``hooks``/``hook_items`` (one
+    pane, `_hook_pane_entries`) and ``pipelines`` (`pipe_pane_lines`) both
+    degrade to a bare ``["(none)"]`` on remote — byte-identical to a
+    genuinely empty local hook/pipeline config, the same fabrication
+    ``cron_jobs_reported`` already closed for the Cron pane. The
+    mechanical sweep also cleared 6 more literal keys as NOT fabricating
+    (``skills``, ``visibility_items``, ``mcp_subscriptions``,
+    ``unknown_config_key_count``, ``unknown_config_keys``, ``ctx_source``)
+    — see #5034's own issue thread for the per-key reasoning; not
+    declared here because there is nothing to gate.
     """
 
     completion_session: bool
@@ -161,6 +177,8 @@ class ChatReadModelCapabilities:
     cron_jobs_reported: bool
     usage_breakdown_reported: bool
     ctx_compaction_reported: bool
+    hooks_reported: bool
+    pipelines_reported: bool
 
 
 def reported_snapshot_keys(
@@ -209,6 +227,8 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     cron_jobs_reported=True,
     usage_breakdown_reported=True,
     ctx_compaction_reported=True,
+    hooks_reported=True,
+    pipelines_reported=True,
 )
 
 #: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these 6
@@ -226,6 +246,8 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     cron_jobs_reported=False,
     usage_breakdown_reported=False,
     ctx_compaction_reported=False,
+    hooks_reported=False,
+    pipelines_reported=False,
 )
 
 
@@ -594,12 +616,19 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # byte-identical to a genuinely empty LOCAL cron config.
         "cron_jobs": [],
         "mcp_servers": [],
+        # `[]` below is correct (hook config is not on the wire); gated by
+        # ``hooks_reported`` above so `_hook_pane_entries` renders "not
+        # reported" instead of its own `["(none)"]` fallback (#5034 — same
+        # fabrication ``cron_jobs_reported`` already closed for the Cron
+        # pane, missed by #5009's original hand-enumerated key list).
         "hooks": [],
         "skills": [],
         # #3378: None (not []) — a remote frame carries no visibility seam at all, and
         # the renderer must say "not wired" rather than "(none)" (which would claim
         # "nothing is narrowed", a statement this frame cannot support).
         "visibility_items": None,
+        # gated by ``hooks_reported`` alongside ``hooks`` above — one pane,
+        # one field (#5034).
         "hook_items": [],
         # #4686: session-local read (MCPConnectionService is process-local,
         # not projected onto the wire) → [] for remote, same "empty" shape
@@ -609,6 +638,10 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # this list as "nothing to add", not "not wired", since the base
         # row itself already came from ``visibility_items``).
         "mcp_subscriptions": [],
+        # `[]` below is correct (pipeline registry is not on the wire);
+        # gated by ``pipelines_reported`` above so `pipe_pane_lines`
+        # renders "not reported" instead of its own `["(none)"]` fallback
+        # (#5034 — same fabrication shape as ``hooks_reported`` above).
         "pipelines": [],
         # #3300 P2b: the server-authoritative sent-queue state IS on the wire
         # (state.py's ``_WIRE_KEYS`` / ``project_status``, folded in by P2a) —

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -662,10 +662,13 @@ def test_hook_rows_carry_the_flipping_hook_slash() -> None:
     flipping the current state — the same operability contract as the visibility
     categories. The item shape is ``_session_hook_items``'s documented
     ``{name, scope, on}`` projection."""
-    snap = {"hook_items": [
-        {"name": "pre_tool_guard", "scope": "project", "on": True},
-        {"name": "post_turn_notify", "scope": "", "on": False},
-    ]}
+    snap = {
+        "hook_items": [
+            {"name": "pre_tool_guard", "scope": "project", "on": True},
+            {"name": "post_turn_notify", "scope": "", "on": False},
+        ],
+        "hooks_reported": True,
+    }
     rows = pane_payload("hook", snapshot=snap)
     cmds = pane_commands("hook", snap)
     assert any("pre_tool_guard" in r and "project" in r for r in rows), rows
@@ -677,6 +680,7 @@ def test_pipe_and_cron_panes_surface_their_entries() -> None:
     (neither has an on/off toggle mechanism, so they carry no command)."""
     snap = {
         "pipelines": [{"name": "nightly", "description": "the nightly pass"}],
+        "pipelines_reported": True,
         "cron_jobs": [{"name": "sweep", "schedule": "0 3 * * *", "enabled": True}],
         "cron_jobs_reported": True,
     }

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -133,6 +133,8 @@ def test_capabilities_dataclass_rejects_a_missing_field():
         cron_jobs_reported=True,
         usage_breakdown_reported=True,
         ctx_compaction_reported=True,
+        hooks_reported=True,
+        pipelines_reported=True,
     )
     with pytest.raises(TypeError):
         ChatReadModelCapabilities(  # type: ignore[call-arg]
@@ -145,7 +147,9 @@ def test_capabilities_dataclass_rejects_a_missing_field():
             cache_usage_reported=True,
             cron_jobs_reported=True,
             usage_breakdown_reported=True,
-            # ctx_compaction_reported omitted
+            ctx_compaction_reported=True,
+            # pipelines_reported omitted (hooks_reported present)
+            hooks_reported=True,
         )
 
 
@@ -163,9 +167,10 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
     the vocabulary itself, not as a second guard.
 
     ``cache_usage_reported`` / ``cron_jobs_reported`` /
-    ``usage_breakdown_reported`` / ``ctx_compaction_reported`` (#5009) are
-    the 4 fields NOT named after a ``ChatReadModel`` method — see the
-    class's own docstring for why they live here anyway."""
+    ``usage_breakdown_reported`` / ``ctx_compaction_reported`` (#5009) /
+    ``hooks_reported`` / ``pipelines_reported`` (#5034) are the 6 fields
+    NOT named after a ``ChatReadModel`` method — see the class's own
+    docstring for why they live here anyway."""
     names = {f.name for f in fields(ChatReadModelCapabilities)}
     assert names == {
         "completion_session",
@@ -178,6 +183,8 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
         "cron_jobs_reported",
         "usage_breakdown_reported",
         "ctx_compaction_reported",
+        "hooks_reported",
+        "pipelines_reported",
     }
 
 

--- a/tests/interfaces/test_5034_hook_pipeline_reported_declaration.py
+++ b/tests/interfaces/test_5034_hook_pipeline_reported_declaration.py
@@ -1,0 +1,157 @@
+"""Tier 1/2: #5034 — hook and pipeline panes declare whether they are
+genuinely reported, closing the same conflation #5009/#5027 already
+closed for cache/cron/usage/compaction, on 2 keys #5009's own
+hand-enumerated list missed.
+
+**How the 2 keys were found** (not hand-enumerated a second time,
+architect's explicit condition on #5034): `project_remote_snapshot`'s
+own return dict was AST-walked to collect every literal (non-``v.get``)
+entry — 19 keys total, posted on #5034's own thread as the population.
+10 of the 19 were already dispositioned (4 declared, 6 dropped with
+reason on #5009's own thread). Of the 9 keys #5009's hand count never
+saw: `hooks`/`hook_items` and `pipelines` genuinely fabricate (this
+issue); `skills`/`visibility_items`/`mcp_subscriptions`/
+`unknown_config_key_count`/`unknown_config_keys`/`ctx_source` do not
+(traced mechanically to their own render sites on #5034's thread —
+`skills` in particular decided by `visibility_items`'s own None/`[]`
+split, the same shape already ruled for `mcp_servers`).
+
+Each declared key, its own render site and its own conflation:
+
+- `hooks_reported`: `_hook_pane_entries`'s `["(none)"]` fallback for an
+  empty `hook_items`/`hooks` pair — byte-identical to a genuinely empty
+  LOCAL hook config.
+- `pipelines_reported`: `pipe_pane_lines`'s `["(none)"]` fallback for an
+  empty `pipelines` list — same shape.
+
+Witnesses, same shape as #5009/#5027's own: each key strip-falsified at
+its own render site, paired with an accept-side test confirming a
+genuinely-reported figure still renders unchanged.
+
+Real `LOCAL_CHAT_READ_CAPABILITIES` / `REMOTE_CHAT_READ_CAPABILITIES` /
+`project_remote_snapshot` — no mocks.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.chrome import (
+    _hook_pane_entries,
+    pipe_pane_lines,
+)
+from reyn.interfaces.repl.read_model import (
+    LOCAL_CHAT_READ_CAPABILITIES,
+    REMOTE_CHAT_READ_CAPABILITIES,
+    project_remote_snapshot,
+    reported_snapshot_keys,
+)
+
+
+def test_capabilities_declare_the_2_keys():
+    """Tier 1: the declarations themselves."""
+    assert LOCAL_CHAT_READ_CAPABILITIES.hooks_reported is True
+    assert LOCAL_CHAT_READ_CAPABILITIES.pipelines_reported is True
+    assert REMOTE_CHAT_READ_CAPABILITIES.hooks_reported is False
+    assert REMOTE_CHAT_READ_CAPABILITIES.pipelines_reported is False
+
+
+def test_the_shared_helper_derives_both_from_the_capabilities_given():
+    """Tier 1: pins `reported_snapshot_keys`'s own pure projection for
+    these 2 fields — no new wiring, the existing generic helper already
+    returns every field."""
+    local_keys = reported_snapshot_keys(LOCAL_CHAT_READ_CAPABILITIES)
+    assert local_keys["hooks_reported"] is True
+    assert local_keys["pipelines_reported"] is True
+
+    remote_keys = reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)
+    assert remote_keys["hooks_reported"] is False
+    assert remote_keys["pipelines_reported"] is False
+
+
+def test_remote_snapshot_declares_both_unreported():
+    """Tier 1: the real producer — `project_remote_snapshot` — carries
+    both declarations through, paired with the existing graceful degrade
+    values those keys already carried."""
+    snap = project_remote_snapshot({})
+    assert snap["hooks_reported"] is False
+    assert snap["hooks"] == []
+    assert snap["hook_items"] == []
+    assert snap["pipelines_reported"] is False
+    assert snap["pipelines"] == []
+
+
+# ── hooks_reported ──────────────────────────────────────────────────────
+
+
+def test_hook_pane_shows_not_reported_instead_of_a_fabricated_none():
+    """Tier 2: strip-falsifier. Reverting the `hooks_reported` gate in
+    `_hook_pane_entries` turns this red — the pane would show
+    `["(none)"]`, indistinguishable from a genuinely empty LOCAL hook
+    config."""
+    snap = {"hook_items": [], "hooks": [], "hooks_reported": False}
+    entries = _hook_pane_entries(snap)
+    rows = [row for row, _cmd in entries]
+    assert rows == ["not reported on this connection"], rows
+
+
+def test_hook_pane_still_lists_real_hooks_when_reported():
+    """Tier 2: accept-side — a genuinely reported, non-empty hook config
+    renders exactly as before this issue."""
+    snap = {
+        "hook_items": [{"name": "pre-commit", "on": True, "scope": "session"}],
+        "hooks_reported": True,
+    }
+    entries = _hook_pane_entries(snap)
+    rows = [row for row, _cmd in entries]
+    assert rows == ["[on] pre-commit  · session"], rows
+
+
+def test_hook_pane_config_only_fallback_still_works_when_reported():
+    """Tier 2: accept-side, the read-only `hooks` fallback (no session-
+    backed `hook_items`) still renders when genuinely reported."""
+    snap = {
+        "hook_items": [],
+        "hooks": [{"label": "lint-on-save"}],
+        "hooks_reported": True,
+    }
+    entries = _hook_pane_entries(snap)
+    rows = [row for row, _cmd in entries]
+    assert rows == ["lint-on-save"], rows
+
+
+# ── pipelines_reported ──────────────────────────────────────────────────
+
+
+def test_pipe_pane_shows_not_reported_instead_of_a_fabricated_none():
+    """Tier 2: strip-falsifier. Reverting the `pipelines_reported` gate
+    in `pipe_pane_lines` turns this red — the pane would show
+    `["(none)"]`, indistinguishable from a genuinely empty LOCAL pipeline
+    registry."""
+    snap = {"pipelines": [], "pipelines_reported": False}
+    lines = pipe_pane_lines(snap)
+    assert lines == ["not reported on this connection"], lines
+
+
+def test_pipe_pane_still_lists_real_pipelines_when_reported():
+    """Tier 2: accept-side — a genuinely reported, non-empty pipeline
+    registry renders exactly as before this issue."""
+    snap = {
+        "pipelines": [{"name": "release", "description": "cut a release"}],
+        "pipelines_reported": True,
+    }
+    lines = pipe_pane_lines(snap)
+    assert lines == ["release  cut a release"], lines
+
+
+# ── pre-attach None/{} — the settled safe direction, both keys ─────────
+
+
+def test_a_pre_attach_snapshot_shows_not_reported_for_both_keys_too():
+    """Tier 2: the same pre-attach contract #5009's own keys established
+    extends to these 2 — `pipe_pane_lines(None)` was already exercised
+    for the graceful-empty contract; this pins the "not reported" wording
+    now takes over that same call."""
+    pipe_lines = pipe_pane_lines(None)
+    assert pipe_lines == ["not reported on this connection"], pipe_lines
+
+    hook_entries = _hook_pane_entries({})
+    hook_rows = [row for row, _cmd in hook_entries]
+    assert hook_rows == ["not reported on this connection"], hook_rows


### PR DESCRIPTION
**[tui-coder]** — #5034: 2 more `snapshot()` keys fabricate a value on remote, same shape #5009/#5027 already closed.

## What
`_hook_pane_entries` and `pipe_pane_lines` (`chrome.py`) both fall back to
`["(none)"]` when their backing key is empty. On remote, `hooks`/
`hook_items`/`pipelines` are unconditionally `[]` (`project_remote_
snapshot`, never on the wire) — indistinguishable from a genuinely empty
local hook/pipeline config.

## Why this wasn't caught by #5009
Found while working #5025's own thread, in the same file. #5009's
original 9-key list was hand-enumerated by architect and missed both.

## How the population was re-derived (architect's condition before any
new field)
AST-walked `project_remote_snapshot`'s own return dict for every literal
(non-`v.get`) entry — 19 total, posted on #5034's issue thread as the
population, cross-referenced against what #5009 already dispositioned.
lead-coder independently wrote a second AST walk and confirmed an exact
match (issuecomment-5375099272) before I proceeded. Of the 9 keys never
in architect's original hand count, only `hooks`/`hook_items` and
`pipelines` fabricate. The other 6 (`skills`, `visibility_items`,
`mcp_subscriptions`, `unknown_config_key_count`, `unknown_config_keys`,
`ctx_source`) were traced to their own render sites and confirmed NOT to
fabricate — reasons on #5034's own thread (`skills` in particular: it's
never the decider, `_visibility_pane_rows`'s own `visibility_items is
not None` branch is, the same shape architect already ruled for
`mcp_servers`).

## Scope
`hooks_reported`/`pipelines_reported` added to `ChatReadModelCapabilities`
— zero new wiring; `reported_snapshot_keys` (already generic since #5027)
projects any declared field to both `snapshot()` producers for free.
2 pane gates, same shape as `cron_pane_lines`'s own.

## Test plan
- [x] `tests/interfaces/test_5034_hook_pipeline_reported_declaration.py`
  — 9 new tests: declarations, the shared helper, the real remote
  producer, both panes' strip-falsified gate + accept-side real-data
  case, and the pre-attach `None`/`{}` contract for both. Strip-
  falsified (reverted each gate locally, confirmed the right tests go
  red for the stated reason).
- [x] `tests/interfaces/test_4996_read_model_capabilities.py` updated
  for the 2 new required fields (witness① positive control + full field
  list pin).
- [x] `tests/interfaces/test_3338_tui_status_chrome_liveness.py`'s
  existing hook/pipe fixtures updated with the new `*_reported` keys.
- [x] `ruff check .`
- [x] `scripts/test_tier_audit.py --strict` on the touched test files
- [x] `scripts/verify_module_docstrings.py` on both touched src modules
- [x] `scripts/mypy_ratchet.py`
- [x] `scripts/flat_tests_ratchet.py`
- [x] `scripts/check_tests_path_literal_reference.py`
- [x] `scripts/check_bare_tests_import_reference.py`
- [x] `scripts/check_file_depth_reference.py`
- [x] `.venv/bin/python -m pytest tests/interfaces/ -k "chrome or read_model or 3338 or phase4_3273 or 5009 or 5034 or 4996 or 5025"` — 116 passed
- [ ] (skipped — Visual; standing waiver, owner 2026-08-08)

Closes #5034

🤖 Generated with [Claude Code](https://claude.com/claude-code)
