### PR TITLE
revert(#5028): remove the in-process reyn path disclosure line — no run makes it branch

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -81,8 +81,6 @@ def pytest_configure(config: pytest.Config) -> None:
     """
     import reyn
 
-    _disclose_in_process_reyn_path()
-
     env_identity = _load_env_identity()
     finding = env_identity.check_in_process_tree(
         Path(reyn.__file__), Path(config.rootpath)
@@ -93,42 +91,3 @@ def pytest_configure(config: pytest.Config) -> None:
         f"env-identity (in-process, #3233):\n{finding.render()}",
         returncode=1,
     )
-
-
-def _disclose_in_process_reyn_path() -> None:
-    """Disclose, never gate: write the in-process ``reyn.__file__``
-    resolution directly to stderr — measured to survive ``-q`` (a
-    ``pytest_report_header`` return value does NOT: pytest suppresses its
-    own header section under ``-q``, confirmed by running this exact
-    check both ways before choosing this hook). Never fails/skips/warns.
-
-    #5028's real finding: `pytest_configure`'s check above already catches
-    the case where in-process resolution is WRONG (#3233) — but a test
-    that spawns a SUBPROCESS (`sys.executable -c ...`) re-resolves `reyn`
-    independently, outside that check's reach, and when the subprocess
-    reads a different checkout the failure looks like an ordinary test
-    failure with no signal that environment, not the diff, is the
-    suspect. Six PRs cited this exact class of failure as "known
-    pre-existing" without anyone reading the traceback closely enough to
-    notice a foreign path in it (#5028).
-
-    This line does NOT detect that class of failure by itself — the
-    in-process path it prints is always correct here (guarded by the
-    #3233 check above); a spawned subprocess's own resolution is never
-    read or compared against it. It is a comparison BASELINE: a human
-    reading a subprocess's traceback next to this line can see, at a
-    glance, whether the two disagree, the way the six PRs' own tracebacks
-    already carried the answer (a foreign `sandbox_2` path) that nobody
-    had this line to compare it against.
-
-    A pin/gate was considered and explicitly rejected (architect, #5028):
-    the original harm is that the divergence is INVISIBLE, not that it is
-    POSSIBLE — a gate would need an exclusion list for tests that
-    deliberately exercise a missing/foreign `reyn` (#5010's own dead-end
-    shape: a pass-condition with no valid action for a test whose whole
-    point IS to hit the missing case). Visibility first; whether teeth
-    are still needed after that is a separate, later question.
-    """
-    import reyn
-
-    print(f"in-process reyn resolves to: {Path(reyn.__file__).resolve()}", file=sys.stderr)

--- a/tests/scripts/test_3233_inprocess_env_identity.py
+++ b/tests/scripts/test_3233_inprocess_env_identity.py
@@ -1,22 +1,18 @@
-"""Tier 1: `check_in_process_tree` contract, and wiring witnesses for the root
-`conftest.py` guard it feeds (#3233) plus the disclosure line beside it
-(#5028).
+"""Tier 1: `check_in_process_tree` contract, and a wiring witness for the root
+`conftest.py` guard it feeds (#3233).
 
-Deliberately different shapes, per the architect's #3233 gap note: a Tier-1
-contract test on the pure function alone stays green even if someone deletes
-the `pytest_configure` call that wires it into pytest startup — the function
-would still return correct findings, just never asked. The wiring tests below
-spawn a REAL `pytest --collect-only` subprocess and assert on its actual exit
-code and stderr — the only way to falsify "the guard/disclosure is wired, not
-just present as dead code".
+Two tests, deliberately different shapes, per the architect's #3233 gap note:
+a Tier-1 contract test on the pure function alone stays green even if someone
+deletes the `pytest_configure` call that wires it into pytest startup — the
+function would still return correct findings, just never asked. The second
+test below spawns a REAL `pytest --collect-only` subprocess with a decoy
+`PYTHONPATH` so a `reyn` OUTSIDE this checkout resolves first, and asserts on
+the subprocess's actual exit code and stderr — the only way to falsify "the
+guard is wired, not just present as dead code".
 
-Neither the contract test nor the #3233 wiring test moves the real
-`reyn.__file__`: the contract test passes synthetic paths to the pure
-function directly, and the #3233 wiring test manufactures a decoy package in
-a `tmp_path` rather than touching this checkout's own `src/reyn`. The #5028
-disclosure wiring test below is the one exception — it reads the REAL
-in-process path, because the property under test IS that the real path gets
-printed, not a synthetic one.
+Neither test moves the real `reyn.__file__`: the contract test passes synthetic
+paths to the pure function directly, and the wiring test manufactures a decoy
+package in a `tmp_path` rather than touching this checkout's own `src/reyn`.
 """
 from __future__ import annotations
 
@@ -135,44 +131,3 @@ def test_a_decoy_reyn_cached_before_pytest_starts_makes_startup_exit_nonzero(
     assert "env-identity (in-process, #3233)" in combined
     assert "PYTHONPATH" in combined
     assert str(decoy_reyn / "__init__.py") in combined
-
-
-def test_a_normal_collect_prints_the_in_process_reyn_path() -> None:
-    """Tier 2: the #5028 disclosure line is actually wired into
-    `pytest_configure`, not just present as dead code.
-
-    Same wiring-witness shape as the #3233 test above, on a real
-    `pytest --collect-only` subprocess — a call to
-    `_disclose_in_process_reyn_path` could be deleted from
-    `pytest_configure` and a pure unit test of that function alone would
-    stay green; only a real pytest startup can falsify "it's wired".
-    Uses the REAL in-process `reyn.__file__` (this test file's own
-    interpreter's) deliberately — the property under test is that the
-    disclosure prints the actual resolution, not a decoy.
-
-    Collect target scoped to THIS file only, not a bare repo-wide
-    collect (lead-coder measurement, #5033 review): `pytest_configure`
-    fires before collection even starts, so what gets collected is
-    irrelevant to what's under test — a full-repo collect measured
-    66.8s (56% of CI's 120s per-test kill switch) for zero added
-    coverage; scoped to one file, 11.0s. This is removing unnecessary
-    work from the test, not adding a timeout to it.
-
-    FALSIFY: without this call, #5028's own finding recurs — a
-    subprocess-spawning test's contamination has no baseline path to be
-    compared against, and six PRs already cited that exact failure class
-    as "known pre-existing" without noticing.
-    """
-    import reyn
-
-    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
-    proc = subprocess.run(
-        [sys.executable, "-m", "pytest", "--collect-only", "-q", str(__file__)],
-        cwd=_REPO_ROOT,
-        capture_output=True,
-        text=True,
-    )
-
-    assert f"in-process reyn resolves to: {Path(reyn.__file__).resolve()}" in proc.stderr, (
-        f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
-    )


### PR DESCRIPTION
**[lead-coder]** — part of #5028

## What

Reverts the whole of #5033 — `conftest.py`'s `_disclose_in_process_reyn_path()` and its wiring witness in `tests/scripts/test_3233_inprocess_env_identity.py`.

Architect ruling on #5028 (`issuecomment-5376608140`), retracting an earlier "keep it". Both supports of that earlier ruling were falsified by measurement, not argument.

## Why — the two measurements

**1. No run makes the line branch.** `pyproject.toml:460` sets `pythonpath = ["src"]`, which pytest resolves **relative to rootdir**. Whichever interpreter starts pytest, that checkout's `src` lands at the front of `sys.path`. Measured on `origin/main` @ `075664730`:

| how pytest was started | disclosed value |
|---|---|
| pyenv global `python -m pytest` | `…/lead-coder/src/reyn/__init__.py` |
| `.venv/bin/python -m pytest` | `…/lead-coder/src/reyn/__init__.py` |

Same value. I could not construct a run where it differs.

**2. What it adds is derivable.** Default `pytest` already prints the `rootdir:` header, and the disclosed value is exactly `rootdir + "/src/reyn/__init__.py"`. Only under `-q` does the line carry anything the default run lacks.

**Control — the contamination is real, just not here.** Outside pytest it reproduces immediately:

```
pyenv global  python -c "import reyn; print(reyn.__file__)"
  → …/junk/claude_sandbox/sandbox_2/src/reyn/__init__.py
.venv/bin/python -c "import reyn; print(reyn.__file__)"
  → …/lead-coder/src/reyn/__init__.py
```

The line never read a spawned subprocess's own resolution, so it did not cover that case. It read the in-process path — which the #3233 guard directly above it already proves correct. What is left is a reader's false impression that something is being guarded.

That remaining case (a subprocess reading a foreign checkout) is the actual body of #5028 and is **not designed here** — it stays open as inventory, per the architect's note.

## Why this is not "delete the evidence"

The reasoning survives the removal: a paragraph recording all three findings is on #5028 itself, specifically so the same mechanism is not re-proposed. The architect's stated reason for requiring it — they re-derived a rejected argument hours after rejecting it — applies to me equally.

## Test plan

- [x] `ruff check .` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_3233_inprocess_env_identity.py` — 3 inspected, 0 errors, 0 warnings
- [x] `python scripts/mypy_ratchet.py` — OK: 203 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK, 111 references baselined
- [x] `python scripts/check_bare_tests_import_reference.py` — OK (`tests/` touched)
- [x] `python scripts/check_file_depth_reference.py` — OK (`tests/` touched)
- [x] `pytest tests/scripts/test_3233_inprocess_env_identity.py` — 3 passed
- [x] (skipped — no `docs/` in the diff, so the docs-conditional gates do not apply)
- [x] Dangling-reference sweep: `_disclose_in_process_reyn_path`, the literal `in-process reyn resolves to`, and `5033` outside `tests/fixtures/` — 0 hits each
- [x] Closing-keyword self-check on commit message **and** this body — 0 hits

### ⚠️ Disclosure: my first gate run was measured under a stale venv

`scripts/mypy_ratchet.py` initially reported 1 new `[attr-defined]` pair in `src/reyn/interfaces/inline/textual_chat/presenter.py` — a file this branch does not touch. It reproduced on a pristine `origin/main` checkout too, so it looked like main was red.

It was not. The repo's own **#3723 env-identity gate** caught the real cause when I ran pytest: this venv's `textual-flowview` was installed from `ec10edb2` while `pyproject.toml` pins `d90584af`. After installing the pinned commit, `mypy_ratchet.py` is **OK (203/207 baselined)** and the scoped pytest passes.

Every number in the Test plan above was measured **after** that fix. Recording it because the failure mode is precisely "a stale venv makes main look red and the measurement look valid" — and because #3723 working is worth a witness.

## Reviewer note

Rule 8 applies — this touches `tests/`, so it does not self-merge until a TESTS-READ note lands here. Auto-merge deliberately **not** armed.

The test change is a pure revert: it removes `test_a_normal_collect_prints_the_in_process_reyn_path` and restores the module docstring to its pre-#5033 text. Six-questions on the removed test: Q3 ("who would miss it") is now **nobody** — its only consumer was the mechanism being removed.

part of #5028


---

### 🔴 Open — reviewer needed (rule 8)

- [x] **TESTS-READ note** — landed (issuecomment-5376695710): reyn-reviewer, blocking finding なし. 掲載は lead-coder が逐語転記（reviewer 側が sandbox/gh token で投稿不能、本人が申告）. 元の 🔴 — this PR touches `tests/`, so it does not self-merge until a reviewer records one here. Assigned to **reyn-reviewer** (the standing advisory reviewer for `tests/`-touching PRs; never merges). Initially asked e2e-coder, then withdrawn — they are heads-down on #5012-A and reyn-reviewer is the right desk.

The one question I most want answered independently is six-questions **Q3** on the removed test (`test_a_normal_collect_prints_the_in_process_reyn_path`): *who would miss it if it were gone?* My reading is **nobody** — its only consumer was the mechanism this PR removes. If you read it differently, that blocks the revert, not just the test deletion.

⚠️ Before running pytest locally: this checkout's venv can carry a `textual-flowview` that does not match `pyproject.toml`'s pin (I hit it on this branch — see the Disclosure section above). The #3723 gate will tell you; re-install the pinned commit before trusting any red or green.


