### PR TITLE
docs(agent-worktree-cleanup): deletion safety needs an outside-in axis

### DIFF
--- a/docs/reference/agent-worktree-cleanup.md
+++ b/docs/reference/agent-worktree-cleanup.md
@@ -311,11 +311,20 @@ checkout, a shared library tree, anything a venv might be installed against):
    grep -rn "<tree-name>" docs/ scripts/ *.md *.yaml *.yml 2>/dev/null
    ```
 2. **Install state** — an editable install is a reference to the tree, and
-   it survives every git-state check above:
+   it survives every git-state check above. `~/**/...` only recurses under
+   zsh (bash needs `globstar` set, which most shells don't have) — reads as
+   a silent, confident 0 hits under plain bash, exactly the false-safety
+   reading this whole section exists to prevent. Scan `.venv` dirs first,
+   then look inside each — measured 0.34s against a real multi-project
+   workspace, vs. 20s+ unfinished for a single `find ~ -path
+   "*/site-packages/*..."` sweep:
    ```bash
-   grep -rl "editable.*true\|\"url\".*<tree-path>" \
-     ~/**/.venv/lib/*/site-packages/*.dist-info/direct_url.json 2>/dev/null
-   find ~/**/.venv -name "*.pth" -exec grep -l "<tree-path>" {} \; 2>/dev/null
+   find "$WORKSPACE_ROOT" -maxdepth 5 -type d -name ".venv" 2>/dev/null | while read -r v; do
+     ls "$v"/lib/*/site-packages/*.dist-info/direct_url.json 2>/dev/null
+   done | xargs grep -l "<tree-name>" 2>/dev/null
+   find "$WORKSPACE_ROOT" -maxdepth 5 -type d -name ".venv" 2>/dev/null | while read -r v; do
+     find "$v" -name "*.pth" -exec grep -l "<tree-path>" {} \; 2>/dev/null
+   done
    pip freeze 2>/dev/null | grep -e "<tree-name>"
    ```
 3. **Process cwd** — a process can hold the tree open without a lock file or

--- a/docs/reference/agent-worktree-cleanup.md
+++ b/docs/reference/agent-worktree-cleanup.md
@@ -286,6 +286,57 @@ fi
 - **The script targets only `agent-*` paths under `.claude/worktrees/`.** All
   other worktrees — feature branches, main, etc. — are invisible to it.
 
+## Before deleting ANY tree — not just what this script covers (#5040)
+
+This script's own safety checks (PID-liveness, git merge-state) only look at
+**"is it running"** and **"what's inside it"** — they say nothing about
+**what points AT the tree from outside it**. That gap is not hypothetical:
+on 2026-08-22, `reyn_dev/reyn-self-work` was `rm -rf`'d after every one of
+this script's own kind of check passed clean — `git status --porcelain`
+empty, `--untracked-files=all` empty, `stash` empty, `HEAD == origin/main`,
+`git worktree list`, and a full scan of every process whose `cwd` was under
+the tree. All of it passed. The deletion still broke a live runtime: a
+sibling checkout's venv had that tree installed **editable**, so `import
+reyn` kept succeeding afterward while resolving to nothing (`reyn.__file__
+= None` — the editable finder survived; the tree it pointed at didn't).
+
+**Deletion safety is decided by what points at the tree, not by what's
+inside it.** This is a distinct axis from everything the two checks above
+already do, and this script does not automate it — check it by hand before
+deleting anything this script's `agent-*` filter doesn't reach (a project
+checkout, a shared library tree, anything a venv might be installed against):
+
+1. **Text references** — grep the obvious surfaces:
+   ```bash
+   grep -rn "<tree-name>" docs/ scripts/ *.md *.yaml *.yml 2>/dev/null
+   ```
+2. **Install state** — an editable install is a reference to the tree, and
+   it survives every git-state check above:
+   ```bash
+   grep -rl "editable.*true\|\"url\".*<tree-path>" \
+     ~/**/.venv/lib/*/site-packages/*.dist-info/direct_url.json 2>/dev/null
+   find ~/**/.venv -name "*.pth" -exec grep -l "<tree-path>" {} \; 2>/dev/null
+   pip freeze 2>/dev/null | grep -e "<tree-name>"
+   ```
+3. **Process cwd** — a process can hold the tree open without a lock file or
+   a visible name (reyn rewrites its own process name, so a bare `ps` name
+   grep reads 0 even when a session is live — resolve identity via cwd, not
+   the command column):
+   ```bash
+   lsof -a -d cwd -- 2>/dev/null | grep "<tree-path>"
+   ```
+4. **Worktree registration / symlinks** — a tree can be a registered git
+   worktree of a DIFFERENT repo, or a symlink target, without anything
+   inside it or any process on it saying so:
+   ```bash
+   git -C <other-checkout> worktree list | grep "<tree-path>"
+   find / -maxdepth 6 -type l -lname "*<tree-path>*" 2>/dev/null
+   ```
+5. **The tree's own contents** (uncommitted changes / stash / `HEAD` vs.
+   `origin/main`) — do this LAST, and passing it alone is not clearance;
+   it is what this script already checks, and it is exactly what passed
+   clean on 2026-08-22 while the deletion still broke a live runtime.
+
 ## See also
 
 - [LLM Payload Tracing](dogfood-tracing.md) — complementary debug tooling for


### PR DESCRIPTION
**[docs-maintainer]** — part of #5040

## What

Dispatched by lead-coder: add the axis last night's `reyn-self-work`
deletion incident found missing — `agent-worktree-cleanup.md`'s only
safety claims (PID-liveness, git merge-state) both look at "is it
running" / "what's inside the tree", never at what points AT it from
outside.

New section, "Before deleting ANY tree — not just what this script
covers": copy-pasteable commands (matching the existing PID/git
sections' grain, not prose) for the 3 checks neither existing axis
covers — install state (`direct_url.json` / `*.pth` / `pip freeze -e`),
process cwd (not the `ps` command column — reyn rewrites its own
process name), and worktree registration/symlinks — plus text
references, and the tree's own contents last (what the script already
checks, and what passed clean last night while the deletion still
broke a live runtime).

Confirmed `scripts/cleanup_agent_worktrees.py` itself doesn't check
install-state either (`grep -n "direct_url\|\.pth\|editable"` — 0
hits) — this is a real, currently-uncovered axis in both the script
and the doc, not just an undocumented existing check; scope held to
the doc per the dispatch (no script change requested).

**This doc found a real, currently-broken venv the day it was
written**: running step 2 for real surfaced `reyn-self/repos/coder-smith/
.venv` pointing editable at a `reyn-self/repo` path that no longer
exists (moved to `repos/<name>/`) — `reyn.__file__` would resolve to
`None` on that agent's next start. Flagged to architect (out of this
PR's scope — docs-only, no runtime fix here).

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no
      `Aborted`/`WARNING`; pre-existing INFO-level unpublished `.ja.md`
      anchor gaps only, unrelated to this edit
- [x] `python scripts/check_doc_anchors.py` (run after the strict
      build, needs `site/`) — "no dangling anchors into published
      pages"
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Closing-keyword self-check on commit message + this PR body — 0
      hits
- [x] (skipped — docs-only change, no `tests/` touched, TESTS-READ
      rule 8 does not apply per dispatch)

part of #5040

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

- [x] 🔴 **手順②のコマンドが bash で動かない**（`~/**/` は zsh 限定、bash は `globstar` 未設定で展開されない）。実測 `bash → exit=2 / 出力なし`、`zsh → exit=0 / 3 件`。**bash 利用者には「0 件」に見え、この doc が防ごうとしている沈黙した 0 件を doc 自身が再生産する。** — FIXED (`a949fd443`): `.venv` を先に絞ってから中を引く2段構成に変更、両シェルで0.34秒実測（lead-coderのコメント記載のコマンドをそのまま採用）。`find ~ -path "*/site-packages/*..."`単発は不採用（両シェル20秒超未完了）。
