### PR TITLE
feat(#4995): ThreadedTransportProxy — the ClientTransport thread boundary

### DIFF
--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -350,7 +350,17 @@ class ThreadedTransportProxy(ClientTransport):
             try:
                 await self._pump_task
             except asyncio.CancelledError:
-                pass
+                # #4988's own gate (this coroutine IS running as a task,
+                # scheduled via ``run_coroutine_threadsafe``): a bare
+                # ``pass`` here would swallow BOTH this method's own
+                # ``_pump_task.cancel()`` outcome AND an independent,
+                # external cancellation of THIS coroutine's own task at
+                # this exact await (e.g. a shutdown sweep) — checking
+                # ``cancelling()`` before absorbing is session.py's own
+                # #3377 precedent, not a new pattern.
+                _this_task = asyncio.current_task()
+                if _this_task is not None and _this_task.cancelling() > 0:
+                    raise
 
     async def shutdown(self) -> None:
         await self._call_on_worker("shutdown")

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -51,6 +51,18 @@ on its own). Wiring THIS class in as ``TextualChatApp``'s / ``run_repl``'s
 default local transport is left to a follow-up (#5048) — this PR's
 deliverable is the mechanism itself, with real witnesses, not the
 production cutover.
+
+**As of 2026-08-22, this class has NO production call site** —
+:class:`ThreadedTransportProxy` is constructed only from
+``tests/interfaces/test_4995_threaded_transport_proxy.py``.
+``TextualChatApp``/``run_repl`` still construct ``InProcessTransport``
+directly; wiring this proxy in is #5048's own deliverable, not this
+one's. Read this line here, not only in the PR body or the test
+module's own docstring — a PR body is history nobody re-reads once
+merged, and a test docstring is read only by whoever opens the test;
+this is the one place a future reader of THIS file's own code will
+actually see the gap (the same "declared but nobody reads it" shape
+named 3 times tonight, e.g. #5033's own disclosure-line finding).
 """
 from __future__ import annotations
 

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -1,0 +1,360 @@
+"""``ThreadedTransportProxy`` — the #4995 thread boundary for ``ClientTransport``.
+
+**Redesign history, kept honest** (this issue went through 2 rejected
+approaches before settling — both measured, not guessed):
+
+1. First attempt: offload individual CPU-heavy functions (elide accounting,
+   turn serialise, event-log emit) one at a time via ``asyncio.to_thread``,
+   each at its own call site. REJECTED (architect, self-flagged as their own
+   issue-body residue): "N seams (one per function)" where "1 seam (the
+   transport)" already exists and already has the properties a thread
+   boundary needs — a single writer, an ordered stream. ``in_process.py``'s
+   own docstring already states this: "the client writes to the world ONLY
+   through this seam (single-writer)".
+2. Second attempt (the fix for ①): ``asyncio.to_thread(build_history)`` at
+   its 2 call sites, keeping ``ChatReadModel`` reads synchronized with a
+   ``threading.Lock``. REJECTED (lead-coder, measured self-contradiction):
+   a lock held by the core thread while it does I/O (``_load_older_
+   entries``) is exactly the "TUI does not get scheduled" symptom #4995
+   exists to remove, just moved from the event loop to a mutex — the very
+   witness this issue requires (UI advances while the worker is held open)
+   would go red under this design.
+3. Settled: **immutable snapshot hand-off, not shared mutable state**. The
+   core thread OWNS ``Session``/``AgentRegistry`` exclusively — nothing on
+   the caller (TUI) thread ever reads their live, mutable attributes
+   directly. Every value the caller thread needs (frames, ``has_session()``,
+   ``pending_intervention_head()``, etc.) is refreshed into ONE overwriting
+   slot (:class:`_ThreadedSnapshot`) each time the core thread produces a
+   frame — the same moment production code already treats as "something the
+   client should learn about" (:mod:`reyn.interfaces.transport.frames`'s own
+   unified-stream design). No lock is needed because there is no shared
+   MUTABLE state to protect — the slot holds a fresh, frozen dataclass
+   instance each time, and a single attribute assignment is a GIL-atomic
+   pointer swap in CPython, never a partial/torn read.
+
+This is genuinely an EXTENSION of the existing ``call_soon_threadsafe``
+mechanism the frame stream already needs (a frame produced on the core
+thread must reach the caller thread's ``asyncio.Queue`` via
+``call_soon_threadsafe`` regardless of this class), not a second mechanism
+running alongside it — the snapshot slot is written in the SAME callback
+that schedules the frame delivery.
+
+**Scope, explicit** (per lead-coder's #4995 ruling): 3 ``ChatReadModel``/
+``ClientTransport`` methods are NOT satisfiable by this snapshot design and
+are deliberately left unwired here — see #5044 (``completion_session()``
+returns a LIVE ``Session`` reference, not a copyable value;
+``load_older_conversation_history()`` mutates ``Session.history`` and
+performs disk I/O, confirmed by reading it, not guessed) and #5045
+(``clear_pending_command_ui()`` is a WRITE living on a type named "read
+model" — a pre-existing contract defect, independent of threading, filed
+on its own). Wiring THIS class in as ``TextualChatApp``'s / ``run_repl``'s
+default local transport is left to a follow-up (#5048) — this PR's
+deliverable is the mechanism itself, with real witnesses, not the
+production cutover.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable
+
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.drain import suspend_between_frames
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+    from reyn.runtime.outbox import OutboxMessage
+
+
+@dataclass(frozen=True)
+class _ThreadedSnapshot:
+    """The frozen, single-slot value the caller (TUI) thread reads — every
+    field here mirrors a SYNCHRONOUS ``ClientTransport`` accessor
+    (:meth:`ClientTransport.has_session` and its 3 siblings) that would
+    otherwise read the core thread's live, mutable state directly. Refreshed
+    as ONE unit each time the core thread produces a frame (see this
+    module's own docstring for why one slot, not 4 separately-timestamped
+    caches, and why no lock is needed).
+
+    ``read_model_snapshot`` piggybacks the SAME refresh — a caller wiring a
+    thread-local ``ChatReadModel`` (e.g. ``RegistryReadModel``) over this
+    proxy reads ITS OWN ``snapshot()`` from here rather than reaching into
+    the registry directly from the caller thread, closing the same
+    TUI-reads-vs-core-writes race this whole class exists to remove.
+    ``None`` before the first frame arrives — the SAME pre-attach contract
+    ``project_remote_snapshot``'s callers already have (#5009's own
+    ``cost_pane_lines(None)``/``ctx_pane_lines(None)`` degrade), not a new
+    third state invented for this class."""
+
+    has_session: bool
+    attach_failed: bool
+    pending_intervention_head: "Any | None"
+    reyn_state_root: "Path | None"
+    read_model_snapshot: "dict | None"
+
+
+_EMPTY_SNAPSHOT = _ThreadedSnapshot(
+    has_session=False,
+    attach_failed=False,
+    pending_intervention_head=None,
+    reyn_state_root=None,
+    read_model_snapshot=None,
+)
+
+
+class ThreadedTransportProxy(ClientTransport):
+    """Runs a real ``ClientTransport`` (and whatever it wraps — a
+    ``Session``/``AgentRegistry``, in production) on a DEDICATED worker
+    thread with its own event loop, presenting the identical
+    ``ClientTransport`` surface to a caller on a DIFFERENT thread (the TUI's
+    own asyncio loop).
+
+    ``transport_factory`` is called ON THE WORKER THREAD, inside its own
+    loop — deliberately deferred construction, not a transport built on the
+    caller thread and handed over, so the registry/session it wraps is
+    OWNED by the worker thread from the moment it exists. Nothing about the
+    inner transport is ever touched from the caller thread except through
+    this proxy's own methods.
+
+    ``read_model_snapshot_fn`` is optional — a zero-arg callable (typically
+    a thread-local ``ChatReadModel.snapshot``, e.g. ``RegistryReadModel``
+    bound to the SAME registry the worker thread owns) called ON THE WORKER
+    THREAD alongside every frame, whose result rides in
+    :class:`_ThreadedSnapshot` for the caller thread to read.
+    """
+
+    def __init__(
+        self,
+        transport_factory: "Callable[[], ClientTransport]",
+        *,
+        read_model_snapshot_fn: "Callable[[], dict] | None" = None,
+    ) -> None:
+        self._transport_factory = transport_factory
+        self._read_model_snapshot_fn = read_model_snapshot_fn
+        self._inner: "ClientTransport | None" = None
+        self._worker_loop: "asyncio.AbstractEventLoop | None" = None
+        self._thread: "threading.Thread | None" = None
+        self._worker_thread_ident: "int | None" = None
+        self._caller_loop: "asyncio.AbstractEventLoop | None" = None
+        self._caller_queue: "asyncio.Queue[DisplayFrame | EventFrame] | None" = None
+        # Single overwriting slot (#4995's own settled design, see module
+        # docstring) — a plain attribute, not a queue: only the LATEST
+        # snapshot is ever meaningful, so an older one is safe to discard
+        # outright rather than accumulate (CLAUDE.md six-questions #5 — this
+        # is bounded by the TYPE, not by a discipline of "don't push too
+        # often").
+        self._latest: "_ThreadedSnapshot" = _EMPTY_SNAPSHOT
+        self._ready = threading.Event()
+        self._pump_task: "asyncio.Task | None" = None
+
+    # -- lifecycle ------------------------------------------------------
+
+    @property
+    def worker_thread_ident(self) -> "int | None":
+        """The worker thread's ``threading.get_ident()`` — witness① reads
+        this directly (structural: is the work genuinely elsewhere)."""
+        return self._worker_thread_ident
+
+    def start(self) -> None:
+        self._caller_loop = asyncio.get_event_loop()
+        self._caller_queue = asyncio.Queue()
+        self._thread = threading.Thread(
+            target=self._run_worker, name="reyn-core-worker", daemon=True,
+        )
+        self._thread.start()
+        # Bounded by CI's own kill switch (CLAUDE.md floor/ceiling rule) —
+        # not a sleep, not an attempts=N poll: an unbounded wait on a
+        # condition the worker thread itself sets the instant its loop and
+        # inner transport exist.
+        self._ready.wait()
+
+    def _run_worker(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._worker_loop = loop
+        self._worker_thread_ident = threading.get_ident()
+        self._inner = self._transport_factory()
+        self._inner.start()
+        self._pump_task = loop.create_task(self._pump_frames())
+        self._ready.set()
+        loop.run_forever()
+
+    async def _pump_frames(self) -> None:
+        """Runs ON THE WORKER LOOP. Drains the inner transport's own frame
+        stream and, for EACH frame, refreshes the single snapshot slot
+        BEFORE handing the frame to the caller thread — a reader that sees
+        the frame is guaranteed to see a snapshot at least that fresh."""
+        assert self._inner is not None
+        async for frame in self._inner.frames():
+            self._latest = _ThreadedSnapshot(
+                has_session=self._inner.has_session(),
+                attach_failed=self._inner.attach_failed(),
+                pending_intervention_head=self._inner.pending_intervention_head(),
+                reyn_state_root=self._inner.reyn_state_root(),
+                read_model_snapshot=(
+                    self._read_model_snapshot_fn()
+                    if self._read_model_snapshot_fn is not None
+                    else None
+                ),
+            )
+            assert self._caller_loop is not None and self._caller_queue is not None
+            self._caller_loop.call_soon_threadsafe(
+                self._caller_queue.put_nowait, frame,
+            )
+
+    def close(self) -> None:
+        if self._worker_loop is None:
+            return
+        self._worker_loop.call_soon_threadsafe(self._close_on_worker)
+
+    def _close_on_worker(self) -> None:
+        if self._inner is not None:
+            self._inner.close()
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame | EventFrame]":
+        assert self._caller_queue is not None
+        while True:
+            frame = await self._caller_queue.get()
+            # #3570: unconditional suspension point, once per frame — same
+            # reasoning as ``InProcessTransport.frames``'s own identical
+            # line (see ``drain.py``'s own docstring): ``Queue.get()``
+            # returns without suspending whenever the queue is non-empty, so
+            # a burst of frames pushed by the worker thread between two
+            # visits of this generator would otherwise drain to exhaustion
+            # with the CALLER's loop never running anything else.
+            await suspend_between_frames()
+            yield frame
+
+    # -- caller-thread reads: the single snapshot slot -------------------
+
+    def has_session(self) -> bool:
+        return self._latest.has_session
+
+    def attach_failed(self) -> bool:
+        return self._latest.attach_failed
+
+    def pending_intervention_head(self) -> "object | None":
+        return self._latest.pending_intervention_head
+
+    def reyn_state_root(self) -> "Path | None":
+        return self._latest.reyn_state_root
+
+    def read_model_snapshot(self) -> "dict | None":
+        """Not part of ``ClientTransport`` — the seam a thread-local
+        ``ChatReadModel`` (e.g. a ``RegistryReadModel`` subclass bound to
+        this proxy) calls instead of reading the registry directly."""
+        return self._latest.read_model_snapshot
+
+    # -- caller-thread writes: marshalled onto the worker loop -----------
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        # Fire-and-forget onto the worker loop — ``inner.put_display``'s own
+        # queue is an ``asyncio.Queue`` owned by that loop, not safe to
+        # touch (``put_nowait``) from a foreign thread directly.
+        if self._worker_loop is None or self._inner is None:
+            return
+        self._worker_loop.call_soon_threadsafe(self._inner.put_display, msg)
+
+    async def _call_on_worker(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        """Generic dispatch for every ASYNC ``ClientTransport`` method this
+        proxy forwards — one shared helper rather than N near-identical
+        ``run_coroutine_threadsafe`` + ``wrap_future`` bodies (the shape
+        #5027 already measured and collapsed for ``reported_snapshot_
+        keys``: N call sites is N places a future method could be wired to
+        only 1). ``asyncio.wrap_future`` is what makes this genuinely
+        non-blocking for the CALLER's own loop — the caller ``await``s a
+        real asyncio Future tied to its own loop, which only resolves once
+        the worker loop's coroutine completes; the caller loop keeps
+        scheduling everything else (this IS witness②'s mechanism, not a
+        second one)."""
+        assert self._worker_loop is not None and self._inner is not None
+        method = getattr(self._inner, name)
+        concurrent_future = asyncio.run_coroutine_threadsafe(
+            method(*args, **kwargs), self._worker_loop,
+        )
+        return await asyncio.wrap_future(concurrent_future)
+
+    async def submit_user_text(self, text: str) -> str:
+        return await self._call_on_worker("submit_user_text", text)
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return await self._call_on_worker(
+            "answer_intervention_text", text, intervention_id=intervention_id,
+        )
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return await self._call_on_worker(
+            "answer_intervention_choice", choice_id, intervention_id=intervention_id,
+        )
+
+    async def cancel_inflight(self) -> str:
+        return await self._call_on_worker("cancel_inflight")
+
+    async def cancel_queued(self, msg_id: str) -> bool:
+        return await self._call_on_worker("cancel_queued", msg_id)
+
+    async def run_slash_command(self, name: str, args: str) -> bool:
+        return await self._call_on_worker("run_slash_command", name, args)
+
+    async def request_attach(self, agent_name: str) -> bool:
+        return await self._call_on_worker("request_attach", agent_name)
+
+    async def request_session_switch(self, session_id: str) -> bool:
+        return await self._call_on_worker("request_session_switch", session_id)
+
+    async def request_artifact_list(
+        self, *, agent: str,
+    ) -> "tuple[list[dict], int]":
+        return await self._call_on_worker("request_artifact_list", agent=agent)
+
+    async def _cancel_pump_on_worker(self) -> None:
+        """Runs ON THE WORKER LOOP (via ``run_coroutine_threadsafe``) so
+        cancelling the pump task is properly awaited before this proxy asks
+        the loop to stop — a bare ``call_soon_threadsafe(pump_task.cancel)``
+        with no await races the loop's own stop: cancellation is only
+        delivered on the task's NEXT resumption, which may not happen
+        before a fire-and-forget stop already ends ``run_forever()``,
+        leaving the task "destroyed but pending" on teardown.
+
+        Deliberately does NOT call ``loop.stop()`` itself — a task that
+        stops its OWN loop as its last statement races its own "done"
+        callback delivery (``Task.set_result`` schedules callbacks via
+        ``call_soon`` for a LATER iteration; ``run_forever`` can already
+        have exited by then), which is exactly what left ``shutdown()``
+        hanging on ``wrap_future`` forever the first time this was written
+        — the loop never ran the callback that would have copied this
+        coroutine's result into the caller-visible future. ``shutdown()``
+        stops the loop itself, as a separate step, once this has
+        genuinely returned."""
+        if self._pump_task is not None:
+            self._pump_task.cancel()
+            try:
+                await self._pump_task
+            except asyncio.CancelledError:
+                pass
+
+    async def shutdown(self) -> None:
+        await self._call_on_worker("shutdown")
+        assert self._worker_loop is not None and self._thread is not None
+        concurrent_future = asyncio.run_coroutine_threadsafe(
+            self._cancel_pump_on_worker(), self._worker_loop,
+        )
+        await asyncio.wrap_future(concurrent_future)
+        self._worker_loop.call_soon_threadsafe(self._worker_loop.stop)
+        # ``Thread.join()`` blocks — off the caller's own loop via
+        # ``asyncio.to_thread`` so ``shutdown()`` staying a coroutine never
+        # reintroduces the exact "TUI does not get scheduled" symptom this
+        # class exists to remove. It is also the REAL completion signal
+        # here: the loop has genuinely stopped and the thread function has
+        # returned once ``join()`` unblocks, not merely "a stop was asked for".
+        await asyncio.to_thread(self._thread.join)
+
+
+__all__ = ["ThreadedTransportProxy"]

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -1,0 +1,232 @@
+"""Tier 1/2: #4995 — ``ThreadedTransportProxy`` puts a real ``ClientTransport``
+on a dedicated worker thread with its own event loop, so competing work
+(e.g. the router's own turn processing) no longer starves the TUI's own
+scheduling on a shared loop.
+
+**Design history, kept honest** (2 approaches rejected before this one
+settled — see ``threaded.py``'s own module docstring for the full
+rationale): a "one seam per offloaded function" shape (``asyncio.to_thread``
+at each hot-path call site) was rejected first (architect: N seams where 1
+— the transport — already exists and already has the right properties); a
+``threading.Lock``-synchronized variant of the SAME single seam was
+rejected second (lead-coder, measured self-contradiction: a lock held by
+the core thread during I/O reproduces exactly the "TUI does not get
+scheduled" symptom this issue exists to remove — witness② below would go
+red under that design). Settled: immutable snapshot hand-off, no shared
+mutable state, no lock.
+
+**Both required witnesses, per lead-coder's own #4995 ruling — neither
+alone is sufficient** (① alone only shows "somewhere else", not "the UI
+still moves"; ② alone cannot tell a genuinely different thread apart from
+a coincidence): no ``sleep``/``timeout``/``attempts=N`` anywhere (CLAUDE.md
+floor/ceiling rule) — ① compares thread identities, never a duration; ②
+gates the worker on a real ``threading.Event`` the test holds open and
+waits on a second real ``threading.Event`` (via ``asyncio.to_thread``)
+rather than any bounded/timed poll.
+
+Real ``ThreadedTransportProxy`` — the "inner" transport under test is a
+minimal, real ``ClientTransport`` subclass (not a mock/MagicMock — CLAUDE.md
+forbids faking a collaborator that's cheaply constructible; this one has no
+cheap real production instance to construct from without a live Session/
+AgentRegistry, so a small real hand-written implementation is the
+established pattern here, mirroring ``test_4983_session_switch_off_thread.
+py``'s own ``QueueTransport``).
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import TYPE_CHECKING, AsyncIterator
+
+import pytest
+
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.threaded import ThreadedTransportProxy
+
+if TYPE_CHECKING:
+    from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+    from reyn.runtime.outbox import OutboxMessage
+
+
+class _RecordingTransport(ClientTransport):
+    """A minimal, real ``ClientTransport``. ``frames()`` never yields
+    anything in these tests (an unresolved real ``asyncio.Event`` — an
+    unbounded wait, not a duration) since neither witness needs a frame to
+    flow; ``submit_user_text`` is the one method under test, gated by a
+    ``threading.Event`` the test controls."""
+
+    def __init__(self, *, gate: "threading.Event | None" = None,
+                 started: "threading.Event | None" = None) -> None:
+        self._gate = gate
+        self._started = started
+        self.call_idents: "list[int]" = []
+        self._never = asyncio.Event()
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame | EventFrame]":
+        await self._never.wait()
+        yield  # pragma: no cover - never reached, satisfies the generator shape
+
+    async def submit_user_text(self, text: str) -> str:
+        self.call_idents.append(threading.get_ident())
+        if self._started is not None:
+            self._started.set()
+        if self._gate is not None:
+            # Blocks the WORKER thread only — a real threading.Event.wait(),
+            # unbounded (CLAUDE.md: wait on the condition, never a sleep).
+            self._gate.wait()
+        return f"echo:{text}"
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self):
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> str:
+        return ""
+
+    async def shutdown(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_witness_1_worker_work_runs_on_a_different_thread_than_the_caller():
+    """Tier 1: structural witness. ``submit_user_text`` is dispatched
+    through the proxy; the thread it actually executed on must differ from
+    the calling (test/event-loop) thread.
+
+    Strip-falsifier (performed manually before submission, not re-run in
+    CI — reverting would mean calling the inner transport directly with no
+    thread at all): calling ``inner.submit_user_text`` directly, bypassing
+    the proxy, makes ``call_idents == [threading.get_ident()]`` — the SAME
+    thread as the caller — turning this red."""
+    caller_ident = threading.get_ident()
+    inner = _RecordingTransport()
+    proxy = ThreadedTransportProxy(lambda: inner)
+    proxy.start()
+    try:
+        result = await proxy.submit_user_text("hello")
+        assert result == "echo:hello"
+        assert inner.call_idents == [proxy.worker_thread_ident]
+        assert proxy.worker_thread_ident != caller_ident, (
+            "the worker's own recorded thread identity must differ from "
+            "the caller's — this is the whole point of the thread boundary"
+        )
+    finally:
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_witness_2_the_caller_loop_keeps_advancing_while_the_worker_is_blocked():
+    """Tier 2: progress witness. While the worker thread is deliberately
+    held open inside ``submit_user_text`` (a real ``threading.Event.wait()``,
+    released only at the end of this test), the CALLER's own event loop
+    must keep scheduling other work — the actual defect #4995 exists to
+    remove is the TUI not getting scheduled while the core does something
+    slow on a SHARED loop.
+
+    Strip-falsifier (performed manually, not re-run in CI — reverting would
+    hang the test process): if ``ThreadedTransportProxy._call_on_worker``
+    dispatched inline (called ``inner.submit_user_text`` directly on the
+    caller's own thread, no ``run_coroutine_threadsafe``/thread hop at all)
+    instead of on the worker thread, ``self._gate.wait()`` would block the
+    CALLER's own thread — including its event loop — and the ``asyncio.
+    sleep(0)`` loop below could never run even once: this test would hang
+    until the harness's own CI timeout killed it, never reaching the
+    ``assert progressed == 50`` line. This was verified by temporarily
+    forcing ``_call_on_worker`` to await the inner coroutine directly (no
+    thread) and observing the hang under a bounded ``pytest --timeout``
+    invocation, then reverting — not left as an automated test, since a
+    genuinely hanging test is exactly the failure mode CI's own kill switch
+    exists to catch, not something to reproduce on every real run."""
+    gate = threading.Event()
+    started = threading.Event()
+    inner = _RecordingTransport(gate=gate, started=started)
+    proxy = ThreadedTransportProxy(lambda: inner)
+    proxy.start()
+    try:
+        submit_task = asyncio.create_task(proxy.submit_user_text("hi"))
+        # Unbounded wait on a real condition (started.wait()), off the
+        # caller's own loop via to_thread — not a sleep, not a poll.
+        await asyncio.to_thread(started.wait)
+
+        progressed = 0
+        for _ in range(50):
+            await asyncio.sleep(0)
+            progressed += 1
+        assert progressed == 50, (
+            "the caller loop must keep scheduling other work while the "
+            "worker thread sits inside a blocking call"
+        )
+        assert not submit_task.done(), (
+            "the worker call must still be blocked at this point — proves "
+            "the 50 iterations above genuinely overlapped it, rather than "
+            "the worker having already finished before they ran"
+        )
+
+        gate.set()
+        result = await submit_task
+        assert result == "echo:hi"
+    finally:
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_accept_side_frames_and_sync_reads_flow_through_the_proxy():
+    """Tier 2: accept-side — the proxy is not JUST a thread hop for one
+    async method; the frame stream and the synchronous passthrough reads
+    (``has_session`` etc., read from the single snapshot slot, refreshed
+    alongside each frame — see ``threaded.py``'s own module docstring) work
+    end-to-end with a real inner transport that actually produces frames
+    and reports a real session."""
+    from reyn.interfaces.transport.frames import DisplayFrame
+    from reyn.runtime.outbox import OutboxMessage
+
+    class _FramingTransport(_RecordingTransport):
+        """Yields exactly one real frame (constructed at ``__init__`` time,
+        no cross-thread test injection needed — the worker thread's own
+        pump loop is what drains this and delivers it), then hangs on an
+        unresolved real ``asyncio.Event`` forever (unbounded wait, not a
+        duration) since this test needs no second frame."""
+
+        async def frames(self):
+            yield DisplayFrame(OutboxMessage(kind="status", text="hello from core"))
+            await self._never.wait()
+
+    inner = _FramingTransport()
+    proxy = ThreadedTransportProxy(
+        lambda: inner, read_model_snapshot_fn=lambda: {"model": "test-model"},
+    )
+    proxy.start()
+    try:
+        # Pre-first-frame: the pre-attach contract (None), same shape
+        # #5009's own cost/ctx panes already rely on.
+        assert proxy.has_session() is False
+        assert proxy.read_model_snapshot() is None
+
+        frame = await proxy.frames().__anext__()
+        assert frame.message.text == "hello from core"
+
+        assert proxy.has_session() is True
+        assert proxy.read_model_snapshot() == {"model": "test-model"}
+    finally:
+        await proxy.shutdown()

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -1,7 +1,26 @@
-"""Tier 1/2: #4995 — ``ThreadedTransportProxy`` puts a real ``ClientTransport``
-on a dedicated worker thread with its own event loop, so competing work
-(e.g. the router's own turn processing) no longer starves the TUI's own
-scheduling on a shared loop.
+"""Tier 2: #4995 — ``ThreadedTransportProxy`` puts a real ``ClientTransport``
+on a dedicated worker thread with its own event loop — an OS-level
+invariant (genuinely different threads, a real ``threading.Event``
+blocking one of them) rather than a Reyn-internal contract, so this file
+declares Tier 2 throughout, not a dual Tier 1/2 (lead-coder's own
+#4995 review: a double declaration lets ``test_tier_audit.py``'s string
+match pass either reading, which avoids rather than answers CLAUDE.md's
+six-questions #6 — only a human can say which Tier a test is really
+pinning, and the answer here is one, not both).
+
+Scope, explicit (lead-coder's own #4995 review, said again here so it is
+not read from the PR body alone): this file does NOT prove the TUI
+becomes more responsive — that cutover (making ``TextualChatApp``/
+``run_repl`` actually construct a ``ThreadedTransportProxy`` instead of
+an ``InProcessTransport``) is #5048. What is proven here is the mechanism
+itself: a real ``ClientTransport`` genuinely runs on a different thread,
+and a caller on another thread keeps advancing while that thread is
+deliberately held open — the load-bearing PRECONDITION for #5048's own
+responsiveness claim, not that claim itself.
+
+Puts a real ``ClientTransport`` on a dedicated worker thread with its own
+event loop, so competing work (e.g. the router's own turn processing) no
+longer starves the TUI's own scheduling on a shared loop.
 
 **Design history, kept honest** (2 approaches rejected before this one
 settled — see ``threaded.py``'s own module docstring for the full
@@ -169,6 +188,9 @@ async def test_witness_2_the_caller_loop_keeps_advancing_while_the_worker_is_blo
         # caller's own loop via to_thread — not a sleep, not a poll.
         await asyncio.to_thread(started.wait)
 
+        # N is arbitrary — 50 carries no meaning of its own (not a
+        # threshold; any N > 0 that lets the assertion below distinguish
+        # "genuinely kept advancing" from "ran zero more times" would do).
         progressed = 0
         for _ in range(50):
             await asyncio.sleep(0)

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -219,7 +219,16 @@ async def test_accept_side_frames_and_sync_reads_flow_through_the_proxy():
     (``has_session`` etc., read from the single snapshot slot, refreshed
     alongside each frame — see ``threaded.py``'s own module docstring) work
     end-to-end with a real inner transport that actually produces frames
-    and reports a real session."""
+    and reports a real session.
+
+    Strip-falsified for real (architect + lead-coder, post-CI): once the
+    pre-frame phase is genuinely gated by a real ``threading.Event`` (not
+    raced), a strip of the MECHANISM must go red DETERMINISTICALLY, not
+    merely "not reproduced locally" — reverting ``has_session()`` to read
+    ``self._inner.has_session()`` directly (bypassing the single-slot
+    snapshot) turned this red immediately (``assert True is False``),
+    every time, confirming the assertion genuinely depends on the slot
+    mechanism rather than on timing. Restored before this commit."""
     from reyn.interfaces.transport.frames import DisplayFrame
     from reyn.runtime.outbox import OutboxMessage
 
@@ -252,15 +261,26 @@ async def test_accept_side_frames_and_sync_reads_flow_through_the_proxy():
     )
     proxy.start()
     try:
-        # Pre-first-frame: the pre-attach contract (None), same shape
-        # #5009's own cost/ctx panes already rely on. Genuinely pre-frame
-        # now — the worker cannot have pumped anything yet, since
-        # `_FramingTransport.frames()` is still blocked on
-        # `release_first_frame` above.
-        assert proxy.has_session() is False
-        assert proxy.read_model_snapshot() is None
+        try:
+            # Pre-first-frame: the pre-attach contract (None), same shape
+            # #5009's own cost/ctx panes already rely on. Genuinely
+            # pre-frame now — the worker cannot have pumped anything yet,
+            # since `_FramingTransport.frames()` is still blocked on
+            # `release_first_frame` above.
+            assert proxy.has_session() is False
+            assert proxy.read_model_snapshot() is None
+        finally:
+            # Release regardless of the assertions' own outcome — the
+            # generator's `await asyncio.to_thread(release_first_frame.
+            # wait)` runs in a NON-daemon threadpool-executor thread; an
+            # assertion failure here that left this Event unset would
+            # leak that thread forever, and CPython's own atexit hook for
+            # the default thread pool then hangs the WHOLE interpreter at
+            # process exit waiting for it to join — turning a normal
+            # AssertionError into what looks like a hang (found while
+            # investigating a requested strip-falsify, not guessed).
+            release_first_frame.set()
 
-        release_first_frame.set()
         frame = await proxy.frames().__anext__()
         assert frame.message.text == "hello from core"
 

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -223,14 +223,26 @@ async def test_accept_side_frames_and_sync_reads_flow_through_the_proxy():
     from reyn.interfaces.transport.frames import DisplayFrame
     from reyn.runtime.outbox import OutboxMessage
 
+    # #4995 CI finding (lead-coder): the pre-first-frame assertion below
+    # previously raced the worker thread's own pump — nothing held the
+    # first frame back, so whether the caller reached the assertion before
+    # or after `_pump_frames` refreshed the snapshot slot was a coin flip
+    # (green locally only because the caller happened to win on a fast
+    # machine). Gated the same way witness② already gates the worker
+    # thread — a real `threading.Event` the test controls — so the
+    # pre-frame phase this test's own docstring claims is now genuinely
+    # constructed, not merely hoped for. No sleep/timeout/attempts.
+    release_first_frame = threading.Event()
+
     class _FramingTransport(_RecordingTransport):
-        """Yields exactly one real frame (constructed at ``__init__`` time,
-        no cross-thread test injection needed — the worker thread's own
-        pump loop is what drains this and delivers it), then hangs on an
+        """Yields exactly one real frame, held back until the test releases
+        ``release_first_frame`` — constructing the pre-frame phase this
+        test actually asserts on, not racing it — then hangs on an
         unresolved real ``asyncio.Event`` forever (unbounded wait, not a
         duration) since this test needs no second frame."""
 
         async def frames(self):
+            await asyncio.to_thread(release_first_frame.wait)
             yield DisplayFrame(OutboxMessage(kind="status", text="hello from core"))
             await self._never.wait()
 
@@ -241,10 +253,14 @@ async def test_accept_side_frames_and_sync_reads_flow_through_the_proxy():
     proxy.start()
     try:
         # Pre-first-frame: the pre-attach contract (None), same shape
-        # #5009's own cost/ctx panes already rely on.
+        # #5009's own cost/ctx panes already rely on. Genuinely pre-frame
+        # now — the worker cannot have pumped anything yet, since
+        # `_FramingTransport.frames()` is still blocked on
+        # `release_first_frame` above.
         assert proxy.has_session() is False
         assert proxy.read_model_snapshot() is None
 
+        release_first_frame.set()
         frame = await proxy.frames().__anext__()
         assert frame.message.text == "hello from core"
 

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -129,7 +129,7 @@ class _RecordingTransport(ClientTransport):
 
 @pytest.mark.asyncio
 async def test_witness_1_worker_work_runs_on_a_different_thread_than_the_caller():
-    """Tier 1: structural witness. ``submit_user_text`` is dispatched
+    """Tier 2: structural witness. ``submit_user_text`` is dispatched
     through the proxy; the thread it actually executed on must differ from
     the calling (test/event-loop) thread.
 


### PR DESCRIPTION
**[tui-coder]** — #4995: `ThreadedTransportProxy`, the settled ClientTransport thread boundary.

## What
Runs a real `ClientTransport` (and whatever it wraps — a `Session`/`AgentRegistry`, in production) on a dedicated worker thread with its own event loop, presenting the identical `ClientTransport` surface to a caller on a different thread (the TUI's own asyncio loop). #4995's settled design: 1 boundary (the transport — already single-writer/ordered, per `in_process.py`'s own docstring), not N per-function offloads.

## Design history, kept honest
Went through 2 measured rejections before settling (full rationale in `threaded.py`'s own module docstring):
1. "N seams, one per hot-path function" (`asyncio.to_thread` per call site) — rejected by architect (self-flagged as their own issue-body residue): the transport already has the properties a thread boundary needs.
2. `asyncio.to_thread(build_history)` + a `threading.Lock` synchronizing `ChatReadModel` reads — rejected by lead-coder (measured self-contradiction): a lock held by the core thread during I/O reproduces exactly the "TUI does not get scheduled" symptom this issue exists to remove, and would turn its own required witness red.
3. Settled: **immutable snapshot hand-off, no shared mutable state, no lock**. The core thread owns `Session`/`AgentRegistry` exclusively; every value the caller thread needs (frames, `has_session()`, `pending_intervention_head()`, etc.) is refreshed into ONE overwriting slot each time the core thread produces a frame — a single-slot design (not a queue), so "does not accumulate" is a property of the TYPE, not a discipline (CLAUDE.md six-questions #5). `call_soon_threadsafe` is the SAME mechanism the frame stream already needs, extended — not a second mechanism.

## Scope — this PR does NOT yet make the TUI more responsive
Per lead-coder's own review: what this PR proves is the MECHANISM — a real `ClientTransport` genuinely runs on a different thread, and a caller on another thread keeps advancing while that thread is deliberately held open. It does NOT wire `TextualChatApp`/`run_repl` to actually construct a `ThreadedTransportProxy` instead of `InProcessTransport` — that cutover, where responsiveness would actually become observable, is #5048. This PR is the load-bearing precondition for that claim, not the claim itself.

## Scope — 3 methods deliberately left unwired
Found by actually reading them, not guessed (lead-coder's own condition before this PR):
- `completion_session()` returns a LIVE `Session` reference, not a copyable value.
- `load_older_conversation_history()` mutates `Session.history` and performs disk I/O (confirmed by reading `extend_history_backward()`).

Both filed as #5044, `part of #4995`.

`clear_pending_command_ui()` is a WRITE living on a type named "read model" — a pre-existing contract defect, independent of threading. Filed as its OWN issue, #5045 (NOT part of #4995 — lead-coder's ruling: true regardless of this issue).

Wiring this proxy in as `TextualChatApp`'s/`run_repl`'s default local transport is a separate cutover, filed as #5048, `part of #4995`.

## Test plan
- [x] `tests/interfaces/test_4995_threaded_transport_proxy.py` — 2 REQUIRED witnesses (lead-coder's own ruling, neither sufficient alone): ① structural (worker's own recorded thread identity differs from the caller's) ② progress (the caller's event loop keeps scheduling other work — an arbitrary N=50 `asyncio.sleep(0)` iterations, N itself carries no meaning, noted inline — while a real `threading.Event` holds the worker thread open inside a blocking call). No `sleep`/`timeout`/`attempts=N` anywhere. Plus 1 accept-side test (frames + sync passthrough reads flow through the proxy end-to-end with a real inner transport). Declares Tier 2 throughout (fixed a Tier 1/2 double-declaration lead-coder's review caught — a genuinely different OS thread is an OS-level invariant, not a Reyn-internal contract, and a double declaration lets `test_tier_audit.py`'s string match avoid rather than answer CLAUDE.md's six-questions #6).
- [x] Both witnesses strip-falsified manually before this commit (not left as automated re-runs — reverting witness② genuinely hangs the process): reverting the dispatch to call the inner transport inline (no thread hop) made witness① show the SAME thread identity, and made witness② hang until pytest's own `--timeout` killed it — confirming the exact deadlock this design removes, not merely a wrong value.
- [x] `ruff check .`
- [x] `scripts/test_tier_audit.py --strict` on the new test file
- [x] `scripts/verify_module_docstrings.py` on the new src module
- [x] `scripts/mypy_ratchet.py`
- [x] `scripts/flat_tests_ratchet.py`
- [x] `scripts/check_tests_path_literal_reference.py` (re-run right before push, main moved twice tonight — no rebase needed, already current)
- [x] `scripts/check_bare_tests_import_reference.py`
- [x] `scripts/check_file_depth_reference.py`
- [x] `tests/interfaces/test_stream_drain_yield_3570.py` (repo-wide frame-drain gate — `frames()` needed the SAME `suspend_between_frames()` pairing `InProcessTransport.frames()` already has; caught by the gate, fixed)
- [x] `.venv/bin/python -m pytest tests/interfaces/ -k "transport or 4995 or client_transport"` — 43 passed
- [ ] (skipped — Visual; standing waiver, owner 2026-08-08)

part of #4995

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

- [x] **`threaded.py` の module docstring に 1 行** — ✅ 済 (`378799312`, :55-62)。lead-coder が実ファイルで確認。求めた以上の形で、**なぜその面に置くのか**（PR 本文は merge 後に誰も読まない履歴／test docstring は test を開く人にしか届かない）まで書かれている。元の — 「2026-08-22 時点で production の呼び口は無い。配線は #5048。それまでこの型はテストからのみ構築される」。実測: 構築はテスト内 3 箇所のみ、production の呼び口 0。**PR 本文は履歴、test docstring は test 読者にしか届かない** — 次に `threaded.py` を開く人が読む面に置く（architect: `issuecomment-5377001274`、lead-coder が最初に指した面が誤り）。
- [x] 🟡 **#5048 の本文に「#5049 が入った日」を 1 行** — マージ後に実日付/コミットで追記する、と著者が明言（マージ前に書けない値のため。**約束を面に固定した**ので第 3 の沈黙状態にはならない）。元の — 放置の長さが見えるように（機構は足さない）。

- [x] ~~🔴~~ **`cancel-swallow gate` FAILED** — ✅ 解消 (`378799312`): `cancelling() > 0` で `raise`、先例 #3377 を引いた理由コメント付き、strip-falsify 済（著者報告）。lead-coder が実コードを確認。元の — `threaded.py:350`、`self._pump_task` を cancel→await→`CancelledError` 無条件 catch。**この gate の母集団は 0** ∴ 継承債務でなく本 PR の regression。処方: `asyncio.current_task().cancelling() > 0` を except で見て真なら `raise`（先例 `session.py` #3377、worked example `events.py` の `drain()`/`stop_dispatch()` #4988）。
- [x] **Tier 宣言の不一致** — ✅ 解消 (`378799312`): 全宣言が Tier 2 に統一、module docstring も六問 #6 を引いて理由を記載。元の — module docstring は「Tier 2 throughout」と主張するが `test_witness_1` の docstring（:132）は「Tier 1: structural witness.」のまま。CI は per-function 一致でどちらも通る ∴ **module docstring の自己申告が偽**。どちらに寄せるかは著者の判断（六問の 6 は書いた人にしか答えられない）、一致していればよい。



- [x] ~~🔴~~ **accept-side テストが構造的にレースしている** — ✅ 解消 (`d454562d9`): `release_first_frame` (threading.Event) で 1 本目の yield 前に停止。`_latest` の書き込みは `_pump_frames` の 1 箇所のみ ∴ **pre-frame 位相は原理的にレースしない**。sleep/timeout/attempts なし。**lead-coder は回数でなく構造で検証**（レース修正に反復緑は証拠にならないため）。元の — `:245 assert proxy.has_session() is False` は `start()` 直後の「まだ 1 本目が来ていない位相」を主張するが、**その位相をテストが作っていない**（worker の pump と呼び手の到達順で決まる）。CI 3.11/3.12 とも赤、ローカル緑は速い機械で呼び手が勝っただけ。**処方は witness ② と同じ `threading.Event` で 1 本目を止める**（`sleep`/`timeout`/`attempts` を使わない）。


- [x] ~~🔴~~ **マージ前に strip 1 回** — ✅ 実施 (`3524393d2`): `has_session()` を `self._inner` 直読みに戻すと**即座に決定的に red、毎回再現**。**さらに実バグを 1 件発見** — 事前 assert 失敗時に `release_first_frame` が未 set のまま非 daemon threadpool スレッドが leak し、CPython の atexit join で**プロセス全体が hang**（AssertionError が hang に化ける）。try/finally で release を保証。元の（architect `issuecomment-5377142401`、lead-coder が blocking に格上げ）— 修正後は pre-frame の窓が **Event で無限に開いている** ∴ **strip は決定的に赤になるはず**。狙う先は gate ではなく機構: `has_session()`/`read_model_snapshot()` が単一スロットでなく**内側の transport を直接読む**ように戻す。**赤になれば記録を直すだけ／赤にならなければ構成が思ったとおりでない**（この PR で直す）。「実行した strip」と「効いた strip」は別。

