### PR TITLE
feat(#5050): remote intervention_head() no longer lies None (①②; ③ deferred)

### DIFF
--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -28,10 +28,15 @@ status/region state from, with two implementations —
 **Frame-sufficiency (what a remote client CAN show).** The server projects only
 the MAIN-bar subset onto the wire (``state.py``'s ``project_status`` /
 ``_WIRE_KEYS``): ``model`` · ``attached_name`` · ``cost_agent`` / ``cost_total``
-/ ``agent_tokens`` · ``ctx_used`` / ``ctx_window`` · ``waiting_on``. Those chip
-VALUES render on remote. The dropdown EXPANSIONS (cost/ctx detail tuples, the
-``/model`` class picker, the agent/session tree, the ``…`` sub-bar
-toggle counts), the interactive intervention / rewind PICKERS, and the
+/ ``agent_tokens`` · ``ctx_used`` / ``ctx_window`` · ``waiting_on`` ·
+``pending_intervention_head`` (#5050). Those chip VALUES, and now the pending
+intervention head itself, are genuinely readable via :meth:`RemoteReadModel.
+intervention_head` rather than an unconditional None (#5050 closed the
+#4996-family lying-None this method carried — see its own docstring; whether
+a remote-side RENDERING surface actually consumes this yet is separate and
+untouched by #5050, tracked in its own issue thread). The dropdown EXPANSIONS
+(cost/ctx detail tuples, the ``/model`` class picker, the agent/session tree,
+the ``…`` sub-bar toggle counts), the interactive rewind PICKER, and the
 persisted past-turn CONVERSATION log (``conversation_history`` — the #3273
 Phase-5 restore-on-restart source) are session-local and are NOT on the wire —
 the remote model returns empty/``—``/0 for them (graceful degrade), never a fake
@@ -231,13 +236,16 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     pipelines_reported=True,
 )
 
-#: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these 6
+#: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these
 #: methods' own docstrings already document (session-local state the AG-UI
 #: wire does not project): every one of them always degrades, independent of
-#: server-side state. See the module docstring's "Frame-sufficiency" section.
+#: server-side state — with ONE exception, ``intervention_head`` (#5050):
+#: STATE_SNAPSHOT/STATE_DELTA now carry ``pending_intervention_head``, so
+#: this one genuinely reflects live server-side state rather than always
+#: degrading. See the module docstring's "Frame-sufficiency" section.
 REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     completion_session=False,
-    intervention_head=False,
+    intervention_head=True,
     pending_command_ui=False,
     has_command_ui_region=False,
     conversation_history=False,
@@ -277,9 +285,27 @@ class ChatReadModel(ABC):
     @abstractmethod
     def intervention_head(self) -> "object | None":
         """The head closed-set intervention (with ``.id`` / ``.choices``) for the
-        above-input region selector, or None. Remote returns None: a remote
-        intervention rides the display prompt and is answered on the input line
-        (via the transport), not through the local region picker."""
+        above-input region selector, or None.
+
+        LOCAL returns the real ``UserIntervention`` object (``.id``/
+        ``.choices`` as real attributes). REMOTE returns the JSON-safe wire
+        projection (``{id, prompt, detail, choices: [{id, label, hotkey},
+        ...]}``) read off ``pending_intervention_head`` on the transport's
+        STATE_SNAPSHOT/STATE_DELTA-fed status view — a DICT, not an object
+        with attributes.
+
+        #5050: previously an unconditional None here, regardless of
+        server-side state — the #4996-family lying-None pattern
+        (``ChatReadModelCapabilities``'s own docstring names it): "never
+        supported" and "nothing pending right now" rode the identical
+        ``None``, indistinguishable to a caller. This was true independent
+        of whether choices themselves reach a remote client some OTHER way
+        (they do, via a separate AG-UI frontend-tool encoding — #5050's own
+        issue thread; NOT what this method's prior None was hiding). Fixing
+        this source is a precondition for any remote consumer of THIS method
+        to ever tell the two states apart, whether or not one is wired up
+        yet (``REMOTE_CHAT_READ_CAPABILITIES.intervention_head`` is the
+        companion declaration — see its own comment)."""
 
     @abstractmethod
     def pending_command_ui(self) -> "dict | None":
@@ -701,7 +727,16 @@ class RemoteReadModel(ChatReadModel):
         return None
 
     def intervention_head(self):
-        return None
+        # #5050: previously unconditional None — see this module's #5050
+        # commit for the full account. STATE_SNAPSHOT/STATE_DELTA now carry
+        # ``pending_intervention_head`` (status._snapshot's own doc), so a
+        # remote client CAN read it, the same live-tick pattern
+        # :meth:`snapshot` above already uses (``transport.status.values``).
+        # Returns the JSON-safe dict projection ({id, prompt, detail,
+        # choices: [{id, label, hotkey}, ...]}), not a ``UserIntervention``
+        # instance — a remote consumer never held a real one to begin with.
+        values = getattr(getattr(self._transport, "status", None), "values", None)
+        return (values or {}).get("pending_intervention_head")
 
     def pending_command_ui(self):
         return None

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -432,6 +432,32 @@ def _snapshot(registry, config=None):
     # lets the row surface ask directly, and keeps the never-fabricate contract
     # in ONE place (``BudgetTracker.turn_usage`` returns None, not 0).
     turn_usage_fn = s.turn_usage
+    # #5050: the SAME head ``ClientTransport.pending_intervention_head()``
+    # (in_process.py) already returns for the in-process path
+    # (``s.interventions.head()``), projected here to a JSON-safe dict so it
+    # can also ride STATE_SNAPSHOT/STATE_DELTA — the source
+    # ``RemoteReadModel.intervention_head()`` reads instead of an
+    # unconditional None (read_model.py's own #5050 fix: that method was
+    # conflating "unsupported" with "nothing pending now", the #4996-family
+    # lying-None pattern, independent of whether choices already reach a
+    # remote client some OTHER way — they do, via a separate AG-UI
+    # frontend-tool encoding; that path is untouched here). Shape mirrors
+    # ``intervention_handler._iv_meta``'s established choices convention
+    # (id/label/hotkey per entry). ``None`` when nothing is pending — never a
+    # fabricated placeholder.
+    _head = s.interventions.head()
+    pending_intervention_head = (
+        {
+            "id": _head.id,
+            "prompt": _head.prompt,
+            "detail": _head.detail,
+            "choices": [
+                {"id": c.id, "label": c.label, "hotkey": c.hotkey}
+                for c in _head.choices
+            ],
+        }
+        if _head is not None else None
+    )
     return {
         # #5009 / #5009 closing pass: every ``*_reported`` declaration is
         # projected in ONE call, from ONE source
@@ -440,6 +466,7 @@ def _snapshot(registry, config=None):
         # generic projection replaced 4 near-identical hand-typed
         # call sites.
         **_reported_snapshot_keys(),
+        "pending_intervention_head": pending_intervention_head,
         "model": s.model,
         "model_active_class": s.active_model_class(),
         "model_classes": list(s.known_model_classes()),

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -45,6 +45,12 @@ _WIRE_KEYS = (
     "ctx_used",
     "ctx_window",
     "waiting_on",
+    # #5050: the pending closed-set intervention (id/prompt/detail/choices),
+    # or None — the source ``RemoteReadModel.intervention_head()`` reads
+    # instead of an unconditional None (the #4996-family lying-None fix —
+    # see that method's own docstring). See ``status._snapshot``'s own
+    # docstring for the shape.
+    "pending_intervention_head",
     # #3300 P2a: server-authoritative sent-queue state — the undispatched
     # inbox queue (list of {msg_id, chain_id, text}) + whether a turn is
     # currently dispatched. Rides this SAME STATE_SNAPSHOT/STATE_DELTA
@@ -82,6 +88,8 @@ def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) 
         "ctx_used": snap.get("ctx_used", 0),
         "ctx_window": snap.get("ctx_window", 0),
         "waiting_on": waiting_on,
+        # #5050: see _WIRE_KEYS above.
+        "pending_intervention_head": snap.get("pending_intervention_head"),
         # #3300 P2a: sent-queue state, see _WIRE_KEYS above.
         "queue": snap.get("queue", []),
         "turn_active": snap.get("turn_active", False),

--- a/tests/interfaces/test_agui_remote_inline_p3.py
+++ b/tests/interfaces/test_agui_remote_inline_p3.py
@@ -109,7 +109,7 @@ async def test_remote_read_model_projects_wire_status() -> None:
 
 @pytest.mark.asyncio
 async def test_remote_read_model_projects_pending_intervention_head() -> None:
-    """Tier 2: #5050 -- when STATE_SNAPSHOT carries a pending intervention
+    """Tier 1: #5050 -- when STATE_SNAPSHOT carries a pending intervention
     head (choices included), ``RemoteReadModel.intervention_head()`` returns
     it — instead of the unconditional None it returned before #5050 (the
     #4996-family lying-None: "unsupported" and "nothing pending now" rode
@@ -165,7 +165,7 @@ async def test_remote_read_model_projects_pending_intervention_head() -> None:
 
 @pytest.mark.asyncio
 async def test_remote_read_model_intervention_head_is_none_not_unsupported() -> None:
-    """Tier 2: #5050 reverse direction -- a REAL STATE_SNAPSHOT that carries
+    """Tier 1: #5050 reverse direction -- a REAL STATE_SNAPSHOT that carries
     ``pending_intervention_head: None`` (nothing pending right now, but the
     server genuinely reported on the question) still reads back as None
     through ``RemoteReadModel.intervention_head()`` — the correct value,

--- a/tests/interfaces/test_agui_remote_inline_p3.py
+++ b/tests/interfaces/test_agui_remote_inline_p3.py
@@ -107,6 +107,94 @@ async def test_remote_read_model_projects_wire_status() -> None:
     assert snap["ctx_window"] == 1000
 
 
+@pytest.mark.asyncio
+async def test_remote_read_model_projects_pending_intervention_head() -> None:
+    """Tier 2: #5050 -- when STATE_SNAPSHOT carries a pending intervention
+    head (choices included), ``RemoteReadModel.intervention_head()`` returns
+    it — instead of the unconditional None it returned before #5050 (the
+    #4996-family lying-None: "unsupported" and "nothing pending now" rode
+    the identical value). This is the ruled witness (lead-coder,
+    issuecomment-5377022077) — NOT a claim that remote UI rendering shows
+    these choices today: how choices actually reach a remote client's
+    picker is a SEPARATE, deferred question (#5050's own issue thread —
+    they already arrive via a different AG-UI frontend-tool encoding,
+    confirmed independently; #5050 fixes the read-model source, not that
+    consumer).
+
+    FALSIFY: dropping ``pending_intervention_head`` from ``_WIRE_KEYS``/
+    ``project_status`` (state.py) turns this RED (``intervention_head()``
+    reverts to None even though the server-side state carries a real head).
+    See the sibling test below for the reverse direction: no pending head
+    on the wire still correctly returns None (not fabricated)."""
+    state = {
+        "attached_name": "researcher", "model": "opus",
+        "pending_intervention_head": {
+            "id": "iv-1", "prompt": "Allow write to src/foo.py?", "detail": "",
+            "choices": [
+                {"id": "yes", "label": "[y]es", "hotkey": "y"},
+                {"id": "always", "label": "[A]lways", "hotkey": "A"},
+                {"id": "no", "label": "[n]o", "hotkey": "n"},
+                {"id": "never", "label": "[N]ever", "hotkey": "N"},
+            ],
+        },
+    }
+
+    async def frames():
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    emitter = AgUiEmitter(frames(), lambda: dict(state))
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_SNAPSHOT" in sse
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    async for _f in transport.frames():
+        pass  # drain → applies STATE_* to transport.status
+
+    head = RemoteReadModel(transport).intervention_head()
+    assert head is not None
+    assert head["id"] == "iv-1"
+    assert head["prompt"] == "Allow write to src/foo.py?"
+    assert [c["id"] for c in head["choices"]] == ["yes", "always", "no", "never"]
+    assert [c["label"] for c in head["choices"]] == [
+        "[y]es", "[A]lways", "[n]o", "[N]ever",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_remote_read_model_intervention_head_is_none_not_unsupported() -> None:
+    """Tier 2: #5050 reverse direction -- a REAL STATE_SNAPSHOT that carries
+    ``pending_intervention_head: None`` (nothing pending right now, but the
+    server genuinely reported on the question) still reads back as None
+    through ``RemoteReadModel.intervention_head()`` — the correct value,
+    not a symptom of the OLD unconditional-None bug. Distinguishing this
+    from #4996-family "declared unsupported" is exactly what
+    ``REMOTE_CHAT_READ_CAPABILITIES.intervention_head=True`` (flipped by
+    #5050) now lets a caller do: a supported method genuinely returning
+    None here means "nothing pending", never "can't tell you"."""
+    state = {"attached_name": "researcher", "model": "opus", "pending_intervention_head": None}
+
+    async def frames():
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    emitter = AgUiEmitter(frames(), lambda: dict(state))
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_SNAPSHOT" in sse
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    async for _f in transport.frames():
+        pass  # drain → applies STATE_* to transport.status
+
+    rm = RemoteReadModel(transport)
+    assert rm.capabilities.intervention_head is True
+    assert rm.intervention_head() is None
+
+
 # --- graceful degrade: session-local affordances are empty, never faked --------
 
 


### PR DESCRIPTION
**[e2e-coder]** — remote `intervention_head()` no longer lies `None` (#5050 items ①②; ③ deferred — see below).

<!-- closing-check: discussing #5050 -->
part of #5050

## What
`RemoteReadModel.intervention_head()` returned an unconditional `None` regardless of server-side state — the #4996-family lying-`None` pattern (conflating "never supported" with "nothing pending right now"). Fixed by piggybacking `pending_intervention_head` onto `STATE_SNAPSHOT`/`STATE_DELTA` (the same channel every other MAIN-bar chip value already rides) and reading it back from there:

- `status.py`'s `_snapshot()` — new `pending_intervention_head` key: `{id, prompt, detail, choices: [{id, label, hotkey}, ...]}` or `None`, a JSON-safe projection of `s.interventions.head()`. Shape mirrors `intervention_handler._iv_meta`'s established choices convention.
- `state.py` — added to `_WIRE_KEYS` + `project_status`.
- `read_model.py` — `RemoteReadModel.intervention_head()` reads it off `transport.status.values` (same live-tick pattern `.snapshot()` already uses). `REMOTE_CHAT_READ_CAPABILITIES.intervention_head` flipped `False → True` to match.

## Root-cause correction — recorded honestly, not smoothed over
My first-draft framing (in an earlier commit on this branch, since rewritten) guessed the gap was "a client that missed the one-shot `kind="intervention"` announcement — late join / reconnect — has no way to learn what's pending." I flagged this to lead-coder **before** writing any rendering code, since the issue's own witness ("remote selecting `always` writes to `.reyn/approvals.yaml`") crosses a frontend-tool layer neither of us had directly observed.

lead-coder's independent trace (`issuecomment-5377022077`) went a step further and **falsified that framing too**:
- `CONTROL_FILTER_KINDS` only filters `__end__`/`__open_artifact__` — `"intervention"` is never filtered.
- Late-join is already covered: `_reconnect_snapshot_chunks` → `encode_messages_snapshot` resends the **full** DisplayFrame backlog, choices included.
- `generic_yn_choices()` (`[y]es / [A]lways / [n]o / [N]ever`, including `ALWAYS → _persist(key, True)`) is already what `_prompt` builds — choices were never missing from what the server sends.

∴ "remote shows no choices" is real (owner's own repro) but its cause is **neither the transport nor the backlog nor a missing choices set** — it's somewhere in how a remote frontend renders what it already received, and **neither of us has observed that yet**. Guessing the target and patching it risked fixing code that isn't where the symptom lives.

**Ruling (lead-coder)**: item ③ is **deferred**, tracked in #5050's own issue thread, to return together with the frontend-rendering finding once identified. Items ①② stand on their own merit — the lying-`None` on `intervention_head()` is a real defect independent of whether ③'s eventual fix turns out to need this source or a different one.

## Tests (`tests/interfaces/test_agui_remote_inline_p3.py`, no mocks)
Witness **replaced** per lead-coder's explicit instruction — the original "remote answering `always` writes `approvals.yaml`" crosses the unobserved frontend layer and could go red for an unrelated reason:

- `test_remote_read_model_projects_pending_intervention_head` — real emitter → wire → `AgUiTransport`; `STATE_SNAPSHOT` carries a head with choices; `intervention_head()` returns it verbatim. Strip-falsified both directions (removing the wire key, and reverting the accessor to `return None`) — both RED for the right reason, restored.
- `test_remote_read_model_intervention_head_is_none_not_unsupported` (reverse direction, lead-coder's explicit ask) — a real `STATE_SNAPSHOT` with `pending_intervention_head=None` reads back as `None`, **and** `capabilities.intervention_head is True` — proving "nothing pending" and "unsupported" are now distinguishable, not just coincidentally both `None`.

## Local gates (fresh, `.venv/bin/python` explicit)
- [x] `ruff check` — clean
- [x] `test_tier_audit.py --strict` — clean, 9 tests inspected, 0 Tier-4
- [x] `verify_module_docstrings.py` — clean
- [x] `mypy_ratchet.py` — clean, 203 findings all baselined, 0 new
- [x] `flat_tests_ratchet.py` — clean
- [x] `check_tests_path_literal_reference.py` — clean (re-run right before push, main at `a4127d43e`)
- [x] `check_bare_tests_import_reference.py` — clean
- [x] `check_file_depth_reference.py` — clean
- [x] Scoped `pytest` — green, 204 tests (agui/status/read_model/capabilities + connect-parity + reachability suites)

## Test plan
- [x] Automated tests above (real emitter → wire → transport, strip-falsified both directions)
- [x] (skipped — Visual, standing waiver 2026-08-08: no rendering surface touched in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
