### PR TITLE
docs(test-review): six-questions Q5 bites on the failing path too

### DIFF
--- a/docs/deep-dives/contributing/test-review-six-questions.md
+++ b/docs/deep-dives/contributing/test-review-six-questions.md
@@ -78,12 +78,16 @@ Ask each test in the diff:
    is a non-daemon thread; what bounds it is nothing inside the test
    — the existing blocking condition ("if something outside the test
    bounds it, it is not a bound") applies exactly, just on the RED
-   path instead of the green one. The visible symptom was not a
-   traceback — it was CI hanging until the timeout killed it, an
-   `AssertionError` disguised as a hang. Three independent static
-   reads — two human reviewers and one automated check — all read
-   this test and confirmed the passing path was sound; none traced the
-   failing path until the hang was reproduced directly. **When reading a test that holds an `Event`/`Lock`/
+   path instead of the green one. CI itself saw an ordinary
+   `AssertionError` — the hang only surfaced during a LOCAL
+   strip-falsify run (reverting the fix and re-running by hand), which
+   is exactly the point: **an ordinary CI run does not teach you this
+   — only deliberately forcing the failing branch does.** Three
+   independent static reads — two reviewer sessions and one automated
+   check — all read this test and confirmed the passing path was
+   sound; none traced the failing path until the strip-falsify hang
+   was reproduced directly. **When reading a test that holds an
+   `Event`/`Lock`/
    thread/subprocess/temp file across multiple asserts, trace from
    each assert's failure point forward to the test's own `finally` (or
    its absence) and name what does NOT get released** — that is a

--- a/docs/deep-dives/contributing/test-review-six-questions.md
+++ b/docs/deep-dives/contributing/test-review-six-questions.md
@@ -65,6 +65,30 @@ Ask each test in the diff:
    whose length is decided by the *caller's* pace is unbounded by construction.
    (#3872: the app's timer paced it at 10fps; `list()` paced it at CPU speed, and
    the collecting starved the worker thread it was waiting on — 10 GB.)
+
+   **5 bears on the FAILING path, not just the passing one.** PR #5049
+   (#4995): a witness test held a real `threading.Event` open across an
+   `asyncio.to_thread`-dispatched worker call, released only after a
+   sequence of asserts. When one of those asserts fails, the `Event`
+   is never `.set()` — the worker thread stays blocked inside
+   `Event.wait()` forever, `asyncio.to_thread`'s underlying
+   threadpool thread is never daemon, and CPython's default
+   threadpool executor registers an `atexit` hook that joins every
+   outstanding worker before the interpreter exits. What accumulates
+   is a non-daemon thread; what bounds it is nothing inside the test
+   — the existing blocking condition ("if something outside the test
+   bounds it, it is not a bound") applies exactly, just on the RED
+   path instead of the green one. The visible symptom was not a
+   traceback — it was CI hanging until the timeout killed it, an
+   `AssertionError` disguised as a hang. Three independent static
+   reads — two human reviewers and one automated check — all read
+   this test and confirmed the passing path was sound; none traced the
+   failing path until the hang was reproduced directly. **When reading a test that holds an `Event`/`Lock`/
+   thread/subprocess/temp file across multiple asserts, trace from
+   each assert's failure point forward to the test's own `finally` (or
+   its absence) and name what does NOT get released** — that is a
+   different read than confirming the asserts are individually
+   meaningful, and the six questions do not perform it automatically.
 6. **Is the declared Tier the true one?** Only a human can answer this; the audit
    cannot. Say which of 1's answers you reached and why.
 


### PR DESCRIPTION
**[docs-maintainer]** — dispatched by lead-coder, no tracking issue

## What

`docs/deep-dives/contributing/test-review-six-questions.md` § question 5
("what does it accumulate, and who bounds it") only had instances on the
passing path. Added a real instance from PR #5049 (#4995): a witness test
held a real `threading.Event` open across an `asyncio.to_thread`-dispatched
worker call, released only after a sequence of asserts. When one of those
asserts fails, the `Event` is never `.set()` — the worker thread stays
blocked in `Event.wait()` forever, its `asyncio.to_thread` threadpool
thread is never daemon, and CPython's default threadpool executor's
`atexit` hook joins every outstanding worker before the interpreter can
exit. What accumulates is a non-daemon thread; what bounds it is nothing
inside the test. The existing blocking condition applies exactly — just
on the RED path instead of the green one. Not a new rule, an applied
instance of the existing one.

CI itself saw an ordinary `AssertionError` on this — the hang only
surfaced during a local strip-falsify run (reverting the fix and
re-running by hand). That is the point the instance now makes directly:
an ordinary CI run doesn't teach this, only deliberately forcing the
failing branch does.

Also records the meta-fact (per dispatch): 2 reviewer sessions + 1
automated check all read this test and confirmed the passing path was
sound; none traced the failing path until the strip-falsify hang was
reproduced directly. Closes with the reading technique this points to:
trace from an assert's failure point forward to the test's own `finally`
(or its absence) and name what does NOT get released.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no
      `Aborted`/`WARNING`; pre-existing INFO-level unpublished `.ja.md`
      anchor gaps only, unrelated to this edit
- [x] `python scripts/check_doc_anchors.py` (run after the strict build,
      needs `site/`) — "no dangling anchors into published pages"
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Closing-keyword self-check on commit message + this PR body — 0
      hits
- [x] (skipped — docs-only change, no `tests/` touched, TESTS-READ rule
      8 does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

- [x] 🔴 **「CI hanging until the timeout killed it」が事実と違う** — FIXED (`6dec2a060`): CIは通常のAssertionErrorだったこと、hangはlocal strip実行でのみ起きたことを直接記述。「CIが自然に教える」ではなく「stripしないと出ない」を核に。
- [x] 🔴 **「two human reviewers」— 人間は読んでいない** — FIXED (`6dec2a060`): 「two reviewer sessions and one automated check」に修正。
