### PR TITLE
fix(#5047): a replayed, already-answered intervention no longer registers as pending

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -103,7 +103,7 @@ from .presenter import (
     ReynPresenter,
     _neutralized_label,
 )
-from .restore import RESUME_DIVIDER, project_restored_frames
+from .restore import RESTORED_META_KEY, RESUME_DIVIDER, project_restored_frames
 from .rewind_picker import RewindPicker
 from .search_bar import SearchBar
 from .sent_queue import SentQueue
@@ -4447,7 +4447,36 @@ class TextualChatApp(App):
         self._register_call_parent(entry, kind, meta)
         if kind == "presentation":
             self._begin_image_resolutions(entry, msg)
-        if kind == "intervention":
+        # #5047: a REPLAYED (backlog) intervention reaches here on every
+        # (re)connect — ``restore.py``'s ``project_restored_frames``
+        # projects a history entry that WAS already answered into this
+        # SAME ``kind="intervention"`` shape, specifically so it renders
+        # through the presenter's existing RESOLVED branch
+        # (``ReynPresenter._present_intervention_pending``, keyed on
+        # ``meta["_answer_label"]``, same as ``gutter.py``'s own check at
+        # :228). Registering it as PENDING too (the old unconditional
+        # branch below) put a fake already-resolved entry into
+        # ``self._pending_ivs`` — harmless-looking (the presenter still
+        # drew "✓ answered"), but ``answer_oldest_intervention_text``/
+        # ``_choice`` deliver to the registry's OLDEST pending: a genuine
+        # answer could be misdelivered to whichever real entry sorts
+        # after this phantom one.
+        #
+        # ``RESTORED_META_KEY`` (fixed ``True``/absent), not
+        # ``_answer_label``: a restored intervention frame's
+        # ``_answer_label`` can itself be the EMPTY STRING (`restore.py`'s
+        # own ``meta.get(INTERVENTION_ANSWER_META_KEY, "")`` — a falsy
+        # check on the VALUE lets an empty-label restored frame slip
+        # through, the identical #4996-family "the value's own absence
+        # doesn't distinguish two different reasons" conflation, here on
+        # emptiness rather than None (lead-coder, mid-implementation,
+        # measured — `restore.py:95-104` — not guessed). Every restored
+        # ``kind="intervention"`` frame is, by construction, always
+        # already-answered (`restore.py`'s own docstring: an intervention
+        # NEVER answered has no history trace to restore from at all), so
+        # this marker is both necessary and sufficient — no restored
+        # intervention is ever genuinely still pending.
+        if kind == "intervention" and not (msg.meta or {}).get(RESTORED_META_KEY):
             self._present_intervention(msg, entry)
         else:
             self._apply_lifecycle_state(msg, entry)

--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -225,7 +225,18 @@ def _gutter_glyph_color(msg: "OutboxMessage") -> "tuple[str, str]":
         # left to distinguish the two, so both legs are special-cased here
         # rather than falling through to ``_KIND_LINE["intervention"]``'s
         # amber ("needs you") colour:
-        if not (msg.meta or {}).get("_answer_label"):
+        # #5047: presence of the KEY, not truthiness of its VALUE — a
+        # restored (backlog-replayed) intervention's ``_answer_label`` can
+        # itself be the empty string (``restore.py``'s own ``meta.get(
+        # INTERVENTION_ANSWER_META_KEY, "")``), and a falsy check on the
+        # value would render that restored, already-answered entry as
+        # still-PENDING (dim ⋯) — the same emptiness-vs-absence conflation
+        # app.py's own ``_present_intervention`` guard was measured to have
+        # (lead-coder, mid-#5047-implementation). A genuine LIVE pending
+        # intervention never carries this key at all until answered
+        # (``_resolve_intervention`` is what first sets it), so presence
+        # alone is both necessary and sufficient here.
+        if "_answer_label" not in (msg.meta or {}):
             # PENDING: a dim "awaiting" marker instead of the kind's normal
             # amber glyph.
             return "⋯", _CC_DIM

--- a/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
+++ b/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
@@ -1,0 +1,243 @@
+"""Tier 2: #5047 — a REPLAYED, already-answered intervention frame must not
+be registered as pending.
+
+Real chain of causes (lead-coder's own trace, `issuecomment-5377193342`,
+architect's ruling `issuecomment-5377199266`): on every (re)connect,
+``restore.py``'s ``project_restored_frames`` projects a history entry that
+WAS already answered into the SAME ``kind="intervention"`` shape a genuine
+LIVE pending one uses. `app.py`'s ``_present_intervention`` call site had
+no guard distinguishing the two, so this replayed, already-resolved frame
+was ALSO registered into ``self._pending_ivs`` / ``InterventionPanel.
+add_pending`` — a fake pending entry sitting in the same registry a genuine
+one lives in.
+
+**The real harm is not visual** (architect's own point): ``answer_oldest_
+intervention_text``/``_choice`` deliver to the registry's OLDEST pending —
+a phantom already-answered entry sorting ahead of a real pending one
+misdirects the NEXT genuine answer to whichever real entry happens to sort
+after the phantom, not the one the user actually meant.
+
+**The discriminator, corrected mid-implementation** (lead-coder, measured
+against ``restore.py:95-104``, not guessed): the first draft of this fix
+guarded on ``meta["_answer_label"]`` being truthy — but a restored frame's
+``_answer_label`` can itself be the EMPTY STRING (``restore.py``'s own
+``meta.get(INTERVENTION_ANSWER_META_KEY, "")``), so a falsy-VALUE check
+lets an empty-label restored frame slip through and register as pending
+anyway — the #4996-family "the value's own absence doesn't distinguish two
+different reasons" conflation, here on emptiness rather than None. Fixed
+to check ``RESTORED_META_KEY`` (fixed ``True``/absent) instead — every
+restored ``kind="intervention"`` frame is, by construction, always
+already-answered (an intervention never answered has no history trace to
+restore from at all), so this marker is both necessary and sufficient.
+``gutter.py``'s own sibling check (:228) had the identical value-truthiness
+trap (found in the same investigation) and is fixed alongside — presence
+of the ``_answer_label`` KEY, not its value.
+
+This test's own witness is the fake-pending REGISTRATION itself (the panel
+never opening), not the rendered text (which was already correct before
+this fix — the presenter's RESOLVED branch pre-dates #5047 and checks
+``answer is not None``, never truthiness).
+
+Real ``TextualChatApp`` + a real, minimal ``ClientTransport`` (no mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
+from reyn.interfaces.inline.textual_chat.restore import RESTORED_META_KEY
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _ReplayTransport(ClientTransport):
+    """A real, minimal ``ClientTransport`` that replays a fixed frame list —
+    mirrors ``test_textual_chat_intervention_panel_3299.py``'s own
+    ``RecordingTransport`` shape, not imported from it (that class lives in
+    a sibling test module, and this repo's own tests don't cross-import
+    each other's private fixtures)."""
+
+    def __init__(self, messages: "list[OutboxMessage]") -> None:
+        self._messages = list(messages)
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        for msg in self._messages:
+            yield DisplayFrame(msg)
+        await asyncio.Event().wait()
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self):
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> str:
+        return ""
+
+    async def shutdown(self) -> None:
+        return None
+
+
+def _restored_answered_frame(*, answer_label: str) -> OutboxMessage:
+    """Shaped EXACTLY like ``restore.py``'s ``project_restored_frames`` own
+    projection of an already-answered history entry (:305-314): ``kind=
+    "intervention"``, ``RESTORED_META_KEY: True``, no ``intervention_id``
+    (a restored entry carries none — this is itself part of #5047's own
+    misdelivery mechanism, not something this test needs to exercise
+    further)."""
+    return OutboxMessage(
+        kind="intervention",
+        text="Allow fetching from 'news.ycombinator.com'?",
+        meta={
+            RESTORED_META_KEY: True,
+            "prompt": "Allow fetching from 'news.ycombinator.com'?",
+            "detail": None,
+            "_answer_label": answer_label,
+        },
+    )
+
+
+def _genuine_pending_frame() -> OutboxMessage:
+    """A real LIVE pending intervention — no ``RESTORED_META_KEY``, no
+    ``_answer_label`` yet."""
+    return OutboxMessage(
+        kind="intervention",
+        text="Allow write to /etc/hosts?",
+        meta={
+            "intervention_id": "iv-live",
+            "prompt": "Allow write to /etc/hosts?",
+            "choices": [
+                {"id": "yes", "label": "Yes", "hotkey": "y"},
+                {"id": "no", "label": "No", "hotkey": "n"},
+            ],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_replayed_answered_intervention_does_not_open_the_pending_panel():
+    """Tier 2: strip-falsifier. A backlog replay carrying ONLY an already-
+    answered intervention must never open the panel — reverting the
+    ``RESTORED_META_KEY`` guard in ``app.py`` (registering it as pending
+    again) turns this red (``panel.display`` becomes True for a frame that
+    was never actually pending)."""
+    transport = _ReplayTransport([_restored_answered_frame(answer_label="Always")])
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        assert panel.display is False, (
+            "an already-answered replayed intervention must not register "
+            "as pending — the panel should never open for it"
+        )
+        assert panel.has_pending() is False, (
+            "a phantom entry was registered as pending (public "
+            "has_pending() surface, not private app state)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_replayed_intervention_with_an_empty_answer_label_still_excluded():
+    """Tier 2: the falsifying edge case that moved the discriminator from
+    ``_answer_label`` to ``RESTORED_META_KEY`` mid-implementation. An empty-
+    string ``_answer_label`` (a real shape ``restore.py`` can produce —
+    ``meta.get(INTERVENTION_ANSWER_META_KEY, "")``) must still be excluded
+    from pending registration. A guard checking ``not meta.get(
+    "_answer_label")`` (falsy-VALUE, the first-draft mistake) would treat
+    the empty string the same as "key absent" and let this slip through —
+    this test pins that the ACTUAL guard (key presence) does not have that
+    gap."""
+    transport = _ReplayTransport([_restored_answered_frame(answer_label="")])
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        assert panel.display is False, (
+            "an empty _answer_label must not be mistaken for a genuinely "
+            "pending intervention"
+        )
+        assert panel.has_pending() is False
+
+
+def test_gutter_reads_an_empty_answer_label_as_resolved_not_pending():
+    """Tier 2: strip-falsifier for the sibling ``gutter.py`` fix (same
+    investigation, same emptiness-vs-absence trap). A restored intervention
+    with an empty ``_answer_label`` must get the RESOLVED (dim, not the
+    amber "needs you") gutter glyph, not the PENDING one — reverting
+    ``_gutter_glyph_color``'s check back to ``not (msg.meta or {}).get(
+    "_answer_label")`` (falsy-VALUE) turns this red: an empty string is
+    falsy, so it would render as still-PENDING."""
+    from reyn.interfaces.inline.textual_chat.gutter import _gutter_glyph_color
+
+    resolved_empty = OutboxMessage(
+        kind="intervention", text="…", meta={"_answer_label": ""},
+    )
+    pending = OutboxMessage(kind="intervention", text="…", meta={})
+
+    glyph_resolved, color_resolved = _gutter_glyph_color(resolved_empty)
+    glyph_pending, color_pending = _gutter_glyph_color(pending)
+
+    assert glyph_resolved != glyph_pending or color_resolved != color_pending, (
+        f"an empty-label resolved intervention must render distinctly from "
+        f"a genuinely pending one; both got ({glyph_resolved!r}, "
+        f"{color_resolved!r})"
+    )
+    assert glyph_pending == "⋯", pending
+    assert glyph_resolved != "⋯", (
+        "empty _answer_label read as pending — the emptiness-vs-absence "
+        "trap this test exists to catch"
+    )
+
+
+@pytest.mark.asyncio
+async def test_genuine_pending_intervention_still_opens_the_panel():
+    """Tier 2: accept-side — a genuinely LIVE pending intervention (no
+    ``RESTORED_META_KEY``) still registers and opens the panel exactly as
+    before this fix; an "always skip registration" implementation would
+    pass the strip-falsifiers above vacuously without this."""
+    transport = _ReplayTransport([_genuine_pending_frame()])
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        assert panel.display is True, (
+            "a genuine pending intervention must still register and open "
+            "the panel"
+        )
+        assert panel.has_pending() is True

--- a/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
+++ b/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
@@ -54,6 +54,8 @@ from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
+_GUTTER_WIDTH = 2
+
 
 class _ReplayTransport(ClientTransport):
     """A real, minimal ``ClientTransport`` that replays a fixed frame list —
@@ -197,26 +199,46 @@ def test_gutter_reads_an_empty_answer_label_as_resolved_not_pending():
     investigation, same emptiness-vs-absence trap). A restored intervention
     with an empty ``_answer_label`` must get the RESOLVED (dim, not the
     amber "needs you") gutter glyph, not the PENDING one — reverting
-    ``_gutter_glyph_color``'s check back to ``not (msg.meta or {}).get(
+    ``ReynGutter``'s "intervention" branch back to ``not (msg.meta or {}).get(
     "_answer_label")`` (falsy-VALUE) turns this red: an empty string is
-    falsy, so it would render as still-PENDING."""
-    from reyn.interfaces.inline.textual_chat.gutter import _gutter_glyph_color
+    falsy, so it would render as still-PENDING.
 
-    resolved_empty = OutboxMessage(
-        kind="intervention", text="…", meta={"_answer_label": ""},
+    Uses the PUBLIC ``ReynGutter.decorate`` surface over a real
+    ``FlowModel``/``Entry`` pair (``textual_flowview`` — no mount needed,
+    ``FlowModel`` is a plain, UI-less collection) rather than importing the
+    private ``_gutter_glyph_color`` helper directly (lead-coder's TESTS-READY
+    finding on the first draft — CLAUDE.md's own testing policy: use the
+    public surface, and its absence is itself a finding when there is
+    none — here there IS one, ``decorate``, already exercised by
+    ``test_textual_chat_intervention_panel_3299.py``'s own
+    ``test_resolved_intervention_gutter_is_not_the_needs_you_amber``)."""
+    from textual_flowview import FlowModel
+
+    from reyn.interfaces.inline.textual_chat.gutter import ReynGutter
+
+    gutter = ReynGutter()
+    model: "FlowModel[OutboxMessage]" = FlowModel()
+
+    resolved_empty = model.append(
+        OutboxMessage(kind="intervention", text="…", meta={"_answer_label": ""}),
     )
-    pending = OutboxMessage(kind="intervention", text="…", meta={})
+    pending = model.append(
+        OutboxMessage(kind="intervention", text="…", meta={}),
+    )
 
-    glyph_resolved, color_resolved = _gutter_glyph_color(resolved_empty)
-    glyph_pending, color_pending = _gutter_glyph_color(pending)
+    rendered_resolved = gutter.decorate(resolved_empty, width=_GUTTER_WIDTH, height=1)
+    rendered_pending = gutter.decorate(pending, width=_GUTTER_WIDTH, height=1)
 
-    assert glyph_resolved != glyph_pending or color_resolved != color_pending, (
+    assert (
+        rendered_resolved.plain != rendered_pending.plain
+        or rendered_resolved.style != rendered_pending.style
+    ), (
         f"an empty-label resolved intervention must render distinctly from "
-        f"a genuinely pending one; both got ({glyph_resolved!r}, "
-        f"{color_resolved!r})"
+        f"a genuinely pending one; both got "
+        f"({rendered_resolved.plain!r}, {rendered_resolved.style!r})"
     )
-    assert glyph_pending == "⋯", pending
-    assert glyph_resolved != "⋯", (
+    assert "⋯" in rendered_pending.plain, rendered_pending.plain
+    assert "⋯" not in rendered_resolved.plain, (
         "empty _answer_label read as pending — the emptiness-vs-absence "
         "trap this test exists to catch"
     )


### PR DESCRIPTION
**[tui-coder]** — #5047 fix ①: client-side guard, per lead-coder's dispatch.

## What
On every (re)connect, `restore.py`'s `project_restored_frames` projects a history entry that WAS already answered into the SAME `kind="intervention"` shape a genuine LIVE pending one uses. `app.py`'s `_present_intervention` call site had no guard distinguishing the two, so this replayed, already-resolved frame was ALSO registered into `self._pending_ivs` / `InterventionPanel.add_pending` — a fake pending entry sitting in the same registry a genuine one lives in.

**The real harm is not visual** (architect's own point, `issuecomment-5377199266`): `answer_oldest_intervention_text`/`_choice` deliver to the registry's OLDEST pending — a phantom already-answered entry sorting ahead of a real pending one misdirects the NEXT genuine answer to whichever real entry sorts after the phantom, not the one the user actually meant.

## Discriminator, corrected mid-implementation
First draft guarded on `meta["_answer_label"]` being truthy. lead-coder measured (`restore.py:95-104`, not guessed) that a restored frame's `_answer_label` can itself be the **empty string** (`meta.get(INTERVENTION_ANSWER_META_KEY, "")`) — a falsy-VALUE check lets an empty-label restored frame slip through, the #4996-family "the value's own absence doesn't distinguish two different reasons" conflation, here on emptiness rather than None.

Fixed to check `RESTORED_META_KEY` (fixed `True`/absent) instead — every restored `kind="intervention"` frame is, by construction, always already-answered (an intervention never answered has no history trace to restore from at all), so this marker is both necessary and sufficient.

`gutter.py`'s own sibling check (:228, the PENDING/RESOLVED gutter-glyph branch) had the identical value-truthiness trap — found in the same investigation, fixed alongside (presence of the `_answer_label` KEY, not its value; `presenter.py`'s own equivalent check already used `is not None`, so only `gutter.py` needed this).

## Scope
Per lead-coder's explicit instruction: does NOT move `answer_oldest_intervention_*` to by-id (repo policy violation that predates this issue, but "counting every caller first" is separate work, filed by lead-coder as its own issue — not bundled here).

## Test plan
- [x] `tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py` — 4 tests: strip-falsifier (replayed answered intervention must not open the panel), the falsifying empty-label edge case that moved the discriminator, the sibling `gutter.py` fix's own strip-falsifier, and an accept-side test (a genuine live pending intervention still registers normally).
- [x] Both fixes strip-falsified manually before this commit (reverted each guard, confirmed the matching tests go red for the stated reason, restored).
- [x] Uses the public `InterventionPanel.has_pending()` surface, not private `app._pending_ivs` (caught by `test_tier_audit.py`'s Rule 8 during the pre-PR gate run, fixed before this commit).
- [x] `ruff check .`
- [x] `scripts/test_tier_audit.py --strict` on the new test file
- [x] `scripts/verify_module_docstrings.py` on both touched src modules
- [x] `scripts/mypy_ratchet.py`
- [x] `scripts/flat_tests_ratchet.py`
- [x] `scripts/check_tests_path_literal_reference.py` (fresh worktree off main's own tip, `664159bac`)
- [x] `scripts/check_bare_tests_import_reference.py`
- [x] `scripts/check_file_depth_reference.py`
- [x] `.venv/bin/python -m pytest tests/interfaces/ -k "intervention or gutter or restore or 5047 or 3299 or 3540 or 4788"` — 190 passed
- [ ] (skipped — Visual; standing waiver, owner 2026-08-08)

part of #5047

🤖 Generated with [Claude Code](https://claude.com/claude-code)
