### PR TITLE
fix(#5057): re-key the fake-pending intervention guard on intervention_id presence

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -103,7 +103,7 @@ from .presenter import (
     ReynPresenter,
     _neutralized_label,
 )
-from .restore import RESTORED_META_KEY, RESUME_DIVIDER, project_restored_frames
+from .restore import RESUME_DIVIDER, project_restored_frames
 from .rewind_picker import RewindPicker
 from .search_bar import SearchBar
 from .sent_queue import SentQueue
@@ -4447,36 +4447,47 @@ class TextualChatApp(App):
         self._register_call_parent(entry, kind, meta)
         if kind == "presentation":
             self._begin_image_resolutions(entry, msg)
-        # #5047: a REPLAYED (backlog) intervention reaches here on every
-        # (re)connect — ``restore.py``'s ``project_restored_frames``
-        # projects a history entry that WAS already answered into this
-        # SAME ``kind="intervention"`` shape, specifically so it renders
-        # through the presenter's existing RESOLVED branch
-        # (``ReynPresenter._present_intervention_pending``, keyed on
-        # ``meta["_answer_label"]``, same as ``gutter.py``'s own check at
-        # :228). Registering it as PENDING too (the old unconditional
-        # branch below) put a fake already-resolved entry into
-        # ``self._pending_ivs`` — harmless-looking (the presenter still
-        # drew "✓ answered"), but ``answer_oldest_intervention_text``/
-        # ``_choice`` deliver to the registry's OLDEST pending: a genuine
-        # answer could be misdelivered to whichever real entry sorts
-        # after this phantom one.
+        # #5047/#5057: a fake-pending ``kind="intervention"`` frame reaches
+        # here from more than one producer, and registering it as PENDING
+        # (the old unconditional branch below) put a phantom entry into
+        # ``self._pending_ivs`` — harmless-looking (the presenter can still
+        # draw it correctly, or it can be answered), but a genuine answer
+        # ``answer_oldest_intervention_text``/``_choice`` delivers to the
+        # registry's OLDEST pending: without a real ``intervention_id`` on
+        # THIS entry, an answer meant for it falls through to that
+        # oldest-pending fallback and can misdeliver to a completely
+        # unrelated, actually-pending entry.
         #
-        # ``RESTORED_META_KEY`` (fixed ``True``/absent), not
-        # ``_answer_label``: a restored intervention frame's
-        # ``_answer_label`` can itself be the EMPTY STRING (`restore.py`'s
-        # own ``meta.get(INTERVENTION_ANSWER_META_KEY, "")`` — a falsy
-        # check on the VALUE lets an empty-label restored frame slip
-        # through, the identical #4996-family "the value's own absence
-        # doesn't distinguish two different reasons" conflation, here on
-        # emptiness rather than None (lead-coder, mid-implementation,
-        # measured — `restore.py:95-104` — not guessed). Every restored
-        # ``kind="intervention"`` frame is, by construction, always
-        # already-answered (`restore.py`'s own docstring: an intervention
-        # NEVER answered has no history trace to restore from at all), so
-        # this marker is both necessary and sufficient — no restored
-        # intervention is ever genuinely still pending.
-        if kind == "intervention" and not (msg.meta or {}).get(RESTORED_META_KEY):
+        # #5047's own instance was a REPLAYED (backlog) intervention —
+        # ``restore.py``'s ``project_restored_frames`` projects an
+        # already-answered history entry into this SAME ``kind="intervention"``
+        # shape so it renders through the presenter's RESOLVED branch. #5057
+        # found TWO MORE producers with the identical shape (no
+        # ``intervention_id``, not restored either): ``stream_client.py``'s
+        # and this class's own ``/rewind`` text-list fallback, which reuse
+        # ``kind="intervention"`` purely for its PERSISTENT-render property
+        # (never un-answered "waiting" state to begin with). The original
+        # #5047 fix keyed on ``RESTORED_META_KEY`` — a marker naming ONE
+        # producer, not the property that actually matters, so it missed
+        # these two by construction (a fix keyed on "which producer wrote
+        # this" always misses the NEXT producer; #5057 is that miss
+        # happening).
+        #
+        # ``intervention_id`` presence is the real discriminator: it is the
+        # SAME value that decides, downstream, whether an answer can be
+        # routed ``answer_intervention_by_id`` (safe) or falls to
+        # ``answer_oldest_*`` (misdeliverable) — see
+        # ``ClientTransport.answer_intervention_text``/``_choice``'s own
+        # docstrings. ``announce`` (``intervention_handler.py``, the ONLY
+        # producer of a genuinely still-pending intervention) is also the
+        # ONLY one that sets it (``_iv_meta``, unconditionally). Discards:
+        # a future producer that legitimately needs pending-registration
+        # WITHOUT a real answerable id would silently fail this check too —
+        # none is known to exist today (only ``announce`` needs
+        # registration), but a new one must set ``intervention_id`` to a
+        # real, answerable id to pass, not merely omit the restored/rewind
+        # markers this replaces.
+        if kind == "intervention" and (msg.meta or {}).get("intervention_id"):
             self._present_intervention(msg, entry)
         else:
             self._apply_lifecycle_state(msg, entry)

--- a/tests/interfaces/test_5057_fake_pending_rewind_frame_not_registered.py
+++ b/tests/interfaces/test_5057_fake_pending_rewind_frame_not_registered.py
@@ -1,0 +1,132 @@
+"""Tier 2: #5057 — a `/rewind` text-list fallback must not register as a
+pending intervention either (the SAME hole #5047 closed for restored
+frames, reopened by a different producer).
+
+Real chain of causes: `app.py`'s own `/rewind` fallback (`_handle_rewind_
+request`, reached when no structured command-UI request is available —
+the REMOTE case, `pending_command_ui()` is always None there by design)
+reuses `kind="intervention"` purely for its PERSISTENT-render property (a
+`kind="status"` row would be transient and vanish) — `replace(msg,
+kind="intervention")` on the ORIGINAL `__rewind_list__` sentinel, which
+carries no `intervention_id`. `stream_client.py`'s plain-client sibling
+does the identical thing (`OutboxMessage(kind="intervention", text=
+msg.text)`, no meta at all).
+
+#5047's own fix guarded on `RESTORED_META_KEY` — a marker naming ONE
+producer (`restore.py`), not the property that actually decides whether an
+answer can be routed safely. This rewind-list frame carries neither
+`RESTORED_META_KEY` NOR a real `intervention_id`, so it slipped straight
+through that guard and registered as fake-pending exactly like #5047's own
+case did — the "a fix keyed on which producer wrote this always misses the
+next producer" failure #5057 measured directly (`issuecomment-5377340171`
+census: 4 producers, only `announce` sets `intervention_id`).
+
+The fix (this PR) re-keys the guard on `intervention_id` PRESENCE instead
+— the value that decides, downstream, whether ``answer_intervention_by_id``
+(safe) or ``answer_oldest_*`` (misdeliverable) gets used. This test is
+that fix's own strip-falsifier for the rewind-frame instance specifically
+(the #5047 file's own 4 tests already re-verify the restored-frame
+instance still passes under the new discriminator).
+
+Real ``TextualChatApp`` + a real, minimal ``ClientTransport`` (no mocks) —
+mirrors `test_5047_replayed_answered_intervention_not_pending.py`'s own
+`_ReplayTransport` shape (not imported from it — this repo's own tests
+don't cross-import each other's private fixtures).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _ReplayTransport(ClientTransport):
+    """A real, minimal ``ClientTransport`` that replays a fixed frame list."""
+
+    def __init__(self, messages: "list[OutboxMessage]") -> None:
+        self._messages = list(messages)
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        for msg in self._messages:
+            yield DisplayFrame(msg)
+        await asyncio.Event().wait()
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self):
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> str:
+        return ""
+
+    async def shutdown(self) -> None:
+        return None
+
+
+def _rewind_list_frame() -> OutboxMessage:
+    """Shaped exactly like the real ``__rewind_list__`` sentinel a REMOTE
+    server sends when no structured command-UI request is on the wire
+    (``pending_command_ui()`` is None there by design, read_model.py) — no
+    ``intervention_id``, no ``RESTORED_META_KEY``; `app.py`'s own
+    `_handle_rewind_request` re-tags this SAME frame's ``kind`` to
+    ``"intervention"`` when it arrives (the code path this test drives)."""
+    return OutboxMessage(
+        kind="__rewind_list__",
+        text="Rewind points:\n  1. abc123 - fix bug\n  2. def456 - add feature",
+    )
+
+
+@pytest.mark.asyncio
+async def test_rewind_list_fallback_does_not_open_the_pending_panel():
+    """Tier 2: strip-falsifier. A `__rewind_list__` sentinel (no structured
+    command-UI request pending, forcing the text fallback) must never open
+    the intervention panel — reverting the `intervention_id`-presence guard
+    in `app.py` back to a `RESTORED_META_KEY`-only check (#5047's original
+    form) turns this red: the rewind-list frame carries neither marker, so
+    it registers as pending again."""
+    transport = _ReplayTransport([_rewind_list_frame()])
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        assert panel.display is False, (
+            "a /rewind text-list fallback must not register as pending — "
+            "the panel should never open for it"
+        )
+        assert panel.has_pending() is False, (
+            "a phantom entry was registered as pending (public "
+            "has_pending() surface, not private app state)"
+        )

--- a/tests/interfaces/test_5057_fake_pending_rewind_frame_not_registered.py
+++ b/tests/interfaces/test_5057_fake_pending_rewind_frame_not_registered.py
@@ -110,16 +110,38 @@ def _rewind_list_frame() -> OutboxMessage:
 async def test_rewind_list_fallback_does_not_open_the_pending_panel():
     """Tier 2: strip-falsifier. A `__rewind_list__` sentinel (no structured
     command-UI request pending, forcing the text fallback) must never open
-    the intervention panel — reverting the `intervention_id`-presence guard
-    in `app.py` back to a `RESTORED_META_KEY`-only check (#5047's original
-    form) turns this red: the rewind-list frame carries neither marker, so
-    it registers as pending again."""
+    the intervention panel — reverting the guard in `app.py`'s
+    `_ingest_frame` to unconditional (`if kind == "intervention":`, no
+    `intervention_id` check at all) turns this RED: the rewind-list frame
+    then registers as pending (confirmed by actually running the strip,
+    not asserted from reading the diff).
+
+    architect's non-block finding (PR #5060 TESTS-READ,
+    issuecomment-5377534130): the 2 assertions below are both negative
+    (panel stays closed) — `_ingest_frame`'s own `except Exception:
+    logger.exception` swallows a processing exception silently, so an
+    exception midway would ALSO leave the panel closed and pass these
+    2 asserts for the WRONG reason (six-questions Q4). Closed with a
+    POSITIVE assertion: the rewind list's own text must actually have
+    reached the conversation flow (proving the frame was processed at
+    all, not silently dropped)."""
     transport = _ReplayTransport([_rewind_list_frame()])
     app = TextualChatApp(transport=transport)
 
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         await pilot.pause()
+
+        from textual_flowview import FlowView
+
+        flow = app.query_one(FlowView)
+        rendered_texts = [e.item.text for e in flow.entries]
+        assert any("Rewind points" in t for t in rendered_texts), (
+            "the rewind-list frame must actually land in the conversation "
+            "(proves _ingest_frame processed it, rather than an exception "
+            "being silently swallowed and coincidentally also leaving the "
+            f"panel closed) — got entries: {rendered_texts!r}"
+        )
 
         panel = app.query_one(InterventionPanel)
         assert panel.display is False, (


### PR DESCRIPTION
**[e2e-coder]** — re-key the fake-pending intervention guard on `intervention_id` presence (2 more producers had the #5047 gap).

<!-- closing-check: discussing #5057 -->
part of #5057

## What
#5047 fixed one instance of "a fake `kind='intervention'` frame gets registered as pending" (a REPLAYED, already-answered intervention from `restore.py`). The fix keyed on `RESTORED_META_KEY` — a marker naming that one producer, not the property that actually decides safety. My #5057 census (`issuecomment-5377444xxx`) found **2 more producers with the identical shape**: `stream_client.py`'s and this app's own `/rewind` text-list fallback (`__rewind_list__` re-tagged to `kind="intervention"` purely for its persistent-render property) — no `intervention_id`, no `RESTORED_META_KEY` either. A producer-named marker structurally cannot see the next producer; that's exactly what happened here.

- `app.py:_ingest_frame`'s guard re-keyed from `not (msg.meta or {}).get(RESTORED_META_KEY)` to `(msg.meta or {}).get("intervention_id")` — `intervention_id` presence is the SAME value that decides, downstream, whether an answer routes `answer_intervention_by_id` (safe) or falls to `answer_oldest_*` (misdeliverable — the exact #5047 harm class), so it's the real discriminator rather than a per-producer tag.
- Confirmed reachable for the Textual surface: `_handle_rewind_request` takes this path whenever no structured command-UI request is on the wire — **REMOTE always** (`pending_command_ui()` is None there by design).
- `stream_client.py`'s own sibling is **not** vulnerable to the same registration hazard — its answer routing gates on `transport.pending_intervention_head() is not None` (the real registry state, independent of what's displayed), so a rewind-list frame there never enters a fake "pending" store. Confirmed by re-reading the gate, not assumed.
- `RESTORED_META_KEY`'s import in `app.py` is now unused (removed) — `restore.py`'s own definition/usage is untouched.
- Comment states what the narrowing discards (architect's own rule): a future producer needing pending-registration without a real answerable id would also fail this check — none is known to exist today.

## Tests
New `tests/interfaces/test_5057_fake_pending_rewind_frame_not_registered.py` (1 test, mirrors `test_5047_...`'s own `_ReplayTransport` shape, no mocks): a real `__rewind_list__` sentinel, driven through a real `TextualChatApp`, must not open the intervention panel. Strip-falsified: reverting the guard to unconditional registration turns this RED (panel opens), confirmed, then restored.

All 4 pre-existing `#5047` tests re-run against the new discriminator — still green (a strict generalization, not a behavior change for #5047's own instance).

## Local gates (fresh, `.venv/bin/python` explicit)
- [x] `ruff check` — clean
- [x] `test_tier_audit.py --strict` — clean, 5 tests inspected, 0 Tier-4
- [x] `verify_module_docstrings.py` — clean
- [x] `mypy_ratchet.py` — clean, 203 findings all baselined, 0 new
- [x] `check_tests_path_literal_reference.py` — clean (re-run right before push, main at `49ce64741`)
- [x] `check_bare_tests_import_reference.py` — clean
- [x] `check_file_depth_reference.py` — clean
- [x] `flat_tests_ratchet.py` — clean
- [x] Scoped `pytest` — green, 271 (every textual_chat/intervention/rewind test in `tests/interfaces/`)

## Test plan
- [x] Automated tests above, strip-falsified (real `TextualChatApp`, no mocks)
- [x] (skipped — Visual, standing waiver 2026-08-08: N/A, no visual behavior change — the fix is a registration-guard condition, not rendering)

## Coordination note
lead-coder is separately notifying tui-coder that this PR and their in-flight #5050③ work both touch `app.py`, in different regions (`_ingest_frame`'s guard here vs `on_mount` + a new primitive there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

- [x] **TESTS-READ（rule 8）** — ✅ architect 実施済 (issuecomment-5377534130)、判別子の置換を restore.py:305-315 で確認。**逆向きも実測**: 本物の id は `uuid4().hex` ∴ 常に非空。元の依頼: CI 緑・lead-coder の block なし（`issuecomment-5377492456`）だが、`tests/` を触るため note が landing するまで自己マージしない。
  - 見てほしい点は 1 つに絞ってある: **判別子の置換（`RESTORED_META_KEY` → `intervention_id` の有無）が、#5056 で塞いだものを塞いだままか**。architect は #5056 の TESTS-READ を出した本人なので、**一度通した判断を母集団が増えたことで置き換える形**を、同じ目で連続して見てもらう狙い。
  - lead-coder が既に確認済（重複不要）: restore は除外されたまま／`_iv_meta` が無条件で id を入れる／accept 側は**別ファイル**（`test_5047_...py` の `_genuine_pending_frame` が `intervention_id: "iv-live"` を持つ）で vacuity が塞がれている／空文字 id は falsy で登録されない。

- [x] **肯定 assert を 1 本** — ✅ 済 (`f458ac90b`, :139): `assert any("Rewind points" in t for t in rendered_texts)`。ingest が例外を握りつぶした場合は何も render されない ∴ 例外経路が閉じた。元の 🔴（architect は非 block、lead-coder が blocking に格上げ）— 現状の assert は否定 2 本のみで、`app.py:6020` の `except Exception: logger.exception` により **ingest 中に例外が出てもパネルは閉じたまま＝緑**。本文の strip が RED を観測しているが、**その証拠は本文にあり test に無い**。fallback は `app.py:4156` で ingest される ∴ **rewind list の本文が会話に載ることを 1 本 assert** すれば例外経路が閉じる。
- [x] **docstring の strip と実行した strip が別物** — ✅ 済 (`f458ac90b`): 実際に走らせた側（unconditional へ戻す）に記述を揃え、**「confirmed by actually running the strip, not asserted from reading the diff」**まで明記。元の 🔴 — docstring は「`RESTORED_META_KEY`-only へ戻す」、実際に走らせたのは「unconditional」。結論は同じだが**走らせていない strip を走らせたように書いている**。1 行でどちらかに揃える。**strip の記述は、次にこのテストを疑う人が最初に読む場所**。

