### PR TITLE
fix(#5058): test_mcp_sse.py no longer skips on a guard it never needs

### DIFF
--- a/src/reyn/interfaces/web/surfaces.py
+++ b/src/reyn/interfaces/web/surfaces.py
@@ -223,10 +223,12 @@ def _mount_a2a(app: FastAPI, config: "ReynConfig | None") -> APIRouter | None:
 def _mount_mcp(app: FastAPI, config: "ReynConfig | None") -> APIRouter | None:
     """MCP-over-SSE surface — OFF by default (broad machine-integration port).
 
-    The message-mount append is best-effort (defensive: the mcp SDK ships
-    transitively via the core ``fastmcp`` dependency, so ``ImportError`` here
-    indicates a broken install, not a normal absent-extra path) — a failure
-    there does not prevent the GET /mcp/sse router from mounting.
+    The message-mount append is best-effort (defensive: the mcp SDK is
+    itself a DIRECT core dependency (``pyproject.toml``'s ``mcp>=2.0,<3.0``
+    — #4412; ``fastmcp`` was dropped from core AND every extra entirely,
+    #4302, and never carried mcp), so ``ImportError`` here indicates a
+    broken install, not a normal absent-extra path) — a failure there does
+    not prevent the GET /mcp/sse router from mounting.
     """
     from reyn.interfaces.web.routers import mcp as _mcp_router
     try:
@@ -234,7 +236,7 @@ def _mount_mcp(app: FastAPI, config: "ReynConfig | None") -> APIRouter | None:
     except ImportError:  # pragma: no cover — mcp SDK unexpectedly missing
         logger.info(
             "mcp SDK not importable; /mcp/messages POST endpoint disabled. "
-            "The mcp SDK ships with the core `fastmcp` dependency — reinstall reyn "
+            "mcp is a core dependency — reinstall reyn "
             "(e.g. pip install -e .) to enable MCP-over-SSE."
         )
     return _mcp_router.router

--- a/tests/web/test_mcp_sse.py
+++ b/tests/web/test_mcp_sse.py
@@ -35,7 +35,13 @@ if str(_WORKTREE_SRC) not in sys.path:
 # Skip the whole module if optional deps are missing.
 pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
 pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
-pytest.importorskip("mcp", reason="mcp not installed ([mcp] extra missing)")
+# #5058 (group C): this file never imports the mcp SDK — both tests exercise
+# /mcp/messages purely over HTTP via TestClient, checking the mount's own 4xx
+# handling. _mount_mcp (surfaces.py) already catches an mcp ImportError
+# defensively at app-build time (mcp ships transitively via the core
+# `fastmcp` dependency, so that path is a broken-install signal, not a normal
+# absent-extra one) — this test file was skipping for a reason unrelated to
+# what it actually tests.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/test_mcp_sse.py
+++ b/tests/web/test_mcp_sse.py
@@ -38,10 +38,11 @@ pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)"
 # #5058 (group C): this file never imports the mcp SDK — both tests exercise
 # /mcp/messages purely over HTTP via TestClient, checking the mount's own 4xx
 # handling. _mount_mcp (surfaces.py) already catches an mcp ImportError
-# defensively at app-build time (mcp ships transitively via the core
-# `fastmcp` dependency, so that path is a broken-install signal, not a normal
-# absent-extra one) — this test file was skipping for a reason unrelated to
-# what it actually tests.
+# defensively at app-build time (mcp is itself a DIRECT core dependency,
+# `pyproject.toml`'s `mcp>=2.0,<3.0` -- #4412; fastmcp was dropped from
+# core AND every extra entirely, #4302, and never carried mcp -- so that
+# path is a broken-install signal, not a normal absent-extra one) -- this
+# test file was skipping for a reason unrelated to what it actually tests.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[docs-maintainer]** — part of #5058

## What

Group C item, confirmed erroneous (lead-coder measurement,
issuecomment-5377383060/5377458008): `tests/web/test_mcp_sse.py` never
imports the mcp SDK — both tests exercise `/mcp/messages` purely over
HTTP via `TestClient`, checking the mount's own 4xx handling on
bad/missing `session_id`. The module-level `pytest.importorskip("mcp",
...)` was skipping on a reason unrelated to what the file actually
tests.

Dispatch was narrowed to this single file (lead-coder,
2nd broker message) after realizing `test_mcp_capability_
advertising_271_m3.py`'s module-level guard covers 6 tests spanning
groups A/B/C together, so a same-shape fix there risks baring an
A-group test (mcp SDK direct use) ahead of that group's still-pending
ruling — not touched, correctly out of scope now.

`_mount_mcp` (`surfaces.py`) already catches an `mcp` `ImportError`
defensively at app-build time — the mcp SDK ships transitively via the
core `fastmcp` dependency, so that path is a broken-install signal,
not a normal absent-extra one. Both tests previously silently skipped
on a healthy install missing only mcp; they now run and pass.

## Test plan

- [x] `.venv/bin/python -m pytest tests/web/test_mcp_sse.py -v` — 2/2
      passed (both previously silently skipped)
- [x] `ruff check tests/web/test_mcp_sse.py` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/web/test_mcp_sse.py`
      — 2 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py tests/web/test_mcp_sse.py`
      — OK
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] Closing-keyword self-check on commit message + this PR body — 0
      hits
- [x] TESTS-READ: this PR touches `tests/` — lead-coder said they'll
      handle review for this dispatch

part of #5058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

- [x] ~~🔴~~ **コメントの記述が偽** — ✅ 解消 (`bb5a32f86`): **出所（surfaces.py の docstring と実行時エラー文）まで直した**。「and never carried mcp」まで足しており「昔は運んでいた」と読めない形。元の — 「mcp ships transitively via the core `fastmcp` dependency」。実測: **① mcp は direct core dependency**（`pyproject.toml:189` `"mcp>=2.0,<3.0"`、`dependencies = [` の内側）／**② fastmcp は core でも extra でもない**（`:353-354`「#4302 dropped fastmcp from core (and every extra) entirely」、`:190`「fastmcp stays DROPPED」）。**結論（broken-install signal であって absent-extra ではない）は正しいが、根拠が偽。**コメントは doc-drift gate が拾わない面なので、ここで直す。

- [x] 🔴 **コメントの記述が偽** — FIXED (`bb5a32f86`): 「mcp is a DIRECT core dependency (`mcp>=2.0,<3.0`, #4412); fastmcp was dropped from core AND every extra entirely, #4302, and never carried mcp」に訂正。同じ偽記述が既存の `src/reyn/interfaces/web/surfaces.py`（`_mount_mcp`のdocstring + 実行時logメッセージ）にもあった(自分がそこから写した元)ので、同じPRで両方直しました — 私のコピーだけでなく、根拠が偽だった元の箇所も。結論("ImportErrorはbroken-installを意味する")自体は正しいまま、根拠のみ訂正。



---

- [x] **TESTS-READ（rule 8）** — ✅ e2e-coder 実施済 (issuecomment-5377513211)。**再読解でなく実測**: `sys.modules["mcp"]=None` で mcp を強制的に不在にし、app import 成功 + 期待どおり 4xx を確認。エラー文言を pin するテスト 0 件も確認。pyproject（mcp=core / fastmcp=完全除去）も独立に裏取り。block なし。元の依頼: CI 待ち・lead-coder の block は解除済（`issuecomment-5377502987`）だが、`tests/` を触るため note が landing するまで自己マージしない。
  - 依頼理由: e2e-coder が #5058 の census と 12 件測定をやっており、**母集団の文脈を持っている**。
  - 見てほしい点: ①除去が正しいか（測定では「mcp SDK 不使用、本体は HTTP 経由」）②`fastapi`/`httpx` の importorskip を**残した**のが正しいか（fastapi は #5051 で core になった ∴ 本来 #5058 B/A と同じ議論の対象。残す判断の**理由が PR に書かれているか**）③**実行時エラー文が変わっている** — その文言を pin しているテストが在るか。

