### PR TITLE
fix(#5058): remove the remaining 11 mcp importorskip sites (main body)

### DIFF
--- a/tests/core/test_mcp_server_progress_271.py
+++ b/tests/core/test_mcp_server_progress_271.py
@@ -43,11 +43,13 @@ from typing import Any
 
 import pytest
 
-pytest.importorskip("mcp", reason="mcp not installed")
-
-from reyn.core.events.events import EventLog  # noqa: E402
-from reyn.mcp.server import _MCPProgressBridge  # noqa: E402
-from reyn.schemas.models import Event  # noqa: E402
+# #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an importorskip
+# here was a silent skip on a broken install, not a normal absent-extra
+# path (architect ruling, gh issue view 5058: "the correct behavior is
+# red"). Removed; a genuinely broken install now fails loud instead.
+from reyn.core.events.events import EventLog
+from reyn.mcp.server import _MCPProgressBridge
+from reyn.schemas.models import Event
 
 
 class _FakeSession:

--- a/tests/gateway/sample_slack/test_outbound.py
+++ b/tests/gateway/sample_slack/test_outbound.py
@@ -16,8 +16,6 @@ import json
 import sys
 import types
 
-import pytest
-
 from reyn.gateway.sample_slack import register_tools
 from reyn.gateway.sample_slack.webhook import build_send_tool
 
@@ -144,7 +142,10 @@ def test_build_server_lists_and_dispatches_extra_tool(tmp_path):
     hand-rolled equivalent of the removed
     ``mcp.shared.memory.create_connected_server_and_client_session``)
     rather than the SDK helper this test used before the bump."""
-    pytest.importorskip("mcp")
+    # #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an
+    # importorskip here was a silent skip on a broken install, not a
+    # normal absent-extra path (architect ruling, gh issue view 5058:
+    # "the correct behavior is red"). Removed.
     from reyn.core.events.state_log import StateLog
     from reyn.mcp.extra_tool import ExtraTool
     from reyn.mcp.server import build_server

--- a/tests/interfaces/test_progress_bridge_task_leak_3390.py
+++ b/tests/interfaces/test_progress_bridge_task_leak_3390.py
@@ -28,8 +28,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from reyn.core.events.events import EventLog
 
 _N = 25
@@ -105,7 +103,10 @@ def test_mcp_bridge_tracked_task_count_does_not_grow_with_event_count() -> None:
     ``EventLog`` leaves the MCP bridge's ``tracked_task_count`` bounded,
     not proportional to N. Mirrors the A2A case above (#3390 is one
     defect, two files)."""
-    pytest.importorskip("mcp", reason="mcp not installed")
+    # #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an
+    # importorskip here was a silent skip on a broken install, not a
+    # normal absent-extra path (architect ruling, gh issue view 5058:
+    # "the correct behavior is red"). Removed.
     from reyn.mcp.server import _MCPProgressBridge
 
     events = EventLog()

--- a/tests/interfaces/test_progress_lifecycle_fanout_3357.py
+++ b/tests/interfaces/test_progress_lifecycle_fanout_3357.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 import ast
 import asyncio
 
-import pytest
-
 from reyn.core.events.events import EventLog
 from reyn.core.events.progress_lifecycle import (
     PROGRESS_LIFECYCLE_EVENTS,
@@ -157,7 +155,10 @@ def test_both_bridges_forward_the_shared_declaration() -> None:
     the two protocols cannot drift apart. Give either bridge a private copy →
     this still passes on equality but RED on identity, which is the point: the
     copy is what allowed #3357's two dead kinds to sit in both files."""
-    pytest.importorskip("mcp", reason="MCP SDK not installed")
+    # #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an
+    # importorskip here was a silent skip on a broken install, not a
+    # normal absent-extra path (architect ruling, gh issue view 5058:
+    # "the correct behavior is red"). Removed.
     from reyn.interfaces.web.routers.a2a import _A2AProgressBridge
     from reyn.mcp.server import _MCPProgressBridge
 
@@ -171,7 +172,10 @@ def test_mcp_initialize_advertises_the_forwarded_kinds() -> None:
     forwards — derived from the constant, not restated. Hardcode the list back →
     RED as soon as the forwarded set changes (the claim/reality gate #271 M3
     asked for, previously a source-text pin that instead FROZE the dead kinds)."""
-    pytest.importorskip("mcp", reason="MCP SDK not installed")
+    # #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an
+    # importorskip here was a silent skip on a broken install, not a
+    # normal absent-extra path (architect ruling, gh issue view 5058:
+    # "the correct behavior is red"). Removed.
     from mcp.server import Server
 
     from reyn.mcp.server import build_init_options

--- a/tests/mcp/test_2421_gateway_real_substrate.py
+++ b/tests/mcp/test_2421_gateway_real_substrate.py
@@ -8,7 +8,7 @@ the broken transport — the off-task-orphaning hypothesis (b) — end-to-end, n
 Expected: ``gateway.list_tools`` raises ``MCPFault`` (contained), the test process SURVIVES (no
 uncontained BaseExceptionGroup escaping to the loop). This is the "fake-blind" gap lead flagged: the
 fake tests prove the boundary LOGIC; this proves it against the real substrate that produced the
-crash. Real subprocess (no mock); skipped if the ``mcp`` SDK server API is unavailable.
+crash. Real subprocess (no mock).
 """
 from __future__ import annotations
 
@@ -16,7 +16,12 @@ import sys
 
 import pytest
 
-pytest.importorskip("mcp.server", reason="mcp SDK server API required for the real-substrate test")
+# #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an
+# importorskip("mcp.server", ...) here was a silent skip on a broken
+# install, not a normal absent-extra path (architect ruling, gh issue view
+# 5058: mcp's own distribution ships mcp/server/ unconditionally -- "mcp
+# present but mcp.server absent" is not a real installed-package shape).
+# Removed; a genuinely broken install now fails loud instead.
 
 # A real low-level stdio MCP server that handshakes fine, then its subprocess DIES on list_tools.
 # #4368 (mcp 2.0 port): @app.list_tools() is gone on mcp 2.0 (measured live) -- the handler is now

--- a/tests/mcp/test_mcp_capability_advertising_271_m3.py
+++ b/tests/mcp/test_mcp_capability_advertising_271_m3.py
@@ -31,11 +31,15 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
-
 from tests._support.paths import REPO_ROOT
 
-pytest.importorskip("mcp", reason="MCP SDK not installed")
+# #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an importorskip
+# here was a silent skip on a broken install, not a normal absent-extra
+# path (architect ruling, gh issue view 5058: "the correct behavior is
+# red"). Removed; a genuinely broken install now fails loud instead. This
+# guard covered a MIXED population (3 direct mcp SDK users, 1 indirect
+# reyn.mcp.server user, 2 that touch neither -- source-text/AST checks
+# with no mcp dependency at all), all converging on the same fix.
 
 
 # ── 1. NotificationOptions: lists are static ──────────────────────────

--- a/tests/mcp/test_mcp_client_stderr_capture.py
+++ b/tests/mcp/test_mcp_client_stderr_capture.py
@@ -162,7 +162,10 @@ def test_initialize_failure_includes_stderr_tail_in_error(monkeypatch) -> None:
     ``errlog=`` it's called with, simulating what a real subprocess's stderr
     capture would have produced before dying.
     """
-    pytest.importorskip("mcp")
+    # #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an
+    # importorskip here was a silent skip on a broken install, not a
+    # normal absent-extra path (architect ruling, gh issue view 5058:
+    # "the correct behavior is red"). Removed.
     client = _client()
 
     class _BrokenAsyncCM:
@@ -220,7 +223,10 @@ def test_initialize_failure_with_real_subprocess_captures_its_actual_stderr() ->
     subprocess's own exit is the only thing waited on, via
     ``asyncio.run``'s normal await chain).
     """
-    pytest.importorskip("mcp")
+    # #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an
+    # importorskip here was a silent skip on a broken install, not a
+    # normal absent-extra path (architect ruling, gh issue view 5058:
+    # "the correct behavior is red"). Removed.
     client = MCPClient({
         "type": "stdio",
         "command": sys.executable,

--- a/tests/mcp/test_mcp_iv_support_270_phase_b.py
+++ b/tests/mcp/test_mcp_iv_support_270_phase_b.py
@@ -34,11 +34,12 @@ import asyncio
 import inspect
 import json
 
-import pytest
-
 from tests._support.paths import REPO_ROOT
 
-pytest.importorskip("mcp", reason="MCP SDK not installed")
+# #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an importorskip
+# here was a silent skip on a broken install, not a normal absent-extra
+# path (architect ruling, gh issue view 5058: "the correct behavior is
+# red"). Removed; a genuinely broken install now fails loud instead.
 
 
 # ── 1. _MCPInterventionBus α observer shape ──────────────────────────

--- a/tests/runtime/test_mcp_server_resources_adapter.py
+++ b/tests/runtime/test_mcp_server_resources_adapter.py
@@ -26,8 +26,10 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("mcp", reason="MCP SDK not installed")
-
+# #5058: mcp is a core dependency (mcp>=2.0,<3.0, #4412) -- an importorskip
+# here was a silent skip on a broken install, not a normal absent-extra
+# path (architect ruling, gh issue view 5058: "the correct behavior is
+# red"). Removed; a genuinely broken install now fails loud instead.
 from reyn.core.events.state_log import StateLog
 from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
 from reyn.mcp.server import build_server


### PR DESCRIPTION
**[e2e-coder]** — remove the remaining 11 `mcp` `importorskip` sites (#5058 main body).

<!-- closing-check: discussing #5058 -->
part of #5058

## What
Architect's ruling (`gh issue view 5058`, confirmed measurements): A (direct mcp SDK use) == B (indirect, via `reyn.mcp.*`) — neither justifies a skip. "Version-difference could still make import fail" doesn't hold: `importorskip` only sees ABSENCE (`ModuleNotFoundError` on the named module); a version incompatibility elsewhere in the import chain still raises normally and reaches pytest as a real failure, not a skip. C (no mcp usage at all) — the skip was simply unnecessary. The `mcp.server` variant is the same class (mcp's own distribution ships `mcp/server/` unconditionally, 122 files, measured).

∴ all 11 remaining sites converge on the identical fix regardless of A/B/C classification: remove the `pytest.importorskip("mcp", ...)` call. mcp is a core dependency (`mcp>=2.0,<3.0`, #4412) — a genuinely broken install should fail loud, not silently skip past the very thing that would have caught it.

## Unit of work: the GUARD, not the group
`test_mcp_capability_advertising_271_m3.py:38`'s single module-level guard covers a MIXED population (3 direct-use, 1 indirect-use, 2 that touch mcp not at all) — classified in full before deciding anything (lead-coder's explicit instruction: don't split A off a guard covering an unresolved population). All 6 converge on the same fix, but that was verified, not assumed.

## Files (9 files, 11 sites — 1 site, `test_mcp_sse.py`, already fixed in #5061 on main)
- `tests/core/test_mcp_server_progress_271.py` (1, module-level, 11 tests)
- `tests/runtime/test_mcp_server_resources_adapter.py` (1, module-level, 3 tests)
- `tests/mcp/test_mcp_iv_support_270_phase_b.py` (1, module-level, 12 tests)
- `tests/mcp/test_mcp_capability_advertising_271_m3.py` (1, module-level, 6 tests, mixed population)
- `tests/gateway/sample_slack/test_outbound.py` (1, function-level)
- `tests/mcp/test_mcp_client_stderr_capture.py` (2, function-level)
- `tests/interfaces/test_progress_lifecycle_fanout_3357.py` (2, function-level, mixed direct/indirect within the SAME file)
- `tests/interfaces/test_progress_bridge_task_leak_3390.py` (1, function-level)
- `tests/mcp/test_2421_gateway_real_substrate.py` (1, module-level, `mcp.server` variant)

Each site: the `importorskip` line removed, replaced with a one-line comment naming #5058 + the ruling. `import pytest` dropped where it became genuinely unused as a result (checked per file — `test_2421` needed it re-added after an over-eager first removal since `@pytest.mark.asyncio`/`pytest.raises` are both still used there; caught by ruff + a real collection run).

## Witness
Real, forced-absence run (not a diff read): `sys.modules["mcp"] = None` before collecting `test_mcp_server_progress_271.py` now produces a loud `ModuleNotFoundError` at collection (the real import chain: `reyn.mcp.server` → `reyn.mcp.client` → `reyn.mcp.subscription_port` → `mcp.client.subscriptions`), not a skip — confirms the "correct behavior is red" claim directly (same class of check #5061 used — I TESTS-READ'd that one before starting this dispatch).

## Local gates (fresh, `.venv/bin/python` explicit)
- [x] `ruff check` — clean (all 9 files)
- [x] `test_tier_audit.py --strict` — clean, 59 tests inspected, 0 Tier-4
- [x] `verify_module_docstrings.py` — clean
- [x] `mypy_ratchet.py` — clean, 203 findings all baselined, 0 new
- [x] `check_tests_path_literal_reference.py` — clean (re-run right before push, main at `19178b856`)
- [x] `check_bare_tests_import_reference.py` — clean
- [x] `check_file_depth_reference.py` — clean
- [x] `flat_tests_ratchet.py` — clean
- [x] Scoped `pytest` — green, 59 (every touched file, all previously-skipped tests now running and passing)

No gate/CI check added in this PR (architect/lead-coder's explicit sequencing: fix the 12 existing sites first, add re-prevention after — a gate added before the fixes land would turn the entire existing suite red).

## Test plan
- [x] Automated tests above + the forced-absence witness (real `sys.modules` manipulation, no mocks)
- [x] (skipped — Visual, standing waiver 2026-08-08: N/A, no UI surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
