### PR TITLE
fix(#5050): remote client presents local-parity choices for a pending intervention it never saw the live announce for

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -4013,28 +4013,38 @@ class TextualChatApp(App):
         from ``AgUiTransport.frames()``, ever, confirmed by direct
         reproduction, not guessed).
 
-        ``switch_generation=<int>`` (the switch case) does NOT re-await
-        ``state_ready()`` — architect ruling: the SAME ``AgUiTransport``
-        instance persists across a switch (only the attached agent
-        changes server-side), so its one-shot ``state_ready()`` Event,
-        already set by the FIRST session's own initial snapshot, would
-        resolve immediately on a later switch WITHOUT reflecting whether
-        the NEW session's own state has actually landed — the same
-        #4996-family "lying-ready" shape. This is safe because
-        :meth:`_handle_session_switch_event` only runs in response to a
-        ``session_attached`` event FRAME :meth:`_pump_frames` has
-        already processed — any STATE_* update delivered in the SAME
-        reconnect burst has therefore already been applied to
-        ``transport.status.values`` by the time this call reads
-        ``intervention_head()``. What DOES matter for the switch case is
-        the EXISTING ``_session_switch_generation`` supersede guard
-        (:meth:`_handle_session_switch_event`'s own docstring) — a LATER
-        switch may have already superseded this one while this call was
-        waiting on the panel-mount below; re-checked immediately before
-        presenting, not just at entry. No new generation mechanism is
-        introduced here (architect: do not invent a second one)."""
-        if switch_generation is None:
-            await self._transport.state_ready()
+        ``switch_generation=<int>`` (the switch case) ALSO awaits
+        ``state_ready()`` — corrected mid-review (architect co-vet,
+        issuecomment-5377613210) from this PR's OWN first draft, which
+        skipped the re-await on the theory that any STATE_* update in the
+        SAME reconnect burst was "already applied by the time this call
+        reads". Measured backwards: ``AgUiEmitter``'s reconnect-protocol
+        barrier forwards the ``session_attached`` frame STRICTLY BEFORE
+        its STATE_SNAPSHOT re-fire (``emitter.py``'s own module
+        docstring — "the barrier ordering is the whole point"), so
+        ``transport.status`` still reflects the OLD session at the
+        instant this method's caller runs; skipping the re-await either
+        misdelivers the OLD session's own pending head onto the NEW
+        session's view (wrong id), or reads ``None`` and never presents
+        the NEW session's real pending intervention — the exact defect
+        witness ③ exists to catch.
+
+        What actually fixes "lying-ready" (architect's own correction of
+        their own earlier ruling: "stop re-awaiting a one-shot Event" was
+        never the same as "stop awaiting entirely") is that
+        ``AgUiTransport`` now clears ``state_ready()``'s Event the moment
+        it decodes a ``session_attached`` frame (see that decode site's
+        own comment) — so each switch starts a fresh, awaitable episode
+        instead of resolving instantly off the FIRST session's stale
+        ``set()``. ``_session_switch_generation`` answers a DIFFERENT
+        question ("is this still the latest switch") and is unrelated —
+        no second generation mechanism was introduced for this."""
+        await self._transport.state_ready()
+        if (
+            switch_generation is not None
+            and self._session_switch_generation != switch_generation
+        ):
+            return
         if self._read_model is None:
             return
         head = self._read_model.intervention_head()
@@ -5382,10 +5392,10 @@ class TextualChatApp(App):
         # so nothing else on this path would ever present it. Fired as a
         # separate worker (never blocks the off-thread history read just
         # below); gated on THIS call's own claimed generation, re-checked
-        # after its panel-mount wait, so a LATER switch that supersedes
-        # this one before it gets to present is a no-op here too — see
-        # :meth:`_present_hydrated_intervention_head_if_pending`'s own
-        # docstring for why ``state_ready()`` is not re-awaited here.
+        # after ``state_ready()`` (which re-awaits per-episode for a
+        # switch too — see that method's own docstring for the ordering
+        # bug this corrects) and again after its panel-mount wait, so a
+        # LATER switch that supersedes this one at any point is a no-op.
         self.run_worker(
             self._present_hydrated_intervention_head_if_pending(
                 switch_generation=my_switch_generation,

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2298,6 +2298,17 @@ class TextualChatApp(App):
 
         _disarm_stall_trace()
         self.run_worker(self._pump_frames(), name="frames", exclusive=True)
+        # #5050 ③: a SEPARATE worker, not sequenced inside ``_pump_frames``
+        # itself — that loop can run forever (a live connection) or never
+        # yield a single frame at all (the exact scenario this exists
+        # for), so "after the frame loop" is not a usable sequencing
+        # point. Concurrency with the frame pump is safe: this worker's
+        # own ``_await_iv_panel_composed`` wait is a real, unbounded
+        # condition-wait, not a timing assumption about interleaving.
+        self.run_worker(
+            self._present_hydrated_intervention_head_if_pending(),
+            name="hydrated-iv-head", exclusive=False,
+        )
         # #3539: started alongside the frame pump rather than earlier in this
         # method — the worker manager is what makes a coroutine here actually
         # run, and a call placed before the pump's own is silently never
@@ -3939,6 +3950,155 @@ class TextualChatApp(App):
         choices = meta.get("choices")
         self._iv_panel.add_pending(key, prompt=prompt, detail=detail, choices=choices)
 
+    async def _await_iv_panel_composed(self) -> None:
+        """Cooperative, UNBOUNDED wait (``asyncio.sleep(0)`` — a yield,
+        not a duration; CLAUDE.md's accepted "wait on a real condition
+        unboundedly" shape) for :attr:`_iv_panel`'s nested
+        ``TabbedContent`` to finish composing its internal ``#tabs-list``
+        ``Horizontal``.
+
+        #5050 ③, measured: Textual mounts a STATIC compose tree
+        (``InterventionPanel`` → ``TabbedContent`` → ``ContentTabs`` →
+        this ``Horizontal``) over SEVERAL event-loop turns after the
+        ancestor itself becomes ``is_attached`` — calling
+        ``InterventionPanel.add_pending`` (which does
+        ``TabbedContent.add_pane`` → ``ContentTabs.add_tab`` →
+        ``Horizontal#tabs-list.mount(...)``) before that settles raises a
+        real ``MountError`` (``Widget.mount``'s own ``is_attached`` guard
+        — see ``textual/widget.py``). The EXISTING live-frame path
+        (:meth:`_ingest_frame` → :meth:`_present_intervention`) never hit
+        this because frame arrival is naturally preceded by enough real
+        ``await`` points (SSE reads/decodes) for mounting to have long
+        settled by the time a frame's body runs; THIS path can run as
+        early as the very first event-loop turn after ``on_mount``,
+        before any of those awaits have happened — so it needs its own
+        explicit wait rather than borrowing the frame path's incidental
+        one."""
+        import asyncio  # noqa: PLC0415
+
+        while True:
+            try:
+                tabs_list = self._iv_panel.query_one("#tabs-list")
+            except Exception:
+                tabs_list = None
+            if tabs_list is not None and tabs_list.is_attached:
+                return
+            await asyncio.sleep(0)
+
+    async def _present_hydrated_intervention_head_if_pending(
+        self, *, switch_generation: "int | None" = None,
+    ) -> None:
+        """#5050 ③: present a genuinely PENDING intervention this client
+        never received the live announce for — reads ``ChatReadModel.
+        intervention_head()`` (declared #4996, wired for remote by #5053)
+        and, if non-None, routes it through the SAME ``_ingest_frame`` →
+        ``_present_intervention`` path a live announce frame already
+        uses, rather than a second display mechanism.
+
+        ONE shared entry point, called from BOTH :meth:`on_mount`
+        (``switch_generation=None``) and
+        :meth:`_handle_session_switch_event` (``switch_generation=`` the
+        generation THAT call claimed at its own entry) — placed next to
+        that method's own :meth:`_seed_queue_view` eager-reseed call,
+        same rationale verbatim: deferring to the generic first-frame
+        gate would need a frame AFTER this barrier to ever fire, and a
+        session with an already-pending intervention but no OTHER
+        activity would never get one.
+
+        ``switch_generation=None`` (the mount case) awaits
+        ``self._transport.state_ready()`` first — a SEPARATE axis from
+        the frame stream (see that method's own docstring on
+        ``ClientTransport`` for why frame arrival cannot be the gate: a
+        session with genuinely nothing else happening yields ZERO frames
+        from ``AgUiTransport.frames()``, ever, confirmed by direct
+        reproduction, not guessed).
+
+        ``switch_generation=<int>`` (the switch case) does NOT re-await
+        ``state_ready()`` — architect ruling: the SAME ``AgUiTransport``
+        instance persists across a switch (only the attached agent
+        changes server-side), so its one-shot ``state_ready()`` Event,
+        already set by the FIRST session's own initial snapshot, would
+        resolve immediately on a later switch WITHOUT reflecting whether
+        the NEW session's own state has actually landed — the same
+        #4996-family "lying-ready" shape. This is safe because
+        :meth:`_handle_session_switch_event` only runs in response to a
+        ``session_attached`` event FRAME :meth:`_pump_frames` has
+        already processed — any STATE_* update delivered in the SAME
+        reconnect burst has therefore already been applied to
+        ``transport.status.values`` by the time this call reads
+        ``intervention_head()``. What DOES matter for the switch case is
+        the EXISTING ``_session_switch_generation`` supersede guard
+        (:meth:`_handle_session_switch_event`'s own docstring) — a LATER
+        switch may have already superseded this one while this call was
+        waiting on the panel-mount below; re-checked immediately before
+        presenting, not just at entry. No new generation mechanism is
+        introduced here (architect: do not invent a second one)."""
+        if switch_generation is None:
+            await self._transport.state_ready()
+        if self._read_model is None:
+            return
+        head = self._read_model.intervention_head()
+        if head is None:
+            return
+        await self._await_iv_panel_composed()
+        if (
+            switch_generation is not None
+            and self._session_switch_generation != switch_generation
+        ):
+            return
+        self._present_hydrated_intervention_head(head)
+
+    def _present_hydrated_intervention_head(self, head: object) -> None:
+        """#5050 ③: normalize an already-fetched ``intervention_head()``
+        result and route it through the SAME ``_ingest_frame`` →
+        ``_present_intervention`` path a live announce frame already
+        uses.
+
+        ``intervention_head()`` returns two different SHAPES depending on
+        implementation (measured, #5053's own record): LOCAL
+        (``RegistryReadModel``) returns the real ``UserIntervention``
+        OBJECT (attribute access — ``.id``/``.prompt``/``.detail``/
+        ``.choices``, each choice a real ``InterventionChoice`` with
+        ``.id``/``.label``/``.hotkey``); REMOTE (``RemoteReadModel``)
+        returns the JSON-safe WIRE projection — a plain dict (``head["id"]``
+        etc.), choices as a list of plain dicts. Decided HERE, before
+        writing any consumer: normalize BOTH into the one dict shape
+        ``_present_intervention`` already expects (it only ever reads
+        ``msg.meta`` — a plain dict, regardless of transport) — one
+        normalization boundary, not two call sites that could drift.
+
+        Called only from :meth:`_present_hydrated_intervention_head_if_
+        pending`, which already established ``head is not None`` and
+        that the panel is safe to mutate — never races a live announce
+        for the SAME intervention: there is only one announce, ever, and
+        if this call sees a pending head here, that means the announce
+        already happened before this client's own state became ready."""
+        from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
+        if isinstance(head, dict):
+            iv_id = head.get("id")
+            prompt = head.get("prompt") or ""
+            detail = head.get("detail")
+            choices = head.get("choices")
+        else:
+            iv_id = head.id
+            prompt = head.prompt
+            detail = head.detail or None
+            choices = [
+                {"id": c.id, "label": c.label, "hotkey": c.hotkey}
+                for c in (head.choices or [])
+            ] or None
+        msg = OutboxMessage(
+            kind="intervention",
+            text=str(prompt),
+            meta={
+                "intervention_id": iv_id,
+                "prompt": prompt,
+                "detail": detail,
+                "choices": choices,
+            },
+        )
+        self._ingest_frame(msg)
+
     def _resolve_intervention(self, key: object, answer_label: str) -> None:
         """Settle intervention ``key``'s flow entry + tab once an answer has
         been delivered through the transport funnel (#3308 — replaces P2's
@@ -5215,6 +5375,23 @@ class TextualChatApp(App):
         except Exception:
             logger.exception("textual chat: switch queue-view reseed failed")
         self._queue_seeded = True
+        # #5050 ③: SAME reasoning — a switch to an agent that already has
+        # a pending intervention gets no live announce (restore.py: an
+        # unanswered intervention leaves no history trace, and
+        # ``_apply_hydrated_messages`` below only ever replays history),
+        # so nothing else on this path would ever present it. Fired as a
+        # separate worker (never blocks the off-thread history read just
+        # below); gated on THIS call's own claimed generation, re-checked
+        # after its panel-mount wait, so a LATER switch that supersedes
+        # this one before it gets to present is a no-op here too — see
+        # :meth:`_present_hydrated_intervention_head_if_pending`'s own
+        # docstring for why ``state_ready()`` is not re-awaited here.
+        self.run_worker(
+            self._present_hydrated_intervention_head_if_pending(
+                switch_generation=my_switch_generation,
+            ),
+            name="hydrated-iv-head-switch", exclusive=False,
+        )
         # #4983: step ① (the disk read) runs OFF the event loop — the
         # measured defect this issue exists for (a synchronous
         # `conversation_history()` call blocking the TUI's own event

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -171,6 +171,17 @@ class _ErrorWatchingTransport(ClientTransport):
     def start(self) -> None:
         self._inner.start()
 
+    async def state_ready(self) -> None:
+        # #5050 ③ follow-up (CI-caught, test_error_watching_transport_
+        # total_delegation_4884.py): without this override, this wrapper
+        # falls back to ``ClientTransport``'s own base default (return
+        # immediately) instead of the WRAPPED transport's real readiness
+        # — a slash handler asking "has state landed" would get told
+        # "yes" instantly regardless of the inner transport's actual
+        # state, the same lying-ready shape architect's switch-case
+        # finding named, just a second delegation site it rides through.
+        await self._inner.state_ready()
+
     def close(self) -> None:
         self._inner.close()
 

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -160,6 +160,20 @@ class AgUiTransport(ClientTransport):
                 # (architect: do not invent a second generation mechanism)
                 # — this Event answers "has THIS episode's state landed",
                 # the generation answers "is this still the latest switch".
+                # ★unconditional clear, conditional re-set (architect
+                # non-block, issuecomment-5377689986): the NEXT set() is
+                # NOT guaranteed by this client alone — it depends on the
+                # SERVER actually re-firing a snapshot, which
+                # ``emitter.py:184``'s own guard only does when a
+                # ``backlog_provider`` was wired (``if etype ==
+                # "session_attached" and self._backlog_provider is not
+                # None``). Production always reaches this: ``endpoint.py``'s
+                # own AG-UI route always constructs the emitter WITH one
+                # (search that file for where it is passed). A caller
+                # against a THIRD-PARTY AG-UI server, or a test emitter
+                # built without one, would leave this Event cleared
+                # forever — ``state_ready()`` never returning is the
+                # visible symptom, not a silent wrong answer.
                 if (
                     isinstance(decoded, EventFrame)
                     and getattr(decoded.event, "type", None) == "session_attached"

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -28,6 +28,7 @@ footgun where a client kills the server).
 """
 from __future__ import annotations
 
+import asyncio
 from typing import AsyncIterator, Awaitable, Callable
 
 from reyn.interfaces.transport.agui.protocol import (
@@ -65,6 +66,12 @@ class AgUiTransport(ClientTransport):
         # TOOL_CALL_RESULT toolCallId, P3/R1). Set when the server emits the
         # intervention frontend-tool; cleared when it resolves (answered / DENY).
         self._pending_intervention_id: "str | None" = None
+        # #5050 ③: set once the FIRST STATE_SNAPSHOT (always the first thing
+        # the reconnect protocol sends — ``AgUiEmitter.stream``'s own
+        # ordering) has been decoded into ``self._status`` — see
+        # :meth:`state_ready`'s own docstring (on the base class) for why
+        # this is a separate axis from :meth:`frames`.
+        self._state_ready_event = asyncio.Event()
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -72,6 +79,9 @@ class AgUiTransport(ClientTransport):
         # The SSE line source is created and owned by the caller (the httpx
         # connect happens before construction); nothing to wire up here.
         return None
+
+    async def state_ready(self) -> None:
+        await self._state_ready_event.wait()
 
     def close(self) -> None:
         self._connected = False
@@ -113,6 +123,12 @@ class AgUiTransport(ClientTransport):
                     self._status.apply_snapshot(decoded.snapshot)
                 if decoded.delta is not None:
                     self._status.apply_delta(decoded.delta)
+                # #5050 ③: either kind of STATE_* update means the status
+                # side-channel now reflects at least one genuine server
+                # update — see :meth:`state_ready`'s own docstring for why
+                # this is set here, independent of whether this block also
+                # yields any display Frame.
+                self._state_ready_event.set()
             elif isinstance(decoded, MessagesSnapshot):
                 out.extend(self._reguard_frame(f) for f in decoded.frames)
             elif isinstance(decoded, InterventionTool):

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -42,7 +42,7 @@ from reyn.interfaces.transport.agui.protocol import (
 from reyn.interfaces.transport.agui.state import RemoteStatusView, reguard_nodes
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.drain import suspend_between_frames
-from reyn.interfaces.transport.frames import DisplayFrame, Frame
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, Frame
 
 
 class AgUiTransport(ClientTransport):
@@ -141,6 +141,30 @@ class AgUiTransport(ClientTransport):
                 if decoded.intervention_id == self._pending_intervention_id:
                     self._pending_intervention_id = None
             else:  # a Frame
+                # #5050 ③ (architect co-vet, issuecomment-5377613210 — a
+                # correction of this PR's OWN first draft): a
+                # ``session_attached`` EventFrame starts a NEW episode —
+                # ``AgUiEmitter``'s reconnect-protocol barrier
+                # (``emitter.py``'s own module docstring: the STATE_SNAPSHOT
+                # re-fire happens STRICTLY AFTER the ``session_attached``
+                # frame is forwarded, never before) means ``self._status``
+                # still reflects the OLD session's state at the instant this
+                # frame is decoded. Clearing the Event here — rather than
+                # leaving the FIRST session's one-shot ``set()`` standing
+                # forever — makes a SECOND ``await state_ready()`` after a
+                # switch correctly wait for THIS episode's own fresh
+                # snapshot instead of resolving immediately on stale data
+                # (the "lying-ready" shape architect's original ruling
+                # named, now applied per-episode instead of once ever).
+                # ``_session_switch_generation`` is unrelated and unchanged
+                # (architect: do not invent a second generation mechanism)
+                # — this Event answers "has THIS episode's state landed",
+                # the generation answers "is this still the latest switch".
+                if (
+                    isinstance(decoded, EventFrame)
+                    and getattr(decoded.event, "type", None) == "session_attached"
+                ):
+                    self._state_ready_event.clear()
                 out.append(self._reguard_frame(decoded))
         return out
 

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -280,6 +280,38 @@ class ClientTransport(ABC):
         the default ``([], 0)`` preserves their behavior unchanged."""
         return [], 0
 
+    async def state_ready(self) -> None:
+        """Return once this transport's own STATUS/state-read side-channel
+        (whatever ``ChatReadModel.snapshot()``/``intervention_head()``/etc.
+        read) reflects at least one genuine update — DELIBERATELY a
+        SEPARATE axis from :meth:`frames` (#5050 ③, architect ruling): a
+        caller that wants to consult a status-derived read (e.g.
+        ``intervention_head()`` at mount, to present a pending intervention
+        this client never saw the live announce for) must not gate that on
+        "has a display FRAME arrived", because state changes are announced
+        to the wire only as a side effect of a frame in the current
+        protocol (#4996's own docstring: "a STATE_DELTA after each frame
+        when projected status changes") — a session with genuinely nothing
+        else happening (measured, #5050's own finding: a fresh AG-UI
+        connect carrying only STATE_SNAPSHOT + no further activity yields
+        ZERO frames from :meth:`frames`, ever) would make a frame-gated
+        wait hang forever, not merely late.
+
+        The default here (return immediately) is correct for any
+        transport whose status-read is ALREADY fresh the instant it is
+        asked — every implementation with no separate wire round-trip
+        (``InProcessTransport`` reads the live registry directly; any
+        narrow-purpose ``ClientTransport`` test stub that never overrode
+        this). ``AgUiTransport`` is the one implementation with a genuine
+        "not yet" window (before its first STATE_SNAPSHOT has been
+        decoded) and overrides this to actually wait.
+
+        NOT merged into :meth:`frames` on purpose — mixing "produce
+        display frames" with "has status state landed" would be the
+        exact "two axes fused into one seam" shape #5041 ① already named
+        as a hazard elsewhere tonight."""
+        return None
+
     def reyn_state_root(self) -> "Path | None":
         """The attached session's project `.reyn` root, or None (#3721).
 

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -306,6 +306,19 @@ class ThreadedTransportProxy(ClientTransport):
             "answer_intervention_choice", choice_id, intervention_id=intervention_id,
         )
 
+    async def state_ready(self) -> None:
+        # #5050 ③ follow-up (lead-coder, issuecomment-5377682724 — the
+        # 3rd lying-ready site found across the 3 production wrappers
+        # this axis had to be threaded through): the base default (return
+        # immediately) would be WRONG here specifically because the inner
+        # transport's ``state_ready()`` awaits an ``asyncio.Event`` that
+        # lives on the WORKER loop, not the caller's — falling through to
+        # the base default skips the only place that Event is ever
+        # actually waited on. ``_call_on_worker`` (not a bespoke bridge)
+        # marshals the coroutine onto the worker loop exactly like every
+        # other delegated async method above.
+        await self._call_on_worker("state_ready")
+
     async def cancel_inflight(self) -> str:
         return await self._call_on_worker("cancel_inflight")
 

--- a/tests/interfaces/test_5050_remote_pending_intervention_choices.py
+++ b/tests/interfaces/test_5050_remote_pending_intervention_choices.py
@@ -1,0 +1,398 @@
+"""Tier 2: #5050 ③ — a remote client presents choices (and can answer
+``always``) for an intervention it was never around to see the live
+announce for.
+
+Real chain (owner repro, `reyn chat --connect`): #5053 landed ①② —
+``STATE_SNAPSHOT``/``STATE_DELTA`` carry ``pending_intervention_head``,
+and ``RemoteReadModel.intervention_head()`` returns it instead of an
+unconditional ``None``. Nothing consumed that method before this fix
+(measured by grep, #5050's own issue thread) — ``app.py``'s
+``_present_hydrated_intervention_head_if_pending`` is the first consumer,
+called from BOTH ``on_mount`` (once ``ClientTransport.state_ready()``
+resolves — a NEW, separate primitive from ``frames()``, see that method's
+own docstring on ``ClientTransport`` for why frame arrival cannot be the
+gate: a session with genuinely nothing else happening yields ZERO frames
+from ``AgUiTransport.frames()``, ever, confirmed by direct reproduction
+before this fix, not guessed) and ``_handle_session_attached_event`` (a
+session switch to an agent that already has a pending intervention —
+gated on the EXISTING ``_session_switch_generation`` supersede guard
+instead, never re-awaiting ``state_ready()``; see that method's own
+docstring for why).
+
+Owner escalated the accept criterion mid-implementation twice
+(issuecomment-5377475482, -5377481917): "iv 選択肢については local と同じ
+UI/UX を期待してる" — a free-text fallback (the Composer's ``Input``,
+exactly what owner's own report showed as "Type your answer") satisfies a
+weaker "something got presented" witness without satisfying this. Three
+required witnesses now (lead-coder's own #5050③ ruling):
+
+- **①** (kept from the issue's original form, deliberately crossing the
+  frontend layer — architect: "layer-crossing is intentional here, not
+  crossing lets 'rendered but the answer doesn't land' pass"): a remote
+  client selecting `[A]lways` for a real permission intervention actually
+  persists to `.reyn/approvals.yaml` — not just that the panel drew
+  something.
+- **②** (the one directly reproducing owner's own symptom, and the one
+  that would have caught the FIRST (broken) mount-time design — reading
+  ``intervention_head()`` before the frame pump had decoded anything):
+  a reconnect whose SSE carries ONLY a STATE_SNAPSHOT and never yields a
+  single Frame from ``transport.frames()`` still gets the pending
+  intervention presented — the real ``InterventionPanel``, not the
+  Composer's free-text input — with real choices.
+- **③** (architect's own follow-up finding: the mount-time fix alone does
+  not cover this): a session SWITCH to an agent that already has a
+  pending intervention also presents it, with local-parity choices — an
+  unanswered intervention leaves no history trace (#5047), so nothing on
+  the ordinary reset-and-rehydrate switch path would present it otherwise.
+
+Real ``Session`` + real ``PermissionResolver`` + real ``AgentRegistry`` +
+real ``AgUiEmitter`` + real ``AgUiTransport`` + a real mounted
+``TextualChatApp`` — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+import yaml
+from textual_flowview import FlowView
+
+from reyn.core.events.events import Event
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
+from reyn.interfaces.repl.read_model import RemoteReadModel
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.agent_session import make_session
+
+
+async def _sse_lines_then_hang(text: str):
+    """Yields ``text``'s own lines then blocks forever on a real
+    never-resolving primitive (an ``asyncio.Event`` nothing ever
+    ``.set()``s), matching a REAL open AG-UI connection with nothing
+    further to report yet.
+
+    #5050 ③, measured: a genuinely EXHAUSTED SSE source (a plain
+    line-by-line generator over a FIXED string, then done) makes
+    ``AgUiTransport.frames()`` raise ``StopAsyncIteration`` on its very
+    first ``__anext__()`` when there is nothing to yield — which makes
+    ``_pump_frames``'s ``async for`` loop complete with ZERO iterations
+    and fall straight into its own ``finally: self.exit()`` (a genuine
+    "the connection is over, quit the app" — correct for an actually-
+    closed stream, wrong for THIS scenario). A real long-lived connection
+    never exhausts this way; it just has nothing more to send yet. A
+    finite generator here would tear the WHOLE APP down via that
+    ``finally`` before witness ②'s own hydrated-intervention-head worker
+    ever gets a chance to run — not a mount race, a test artifact that
+    doesn't match the real bug shape."""
+    for line in text.split("\n"):
+        yield line
+    await asyncio.Event().wait()
+
+
+async def _never_yields():
+    """A real, empty async generator — matches the ACTUAL shape #5050's
+    own reproduction found: a session with genuinely nothing else
+    happening produces no live DisplayFrame at all (``__end__`` is a
+    control sentinel the emitter never forwards — see its own docstring)."""
+    if False:  # noqa: SIM103 — the idiomatic empty-async-generator shape
+        yield
+
+
+_AGENT = "test-agent"
+
+
+def _make_session_with_resolver(
+    tmp_path: Path,
+) -> "tuple[Session, PermissionResolver, AgentRegistry]":
+    """A real ``Session`` + a real ``AgentRegistry`` wired to attach IT
+    (not a registry-constructed session of its own) — witness ①'s
+    ``_snapshot()`` reads several registry accessors beyond
+    ``attached_session`` (cost/token/unpriced, keyed by ``attached_name``),
+    so a full real registry is cheaper and more honest than hand-rolling
+    each of those methods (matching ``test_3338_tui_status_chrome_
+    liveness.py``'s own ``holder``-back-reference factory pattern).
+
+    Marks the session attached via ``registry._connection.switch`` directly
+    — NOT ``registry.attach()`` — because ``attach()`` unconditionally
+    starts the registry-level outbox forwarder AND (unless
+    ``start_runner=False``) the full ``session.run()`` router loop; this
+    test drives the intervention and drains ``session.outbox`` manually,
+    neither of which this scenario needs or wants running underneath it."""
+    perm = PermissionResolver({}, project_root=tmp_path, interactive=True)
+    state_log = StateLog(tmp_path / "state.wal")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        return make_session(
+            agent_name=profile.name,
+            permission_resolver=perm,
+            state_log=state_log,
+            snapshot_path=tmp_path / f"{profile.name}_snap.json",
+            workspace_base_dir=tmp_path,
+            registry=holder.get("reg"),
+        )
+
+    registry = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+    holder["reg"] = registry
+    AgentProfile.new(_AGENT, role="").save(tmp_path / ".reyn" / "agents" / _AGENT)
+    session = registry.get_or_load(_AGENT)
+    registry._connection.switch((_AGENT, _DEFAULT_SID))
+    session.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+    return session, perm, registry
+
+
+@pytest.mark.asyncio
+async def test_remote_always_choice_persists_to_approvals_yaml(tmp_path, monkeypatch):
+    """Tier 2: witness ① — a remote client selecting [A]lways for a real
+    permission intervention actually persists the grant to
+    ``.reyn/approvals.yaml`` — the layer-crossing witness (architect):
+    rendering without the answer landing would pass a narrower test."""
+    monkeypatch.chdir(tmp_path)
+    session, perm, registry = _make_session_with_resolver(tmp_path)
+    decl = PermissionDecl(http_get=[{"host": "*"}])
+
+    # The real permission gate, raising a real UserIntervention with
+    # generic_yn_choices() through the SAME bus production uses
+    # (session._make_router_intervention_bus()) — no full router/tool
+    # dispatch needed; that machinery is not the subject under test here.
+    require_task = asyncio.ensure_future(
+        perm.require_http_get(
+            decl, "news.ycombinator.com",
+            session._make_router_intervention_bus(), actor="chat_router",
+        )
+    )
+    announce_msg = await asyncio.wait_for(session.outbox.get(), timeout=2.0)
+    assert announce_msg.kind == "intervention"
+    assert announce_msg.meta.get("choices")
+    assert announce_msg.meta.get("intervention_id"), (
+        "the real production announce carries an intervention_id — this "
+        "test's own send() correlates the panel's answer through it"
+    )
+
+    def session_snapshot() -> dict:
+        from reyn.interfaces.repl.status import _snapshot
+        return _snapshot(registry) or {}
+
+    # Server side: this connection arrives AFTER the intervention was
+    # already raised (#5050③'s own scenario) — the announce frame is not
+    # replayed to a fresh connect (#5047's own finding: an unanswered
+    # intervention has no history trace); only STATE_SNAPSHOT carries it
+    # (#5053). No DisplayFrame at all in this stream.
+    emitter = AgUiEmitter(_never_yields(), session_snapshot)
+
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_SNAPSHOT" in sse
+
+    async def send(payload: dict) -> bool:
+        if payload.get("type") == "TOOL_CALL_RESULT":
+            return await session.answer_intervention_by_id(
+                str(payload.get("toolCallId")),
+                choice_id_override=payload.get("choiceId"),
+            )
+        return False
+
+    transport = AgUiTransport(_sse_lines_then_hang(sse), send)
+    app = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        assert panel.display is True, "the pending intervention never got presented"
+        assert panel.has_pending() is True
+
+        # generic_yn_choices() order: [y]es, [A]lways, [n]o, [N]ever — the
+        # panel pre-highlights the first option (#3299 P2 owner decision),
+        # so ONE "down" reaches [A]lways.
+        await pilot.press("down")
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+    await asyncio.wait_for(require_task, timeout=2.0)
+
+    approvals_path = tmp_path / ".reyn" / "approvals.yaml"
+    assert approvals_path.exists(), "always was never persisted to approvals.yaml"
+    saved = yaml.safe_load(approvals_path.read_text(encoding="utf-8")) or {}
+    assert saved.get("chat_router/http.get/news.ycombinator.com") is True, saved
+
+
+@pytest.mark.asyncio
+async def test_remote_pending_intervention_presents_even_when_no_frame_ever_arrives(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: witness ② — the reproduction of owner's own symptom, and the
+    one that would have caught the FIRST (broken) design: a reconnect
+    whose ``AgUiTransport.frames()`` yields ZERO frames (a real,
+    reproduced shape — see ``_never_yields``'s own docstring) still
+    presents the pending intervention with real choices, because
+    ``state_ready()`` — not frame arrival — is what gates the read.
+
+    Strip-falsifier: removing the ``await self._transport.state_ready()``
+    in ``_present_hydrated_intervention_head_if_pending`` (reading
+    ``intervention_head()`` immediately at mount instead) turns this red
+    — ``RemoteReadModel.intervention_head()`` reads
+    ``transport.status.values``, which is still empty at that instant
+    (measured directly, #5050's own reproduction script) — the panel
+    would never open."""
+    monkeypatch.chdir(tmp_path)
+
+    state = {
+        "attached_name": "test-agent", "model": "opus",
+        "pending_intervention_head": {
+            "id": "iv-standalone",
+            "prompt": "Allow fetching from 'docs.example.com'?",
+            "detail": None,
+            "choices": [
+                {"id": "yes", "label": "[y]es", "hotkey": "y"},
+                {"id": "always", "label": "[A]lways", "hotkey": "A"},
+                {"id": "no", "label": "[n]o", "hotkey": "n"},
+                {"id": "never", "label": "[N]ever", "hotkey": "N"},
+            ],
+        },
+    }
+
+    emitter = AgUiEmitter(_never_yields(), lambda: dict(state))
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_SNAPSHOT" in sse
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines_then_hang(sse), _noop_send)
+    app = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(10):
+            await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        assert panel.display is True, (
+            "a pending intervention behind a frame-less STATE_SNAPSHOT "
+            "reconnect was never presented"
+        )
+        assert panel.has_pending() is True
+        # ★owner-required local parity (issuecomment-5377475482): the real
+        # choice set (a RadioSet), NOT the Composer's free-text Input —
+        # owner's own reported symptom was "Type your answer" appearing
+        # instead of the choices this intervention actually carries.
+        assert panel.query("RadioSet"), (
+            "the hydrated intervention rendered as a free-text prompt, "
+            "not the local-parity choice set"
+        )
+
+        # A real flow entry rendered too (the presenter side, not just the
+        # interactive panel) — no chip options on it (#3299 P1 contract).
+        entries = [
+            e for e in app.query_one(FlowView).entries if e.item.kind == "intervention"
+        ]
+        assert entries, "the hydrated intervention never reached the flow view"
+        assert any(
+            "Allow fetching from 'docs.example.com'?" in e.item.text for e in entries
+        )
+
+
+@pytest.mark.asyncio
+async def test_remote_switch_to_agent_with_pending_intervention_presents_it(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: witness ③ — architect's own follow-up finding: witness ②'s
+    mount-time fix does NOT cover a session SWITCH to an agent that already
+    has a pending intervention. ``_handle_session_attached_event`` resets
+    every per-session client state and rehydrates from history — but an
+    unanswered intervention leaves no history trace (#5047's own finding,
+    ``restore.py``), so nothing on that path would ever present it without
+    this PR's shared ``_present_hydrated_intervention_head_if_pending``
+    call, gated on the SAME ``_session_switch_generation`` supersede guard
+    ``_handle_session_attached_event`` already uses (architect ruling: no
+    new generation mechanism) rather than re-awaiting ``state_ready()``
+    (the SAME ``AgUiTransport`` persists across a switch — its one-shot
+    Event, already set by the FIRST session's snapshot, would resolve
+    immediately and lie about the NEW session's own readiness).
+
+    Drives the real ``_handle_session_attached_event`` handler directly
+    with a real ``Event`` (matching ``test_4983_session_switch_off_thread
+    .py``'s own established idiom for testing this handler in isolation)
+    — the connection's initial STATE_SNAPSHOT carries no pending
+    intervention; the switch's own (simulated) reconnect burst updates
+    ``transport.status`` with the NEW session's pending intervention
+    BEFORE the handler runs, matching production ordering (the handler
+    only runs in response to a ``session_attached`` frame the SAME
+    ``_pump_frames`` loop has already processed, by which point any
+    co-delivered STATE_* update is already applied).
+
+    Strip-falsifier: commenting out this PR's ``run_worker(self.
+    _present_hydrated_intervention_head_if_pending(switch_generation=...))``
+    call in ``_handle_session_attached_event`` turns this red — the panel
+    never opens for the switched-to agent's pending intervention."""
+    monkeypatch.chdir(tmp_path)
+
+    initial_state = {"attached_name": "agent-a", "model": "opus"}
+    emitter = AgUiEmitter(_never_yields(), lambda: dict(initial_state))
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_SNAPSHOT" in sse
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines_then_hang(sse), _noop_send)
+    app = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(10):
+            await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        assert panel.display is False, (
+            "sanity: agent-a's own snapshot carries no pending intervention"
+        )
+
+        # Simulate the switch's own reconnect burst: agent-b's fresh
+        # STATE_SNAPSHOT (carrying its pending intervention) landing on
+        # this SAME transport instance BEFORE the session_attached handler
+        # runs — matching production ordering (see this test's own
+        # docstring).
+        transport.status.apply_snapshot({
+            "attached_name": "agent-b", "model": "opus",
+            "pending_intervention_head": {
+                "id": "iv-agent-b",
+                "prompt": "Allow fetching from 'switched.example.com'?",
+                "detail": None,
+                "choices": [
+                    {"id": "yes", "label": "[y]es", "hotkey": "y"},
+                    {"id": "always", "label": "[A]lways", "hotkey": "A"},
+                    {"id": "no", "label": "[n]o", "hotkey": "n"},
+                    {"id": "never", "label": "[N]ever", "hotkey": "N"},
+                ],
+            },
+        })
+
+        await app._handle_session_attached_event(
+            Event(type="session_attached", data={"agent": "agent-b", "session_id": None})
+        )
+        for _ in range(10):
+            await pilot.pause()
+
+        assert panel.display is True, (
+            "a switch to an agent with a pending intervention was never presented"
+        )
+        assert panel.has_pending() is True
+        # ★owner-required local parity: the real InterventionPanel's choice
+        # set (a RadioSet), not the Composer's free-text Input — owner's own
+        # reported symptom on the mount-time case was "Type your answer"
+        # appearing instead.
+        assert panel.query("RadioSet"), (
+            "the switched-to intervention rendered as a free-text prompt, "
+            "not the local-parity choice set"
+        )

--- a/tests/interfaces/test_5050_remote_pending_intervention_choices.py
+++ b/tests/interfaces/test_5050_remote_pending_intervention_choices.py
@@ -65,6 +65,12 @@ from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionP
 from reyn.interfaces.repl.read_model import RemoteReadModel
 from reyn.interfaces.transport.agui.client import AgUiTransport
 from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.protocol import (
+    encode_frame,
+    encode_state_snapshot,
+    to_sse,
+)
+from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
@@ -90,9 +96,22 @@ async def _sse_lines_then_hang(text: str):
     finite generator here would tear the WHOLE APP down via that
     ``finally`` before witness ②'s own hydrated-intervention-head worker
     ever gets a chance to run — not a mount race, a test artifact that
-    doesn't match the real bug shape."""
+    doesn't match the real bug shape.
+
+    A real ``asyncio.sleep(0)`` BETWEEN every yielded line (not merely
+    after the whole block) — without it, ``_pump_frames``'s own worker
+    (scheduled first in ``on_mount``) decodes the entire single-block SSE
+    text with NO intervening real suspension, so it reaches ``_state_
+    ready_event.set()`` before the hydrated-intervention-head worker
+    (scheduled second) ever gets a first turn — making ``state_ready()``'s
+    own await a no-op in THIS construction and any strip of it silently
+    pass (measured: 3/3 stripped runs passed regardless). The per-line
+    yield gives the second worker a genuine, non-hypothetical chance to
+    read ``intervention_head()`` before the block finishes decoding,
+    which is what makes the strip-falsifier below actually load-bearing."""
     for line in text.split("\n"):
         yield line
+        await asyncio.sleep(0)
     await asyncio.Event().wait()
 
 
@@ -103,6 +122,15 @@ async def _never_yields():
     control sentinel the emitter never forwards — see its own docstring)."""
     if False:  # noqa: SIM103 — the idiomatic empty-async-generator shape
         yield
+
+
+async def _wait_until(pilot, condition) -> None:
+    """Poll ``pilot.pause()`` unboundedly until ``condition()`` is true —
+    CLAUDE.md's Ceiling rule (no ``range(N)`` wrapping a wait; wait on the
+    condition unboundedly, CI's own ``--timeout`` is the kill switch), not
+    a fixed pause count that could pass on luck or silently under-wait."""
+    while not condition():
+        await pilot.pause()
 
 
 _AGENT = "test-agent"
@@ -152,10 +180,19 @@ def _make_session_with_resolver(
 
 @pytest.mark.asyncio
 async def test_remote_always_choice_persists_to_approvals_yaml(tmp_path, monkeypatch):
-    """Tier 2: witness ① — a remote client selecting [A]lways for a real
-    permission intervention actually persists the grant to
-    ``.reyn/approvals.yaml`` — the layer-crossing witness (architect):
-    rendering without the answer landing would pass a narrower test."""
+    """Tier 2: witness ① — the COMBINED witness lead-coder's own #5050③
+    block found missing (no single test looked at the whole SET owner
+    required): a construction where ``transport.frames()`` yields ZERO
+    frames (the exact reconnect-after-the-fact scenario ② also covers)
+    where (a) the real ``InterventionPanel`` appears — not the Composer's
+    free-text input, (b) its choice set matches local's (``[A]lways``
+    selectable), and (c) selecting it actually persists a grant to
+    ``.reyn/approvals.yaml`` — the layer-crossing half (architect):
+    rendering without the answer landing would pass a narrower test.
+
+    No ceiling anywhere below (CLAUDE.md Ceiling rule): every wait is on
+    a real condition (:func:`_wait_until`, or a bare ``await`` on a
+    coroutine/queue this test's own setup guarantees resolves)."""
     monkeypatch.chdir(tmp_path)
     session, perm, registry = _make_session_with_resolver(tmp_path)
     decl = PermissionDecl(http_get=[{"host": "*"}])
@@ -170,7 +207,7 @@ async def test_remote_always_choice_persists_to_approvals_yaml(tmp_path, monkeyp
             session._make_router_intervention_bus(), actor="chat_router",
         )
     )
-    announce_msg = await asyncio.wait_for(session.outbox.get(), timeout=2.0)
+    announce_msg = await session.outbox.get()
     assert announce_msg.kind == "intervention"
     assert announce_msg.meta.get("choices")
     assert announce_msg.meta.get("intervention_id"), (
@@ -186,7 +223,8 @@ async def test_remote_always_choice_persists_to_approvals_yaml(tmp_path, monkeyp
     # already raised (#5050③'s own scenario) — the announce frame is not
     # replayed to a fresh connect (#5047's own finding: an unanswered
     # intervention has no history trace); only STATE_SNAPSHOT carries it
-    # (#5053). No DisplayFrame at all in this stream.
+    # (#5053). No DisplayFrame at all in this stream — the SAME
+    # frame-free construction as witness ②.
     emitter = AgUiEmitter(_never_yields(), session_snapshot)
 
     sse = "".join([chunk async for chunk in emitter.stream()])
@@ -204,26 +242,34 @@ async def test_remote_always_choice_persists_to_approvals_yaml(tmp_path, monkeyp
     app = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
 
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
-        await pilot.pause()
-        await pilot.pause()
-
         panel = app.query_one(InterventionPanel)
-        assert panel.display is True, "the pending intervention never got presented"
+        await _wait_until(pilot, lambda: panel.display is True)
         assert panel.has_pending() is True
+        # ★owner-required local parity (issuecomment-5377475482): the real
+        # choice set (a RadioSet), NOT the Composer's free-text Input.
+        radio_set = panel.query_one("RadioSet")
+        assert radio_set, (
+            "the hydrated intervention rendered as a free-text prompt, "
+            "not the local-parity choice set"
+        )
+        # The panel's own auto-focus (``on_tabbed_content_tab_activated``)
+        # is deferred via ``call_after_refresh`` — ``panel.display`` becomes
+        # True a full refresh cycle BEFORE focus actually lands on the
+        # RadioSet. Waiting on the REAL condition (has_focus), not an
+        # arbitrary extra pause, avoids pressing keys before Textual is
+        # ready to route them to this widget.
+        await _wait_until(pilot, lambda: radio_set.has_focus)
 
         # generic_yn_choices() order: [y]es, [A]lways, [n]o, [N]ever — the
         # panel pre-highlights the first option (#3299 P2 owner decision),
         # so ONE "down" reaches [A]lways.
         await pilot.press("down")
         await pilot.press("enter")
-        await pilot.pause()
-        await pilot.pause()
+        approvals_path = tmp_path / ".reyn" / "approvals.yaml"
+        await _wait_until(pilot, lambda: approvals_path.exists())
 
-    await asyncio.wait_for(require_task, timeout=2.0)
+    await require_task
 
-    approvals_path = tmp_path / ".reyn" / "approvals.yaml"
-    assert approvals_path.exists(), "always was never persisted to approvals.yaml"
     saved = yaml.safe_load(approvals_path.read_text(encoding="utf-8")) or {}
     assert saved.get("chat_router/http.get/news.ycombinator.com") is True, saved
 
@@ -274,14 +320,8 @@ async def test_remote_pending_intervention_presents_even_when_no_frame_ever_arri
     app = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
 
     async with app.run_test(size=(100, 30)) as pilot:
-        for _ in range(10):
-            await pilot.pause()
-
         panel = app.query_one(InterventionPanel)
-        assert panel.display is True, (
-            "a pending intervention behind a frame-less STATE_SNAPSHOT "
-            "reconnect was never presented"
-        )
+        await _wait_until(pilot, lambda: panel.display is True)
         assert panel.has_pending() is True
         # ★owner-required local parity (issuecomment-5377475482): the real
         # choice set (a RadioSet), NOT the Composer's free-text Input —
@@ -303,6 +343,47 @@ async def test_remote_pending_intervention_presents_even_when_no_frame_ever_arri
         )
 
 
+async def _sse_burst_then_switch_then_hang(
+    initial_sse: str, switch_sse: str, release: "asyncio.Event",
+):
+    """Yield ``initial_sse``'s lines, then BLOCK (a real, unbounded
+    ``asyncio.Event().wait()`` — nothing this test's own setup resolves
+    until the test itself calls ``release.set()``) until ``release`` is
+    set, then yield ``switch_sse``'s lines, then hang forever (matching
+    :func:`_sse_lines_then_hang`'s own rationale: a real connection never
+    exhausts ``frames()`` this way).
+
+    #5050③ co-vet correction (architect, issuecomment-5377613210): the
+    FIRST draft of witness ③ simulated the switch by calling
+    ``transport.status.apply_snapshot(...)`` directly, BEFORE invoking
+    ``_handle_session_attached_event`` — backwards. ``AgUiEmitter``'s own
+    reconnect-protocol barrier (``emitter.py``'s module docstring: "the
+    re-fire happens strictly AFTER the ``session_attached`` frame is
+    forwarded — never before") means production has the switched-to
+    session's STATE_SNAPSHOT arrive AFTER the ``session_attached`` frame,
+    not before. This generator reproduces that real ordering: ``switch_
+    sse`` below is built as a session_attached EventFrame followed by the
+    NEW session's own STATE_SNAPSHOT, and the app's REAL ``_pump_frames``
+    loop (not a hand-invoked handler call) decodes both in that order —
+    so the fix under test (``AgUiTransport`` clearing ``state_ready()``'s
+    Event on ``session_attached`` decode, setting it again on the NEXT
+    STATE_SNAPSHOT) is exercised exactly as production hits it.
+
+    A real ``asyncio.sleep(0)`` between every yielded line — same
+    reasoning as :func:`_sse_lines_then_hang`'s own docstring: without a
+    genuine per-line suspension, a worker scheduled after ``_pump_frames``
+    never gets a real chance to observe an in-between state, silently
+    weakening any strip-falsifier that depends on that window existing."""
+    for line in initial_sse.split("\n"):
+        yield line
+        await asyncio.sleep(0)
+    await release.wait()
+    for line in switch_sse.split("\n"):
+        yield line
+        await asyncio.sleep(0)
+    await asyncio.Event().wait()
+
+
 @pytest.mark.asyncio
 async def test_remote_switch_to_agent_with_pending_intervention_presents_it(
     tmp_path, monkeypatch,
@@ -314,23 +395,17 @@ async def test_remote_switch_to_agent_with_pending_intervention_presents_it(
     unanswered intervention leaves no history trace (#5047's own finding,
     ``restore.py``), so nothing on that path would ever present it without
     this PR's shared ``_present_hydrated_intervention_head_if_pending``
-    call, gated on the SAME ``_session_switch_generation`` supersede guard
-    ``_handle_session_attached_event`` already uses (architect ruling: no
-    new generation mechanism) rather than re-awaiting ``state_ready()``
-    (the SAME ``AgUiTransport`` persists across a switch — its one-shot
-    Event, already set by the FIRST session's snapshot, would resolve
-    immediately and lie about the NEW session's own readiness).
+    call.
 
-    Drives the real ``_handle_session_attached_event`` handler directly
-    with a real ``Event`` (matching ``test_4983_session_switch_off_thread
-    .py``'s own established idiom for testing this handler in isolation)
-    — the connection's initial STATE_SNAPSHOT carries no pending
-    intervention; the switch's own (simulated) reconnect burst updates
-    ``transport.status`` with the NEW session's pending intervention
-    BEFORE the handler runs, matching production ordering (the handler
-    only runs in response to a ``session_attached`` frame the SAME
-    ``_pump_frames`` loop has already processed, by which point any
-    co-delivered STATE_* update is already applied).
+    Drives the switch through the REAL ``_pump_frames`` pipeline — a real
+    ``session_attached`` ``EventFrame`` followed by the NEW session's own
+    STATE_SNAPSHOT, encoded and decoded through the actual wire codec
+    (``encode_frame``/``encode_state_snapshot``/``to_sse``), in PRODUCTION
+    ORDER (session_attached strictly before the fresh snapshot — see
+    :func:`_sse_burst_then_switch_then_hang`'s own docstring for the
+    ordering bug this corrects over this PR's first draft) — never a
+    hand-invoked ``_handle_session_attached_event`` call, so the handler
+    fires exactly when and how production fires it.
 
     Strip-falsifier: commenting out this PR's ``run_worker(self.
     _present_hydrated_intervention_head_if_pending(switch_generation=...))``
@@ -340,53 +415,46 @@ async def test_remote_switch_to_agent_with_pending_intervention_presents_it(
 
     initial_state = {"attached_name": "agent-a", "model": "opus"}
     emitter = AgUiEmitter(_never_yields(), lambda: dict(initial_state))
-    sse = "".join([chunk async for chunk in emitter.stream()])
-    assert "STATE_SNAPSHOT" in sse
+    initial_sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_SNAPSHOT" in initial_sse
+
+    agent_b_state = {
+        "attached_name": "agent-b", "model": "opus",
+        "pending_intervention_head": {
+            "id": "iv-agent-b",
+            "prompt": "Allow fetching from 'switched.example.com'?",
+            "detail": None,
+            "choices": [
+                {"id": "yes", "label": "[y]es", "hotkey": "y"},
+                {"id": "always", "label": "[A]lways", "hotkey": "A"},
+                {"id": "no", "label": "[n]o", "hotkey": "n"},
+                {"id": "never", "label": "[N]ever", "hotkey": "N"},
+            ],
+        },
+    }
+    # The real wire encoding, PRODUCTION ORDER: session_attached EventFrame
+    # first, agent-b's own fresh STATE_SNAPSHOT strictly after (matches
+    # ``_SessionFrameSource``/``AgUiEmitter``'s real reconnect barrier).
+    switch_sse = to_sse(
+        encode_frame(
+            EventFrame(Event(type="session_attached", data={"agent": "agent-b", "session_id": None}))
+        )
+    ) + to_sse(encode_state_snapshot(agent_b_state))
+
+    release = asyncio.Event()
 
     async def _noop_send(_payload):
         return None
 
-    transport = AgUiTransport(_sse_lines_then_hang(sse), _noop_send)
+    transport = AgUiTransport(
+        _sse_burst_then_switch_then_hang(initial_sse, switch_sse, release), _noop_send,
+    )
     app = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
 
     async with app.run_test(size=(100, 30)) as pilot:
-        for _ in range(10):
-            await pilot.pause()
-
         panel = app.query_one(InterventionPanel)
-        assert panel.display is False, (
-            "sanity: agent-a's own snapshot carries no pending intervention"
-        )
-
-        # Simulate the switch's own reconnect burst: agent-b's fresh
-        # STATE_SNAPSHOT (carrying its pending intervention) landing on
-        # this SAME transport instance BEFORE the session_attached handler
-        # runs — matching production ordering (see this test's own
-        # docstring).
-        transport.status.apply_snapshot({
-            "attached_name": "agent-b", "model": "opus",
-            "pending_intervention_head": {
-                "id": "iv-agent-b",
-                "prompt": "Allow fetching from 'switched.example.com'?",
-                "detail": None,
-                "choices": [
-                    {"id": "yes", "label": "[y]es", "hotkey": "y"},
-                    {"id": "always", "label": "[A]lways", "hotkey": "A"},
-                    {"id": "no", "label": "[n]o", "hotkey": "n"},
-                    {"id": "never", "label": "[N]ever", "hotkey": "N"},
-                ],
-            },
-        })
-
-        await app._handle_session_attached_event(
-            Event(type="session_attached", data={"agent": "agent-b", "session_id": None})
-        )
-        for _ in range(10):
-            await pilot.pause()
-
-        assert panel.display is True, (
-            "a switch to an agent with a pending intervention was never presented"
-        )
+        release.set()
+        await _wait_until(pilot, lambda: panel.display is True)
         assert panel.has_pending() is True
         # ★owner-required local parity: the real InterventionPanel's choice
         # set (a RadioSet), not the Composer's free-text Input — owner's own

--- a/tests/interfaces/test_5050_remote_pending_intervention_choices.py
+++ b/tests/interfaces/test_5050_remote_pending_intervention_choices.py
@@ -15,9 +15,13 @@ gate: a session with genuinely nothing else happening yields ZERO frames
 from ``AgUiTransport.frames()``, ever, confirmed by direct reproduction
 before this fix, not guessed) and ``_handle_session_attached_event`` (a
 session switch to an agent that already has a pending intervention —
-gated on the EXISTING ``_session_switch_generation`` supersede guard
-instead, never re-awaiting ``state_ready()``; see that method's own
-docstring for why).
+gated on the EXISTING ``_session_switch_generation`` supersede guard,
+AND re-awaiting ``state_ready()`` too — corrected mid-review, architect
+co-vet issuecomment-5377613210, from this PR's own first draft, which
+skipped that re-await on the mistaken theory that a switch's state was
+"already applied" by the time the handler runs; see that method's own
+docstring for the real ordering and why the fix is per-episode
+``state_ready()`` clearing, not "await nothing").
 
 Owner escalated the accept criterion mid-implementation twice
 (issuecomment-5377475482, -5377481917): "iv 選択肢については local と同じ


### PR DESCRIPTION
**[tui-coder]** — part of #5050 — item ③: remote client presents local-parity choices for a pending intervention it never saw the live announce for.

## Root cause
A remote AG-UI client that connects (or switches) to a session with an already-pending intervention never received the live announce frame for it — owner's reported symptom was the Composer's free-text input appearing instead of the real `InterventionPanel` with local's choice set. Architect measured (issuecomment-5377475482) that "remote can't show choices" is false in general: `agui/client.py`'s `answer_intervention_choice` and `app.py`'s existing `kind=="intervention"` → `_present_intervention` path already work for remote when the intervention fires *during* an active connection. The only broken case is a connection/switch where the intervention was already pending *before* it attached.

## Fix
- `app.py`: `_present_hydrated_intervention_head_if_pending`, ONE shared entry point that reads `ChatReadModel.intervention_head()` and, if non-None, routes it through the SAME `_ingest_frame` → `_present_intervention` path a live announce already uses. Called from both `on_mount` (mount case) and `_handle_session_attached_event` (switch case), reusing the EXISTING `_session_switch_generation` supersede guard for the latter (no new generation mechanism).
- `client_transport.py` / `agui/client.py`: new `state_ready()` primitive, deliberately a SEPARATE axis from `frames()` — measured that a reconnect stream carrying only a STATE_SNAPSHOT makes `AgUiTransport.frames()` yield ZERO frames, ever, so reading `intervention_head()` before that snapshot decodes would race and lose. `AgUiTransport` sets the Event whenever it decodes **either** a STATE_SNAPSHOT **or** a STATE_DELTA (not snapshot-only — corrected wording from an earlier draft of this description).
- A real Textual widget-mount race surfaced while wiring the mount case (presenting before `InterventionPanel`'s nested `TabbedContent` finishes composing raises `MountError`) — fixed with `_await_iv_panel_composed`, an explicit condition-wait on the widget's own `is_attached` (`while True: await asyncio.sleep(0)` — genuinely unbounded by design, matching `_pump_frames`'s own no-ceiling shape in production; nothing here is a disguised retry count).
- **Switch-case ordering bug, found in review (architect, issuecomment-5377613210)**: the first draft skipped re-awaiting `state_ready()` on a switch, reasoning the same `AgUiTransport` instance persisting across a switch made its one-shot Event "already applied" by the time the switch handler runs. Backwards: `AgUiEmitter`'s own reconnect barrier forwards `session_attached` **strictly before** its STATE_SNAPSHOT re-fire (emitter.py:184-190 / module docstring), so at the instant the switch handler actually runs, `transport.status` still reflects the OLD session — either misdelivering the old session's own pending head onto the new session's view, or reading `None` and never presenting the new session's real pending intervention (the exact defect ③ exists to fix). Fixed per architect's own recipe: `AgUiTransport` now clears `state_ready()`'s Event on `session_attached` decode and sets it again on the next STATE_SNAPSHOT — the switch case now re-awaits `state_ready()` too. `_session_switch_generation` is unchanged.
- **A second lying-ready site, CI-caught** (`test_error_watching_transport_total_delegation_4884.py`): the slash-command path's `_ErrorWatchingTransport` wrapper didn't delegate `state_ready()`, silently falling back to the base default (instant-ready). Fixed — matches every other method on that wrapper.
- `_pump_frames`'s own `finally: self.exit()` (pre-existing, unrelated to this PR) is not touched here — it is the correct behavior for a genuinely closed connection. The tests below avoid tripping it by modeling a real OPEN connection (an SSE generator that never exhausts, hanging on a real `asyncio.Event().wait()`) rather than a finite one; a finite fake source is a test artifact that doesn't match how a real long-lived AG-UI connection behaves, and produced 4 rounds of a red herring `MountError` before this was found.

## Witnesses (lead-coder's #5050③ ruling, escalated by owner to require local-parity choices, then found under-specified in review)
① **the combined witness** (lead-coder's review found no single test covered the owner's actual requirement as a SET): in one frame-free construction — (a) the real `InterventionPanel` appears, not the Composer's free-text input, (b) its choice set matches local's (`[A]lways` selectable), (c) selecting it persists to `.reyn/approvals.yaml`.
② a frame-less STATE_SNAPSHOT-only reconnect presents the real `InterventionPanel` with local's choice set — strip-verified (removing the `state_ready()` await turns it red; also re-verified the strip is genuinely load-bearing, see Test plan).
③ a session switch to an agent with an already-pending intervention presents it with local-parity choices, driven through the REAL `_pump_frames` pipeline with production-ordered SSE (session_attached strictly before the fresh snapshot) — strip-verified both for the switch-case call site and for `state_ready()` itself.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_5050_remote_pending_intervention_choices.py`
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Scoped pytest (`-k "intervention or 5050 or 3299 or session_attached or 4983 or 3310 or 5057 or 5047 or 4884 or slash"`, 346 passed) + the 3 tests individually × 3 runs each (no flakes)
- [x] Strip-falsify, all re-verified genuinely load-bearing after review found the FIRST attempt's strips were not (the frame-free SSE fakes decoded their one block with zero real event-loop suspension, so `_pump_frames` always beat the hydrated-intervention-head worker to `state_ready()`'s Event regardless of the strip — 3/3 stripped runs passed silently). Fixed by giving both fake SSE sources a real per-line `asyncio.sleep(0)`; re-verified 3/3 stripped runs now fail for: state_ready() removal (②, ③) and the switch-case call site removal (③).
- [x] Also fixed a genuine flake the review's ceiling findings surfaced: the panel's auto-focus onto its RadioSet is deferred via `call_after_refresh`, landing a full cycle after `panel.display` itself goes True — pressing keys before focus actually arrives raced silently (4/5 local failures before the fix). Now waits on the real `has_focus` condition instead.
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Review resolution (architect / lead-coder blocks above, all addressed in the latest push):**
- [x] 🔴 **[architect] witness ③ backwards ordering** — fixed per architect's own recipe (session_attached clears `state_ready()`'s Event, next STATE_SNAPSHOT sets it; switch case re-awaits). Test rewritten to drive the REAL `_pump_frames` pipeline with production-ordered SSE instead of hand-simulating the update.
- [x] 🔴 **[architect] `range(10): await pilot.pause()` × 2** — replaced with unbounded condition-waits.
- [x] 🔴 **`range(10): await pilot.pause()` × 3** — same, all replaced.
- [x] 🔴 **`asyncio.wait_for(..., timeout=2.0)` × 2** — removed; both awaited coroutines directly (no ceiling).
- [x] 🔴 **owner's requirement not witnessed as a SET in any one test** — witness ① rewritten to be the combined witness (frame-free + real panel + local-parity choices + approvals.yaml persistence, all in one test).
- [x] 🔴 **[lead-coder] `ThreadedTransportProxy` does not delegate `state_ready`** — measured on main with the SAME `vars(cls)` computation #4884's gate uses: this class defined **18/18** public `ClientTransport` methods in its own body. This PR is what opens the first hole in it (`threaded.py` on head `3e6637e` has no `state_ready`). It falls through to the base default = answers **"already ready"** — and this is the thread-boundary proxy, where `state_ready` awaits an Event owned by the worker loop, i.e. the one place the wait exists at all. Third lying-ready path in this PR's blast radius (switch re-await / `_ErrorWatchingTransport` / this). **Add `state_ready` to `ThreadedTransportProxy` only** — do NOT generalise #4884's gate here (that goes on issue #5043: of 5 production wrappers, exactly 1 is covered by a total-delegation gate). Full evidence: the PR comment above.
- [x] 🟡 **PR description mismatch** — corrected above: `AgUiTransport` sets `state_ready()` on either STATE_SNAPSHOT or STATE_DELTA, not snapshot-only.
- [x] 🟡 **Explain `_await_iv_panel_composed`'s unbounded poll and why `_pump_frames`'s `finally: self.exit()` doesn't need a production-side fix** — both explained in the Fix section above.
- [x] 🔴 **[architect] BLOCK ② — test module docstring の `never re-awaiting state_ready()` が、この PR の変更に対して偽（`issuecomment-5377678xxx`）。同 PR で修正。** → fixed: docstring now describes the actual (re-awaiting) design; also added the requested one-line note on `emitter.py:184`/`endpoint.py:526`'s server-side guarantee next to the `clear()` call.
- [x] 🔴 **[lead-coder] the TESTS-READ note is stale** — e2e-coder's note (03:29:38Z) read commit `5faa4f21c` (03:23:41Z); the test rewrite `3e6637e7e` landed 03:44:24Z, **15 minutes later**. The body's own ticks say witness ① and ③ were *rewritten* — so nobody has read the tests that are actually in this PR now. Rule 8 only checks that a note **landed**, not that it read **this tree**. A fresh TESTS-READ against head `3e6637e` is requested from docs-maintainer (independent — no design or implementation involvement here). This does not retract e2e-coder's note: it was correct for the tree it read.

**TESTS-READ**: architect performed a fresh TESTS-READ against head `3e6637e` (issuecomment-5377705776) — scope was this PR's 3 tests plus the `state_ready()` primitive; RadioSet-presence and approvals.yaml persistence positively verified, the switch-episode worker and the no-`backlog_provider` case both confirmed accounted for (not silent).
- [x] 🔴 **[lead-coder] no INDEPENDENT read of the current tests** — architect's fresh TESTS-READ closed the *staleness* axis but not the *independence* one: architect prescribed this very design (clear on `session_attached`, set on the next `STATE_*`), so witness ③ is a test written to their own recipe — the weakest position for six-questions Q2 (implementation transcribed) and Q3 (who would miss it). e2e-coder's note is independent but read a superseded tree. I am not independent either: my three blocks are what caused the rewrites. Asking docs-maintainer for a **delta-only** read (witness ① rewrite, witness ③ rewrite, the `state_ready` additions). Not merging on "two people already read it" — each is missing a different qualification.

