### PR TITLE
fix(#5065): audit-event the /api/permissions REST router's own writer

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -158,6 +158,8 @@ oauth_login_started
 peer_reply_failed_surfaced
 pending_intervention_claimed
 pending_intervention_discarded
+permission_approval_revoked
+permission_approvals_cleared
 permission_denied
 permission_granted
 pipeline_install_skipped
@@ -399,6 +401,7 @@ Each Control IR op kind emits its own event:
 | `index_updated` | `index_update` op — `source`, `added: int`, `updated: int`, `removed: int`, `skipped: int` |
 | `control_ir_skipped`, `control_ir_failed` | dispatch failures (`control_ir_skipped` reasons include `handler_not_implemented`) |
 | `permission_denied` | When an op is denied by the resolver |
+| `permission_approval_revoked`, `permission_approvals_cleared` | #5065 — a management operation on the SAVED-approvals store (`.reyn/approvals.yaml`), e.g. the `/api/permissions` REST router. Distinct from `permission_granted`/`permission_denied` above (those are in-run decisions, hence `run_id`/`actor`/`phase`; these happen outside any run, so they carry neither): `permission_approval_revoked` — `key`, `surface`; `permission_approvals_cleared` — `count`, `surface`. |
 
 ## MCP
 

--- a/docs/reference/runtime/reyn-dir-layout.md
+++ b/docs/reference/runtime/reyn-dir-layout.md
@@ -210,8 +210,17 @@ To change config, call the dedicated op (which writes the `.yaml` as a **new con
 - hooks → `hooks_add`
 - index sources → the index ops
 
-`approvals.yaml` (top-level *persist*) is likewise write-gated — it is written only via the
-permission-approval flow (`_persist`), never a raw `file.write`. `memory/`, `cache/`, and
+`approvals.yaml` (top-level *persist*) is likewise write-gated for its primary writer — the
+security-side permission-approval flow (`_persist`) never does a raw `file.write`. The
+`/api/permissions` REST router's own management operations (`revoke_permission` /
+`clear_permissions`, `interfaces/web/routers/permissions.py`) are a SECOND, direct writer
+(`_save`, a raw `path.write_text`) — write-gating does not apply to `approvals.yaml` the way
+it applies to `config/`/`state/` (there is no dedicated-op enforcement mechanism for a
+top-level *persist* file), so this second writer is legitimate, not a violation. What it must
+not do is write silently: each REST route above emits its own audit-event
+(`permission_approval_revoked` / `permission_approvals_cleared`, #5065) alongside the raw
+write, so `approvals.yaml`'s permission-shape changes stay observable through
+`.reyn/events` regardless of which of the two writers made them. `memory/`, `cache/`, and
 other non-recovery-core `.reyn/` paths are ordinary writable zones.
 
 ## Where does a new subsystem put its data?

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -85,6 +85,18 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # record at the top of this module before touching it.
     "permission_granted": frozenset({"run_id", "actor", "phase"}),
     "permission_denied": frozenset({"run_id", "actor", "phase"}),
+    # #5065: a management operation on the SAVED-approvals store
+    # (.reyn/approvals.yaml, permissions.py's REST router), not an in-run
+    # permission decision — a different event from permission_granted/
+    # permission_denied above (which ARE in-run, hence run_id/actor/phase).
+    # This happens outside any run, so it carries no run_id/actor/phase —
+    # fabricating those would violate the band's "reconstructible", not
+    # "fields present", requirement (architect ruling, #5065). Two typed
+    # kinds rather than one kind + an "operation" string field, because
+    # their answerable fields genuinely differ (a single revoke names the
+    # key it removed; a bulk clear has no single key to name).
+    "permission_approval_revoked": frozenset({"key", "surface"}),
+    "permission_approvals_cleared": frozenset({"count", "surface"}),
     # User intervention (op_runtime/ask_user.py)
     "user_intervention_requested": frozenset({"run_id", "actor", "intervention_id"}),
     "user_intervention_received": frozenset({"run_id", "actor", "intervention_id"}),
@@ -337,6 +349,8 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "peer_reply_failed_surfaced",
     "pending_intervention_claimed",
     "pending_intervention_discarded",
+    "permission_approval_revoked",
+    "permission_approvals_cleared",
     "permission_denied",
     "permission_granted",
     "pipeline_install_skipped",
@@ -458,6 +472,10 @@ KIND_EMIT_SEAMS: dict[str, str | None] = {
     # ``emit_cli_event(kind, **payload)`` — audit emit from a CLI entry point
     # that has no session (writes to ``.reyn/events/direct/cli``).
     "emit_cli_event": None,
+    # ``emit_direct_event(kind, *, surface, reyn_root, **payload)`` (#5065) —
+    # the general "no live Session" seam ``emit_cli_event`` above is a thin
+    # wrapper over; writes to ``.reyn/events/direct/<surface>``.
+    "emit_direct_event": None,
     # ``Session.emit_audit_event(event_type, **data)`` — the narrow public seam
     # the AG-UI transport records surface-lifecycle attribution through.
     "emit_audit_event": None,
@@ -539,11 +557,25 @@ DYNAMIC_KIND_EMIT_SITES: tuple[DynamicEmitSite, ...] = (
     DynamicEmitSite(
         module="src/reyn/core/events/events.py",
         function="emit_cli_event",
+        seam="emit_direct_event",
+        classification="FORWARDER",
+        reason=(
+            "``emit_cli_event`` is itself a registered seam (#5065: now a thin "
+            "wrapper over ``emit_direct_event``); its own call sites pass "
+            "literal kinds and are censused there."
+        ),
+    ),
+    DynamicEmitSite(
+        module="src/reyn/core/events/events.py",
+        function="emit_direct_event",
         seam="emit",
         classification="FORWARDER",
         reason=(
-            "``emit_cli_event`` is itself a registered seam; its own call sites "
-            "pass literal kinds and are censused there."
+            "#5065: ``emit_direct_event`` is itself a registered seam (the "
+            "general 'no live Session' emit path ``emit_cli_event`` above "
+            "wraps); its own callers (``emit_cli_event`` and, e.g., the "
+            "``/api/permissions`` REST router) pass literal kinds and are "
+            "censused there."
         ),
     ),
     DynamicEmitSite(

--- a/src/reyn/core/events/events.py
+++ b/src/reyn/core/events/events.py
@@ -830,52 +830,81 @@ def _find_reyn_dir(start: Path) -> Path | None:
         current = parent
 
 
-def emit_cli_event(kind: str, **payload) -> None:
-    """Emit a one-off P6 event from a CLI context (no active session).
+def emit_direct_event(
+    kind: str,
+    *,
+    surface: str,
+    reyn_root: Path,
+    track_audit_seq: bool = True,
+    **payload,
+) -> None:
+    """Emit a one-off P6 audit event from a context with no live ``Session``
+    (#5065: generalizes the #4496 CLI-only seam below — a REST/web mutation
+    has the same "no Session to call ``emit_audit_event`` through" shape a
+    CLI command does; ``.reyn/events`` is a workspace-plane concern
+    (band: workspace-SSoT), and ``Session`` is a convenience layered on top
+    of it, not its owner).
 
-    Routes to ``.reyn/events/direct/cli/<YYYY-MM-DD>.jsonl``. Locates the
-    ``.reyn/`` dir by walking up from ``Path.cwd()``. If no ``.reyn/``
-    directory is found, logs a warning and returns silently — the caller's
-    operation is the primary action; audit-emit failure must not propagate.
+    Routes to ``<reyn_root>/events/direct/<surface>/<YYYY-MM-DD>.jsonl``.
+    ``reyn_root`` (the ``.reyn/`` dir itself) is supplied by the caller —
+    this function does no cwd-based discovery of its own. A long-lived
+    server process's cwd is not reliably its project root (the same
+    cwd-anchor hazard ``permissions.py`` already fixed once, #2415); a
+    caller that has a resolved project root (e.g. a FastAPI route's
+    ``get_project_root`` dependency) must pass it through explicitly
+    rather than let this function re-derive it from ``Path.cwd()``.
+
+    ``track_audit_seq`` defaults to ``True`` (a series assumption) — pass
+    ``False`` only for a genuinely one-shot-per-process caller. #4496's
+    "omit audit_seq, a single event isn't a series a gap can be detected
+    in" ruling was scoped to that one-shot CLI shape specifically; it does
+    not generalize to a long-lived surface (e.g. a web server) that emits
+    many events from the same process — those DO form a series.
 
     The file is appended to (P6 append-only contract). Dir creation is
-    idempotent (``mkdir(parents=True, exist_ok=True)``).
+    idempotent (``mkdir(parents=True, exist_ok=True)``). If ``reyn_root``
+    does not exist, logs a warning and returns silently — the caller's
+    operation is the primary action; audit-emit failure must not
+    propagate.
+
+    ``surface`` is stamped into the emitted event's own payload (a
+    ``"surface"`` field, deterministic — a caller-supplied ``surface`` key
+    in ``**payload`` is overwritten, never merged), not just used for the
+    ``EventLog``'s ``emitter`` label — the latter is not treated as a
+    per-kind schema field by the census/vocabulary tooling, so a kind that
+    declares ``surface`` as required (e.g. #5065's
+    ``permission_approval_revoked``) needs it as real payload data.
     """
     from reyn.core.events.event_store import EventStore
 
-    reyn_dir = _find_reyn_dir(Path.cwd())
-    if reyn_dir is None:
+    reyn_root = Path(reyn_root)
+    if not reyn_root.is_dir():
         logger.warning(
-            "emit_cli_event: no .reyn/ directory found from %s; "
-            "skipping P6 audit emit for event %r",
-            Path.cwd(),
+            "emit_direct_event: %s does not exist; skipping P6 audit emit "
+            "for event %r",
+            reyn_root,
             kind,
         )
         return
 
-    cli_dir = reyn_dir / "events" / "direct" / "cli"
+    event_dir = reyn_root / "events" / "direct" / surface
     today = date.today().isoformat()  # YYYY-MM-DD
-    # Use a date-named suffix so each day's CLI events land in one predictable file.
+    # Use a date-named suffix so each day's events land in one predictable file.
     # max_bytes=0 / max_age_seconds=0 disables rotation — the suffix IS the date.
-    store = EventStore(cli_dir, max_bytes=0, max_age_seconds=0, suffix=f"_{today}")
-    # #4496 PR-1: a one-off CLI event has no continuity to protect — a
-    # single event from a single process is not a series a gap can be
-    # detected in, so audit_seq is omitted entirely (architect's ruling)
-    # rather than always stamping a meaningless `1`. `emitter="cli"` is a
-    # legible label (not a random per-instance token — nothing needs to
-    # distinguish one CLI invocation's emitter from another's, since
-    # neither carries a sequence to compare).
+    store = EventStore(event_dir, max_bytes=0, max_age_seconds=0, suffix=f"_{today}")
     # #4966 (architect ruling, found via CI): this EventLog has no owner
     # who will ever call `drain()`/`stop_dispatch()` on it — the function
     # returns right after the one `emit()` call, nothing holds a
     # reference afterward. `_force_inline=True` declares that explicitly
     # rather than letting the mechanism GUESS it from "no loop is running"
     # (a guess that fails silently the moment a loop DOES happen to be
-    # running around this call site, e.g. `emit_cli_event` invoked
+    # running around this call site, e.g. this function invoked
     # synchronously from inside an async caller). This is the ONE
     # sanctioned call site for `_force_inline` — see `EventLog.__init__`'s
     # own docstring for why it stays private and single-site, and the
-    # bounding test that enforces exactly that.
+    # bounding test that enforces exactly that (every direct-event caller
+    # below routes through THIS one construction, not a construction of
+    # its own).
     # Without it: a spawned-but-never-drained consumer task gets silently
     # abandoned, and when the loop eventually tears down, asyncio reports
     # it as its OWN "Task was destroyed but it is pending!" unhandled-
@@ -885,6 +914,39 @@ def emit_cli_event(kind: str, **payload) -> None:
     # test_durable_capture_survives_prompt_toolkit_prompt_wait's own
     # `[event] = events` unpack going from 1 to 2 elements).
     event_log = EventLog(
-        subscribers=[store], emitter="cli", track_audit_seq=False, _force_inline=True,
+        subscribers=[store], emitter=surface, track_audit_seq=track_audit_seq,
+        _force_inline=True,
     )
-    event_log.emit(kind, **payload)
+    # Stamp `surface` into the payload itself too (not just the EventLog's
+    # own `emitter` label, which the census/schema tooling does not treat
+    # as a per-kind field) -- deterministic, not caller-wins, so a stray
+    # caller-supplied `surface` key can never silently diverge from the
+    # directory this event actually landed under.
+    event_log.emit(kind, **{**payload, "surface": surface})
+
+
+def emit_cli_event(kind: str, **payload) -> None:
+    """Emit a one-off P6 event from a CLI context (no active session).
+
+    Thin wrapper over :func:`emit_direct_event`: ``surface="cli"``,
+    ``reyn_root`` located by walking up from ``Path.cwd()`` (a CLI process's
+    cwd IS a reasonable project-root anchor, unlike a long-lived server's —
+    see that function's own docstring), ``track_audit_seq=False`` (#4496
+    PR-1: a one-off CLI event has no continuity to protect — a single event
+    from a single process is not a series a gap can be detected in, so
+    audit_seq is omitted entirely, architect's ruling, rather than always
+    stamping a meaningless ``1``). If no ``.reyn/`` directory is found,
+    logs a warning and returns silently (see :func:`emit_direct_event`).
+    """
+    reyn_dir = _find_reyn_dir(Path.cwd())
+    if reyn_dir is None:
+        logger.warning(
+            "emit_cli_event: no .reyn/ directory found from %s; "
+            "skipping P6 audit emit for event %r",
+            Path.cwd(),
+            kind,
+        )
+        return
+    emit_direct_event(
+        kind, surface="cli", reyn_root=reyn_dir, track_audit_seq=False, **payload,
+    )

--- a/src/reyn/core/events/events.py
+++ b/src/reyn/core/events/events.py
@@ -865,7 +865,11 @@ def emit_direct_event(
     idempotent (``mkdir(parents=True, exist_ok=True)``). If ``reyn_root``
     does not exist, logs a warning and returns silently — the caller's
     operation is the primary action; audit-emit failure must not
-    propagate.
+    propagate. This makes the guarantee best-effort, not just here but at
+    the underlying ``EventStore.write`` too (its own per-subscriber
+    isolation logs and swallows rather than raises) — a caller's primary
+    write can succeed while its audit record silently does not; there is
+    no separate signal distinguishing that case from "nothing happened."
 
     ``surface`` is stamped into the emitted event's own payload (a
     ``"surface"`` field, deterministic — a caller-supplied ``surface`` key

--- a/src/reyn/interfaces/web/routers/permissions.py
+++ b/src/reyn/interfaces/web/routers/permissions.py
@@ -18,9 +18,16 @@ import yaml
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from pydantic import BaseModel
 
+from reyn.core.events.events import emit_direct_event
 from reyn.interfaces.web.deps import get_project_root
 
 router = APIRouter(tags=["permissions"])
+
+# #5065: the audit-event surface label — both the ``emit_direct_event`` seam's
+# own directory/emitter axis (``.reyn/events/direct/web/``) AND the payload's
+# ``surface`` field (part of the new kinds' required fields below) are stamped
+# from this ONE constant, so the two never drift apart.
+_SURFACE = "web"
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -80,7 +87,13 @@ async def revoke_permission(
     key: str,
     project_root: Path = Depends(get_project_root),
 ) -> None:
-    """Revoke a single approval entry by its key."""
+    """Revoke a single approval entry by its key.
+
+    #5065: this is a management operation on the SAVED-approvals store, not
+    an in-run permission decision — ``_save`` below is a raw write with no
+    audit trail of its own (unlike the security-side ``_persist`` flow),
+    so this route emits the audit-event itself, naming the revoked key.
+    """
     data = _load(project_root)
     if key not in data:
         raise HTTPException(
@@ -89,6 +102,12 @@ async def revoke_permission(
         )
     del data[key]
     _save(data, project_root)
+    emit_direct_event(
+        "permission_approval_revoked",
+        surface=_SURFACE,
+        reyn_root=project_root / ".reyn",
+        key=key,
+    )
 
 
 @router.delete("/permissions", status_code=status.HTTP_204_NO_CONTENT)
@@ -96,10 +115,22 @@ async def clear_permissions(
     confirm: bool = Body(default=False, embed=True),
     project_root: Path = Depends(get_project_root),
 ) -> None:
-    """Clear all saved approvals. Requires body: {\"confirm\": true}."""
+    """Clear all saved approvals. Requires body: {\"confirm\": true}.
+
+    #5065: same audit gap as :func:`revoke_permission` above — a bulk clear
+    has no single key to name, so the audit-event carries the count of
+    entries actually cleared instead.
+    """
     if not confirm:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Pass {\"confirm\": true} in the request body to clear all approvals.",
         )
+    count = len(_load(project_root))
     _save({}, project_root)
+    emit_direct_event(
+        "permission_approvals_cleared",
+        surface=_SURFACE,
+        reyn_root=project_root / ".reyn",
+        count=count,
+    )

--- a/src/reyn/interfaces/web/routers/permissions.py
+++ b/src/reyn/interfaces/web/routers/permissions.py
@@ -93,6 +93,9 @@ async def revoke_permission(
     an in-run permission decision — ``_save`` below is a raw write with no
     audit trail of its own (unlike the security-side ``_persist`` flow),
     so this route emits the audit-event itself, naming the revoked key.
+    Best-effort: the emit runs AFTER ``_save`` and swallows its own failure
+    (see ``emit_direct_event``'s docstring) — the write always lands, but on
+    an emit failure the audit trail does not record it.
     """
     data = _load(project_root)
     if key not in data:
@@ -119,7 +122,8 @@ async def clear_permissions(
 
     #5065: same audit gap as :func:`revoke_permission` above — a bulk clear
     has no single key to name, so the audit-event carries the count of
-    entries actually cleared instead.
+    entries actually cleared instead. Same best-effort scope as that route:
+    the emit runs after ``_save`` and swallows its own failure.
     """
     if not confirm:
         raise HTTPException(

--- a/tests/web/test_5065_permissions_router_emits_audit_event.py
+++ b/tests/web/test_5065_permissions_router_emits_audit_event.py
@@ -33,8 +33,18 @@ _WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 
-fastapi = pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
-httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
+# fastapi is a core dependency since #5051 (pyproject.toml's `dependencies`,
+# no marker) -- an importorskip here would be exactly the silent-skip-on-a-
+# broken-install shape #5058 closed (architect ruling, found reviewing this
+# PR: the correct behavior on a genuinely broken install is red, not a
+# skip). Hard import.
+import fastapi  # noqa: F401
+
+# httpx is NOT yet a declared dependency (that's #5059's own content) --
+# this importorskip is legitimate today. Remove it the same PR #5059 lands
+# (declaring httpx would make this the same #5058-class violation as the
+# fastapi guard above).
+httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient; remove this guard when #5059 declares httpx as a dependency)")
 
 
 @pytest.fixture()

--- a/tests/web/test_5065_permissions_router_emits_audit_event.py
+++ b/tests/web/test_5065_permissions_router_emits_audit_event.py
@@ -1,0 +1,161 @@
+"""Tier 2: #5065 — the ``/api/permissions`` REST router's own management
+operations (revoke a single approval, clear all approvals) each emit a
+P6 audit-event, closing the band violation (permission x audit-events)
+this issue names: ``.reyn/approvals.yaml`` had two writers (the
+security-side ``_persist`` flow, which journals, and this router's own
+``_save``, a raw ``path.write_text`` with no audit trail of its own) and
+only one of them was observable through ``.reyn/events``.
+
+Real FastAPI TestClient + a real on-disk ``.reyn/`` tree throughout — no
+mocks. Witness reads the actual ``.reyn/events/`` files this PR's new
+``emit_direct_event`` seam writes (mirrors ``emit_cli_event``'s own
+``.reyn/events/direct/cli/`` shape, generalized to
+``.reyn/events/direct/<surface>/`` — here ``surface="web"``).
+
+Strip-falsifier for each witness: comment out the corresponding
+``emit_direct_event(...)`` call in ``routers/permissions.py`` — the
+route still returns 204 (the write itself is untouched) but no new
+``.reyn/events`` file/line appears, turning the witness red.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+from tests._support.paths import REPO_ROOT
+
+_WORKTREE_SRC = REPO_ROOT / "src"
+if str(_WORKTREE_SRC) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE_SRC))
+
+fastapi = pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
+
+
+@pytest.fixture()
+def tmp_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Same fixture shape as ``test_4482_get_artifact_by_ref.py``'s own — a
+    minimal Reyn project, deps cleared, cwd chdir'd."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir(parents=True)
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+
+    import reyn.interfaces.web.deps as deps
+    deps._get_project_root.cache_clear()
+    deps._load_config.cache_clear()
+    deps._state_log = None
+    deps._budget_tracker = None
+    deps._perm_resolver = None
+    deps._registry = None
+
+    monkeypatch.setattr("reyn.config._find_project_root", lambda _cwd: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    yield tmp_path
+
+    deps._get_project_root.cache_clear()
+    deps._load_config.cache_clear()
+    deps._state_log = None
+    deps._budget_tracker = None
+    deps._perm_resolver = None
+    deps._registry = None
+
+
+def _client():
+    from reyn.interfaces.web.server import app
+    from tests._support.web_auth import local_operator_client
+    return local_operator_client(app, raise_server_exceptions=False)
+
+
+def _seed_approval(tmp_project: Path, key: str, approved: bool = True) -> None:
+    path = tmp_project / ".reyn" / "approvals.yaml"
+    data = {}
+    if path.exists():
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    data[key] = approved
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+
+def _read_direct_web_events(tmp_project: Path) -> list[dict]:
+    """Read every event line under .reyn/events/direct/web/ (this PR's new
+    ``surface="web"`` directory — mirrors ``emit_cli_event``'s own
+    ``direct/cli/`` shape, see that seam's own docstring)."""
+    web_dir = tmp_project / ".reyn" / "events" / "direct" / "web"
+    if not web_dir.is_dir():
+        return []
+    out: list[dict] = []
+    for f in sorted(web_dir.glob("*/*.jsonl")):  # month-dir nesting, see EventStore._open_new_file
+        for line in f.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+# ── witness ① — revoke_permission ─────────────────────────────────────────
+
+
+def test_revoke_permission_emits_one_audit_event_naming_the_key(tmp_project: Path):
+    """Tier 2: DELETE /api/permissions/{key} once -> exactly one new
+    ``.reyn/events`` entry, naming the REVOKED key (not just "one more
+    event appeared" -- a count-only witness is blind to a mismatched key,
+    per lead-coder's own strengthening of this issue's accept criterion)."""
+    _seed_approval(tmp_project, "chat_router/http.get/example.com")
+    assert _read_direct_web_events(tmp_project) == []
+
+    response = _client().delete("/api/permissions/chat_router%2Fhttp.get%2Fexample.com")
+    assert response.status_code == 204, response.text
+
+    events = _read_direct_web_events(tmp_project)
+    assert events, "expected an audit event, got none"
+    assert events[1:] == [], f"expected exactly one audit event, got {events}"
+    assert events[0]["type"] == "permission_approval_revoked"
+    assert events[0]["data"]["key"] == "chat_router/http.get/example.com"
+    assert events[0]["data"]["surface"] == "web"
+
+    # The write itself is unaffected by the audit addition -- approvals.yaml
+    # no longer carries the revoked key.
+    saved = yaml.safe_load(
+        (tmp_project / ".reyn" / "approvals.yaml").read_text(encoding="utf-8")
+    ) or {}
+    assert "chat_router/http.get/example.com" not in saved
+
+
+# ── witness ② — clear_permissions ─────────────────────────────────────────
+
+
+def test_clear_permissions_emits_one_audit_event_with_the_cleared_count(
+    tmp_project: Path,
+):
+    """Tier 2: DELETE /api/permissions (bulk clear) also emits an
+    audit-event -- lead-coder's explicit strengthening: "clear_permissions
+    must carry the SAME witness -- a form where only one of the two
+    writers is structurally impossible." No single key to name for a bulk
+    clear, so the event carries the count of entries actually cleared."""
+    _seed_approval(tmp_project, "chat_router/http.get/a.example.com")
+    _seed_approval(tmp_project, "chat_router/http.get/b.example.com")
+    assert _read_direct_web_events(tmp_project) == []
+
+    response = _client().request(
+        "DELETE", "/api/permissions", json={"confirm": True},
+    )
+    assert response.status_code == 204, response.text
+
+    events = _read_direct_web_events(tmp_project)
+    assert events, "expected an audit event, got none"
+    assert events[1:] == [], f"expected exactly one audit event, got {events}"
+    assert events[0]["type"] == "permission_approvals_cleared"
+    assert events[0]["data"]["count"] == 2
+    assert events[0]["data"]["surface"] == "web"
+
+    saved = yaml.safe_load(
+        (tmp_project / ".reyn" / "approvals.yaml").read_text(encoding="utf-8")
+    ) or {}
+    assert saved == {}


### PR DESCRIPTION
**[e2e-coder]** — part of #5047 — band violation: permission x audit-events (#5065, architect ruling).

## Root cause

`.reyn/approvals.yaml` had two writers: the security-side permission-approval flow (`_persist`, journals) and `interfaces/web/routers/permissions.py`'s own `revoke_permission`/`clear_permissions` (`_save`, a raw `path.write_text`, no audit trail). Only one was observable through `.reyn/events`.

**Why nobody wrote it** (architect measurement, verified independently): the only existing audit-emit seam reachable without a live `Session` is `Session.emit_audit_event` itself; a REST `DELETE` has no `Session`, and the existing `permission_granted`/`permission_denied` kinds require `run_id`/`actor`/`phase` (in-run scoped, `event_schema.py:86-87`) which a REST DELETE has none of. There was no door, not neglect.

## Fix (architect ruling — seam and kind both)

- `events.py`: `emit_cli_event`'s own EventStore/EventLog construction generalized into a new `emit_direct_event(kind, *, surface, reyn_root, track_audit_seq=True, **payload)` seam. `emit_cli_event` becomes a thin `surface="cli"` wrapper — unchanged behavior/call sites. Reachable from `project_root`, never `Session` (`.reyn/events` is workspace-SSoT plane; `Session` is a convenience layered on top, not the owner). `track_audit_seq` defaults `True` here — #4496's audit_seq-omission ruling was scoped to CLI's genuine one-shot-per-process shape, which does not generalize to a long-lived web server emitting many events from the same process (those form a real series).
- `event_schema.py`: two new **typed** kinds (not one kind + an `operation` string — their answerable fields genuinely differ): `permission_approval_revoked` `{key, surface}` / `permission_approvals_cleared` `{count, surface}`. No `run_id`/`actor`/`phase` — fabricating them would violate the band's *reconstructible* requirement, not satisfy it.
- `permissions.py`: both routes emit their event right after `_save`.
- `reyn-dir-layout.md:213`: fixed the stale "approvals.yaml is written only via the permission-approval flow, never a raw `file.write`" claim (docs-maintainer's audit HIT) — `_save` always was a second raw writer; what changes here is that it's no longer *silent*. Re-read the whole write-gate section, not just the one line.

## Witnesses (lead-coder's strengthened accept criterion)

Not just "one more event appeared" (blind to a mismatched key):
- revoke: `DELETE /api/permissions/{key}` once → exactly one new `.reyn/events` entry, naming the **revoked key**.
- clear: `DELETE /api/permissions` (bulk) → exactly one new entry, carrying the **count** of entries actually cleared.

Both **strip-verified**: commenting out the `emit_direct_event` call at either route turns its own witness red (confirmed for the right reason — the write itself still succeeds, only the audit-event is missing); restored, both green.

## Population note — arc-closure remainder (architect's `@router.(delete|patch)` census, 6 sites)

The other 4 sites (permissions.py's own 2 are this PR):
- `agents.py:103`, `topologies.py:112`, `topologies.py:151` — **not gaps**. Verified directly: `AgentRegistry.archive_agent`/`delete_topology`/`add_topology_member`/`remove_topology_member` already emit `agent_archived`/`agent_purged`/`topology_removed`/`topology_updated` through the existing #2103 seam. False positives of the grep pattern.
- `budget.py:100` (`PATCH /api/budget/caps`) — **genuine gap, filed as #5067**. Per lead-coder's pre-ruling, cost/budget is its own band member and not subject to the arc's count threshold, so this could not be dropped.

No remainder left silent (arc-closure remainder rule).

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/web/test_5065_permissions_router_emits_audit_event.py`
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py` (re-run right before push)
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → `check_doc_anchors.py` → `check_retired_config_keys_denylist.py`
- [x] Scoped pytest (audit-event vocabulary + #4496 + this PR's own tests + related pipeline/asyncio-diagnostics `emit_cli_event` consumers, all green), strip-falsify verified for both witnesses
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- [x] 🔴 **[architect] BLOCK（解除 2026-08-22 issuecomment-5377782646） — `pytest.importorskip("fastapi")` は core dep（pyproject:302、`dependencies` 内・marker 無し）への skip で、#5058 の裁定に当たる（#5062 が今夜消した形）。`issuecomment-5377718xxx`**