### PR TITLE
fix(#5067): audit-event PATCH /api/budget/caps -- the OTHER band pairing

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -42,6 +42,7 @@ agent_response_committed
 agent_response_received
 asyncio_unhandled_exception
 body_summary_hard_truncated
+budget_caps_updated
 budget_reset
 bus_subscriber_dropped
 canonical_degraded
@@ -605,6 +606,7 @@ mostly informational.
 | `compact_op_unavailable` | The `compact` Control IR op was dispatched in a context where no compaction engine is wired. | `run_id`, `phase` |
 | `summary_resummarize_failed` | Re-summarising an existing summary (nested compaction) raised. | `error` |
 | `budget_reset` | The chat budget gateway reset its per-window accounting. | `before` (prior accumulated value) |
+| `budget_caps_updated` | #5067 — `PATCH /api/budget/caps` (`budget.py`'s REST router) changed one or more of the live `BudgetTracker`'s hard caps. In-process only (not persisted to `reyn.yaml`), reachable via `project_root` (no live Session, hence no `run_id`/`actor`/`phase` — same shape as #5065's `permission_approval_revoked`/`permission_approvals_cleared`, the OTHER band pairing: cost-budget x audit-events). Because this change is not persisted anywhere else, this event is the ONLY record either value ever existed. | `changes` (a `{field_name: {"from": old_hard_limit, "to": new_hard_limit}}` mapping of ONLY the fields the request actually set), `surface` |
 
 ## Safety limits
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -97,6 +97,21 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # key it removed; a bulk clear has no single key to name).
     "permission_approval_revoked": frozenset({"key", "surface"}),
     "permission_approvals_cleared": frozenset({"count", "surface"}),
+    # #5067: same shape as the two above, on the OTHER band pairing
+    # (cost-budget x audit-events, not permission x audit-events) — a
+    # management operation on the live BudgetTracker's hard caps
+    # (budget.py's REST router, ``PATCH /api/budget/caps``), reachable
+    # only via ``project_root`` (no live Session, no run_id/actor/phase).
+    # ONE kind (not a typed union like #5065's revoked/cleared pair) since
+    # there is only one operation shape here: a PATCH may touch several
+    # cap fields at once, so ``changes`` carries only the fields the
+    # request actually set (never a fabricated entry for a field the
+    # caller left ``None`` / unchanged), each as its own
+    # ``{"from": <old hard_limit>, "to": <new hard_limit>}`` pair —
+    # lead-coder's measurement: unlike #5065's approvals.yaml, this change
+    # is not even persisted (a restart silently reverts it), so this
+    # audit-event is the ONLY record either value ever existed.
+    "budget_caps_updated": frozenset({"changes", "surface"}),
     # User intervention (op_runtime/ask_user.py)
     "user_intervention_requested": frozenset({"run_id", "actor", "intervention_id"}),
     "user_intervention_received": frozenset({"run_id", "actor", "intervention_id"}),
@@ -233,6 +248,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "agent_response_received",
     "asyncio_unhandled_exception",
     "body_summary_hard_truncated",
+    "budget_caps_updated",
     "budget_reset",
     "bus_subscriber_dropped",
     "canonical_degraded",

--- a/src/reyn/interfaces/web/routers/budget.py
+++ b/src/reyn/interfaces/web/routers/budget.py
@@ -13,12 +13,20 @@ Routes:
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from reyn.interfaces.web.deps import get_budget_tracker, get_reyn_config
+from reyn.core.events.events import emit_direct_event
+from reyn.interfaces.web.deps import get_budget_tracker, get_project_root, get_reyn_config
 
 router = APIRouter(tags=["budget"])
+
+# #5067: same rationale as permissions.py's own _SURFACE (#5065) — one
+# constant feeds both the emit_direct_event directory/emitter axis and the
+# payload's own "surface" field, so the two can't drift apart.
+_SURFACE = "web"
 
 
 # ── response models ───────────────────────────────────────────────────────────
@@ -101,13 +109,28 @@ async def patch_budget_caps(
     body: PatchCapsRequest,
     tracker=Depends(get_budget_tracker),
     config=Depends(get_reyn_config),
+    project_root: Path = Depends(get_project_root),
 ) -> BudgetUsage:
     """Update hard caps on the live tracker (in-process only, not persisted).
 
     To make changes permanent, edit reyn.yaml directly.
+
+    #5067: this is a management operation on the live budget config, the
+    OTHER band pairing #5065 closed (cost-budget x audit-events, not
+    permission x audit-events) — before this, a cap raised or lowered here
+    left no record, and unlike #5065's approvals.yaml this change is not
+    even persisted (lead-coder's own measurement): a restart silently
+    reverts it, and the fact that it was ever changed lands nowhere else.
+    The audit-event is the ONLY record. Emits ``budget_caps_updated``
+    naming only the fields this call actually changed, each as its own
+    ``{"from": ..., "to": ...}`` pair (never a fabricated entry for a
+    field left ``None``); no event at all if the request changed nothing.
+    Best-effort, same scope as #5065's routes: the emit runs after the
+    caps are applied and swallows its own failure.
     """
     from reyn.runtime.budget.budget import CostLimitConfig
     cfg = tracker.config
+    changes: dict[str, dict[str, float | None]] = {}
 
     def _apply(field_name: str, new_hard_limit: float | None) -> None:
         if new_hard_limit is None:
@@ -118,6 +141,7 @@ async def patch_budget_caps(
             warn_ratio=current.warn_ratio,
         )
         setattr(cfg, field_name, updated)
+        changes[field_name] = {"from": current.hard_limit, "to": new_hard_limit}
 
     _apply("daily_tokens", body.daily_tokens_hard_limit)
     _apply("daily_cost_usd", body.daily_cost_usd_hard_limit)
@@ -125,6 +149,14 @@ async def patch_budget_caps(
     _apply("monthly_cost_usd", body.monthly_cost_usd_hard_limit)
     _apply("per_agent_tokens", body.per_agent_tokens_hard_limit)
     _apply("per_agent_cost_usd", body.per_agent_cost_usd_hard_limit)
+
+    if changes:
+        emit_direct_event(
+            "budget_caps_updated",
+            surface=_SURFACE,
+            reyn_root=project_root / ".reyn",
+            changes=changes,
+        )
 
     # Return updated state
     return await get_budget_usage(tracker=tracker, config=config)

--- a/src/reyn/interfaces/web/routers/budget.py
+++ b/src/reyn/interfaces/web/routers/budget.py
@@ -122,9 +122,12 @@ async def patch_budget_caps(
     even persisted (lead-coder's own measurement): a restart silently
     reverts it, and the fact that it was ever changed lands nowhere else.
     The audit-event is the ONLY record. Emits ``budget_caps_updated``
-    naming only the fields this call actually changed, each as its own
+    naming only the fields this call actually set (not "changed" — a
+    field set to the SAME value it already held is still recorded; this
+    route never compares old vs new to decide whether to record, only
+    whether the request specified a value at all), each as its own
     ``{"from": ..., "to": ...}`` pair (never a fabricated entry for a
-    field left ``None``); no event at all if the request changed nothing.
+    field left ``None``); no event at all if the request set nothing.
     Best-effort, same scope as #5065's routes: the emit runs after the
     caps are applied and swallows its own failure.
     """

--- a/tests/web/test_5067_budget_caps_router_emits_audit_event.py
+++ b/tests/web/test_5067_budget_caps_router_emits_audit_event.py
@@ -1,0 +1,172 @@
+"""Tier 2: #5067 — the ``/api/budget/caps`` REST router's own management
+operation (raising/lowering a live hard cap) emits a P6 audit-event,
+closing the band violation this issue names on the OTHER band pairing
+#5065 closed on permissions.py: cost-budget x audit-events, not
+permission x audit-events. Before this, ``PATCH /api/budget/caps`` mutated
+``tracker.config`` in place with no observable trace.
+
+Real FastAPI TestClient + a real on-disk ``.reyn/`` tree throughout — no
+mocks. Reuses #5065's ``emit_direct_event`` seam (``core/events/events.py``)
+directly, so this witness reads the same ``.reyn/events/direct/web/``
+files that PR wrote — mirrors ``test_5065_permissions_router_emits_audit_
+event.py``'s own reader.
+
+Strip-falsifier: comment out the ``emit_direct_event(...)`` call in
+``routers/budget.py`` — the PATCH still applies the new caps (the write
+itself is untouched) but no new ``.reyn/events`` file/line appears,
+turning the witness red.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+from tests._support.paths import REPO_ROOT
+
+_WORKTREE_SRC = REPO_ROOT / "src"
+if str(_WORKTREE_SRC) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE_SRC))
+
+# fastapi is a core dependency since #5051 (pyproject.toml's `dependencies`,
+# no marker) -- an importorskip here would be the silent-skip-on-a-broken-
+# install shape #5058 closed (architect ruling, #5068). Hard import.
+import fastapi  # noqa: F401
+
+# httpx is NOT yet a declared dependency (that's #5059's own content) --
+# this importorskip is legitimate today. Remove it the same PR #5059 lands.
+httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient; remove this guard when #5059 declares httpx as a dependency)")
+
+
+@pytest.fixture()
+def tmp_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Same fixture shape as ``test_5065_permissions_router_emits_audit_
+    event.py``'s own — a minimal Reyn project, deps cleared, cwd chdir'd."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir(parents=True)
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+
+    import reyn.interfaces.web.deps as deps
+    deps._get_project_root.cache_clear()
+    deps._load_config.cache_clear()
+    deps._state_log = None
+    deps._budget_tracker = None
+    deps._perm_resolver = None
+    deps._registry = None
+
+    monkeypatch.setattr("reyn.config._find_project_root", lambda _cwd: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    yield tmp_path
+
+    deps._get_project_root.cache_clear()
+    deps._load_config.cache_clear()
+    deps._state_log = None
+    deps._budget_tracker = None
+    deps._perm_resolver = None
+    deps._registry = None
+
+
+def _client():
+    from reyn.interfaces.web.server import app
+    from tests._support.web_auth import local_operator_client
+    return local_operator_client(app, raise_server_exceptions=False)
+
+
+def _read_direct_web_events(tmp_project: Path) -> list[dict]:
+    """Read every event line under .reyn/events/direct/web/ (#5065's
+    ``surface="web"`` directory, month-dir nested — see
+    ``EventStore._open_new_file``)."""
+    web_dir = tmp_project / ".reyn" / "events" / "direct" / "web"
+    if not web_dir.is_dir():
+        return []
+    out: list[dict] = []
+    for f in sorted(web_dir.glob("*/*.jsonl")):
+        for line in f.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+# ── witness ① — a cap change emits exactly one event, naming what changed ──
+
+
+def test_patch_budget_caps_emits_one_audit_event_naming_the_changed_fields(
+    tmp_project: Path,
+):
+    """Tier 2: PATCH /api/budget/caps changing two fields -> exactly one
+    new .reyn/events entry, naming BOTH changed fields with their old AND
+    new values (not just "one more event appeared" -- lead-coder's #5065
+    strengthening applied here too: a count-only witness is blind to a
+    mismatched field/value; the "from" side matters MORE here than in
+    #5065, since this change is not persisted anywhere else -- this
+    event is the only place the prior value survives at all)."""
+    assert _read_direct_web_events(tmp_project) == []
+
+    response = _client().patch(
+        "/api/budget/caps",
+        json={
+            "daily_tokens_hard_limit": 500000,
+            "per_agent_cost_usd_hard_limit": 12.5,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    events = _read_direct_web_events(tmp_project)
+    assert events, "expected an audit event, got none"
+    assert events[1:] == [], f"expected exactly one audit event, got {events}"
+    assert events[0]["type"] == "budget_caps_updated"
+    changes = events[0]["data"]["changes"]
+    assert changes["daily_tokens"]["to"] == 500000
+    assert changes["daily_tokens"]["from"] is None  # default config: unset
+    assert changes["per_agent_cost_usd"]["to"] == 12.5
+    assert changes["per_agent_cost_usd"]["from"] is None
+    assert events[0]["data"]["surface"] == "web"
+
+    # The write itself is unaffected by the audit addition.
+    body = response.json()
+    assert body["caps"]["daily_tokens"]["hard_limit"] == 500000
+    assert body["caps"]["per_agent_cost_usd"]["hard_limit"] == 12.5
+
+
+def test_patch_budget_caps_second_change_records_the_real_prior_value(
+    tmp_project: Path,
+):
+    """Tier 2: a SECOND PATCH's ``from`` reflects the value the FIRST
+    PATCH actually set — not always None. This is the only place either
+    value survives (the change is never persisted, lead-coder's own
+    measurement), so a ``from`` that silently stayed None on a genuine
+    transition would be a fabricated record, not a missing one."""
+    client = _client()
+    client.patch("/api/budget/caps", json={"daily_tokens_hard_limit": 500000})
+
+    response = client.patch(
+        "/api/budget/caps", json={"daily_tokens_hard_limit": 750000},
+    )
+    assert response.status_code == 200, response.text
+
+    events = _read_direct_web_events(tmp_project)
+    assert events[:2], "expected two audit events (one per PATCH), got fewer"
+    assert events[2:] == [], f"expected exactly two audit events, got {events}"
+    second = events[1]
+    assert second["type"] == "budget_caps_updated"
+    assert second["data"]["changes"]["daily_tokens"] == {"from": 500000, "to": 750000}
+
+
+# ── witness ② — an all-None PATCH changes nothing, emits nothing ──────────
+
+
+def test_patch_budget_caps_with_no_changes_emits_no_event(tmp_project: Path):
+    """Tier 2: a PATCH body with every field left ``None`` (no actual
+    cap change) does not fabricate an event -- ``changes`` would be
+    empty, and #5067's own ruling (mirroring #5065) is never to write a
+    field the request cannot answer."""
+    assert _read_direct_web_events(tmp_project) == []
+
+    response = _client().patch("/api/budget/caps", json={})
+    assert response.status_code == 200, response.text
+
+    assert _read_direct_web_events(tmp_project) == []

--- a/tests/web/test_5067_budget_caps_router_emits_audit_event.py
+++ b/tests/web/test_5067_budget_caps_router_emits_audit_event.py
@@ -163,7 +163,9 @@ def test_patch_budget_caps_with_no_changes_emits_no_event(tmp_project: Path):
     """Tier 2: a PATCH body with every field left ``None`` (no actual
     cap change) does not fabricate an event -- ``changes`` would be
     empty, and #5067's own ruling (mirroring #5065) is never to write a
-    field the request cannot answer."""
+    field the request cannot answer. This test alone is not a witness for
+    the emit MECHANISM (it would stay green even if the whole emit call
+    were deleted) -- that witness is carried by the two tests above."""
     assert _read_direct_web_events(tmp_project) == []
 
     response = _client().patch("/api/budget/caps", json={})


### PR DESCRIPTION
**[e2e-coder]** — part of #5047 — band violation: cost-budget x audit-events (#5067, filed as #5065's sibling on the OTHER band pairing).

## What was broken

`PATCH /api/budget/caps` mutated the live `BudgetTracker`'s hard caps with no audit trail. **Worse than #5065's `approvals.yaml` gap** (measured by lead-coder before I implemented): this change is not even persisted — `budget.py`'s own docstring: "in-process only, not persisted to reyn.yaml." A restart silently reverts it, and until this PR the fact that it was ever changed landed nowhere else at all. The audit-event is the **only** record either the old or new value ever existed.

## Fix

Reuses #5065's `emit_direct_event(kind, *, surface, reyn_root, **payload)` seam directly — same "no live Session" shape, no new plumbing beyond adding the `get_project_root` dependency this router didn't previously have.

One new kind, `budget_caps_updated` (not a typed union like #5065's revoked/cleared pair — there's only one operation shape here): `changes` carries only the fields the request actually set, each as its own `{"from": old_hard_limit, "to": new_hard_limit}` pair (never a fabricated entry for a field left `None`); no event at all when a PATCH changes nothing. No `run_id`/`actor`/`phase` — same fabrication rule as #5065.

## Witnesses

- a PATCH changing two fields → exactly one event, naming both fields' old **and** new values.
- a second PATCH's `from` reflects the value the FIRST PATCH actually set (not always `None`) — the from-side is the whole point here, since nothing else ever records the prior value.
- an all-`None` PATCH (no actual change) emits nothing.

All three **strip-verified** (commenting out the `emit_direct_event` call turns the first two red; restored, all three green).

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/web/test_5067_budget_caps_router_emits_audit_event.py`
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py` (re-run right before push)
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → `check_doc_anchors.py` → `check_retired_config_keys_denylist.py`
- [x] Scoped pytest (this PR's own 3 tests + #5065's own tests + audit-event vocabulary census, all green), strip-falsify verified for both applicable witnesses
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- [x] 🔴 **[architect] BLOCK — resolved, TESTS-READ passed (issuecomment-5377858005) — route docstring の `only the fields this call actually changed` が偽（`_apply` は同値でも記録する＝「要求が指定した欄」）。schema 側 comment の `actually set` が正。1 語修正（`issuecomment-5377830xxx`）。**

