### PR TITLE
fix(#5048 prep): total-delegation gate on ThreadedTransportProxy

### DIFF
--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -136,6 +136,16 @@ class ThreadedTransportProxy(ClientTransport):
     bound to the SAME registry the worker thread owns) called ON THE WORKER
     THREAD alongside every frame, whose result rides in
     :class:`_ThreadedSnapshot` for the caller thread to read.
+
+    Delegation is total and explicit: every public ``ClientTransport``
+    method is defined directly on THIS class's own body — never silently
+    inherited from ``ClientTransport``'s own base default — enforced by
+    ``test_threaded_transport_proxy_total_delegation_5048.py`` (#5048,
+    mirroring #4884's identical claim/gate pairing for
+    ``_ErrorWatchingTransport``). A method missing here would fall back to
+    the base default across the WORKER-THREAD boundary specifically —
+    silently answering with a value that reflects nothing about the real
+    inner transport's state, not merely a generic wrong answer.
     """
 
     def __init__(

--- a/tests/interfaces/test_threaded_transport_proxy_total_delegation_5048.py
+++ b/tests/interfaces/test_threaded_transport_proxy_total_delegation_5048.py
@@ -1,0 +1,73 @@
+"""Tier 2: #5048 — ThreadedTransportProxy's own total-delegation claim,
+made real the same way #4884 already did for _ErrorWatchingTransport.
+
+lead-coder's own measurement (#5050③ review, the same night this PR
+lands): of the production ClientTransport wrappers, exactly ONE
+(_ErrorWatchingTransport) had a live gate against this exact shape — a
+future method added to ClientTransport that a wrapper forgets to
+delegate, silently falling through to ClientTransport's own base
+default instead of the wrapped transport's real value. ThreadedTransport
+Proxy had none, and the SAME night's ``state_ready()`` addition opened
+exactly that hole (fixed in the #5050③ review round) — caught only
+because lead-coder happened to enumerate all 18 methods by hand before
+that PR, not by a gate.
+
+Why THIS class, now (issuecomment-5377858174): before #5048,
+ThreadedTransportProxy had ZERO production call sites (its own class
+docstring, pre-#5048: "NO production call site") — a delegation gap here
+had no real consequence. #5048 wires it in as TextualChatApp's/run_repl's
+DEFAULT local transport, so a silent delegation gap now means every local
+session reads a base-default (wrong) answer through the thread boundary
+instead of the worker-owned transport's real one. Per lead-coder's
+explicit scoping: this gate covers ONLY ThreadedTransportProxy — NOT a
+general delegation-completeness sweep across every ClientTransport
+wrapper (SessionBoundTransport is a deliberate SEND-side-only design,
+13/18 by intent, not an oversight; generalizing the #4884 shape to every
+wrapper is #5043's own scope, not this issue's)."""
+from __future__ import annotations
+
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.threaded import ThreadedTransportProxy
+
+
+def _own_public_methods(cls: type) -> "set[str]":
+    """Names of public callables defined directly on ``cls``'s own class
+    body (``vars(cls)``, NOT ``dir(cls)`` — the latter includes inherited
+    members, which is exactly the silent-fallback shape under test)."""
+    return {
+        name for name, member in vars(cls).items()
+        if not name.startswith("_") and callable(member)
+    }
+
+
+def test_threaded_transport_proxy_overrides_every_client_transport_method() -> None:
+    """Tier 2: every PUBLIC ClientTransport method must be defined directly
+    on ThreadedTransportProxy's own class body, not silently inherited
+    from ClientTransport's own (deliberate, for OTHER narrow-purpose test
+    stubs) default. A member missing here means a caller crossing this
+    thread boundary gets ClientTransport's fallback value instead of the
+    worker-owned inner transport's real one — invisible until #5048's own
+    production cutover, at which point it is every local session's
+    answer, not a hypothetical one."""
+    base_public = _own_public_methods(ClientTransport)
+    own_public = _own_public_methods(ThreadedTransportProxy)
+    missing = base_public - own_public
+    assert not missing, (
+        f"ThreadedTransportProxy's own class body does not define "
+        f"{sorted(missing)} — it silently falls through to "
+        f"ClientTransport's own base default for these, and (post-#5048) "
+        f"that default becomes every local session's answer, not the "
+        f"worker-owned inner transport's real one."
+    )
+
+
+def test_positive_control_the_walk_actually_sees_client_transport_methods() -> None:
+    """Tier 2: positive control (per this repo's own testing policy —
+    a broken enumeration passes the ceiling above trivially) — confirms
+    ``_own_public_methods`` genuinely finds real members, not an empty
+    set that would make the assertion above vacuous."""
+    base_public = _own_public_methods(ClientTransport)
+    assert {"request_attach", "request_session_switch", "shutdown"} <= base_public, (
+        f"the member-enumeration is broken — it produced {base_public!r}, "
+        "which does not contain methods ClientTransport certainly has."
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #5048, landed first per the issue's own condition (issuecomment-5377858174).

## What
Adds a total-delegation gate on `ThreadedTransportProxy`, mirroring #4884's exact shape for `_ErrorWatchingTransport`: every public `ClientTransport` method must be defined directly on the class's own body (`vars(cls)`, not `dir(cls)` — the latter includes inherited members, which is the exact silent-fallback shape under test).

## Why now, why first (not just "smaller so first")
Before #5048, `ThreadedTransportProxy` had zero production call sites — a delegation gap here had no consequence. #5048 makes it the TUI's default local transport, so a gap means every local session silently reads `ClientTransport`'s base-default answer through the thread boundary instead of the worker-owned inner transport's real one — this happened for real the same night PR #5064 added `state_ready()`, caught only because it was enumerated by hand before that PR, not by a gate.

The gate only does its job landed **before** the cutover: landed after, a delegation gap introduced *during* the cutover PR would never turn anything red — nobody would be looking. Landed first, it makes (1) a genuine precondition-check for (2), not just an independent smaller PR that happens to ship earlier.

Scoped to `ThreadedTransportProxy` only, per explicit instruction — not a general sweep across every `ClientTransport` wrapper (`SessionBoundTransport` is a deliberate SEND-side-only design, 13/18 by intent; generalizing #4884's shape to every wrapper is #5043's own scope).

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_threaded_transport_proxy_total_delegation_5048.py`
- [x] `python scripts/verify_module_docstrings.py` on the changed src file (none changed — test-only PR)
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] New test (2 passed) + `test_4995_threaded_transport_proxy.py` (3 passed)
- [x] Strip-verified: commenting out `state_ready()` on `ThreadedTransportProxy` turns the gate red, naming the missing method.
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- [x] 🔴 **[lead-coder] the test docstring borrows a precedent that does not exist** — e2e-coder's TESTS-READ finding, escalated (one sentence to fix, same bar I applied to #5070). `dispatch.py` carries an explicit class-level claim ("Delegation is total and explicit: every method forwards"); `threaded.py` carries no equivalent — only `_call_on_worker`'s own docstring, scoped to ASYNC methods and to "this proxy forwards". So "made real the same way #4884 already did" asserts something false about a claim, inside a test whose whole subject is claims not being enforced. Prefer adding the one-sentence total-delegation claim to `ThreadedTransportProxy`'s class docstring (then both the claim and the framing become true, and a reader of the soon-to-be-default local transport sees it — nobody reads the gate); rewording the test docstring instead is equally acceptable.

> **[lead-coder] verified on head `8b3b269`** — option B taken: `ThreadedTransportProxy`'s class docstring now carries the claim ("Delegation is total and explicit: every public `ClientTransport` method is defined directly on THIS class's own body") AND names the gate that enforces it, mirroring #4884's claim/gate pairing. The test's "made real the same way #4884 already did" is now true. The added last sentence also says why a miss here is worse than a generic wrong answer — it crosses the worker-thread boundary. Ticked by me, not the author.
