### PR TITLE
fix(#5045): move clear_pending_command_ui's write off ChatReadModel onto ClientTransport

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -4252,7 +4252,7 @@ class TextualChatApp(App):
                 kind="status", text=f"could not open {resolved.name} — no OS opener available",
             ))
 
-    def _handle_rewind_request(self, msg: "OutboxMessage") -> None:
+    async def _handle_rewind_request(self, msg: "OutboxMessage") -> None:
         """Consume a ``__rewind_list__`` sentinel: show the picker, or the text
         fallback (#3362).
 
@@ -4266,8 +4266,9 @@ class TextualChatApp(App):
           (``{"kind": "rewind", "points": [...]}``) the picker is populated from
           the POINTS and the sentinel's pre-rendered text is dropped — one list,
           not a list plus a duplicate transcript row. The request is consumed
-          (``clear_pending_command_ui``) so it can never be replayed onto a later
-          sentinel.
+          (``ClientTransport.clear_pending_command_ui`` — #5045: moved off the
+          read model, which must not write) so it can never be replayed onto a
+          later sentinel.
         - No structured request available — the REMOTE case, where command-UI is
           not on the AG-UI wire and ``pending_command_ui()`` is ``None`` by
           design (``read_model.py``) — falls back to appending the sentinel's
@@ -4289,10 +4290,18 @@ class TextualChatApp(App):
         invisible). A ``kind="status"`` flow row — the same idiom this
         module already uses for other command-triggered feedback (the
         voice-transcription "⏳ transcribing…"/hint rows above) — says why,
-        and what to do instead. The read-model request is still consumed
-        (``clear_pending_command_ui``) even when refused: a request left
-        pending would replay onto whatever picker interaction happens
-        next, attributing THIS refused open to a later, unrelated one."""
+        and what to do instead. The request is still consumed even when
+        refused: a request left pending would replay onto whatever picker
+        interaction happens next, attributing THIS refused open to a
+        later, unrelated one.
+
+        #5045: ``async def`` now (was ``def``) — the consume step goes
+        through ``self._transport.clear_pending_command_ui()``, which for
+        ``ThreadedTransportProxy`` crosses a real thread boundary
+        (``_call_on_worker``). Safe to await here: the sole call site
+        (``_pump_frames``) already awaits its siblings
+        (``_handle_copy_request``/``_handle_open_artifact_request``) the
+        same way."""
         from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
 
         request = None
@@ -4305,7 +4314,7 @@ class TextualChatApp(App):
         if request and request.get("kind") == "rewind" and points:
             if self._iv_panel.display:
                 try:
-                    self._read_model.clear_pending_command_ui()
+                    await self._transport.clear_pending_command_ui()
                 except Exception:
                     logger.exception("textual chat: command-UI clear failed")
                 self._ingest_frame(OutboxMessage(
@@ -4318,7 +4327,7 @@ class TextualChatApp(App):
                 return
             self._rewind_picker.show_points(list(points))
             try:
-                self._read_model.clear_pending_command_ui()
+                await self._transport.clear_pending_command_ui()
             except Exception:
                 logger.exception("textual chat: command-UI clear failed")
             return
@@ -6217,7 +6226,7 @@ class TextualChatApp(App):
                             logger.exception("textual chat: /copy sentinel failed")
                     elif msg.kind == "__rewind_list__":
                         try:
-                            self._handle_rewind_request(msg)
+                            await self._handle_rewind_request(msg)
                         except Exception:
                             logger.exception("textual chat: /rewind sentinel failed")
                     elif msg.kind == "__open_artifact__":

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -312,10 +312,6 @@ class ChatReadModel(ABC):
         """The pending command-UI request (the ``/rewind`` picker), or None.
         Command-UI is inline-app-local state, not on the wire → None for remote."""
 
-    @abstractmethod
-    def clear_pending_command_ui(self) -> None:
-        """Consume the pending command-UI request (no-op when unsupported)."""
-
     @property
     @abstractmethod
     def has_command_ui_region(self) -> bool:
@@ -460,11 +456,6 @@ class RegistryReadModel(ChatReadModel):
     def pending_command_ui(self):
         s = self._attached()
         return s.pending_command_ui if s is not None else None
-
-    def clear_pending_command_ui(self) -> None:
-        s = self._attached()
-        if s is not None:
-            s.set_pending_command_ui(None)
 
     @property
     def has_command_ui_region(self) -> bool:
@@ -739,9 +730,6 @@ class RemoteReadModel(ChatReadModel):
         return (values or {}).get("pending_intervention_head")
 
     def pending_command_ui(self):
-        return None
-
-    def clear_pending_command_ui(self) -> None:
         return None
 
     @property

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -197,6 +197,9 @@ class _ErrorWatchingTransport(ClientTransport):
     def pending_intervention_head(self) -> "object | None":
         return self._inner.pending_intervention_head()
 
+    async def clear_pending_command_ui(self) -> None:
+        await self._inner.clear_pending_command_ui()
+
     def reyn_state_root(self) -> "Path | None":
         return self._inner.reyn_state_root()
 

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -312,6 +312,32 @@ class ClientTransport(ABC):
         as a hazard elsewhere tonight."""
         return None
 
+    async def clear_pending_command_ui(self) -> None:
+        """Consume the pending command-UI request (the ``/rewind`` picker's
+        own points, or any future command-UI kind) — a no-op wherever there
+        is nothing to consume.
+
+        #5045: moved here from ``ChatReadModel.clear_pending_command_ui``
+        (retired — see that class's own history), which MUTATED ``Session``
+        state (``s.set_pending_command_ui(None)``) despite ``ChatReadModel``
+        being named and documented as read-only. True independent of any
+        threading concern, but #5048's core-off-thread cutover is what makes
+        it load-bearing: a read model bound to a registry that now lives on
+        a WORKER thread cannot safely call a mutating method on that
+        registry's ``Session`` directly — the write needs to cross the
+        thread boundary the same way every OTHER write already does
+        (:meth:`submit_user_text`/:meth:`answer_intervention_choice`/etc.),
+        not through a read-only seam that happens to expose one exception.
+
+        The default here (no-op) is correct for any transport with no
+        local command-UI concept at all — command-UI is INLINE-APP-LOCAL
+        state (never on the wire, mirroring ``pending_command_ui()``'s own
+        ``None`` for remote): ``AgUiTransport`` inherits this default
+        unchanged. ``InProcessTransport`` overrides it to perform the real
+        clear; ``ThreadedTransportProxy`` overrides it to marshal the call
+        onto the worker thread that owns the ``Session``."""
+        return None
+
     def reyn_state_root(self) -> "Path | None":
         """The attached session's project `.reyn` root, or None (#3721).
 

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -172,6 +172,16 @@ class InProcessTransport(ClientTransport):
         s = self._attached()
         return s.interventions.head() if s is not None else None
 
+    async def clear_pending_command_ui(self) -> None:
+        # #5045: the real write side, moved off ChatReadModel (retired
+        # there — see ClientTransport.clear_pending_command_ui's own
+        # docstring for why). Same-thread here (in-process), so no
+        # marshaling needed — ThreadedTransportProxy's own override is
+        # where this crosses a real thread boundary.
+        s = self._attached()
+        if s is not None:
+            s.set_pending_command_ui(None)
+
     def reyn_state_root(self) -> "Path | None":
         # #3721: `Session.workspace_dir` is the same PUBLIC per-agent path
         # `Agent.workspace_dir` resolves (#3705) — `.reyn/agents/<name>` — so

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -39,18 +39,19 @@ thread must reach the caller thread's ``asyncio.Queue`` via
 running alongside it — the snapshot slot is written in the SAME callback
 that schedules the frame delivery.
 
-**Scope, explicit** (per lead-coder's #4995 ruling): 3 ``ChatReadModel``/
-``ClientTransport`` methods are NOT satisfiable by this snapshot design and
-are deliberately left unwired here — see #5044 (``completion_session()``
-returns a LIVE ``Session`` reference, not a copyable value;
-``load_older_conversation_history()`` mutates ``Session.history`` and
-performs disk I/O, confirmed by reading it, not guessed) and #5045
-(``clear_pending_command_ui()`` is a WRITE living on a type named "read
-model" — a pre-existing contract defect, independent of threading, filed
-on its own). Wiring THIS class in as ``TextualChatApp``'s / ``run_repl``'s
-default local transport is left to a follow-up (#5048) — this PR's
-deliverable is the mechanism itself, with real witnesses, not the
-production cutover.
+**Scope, explicit** (per lead-coder's #4995 ruling): 2 ``ChatReadModel``
+methods are NOT satisfiable by this snapshot design and are deliberately
+left unwired here — see #5044 (``completion_session()`` returns a LIVE
+``Session`` reference, not a copyable value; ``load_older_conversation_
+history()`` mutates ``Session.history`` and performs disk I/O, confirmed
+by reading it, not guessed). #5045 (``clear_pending_command_ui()`` was a
+WRITE living on a type named "read model") is CLOSED — the write moved
+to :meth:`ClientTransport.clear_pending_command_ui`, and this class's own
+:meth:`clear_pending_command_ui` override marshals it onto the worker
+thread the same way every other write above does. Wiring THIS class in
+as ``TextualChatApp``'s / ``run_repl``'s default local transport is left
+to a follow-up (#5048) — this PR's deliverable is the mechanism itself,
+with real witnesses, not the production cutover.
 
 **As of 2026-08-22, this class has NO production call site** —
 :class:`ThreadedTransportProxy` is constructed only from
@@ -318,6 +319,17 @@ class ThreadedTransportProxy(ClientTransport):
         # marshals the coroutine onto the worker loop exactly like every
         # other delegated async method above.
         await self._call_on_worker("state_ready")
+
+    async def clear_pending_command_ui(self) -> None:
+        # #5045: the real write, marshalled onto the worker thread that
+        # owns the Session — same reasoning as state_ready() just above:
+        # ClientTransport's own base default (a no-op) would silently
+        # fail to clear anything, since the inner transport's own
+        # InProcessTransport override is what actually calls
+        # Session.set_pending_command_ui, and that Session object is
+        # owned by the WORKER thread, never safe to touch directly from
+        # the caller thread.
+        await self._call_on_worker("clear_pending_command_ui")
 
     async def cancel_inflight(self) -> str:
         return await self._call_on_worker("cancel_inflight")

--- a/tests/interfaces/test_4817_rewind_yields_to_open_intervention.py
+++ b/tests/interfaces/test_4817_rewind_yields_to_open_intervention.py
@@ -51,8 +51,12 @@ class QueueTransport(ClientTransport):
     ``asyncio.Queue`` a test pushes onto (mirrors the same harness shape used
     throughout ``test_4788_rewind_picker_escape_dismiss.py``)."""
 
-    def __init__(self) -> None:
+    def __init__(self, session: "object | None" = None) -> None:
         self._queue: "asyncio.Queue" = asyncio.Queue()
+        #: #5045: the real write side moved from ChatReadModel onto
+        #: ClientTransport — this fixture needs the real Session to
+        #: perform it, same as InProcessTransport's own override does.
+        self._session = session
 
     def start(self) -> None:
         pass
@@ -91,6 +95,10 @@ class QueueTransport(ClientTransport):
 
     def put_display(self, msg: OutboxMessage) -> None:
         self.push_display(msg)
+
+    async def clear_pending_command_ui(self) -> None:
+        if self._session is not None:
+            self._session.set_pending_command_ui(None)
 
     async def cancel_inflight(self) -> None:
         pass
@@ -136,7 +144,7 @@ async def test_rewind_does_not_open_while_an_intervention_is_showing(
     try:
         await reg.attach("alpha")
         alpha = reg.get_session("alpha")
-        transport = QueueTransport()
+        transport = QueueTransport(session=alpha)
         app = TextualChatApp(
             transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
         )

--- a/tests/interfaces/test_textual_chat_copy_rewind_3362.py
+++ b/tests/interfaces/test_textual_chat_copy_rewind_3362.py
@@ -87,9 +87,6 @@ class _PickerReadModel(ChatReadModel):
     ) -> None:
         self._pending = pending
         self._messages = list(messages or [])
-        #: How many times the app consumed the request — public so a test can
-        #: assert the consumption without reaching into private state.
-        self.cleared = 0
 
     def snapshot(self, config=None):
         return None
@@ -99,10 +96,6 @@ class _PickerReadModel(ChatReadModel):
 
     def pending_command_ui(self):
         return self._pending
-
-    def clear_pending_command_ui(self) -> None:
-        self._pending = None
-        self.cleared += 1
 
     @property
     def has_command_ui_region(self) -> bool:
@@ -140,6 +133,11 @@ class ScriptedTransport(ClientTransport):
         # #3595 S5: a slash line the app routes is RUN as a command through this
         # seam; ``submitted`` keeps its meaning of "went out as a turn".
         self.commands: "list[str]" = []
+        #: #5045: how many times the app consumed the pending command-UI
+        #: request through THIS seam (moved off the read model, which must
+        #: not write) — public so a test can assert the consumption without
+        #: reaching into private state.
+        self.cleared = 0
 
     def start(self) -> None:  # pragma: no cover - trivial
         pass
@@ -173,6 +171,9 @@ class ScriptedTransport(ClientTransport):
 
     def put_display(self, msg: "OutboxMessage") -> None:
         self._messages.append(msg)
+
+    async def clear_pending_command_ui(self) -> None:
+        self.cleared += 1
 
     async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
         pass
@@ -409,7 +410,7 @@ async def test_rewind_sentinel_opens_the_picker_with_the_checkpoints() -> None:
         assert picker.has_points()
         rows = picker.query_one("#rewind-picker-options").option_count
         assert rows == len(_POINTS), f"{rows} rows for {len(_POINTS)} checkpoints"
-        assert read_model.cleared == 1, (
+        assert transport.cleared == 1, (
             "the command-UI request was not consumed — it would replay onto a "
             "later sentinel"
         )


### PR DESCRIPTION
**[tui-coder]** — part of #5045.

## Root cause
`RegistryReadModel.clear_pending_command_ui()` called `Session.set_pending_command_ui(None)` — a genuine mutation of `Session` state on a type named and documented as read-only (`ChatReadModel`). True independent of any threading concern, but #5048's core-off-thread cutover is what makes it load-bearing: a read model bound to a registry now living on a WORKER thread cannot safely call a mutating method on that registry's `Session` directly — the write needs to cross the thread boundary the same way every other write already does.

## Fix
- Added `ClientTransport.clear_pending_command_ui()` (default no-op, matching `state_ready()`'s established pattern — command-UI is inline-app-local, never on the wire, same reason `pending_command_ui()` already returns `None` for remote).
- Delegated through the 3 production wrappers that need it: `InProcessTransport` (the real write, same-thread), `ThreadedTransportProxy` (via `_call_on_worker`, crossing the real thread boundary — the cross-thread marshalling that #5048's cutover depends on), `_ErrorWatchingTransport` (pass-through).
- Removed the method from `ChatReadModel`'s abstract contract and both concrete implementations (`RegistryReadModel`, `RemoteReadModel`) — the actual #5045 fix.
- `app.py`'s `_handle_rewind_request` is now `async` (was sync) and calls `self._transport.clear_pending_command_ui()` instead of the read model's; its sole call site (`_pump_frames`) already awaits its siblings the same way.
- Updated `threaded.py`'s own module docstring, which had explicitly named #5045 as a deliberately-unaddressed gap — now states it's closed.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on changed test files
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Full `tests/interfaces/` sweep (no failures) + targeted rerun of the 2 fixtures that needed updating (`test_textual_chat_copy_rewind_3362.py`, `test_4817_rewind_yields_to_open_intervention.py`) — both had fake `ChatReadModel`s tracking consumption on the now-removed method; moved tracking onto their transport fixtures instead (one adds a `.cleared` counter, the other takes a real `Session` reference to perform the real write)
- [x] Strip-verified: commenting out the app.py call site turns `test_rewind_sentinel_opens_the_picker_with_the_checkpoints` red
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

