### PR TITLE
feat(#5044 partial): cross-thread extend_history_backward on ThreadedTransportProxy

### DIFF
--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -70,7 +70,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncIterator, Callable
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Coroutine
 
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.drain import suspend_between_frames
@@ -138,18 +138,32 @@ class ThreadedTransportProxy(ClientTransport):
     THREAD alongside every frame, whose result rides in
     :class:`_ThreadedSnapshot` for the caller thread to read.
 
-    ``read_model_extend_history_fn`` is optional too — a
+    ``read_model_extend_history_fn`` is optional too — an ASYNC
     ``(agent, session_id) -> int`` callable (typically the SAME
-    ``RegistryReadModel``'s bound ``load_older_conversation_history``)
-    marshalled onto the worker thread ON DEMAND via
+    ``RegistryReadModel``'s bound ``Session.extend_history_backward_
+    async``) marshalled onto the worker thread ON DEMAND via
     :meth:`extend_history_backward`, unlike ``read_model_snapshot_fn``
     which runs unconditionally alongside every frame. #5044: this one
     genuinely MUTATES ``Session.history`` and performs disk I/O — not
     satisfiable by the snapshot design's read-only push, so it gets its
     own pull-style cross-thread call instead (mirroring
     :meth:`_call_on_worker`'s own ``run_coroutine_threadsafe`` +
-    ``wrap_future`` shape, but for a caller-supplied SYNC closure rather
-    than one of ``self._inner``'s own async methods).
+    ``wrap_future`` shape, but for a caller-supplied closure rather than
+    one of ``self._inner``'s own methods).
+
+    #5079/#4995 (architect ruling, issuecomment-5378398588): the supplied
+    closure is expected to be ASYNC and to do its OWN "read off the loop,
+    apply on the loop" split internally — mirroring #4983's own precedent
+    in ``textual_chat/app.py`` (``_handle_session_attached_event``: step
+    ① the disk read runs OFF the event loop via ``asyncio.to_thread``,
+    step ② the small in-memory apply stays on the loop). This proxy does
+    NOT impose that split itself — it is transport-generic and has no
+    Session-specific knowledge of what "the read" vs "the apply" even
+    are; it only marshals whatever coroutine the closure returns onto the
+    worker loop and awaits it, so a closure that internally awaits
+    ``asyncio.to_thread(...)`` genuinely frees the worker loop for that
+    span, while the closure's own final synchronous mutation step still
+    runs safely on the loop that owns ``Session``.
 
     Delegation is total and explicit: every public ``ClientTransport``
     method is defined directly on THIS class's own body — never silently
@@ -168,7 +182,7 @@ class ThreadedTransportProxy(ClientTransport):
         *,
         read_model_snapshot_fn: "Callable[[], dict] | None" = None,
         read_model_extend_history_fn: (
-            "Callable[[str | None, str | None], int] | None"
+            "Callable[[str | None, str | None], Coroutine[Any, Any, int]] | None"
         ) = None,
     ) -> None:
         self._transport_factory = transport_factory
@@ -300,24 +314,26 @@ class ThreadedTransportProxy(ClientTransport):
         needs the REAL, POST-mutation count back, not a value that was
         already frozen into a snapshot slot before this call happened.
 
-        Runs ``read_model_extend_history_fn`` ON THE WORKER THREAD (via
-        ``run_coroutine_threadsafe`` + ``wrap_future`` — the SAME
+        Schedules ``read_model_extend_history_fn`` (an ASYNC closure — see
+        this class's own docstring for why) ON THE WORKER THREAD's loop
+        (via ``run_coroutine_threadsafe`` + ``wrap_future`` — the SAME
         non-blocking shape :meth:`_call_on_worker` gives every ASYNC
-        ``ClientTransport`` method below, just for a caller-supplied SYNC
-        closure instead of one of ``self._inner``'s own methods) and
-        awaits the real result. Returns ``0`` (already-exhausted, never a
-        fabricated count — same convention ``ChatReadModel.
-        load_older_conversation_history``'s own docstring states for its
-        remote impl) when no callable was supplied at construction, or
-        when this proxy has not been started yet."""
+        ``ClientTransport`` method below) and awaits the real result. The
+        closure's own internal ``await`` points (#5079/#4995: its own
+        off-loop disk read) run exactly where scheduled — this call
+        itself does not block the worker loop for their duration, only
+        for the closure's brief synchronous portions. Returns ``0``
+        (already-exhausted, never a fabricated count — same convention
+        ``ChatReadModel.load_older_conversation_history``'s own docstring
+        states for its remote impl) when no callable was supplied at
+        construction, or when this proxy has not been started yet."""
         if self._read_model_extend_history_fn is None or self._worker_loop is None:
             return 0
         fn = self._read_model_extend_history_fn
 
-        async def _call() -> int:
-            return fn(agent, session_id)
-
-        concurrent_future = asyncio.run_coroutine_threadsafe(_call(), self._worker_loop)
+        concurrent_future = asyncio.run_coroutine_threadsafe(
+            fn(agent, session_id), self._worker_loop,
+        )
         return await asyncio.wrap_future(concurrent_future)
 
     # -- caller-thread writes: marshalled onto the worker loop -----------

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -138,6 +138,19 @@ class ThreadedTransportProxy(ClientTransport):
     THREAD alongside every frame, whose result rides in
     :class:`_ThreadedSnapshot` for the caller thread to read.
 
+    ``read_model_extend_history_fn`` is optional too — a
+    ``(agent, session_id) -> int`` callable (typically the SAME
+    ``RegistryReadModel``'s bound ``load_older_conversation_history``)
+    marshalled onto the worker thread ON DEMAND via
+    :meth:`extend_history_backward`, unlike ``read_model_snapshot_fn``
+    which runs unconditionally alongside every frame. #5044: this one
+    genuinely MUTATES ``Session.history`` and performs disk I/O — not
+    satisfiable by the snapshot design's read-only push, so it gets its
+    own pull-style cross-thread call instead (mirroring
+    :meth:`_call_on_worker`'s own ``run_coroutine_threadsafe`` +
+    ``wrap_future`` shape, but for a caller-supplied SYNC closure rather
+    than one of ``self._inner``'s own async methods).
+
     Delegation is total and explicit: every public ``ClientTransport``
     method is defined directly on THIS class's own body — never silently
     inherited from ``ClientTransport``'s own base default — enforced by
@@ -154,9 +167,13 @@ class ThreadedTransportProxy(ClientTransport):
         transport_factory: "Callable[[], ClientTransport]",
         *,
         read_model_snapshot_fn: "Callable[[], dict] | None" = None,
+        read_model_extend_history_fn: (
+            "Callable[[str | None, str | None], int] | None"
+        ) = None,
     ) -> None:
         self._transport_factory = transport_factory
         self._read_model_snapshot_fn = read_model_snapshot_fn
+        self._read_model_extend_history_fn = read_model_extend_history_fn
         self._inner: "ClientTransport | None" = None
         self._worker_loop: "asyncio.AbstractEventLoop | None" = None
         self._thread: "threading.Thread | None" = None
@@ -270,6 +287,38 @@ class ThreadedTransportProxy(ClientTransport):
         ``ChatReadModel`` (e.g. a ``RegistryReadModel`` subclass bound to
         this proxy) calls instead of reading the registry directly."""
         return self._latest.read_model_snapshot
+
+    async def extend_history_backward(
+        self, *, agent: "str | None" = None, session_id: "str | None" = None,
+    ) -> int:
+        """Not part of ``ClientTransport`` either — #5044's cross-thread
+        sibling to ``read_model_snapshot`` above, for the ONE
+        ``ChatReadModel`` operation the snapshot design cannot satisfy:
+        ``RegistryReadModel.load_older_conversation_history`` genuinely
+        MUTATES ``Session.history`` and performs disk I/O (confirmed by
+        reading it, not guessed — #5044's own issue body), so a caller
+        needs the REAL, POST-mutation count back, not a value that was
+        already frozen into a snapshot slot before this call happened.
+
+        Runs ``read_model_extend_history_fn`` ON THE WORKER THREAD (via
+        ``run_coroutine_threadsafe`` + ``wrap_future`` — the SAME
+        non-blocking shape :meth:`_call_on_worker` gives every ASYNC
+        ``ClientTransport`` method below, just for a caller-supplied SYNC
+        closure instead of one of ``self._inner``'s own methods) and
+        awaits the real result. Returns ``0`` (already-exhausted, never a
+        fabricated count — same convention ``ChatReadModel.
+        load_older_conversation_history``'s own docstring states for its
+        remote impl) when no callable was supplied at construction, or
+        when this proxy has not been started yet."""
+        if self._read_model_extend_history_fn is None or self._worker_loop is None:
+            return 0
+        fn = self._read_model_extend_history_fn
+
+        async def _call() -> int:
+            return fn(agent, session_id)
+
+        concurrent_future = asyncio.run_coroutine_threadsafe(_call(), self._worker_loop)
+        return await asyncio.wrap_future(concurrent_future)
 
     # -- caller-thread writes: marshalled onto the worker loop -----------
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3905,6 +3905,55 @@ class Session:
         oldest_seq = self.history[0].seq if self.history else 0
         return self._load_older_entries(before_seq=oldest_seq, min_lines=min_lines)
 
+    async def extend_history_backward_async(
+        self, *, min_lines: int = _HISTORY_HYDRATE_MIN_LINES,
+    ) -> int:
+        """#5079/#4995 (architect ruling, issuecomment-5378398588): the
+        cross-thread-safe sibling of :meth:`extend_history_backward`,
+        following #4983's own precedent in THIS SAME FILE
+        (:meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.
+        _handle_session_attached_event`) — the same "read off the loop,
+        apply on the loop" split, applied to a second place, no new
+        mechanism:
+
+        - Step ① (the disk read, :func:`~reyn.runtime.history_tail_
+          reader.read_history_before`, plus the pure
+          :meth:`_parse_history_line` parse) is not ``Session``'s own —
+          it constructs a VALUE, touching nothing mutable — so it runs
+          OFF the loop via ``asyncio.to_thread``, freeing the worker loop
+          (once #5048 wires this in) to keep servicing everything else —
+          router turns, other frames — while the read is in flight.
+        - Step ② (splicing the parsed entries into ``self.history``) IS
+          ``Session``'s own — a small, in-memory, synchronous mutation —
+          so it stays exactly where :meth:`_load_older_entries` already
+          puts it.
+
+        Guarded against the same race #4983 solved, reusing the EXISTING
+        ``before_seq`` value as the staleness token (architect's explicit
+        instruction: reuse, don't invent a new generation mechanism) —
+        captured from ``self.history[0].seq`` at entry; if ``self.
+        history``'s own oldest ``seq`` no longer matches by the time the
+        read returns (another path already prepended, or history was
+        reset from under this call — e.g. a session switch), applying the
+        stale read would duplicate or misorder entries, so it is skipped:
+        a no-op, the same word #4983's own docstring uses for its
+        supersede case, not a new concept."""
+        from reyn.runtime.history_tail_reader import read_history_before
+
+        before_seq = self.history[0].seq if self.history else 0
+        lines = await asyncio.to_thread(
+            read_history_before,
+            self.history_path, before_seq=before_seq, min_lines=min_lines,
+        )
+        if not lines:
+            return 0
+        parsed = [m for line in lines if (m := self._parse_history_line(line)) is not None]
+        current_oldest_seq = self.history[0].seq if self.history else 0
+        if current_oldest_seq != before_seq:
+            return 0
+        self.history[0:0] = parsed
+        return len(parsed)
+
     def load_history(self) -> None:
         """#4387 Phase B ①: hydrate ``self.history`` at startup WITHOUT
         necessarily reading the whole (potentially huge — owner's real

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -481,7 +481,19 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: gate's own documented carve-out) — no write capability, no state
 #: mutation, and the consumer is an LLM-callable tool's OpContext supplier,
 #: not `ClientTransport`.
-_PUBLIC_MEMBER_CEILING = 115
+#: Raised 115 -> 116 for #5079/#4995: ``extend_history_backward_async`` — a
+#: NEW method, the async sibling of the EXISTING (already-counted)
+#: ``extend_history_backward``. Public rather than private per architect
+#: ruling (issuecomment-5378398588): its consumer is
+#: ``ThreadedTransportProxy``'s ``read_model_extend_history_fn`` closure,
+#: which lives OUTSIDE `Session` on the worker thread's own boundary — a
+#: cross-object call, not a slash handler reaching into its own session's
+#: private state. Genuinely unrelated to the gate's failure mode (it does
+#: not exist to let a slash handler bypass an operation; it exists because
+#: #4995's cross-thread marshal needs a coroutine it can hand to
+#: ``run_coroutine_threadsafe``, and a private method cannot be that
+#: closure's target from outside the class).
+_PUBLIC_MEMBER_CEILING = 116
 
 
 def test_session_public_surface_does_not_grow() -> None:

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -54,6 +54,7 @@ py``'s own ``QueueTransport``).
 from __future__ import annotations
 
 import asyncio
+import json
 import threading
 from typing import TYPE_CHECKING, AsyncIterator
 
@@ -322,7 +323,11 @@ async def test_extend_history_backward_runs_the_closure_on_the_worker_thread():
     caller_ident = threading.get_ident()
     call_idents: "list[int]" = []
 
-    def _extend(agent: "str | None", session_id: "str | None") -> int:
+    async def _extend(agent: "str | None", session_id: "str | None") -> int:
+        # #5079/#4995: real closures are async and internally await an
+        # off-loop step (architect ruling) -- a real (if trivial) await
+        # here, not a bare sync function pretending to be one.
+        await asyncio.sleep(0)
         call_idents.append(threading.get_ident())
         assert agent == "researcher"
         assert session_id == "abc"
@@ -363,4 +368,212 @@ async def test_extend_history_backward_returns_zero_when_nothing_was_supplied():
         result = await proxy.extend_history_backward(agent="researcher")
         assert result == 0
     finally:
+        await proxy.shutdown()
+
+
+# ── #5079/#4995 architect ruling (issuecomment-5378398588) — the real
+# Session.extend_history_backward_async split, exercised through THIS
+# proxy: step ① (disk read) runs OFF the worker loop via asyncio.to_thread,
+# step ② (the small in-memory splice) stays on it, guarded by the EXISTING
+# before_seq value as the staleness token (no new generation mechanism —
+# #4983's own precedent, applied here). These two witnesses are the ones
+# architect's ruling names explicitly: ① paging must not stall the worker
+# loop's own frame production (structural — counted iterations, never a
+# duration) and ② a stale apply (history moved under the read) must be a
+# no-op, not a corrupting splice.
+
+
+def _write_history_lines(path, seqs) -> list[str]:
+    lines = [
+        json.dumps({"role": "user", "content": f"msg {n}", "seq": n}) for n in seqs
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return lines
+
+
+def _make_history_session(tmp_path):
+    """A real ``Session`` with a real ``history.jsonl`` on disk (seq
+    1..10) and ``self.history`` manually seeded to "only the tail (6..10)
+    is loaded" — the exact precondition ``extend_history_backward_async``
+    is meant to satisfy (older entries on disk, nothing loaded yet).
+    Bypasses ``load_history()``'s own 200-line tail sizing (irrelevant to
+    what's under test here) by seeding ``self.history`` directly — the
+    method under test only ever reads ``self.history[0].seq``, not how
+    it got there."""
+    from tests._support.agent_session import make_session
+
+    project_root = tmp_path / "project"
+    session = make_session(
+        agent_name="alpha", workspace_state_dir=project_root / ".reyn",
+        snapshot_path=(
+            project_root / ".reyn" / "agents" / "alpha" / "state" / "snapshot.json"
+        ),
+    )
+    lines = _write_history_lines(session.history_path, range(1, 11))
+    session.history = [
+        m for line in lines[5:] if (m := session._parse_history_line(line)) is not None
+    ]
+    return session
+
+
+class _FramingTransport(_RecordingTransport):
+    """Yields frames indefinitely, one per drain — lets a test COUNT how
+    many the worker loop produces while something else is gated open,
+    the same structural-progress shape witness② (in the #4995 file
+    above) already established, applied to a frame producer instead of
+    a blocked call."""
+
+    async def frames(self):
+        n = 0
+        while True:
+            from reyn.interfaces.transport.frames import DisplayFrame
+            from reyn.runtime.outbox import OutboxMessage
+            yield DisplayFrame(OutboxMessage(kind="status", text=f"frame {n}"))
+            n += 1
+            await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_extend_history_backward_async_does_not_stall_the_worker_loops_frame_drain(
+    tmp_path,
+):
+    """Tier 2: architect ruling (#5079/#4995) — while
+    ``Session.extend_history_backward_async``'s own disk-read step is
+    gated open (a real ``threading.Event``, the SAME technique witness②
+    above already establishes — never a duration), the worker loop must
+    keep producing frames from the inner transport — structural proof the
+    read genuinely left the worker loop (#4983's own precedent, applied
+    to this second place).
+
+    Strip-falsifier: reverting ``extend_history_backward_async`` to call
+    ``read_history_before`` synchronously (no ``asyncio.to_thread``) makes
+    this hang — the gated read would block the SAME worker loop
+    ``_pump_frames`` needs to keep yielding frames, so the drain loop
+    below would never get a chance to run at all."""
+    import reyn.runtime.history_tail_reader as history_tail_reader
+
+    real_read = history_tail_reader.read_history_before
+    read_gate = threading.Event()
+    read_started = threading.Event()
+
+    def _gated_read(*args, **kwargs):
+        read_started.set()
+        read_gate.wait()
+        return real_read(*args, **kwargs)
+
+    session = _make_history_session(tmp_path)
+    inner = _FramingTransport()
+
+    async def _extend(agent, session_id):
+        return await session.extend_history_backward_async()
+
+    proxy = ThreadedTransportProxy(
+        lambda: inner, read_model_extend_history_fn=_extend,
+    )
+    proxy.start()
+    history_tail_reader.read_history_before = _gated_read
+    try:
+        extend_task = asyncio.create_task(
+            proxy.extend_history_backward(agent="alpha"),
+        )
+        await asyncio.to_thread(read_started.wait)
+
+        frame_iter = proxy.frames()
+        drained = 0
+        for _ in range(20):
+            await frame_iter.__anext__()
+            drained += 1
+        assert drained == 20, (
+            "the worker loop's own frame production stalled while "
+            "extend_history_backward_async's disk read was gated open "
+            "-- the read did not genuinely leave the worker loop"
+        )
+        assert not extend_task.done(), (
+            "the gated read must still be in flight at this point -- "
+            "proves the 20 drained frames genuinely overlapped it"
+        )
+
+        read_gate.set()
+        result = await extend_task
+        assert result == 5
+        assert [m.content for m in session.history[:5]] == [
+            "msg 1", "msg 2", "msg 3", "msg 4", "msg 5",
+        ]
+    finally:
+        history_tail_reader.read_history_before = real_read
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_extend_history_backward_async_apply_is_a_no_op_when_history_moved_mid_read(
+    tmp_path,
+):
+    """Tier 2: architect ruling (#5079/#4995) — #4983's own supersede-guard
+    shape, applied here via the EXISTING ``before_seq`` value as the
+    staleness token — no new generation mechanism. If ``self.history``'s
+    own oldest ``seq`` no longer matches what ``before_seq`` captured by
+    the time the gated disk read returns (another path already moved
+    history out from under this call — simulated here directly), applying
+    the stale read is a no-op: ``self.history`` is left exactly as the
+    intervening mutation left it, never spliced with the now-stale read.
+
+    Strip-falsifier: removing the ``current_oldest_seq != before_seq``
+    guard in ``extend_history_backward_async`` (splicing unconditionally,
+    as its sibling ``_load_older_entries`` does — correctly, since THAT
+    one is never called across an await gap) turns this red — the stale
+    entries would be prepended anyway, duplicating/misordering the
+    intervening mutation's own state."""
+    import reyn.runtime.history_tail_reader as history_tail_reader
+
+    real_read = history_tail_reader.read_history_before
+    read_gate = threading.Event()
+    read_started = threading.Event()
+
+    def _gated_read(*args, **kwargs):
+        read_started.set()
+        read_gate.wait()
+        return real_read(*args, **kwargs)
+
+    session = _make_history_session(tmp_path)
+    inner = _FramingTransport()
+
+    async def _extend(agent, session_id):
+        return await session.extend_history_backward_async()
+
+    proxy = ThreadedTransportProxy(
+        lambda: inner, read_model_extend_history_fn=_extend,
+    )
+    proxy.start()
+    history_tail_reader.read_history_before = _gated_read
+    try:
+        extend_task = asyncio.create_task(
+            proxy.extend_history_backward(agent="alpha"),
+        )
+        await asyncio.to_thread(read_started.wait)
+
+        # Simulate a concurrent path moving history out from under this
+        # call, WHILE the read is still gated -- the exact race window
+        # #4983's own docstring names ("a LATER switch may have claimed a
+        # newer generation ... while the read above was still in
+        # flight").
+        intruder = session._parse_history_line(
+            json.dumps({"role": "user", "content": "intruder", "seq": 99}),
+        )
+        session.history.insert(0, intruder)
+
+        read_gate.set()
+        result = await extend_task
+        assert result == 0, (
+            "a stale read (history moved mid-read) must report 0 "
+            "prepended, not the count it would have prepended before "
+            "the race"
+        )
+        assert session.history[0].content == "intruder", (
+            "the intervening mutation must survive UNTOUCHED -- the "
+            "stale read must not splice its own (now-wrong) entries in "
+            "front of it"
+        )
+    finally:
+        history_tail_reader.read_history_before = real_read
         await proxy.shutdown()

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -501,6 +501,16 @@ async def test_extend_history_backward_async_does_not_stall_the_worker_loops_fra
             "msg 1", "msg 2", "msg 3", "msg 4", "msg 5",
         ]
     finally:
+        # Release the gate FIRST, before anything else: an assert above
+        # can fail before read_gate.set() is reached, leaving the
+        # asyncio.to_thread-spawned (non-daemon) worker blocked on
+        # read_gate.wait() forever. proxy.shutdown() does not unblock an
+        # Event-waiting thread, and CPython's default threadpool joins
+        # its threads at atexit -- so an unreleased gate turns a clean
+        # AssertionError into a process hang (architect finding,
+        # issuecomment-5378539254). Safe to call twice (Event.set() is
+        # idempotent).
+        read_gate.set()
         history_tail_reader.read_history_before = real_read
         await proxy.shutdown()
 

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -585,5 +585,12 @@ async def test_extend_history_backward_async_apply_is_a_no_op_when_history_moved
             "front of it"
         )
     finally:
+        # Same reasoning as the sibling witness above: release the gate
+        # FIRST. Even though read_gate.set() sits before every assert
+        # here, _parse_history_line(...) / session.history.insert(...)
+        # can themselves raise before reaching it -- an unreleased gate
+        # is the same process-hang failure mode (architect finding,
+        # issuecomment-5378577064).
+        read_gate.set()
         history_tail_reader.read_history_before = real_read
         await proxy.shutdown()

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -288,3 +288,79 @@ async def test_accept_side_frames_and_sync_reads_flow_through_the_proxy():
         assert proxy.read_model_snapshot() == {"model": "test-model"}
     finally:
         await proxy.shutdown()
+
+
+# ── #5044: extend_history_backward's own cross-thread pull call ──────────
+#
+# read_model_snapshot above is a PUSH: the worker refreshes it unconditionally
+# alongside every frame, read-only, never touching disk. #5044's own issue
+# body: RegistryReadModel.load_older_conversation_history() genuinely
+# MUTATES Session.history and performs disk I/O — not satisfiable by that
+# push design, so it needs its own PULL-style cross-thread call instead
+# (extend_history_backward), on demand, returning the real post-mutation
+# count. These two tests are that call's own witness — mirroring witness①
+# above (a different code path: a caller-supplied closure marshalled via
+# `run_coroutine_threadsafe`, not one of `_inner`'s own async methods,
+# so #4995's own thread-identity claim needs re-proving for THIS path) —
+# and the "nothing supplied" default, which #5044's issue body requires be
+# 0 (never fabricated), mirroring ChatReadModel.load_older_conversation_
+# history's own remote-impl convention.
+
+
+@pytest.mark.asyncio
+async def test_extend_history_backward_runs_the_closure_on_the_worker_thread():
+    """Tier 2: structural witness, same shape as witness①. The supplied
+    ``read_model_extend_history_fn`` must execute on the WORKER thread, not
+    the caller's — the whole point of routing it through this proxy rather
+    than calling a registry-bound closure directly from the caller thread
+    (which would touch the worker-owned registry from a foreign thread).
+
+    Strip-falsifier: calling ``fn`` directly from ``extend_history_backward``
+    without the ``run_coroutine_threadsafe`` marshal (i.e. on the caller's
+    own thread) makes ``call_idents == [threading.get_ident()]`` — the
+    caller's own identity, not the worker's — turning this red."""
+    caller_ident = threading.get_ident()
+    call_idents: "list[int]" = []
+
+    def _extend(agent: "str | None", session_id: "str | None") -> int:
+        call_idents.append(threading.get_ident())
+        assert agent == "researcher"
+        assert session_id == "abc"
+        return 7
+
+    inner = _RecordingTransport()
+    proxy = ThreadedTransportProxy(
+        lambda: inner, read_model_extend_history_fn=_extend,
+    )
+    proxy.start()
+    try:
+        result = await proxy.extend_history_backward(
+            agent="researcher", session_id="abc",
+        )
+        assert result == 7
+        assert call_idents == [proxy.worker_thread_ident]
+        assert proxy.worker_thread_ident != caller_ident, (
+            "the closure's own recorded thread identity must differ from "
+            "the caller's — the same thread-boundary claim witness① makes "
+            "for submit_user_text, re-proven here for a DIFFERENT code path"
+        )
+    finally:
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_extend_history_backward_returns_zero_when_nothing_was_supplied():
+    """Tier 2: no ``read_model_extend_history_fn`` given at construction ->
+    ``0``, never a fabricated count — #5044's own issue body states this
+    convention explicitly, mirroring ``ChatReadModel.
+    load_older_conversation_history``'s own remote-impl contract (a remote
+    client has nothing to extend into either, and answers 0, never a made
+    up value)."""
+    inner = _RecordingTransport()
+    proxy = ThreadedTransportProxy(lambda: inner)
+    proxy.start()
+    try:
+        result = await proxy.extend_history_backward(agent="researcher")
+        assert result == 0
+    finally:
+        await proxy.shutdown()


### PR DESCRIPTION
**[e2e-coder]** — part of #4995 → #5048.

## Scope: half of #5044

Only `load_older_conversation_history()`'s cross-thread mechanism. The `completion_session()` half is held pending a design ruling — posted as a measurement to #5044 (issuecomment-5378101999), not picked myself: its consumer, `TextualChatApp.completion_state()`, is synchronous and fires on every keystroke, feeding a synchronous `CompleterFn` contract (`interfaces/slash/__init__.py`'s `Callable[..., list[str]]`). A cross-thread `await` round-trip doesn't fit that call chain without either blocking the caller thread (defeats #4995's own purpose), making the Composer's completion hook async (a ripple past this issue's own scope), or deriving completions from a periodic snapshot instead of a live per-keystroke fetch — a genuine fork in `ThreadedTransportProxy`'s public shape, not mine to pick alone.

## What's here

`RegistryReadModel.load_older_conversation_history()` has no such fork: it genuinely mutates `Session.history` and performs disk I/O (#5044's own issue body, confirmed by reading it), so it's not satisfiable by #4995's existing read-only snapshot-push design — it needs its own pull-style cross-thread call.

- `ThreadedTransportProxy` gains an optional `read_model_extend_history_fn` constructor param (a `(agent, session_id) -> int` closure — the SAME caller-injected-worker-thread-closure shape `read_model_snapshot_fn` already established, not a new mechanism family) and `extend_history_backward()`, which marshals that closure onto the worker thread via `run_coroutine_threadsafe` + `wrap_future` — the same non-blocking shape `_call_on_worker` already gives every async `ClientTransport` method, generalized for a caller-supplied sync closure rather than one of `self._inner`'s own async methods.
- Not part of `ClientTransport`'s own interface (mirrors `read_model_snapshot`'s own precedent) — #5075's total-delegation gate is unaffected: it only enforces every `ClientTransport` member is overridden, not that this class adds nothing beyond that surface.
- Returns `0` (never fabricated) when no closure was supplied — mirrors `ChatReadModel.load_older_conversation_history`'s own remote-impl convention.

## Witnesses

- the closure genuinely runs on the worker thread, not the caller's (mirrors witness① for a different code path — a caller-supplied closure marshalled via `run_coroutine_threadsafe`, not one of `_inner`'s own methods, so the thread-identity claim needs re-proving here).
- the zero-default when nothing was supplied.

Both **strip-verified** (calling the closure directly on the caller thread, bypassing the marshal, turns the thread-identity witness red; restored, both green).

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4995_threaded_transport_proxy.py`
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py` (re-run right before push, after rebasing onto #5078's landing)
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Scoped pytest (this file's own 5 tests + the total-delegation gate, all green), strip-falsify verified
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Revision: architect ruling applied (issuecomment-5378398588)

- [x] 🔴 **[lead-coder] `extend_history_backward` runs its sync, disk-I/O closure ON the worker event loop** — **RESOLVED.** Architect ruled: apply the SAME split `_handle_session_attached_event` (#4983) already established — step① (disk read) runs OFF the event loop via `asyncio.to_thread`, step② (apply the mutation to `Session.history`) stays ON the loop, guarded by a staleness token re-checked right before the mutation. Reuse the EXISTING `before_seq` value as that token rather than inventing a new generation counter.

**What changed:**
- `Session.extend_history_backward_async()` (new, async sibling of the existing sync `extend_history_backward`): captures `before_seq = self.history[0].seq if self.history else 0`, does `await asyncio.to_thread(read_history_before, ...)`, parses off-loop-returned lines, then re-checks `self.history[0].seq == before_seq` immediately before `self.history[0:0] = parsed` — a stale read (history moved under it) is a silent no-op, never a wrong-position insert.
- `ThreadedTransportProxy.read_model_extend_history_fn` is now itself async (`Callable[[str|None,str|None], Coroutine[Any,Any,int]]`) — `extend_history_backward()` hands the coroutine straight to `run_coroutine_threadsafe`, no synchronous work runs on the worker loop at any point.
- Two new witnesses, both real `threading.Event` gates (never a duration):
  - `test_extend_history_backward_async_does_not_stall_the_worker_loops_frame_drain` — gates the disk read open, drains 20 frames from the SAME worker loop while the read is held, asserts the extend task is still not done, then releases and checks the correct result. **Strip-falsified manually** (not left as an automated CI strip, per the test's own docstring): reverting to a synchronous `read_history_before(...)` call hung the process (`timeout 15` killed it, exit 124) — confirming the gated read really does block the same loop `_pump_frames` needs. Restored, green.
  - `test_extend_history_backward_async_apply_is_a_no_op_when_history_moved_mid_read` — inserts an intruder message into `session.history` while the read is gated open, releases, asserts the extend result is `0` and the intruder survives untouched. Strip-falsified by removing the `before_seq` guard (flips to `assert 5 == 0` failing), restored, green.

All local gates re-run clean post-revision: ruff, tier-audit --strict (all 7 tests OK), module-docstrings, mypy_ratchet, flat_tests_ratchet, path-literal-reference (re-run after rebase onto latest origin/main / #5081's landing), bare-import-reference, file-depth-reference. Full test file: `7 passed`.

part of #5044, part of #4995
- [x] 🔴 **[lead-coder] the drain witness turns an assertion failure into a process hang** — its `finally` restores the monkeypatch and shuts the proxy down but never calls `read_gate.set()`, and `read_gate.set()` sits AFTER both asserts. If either assert fails, `_gated_read` stays blocked on `read_gate.wait()` inside a NON-DAEMON `asyncio.to_thread` pool thread that `proxy.shutdown()` does not release, and CPython joins that pool at interpreter exit — so the AssertionError becomes a hang. Same shape as the defect found on #5049 (same `to_thread` + `threading.Event`, same missing set in `finally`): six-questions Q5 bites on the FAILING path — what accumulates is a non-daemon thread and what bounds it is outside the test. Set the gate first thing in `finally`; also handle `extend_task` on that path.

