### PR TITLE
fix(#5057): close the id-less intervention-family hole structurally (axis A + axis B)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -4139,7 +4139,17 @@ class TextualChatApp(App):
         if resolved is not None:
             entry, _iv_id = resolved
             meta = entry.item.meta or {}
-            entry.set_item(replace(entry.item, meta={**meta, "_answer_label": answer_label}))
+            # #5057 axis B: the fold also swaps kind to "intervention_resolved"
+            # (not just meta) — kind alone is now the resolved/pending
+            # discriminator presenter.py/gutter.py read, not `_answer_label`
+            # presence.
+            entry.set_item(
+                replace(
+                    entry.item,
+                    kind="intervention_resolved",
+                    meta={**meta, "_answer_label": answer_label},
+                )
+            )
             entry.set_state(EntryState.DEFAULT)
         if self._pending_ivs:
             # Other tabs are still pending — the panel (and whichever tab was
@@ -4331,9 +4341,18 @@ class TextualChatApp(App):
             except Exception:
                 logger.exception("textual chat: command-UI clear failed")
             return
-        # persistent kind (not transient "status") so the list stays readable —
-        # the same choice the plain client's fallback leg makes.
-        self._ingest_frame(replace(msg, kind="intervention"))
+        # persistent kind (not transient "status") so the list stays
+        # readable — the same choice the plain client's fallback leg
+        # makes. #5047 (axis A): was "intervention" purely for this
+        # persistence property, not because a rewind list IS a question
+        # — OutboxMessage.__post_init__ now requires a genuine
+        # meta["intervention_id"] for that family, which this frame never
+        # had. "system" is the SAME "persistent info row" kind
+        # OutboxMessage.from_wire demotes an identity-less wire
+        # intervention frame to (stream_client.py's own fallback leg uses
+        # it too) — giving rewind its OWN distinct kind (axis C) is a
+        # separate, later step.
+        self._ingest_frame(replace(msg, kind="system"))
 
     async def on_rewind_picker_point_selected(
         self, event: "RewindPicker.PointSelected"
@@ -4626,47 +4645,48 @@ class TextualChatApp(App):
         self._register_call_parent(entry, kind, meta)
         if kind == "presentation":
             self._begin_image_resolutions(entry, msg)
-        # #5047/#5057: a fake-pending ``kind="intervention"`` frame reaches
-        # here from more than one producer, and registering it as PENDING
-        # (the old unconditional branch below) put a phantom entry into
-        # ``self._pending_ivs`` — harmless-looking (the presenter can still
-        # draw it correctly, or it can be answered), but a genuine answer
-        # ``answer_oldest_intervention_text``/``_choice`` delivers to the
-        # registry's OLDEST pending: without a real ``intervention_id`` on
-        # THIS entry, an answer meant for it falls through to that
-        # oldest-pending fallback and can misdeliver to a completely
-        # unrelated, actually-pending entry.
-        #
-        # #5047's own instance was a REPLAYED (backlog) intervention —
-        # ``restore.py``'s ``project_restored_frames`` projects an
-        # already-answered history entry into this SAME ``kind="intervention"``
-        # shape so it renders through the presenter's RESOLVED branch. #5057
-        # found TWO MORE producers with the identical shape (no
-        # ``intervention_id``, not restored either): ``stream_client.py``'s
-        # and this class's own ``/rewind`` text-list fallback, which reuse
-        # ``kind="intervention"`` purely for its PERSISTENT-render property
-        # (never un-answered "waiting" state to begin with). The original
-        # #5047 fix keyed on ``RESTORED_META_KEY`` — a marker naming ONE
-        # producer, not the property that actually matters, so it missed
-        # these two by construction (a fix keyed on "which producer wrote
-        # this" always misses the NEXT producer; #5057 is that miss
-        # happening).
-        #
-        # ``intervention_id`` presence is the real discriminator: it is the
-        # SAME value that decides, downstream, whether an answer can be
-        # routed ``answer_intervention_by_id`` (safe) or falls to
-        # ``answer_oldest_*`` (misdeliverable) — see
-        # ``ClientTransport.answer_intervention_text``/``_choice``'s own
-        # docstrings. ``announce`` (``intervention_handler.py``, the ONLY
-        # producer of a genuinely still-pending intervention) is also the
-        # ONLY one that sets it (``_iv_meta``, unconditionally). Discards:
-        # a future producer that legitimately needs pending-registration
-        # WITHOUT a real answerable id would silently fail this check too —
-        # none is known to exist today (only ``announce`` needs
-        # registration), but a new one must set ``intervention_id`` to a
-        # real, answerable id to pass, not merely omit the restored/rewind
-        # markers this replaces.
-        if kind == "intervention" and (msg.meta or {}).get("intervention_id"):
+        # #5047/#5057 (structural fix, architect's confirmed design —
+        # axis A + axis B, same PR): registration is now `kind ==
+        # "intervention"` alone, no meta inspected here at all. This used
+        # to be a `meta.get("intervention_id")` presence check (#5060,
+        # itself a fix for #5056's own narrower `RESTORED_META_KEY` check)
+        # guarding against a fake-pending frame from a producer with no
+        # real identity — restore.py's replayed (backlog) intervention, and
+        # #5057's own two further finds (stream_client.py's and this
+        # class's own /rewind text-list fallback, both reusing
+        # `kind="intervention"` purely for its PERSISTENT-render
+        # property). All 3 are fixed at their own construction sites
+        # instead, via TWO complementary axes: axis A
+        # (`OutboxMessage.__post_init__` requires a genuine
+        # `meta["intervention_id"]` for the whole intervention family at
+        # CONSTRUCTION time; `OutboxMessage.from_wire` demotes an
+        # identity-less wire frame to `kind="system"` before it ever
+        # reaches here) closes the two rewind-fallback producers (they
+        # never had an id, so they now build `kind="system"` directly).
+        # Axis A alone does NOT close restore.py's replayed-answered
+        # producer, though — that one DOES carry a real id (`deliver_
+        # answer_to` stamps it), so axis A would let it back in as a
+        # fake-pending "intervention" frame (measured independently by
+        # architect from the ingest side and by tui-coder from the panel
+        # side — `InterventionPanel.add_pending` has no resolved/pending
+        # awareness at all — while implementing this fix; #5057
+        # issuecomment-5378183009). Axis B closes THAT gap: an
+        # already-resolved frame builds `kind="intervention_resolved"`
+        # (restore.py's projection, and the two live-answer fold sites,
+        # :meth:`_resolve_intervention` / :meth:`_handle_intervention_
+        # answer_event`) — a DIFFERENT kind, so it never reaches this
+        # branch at all, registering nothing. A `kind == "intervention"`
+        # frame reaching this branch is, by construction (axis A) AND by
+        # never being the resolved shape (axis B), never able to be a
+        # fake pending entry. The 3 former producers of the fake-
+        # pending shape (restore.py, stream_client.py, this app's own
+        # rewind fallback) were fixed at their own construction sites
+        # instead: restore.py always builds `kind="intervention_resolved"`
+        # (its projection is ALWAYS an already-answered entry — an
+        # unanswered intervention has no history trace at all); the two
+        # rewind producers now build `kind="system"` directly, never
+        # "intervention" at all.
+        if kind == "intervention":
             self._present_intervention(msg, entry)
         else:
             self._apply_lifecycle_state(msg, entry)
@@ -5614,7 +5634,15 @@ class TextualChatApp(App):
         entry = self._announced_intervention_entry(iv_id) if iv_id else None
         if entry is not None:
             meta = entry.item.meta or {}
-            entry.set_item(replace(entry.item, meta={**meta, "_answer_label": raw_text}))
+            # #5057 axis B: same fold as _resolve_intervention — kind swaps
+            # to "intervention_resolved" too, not just meta.
+            entry.set_item(
+                replace(
+                    entry.item,
+                    kind="intervention_resolved",
+                    meta={**meta, "_answer_label": raw_text},
+                )
+            )
             return
         meta = dict(data.get("meta") or {})
         self._ingest_frame(

--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -217,26 +217,31 @@ def _gutter_glyph_color(msg: "OutboxMessage") -> "tuple[str, str]":
         return "⎿", _CC_DIM
     if kind == "tool_call_failed":
         return "⎿", _CC_ERR
-    if kind == "intervention":
+    if kind in ("intervention", "intervention_resolved"):
         # #3299 P2 §5: an intervention's flow entry stays EntryState.DEFAULT in
         # BOTH the pending and resolved cases (never RUNNING/SUCCESS/ERROR — an
         # answer is neither an outcome to celebrate nor a failure, #3296). With
         # the state fixed at DEFAULT, the gutter's kind colour is the only axis
         # left to distinguish the two, so both legs are special-cased here
         # rather than falling through to ``_KIND_LINE["intervention"]``'s
-        # amber ("needs you") colour:
-        # #5047: presence of the KEY, not truthiness of its VALUE — a
-        # restored (backlog-replayed) intervention's ``_answer_label`` can
-        # itself be the empty string (``restore.py``'s own ``meta.get(
-        # INTERVENTION_ANSWER_META_KEY, "")``), and a falsy check on the
-        # value would render that restored, already-answered entry as
-        # still-PENDING (dim ⋯) — the same emptiness-vs-absence conflation
-        # app.py's own ``_present_intervention`` guard was measured to have
-        # (lead-coder, mid-#5047-implementation). A genuine LIVE pending
-        # intervention never carries this key at all until answered
-        # (``_resolve_intervention`` is what first sets it), so presence
-        # alone is both necessary and sufficient here.
-        if "_answer_label" not in (msg.meta or {}):
+        # amber ("needs you") colour.
+        #
+        # #5057 axis B: the branch is now on KIND, not on ``_answer_label``
+        # meta presence. Before axis B, both pending and resolved shared the
+        # SAME "intervention" kind, so this had to read meta — and a
+        # presence check (not a truthiness check on the label's VALUE) was
+        # itself a #5047-era fix: a restored (backlog-replayed) intervention's
+        # ``_answer_label`` can be the empty string (``restore.py``'s own
+        # ``meta.get(INTERVENTION_ANSWER_META_KEY, "")``), so a falsy check
+        # on the value would have rendered that already-answered entry as
+        # still-PENDING (dim ⋯). Architect + lead-coder later found this
+        # presence check was one of 3 independently-written `_answer_label`
+        # reads scattered across this file / presenter.py / the
+        # (since-removed) panel-registration guard — axis B's whole point is
+        # that a resolved entry now carries its OWN kind
+        # ("intervention_resolved", #5057), so no meta read is needed here
+        # at all to answer "is this resolved".
+        if kind == "intervention":
             # PENDING: a dim "awaiting" marker instead of the kind's normal
             # amber glyph.
             return "⋯", _CC_DIM

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -862,16 +862,27 @@ class ReynPresenter:
         populates + focuses it), so the flow entry itself never renders chips
         or an input.
 
-        Pending (no ``_answer_label`` meta yet): the neutralized prompt head
-        plus a dim ``⋯ respond in the panel below`` hint — the "◆ needs you"
-        amber gutter (kind-driven) already marks the row. Resolved
-        (``_answer_label`` set by the app once the panel delivers an answer,
-        OR by the restore projection reading a persisted answer straight off
-        history — #3299 P4): the head plus a green ``✓ answered: <label>``
-        line (basic — the placeholder→resolved in-place churn-zero polish is
-        P2, not built here). ``_answer_label`` is neutralized at THIS call
-        site — the SAME leaf-neutralization discipline ``_intervention_head``
-        already applies to ``prompt``/``detail`` (#2770) — because a matched
+        Pending (``item.kind == "intervention"``): the neutralized prompt
+        head plus a dim ``⋯ respond in the panel below`` hint — the "◆ needs
+        you" amber gutter (kind-driven) already marks the row. Resolved
+        (``item.kind == "intervention_resolved"`` — #5057 axis B: either the
+        app folded a LIVE entry to this kind once the panel delivered an
+        answer, or the restore projection built it straight off a persisted
+        answer, #3299 P4): the head plus a green ``✓ answered: <label>`` line
+        (basic — the placeholder→resolved in-place churn-zero polish is P2,
+        not built here). Before axis B this branched on ``_answer_label``
+        meta PRESENCE rather than kind — folded into the same "intervention"
+        kind either way; a truthiness check on the label's VALUE was the
+        #5056 defect (an empty-string answer read as still-pending), and
+        even the presence check was one of 3 independently-written
+        `_answer_label` reads architect+lead-coder found scattered across
+        this file/gutter.py/the (since-removed) panel-registration guard —
+        axis B's whole point is that dispatching on the sibling KIND removes
+        the need for any of them to inspect meta to answer "is this
+        resolved". The label TEXT itself still comes from meta (kind alone
+        doesn't carry the string), neutralized at THIS call site — the SAME
+        leaf-neutralization discipline ``_intervention_head`` already
+        applies to ``prompt``/``detail`` (#2770) — because a matched
         CLOSED-SET choice's label is model-supplied / untrusted the same way
         the prompt is; a RESTORED answer arrives RAW (persisted RAW by design
         — neutralize only at display boundaries, never at write time), and
@@ -884,8 +895,8 @@ class ReynPresenter:
         meta = item.meta or {}
         head = _intervention_head(item)
         head_h = self._measure(head, width)
-        answer = meta.get("_answer_label")
-        if answer is not None:
+        if item.kind == "intervention_resolved":
+            answer = meta.get("_answer_label", "")
             resolved = Text.assemble(
                 ("  ✓ answered: ", _CC_DIM),
                 (_neutralized_label(str(answer)), f"bold {_CC_DONE}"),
@@ -920,7 +931,12 @@ class ReynPresenter:
         # pre-0.21.0 body, which always operated on the item.
         item = entry.item
         meta = item.meta or {}
-        if item.kind == "intervention":
+        # #5057 axis B: "intervention" (still pending, or a live entry just
+        # folded to resolved in place) and "intervention_resolved" (restore's
+        # always-answered projection) both render through the SAME function —
+        # the sibling kind carries the resolved/pending distinction now, see
+        # that function's own docstring for what changed inside it.
+        if item.kind in ("intervention", "intervention_resolved"):
             return self._present_intervention_pending(item, width)
         if item.kind == "tool_call_started" and meta.get(_RUNNING_SINCE_KEY) is not None:
             return self._present_running_tool(item, width)

--- a/src/reyn/interfaces/inline/textual_chat/restore.py
+++ b/src/reyn/interfaces/inline/textual_chat/restore.py
@@ -77,16 +77,20 @@ CLOSED-SET answer's own ``ChatMessage.content`` is an empty string; see
 ``INTERVENTION_ANSWER_META_KEY``, :mod:`reyn.runtime.chat_message`). One
 history entry is already fully self-contained — this projection just reads
 it, with no join/correlation step and therefore no GUESSED-key risk (the
-#3287 / #3299 P2 defect class this arc hit twice before). It projects
-straight into the SAME ``kind="intervention"`` shape a LIVE resolved entry
-uses (``meta["prompt"]`` / ``meta["detail"]`` for the head,
+#3287 / #3299 P2 defect class this arc hit twice before). It projects into
+``kind="intervention_resolved"`` (#5057 axis B — the sibling kind a LIVE
+entry is folded to once answered, :meth:`TextualChatApp._resolve_intervention` /
+:meth:`TextualChatApp._handle_intervention_answer_event`), carrying
+``meta["prompt"]`` / ``meta["detail"]`` for the head and
 ``meta["_answer_label"]`` for the "✓ answered: ..." line —
-``ReynPresenter._present_intervention_pending``'s RESOLVED branch, no
-presenter change needed), so a restored Q→A reads through the EXACT SAME
-render path — and hits the EXACT SAME neutralization boundary (the prompt /
-detail / a matched choice's label are all model-derived / untrusted; that
-presenter call site is where they get neutralized, never here) — a live
-resolved entry does. P5's out-of-order answering is safe by construction:
+``ReynPresenter._present_intervention_pending`` renders both kinds through
+the ONE function (:meth:`ReynPresenter.present` dispatches ``intervention``
+and ``intervention_resolved`` to the same call), so a restored Q→A reads
+through the EXACT SAME render path — and hits the EXACT SAME neutralization
+boundary (the prompt / detail / a matched choice's label are all
+model-derived / untrusted; that presenter call site is where they get
+neutralized, never here) — a live resolved entry does. P5's out-of-order
+answering is safe by construction:
 each answer record carries its OWN question, so answering interventions in
 any order restores each with its correct pairing. An intervention that was
 NEVER answered leaves no history trace at all (``announce`` never appends)
@@ -302,15 +306,35 @@ def project_restored_frames(
                 # history trace at all (``announce`` never appends to
                 # history) — nothing to project, which is the specified
                 # behavior, not an omission.
+                #
+                # #5057 (axis B — architect's confirmed design): this
+                # projection is ALWAYS an already-answered entry (an
+                # unanswered intervention has no history trace at all, per
+                # the docstring above), so it builds ``kind=
+                # "intervention_resolved"`` — the sibling kind axis B adds
+                # specifically so a resolved frame IS structurally distinct
+                # from a genuinely pending one, rather than relying on
+                # ``_ingest_frame`` (or anything downstream) to inspect
+                # ``meta`` to tell them apart. ``intervention_resolved`` is
+                # NOT in ``outbox._INTERVENTION_FAMILY_KINDS`` — axis A's
+                # identity requirement does not apply here (a resolved
+                # frame is never answered again, so it needs no
+                # correlation anchor), which is what lets this branch stay
+                # ONE shape instead of the id-present/id-absent split axis
+                # A alone forced (#5047's own history: a record from
+                # BEFORE ``deliver_answer_to`` started stamping
+                # ``intervention_id`` carries none, and that must render
+                # exactly the same as one that does).
                 frames.append(
                     OutboxMessage(
-                        kind="intervention",
+                        kind="intervention_resolved",
                         text=str(prompt),
                         meta={
                             RESTORED_META_KEY: True,
                             "prompt": prompt,
                             "detail": meta.get(INTERVENTION_DETAIL_META_KEY),
                             "_answer_label": meta.get(INTERVENTION_ANSWER_META_KEY, ""),
+                            "intervention_id": meta.get("intervention_id"),
                         },
                     )
                 )

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -106,7 +106,7 @@ class ChatRenderer:
     def message(self, msg: OutboxMessage) -> None:
         """Render one outbox item.
 
-        msg.kind ∈ {"agent","status","error","intervention","trace"}
+        msg.kind ∈ {"agent","status","error","intervention","intervention_resolved","trace"}
         msg.meta carries provenance (actor, run_id, run_id_short, ...)
         """
 
@@ -150,6 +150,11 @@ class ConsoleChatRenderer(ChatRenderer):
         "status": "[…]",
         "error": "[error]",
         "intervention": "[ask]",
+        # #5057 axis B: an already-answered intervention (restore's backlog
+        # projection, or a live one folded in place once answered) is a
+        # DIFFERENT kind from "intervention" now — give it its own prefix
+        # rather than falling through to `_PREFIX.get(kind, "")`'s silent "".
+        "intervention_resolved": "[answered]",
         "trace": "[trace]",
     }
 

--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -318,8 +318,18 @@ async def run_output_loop(
             # swallowed for a picker that never arrives.
             if renderer.uses_app_input() and command_ui_region:
                 continue
-            # persistent kind (not transient "status") so the list stays readable
-            msg = OutboxMessage(kind="intervention", text=msg.text)
+            # persistent kind (not transient "status") so the list stays
+            # readable. #5047 (axis A): was "intervention" purely for this
+            # persistence property, not because a rewind list IS a
+            # question — OutboxMessage.__post_init__ now requires a genuine
+            # meta["intervention_id"] for that family, which this frame
+            # never had. "system" is the SAME "persistent info row" kind
+            # OutboxMessage.from_wire demotes an identity-less wire
+            # intervention frame to — giving rewind its OWN distinct kind
+            # (axis C) is a separate, later step; this keeps the existing
+            # persistent-render behavior without claiming an identity this
+            # frame never had.
+            msg = OutboxMessage(kind="system", text=msg.text)
         # On a real terminal: wrap in run_in_terminal so the prompt is cleared
         # before output and redrawn after — required for ANSI/Rich to render
         # cleanly without corrupting the prompt.

--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -163,7 +163,14 @@ class AgUiEmitter:
             # terminal TOOL_CALL_RESULT so a pending frontend-tool never dangles.
             if isinstance(frame, DisplayFrame):
                 msg = frame.message
-                if msg.kind == "intervention" and (msg.meta or {}).get("intervention_id"):
+                # #5047: the `and (msg.meta or {}).get("intervention_id")`
+                # this line used to carry is now redundant — dropped, not
+                # merely simplified: `OutboxMessage.__post_init__` requires
+                # a genuine `intervention_id` for every `kind=="intervention"`
+                # frame at construction time, so a frame reaching here with
+                # that kind is guaranteed to carry one. This is itself the
+                # observation point that the fix landed.
+                if msg.kind == "intervention":
                     yield to_sse(encode_intervention_tool_start(dict(msg.meta)))
             if isinstance(frame, EventFrame):
                 ev = frame.event

--- a/src/reyn/interfaces/transport/agui/profile.py
+++ b/src/reyn/interfaces/transport/agui/profile.py
@@ -86,6 +86,10 @@ CUSTOM_PROFILE: dict[str, CustomName] = _entries(
         "an intervention prompt is displayed (the reyn client draws it natively; the answer round-trip rides the reyn.intervention.* frontend-tool)",
     ),
     CustomName(
+        "reyn.display.intervention_resolved", DISPLAY_NS, "{text: str}",
+        "#5057 axis B: an ALREADY-ANSWERED intervention — replayed from history on reconnect or folded in place after a live answer. A distinct kind from reyn.display.intervention on purpose: it never emits a companion reyn.intervention.* frontend-tool (nothing to answer), and the reyn client never registers it as pending",
+    ),
+    CustomName(
         "reyn.display.presentation", DISPLAY_NS, "{text: str}",
         "a present op's text; the render-node model rides the _reyn block's meta.nodes, inert on the wire",
     ),

--- a/src/reyn/runtime/outbox.py
+++ b/src/reyn/runtime/outbox.py
@@ -62,6 +62,13 @@ _STANDARD_DISPLAY_KINDS: "frozenset[str]" = frozenset({
 # silent no-ops (they ride as reyn.display.* CUSTOM, round-trip losslessly).
 _PROFILED_DISPLAY_KINDS: "frozenset[str]" = frozenset({
     "intervention",         # native prompt UI (answer round-trip via reyn.intervention.*)
+    "intervention_resolved",  # #5057 axis B: an ALREADY-ANSWERED intervention —
+                              # replayed from history or folded in place after a
+                              # live answer. Never routes to the panel (never a
+                              # frontend-tool round-trip) — the sibling kind IS
+                              # the resolved/pending discriminator, so nothing
+                              # downstream needs to read meta to tell the two
+                              # apart.
     "presentation",         # a present op's text; render-node model on _reyn meta.nodes
     "user",                 # a user-authored line echoed live to the scrollback
     "system",               # persisted lifecycle/status chrome (compaction / budget / cost-warn)
@@ -98,6 +105,25 @@ CONTROL_KINDS: "frozenset[str]" = frozenset({
 
 # The complete closed vocabulary of valid OutboxMessage.kind values.
 VOCABULARY: "frozenset[str]" = DISPLAY_KINDS | CONTROL_KINDS
+
+# #5047/#5057 (structural fix, architect's confirmed design — axis A): the
+# intervention-family kinds — every one of these REQUIRES
+# ``meta["intervention_id"]`` to be a genuine identity, checked by
+# :meth:`OutboxMessage.__post_init__` (in-process construction) and
+# demoted-around by :meth:`OutboxMessage.from_wire` (untrusted wire
+# construction, which cannot fail-close).
+#
+# #5057 axis B deliberately does NOT add ``"intervention_resolved"`` here.
+# Identity is required because a frame in this family can still be ANSWERED
+# — the id is the correlation anchor ``answer_intervention_by_id`` needs.
+# An already-resolved frame is never answered again, so it carries no such
+# requirement; giving it its OWN kind (rather than growing this set) is
+# what lets ``_ingest_frame``'s registration guard become a bare
+# ``kind == "intervention"`` check with no meta inspection at all — the
+# sibling kind IS the resolved/pending discriminator now, so this set stays
+# exactly ``{"intervention"}`` rather than "growing" the way an earlier
+# draft of this comment expected.
+_INTERVENTION_FAMILY_KINDS: "frozenset[str]" = frozenset({"intervention"})
 
 
 @dataclass(frozen=True)
@@ -140,6 +166,24 @@ class OutboxMessage:
                 "CUSTOM name on the AG-UI wire. Untrusted wire values must use "
                 "OutboxMessage.from_wire (lenient)."
             )
+        # #5047 (axis A — architect's confirmed design): identity is not
+        # optional for the intervention family. Before this, `kind` was a
+        # closed, validated vocabulary while `intervention_id` lived
+        # unchecked inside the free-form `meta` dict — a well-formed
+        # `kind="intervention"` frame could be built with no identity at
+        # all, and #5047's own real-environment bug (a restored/replayed
+        # frame silently registering as a fresh pending intervention) is
+        # exactly what that gap let through. Checked HERE, in the SAME
+        # constructor that already validates `kind` — one mechanism, not
+        # two. Untrusted WIRE values still cannot fail-close this way —
+        # see :meth:`from_wire`'s own demotion instead.
+        if self.kind in _INTERVENTION_FAMILY_KINDS and not self.meta.get("intervention_id"):
+            raise ValueError(
+                f"OutboxMessage.kind {self.kind!r} requires a genuine "
+                "meta['intervention_id'] — every intervention-family frame "
+                "must carry its own identity at construction time, never "
+                "recovered later by position or absence (#5047)."
+            )
 
     @classmethod
     def from_wire(
@@ -156,7 +200,25 @@ class OutboxMessage:
         degrade gracefully (ignore-unknown), never fail-close — so decode routes
         around :meth:`__post_init__` here. All PRODUCTION construction uses the
         validating ``__init__``. Bypasses ``__init__`` via ``object.__new__`` +
-        ``object.__setattr__`` (the dataclass is frozen)."""
+        ``object.__setattr__`` (the dataclass is frozen).
+
+        #5047 (axis A, wire side — architect's confirmed design): a wire
+        frame carrying a KNOWN intervention-family ``kind`` but no
+        ``meta["intervention_id"]`` is DEMOTED to ``kind="system"`` rather
+        than built as-is. Requiring identity here the way ``__post_init__``
+        does for in-process construction would mean fail-closing on
+        untrusted wire data — "never fail-close" is this method's own
+        founding rule, not negotiable. Demotion satisfies BOTH constraints
+        at once: the frame is never silently dropped (it renders, as a
+        plain persistent info row — the same "lifecycle chrome" kind
+        already used for compaction/budget/cost-warn), and it can never
+        claim an identity it does not have, so it can never register as
+        pending or become an answer's destination. This is UNRELATED to
+        ignore-unknown (an UNKNOWN kind is untouched by this — that is a
+        different failure mode, ignored exactly as before); this only
+        catches a KNOWN kind with a missing REQUIRED field."""
+        if kind in _INTERVENTION_FAMILY_KINDS and not (meta or {}).get("intervention_id"):
+            kind = "system"
         obj = object.__new__(cls)
         object.__setattr__(obj, "kind", kind)
         object.__setattr__(obj, "text", text)

--- a/tests/interfaces/test_3540_intervention_answer_fold.py
+++ b/tests/interfaces/test_3540_intervention_answer_fold.py
@@ -162,8 +162,14 @@ def _render(msg: OutboxMessage) -> str:
 def _signature(msg: OutboxMessage) -> "tuple[str, str]":
     """The comparable shape of one entry: its kind plus what it actually
     renders as. Compared LIVE-vs-RESTORE only — never against a literal, so
-    this pins no formatting of its own."""
-    if msg.kind == "intervention":
+    this pins no formatting of its own.
+
+    #5057 axis B: a live-answered entry folds to ``kind=
+    "intervention_resolved"``, the SAME sibling kind restore's projection
+    builds directly — both go through the ONE presenter function
+    (``ReynPresenter._present_intervention_pending``, dispatched for either
+    kind), so both must be rendered here too, not just "intervention"."""
+    if msg.kind in ("intervention", "intervention_resolved"):
         return (msg.kind, _render(msg))
     return (msg.kind, msg.text)
 
@@ -204,7 +210,9 @@ async def test_answered_intervention_is_one_entry_pending_and_after() -> None:
 
         # ── after answering ──
         answered = _flow_items(app)
-        assert [m.kind for m in answered] == ["intervention"], (
+        # #5057 axis B: the fold also swaps kind to "intervention_resolved"
+        # (still the SAME entry object, settled in place — never a second row).
+        assert [m.kind for m in answered] == ["intervention_resolved"], (
             "answering must settle the SAME entry, never append a second row; "
             f"got {[m.kind for m in answered]}"
         )
@@ -320,7 +328,8 @@ async def test_live_and_restore_produce_the_same_entry_sequence(tmp_path: Path) 
     )
     # Non-vacuity: both sides must actually SHOW the answered Q→A — two empty
     # sequences would otherwise compare equal.
-    assert [kind for kind, _ in live] == ["intervention"], (
+    # #5057 axis B: both sides settle to the resolved sibling kind.
+    assert [kind for kind, _ in live] == ["intervention_resolved"], (
         f"expected exactly the answered Q→A entry on both sides, got {live!r}"
     )
     assert "Delete the branch?" in live[0][1] and "Yes" in live[0][1]

--- a/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
+++ b/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
@@ -1,5 +1,5 @@
-"""Tier 2: #5047 — a REPLAYED, already-answered intervention frame must not
-be registered as pending.
+"""Tier 2: #5047/#5057 — a REPLAYED, already-answered intervention frame must
+not be registered as pending.
 
 Real chain of causes (lead-coder's own trace, `issuecomment-5377193342`,
 architect's ruling `issuecomment-5377199266`): on every (re)connect,
@@ -17,26 +17,53 @@ a phantom already-answered entry sorting ahead of a real pending one
 misdirects the NEXT genuine answer to whichever real entry happens to sort
 after the phantom, not the one the user actually meant.
 
-**The discriminator, corrected mid-implementation** (lead-coder, measured
-against ``restore.py:95-104``, not guessed): the first draft of this fix
-guarded on ``meta["_answer_label"]`` being truthy — but a restored frame's
-``_answer_label`` can itself be the EMPTY STRING (``restore.py``'s own
-``meta.get(INTERVENTION_ANSWER_META_KEY, "")``), so a falsy-VALUE check
-lets an empty-label restored frame slip through and register as pending
-anyway — the #4996-family "the value's own absence doesn't distinguish two
-different reasons" conflation, here on emptiness rather than None. Fixed
-to check ``RESTORED_META_KEY`` (fixed ``True``/absent) instead — every
-restored ``kind="intervention"`` frame is, by construction, always
-already-answered (an intervention never answered has no history trace to
-restore from at all), so this marker is both necessary and sufficient.
-``gutter.py``'s own sibling check (:228) had the identical value-truthiness
-trap (found in the same investigation) and is fixed alongside — presence
-of the ``_answer_label`` KEY, not its value.
+**Two guards were tried and retired before the settled mechanism below**:
+
+1. A first draft guarded on ``meta["_answer_label"]`` being truthy — but a
+   restored frame's ``_answer_label`` can itself be the EMPTY STRING
+   (``restore.py``'s own ``meta.get(INTERVENTION_ANSWER_META_KEY, "")``), so
+   a falsy-VALUE check let an empty-label restored frame slip through and
+   register as pending anyway (the #4996-family "the value's own absence
+   doesn't distinguish two different reasons" conflation, here on
+   emptiness rather than None).
+2. #5056/#5060 fixed that by checking marker PRESENCE instead
+   (``RESTORED_META_KEY`` / ``meta.get("intervention_id")``) — correct for
+   the producer population known at the time, but producer-specific: #5057
+   found TWO more producers (``stream_client.py``'s and `app.py`'s own
+   ``/rewind`` text-list fallback) that reused ``kind="intervention"`` with
+   neither marker, which the guard never covered, AND #5057 also measured
+   that once axis A (below) requires every ``kind="intervention"`` frame to
+   carry a real ``intervention_id``, ``restore.py``'s answered projection
+   would ALSO come to carry one (``deliver_answer_to`` already stamps it on
+   the history entry) — silently reopening the exact hole #5056 closed
+   (issuecomment-5378183009, found independently from the panel side —
+   ``InterventionPanel.add_pending`` has zero ``_answer_label`` awareness —
+   while architect found the same collision from the ingest side).
+
+**The settled mechanism (axis A + axis B, architect's confirmed design,
+same PR)**: axis A (``OutboxMessage.__post_init__`` / ``.from_wire``,
+``outbox.py``) makes ``meta["intervention_id"]`` a genuine constructor-time
+requirement for ``kind="intervention"`` — a producer with no real identity
+(the two ``/rewind`` fallbacks) can no longer build that kind at all, so
+they build ``kind="system"`` instead. Axis B gives an ALREADY-ANSWERED
+frame its OWN sibling kind, ``"intervention_resolved"`` — NOT in axis A's
+identity-required family (a resolved frame is never answered again, so it
+needs no correlation anchor) — so ``restore.py``'s projection (and the two
+live-answer fold sites, ``TextualChatApp._resolve_intervention`` /
+``_handle_intervention_answer_event``) build/fold to THAT kind instead of
+``"intervention"``. ``app.py``'s ``_ingest_frame`` registration guard is
+then a bare ``kind == "intervention"`` check with NO meta inspected at all
+— structurally unable to register a resolved frame, because a resolved
+frame is never that kind. This is not a marker anyone could add a THIRD
+producer without (axis A/B are enforced at ``OutboxMessage`` construction
+itself, not at the ingest call site), closing the class of bug rather than
+its 3 known instances.
 
 This test's own witness is the fake-pending REGISTRATION itself (the panel
-never opening), not the rendered text (which was already correct before
-this fix — the presenter's RESOLVED branch pre-dates #5047 and checks
-``answer is not None``, never truthiness).
+never opening), not the rendered text (the presenter's RESOLVED branch
+renders identically for both kinds it recognizes — see
+``ReynPresenter._present_intervention_pending``'s own docstring for what
+changed inside it).
 
 Real ``TextualChatApp`` + a real, minimal ``ClientTransport`` (no mocks).
 """
@@ -107,27 +134,33 @@ class _ReplayTransport(ClientTransport):
         return None
 
 
-def _restored_answered_frame(*, answer_label: str) -> OutboxMessage:
+def _restored_answered_frame(
+    *, answer_label: str, intervention_id: "str | None" = "iv-restored",
+) -> OutboxMessage:
     """Shaped EXACTLY like ``restore.py``'s ``project_restored_frames`` own
-    projection of an already-answered history entry (:305-314): ``kind=
-    "intervention"``, ``RESTORED_META_KEY: True``, no ``intervention_id``
-    (a restored entry carries none — this is itself part of #5047's own
-    misdelivery mechanism, not something this test needs to exercise
-    further)."""
+    projection of an already-answered history entry (#5057 axis B):
+    ``kind="intervention_resolved"``, ``RESTORED_META_KEY: True``.
+    ``intervention_id`` defaults to a real value (the common case —
+    ``deliver_answer_to`` stamps it on the history entry) but can be
+    ``None`` too (a record from before that stamping existed) — axis B's
+    whole point is that BOTH shapes are equally excluded from pending
+    registration, since neither is ``kind="intervention"``."""
     return OutboxMessage(
-        kind="intervention",
+        kind="intervention_resolved",
         text="Allow fetching from 'news.ycombinator.com'?",
         meta={
             RESTORED_META_KEY: True,
             "prompt": "Allow fetching from 'news.ycombinator.com'?",
             "detail": None,
             "_answer_label": answer_label,
+            "intervention_id": intervention_id,
         },
     )
 
 
 def _genuine_pending_frame() -> OutboxMessage:
-    """A real LIVE pending intervention — no ``RESTORED_META_KEY``, no
+    """A real LIVE pending intervention — ``kind="intervention"`` (axis A
+    requires the real ``intervention_id`` below at construction time), no
     ``_answer_label`` yet."""
     return OutboxMessage(
         kind="intervention",
@@ -146,11 +179,15 @@ def _genuine_pending_frame() -> OutboxMessage:
 @pytest.mark.asyncio
 async def test_replayed_answered_intervention_does_not_open_the_pending_panel():
     """Tier 2: strip-falsifier. A backlog replay carrying ONLY an already-
-    answered intervention must never open the panel — reverting the
-    ``RESTORED_META_KEY`` guard in ``app.py`` (registering it as pending
-    again) turns this red (``panel.display`` becomes True for a frame that
-    was never actually pending)."""
-    transport = _ReplayTransport([_restored_answered_frame(answer_label="Always")])
+    answered intervention must never open the panel — reverting
+    ``restore.py``'s projection (or the two live-answer fold sites) back to
+    ``kind="intervention"`` instead of ``"intervention_resolved"`` turns
+    this red (``panel.display`` becomes True for a frame that was never
+    actually pending), because ``_ingest_frame``'s bare ``kind ==
+    "intervention"`` guard would then register it."""
+    transport = _ReplayTransport(
+        [_restored_answered_frame(answer_label="Always")]
+    )
     app = TextualChatApp(transport=transport)
 
     async with app.run_test(size=(100, 30)) as pilot:
@@ -170,15 +207,14 @@ async def test_replayed_answered_intervention_does_not_open_the_pending_panel():
 
 @pytest.mark.asyncio
 async def test_replayed_intervention_with_an_empty_answer_label_still_excluded():
-    """Tier 2: the falsifying edge case that moved the discriminator from
-    ``_answer_label`` to ``RESTORED_META_KEY`` mid-implementation. An empty-
-    string ``_answer_label`` (a real shape ``restore.py`` can produce —
+    """Tier 2: the falsifying edge case that originally moved the
+    discriminator away from ``_answer_label`` truthiness, now covered
+    structurally instead of by a meta check. An empty-string
+    ``_answer_label`` (a real shape ``restore.py`` can produce —
     ``meta.get(INTERVENTION_ANSWER_META_KEY, "")``) must still be excluded
-    from pending registration. A guard checking ``not meta.get(
-    "_answer_label")`` (falsy-VALUE, the first-draft mistake) would treat
-    the empty string the same as "key absent" and let this slip through —
-    this test pins that the ACTUAL guard (key presence) does not have that
-    gap."""
+    from pending registration — the guard no longer inspects
+    ``_answer_label`` at all (kind alone decides), so this can no longer
+    regress the way a falsy-VALUE meta check once did."""
     transport = _ReplayTransport([_restored_answered_frame(answer_label="")])
     app = TextualChatApp(transport=transport)
 
@@ -194,14 +230,42 @@ async def test_replayed_intervention_with_an_empty_answer_label_still_excluded()
         assert panel.has_pending() is False
 
 
-def test_gutter_reads_an_empty_answer_label_as_resolved_not_pending():
-    """Tier 2: strip-falsifier for the sibling ``gutter.py`` fix (same
-    investigation, same emptiness-vs-absence trap). A restored intervention
-    with an empty ``_answer_label`` must get the RESOLVED (dim, not the
-    amber "needs you") gutter glyph, not the PENDING one — reverting
-    ``ReynGutter``'s "intervention" branch back to ``not (msg.meta or {}).get(
-    "_answer_label")`` (falsy-VALUE) turns this red: an empty string is
-    falsy, so it would render as still-PENDING.
+@pytest.mark.asyncio
+async def test_replayed_answered_intervention_with_no_id_still_excluded():
+    """Tier 2: a history record from BEFORE ``deliver_answer_to`` started
+    stamping ``intervention_id`` (or any other reason the id is absent)
+    projects with ``intervention_id: None`` — axis B does not require
+    identity for ``kind="intervention_resolved"`` (it is never answered
+    again), so this must be excluded from pending registration exactly
+    like the identified case above. Strip-falsifier for axis B's own
+    "identity not required" half: a regression that made
+    ``intervention_resolved`` construction REQUIRE an id would make this
+    fixture itself raise, not merely fail the assertion."""
+    transport = _ReplayTransport(
+        [_restored_answered_frame(answer_label="Always", intervention_id=None)]
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        assert panel.display is False
+        assert panel.has_pending() is False
+
+
+def test_gutter_reads_the_resolved_kind_as_resolved_not_pending():
+    """Tier 2: strip-falsifier for the sibling ``gutter.py`` fix (#5057
+    axis B). A restored/resolved intervention — ``kind=
+    "intervention_resolved"``, regardless of its ``_answer_label`` value —
+    must get the RESOLVED (dim-glyph, ``_CC_DONE``-toned) gutter render,
+    never the PENDING one — reverting ``ReynGutter``'s branch back to
+    reading ``_answer_label`` meta (rather than dispatching on kind) is
+    exactly the class of regression this test would catch if that read
+    were reintroduced with the old falsy-VALUE bug: an empty
+    ``_answer_label`` NO LONGER matters here at all — the kind alone
+    settles it.
 
     Uses the PUBLIC ``ReynGutter.decorate`` surface over a real
     ``FlowModel``/``Entry`` pair (``textual_flowview`` — no mount needed,
@@ -220,10 +284,14 @@ def test_gutter_reads_an_empty_answer_label_as_resolved_not_pending():
     model: "FlowModel[OutboxMessage]" = FlowModel()
 
     resolved_empty = model.append(
-        OutboxMessage(kind="intervention", text="…", meta={"_answer_label": ""}),
+        OutboxMessage(
+            kind="intervention_resolved", text="…", meta={"_answer_label": ""},
+        ),
     )
     pending = model.append(
-        OutboxMessage(kind="intervention", text="…", meta={}),
+        OutboxMessage(
+            kind="intervention", text="…", meta={"intervention_id": "iv-live"},
+        ),
     )
 
     rendered_resolved = gutter.decorate(resolved_empty, width=_GUTTER_WIDTH, height=1)
@@ -239,16 +307,15 @@ def test_gutter_reads_an_empty_answer_label_as_resolved_not_pending():
     )
     assert "⋯" in rendered_pending.plain, rendered_pending.plain
     assert "⋯" not in rendered_resolved.plain, (
-        "empty _answer_label read as pending — the emptiness-vs-absence "
-        "trap this test exists to catch"
+        "a resolved-kind intervention rendered as pending"
     )
 
 
 @pytest.mark.asyncio
 async def test_genuine_pending_intervention_still_opens_the_panel():
-    """Tier 2: accept-side — a genuinely LIVE pending intervention (no
-    ``RESTORED_META_KEY``) still registers and opens the panel exactly as
-    before this fix; an "always skip registration" implementation would
+    """Tier 2: accept-side — a genuinely LIVE pending intervention
+    (``kind="intervention"``) still registers and opens the panel exactly
+    as before this fix; an "always skip registration" implementation would
     pass the strip-falsifiers above vacuously without this."""
     transport = _ReplayTransport([_genuine_pending_frame()])
     app = TextualChatApp(transport=transport)

--- a/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
+++ b/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
@@ -73,6 +73,7 @@ import asyncio
 from typing import AsyncIterator
 
 import pytest
+from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
@@ -253,6 +254,78 @@ async def test_replayed_answered_intervention_with_no_id_still_excluded():
         panel = app.query_one(InterventionPanel)
         assert panel.display is False
         assert panel.has_pending() is False
+
+
+@pytest.mark.asyncio
+async def test_wire_decoded_idless_intervention_frame_is_demoted_never_pending():
+    """Tier 2: witness ④ — axis A's WIRE-side defense (block on PR #5082,
+    docs-maintainer TESTS-READ + lead-coder: "the wire-side demotion has no
+    witness anywhere in this diff" — `test_agui_mapping_completeness.py`'s
+    own comment pointed at a test that does not cover this, and
+    `test_outbox_vocabulary.py` only covers the UNRELATED ignore-unknown
+    path).
+
+    ``in-process`` construction is guarded by ``OutboxMessage.__post_init__``
+    (axis A) — but a REMOTE reconnect-backlog frame is UNTRUSTED wire data
+    (``agui/protocol.py:decode_event``'s ``"messages"``/``"display"``
+    branches, both routed through ``OutboxMessage.from_wire``, which cannot
+    fail-close) — the EXACT path #5047's own real-environment bug rode
+    through. This test decodes a wire event shaped exactly like a remote
+    server's reconnect-backlog entry for a KNOWN intervention-family kind
+    with NO ``intervention_id`` (a malicious or simply out-of-date peer),
+    through the REAL ``decode_event`` entry point (not calling
+    ``from_wire`` directly), and proves BOTH halves of the "never
+    fail-close, never register as pending" contract: the frame is DRAWN
+    (never silently dropped — "no exception was raised" is not the claim
+    here), AND the panel never opens for it.
+
+    Strip-falsifier: removing the demotion clause in
+    ``OutboxMessage.from_wire`` (verified locally) turns this red twice
+    over — the frame's kind reverts to the raw wire value ``"intervention"``
+    (no longer demoted) and ``panel.has_pending()`` becomes ``True``
+    (registers as a fake-pending entry with no real id, #5047's own
+    original bug, reintroduced via the wire path this test drives)."""
+    from reyn.interfaces.transport.agui.protocol import decode_event
+
+    decoded = decode_event(
+        "CUSTOM",
+        {
+            "_reyn": {
+                "frame": "display",
+                "kind": "intervention",
+                "text": "Allow fetching from 'evil.example'?",
+                "meta": {},  # no intervention_id -- the untrusted-peer shape
+            },
+        },
+    )
+    assert decoded is not None, "a known intervention-family kind must decode, not ignore-unknown"
+    wire_msg = decoded.message
+    # The demotion itself: a KNOWN kind with no identity is never allowed to
+    # reach the app as "intervention" — draws as ordinary chrome instead.
+    assert wire_msg.kind == "system", (
+        f"expected the wire decode to demote an id-less 'intervention' frame "
+        f"to 'system'; got kind={wire_msg.kind!r}"
+    )
+
+    transport = _ReplayTransport([wire_msg])
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        # Drawn, not dropped: the frame reached the flow at all.
+        flow_kinds = [e.item.kind for e in app.query_one(FlowView).entries]
+        assert "system" in flow_kinds, (
+            f"the demoted frame was never rendered at all — expected it to "
+            f"draw as ordinary chrome, got flow kinds={flow_kinds!r}"
+        )
+
+        panel = app.query_one(InterventionPanel)
+        assert panel.has_pending() is False, (
+            "a wire-decoded, id-less intervention-family frame registered as "
+            "pending — the exact remote path #5047's own bug rode through"
+        )
 
 
 def test_gutter_reads_the_resolved_kind_as_resolved_not_pending():

--- a/tests/interfaces/test_agui_mapping_completeness.py
+++ b/tests/interfaces/test_agui_mapping_completeness.py
@@ -128,14 +128,20 @@ def test_every_display_kind_round_trips_over_the_wire() -> None:
         # not producer kinds — the codec must round-trip any kind, so bypass the
         # producer vocabulary gate on the test input.
         #
-        # #5047 axis A (wire side): ``from_wire`` deliberately demotes a KNOWN
-        # intervention-family kind with no genuine ``intervention_id`` to
-        # ``"system"`` (never fail-close on untrusted wire data) — that
-        # demotion is the SUBJECT of a dedicated test elsewhere
-        # (``test_outbox_vocabulary.py``), not a round-trip bug this test
-        # should flag. Give "intervention" the identity it structurally
-        # requires so THIS test still proves the round-trip for a
-        # well-formed intervention frame, same as every other kind.
+        # #5047/#5057 axis A (wire side): ``from_wire`` deliberately demotes
+        # a KNOWN intervention-family kind with no genuine
+        # ``intervention_id`` to ``"system"`` (never fail-close on
+        # untrusted wire data) — that demotion is the SUBJECT of a
+        # dedicated test elsewhere
+        # (``test_5047_replayed_answered_intervention_not_pending.py``'s
+        # own ``test_wire_decoded_idless_intervention_frame_is_demoted_
+        # never_pending``, added on PR #5082's docs-maintainer/lead-coder
+        # TESTS-READ block — this round-trip test's OWN kind set always
+        # supplies an id, so it would never have caught the demotion going
+        # missing), not a round-trip bug THIS test should flag. Give
+        # "intervention" the identity it structurally requires so THIS
+        # test still proves the round-trip for a well-formed intervention
+        # frame, same as every other kind.
         meta = {"k": "v", "intervention_id": "iv-x"} if kind == "intervention" else {"k": "v"}
         frame = DisplayFrame(OutboxMessage.from_wire(kind=kind, text="body", meta=meta))
         decoded = _roundtrip(frame)

--- a/tests/interfaces/test_agui_mapping_completeness.py
+++ b/tests/interfaces/test_agui_mapping_completeness.py
@@ -127,12 +127,22 @@ def test_every_display_kind_round_trips_over_the_wire() -> None:
         # kind set, which over-reports phantom strings (e.g. ``nodes``) that are
         # not producer kinds — the codec must round-trip any kind, so bypass the
         # producer vocabulary gate on the test input.
-        frame = DisplayFrame(OutboxMessage.from_wire(kind=kind, text="body", meta={"k": "v"}))
+        #
+        # #5047 axis A (wire side): ``from_wire`` deliberately demotes a KNOWN
+        # intervention-family kind with no genuine ``intervention_id`` to
+        # ``"system"`` (never fail-close on untrusted wire data) — that
+        # demotion is the SUBJECT of a dedicated test elsewhere
+        # (``test_outbox_vocabulary.py``), not a round-trip bug this test
+        # should flag. Give "intervention" the identity it structurally
+        # requires so THIS test still proves the round-trip for a
+        # well-formed intervention frame, same as every other kind.
+        meta = {"k": "v", "intervention_id": "iv-x"} if kind == "intervention" else {"k": "v"}
+        frame = DisplayFrame(OutboxMessage.from_wire(kind=kind, text="body", meta=meta))
         decoded = _roundtrip(frame)
         assert isinstance(decoded, DisplayFrame), f"{kind!r} did not decode to a DisplayFrame"
         assert decoded.message.kind == kind, f"{kind!r} kind mangled → {decoded.message.kind!r}"
         assert decoded.message.text == "body"
-        assert decoded.message.meta == {"k": "v"}
+        assert decoded.message.meta == meta
 
 
 def test_every_forwarded_audit_event_round_trips_over_the_wire() -> None:

--- a/tests/interfaces/test_agui_transport_bit_identical.py
+++ b/tests/interfaces/test_agui_transport_bit_identical.py
@@ -36,7 +36,10 @@ _DISPLAY = [
     OutboxMessage(kind="agent", text="hello [world] <ok>"),
     OutboxMessage(kind="status", text="thinking about it"),
     OutboxMessage(kind="error", text="something failed"),
-    OutboxMessage(kind="intervention", text="approve this? [y/N]"),
+    OutboxMessage(
+        kind="intervention", text="approve this? [y/N]",
+        meta={"intervention_id": "iv-bit-identical"},  # #5047 axis A
+    ),
     OutboxMessage(kind="trace", text="· ran a tool"),
 ]
 

--- a/tests/interfaces/test_inline_pr3a_app.py
+++ b/tests/interfaces/test_inline_pr3a_app.py
@@ -271,7 +271,12 @@ def test_intervention_message_sets_waiting_for_you():
     from reyn.runtime.outbox import OutboxMessage
     r = InlineChatRenderer()
     r.on_audit_event(_evt("turn_started"))
-    r.message(OutboxMessage(kind="intervention", text="Continue?"))
+    r.message(
+        OutboxMessage(
+            kind="intervention", text="Continue?",
+            meta={"intervention_id": "iv-pr3a"},  # #5047 axis A
+        )
+    )
     text = "".join(t for _, t in r.working_frags(time.monotonic()))
     assert "Waiting for you" in text
 
@@ -282,7 +287,12 @@ def test_user_answered_intervention_resets_to_thinking():
     from reyn.runtime.outbox import OutboxMessage
     r = InlineChatRenderer()
     r.on_audit_event(_evt("turn_started"))
-    r.message(OutboxMessage(kind="intervention", text="Continue?"))
+    r.message(
+        OutboxMessage(
+            kind="intervention", text="Continue?",
+            meta={"intervention_id": "iv-pr3a"},  # #5047 axis A
+        )
+    )
     r.on_audit_event(_evt("user_answered_intervention"))
     text = "".join(t for _, t in r.working_frags(time.monotonic()))
     assert "Thinking" in text

--- a/tests/interfaces/test_inline_renderer_cutover.py
+++ b/tests/interfaces/test_inline_renderer_cutover.py
@@ -141,15 +141,24 @@ def test_trace_line_uses_corner_marker() -> None:
 
 
 def test_intervention_keeps_question_text() -> None:
-    """Tier 2: an intervention line preserves the question text."""
-    out = _plain("intervention", "Which file?")
+    """Tier 2: an intervention line preserves the question text.
+
+    #5047 axis A: a genuine ``intervention_id`` is required, otherwise
+    ``OutboxMessage.from_wire`` demotes to ``kind="system"`` (the frame is
+    no longer identity-less — this test is about a WELL-FORMED
+    intervention, not the demotion path, which has its own dedicated
+    witness elsewhere)."""
+    out = _plain("intervention", "Which file?", meta={"intervention_id": "iv-x"})
     assert "Which file?" in out
 
 
 def test_intervention_suppresses_run_id_short_prefix() -> None:
     """Tier 2: intervention drops the [#short] run-id hash — it is cryptic noise on
     an interactive user-facing prompt where disambiguation is unnecessary (#2243)."""
-    out = _plain("intervention", "Confirm?", meta={"run_id_short": "ab12"})
+    out = _plain(
+        "intervention", "Confirm?",
+        meta={"run_id_short": "ab12", "intervention_id": "iv-x"},
+    )
     assert "#ab12" not in out
     assert "Confirm?" in out
 
@@ -159,7 +168,7 @@ def test_intervention_keeps_actor_prefix_when_present() -> None:
     actor is asking — only run_id_short (the cryptic hash) is suppressed."""
     out = _plain(
         "intervention", "Confirm?",
-        meta={"actor": "skill_builder", "run_id_short": "ab12"},
+        meta={"actor": "skill_builder", "run_id_short": "ab12", "intervention_id": "iv-x"},
     )
     assert "skill_builder" in out
     assert "#ab12" not in out
@@ -170,7 +179,7 @@ def test_kinds_use_distinct_markers() -> None:
     """Tier 2: message kinds carry distinct glyphs so the eye separates them — the
     assistant ● is not reused for an intervention (◆) or a tool invocation (▸)."""
     agent = _plain("agent", "x")
-    interv = _plain("intervention", "x")
+    interv = _plain("intervention", "x", meta={"intervention_id": "iv-x"})
     tool = _plain("tool_call_started", "", {"tool": "Bash", "args": {}})
     assert "●" in agent
     assert "◆" in interv and "●" not in interv

--- a/tests/interfaces/test_outbox_vocabulary.py
+++ b/tests/interfaces/test_outbox_vocabulary.py
@@ -33,9 +33,16 @@ _SRC = REPO_ROOT / "src" / "reyn"
 
 
 def test_construction_accepts_every_vocabulary_kind() -> None:
-    """Tier 2: each of the closed-vocabulary kinds constructs (validated __init__)."""
+    """Tier 2: each of the closed-vocabulary kinds constructs (validated __init__).
+
+    #5047 axis A: the intervention-family kinds (``_INTERVENTION_FAMILY_KINDS``,
+    today just ``"intervention"``) additionally require a genuine
+    ``meta["intervention_id"]`` at construction — every OTHER kind still
+    constructs from bare ``kind``+``text`` alone, which is what this loop
+    pins for the rest of the vocabulary."""
     for kind in VOCABULARY:
-        msg = OutboxMessage(kind=kind, text="x")
+        meta = {"intervention_id": "iv-test"} if kind == "intervention" else {}
+        msg = OutboxMessage(kind=kind, text="x", meta=meta)
         assert msg.kind == kind
     # The vocabulary is the disjoint union of DISPLAY_KINDS and CONTROL_KINDS.
     assert DISPLAY_KINDS.isdisjoint(CONTROL_KINDS)

--- a/tests/interfaces/test_textual_chat_intervention_panel_3299.py
+++ b/tests/interfaces/test_textual_chat_intervention_panel_3299.py
@@ -226,9 +226,16 @@ def _third_choice_intervention() -> OutboxMessage:
     )
 
 
+#: #5057 axis B: a resolved LIVE entry is folded to "intervention_resolved"
+#: in place (the SAME entry object — churn-zero, #3299 P2 §4), never back to
+#: plain "intervention". These two helpers look up "the intervention flow
+#: entry/entries" both before AND after resolving, so both kinds count.
+_IV_KINDS = ("intervention", "intervention_resolved")
+
+
 def _iv_entry(app: TextualChatApp):
     entries = [
-        e for e in app.query_one(FlowView).entries if e.item.kind == "intervention"
+        e for e in app.query_one(FlowView).entries if e.item.kind in _IV_KINDS
     ]
     assert len(entries) == 1, f"expected one intervention entry, got {len(entries)}"
     return entries[0]
@@ -239,7 +246,7 @@ def _iv_entries(app: TextualChatApp):
     return {
         e.item.meta.get("intervention_id"): e
         for e in app.query_one(FlowView).entries
-        if e.item.kind == "intervention"
+        if e.item.kind in _IV_KINDS
     }
 
 
@@ -1210,10 +1217,10 @@ async def test_resolve_updates_the_same_entry_no_new_entry_appended() -> None:
         await pilot.pause()
 
         before = {
-            id(e) for e in app.query_one(FlowView).entries if e.item.kind == "intervention"
+            id(e) for e in app.query_one(FlowView).entries if e.item.kind in _IV_KINDS
         }
         entry_before = next(
-            e for e in app.query_one(FlowView).entries if e.item.kind == "intervention"
+            e for e in app.query_one(FlowView).entries if e.item.kind in _IV_KINDS
         )
 
         await pilot.press("enter")  # blind Enter answers the pre-highlighted "Yes"
@@ -1221,7 +1228,7 @@ async def test_resolve_updates_the_same_entry_no_new_entry_appended() -> None:
         await pilot.pause()
 
         after = {
-            id(e) for e in app.query_one(FlowView).entries if e.item.kind == "intervention"
+            id(e) for e in app.query_one(FlowView).entries if e.item.kind in _IV_KINDS
         }
         assert after == before, (
             "resolving changed the SET of intervention flow-entry objects — "

--- a/tests/interfaces/test_textual_chat_phase2_3273.py
+++ b/tests/interfaces/test_textual_chat_phase2_3273.py
@@ -470,7 +470,10 @@ def test_left_gutter_vocabulary_is_all_single_cell() -> None:
     future glyph added to any of those sources is automatically covered."""
     glyphs: "set[str]" = set(_RUNNING_FRAMES)
     for kind in _KIND_LINE:
-        glyph, _ = _gutter_glyph_color(OutboxMessage(kind=kind, text=""))
+        # #5047 axis A: "intervention" additionally requires a genuine
+        # meta["intervention_id"] at construction time.
+        meta = {"intervention_id": "iv-x"} if kind == "intervention" else {}
+        glyph, _ = _gutter_glyph_color(OutboxMessage(kind=kind, text="", meta=meta))
         glyphs.add(glyph)
     glyph, _ = _gutter_glyph_color(
         OutboxMessage(kind="tool_call_started", text="grep", meta={"tool": "grep"})
@@ -484,12 +487,16 @@ def test_left_gutter_vocabulary_is_all_single_cell() -> None:
         OutboxMessage(kind="tool_call_failed", text="", meta={"tool": "grep"})
     )
     glyphs.add(glyph)
-    # intervention: pending (no _answer_label) and resolved (has one) are two
-    # distinct glyph branches (#3324) — both enumerated.
-    glyph, _ = _gutter_glyph_color(OutboxMessage(kind="intervention", text="", meta={}))
+    # intervention: pending ("intervention") and resolved
+    # ("intervention_resolved") are two distinct glyph branches (#3324,
+    # re-keyed on KIND rather than `_answer_label` meta by #5057 axis B) —
+    # both enumerated.
+    glyph, _ = _gutter_glyph_color(
+        OutboxMessage(kind="intervention", text="", meta={"intervention_id": "iv-x"})
+    )
     glyphs.add(glyph)
     glyph, _ = _gutter_glyph_color(
-        OutboxMessage(kind="intervention", text="", meta={"_answer_label": "yes"})
+        OutboxMessage(kind="intervention_resolved", text="", meta={"_answer_label": "yes"})
     )
     glyphs.add(glyph)
 

--- a/tests/interfaces/test_textual_chat_row_contrast_3367.py
+++ b/tests/interfaces/test_textual_chat_row_contrast_3367.py
@@ -188,6 +188,13 @@ def _scenarios() -> "list[tuple[str, OutboxMessage]]":
             meta[RUNNING_SINCE_KEY] = 0.0
         if answered:
             meta["_answer_label"] = "yes"
+        if kind == "intervention":
+            # #5047 axis A: OutboxMessage.__post_init__ requires a genuine
+            # meta["intervention_id"] for this kind at construction time —
+            # every OTHER kind in DISPLAY_KINDS (including the sibling
+            # "intervention_resolved") constructs from the payload above
+            # alone.
+            meta["intervention_id"] = "iv-contrast-scenario"
         label = (
             f"kind={kind} settled={settle_kind} "
             f"failed_result={result is _FAILING_RESULT} "

--- a/tests/interfaces/test_transport_bit_identical.py
+++ b/tests/interfaces/test_transport_bit_identical.py
@@ -41,7 +41,10 @@ _DISPLAY = [
     OutboxMessage(kind="agent", text="hello [world] <ok>"),
     OutboxMessage(kind="status", text="thinking about it"),
     OutboxMessage(kind="error", text="something failed"),
-    OutboxMessage(kind="intervention", text="approve this? [y/N]"),
+    OutboxMessage(
+        kind="intervention", text="approve this? [y/N]",
+        meta={"intervention_id": "iv-bit-identical"},  # #5047 axis A
+    ),
     OutboxMessage(kind="trace", text="· ran a tool"),
 ]
 

--- a/tests/runtime/test_3299_p4_intervention_restore_qa.py
+++ b/tests/runtime/test_3299_p4_intervention_restore_qa.py
@@ -110,9 +110,9 @@ def _answered_message(
 
 def test_restored_answered_intervention_is_one_entry_with_both_qa() -> None:
     """Tier 1: a single answered-intervention history record projects to
-    EXACTLY ONE ``kind="intervention"`` frame (never two, never a bare
-    ``kind="user"`` echo of the empty answer text) whose rendered content
-    contains BOTH the question and the answer.
+    EXACTLY ONE ``kind="intervention_resolved"`` frame (#5057 axis B — never
+    two, never a bare ``kind="user"`` echo of the empty answer text) whose
+    rendered content contains BOTH the question and the answer.
 
     NON-VACUITY: before this PR, ``project_restored_frames`` had no
     ``INTERVENTION_PROMPT_META_KEY`` branch at all — this message would have
@@ -120,10 +120,10 @@ def test_restored_answered_intervention_is_one_entry_with_both_qa() -> None:
     EMPTY row (``m.text == ""`` for a choice-style answer), losing BOTH the
     question and the answer. Verified locally by reverting the ``if prompt:``
     branch in ``restore.py``: the assertions below flip RED (no
-    ``kind="intervention"`` frame is produced at all)."""
+    ``kind="intervention_resolved"`` frame is produced at all)."""
     msgs = [_answered_message(iv_id="iv-1", prompt="Proceed with deploy?", answer="Yes")]
     frames = [f for f in project_restored_frames(msgs) if f.kind != "system"]
-    assert [f.kind for f in frames] == ["intervention"], (
+    assert [f.kind for f in frames] == ["intervention_resolved"], (
         f"expected exactly one intervention entry, got kinds={[f.kind for f in frames]}"
     )
 
@@ -149,7 +149,7 @@ def test_restored_free_text_answer_also_one_entry_with_both_qa() -> None:
         },
     )
     frames = [f for f in project_restored_frames([msg]) if f.kind != "system"]
-    assert [f.kind for f in frames] == ["intervention"], (
+    assert [f.kind for f in frames] == ["intervention_resolved"], (
         f"expected exactly one intervention entry, got kinds={[f.kind for f in frames]}"
     )
     rendered = _render(frames[0])
@@ -215,7 +215,7 @@ def test_out_of_order_answers_each_restore_with_their_own_question() -> None:
         _answered_message(iv_id="iv-A", prompt="Delete branch A?", answer="Yes"),
     ]
     frames = [f for f in project_restored_frames(msgs) if f.kind != "system"]
-    assert [f.kind for f in frames] == ["intervention", "intervention"], (
+    assert [f.kind for f in frames] == ["intervention_resolved", "intervention_resolved"], (
         f"expected exactly two intervention entries, got kinds={[f.kind for f in frames]}"
     )
     first, second = (_render(f) for f in frames)
@@ -244,7 +244,7 @@ def test_unanswered_intervention_has_no_restored_trace() -> None:
     ]
     frames = [f for f in project_restored_frames(msgs) if f.kind != "system"]
     kinds = [f.kind for f in frames]
-    assert "intervention" not in kinds
+    assert "intervention_resolved" not in kinds
     assert kinds == ["user", "agent", "user"]
 
 
@@ -393,7 +393,7 @@ async def test_producer_closed_set_answer_round_trips_through_restore(tmp_path: 
 
     msg = ChatMessage(role=entry["role"], content=entry["text"], meta=entry["meta"])
     frames = [f for f in project_restored_frames([msg]) if f.kind != "system"]
-    assert [f.kind for f in frames] == ["intervention"], (
+    assert [f.kind for f in frames] == ["intervention_resolved"], (
         f"expected exactly one intervention entry, got kinds={[f.kind for f in frames]}"
     )
     rendered = _render(frames[0])

--- a/tests/runtime/test_fp0041_prd2_outbox_interceptor.py
+++ b/tests/runtime/test_fp0041_prd2_outbox_interceptor.py
@@ -338,7 +338,10 @@ async def test_make_interceptor_skips_non_dispatchable_kinds():
     )
     rt = ExternalRef(transport="slack", destination={})
     for kind in ("status", "trace", "__end__", "intervention", "error"):
-        msg = OutboxMessage(kind=kind, text="x", reply_to=rt)
+        # #5047 axis A: "intervention" additionally requires a genuine
+        # meta["intervention_id"] at construction time.
+        meta = {"intervention_id": "iv-x"} if kind == "intervention" else {}
+        msg = OutboxMessage(kind=kind, text="x", meta=meta, reply_to=rt)
         assert (await interceptor(msg)) is False, f"kind={kind} unexpectedly handled"
 
 


### PR DESCRIPTION
**[tui-coder]** — part of #5057 (structural follow-up to #5047/#5056/#5060 — architect's confirmed design, axis A + axis B).

## What

Closes the id-less intervention-family hole structurally, replacing 2 successive marker-based guards with 2 complementary invariants enforced at `OutboxMessage` construction:

- **Axis A** (`outbox.py`): `OutboxMessage.__post_init__` requires a genuine `meta["intervention_id"]` for `kind="intervention"`; `OutboxMessage.from_wire` demotes an identity-less wire frame to `kind="system"` (never fail-close on untrusted wire data). Closes the two `/rewind` text-list fallbacks (`stream_client.py`, `app.py`) — neither carried a real id, so they now build `kind="system"` directly.
- **Axis B** (this PR, found necessary mid-implementation — see below): an already-resolved intervention gets its own sibling kind, `"intervention_resolved"` — not in the identity-required family (never answered again). `restore.py`'s projection and the two live-answer fold sites (`_resolve_intervention` / `_handle_intervention_answer_event`) build/fold to that kind. `_ingest_frame`'s registration guard collapses to a bare `kind == "intervention"` check, no meta inspected — structurally unable to register a resolved frame.

## Why axis B, not just axis A

Axis A alone reopens the exact hole #5056 closed: `deliver_answer_to` already stamps a real `intervention_id` on the history entry, so requiring identity just makes `restore.py`'s replayed-answered projection carry an id too — indistinguishable from a genuine pending frame once the registration guard trusts identity alone. Found independently from two directions while implementing (architect from the ingest side, tui-coder from the panel side — `InterventionPanel.add_pending` has zero resolved/pending awareness) and reported before continuing rather than silently "fixing" the 3 then-failing tests by patching their fixtures (#5057 issuecomment-5378183009). Confirmed via broker: axis A+B were always meant to land in the same PR, not axis B deferred.

Axis B also lets 3 independently-written `_answer_label` meta reads (presenter.py, gutter.py, the retired panel-registration guard) collapse to one KIND check — architect's own acceptance bar: axis B counts as landed only once those reads disappear/simplify, not merely once a sibling kind exists.

## Test plan

- [x] `ruff check` on all changed files — clean
- [x] `scripts/test_tier_audit.py --strict` on all changed test files — 109 tests, 0 Tier-4 violations
- [x] `scripts/verify_module_docstrings.py` on all changed src files — OK
- [x] `scripts/mypy_ratchet.py` — OK (baselined, no new findings)
- [x] `scripts/flat_tests_ratchet.py` — OK
- [x] `scripts/check_tests_path_literal_reference.py` — OK
- [x] `scripts/check_bare_tests_import_reference.py` — OK
- [x] `scripts/check_file_depth_reference.py` — OK
- [x] Scoped pytest: 263 tests across every intervention/rewind/outbox/AG-UI-mapping/gutter/presenter test file touched or adjacent to this change — all green
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

- [x] 🔴 **[docs-maintainer] TESTS-READ block — witness④ (from_wire's wire-side demotion) has no test anywhere in this PR.** `test_agui_mapping_completeness.py:131-138`'s comment claims the demotion is "the SUBJECT of a dedicated test elsewhere (`test_outbox_vocabulary.py`)" — that test does not exist. Independently strip-falsified: removed the `from_wire` demotion clause, ran all 11 touched test files (110 tests) — all still pass. The wire-side identity-demotion path (the one axis A can't fail-close on, per architect's own framing) is currently unwitnessed. Full evidence: issuecomment-5378298573.


**FIXED (`fada220cf`)** — independently re-verified, not just re-read: ran the new witness `test_wire_decoded_idless_intervention_frame_is_demoted_never_pending` myself (passes), then independently stripped the `from_wire` demotion clause again and confirmed it fails for the stated reason (`AssertionError: expected ... to 'system'; got kind='intervention'`), restored, all 6 tests in the file green. Genuinely load-bearing.
