### PR TITLE
fix(#5057): plain --cui delivers intervention answers BY ID, retire answer_oldest_intervention_*

### DIFF
--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -62,7 +62,16 @@ def _pending_head_id(head: object) -> "str | None":
     a behavior change for either), but the id this function returns feeds
     straight into ``answer_intervention_by_id`` — a caller passing a
     genuinely wrong shape deserves "no pending intervention recognized"
-    (falls through to a normal turn), never a corrupted delivery target."""
+    (falls through to a normal turn), never a corrupted delivery target.
+    The fall-through read as "correct" is really only guaranteed today
+    because NEITHER production transport can trigger it (a resolved-
+    elsewhere intervention is the one case this repo's own #2690 fix
+    already made this exact fall-through mean); a hypothetical future
+    third shape arriving alongside a genuinely still-pending intervention
+    would fall through the SAME way but for a different reason — silence
+    over a broken destination, not "already answered". Still the right
+    choice (never deliver to a destination this function couldn't
+    verify), named here so a future reader isn't left to rediscover it."""
     if isinstance(head, str):
         return head
     iv_id = getattr(head, "id", None)

--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -49,11 +49,34 @@ def _pending_head_id(head: object) -> "str | None":
     (``InProcessTransport``/``SessionBoundTransport`` — #5047 axis A
     guarantees its ``.id`` is a genuine identity, not merely "the oldest"),
     or a bare id string (``AgUiTransport``'s own ``_pending_intervention_id``).
-    Not a form-sniff over ambiguous shapes — these are the two production
-    transports' own established contracts, and both id forward to the same
-    ``answer_intervention_by_id`` funnel identically."""
-    iv_id = getattr(head, "id", head)
-    return str(iv_id) if iv_id is not None else None
+
+    An unrecognized third shape returns ``None`` (logged) rather than
+    silently coercing it into SOME string via ``str(...)`` — architect's own
+    review finding on this PR (#5057): a naive ``getattr(head, "id", head)``
+    would happily turn e.g. a dict-shaped value (a genuinely similar-looking
+    but DIFFERENT contract lives nearby, ``RemoteReadModel.intervention_
+    head()``'s own dict projection) into a garbage id string via ``str()``
+    — the exact #4996-family "failure that looks like success" this repo's
+    own vocabulary names. Never reached by the two production transports
+    today (this IS a strict narrowing of a check that never fires yet, not
+    a behavior change for either), but the id this function returns feeds
+    straight into ``answer_intervention_by_id`` — a caller passing a
+    genuinely wrong shape deserves "no pending intervention recognized"
+    (falls through to a normal turn), never a corrupted delivery target."""
+    if isinstance(head, str):
+        return head
+    iv_id = getattr(head, "id", None)
+    if isinstance(iv_id, str) and iv_id:
+        return iv_id
+    if head is not None:
+        logger.warning(
+            "#5057: pending_intervention_head() returned an unrecognized "
+            "shape (%s) -- neither a bare id string nor an object with a "
+            "genuine string .id. Treating as no pending intervention "
+            "rather than deriving a garbage id from it.",
+            type(head).__name__,
+        )
+    return None
 
 
 async def run_input_loop(

--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -43,6 +43,19 @@ def _simple_status(text: str) -> OutboxMessage:
     return OutboxMessage(kind="status", text=text)
 
 
+def _pending_head_id(head: object) -> "str | None":
+    """Extract the id from :meth:`ClientTransport.pending_intervention_head`'s
+    two established return shapes (#5057): a real ``UserIntervention``
+    (``InProcessTransport``/``SessionBoundTransport`` — #5047 axis A
+    guarantees its ``.id`` is a genuine identity, not merely "the oldest"),
+    or a bare id string (``AgUiTransport``'s own ``_pending_intervention_id``).
+    Not a form-sniff over ambiguous shapes — these are the two production
+    transports' own established contracts, and both id forward to the same
+    ``answer_intervention_by_id`` funnel identically."""
+    iv_id = getattr(head, "id", head)
+    return str(iv_id) if iv_id is not None else None
+
+
 async def run_input_loop(
     transport: ClientTransport,
     prompt_session: PromptSession,
@@ -196,8 +209,27 @@ async def route_input_line(
     # Everything below is TURN text: a command returned above, so the two
     # ``not text.startswith("/")`` guards this function used to carry are gone
     # rather than left as conditions that can no longer be false (#3595 S5).
-    if transport.pending_intervention_head() is not None:
-        if await transport.answer_intervention_text(text):
+    head = transport.pending_intervention_head()
+    if head is not None:
+        # #5057 (architect's own trace): deliver BY the id CAPTURED HERE, at
+        # check time — never let the transport funnel re-read "whichever
+        # intervention is head NOW" at delivery time. Before this, this
+        # branch called `answer_intervention_text(text)` with NO id at all,
+        # which fell through to `answer_oldest_intervention_text` — the
+        # SAME head-of-queue race #3299 P2's own `answer_intervention_by_id`
+        # (R1) was invented to close for every OTHER surface: if a second
+        # queued intervention resolves (via `/answer`, an A2A peer, …)
+        # between this check and the reply being typed, the NEXT head is a
+        # DIFFERENT intervention than the one the operator is answering —
+        # the exact multi-pending misdelivery #5047 traced. `head` here is
+        # ALWAYS a genuine `UserIntervention` (in-process/session-bound) or
+        # a bare id string (the AG-UI remote transport, `client.py`'s own
+        # `_pending_intervention_id`) — `getattr(head, "id", head)`
+        # extracts the id either way, not sniffed on ambiguity, just the
+        # two established production shapes (#5047 axis A guarantees
+        # `head.id` is a real identity now, not merely "the oldest").
+        iv_id = _pending_head_id(head)
+        if await transport.answer_intervention_text(text, intervention_id=iv_id):
             return
     # Mark a reply as in flight before submit so the pacing gate on the next
     # iteration blocks until the output loop signals it. A command would

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -266,13 +266,20 @@ class InProcessTransport(ClientTransport):
         s = self._attached()
         if s is None:
             return False
-        if intervention_id is not None:
-            # #3299 P2 (R1): deliver BY ID through the existing id-aware
-            # session funnel — never the head, which a second queued
-            # intervention could have displaced since the caller's copy was
-            # displayed (the multi-pending mis-delivery this closes).
-            return bool(await s.answer_intervention_by_id(intervention_id, text))
-        return bool(await s.answer_oldest_intervention_text(text))
+        # #3299 P2 (R1) / #5057 (the oldest-fallback closed): deliver BY ID
+        # through the existing id-aware session funnel — never the head,
+        # which a second queued intervention could have displaced since the
+        # caller's copy was displayed (the multi-pending mis-delivery this
+        # closes). Every real caller passes a genuine id now (#5047 axis A
+        # requires one at `OutboxMessage` construction; the plain `--cui`
+        # client's own remaining id-less call site was fixed in the SAME PR,
+        # `stream_client.py`'s `_pending_head_id`) — an absent id is a
+        # non-conforming caller, and answers False (fail-closed, never
+        # "guess the oldest") rather than the removed `answer_oldest_
+        # intervention_text` fallback.
+        if intervention_id is None:
+            return False
+        return bool(await s.answer_intervention_by_id(intervention_id, text))
 
     async def answer_intervention_choice(
         self, choice_id: str, *, intervention_id: "str | None" = None
@@ -280,13 +287,15 @@ class InProcessTransport(ClientTransport):
         s = self._attached()
         if s is None:
             return False
-        if intervention_id is not None:
-            return bool(
-                await s.answer_intervention_by_id(
-                    intervention_id, "", choice_id_override=choice_id
-                )
+        # #5057: see answer_intervention_text's own comment — the same
+        # fail-closed-on-no-id contract, the oldest-fallback removed.
+        if intervention_id is None:
+            return False
+        return bool(
+            await s.answer_intervention_by_id(
+                intervention_id, "", choice_id_override=choice_id
             )
-        return bool(await s.answer_oldest_intervention_choice(choice_id))
+        )
 
     def put_display(self, msg: "OutboxMessage") -> None:
         # Client-authored display (user echo, /copy result, resolved-answer

--- a/src/reyn/interfaces/transport/session_bound.py
+++ b/src/reyn/interfaces/transport/session_bound.py
@@ -104,22 +104,25 @@ class SessionBoundTransport(ClientTransport):
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None
     ) -> bool:
-        if intervention_id is not None:
-            return bool(
-                await self._session.answer_intervention_by_id(intervention_id, text)
-            )
-        return bool(await self._session.answer_oldest_intervention_text(text))
+        # #5057: the oldest-fallback closed — see InProcessTransport's own
+        # mirror of this method for the full rationale. Fail-closed on no
+        # id, never "guess the oldest".
+        if intervention_id is None:
+            return False
+        return bool(
+            await self._session.answer_intervention_by_id(intervention_id, text)
+        )
 
     async def answer_intervention_choice(
         self, choice_id: str, *, intervention_id: "str | None" = None
     ) -> bool:
-        if intervention_id is not None:
-            return bool(
-                await self._session.answer_intervention_by_id(
-                    intervention_id, "", choice_id_override=choice_id
-                )
+        if intervention_id is None:
+            return False
+        return bool(
+            await self._session.answer_intervention_by_id(
+                intervention_id, "", choice_id_override=choice_id
             )
-        return bool(await self._session.answer_oldest_intervention_choice(choice_id))
+        )
 
     def put_display(self, msg: "OutboxMessage") -> None:
         self._display_sink(msg)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -7464,31 +7464,14 @@ class Session:
         """Thin wrapper → InterventionHandler.maybe_answer."""
         return await self._intervention_handler.maybe_answer(text)
 
-    async def answer_oldest_intervention_choice(self, choice_id: str) -> bool:
-        """Deliver a chosen choice id to the oldest pending intervention.
-
-        The inline region selector calls this when the user picks a choice: the
-        id is authoritative (bypasses text/hotkey ``match_choice``), reusing the
-        same ``choice_id_override`` path A2A peer answers use. Returns False when
-        nothing is pending. A public UI seam for closed-set typed-input.
-        """
-        iv = self._interventions.head()
-        if iv is None:
-            return False
-        return await self._deliver_answer_to(iv, "", choice_id_override=choice_id)
-
-    async def answer_oldest_intervention_text(self, text: str) -> bool:
-        """Deliver a free-text answer to the oldest pending intervention.
-
-        The inline CUI calls this when the user submits text via the normal
-        input bar while an ask_user intervention is pending. Uses match_choice
-        so hotkeys (``"1"`` → first option) and option names resolve correctly.
-        Returns False when nothing is pending.
-        """
-        iv = self._interventions.head()
-        if iv is None:
-            return False
-        return await self._deliver_answer_to(iv, text)
+    # #5057: `answer_oldest_intervention_choice`/`_text` (deliver to
+    # `self._interventions.head()`, "the oldest pending") are RETIRED — the
+    # multi-pending head-of-queue race #3299 P2's `answer_intervention_by_id`
+    # (R1) closed for every OTHER caller. Their last caller,
+    # `stream_client.py`'s plain `--cui` answer path, now captures the head's
+    # own id at check time and delivers BY ID through `answer_intervention_
+    # by_id` below, same as every other surface (architect's own trace,
+    # #5057 issuecomment-5378442342 / lead-coder's relay).
 
     async def _deliver_answer_to(
         self,

--- a/tests/_support/slash.py
+++ b/tests/_support/slash.py
@@ -117,22 +117,24 @@ class RecordingTransport(ClientTransport):
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None
     ) -> bool:
-        if intervention_id is not None:
-            return bool(
-                await self._session.answer_intervention_by_id(intervention_id, text)
-            )
-        return bool(await self._session.answer_oldest_intervention_text(text))
+        # #5057: mirrors InProcessTransport/SessionBoundTransport's own fix
+        # -- the oldest-fallback retired, fail-closed on no id.
+        if intervention_id is None:
+            return False
+        return bool(
+            await self._session.answer_intervention_by_id(intervention_id, text)
+        )
 
     async def answer_intervention_choice(
         self, choice_id: str, *, intervention_id: "str | None" = None
     ) -> bool:
-        if intervention_id is not None:
-            return bool(
-                await self._session.answer_intervention_by_id(
-                    intervention_id, "", choice_id_override=choice_id
-                )
+        if intervention_id is None:
+            return False
+        return bool(
+            await self._session.answer_intervention_by_id(
+                intervention_id, "", choice_id_override=choice_id
             )
-        return bool(await self._session.answer_oldest_intervention_choice(choice_id))
+        )
 
     async def cancel_inflight(self) -> str:
         return await self._session.cancel_inflight()

--- a/tests/core/test_agui_attribution.py
+++ b/tests/core/test_agui_attribution.py
@@ -85,7 +85,8 @@ async def test_local_answer_has_no_wire_attribution(tmp_path, monkeypatch) -> No
     task = asyncio.ensure_future(session._dispatch_intervention(iv))
     await wait_until(lambda: bool(session.interventions.list_active()))
 
-    await session.answer_oldest_intervention_text("ok")
+    # #5057: answer_oldest_intervention_text retired -- deliver BY ID (R1).
+    await session.answer_intervention_by_id(iv.id, "ok")
     await asyncio.wait_for(task, timeout=2.0)
 
     assert captured

--- a/tests/interfaces/test_3328_connect_remote_parity_witness.py
+++ b/tests/interfaces/test_3328_connect_remote_parity_witness.py
@@ -38,7 +38,9 @@ never through ``run_remote_repl`` itself).
    over-the-wire answer (a real ``TOOL_CALL_RESULT`` POST, driven by the
    production ``AgUiTransport.answer_intervention_text``) resolves the SAME
    ``InterventionAnswer`` shape (raw, unfenced ``text``) a LOCAL direct answer
-   (``session.answer_oldest_intervention_text``) produces for an equivalent
+   (``session.answer_intervention_by_id``, #5057 — this test's own local
+   oracle call migrated when the retired ``answer_oldest_intervention_text``
+   was removed) produces for an equivalent
    local intervention — both go through ``external_source=False`` (operator,
    unfenced — the P0 keystone), verified on both paths in the same test.
 
@@ -371,7 +373,8 @@ async def test_connect_intervention_round_trip_matches_local_unfenced_answer(
     local_iv = UserIntervention(kind="ask_user", prompt="Proceed?", run_id="r-local")
     local_task = asyncio.ensure_future(session._intervention_handler.dispatch(local_iv))
     await wait_until(lambda: bool(session._interventions.list_active()))
-    local_answered = await session.answer_oldest_intervention_text("yes-locally")
+    # #5057: answer_oldest_intervention_text retired -- deliver BY ID (R1).
+    local_answered = await session.answer_intervention_by_id(local_iv.id, "yes-locally")
     assert local_answered is True
     local_answer = await asyncio.wait_for(local_task, timeout=5.0)
 

--- a/tests/interfaces/test_5057_cui_answer_targets_captured_head.py
+++ b/tests/interfaces/test_5057_cui_answer_targets_captured_head.py
@@ -1,0 +1,117 @@
+"""Tier 2: #5057 -- plain ``--cui``'s intervention-answer path delivers BY the
+head's OWN id, not the retired ``answer_oldest_intervention_text`` fallback
+(which re-derived "whichever intervention is head" fresh, independent of
+what ``pending_intervention_head()`` itself had just returned to the caller).
+
+Real chain of causes (architect's own trace, issuecomment-5378442342;
+lead-coder's relay): ``stream_client.route_input_line`` already reads
+``transport.pending_intervention_head()`` to decide WHETHER to deliver
+directly -- but, before this fix, threw that value away and called
+``transport.answer_intervention_text(text)`` with no id at all. That fell
+through to ``InProcessTransport``/``SessionBoundTransport``'s own
+id-less branch, which called ``Session.answer_oldest_intervention_text`` --
+a SEPARATE, independent re-read of ``self._interventions.head()`` one layer
+down. Two layers agreeing "there is a pending intervention" is not the same
+as both agreeing on WHICH one: #3299 P2's own ``answer_intervention_by_id``
+(R1) was invented precisely so a reply is delivered to the id the caller
+was actually shown, never re-derived by position at the delivery layer --
+every OTHER surface (Textual's panel, the AG-UI wire) already worked this
+way; plain ``--cui`` was the one producer #5057 measured that still hadn't
+migrated (#5047's own scoping thread).
+
+This test proves the id actually flows end-to-end with TWO real, distinct
+pending interventions -- with only one pending, "answered by id" and
+"answered by re-derived position" are indistinguishable (both single
+plausible targets), so a second, non-head intervention is required as a
+witness that the SPECIFIC id -- not merely "some pending intervention" --
+was threaded through and left the non-target untouched.
+
+Strip-falsifier: disabling ``route_input_line``'s direct-delivery branch
+(the pre-#5057 shape, minus even the id-less fallback call, since
+``InProcessTransport``'s own id-less branch is now fail-closed rather than
+"answer_oldest") turns this RED -- verified locally: A's ``asyncio.wait_for``
+below TIMES OUT rather than resolving, since nothing answers it at all.
+
+Real ``Session`` + real ``InProcessTransport`` + the real
+``InterventionHandler`` dispatch path -- no mocks, per the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.repl.stream_client import route_input_line
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
+from reyn.user_intervention import UserIntervention
+from tests._async_wait import wait_until
+from tests._support.agent_session import make_session
+
+
+def _transport_for(session) -> InProcessTransport:
+    """The local ClientTransport over a single-session registry -- the
+    production send seam the ``--cui`` client routes input through (mirrors
+    ``test_cui_permission_answer_resumes_2690.py``'s own helper)."""
+    return InProcessTransport(
+        SimpleNamespace(attached_session=lambda: session),
+        intervention_channel=DEFAULT_CHAT_CHANNEL_ID,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cui_answer_targets_the_head_intervention_leaving_the_second_untouched(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: two real pending interventions (A dispatched first = head, B
+    queued behind it); one plain-``--cui`` reply through the real production
+    ``route_input_line`` resolves ONLY A, with A's own text, leaving B
+    genuinely still pending -- not "some intervention got answered", the
+    SPECIFIC one the transport's own head reported."""
+    session = make_session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+        snapshot_path=tmp_path / ".reyn" / "snap.json",
+        workspace_base_dir=tmp_path,
+    )
+    # run_repl registers this listener on the attached session -- without it
+    # the listener-presence guard auto-refuses every intervention.
+    session.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+    transport = _transport_for(session)
+
+    iv_a = UserIntervention(kind="ask_user", prompt="Proceed with A?", run_id="r-a")
+    iv_b = UserIntervention(kind="ask_user", prompt="Proceed with B?", run_id="r-b")
+    task_a = asyncio.ensure_future(session._intervention_handler.dispatch(iv_a))
+    await wait_until(lambda: bool(session.interventions.list_active()))
+    task_b = asyncio.ensure_future(session._intervention_handler.dispatch(iv_b))
+    await wait_until(lambda: len(session.interventions.list_active()) == 2)
+
+    head = transport.pending_intervention_head()
+    assert getattr(head, "id", head) == iv_a.id, (
+        "the head must be the FIRST-dispatched intervention (FIFO) -- the "
+        "test's own premise, not the fix under test"
+    )
+
+    await route_input_line(transport, "answer meant for A", None)
+
+    answer_a = await asyncio.wait_for(task_a, timeout=5.0)
+    assert answer_a.text == "answer meant for A", (
+        f"A must resolve with its own reply text, got {answer_a!r}"
+    )
+    assert not task_b.done(), (
+        "B must remain genuinely pending -- a misdelivery to B (the "
+        "retired oldest-fallback re-reading head at a lower layer) would "
+        "resolve it with text meant for A"
+    )
+    assert iv_b.id in {iv.id for iv in session.interventions.list_active()}, (
+        "B must still be the one active, untouched intervention"
+    )
+
+    # Clean up B so the test doesn't leak a dangling task.
+    resolved_b = await session.answer_intervention_by_id(iv_b.id, "answer meant for B")
+    assert resolved_b is True
+    answer_b = await asyncio.wait_for(task_b, timeout=5.0)
+    assert answer_b.text == "answer meant for B"

--- a/tests/interfaces/test_5057_cui_answer_targets_captured_head.py
+++ b/tests/interfaces/test_5057_cui_answer_targets_captured_head.py
@@ -115,3 +115,53 @@ async def test_cui_answer_targets_the_head_intervention_leaving_the_second_untou
     assert resolved_b is True
     answer_b = await asyncio.wait_for(task_b, timeout=5.0)
     assert answer_b.text == "answer meant for B"
+
+
+# ── _pending_head_id's own shape-check (architect's PR #5083 review finding) ─
+
+
+def test_pending_head_id_accepts_a_bare_string_and_an_object_with_a_string_id() -> None:
+    """Tier 2: the two RECOGNIZED shapes -- ``AgUiTransport``'s own bare id
+    string, and ``InProcessTransport``/``SessionBoundTransport``'s real
+    ``UserIntervention`` object (any object exposing a genuine string
+    ``.id`` is treated identically, matching the family, not just the one
+    concrete class)."""
+    from reyn.interfaces.repl.stream_client import _pending_head_id
+
+    assert _pending_head_id("iv-remote") == "iv-remote"
+
+    iv = UserIntervention(kind="ask_user", prompt="x?", run_id="r")
+    assert _pending_head_id(iv) == iv.id
+
+    assert _pending_head_id(None) is None
+
+
+def test_pending_head_id_refuses_to_derive_a_garbage_id_from_an_unrecognized_shape() -> (
+    None
+):
+    """Tier 2: strip-falsifier for architect's PR #5083 review finding -- a
+    THIRD shape (neither a bare string nor an object with a genuine string
+    ``.id``) must return ``None``, never a silently-coerced ``str(...)`` of
+    the whole value. A dict is the concrete near-miss named in review: a
+    genuinely similar-looking but DIFFERENT contract
+    (``RemoteReadModel.intervention_head()``) really does return a dict
+    shape nearby in this codebase, so this is not a hypothetical.
+
+    Strip-falsifier: reverting to the naive ``getattr(head, "id", head)``
+    (this function's own pre-review form) turns this red -- it would
+    return ``str({"id": "iv-x", ...})`` instead of ``None``, verified
+    locally."""
+    from reyn.interfaces.repl.stream_client import _pending_head_id
+
+    dict_shaped = {"id": "iv-x", "prompt": "Allow?", "choices": []}
+    assert _pending_head_id(dict_shaped) is None, (
+        f"a dict-shaped value must never be silently coerced into an id "
+        f"string; got {_pending_head_id(dict_shaped)!r}"
+    )
+
+    # An object whose own .id is itself the WRONG type (not a string) is the
+    # same hazard one layer down -- also refused, never str()-coerced.
+    class _WrongIdType:
+        id = 12345
+
+    assert _pending_head_id(_WrongIdType()) is None

--- a/tests/interfaces/test_cui_permission_answer_resumes_2690.py
+++ b/tests/interfaces/test_cui_permission_answer_resumes_2690.py
@@ -19,8 +19,10 @@ requiring permission, so it is the first to hit the dead answer-delivery path.
 
 The fix (``stream_client.route_input_line``) delivers a non-slash line directly
 to the pending intervention via the transport's ``answer_intervention_text``
-seam (wrapping ``answer_oldest_intervention_text``), bypassing the inbox so the
-future resolves. Here the client's ``ClientTransport`` is the local
+seam (delivered BY ID, R1 — #5057 migrated this from the retired ``answer_
+oldest_intervention_text`` to ``_pending_head_id``'s captured-at-check-time
+id), bypassing the inbox so the future resolves. Here the client's
+``ClientTransport`` is the local
 ``InProcessTransport`` over a single-session registry — the same seam production
 uses.
 

--- a/tests/runtime/test_2769_agent_step_intervention_reaches_invoker.py
+++ b/tests/runtime/test_2769_agent_step_intervention_reaches_invoker.py
@@ -197,7 +197,10 @@ async def test_attached_agent_step_permission_reaches_invoker_operator(tmp_path:
     await wait_until(lambda: bool(invoker.interventions.list_active()))
     # The operator picks the affirmative choice on the invoker surface (the authoritative
     # closed-set choice path the inline selector uses — bypasses text/hotkey match_choice).
-    consumed = await invoker.answer_oldest_intervention_choice(YES)
+    # #5057: answer_oldest_intervention_choice retired -- deliver BY ID (R1).
+    head = invoker.interventions.head()
+    assert head is not None
+    consumed = await invoker.answer_intervention_by_id(head.id, "", choice_id_override=YES)
     assert consumed is True
     answer = await asyncio.wait_for(deliver, timeout=5.0)
     # The operator's affirmative reached the agent-step's permission op (a real grant, not a refusal).

--- a/tests/runtime/test_3049_driver_router_op_intervention_reaches_originator.py
+++ b/tests/runtime/test_3049_driver_router_op_intervention_reaches_originator.py
@@ -122,7 +122,10 @@ async def test_attached_driver_mcp_permission_reaches_originator_operator(tmp_pa
     )
 
     # The operator grants on the originator surface; require_mcp returns (allow), no hang.
-    consumed = await originator.answer_oldest_intervention_choice(YES)
+    # #5057: answer_oldest_intervention_choice retired -- deliver BY ID (R1).
+    head = originator.interventions.head()
+    assert head is not None
+    consumed = await originator.answer_intervention_by_id(head.id, "", choice_id_override=YES)
     assert consumed is True
     await asyncio.wait_for(gate, timeout=5.0)  # returns None on allow; MUST NOT raise/hang
 
@@ -148,7 +151,10 @@ async def test_attached_driver_permission_kind_agnostic_same_bus(tmp_path: Path)
 
     gate = asyncio.ensure_future(resolver.require_tool(decl, _TOOL, bus))
     await wait_until(lambda: bool(originator.interventions.list_active()))
-    consumed = await originator.answer_oldest_intervention_choice(YES)
+    # #5057: answer_oldest_intervention_choice retired -- deliver BY ID (R1).
+    head = originator.interventions.head()
+    assert head is not None
+    consumed = await originator.answer_intervention_by_id(head.id, "", choice_id_override=YES)
     assert consumed is True
     await asyncio.wait_for(gate, timeout=5.0)
 

--- a/tests/runtime/test_3053_budget_bus_bridge_aware.py
+++ b/tests/runtime/test_3053_budget_bus_bridge_aware.py
@@ -134,7 +134,10 @@ async def test_attached_driver_budget_exceed_prompt_reaches_originator_operator(
         "instead of its live listener."
     )
 
-    consumed = await originator.answer_oldest_intervention_choice(YES)
+    # #5057: answer_oldest_intervention_choice retired -- deliver BY ID (R1).
+    head = originator.interventions.head()
+    assert head is not None
+    consumed = await originator.answer_intervention_by_id(head.id, "", choice_id_override=YES)
     assert consumed is True
     allow_continue = await asyncio.wait_for(gate, timeout=5.0)
     assert allow_continue is True, (


### PR DESCRIPTION
**[tui-coder]** — part of #5057 (final step, per architect's decision issuecomment-5378442342 / lead-coder's relay).

## What

Plain `--cui`'s intervention-answer path now delivers BY ID (#3299 P2's R1 — "answer BY-ID, never answer-oldest"), the last producer that hadn't migrated. `answer_oldest_intervention_text`/`_choice` are retired.

## Why this took an extra round to scope correctly

My own earlier scoping check (#5057 issuecomment-5378427422) found `answer_oldest_intervention_*` is **not** dead code — it's plain `--cui`'s entire intervention-answer mechanism (`stream_client.py:200` called `answer_intervention_text(text)` with no id at all). A straight deletion would have broken `--cui` outright. Architect traced the actual fix (issuecomment-5378442342): `route_input_line` already reads `pending_intervention_head()` two lines above the delivery call — it just never passed that value through. Passing it closes both the "fallback to delete" question and a real (if narrow) misdelivery class: the retired `answer_oldest_intervention_text` re-derived "whichever intervention is head" one layer down, independent of what the caller had actually just checked.

## Order (matters — reversing it breaks `--cui`)

1. `stream_client.py` — extract and pass the head's own id.
2. `in_process.py`/`session_bound.py` — id-less branch fails closed (not "guess the oldest").
3. `session.py` — delete `answer_oldest_intervention_text`/`_choice`.

`_maybe_answer_oldest_intervention` (a different, router-inbox-level mechanism) is untouched — confirmed out of scope by a repo-wide grep.

## New witness

`test_5057_cui_answer_targets_captured_head.py` — two real pending interventions; one `--cui` reply resolves only the head, leaving the second genuinely untouched (a single pending intervention can't distinguish "answered by id" from "answered by re-derived position", so a second is the actual witness). Strip-verified locally: disabling the direct-delivery branch times out rather than answering anything.

## Test plan

- [x] `ruff check` on all changed files — clean
- [x] `scripts/test_tier_audit.py --strict` — 21 tests, 0 Tier-4 violations
- [x] `scripts/verify_module_docstrings.py` — OK
- [x] `scripts/mypy_ratchet.py` — OK (baselined)
- [x] `scripts/flat_tests_ratchet.py` — OK
- [x] `scripts/check_tests_path_literal_reference.py` — OK
- [x] `scripts/check_bare_tests_import_reference.py` — OK
- [x] `scripts/check_file_depth_reference.py` — OK
- [x] Scoped pytest: 75 tests across every intervention-answer/transport/stream-client file touched or adjacent — all green
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- [x] 🔴 **[lead-coder, escalating architect's note] `getattr(head, "id", head)` accepts anything and fails silently** — a dict has no `.id` attribute, so `getattr` returns the dict itself and `str({...})` travels downstream as an id that matches nothing: the delivery fails silently (#4996 family). The trap is maximally misleading because the dict-shaped neighbour is exactly the shape that HAS an id: `read_model.py:720` `RemoteReadModel.intervention_head` verbatim "Returns the JSON-safe dict projection ({id, prompt, detail, choices: ...})" — near-identical name, different shape, and `getattr` is precisely the mechanism that cannot read it. Not reachable with today's two shapes, which is what makes it silent. One line: unexpected shapes return `None` or raise, never get wrapped in `str()`. I read this line and passed it because the docstring names the limit — naming a boundary is not enforcing it (second time tonight I made that read; the first was praising this PR family's "SESSION-layer is out of scope" note on #5081).

