### PR TITLE
feat(#5084 partial): AgentProfile.broker_identity -- flat, absent=non-participant

### DIFF
--- a/docs/reference/cli/agent.md
+++ b/docs/reference/cli/agent.md
@@ -102,7 +102,7 @@ Each agent owns `.reyn/agents/<name>/`:
 
 | Path | Purpose |
 |------|---------|
-| `profile.yaml` | name / role / created_at / allowed_mcp / preferences / bounding |
+| `profile.yaml` | name / role / created_at / allowed_mcp / preferences / bounding / base_dir / broker_identity |
 | `history.jsonl` | append-only conversation + agent message log |
 | `events.jsonl` | runtime event audit log |
 | `memory/MEMORY.md` + body files | agent-scoped memory layer |

--- a/src/reyn/runtime/profile.py
+++ b/src/reyn/runtime/profile.py
@@ -74,16 +74,32 @@ class AgentProfile:
     # to the project's own base_dir, same convention as `allowed_mcp`'s
     # None).
     base_dir: "str | None" = None
+    # #5084 ③ (owner-directed, issue #5084): a FLAT identity column, the
+    # SAME shape as `name`/`role` above -- not a layered override axis
+    # like `preferences`/`bounding`/`base_dir`. Architect ruling
+    # (issuecomment-5378399712 on #5084): the project layer has no such
+    # value to override ("N agents, no single broker id" -- there is
+    # nothing for a project-wide default to mean), so this is not a
+    # ③-preference/②-bounding/①-capability axis at all, just a plain
+    # per-agent field. `None` (absent) means "this agent does not
+    # participate in broker coordination" -- owner's own words: "the
+    # default agent stays an admin-only agent; it doesn't need to join
+    # development." No special-case branch anywhere reads this as
+    # anything other than absent -- an agent created without it simply
+    # has no identity, the same as one that never set `role`.
+    broker_identity: "str | None" = None
 
     @classmethod
     def new(
         cls, name: str, role: str = "", *, base_dir: "str | None" = None,
+        broker_identity: "str | None" = None,
     ) -> "AgentProfile":
         return cls(
             name=name,
             role=role,
             created_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
             base_dir=base_dir,
+            broker_identity=broker_identity,
         )
 
     @classmethod
@@ -121,6 +137,8 @@ class AgentProfile:
         validate_bounding(bounding, source=f"agent {name!r} profile.yaml")
         raw_base_dir = data.get("base_dir")
         base_dir = str(raw_base_dir) if raw_base_dir else None
+        raw_broker_identity = data.get("broker_identity")
+        broker_identity = str(raw_broker_identity) if raw_broker_identity else None
         return cls(
             name=name,
             role=str(data.get("role", "") or ""),
@@ -129,6 +147,7 @@ class AgentProfile:
             preferences=preferences,
             bounding=bounding,
             base_dir=base_dir,
+            broker_identity=broker_identity,
         )
 
     def save(self, agent_dir: Path) -> None:
@@ -150,6 +169,8 @@ class AgentProfile:
             payload["bounding"] = dict(self.bounding)
         if self.base_dir is not None:
             payload["base_dir"] = self.base_dir
+        if self.broker_identity is not None:
+            payload["broker_identity"] = self.broker_identity
         path.write_text(
             yaml.safe_dump(payload, allow_unicode=True, sort_keys=False),
             encoding="utf-8",

--- a/tests/runtime/test_5084_agent_broker_identity.py
+++ b/tests/runtime/test_5084_agent_broker_identity.py
@@ -1,0 +1,107 @@
+"""Tier 2: #5084 ③ — ``AgentProfile.broker_identity``, a FLAT identity
+column, the SAME shape as ``name``/``role`` — not a layered override axis
+like ``preferences``/``bounding``/``base_dir``.
+
+Architect ruling (issuecomment-5378399712 on #5084): the project layer has
+no such value to override in the first place ("N agents, no single broker
+id" — there is nothing for a project-wide default to mean), so this is not
+a ①-capability/②-bounding/③-preference axis at all, just a plain per-agent
+field. ``None`` (absent) means "this agent does not participate in broker
+coordination" — owner's own words: the default agent stays admin-only and
+does not need to join development. No workspace bound, no protect-at-use
+gate: unlike ``base_dir`` (#5080/#5081), this value carries no filesystem
+or exec capability, so there is nothing for a write-time-only check to
+leave open at a second read path.
+
+Real ``AgentProfile``/``AgentRegistry`` construction throughout — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+
+
+def _no_factory(profile):
+    raise RuntimeError("session factory not used in these write-side tests")
+
+
+# ── round-trip ────────────────────────────────────────────────────────────
+
+
+def test_broker_identity_round_trips_through_profile_yaml(tmp_path: Path) -> None:
+    """Tier 2: a ``broker_identity`` written via
+    ``AgentProfile.new(...).save(...)`` reads back unchanged — the
+    write/read pair a human hand-editing
+    ``profile.yaml`` relies on (#5084's own stated goal: declare an agent
+    purely by writing the file, no slash command needed)."""
+    agent_dir = tmp_path / "agents" / "coder-smith"
+    profile = AgentProfile.new(
+        "coder-smith", role="pairs on the coder role", broker_identity="coder-smith",
+    )
+    profile.save(agent_dir)
+
+    loaded = AgentProfile.load(agent_dir)
+    assert loaded.broker_identity == "coder-smith"
+    # Positive control: an enumeration/parse bug that silently drops every
+    # unrecognised key would also make this pass trivially — assert a
+    # SIBLING field survives the same round trip too.
+    assert loaded.role == "pairs on the coder role"
+
+
+def test_broker_identity_omitted_from_yaml_when_absent(tmp_path: Path) -> None:
+    """Tier 2: a profile with no ``broker_identity`` set writes no such key
+    at all (the SAME "keep the on-disk shape minimal" convention
+    ``allowed_mcp``/
+    ``base_dir`` already follow — no ``null`` residue for a human editing
+    the file by hand to puzzle over)."""
+    agent_dir = tmp_path / "agents" / "plain"
+    AgentProfile.new("plain").save(agent_dir)
+
+    raw = (agent_dir / "profile.yaml").read_text(encoding="utf-8")
+    assert "broker_identity" not in raw
+
+    loaded = AgentProfile.load(agent_dir)
+    assert loaded.broker_identity is None
+
+
+# ── default is absent ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_created_through_the_normal_seam_has_no_broker_identity_by_default(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ``registry.create_agent(name)`` — the ONE creation seam every
+    surface (CLI / web / slash / the ``spawn_agent`` LLM tool) routes
+    through — does not set ``broker_identity``. Absent is the correct
+    default for every agent created this way — no name-based special case
+    is needed anywhere because absence already means non-participation."""
+    project_root = tmp_path / "project"
+    reg = AgentRegistry(project_root=project_root, session_factory=_no_factory)
+
+    profile = await reg.create_agent("coder-jones")
+
+    assert profile.broker_identity is None
+    reloaded = AgentProfile.load(project_root / ".reyn" / "agents" / "coder-jones")
+    assert reloaded.broker_identity is None
+
+
+def test_the_project_default_agent_bootstraps_with_no_broker_identity(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the project's own ``default`` agent — auto-bootstrapped by
+    ``AgentRegistry.__init__`` itself (``AgentProfile.new(DEFAULT_AGENT_
+    NAME, ...)``, bypassing ``create_agent``'s seam entirely, so
+    ``reyn chat`` works before any agent is explicitly created) — has no
+    ``broker_identity`` either. Owner's own words: the default agent stays
+    admin-only and does not need to join development; this is what makes
+    that true without a single name-based branch anywhere in the runtime."""
+    project_root = tmp_path / "project"
+    AgentRegistry(project_root=project_root, session_factory=_no_factory)
+
+    default_profile = AgentProfile.load(project_root / ".reyn" / "agents" / "default")
+    assert default_profile.broker_identity is None


### PR DESCRIPTION
**[e2e-coder]** — part of #5084 → #4206.

## Scope: ③ only (split with tui-coder — they take ②/④)

`AgentProfile.broker_identity` — a FLAT identity column, the same shape as `name`/`role`. Architect ruling (issuecomment-5378399712): the project layer has no project-wide value for this to override in the first place ("N agents, no single broker id" — nothing for a project-wide default to mean), so this is NOT a ①-capability/②-bounding/③-preference layered axis at all, just a plain per-agent field.

## What's here

- `AgentProfile` gains `broker_identity: str | None = None`, load/save round-trip (omitted from the on-disk YAML when absent, matching the `allowed_mcp`/`base_dir` "keep the shape minimal" convention), threaded into `AgentProfile.new()` for constructor parity.
- `None` (absent) means "this agent does not participate in broker coordination" — owner's own words: the default agent stays admin-only and does not need to join development. No name-based special case anywhere: an agent created without it (including the project's own auto-bootstrapped `default`, which never calls `create_agent`'s seam at all — `AgentRegistry.__init__` writes it directly) simply has none.
- **Not** threaded through `registry.create()`/`create_agent()`/CLI/slash/web/the `spawn_agent` tool — #5084's own stated goal is declaring an agent purely by hand-writing `profile.yaml`, no slash command needed, so adding kwargs across 5 creation surfaces would be scope beyond what's asked. If a future issue wants `--broker-identity` on the CLI/tool, that's a separate, explicit ask.
- No workspace bound, no protect-at-use gate: unlike `base_dir` (#5080/#5081) this value carries no filesystem or exec capability, so there is no second write path for a write-time-only check to leave open — the architect BLOCK class from #5081 doesn't apply here.

## Witnesses

4 tests: round-trip through `profile.yaml`, omitted-from-YAML-when-absent, `create_agent`-seam default (a freshly created agent has none), and the auto-bootstrapped project `default` agent (never touches `create_agent`'s seam at all, still has none). Round-trip **strip-verified**: removing the `save()`-side write flips the assertion red with the actual `None` value shown in the failure; restored, green.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5084_agent_broker_identity.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/profile.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py` (re-run right before push)
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Scoped pytest: this file (4/4) + sibling profile/base_dir/topology-binding suites (36/36 total), strip-falsify verified
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

part of #5084, part of #4206
- [x] 🔴 **[lead-coder] `docs/reference/cli/agent.md:105` enumerates `profile.yaml`'s fields and this PR falsifies it** — the row reads `name / role / created_at / allowed_mcp / preferences / bounding`; adding `broker_identity` makes that list wrong. It is ALREADY wrong: `base_dir` (#5081, which I merged) is missing too — #5081 touched this file but not this line. Add both in the same edit. The three softer enumerations (`multi-agent.md:49`, `chat.md:55`, `agent.md:49`) are phrased as partial ("name, role, optional …") — your call. Note on why I missed it at #5081: my pre-merge "what does this make false" sweep grepped for `base_dir`, and this line is stale precisely BECAUSE it lacks that word — a term grep can never find an enumeration that omits the term. The needle has to be the enumeration's other members, or the enumerated structure's name.

> **[lead-coder] verified on head `df0b2a3e`** — the row now reads `name / role / created_at / allowed_mcp / preferences / bounding / base_dir / broker_identity`, so it carries the field I merged without it (#5081) as well as this PR's. Leaving the three partial-list mentions untouched is the right call: they are phrased as "name, role, optional …" and do not claim completeness.
