### PR TITLE
feat(#5044 partial): completion_session() returns a value, never the live Session

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1836,43 +1836,37 @@ class TextualChatApp(App):
     def completion_state(self, text: str) -> CompletionState:
         """The ``/``-command / ``:``-skill completion state for ``text`` (#3354).
 
-        The app's job here is ONLY to resolve the live sources and hand them to
-        the pure
+        The app's job here is ONLY to resolve the source and hand it to the pure
         :func:`~reyn.interfaces.inline.textual_chat.completion.compute_completion`
-        — no candidate is produced here. The two live sources both come off the
-        SAME :class:`~reyn.interfaces.repl.read_model.ChatReadModel` seam every
-        other session-local read uses:
+        — no candidate is produced here. Both live sources a command's
+        ``CompleterFn`` and the ``:`` skill completer need come off ONE
+        :class:`~reyn.interfaces.repl.read_model.CompletionSourceSnapshot`
+        VALUE (#5044, architect ruling — never a live ``Session``; see that
+        class's own docstring), read through the SAME
+        :class:`~reyn.interfaces.repl.read_model.ChatReadModel` seam every
+        other session-local read uses
+        (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.completion_session`).
 
-        - the local ``Session``
-          (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.completion_session`)
-          a command's ``CompleterFn`` is called with, and
-        - that session's registered skills (its public
-          :meth:`~reyn.runtime.session.Session.available_skills`), the same list
-          the ``:`` INVOCATION path filters its ``menu``/``on_demand``/``hidden``
-          surface from.
-
-        A remote client holds no session, so BOTH stay ``None`` — which
-        ``compute_completion`` reads as "source unavailable" and answers with
-        SILENCE, not an empty menu (an empty menu would read as "no such command
-        exists"; see that function's ``session``/``skills`` contract). ``/``
-        command-name completion is registry-derived and transport-independent, so
-        it keeps working there. ``None`` is likewise the answer when the skill
-        read RAISES: a failed read is an unavailable source, never an empty one.
-        Public because the ``Composer`` calls it as the app's completion hook.
+        A remote client holds no session, so the snapshot stays ``None`` —
+        which ``compute_completion`` reads as "source unavailable" and answers
+        with SILENCE, not an empty menu (an empty menu would read as "no such
+        command exists"; see that function's ``source``/``skills`` contract).
+        ``/`` command-name completion is registry-derived and
+        transport-independent, so it keeps working there. ``None`` is
+        likewise the answer when the read RAISES: a failed read is an
+        unavailable source, never an empty one. Public because the
+        ``Composer`` calls it as the app's completion hook.
         """
-        session = None
+        source = None
         skills: "list | None" = None
         if self._read_model is not None:
             try:
-                session = self._read_model.completion_session()
+                source = self._read_model.completion_session()
             except Exception:
                 logger.exception("textual chat: completion session read failed")
-        if session is not None:
-            try:
-                skills = list(session.available_skills())
-            except Exception:
-                logger.exception("textual chat: completion skill read failed")
-        return compute_completion(text, session=session, skills=skills)
+        if source is not None:
+            skills = list(source.available_skills)
+        return compute_completion(text, source=source, skills=skills)
 
     def _turn_usage(self, chain_id: str) -> "dict | None":
         """The real per-turn figures for ``chain_id``, or ``None`` when there

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1845,7 +1845,7 @@ class TextualChatApp(App):
         class's own docstring), read through the SAME
         :class:`~reyn.interfaces.repl.read_model.ChatReadModel` seam every
         other session-local read uses
-        (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.completion_session`).
+        (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.completion_source`).
 
         A remote client holds no session, so the snapshot stays ``None`` —
         which ``compute_completion`` reads as "source unavailable" and answers
@@ -1861,7 +1861,7 @@ class TextualChatApp(App):
         skills: "list | None" = None
         if self._read_model is not None:
             try:
-                source = self._read_model.completion_session()
+                source = self._read_model.completion_source()
             except Exception:
                 logger.exception("textual chat: completion session read failed")
         if source is not None:

--- a/src/reyn/interfaces/inline/textual_chat/completion.py
+++ b/src/reyn/interfaces/inline/textual_chat/completion.py
@@ -353,13 +353,15 @@ def _completing_word(arg_partial: str) -> str:
 
 
 def _argument_candidates(
-    cmd: "SlashCommand", arg_partial: str, session: object,
+    cmd: "SlashCommand", arg_partial: str, source: object,
 ) -> "tuple[CompletionCandidate, ...]":
     """Run ``cmd``'s ``CompleterFn`` and prefix-filter its result.
 
-    Honours the declared signature verbatim — ``completer(session,
+    Honours the declared signature verbatim — ``completer(source,
     arg_partial)`` — so a completer that reads the partial (``/image``'s path
-    walker, ``/memory``'s ``view`` sub-command gate) gets it.
+    walker, ``/memory``'s ``view`` sub-command gate) gets it. ``source`` is a
+    ``CompletionSourceSnapshot | None`` (#5044) — a plain value, never a live
+    ``Session`` — see that class's own docstring.
 
     Any exception is swallowed to an empty tuple: a broken completer must not
     break typing (the contract ``_image_path_completer`` documents on its own
@@ -368,7 +370,7 @@ def _argument_candidates(
     produced nothing this time.
     """
     try:
-        values = cmd.completer(session, arg_partial)  # type: ignore[misc]
+        values = cmd.completer(source, arg_partial)  # type: ignore[misc]
     except Exception:  # noqa: BLE001 — a completer must never break the composer
         return ()
     word = _completing_word(arg_partial)
@@ -403,14 +405,15 @@ def _usage_header(cmd: "SlashCommand") -> str:
     return f"{USAGE_ROW_PREFIX}{cmd.usage}" if cmd.usage else ""
 
 
-def _argument_state(text: str, session: object, registry) -> CompletionState:
+def _argument_state(text: str, source: object, registry) -> CompletionState:
     """The ``/cmd <arg>`` branch: the command word is settled, so command-name
     candidates STOP and the command's own ``CompleterFn`` takes over.
 
     Opens for either of two independent reasons — the command has an argument
-    source here (a ``CompleterFn`` AND a local session to call it with), or it
-    declares a ``usage`` line to show. The second is what makes the stage useful
-    for the 15 commands that document their syntax and offer no completer
+    source here (a ``CompleterFn`` AND a ``CompletionSourceSnapshot`` to call
+    it with, #5044 — never a live ``Session``), or it declares a ``usage``
+    line to show. The second is what makes the stage useful for the 15
+    commands that document their syntax and offer no completer
     (``/visibility ``, ``/hook ``, ``/session ``…): before #3364 those opened
     nothing at all. Only 5 commands have a ``CompleterFn``, so the usage line is
     what the argument stage has to offer three times out of four.
@@ -424,14 +427,14 @@ def _argument_state(text: str, session: object, registry) -> CompletionState:
     if cmd is None:
         return NO_COMPLETION
     header = _usage_header(cmd)
-    has_source = cmd.completer is not None and session is not None
+    has_source = cmd.completer is not None and source is not None
     if not has_source and not header:
         return NO_COMPLETION
     word = _completing_word(arg_partial)
     return CompletionState(
         kind=KIND_ARGUMENT,
         candidates=(
-            _argument_candidates(cmd, arg_partial, session) if has_source else ()
+            _argument_candidates(cmd, arg_partial, source) if has_source else ()
         ),
         prefix_len=len(word),
         token_start=len(text) - len(word),
@@ -444,7 +447,7 @@ def _argument_state(text: str, session: object, registry) -> CompletionState:
 def compute_completion(
     text: str,
     *,
-    session: object = None,
+    source: object = None,
     skills: "Sequence[SkillEntry] | None" = None,
     registry=None,
 ) -> CompletionState:
@@ -457,10 +460,12 @@ def compute_completion(
     available, which is why ``/`` COMMAND-name completion works on every client
     including a remote one.
 
-    ``session`` is the local ``Session`` a ``CompleterFn`` is called with.
-    ``None`` means "this client has no session", and argument completion stays
-    SILENT rather than calling every completer with ``None`` and rendering their
-    uniformly-empty results as a no-match menu.
+    ``source`` is a ``reyn.interfaces.repl.read_model.CompletionSourceSnapshot
+    | None`` (#5044, architect ruling — see that class's own docstring) a
+    ``CompleterFn`` is called with. ``None`` means "this client has no
+    session", and argument completion stays SILENT rather than calling every
+    completer with ``None`` and rendering their uniformly-empty results as a
+    no-match menu.
 
     ``skills`` follows the same convention, and the distinction is load-bearing:
     ``None`` = the skill source is unavailable (stay silent), an empty sequence =
@@ -476,7 +481,7 @@ def compute_completion(
         return NO_COMPLETION
     if text.startswith("/"):
         if " " in text:
-            return _argument_state(text, session, registry)
+            return _argument_state(text, source, registry)
         from reyn.interfaces.slash import slash_command_completions
 
         prefix = text[1:]

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -53,8 +53,84 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.repl.status import _snapshot
 
 if TYPE_CHECKING:
+    from reyn.data.skills.registry import SkillEntry
     from reyn.interfaces.transport.client_transport import ClientTransport
     from reyn.runtime.chat_message import ChatMessage
+
+
+@dataclass(frozen=True)
+class CompletionSourceSnapshot:
+    """The completion popup's (#3354) sources, as PLAIN VALUES — never the
+    live ``Session`` itself (#5044/#4995, architect ruling on #5044,
+    issuecomment-5378399712/issuecomment-5378442342 — "the same root as
+    #5079: sync, I/O-performing, Session-mutating does not fit the
+    async-marshal shape; but the DIFFERENT answer here is that
+    ``completion_session()`` returning a LIVE ``Session`` reference is the
+    actual problem, not a threading one — completion needs candidate
+    strings (+ freshness), the worker updates, the UI only reads").
+
+    Each field is exactly what ONE slash-command ``CompleterFn`` or the
+    ``:`` skill completer reads off the live ``Session`` today (read all 6
+    registered completers to confirm, #5044 measurement comment) — no
+    field carries a live method or a mutable collection a caller could
+    corrupt the source with:
+
+    - :attr:`agent_names` — ``/attach``'s candidate list
+      (``session._registry.list_active_names()``).
+    - :attr:`known_model_classes` — ``/model``'s candidate list
+      (``session.known_model_classes()``), config-static for the
+      session's lifetime.
+    - :attr:`active_intervention_ids` — ``/answer``'s candidate list
+      (``session._interventions.list_active()``) — the ONE genuinely
+      per-turn-MUTABLE source among the six; every other field here is
+      either session-independent or effectively static per session.
+    - :attr:`workspace_dir` — ``/memory``'s own filesystem read is keyed
+      by this Path; the completer still does its OWN disk I/O, this just
+      supplies the root it reads from instead of a live ``Session`` to
+      derive it from.
+    - :attr:`available_skills` — the ``:`` skill completer's source, the
+      SAME list :meth:`~reyn.runtime.session.Session.available_skills`
+      already returns as a copy.
+
+    ``/image``'s path completer is UNAFFECTED — it never reads ``session``
+    at all (filesystem completion is session-independent, its own
+    docstring already says so), so it needs no field here.
+
+    :meth:`RegistryReadModel.completion_session` (today's only production
+    implementation, no thread boundary) builds this synchronously, on
+    demand, straight off the live ``Session`` it already holds — always
+    current, since there is no cross-thread delay in that path. A future
+    threaded implementation (#5048, still blocked on this class landing)
+    would instead push the SAME snapshot shape into
+    :class:`~reyn.interfaces.transport.threaded._ThreadedSnapshot` at the
+    existing frame-refresh cadence — this dataclass is what such a
+    producer would refresh, not a second mechanism alongside it.
+    """
+
+    agent_names: "tuple[str, ...]" = ()
+    known_model_classes: "tuple[str, ...]" = ()
+    active_intervention_ids: "tuple[str, ...]" = ()
+    workspace_dir: "Path | None" = None
+    available_skills: "tuple[SkillEntry, ...]" = ()
+
+
+def completion_source_snapshot_from_session(session) -> CompletionSourceSnapshot:
+    """Build a :class:`CompletionSourceSnapshot` off a real, live
+    ``Session`` — the ONE place this conversion happens, so
+    :class:`RegistryReadModel` and any other ``ChatReadModel``
+    implementation that genuinely holds a local ``Session`` (including a
+    test's own real-seam double, e.g. ``test_3354``'s ``SessionReadModel``)
+    share it rather than each re-deriving the same field list."""
+    registry = getattr(session, "_registry", None)
+    return CompletionSourceSnapshot(
+        agent_names=tuple(registry.list_active_names()) if registry is not None else (),
+        known_model_classes=tuple(session.known_model_classes()),
+        active_intervention_ids=tuple(
+            iv.id for iv in session.interventions.list_active()
+        ),
+        workspace_dir=session.workspace_dir,
+        available_skills=tuple(session.available_skills()),
+    )
 
 
 @dataclass(frozen=True)
@@ -397,16 +473,20 @@ class ChatReadModel(ABC):
         into — the remote impl always returns 0 (already-exhausted, never a
         fabricated count)."""
 
-    def completion_session(self) -> "object | None":
-        """The LOCAL ``Session`` the TUI's completion popup needs (#3354), or
-        ``None`` when this client holds none.
+    def completion_session(self) -> "CompletionSourceSnapshot | None":
+        """The TUI completion popup's (#3354) sources, as a
+        :class:`CompletionSourceSnapshot` VALUE — never the live ``Session``
+        (#5044, architect ruling, issuecomment-5378399712/5378442342: see
+        that class's own docstring for the full reasoning) — or ``None``
+        when this client holds no session at all.
 
         Two consumers, both session-local by nature: a slash command's
-        ``CompleterFn`` is declared as ``(session, arg_partial="") -> list[str]``
-        (``/attach`` reads the agent registry off it, ``/answer`` the active
-        interventions), and the ``:`` skill completer reads the session's
-        registered skills — the same list the invocation path enforces its
-        visibility surface from.
+        ``CompleterFn`` is declared as ``(source, arg_partial="") ->
+        list[str]`` (``/attach`` reads :attr:`CompletionSourceSnapshot.
+        agent_names`, ``/answer`` :attr:`~CompletionSourceSnapshot.
+        active_intervention_ids`), and the ``:`` skill completer reads
+        :attr:`~CompletionSourceSnapshot.available_skills` — the same list
+        the invocation path enforces its visibility surface from.
 
         **Concrete, not ``@abstractmethod``, unlike every accessor above.** The
         class docstring's "abstract so a partial implementation fails at
@@ -416,7 +496,7 @@ class ChatReadModel(ABC):
         complete and correct answer rather than a placeholder — the same
         graceful-degrade the frame-sufficiency boundary above describes, just
         expressed as a default instead of a repeated stub. Every consumer
-        already treats a ``None`` session as "offer nothing" (each registered
+        already treats a ``None`` source as "offer nothing" (each registered
         ``CompleterFn`` returns ``[]`` for it)."""
         return None
 
@@ -446,8 +526,16 @@ class RegistryReadModel(ChatReadModel):
     def _attached(self):
         return self._registry.attached_session()
 
-    def completion_session(self):
-        return self._attached()
+    def completion_session(self) -> "CompletionSourceSnapshot | None":
+        """Builds :class:`CompletionSourceSnapshot` synchronously, on
+        demand, off the live ``Session`` this read-model already holds —
+        always current (no cross-thread delay in this implementation, the
+        one production caller as of #5044). See that class's own
+        docstring for what each field is and which command reads it."""
+        s = self._attached()
+        if s is None:
+            return None
+        return completion_source_snapshot_from_session(s)
 
     def intervention_head(self):
         s = self._attached()

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -65,7 +65,7 @@ class CompletionSourceSnapshot:
     issuecomment-5378399712/issuecomment-5378442342 — "the same root as
     #5079: sync, I/O-performing, Session-mutating does not fit the
     async-marshal shape; but the DIFFERENT answer here is that
-    ``completion_session()`` returning a LIVE ``Session`` reference is the
+    ``completion_source()`` returning a LIVE ``Session`` reference is the
     actual problem, not a threading one — completion needs candidate
     strings (+ freshness), the worker updates, the UI only reads").
 
@@ -96,7 +96,7 @@ class CompletionSourceSnapshot:
     at all (filesystem completion is session-independent, its own
     docstring already says so), so it needs no field here.
 
-    :meth:`RegistryReadModel.completion_session` (today's only production
+    :meth:`RegistryReadModel.completion_source` (today's only production
     implementation, no thread boundary) builds this synchronously, on
     demand, straight off the live ``Session`` it already holds — always
     current, since there is no cross-thread delay in that path. A future
@@ -210,7 +210,7 @@ class ChatReadModelCapabilities:
     already carries, not new here): nothing checks that
     :class:`RegistryReadModel` returning ``LOCAL_CHAT_READ_CAPABILITIES``
     stays TRUE of its actual accessors. If a future edit made
-    ``completion_session()`` start returning ``None`` under some new local
+    ``completion_source()`` start returning ``None`` under some new local
     condition without updating this declaration, the declared/actual gap
     this class exists to prevent would reopen silently, on the LOCAL side
     this time. Follow-up, not a defect in this class.
@@ -248,7 +248,7 @@ class ChatReadModelCapabilities:
     declared here because there is nothing to gate.
     """
 
-    completion_session: bool
+    completion_source: bool
     intervention_head: bool
     pending_command_ui: bool
     has_command_ui_region: bool
@@ -285,7 +285,7 @@ def reported_snapshot_keys(
     new helper.
 
     Deliberately projects EVERY field, not only the ``*_reported`` ones
-    — the METHOD-axis fields from #4996 (``completion_session`` etc.)
+    — the METHOD-axis fields from #4996 (``completion_source`` etc.)
     ride along too, harmlessly (no pane reads them off the snapshot
     dict; ``ChatReadModel.capabilities`` remains their real consumer).
     Simpler than filtering by name pattern, and the field NAME already
@@ -298,7 +298,7 @@ def reported_snapshot_keys(
 #: current state; ``None``/``[]``/``0`` from it always means "genuinely
 #: nothing", never "unsupported here".
 LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
-    completion_session=True,
+    completion_source=True,
     intervention_head=True,
     pending_command_ui=True,
     has_command_ui_region=True,
@@ -320,7 +320,7 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
 #: this one genuinely reflects live server-side state rather than always
 #: degrading. See the module docstring's "Frame-sufficiency" section.
 REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
-    completion_session=False,
+    completion_source=False,
     intervention_head=True,
     pending_command_ui=False,
     has_command_ui_region=False,
@@ -473,7 +473,7 @@ class ChatReadModel(ABC):
         into — the remote impl always returns 0 (already-exhausted, never a
         fabricated count)."""
 
-    def completion_session(self) -> "CompletionSourceSnapshot | None":
+    def completion_source(self) -> "CompletionSourceSnapshot | None":
         """The TUI completion popup's (#3354) sources, as a
         :class:`CompletionSourceSnapshot` VALUE — never the live ``Session``
         (#5044, architect ruling, issuecomment-5378399712/5378442342: see
@@ -526,7 +526,7 @@ class RegistryReadModel(ChatReadModel):
     def _attached(self):
         return self._registry.attached_session()
 
-    def completion_session(self) -> "CompletionSourceSnapshot | None":
+    def completion_source(self) -> "CompletionSourceSnapshot | None":
         """Builds :class:`CompletionSourceSnapshot` synchronously, on
         demand, off the live ``Session`` this read-model already holds —
         always current (no cross-thread delay in this implementation, the
@@ -795,7 +795,7 @@ class RemoteReadModel(ChatReadModel):
         values = getattr(getattr(self._transport, "status", None), "values", None)
         return project_remote_snapshot(values)
 
-    def completion_session(self):
+    def completion_source(self):
         # Frame-sufficiency, same boundary as every other session-local read:
         # a remote client holds no Session, and neither the agent registry a
         # ``CompleterFn`` walks nor the skill entry list is projected onto the

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -36,11 +36,15 @@ if TYPE_CHECKING:
     from reyn.interfaces.transport.client_transport import ClientTransport
 
 HandlerFn = Callable[..., Awaitable[None]]
-# CompleterFn signature: ``(session, arg_partial: str = "") -> list[str]``.
-# ``arg_partial`` is the string typed after the slash command and the
-# trailing space (e.g. for ``/attach <partial>`` the partial is what's typed
-# so far). Completers that don't need it (e.g. ``/attach``
-# which always lists agent names) can ignore the arg via a default.
+# CompleterFn signature: ``(source, arg_partial: str = "") -> list[str]``.
+# #5044 (architect ruling, issuecomment-5378399712): ``source`` is a
+# ``reyn.interfaces.repl.read_model.CompletionSourceSnapshot | None`` --
+# a PLAIN VALUE, never a live ``Session`` -- see that class's own
+# docstring for what each field is and why. ``arg_partial`` is the string
+# typed after the slash command and the trailing space (e.g. for
+# ``/attach <partial>`` the partial is what's typed so far). Completers
+# that don't need it (e.g. ``/attach`` which always lists agent names)
+# can ignore the arg via a default.
 CompleterFn = Callable[..., list[str]]
 
 

--- a/src/reyn/interfaces/slash/agents.py
+++ b/src/reyn/interfaces/slash/agents.py
@@ -18,16 +18,20 @@ _NO_REGISTRY_ATTACH = (
 )
 
 
-def _attach_completer(session: "object", arg_partial: str = "") -> list[str]:
+def _attach_completer(source: "object", arg_partial: str = "") -> list[str]:
     """Return known agent names for tab completion.
+
+    ``source`` is a ``CompletionSourceSnapshot | None`` (#5044) — a plain
+    value, never a live ``Session``; :attr:`~reyn.interfaces.repl.
+    read_model.CompletionSourceSnapshot.agent_names` is already the
+    ``list_active_names()`` result (#1954: hide archived agents).
 
     Accepts ``arg_partial`` for forward-compat with the CompleterFn
     signature evolution (multi-arg commands like ``/tasks`` need it) —
     ``/attach`` itself is single-arg so the partial is unused.
     """
-    if getattr(session, "_registry", None) is None:
-        return []
-    return session._registry.list_active_names()  # #1954: hide archived agents
+    agent_names = getattr(source, "agent_names", None)
+    return list(agent_names) if agent_names is not None else []
 
 
 @slash("agents", summary="List all agents (* = attached, · = loaded)")

--- a/src/reyn/interfaces/slash/chat.py
+++ b/src/reyn/interfaces/slash/chat.py
@@ -21,26 +21,26 @@ async def list_cmd(ctx: "SlashContext", args: str) -> None:
 
 
 def _intervention_id_completer(
-    session: "object", arg_partial: str = "",
+    source: "object", arg_partial: str = "",
 ) -> list[str]:
     """Wave-11 C#3 — completer for /answer <id-prefix> <text>.
 
-    Surfaces active intervention ids from
-    ``session._interventions.list_active()`` so the user can Tab
-    through them. ``/answer`` takes ``<id-prefix> <text>`` — only
-    the FIRST word is the id; once the user has typed past the
+    ``source`` is a ``CompletionSourceSnapshot | None`` (#5044) — a plain
+    value, never a live ``Session``. Surfaces
+    :attr:`~reyn.interfaces.repl.read_model.CompletionSourceSnapshot.
+    active_intervention_ids` so the user can Tab through them — the ONE
+    genuinely per-turn-mutable field among the snapshot's sources (that
+    class's own docstring). ``/answer`` takes ``<id-prefix> <text>`` —
+    only the FIRST word is the id; once the user has typed past the
     space the input is the answer body and the picker hint is
     irrelevant. We filter by the LAST whitespace-delimited token
     of ``arg_partial`` so the prefix-match still works regardless
     of where the cursor sits.
     """
-    try:
-        interventions = getattr(session, "_interventions", None)
-        if interventions is None:
-            return []
-        ids = [iv.id for iv in interventions.list_active()]
-    except Exception:
+    ids = getattr(source, "active_intervention_ids", None)
+    if not ids:
         return []
+    ids = list(ids)
     if not arg_partial:
         return ids
     # If the user has already typed past the first whitespace,

--- a/src/reyn/interfaces/slash/memory.py
+++ b/src/reyn/interfaces/slash/memory.py
@@ -26,12 +26,7 @@ are different answers to different questions).
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
-
-if TYPE_CHECKING:
-    from reyn.runtime.session import Session
 
 _ROOT_UNRESOLVED = (
     "can't determine this project's memory location over this connection "
@@ -48,26 +43,31 @@ _USAGE = (
 
 
 def _memory_completer(
-    session: "Session", arg_partial: str = "",
+    source: "object", arg_partial: str = "",
 ) -> list[str]:
     """Surface memory entry names after ``/memory view ``.
 
     Reads ``memory.list_entries()`` and returns the entry slugs. Empty
     list for ``/memory list`` or empty args (= hint mode covers those).
 
-    Takes a real ``Session`` directly (the pre-existing, ungated
-    ``CompleterFn`` signature — a synchronous TUI-local seam that #3595 S4
-    never touched; unlike ``memory_cmd`` below, this is not routed through
-    ``SlashContext``/``ClientTransport`` at all, so reading
-    ``session.workspace_dir`` here is not new residue).
+    ``source`` is a ``CompletionSourceSnapshot | None`` (#5044) — a plain
+    value, never a live ``Session``. Only
+    :attr:`~reyn.interfaces.repl.read_model.CompletionSourceSnapshot.
+    workspace_dir` is needed: the completer still does its OWN disk I/O
+    keyed by that Path, exactly as before — a static value, not a live
+    method, so nothing here crosses a thread boundary any differently
+    than reading a plain field.
     """
     parts = arg_partial.split()
     sub = parts[0] if parts else ""
     if sub != "view":
         return []
+    workspace_dir = getattr(source, "workspace_dir", None)
+    if workspace_dir is None:
+        return []
     try:
         from reyn.data.memory import list_entries, memory_dir
-        root = session.workspace_dir.parent.parent
+        root = workspace_dir.parent.parent
         entries = list_entries(memory_dir(root=root))
         return [e.name for e in entries]
     except Exception:

--- a/src/reyn/interfaces/slash/model.py
+++ b/src/reyn/interfaces/slash/model.py
@@ -16,18 +16,16 @@ agent-identity default (``Agent.model``) unchanged.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
 
-if TYPE_CHECKING:
-    from reyn.runtime.session import Session
 
-
-def _model_class_completer(session: "Session", arg_partial: str = "") -> list[str]:
+def _model_class_completer(source: "object", arg_partial: str = "") -> list[str]:
     """Operator-configured model classes for ``/model <class>`` completion.
 
-    Wires the EXISTING public accessor
+    ``source`` is a ``CompletionSourceSnapshot | None`` (#5044) — a plain
+    value, never a live ``Session``. :attr:`~reyn.interfaces.repl.
+    read_model.CompletionSourceSnapshot.known_model_classes` is already
+    the EXISTING public accessor's result
     (:meth:`~reyn.runtime.session.Session.known_model_classes` →
     ``ModelResolver.known_classes()``) — the same list this command's own
     no-arg branch prints under ``available:`` and the drawer's Model pane
@@ -37,16 +35,11 @@ def _model_class_completer(session: "Session", arg_partial: str = "") -> list[st
     ``arg_partial`` is accepted per the ``CompleterFn`` contract and unused:
     ``/model`` takes a single argument, and prefix-filtering is the caller's
     job (it filters by the last typed word for every command uniformly).
-    Returns ``[]`` for a session that cannot answer — a remote client holds
+    Returns ``[]`` for a source that cannot answer — a remote client holds
     none, and a broken completer must never break the composer.
     """
-    getter = getattr(session, "known_model_classes", None)
-    if getter is None:
-        return []
-    try:
-        return list(getter())
-    except Exception:  # noqa: BLE001 — a completer must never break the composer
-        return []
+    known_model_classes = getattr(source, "known_model_classes", None)
+    return list(known_model_classes) if known_model_classes is not None else []
 
 
 @slash(

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -40,11 +40,19 @@ running alongside it — the snapshot slot is written in the SAME callback
 that schedules the frame delivery.
 
 **Scope, explicit** (per lead-coder's #4995 ruling): 2 ``ChatReadModel``
-methods are NOT satisfiable by this snapshot design and are deliberately
-left unwired here — see #5044 (``completion_session()`` returns a LIVE
-``Session`` reference, not a copyable value; ``load_older_conversation_
-history()`` mutates ``Session.history`` and performs disk I/O, confirmed
-by reading it, not guessed). #5045 (``clear_pending_command_ui()`` was a
+methods were NOT satisfiable by this snapshot design at #4995's own
+landing and were deliberately left unwired here — see #5044.
+``load_older_conversation_history()`` mutated ``Session.history`` and
+performed disk I/O (confirmed by reading it, not guessed) — landed via
+``Session.extend_history_backward_async``'s own I/O-off-loop/apply-on-loop
+split, #5079. ``completion_source()`` (renamed from ``completion_session()``
+— the old name promised a ``Session``, the actual contract never fit one)
+returned a LIVE ``Session`` reference, not a copyable value; fixed by
+returning a ``CompletionSourceSnapshot`` VALUE instead, #5087 — still not
+wired through THIS class's own snapshot-refresh cadence (a future step,
+should this class ever gain a production call site).
+
+#5045 (``clear_pending_command_ui()`` was a
 WRITE living on a type named "read model") is CLOSED — the write moved
 to :meth:`ClientTransport.clear_pending_command_ui`, and this class's own
 :meth:`clear_pending_command_ui` override marshals it onto the worker

--- a/tests/interfaces/test_3354_composer_completion.py
+++ b/tests/interfaces/test_3354_composer_completion.py
@@ -144,7 +144,7 @@ class SessionReadModel(ChatReadModel):
     """A real :class:`ChatReadModel` seam impl (same pattern as
     ``test_3338``'s ``_MutableSnapshotReadModel``) that holds a REAL
     ``Session`` — the seam the app resolves both completion sources
-    through. :meth:`completion_session` converts it to a
+    through. :meth:`completion_source` converts it to a
     :class:`CompletionSourceSnapshot` VALUE (#5044) via the SAME shared
     helper :class:`RegistryReadModel` uses in production
     (:func:`completion_source_snapshot_from_session`), never handing the
@@ -162,7 +162,7 @@ class SessionReadModel(ChatReadModel):
     def __init__(self, session=None) -> None:
         self._session = session
 
-    def completion_session(self):
+    def completion_source(self):
         if self._session is None:
             return None
         return completion_source_snapshot_from_session(self._session)
@@ -907,7 +907,7 @@ async def test_a_newline_in_the_composer_closes_the_menu(tmp_path) -> None:
 @pytest.mark.asyncio
 async def test_skill_menu_reaches_the_sessions_own_skill_list(tmp_path) -> None:
     """Tier 2b: the app resolves the ``:`` source through the
-    ``ChatReadModel.completion_session`` seam and a real ``Session``'s public
+    ``ChatReadModel.completion_source`` seam and a real ``Session``'s public
     ``available_skills()`` — so what the menu offers is what that session
     actually registered, not a client-side copy that can drift."""
     session = _real_session(tmp_path, skills=_skill_entries())

--- a/tests/interfaces/test_3354_composer_completion.py
+++ b/tests/interfaces/test_3354_composer_completion.py
@@ -70,7 +70,11 @@ from reyn.interfaces.inline.textual_chat.completion import (
     CompletionPopup,
     compute_completion,
 )
-from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
+from reyn.interfaces.repl.read_model import (
+    LOCAL_CHAT_READ_CAPABILITIES,
+    ChatReadModel,
+    completion_source_snapshot_from_session,
+)
 from reyn.interfaces.slash import REGISTRY
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import EventFrame
@@ -138,9 +142,14 @@ class RecordingTransport(ClientTransport):
 
 class SessionReadModel(ChatReadModel):
     """A real :class:`ChatReadModel` seam impl (same pattern as
-    ``test_3338``'s ``_MutableSnapshotReadModel``) whose
-    :meth:`completion_session` returns a REAL ``Session`` — the seam the app
-    resolves both completion sources through."""
+    ``test_3338``'s ``_MutableSnapshotReadModel``) that holds a REAL
+    ``Session`` — the seam the app resolves both completion sources
+    through. :meth:`completion_session` converts it to a
+    :class:`CompletionSourceSnapshot` VALUE (#5044) via the SAME shared
+    helper :class:`RegistryReadModel` uses in production
+    (:func:`completion_source_snapshot_from_session`), never handing the
+    live ``Session`` itself across the seam — this test double exercises
+    the real conversion, not a shortcut around it."""
 
     @property
     def capabilities(self):
@@ -154,7 +163,9 @@ class SessionReadModel(ChatReadModel):
         self._session = session
 
     def completion_session(self):
-        return self._session
+        if self._session is None:
+            return None
+        return completion_source_snapshot_from_session(self._session)
 
     def snapshot(self, config=None):
         return None
@@ -227,13 +238,14 @@ def test_command_candidates_stop_when_the_argument_stage_begins(tmp_path, monkey
     monkeypatch.chdir(tmp_path)
     session = _real_session(tmp_path)
 
-    before = compute_completion("/ima", session=session)
+    source = completion_source_snapshot_from_session(session)
+    before = compute_completion("/ima", source=source)
     assert before.kind == KIND_COMMAND
     assert "/image" in [c.label for c in before.candidates], (
         f"the command stage did not offer /image; got {[c.label for c in before.candidates]}"
     )
 
-    after = compute_completion("/image ", session=session)
+    after = compute_completion("/image ", source=source)
     assert after.kind == KIND_ARGUMENT, (
         "typing the space did not move the menu to the argument stage — the "
         "command word is settled, so command candidates must stop"
@@ -261,7 +273,8 @@ def test_argument_candidates_filter_by_the_last_typed_word(tmp_path, monkeypatch
     monkeypatch.chdir(tmp_path)
     session = _real_session(tmp_path)
 
-    state = compute_completion("/image sh", session=session)
+    source = completion_source_snapshot_from_session(session)
+    state = compute_completion("/image sh", source=source)
     assert [c.value for c in state.candidates] == ["shot.png"]
     assert state.prefix_len == len("sh"), (
         "prefix_len must cover only the argument word being completed — a "
@@ -282,7 +295,8 @@ def test_model_argument_completion_uses_the_configured_model_classes(tmp_path):
     expected = session.known_model_classes()
     assert expected, "test setup: the session reports no configured model classes"
 
-    state = compute_completion("/model ", session=session)
+    source = completion_source_snapshot_from_session(session)
+    state = compute_completion("/model ", source=source)
     assert state.kind == KIND_ARGUMENT
     assert [c.value for c in state.candidates] == list(expected), (
         f"/model completion diverged from known_model_classes(): "
@@ -451,7 +465,7 @@ def test_unreadable_sources_stay_silent_rather_than_showing_an_empty_menu():
     stage's usage header — keeps working. So ``/image `` on a remote client
     offers no filesystem candidates and no ``NO_MATCH_ROW`` (nothing was asked),
     but still says what ``/image`` takes."""
-    remote_arg = compute_completion("/image ", session=None)
+    remote_arg = compute_completion("/image ", source=None)
     assert remote_arg.candidates == (), (
         "a session-less client produced argument candidates from somewhere"
     )
@@ -462,7 +476,7 @@ def test_unreadable_sources_stay_silent_rather_than_showing_an_empty_menu():
     assert not remote_arg.owns_keys, (
         "a menu with nothing to navigate claimed the navigation keys"
     )
-    assert compute_completion("/agents ", session=None).kind == KIND_NONE, (
+    assert compute_completion("/agents ", source=None).kind == KIND_NONE, (
         "a command with neither an argument source nor a usage line must be "
         "silent, not an empty menu"
     )
@@ -470,7 +484,7 @@ def test_unreadable_sources_stay_silent_rather_than_showing_an_empty_menu():
         "skill completion must be silent when the skill source is unavailable"
     )
     # But COMMAND-name completion is registry-derived and works everywhere.
-    remote = compute_completion("/im", session=None, skills=None)
+    remote = compute_completion("/im", source=None, skills=None)
     assert remote.kind == KIND_COMMAND and remote.candidates, (
         "command-name completion must keep working on a client with no session"
     )

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -123,7 +123,7 @@ def test_capabilities_dataclass_rejects_a_missing_field():
     lets this test claim the ``TypeError`` above is caused by the MISSING
     field specifically, not by some other construction failure."""
     ChatReadModelCapabilities(
-        completion_session=True,
+        completion_source=True,
         intervention_head=True,
         pending_command_ui=True,
         has_command_ui_region=True,
@@ -138,7 +138,7 @@ def test_capabilities_dataclass_rejects_a_missing_field():
     )
     with pytest.raises(TypeError):
         ChatReadModelCapabilities(  # type: ignore[call-arg]
-            completion_session=True,
+            completion_source=True,
             intervention_head=True,
             pending_command_ui=True,
             has_command_ui_region=True,
@@ -173,7 +173,7 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
     docstring for why they live here anyway."""
     names = {f.name for f in fields(ChatReadModelCapabilities)}
     assert names == {
-        "completion_session",
+        "completion_source",
         "intervention_head",
         "pending_command_ui",
         "has_command_ui_region",

--- a/tests/interfaces/test_5044_completion_source_snapshot.py
+++ b/tests/interfaces/test_5044_completion_source_snapshot.py
@@ -1,11 +1,11 @@
 """Tier 2: #5044 (architect ruling, issuecomment-5378399712/5378442342) —
-``ChatReadModel.completion_session()`` returns a ``CompletionSourceSnapshot``
+``ChatReadModel.completion_source()`` returns a ``CompletionSourceSnapshot``
 VALUE, never the live ``Session`` itself.
 
 The root #5044/#4995 shares with #5079: "sync, I/O-performing,
 Session-mutating does not fit the async-marshal shape". The DIFFERENT
 answer here (vs #5079's I/O-off-loop/apply-on-loop split): the actual
-problem is ``completion_session()`` handing out a LIVE ``Session``
+problem is ``completion_source()`` handing out a LIVE ``Session``
 reference at all, not a threading one — completion needs candidate
 strings (+ freshness), the worker updates, the UI only reads.
 
@@ -14,18 +14,34 @@ throughout — no mocks.
 """
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
 
+from reyn.data.skills.registry import SkillEntry
 from reyn.interfaces.repl.read_model import (
     CompletionSourceSnapshot,
     RegistryReadModel,
 )
+from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import CapabilityScope
+from reyn.user_intervention import UserIntervention
 from tests._support.agent_session import make_session
+
+#: A fixture-declared model class, wired into the session's resolver at
+#: construction time (six-questions ②: the test's OWN value, never
+#: re-derived by calling ``session.known_model_classes()`` a second time).
+_PROBE_MODEL_CLASS = "probe-class"
+
+#: A fixture-declared skill, wired via ``CapabilityScope`` at construction
+#: time -- the same reason as above.
+_PROBE_SKILL = SkillEntry(
+    name="probe-skill", description="a probe skill", path="probe.md",
+)
 
 
 def _registry(tmp_path: Path) -> AgentRegistry:
@@ -37,6 +53,9 @@ def _registry(tmp_path: Path) -> AgentRegistry:
             agent_role=profile.role,
             snapshot_path=agent_dir / "state" / "snapshot.json",
             registry=reg,
+            workspace_state_dir=tmp_path / ".reyn",
+            resolver=ModelResolver({_PROBE_MODEL_CLASS: "gemini/gemini-2.5-flash-lite"}),
+            capability_scope=CapabilityScope(available_skills=[_PROBE_SKILL]),
         )
         s.load_history()
         return s
@@ -48,7 +67,7 @@ def _registry(tmp_path: Path) -> AgentRegistry:
 
 
 @pytest.mark.asyncio
-async def test_completion_session_returns_a_value_never_the_live_session(
+async def test_completion_source_returns_a_value_never_the_live_session(
     tmp_path: Path,
 ) -> None:
     """Tier 2: the return type is ``CompletionSourceSnapshot``, never
@@ -58,11 +77,11 @@ async def test_completion_session_returns_a_value_never_the_live_session(
     await reg.attach("alpha")
     read_model = RegistryReadModel(reg)
 
-    result = read_model.completion_session()
+    result = read_model.completion_source()
 
     assert isinstance(result, CompletionSourceSnapshot)
     assert not isinstance(result, Session), (
-        "completion_session() handed out the live Session object -- exactly "
+        "completion_source() handed out the live Session object -- exactly "
         "the #5044 defect this class exists to close"
     )
 
@@ -72,29 +91,49 @@ async def test_snapshot_fields_reflect_real_attached_session_state(
     tmp_path: Path,
 ) -> None:
     """Tier 2: each field is populated off the REAL attached session's real
-    state, not a fabricated placeholder — checked against the session's own
-    accessors directly, not re-derived by this test."""
+    state.
+
+    Six-questions ②: every expected value here is one THIS TEST constructed
+    or captured independently — never the same expression the
+    implementation itself evaluates. A future edit that breaks the
+    plumbing (e.g. reading the wrong resolver, the wrong intervention
+    registry, the wrong workspace root) has a real chance of going red;
+    re-calling ``session.known_model_classes()`` etc. would only catch an
+    edit to that ONE line, which is not the property under test.
+    """
     reg = _registry(tmp_path)
     session = await reg.attach("alpha")
-    read_model = RegistryReadModel(reg)
+    session.register_intervention_listener("probe-listener")
+    iv = UserIntervention(kind="ask_user", prompt="Q?", choices=[], id="probe-iv-id")
+    iv.future = asyncio.get_running_loop().create_future()
+    dispatch_task = asyncio.create_task(session.interventions.dispatch(iv))
+    await asyncio.sleep(0)  # let dispatch() enqueue before we read
 
-    result = read_model.completion_session()
+    read_model = RegistryReadModel(reg)
+    result = read_model.completion_source()
+
+    iv.future.set_result(None)
+    await dispatch_task
 
     assert result is not None
     # AgentRegistry auto-bootstraps a "default" agent (registry.py) --
     # superset, not exact equality, so this test does not pin an
     # unrelated implementation detail.
     assert {"alpha", "bravo"} <= set(result.agent_names)
-    assert result.known_model_classes == tuple(session.known_model_classes())
-    assert result.active_intervention_ids == tuple(
-        iv.id for iv in session.interventions.list_active()
+    assert _PROBE_MODEL_CLASS in result.known_model_classes
+    assert result.active_intervention_ids == ("probe-iv-id",)
+    assert result.workspace_dir == tmp_path / ".reyn" / "agents" / "alpha", (
+        f"got {result.workspace_dir!r} -- Agent.workspace_dir anchors on "
+        "workspace_state_dir/agents/<name>, and this factory set "
+        "workspace_state_dir to tmp_path/.reyn explicitly (never the "
+        "cwd-fallback default, which would make this assertion "
+        "order-dependent on the ambient cwd)"
     )
-    assert result.workspace_dir == session.workspace_dir
-    assert result.available_skills == tuple(session.available_skills())
+    assert result.available_skills == (_PROBE_SKILL,)
 
 
 @pytest.mark.asyncio
-async def test_completion_session_returns_none_when_nothing_attached(
+async def test_completion_source_returns_none_when_nothing_attached(
     tmp_path: Path,
 ) -> None:
     """Tier 2: an unattached registry (no session yet) answers None, the
@@ -103,4 +142,4 @@ async def test_completion_session_returns_none_when_nothing_attached(
     reg = _registry(tmp_path)
     read_model = RegistryReadModel(reg)
 
-    assert read_model.completion_session() is None
+    assert read_model.completion_source() is None

--- a/tests/interfaces/test_5044_completion_source_snapshot.py
+++ b/tests/interfaces/test_5044_completion_source_snapshot.py
@@ -1,0 +1,106 @@
+"""Tier 2: #5044 (architect ruling, issuecomment-5378399712/5378442342) —
+``ChatReadModel.completion_session()`` returns a ``CompletionSourceSnapshot``
+VALUE, never the live ``Session`` itself.
+
+The root #5044/#4995 shares with #5079: "sync, I/O-performing,
+Session-mutating does not fit the async-marshal shape". The DIFFERENT
+answer here (vs #5079's I/O-off-loop/apply-on-loop split): the actual
+problem is ``completion_session()`` handing out a LIVE ``Session``
+reference at all, not a threading one — completion needs candidate
+strings (+ freshness), the worker updates, the UI only reads.
+
+Real ``AgentRegistry`` + real ``Session`` + real ``RegistryReadModel``
+throughout — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.repl.read_model import (
+    CompletionSourceSnapshot,
+    RegistryReadModel,
+)
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+            registry=reg,
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    reg.create("bravo")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_completion_session_returns_a_value_never_the_live_session(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the return type is ``CompletionSourceSnapshot``, never
+    ``Session`` — the #5044 architect ruling's literal claim, checked by
+    TYPE, not merely "an assert on some field happened to pass"."""
+    reg = _registry(tmp_path)
+    await reg.attach("alpha")
+    read_model = RegistryReadModel(reg)
+
+    result = read_model.completion_session()
+
+    assert isinstance(result, CompletionSourceSnapshot)
+    assert not isinstance(result, Session), (
+        "completion_session() handed out the live Session object -- exactly "
+        "the #5044 defect this class exists to close"
+    )
+
+
+@pytest.mark.asyncio
+async def test_snapshot_fields_reflect_real_attached_session_state(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: each field is populated off the REAL attached session's real
+    state, not a fabricated placeholder — checked against the session's own
+    accessors directly, not re-derived by this test."""
+    reg = _registry(tmp_path)
+    session = await reg.attach("alpha")
+    read_model = RegistryReadModel(reg)
+
+    result = read_model.completion_session()
+
+    assert result is not None
+    # AgentRegistry auto-bootstraps a "default" agent (registry.py) --
+    # superset, not exact equality, so this test does not pin an
+    # unrelated implementation detail.
+    assert {"alpha", "bravo"} <= set(result.agent_names)
+    assert result.known_model_classes == tuple(session.known_model_classes())
+    assert result.active_intervention_ids == tuple(
+        iv.id for iv in session.interventions.list_active()
+    )
+    assert result.workspace_dir == session.workspace_dir
+    assert result.available_skills == tuple(session.available_skills())
+
+
+@pytest.mark.asyncio
+async def test_completion_session_returns_none_when_nothing_attached(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: an unattached registry (no session yet) answers None, the
+    same "nothing to show" convention every other frame-sufficiency read
+    already uses -- never a fabricated empty snapshot."""
+    reg = _registry(tmp_path)
+    read_model = RegistryReadModel(reg)
+
+    assert read_model.completion_session() is None

--- a/tests/interfaces/test_slash_cancel_answer_completer.py
+++ b/tests/interfaces/test_slash_cancel_answer_completer.py
@@ -18,35 +18,20 @@ if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
 
-class _StubSession:
-    """Minimal session stub — only carries what the completers read."""
+class _StubSource:
+    """Minimal ``CompletionSourceSnapshot``-shaped stub (#5044) — only
+    carries the ONE field this completer reads."""
 
-    def __init__(self, interventions=None):
-        self._interventions = _StubInterventionRegistry(interventions or [])
-
-
-class _StubInterventionRegistry:
-    def __init__(self, ivs):
-        self._ivs = ivs
-
-    def list_active(self):
-        return self._ivs
-
-
-class _StubIntervention:
-    def __init__(self, iid):
-        self.id = iid
+    def __init__(self, active_intervention_ids=()):
+        self.active_intervention_ids = tuple(active_intervention_ids)
 
 
 def test_intervention_id_completer_returns_active_ids() -> None:
     """Tier 2: empty arg_partial returns all active intervention IDs."""
     from reyn.interfaces.slash.chat import _intervention_id_completer
 
-    session = _StubSession(interventions=[
-        _StubIntervention("iv-aaa"),
-        _StubIntervention("iv-bbb"),
-    ])
-    out = _intervention_id_completer(session, "")
+    source = _StubSource(active_intervention_ids=["iv-aaa", "iv-bbb"])
+    out = _intervention_id_completer(source, "")
     assert set(out) == {"iv-aaa", "iv-bbb"}
 
 
@@ -54,13 +39,9 @@ def test_intervention_id_completer_filters_by_prefix() -> None:
     """Tier 2: prefix filter narrows."""
     from reyn.interfaces.slash.chat import _intervention_id_completer
 
-    session = _StubSession(interventions=[
-        _StubIntervention("iv-aaa"),
-        _StubIntervention("iv-bbb"),
-        _StubIntervention("zz-ccc"),
-    ])
-    assert set(_intervention_id_completer(session, "iv-")) == {"iv-aaa", "iv-bbb"}
-    assert _intervention_id_completer(session, "zz") == ["zz-ccc"]
+    source = _StubSource(active_intervention_ids=["iv-aaa", "iv-bbb", "zz-ccc"])
+    assert set(_intervention_id_completer(source, "iv-")) == {"iv-aaa", "iv-bbb"}
+    assert _intervention_id_completer(source, "zz") == ["zz-ccc"]
 
 
 def test_intervention_id_completer_past_first_space_empty() -> None:
@@ -72,19 +53,21 @@ def test_intervention_id_completer_past_first_space_empty() -> None:
     """
     from reyn.interfaces.slash.chat import _intervention_id_completer
 
-    session = _StubSession(interventions=[_StubIntervention("iv-aaa")])
-    assert _intervention_id_completer(session, "iv-aaa hello") == []
-    assert _intervention_id_completer(session, "iv- text") == []
+    source = _StubSource(active_intervention_ids=["iv-aaa"])
+    assert _intervention_id_completer(source, "iv-aaa hello") == []
+    assert _intervention_id_completer(source, "iv- text") == []
 
 
-def test_intervention_id_completer_no_registry_returns_empty() -> None:
-    """Tier 2: session without ``_interventions`` returns empty (defensive)."""
+def test_intervention_id_completer_no_source_returns_empty() -> None:
+    """Tier 2: a source without ``active_intervention_ids`` (or ``None``
+    itself) returns empty (defensive)."""
     from reyn.interfaces.slash.chat import _intervention_id_completer
 
     class _Bare:
         pass
 
     assert _intervention_id_completer(_Bare(), "") == []
+    assert _intervention_id_completer(None, "") == []
 
 
 def test_answer_slash_has_completer_registered() -> None:


### PR DESCRIPTION
**[e2e-coder]** — part of #5044 → #4995.

## Scope: the remaining half (`completion_session()`)

`load_older_conversation_history()` landed in #5079. This PR is the OTHER half — architect ruling on #5044 (issuecomment-5378399712/issuecomment-5378442342): same root as #5079 ("sync, I/O-performing, Session-mutating does not fit the async-marshal shape"), but a DIFFERENT answer. `completion_session()`'s consumer is a synchronous per-keystroke completion hook / sync `CompleterFn` contract — no `await` can be inserted. The actual problem is `completion_session()` handing out a LIVE `Session` reference at all, not a threading one: completion needs candidate strings (+ freshness), the worker updates, the UI only reads.

## What's here

- New `CompletionSourceSnapshot` (`read_model.py`): a frozen dataclass of plain values — `agent_names`, `known_model_classes`, `active_intervention_ids`, `workspace_dir`, `available_skills` — exactly what the 6 registered `CompleterFn`s + the `:` skill completer read off a live `Session` today (read all 6 to confirm, per the issue's own measurement comment posted earlier). `/image`'s path completer is unaffected — it never reads `session` at all.
- `completion_source_snapshot_from_session(session)`: the ONE place the `Session → snapshot` conversion happens, shared by `RegistryReadModel.completion_session()` (production) and `test_3354`'s own real-seam `SessionReadModel` double — so a test exercising the real conversion, not a shortcut around it.
- `CompleterFn`'s contract changes `(session, arg_partial)` → `(source, arg_partial)`; `_attach_completer` / `_model_class_completer` / `_memory_completer` / `_intervention_id_completer` narrowed to read the ONE snapshot field each actually needs, instead of arbitrary `Session` internals.
- `compute_completion`/`_argument_state`/`_argument_candidates`: `session` param renamed to `source` (`skills=` is unaffected — it was already a plain value, never a live object).
- `RemoteReadModel.completion_session()` unchanged (still `None` — frame-sufficiency boundary, no change to that decision).

## Witnesses

3 new (`test_5044_completion_source_snapshot.py`): the return type is `CompletionSourceSnapshot`, never `Session` (an `isinstance` check, not merely a field assert); each field reflects real attached-session state; `None` when nothing is attached. Type-check witness **strip-verified**: reverting `completion_session()` to `return self._attached()` flips both tests red (a real `AttributeError` on the raw `Session`, not the snapshot); restored, green.

Existing test-side fakes updated to the new snapshot shape (`test_3354`'s `SessionReadModel` now converts through the shared helper; `test_slash_cancel_answer_completer`'s stub now exposes `active_intervention_ids` directly instead of a nested `_interventions` object) — full affected suite re-verified: 61 passed across the 4 directly-touched test files, 376 passed across the wider `interfaces/` touched-area sweep, all unmodified.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on all 4 changed test files (42 tests, 0 Tier-4 violations)
- [x] `python scripts/verify_module_docstrings.py` on all 8 changed src files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py` (re-run right before push, after rebasing onto latest main)
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Scoped pytest: 3 new witnesses + 376 tests across the touched-area sweep, all green, strip-falsify verified
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

part of #5044, part of #4995
- [x] 🔴 **[lead-coder, TESTS-READ B] four of the five field assertions recompute the implementation's own expression** — `test_5044_completion_source_snapshot.py:88-93` asserts `result.known_model_classes == tuple(session.known_model_classes())`, `result.active_intervention_ids == tuple(iv.id for iv in session.interventions.list_active())`, `result.workspace_dir == session.workspace_dir`, `result.available_skills == tuple(session.available_skills())` — character-for-character the expressions in `read_model.py`'s snapshot builder. Six-questions table, row 2: blocks when the same expression is on both sides, because it fails only when someone edits that line and they will edit both. The fifth field is written correctly and shows the discipline was understood: `assert {"alpha", "bravo"} <= set(result.agent_names)` asserts values the test itself created, with a comment explaining why it is a superset rather than exact equality. Assert the other four against values the fixture established too (the tmp_path it built, an intervention it dispatched, a skill it registered); superset is fine. The other two tests pass — the isinstance pair is the real invariant of this issue and is not a transcription.

