### PR TITLE
docs(#4206): output_language's scope note misses its agent/session reach

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -48,6 +48,15 @@ reload）、`reyn.yaml` 側に書いた同じキーは他と同じく再起動�
 **セッション面**（`<session-state-dir>/config.yaml`）にも書けます。
 そちらは [permission-model](../../concepts/runtime/permission-model.md) を参照。
 
+**別の例外（#4206 slice 1）**: `output_language` は③ **preference** キー
+（自由上書き、restrict-only ではない）の一つでもあり、エージェント自身の
+`profile.yaml`（またはセッション自身の `config.yaml`）の `preferences:`
+マッピングで設定できます — このレイヤーでは再起動待ちではなく live に
+読まれます（`reyn.runtime.preferences.PREFERENCE_KEYS` が正の一覧）。
+この行の「PRJ のみ」は reyn.yaml 側のデフォルトの説明としては正しいまま
+です — エージェント／セッション面から到達不能という意味ではありません。
+参照: [agent.md § `preferences`](../cli/agent.md#preferences-4206-slice-1-the-3-axis-free-override-not-restrict-only)（EN 版）。
+
 **置き場の原理(#4174 T7)**: ある設定が**その subsystem 自身のコードパスからしか
 読まれない**なら、所有ブロックの下にネストします（例: `embedding.cost_warn_threshold`
 — embedding/indexing パイプライン内の 1 箇所でしか読まれない）。**単一の subsystem

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -48,14 +48,19 @@ reload）、`reyn.yaml` 側に書いた同じキーは他と同じく再起動�
 **セッション面**（`<session-state-dir>/config.yaml`）にも書けます。
 そちらは [permission-model](../../concepts/runtime/permission-model.md) を参照。
 
-**別の例外（#4206 slice 1）**: `output_language` は③ **preference** キー
-（自由上書き、restrict-only ではない）の一つでもあり、エージェント自身の
-`profile.yaml`（またはセッション自身の `config.yaml`）の `preferences:`
-マッピングで設定できます — このレイヤーでは再起動待ちではなく live に
-読まれます（`reyn.runtime.preferences.PREFERENCE_KEYS` が正の一覧）。
-この行の「PRJ のみ」は reyn.yaml 側のデフォルトの説明としては正しいまま
-です — エージェント／セッション面から到達不能という意味ではありません。
-参照: [agent.md § `preferences`](../cli/agent.md#preferences-4206-slice-1-the-3-axis-free-override-not-restrict-only)（EN 版）。
+**別の例外（#4206 slice 1）**: 下の表の `output_language` 行は「書く面 /
+再読込」列でまだ「PRJ のみ」と読めます — その列は「どのファイルか」と
+「いつ効くか」を混同しており（architect の実測、#4206 issue コメント）、
+「どのレイヤーが値を持てるか」という第 3 の軸を表す語彙を持っていません。
+その軸自体の（まだ暫定・手書きの）語彙で言えば、`output_language` は
+`project·agent` です — エージェント自身の `profile.yaml`（またはセッション
+自身の `config.yaml`）の `preferences:` マッピングでも設定でき、この
+レイヤーでは再起動待ちではなく live に読まれます（`reyn.runtime.
+preferences.PREFERENCE_KEYS` が正の一覧）。参照:
+[agent.md § `preferences`](../cli/agent.md#preferences-4206-slice-1-the-3-axis-free-override-not-restrict-only)
+（EN 版）。導出された `Declared in` 列（`PREFERENCE_KEYS` 等に対して CI で
+検査され、手作業では維持しない）は #4206 で追跡中、#5084 の残りスライスの
+後です — それまでこの注記は暫定のままです。
 
 **置き場の原理(#4174 T7)**: ある設定が**その subsystem 自身のコードパスからしか
 読まれない**なら、所有ブロックの下にネストします（例: `embedding.cost_warn_threshold`

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -51,6 +51,16 @@ can additionally be written on an **agent** surface (`.reyn/agents/<name>/`,
 (`<session-state-dir>/config.yaml`) — see
 [permission-model](../../concepts/runtime/permission-model.md).
 
+A DIFFERENT exception (#4206 slice 1): `output_language` is ALSO one of a
+small set of ③ **preference** keys (free-override, no restrict-only
+composition) an agent's own `profile.yaml` — or a session's own
+`config.yaml` — may set under a `preferences:` mapping, read live rather
+than restart-gated at that layer (`reyn.runtime.preferences.
+PREFERENCE_KEYS` is the authoritative list). This row's "PRJ only" still
+describes the reyn.yaml DEFAULT correctly; it does not mean the key is
+unreachable from the agent/session layers. See
+[agent.md § `preferences`](../cli/agent.md#preferences-4206-slice-1-the-3-axis-free-override-not-restrict-only).
+
 **Placement principle (#4174 T7)**: a setting nests under an owning block when
 only that subsystem's own code path ever reads it (e.g. `embedding.cost_warn_threshold`
 — read once, inside the embedding/indexing pipeline, nowhere else). It gets a

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -51,15 +51,19 @@ can additionally be written on an **agent** surface (`.reyn/agents/<name>/`,
 (`<session-state-dir>/config.yaml`) — see
 [permission-model](../../concepts/runtime/permission-model.md).
 
-A DIFFERENT exception (#4206 slice 1): `output_language` is ALSO one of a
-small set of ③ **preference** keys (free-override, no restrict-only
-composition) an agent's own `profile.yaml` — or a session's own
-`config.yaml` — may set under a `preferences:` mapping, read live rather
-than restart-gated at that layer (`reyn.runtime.preferences.
-PREFERENCE_KEYS` is the authoritative list). This row's "PRJ only" still
-describes the reyn.yaml DEFAULT correctly; it does not mean the key is
-unreachable from the agent/session layers. See
+A DIFFERENT exception (#4206 slice 1): `output_language`'s row below still
+reads "PRJ only" in the "Written on / reload" column — that column
+conflates WHICH FILE with WHEN IT TAKES EFFECT (architect finding,
+issuecomment on #4206), so it has no vocabulary for a third axis, WHICH
+LAYER may declare a key. In that axis's own (still provisional, hand-typed)
+vocabulary, `output_language` is `project·agent`: an agent's own
+`profile.yaml` — or a session's own `config.yaml` — may ALSO set it under a
+`preferences:` mapping, read live rather than restart-gated at that layer
+(`reyn.runtime.preferences.PREFERENCE_KEYS` is the authoritative list). See
 [agent.md § `preferences`](../cli/agent.md#preferences-4206-slice-1-the-3-axis-free-override-not-restrict-only).
+A derived `Declared in` column (checked in CI against `PREFERENCE_KEYS`
+and its siblings, not hand-maintained) is tracked in #4206, ordered after
+#5084's remaining slices — this note stays provisional until then.
 
 **Placement principle (#4174 T7)**: a setting nests under an owning block when
 only that subsystem's own code path ever reads it (e.g. `embedding.cost_warn_threshold`


### PR DESCRIPTION
**[e2e-coder]** — part of #4206.

## What

`docs/reference/config/reyn-yaml.md:69` (+ `.ja.md`) never disclosed that `output_language` reaches the agent/session layers too — stale since #4206 slice 1 (`7edb831bf`), per `src/reyn/runtime/profile.py:14-16` / `reyn.runtime.preferences.PREFERENCE_KEYS` (lead-coder finding, #4206 issue thread).

## Fix

The "Written on / reload" table's own scope is deliberately narrow (the doc's own prose: "this table's axis is only the two project-level surfaces"), and there's already a precedent for the wider reach — `hooks`/`composers`/the permission keys are named in a follow-up paragraph as ALSO writable on an agent/session surface. `output_language` became one of these too (#4206 slice 1) but was never added to that list.

Mirrors the existing precedent exactly rather than editing the row's own "PRJ only" text (which stays correct under the table's own declared axis — the `reyn.yaml` default really is PRJ-only; what was missing was the separate note that the key also reaches further).

`project_context_path` (the sibling `PREFERENCE_KEYS`-adjacent key lead-coder also measured stale) is deliberately **not** touched here — #5086 already owns that fix.

## Verification

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml`
- [x] `python scripts/check_doc_anchors.py` — the new `agent.md#preferences-...` anchor confirmed present in the built site (`grep`'d the rendered HTML directly, not just trusted the gate)
- [x] `python scripts/check_retired_config_keys_denylist.py`
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

part of #4206
- [x] 🔴 **[lead-coder] one sentence certifies the column as correct when its own legend says otherwise** — the note states the row's `PRJ only` "remains correct as a description of the reyn.yaml-side default", but the column's legend (`reyn-yaml.md:25-26`) reads "Most keys **can only be written in** `reyn.yaml` / `reyn.local.yaml` (= PRJ scope) … **The file split IS the write-gate boundary**" — the column is about WHICH FILE may write the key, and this PR documents that `preferences:` in `profile.yaml` may. Say the column cannot yet express this state (vocabulary under discussion on #4206) rather than that it is correct: the column has one value across all 26 rows, so each author reinterprets it, and a sentence certifying it will be cited by the next person as a reason not to fix it — the same shape as the "tested elsewhere" comment that skipped my own check on #5082. Everything else in the note is accurate and well-scoped (preferences path, live-not-restart, PREFERENCE_KEYS named, both languages).

