### PR TITLE
fix(#5048): ThreadedTransportProxy narrows pending_intervention_head() to a bare id, never the live object

### DIFF
--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -28,7 +28,7 @@ from prompt_toolkit.application.current import get_app_or_none
 from prompt_toolkit.patch_stdout import patch_stdout
 
 from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransport, pending_head_id
 from reyn.interfaces.transport.frames import FrameTag
 from reyn.runtime.outbox import OutboxMessage
 
@@ -44,48 +44,18 @@ def _simple_status(text: str) -> OutboxMessage:
 
 
 def _pending_head_id(head: object) -> "str | None":
-    """Extract the id from :meth:`ClientTransport.pending_intervention_head`'s
-    two established return shapes (#5057): a real ``UserIntervention``
-    (``InProcessTransport``/``SessionBoundTransport`` — #5047 axis A
-    guarantees its ``.id`` is a genuine identity, not merely "the oldest"),
-    or a bare id string (``AgUiTransport``'s own ``_pending_intervention_id``).
-
-    An unrecognized third shape returns ``None`` (logged) rather than
-    silently coercing it into SOME string via ``str(...)`` — architect's own
-    review finding on this PR (#5057): a naive ``getattr(head, "id", head)``
-    would happily turn e.g. a dict-shaped value (a genuinely similar-looking
-    but DIFFERENT contract lives nearby, ``RemoteReadModel.intervention_
-    head()``'s own dict projection) into a garbage id string via ``str()``
-    — the exact #4996-family "failure that looks like success" this repo's
-    own vocabulary names. Never reached by the two production transports
-    today (this IS a strict narrowing of a check that never fires yet, not
-    a behavior change for either), but the id this function returns feeds
-    straight into ``answer_intervention_by_id`` — a caller passing a
-    genuinely wrong shape deserves "no pending intervention recognized"
-    (falls through to a normal turn), never a corrupted delivery target.
-    The fall-through read as "correct" is really only guaranteed today
-    because NEITHER production transport can trigger it (a resolved-
-    elsewhere intervention is the one case this repo's own #2690 fix
-    already made this exact fall-through mean); a hypothetical future
-    third shape arriving alongside a genuinely still-pending intervention
-    would fall through the SAME way but for a different reason — silence
-    over a broken destination, not "already answered". Still the right
-    choice (never deliver to a destination this function couldn't
-    verify), named here so a future reader isn't left to rediscover it."""
-    if isinstance(head, str):
-        return head
-    iv_id = getattr(head, "id", None)
-    if isinstance(iv_id, str) and iv_id:
-        return iv_id
-    if head is not None:
-        logger.warning(
-            "#5057: pending_intervention_head() returned an unrecognized "
-            "shape (%s) -- neither a bare id string nor an object with a "
-            "genuine string .id. Treating as no pending intervention "
-            "rather than deriving a garbage id from it.",
-            type(head).__name__,
-        )
-    return None
+    """Thin call-site wrapper over the SHARED narrowing,
+    :func:`reyn.interfaces.transport.client_transport.pending_head_id` —
+    #5089's own lead-coder review finding (#5043's discriminator: "2 or
+    more copies — ask whether it can be deleted"): this module's own
+    hand-written copy used to live here (added for #5057, the original of
+    the two), until a SECOND, independently-written copy for
+    :mod:`reyn.interfaces.transport.threaded` silently dropped this one's
+    loud-failure half. See the shared function's own docstring for the
+    full narrowing rationale (two established return shapes, why a naive
+    ``getattr(head, "id", head)`` is unsafe, the #4996/#5047 family this
+    guards against) — kept there now, not duplicated here."""
+    return pending_head_id(head, caller="stream_client")
 
 
 async def run_input_loop(

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -34,8 +34,11 @@ a method whose contract is "produce frames".
 """
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, AsyncIterator
+
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -136,7 +139,17 @@ class ClientTransport(ABC):
 
     @abstractmethod
     def pending_intervention_head(self) -> "object | None":
-        """The oldest pending intervention handle, or None — client routing input."""
+        """The oldest pending intervention handle, or None — client routing input.
+
+        Two established return shapes across today's implementations
+        (#5057): a real ``UserIntervention`` (``InProcessTransport``/
+        ``SessionBoundTransport``) or a bare id string
+        (``AgUiTransport``'s own ``_pending_intervention_id`` — a remote
+        connection has no live object to hand back). A caller that only
+        needs the id (every consumer today does) should narrow through
+        :func:`pending_head_id` below rather than re-deriving this
+        narrowing at each call site — see its own docstring for why a
+        second, independently-written copy is a real hazard, not tidiness."""
 
     @abstractmethod
     def put_display(self, msg: "OutboxMessage") -> None:
@@ -368,4 +381,54 @@ class ClientTransport(ABC):
         """Tear the session (and its registry) down — the /quit / EOF seam."""
 
 
-__all__ = ["ClientTransport"]
+def pending_head_id(head: object, *, caller: str) -> "str | None":
+    """Narrow :meth:`ClientTransport.pending_intervention_head`'s two
+    established return shapes (#5057) down to a bare id string: a real
+    ``UserIntervention`` (``InProcessTransport``/``SessionBoundTransport`` —
+    #5047 axis A guarantees its ``.id`` is a genuine identity, not merely
+    "the oldest"), or a bare id string already (``AgUiTransport``'s own
+    ``_pending_intervention_id``).
+
+    THE single copy of this narrowing (lead-coder's #5089 review finding,
+    #5043's own discriminator: "2 or more copies — ask whether it can be
+    deleted"): a second, independently-written copy of the SAME narrowing
+    silently DROPPED its sibling's loud-failure half (:mod:`reyn.
+    interfaces.repl.stream_client`'s original ``_pending_head_id`` warned
+    on an unrecognized shape before returning ``None``; a fresh copy
+    written for :mod:`reyn.interfaces.transport.threaded` returned ``None``
+    silently) — the exact #4996/#5047 family: a silent ``None`` here reads
+    to a caller as "no pending intervention", not "I couldn't tell", and
+    ``ThreadedTransportProxy``'s own snapshot slot is exactly the kind of
+    place a caller (the TUI thread) has no way to distinguish the two.
+
+    ``caller`` names the call site in the warning (e.g. ``"stream_client"``,
+    ``"ThreadedTransportProxy"``) so a future third call site's warning is
+    distinguishable in logs — never reached by the two production
+    transports today (this is a strict narrowing of a check that never
+    fires yet, not a behavior change for either), but the id this function
+    returns can feed straight into ``answer_intervention_by_id``: a caller
+    passing a genuinely wrong shape deserves "no pending intervention
+    recognized" (falls through to a normal turn), never a corrupted
+    delivery target — never a naive ``getattr(head, "id", head)`` either,
+    which would happily turn e.g. a dict-shaped value (a genuinely
+    similar-looking but DIFFERENT contract lives nearby, ``RemoteReadModel.
+    intervention_head()``'s own dict projection) into a garbage id string
+    via ``str(...)``."""
+    if head is None:
+        return None
+    if isinstance(head, str):
+        return head
+    iv_id = getattr(head, "id", None)
+    if isinstance(iv_id, str) and iv_id:
+        return iv_id
+    _logger.warning(
+        "%s: pending_intervention_head() returned an unrecognized shape "
+        "(%s) -- neither a bare id string nor an object with a genuine "
+        "string .id. Treating as no pending intervention rather than "
+        "deriving a garbage id from it.",
+        caller, type(head).__name__,
+    )
+    return None
+
+
+__all__ = ["ClientTransport", "pending_head_id"]

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -80,7 +80,7 @@ import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Coroutine
 
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransport, pending_head_id
 from reyn.interfaces.transport.drain import suspend_between_frames
 
 if TYPE_CHECKING:
@@ -124,37 +124,6 @@ _EMPTY_SNAPSHOT = _ThreadedSnapshot(
     reyn_state_root=None,
     read_model_snapshot=None,
 )
-
-
-def _pending_head_id(head: object) -> "str | None":
-    """Narrow whatever ``self._inner.pending_intervention_head()`` returned
-    down to a bare id string before it enters the snapshot slot.
-
-    Architect's finding (pre-#5048 cutover review): ``InProcessTransport``'s
-    own ``pending_intervention_head()`` returns the LIVE ``UserIntervention``
-    — a mutable, thread-affine object carrying an ``asyncio.Future`` bound
-    to the WORKER loop. Handing it straight into ``_ThreadedSnapshot``
-    would cross that live object onto the caller (TUI) thread, contradicting
-    this module's own stated contract ("nothing on the caller thread ever
-    reads their live, mutable attributes directly" / "every value ... is
-    refreshed into ONE overwriting slot") — a value, never an owned object
-    (the same family as #5044's ruling). Today's only consumers read
-    ``.id`` (``stream_client.py``'s own ``_pending_head_id`` — this
-    function's own name and shape deliberately mirror it), so extracting
-    the id here loses nothing while closing the boundary violation before
-    a future consumer reaches for ``.prompt``/``.choices``/``.future``.
-
-    ``AgUiTransport.pending_intervention_head()`` already returns a bare id
-    string (never the live object at all — there is no live object to
-    cross a remote connection), so this is a no-op for that inner
-    transport; the narrowing only bites for ``InProcessTransport`` (and
-    ``SessionBoundTransport``, which wraps it)."""
-    if head is None:
-        return None
-    if isinstance(head, str):
-        return head
-    iv_id = getattr(head, "id", None)
-    return iv_id if isinstance(iv_id, str) and iv_id else None
 
 
 class ThreadedTransportProxy(ClientTransport):
@@ -285,8 +254,9 @@ class ThreadedTransportProxy(ClientTransport):
             self._latest = _ThreadedSnapshot(
                 has_session=self._inner.has_session(),
                 attach_failed=self._inner.attach_failed(),
-                pending_intervention_head=_pending_head_id(
+                pending_intervention_head=pending_head_id(
                     self._inner.pending_intervention_head(),
+                    caller="ThreadedTransportProxy",
                 ),
                 reyn_state_root=self._inner.reyn_state_root(),
                 read_model_snapshot=(

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -112,7 +112,7 @@ class _ThreadedSnapshot:
 
     has_session: bool
     attach_failed: bool
-    pending_intervention_head: "Any | None"
+    pending_intervention_head: "str | None"
     reyn_state_root: "Path | None"
     read_model_snapshot: "dict | None"
 
@@ -124,6 +124,37 @@ _EMPTY_SNAPSHOT = _ThreadedSnapshot(
     reyn_state_root=None,
     read_model_snapshot=None,
 )
+
+
+def _pending_head_id(head: object) -> "str | None":
+    """Narrow whatever ``self._inner.pending_intervention_head()`` returned
+    down to a bare id string before it enters the snapshot slot.
+
+    Architect's finding (pre-#5048 cutover review): ``InProcessTransport``'s
+    own ``pending_intervention_head()`` returns the LIVE ``UserIntervention``
+    — a mutable, thread-affine object carrying an ``asyncio.Future`` bound
+    to the WORKER loop. Handing it straight into ``_ThreadedSnapshot``
+    would cross that live object onto the caller (TUI) thread, contradicting
+    this module's own stated contract ("nothing on the caller thread ever
+    reads their live, mutable attributes directly" / "every value ... is
+    refreshed into ONE overwriting slot") — a value, never an owned object
+    (the same family as #5044's ruling). Today's only consumers read
+    ``.id`` (``stream_client.py``'s own ``_pending_head_id`` — this
+    function's own name and shape deliberately mirror it), so extracting
+    the id here loses nothing while closing the boundary violation before
+    a future consumer reaches for ``.prompt``/``.choices``/``.future``.
+
+    ``AgUiTransport.pending_intervention_head()`` already returns a bare id
+    string (never the live object at all — there is no live object to
+    cross a remote connection), so this is a no-op for that inner
+    transport; the narrowing only bites for ``InProcessTransport`` (and
+    ``SessionBoundTransport``, which wraps it)."""
+    if head is None:
+        return None
+    if isinstance(head, str):
+        return head
+    iv_id = getattr(head, "id", None)
+    return iv_id if isinstance(iv_id, str) and iv_id else None
 
 
 class ThreadedTransportProxy(ClientTransport):
@@ -254,7 +285,9 @@ class ThreadedTransportProxy(ClientTransport):
             self._latest = _ThreadedSnapshot(
                 has_session=self._inner.has_session(),
                 attach_failed=self._inner.attach_failed(),
-                pending_intervention_head=self._inner.pending_intervention_head(),
+                pending_intervention_head=_pending_head_id(
+                    self._inner.pending_intervention_head(),
+                ),
                 reyn_state_root=self._inner.reyn_state_root(),
                 read_model_snapshot=(
                     self._read_model_snapshot_fn()
@@ -298,7 +331,7 @@ class ThreadedTransportProxy(ClientTransport):
     def attach_failed(self) -> bool:
         return self._latest.attach_failed
 
-    def pending_intervention_head(self) -> "object | None":
+    def pending_intervention_head(self) -> "str | None":
         return self._latest.pending_intervention_head
 
     def reyn_state_root(self) -> "Path | None":

--- a/tests/interfaces/test_5048_threaded_proxy_pending_head_not_live_object.py
+++ b/tests/interfaces/test_5048_threaded_proxy_pending_head_not_live_object.py
@@ -1,0 +1,165 @@
+"""Tier 2: #5048 pre-cutover finding (architect) — ``ThreadedTransportProxy``
+must never hand the LIVE ``UserIntervention`` object across the thread
+boundary, only its ``id``.
+
+Real measurement, not a hypothetical: ``InProcessTransport.pending_
+intervention_head()`` returns ``Session.interventions.head()`` VERBATIM —
+the actual ``UserIntervention``, which carries a mutable ``future:
+asyncio.Future`` bound to the WORKER loop. Before this fix,
+``ThreadedTransportProxy`` copied that live reference straight into its
+own ``_ThreadedSnapshot`` slot, contradicting ``threaded.py``'s own module
+docstring ("nothing on the caller (TUI) thread ever reads their live,
+mutable attributes directly" / "every value ... is refreshed into ONE
+overwriting slot"). No consumer reads more than ``.id`` today (``stream_
+client.py``'s own ``_pending_head_id``), so the leak was latent, not the
+"value not the owned object" contract #5044 already ruled on for this
+same class family — this is what makes it the right shape to fix BEFORE
+#5048's cutover promotes this class to the TUI's default transport and
+gains consumers that might reach for ``.prompt``/``.choices``/``.future``.
+
+Real ``ThreadedTransportProxy`` + a real (non-mock) ``ClientTransport``
+stand-in whose ``pending_intervention_head()`` returns an object shaped
+exactly like the real ``UserIntervention`` (an ``id`` plus a genuinely
+live, unresolved ``asyncio.Future`` bound to ITS OWN loop) — the same
+"small real hand-written implementation" pattern
+``test_4995_threaded_transport_proxy.py`` already establishes for this
+class, not a mock.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, AsyncIterator
+
+import pytest
+
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.threaded import ThreadedTransportProxy
+
+if TYPE_CHECKING:
+    from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+    from reyn.runtime.outbox import OutboxMessage
+
+
+class _FakeIntervention:
+    """Shaped like the real ``UserIntervention`` in exactly the ways this
+    fix cares about: a stable ``id`` plus a genuinely live, unresolved
+    ``asyncio.Future`` — the mutable, thread-affine attribute that must
+    never reach the caller thread. Not the real dataclass itself (that
+    would require constructing it on the worker's own loop just to prove a
+    point already provable with a lighter stand-in) — but real enough that
+    ``getattr(head, "id", None)`` and "does this carry a live Future" are
+    both genuine, not simulated."""
+
+    def __init__(self, iv_id: str, future: "asyncio.Future") -> None:
+        self.id = iv_id
+        self.future = future
+
+
+class _InterveningTransport(ClientTransport):
+    """A minimal, real ``ClientTransport`` whose ``pending_intervention_
+    head()`` returns a live ``_FakeIntervention`` — mirroring ``InProcess
+    Transport``'s own real behaviour (``s.interventions.head()`` returned
+    verbatim), not a made-up shape."""
+
+    def __init__(self, head: "_FakeIntervention | None") -> None:
+        self._head = head
+        self._never = asyncio.Event()
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame | EventFrame]":
+        from reyn.interfaces.transport.frames import DisplayFrame
+        from reyn.runtime.outbox import OutboxMessage
+
+        yield DisplayFrame(OutboxMessage(kind="status", text="frame"))
+        await self._never.wait()
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self):
+        return self._head
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> str:
+        return ""
+
+    async def shutdown(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_pending_intervention_head_never_crosses_the_live_object():
+    """Tier 2: the snapshot slot carries the bare ``id`` string, never the
+    ``_FakeIntervention`` instance (and never its ``.future``) — the caller
+    thread genuinely cannot reach the live object through this seam.
+
+    Strip-falsifier: reverting ``_pump_frames`` to
+    ``pending_intervention_head=self._inner.pending_intervention_head()``
+    (dropping the ``_pending_head_id`` narrowing) makes
+    ``proxy.pending_intervention_head()`` return the ``_FakeIntervention``
+    instance itself — this assertion (``isinstance(..., str)``) turns red.
+    Verified locally by temporarily reverting that one line."""
+    worker_future_holder: "list[asyncio.Future]" = []
+
+    class _HeadProducingTransport(_InterveningTransport):
+        def start(self) -> None:
+            # The Future must belong to the WORKER's own loop (constructed
+            # after the worker thread's loop exists) to genuinely mirror
+            # the real UserIntervention's thread-affinity — this is what
+            # makes "the caller must never touch it" a real hazard, not a
+            # simulated one.
+            fut = asyncio.get_event_loop().create_future()
+            worker_future_holder.append(fut)
+            self._head = _FakeIntervention("iv-42", fut)
+
+    inner = _HeadProducingTransport(head=None)
+    proxy = ThreadedTransportProxy(lambda: inner)
+    proxy.start()
+    try:
+        frame = await proxy.frames().__anext__()
+        assert frame.message.text == "frame"
+
+        head = proxy.pending_intervention_head()
+        assert head == "iv-42", f"expected the bare id, got {head!r}"
+        assert isinstance(head, str), (
+            "the live _FakeIntervention (and its worker-bound Future) must "
+            "never reach the caller thread through this seam"
+        )
+    finally:
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_no_pending_intervention_stays_none():
+    """Tier 2: regression guard — the ordinary "nothing pending" case
+    (every pre-#5048 caller, including today's #4995 tests) is unaffected:
+    ``None`` in, ``None`` out."""
+    inner = _InterveningTransport(head=None)
+    proxy = ThreadedTransportProxy(lambda: inner)
+    proxy.start()
+    try:
+        frame = await proxy.frames().__anext__()
+        assert frame.message.text == "frame"
+        assert proxy.pending_intervention_head() is None
+    finally:
+        await proxy.shutdown()

--- a/tests/interfaces/test_5048_threaded_proxy_pending_head_not_live_object.py
+++ b/tests/interfaces/test_5048_threaded_proxy_pending_head_not_live_object.py
@@ -10,9 +10,10 @@ asyncio.Future`` bound to the WORKER loop. Before this fix,
 own ``_ThreadedSnapshot`` slot, contradicting ``threaded.py``'s own module
 docstring ("nothing on the caller (TUI) thread ever reads their live,
 mutable attributes directly" / "every value ... is refreshed into ONE
-overwriting slot"). No consumer reads more than ``.id`` today (``stream_
-client.py``'s own ``_pending_head_id``), so the leak was latent, not the
-"value not the owned object" contract #5044 already ruled on for this
+overwriting slot"). No consumer reads more than ``.id`` today (the shared
+:func:`reyn.interfaces.transport.client_transport.pending_head_id`), so
+the leak was latent, not the "value not the owned object" contract #5044
+already ruled on for this
 same class family — this is what makes it the right shape to fix BEFORE
 #5048's cutover promotes this class to the TUI's default transport and
 gains consumers that might reach for ``.prompt``/``.choices``/``.future``.
@@ -61,7 +62,7 @@ class _InterveningTransport(ClientTransport):
     Transport``'s own real behaviour (``s.interventions.head()`` returned
     verbatim), not a made-up shape."""
 
-    def __init__(self, head: "_FakeIntervention | None") -> None:
+    def __init__(self, head: object) -> None:
         self._head = head
         self._never = asyncio.Event()
 
@@ -115,7 +116,7 @@ async def test_pending_intervention_head_never_crosses_the_live_object():
 
     Strip-falsifier: reverting ``_pump_frames`` to
     ``pending_intervention_head=self._inner.pending_intervention_head()``
-    (dropping the ``_pending_head_id`` narrowing) makes
+    (dropping the ``pending_head_id`` narrowing) makes
     ``proxy.pending_intervention_head()`` return the ``_FakeIntervention``
     instance itself — this assertion (``isinstance(..., str)``) turns red.
     Verified locally by temporarily reverting that one line."""
@@ -161,5 +162,43 @@ async def test_no_pending_intervention_stays_none():
         frame = await proxy.frames().__anext__()
         assert frame.message.text == "frame"
         assert proxy.pending_intervention_head() is None
+    finally:
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_an_unrecognized_shape_warns_here_too_not_just_in_stream_client(caplog):
+    """Tier 2: lead-coder's #5089 review finding — before the shared
+    :func:`~reyn.interfaces.transport.client_transport.pending_head_id`
+    existed, this module had its OWN independently-written copy of the
+    narrowing that silently returned ``None`` on an unrecognized shape,
+    dropping the loud-``logger.warning`` half its sibling in ``stream_
+    client.py`` already had (the #4996/#5047 family: a silent ``None`` here
+    reads to the caller as "no pending intervention", not "I couldn't
+    tell"). Now both call sites share ONE function, so this module gets
+    the warning for free — asserted here, not just in stream_client's own
+    tests, since a future third copy is exactly what this witness guards
+    against.
+
+    Strip-falsifier: reverting ``ThreadedTransportProxy``'s call site back
+    to its own hand-written copy (the pre-#5089-fix-round-2 shape, silently
+    returning ``None``) turns this red — verified locally."""
+    import logging
+
+    inner = _InterveningTransport(head={"id": "iv-x", "prompt": "not a real shape"})
+    proxy = ThreadedTransportProxy(lambda: inner)
+    proxy.start()
+    try:
+        with caplog.at_level(logging.WARNING):
+            frame = await proxy.frames().__anext__()
+        assert frame.message.text == "frame"
+        assert proxy.pending_intervention_head() is None
+        assert any(
+            "unrecognized shape" in r.message and "ThreadedTransportProxy" in r.message
+            for r in caplog.records
+        ), (
+            "expected the shared pending_head_id() warning, naming this "
+            f"class as the caller; got log records: {[r.message for r in caplog.records]!r}"
+        )
     finally:
         await proxy.shutdown()


### PR DESCRIPTION
**[tui-coder]** — pre-cutover fix for #5048, per architect's finding on this issue's own thread: `ThreadedTransportProxy.pending_intervention_head()` was copying the live `UserIntervention` (with its worker-loop-bound `asyncio.Future`) into the cross-thread snapshot slot, contradicting the class's own stated contract.

## Fix
`_pump_frames` now narrows through a new `_pending_head_id()` helper before the value enters `_ThreadedSnapshot` — extracts `.id` when the inner transport handed back a live object (`InProcessTransport`/`SessionBoundTransport`), passes a bare string through unchanged (`AgUiTransport`, which already never crosses a live object). Field type tightens `Any | None` → `str | None`.

Same family as the #5044 ruling architect cited: return a value, never an owned object.

## Test plan
- [x] `ruff check` — clean
- [x] `scripts/test_tier_audit.py --strict` on the new test file — 0 Tier-4 violations
- [x] `scripts/verify_module_docstrings.py` — OK
- [x] `scripts/mypy_ratchet.py` — OK (findings count went DOWN, 202→201)
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] New witness (`test_5048_threaded_proxy_pending_head_not_live_object.py`) strip-verified locally: reverting the `_pump_frames` line to pass the raw `pending_intervention_head()` result through turns `test_pending_intervention_head_never_crosses_the_live_object` red
- [x] Scoped sweep: `tests/interfaces/` filtered to threaded/intervention/pending_head/agui/stream_client/4995/5057 — 204 passed
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

part of #5048 (unblocks the cutover's own remaining open point — architect said "fix here or separately, but before cutover"; landing it separately keeps the actual cutover PR smaller).
- [x] 🔴 **[lead-coder] this is the second copy of `_pending_head_id`, and the copy dropped the loud failure** — `stream_client.py:77-81` (added because #5083 blocked on silently coercing an unrecognized shape) warns before returning None; `threaded.py:156-157` returns None silently. Here a silent None lands in the snapshot slot, so the caller (TUI) thread reads "no pending intervention" — a silent wrong answer, the #4996/#5047 family. Also: don't create the second copy at all. My own discriminator from #5043 is "how many copies — 0 means coverage, 1 means wiring, 2 or more means ask whether it can be deleted", and tonight's precedent is #5086 extracting `_within_workspace` out of a closure rather than duplicating it. Put `_pending_head_id` in one place and have both call it; if you keep two, the threaded one must warn too. The narrowing itself is right and needed — a live `UserIntervention` carries a worker-loop-bound `asyncio.Future` and must not cross to the caller thread.



**[tui-coder]** — fixed (c32b167ca): extracted the narrowing to `client_transport.py` (the Protocol's own home module — same #5086 precedent) as `pending_head_id(head, *, caller)`; both `stream_client.py` and `threaded.py` now call it, `caller` labels which site logged. Added a witness that `ThreadedTransportProxy`'s own call site warns too, strip-verified. CI running.

