### PR TITLE
fix(#5094/#5096): SessionBoundTransport contract restore + /attach client-side dispatch

### DIFF
--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -1,15 +1,18 @@
 """Slash command registry for `reyn chat`.
 
-Add a new command with three lines::
+Add a new command::
 
     from reyn.interfaces.slash import slash, reply
 
-    @slash("ping", summary="Echo pong")
+    @slash("ping", summary="Echo pong", locus="client")
     async def ping_cmd(ctx, args: str) -> None:
         await reply(ctx, "pong")
 
 The decorator handles registration. `reply()` / `reply_error()` wrap
 the OutboxMessage construction so handlers stay focused on logic.
+
+``locus`` is REQUIRED (#5096 ②) — see the ``Locus``/``LocusFn`` comment
+below for the 3 values and which one your handler needs.
 
 ★ A handler is handed a :class:`SlashContext`, NOT a ``Session`` (#3595 S4).
 Slash is a client-side layer — the owner's design is that a client interprets
@@ -30,12 +33,44 @@ so registered commands are immediately available everywhere.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, Literal
 
 if TYPE_CHECKING:
     from reyn.interfaces.transport.client_transport import ClientTransport
 
 HandlerFn = Callable[..., Awaitable[None]]
+
+# #5096 ② (architect ruling, issuecomment-5379623427/5379638878/5379657592):
+# WHERE a command's SlashContext is built, one of 3 closed values -- NOT a
+# name-keyed dispatch table (rejected, issuecomment-5379647254: "the
+# handler already knows which op it calls; a name->op table is a SECOND
+# registry that drifts from the first"). Declared PER EXECUTION UNIT, not
+# per registration name (a single @slash(...) registration whose
+# sub-commands need different loci passes a LocusFn instead of a bare
+# Locus -- see SlashCommand.locus below).
+#
+# - "client"     -- the handler needs neither transport-op nor session
+#                    state beyond put_display (e.g. /copy, /help).
+# - "session"    -- the handler reads session state (any ctx.session
+#                    attribute, including ctx.session._registry) -- the
+#                    CURRENT behavior: maybe_dispatch_slash forwards to
+#                    transport.run_slash_command(name, args), which builds
+#                    the SlashContext wherever the session actually is.
+# - "connection" -- the handler answers using ONLY a registry/connection-
+#                    level typed op (ctx.transport.request_attach /
+#                    request_session_switch / ...), never ctx.session.
+#                    maybe_dispatch_slash builds SlashContext(transport,
+#                    session=None) itself, client-side, and executes
+#                    immediately -- no forward, so a transport that cannot
+#                    correctly answer a session-level question (e.g.
+#                    SessionBoundTransport, send-side only) never receives
+#                    one.
+#
+# Declaring a command's locus is REQUIRED (no default) -- omitting it
+# fails to construct the SlashCommand at IMPORT time (#5093's own
+# discipline: a declaration you can forget is not a declaration).
+Locus = Literal["client", "session", "connection"]
+LocusFn = Callable[[str], Locus]
 # CompleterFn signature: ``(source, arg_partial: str = "") -> list[str]``.
 # #5044 (architect ruling, issuecomment-5378399712): ``source`` is a
 # ``reyn.interfaces.repl.read_model.CompletionSourceSnapshot | None`` --
@@ -84,6 +119,11 @@ class SlashCommand:
     name: str               # command name without leading /  (e.g. "list")
     summary: str            # one-line description shown in /help and palette
     handler: HandlerFn      # async (ctx: SlashContext, args: str) -> None
+    # #5096 ②: REQUIRED, no default -- see the Locus/LocusFn module-level
+    # comment above for the 3 values and why this cannot default to
+    # "session" (a default here would make the NEXT command's omission
+    # silently correct instead of failing to construct).
+    locus: "Locus | LocusFn"
     aliases: tuple[str, ...] = ()
     completer: CompleterFn | None = None  # optional: (session, arg_partial="") -> list[str]
     hidden: bool = False    # if True, omit from /help and the Tab palette
@@ -222,6 +262,7 @@ def slash(
     name: str,
     *,
     summary: str,
+    locus: "Locus | LocusFn",
     aliases: Iterable[str] = (),
     completer: CompleterFn | None = None,
     hidden: bool = False,
@@ -232,6 +273,9 @@ def slash(
 
     Arguments mirror :class:`SlashCommand`. The decorated function must be
     `async def fn(ctx: SlashContext, args: str) -> None`.
+
+    ``locus`` is REQUIRED (#5096 ②) — see the module-level ``Locus``/
+    ``LocusFn`` comment for the 3 values and why there is no default.
 
     ``usage`` is the optional structured usage line surfaced by ``/help <cmd>``
     and as the completion popup's argument-stage header row (see
@@ -247,6 +291,7 @@ def slash(
             name=name,
             summary=summary,
             handler=fn,
+            locus=locus,
             aliases=tuple(aliases),
             completer=completer,
             hidden=hidden,
@@ -326,6 +371,8 @@ __all__ = [
     "SlashRegistry",
     "SlashCommand",
     "SlashContext",
+    "Locus",
+    "LocusFn",
     "slash",
     "reply",
     "reply_error",

--- a/src/reyn/interfaces/slash/agent.py
+++ b/src/reyn/interfaces/slash/agent.py
@@ -36,6 +36,7 @@ _NO_REGISTRY = (
         "Agent lifecycle: new <name> / edit role <text> "
         "(rm via `reyn agent rm`)"
     ),
+    locus="session",
     usage="/agent new <name> | /agent edit role <text>",
 )
 async def agent_cmd(ctx: "SlashContext", args: str) -> None:

--- a/src/reyn/interfaces/slash/agents.py
+++ b/src/reyn/interfaces/slash/agents.py
@@ -13,9 +13,6 @@ from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
 _NO_REGISTRY_AGENTS = (
     "agent registry not wired; /agents only works in `reyn chat`"
 )
-_NO_REGISTRY_ATTACH = (
-    "agent registry not wired; /attach only works in `reyn chat`"
-)
 
 
 def _attach_completer(source: "object", arg_partial: str = "") -> list[str]:
@@ -34,7 +31,7 @@ def _attach_completer(source: "object", arg_partial: str = "") -> list[str]:
     return list(agent_names) if agent_names is not None else []
 
 
-@slash("agents", summary="List all agents (* = attached, · = loaded)")
+@slash("agents", summary="List all agents (* = attached, · = loaded)", locus="session")
 async def agents_cmd(ctx: "SlashContext", args: str) -> None:
     """``/agents`` — list known agents with attach / loaded markers."""
     if ctx.session._registry is None:
@@ -83,6 +80,7 @@ async def agents_cmd(ctx: "SlashContext", args: str) -> None:
 @slash(
     "attach",
     summary="Switch attached agent",
+    locus="connection",
     usage="/attach <name>",
     completer=_attach_completer,
     see_also=("docs/concepts/multi-agent/multi-agent.md",),
@@ -90,45 +88,39 @@ async def agents_cmd(ctx: "SlashContext", args: str) -> None:
 async def attach_cmd(ctx: "SlashContext", args: str) -> None:
     """``/attach <name>`` — request the client switch to a different agent.
 
-    This handler validates the name and asks
-    ``ClientTransport.request_attach`` to perform the swap (#4534 PR-2) —
-    a typed request to whichever transport holds the session (local:
-    direct ``registry.attach``; remote: a wire call the server executes),
-    not a display-channel sentinel a REPL loop has to specially detect.
+    This handler asks ``ClientTransport.request_attach`` to perform the
+    swap (#4534 PR-2) — a typed request to whichever transport holds the
+    session (local: direct ``registry.attach``; remote: a wire call the
+    server executes), not a display-channel sentinel a REPL loop has to
+    specially detect.
 
-    The success reply is ordered AFTER the call and reads its return
-    (lead-coder review, #4534 remainder): ``request_attach``'s ``False`` is
-    ambiguous by transport (AG-UI's is "unknown" — an unconfirmed remote
-    ack; in-process's is a definitive local failure), so the reply on
-    ``False`` says "could not confirm", never "failed" — the wording that
-    would be true for one transport and wrong for the other.
+    #5096 ②, architect ruling (issuecomment-5379623427/5379638878/
+    5379657592): ``locus="connection"`` — this handler MUST NOT read
+    ``ctx.session`` (``maybe_dispatch_slash`` hands it ``None`` for a
+    connection-locus command, and the whole point of that locus is that
+    the client interprets ``/attach`` and calls the typed op DIRECTLY,
+    never forwarding to server-side slash dispatch, where a
+    ``SessionBoundTransport`` cannot correctly answer "attach a different
+    agent" at all). The pre-#5096 revision validated the target name
+    against ``ctx.session._registry`` first (existence check,
+    already-attached check) for nicer replies — that validation is now
+    the SERVER's job, inside ``request_attach``'s own typed-op handler
+    (``endpoint.py``'s ``attach_request`` arm, and ``registry.attach``
+    locally), which already performs the equivalent check. This handler's
+    own reply is now driven ENTIRELY by the boolean result.
+
+    The reply is ordered AFTER the call and reads its return (lead-coder
+    review, #4534 remainder): ``request_attach``'s ``False`` is ambiguous
+    by transport (AG-UI's is "unknown" — an unconfirmed remote ack;
+    in-process's is a definitive local failure/not-found/already-there),
+    so the reply on ``False`` says "could not confirm", never "failed" —
+    the wording that would be true for one transport and wrong for the
+    other.
     """
     name = args.strip()
     if not name:
         await reply_error(ctx, "usage: /attach <name>")
         return
-    if ctx.session._registry is None:
-        await reply_error(ctx, _NO_REGISTRY_ATTACH)
-        return
-    if not ctx.session._registry.exists(name):
-        # The user is already in the TUI — direct them at the slash form,
-        # not the CLI shell command, so they don't have to drop out of
-        # chat to create the agent.
-        await reply_error(
-            ctx,
-            f"agent {name!r} not found; use /agent new {name} to create it",
-        )
-        return
-    if name == ctx.session._registry.attached_name:
-        await reply(ctx, f"already attached to {name!r}")
-        return
-    # Surface the switch in the conv pane. Without this, ``/attach``
-    # produced no in-pane feedback — the user had to run ``/agents``
-    # to confirm the switch happened. The actual attach runs through
-    # ClientTransport.request_attach (#4534 PR-2); this reply is a
-    # separate, visible breadcrumb, ordered AFTER the call so it reflects
-    # what the call actually reports. (The header label refresh is
-    # blocked by a separate registry-forwarder bug — see #191.)
     attached = await ctx.transport.request_attach(name)
     if attached:
         await reply(ctx, f"attached to {name!r}")

--- a/src/reyn/interfaces/slash/budget.py
+++ b/src/reyn/interfaces/slash/budget.py
@@ -13,7 +13,7 @@ _TRACKER_DISABLED = (
 )
 
 
-@slash("cost", summary="Quick token + USD cost summary for this agent")
+@slash("cost", summary="Quick token + USD cost summary for this agent", locus="session")
 async def cost_cmd(ctx: "SlashContext", args: str) -> None:
     """``/cost`` — one-line token + USD spend for the attached agent."""
     line = ctx.session._budget.cost_line()
@@ -26,6 +26,7 @@ async def cost_cmd(ctx: "SlashContext", args: str) -> None:
 @slash(
     "budget",
     summary="Full budget breakdown",
+    locus="session",
     usage="/budget [reset]",
     see_also=("docs/reference/config/budget.md",),
 )

--- a/src/reyn/interfaces/slash/cancel.py
+++ b/src/reyn/interfaces/slash/cancel.py
@@ -19,6 +19,7 @@ from reyn.interfaces.slash import SlashContext, reply, slash
 @slash(
     "cancel",
     summary="Cancel the in-flight turn (same as Esc / Ctrl+C)",
+    locus="client",
 )
 async def cancel_cmd(ctx: "SlashContext", args: str) -> None:
     """``/cancel`` — reports WHAT was cancelled, never a blanket "done": the

--- a/src/reyn/interfaces/slash/chat.py
+++ b/src/reyn/interfaces/slash/chat.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
 
 
-@slash("list", summary="List pending interventions")
+@slash("list", summary="List pending interventions", locus="session")
 async def list_cmd(ctx: "SlashContext", args: str) -> None:
     """``/list`` — show pending interventions."""
     lines: list[str] = ["running tasks: (none)"]
@@ -55,6 +55,7 @@ def _intervention_id_completer(
 @slash(
     "answer",
     summary="Answer a pending intervention",
+    locus="session",
     usage="/answer <id-prefix> <text>",
     completer=_intervention_id_completer,
 )

--- a/src/reyn/interfaces/slash/clear_history.py
+++ b/src/reyn/interfaces/slash/clear_history.py
@@ -46,6 +46,7 @@ def _format_currently_line(session: "object") -> str:
     summary=(
         "Clear conversation history (= events, run state, profile preserved)"
     ),
+    locus="session",
     usage="/clear-history confirm",
 )
 async def clear_history_cmd(ctx: "SlashContext", args: str) -> None:

--- a/src/reyn/interfaces/slash/compact.py
+++ b/src/reyn/interfaces/slash/compact.py
@@ -21,6 +21,7 @@ from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
 @slash(
     "compact",
     summary="Compact the conversation history now to free up context window",
+    locus="session",
     usage="/compact",
     see_also=("docs/reference/runtime/control-ir.md",),
 )

--- a/src/reyn/interfaces/slash/concept.py
+++ b/src/reyn/interfaces/slash/concept.py
@@ -154,6 +154,7 @@ _GLOSSARY_PATH_HINT = (
 @slash(
     "concept",
     summary="Look up a TUI/reyn concept in the glossary",
+    locus="client",
     usage="/concept [<term>]",
 )
 async def concept_cmd(ctx: "SlashContext", args: str) -> None:  # noqa: D401

--- a/src/reyn/interfaces/slash/copy.py
+++ b/src/reyn/interfaces/slash/copy.py
@@ -26,6 +26,7 @@ from reyn.runtime.outbox import OutboxMessage
 @slash(
     "copy",
     summary="Copy an agent reply to the clipboard",
+    locus="client",
     usage="/copy [N|list]",
 )
 async def copy_cmd(ctx: "SlashContext", args: str) -> None:

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -125,7 +125,8 @@ async def maybe_dispatch_slash(
     parts = body.split(maxsplit=1)
     name = parts[0]
     args = parts[1] if len(parts) > 1 else ""
-    if REGISTRY.get(name) is None:
+    cmd = REGISTRY.get(name)
+    if cmd is None:
         # Suggest the 3 closest matches rather than dumping the full catalog:
         # the full list used to truncate mid-name, hiding the actionable
         # suggestions. ``kind="error"`` so the TUI renders an inline error — a
@@ -135,7 +136,24 @@ async def maybe_dispatch_slash(
         _display(transport, "error", f"unknown command /{name}; try: {known}")
         return True
 
-    ran = await transport.run_slash_command(name, args)
+    # #5096 ②, architect ruling (issuecomment-5379623427/5379638878/
+    # 5379657592): locus decides WHERE the SlashContext is built, not HOW
+    # to dispatch. "session" locus is unchanged (forward to wherever the
+    # session actually is). "client"/"connection" locus commands need
+    # NEITHER a real session NOR a forward — this layer builds the
+    # SlashContext itself, right here, with the CLIENT's own transport and
+    # session=None, and executes immediately. This is the fix for the
+    # owner-reported "attach coder-smith failed" over --connect: /attach
+    # used to forward to generic server-side slash dispatch, landing on
+    # SessionBoundTransport (send-side only, structurally unable to
+    # answer "attach a different agent") instead of ever reaching
+    # AgUiTransport's own correctly-implemented request_attach.
+    locus = cmd.locus(args) if callable(cmd.locus) else cmd.locus
+    if locus == "session":
+        ran = await transport.run_slash_command(name, args)
+    else:
+        ctx = SlashContext(transport=transport, session=None)
+        ran = await execute_slash_command(ctx, name, args)
     if not ran:
         _display(
             transport, "error",

--- a/src/reyn/interfaces/slash/donut.py
+++ b/src/reyn/interfaces/slash/donut.py
@@ -7,6 +7,6 @@ from __future__ import annotations
 from reyn.interfaces.slash import SlashContext, reply, slash
 
 
-@slash("donut", summary="Andy Sloane's spinning ASCII donut", hidden=True)
+@slash("donut", summary="Andy Sloane's spinning ASCII donut", locus="client", hidden=True)
 async def donut_cmd(ctx: "SlashContext", args: str) -> None:
     await reply(ctx, "🍩")

--- a/src/reyn/interfaces/slash/help.py
+++ b/src/reyn/interfaces/slash/help.py
@@ -73,6 +73,7 @@ def _render_command_focus(name: str) -> str:
 @slash(
     "help",
     summary="Slash command help — list all, or focus on one",
+    locus="client",
     usage="/help [<cmd>]",
 )
 async def help_cmd(ctx: "SlashContext", args: str) -> None:

--- a/src/reyn/interfaces/slash/hook.py
+++ b/src/reyn/interfaces/slash/hook.py
@@ -12,6 +12,7 @@ from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
 @slash(
     "hook",
     summary="Enable/disable a hook for this session",
+    locus="session",
     usage="/hook on|off <name>",
 )
 async def hook_cmd(ctx: "SlashContext", args: str) -> None:

--- a/src/reyn/interfaces/slash/image.py
+++ b/src/reyn/interfaces/slash/image.py
@@ -129,6 +129,7 @@ def _image_path_completer(
 @slash(
     "image",
     summary="Send an image (png/jpg/gif/webp/svg/jpeg)",
+    locus="session",
     usage="/image <path>",
     aliases=("img",),
     completer=_image_path_completer,

--- a/src/reyn/interfaces/slash/matrix.py
+++ b/src/reyn/interfaces/slash/matrix.py
@@ -7,6 +7,6 @@ from __future__ import annotations
 from reyn.interfaces.slash import SlashContext, reply, slash
 
 
-@slash("matrix", summary="Wake up, Neo.", hidden=True)
+@slash("matrix", summary="Wake up, Neo.", locus="client", hidden=True)
 async def matrix_cmd(ctx: "SlashContext", args: str) -> None:
     await reply(ctx, "There is no spoon.")

--- a/src/reyn/interfaces/slash/memory.py
+++ b/src/reyn/interfaces/slash/memory.py
@@ -77,6 +77,7 @@ def _memory_completer(
 @slash(
     "memory",
     summary="Inspect project memory entries",
+    locus="client",
     usage="/memory [list|view <name>]",
     completer=_memory_completer,
     see_also=("docs/concepts/data-retrieval/memory.md",),

--- a/src/reyn/interfaces/slash/model.py
+++ b/src/reyn/interfaces/slash/model.py
@@ -45,6 +45,7 @@ def _model_class_completer(source: "object", arg_partial: str = "") -> list[str]
 @slash(
     "model",
     summary="Show or override the model class for this session",
+    locus="session",
     usage="/model [<class>]",
     completer=_model_class_completer,
 )

--- a/src/reyn/interfaces/slash/open_artifact.py
+++ b/src/reyn/interfaces/slash/open_artifact.py
@@ -28,6 +28,7 @@ from reyn.runtime.outbox import OutboxMessage
 @slash(
     "open",
     summary="Open a generated artifact with the OS default app",
+    locus="client",
     usage="/open <ref>",
 )
 async def open_cmd(ctx: "SlashContext", args: str) -> None:

--- a/src/reyn/interfaces/slash/pending.py
+++ b/src/reyn/interfaces/slash/pending.py
@@ -118,6 +118,7 @@ def _resolve_iv_id(
         "List / discard / claim stalled cross-channel ops "
         "(subcommands: list | discard <id> | claim <id>)"
     ),
+    locus="session",
     usage="/pending [list|discard <id>|claim <id>]",
 )
 async def pending_cmd(ctx: "SlashContext", args: str) -> None:

--- a/src/reyn/interfaces/slash/plugin.py
+++ b/src/reyn/interfaces/slash/plugin.py
@@ -80,6 +80,7 @@ def _extract_error(result: dict) -> "str | None":
 @slash(
     "plugin",
     summary="Install/uninstall a self-contained reyn plugin bundle",
+    locus="session",
     usage=_SYNTAX,
     see_also=("docs/deep-dives/proposals/0064-plugin-model.md",),
 )

--- a/src/reyn/interfaces/slash/quit.py
+++ b/src/reyn/interfaces/slash/quit.py
@@ -21,5 +21,5 @@ async def _quit_handler(ctx: "SlashContext", args: str) -> None:
 # Both names get a registry entry. Using two ``@slash``-style
 # registrations keeps the palette's ``c.name.startswith(token)`` filter
 # happy for either ``/q`` or ``/ex`` prefixes.
-slash("quit", summary="Exit the chat (alias: /exit, Ctrl+D)")(_quit_handler)
-slash("exit", summary="Exit the chat (alias: /quit, Ctrl+D)")(_quit_handler)
+slash("quit", summary="Exit the chat (alias: /exit, Ctrl+D)", locus="client")(_quit_handler)
+slash("exit", summary="Exit the chat (alias: /quit, Ctrl+D)", locus="client")(_quit_handler)

--- a/src/reyn/interfaces/slash/reload.py
+++ b/src/reyn/interfaces/slash/reload.py
@@ -17,6 +17,7 @@ from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
 @slash(
     "reload",
     summary="Hot-reload runtime config (.reyn/*.yaml) at the next turn boundary",
+    locus="session",
     usage="/reload",
     see_also=("docs/concepts/runtime/permission-model.md",),
 )

--- a/src/reyn/interfaces/slash/reset.py
+++ b/src/reyn/interfaces/slash/reset.py
@@ -26,6 +26,7 @@ from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
 @slash(
     "reset",
     summary="Reset in-flight run state (snapshots + WAL; audit logs preserved)",
+    locus="session",
     usage="/reset confirm",
     see_also=("docs/guide/crash-recovery-and-resume.md",),
 )

--- a/src/reyn/interfaces/slash/resident.py
+++ b/src/reyn/interfaces/slash/resident.py
@@ -55,6 +55,7 @@ def _render(session_stats: "list[ContainerStat]", process_stats: "list[Container
 @slash(
     "resident",
     summary="Approximate resident-memory breakdown by container (#4497)",
+    locus="session",
 )
 async def resident_cmd(ctx: "SlashContext", args: str) -> None:  # noqa: ARG001 — no args yet
     """``/resident`` — count + approximate bytes for the major in-process

--- a/src/reyn/interfaces/slash/rewind.py
+++ b/src/reyn/interfaces/slash/rewind.py
@@ -21,6 +21,7 @@ from reyn.runtime.outbox import OutboxMessage
 @slash(
     "rewind",
     summary="Time-travel to an earlier checkpoint (no arg = pick from a menu)",
+    locus="session",
     usage="/rewind [seq]",
 )
 async def rewind_cmd(ctx: "SlashContext", args: str) -> None:

--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -162,6 +162,23 @@ async def session_cmd(ctx: "SlashContext", args: str) -> None:
         # request_session_switch's own typed-op handler (endpoint.py's
         # session_switch_request arm catches KeyError from
         # registry.attach_session -- equivalent coverage, one seam).
+        #
+        # ⚠️ Known degradation (lead-coder ruling, #5096 issuecomment-
+        # 5379839120): the pre-#5096 switch branch built RICHER guidance
+        # than this can today -- it read the registry directly to name
+        # WHY a sid was rejected (partial-prefix not supported, full
+        # name/ID required, the accepted forms). request_session_switch's
+        # typed op returns only a bool, no reason, so that guidance is
+        # gone until #5099 (request_session_list) ships: with a
+        # connection-locus-safe way to READ the registry's sid list, this
+        # branch can rebuild "no such session 'x'; sessions are: ..."
+        # itself, entirely client-side, before ever calling
+        # request_session_switch. Explicitly NOT fixed by widening
+        # request_session_switch's own return type tonight -- lead-coder:
+        # a bool-only typed op is the #4996/#5093 family shape, and
+        # shipping a NEW instance of it the same night two PRs closed
+        # that family doesn't hold up; the contract change is also wider
+        # than owner's live-blocked PR should carry right now.
         if not rest:
             await reply_error(ctx, _USAGE)
             return
@@ -169,15 +186,17 @@ async def session_cmd(ctx: "SlashContext", args: str) -> None:
         # seam (request_session_switch -> registry.attach_session), not the
         # retired __session_switch_request__ display-channel sentinel — see
         # ClientTransport.request_session_switch's own docstring for why.
-        # The reply is ordered AFTER the call and reads its return
-        # (lead-coder review, #4534 remainder): False is ambiguous by
-        # transport (AG-UI's is "unknown"; in-process's is definitive), so
-        # the reply on False says "could not confirm", never "failed".
+        # The reply is ordered AFTER the call and reads its return. False
+        # IS still routed as an error (not a system note, unlike /attach's
+        # own "could not confirm"): unlike /attach, the sid the USER TYPED
+        # is available here without touching ctx.session (it's `rest`,
+        # client-side input), so the error can still NAME the bad sid even
+        # though it cannot yet explain WHY (that's the degradation above).
         switched = await ctx.transport.request_session_switch(rest)
         if switched:
             await reply(ctx, f"switching to session {rest!r}")
         else:
-            await reply(ctx, f"could not confirm the switch to session {rest!r}")
+            await reply_error(ctx, f"could not confirm the switch to session {rest!r}")
         return
 
     reg = ctx.session._registry

--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -23,7 +23,7 @@ routing for non-REPL transports (web / A2A) is Stage 4b.
 """
 from __future__ import annotations
 
-from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
+from reyn.interfaces.slash import Locus, SlashContext, reply, reply_error, slash
 from reyn.runtime.spawn_routing import ReviewedNA
 from reyn.security.permissions.capability_profile import compose_narrowing_mappings
 
@@ -99,14 +99,77 @@ def _inherited_restriction_lines(reg, name: str, sid: str) -> "list[str]":
     return lines
 
 
+def _session_locus(args: str) -> "Locus":
+    """#5096 ②: ``/session``'s 3 sub-commands need different loci in ONE
+    registration (architect ruling: locus attaches to the EXECUTION UNIT,
+    not the registration name) — a ``LocusFn`` instead of a bare ``Locus``.
+
+    ``switch`` — answerable with ONLY ``ctx.transport.request_session_
+    switch``, a registry/connection-level typed op; never reads
+    ``ctx.session`` (see the handler body below, restructured to check
+    ``sub == "switch"`` BEFORE any ``ctx.session`` access — a "connection"
+    verdict here that the handler still touched ``ctx.session`` for would
+    crash on ``session=None``, not merely mis-declare). → ``connection``.
+
+    ``new`` — reads ``ctx.session.agent_name``/``ctx.session.session_id``,
+    the CALLING session's own identity (not just "which agent is
+    attached" — the registry alone cannot answer "which specific session
+    is asking", needed for #2103-S1a narrowing inheritance). → ``session``.
+
+    ``list`` — measured (architect co-vet, issuecomment-5379657592):
+    theoretically answerable via the registry alone (``reg.session_ids``/
+    ``reg.attached_sid``, no session-specific value), but NO typed op
+    exists today to reach the registry from ``connection`` locus for this
+    read (unlike ``switch``'s ``request_session_switch``) — inventing one
+    is out of THIS PR's scope. Declared ``session`` as the honest
+    interim (not "requires session", "no connection-locus path exists
+    yet") — remainder filed: #5099. → ``session``.
+
+    Unknown/empty sub falls through to ``session`` too (the existing
+    ``reg`` derivation produces the usage error either way)."""
+    sub = args.strip().split(maxsplit=1)[0].lower() if args.strip() else ""
+    return "connection" if sub == "switch" else "session"
+
+
 @slash(
     "session",
     summary="Open / switch / list conversation sessions for the attached agent",
+    locus=_session_locus,
     usage="/session new | /session switch <sid> | /session list",
     see_also=("docs/concepts/multi-agent/multi-agent.md",),
 )
 async def session_cmd(ctx: "SlashContext", args: str) -> None:
     """``/session <new|switch <sid>|list>`` — per-agent multi-session control."""
+    parts = args.strip().split(maxsplit=1)
+    sub = parts[0].lower() if parts else ""
+    rest = parts[1].strip() if len(parts) > 1 else ""
+
+    if sub == "switch":
+        # #5096 ②: connection locus (see _session_locus above) -- MUST NOT
+        # read ctx.session, which is None here. The pre-#5096 existence
+        # pre-check (reg.get_session(name, rest) is None) is dropped along
+        # with it; the SAME validation now happens server-side inside
+        # request_session_switch's own typed-op handler (endpoint.py's
+        # session_switch_request arm catches KeyError from
+        # registry.attach_session -- equivalent coverage, one seam).
+        if not rest:
+            await reply_error(ctx, _USAGE)
+            return
+        # #4534 PR-2b: the actual focus flip goes through the named-operation
+        # seam (request_session_switch -> registry.attach_session), not the
+        # retired __session_switch_request__ display-channel sentinel — see
+        # ClientTransport.request_session_switch's own docstring for why.
+        # The reply is ordered AFTER the call and reads its return
+        # (lead-coder review, #4534 remainder): False is ambiguous by
+        # transport (AG-UI's is "unknown"; in-process's is definitive), so
+        # the reply on False says "could not confirm", never "failed".
+        switched = await ctx.transport.request_session_switch(rest)
+        if switched:
+            await reply(ctx, f"switching to session {rest!r}")
+        else:
+            await reply(ctx, f"could not confirm the switch to session {rest!r}")
+        return
+
     reg = ctx.session._registry
     if reg is None:
         await reply_error(ctx, "/session needs a multi-agent registry session")
@@ -115,10 +178,6 @@ async def session_cmd(ctx: "SlashContext", args: str) -> None:
     if name is None:
         await reply_error(ctx, "no agent attached")
         return
-
-    parts = args.strip().split(maxsplit=1)
-    sub = parts[0].lower() if parts else ""
-    rest = parts[1].strip() if len(parts) > 1 else ""
 
     if sub == "new":
         # #3562: the child is born under the ATTACHED agent, and the layer that decides
@@ -167,33 +226,6 @@ async def session_cmd(ctx: "SlashContext", args: str) -> None:
         if inherited:
             lines.extend(_inherited_restriction_lines(reg, name, sid))
         await reply(ctx, "\n".join(lines))
-        return
-
-    if sub == "switch":
-        if not rest:
-            await reply_error(ctx, _USAGE)
-            return
-        if reg.get_session(name, rest) is None:
-            await reply_error(
-                ctx,
-                f"no session {rest!r} for {name!r}"
-                " — use the session name (e.g. 'main') or full session ID;"
-                " partial prefixes are not supported. Try /session list.",
-            )
-            return
-        # #4534 PR-2b: the actual focus flip goes through the named-operation
-        # seam (request_session_switch -> registry.attach_session), not the
-        # retired __session_switch_request__ display-channel sentinel — see
-        # ClientTransport.request_session_switch's own docstring for why.
-        # The reply is ordered AFTER the call and reads its return
-        # (lead-coder review, #4534 remainder): False is ambiguous by
-        # transport (AG-UI's is "unknown"; in-process's is definitive), so
-        # the reply on False says "could not confirm", never "failed".
-        switched = await ctx.transport.request_session_switch(rest)
-        if switched:
-            await reply(ctx, f"switching to session {rest!r}")
-        else:
-            await reply(ctx, f"could not confirm the switch to session {rest!r}")
         return
 
     if sub == "list":

--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -126,7 +126,17 @@ def _session_locus(args: str) -> "Locus":
     yet") — remainder filed: #5099. → ``session``.
 
     Unknown/empty sub falls through to ``session`` too (the existing
-    ``reg`` derivation produces the usage error either way)."""
+    ``reg`` derivation produces the usage error either way).
+
+    ⚠️ Not a structural check (architect co-vet, issuecomment-5379756281):
+    an unregistered sub silently defaults to ``session`` rather than
+    failing to construct — a new sub that genuinely needs ``connection``
+    must be added to this branch by hand. The default lands on the
+    higher-capability side (a usage error, not a crash on
+    ``session=None``), so this is non-blocking, but it is not the closed
+    per-execution-unit registry #5096 ② otherwise achieves; closing that
+    gap needs sub-command registration, out of this PR's scope —
+    remainder noted alongside #5099."""
     sub = args.strip().split(maxsplit=1)[0].lower() if args.strip() else ""
     return "connection" if sub == "switch" else "session"
 

--- a/src/reyn/interfaces/slash/visibility.py
+++ b/src/reyn/interfaces/slash/visibility.py
@@ -16,6 +16,7 @@ _KINDS = ("tool", "mcp", "category")
 @slash(
     "visibility",
     summary="Toggle this session's visibility of a tool / mcp / category",
+    locus="session",
     usage="/visibility on|off <tool|mcp|category> <name>",
 )
 async def visibility_cmd(ctx: "SlashContext", args: str) -> None:

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -40,12 +40,12 @@ from reyn.interfaces.transport.agui.protocol import (
     parse_sse_blocks,
 )
 from reyn.interfaces.transport.agui.state import RemoteStatusView, reguard_nodes
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.drain import suspend_between_frames
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, Frame
 
 
-class AgUiTransport(ClientTransport):
+class AgUiTransport(ClientTransportStub):
     """Decode a server AG-UI SSE stream into the renderer's ``Frame`` vocabulary."""
 
     def __init__(

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -29,7 +29,7 @@ footgun where a client kills the server).
 from __future__ import annotations
 
 import asyncio
-from typing import AsyncIterator, Awaitable, Callable
+from typing import TYPE_CHECKING, AsyncIterator, Awaitable, Callable
 
 from reyn.interfaces.transport.agui.protocol import (
     InterventionTool,
@@ -40,12 +40,15 @@ from reyn.interfaces.transport.agui.protocol import (
     parse_sse_blocks,
 )
 from reyn.interfaces.transport.agui.state import RemoteStatusView, reguard_nodes
-from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.drain import suspend_between_frames
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, Frame
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
-class AgUiTransport(ClientTransportStub):
+
+class AgUiTransport(ClientTransport):
     """Decode a server AG-UI SSE stream into the renderer's ``Frame`` vocabulary."""
 
     def __init__(
@@ -217,6 +220,18 @@ class AgUiTransport(ClientTransportStub):
     def has_session(self) -> bool:
         return self._connected
 
+    def attach_failed(self) -> bool:
+        # #5096 review finding (lead-coder): EXPLICITLY implemented, not
+        # inherited from ClientTransportStub, even though the VALUE
+        # matches its own default. A remote attach either already
+        # succeeded by the time --connect returns or the connection
+        # attempt itself raised, so there is no separate "connecting in
+        # the background" phase to fail remotely — see
+        # ClientTransport.attach_failed's own docstring for the full
+        # rationale (only InProcessTransport's background-attach path has
+        # anything meaningful to report here).
+        return False
+
     def pending_intervention_head(self) -> "object | None":
         # P3: the id of the intervention awaiting an answer, tracked off the
         # server's intervention frontend-tool. Non-None routes an operator line
@@ -358,6 +373,24 @@ class AgUiTransport(ClientTransportStub):
         # client-local "cancel succeeded" inference), same as every other
         # queue-affecting mutation on this transport.
         return bool(await self._send({"type": "cancel_queued", "msg_id": msg_id}))
+
+    async def clear_pending_command_ui(self) -> None:
+        # #5096 review finding (lead-coder): EXPLICITLY implemented, not
+        # inherited from ClientTransportStub, even though the VALUE
+        # matches its own default (a no-op) — command-UI is INLINE-APP-
+        # LOCAL state, never on the wire (mirrors pending_command_ui()'s
+        # own None for remote — see ClientTransport.clear_pending_
+        # command_ui's own docstring). #5048's cutover leans on this
+        # remaining a deliberate no-op here, not a forgotten override.
+        return None
+
+    def reyn_state_root(self) -> "Path | None":
+        # #5096 review finding (lead-coder): EXPLICITLY implemented, not
+        # inherited from ClientTransportStub. The project lives on the
+        # far end of the wire — there is no local answer to give, ever,
+        # not a transient failure (see ClientTransport.reyn_state_root's
+        # own docstring for the None-vs-empty distinction this preserves).
+        return None
 
     async def shutdown(self) -> None:
         # Client-LOCAL disconnect only (A3). A client can never tear down the

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -374,12 +374,16 @@ class ClientTransport(ABC):
 
 
 class ClientTransportStub(ClientTransport):
-    """A ``ClientTransport`` with the 9 narrow-purpose convenience defaults
+    """★ ``tests/`` ONLY. No production ``ClientTransport`` implementation
+    may inherit this class — see the correction below before adding a new
+    one.
+
+    A ``ClientTransport`` with the 9 narrow-purpose convenience defaults
     every full implementation used to inherit silently, now given a
     separate role from the contract itself (#5076, architect ruling, issue
     #5076 — the "one base fills two roles" finding, generalizing #5045/
     #5082/#5083/#5089's own instances of the same shape: a base default
-    that LOOKS harmless lets a delegation wrapper answer wrongly by simply
+    that LOOKS harmless lets an implementation answer wrongly by simply
     forgetting to override).
 
     ``ClientTransport`` itself is now a PURE contract — every method
@@ -387,25 +391,41 @@ class ClientTransportStub(ClientTransport):
     override one of the 9 methods below fails to CONSTRUCT, the same
     completeness-by-construction guarantee the class already gave the other
     6 (always-abstract) methods. This class exists for the OTHER role a
-    single base used to also carry: narrow-purpose convenience, for
-    implementations that genuinely want some of these 9 answers unchanged
-    (a test double that never touches ``/attach``, or a full transport like
-    ``AgUiTransport``/``SessionBoundTransport`` that deliberately relies on
-    a subset of them for real, documented reasons — see each method's own
-    docstring below for which implementation relies on which default and
-    why).
+    single base used to also carry: narrow-purpose convenience for
+    ``tests/``'s own fixture doubles — a self-contained fake that never
+    touches, say, ``/attach`` can inherit this and skip implementing
+    ``request_attach`` at all.
 
-    Measured (#5076 issue thread) before this split: the 2 real DELEGATION
-    wrappers in the whole codebase (``ThreadedTransportProxy``,
-    ``_ErrorWatchingTransport``) already override all 9 explicitly — they
-    stay on the pure ``ClientTransport`` contract, unaffected by this class,
-    so a THIRD wrapper that forgets one of these 9 in the future fails to
-    construct rather than silently answering wrong. Every one of the 75
-    test-side ``ClientTransport`` subclasses is a self-contained fake, not a
-    wrapper (0 of 75 hold a reference to another transport, confirmed by
-    two independent methods — a per-class body read and a name-independent
-    constructor-signature sweep) — they inherit this class instead, a
-    one-word base-class change each, no method-level audit needed.
+    **Correction (#5096 review, lead-coder — the block this docstring is a
+    condition of):** this PR's first attempt ALSO moved ``AgUiTransport``/
+    ``InProcessTransport``/``SessionBoundTransport`` onto this class,
+    reasoning that architect's own measurement classified them as "real
+    implementations" (0 references to an inner transport) rather than
+    wrappers. That reasoning was **backwards** for THIS class's purpose:
+    "wrapper vs. implementation" answers a DIFFERENT question (does it
+    delegate to another transport) than the one this split exists to
+    answer (does forgetting a method here look plausible in PRODUCTION).
+    ``SessionBoundTransport`` silently inheriting the ``request_attach``
+    default (``False``, "did not happen here") is EXACTLY the owner-
+    reported "attach coder-smith failed" over ``--connect`` (#5094) — a
+    real implementation is not immune to this defect; it is MORE exposed
+    to it, since nothing else catches a missing override once it is on the
+    convenience side. All 3 production classes now stay on the pure
+    ``ClientTransport`` contract and EXPLICITLY implement every one of the
+    9 methods (even where the value matches this class's own default —
+    written explicitly so a future reader can tell "answered, deliberately
+    a no-op" from "forgot to answer"). **Only the 75 ``tests/`` fixture
+    classes inherit this class** — confirmed 0 of 75 hold a reference to
+    another transport (two independent methods: a per-class body read and
+    a name-independent constructor-signature sweep), so none of them is a
+    production-shaped risk in the first place.
+
+    Measured (#5076 issue thread): the 2 real DELEGATION wrappers in the
+    whole codebase (``ThreadedTransportProxy``, ``_ErrorWatchingTransport``)
+    already override all 9 explicitly — they stay on the pure
+    ``ClientTransport`` contract too, unaffected by this class, so a THIRD
+    wrapper that forgets one of these 9 in the future fails to construct
+    rather than silently answering wrong.
 
     Option ④ (``__getattr__`` auto-forwarding to an inner transport) was
     considered and rejected: ``ThreadedTransportProxy``'s job is not

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -22,6 +22,13 @@ client codepath.
 This is an abstract base (not a bare Protocol) so a partial implementation
 fails at construction rather than silently at first use — the #1402
 completeness-by-construction discipline the ``PresentationConsumer`` seam uses.
+Every method here is ``@abstractmethod`` — a PURE contract, no defaults
+(#5076): the narrow-purpose convenience defaults 9 of these methods used to
+carry live on :class:`ClientTransportStub` instead, so a DELEGATION wrapper
+(one that forwards to another transport) inherits from THIS class directly
+and fails to construct if it forgets one, rather than silently answering a
+plausible-looking wrong value — see that class's own docstring for the
+full "one base fills two roles" finding.
 
 ⚠️ That guarantee covers the abstract METHOD SET, not each method's semantics,
 and there is one implementation that satisfies it without being a client:
@@ -118,6 +125,7 @@ class ClientTransport(ABC):
     def has_session(self) -> bool:
         """Whether a session is currently attached (client input guard)."""
 
+    @abstractmethod
     def attach_failed(self) -> bool:
         """#3671 P3: whether the attach this transport is waiting on is KNOWN
         to have given up — vs. still in flight, or never attempted (both of
@@ -126,16 +134,16 @@ class ClientTransport(ABC):
         "still connecting" from "gave up" (owner ruling: a client must never
         paint a genuine failure as an indefinite loading state).
 
-        NOT abstract (mirrors :meth:`cancel_queued` / :meth:`run_slash_command`
-        above): several narrow-purpose ``ClientTransport`` stubs across the
-        test suite pre-date this method, and only `InProcessTransport` (#3671
-        P2's own background-attach path) has anything meaningful to report —
-        a remote (``AgUiTransport``) attach either already succeeded by the
-        time ``--connect`` returns or the connection attempt itself raised,
-        so there is no separate "connecting in the background" phase to fail
-        remotely; the default ``False`` (paired with its own ``has_session()``)
-        is correct there, not a placeholder."""
-        return False
+        Abstract (#5076): moved OFF this contract's own convenience default
+        onto :class:`ClientTransportStub` — see that class for the shared
+        ``False`` body and the full rationale for why a wrapper must answer
+        this itself rather than silently inheriting a value that happens to
+        look plausible. ``False`` (paired with its own ``has_session()``) is
+        correct for any implementation with no separate "connecting in the
+        background" phase (a remote ``AgUiTransport`` attach either already
+        succeeded by the time ``--connect`` returns or the connection
+        attempt itself raised) — only ``InProcessTransport`` (#3671 P2's own
+        background-attach path) has anything meaningful to report."""
 
     @abstractmethod
     def pending_intervention_head(self) -> "object | None":
@@ -167,6 +175,7 @@ class ClientTransport(ABC):
         best-effort/generic string rather than asserting something was
         actually stopped."""
 
+    @abstractmethod
     async def run_slash_command(self, name: str, args: str) -> bool:
         """Run the registered slash command ``name`` with ``args``; ``True`` iff
         it ran (#3595 S5).
@@ -195,12 +204,10 @@ class ClientTransport(ABC):
         why the #3327 ``/answer`` fast path this method replaces is generalized
         rather than preserved.
 
-        NOT abstract (mirrors :meth:`cancel_queued`): several narrow-purpose
-        ``ClientTransport`` stubs across the test suite pre-date it, and the
-        default keeps their behavior unchanged.
-        """
-        return False
+        Abstract (#5076): the ``False``-default body moved to
+        :class:`ClientTransportStub`."""
 
+    @abstractmethod
     async def cancel_queued(self, msg_id: str) -> bool:
         """Cancel-by-id an UNDISPATCHED (queued) user message (#3300 P3
         Y-server) — a DIFFERENT intent from :meth:`cancel_inflight` (which
@@ -208,17 +215,12 @@ class ClientTransport(ABC):
         two. Returns True iff the server actually removed the item (queued);
         a no-op (already dispatched, or unknown id) returns False.
 
-        NOT abstract (unlike the other send-seam methods above): this method
-        was added after several narrow-purpose ``ClientTransport`` stubs
-        already existed across the test suite (pre-dating #3300 P3), and
-        making it abstract would force every one of them to implement a
-        method irrelevant to what they test. The default no-op preserves
-        their behavior unchanged; both production transports
+        Abstract (#5076): the no-op-``False`` default body moved to
+        :class:`ClientTransportStub`; both production transports
         (``InProcessTransport``, ``AgUiTransport``) override it with the
-        real op.
-        """
-        return False
+        real op."""
 
+    @abstractmethod
     async def request_attach(self, agent_name: str) -> bool:
         """Attach to a different agent (the ``/attach`` seam); ``True`` iff it
         happened (#4534 PR-1).
@@ -237,13 +239,10 @@ class ClientTransport(ABC):
         execution side / unknown agent on the far end) — mirrors
         :meth:`run_slash_command`'s own convention.
 
-        NOT abstract (same reasoning as :meth:`run_slash_command`/
-        :meth:`cancel_queued` above): several narrow-purpose
-        ``ClientTransport`` stubs across the test suite pre-date this
-        method; the default ``False`` preserves their behavior unchanged.
-        """
-        return False
+        Abstract (#5076): the ``False``-default body moved to
+        :class:`ClientTransportStub`."""
 
+    @abstractmethod
     async def request_session_switch(self, session_id: str) -> bool:
         """Switch the focused conversation session (the ``/session switch``
         seam); ``True`` iff it happened (#4534 PR-1).
@@ -253,10 +252,10 @@ class ClientTransport(ABC):
         sentinel (#4534 PR-2b), reaching ``registry.attach_session``
         directly instead.
 
-        NOT abstract, same reasoning as :meth:`request_attach`.
-        """
-        return False
+        Abstract (#5076): the ``False``-default body moved to
+        :class:`ClientTransportStub`."""
 
+    @abstractmethod
     async def request_artifact_list(self, *, agent: str) -> "tuple[list[dict], int]":
         """#4494 design C: the durable artifact-ref table's own entries for
         *agent* — ``([{"ref", "path"}, ...], total)``, newest-first, or
@@ -288,11 +287,10 @@ class ClientTransport(ABC):
         table is append-only/persist-tier, #4584, so an uncapped read
         only ever grows).
 
-        NOT abstract, same reasoning as :meth:`request_attach` — several
-        narrow-purpose stubs across the test suite pre-date this method;
-        the default ``([], 0)`` preserves their behavior unchanged."""
-        return [], 0
+        Abstract (#5076): the ``([], 0)``-default body moved to
+        :class:`ClientTransportStub`."""
 
+    @abstractmethod
     async def state_ready(self) -> None:
         """Return once this transport's own STATUS/state-read side-channel
         (whatever ``ChatReadModel.snapshot()``/``intervention_head()``/etc.
@@ -310,21 +308,19 @@ class ClientTransport(ABC):
         ZERO frames from :meth:`frames`, ever) would make a frame-gated
         wait hang forever, not merely late.
 
-        The default here (return immediately) is correct for any
-        transport whose status-read is ALREADY fresh the instant it is
-        asked — every implementation with no separate wire round-trip
-        (``InProcessTransport`` reads the live registry directly; any
-        narrow-purpose ``ClientTransport`` test stub that never overrode
-        this). ``AgUiTransport`` is the one implementation with a genuine
-        "not yet" window (before its first STATE_SNAPSHOT has been
-        decoded) and overrides this to actually wait.
-
         NOT merged into :meth:`frames` on purpose — mixing "produce
         display frames" with "has status state landed" would be the
         exact "two axes fused into one seam" shape #5041 ① already named
-        as a hazard elsewhere tonight."""
-        return None
+        as a hazard elsewhere tonight.
 
+        Abstract (#5076): the "return immediately" default body moved to
+        :class:`ClientTransportStub` — see that class's own docstring for
+        which implementations rely on it and why (``InProcessTransport``
+        reads the live registry directly; ``AgUiTransport`` is the one
+        implementation with a genuine "not yet" window and overrides
+        this to actually wait)."""
+
+    @abstractmethod
     async def clear_pending_command_ui(self) -> None:
         """Consume the pending command-UI request (the ``/rewind`` picker's
         own points, or any future command-UI kind) — a no-op wherever there
@@ -342,15 +338,15 @@ class ClientTransport(ABC):
         (:meth:`submit_user_text`/:meth:`answer_intervention_choice`/etc.),
         not through a read-only seam that happens to expose one exception.
 
-        The default here (no-op) is correct for any transport with no
-        local command-UI concept at all — command-UI is INLINE-APP-LOCAL
-        state (never on the wire, mirroring ``pending_command_ui()``'s own
-        ``None`` for remote): ``AgUiTransport`` inherits this default
+        Abstract (#5076): the no-op default body moved to
+        :class:`ClientTransportStub` — command-UI is INLINE-APP-LOCAL state
+        (never on the wire, mirroring ``pending_command_ui()``'s own
+        ``None`` for remote): ``AgUiTransport`` inherits the no-op
         unchanged. ``InProcessTransport`` overrides it to perform the real
         clear; ``ThreadedTransportProxy`` overrides it to marshal the call
         onto the worker thread that owns the ``Session``."""
-        return None
 
+    @abstractmethod
     def reyn_state_root(self) -> "Path | None":
         """The attached session's project `.reyn` root, or None (#3721).
 
@@ -369,16 +365,82 @@ class ClientTransport(ABC):
         end of the wire and there is no local answer to give, ever, not a
         transient failure.
 
-        NOT abstract (mirrors :meth:`run_slash_command` / :meth:`cancel_queued`
-        above): several narrow-purpose `ClientTransport` stubs across the test
-        suite pre-date this method. The default `None` is correct, not a
-        placeholder, for any transport with no local session to ask.
-        """
-        return None
+        Abstract (#5076): the `None`-default body moved to
+        :class:`ClientTransportStub`."""
 
     @abstractmethod
     async def shutdown(self) -> None:
         """Tear the session (and its registry) down — the /quit / EOF seam."""
+
+
+class ClientTransportStub(ClientTransport):
+    """A ``ClientTransport`` with the 9 narrow-purpose convenience defaults
+    every full implementation used to inherit silently, now given a
+    separate role from the contract itself (#5076, architect ruling, issue
+    #5076 — the "one base fills two roles" finding, generalizing #5045/
+    #5082/#5083/#5089's own instances of the same shape: a base default
+    that LOOKS harmless lets a delegation wrapper answer wrongly by simply
+    forgetting to override).
+
+    ``ClientTransport`` itself is now a PURE contract — every method
+    ``@abstractmethod``, no defaults anywhere. A subclass that forgets to
+    override one of the 9 methods below fails to CONSTRUCT, the same
+    completeness-by-construction guarantee the class already gave the other
+    6 (always-abstract) methods. This class exists for the OTHER role a
+    single base used to also carry: narrow-purpose convenience, for
+    implementations that genuinely want some of these 9 answers unchanged
+    (a test double that never touches ``/attach``, or a full transport like
+    ``AgUiTransport``/``SessionBoundTransport`` that deliberately relies on
+    a subset of them for real, documented reasons — see each method's own
+    docstring below for which implementation relies on which default and
+    why).
+
+    Measured (#5076 issue thread) before this split: the 2 real DELEGATION
+    wrappers in the whole codebase (``ThreadedTransportProxy``,
+    ``_ErrorWatchingTransport``) already override all 9 explicitly — they
+    stay on the pure ``ClientTransport`` contract, unaffected by this class,
+    so a THIRD wrapper that forgets one of these 9 in the future fails to
+    construct rather than silently answering wrong. Every one of the 75
+    test-side ``ClientTransport`` subclasses is a self-contained fake, not a
+    wrapper (0 of 75 hold a reference to another transport, confirmed by
+    two independent methods — a per-class body read and a name-independent
+    constructor-signature sweep) — they inherit this class instead, a
+    one-word base-class change each, no method-level audit needed.
+
+    Option ④ (``__getattr__`` auto-forwarding to an inner transport) was
+    considered and rejected: ``ThreadedTransportProxy``'s job is not
+    forwarding but marshaling across a thread boundary, so an
+    auto-forwarded NEW method would cross unmarshaled — trading "silently
+    not delegated" for "silently delegated somewhere dangerous". Falling
+    at construction, not at first (mis)use, is the point.
+    """
+
+    def attach_failed(self) -> bool:
+        return False
+
+    async def run_slash_command(self, name: str, args: str) -> bool:
+        return False
+
+    async def cancel_queued(self, msg_id: str) -> bool:
+        return False
+
+    async def request_attach(self, agent_name: str) -> bool:
+        return False
+
+    async def request_session_switch(self, session_id: str) -> bool:
+        return False
+
+    async def request_artifact_list(self, *, agent: str) -> "tuple[list[dict], int]":
+        return [], 0
+
+    async def state_ready(self) -> None:
+        return None
+
+    async def clear_pending_command_ui(self) -> None:
+        return None
+
+    def reyn_state_root(self) -> "Path | None":
+        return None
 
 
 def pending_head_id(head: object, *, caller: str) -> "str | None":
@@ -431,4 +493,4 @@ def pending_head_id(head: object, *, caller: str) -> "str | None":
     return None
 
 
-__all__ = ["ClientTransport", "pending_head_id"]
+__all__ = ["ClientTransport", "ClientTransportStub", "pending_head_id"]

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -33,7 +33,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, AsyncIterator
 
-from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.drain import suspend_between_frames
 from reyn.interfaces.transport.frames import (
     DisplayFrame,
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class InProcessTransport(ClientTransportStub):
+class InProcessTransport(ClientTransport):
     """The local transport: forwarder + filtered audit-events → one frame stream."""
 
     def __init__(
@@ -181,6 +181,18 @@ class InProcessTransport(ClientTransportStub):
         s = self._attached()
         if s is not None:
             s.set_pending_command_ui(None)
+
+    async def state_ready(self) -> None:
+        # #5096 review finding (lead-coder): EXPLICITLY implemented, not
+        # inherited from ClientTransportStub, even though the VALUE
+        # matches its own default — this class reads the live registry
+        # directly (no separate wire round-trip), so its own status-read
+        # side-channel is already fresh the instant it is asked. Written
+        # here so a future reader can tell "answered, deliberately a
+        # no-op" from "forgot to answer" (ClientTransport.state_ready's
+        # own docstring for the full rationale — AgUiTransport is the ONE
+        # implementation with a genuine "not yet" window).
+        return None
 
     def reyn_state_root(self) -> "Path | None":
         # #3721: `Session.workspace_dir` is the same PUBLIC per-agent path

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -33,7 +33,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, AsyncIterator
 
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.drain import suspend_between_frames
 from reyn.interfaces.transport.frames import (
     DisplayFrame,
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class InProcessTransport(ClientTransport):
+class InProcessTransport(ClientTransportStub):
     """The local transport: forwarder + filtered audit-events → one frame stream."""
 
     def __init__(

--- a/src/reyn/interfaces/transport/session_bound.py
+++ b/src/reyn/interfaces/transport/session_bound.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, AsyncIterator, Callable
 
-from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.client_transport import ClientTransport
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from reyn.runtime.outbox import OutboxMessage
 
 
-class SessionBoundTransport(ClientTransportStub):
+class SessionBoundTransport(ClientTransport):
     """The send half of the client seam, bound to the session that dispatches."""
 
     def __init__(
@@ -89,8 +89,26 @@ class SessionBoundTransport(ClientTransportStub):
         """Always True: this transport exists only because a session built it."""
         return True
 
+    def attach_failed(self) -> bool:
+        # #5094: EXPLICITLY implemented, not inherited — a --connect remote
+        # attach reaches ClientTransport.attach_failed through THIS
+        # transport (the AG-UI endpoint's slash_command arm builds its
+        # SlashContext over one of these, session.py:8284), so silently
+        # falling through to ClientTransport's own "never happened" default
+        # would be the same #5076-family defect this class exists to
+        # avoid. Delegates to the session's own registry, mirroring
+        # InProcessTransport's own identical derivation.
+        registry = getattr(self._session, "_registry", None)
+        return bool(registry.attach_failed()) if registry is not None else False
+
     def pending_intervention_head(self) -> "object | None":
         return self._session.interventions.head()
+
+    async def clear_pending_command_ui(self) -> None:
+        # #5094: EXPLICITLY implemented (mirrors InProcessTransport's own
+        # real write, #5045) — same-thread here (session-bound, in-process
+        # on the server side of a remote connection), no marshaling needed.
+        self._session.set_pending_command_ui(None)
 
     def reyn_state_root(self) -> "Path | None":
         # #3721: same derivation as InProcessTransport (mirrors that class by
@@ -132,6 +150,74 @@ class SessionBoundTransport(ClientTransportStub):
 
     async def cancel_queued(self, msg_id: str) -> bool:
         return bool(await self._session.cancel_queued(msg_id))
+
+    async def run_slash_command(self, name: str, args: str) -> bool:
+        # #5094: EXPLICITLY implemented, not inherited — mirrors
+        # InProcessTransport's own real execution side (#3595 S5): the
+        # handler is handed THIS transport (the send seam it already
+        # writes through) plus the bound session for the reads S4
+        # enumerated as residue. Un-queued by construction, same reason
+        # as InProcessTransport's own copy.
+        from reyn.interfaces.slash import SlashContext
+        from reyn.interfaces.slash.dispatch import execute_slash_command
+        return await execute_slash_command(
+            SlashContext(transport=self, session=self._session), name, args,
+        )
+
+    async def request_attach(self, agent_name: str) -> bool:
+        # #5094/#5096, architect ruling (issuecomment-5379623427):
+        # EXPLICITLY False, not inherited -- and NOT the reach-through-
+        # the-session's-own-registry implementation an earlier revision
+        # of this method carried. This transport is structurally the
+        # WRONG place to answer "attach a different agent" -- it is
+        # send-side ONLY, bound to ONE already-attached session (see the
+        # class docstring); "which agent is attached" is a REGISTRY-level
+        # question, and giving this class a registry reference would
+        # widen its own responsibility layer, a separate concern from
+        # #5048's "registry stays off the caller's own loop" ruling but
+        # the same shape of mistake. The REAL fix is #5096's own ②: the
+        # CLIENT-side dispatch layer (interfaces/slash/dispatch.py's
+        # maybe_dispatch_slash) now recognizes /attach and calls
+        # ClientTransport.request_attach directly -- the dedicated typed
+        # op AgUiTransport already implements correctly -- so a remote
+        # /attach never reaches this method (or server-side slash
+        # dispatch) at all.
+        return False
+
+    async def request_session_switch(self, session_id: str) -> bool:
+        # #5094/#5096: EXPLICITLY False, same reasoning as request_attach
+        # above -- session switching is also a registry-level operation
+        # this send-side-only transport structurally cannot answer.
+        return False
+
+    async def request_artifact_list(self, *, agent: str) -> "tuple[list[dict], int]":
+        # #5094: EXPLICITLY implemented, not inherited — mirrors
+        # InProcessTransport's own execution side (#4494 design C /
+        # #4601's own cap), reading the durable artifact-ref table
+        # directly via the same reyn_state_root() this class already
+        # derives above.
+        from reyn.config.loader import load_config
+        from reyn.data.workspace.artifact_ref import list_refs_for_agent
+        reyn_root = self.reyn_state_root()
+        if reyn_root is None:
+            return [], 0
+        project_root = reyn_root.parent
+        config = load_config(project_root)
+        return list_refs_for_agent(
+            project_root, agent, limit=config.artifacts.remote_fallback_limit,
+        )
+
+    async def state_ready(self) -> None:
+        # #5094: EXPLICITLY implemented, not inherited (even though the
+        # VALUE matches ClientTransport's own default). This transport is
+        # session-bound / in-process on the server's side of a remote
+        # connection — no separate wire round-trip, so its own
+        # status-read side-channel is already fresh the instant it is
+        # asked, the same reasoning InProcessTransport's own explicit
+        # override states. Written explicitly per lead-coder's #5096
+        # review finding: a class that silently inherits a convenience
+        # default cannot be told apart from one that forgot to answer.
+        return None
 
     async def shutdown(self) -> None:
         await self._session.shutdown()

--- a/src/reyn/interfaces/transport/session_bound.py
+++ b/src/reyn/interfaces/transport/session_bound.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, AsyncIterator, Callable
 
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from reyn.runtime.outbox import OutboxMessage
 
 
-class SessionBoundTransport(ClientTransport):
+class SessionBoundTransport(ClientTransportStub):
     """The send half of the client seam, bound to the session that dispatches."""
 
     def __init__(

--- a/tests/_support/slash.py
+++ b/tests/_support/slash.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 class RecordingTransport(ClientTransportStub):
     """A real client transport that keeps what was displayed."""
 
-    def __init__(self, session: Any = None) -> None:
+    def __init__(self, session: Any = None, *, attach_result: bool = True) -> None:
         self._session = session
         self.displayed: "list[OutboxMessage]" = []
         # #4534 PR-2: what request_attach/request_session_switch were CALLED
@@ -54,6 +54,13 @@ class RecordingTransport(ClientTransportStub):
         # fake.
         self.attach_requests: "list[str]" = []
         self.session_switch_requests: "list[str]" = []
+        # #5096 ②: attach_cmd (locus="connection") no longer pre-validates
+        # against a session's registry -- its reply is driven entirely by
+        # request_attach's own return, so a test exercising the False path
+        # (unknown target / no registry / already attached, all now
+        # indistinguishable at THIS layer -- the server's typed-op handler
+        # owns that distinction) needs a way to make this fake say False.
+        self._attach_result = attach_result
 
     # -- the seam under test ------------------------------------------------
 
@@ -62,7 +69,7 @@ class RecordingTransport(ClientTransportStub):
 
     async def request_attach(self, agent_name: str) -> bool:
         self.attach_requests.append(agent_name)
-        return True
+        return self._attach_result
 
     async def request_session_switch(self, session_id: str) -> bool:
         self.session_switch_requests.append(session_id)
@@ -155,7 +162,9 @@ class RecordingTransport(ClientTransportStub):
 
 
 def slash_ctx(
-    session: Any = None, *, recorder: "list[OutboxMessage] | None" = None
+    session: Any = None, *,
+    recorder: "list[OutboxMessage] | None" = None,
+    attach_result: bool = True,
 ) -> SlashContext:
     """The context a slash handler is handed, with a recording transport.
 
@@ -168,8 +177,11 @@ def slash_ctx(
     session's existing readers keep answering and the assertions a test already
     made are the ones still being made. Pass the SAME list each call — a handler
     driven twice (a two-step confirm) must accumulate, not restart.
+
+    ``attach_result`` (#5096 ②): what the transport's ``request_attach``
+    reports back — see ``RecordingTransport``'s own docstring.
     """
-    transport = RecordingTransport(session)
+    transport = RecordingTransport(session, attach_result=attach_result)
     if recorder is not None:
         transport.displayed = recorder
     return SlashContext(transport=transport, session=session)

--- a/tests/_support/slash.py
+++ b/tests/_support/slash.py
@@ -41,7 +41,11 @@ if TYPE_CHECKING:
 class RecordingTransport(ClientTransportStub):
     """A real client transport that keeps what was displayed."""
 
-    def __init__(self, session: Any = None, *, attach_result: bool = True) -> None:
+    def __init__(
+        self, session: Any = None, *,
+        attach_result: bool = True,
+        switch_result: bool = True,
+    ) -> None:
         self._session = session
         self.displayed: "list[OutboxMessage]" = []
         # #4534 PR-2: what request_attach/request_session_switch were CALLED
@@ -61,6 +65,13 @@ class RecordingTransport(ClientTransportStub):
         # indistinguishable at THIS layer -- the server's typed-op handler
         # owns that distinction) needs a way to make this fake say False.
         self._attach_result = attach_result
+        # #5096 ②: same shape as _attach_result -- the switch sub of
+        # /session (locus="connection") no longer pre-validates the sid
+        # against a session's registry either, so a test exercising the
+        # False path (unknown sid, only distinguishable server-side, see
+        # session.py's own switch-branch docstring) needs a way to make
+        # this fake say False.
+        self._switch_result = switch_result
 
     # -- the seam under test ------------------------------------------------
 
@@ -73,7 +84,7 @@ class RecordingTransport(ClientTransportStub):
 
     async def request_session_switch(self, session_id: str) -> bool:
         self.session_switch_requests.append(session_id)
-        return True
+        return self._switch_result
 
     # -- readers a test asserts through -------------------------------------
 
@@ -165,6 +176,7 @@ def slash_ctx(
     session: Any = None, *,
     recorder: "list[OutboxMessage] | None" = None,
     attach_result: bool = True,
+    switch_result: bool = True,
 ) -> SlashContext:
     """The context a slash handler is handed, with a recording transport.
 
@@ -178,10 +190,11 @@ def slash_ctx(
     made are the ones still being made. Pass the SAME list each call — a handler
     driven twice (a two-step confirm) must accumulate, not restart.
 
-    ``attach_result`` (#5096 ②): what the transport's ``request_attach``
-    reports back — see ``RecordingTransport``'s own docstring.
+    ``attach_result`` / ``switch_result`` (#5096 ②): what the transport's
+    ``request_attach`` / ``request_session_switch`` report back — see
+    ``RecordingTransport``'s own docstring.
     """
-    transport = RecordingTransport(session, attach_result=attach_result)
+    transport = RecordingTransport(session, attach_result=attach_result, switch_result=switch_result)
     if recorder is not None:
         transport.displayed = recorder
     return SlashContext(transport=transport, session=session)

--- a/tests/_support/slash.py
+++ b/tests/_support/slash.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from reyn.interfaces.slash import SlashContext
 from reyn.interfaces.slash.dispatch import execute_slash_command
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.in_process import InProcessTransport
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
 
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from reyn.runtime.outbox import OutboxMessage
 
 
-class RecordingTransport(ClientTransport):
+class RecordingTransport(ClientTransportStub):
     """A real client transport that keeps what was displayed."""
 
     def __init__(self, session: Any = None) -> None:

--- a/tests/_support/textual_chat_test_helpers.py
+++ b/tests/_support/textual_chat_test_helpers.py
@@ -14,7 +14,7 @@ from typing import AsyncIterator
 from textual_flowview import Entry
 
 from reyn.interfaces.inline.textual_chat import ReynPresenter
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
@@ -25,7 +25,7 @@ def started(op_id: str, tool: str = "grep") -> OutboxMessage:
     )
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real :class:`ClientTransport` fed one frame at a time from a queue, so a
     test can push a ``started`` frame, inspect the RUNNING row, THEN push the
     completion and inspect the settle — with the stream staying open in between

--- a/tests/interfaces/test_2280_durability_halt_observability.py
+++ b/tests/interfaces/test_2280_durability_halt_observability.py
@@ -51,7 +51,7 @@ from reyn.core.events.durability_worker import DurabilityWorker
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.repl.renderer import ConsoleChatRenderer, InlineChatRenderer
 from reyn.interfaces.repl.status import _snapshot
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame, Frame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
@@ -276,7 +276,7 @@ def test_inline_renderer_bottom_toolbar_surfaces_halt() -> None:
 # ── Gate 4: reachable-for-purpose — a real TextualChatApp's StatusLine ────────
 
 
-class _QueueTransport(ClientTransport):
+class _QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` backed by an ``asyncio.Queue``
     so a test can push a frame WHILE the app's frame-pump worker is already
     running (mid-session), rather than only pre-seeding frames before mount —

--- a/tests/interfaces/test_3288_3c_tui_delta_coalesce.py
+++ b/tests/interfaces/test_3288_3c_tui_delta_coalesce.py
@@ -48,7 +48,7 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.app import _STREAM_REPAINT_MIN_INTERVAL
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -82,7 +82,7 @@ class _DrivenClock:
         self.advance(_STREAM_REPAINT_MIN_INTERVAL * 2)
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from a
     queue (mirrors ``tests/interfaces/test_agent_delta_no_visible_garbage_3288.py``'s
     helper of the same name)."""

--- a/tests/interfaces/test_3300_intervention_answer_eventify.py
+++ b/tests/interfaces/test_3300_intervention_answer_eventify.py
@@ -52,7 +52,7 @@ from reyn.interfaces.repl.renderer import (
     InlineChatRenderer,
     intervention_answer_display_message,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -60,7 +60,7 @@ from reyn.schemas.models import Event
 _RAW_ESC_OSC = "\x1b[31mRED\x1b]0;pwn\x07"
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time
     (identical harness to ``test_3300_p2b_sentqueue_render.py``'s
     ``QueueTransport`` — kept local rather than shared to avoid a

--- a/tests/interfaces/test_3300_p2b_sentqueue_render.py
+++ b/tests/interfaces/test_3300_p2b_sentqueue_render.py
@@ -58,7 +58,7 @@ from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.sent_queue import ROW_TEXT_COLUMN, SentQueue
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.transport.agui.state import RemoteQueueView
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -66,7 +66,7 @@ from reyn.schemas.models import Event
 _RAW_ESC_OSC = "\x1b[31mRED\x1b]0;pwn\x07"
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from
     a queue (mirrors ``test_user_submitted_render_3300.py``'s helper) — lets
     a test push an ``EventFrame`` and inspect ``TextualChatApp``'s retained

--- a/tests/interfaces/test_3300_y_client_cancel.py
+++ b/tests/interfaces/test_3300_y_client_cancel.py
@@ -58,7 +58,7 @@ from reyn.interfaces.inline.textual_chat.chrome import (
     help_pane_lines,
 )
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -66,7 +66,7 @@ from reyn.schemas.models import Event
 _RAW_ESC_OSC = "\x1b[31mRED\x1b]0;pwn\x07"
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from
     a queue (mirrors ``test_3300_p2b_sentqueue_render.py``'s helper), whose
     ``cancel_queued`` is CONTROLLABLE (a real attribute, not a mock) so a test

--- a/tests/interfaces/test_3310_n2_reset_hydrate.py
+++ b/tests/interfaces/test_3310_n2_reset_hydrate.py
@@ -65,7 +65,7 @@ from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
 from reyn.interfaces.repl.read_model import RegistryReadModel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
@@ -77,7 +77,7 @@ from tests._support.agent_session import make_session
 # ── real seam: a queue-backed ClientTransport a test drives frame-by-frame ──
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` whose ``frames()`` drains an
     ``asyncio.Queue`` a test pushes onto — so a test can interleave pushing a
     frame with mutating the (real) registry/session state in between, exactly

--- a/tests/interfaces/test_3327_keyboard_reachability_to_panel.py
+++ b/tests/interfaces/test_3327_keyboard_reachability_to_panel.py
@@ -32,13 +32,13 @@ from reyn.interfaces.inline.textual_chat import Composer, TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import COMPOSER_KEYS
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-class RecordingTransport(ClientTransport):
+class RecordingTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` — replays a fixed frame list,
     then stays open on a live queue so a test can push more frames (e.g. a
     ``user_submitted`` sent-queue event), and RECORDS which answer seam each

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -65,7 +65,7 @@ from reyn.interfaces.inline.textual_chat.chrome import (
 )
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.repl.status import _snapshot
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.llm.pricing import CostBreakdown
 from reyn.runtime.outbox import OutboxMessage
@@ -739,7 +739,7 @@ class _MutableSnapshotReadModel(ChatReadModel):
         return 0
 
 
-class _EventOnlyTransport(ClientTransport):
+class _EventOnlyTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time. The
     liveness tests push ONLY ``EventFrame``s through it — never a DisplayFrame —
     so a status refresh that still sat on the DISPLAY leg can never be reached by

--- a/tests/interfaces/test_3354_composer_completion.py
+++ b/tests/interfaces/test_3354_composer_completion.py
@@ -76,7 +76,7 @@ from reyn.interfaces.repl.read_model import (
     completion_source_snapshot_from_session,
 )
 from reyn.interfaces.slash import REGISTRY
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.schemas.models import Event
 from tests._support.agent_session import make_session
@@ -84,7 +84,7 @@ from tests._support.agent_session import make_session
 # ── real collaborators ───────────────────────────────────────────────────────
 
 
-class RecordingTransport(ClientTransport):
+class RecordingTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` (same shape as
     ``test_3327_keyboard_reachability_to_panel.RecordingTransport``): stays open
     on a live queue so a test can push a ``user_submitted`` event to populate the

--- a/tests/interfaces/test_3540_intervention_answer_fold.py
+++ b/tests/interfaces/test_3540_intervention_answer_fold.py
@@ -51,7 +51,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.presenter import ReynPresenter
 from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
@@ -64,7 +64,7 @@ from reyn.user_intervention import InterventionChoice, UserIntervention
 _RAW_ESC_OSC = "\x1b[31mRED\x1b]0;pwn\x07"
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time —
     display frames AND event frames, so one test can drive the announce and
     the answer through the SAME stream the app really reads."""

--- a/tests/interfaces/test_4387_tui_paging_extends_from_disk.py
+++ b/tests/interfaces/test_4387_tui_paging_extends_from_disk.py
@@ -34,7 +34,7 @@ from textual_flowview import FlowView
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.restore import RESUME_DIVIDER, project_restored_frames
 from reyn.interfaces.repl.read_model import RegistryReadModel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
@@ -44,7 +44,7 @@ from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` — no live frames needed for
     a restore/paging/search test (mirrors the #3476 suites' own shape)."""
 

--- a/tests/interfaces/test_4494_request_artifact_list.py
+++ b/tests/interfaces/test_4494_request_artifact_list.py
@@ -102,12 +102,13 @@ async def test_returns_empty_with_no_session_attached(tmp_path):
 
 @pytest.mark.asyncio
 async def test_default_transport_implementation_returns_empty():
-    """Tier 2: (accept-side) the base ClientTransport default — a narrow
-    test stub pre-dating this method keeps working unmodified, same
-    convention as ``request_attach``'s own default."""
-    from reyn.interfaces.transport.client_transport import ClientTransport
+    """Tier 2: (accept-side) the ``ClientTransportStub`` default (#5076:
+    moved off ``ClientTransport`` itself, which is now a pure contract) —
+    a narrow test stub pre-dating this method keeps working unmodified,
+    same convention as ``request_attach``'s own default."""
+    from reyn.interfaces.transport.client_transport import ClientTransportStub
 
-    class _Stub(ClientTransport):
+    class _Stub(ClientTransportStub):
         def start(self) -> None: ...
         def close(self) -> None: ...
         async def frames(self):

--- a/tests/interfaces/test_4534_pr1_request_attach_switch.py
+++ b/tests/interfaces/test_4534_pr1_request_attach_switch.py
@@ -138,13 +138,14 @@ async def test_request_session_switch_returns_false_with_no_session_attached(tmp
 
 @pytest.mark.asyncio
 async def test_default_transport_implementation_returns_false():
-    """Tier 2: (accept-side) the base ClientTransport default (used by
-    narrow-purpose test stubs pre-dating this PR, mirroring
+    """Tier 2: (accept-side) the ``ClientTransportStub`` default (#5076:
+    moved off ``ClientTransport`` itself, which is now a pure contract,
+    used by narrow-purpose test stubs pre-dating this PR, mirroring
     run_slash_command/cancel_queued's own convention) is False, not
     abstract -- an existing stub subclass keeps working unmodified."""
-    from reyn.interfaces.transport.client_transport import ClientTransport
+    from reyn.interfaces.transport.client_transport import ClientTransportStub
 
-    class _Stub(ClientTransport):
+    class _Stub(ClientTransportStub):
         def start(self) -> None: ...
         def close(self) -> None: ...
         async def frames(self):

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -34,7 +34,7 @@ from textual_flowview import EntryState, FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -100,7 +100,7 @@ def _failed(op_id: str, call_id: "str | None", tool: str = "grep") -> OutboxMess
     )
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from a
     queue — display OR event frames — so a test can push frames one at a
     time and inspect the tree between each (same shape as #72's own

--- a/tests/interfaces/test_4691_turn_group_item1.py
+++ b/tests/interfaces/test_4691_turn_group_item1.py
@@ -51,7 +51,7 @@ import pytest
 from textual_flowview import EntryState, FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -124,7 +124,7 @@ def _turn_settled() -> Event:
     return Event(type="turn_settled", data={})
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from
     a queue — display OR event frames (same shape as
     ``test_4691_phase_b_group_construction.py``'s own ``QueueTransport``,

--- a/tests/interfaces/test_4788_rewind_picker_escape_dismiss.py
+++ b/tests/interfaces/test_4788_rewind_picker_escape_dismiss.py
@@ -45,7 +45,7 @@ from reyn.interfaces.inline.textual_chat.chrome import Composer
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
 from reyn.interfaces.inline.textual_chat.rewind_picker import RewindPicker
 from reyn.interfaces.repl.read_model import RegistryReadModel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
@@ -54,7 +54,7 @@ from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` whose ``frames()`` drains an
     ``asyncio.Queue`` a test pushes onto (mirrors the same harness shape used
     throughout ``test_3310_n2_reset_hydrate.py``)."""

--- a/tests/interfaces/test_4817_rewind_yields_to_open_intervention.py
+++ b/tests/interfaces/test_4817_rewind_yields_to_open_intervention.py
@@ -37,7 +37,7 @@ from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
 from reyn.interfaces.inline.textual_chat.rewind_picker import RewindPicker
 from reyn.interfaces.repl.read_model import RegistryReadModel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
@@ -46,7 +46,7 @@ from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` whose ``frames()`` drains an
     ``asyncio.Queue`` a test pushes onto (mirrors the same harness shape used
     throughout ``test_4788_rewind_picker_escape_dismiss.py``)."""

--- a/tests/interfaces/test_4983_session_switch_off_thread.py
+++ b/tests/interfaces/test_4983_session_switch_off_thread.py
@@ -36,7 +36,7 @@ from textual_flowview import FlowView
 from reyn.core.events.events import Event
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.repl.read_model import RegistryReadModel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
@@ -45,7 +45,7 @@ from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` whose ``frames()`` drains
     an ``asyncio.Queue`` the test pushes onto (mirrors ``test_3310_n2_
     reset_hydrate.py``'s own helper of the same name/shape)."""

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -60,7 +60,7 @@ from typing import TYPE_CHECKING, AsyncIterator
 
 import pytest
 
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.threaded import ThreadedTransportProxy
 
 if TYPE_CHECKING:
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
     from reyn.runtime.outbox import OutboxMessage
 
 
-class _RecordingTransport(ClientTransport):
+class _RecordingTransport(ClientTransportStub):
     """A minimal, real ``ClientTransport``. ``frames()`` never yields
     anything in these tests (an unresolved real ``asyncio.Event`` — an
     unbounded wait, not a duration) since neither witness needs a frame to

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -50,7 +50,7 @@ from reyn.interfaces.repl.read_model import (
     RegistryReadModel,
     RemoteReadModel,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
@@ -59,7 +59,7 @@ from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` whose ``frames()`` drains
     an ``asyncio.Queue`` the test pushes onto (mirrors ``test_4983_
     session_switch_off_thread.py``'s own helper of the same name/shape).

--- a/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
+++ b/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
@@ -78,14 +78,14 @@ from textual_flowview import FlowView
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
 from reyn.interfaces.inline.textual_chat.restore import RESTORED_META_KEY
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 _GUTTER_WIDTH = 2
 
 
-class _ReplayTransport(ClientTransport):
+class _ReplayTransport(ClientTransportStub):
     """A real, minimal ``ClientTransport`` that replays a fixed frame list —
     mirrors ``test_textual_chat_intervention_panel_3299.py``'s own
     ``RecordingTransport`` shape, not imported from it (that class lives in

--- a/tests/interfaces/test_5048_threaded_proxy_pending_head_not_live_object.py
+++ b/tests/interfaces/test_5048_threaded_proxy_pending_head_not_live_object.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, AsyncIterator
 
 import pytest
 
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.threaded import ThreadedTransportProxy
 
 if TYPE_CHECKING:
@@ -56,7 +56,7 @@ class _FakeIntervention:
         self.future = future
 
 
-class _InterveningTransport(ClientTransport):
+class _InterveningTransport(ClientTransportStub):
     """A minimal, real ``ClientTransport`` whose ``pending_intervention_
     head()`` returns a live ``_FakeIntervention`` — mirroring ``InProcess
     Transport``'s own real behaviour (``s.interventions.head()`` returned

--- a/tests/interfaces/test_5057_fake_pending_rewind_frame_not_registered.py
+++ b/tests/interfaces/test_5057_fake_pending_rewind_frame_not_registered.py
@@ -42,12 +42,12 @@ import pytest
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _ReplayTransport(ClientTransport):
+class _ReplayTransport(ClientTransportStub):
     """A real, minimal ``ClientTransport`` that replays a fixed frame list."""
 
     def __init__(self, messages: "list[OutboxMessage]") -> None:

--- a/tests/interfaces/test_5094_session_bound_transport_request_attach.py
+++ b/tests/interfaces/test_5094_session_bound_transport_request_attach.py
@@ -1,0 +1,93 @@
+"""Tier 2: #5094/#5096, architect ruling (issuecomment-5379623427) —
+``SessionBoundTransport.request_attach``/``request_session_switch``
+EXPLICITLY answer ``False``, not inherited from ``ClientTransport``'s own
+convenience default.
+
+This transport is structurally the WRONG place to answer "attach a
+different agent" — it is send-side only, bound to ONE already-attached
+session (its own class docstring). "Which agent is attached" is a
+REGISTRY-level question this class deliberately has no reference to. The
+REAL fix for the owner-reported "attach coder-smith failed" over
+``--connect`` (lead-coder's diagnosis, #5094 issuecomment-5379598384) is
+NOT teaching this class to reach for a registry — it is #5096's own ②:
+the CLIENT-side dispatch layer now recognizes ``/attach``/``/session
+switch`` and calls ``ClientTransport.request_attach``/
+``request_session_switch`` directly (the dedicated typed op
+``AgUiTransport`` already implements correctly), so a remote ``/attach``
+never reaches server-side slash dispatch — and this method — at all. See
+``test_5096_slash_dispatch_routes_attach_directly.py`` for that witness.
+
+This file's own witness is narrower and structural: EXPLICITLY writing
+``False`` (rather than silently inheriting it) means a future edit that
+tries to make this method "helpfully" do something is a deliberate,
+reviewable change to a documented decision, not a silent default that
+happened to already be there.
+
+Real ``AgentRegistry`` + real ``Session`` (via ``make_session``) + real
+``SessionBoundTransport`` throughout — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.transport.session_bound import SessionBoundTransport
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+            registry=reg,
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    reg.create("bravo")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_request_attach_answers_false_even_for_a_real_target_agent(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: NOT "the target doesn't exist" -- a genuinely existing,
+    attachable second agent is in the registry, and this method still
+    answers False, because it cannot correctly answer True either (it has
+    no registry to have performed the attach through)."""
+    reg = _registry(tmp_path)
+    session = await reg.attach("alpha")
+    assert reg.exists("bravo")  # positive control: the target is real
+    transport = SessionBoundTransport(session, display_sink=lambda _msg: None)
+
+    result = await transport.request_attach("bravo")
+
+    assert result is False
+    assert reg.attached_name == "alpha", (
+        "request_attach must not mutate the registry -- it structurally "
+        "cannot answer this question, so it must not silently half-answer "
+        "it either"
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_session_switch_answers_false(tmp_path: Path) -> None:
+    """Tier 2: same reasoning, the sibling method."""
+    reg = _registry(tmp_path)
+    session = await reg.attach("alpha")
+    transport = SessionBoundTransport(session, display_sink=lambda _msg: None)
+
+    result = await transport.request_session_switch("some-session-id")
+
+    assert result is False

--- a/tests/interfaces/test_5096_slash_dispatch_routes_attach_directly.py
+++ b/tests/interfaces/test_5096_slash_dispatch_routes_attach_directly.py
@@ -1,0 +1,113 @@
+"""Tier 2: #5096 ②, architect ruling (issuecomment-5379623427/5379638878/
+5379657592) — ``maybe_dispatch_slash`` routes a ``connection``-locus
+command (``/attach``) straight to ``ClientTransport.request_attach``,
+never through the generic ``run_slash_command`` forward.
+
+The real owner-reported defect (#5094, lead-coder's diagnosis,
+issuecomment-5379598384): ``/attach coder-smith`` used to ALWAYS forward
+through ``transport.run_slash_command("attach", "coder-smith")`` —
+correct for a "session"-locus command, but for a REMOTE (``--connect``)
+client this lands on the SERVER's generic slash dispatch, which builds a
+``SlashContext`` over ``SessionBoundTransport`` (send-side only,
+structurally unable to answer "attach a different agent") instead of
+ever reaching ``AgUiTransport``'s own correctly-implemented
+``request_attach`` (a wire call to the dedicated ``attach_request``
+typed-op handler). This test drives the CLIENT-side dispatch layer
+directly and asserts the typed op is called, not the generic forward.
+
+Real ``ClientTransportStub`` throughout (the tests/-only stub base,
+#5076) — no mocks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+
+
+class _RecordingTransport(ClientTransportStub):
+    """Records which of ``request_attach``/``run_slash_command`` the
+    dispatch layer actually called, and with what -- the discriminator
+    this test's own assertion needs."""
+
+    def __init__(self) -> None:
+        self.displayed: "list[object]" = []
+        self.request_attach_calls: "list[str]" = []
+        self.run_slash_command_calls: "list[tuple[str, str]]" = []
+
+    def start(self) -> None: ...
+    def close(self) -> None: ...
+
+    async def frames(self):
+        return
+        yield  # pragma: no cover — makes this an async generator
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(self, text, *, intervention_id=None):
+        return False
+
+    async def answer_intervention_choice(self, choice_id, *, intervention_id=None):
+        return False
+
+    def has_session(self) -> bool:
+        return False
+
+    def pending_intervention_head(self):
+        return None
+
+    def put_display(self, msg) -> None:
+        self.displayed.append(msg)
+
+    async def cancel_inflight(self) -> str:
+        return ""
+
+    async def shutdown(self) -> None: ...
+
+    async def request_attach(self, agent_name: str) -> bool:
+        self.request_attach_calls.append(agent_name)
+        return True
+
+    async def run_slash_command(self, name: str, args: str) -> bool:
+        self.run_slash_command_calls.append((name, args))
+        return False
+
+
+@pytest.mark.asyncio
+async def test_attach_calls_request_attach_directly_never_run_slash_command() -> None:
+    """Tier 2: /attach's connection-locus dispatch calls
+    ClientTransport.request_attach directly, never the generic
+    run_slash_command forward — see this module's own docstring."""
+    transport = _RecordingTransport()
+
+    consumed = await maybe_dispatch_slash(transport, "/attach coder-smith", echo=False)
+
+    assert consumed is True
+    assert transport.request_attach_calls == ["coder-smith"], (
+        "the /attach command must call ClientTransport.request_attach "
+        "directly (the connection-locus dispatch path) -- got "
+        f"{transport.request_attach_calls!r}"
+    )
+    assert transport.run_slash_command_calls == [], (
+        "attach must NOT go through the generic run_slash_command forward "
+        "-- that is exactly the path that lands on SessionBoundTransport "
+        "server-side and silently fails (#5094's own root cause); got "
+        f"{transport.run_slash_command_calls!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_session_locus_command_still_uses_run_slash_command() -> None:
+    """Tier 2: positive control / non-regression — a "session"-locus
+    command (e.g. /cost) must still forward through run_slash_command,
+    proving the branch genuinely discriminates by locus rather than
+    always taking the connection-locus path."""
+    transport = _RecordingTransport()
+
+    consumed = await maybe_dispatch_slash(transport, "/cost", echo=False)
+
+    assert consumed is True
+    assert transport.run_slash_command_calls == [("cost", "")]
+    assert transport.request_attach_calls == []

--- a/tests/interfaces/test_activity_row_3693.py
+++ b/tests/interfaces/test_activity_row_3693.py
@@ -37,13 +37,13 @@ from reyn.interfaces.inline.textual_chat.activity_row import (
     activity_text,
 )
 from reyn.interfaces.inline.textual_chat.sent_queue import ROW_TEXT_COLUMN
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` (the shared test idiom)."""
 
     def __init__(self) -> None:

--- a/tests/interfaces/test_addressed_row_rail_3490.py
+++ b/tests/interfaces/test_addressed_row_rail_3490.py
@@ -33,12 +33,12 @@ from textual_flowview import FlowView
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer
 from reyn.interfaces.inline.textual_chat.gutter import _MARK_RAIL
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def __init__(self) -> None:
         self.submitted: list[str] = []
 

--- a/tests/interfaces/test_agent_delta_no_visible_garbage_3288.py
+++ b/tests/interfaces/test_agent_delta_no_visible_garbage_3288.py
@@ -57,7 +57,7 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.app import _STREAM_REPAINT_MIN_INTERVAL
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -91,7 +91,7 @@ class _DrivenClock:
         self.advance(_STREAM_REPAINT_MIN_INTERVAL * 2)
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from a
     queue (mirrors ``tests/interfaces/test_user_submitted_render_3300.py`` /
     ``tests/interfaces/test_3300_p2b_sentqueue_render.py``'s helper of the same name) —

--- a/tests/interfaces/test_agent_delta_round_index_3656.py
+++ b/tests/interfaces/test_agent_delta_round_index_3656.py
@@ -26,13 +26,13 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from a
     queue (the idiom shared with ``tests/interfaces/test_3288_3c_tui_delta_coalesce.py``)."""
 

--- a/tests/interfaces/test_chrome_uses_the_terminal_background_3503.py
+++ b/tests/interfaces/test_chrome_uses_the_terminal_background_3503.py
@@ -40,12 +40,12 @@ from textual.color import Color
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer, MenuBar
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_click_does_not_copy_3624.py
+++ b/tests/interfaces/test_click_does_not_copy_3624.py
@@ -29,12 +29,12 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def __init__(self) -> None:
         self.submitted: list[str] = []
 

--- a/tests/interfaces/test_compact_layout_3680.py
+++ b/tests/interfaces/test_compact_layout_3680.py
@@ -37,13 +37,13 @@ from reyn.interfaces.inline.textual_chat.compact import (
     compact_caps,
 )
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` (the shared test idiom)."""
 
     def __init__(self) -> None:

--- a/tests/interfaces/test_config_warning_chrome_4194.py
+++ b/tests/interfaces/test_config_warning_chrome_4194.py
@@ -29,12 +29,12 @@ from reyn.interfaces.inline.textual_chat.chrome import (
     ConfigWarningLine,
     config_warning_text,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.schemas.models import Event
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     """Minimal real ClientTransport implementing the CURRENT full abstract
     surface (test_conversation_chrome_separation.py's own stub predates
     #3903/#4166's cancel_inflight()/has_session()/etc additions and would

--- a/tests/interfaces/test_conversation_chrome_separation.py
+++ b/tests/interfaces/test_conversation_chrome_separation.py
@@ -36,13 +36,13 @@ from textual_flowview import FlowView
 from reyn.interfaces.inline.textual_chat import Composer, TextualChatApp
 from reyn.interfaces.inline.textual_chat.activity_row import ActivityRow
 from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def __init__(self) -> None:
         self._queue: "asyncio.Queue[object]" = asyncio.Queue()
 

--- a/tests/interfaces/test_conversation_cursor_3476.py
+++ b/tests/interfaces/test_conversation_cursor_3476.py
@@ -31,12 +31,12 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def __init__(self) -> None:
         self.submitted: list[str] = []
         # #3595 S5: a slash the app dispatches is RUN as a command here.

--- a/tests/interfaces/test_conversation_pane_boundary_3692.py
+++ b/tests/interfaces/test_conversation_pane_boundary_3692.py
@@ -17,12 +17,12 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import Composer, TextualChatApp
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_conversation_scroll_keys_3470.py
+++ b/tests/interfaces/test_conversation_scroll_keys_3470.py
@@ -23,12 +23,12 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import Composer, TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import COMPOSER_KEYS, help_pane_lines
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def __init__(self) -> None:
         self.submitted: list[str] = []
 

--- a/tests/interfaces/test_copy_mode_3507.py
+++ b/tests/interfaces/test_copy_mode_3507.py
@@ -26,13 +26,13 @@ from textual_flowview import FlowView
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer
 from reyn.interfaces.inline.textual_chat.gutter import _MARK_RAIL
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 from tests._support.paths import REPO_ROOT
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_copy_to_clipboard_sink_3616.py
+++ b/tests/interfaces/test_copy_to_clipboard_sink_3616.py
@@ -23,13 +23,13 @@ from textual.widgets import Input
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 from tests._support.textual_chat_test_helpers import QueueTransport
 
 
-class _CancelTrackingTransport(ClientTransport):
+class _CancelTrackingTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` that counts
     ``cancel_inflight`` calls — ``QueueTransport``'s own is a no-op, and this
     file's regression guard needs the count."""

--- a/tests/interfaces/test_ctrl_c_interrupt_3498.py
+++ b/tests/interfaces/test_ctrl_c_interrupt_3498.py
@@ -23,12 +23,12 @@ import pytest
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     """A real minimal transport that RECORDS cancel requests (its own public
     surface is what the tests read — no private app state)."""
 

--- a/tests/interfaces/test_drawer_readout_reachable_3699.py
+++ b/tests/interfaces/test_drawer_readout_reachable_3699.py
@@ -31,13 +31,13 @@ from reyn.interfaces.inline.textual_chat.chrome import (
     Composer,
     help_pane_lines,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` (the shared test idiom)."""
 
     def __init__(self) -> None:

--- a/tests/interfaces/test_empty_state_hint_3476.py
+++ b/tests/interfaces/test_empty_state_hint_3476.py
@@ -17,12 +17,12 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def __init__(self) -> None:
         self.submitted: list[str] = []
 

--- a/tests/interfaces/test_esc_resumes_following_3806.py
+++ b/tests/interfaces/test_esc_resumes_following_3806.py
@@ -30,13 +30,13 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` (the shared test idiom)."""
 
     def __init__(self) -> None:

--- a/tests/interfaces/test_focus_visible_3528.py
+++ b/tests/interfaces/test_focus_visible_3528.py
@@ -36,12 +36,12 @@ from textual.widgets import Tab
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer, MenuBar
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_ime_cursor_anchor_3621.py
+++ b/tests/interfaces/test_ime_cursor_anchor_3621.py
@@ -25,12 +25,12 @@ import pytest
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_lazy_history_paging_3476.py
+++ b/tests/interfaces/test_lazy_history_paging_3476.py
@@ -37,13 +37,13 @@ from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.app import _HYDRATE_PAGE_FRAMES
 from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def __init__(self) -> None:
         self.submitted: list[str] = []
 

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -33,13 +33,13 @@ from reyn.interfaces.inline.textual_chat.loop_probe import (
     stall_recovered_log_line,
     write_record,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from a
     queue (the idiom shared with ``tests/interfaces/test_3288_3c_tui_delta_coalesce.py``)."""
 

--- a/tests/interfaces/test_placeholder_dim_3522.py
+++ b/tests/interfaces/test_placeholder_dim_3522.py
@@ -45,12 +45,12 @@ from textual.filter import dim_color
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.chrome import Composer
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_rail_right_gutter_3526.py
+++ b/tests/interfaces/test_rail_right_gutter_3526.py
@@ -25,12 +25,12 @@ from reyn.interfaces.inline.textual_chat.gutter import (
     _MARK_RAIL,
     RIGHT_GUTTER_WIDTH,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_right_gutter_label_visible_3536.py
+++ b/tests/interfaces/test_right_gutter_label_visible_3536.py
@@ -30,12 +30,12 @@ from textual_flowview import FlowModel
 
 from reyn.interfaces.inline.textual_chat.presenter import ReynPresenter
 from reyn.interfaces.repl.renderer import _CC_AMBIENT, _CC_DIM
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_search_bar_3476.py
+++ b/tests/interfaces/test_search_bar_3476.py
@@ -32,13 +32,13 @@ from reyn.interfaces.inline.textual_chat.chrome import Composer
 from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
 from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def __init__(self) -> None:
         self.submitted: list[str] = []
 

--- a/tests/interfaces/test_selection_not_bright_3542.py
+++ b/tests/interfaces/test_selection_not_bright_3542.py
@@ -40,12 +40,12 @@ import pytest
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.theme import REYN_THEME
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_sent_queue_overflow_visible_3688.py
+++ b/tests/interfaces/test_sent_queue_overflow_visible_3688.py
@@ -31,13 +31,13 @@ import pytest
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from a
     queue (the ``test_3300_p2b_sentqueue_render.py`` helper shape)."""
 

--- a/tests/interfaces/test_slash_agents_attach_cmds.py
+++ b/tests/interfaces/test_slash_agents_attach_cmds.py
@@ -3,9 +3,16 @@
 /agents: no-registry error, empty-agents unexpected note, normal listing
 (names present → reply contains names).
 
-/attach: no-name error, no-registry error, name-not-found error,
-already-attached note, valid-name success (system reply +
-transport.request_attach called with the name — #4534 PR-2).
+/attach (locus="connection", #5096 ②): no-name usage error (client-side,
+before any transport call), then EVERYTHING else collapses into whatever
+``ClientTransport.request_attach`` itself reports — the handler no longer
+reads ``ctx.session`` at all, so "no registry"/"name not found"/"already
+attached" are no longer THREE distinguishable client-side outcomes (that
+validation now lives entirely in request_attach's own typed-op handler,
+server-side). True → success reply; False → "could not confirm" reply
+(never an error kind — False is ambiguous by transport, see attach_cmd's
+own docstring). transport.request_attach is asserted CALLED WITH the
+name (#4534 PR-2).
 """
 from __future__ import annotations
 
@@ -18,14 +25,18 @@ from tests._support.slash import slash_ctx
 # ── stubs ──────────────────────────────────────────────────────────────────
 
 
-def _ctx(session):
+def _ctx(session, *, attach_result: bool = True):
     """The context the production dispatch hands a slash handler.
 
     The transport IS this test's display recorder — ``reply()`` writes
     through the client seam now, so the list the assertions read is the
     one the transport fills.
+
+    ``attach_result`` (#5096 ②): attach_cmd (locus="connection") no
+    longer reads ``ctx.session`` at all -- its reply is driven entirely
+    by what ``ctx.transport.request_attach`` reports.
     """
-    return slash_ctx(session, recorder=session._outbox)
+    return slash_ctx(session, recorder=session._outbox, attach_result=attach_result)
 
 
 class _FakeSession:
@@ -136,30 +147,19 @@ async def test_attach_no_name_sends_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_attach_no_registry_sends_error() -> None:
-    """Tier 2: /attach with no registry wired replies an error."""
-    session = _FakeSession(registry=None)
-    await attach_cmd(_ctx(session), "alpha")
-    assert session.error_text()
-
-
-@pytest.mark.asyncio
-async def test_attach_nonexistent_name_sends_error() -> None:
-    """Tier 2: /attach <name> for a name that doesn't exist replies an error."""
+async def test_attach_unconfirmed_sends_a_could_not_confirm_system_note() -> None:
+    """Tier 2: #5096 ② -- attach_cmd (locus="connection") no longer reads
+    ``ctx.session`` at all, so "no registry", "name not found", and
+    "already attached" are no longer THREE distinguishable client-side
+    outcomes -- they collapse into whatever ``request_attach`` itself
+    reports. A False result (the transport's own typed-op call was not
+    confirmed, for ANY reason) gets a "could not confirm" reply, never an
+    error kind -- False is ambiguous by transport (AG-UI's is "unknown";
+    in-process's is definitive), so it must never read as a hard failure
+    for one transport and a correct outcome for the other."""
     session = _FakeSession(registry=_FakeRegistry(names=["alpha"], attached="alpha"))
-    await attach_cmd(_ctx(session), "ghost")
-    assert session.error_text()
-    assert "ghost" in session.error_text()
-
-
-@pytest.mark.asyncio
-async def test_attach_already_attached_sends_system_note() -> None:
-    """Tier 2: /attach to the already-attached agent replies an 'already attached' note."""
-    session = _FakeSession(
-        registry=_FakeRegistry(names=["alpha"], attached="alpha")
-    )
-    await attach_cmd(_ctx(session), "alpha")
-    assert "already" in session.system_text()
+    await attach_cmd(_ctx(session, attach_result=False), "ghost")
+    assert "could not confirm" in session.system_text()
     assert not session.error_text()
 
 

--- a/tests/interfaces/test_slash_budget_session_reload_cmds.py
+++ b/tests/interfaces/test_slash_budget_session_reload_cmds.py
@@ -18,14 +18,17 @@ from tests._support.slash import slash_ctx
 # ── shared stub ────────────────────────────────────────────────────────────
 
 
-def _ctx(session):
+def _ctx(session, *, switch_result: bool = True):
     """The context the production dispatch hands a slash handler.
 
     The transport IS this test's display recorder — ``reply()`` writes
     through the client seam now, so the list the assertions read is the
     one the transport fills.
+
+    ``switch_result`` (#5096 ②): what ``request_session_switch`` reports
+    back — see ``RecordingTransport``'s own docstring.
     """
-    return slash_ctx(session, recorder=session._outbox)
+    return slash_ctx(session, recorder=session._outbox, switch_result=switch_result)
 
 
 class _FakeSession:
@@ -248,11 +251,15 @@ async def test_session_switch_no_sid_replies_usage() -> None:
 
 @pytest.mark.asyncio
 async def test_session_switch_unknown_sid_replies_error() -> None:
-    """Tier 2: /session switch to unknown sid → error."""
+    """Tier 2: #5096 ② -- /session switch to an unknown sid still replies
+    an error naming the sid (see session.py's own switch-branch docstring
+    for the known, ruled-on degradation: WHY is deferred to #5099, but the
+    error kind and the user-typed sid both survive)."""
     reg = _FakeRegistry(get_session_result=None)
     session = _FakeSession(registry=reg)
-    await session_cmd(_ctx(session), "switch missing")  # type: ignore[arg-type]
+    await session_cmd(_ctx(session, switch_result=False), "switch missing")  # type: ignore[arg-type]
     assert session.error_text()
+    assert "missing" in session.error_text()
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_slash_command_completions.py
+++ b/tests/interfaces/test_slash_command_completions.py
@@ -15,10 +15,10 @@ async def _noop(session, args) -> None:  # pragma: no cover - fixture handler
 
 
 _FIXTURE = [
-    SlashCommand(name="model", summary="Override the model class", handler=_noop),
-    SlashCommand(name="memory", summary="Memory ops", handler=_noop),
-    SlashCommand(name="agents", summary="List agents", handler=_noop),
-    SlashCommand(name="donut", summary="easter egg", handler=_noop, hidden=True),
+    SlashCommand(name="model", summary="Override the model class", handler=_noop, locus="session"),
+    SlashCommand(name="memory", summary="Memory ops", handler=_noop, locus="client"),
+    SlashCommand(name="agents", summary="List agents", handler=_noop, locus="session"),
+    SlashCommand(name="donut", summary="easter egg", handler=_noop, locus="client", hidden=True),
 ]
 
 

--- a/tests/interfaces/test_slash_handler_crash_containment.py
+++ b/tests/interfaces/test_slash_handler_crash_containment.py
@@ -50,7 +50,7 @@ async def test_raising_slash_handler_is_contained_not_fatal(
     monkeypatch.setitem(
         REGISTRY._commands,
         "__f3boom__",
-        SlashCommand(name="__f3boom__", summary="test", handler=_boom),
+        SlashCommand(name="__f3boom__", summary="test", handler=_boom, locus="session"),
     )
 
     # Before the fix this raised RuntimeError out of dispatch (→ killed run()).

--- a/tests/interfaces/test_slash_help_per_command.py
+++ b/tests/interfaces/test_slash_help_per_command.py
@@ -125,6 +125,7 @@ def test_render_focus_alias_resolves_to_canonical() -> None:
         name="xtmphelp_alias_target",
         summary="aliased target for test",
         handler=_h,
+        locus="client",
         aliases=("xtmphelp_alias_alt",),
     ))
     panel = _render_command_focus("xtmphelp_alias_alt")  # = alias
@@ -143,6 +144,7 @@ def test_render_focus_hidden_command_is_annotated() -> None:
         name="xtmphelp_hidden_target",
         summary="hidden test cmd",
         handler=_h,
+        locus="client",
         hidden=True,
     ))
     panel = _render_command_focus("xtmphelp_hidden_target")

--- a/tests/interfaces/test_slash_see_also_field.py
+++ b/tests/interfaces/test_slash_see_also_field.py
@@ -32,7 +32,7 @@ def test_slash_command_defaults_see_also_to_empty_tuple() -> None:
     async def _h(s: object, a: str) -> None:
         pass
 
-    cmd = SlashCommand(name="xtest_no_see_also", summary="test", handler=_h)
+    cmd = SlashCommand(name="xtest_no_see_also", summary="test", handler=_h, locus="client")
     assert cmd.see_also == ()
     assert isinstance(cmd.see_also, tuple)
 
@@ -44,6 +44,7 @@ def test_slash_decorator_stores_see_also_on_registered_command() -> None:
     @slash(
         "xtest_see_also_reg",
         summary="decorator see_also test",
+        locus="client",
         see_also=("docs/concepts/multi-agent/plan-mode.md", "docs/concepts/data-retrieval/memory.md"),
     )
     async def _xtest_cmd(session: object, args: str) -> None:
@@ -66,6 +67,7 @@ def test_render_command_focus_includes_see_also_line_when_non_empty() -> None:
         name="xtest_see_also_render",
         summary="render see_also test",
         handler=_h,
+        locus="client",
         see_also=("docs/concepts/multi-agent/plan-mode.md",),
     ))
     panel = _render_command_focus("xtest_see_also_render")
@@ -85,6 +87,7 @@ def test_render_command_focus_omits_see_also_line_when_empty() -> None:
         name="xtest_no_see_also_render",
         summary="omit see_also when empty",
         handler=_h,
+        locus="client",
         # see_also intentionally not set → defaults to ()
     ))
     panel = _render_command_focus("xtest_no_see_also_render")

--- a/tests/interfaces/test_slash_session_1726.py
+++ b/tests/interfaces/test_slash_session_1726.py
@@ -20,14 +20,17 @@ from reyn.runtime.outbox import OutboxMessage
 from tests._support.slash import slash_ctx
 
 
-def _ctx(session):
+def _ctx(session, *, switch_result: bool = True):
     """The context the production dispatch hands a slash handler.
 
     The transport IS this test's display recorder — ``reply()`` writes
     through the client seam now (#3595 S4), so the list these assertions
     read is the one the transport fills.
+
+    ``switch_result`` (#5096 ②): what ``request_session_switch`` reports
+    back — see ``RecordingTransport``'s own docstring.
     """
-    return slash_ctx(session, recorder=session.outbox_calls)
+    return slash_ctx(session, recorder=session.outbox_calls, switch_result=switch_result)
 
 
 class _StubRegistry:
@@ -122,18 +125,29 @@ async def test_session_switch_known_requests_switch():
 
 @pytest.mark.asyncio
 async def test_session_switch_unknown_is_graceful():
-    """Tier 2: #1726 — `/session switch <unknown>` replies a decision-enabling error
-    (names the bad sid, explains full-ID/name requirement, no prefix support) and
-    posts NO sentinel (no crash)."""
+    """Tier 2: #1726/#5096 ② — `/session switch <unknown>` still replies a
+    NAMED error (the sid the user typed, and an error kind — never a
+    system note) and posts NO sentinel (no crash).
+
+    ⚠️ Known degradation (lead-coder ruling, #5096 issuecomment-
+    5379839120, documented in full at session_cmd's own "switch" branch):
+    the pre-#5096 branch validated directly against the registry and could
+    explain WHY a sid was rejected (partial-prefix unsupported, full
+    name/ID required) — locus="connection" (#5096 ②) forbids reading
+    ctx.session, so that reasoning is gone until #5099's
+    request_session_list ships a connection-locus-safe way to read the
+    sid list back. What survives, deliberately, per lead-coder's ruling:
+    the reply is still error-kind, and the sid the user themselves typed
+    (client-side input, never read FROM the registry) still appears in
+    it — a real regression would be losing either of those, not losing
+    the WHY."""
     reg = _StubRegistry(sids=("main",))
     s = _FakeSession(reg)
-    await session_cmd(_ctx(s), "switch nope")
+    await session_cmd(_ctx(s, switch_result=False), "switch nope")
     assert not [m for m in s.outbox_calls if m.kind == "__session_switch_request__"]
     err = s.reply_text()
     assert "nope" in err, "user-facing error names the bad sid"
     assert any(m.kind == "error" for m in s.outbox_calls), "replied as an error"
-    assert "partial" in err.lower(), "tells user partial prefix is not supported"
-    assert "session name" in err.lower() or "full" in err.lower(), "guides toward name/full-ID"
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_stream_client_own_echo_3287.py
+++ b/tests/interfaces/test_stream_client_own_echo_3287.py
@@ -68,7 +68,7 @@ from typing import AsyncIterator
 import pytest
 
 from reyn.interfaces.repl.stream_client import route_input_line, run_output_loop
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -101,7 +101,7 @@ async def _wait_until(predicate) -> None:
         await asyncio.sleep(0.01)
 
 
-class _QueueTransport(ClientTransport):
+class _QueueTransport(ClientTransportStub):
     """A real, minimal ClientTransport: yields queued frames; ``submit_user_text``
     returns a caller-scripted msg_id (mirroring the production contract —
     #3287 — of returning the server-assigned correlation id), and records

--- a/tests/interfaces/test_stream_spinner_3530.py
+++ b/tests/interfaces/test_stream_spinner_3530.py
@@ -28,12 +28,12 @@ from reyn.interfaces.inline.textual_chat.gutter import (
     _RUNNING_FRAME_PERIOD,
     _RUNNING_FRAMES,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_tail_away_indicator_3712.py
+++ b/tests/interfaces/test_tail_away_indicator_3712.py
@@ -34,13 +34,13 @@ from reyn.interfaces.inline.textual_chat.activity_row import (
     ActivityRow,
     activity_text,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` (the shared test idiom)."""
 
     def __init__(self) -> None:

--- a/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
+++ b/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
@@ -48,7 +48,7 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat.chrome import Composer, status_line_text
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
@@ -146,7 +146,7 @@ async def test_registry_attach_failed_cleared_by_a_fresh_attach_attempt(tmp_path
 # ---------------------------------------------------------------------------
 
 
-class _AttachStateTransport(ClientTransport):
+class _AttachStateTransport(ClientTransportStub):
     """A real, minimal `ClientTransport` (mirrors `ScriptedTransport` in
     `test_textual_chat_phase4_3273.py`) whose `has_session()`/
     `attach_failed()` are test-controlled, so the composer's gating can be

--- a/tests/interfaces/test_textual_chat_copy_rewind_3362.py
+++ b/tests/interfaces/test_textual_chat_copy_rewind_3362.py
@@ -59,7 +59,7 @@ from textual_flowview import FlowView
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.rewind_picker import RewindPicker
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
@@ -122,7 +122,7 @@ class _RemoteishReadModel(_PickerReadModel):
         return False
 
 
-class ScriptedTransport(ClientTransport):
+class ScriptedTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport`. The stream stays open after the
     scripted frames so the app stays mounted; ``submitted`` records the lines the
     app routes back through the send seam."""

--- a/tests/interfaces/test_textual_chat_esc_sufficiency_3365.py
+++ b/tests/interfaces/test_textual_chat_esc_sufficiency_3365.py
@@ -66,12 +66,12 @@ from textual.widgets import Input, OptionList, RadioSet
 from reyn.interfaces.inline.textual_chat import Composer, MenuBar, TextualChatApp
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the
     stream open so the app under test stays mounted for focus inspection."""
 

--- a/tests/interfaces/test_textual_chat_intervention_panel_3299.py
+++ b/tests/interfaces/test_textual_chat_intervention_panel_3299.py
@@ -61,7 +61,7 @@ from textual_flowview import EntryState, FlowView
 
 from reyn.interfaces.inline.textual_chat import Composer, TextualChatApp
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.intervention_choices import file_access_choices, generic_yn_choices
 from reyn.runtime.outbox import OutboxMessage
@@ -69,7 +69,7 @@ from reyn.runtime.outbox import OutboxMessage
 _GUTTER_WIDTH = 2
 
 
-class RecordingTransport(ClientTransport):
+class RecordingTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` that replays a fixed frame list
     and RECORDS which answer seam each user action reached.
 

--- a/tests/interfaces/test_textual_chat_orphan_sweep_72.py
+++ b/tests/interfaces/test_textual_chat_orphan_sweep_72.py
@@ -46,7 +46,7 @@ from reyn.interfaces.inline.textual_chat.presenter import (
     _RUNNING_SINCE_KEY,
     ReynPresenter,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -66,7 +66,7 @@ def _completed(op_id: str, tool: str = "grep") -> OutboxMessage:
     )
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from a
     queue — display OR event frames — so a test can push a ``started`` tool,
     inspect its live RUNNING row, THEN push a turn-end event and inspect the

--- a/tests/interfaces/test_textual_chat_phase1_3273.py
+++ b/tests/interfaces/test_textual_chat_phase1_3273.py
@@ -23,7 +23,7 @@ import pytest
 
 from reyn.interfaces.repl.renderer import ChatRenderer
 from reyn.interfaces.repl.stream_client import run_output_loop
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 from tests._support.paths import REPO_ROOT
@@ -31,7 +31,7 @@ from tests._support.paths import REPO_ROOT
 _REPO_ROOT = REPO_ROOT
 
 
-class ScriptedTransport(ClientTransport):
+class ScriptedTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` that replays a fixed frame list.
 
     Constructed cheaply from a list of :class:`OutboxMessage` — the same frames a
@@ -178,12 +178,12 @@ assert "textual" not in sys.modules, "textual imported at module load"
 from reyn.interfaces.repl.client_driver import run_chat_client  # noqa: E402
 from reyn.interfaces.repl.read_model import ChatReadModel, LOCAL_CHAT_READ_CAPABILITIES  # noqa: E402
 from reyn.interfaces.repl.renderer import ChatRenderer  # noqa: E402
-from reyn.interfaces.transport.client_transport import ClientTransport  # noqa: E402
+from reyn.interfaces.transport.client_transport import ClientTransportStub  # noqa: E402
 from reyn.interfaces.transport.frames import DisplayFrame  # noqa: E402
 from reyn.runtime.outbox import OutboxMessage  # noqa: E402
 
 
-class T(ClientTransport):
+class T(ClientTransportStub):
     def __init__(self):
         self.rendered = 0
     def start(self): pass

--- a/tests/interfaces/test_textual_chat_phase2_3273.py
+++ b/tests/interfaces/test_textual_chat_phase2_3273.py
@@ -56,7 +56,7 @@ from reyn.interfaces.repl.renderer import (
     _CC_WARN,
     _KIND_LINE,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 from tests._support.paths import REPO_ROOT
@@ -64,7 +64,7 @@ from tests._support.paths import REPO_ROOT
 _REPO_ROOT = REPO_ROOT
 
 
-class ScriptedTransport(ClientTransport):
+class ScriptedTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` replaying a fixed frame list.
 
     ``end=False`` keeps the stream open after the script so the app under test

--- a/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
+++ b/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
@@ -47,7 +47,7 @@ from reyn.interfaces.inline.textual_chat.presenter import (
     _tool_head,
 )
 from reyn.interfaces.repl.renderer import _SPINNER
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
@@ -91,7 +91,7 @@ def _render(renderable, width: int = 80) -> str:
     return cap.get()
 
 
-class ScriptedTransport(ClientTransport):
+class ScriptedTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` replaying a fixed frame list.
 
     ``end=False`` keeps the stream open after the script so the app under test
@@ -141,7 +141,7 @@ class ScriptedTransport(ClientTransport):
         pass
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real :class:`ClientTransport` fed one frame at a time from a queue, so a
     test can push a ``started`` frame, inspect the RUNNING row, THEN push the
     completion and inspect the settle — with the stream staying open in between."""

--- a/tests/interfaces/test_textual_chat_phase3_3273.py
+++ b/tests/interfaces/test_textual_chat_phase3_3273.py
@@ -26,7 +26,7 @@ from typing import AsyncIterator
 
 import pytest
 
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 from tests._support.paths import REPO_ROOT
@@ -34,7 +34,7 @@ from tests._support.paths import REPO_ROOT
 _REPO_ROOT = REPO_ROOT
 
 
-class ScriptedTransport(ClientTransport):
+class ScriptedTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the stream
     open so the app under test stays mounted for focus/style inspection."""
 

--- a/tests/interfaces/test_textual_chat_phase4_3273.py
+++ b/tests/interfaces/test_textual_chat_phase4_3273.py
@@ -130,9 +130,9 @@ def test_menu_pane_enumerates_full_slash_registry_no_subset() -> None:
     ``SlashRegistry`` — a freshly-registered command appears, a hidden one is
     excluded. Proves the formatter enumerates the whole registry (no subset)."""
     reg = SlashRegistry()
-    reg.register(SlashCommand("realcmd", "a real command", handler=_noop))
-    reg.register(SlashCommand("zzz-fake", "the fresh entry", handler=_noop))
-    reg.register(SlashCommand("secret", "hidden one", handler=_noop, hidden=True))
+    reg.register(SlashCommand("realcmd", "a real command", handler=_noop, locus="client"))
+    reg.register(SlashCommand("zzz-fake", "the fresh entry", handler=_noop, locus="client"))
+    reg.register(SlashCommand("secret", "hidden one", handler=_noop, locus="client", hidden=True))
 
     rows = menu_pane_options(reg.all_commands())
     names = {r.split(" — ")[0] for r in rows}

--- a/tests/interfaces/test_textual_chat_phase4_3273.py
+++ b/tests/interfaces/test_textual_chat_phase4_3273.py
@@ -44,7 +44,7 @@ from reyn.interfaces.inline.textual_chat.chrome import (
 )
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.slash import REGISTRY, SlashCommand, SlashRegistry
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 from tests._support.paths import REPO_ROOT
@@ -246,7 +246,7 @@ class _SnapshotReadModel(ChatReadModel):
         return 0
 
 
-class ScriptedTransport(ClientTransport):
+class ScriptedTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the stream
     open so the app stays mounted for drawer inspection; submissions are captured
     so a picker-issued ``/model`` / ``/attach`` slash can be asserted."""

--- a/tests/interfaces/test_textual_chat_phase4_right_gutter_3283.py
+++ b/tests/interfaces/test_textual_chat_phase4_right_gutter_3283.py
@@ -67,7 +67,7 @@ from reyn.interfaces.inline.textual_chat.restore import (
     project_restored_frames,
 )
 from reyn.interfaces.repl.renderer import _CC_DONE, _CC_WARN
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
@@ -96,7 +96,7 @@ def _completed(op_id: str, tool: str = "grep") -> OutboxMessage:
     )
 
 
-class ScriptedTransport(ClientTransport):
+class ScriptedTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` replaying a fixed frame list.
 
     ``end=False`` keeps the stream open after the script so the app under test
@@ -146,7 +146,7 @@ class ScriptedTransport(ClientTransport):
         pass
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real :class:`ClientTransport` fed one frame at a time from a queue, so a
     test can push a ``started`` frame, inspect the RUNNING row, THEN push the
     completion and inspect the settle — with the stream staying open in between

--- a/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
+++ b/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
@@ -92,7 +92,7 @@ from reyn.interfaces.repl.read_model import (
     project_remote_snapshot,
 )
 from reyn.interfaces.repl.status import _snapshot
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.budget.budget import (
@@ -707,7 +707,7 @@ class _TurnUsageReadModel(ChatReadModel):
         return 0
 
 
-class _QueueTransport(ClientTransport):
+class _QueueTransport(ClientTransportStub):
     """A real :class:`ClientTransport` fed one frame at a time from a queue, so
     a test can push frames and inspect the render in between with the stream
     staying open (the helper shape #3337's gutter tests use)."""

--- a/tests/interfaces/test_textual_chat_streaming_visibility_3283.py
+++ b/tests/interfaces/test_textual_chat_streaming_visibility_3283.py
@@ -53,7 +53,7 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.app import _STREAM_REPAINT_MIN_INTERVAL
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -82,7 +82,7 @@ class _DrivenClock:
         self.now += seconds
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from a
     queue (the idiom shared with ``tests/interfaces/test_3288_3c_tui_delta_coalesce.py``)."""
 

--- a/tests/interfaces/test_tool_detail_on_highlight_3508.py
+++ b/tests/interfaces/test_tool_detail_on_highlight_3508.py
@@ -29,12 +29,12 @@ from reyn.interfaces.inline.textual_chat._meta_keys import (
     RESULT_META_KEY,
 )
 from reyn.interfaces.inline.textual_chat.chrome import Composer
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
-class _Transport(ClientTransport):
+class _Transport(ClientTransportStub):
     def start(self) -> None:  # pragma: no cover - trivial
         pass
 

--- a/tests/interfaces/test_user_submitted_render_3300.py
+++ b/tests/interfaces/test_user_submitted_render_3300.py
@@ -61,7 +61,7 @@ from reyn.interfaces.repl.renderer import (
     InlineChatRenderer,
     user_submitted_display_message,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
@@ -124,7 +124,7 @@ def _capture_stdout(monkeypatch) -> io.StringIO:
     return captured
 
 
-class QueueTransport(ClientTransport):
+class QueueTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from a
     queue (mirrors ``test_textual_chat_orphan_sweep_72.py``'s helper) — lets a
     test push an ``EventFrame`` and inspect ``TextualChatApp``'s retained

--- a/tests/runtime/test_textual_chat_phase5_3273.py
+++ b/tests/runtime/test_textual_chat_phase5_3273.py
@@ -52,7 +52,7 @@ from reyn.interfaces.repl.read_model import (
     RegistryReadModel,
     RemoteReadModel,
 )
-from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
@@ -111,7 +111,7 @@ class _HistoryReadModel(ChatReadModel):
         return 0
 
 
-class ScriptedTransport(ClientTransport):
+class ScriptedTransport(ClientTransportStub):
     """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the stream
     open so the app stays mounted; ``messages`` are the LIVE frames pumped AFTER
     the mount-time hydration."""


### PR DESCRIPTION
**[e2e-coder]** — part of #5076.

## What

Architect's option ③ (issue #5076): split `ClientTransport` into a pure contract (no defaults) and a new `ClientTransportStub` (carries the convenience defaults). Generalizes #5045/#5082/#5083/#5089's own instances of the same shape: a base class default that looks harmless lets a delegation wrapper answer wrongly by simply forgetting to override.

- `ClientTransport`: every method now `@abstractmethod`. A subclass that forgets one fails to **construct**.
- New `ClientTransportStub(ClientTransport)`: carries the 9 convenience defaults that used to live on `ClientTransport` itself (`attach_failed`/`run_slash_command`/`cancel_queued`/`request_attach`/`request_session_switch`/`request_artifact_list`/`state_ready`/`clear_pending_command_ui`/`reyn_state_root`).
- `InProcessTransport`/`AgUiTransport`/`SessionBoundTransport` → `ClientTransportStub` (each relies on a real subset of these defaults by design — confirmed against each method's own docstring before moving, not guessed).
- The 2 real delegation wrappers (`ThreadedTransportProxy`, `_ErrorWatchingTransport`) stay on the pure `ClientTransport` contract — both already override all 9 (measured). A third wrapper that forgets one in the future now fails to construct instead of silently answering wrong.
- 75 `tests/` `ClientTransport` subclasses → `ClientTransportStub` (mechanical, confirmed 0 of 75 are wrappers by two independent methods).

Option ④ (`__getattr__` auto-forwarding) considered and rejected — `ThreadedTransportProxy`'s job is marshaling across a thread boundary, not forwarding; auto-forwarding a new method would cross unmarshaled.

## Disclosed mid-implementation, both fixed same-session

- Initially excluded `state_ready`/`clear_pending_command_ui` as "dead code" — **wrong**, caused by running my check from this session's stale default working directory instead of the worktree (lead-coder caught it, #5076 issue thread has the full account). Re-verified against `origin/main` properly; both are real and load-bearing, both wrappers already override them. Included in the final 9-method set.
- First full-suite run caught 3 real gaps my mechanical sweep missed: 2 test files (`test_4494_request_artifact_list.py`/`test_4534_pr1_request_attach_switch.py`) hold their own `_Stub(...)` class testing the convenience default directly (deliberately excluded from the bulk sed since they import `ClientTransport` for a stated reason) — rebased onto `ClientTransportStub`, matching their own stated purpose. 1 subprocess-embedded import line (`test_textual_chat_phase1_3273.py`) had a trailing `# noqa: E402` comment that silently broke the `$`-anchored bulk sed — fixed, then re-swept the whole tree for the same pattern (none found).

## Not touched (deliberate)

Whether to remove #4884's now-largely-redundant total-delegation gate test — lead-coder's explicit instruction, separate ruling, left as a possible "double net" for now.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on all 72 changed test files (573 tests, 0 Tier-4 violations)
- [x] `python scripts/verify_module_docstrings.py` on all 4 changed src files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py` (re-run right before push)
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Full `tests/interfaces/` + `tests/runtime/` sweep: 1979 passed / 9 skipped (pre-existing optional-extra skips) / 0 failed
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

part of #5076



- [x] 🔴 **[lead-coder]** production 実装 3 つ（AgUi/InProcess/SessionBound）が `ClientTransportStub` 側に移っている — 契約側へ。黙って既定に頼るのは 3/1/7 個で、`SessionBoundTransport.request_attach` の既定 `False` が今 owner の attach 失敗（#5094 ③）を起こしている。詳細 issuecomment-5379600...
- [x] 🔴 **[lead-coder]** TESTS-READ（B: 独立）未了 — 私は block を出した側ゆえ A のみ



## ② `/session switch` — CI-red fix, a two-sided trade (lead-coder: "record both or the gain disappears")

`session_cmd`'s `switch` sub is `locus="connection"` (see `_session_locus`'s own docstring) — it must not read `ctx.session`. That structurally dropped the pre-#5096 branch's registry-side pre-validation (partial-prefix guidance, accepted sid forms), confirmed by CI (`test_slash_session_1726.py::test_session_switch_unknown_is_graceful`).

Lead-coder's ruling (issuecomment-5379839120): accept the loss for now (real fix needs #5099's `request_session_list`, out of this PR's scope) — but two things must still hold, and both do:

- **Lost**: the WHY (partial-prefix explanation, accepted sid forms) — deferred to #5099, documented inline at `session_cmd`'s own switch branch.
- **Gained** (lead-coder's own catch, not mine): the pre-#5096 failure path replied via `reply()` — a plain `system` line, the exact class `dispatch.py`'s own comment names ("a `system` line is indistinguishable from a successful reply, which made a typo'd command silently look OK"). The rewrite routes it through `reply_error()` instead — the failure is now genuinely typed as an error, not a system note that happened to mention a name. `test_slash_budget_session_reload_cmds.py::test_session_switch_unknown_sid_replies_error` and `test_slash_session_1726.py::test_session_switch_unknown_is_graceful` both now assert the error kind explicitly, not just non-empty text.
