### PR TITLE
fix(#5094): remote agent tab + model-class picker show the server's real roster

### DIFF
--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -260,6 +260,19 @@ class ChatReadModelCapabilities:
     ctx_compaction_reported: bool
     hooks_reported: bool
     pipelines_reported: bool
+    # #5094: 3 more snapshot-key groups found the SAME way #5034 found
+    # ``hooks_reported``/``pipelines_reported`` — a hand-typed `[]`/`None`
+    # literal in ``project_remote_snapshot`` with no field here to
+    # distinguish "genuinely empty" from "this producer can't report it".
+    # Unlike the earlier 2, these were ALREADY WRONG on `main` (a real,
+    # owner-measured blank remote agent tab), not merely undeclared —
+    # ``agent_roster_reported``/``model_catalog_reported``/
+    # ``attached_name_reported`` are declared here at the SAME time the
+    # underlying wire gap is fixed, so there is no window where the
+    # declaration exists but the value is still fabricated.
+    agent_roster_reported: bool  # covers `agent_names` + `session_tree` together
+    model_catalog_reported: bool  # covers `model_classes` + `model_active_class` together
+    attached_name_reported: bool
 
 
 def reported_snapshot_keys(
@@ -310,15 +323,22 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     ctx_compaction_reported=True,
     hooks_reported=True,
     pipelines_reported=True,
+    agent_roster_reported=True,
+    model_catalog_reported=True,
+    attached_name_reported=True,
 )
 
 #: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these
 #: methods' own docstrings already document (session-local state the AG-UI
 #: wire does not project): every one of them always degrades, independent of
-#: server-side state — with ONE exception, ``intervention_head`` (#5050):
+#: server-side state — with exceptions: ``intervention_head`` (#5050):
 #: STATE_SNAPSHOT/STATE_DELTA now carry ``pending_intervention_head``, so
 #: this one genuinely reflects live server-side state rather than always
-#: degrading. See the module docstring's "Frame-sufficiency" section.
+#: degrading; and ``agent_roster_reported``/``model_catalog_reported``/
+#: ``attached_name_reported`` (#5094, the same fix): those 5 snapshot keys
+#: now ride the SAME wire channel, so a remote agent tab / model-class
+#: picker reflects the server's real roster instead of an unconditional
+#: empty list. See the module docstring's "Frame-sufficiency" section.
 REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     completion_source=False,
     intervention_head=True,
@@ -332,6 +352,9 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     ctx_compaction_reported=False,
     hooks_reported=False,
     pipelines_reported=False,
+    agent_roster_reported=True,
+    model_catalog_reported=True,
+    attached_name_reported=True,
 )
 
 
@@ -654,6 +677,21 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # -- MAIN bar (frame-available via STATE_*) --
         "model": v.get("model") or "—",
         "attached_name": v.get("attached_name"),
+        # #5094: real wire data (agui/state.py's own _WIRE_KEYS carries
+        # these 4) — previously a hand-typed `[]`/`None` literal here
+        # UNCONDITIONALLY emptied a remote client's agent tab and
+        # model-class picker regardless of how many agents/model classes
+        # the server actually had (owner live-blocked on this, #5041).
+        # `agent_names`/`session_tree` are literally what
+        # RegistryReadModel's own `agent_names`/`session_tree` methods
+        # supply locally (`registry.loaded_names()`/`registry.
+        # session_tree()`); `model_active_class`/`model_classes` mirror
+        # `Session.active_model_class()`/`known_model_classes()` the
+        # same way `model` above already does.
+        "model_active_class": v.get("model_active_class"),
+        "model_classes": v.get("model_classes", []),
+        "agent_names": v.get("agent_names", []),
+        "session_tree": v.get("session_tree", []),
         "cost_agent": v.get("cost_agent", 0.0),
         "cost_total": v.get("cost_total", 0.0),
         "cost_usd": v.get("cost_agent", 0.0),
@@ -676,10 +714,6 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # that dataclass reaches every producer for free, no call-site
         # edit required.
         **reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES),
-        "model_active_class": None,
-        "model_classes": [],
-        "agent_names": [],
-        "session_tree": [],
         # The prompt/completion SPLIT below is `0`/`0` while the total is
         # real wire data — an inconsistent breakdown (`0 + 0 != total`)
         # the Cost pane never flags on its own; gated by

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -39,6 +39,19 @@ from reyn.core.present.guard import get_neutralizer
 _WIRE_KEYS = (
     "attached_name",
     "model",
+    # #5094: the agent roster + the model-class picker's own catalog — all
+    # 4 were already computed server-side (``status._snapshot``'s own
+    # ``registry.loaded_names()``/``registry.session_tree()``/
+    # ``Session.active_model_class()``/``Session.known_model_classes()``)
+    # but never forwarded past this filter, so a remote client's agent tab
+    # and model-class picker were unconditionally empty regardless of how
+    # many agents/sessions or model classes the server actually had (owner
+    # live-blocked on this, #5041/#5094). Real per-connection values, same
+    # as every other key here — not a graceful-degrade placeholder.
+    "agent_names",
+    "session_tree",
+    "model_active_class",
+    "model_classes",
     "cost_agent",
     "cost_total",
     "agent_tokens",
@@ -82,6 +95,11 @@ def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) 
     out = {
         "attached_name": snap.get("attached_name"),
         "model": snap.get("model"),
+        # #5094: see _WIRE_KEYS above.
+        "agent_names": snap.get("agent_names", []),
+        "session_tree": snap.get("session_tree", []),
+        "model_active_class": snap.get("model_active_class"),
+        "model_classes": snap.get("model_classes", []),
         "cost_agent": snap.get("cost_agent", 0.0),
         "cost_total": snap.get("cost_total", 0.0),
         "agent_tokens": snap.get("agent_tokens", 0),

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -135,6 +135,9 @@ def test_capabilities_dataclass_rejects_a_missing_field():
         ctx_compaction_reported=True,
         hooks_reported=True,
         pipelines_reported=True,
+        agent_roster_reported=True,
+        model_catalog_reported=True,
+        attached_name_reported=True,
     )
     with pytest.raises(TypeError):
         ChatReadModelCapabilities(  # type: ignore[call-arg]
@@ -168,9 +171,11 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
 
     ``cache_usage_reported`` / ``cron_jobs_reported`` /
     ``usage_breakdown_reported`` / ``ctx_compaction_reported`` (#5009) /
-    ``hooks_reported`` / ``pipelines_reported`` (#5034) are the 6 fields
-    NOT named after a ``ChatReadModel`` method — see the class's own
-    docstring for why they live here anyway."""
+    ``hooks_reported`` / ``pipelines_reported`` (#5034) /
+    ``agent_roster_reported`` / ``model_catalog_reported`` /
+    ``attached_name_reported`` (#5094) are the 9 fields NOT named after a
+    ``ChatReadModel`` method — see the class's own docstring for why they
+    live here anyway."""
     names = {f.name for f in fields(ChatReadModelCapabilities)}
     assert names == {
         "completion_source",
@@ -185,6 +190,9 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
         "ctx_compaction_reported",
         "hooks_reported",
         "pipelines_reported",
+        "agent_roster_reported",
+        "model_catalog_reported",
+        "attached_name_reported",
     }
 
 

--- a/tests/interfaces/test_5094_remote_agent_roster_and_model_catalog.py
+++ b/tests/interfaces/test_5094_remote_agent_roster_and_model_catalog.py
@@ -1,0 +1,135 @@
+"""Tier 2: #5094 — a remote client's agent tab and model-class picker
+reflect the SERVER's real roster, not an unconditional empty literal.
+
+Owner live-blocked on this (relayed via architect/lead-coder): connecting 2
+agents (`--connect x2`, both `default`) showed nothing in the TUI's agent
+tab despite the workspace genuinely having 4 agents. Root cause,
+measured: `agui/state.py`'s own ``_WIRE_KEYS`` filter never forwarded
+`agent_names`/`session_tree`/`model_active_class`/`model_classes` past the
+server's projection, even though `status._snapshot`'s own
+``registry.loaded_names()``/``registry.session_tree()``/``Session.
+active_model_class()``/``known_model_classes()`` calls already compute
+real values server-side — so ``project_remote_snapshot`` (client-side) had
+nothing to read and fell back to a hand-typed `[]`/`None` literal
+regardless of how many agents/model classes the server actually had.
+
+Same real, end-to-end pattern
+`test_agui_state_read_model.py::test_remote_status_view_reflects_snapshot_
+then_delta` already establishes for this wire (real ``AgUiEmitter`` → real
+SSE text → real ``AgUiTransport`` parsing it back) — extended through
+`project_remote_snapshot` (the read-model projection the TUI's own chips
+actually read), not stopping at the raw wire dict.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.repl.read_model import project_remote_snapshot
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+@pytest.mark.asyncio
+async def test_agent_roster_and_model_catalog_ride_the_wire_end_to_end():
+    """Tier 2: the acceptance witness architect specified — a remote
+    client's agent tab must show the ACTUAL count and names the server
+    has, not merely "non-empty". Drives the real emitter → real SSE →
+    real transport → the real `project_remote_snapshot` projection the
+    TUI's own chrome reads, exactly the path a live `--connect` uses."""
+    state = {
+        "cost_agent": 1.0, "cost_total": 1.0, "ctx_used": 10, "ctx_window": 100,
+        "agent_tokens": 5, "attached_name": "default", "model": "m",
+        "agent_names": ["default", "neo", "coder-smith", "coder-brown"],
+        "session_tree": [
+            {"agent": "default"}, {"agent": "neo"},
+            {"agent": "coder-smith"}, {"agent": "coder-brown"},
+        ],
+        "model_active_class": "standard",
+        "model_classes": ["light", "standard", "strong"],
+    }
+
+    def status_provider():
+        return dict(state)
+
+    async def frames():
+        yield OutboxMessage(kind="agent", text="done")
+        yield OutboxMessage(kind="__end__", text="")
+
+    async def _display_frames():
+        async for msg in frames():
+            yield DisplayFrame(msg)
+
+    emitter = AgUiEmitter(_display_frames(), status_provider)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_SNAPSHOT" in sse
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    async for _f in transport.frames():
+        pass  # draining applies STATE_SNAPSHOT to transport.status
+
+    wire_values = transport.status.values
+    projected = project_remote_snapshot(wire_values)
+
+    assert projected["agent_names"] == ["default", "neo", "coder-smith", "coder-brown"], (
+        f"expected all 4 real agent names, got {projected['agent_names']!r}"
+    )
+    assert projected["session_tree"] == [
+        {"agent": "default"}, {"agent": "neo"},
+        {"agent": "coder-smith"}, {"agent": "coder-brown"},
+    ]
+    assert projected["model_active_class"] == "standard"
+    assert projected["model_classes"] == ["light", "standard", "strong"]
+    # The 3 new capability flags must say "reported", not silently omit —
+    # a consumer distinguishing "genuinely empty" from "unsupported" reads
+    # these, not the bare data keys.
+    assert projected["agent_roster_reported"] is True
+    assert projected["model_catalog_reported"] is True
+    assert projected["attached_name_reported"] is True
+
+
+@pytest.mark.asyncio
+async def test_strip_falsifier_removing_the_wire_keys_reverts_to_the_old_empty_bug():
+    """Tier 2: strip-falsifier — with the 4 keys absent from the server's
+    OWN status dict (simulating `_WIRE_KEYS` reverted to not carry them,
+    the exact pre-#5094 shape), the client falls back to the SAME
+    graceful-empty defaults the bug reproduced — confirming the positive
+    witness above genuinely depends on the wire carrying real data, not on
+    `project_remote_snapshot`'s own defaults happening to look right."""
+    state = {
+        "cost_agent": 1.0, "cost_total": 1.0, "ctx_used": 10, "ctx_window": 100,
+        "agent_tokens": 5, "attached_name": "default", "model": "m",
+        # agent_names/session_tree/model_active_class/model_classes
+        # deliberately absent — the pre-#5094 server-side shape.
+    }
+
+    def status_provider():
+        return dict(state)
+
+    async def _display_frames():
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    emitter = AgUiEmitter(_display_frames(), status_provider)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    async for _f in transport.frames():
+        pass
+
+    projected = project_remote_snapshot(transport.status.values)
+    assert projected["agent_names"] == []
+    assert projected["session_tree"] == []
+    assert projected["model_active_class"] is None
+    assert projected["model_classes"] == []


### PR DESCRIPTION
**[tui-coder]** — 🔴 **top priority, owner is live-blocked** (dispatched by lead-coder, confirmed by architect — #5094/#5041). Fixes the display half ("⑦-a") of a remote client's agent tab / model-class picker being unconditionally empty.

## Root cause
`agui/state.py`'s own `_WIRE_KEYS` filter never forwarded `agent_names`/`session_tree`/`model_active_class`/`model_classes` past the server's projection — even though `status._snapshot`'s own `registry.loaded_names()`/`registry.session_tree()`/`Session.active_model_class()`/`known_model_classes()` calls already compute real values server-side. `project_remote_snapshot` (client-side) had nothing to read for these 4 keys and fell back to a hand-typed `[]`/`None` literal, unconditionally — the #4996-family "unsupported and genuinely-0 read as the same value" defect.

## Fix
- `agui/state.py`: add the 4 keys to `_WIRE_KEYS` + `project_status`'s output.
- `read_model.py`: `project_remote_snapshot` reads the real wire values instead of the hardcoded literal.
- `ChatReadModelCapabilities` gains 3 new required fields (`agent_roster_reported`/`model_catalog_reported`/`attached_name_reported`) — declared AND wired to `True` in the same change (no window where declaration exists but value is still fabricated).

## Scope note (confirmed via broker with lead-coder/architect)
#5094's 3rd item (agent-switch failure) is a DIFFERENT bug (#5076 — `SessionBoundTransport` doesn't implement `request_attach`/`request_session_switch`) being fixed separately in PR #5096. **This PR is exactly and only the display half** — landing this alone does NOT close owner's live verification; #5096 is also needed.

## Test plan
- [x] `ruff check` — clean
- [x] `scripts/test_tier_audit.py --strict` on both changed test files — 0 Tier-4 violations
- [x] `scripts/verify_module_docstrings.py` / `scripts/mypy_ratchet.py` — OK
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] New witness (`test_5094_remote_agent_roster_and_model_catalog.py`) is REAL end-to-end (real `AgUiEmitter` → real SSE → real `AgUiTransport` → real `project_remote_snapshot`) — strip-verified: reverting the `_WIRE_KEYS` addition breaks it (confirmed red, restored before commit); a second test confirms the pre-fix shape still degrades gracefully, never fabricates.
- [x] Scoped sweep: `tests/interfaces/` filtered to agui/state/read_model/4996/5094/status — 257 passed
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change — real UI verification needs owner's own live client)

part of #5094 / #5041
