### PR TITLE
docs(#5098): remove the dead _WIRE_KEYS declaration, point 6 citations at project_status

### DIFF
--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -26,8 +26,9 @@ status/region state from, with two implementations —
   read (:func:`project_remote_snapshot`).
 
 **Frame-sufficiency (what a remote client CAN show).** The server projects only
-the MAIN-bar subset onto the wire (``state.py``'s ``project_status`` /
-``_WIRE_KEYS``): ``model`` · ``attached_name`` · ``cost_agent`` / ``cost_total``
+the MAIN-bar subset onto the wire (``state.py``'s ``project_status``, the sole
+source of truth for the wire vocabulary — #5098):
+``model`` · ``attached_name`` · ``cost_agent`` / ``cost_total``
 / ``agent_tokens`` · ``ctx_used`` / ``ctx_window`` · ``waiting_on`` ·
 ``pending_intervention_head`` (#5050). Those chip VALUES, and now the pending
 intervention head itself, are genuinely readable via :meth:`RemoteReadModel.
@@ -677,8 +678,8 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # -- MAIN bar (frame-available via STATE_*) --
         "model": v.get("model") or "—",
         "attached_name": v.get("attached_name"),
-        # #5094: real wire data (agui/state.py's own _WIRE_KEYS carries
-        # these 4) — previously a hand-typed `[]`/`None` literal here
+        # #5094: real wire data (agui/state.py's own project_status dict
+        # carries these 4) — previously a hand-typed `[]`/`None` literal here
         # UNCONDITIONALLY emptied a remote client's agent tab and
         # model-class picker regardless of how many agents/model classes
         # the server actually had (owner live-blocked on this, #5041).
@@ -783,7 +784,7 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # (#5034 — same fabrication shape as ``hooks_reported`` above).
         "pipelines": [],
         # #3300 P2b: the server-authoritative sent-queue state IS on the wire
-        # (state.py's ``_WIRE_KEYS`` / ``project_status``, folded in by P2a) —
+        # (state.py's ``project_status``, folded in by P2a) —
         # project it through unlike the session-local keys above, so
         # ``ChatReadModel.snapshot()`` returns queue info uniformly for BOTH
         # local (``RegistryReadModel``, straight off ``_snapshot()``) and

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -590,6 +590,6 @@ def _snapshot(registry, config=None):
         # the fail-stop set in ``Session._fail_stop_if_durability_dead`` /
         # ``run_one_iteration``. Consumed by the TUI status line
         # (``chrome.status_line_text``) and threaded onto the wire for remote
-        # parity (``agui.state._WIRE_KEYS`` / ``project_status``).
+        # parity (``agui.state.project_status``).
         "halted_reason": s.halted_reason,
     }

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -33,69 +33,42 @@ from dataclasses import dataclass, field
 
 from reyn.core.present.guard import get_neutralizer
 
-# The status keys that ride the wire — the read-model's whole vocabulary. Kept
-# as an explicit projection so a private/expensive snapshot field (e.g. the
-# bound ``ctx_compaction_status_fn`` method) can never leak onto the wire.
-_WIRE_KEYS = (
-    "attached_name",
-    "model",
-    # #5094: the agent roster + the model-class picker's own catalog — all
-    # 4 were already computed server-side (``status._snapshot``'s own
-    # ``registry.loaded_names()``/``registry.session_tree()``/
-    # ``Session.active_model_class()``/``Session.known_model_classes()``)
-    # but never forwarded past this filter, so a remote client's agent tab
-    # and model-class picker were unconditionally empty regardless of how
-    # many agents/sessions or model classes the server actually had (owner
-    # live-blocked on this, #5041/#5094). Real per-connection values, same
-    # as every other key here — not a graceful-degrade placeholder.
-    "agent_names",
-    "session_tree",
-    "model_active_class",
-    "model_classes",
-    "cost_agent",
-    "cost_total",
-    "agent_tokens",
-    "ctx_used",
-    "ctx_window",
-    "waiting_on",
-    # #5050: the pending closed-set intervention (id/prompt/detail/choices),
-    # or None — the source ``RemoteReadModel.intervention_head()`` reads
-    # instead of an unconditional None (the #4996-family lying-None fix —
-    # see that method's own docstring). See ``status._snapshot``'s own
-    # docstring for the shape.
-    "pending_intervention_head",
-    # #3300 P2a: server-authoritative sent-queue state — the undispatched
-    # inbox queue (list of {msg_id, chain_id, text}) + whether a turn is
-    # currently dispatched. Rides this SAME STATE_SNAPSHOT/STATE_DELTA
-    # channel (connect-time snapshot + delta thereafter) so a remote client
-    # is late-joiner-safe: a client connecting mid-turn gets the correct
-    # queue + turn_active from the snapshot rather than needing to have
-    # observed every prior turn_started/user_submitted audit-event.
-    "queue",
-    "turn_active",
-    # The order-race gate token (#3300 P2a design-pass pin D) — see
-    # `RemoteQueueView` below.
-    "queue_seq",
-    # #2280: the durability-halt reason (``None`` while running) — rides this
-    # SAME snapshot/delta channel so a remote status panel surfaces a halt
-    # proactively too, not only the local in-process one.
-    "halted_reason",
-)
-
 
 def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) -> dict:
-    """Project the inline status snapshot to the wire read-model subset.
+    """Project the inline status snapshot to the wire read-model subset —
+    the read-model's WHOLE vocabulary; a private/expensive snapshot field
+    (e.g. the bound ``ctx_compaction_status_fn`` method) can never leak
+    onto the wire because this function's own return dict is the only
+    thing that does.
 
     ``snapshot`` is the CUI's ``_snapshot`` dict (or ``None`` when no session is
     attached). ``waiting_on`` is the current WaitingOn label (from the
     audit-event stream) folded in so the remote panel shows the same
     Thinking / Running / Waiting-for-you state the local one does.
+
+    #5098: this dict literal — not a separate ``_WIRE_KEYS`` tuple that
+    used to sit above this function — is now the sole source of truth for
+    which keys ride the wire. The old split had ``_WIRE_KEYS`` read by
+    NOTHING (a dead declaration authored, then cited 6 times elsewhere as
+    if it gated something) while THIS dict alone actually decided the
+    wire's contents — measured by docs-maintainer's own 2-stage strip on
+    PR #5097's TESTS-READ: deleting ``_WIRE_KEYS`` changed nothing;
+    deleting a key from THIS dict did. A future key belongs here, in one
+    place, not in a second list this function never consulted.
     """
     snap = snapshot or {}
     out = {
         "attached_name": snap.get("attached_name"),
         "model": snap.get("model"),
-        # #5094: see _WIRE_KEYS above.
+        # #5094: the agent roster + the model-class picker's own catalog —
+        # all 4 were already computed server-side (``status._snapshot``'s
+        # own ``registry.loaded_names()``/``registry.session_tree()``/
+        # ``Session.active_model_class()``/``Session.known_model_classes()``)
+        # but never forwarded past this dict, so a remote client's agent
+        # tab and model-class picker were unconditionally empty regardless
+        # of how many agents/sessions or model classes the server actually
+        # had (owner live-blocked on this, #5041/#5094). Real per-connection
+        # values — not a graceful-degrade placeholder.
         "agent_names": snap.get("agent_names", []),
         "session_tree": snap.get("session_tree", []),
         "model_active_class": snap.get("model_active_class"),
@@ -106,13 +79,27 @@ def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) 
         "ctx_used": snap.get("ctx_used", 0),
         "ctx_window": snap.get("ctx_window", 0),
         "waiting_on": waiting_on,
-        # #5050: see _WIRE_KEYS above.
+        # #5050: the pending closed-set intervention (id/prompt/detail/choices),
+        # or None — the source ``RemoteReadModel.intervention_head()`` reads
+        # instead of an unconditional None (the #4996-family lying-None fix —
+        # see that method's own docstring). See ``status._snapshot``'s own
+        # docstring for the shape.
         "pending_intervention_head": snap.get("pending_intervention_head"),
-        # #3300 P2a: sent-queue state, see _WIRE_KEYS above.
+        # #3300 P2a: server-authoritative sent-queue state — the undispatched
+        # inbox queue (list of {msg_id, chain_id, text}) + whether a turn is
+        # currently dispatched. Rides this SAME STATE_SNAPSHOT/STATE_DELTA
+        # channel (connect-time snapshot + delta thereafter) so a remote client
+        # is late-joiner-safe: a client connecting mid-turn gets the correct
+        # queue + turn_active from the snapshot rather than needing to have
+        # observed every prior turn_started/user_submitted audit-event.
         "queue": snap.get("queue", []),
         "turn_active": snap.get("turn_active", False),
+        # The order-race gate token (#3300 P2a design-pass pin D) — see
+        # `RemoteQueueView` below.
         "queue_seq": snap.get("queue_seq", 0),
-        # #2280: see _WIRE_KEYS above.
+        # #2280: the durability-halt reason (``None`` while running) — rides this
+        # SAME snapshot/delta channel so a remote status panel surfaces a halt
+        # proactively too, not only the local in-process one.
         "halted_reason": snap.get("halted_reason"),
     }
     return out

--- a/tests/interfaces/test_5094_remote_agent_roster_and_model_catalog.py
+++ b/tests/interfaces/test_5094_remote_agent_roster_and_model_catalog.py
@@ -4,7 +4,7 @@ reflect the SERVER's real roster, not an unconditional empty literal.
 Owner live-blocked on this (relayed via architect/lead-coder): connecting 2
 agents (`--connect x2`, both `default`) showed nothing in the TUI's agent
 tab despite the workspace genuinely having 4 agents. Root cause,
-measured: `agui/state.py`'s own ``_WIRE_KEYS`` filter never forwarded
+measured: `agui/state.py`'s own ``project_status`` dict never forwarded
 `agent_names`/`session_tree`/`model_active_class`/`model_classes` past the
 server's projection, even though `status._snapshot`'s own
 ``registry.loaded_names()``/``registry.session_tree()``/``Session.
@@ -100,8 +100,8 @@ async def test_agent_roster_and_model_catalog_ride_the_wire_end_to_end():
 @pytest.mark.asyncio
 async def test_strip_falsifier_removing_the_wire_keys_reverts_to_the_old_empty_bug():
     """Tier 2: strip-falsifier — with the 4 keys absent from the server's
-    OWN status dict (simulating `_WIRE_KEYS` reverted to not carry them,
-    the exact pre-#5094 shape), the client falls back to the SAME
+    OWN status dict (simulating `project_status` reverted to not carry
+    them, the exact pre-#5094 shape), the client falls back to the SAME
     graceful-empty defaults the bug reproduced — confirming the positive
     witness above genuinely depends on the wire carrying real data, not on
     `project_remote_snapshot`'s own defaults happening to look right."""

--- a/tests/interfaces/test_agui_remote_inline_p3.py
+++ b/tests/interfaces/test_agui_remote_inline_p3.py
@@ -121,8 +121,9 @@ async def test_remote_read_model_projects_pending_intervention_head() -> None:
     confirmed independently; #5050 fixes the read-model source, not that
     consumer).
 
-    FALSIFY: dropping ``pending_intervention_head`` from ``_WIRE_KEYS``/
-    ``project_status`` (state.py) turns this RED (``intervention_head()``
+    FALSIFY: dropping ``pending_intervention_head`` from ``project_status``
+    (state.py, the sole source of truth for the wire vocabulary — #5098)
+    turns this RED (``intervention_head()``
     reverts to None even though the server-side state carries a real head).
     See the sibling test below for the reverse direction: no pending head
     on the wire still correctly returns None (not fabricated)."""


### PR DESCRIPTION
**[tui-coder]** — pure removal, per lead-coder's #5098 (found during PR #5097's own TESTS-READY-B).

## What
`_WIRE_KEYS` (agui/state.py) had exactly ONE code occurrence — its own definition. `project_status`'s own dict literal has always been the actual, sole source of truth for the wire vocabulary; 6 comments + 1 test docstring cited `_WIRE_KEYS` as if it gated something, so the next person adding a wire key would write it there and get a silent no-op.

- Deleted `_WIRE_KEYS`.
- Rewrote `project_status`'s own docstring to state plainly its dict literal IS the wire vocabulary, folding the useful per-key history comments (agent-roster/model-catalog #5094, pending-intervention #5050, sent-queue #3300, halt-reason #2280) directly into that function.
- Repointed all 6 citations (read_model.py x3, status.py x1, 2 test docstrings) at `project_status`.

Zero behavior change by construction (deleting an unread declaration cannot change anything a strip would catch) — matches the issue's own witness: `grep _WIRE_KEYS` → 0 hits, no strip needed.

## Test plan
- [x] `ruff check` — clean
- [x] `scripts/verify_module_docstrings.py` / `scripts/mypy_ratchet.py` — OK
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` — OK
- [x] `scripts/test_tier_audit.py --strict` on both touched test files — 0 Tier-4 violations
- [x] `grep -rn _WIRE_KEYS src/ tests/ docs/` — only my own `#5098:` historical-note docstring remains, no live references
- [x] Scoped sweep: `tests/interfaces/` filtered to agui/state/read_model/status/4996/5094 — 257 passed
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

part of #5098
