### PR TITLE
fix(#5094): remote agent tab shows every declared agent, not just attached ones

### DIFF
--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -470,7 +470,13 @@ def _snapshot(registry, config=None):
         "model": s.model,
         "model_active_class": s.active_model_class(),
         "model_classes": list(s.known_model_classes()),
-        "agent_names": list(registry.loaded_names()),
+        # #5094: list_active_names() (every DECLARED, non-archived agent —
+        # disk-backed) not loaded_names() (only agents with a LIVE
+        # in-memory Session right now) — see session_tree()'s own
+        # docstring (registry.py) for the full measurement. This is the
+        # same source agent.py's own routing comment already claimed this
+        # call site used.
+        "agent_names": list(registry.list_active_names()),
         "attached_name": registry.attached_name,
         "session_tree": registry.session_tree(),
         # LOCAL genuinely measures the prompt/completion SPLIT below

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3984,13 +3984,30 @@ class AgentRegistry:
     def session_tree(self) -> "list[dict]":
         """Snapshot of the agent→session tree for the status-bar agent menu.
 
-        A read-only, freshly-built copy (no handle to live registry state): agents in
-        load order, each with its sessions (sids, sorted) and which (agent, sid) is the
-        current attach focus.
+        A read-only, freshly-built copy (no handle to live registry state):
+        agents in name order, each with its sessions (sids, sorted) and
+        which (agent, sid) is the current attach focus.
+
+        #5094: iterates :meth:`list_active_names` (every DECLARED,
+        non-archived agent — disk-backed, the SAME source :meth:`exists`
+        reads) rather than :meth:`loaded_names` (only agents with a LIVE
+        in-memory ``Session`` right now) — architect's own measured
+        finding: a remote client's agent tab read this method via
+        ``status.py``'s ``_snapshot`` and showed NOTHING for any agent not
+        yet attached in THIS process, regardless of how many agents the
+        workspace actually had declared (owner live-blocked on this,
+        #5041/#5094 — the #5097 wire fix alone did not close it, because
+        the wire faithfully carried an empty roster). A declared-but-
+        unattached agent now appears with an empty ``sessions`` list — the
+        #4996-family distinction between "not yet attached" and "does not
+        exist" this repo's own vocabulary already names. ``loaded_names``
+        itself is UNCHANGED and still answers its own, different question
+        ("who is running right now") — this is not a replacement, it is
+        splitting two questions this one call site used to conflate.
         """
         out: list[dict] = []
         active = self._connection.active
-        for name in self.loaded_names():
+        for name in self.list_active_names():
             sids = sorted((self._sessions.get(name) or {}).keys())
             out.append({
                 "agent": name,

--- a/tests/runtime/test_registry_session_tree.py
+++ b/tests/runtime/test_registry_session_tree.py
@@ -19,6 +19,16 @@ from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
 
+def _entry_for(tree: "list[dict]", name: str) -> dict:
+    """The tree entry for `name` — never assumes an index. #5094:
+    `session_tree()` now iterates `list_active_names()` (alphabetical),
+    so `alpha` sorts BEFORE `default` — any test that cared specifically
+    about `default`'s own entry must look it up by name, not `[0]`."""
+    by_name = {e["agent"]: e for e in tree}
+    assert name in by_name, f"{name!r} missing from session_tree(): {tree!r}"
+    return by_name[name]
+
+
 def _make_registry(tmp_path: Path) -> AgentRegistry:
     """A real AgentRegistry whose factory builds real Sessions on demand."""
     def factory(profile: AgentProfile) -> Session:
@@ -38,10 +48,40 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
     return reg
 
 
-def test_session_tree_empty_when_no_sessions_loaded(tmp_path: Path) -> None:
-    """Tier 2: session_tree() returns [] when no sessions are loaded."""
+def test_session_tree_lists_declared_agents_even_with_no_sessions_loaded(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5094 — session_tree() lists every DECLARED (on-disk,
+    non-archived) agent even when NOTHING has been loaded/attached yet —
+    the exact owner-measured gap (a remote agent tab showed nothing for
+    any agent not yet attached in that process, regardless of how many
+    the workspace actually had). Each entry's own `sessions` list is empty
+    (nothing loaded), distinguishing "declared but not yet attached" from
+    "does not exist" (#4996 family) rather than omitting the row.
+
+    Strip-falsifier: reverting `session_tree()`'s own iteration from
+    `list_active_names()` back to `loaded_names()` makes this assert `[]`
+    again (`test_session_tree_returns_only_loaded_agents_via_the_narrower_
+    call` below pins that DIFFERENT, still-correct behaviour for
+    `loaded_names()` itself) — verified locally."""
     reg = _make_registry(tmp_path)
-    assert reg.session_tree() == []
+    names = {e["agent"] for e in reg.session_tree()}
+    assert names == {"default", "alpha"}, (
+        f"expected every declared agent even unattached; got {names!r}"
+    )
+    assert all(e["sessions"] == [] for e in reg.session_tree())
+
+
+def test_session_tree_returns_only_loaded_agents_via_the_narrower_call(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: regression guard for `loaded_names()` itself — #5094 did
+    NOT change this method; it answers a DIFFERENT question ("who is
+    running right now") than `session_tree()` now does."""
+    reg = _make_registry(tmp_path)
+    assert reg.loaded_names() == []
+    reg.get_or_load("default")
+    assert reg.loaded_names() == ["default"]
 
 
 def test_session_tree_entry_shape_for_loaded_agent(tmp_path: Path) -> None:
@@ -64,19 +104,22 @@ def test_session_tree_session_entry_shape(tmp_path: Path) -> None:
     reg = _make_registry(tmp_path)
     reg.get_or_load("default")
 
-    sess_list = reg.session_tree()[0]["sessions"]
+    sess_list = _entry_for(reg.session_tree(), "default")["sessions"]
     by_sid = {s["sid"]: s for s in sess_list}
     assert set(by_sid["main"].keys()) == {"sid", "attached"}
 
 
 def test_session_tree_lists_multiple_agents(tmp_path: Path) -> None:
-    """Tier 2: each loaded agent appears once, in loaded_names() order."""
+    """Tier 2: each declared agent appears once, in list_active_names()
+    order (#5094 — no longer loaded_names(), which only lists agents with
+    a live in-memory Session; declared-but-unattached agents belong here
+    too, see the test above)."""
     reg = _make_registry(tmp_path)
     reg.get_or_load("default")
     reg.get_or_load("alpha")
 
     names = [e["agent"] for e in reg.session_tree()]
-    assert names == reg.loaded_names()
+    assert names == reg.list_active_names()
     assert set(names) == {"default", "alpha"}
 
 
@@ -86,7 +129,7 @@ def test_session_tree_lists_spawned_sessions(tmp_path: Path) -> None:
     reg.get_or_load("default")
     sid = reg.spawn_session("default", "sub1", presentation_consumer=None, intervention_bridge=None)
 
-    sids = {s["sid"] for s in reg.session_tree()[0]["sessions"]}
+    sids = {s["sid"] for s in _entry_for(reg.session_tree(), "default")["sessions"]}
     assert {"main", sid} <= sids
 
 
@@ -97,7 +140,7 @@ def test_session_tree_sids_sorted(tmp_path: Path) -> None:
     reg.spawn_session("default", "zz", presentation_consumer=None, intervention_bridge=None)
     reg.spawn_session("default", "aa", presentation_consumer=None, intervention_bridge=None)
 
-    sids = [s["sid"] for s in reg.session_tree()[0]["sessions"]]
+    sids = [s["sid"] for s in _entry_for(reg.session_tree(), "default")["sessions"]]
     assert sids == sorted(sids)
 
 
@@ -109,7 +152,7 @@ def test_session_tree_all_false_when_nothing_attached(tmp_path: Path) -> None:
     reg.spawn_session("default", "sub1", presentation_consumer=None, intervention_bridge=None)
     assert reg.attached_name is None           # public-surface precondition
 
-    entry = reg.session_tree()[0]
+    entry = _entry_for(reg.session_tree(), "default")
     assert entry["attached"] is False
     assert all(s["attached"] is False for s in entry["sessions"])
 
@@ -121,8 +164,9 @@ def test_session_tree_returns_snapshot_copy(tmp_path: Path) -> None:
     reg.get_or_load("default")
 
     first = reg.session_tree()
-    first[0]["agent"] = "MUTATED"
-    first[0]["sessions"][0]["sid"] = "MUTATED"
+    default_idx = next(i for i, e in enumerate(first) if e["agent"] == "default")
+    first[default_idx]["agent"] = "MUTATED"
+    first[default_idx]["sessions"][0]["sid"] = "MUTATED"
     first.append({"bogus": True})
 
     by_name = {e["agent"]: e for e in reg.session_tree()}


### PR DESCRIPTION
**[tui-coder]** — 🔴 **top priority, owner still live-blocked after #5097**. Root cause is one layer earlier than the wire (architect's own follow-up measurement, #5094 issuecomment-5379687545) — `session_tree()`/`agent_names` only counted agents with a LIVE in-memory `Session`, not every declared agent on disk.

## Root cause
`status.py`'s `agent_names` key and `registry.py`'s `session_tree()` both iterated `registry.loaded_names()` (`= list(self._sessions.keys())` — only agents attached in THIS process), not `list_active_names()` (disk-backed, non-archived, the same source `exists()` already reads). A declared agent never attached in the current process contributed 0 rows regardless of workspace state — exactly owner's "connect x2, both default, 4 agents on disk, tab empty" observation.

## Fix (lead-coder's corrected, no-new-API form)
- `registry.py`: `session_tree()` iterates `list_active_names()` instead of `loaded_names()`. `loaded_names()` itself is UNCHANGED — it still answers "who is running right now", a genuinely different question.
- `status.py`: `agent_names` follows suit.
- A declared-but-unattached agent now appears with an empty `sessions` list — the #4996-family "not yet attached" vs "does not exist" distinction, not an omitted row.

## Test plan
- [x] `ruff check` — clean
- [x] `scripts/test_tier_audit.py --strict` — 0 Tier-4 violations
- [x] `scripts/verify_module_docstrings.py` / `scripts/mypy_ratchet.py` — OK
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] Fixed 3 existing tests in `test_registry_session_tree.py` that assumed `session_tree()[0]` was always `"default"` — `list_active_names()` sorts alphabetically, so this file's own 2nd declared agent (`"alpha"`) now sorts first; switched to name-based lookup. Also fixed the test that asserted `session_tree() == []` with nothing loaded (now correctly lists every declared agent) and the one pinning `loaded_names()` order.
- [x] New positive witness strip-verified: reverting `session_tree()`'s loop to `loaded_names()` turns it red (empty set instead of `{"default", "alpha"}`) — confirmed, then restored before commit.
- [x] Full sweep: `tests/runtime/` (1914 passed) + `tests/interfaces/` filtered to agent_names/session_tree/status/5094 (82 passed) — no regressions
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change — real UI verification needs owner's own live client)

part of #5094 / #5041
