### PR TITLE
fix(#5094): AG-UI status provider never returns None on first connect

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -719,8 +719,8 @@ def _agent_pane_entries(
     tree: "Sequence[dict]" = (),
 ) -> "list[tuple[str, str]]":
     """``(row, slash)`` for the agent→session tree (``AgentRegistry.session_tree()``
-    via the snapshot's ``session_tree``), falling back to the flat agent list when
-    the tree is empty.
+    via the snapshot's ``session_tree``), UNIONED with the flat ``names`` list —
+    not an either/or fallback.
 
     The tree shape is the retired chip bar's ``_agent_expansion`` contract, restored
     (#3338): one row per agent plus an indented row per session of that agent, the
@@ -728,22 +728,36 @@ def _agent_pane_entries(
     agent is already attached (``/session switch <sid>``); otherwise it attaches the
     agent first (``/attach <agent>``) — switching into a session of a non-attached
     agent is not a single-command operation, so the row does the reachable half
-    rather than dispatching a command that would fail."""
-    if tree:
-        out: "list[tuple[str, str]]" = []
-        for agent in tree:
-            name = agent.get("agent", "")
-            attached = bool(agent.get("attached"))
-            out.append((f"{'▸' if attached else ' '} {name}", f"/attach {name}"))
-            for sess in agent.get("sessions") or []:
-                sid = sess.get("sid", "")
-                smark = "▸" if sess.get("attached") else " "
-                cmd = f"/session switch {sid}" if attached else f"/attach {name}"
-                out.append((f"    {smark} {sid}", cmd))
-        return out
-    return [
-        (f"{n}  · active" if n == active else n, f"/attach {n}") for n in names
-    ]
+    rather than dispatching a command that would fail.
+
+    #5094 (lead-coder finding, issuecomment-5379848710): an earlier revision
+    used the tree ONLY when non-empty, falling back to the flat list otherwise
+    — correct for a wholly-empty tree, but wrong for a PARTIAL one: an agent
+    present in ``names`` but absent from ``tree`` (e.g. declared but not yet
+    session_tree-enumerated) silently vanished the moment even ONE other agent
+    had a tree entry (measured in-process: 4 ``agent_names`` + 1 ``session_tree``
+    entry rendered as 1 row, not 4). "Declared" and "has a tree entry" are
+    different information — the tree's silence about an agent must never read
+    as that agent not existing. So every agent gets exactly one representation:
+    a tree row if the tree has one, else a flat row — never both, never
+    neither."""
+    out: "list[tuple[str, str]]" = []
+    tree_agents: "set[str]" = set()
+    for agent in tree:
+        name = agent.get("agent", "")
+        tree_agents.add(name)
+        attached = bool(agent.get("attached"))
+        out.append((f"{'▸' if attached else ' '} {name}", f"/attach {name}"))
+        for sess in agent.get("sessions") or []:
+            sid = sess.get("sid", "")
+            smark = "▸" if sess.get("attached") else " "
+            cmd = f"/session switch {sid}" if attached else f"/attach {name}"
+            out.append((f"    {smark} {sid}", cmd))
+    for n in names:
+        if n in tree_agents:
+            continue
+        out.append((f"{n}  · active" if n == active else n, f"/attach {n}"))
+    return out
 
 
 def agent_pane_options(
@@ -753,10 +767,12 @@ def agent_pane_options(
 ) -> list[str]:
     """One row per loaded agent AND per session beneath it, the attach focus
     marked. Derived from the snapshot's ``session_tree`` (=
-    ``AgentRegistry.session_tree()``), degrading to the flat ``agent_names`` list
-    when no tree is available — the FULL loaded set either way, so a
-    freshly-created/attached agent (or a newly-spawned session) appears
-    automatically."""
+    ``AgentRegistry.session_tree()``) UNIONED with the flat ``agent_names``
+    list (see ``_agent_pane_entries``'s own docstring, #5094) — the FULL
+    loaded set either way, so a freshly-created/attached agent (or a
+    newly-spawned session) appears automatically, and an agent the tree
+    hasn't caught up to yet is never silently dropped just because some
+    OTHER agent already has a tree entry."""
     return [row for row, _cmd in _agent_pane_entries(names, active, tree)]
 
 

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -368,30 +368,56 @@ def _reported_snapshot_keys() -> "dict[str, bool]":
 
 
 def _snapshot(registry, config=None):
-    """Read live status values off the attached session via sync accessors."""
+    """Read live status values off the GLOBALLY attached session via sync
+    accessors — ``None`` when nothing is attached (LOCAL's own boot-race
+    window; genuinely "nothing to show yet" for a single-session, single-
+    focus client). See :func:`_snapshot_for_session` for the parameterized
+    body this delegates to, and its own docstring for why a caller that
+    already holds a concrete ``Session`` (AG-UI, per-connection) should call
+    THAT directly instead of going through this global-pointer lookup."""
     s = registry.attached_session()
     if s is None:
         return None
+    return _snapshot_for_session(registry, s, config)
+
+
+def _snapshot_for_session(registry, s, config=None):
+    """Read live status values off an EXPLICIT ``Session`` via sync accessors
+    — the parameterized body :func:`_snapshot` delegates to once it has
+    resolved one off the registry's global attached-pointer.
+
+    #5094: AG-UI's ``_status_provider`` used to call ``_snapshot(registry)``
+    directly, which returns ``None`` wholesale whenever
+    ``registry.attached_session()`` is unset — and it is deliberately never
+    set for an AG-UI connection (see ``AgentRegistry.ensure_running``'s own
+    docstring, #3793 stage 2: AG-UI tracks per-connection attach state itself,
+    via ``SurfaceManager``, and never reads the registry's single global
+    pointer). So the FIRST snapshot of every AG-UI connection — the exact
+    moment a client most wants to see the roster — was unconditionally
+    ``None``: not just the roster, the WHOLE status dict, regardless of
+    #5097/#5104 already having fixed what those keys themselves read.
+
+    The fix is not to make ``ensure_running`` set the global pointer (that
+    pointer is genuinely meaningless across concurrent per-agent
+    connections — one AG-UI process can serve many agents at once, and
+    "the one attached agent" doesn't generalize). It is to stop asking the
+    registry a question a caller who already has its own concrete
+    ``Session`` doesn't need to ask: this function takes ``s`` as a
+    parameter instead of looking it up, so a caller with real
+    per-connection identity (``s.agent_name``, always well-defined for a
+    genuine ``Session``) never depends on whether some OTHER connection
+    happens to hold the global focus."""
     u = s.total_usage
     # Cost breakdown (all via registry.agent_cost_usd — the single source of
     # truth for per-agent cost aggregation across all sids).
     cost_total = sum(registry.agent_cost_usd(name) for name in registry.loaded_names())
-    cost_agent = (
-        registry.agent_cost_usd(registry.attached_name)
-        if registry.attached_name else s.total_cost_usd
-    )
+    cost_agent = registry.agent_cost_usd(s.agent_name)
     # #3695: how many of those calls had no price. Projected NEXT TO the figure
     # it qualifies, from the same accessor family, so a surface cannot show the
     # cost while being unaware that it is incomplete — which is what left the
     # owner reading a frozen number all day as though it were the amount spent.
-    unpriced_calls = (
-        registry.agent_unpriced_calls(registry.attached_name)
-        if registry.attached_name else 0
-    )
-    agent_tokens = (
-        registry.agent_tokens(registry.attached_name)
-        if registry.attached_name else u.total_tokens
-    )
+    unpriced_calls = registry.agent_unpriced_calls(s.agent_name)
+    agent_tokens = registry.agent_tokens(s.agent_name)
     # Headline figure: the single most recent LLM call's prompt_tokens against
     # the model's REAL context window (get_max_input_tokens) — "how close to
     # the model's hard limit am I", matching the Claude Code-style % owners
@@ -477,7 +503,7 @@ def _snapshot(registry, config=None):
         # same source agent.py's own routing comment already claimed this
         # call site used.
         "agent_names": list(registry.list_active_names()),
-        "attached_name": registry.attached_name,
+        "attached_name": s.agent_name,
         "session_tree": registry.session_tree(),
         # LOCAL genuinely measures the prompt/completion SPLIT below
         # (real Session state, u.prompt_tokens/u.completion_tokens) —
@@ -491,10 +517,7 @@ def _snapshot(registry, config=None):
         # Cost-panel breakdown (#cost-panel-breakdown): per-scope CostBreakdown
         # (Input/Output/Saved/Saved% rows) mirroring the 3 $ totals above.
         "cost_breakdown_session": s.total_cost_breakdown,
-        "cost_breakdown_agent": (
-            registry.agent_cost_breakdown(registry.attached_name)
-            if registry.attached_name else s.total_cost_breakdown
-        ),
+        "cost_breakdown_agent": registry.agent_cost_breakdown(s.agent_name),
         "cost_breakdown_project": registry.project_cost_breakdown(),
         # #3339: the CURRENT (or most recent) turn's real token/cost total —
         # every LLM call the turn made, summed under its chain_id by the

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -45,7 +45,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from reyn.core.events.events import Event
 from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
-from reyn.interfaces.repl.status import _snapshot
+from reyn.interfaces.repl.status import _snapshot_for_session
 from reyn.interfaces.transport.agui.emitter import AgUiEmitter
 from reyn.interfaces.transport.agui.surface import (
     SurfaceManager,
@@ -500,7 +500,15 @@ async def agui_events(request: Request, agent_name: str):
     source.start()
 
     def _status_provider():
-        return _snapshot(registry)
+        # #5094: read status off THIS connection's own already-resolved
+        # ``session`` (bound above via ``registry.ensure_running(agent_name)``)
+        # rather than ``_snapshot(registry)``, which reads the registry's
+        # single GLOBAL attached-pointer — deliberately never set for an
+        # AG-UI connection (``ensure_running``'s own #3793-stage-2 docstring)
+        # — and so returned ``None`` wholesale on every first connect,
+        # regardless of what #5097/#5104 already fixed inside that dict. See
+        # ``_snapshot_for_session``'s own docstring for the full reasoning.
+        return _snapshot_for_session(registry, session)
 
     def _backlog_provider(name: str, sid: str) -> "list[Frame]":
         return session_backlog_frames(registry, name, sid)

--- a/tests/interfaces/test_5094_status_provider_never_none_on_connect.py
+++ b/tests/interfaces/test_5094_status_provider_never_none_on_connect.py
@@ -1,0 +1,147 @@
+"""Tier 2: #5094, third layer — AG-UI's status provider must never return
+``None`` on a fresh ``--connect``, and the Agent pane must never silently
+drop an agent the tree hasn't caught up to yet.
+
+Owner STILL live-blocked (relayed via architect/lead-coder) after #5097
+(wire forwarding) and #5104 (``list_active_names()`` vs ``loaded_names()``)
+both landed. Root cause, measured directly off ``ensure_running``'s own
+docstring and ``status._snapshot``'s own body: ``agui/endpoint.py``'s
+``_status_provider`` called ``status._snapshot(registry)`` — which reads
+``registry.attached_session()``, the registry's single GLOBAL attach
+pointer — and returns ``None`` wholesale the instant that pointer is unset.
+``AgentRegistry.ensure_running`` (the boot primitive AG-UI's connection
+handler actually calls) deliberately never sets that pointer (#3793 stage
+2: AG-UI tracks attach state itself, per connection, via
+``SurfaceManager``). So the FIRST snapshot of every AG-UI connection —
+before any ``/attach``-request round-trip — was unconditionally ``None``:
+not just the agent roster, the WHOLE status dict, regardless of what
+#5097/#5104 already fixed inside it.
+
+Fix: ``status._snapshot_for_session(registry, s, config)`` takes the
+``Session`` as a parameter instead of looking one up off the registry's
+global pointer; ``endpoint.py``'s ``_status_provider`` calls it with the
+connection's OWN already-resolved ``session`` (bound via
+``ensure_running``), so it never depends on whether some OTHER connection
+happens to hold the global focus.
+
+Companion fix (lead-coder finding, issuecomment-5379848710): once a
+snapshot can carry a PARTIAL ``session_tree`` (not just wholly-empty-or-
+full), ``chrome.py``'s ``_agent_pane_entries`` either/or branch
+(``if tree: ... else: <flat list>``) silently dropped every agent NOT in
+the tree the moment even one other agent had a tree entry. Fixed to union
+the two sources — witnessed here too, in the same PR that opened the door
+to a partial tree.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat.chrome import agent_pane_options
+from reyn.interfaces.repl.status import _snapshot_for_session
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    """A real AgentRegistry whose factory builds real Sessions on demand —
+    same pattern as test_registry_session_tree.py's own fixture."""
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=BudgetTracker(CostConfig()),
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_snapshot_for_session_is_a_real_dict_with_nothing_globally_attached(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the exact #5094 scenario — ``ensure_running`` never sets the
+    registry's global attach pointer (mirroring AG-UI's real connect path),
+    yet a caller holding the concrete ``Session`` still gets a real
+    snapshot, not the ``None`` a global-pointer read would give."""
+    reg = _make_registry(tmp_path)
+    session = await reg.ensure_running("default")
+
+    # The precondition the bug depended on: nothing globally attached.
+    assert reg.attached_session() is None
+    assert reg.attached_name is None
+
+    snap = _snapshot_for_session(reg, session)
+    assert snap is not None, "a caller with a concrete Session must never see None"
+    assert snap["attached_name"] == "default"
+    assert set(snap["agent_names"]) == {"default", "alpha"}
+    assert {e["agent"] for e in snap["session_tree"]} == {"default", "alpha"}
+
+
+@pytest.mark.asyncio
+async def test_strip_falsifier_the_global_snapshot_still_returns_none_unattached(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: regression guard on the OTHER half of the split — ``_snapshot``
+    (the global-pointer path LOCAL still uses) is UNCHANGED: still ``None``
+    when nothing is globally attached. Proves the fix added a new path for
+    AG-UI rather than silently changing LOCAL's own contract (which a
+    dedicated test double, ``_NoneReadModel`` in
+    test_textual_chat_attach_state_3671_p3.py, depends on to simulate the
+    pre-attach boot window)."""
+    from reyn.interfaces.repl.status import _snapshot
+
+    reg = _make_registry(tmp_path)
+    await reg.ensure_running("default")  # same boot path, still no global attach
+
+    assert _snapshot(reg) is None
+
+
+def test_agent_pane_unions_the_tree_with_the_flat_roster_not_either_or() -> None:
+    """Tier 1: lead-coder's finding — a PARTIAL ``session_tree`` (1 of 4
+    agents) must not make the other 3 vanish. Measured in-process by
+    architect: agent_names=4 + session_tree=1 rendered as 1 row before this
+    fix; must render 4 rows after."""
+    names = ["default", "neo", "coder-smith", "coder-brown"]
+    tree = [{"agent": "default", "attached": True, "sessions": []}]
+
+    rows = agent_pane_options(names, active="default", tree=tree)
+
+    rendered = {r.split("  · active")[0].lstrip("▸ ").strip() for r in rows}
+    assert rendered == set(names), (
+        f"partial tree dropped agents: expected {set(names)!r}, got {rendered!r}"
+    )
+    for missing in ("neo", "coder-smith", "coder-brown"):
+        assert missing in rendered, f"{missing!r} (not in the tree) was dropped: {rows!r}"
+
+
+def test_agent_pane_never_double_renders_an_agent_present_in_both() -> None:
+    """Tier 1: regression guard — an agent WITH a tree entry must not also
+    get a flat-list row (union, not concatenation)."""
+    names = ["default", "alpha"]
+    tree = [
+        {"agent": "default", "attached": True, "sessions": [{"sid": "main", "attached": True}]},
+        {"agent": "alpha", "attached": False, "sessions": []},
+    ]
+    rows = agent_pane_options(names, active="default", tree=tree)
+    # An agent-level row is one with no leading session indent (4 spaces) —
+    # every agent name must own exactly ONE such row, never two (a tree row
+    # AND a flat row for the same agent).
+    agent_rows = [r for r in rows if not r.startswith("    ")]
+    for name in names:
+        matches = [r for r in agent_rows if name in r]
+        assert matches, f"{name!r} has no agent-level row at all: {rows!r}"
+        assert matches[1:] == [], (
+            f"{name!r} rendered more than one agent-level row — union must not "
+            f"concatenate a tree row with a flat row: {rows!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — continues #5094 after #5097 (wire forwarding) + #5104 (`list_active_names()` vs `loaded_names()`) — owner was STILL live-blocked after both landed.

## Root cause (3rd layer)

`agui/endpoint.py`'s `_status_provider` called `status._snapshot(registry)`, which reads the registry's single GLOBAL attach pointer (`registry.attached_session()`) and returns `None` **wholesale** the instant that pointer is unset. `AgentRegistry.ensure_running` — the boot primitive AG-UI's connection handler actually calls — deliberately never sets that pointer (own docstring, #3793 stage 2: AG-UI tracks attach state itself, per connection, via `SurfaceManager`). So the FIRST snapshot of every AG-UI connection, before any `/attach` round-trip, was unconditionally `None`: not just the agent roster, the WHOLE status dict — regardless of what #5097/#5104 already fixed inside it.

## Fix

- `status._snapshot_for_session(registry, s, config)` takes the `Session` as a parameter instead of looking one up off the registry's global pointer. `endpoint.py`'s `_status_provider` now calls it with the connection's own already-resolved `session` (bound via `ensure_running`), so it never depends on whether some OTHER connection holds the global focus.
- `_snapshot(registry, config)` becomes a thin wrapper delegating to it for LOCAL's existing global-pointer path — **unchanged**, still `None` pre-attach (the boot-race window `_NoneReadModel` in `test_textual_chat_attach_state_3671_p3.py` depends on to simulate).
- Companion fix (lead-coder finding, issuecomment-5379848710, filed against this same PR since my prescription is what opens the door to it): once a snapshot can carry a PARTIAL `session_tree`, `chrome.py`'s `_agent_pane_entries` either/or branch (`if tree: … else: <flat list>`) silently dropped every agent NOT in the tree the moment even one other agent had a tree entry (architect's in-process measurement: `agent_names`=4 + `session_tree`=1 → 1 row, not 4). Fixed to union the two sources.

## Tests

4 new tests in `tests/interfaces/test_5094_status_provider_never_none_on_connect.py`, 2 strip-falsified manually (reverted the fix → red → restored → green):
- `test_snapshot_for_session_is_a_real_dict_with_nothing_globally_attached` — real registry + real Session via `ensure_running`, `registry.attached_session()` confirmed `None`, `_snapshot_for_session` still returns a real dict.
- `test_strip_falsifier_the_global_snapshot_still_returns_none_unattached` — regression guard: LOCAL's `_snapshot` path is untouched.
- `test_agent_pane_unions_the_tree_with_the_flat_roster_not_either_or` — partial tree (1/4) no longer drops the other 3.
- `test_agent_pane_never_double_renders_an_agent_present_in_both` — union, not concatenation.

## Verification report (new protocol — merged ≠ done)

**Who**: tui-coder session, this worktree, HEAD `6ba94f580a271be9b664c1108d7d901ae8cf1c6e`.
**What config**: a REAL `uvicorn.Server` bound to a real loopback socket, serving the real `agui` router, backed by a REAL `AgentRegistry` with 4 declared agents (`default`, `neo`, `coder-smith`, `coder-brown`) and a real factory-built `Session` — mirroring `test_3328_connect_remote_parity_witness.py`'s own real-socket harness (not TestClient — that hung on this box for unrelated ASGI-transport reasons I did not chase down; noting it rather than silently switching tools). A real `httpx.AsyncClient` GET against `/agui/chat/default/events` — **no prior `/attach` of any kind**, matching the owner's actual first-connect scenario. `registry.attached_session()` confirmed `None` immediately before the request.
**What was observed** (raw SSE, first STATE_SNAPSHOT):
```
event: STATE_SNAPSHOT
data: {"snapshot": {"attached_name": "default", "model": "standard",
"agent_names": ["coder-brown", "coder-smith", "default", "neo"],
"session_tree": [{"agent": "coder-brown", ...}, {"agent": "coder-smith", ...},
{"agent": "default", ...}, {"agent": "neo", ...}], ...}}
```
Not `null`. All 4 declared agents present in both `agent_names` and `session_tree`, with nothing globally attached — the exact precondition that produced `None` before this fix.

**Not covered by this live run**: a real browser/TUI client rendering the pane visually (this hits the wire directly, not through `agent_pane_options`/Textual) — that half is unit-tested (the 2 pane tests above) but not exercised live. Naming this rather than claiming more than I checked.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_5094_status_provider_never_none_on_connect.py`
- [x] `python scripts/verify_module_docstrings.py` (touched src files)
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] scoped `pytest` (67 tests across the touched surfaces, green)
- [x] real live-socket verification (see report above)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
