### PR TITLE
docs: the `agent`-alone Declared-in value now has no instance, and 3 places still cite the removed field

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -32,8 +32,11 @@ llm:
   これ）、`project · agent`（エージェント自身の `.reyn/agents/<名前>/
   profile.yaml` にも設定可）、`project · agent · session`（セッション自身の
   `<session-state-dir>/config.yaml` にも設定可）、または `agent` 単独
-  （そもそも project 層に値が存在しないキー — `broker_identity` が該当、
-  #5084 ③-a）。**CI で導出/検査される唯一の列**（下記参照）— ②③が
+  （そもそも project 層に値が存在しないキー）。**`agent` 単独は現在
+  該当キーが 0 件です** — 唯一の実例だった `broker_identity` は #5091 で
+  撤去されました（owner 裁定 —「broker」は外部 MCP サーバであって reyn
+  ランタイムの概念ではない）。語彙に値を残すのは、それが名指す境界事例が
+  実在するからであって、今日そこにキーが居るからではありません。**CI で導出/検査される唯一の列**（下記参照）— ②③が
   「スライスで偽にならない」からではありません（★偽になり得るし実際なった
   — 下記 ⑤ が `Reload` の実測インスタンス）。「この呼び出しが live
   re-read かどうか」は★呼び出し site 自身の性質であり、`_HOT_RELOAD_FILES`
@@ -63,8 +66,8 @@ llm:
 
 **`Declared in` 自身の一次ソース**: `src/reyn/runtime/preferences.py` の
 `PREFERENCE_KEYS`（③ preference 軸、#4206）と、`AgentProfile` の明示的な
-agent 層専用フィールド（`project_context_path`、#5086／`broker_identity`、
-#5085）— `tests/repo/test_config_reference_declared_in_4206.py` がこの表の
+agent 層専用フィールド（`project_context_path`、#5086 — #5091 が
+`broker_identity` を撤去して以降はこれ 1 つ）— `tests/repo/test_config_reference_declared_in_4206.py` がこの表の
 `Declared in` セルを CI でそれらと突き合わせます（[`events.md` 自身の
 doc↔code gate](../runtime/events.md) と同じ形）。あるキーが agent/session
 書き込み能力を得たのに本表が追随していなければ → 赤。

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -34,7 +34,11 @@ cause of #5086/#5088 misreading each other):
   `.reyn/agents/<name>/profile.yaml` may also set it), `project · agent ·
   session` (a session's own `<session-state-dir>/config.yaml` may set it
   too), or `agent` alone (no project-wide value exists for this key at
-  all — `broker_identity` is the one case, #5084 ③-a). **This is the ONE
+  all). **`agent` alone currently has NO instance**: its only one,
+  `broker_identity`, was removed by #5091 (owner ruling — "broker" is an
+  external MCP server, not a reyn-runtime concept). The value stays in the
+  vocabulary because the boundary case it names is real, not because a key
+  occupies it today. **This is the ONE
   column derived/checked in CI** (see below) — NOT because ② and ③ can't
   go stale (they can and do: ⁵ below is a real, measured instance for
   `Reload`), but because "does this call site re-read live?" is a
@@ -69,7 +73,8 @@ the registry when one is added.
 **`Declared in`'s own source of truth**: `PREFERENCE_KEYS` in
 `src/reyn/runtime/preferences.py` (the ③ preference axis, #4206) plus the
 explicit agent-layer-only fields on `AgentProfile`
-(`project_context_path`, #5086; `broker_identity`, #5085) —
+(`project_context_path`, #5086 — the only one since #5091 removed
+`broker_identity`) —
 `tests/repo/test_config_reference_declared_in_4206.py` checks this
 table's `Declared in` cells against them in CI, mirroring
 [`events.md`'s own doc↔code gate](../runtime/events.md). A key gaining

--- a/tests/repo/test_config_reference_declared_in_4206.py
+++ b/tests/repo/test_config_reference_declared_in_4206.py
@@ -24,10 +24,13 @@ from. `Declared in` is the one column this repo currently has a source of
 truth for.
 
 Source of truth: `PREFERENCE_KEYS` (`src/reyn/runtime/preferences.py`, the ③
-preference axis) plus the 2 explicit agent-layer-only `AgentProfile` fields
-(`project_context_path` #5086, `broker_identity` #5085 — `broker_identity`
-itself has no project-wide row in this table at all, per architect's own
-note that it is the `agent`-alone boundary case, so it is not checked here).
+preference axis) plus the ONE explicit agent-layer-only `AgentProfile` field
+(`project_context_path` #5086). There were two: `broker_identity` #5085 was
+removed by #5091 (owner ruling — "broker" is an external MCP server, not a
+reyn-runtime concept), which also emptied the `agent`-alone vocabulary value
+it was the sole instance of. Nothing here checked it (it had no row in the
+table), so its removal did not turn this gate red — the doc prose citing it
+did go stale, which is what #5091's follow-up corrected.
 
 Real file reads throughout (the actual doc, the actual `PREFERENCE_KEYS`
 declaration) — no mocks.


### PR DESCRIPTION
**[lead-coder]** — **私が merge した #5095 が作った doc drift です。私が直します。**

```
🔴 ★私の非 ── ★#5095 を merge する前に「★何を偽にするか」を★引いていません
   ── ★今回は★needle が★簡単でした ── ★`git grep broker_identity -- docs/`
   ── ★1 コマンドで★4 箇所 出ます ── ★私は★走らせませんでした
   ── ⚠️ ★同じ形は★#5081 でもやりました（`docs/reference/cli/agent.md:105` を stale のまま merge）
```

## ✅ 実測（`origin/main`、#5095 後）

```
✅ ★機構は 0 ── `derive_broker_hooks` ／ `_derive_broker_hooks` ── ★定義も呼び口も 0
   ── `broker_hooks.py` ── ★ファイルごと 消えている
✅ ★残っている `broker_identity` の 4 箇所は★★全て 散文（★墓標）
   ── ★これは★消してはいけない側です（architect の指摘、私も同意）
   ── ★消すと★次の人が★同じ欄を 足します
🔴 ★但し ★★2 種類 混ざっていました
   ── ★★(a) 墓標 ──「なぜ無いのか」── ★残す（profile.py:29 ／ session.py:5619）
   ── ★★(b) ★★現在形の主張 ──「★これが該当する」「★2 つ在る」── ★★偽 ── ★本 PR で直す
```

## ✅ 直したもの（★3 面）

| 面 | 何が偽だったか |
|---|---|
| `reyn-yaml.md:37` | 逐語「`broker_identity` **is the one case**」— `agent` 単独の**唯一の実例**として引いていた |
| `reyn-yaml.md:72` ＋ `.ja.md` | 「agent 層専用フィールド **2 つ**」— **1 つ**です |
| gate の module docstring | 同じ主張 |

⚪ **語彙の値そのものは残します** —— **`agent` 単独が名指す境界事例（project 層に値が全く無いキー）は実在**し、将来の agent-scoped な欄はそこに着地します。**偽だったのは「今日そこにキーが居る」の方**です。実測で確認: 表の `Declared in` は **26 `project` ／ 6 `project · agent · session` ／ 1 `project · agent`** で、**`agent` 単独の行は 0**。

🔴 **なぜ CI が緑のままだったか** —— **gate の★コードは `broker_identity` を読んでいません**（表に行が無く、test 関数も無い）。**読んでいたのは★散文だけ** ∴ **撤去は gate を赤にしませんでした。**

## Test plan
- [x] `mkdocs build --strict` / `check_doc_anchors.py` / `check_retired_config_keys_denylist.py`
- [x] `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_tests_path_literal_reference.py`
- [x] `test_tier_audit.py --strict`（Tier 4 違反 0）／ `verify_module_docstrings.py`
- [x] `ruff check .` ／ `mypy_ratchet.py` ／ `flat_tests_ratchet.py`
- [x] `pytest tests/repo/test_config_reference_declared_in_4206.py` — 5 passed
- [x] (skipped — Visual 項目なし)

⚪ **`tests/` は docstring のみの変更**ですが、家則 rule 8 は「触ったか」で見るので **TESTS-READ（B）を待ちます**。assert は 1 行も変えていません。
