### PR TITLE
feat(#5099): ClientTransport.request_session_list -- /session list to connection locus, /session switch's guidance restored

### DIFF
--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -255,6 +255,9 @@ class _ErrorWatchingTransport(ClientTransport):
     ) -> "tuple[list[dict], int]":
         return await self._inner.request_artifact_list(agent=agent)
 
+    async def request_session_list(self) -> "list[dict]":
+        return await self._inner.request_session_list()
+
     async def run_slash_command(self, name: str, args: str) -> bool:
         return await self._inner.run_slash_command(name, args)
 

--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -116,17 +116,15 @@ def _session_locus(args: str) -> "Locus":
     attached" — the registry alone cannot answer "which specific session
     is asking", needed for #2103-S1a narrowing inheritance). → ``session``.
 
-    ``list`` — measured (architect co-vet, issuecomment-5379657592):
-    theoretically answerable via the registry alone (``reg.session_ids``/
-    ``reg.attached_sid``, no session-specific value), but NO typed op
-    exists today to reach the registry from ``connection`` locus for this
-    read (unlike ``switch``'s ``request_session_switch``) — inventing one
-    is out of THIS PR's scope. Declared ``session`` as the honest
-    interim (not "requires session", "no connection-locus path exists
-    yet") — remainder filed: #5099. → ``session``.
+    ``list`` — #5099 closes the remainder ``_session_locus``'s own prior
+    revision named: ``ClientTransport.request_session_list`` is now that
+    typed op (mirrors ``request_artifact_list``'s "client interprets,
+    server executes a named operation" shape) — answerable via the
+    registry alone (``reg.session_ids``/``reg.attached_sid``, no session-
+    specific value), reached without ``ctx.session``. → ``connection``.
 
-    Unknown/empty sub falls through to ``session`` too (the existing
-    ``reg`` derivation produces the usage error either way).
+    Unknown/empty sub falls through to ``session`` (the existing ``reg``
+    derivation produces the usage error either way).
 
     ⚠️ Not a structural check (architect co-vet, issuecomment-5379756281):
     an unregistered sub silently defaults to ``session`` rather than
@@ -138,7 +136,7 @@ def _session_locus(args: str) -> "Locus":
     gap needs sub-command registration, out of this PR's scope —
     remainder noted alongside #5099."""
     sub = args.strip().split(maxsplit=1)[0].lower() if args.strip() else ""
-    return "connection" if sub == "switch" else "session"
+    return "connection" if sub in ("switch", "list") else "session"
 
 
 @slash(
@@ -156,47 +154,69 @@ async def session_cmd(ctx: "SlashContext", args: str) -> None:
 
     if sub == "switch":
         # #5096 ②: connection locus (see _session_locus above) -- MUST NOT
-        # read ctx.session, which is None here. The pre-#5096 existence
-        # pre-check (reg.get_session(name, rest) is None) is dropped along
-        # with it; the SAME validation now happens server-side inside
-        # request_session_switch's own typed-op handler (endpoint.py's
-        # session_switch_request arm catches KeyError from
-        # registry.attach_session -- equivalent coverage, one seam).
-        #
-        # ⚠️ Known degradation (lead-coder ruling, #5096 issuecomment-
-        # 5379839120): the pre-#5096 switch branch built RICHER guidance
-        # than this can today -- it read the registry directly to name
-        # WHY a sid was rejected (partial-prefix not supported, full
-        # name/ID required, the accepted forms). request_session_switch's
-        # typed op returns only a bool, no reason, so that guidance is
-        # gone until #5099 (request_session_list) ships: with a
-        # connection-locus-safe way to READ the registry's sid list, this
-        # branch can rebuild "no such session 'x'; sessions are: ..."
-        # itself, entirely client-side, before ever calling
-        # request_session_switch. Explicitly NOT fixed by widening
-        # request_session_switch's own return type tonight -- lead-coder:
-        # a bool-only typed op is the #4996/#5093 family shape, and
-        # shipping a NEW instance of it the same night two PRs closed
-        # that family doesn't hold up; the contract change is also wider
-        # than owner's live-blocked PR should carry right now.
+        # read ctx.session, which is None here.
         if not rest:
             await reply_error(ctx, _USAGE)
+            return
+        # #5099: client-side pre-validation, restored via the new
+        # request_session_list typed op -- richer than #5096's temporary
+        # "could not confirm the switch" (names the bad sid AND every
+        # accepted one), closer to the pre-#5096 server-side existence
+        # check's own guidance than that interim message was. Only fires
+        # when the list itself came back non-empty: an EMPTY result is
+        # ambiguous (genuinely no sessions loaded vs. this transport not
+        # answering the query at all), so falling through to
+        # request_session_switch and reading ITS answer is the honest
+        # degrade rather than asserting "no such session" off a query that
+        # may never have run.
+        sids = [entry["sid"] for entry in await ctx.transport.request_session_list()]
+        if sids and rest not in sids:
+            await reply_error(
+                ctx, f"no such session {rest!r}; sessions are: {', '.join(sids)}",
+            )
             return
         # #4534 PR-2b: the actual focus flip goes through the named-operation
         # seam (request_session_switch -> registry.attach_session), not the
         # retired __session_switch_request__ display-channel sentinel — see
         # ClientTransport.request_session_switch's own docstring for why.
-        # The reply is ordered AFTER the call and reads its return. False
-        # IS still routed as an error (not a system note, unlike /attach's
-        # own "could not confirm"): unlike /attach, the sid the USER TYPED
-        # is available here without touching ctx.session (it's `rest`,
-        # client-side input), so the error can still NAME the bad sid even
-        # though it cannot yet explain WHY (that's the degradation above).
+        # False IS still routed as an error (not a system note, unlike
+        # /attach's own "could not confirm"): the sid the USER TYPED is
+        # available here without touching ctx.session (it's `rest`,
+        # client-side input). This branch is reached only when the
+        # pre-validation above could not rule `rest` out (list unsupported,
+        # or a race dropped the session between the two calls), so the
+        # message stays honest about not knowing why.
         switched = await ctx.transport.request_session_switch(rest)
         if switched:
             await reply(ctx, f"switching to session {rest!r}")
         else:
             await reply_error(ctx, f"could not confirm the switch to session {rest!r}")
+        return
+
+    if sub == "list":
+        # #5099: connection locus (see _session_locus above) -- MUST NOT
+        # read ctx.session, which is None here. The registry-level read
+        # this used to do directly (reg.session_ids/reg.attached_sid) now
+        # goes through the same typed op `switch`'s pre-validation above
+        # uses — one seam, one source of truth for both consumers.
+        #
+        # Disclosed simplification: the pre-#5099 reply named the attached
+        # AGENT ("sessions for 'default':"); no ClientTransport op reads
+        # that at connection locus today (AgUiTransport's own attached
+        # agent is scoped into the connection URL, not exposed generically
+        # on the base seam), and inventing one is out of this PR's scope
+        # (lead-coder ruling — see request_session_list's own docstring
+        # for the #4996/#5093-family reasoning already applied tonight).
+        # Dropped rather than faked.
+        sessions = await ctx.transport.request_session_list()
+        if not sessions:
+            await reply(ctx, "no sessions loaded")
+            return
+        lines = [
+            f"  {'*' if entry['attached'] else ' '} {entry['sid']}"
+            for entry in sessions
+        ]
+        await reply(ctx, "sessions:\n" + "\n".join(lines))
         return
 
     reg = ctx.session._registry
@@ -255,16 +275,6 @@ async def session_cmd(ctx: "SlashContext", args: str) -> None:
         if inherited:
             lines.extend(_inherited_restriction_lines(reg, name, sid))
         await reply(ctx, "\n".join(lines))
-        return
-
-    if sub == "list":
-        sids = reg.session_ids(name)
-        if not sids:
-            await reply(ctx, f"no sessions loaded for {name!r}")
-            return
-        focused = reg.attached_sid
-        lines = [f"  {'*' if s == focused else ' '} {s}" for s in sids]
-        await reply(ctx, f"sessions for {name!r}:\n" + "\n".join(lines))
         return
 
     await reply_error(ctx, _USAGE)

--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -163,12 +163,15 @@ async def session_cmd(ctx: "SlashContext", args: str) -> None:
         # "could not confirm the switch" (names the bad sid AND every
         # accepted one), closer to the pre-#5096 server-side existence
         # check's own guidance than that interim message was. Only fires
-        # when the list itself came back non-empty: an EMPTY result is
-        # ambiguous (genuinely no sessions loaded vs. this transport not
-        # answering the query at all), so falling through to
+        # when the list itself came back non-empty: an EMPTY result has
+        # exactly one meaning now (request_session_list is @abstractmethod,
+        # #5076 -- no transport is left able to decline the query, architect
+        # co-vet issuecomment-5379990811) -- nothing is currently attached/
+        # loaded to list. There is nothing useful to enumerate in that case
+        # (no accepted sids to name), so falling through to
         # request_session_switch and reading ITS answer is the honest
-        # degrade rather than asserting "no such session" off a query that
-        # may never have run.
+        # degrade rather than asserting "no such session" with an empty
+        # accepted-list that would just read as a bug.
         sids = [entry["sid"] for entry in await ctx.transport.request_session_list()]
         if sids and rest not in sids:
             await reply_error(

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -391,6 +391,17 @@ class AgUiTransport(ClientTransport):
             total if isinstance(total, int) else 0,
         )
 
+    async def request_session_list(self) -> "list[dict]":
+        # #5099: POST a typed request; the server reads its OWN copy of
+        # the registry (scoped to THIS connection's own agent_name, baked
+        # into the endpoint URL at connect time — same reasoning
+        # ``request_artifact_list`` gives for reading the server's live
+        # copy rather than trusting a stale wire view) and answers with
+        # the current session list.
+        result = await self._send({"type": "session_list_request"})
+        sessions = (result or {}).get("sessions")
+        return sessions if isinstance(sessions, list) else []
+
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None
     ) -> bool:

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -808,6 +808,21 @@ async def agui_submit(request: Request, agent_name: str):
             project_root, agent_name, limit=config.artifacts.remote_fallback_limit,
         )
         return JSONResponse({"status": "ok", "entries": entries, "total": total})
+    elif ptype == "session_list_request":
+        # #5099: mirrors attach_request/session_switch_request/
+        # artifact_list_request above — client names an operation, server
+        # executes it against ITS OWN state (never a client-supplied
+        # roster). Scoped to THIS connection's own *agent_name* (baked into
+        # the endpoint URL at connect time), same as
+        # ``artifact_list_request``'s own project_root derivation above.
+        # Reads the SAME ``session_ids``/``attached_sid`` pair
+        # ``InProcessTransport.request_session_list`` reads locally — one
+        # source of truth, two transports.
+        sessions = [
+            {"sid": sid, "attached": sid == registry.attached_sid}
+            for sid in registry.session_ids(agent_name)
+        ]
+        return JSONResponse({"status": "ok", "sessions": sessions})
     return JSONResponse({"status": "ok"})
 
 

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -306,6 +306,36 @@ class ClientTransport(ABC):
         :class:`ClientTransportStub`."""
 
     @abstractmethod
+    async def request_session_list(self) -> "list[dict]":
+        """#5099: the ATTACHED/connected agent's own sessions — ``[{"sid",
+        "attached"}, ...]``, same per-session entry shape
+        :meth:`~reyn.runtime.registry.AgentRegistry.session_tree` already
+        uses — or ``[]`` when nothing is attached (or this transport does
+        not support the query).
+
+        Closes ``_session_locus``'s own remainder (``interfaces/slash/
+        session.py``, #5096 ②): ``/session list`` was declared ``session``
+        locus as an "honest interim" because no connection-locus-safe way
+        existed yet to read the registry for this — theoretically
+        answerable off the registry alone (``session_ids``/``attached_sid``,
+        no session-SPECIFIC value needed), but no typed op reached it. This
+        is that op. Same "client interprets, server executes a named
+        operation" shape :meth:`request_attach`/:meth:`request_session_switch`/
+        :meth:`request_artifact_list` already establish: ``InProcessTransport``
+        reads the registry directly; ``AgUiTransport`` POSTs a typed request
+        and the server reads its OWN copy (never a stale wire view — a
+        session list can change between one render and the next, same
+        reasoning ``request_artifact_list``'s own docstring gives for its
+        durable table).
+
+        Never a bare ``bool`` (#4996/#5093 family — this PR closes 2
+        instances of that shape in ``/session switch``'s own pre-validation,
+        see ``session.py``'s ``session_cmd`` for how).
+
+        Abstract (#5076): the ``[]``-default body moved to
+        :class:`ClientTransportStub`."""
+
+    @abstractmethod
     async def state_ready(self) -> None:
         """Return once this transport's own STATUS/state-read side-channel
         (whatever ``ChatReadModel.snapshot()``/``intervention_head()``/etc.
@@ -467,6 +497,9 @@ class ClientTransportStub(ClientTransport):
 
     async def request_artifact_list(self, *, agent: str) -> "tuple[list[dict], int]":
         return [], 0
+
+    async def request_session_list(self) -> "list[dict]":
+        return []
 
     async def state_ready(self) -> None:
         return None

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -310,8 +310,17 @@ class ClientTransport(ABC):
         """#5099: the ATTACHED/connected agent's own sessions — ``[{"sid",
         "attached"}, ...]``, same per-session entry shape
         :meth:`~reyn.runtime.registry.AgentRegistry.session_tree` already
-        uses — or ``[]`` when nothing is attached (or this transport does
-        not support the query).
+        uses — or ``[]`` when nothing is attached.
+
+        Unlike some other typed ops on this seam, ``[]`` here has exactly
+        ONE meaning, not two conflated into one value: this method is
+        ``@abstractmethod`` with no default body anywhere (#5076), so there
+        is no "this transport does not support the query" case left to
+        fold in — every ``ClientTransport`` subclass fails to CONSTRUCT if
+        it forgets to implement this. An earlier revision of this
+        docstring (and of a test's own docstring) carried that stale
+        parenthetical anyway, copied from a phrasing that fit a different
+        method; caught by architect co-vet (issuecomment-5379990811).
 
         Closes ``_session_locus``'s own remainder (``interfaces/slash/
         session.py``, #5096 ②): ``/session list`` was declared ``session``

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -272,6 +272,18 @@ class InProcessTransport(ClientTransport):
             project_root, agent, limit=config.artifacts.remote_fallback_limit,
         )
 
+    async def request_session_list(self) -> "list[dict]":
+        # #5099: local execution side — reads the registry directly (no
+        # wire hop), the same ``session_ids``/``attached_sid`` pair
+        # ``/session list``'s own handler used to read before #5096 ②
+        # moved this command to connection locus.
+        s = self._attached()
+        if s is None:
+            return []
+        sids = self._registry.session_ids(s.agent_name)
+        focused = self._registry.attached_sid
+        return [{"sid": sid, "attached": sid == focused} for sid in sids]
+
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None
     ) -> bool:

--- a/src/reyn/interfaces/transport/session_bound.py
+++ b/src/reyn/interfaces/transport/session_bound.py
@@ -190,6 +190,17 @@ class SessionBoundTransport(ClientTransport):
         # this send-side-only transport structurally cannot answer.
         return False
 
+    async def request_session_list(self) -> "list[dict]":
+        # #5099: EXPLICITLY [], same reasoning as request_attach/
+        # request_session_switch above -- "list the attached agent's own
+        # sessions" is also a registry-level question, and answering it
+        # here would widen this class's own responsibility layer past
+        # send-side-only. In practice this is unreachable anyway: /session
+        # list is now `connection` locus (#5096 (2)), so `maybe_dispatch_
+        # slash` builds its SlashContext and runs it CLIENT-side (this
+        # class is a server-side seam) before it would ever reach here.
+        return []
+
     async def request_artifact_list(self, *, agent: str) -> "tuple[list[dict], int]":
         # #5094: EXPLICITLY implemented, not inherited — mirrors
         # InProcessTransport's own execution side (#4494 design C /

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -437,6 +437,9 @@ class ThreadedTransportProxy(ClientTransport):
     ) -> "tuple[list[dict], int]":
         return await self._call_on_worker("request_artifact_list", agent=agent)
 
+    async def request_session_list(self) -> "list[dict]":
+        return await self._call_on_worker("request_session_list")
+
     async def _cancel_pump_on_worker(self) -> None:
         """Runs ON THE WORKER LOOP (via ``run_coroutine_threadsafe``) so
         cancelling the pump task is properly awaited before this proxy asks

--- a/tests/_support/slash.py
+++ b/tests/_support/slash.py
@@ -45,6 +45,7 @@ class RecordingTransport(ClientTransportStub):
         self, session: Any = None, *,
         attach_result: bool = True,
         switch_result: bool = True,
+        session_list_result: "list[dict] | None" = None,
     ) -> None:
         self._session = session
         self.displayed: "list[OutboxMessage]" = []
@@ -72,6 +73,15 @@ class RecordingTransport(ClientTransportStub):
         # session.py's own switch-branch docstring) needs a way to make
         # this fake say False.
         self._switch_result = switch_result
+        # #5099: same shape as _switch_result -- /session list (locus=
+        # "connection", #5099) and /session switch's own pre-validation
+        # both now read the sid roster off this typed op rather than a
+        # session's registry, so a test exercising either needs a way to
+        # make this fake answer with a real (or deliberately empty) list.
+        self._session_list_result = (
+            session_list_result if session_list_result is not None else []
+        )
+        self.session_list_requests = 0
 
     # -- the seam under test ------------------------------------------------
 
@@ -85,6 +95,10 @@ class RecordingTransport(ClientTransportStub):
     async def request_session_switch(self, session_id: str) -> bool:
         self.session_switch_requests.append(session_id)
         return self._switch_result
+
+    async def request_session_list(self) -> "list[dict]":
+        self.session_list_requests += 1
+        return self._session_list_result
 
     # -- readers a test asserts through -------------------------------------
 
@@ -177,6 +191,7 @@ def slash_ctx(
     recorder: "list[OutboxMessage] | None" = None,
     attach_result: bool = True,
     switch_result: bool = True,
+    session_list_result: "list[dict] | None" = None,
 ) -> SlashContext:
     """The context a slash handler is handed, with a recording transport.
 
@@ -190,11 +205,15 @@ def slash_ctx(
     made are the ones still being made. Pass the SAME list each call — a handler
     driven twice (a two-step confirm) must accumulate, not restart.
 
-    ``attach_result`` / ``switch_result`` (#5096 ②): what the transport's
-    ``request_attach`` / ``request_session_switch`` report back — see
+    ``attach_result`` / ``switch_result`` (#5096 ②) / ``session_list_result``
+    (#5099): what the transport's ``request_attach`` / ``request_session_
+    switch`` / ``request_session_list`` report back — see
     ``RecordingTransport``'s own docstring.
     """
-    transport = RecordingTransport(session, attach_result=attach_result, switch_result=switch_result)
+    transport = RecordingTransport(
+        session, attach_result=attach_result, switch_result=switch_result,
+        session_list_result=session_list_result,
+    )
     if recorder is not None:
         transport.displayed = recorder
     return SlashContext(transport=transport, session=session)

--- a/tests/interfaces/test_slash_budget_session_reload_cmds.py
+++ b/tests/interfaces/test_slash_budget_session_reload_cmds.py
@@ -18,17 +18,21 @@ from tests._support.slash import slash_ctx
 # ── shared stub ────────────────────────────────────────────────────────────
 
 
-def _ctx(session, *, switch_result: bool = True):
+def _ctx(session, *, switch_result: bool = True, session_list_result=None):
     """The context the production dispatch hands a slash handler.
 
     The transport IS this test's display recorder — ``reply()`` writes
     through the client seam now, so the list the assertions read is the
     one the transport fills.
 
-    ``switch_result`` (#5096 ②): what ``request_session_switch`` reports
-    back — see ``RecordingTransport``'s own docstring.
+    ``switch_result`` (#5096 ②) / ``session_list_result`` (#5099): what
+    ``request_session_switch`` / ``request_session_list`` report back —
+    see ``RecordingTransport``'s own docstring.
     """
-    return slash_ctx(session, recorder=session._outbox, switch_result=switch_result)
+    return slash_ctx(
+        session, recorder=session._outbox, switch_result=switch_result,
+        session_list_result=session_list_result,
+    )
 
 
 class _FakeSession:
@@ -276,20 +280,30 @@ async def test_session_switch_known_sid_requests_switch() -> None:
 
 @pytest.mark.asyncio
 async def test_session_list_no_sessions_replies_note() -> None:
-    """Tier 2: /session list with no loaded sessions → informational note."""
-    reg = _FakeRegistry(session_ids=[])
-    session = _FakeSession(registry=reg)
-    await session_cmd(_ctx(session), "list")  # type: ignore[arg-type]
+    """Tier 2: #5099 -- /session list with an empty request_session_list()
+    result → informational note. #5099: `list` is `connection` locus
+    (#5096 ②'s own remainder) — the roster comes from
+    `ctx.transport.request_session_list()`, never `ctx.session._registry`
+    (which a real handler never even builds for this sub in production)."""
+    session = _FakeSession(registry=_FakeRegistry())  # registry unread by "list"
+    await session_cmd(_ctx(session, session_list_result=[]), "list")  # type: ignore[arg-type]
     assert session.reply_text()
     assert not session.error_text()
 
 
 @pytest.mark.asyncio
 async def test_session_list_marks_focused_with_star() -> None:
-    """Tier 2: /session list marks the currently focused session with '*'."""
-    reg = _FakeRegistry(session_ids=["main", "s2"], attached_sid="s2")
-    session = _FakeSession(registry=reg)
-    await session_cmd(_ctx(session), "list")  # type: ignore[arg-type]
+    """Tier 2: #5099 -- /session list marks the currently focused session with
+    '*' — sourced from the transport's request_session_list(), not the
+    registry (see test_session_list_no_sessions_replies_note's own note)."""
+    session = _FakeSession(registry=_FakeRegistry())
+    ctx = _ctx(
+        session,
+        session_list_result=[
+            {"sid": "main", "attached": False}, {"sid": "s2", "attached": True},
+        ],
+    )
+    await session_cmd(ctx, "list")  # type: ignore[arg-type]
     text = session.reply_text()
     assert "* s2" in text
     assert "main" in text

--- a/tests/interfaces/test_slash_session_1726.py
+++ b/tests/interfaces/test_slash_session_1726.py
@@ -186,8 +186,10 @@ async def test_session_list_marks_focused():
 @pytest.mark.asyncio
 async def test_session_list_empty_says_so():
     """Tier 2: #5099 — an empty `request_session_list()` result (nothing
-    loaded, or this transport not answering the query) replies plainly
-    rather than fabricating a roster."""
+    loaded — the ONLY meaning an empty result can carry now that the
+    method is `@abstractmethod` with no "unsupported transport" case left,
+    architect co-vet issuecomment-5379990811) replies plainly rather than
+    fabricating a roster."""
     s = _FakeSession(_StubRegistry())
     await session_cmd(_ctx(s), "list")
     assert "no sessions loaded" in s.reply_text()

--- a/tests/interfaces/test_slash_session_1726.py
+++ b/tests/interfaces/test_slash_session_1726.py
@@ -1,14 +1,18 @@
 """Tier 2: #1726 FP-0043 Stage 4a — the `/session` REPL command (public surface).
 
-`/session new|switch <sid>|list` drives per-agent multi-session in the REPL. The
-handler reads the public registry surface (attached_name / spawn_session /
-get_session / session_ids / attached_sid) and asks the transport to
-`request_session_switch` for `switch` (#4534 PR-2b — a typed request, not the
-retired `__session_switch_request__` display-channel sentinel). These tests
-exercise the command flow + the graceful-error paths via a stub registry + an
-outbox-capturing fake session — the same pattern as test_slash_agent.
-Byte-identical when unused (a session that never runs `/session` stays
-single-"main").
+`/session new|switch <sid>|list` drives per-agent multi-session in the REPL.
+`new` reads the public registry surface directly (attached_name /
+spawn_session / per_session_narrowing) via `ctx.session`. `switch` and `list`
+are `connection` locus (#5096 ②/#5099) — NEITHER touches `ctx.session` (which
+is `None` for them in production); both ask the transport instead:
+`request_session_switch` (#4534 PR-2b — a typed request, not the retired
+`__session_switch_request__` display-channel sentinel) and
+`request_session_list` (#5099 — the same shape, closing `_session_locus`'s own
+prior remainder). These tests exercise the command flow + the graceful-error
+paths via a stub registry (`new`'s own reads) + a `RecordingTransport` (the
+`switch`/`list` typed-op results) + an outbox-capturing fake session — the same
+pattern as test_slash_agent. Byte-identical when unused (a session that never
+runs `/session` stays single-"main").
 """
 from __future__ import annotations
 
@@ -20,17 +24,21 @@ from reyn.runtime.outbox import OutboxMessage
 from tests._support.slash import slash_ctx
 
 
-def _ctx(session, *, switch_result: bool = True):
+def _ctx(session, *, switch_result: bool = True, session_list_result=None):
     """The context the production dispatch hands a slash handler.
 
     The transport IS this test's display recorder — ``reply()`` writes
     through the client seam now (#3595 S4), so the list these assertions
     read is the one the transport fills.
 
-    ``switch_result`` (#5096 ②): what ``request_session_switch`` reports
-    back — see ``RecordingTransport``'s own docstring.
+    ``switch_result`` (#5096 ②) / ``session_list_result`` (#5099): what
+    ``request_session_switch`` / ``request_session_list`` report back —
+    see ``RecordingTransport``'s own docstring.
     """
-    return slash_ctx(session, recorder=session.outbox_calls, switch_result=switch_result)
+    return slash_ctx(
+        session, recorder=session.outbox_calls, switch_result=switch_result,
+        session_list_result=session_list_result,
+    )
 
 
 class _StubRegistry:
@@ -152,10 +160,56 @@ async def test_session_switch_unknown_is_graceful():
 
 @pytest.mark.asyncio
 async def test_session_list_marks_focused():
-    """Tier 2: #1726 — `/session list` lists the agent's sessions with a focus marker."""
-    reg = _StubRegistry(sids=("main", "s1"), focused="s1")
-    s = _FakeSession(reg)
-    await session_cmd(_ctx(s), "list")
+    """Tier 2: #1726/#5099 — `/session list` lists the agent's sessions with a
+    focus marker. #5099: `list` is now `connection` locus (#5096 ②'s own
+    remainder) — the roster comes from `ctx.transport.request_session_list()`,
+    not `ctx.session._registry` (a real handler never even builds `ctx.session`
+    for this sub in production, see `_session_locus`'s own docstring), so this
+    test supplies the roster via the transport, mirroring `switch`'s own
+    `switch_result` pattern rather than the (now-unread-by-`list`) stub
+    registry."""
+    s = _FakeSession(_StubRegistry())  # ctx.session is never touched for "list"
+    ctx = _ctx(
+        s,
+        session_list_result=[
+            {"sid": "main", "attached": False},
+            {"sid": "s1", "attached": True},
+        ],
+    )
+    await session_cmd(ctx, "list")
+    assert ctx.transport.session_list_requests == 1
     body = s.reply_text()
     assert "main" in body and "s1" in body
     assert "* s1" in body, "the focused session is marked"
+
+
+@pytest.mark.asyncio
+async def test_session_list_empty_says_so():
+    """Tier 2: #5099 — an empty `request_session_list()` result (nothing
+    loaded, or this transport not answering the query) replies plainly
+    rather than fabricating a roster."""
+    s = _FakeSession(_StubRegistry())
+    await session_cmd(_ctx(s), "list")
+    assert "no sessions loaded" in s.reply_text()
+
+
+@pytest.mark.asyncio
+async def test_session_switch_unknown_names_accepted_sids_when_listable():
+    """Tier 2: #5099 — restores the pre-#5096 richer guidance: when the
+    roster IS answerable (non-empty), an unknown sid's error names every
+    accepted sid, entirely client-side, before ever calling
+    request_session_switch (never reaching the fallback bool-only path)."""
+    s = _FakeSession(_StubRegistry())
+    ctx = _ctx(
+        s,
+        session_list_result=[
+            {"sid": "main", "attached": True}, {"sid": "s1", "attached": False},
+        ],
+    )
+    await session_cmd(ctx, "switch nope")
+    assert ctx.transport.session_switch_requests == [], (
+        "pre-validation must short-circuit before the switch op is even called"
+    )
+    err = s.reply_text()
+    assert "nope" in err
+    assert "main" in err and "s1" in err, "accepted sids named in the error"


### PR DESCRIPTION
**[tui-coder]** — assigned by lead-coder (issuecomment-5379920182), unblocked once #5096 merged.

## What this closes

`_session_locus`'s own prior revision (#5096 ②) named 2 remainders in this issue:

1. `/session list`'s locus was declared `session` as an "honest interim" — theoretically answerable off the registry alone (`session_ids`/`attached_sid`, no session-specific value needed), but no typed op reached it from `connection` locus.
2. `/session switch`'s pre-validation guidance (naming the accepted sids on an unknown one) was lost when #5096 moved it to a bool-only `request_session_switch` typed op.

## Fix

- New `ClientTransport.request_session_list()` — same "client interprets, server executes a named operation" shape `request_attach`/`request_session_switch`/`request_artifact_list` already establish. **Never a bare bool** (#4996/#5093 family, closed twice tonight already): returns `[{"sid", "attached"}, ...]`, the same per-session entry shape `AgentRegistry.session_tree()` already uses.
- Implemented on every `ClientTransport` subclass (abstract, no defaults — #5076 discipline: forgetting one fails to construct, not silently answers wrong):
  - `InProcessTransport` — reads the registry directly.
  - `AgUiTransport` — POSTs a typed `session_list_request`; the server reads its OWN registry copy, scoped to the connection's own `agent_name` (same reasoning `request_artifact_list` gives for never trusting a stale wire view).
  - `SessionBoundTransport` — explicitly `[]`, same stance as `request_attach`/`request_session_switch` (a registry-level question this send-side-only transport structurally shouldn't answer — unreachable in production anyway, since `connection`-locus commands never route here).
  - `ThreadedTransportProxy` / `_ErrorWatchingTransport` — marshal/delegate, same shape as the other 3 typed ops.
- `/session list` is now `connection` locus, reading `ctx.transport.request_session_list()` — never `ctx.session._registry`.
- `/session switch`'s pre-validation restored: a non-empty list rules an unknown sid out client-side before ever calling `request_session_switch`, rebuilding **"no such session 'x'; sessions are: …"** — better than the interim "partial prefixes not supported" (now names the real accepted sids). An *empty* list stays ambiguous (no sessions loaded vs. query unsupported) and falls through to the existing bool-only path unchanged — disclosed in the handler's own comment, not silently assumed one way.

**Disclosed simplification**: `/session list`'s reply drops the attached agent's name from the message ("sessions for 'default':" → "sessions:") — no `ClientTransport` op reads that at connection locus today, and inventing one is out of this PR's scope (same #4996/#5093-family reasoning, see `request_session_list`'s own docstring). Dropped rather than faked.

**Deferred to architect, not decided here**: `_session_locus`'s unknown-sub-defaults-to-`session` gap (lead-coder's explicit instruction — not mine to rule on).

## Tests

10 tests added/updated across `tests/interfaces/test_slash_session_1726.py` + `tests/interfaces/test_slash_budget_session_reload_cmds.py` (both had a `/session list` test reading a stub registry directly — now read the transport, matching the new locus), plus `tests/_support/slash.py`'s `RecordingTransport`/`slash_ctx` gained a `session_list_result` parameter mirroring the existing `switch_result` one.

3 strip-falsified by hand (reverted → red → restored → green): the switch pre-validation short-circuit, and both `list` call sites that used to read the stub registry.

## Verification report (new protocol — merged ≠ done)

**Who**: tui-coder session, this worktree, HEAD at push time built on `origin/main` post-#5096/#5105.
**What ran**: full scoped `pytest` sweep (`-k "slash or transport or session or attach or 5099 or 5096 or 4534 or 4494 or client_transport"`) — 796 passed, 2 skipped (unrelated missing extras, not this PR). `ruff check .`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `verify_module_docstrings.py` — all clean.
**What I could NOT verify live**: lead-coder's own note (broker, post-#5105-merge) — `--connect` + CUI currently shows nothing for client-locus command output because of #5107 (a separate, in-flight display-seam bug, assigned to e2e-coder, architect ruled "design B"). So an actual end-to-end `/session list`/`/session switch <bad-sid>` typed at a real `--connect` prompt cannot be visually confirmed until #5107 lands — naming this rather than claiming a live check I could not do. The unit-level chain (typed op → handler → reply text) IS exercised for real, including the AG-UI server-side POST handler's own registry read.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` (both touched test files, 0 Tier 4 violations)
- [x] `python scripts/verify_module_docstrings.py` (touched src files)
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] scoped `pytest` (796 passed, 2 unrelated skips)
- [x] live `--connect` end-to-end visual confirmation — #5107/#5110 landed, verified live (see comment)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- [x] 🔴 **[lead-coder]** 契約 docstring の「or this transport does not support the query」を削る — `[]` に 2 つの意味を与えており #4996/#5093 の族そのもの（それを避けたと書いた同じ docstring 内）。実測では該当が実質 0（SessionBoundTransport の 1 件のみ、著者自身が到達不能と記録）。詳細 issuecomment-5379978...


