### PR TITLE
fix(#5107): AgUiTransport.put_display renders locally, contract-first

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6365,31 +6365,34 @@ class TextualChatApp(App):
         #5001: appends directly via :meth:`_ingest_frame`, NOT ``self.
         _transport.put_display(...)``. This is a client-authored notice
         ABOUT this client's own composer state — it was never something the
-        server's outbox needed to carry, and routing it through the
-        transport seam meant ``AgUiTransport.put_display``'s no-op (a
-        CORRECT no-op — a remote client cannot inject into the server's
-        outbox) silently dropped this specific sentence on a remote client,
-        while the header's own connecting/failed STATE (read straight off
-        ``has_session()``/``attach_failed()``, independent of this method)
-        kept rendering — which is exactly why the gap went unnoticed: the
-        state looked fine. ``_ingest_frame`` is the SAME local-model append
-        both an in-process AND a remote client already use elsewhere for
-        purely client-side notices, so this now takes one path regardless
-        of transport, matching what ``AgUiTransport.put_display``'s own
-        docstring already claims for "client-authored echoes" — which
-        wasn't true for this call site until now.
+        server's outbox needed to carry.
+
+        ⚠️ Historical note (#5107 correction): at the time this call site
+        was written, ``AgUiTransport.put_display`` was an unconditional
+        no-op — routing through it would have silently dropped this
+        sentence on a remote client, which is why ``_ingest_frame`` was
+        chosen instead. #5107 (architect ruling B) fixed that no-op —
+        ``put_display`` now genuinely renders on this client's own face —
+        so the ORIGINAL reason to bypass it no longer holds. The bypass
+        stays anyway, for the separate, still-valid reason below
+        (immediacy vs FIFO ordering) — this is a decision that has kept
+        its conclusion but lost its original justification, worth naming
+        so nobody re-derives the wrong reason for it later.
 
         Ordering trade, stated on purpose (architect co-vet on #5004): the
-        OLD ``put_display`` path queued this notice on ``repl_outbox``,
-        landing "in FIFO order with the session's own output" (that
-        method's own docstring, verbatim). Appending via ``_ingest_frame``
-        is IMMEDIATE — it can now land ahead of any session output already
-        sitting in that outbox at the moment Enter was blocked. Deliberate:
-        this notice is about THIS client's own composer state right now,
-        not a delta from the session, so immediate is the right answer,
-        not a regression to paper over — but it IS a real position change,
-        named here so a future ordering-bug hunt doesn't rule this call
-        site out."""
+        OLD ``put_display`` path (pre-#5107, on ``InProcessTransport`` —
+        the only implementation this app used before AG-UI could carry it
+        too) queued this notice on ``repl_outbox``, landing "in FIFO order
+        with the session's own output" (that transport's own docstring,
+        verbatim — see ``ClientTransport.put_display``'s own docstring,
+        #5107, for why that guarantee was never part of the CONTRACT).
+        Appending via ``_ingest_frame`` is IMMEDIATE — it can now land
+        ahead of any session output already sitting in that outbox at the
+        moment Enter was blocked. Deliberate: this notice is about THIS
+        client's own composer state right now, not a delta from the
+        session, so immediate is the right answer, not a regression to
+        paper over — but it IS a real position change, named here so a
+        future ordering-bug hunt doesn't rule this call site out."""
         if self._transport.attach_failed():
             text = "attach failed (see log) — your message was kept; retry once resolved"
         else:
@@ -6441,7 +6444,8 @@ class TextualChatApp(App):
         own submit attempt, never something the server's outbox needed to
         carry, so routing it through the transport seam meant a remote
         client silently lost it to ``AgUiTransport.put_display``'s
-        no-op)."""
+        no-op — fixed since, #5107, but this call site's OWN reason to
+        bypass it stands independent of that fix)."""
         try:
             from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
             if await maybe_dispatch_slash(self._transport, text):

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -225,13 +225,27 @@ class AgUiTransport(ClientTransport):
         no-op invisible rather than merely delayed).
 
         ALWAYS enqueues :data:`_SSE_DONE` on the way out (``finally``),
-        whichever of the 3 exits it takes — the ``__end__`` DisplayFrame
+        whichever of the 4 exits it takes — the ``__end__`` DisplayFrame
         (normal production shutdown), the source running dry with no
-        ``__end__`` (every finite test double), or a raised exception
-        (connection drop). Without this, :meth:`frames` — which now waits
-        on the shared queue rather than driving ``self._sse_lines``
-        itself — has no way to learn "no more SSE frames are coming" and
-        would hang forever on ``await self._display_queue.get()``.
+        ``__end__`` (every finite test double), a raised exception
+        (connection drop), OR :meth:`close` cancelling this task (a
+        ``CancelledError`` still runs ``finally``). Without this,
+        :meth:`frames` — which now waits on the shared queue rather than
+        driving ``self._sse_lines`` itself — has no way to learn "no more
+        SSE frames are coming" and would hang forever on
+        ``await self._display_queue.get()``.
+
+        ``put_nowait``, not ``await put`` (architect co-vet,
+        issuecomment-5380005757): this queue is unbounded today, so
+        ``await put(...)`` never actually suspends — but that is an
+        accident of the current ``maxsize``, not a guarantee this method
+        can lean on. Under cancellation (the 4th exit above), an ``await``
+        inside ``finally`` IS a real suspension point a future bounded
+        queue could get cancelled AT, before the sentinel ever lands —
+        silently breaking the "ALWAYS" this docstring promises.
+        ``put_nowait`` cannot be interrupted mid-call, so the sentinel
+        genuinely always lands, regardless of what ``self._display_queue``
+        becomes later.
         """
         try:
             block: list[str] = []
@@ -263,7 +277,7 @@ class AgUiTransport(ClientTransport):
                     await suspend_between_frames()  # #3570, same reason as above
                     await self._display_queue.put(frame)
         finally:
-            await self._display_queue.put(_SSE_DONE)
+            self._display_queue.put_nowait(_SSE_DONE)
 
     async def frames(self) -> "AsyncIterator[Frame]":
         # Started lazily, once, on first iteration (production calls this

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -47,6 +47,17 @@ from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, Frame
 if TYPE_CHECKING:
     from pathlib import Path
 
+# #5107: the sentinel :meth:`AgUiTransport._pump_sse` enqueues on its own
+# way out (any of its 3 exits — the source running dry, an ``__end__``
+# DisplayFrame, or a raised exception) so :meth:`AgUiTransport.frames`
+# — which now waits on a shared queue instead of driving the SSE source
+# itself — can tell "no more SSE frames are coming" apart from "the queue
+# is just momentarily empty" and stop instead of hanging forever. A
+# module-level ``object()`` rather than ``None``: a locally-authored
+# ``put_display`` call could in principle wrap a falsy/None-ish payload,
+# and this must never be confused with one.
+_SSE_DONE = object()
+
 
 class AgUiTransport(ClientTransport):
     """Decode a server AG-UI SSE stream into the renderer's ``Frame`` vocabulary."""
@@ -75,6 +86,15 @@ class AgUiTransport(ClientTransport):
         # :meth:`state_ready`'s own docstring (on the base class) for why
         # this is a separate axis from :meth:`frames`.
         self._state_ready_event = asyncio.Event()
+        # #5107 (architect ruling B, issuecomment-5379950484): the merge
+        # point between two frame producers — the SSE pump (server-sent
+        # display, below) and :meth:`put_display` (CLIENT-authored display:
+        # a slash reply, an echo, an unknown-command note). Both feed the
+        # SAME queue :meth:`frames` drains, so a locally-authored message
+        # renders through the identical renderer path a server-sent one
+        # does, without waiting on the next SSE event to unblock it.
+        self._display_queue: "asyncio.Queue[Frame | object]" = asyncio.Queue()
+        self._sse_pump_task: "asyncio.Task[None] | None" = None
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -88,6 +108,13 @@ class AgUiTransport(ClientTransport):
 
     def close(self) -> None:
         self._connected = False
+        # #5107: the SSE pump (started lazily by :meth:`frames`) is a
+        # background task now, not inline in the caller's own loop — it
+        # must be told to stop rather than leaking past this transport's
+        # own lifetime (most visible in tests: many short-lived transports
+        # constructed in one process).
+        if self._sse_pump_task is not None:
+            self._sse_pump_task.cancel()
 
     # -- status side-channel ------------------------------------------------
 
@@ -185,35 +212,83 @@ class AgUiTransport(ClientTransport):
                 out.append(self._reguard_frame(decoded))
         return out
 
+    async def _pump_sse(self) -> None:
+        """Decode ``self._sse_lines`` and feed each frame into the shared
+        display queue — the SAME queue :meth:`put_display` feeds (#5107).
+
+        This is the pre-#5107 body of :meth:`frames` itself, moved
+        verbatim into a background task rather than driven inline: a
+        locally-authored :meth:`put_display` call must be able to reach
+        the renderer WITHOUT waiting on the next SSE line to unblock the
+        ``async for`` below (the SSE stream is frequently idle between
+        server events — that idle wait is exactly what made the pre-#5107
+        no-op invisible rather than merely delayed).
+
+        ALWAYS enqueues :data:`_SSE_DONE` on the way out (``finally``),
+        whichever of the 3 exits it takes — the ``__end__`` DisplayFrame
+        (normal production shutdown), the source running dry with no
+        ``__end__`` (every finite test double), or a raised exception
+        (connection drop). Without this, :meth:`frames` — which now waits
+        on the shared queue rather than driving ``self._sse_lines``
+        itself — has no way to learn "no more SSE frames are coming" and
+        would hang forever on ``await self._display_queue.get()``.
+        """
+        try:
+            block: list[str] = []
+            async for raw in self._sse_lines:
+                line = raw.rstrip("\n")
+                if line == "":
+                    if block:
+                        for frame in self._consume_block(block):
+                            # #3570, same property as ``InProcessTransport.frames``:
+                            # one SSE block decodes to MANY frames (a MESSAGES_SNAPSHOT
+                            # reconnect alone carries the whole backlog) and this inner
+                            # loop has no await of its own, while ``aiter_lines`` over a
+                            # buffered read returns without suspending either. Without
+                            # this line whether the loop breathes is a function of how
+                            # much the server packed into one block.
+                            await suspend_between_frames()
+                            await self._display_queue.put(frame)
+                            if (
+                                isinstance(frame, DisplayFrame)
+                                and frame.message.kind == "__end__"
+                            ):
+                                return
+                        block = []
+                    continue
+                block.append(line)
+            # Flush a trailing block with no terminal blank line.
+            if block:
+                for frame in self._consume_block(block):
+                    await suspend_between_frames()  # #3570, same reason as above
+                    await self._display_queue.put(frame)
+        finally:
+            await self._display_queue.put(_SSE_DONE)
+
     async def frames(self) -> "AsyncIterator[Frame]":
-        block: list[str] = []
-        async for raw in self._sse_lines:
-            line = raw.rstrip("\n")
-            if line == "":
-                if block:
-                    for frame in self._consume_block(block):
-                        # #3570, same property as ``InProcessTransport.frames``:
-                        # one SSE block decodes to MANY frames (a MESSAGES_SNAPSHOT
-                        # reconnect alone carries the whole backlog) and this inner
-                        # loop has no await of its own, while ``aiter_lines`` over a
-                        # buffered read returns without suspending either. Without
-                        # this line whether the loop breathes is a function of how
-                        # much the server packed into one block.
-                        await suspend_between_frames()
-                        yield frame
-                        if (
-                            isinstance(frame, DisplayFrame)
-                            and frame.message.kind == "__end__"
-                        ):
-                            return
-                    block = []
-                continue
-            block.append(line)
-        # Flush a trailing block with no terminal blank line.
-        if block:
-            for frame in self._consume_block(block):
-                await suspend_between_frames()  # #3570, same reason as above
-                yield frame
+        # Started lazily, once, on first iteration (production calls this
+        # exactly once per connection — grepped, #5107 co-vet) rather than
+        # in ``__init__``/``start``: an event loop may not be running yet
+        # at construction time, and ``asyncio.create_task`` requires one.
+        if self._sse_pump_task is None:
+            self._sse_pump_task = asyncio.create_task(self._pump_sse())
+        while True:
+            frame = await self._display_queue.get()
+            if frame is _SSE_DONE:
+                return
+            # #3570 gate (test_stream_drain_yield_3570.py's own class gate):
+            # ``queue.get()`` suspends only while the queue is EMPTY — a
+            # burst already sitting in the queue (several ``_pump_sse``
+            # frames from one SSE block, or several rapid ``put_display``
+            # calls) would otherwise hand every ``yield`` to the consumer
+            # with the event loop never running in between. Paired here,
+            # not just in ``_pump_sse`` (which no longer yields at all, so
+            # its own copy doesn't satisfy this gate) — this is the seam
+            # this transport's ``frames()`` actually yields THROUGH now.
+            await suspend_between_frames()
+            yield frame
+            if isinstance(frame, DisplayFrame) and frame.message.kind == "__end__":
+                return
 
     # -- send side ----------------------------------------------------------
 
@@ -350,9 +425,17 @@ class AgUiTransport(ClientTransport):
         return bool(accepted)
 
     def put_display(self, msg) -> None:
-        # A remote client cannot inject into the server's outbox; client-authored
-        # echoes render locally through the renderer, not this seam. No-op here.
-        return None
+        # #5107 (architect ruling B, issuecomment-5379950484; lead-coder's
+        # contract-first correction, issuecomment-5379955824): the contract
+        # (ClientTransport.put_display's own docstring) only ever asked for
+        # "show it on this client's own face" -- this transport CAN satisfy
+        # that; a remote client genuinely cannot inject into the SERVER's
+        # own outbox (a different, stronger claim the old docstring here
+        # made, which was never this method's job to satisfy). Feeds the
+        # SAME queue the SSE-sourced frames merge into (self._pump_sse) so
+        # a slash reply / echo / unknown-command note renders through the
+        # identical renderer path a server-sent message does.
+        self._display_queue.put_nowait(DisplayFrame(msg))
 
     async def cancel_inflight(self) -> str:
         # #3903: fire-and-forget over the wire (no response frame in this

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -161,8 +161,23 @@ class ClientTransport(ABC):
 
     @abstractmethod
     def put_display(self, msg: "OutboxMessage") -> None:
-        """Inject a client-authored display message (user echo, /copy result, …)
-        into the display stream, in order with the session's own output."""
+        """Show a client-authored display message (user echo, /copy result,
+        a slash reply, …) **on this client's own face** — never a promise
+        of injecting into the session's transcript/outbox, which not every
+        implementation can reach (#5107, lead-coder correction of this
+        docstring's own prior wording: "in order with the session's own
+        output" claimed a stronger guarantee — ALL surfaces, transcript-
+        order — than a remote transport can structurally satisfy, which is
+        what made a no-op look like the "honest" answer for one; the
+        contract was asking for something unsatisfiable, not the
+        implementation being lazily wrong).
+
+        ``InProcessTransport``/``SessionBoundTransport`` happen to satisfy
+        this by routing into the session's own outbox (every OTHER
+        attached surface sees it too, in FIFO order) — that is a property
+        of THEIR implementation, not a requirement THIS contract states.
+        ``AgUiTransport`` satisfies it by rendering locally only, on the
+        one face this client itself is."""
 
     @abstractmethod
     async def cancel_inflight(self) -> str:

--- a/tests/interfaces/test_5001_remote_notice_delivery.py
+++ b/tests/interfaces/test_5001_remote_notice_delivery.py
@@ -5,16 +5,24 @@ Both ``TextualChatApp._notify_blocked_on_attach`` (the "still connecting" /
 "attach failed" detail sentence shown when Enter is blocked) and
 ``TextualChatApp._submit``'s exception path (the "input could not be
 submitted: ..." error) used to route through ``self._transport.
-put_display(...)``. ``AgUiTransport.put_display`` is a CORRECT no-op — a
-remote client cannot inject into the server's outbox (#4996③'s own
-falsified design attempt tried to declare this as a "capability" and was
-rejected: nobody read the declaration, since both call sites discarded
-their own outcome already). The real defect was the CALL, not the no-op:
-both notices are entirely CLIENT-SIDE — about THIS client's own composer/
-submit attempt — and never needed the server's outbox at all. The fix
-(architect, #5001) routes them through ``_ingest_frame`` instead, the SAME
-local-model append both an in-process and a remote client already use for
-other purely client-side rows — one path, no transport branch.
+put_display(...)``. At the time this fix was written, ``AgUiTransport.
+put_display`` was an unconditional no-op — a remote client cannot inject
+into the SERVER's own outbox (#4996③'s own falsified design attempt
+tried to declare this as a "capability" and was rejected: nobody read the
+declaration, since both call sites discarded their own outcome already).
+★#5107 correction: that no-op is GONE now — ``put_display`` renders on
+THIS client's own face, which the contract (``ClientTransport.
+put_display``'s own docstring) only ever actually asked for; "inject into
+the server's outbox" was never the real requirement, just what the old
+no-op's own comment (wrongly) argued against. This module's own fix
+still stands on ITS OWN merits though (see ``_notify_blocked_on_attach``'s
+docstring in app.py for the #5107-updated account): both notices are
+entirely CLIENT-SIDE — about THIS client's own composer/submit attempt —
+so routing them through ``_ingest_frame`` is the right call regardless of
+whether ``put_display`` also works now. The fix (architect, #5001) routes
+them through ``_ingest_frame`` instead, the SAME local-model append both
+an in-process and a remote client already use for other purely
+client-side rows — one path, no transport branch.
 
 **Why the header's own "connecting"/"failed" STATE is not enough to catch
 this bug** (architect's own framing): the header reads ``has_session()``/

--- a/tests/interfaces/test_5107_agui_put_display_local_render.py
+++ b/tests/interfaces/test_5107_agui_put_display_local_render.py
@@ -1,0 +1,101 @@
+"""Tier 2: #5107, architect ruling B (issuecomment-5379950484) —
+``AgUiTransport.put_display`` renders a client-authored slash reply
+locally (through the SAME queue :meth:`AgUiTransport.frames` yields
+from), instead of the pre-#5107 no-op that silently dropped it.
+
+lead-coder's contract-first correction (issuecomment-5379955824):
+``ClientTransport.put_display``'s own docstring only ever asked for
+"show it on this client's own face" — the pre-#5107 no-op's stated
+justification ("a remote client cannot inject into the server's
+outbox") answered a DIFFERENT, stronger claim the docstring never
+actually made. Fixed contract-first (this module's own sibling,
+``client_transport.py``), then the implementation.
+
+Two witnesses, per lead-coder's own discriminator: ① alone (a
+success-shaped reply, ``/help``) would stay green for an implementation
+wired ONLY for the happy path; ② (``/attach`` to a name the server
+rejects) exercises the FAILURE branch too. Both strip-falsified below:
+reverting :meth:`AgUiTransport.put_display` to the pre-#5107 no-op
+turns BOTH red.
+
+Real ``AgUiTransport`` (constructed directly, a real, minimal
+``sse_lines``/``send`` pair — the same shape ``test_5001_remote_notice_
+delivery.py`` and ``test_3310_n3_remote_switch_parity.py`` already use)
++ the real ``maybe_dispatch_slash``/slash registry — no mocks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+
+
+async def _empty_sse_lines():
+    return
+    yield  # pragma: no cover - makes this an async generator, never reached
+
+
+async def _drain_display_texts(transport: AgUiTransport) -> "list[str]":
+    """Every ``DisplayFrame`` text ``frames()`` yields before the (empty,
+    test-only) SSE source naturally exhausts and the generator returns."""
+    out: list[str] = []
+    async for frame in transport.frames():
+        if isinstance(frame, DisplayFrame):
+            out.append(frame.message.text)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_help_reply_reaches_a_real_remote_transport() -> None:
+    """Tier 2: #5107 witness ① — ``/help`` (client-locus) is dispatched
+    BEFORE ``frames()`` is ever iterated, so its ``put_display`` calls are
+    already sitting in the transport's own display queue (FIFO, ahead of
+    the empty SSE source's own eventual end-of-stream marker) by the time
+    ``frames()`` starts draining — deterministic, no race against the
+    empty test source's own near-instant exhaustion."""
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_empty_sse_lines(), _noop_send, connected=True)
+
+    consumed = await maybe_dispatch_slash(transport, "/help", echo=False)
+    assert consumed is True
+
+    texts = await _drain_display_texts(transport)
+    assert any(texts), (
+        "‥/help must produce at least one non-empty display line over a "
+        f"real AgUiTransport; got {texts!r}"
+    )
+    assert any("attach" in t.lower() or "session" in t.lower() for t in texts), (
+        f"expected the /help catalog to name at least one other command; got {texts!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_attach_failure_reply_reaches_a_real_remote_transport() -> None:
+    """Tier 2: #5107 witness ② — the FAILURE branch, not just the happy
+    path (lead-coder's own discriminator). ``request_attach``'s typed op
+    reports the target was rejected (a real, minimal ``send`` returning
+    ``{"attached": False}`` — the exact shape ``AgUiTransport.
+    request_attach`` reads), so ``attach_cmd``'s own False branch
+    (#5096 ②) is the one exercised — its "could not confirm" reply must
+    still reach this client, not just a successful attach's."""
+    async def _reject_send(payload):
+        if payload.get("type") == "attach_request":
+            return {"status": "ok", "attached": False}
+        return None
+
+    transport = AgUiTransport(_empty_sse_lines(), _reject_send, connected=True)
+
+    consumed = await maybe_dispatch_slash(transport, "/attach ghost-agent", echo=False)
+    assert consumed is True
+
+    texts = await _drain_display_texts(transport)
+    assert any("ghost-agent" in t for t in texts), (
+        f"the failed-attach reply must name the target agent; got {texts!r}"
+    )
+    assert any("could not confirm" in t.lower() for t in texts), (
+        f"expected attach_cmd's own False-branch wording; got {texts!r}"
+    )

--- a/tests/interfaces/test_5107_agui_put_display_local_render.py
+++ b/tests/interfaces/test_5107_agui_put_display_local_render.py
@@ -18,12 +18,27 @@ rejects) exercises the FAILURE branch too. Both strip-falsified below:
 reverting :meth:`AgUiTransport.put_display` to the pre-#5107 no-op
 turns BOTH red.
 
+A third witness (architect co-vet, issuecomment-5380005757) targets a
+narrower, easy-to-miss claim: ``_pump_sse``'s own docstring says it
+puts the ``_SSE_DONE`` sentinel on EVERY exit — including
+:meth:`AgUiTransport.close` cancelling the pump task — so
+:meth:`AgUiTransport.frames`, blocked on the shared queue's ``get()``,
+is guaranteed to unblock rather than hang forever. ①② never exercise
+that specific exit (the empty test SSE source finishes on its own,
+never via cancellation) — this test drives ``close()`` WHILE ``frames()``
+is genuinely blocked waiting, and was the reason ``put_nowait`` (not
+``await put``) matters: an ``await`` inside a ``finally`` block IS a
+real suspension a future bounded queue could get cancelled AT, before
+the sentinel ever lands.
+
 Real ``AgUiTransport`` (constructed directly, a real, minimal
 ``sse_lines``/``send`` pair — the same shape ``test_5001_remote_notice_
 delivery.py`` and ``test_3310_n3_remote_switch_parity.py`` already use)
 + the real ``maybe_dispatch_slash``/slash registry — no mocks.
 """
 from __future__ import annotations
+
+import asyncio
 
 import pytest
 
@@ -99,3 +114,43 @@ async def test_attach_failure_reply_reaches_a_real_remote_transport() -> None:
     assert any("could not confirm" in t.lower() for t in texts), (
         f"expected attach_cmd's own False-branch wording; got {texts!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_close_while_frames_blocked_on_get_unblocks_frames() -> None:
+    """Tier 2: #5107 witness ③ (architect co-vet, issuecomment-5380005757)
+    — ``close()`` cancelling the background SSE pump is the 4th exit
+    ``_pump_sse``'s own ``finally`` must cover, not just the 3 exits ①②
+    exercise (an empty test source finishing on its own). Drives
+    ``frames()`` against an SSE source that never yields (blocks
+    forever), waits — via a real ``asyncio.Event``, not a duration —
+    until the pump task has genuinely entered its own blocking wait
+    (deterministic: the consumer's ``await self._display_queue.get()``
+    is the very next line after the pump task is created, so by the
+    time the pump signals it has started, the consumer has already
+    suspended on the empty queue too), then calls ``close()``.
+
+    If the sentinel did not land on this exit, ``frames()`` would hang
+    on ``get()`` forever — this test would not fail, it would simply
+    never finish, exactly the failure mode CI's own timeout (not a
+    ``pytest.mark.timeout`` here) is the backstop for."""
+    pump_started = asyncio.Event()
+
+    async def _hanging_sse_lines():
+        pump_started.set()
+        never = asyncio.Event()
+        await never.wait()
+        yield ""  # pragma: no cover — never reached, makes this an async generator
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_hanging_sse_lines(), _noop_send, connected=True)
+
+    drain_task = asyncio.create_task(_drain_display_texts(transport))
+    await pump_started.wait()
+
+    transport.close()
+
+    texts = await drain_task
+    assert texts == [], f"no display frames were ever produced; got {texts!r}"

--- a/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
+++ b/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
@@ -262,9 +262,11 @@ async def test_submit_blocked_while_unattached_preserves_typed_text():
         )
         # #5001: this notice is a client-authored one about THIS client's
         # own composer state — it now appends directly via `_ingest_frame`
-        # rather than `transport.put_display` (a remote client's
-        # `AgUiTransport.put_display` is a correct no-op; routing this
-        # notice through it silently dropped it there). Assert on the
+        # rather than `transport.put_display` (at the time of this fix, a
+        # remote client's `AgUiTransport.put_display` was an unconditional
+        # no-op; routing this notice through it silently dropped it there
+        # — fixed since, #5107, but this call site's own bypass stands on
+        # separate merits, see app.py's own docstring). Assert on the
         # FlowView the operator actually sees, not the transport's own
         # `displayed` list, which this notice no longer reaches.
         rows = [e.item.text or "" for e in app.query_one(FlowView).entries]


### PR DESCRIPTION
**[e2e-coder]** — part of #5107.

## What

Architect ruling B (issuecomment-5379950484), lead-coder's contract-first correction (issuecomment-5379955824): `AgUiTransport.put_display` was an unconditional no-op, justified by "a remote client cannot inject into the server's outbox." That justification answered a claim `ClientTransport.put_display`'s own docstring never actually made — the docstring said "in order with the session's own output" (a transcript-wide guarantee), not "on this client's own face" (what every actual caller — `reply()`/`reply_error()`, `maybe_dispatch_slash`'s echo/unknown-command/error paths — needs). Fixed contract-first, then the implementation.

- `client_transport.py`: `put_display`'s docstring rewritten to state the real, satisfiable contract.
- `agui/client.py`: `AgUiTransport` gains a `_display_queue` fed by both `put_display` (direct) and a new background `_pump_sse` task (the pre-#5107 body of `frames()`, moved verbatim). `frames()` becomes a queue-drain, merging local + server-sent frames through the same renderer path. A `_SSE_DONE` sentinel lets `frames()` distinguish "source exhausted" from "queue momentarily empty" (without it a finite test double, or a real disconnect, hangs `frames()` forever). `close()` cancels the pump task. Re-paired `suspend_between_frames()` with `frames()`'s own `yield` (#3570's class gate — the restructure moved the yield out of the loop that used to carry it).
- Removed the now-false "echo is a separate path" justification; updated 3 other call sites whose comments described the old no-op as current/correct (their own independent fixes still stand).

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on all changed test files
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` (re-run post-rebase) / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] New witness `test_5107_agui_put_display_local_render.py`: `/help` (success-shaped) + `/attach` to a rejected name (failure-shaped, lead-coder's own discriminator so an only-happy-path implementation can't pass) — both against a real `AgUiTransport`, no mocks. Strip-falsified: reverting `put_display` to the pre-#5107 no-op turns both red, restored → green.
- [x] Full `tests/interfaces/` sweep filtered to `agui`/`stream`/`5001`/`5107`/`textual_chat_attach`: 173 passed
- [ ] (Visual — standing waiver 2026-08-08)

part of #5107


- [x] 🔴 **[lead-coder]** `finally` の `await put(_SSE_DONE)` を `put_nowait` に ＋ docstring の「3 exits」を 4 に（4 つ目＝`close()` の `cancel()`）。今の正しさは「queue が無制限」という書かれていない不変条件に乗っており、maxsize を足した日に `frames()` が永久に待つ。witness は architect 指定の③。詳細 issuecomment-5380009...

