### PR TITLE
docs: drop the removal narrative this arc left in profile.py, session.py and the config reference

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -32,11 +32,9 @@ llm:
   これ）、`project · agent`（エージェント自身の `.reyn/agents/<名前>/
   profile.yaml` にも設定可）、`project · agent · session`（セッション自身の
   `<session-state-dir>/config.yaml` にも設定可）、または `agent` 単独
-  （そもそも project 層に値が存在しないキー）。**`agent` 単独は現在
-  該当キーが 0 件です** — 唯一の実例だった `broker_identity` は #5091 で
-  撤去されました（owner 裁定 —「broker」は外部 MCP サーバであって reyn
-  ランタイムの概念ではない）。語彙に値を残すのは、それが名指す境界事例が
-  実在するからであって、今日そこにキーが居るからではありません。**CI で導出/検査される唯一の列**（下記参照）— ②③が
+  （そもそも project 層に値が存在しないキー）。**現在 `agent` 単独の
+  キーは在りません** — この値は実在する境界事例（project 層に値が全く
+  無いキー）を名指すものであって、今日そこにキーが居ることを表しません。**CI で導出/検査される唯一の列**（下記参照）— ②③が
   「スライスで偽にならない」からではありません（★偽になり得るし実際なった
   — 下記 ⑤ が `Reload` の実測インスタンス）。「この呼び出しが live
   re-read かどうか」は★呼び出し site 自身の性質であり、`_HOT_RELOAD_FILES`
@@ -66,8 +64,7 @@ llm:
 
 **`Declared in` 自身の一次ソース**: `src/reyn/runtime/preferences.py` の
 `PREFERENCE_KEYS`（③ preference 軸、#4206）と、`AgentProfile` の明示的な
-agent 層専用フィールド（`project_context_path`、#5086 — #5091 が
-`broker_identity` を撤去して以降はこれ 1 つ）— `tests/repo/test_config_reference_declared_in_4206.py` がこの表の
+agent 層専用フィールド（`project_context_path`、#5086）— `tests/repo/test_config_reference_declared_in_4206.py` がこの表の
 `Declared in` セルを CI でそれらと突き合わせます（[`events.md` 自身の
 doc↔code gate](../runtime/events.md) と同じ形）。あるキーが agent/session
 書き込み能力を得たのに本表が追随していなければ → 赤。

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -34,11 +34,9 @@ cause of #5086/#5088 misreading each other):
   `.reyn/agents/<name>/profile.yaml` may also set it), `project · agent ·
   session` (a session's own `<session-state-dir>/config.yaml` may set it
   too), or `agent` alone (no project-wide value exists for this key at
-  all). **`agent` alone currently has NO instance**: its only one,
-  `broker_identity`, was removed by #5091 (owner ruling — "broker" is an
-  external MCP server, not a reyn-runtime concept). The value stays in the
-  vocabulary because the boundary case it names is real, not because a key
-  occupies it today. **This is the ONE
+  all). **No key is `agent` alone today** — the value names a real boundary
+  case (a key with no project-wide value at all), not an occupied one.
+  **This is the ONE
   column derived/checked in CI** (see below) — NOT because ② and ③ can't
   go stale (they can and do: ⁵ below is a real, measured instance for
   `Reload`), but because "does this call site re-read live?" is a
@@ -73,8 +71,7 @@ the registry when one is added.
 **`Declared in`'s own source of truth**: `PREFERENCE_KEYS` in
 `src/reyn/runtime/preferences.py` (the ③ preference axis, #4206) plus the
 explicit agent-layer-only fields on `AgentProfile`
-(`project_context_path`, #5086 — the only one since #5091 removed
-`broker_identity`) —
+(`project_context_path`, #5086) —
 `tests/repo/test_config_reference_declared_in_4206.py` checks this
 table's `Declared in` cells against them in CI, mirroring
 [`events.md`'s own doc↔code gate](../runtime/events.md). A key gaining

--- a/src/reyn/runtime/profile.py
+++ b/src/reyn/runtime/profile.py
@@ -25,17 +25,6 @@ DIFFERENT, disjoint key vocabulary (`BOUNDING_KEYS`, currently `{"model"}`
 only). Kept as a separate field/key rather than folded into `preferences`
 because the two axes' composition functions differ — see
 `reyn.runtime.bounding`'s module docstring for the full reasoning.
-
-#5084 ③ added a `broker_identity` field here (a flat, non-axis column) —
-REMOVED by #5091 (owner ruling: "broker" is an external MCP server, not a
-reyn-runtime concept; per-agent identity for it is already `AgentProfile.
-name`, and the participation this field drove — a hook subscribing that
-agent's own inbox — is already expressible with the EXISTING per-session
-hooks layer, #2285, no dedicated field needed). If a future integration
-seems to need a similar "identity for external system X" field, that
-itself is the #5091 discriminator firing again (owner's own test: "would
-another integration need the same code?") — the answer is a hand-written
-hook in that agent's own hooks file, not a new column here.
 """
 from __future__ import annotations
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5615,18 +5615,6 @@ class Session:
         - **per-agent** — ``.reyn/agents/<name>/hooks.yaml`` (read directly here, same
           IN-set grain but scoped per agent).
 
-        #5091: an EARLIER revision of this method also derived 2 broker-
-        participation hooks from a dedicated ``AgentProfile.broker_identity``
-        field (#5084 ③-b) — removed. Owner ruling: "broker" is an external
-        MCP server, not a reyn-runtime concept, and the derivation solved a
-        problem the ALREADY-EXISTING per-session hooks layer (below) already
-        solves for free — an agent that wants to subscribe its own broker
-        inbox just writes ``<per-session state dir>/hooks.yaml`` directly
-        (visible ONLY to that one session, so a literal, hand-written
-        ``uri: broker://inbox/<name>`` needs no templating). No mechanism
-        was lost; #5091's own witness demonstrates the identical behaviour
-        with zero code, using this layer alone.
-
         Rebuilding from scratch each call means a removed hook (runtime or per-agent)
         simply isn't in the new registry — removal handled by construction.
 

--- a/tests/repo/test_config_reference_declared_in_4206.py
+++ b/tests/repo/test_config_reference_declared_in_4206.py
@@ -25,12 +25,7 @@ truth for.
 
 Source of truth: `PREFERENCE_KEYS` (`src/reyn/runtime/preferences.py`, the ③
 preference axis) plus the ONE explicit agent-layer-only `AgentProfile` field
-(`project_context_path` #5086). There were two: `broker_identity` #5085 was
-removed by #5091 (owner ruling — "broker" is an external MCP server, not a
-reyn-runtime concept), which also emptied the `agent`-alone vocabulary value
-it was the sole instance of. Nothing here checked it (it had no row in the
-table), so its removal did not turn this gate red — the doc prose citing it
-did go stale, which is what #5091's follow-up corrected.
+(`project_context_path` #5086).
 
 Real file reads throughout (the actual doc, the actual `PREFERENCE_KEYS`
 declaration) — no mocks.


### PR DESCRIPTION
**[lead-coder]** — **owner 裁定「★コードに変更履歴を持ち込むな」。★私が今夜 入れたものを 畳みます。**

```
🔴 ★私の非 ── ★「墓標を残す」を★★私が 支持しました
   ── architect が「消すと 次の人が 同じ欄を 足す」と言い ── ★私は 同意し ── ★#5106 で
      ★docs 側にも★同じ 語りを 書きました
   ── 🔴 ★自分の規則を 当てていません ──「★決定の記録を探せ」── ★決定は★issue と PR に 在ります
   ── 🔴 ★しかも 消したものは★★カテゴリ誤り でした
      ── owner 裁定「broker は 外部 MCP サーバであって reyn の概念ではない」
      ── ∴ ★★間違って入れたものの 記念碑を ★production の source に 建てていました
```

## ✅ 消したもの（★23 行 ＋ doc/test の語り）

| 面 | 何が在ったか |
|---|---|
| `profile.py` module docstring | 「#5084 ③ が field を足し、#5091 が REMOVED」＋将来への助言 **11 行** |
| `session.py` method docstring | 「an EARLIER revision が 2 hooks を導出していた — removed」 **12 行** |
| `reyn-yaml.md` / `.ja.md` | 「唯一の実例だった `broker_identity` は #5091 で撤去」 |
| gate の module docstring | 「There were two: … removed by #5091 …」 |

✅ **残した形は★現在形だけ** —— 「**`agent` 単独のキーは今 在りません。この値は実在する境界事例を名指すもの**」。**なぜ空か**は言いますが、**誰が居て誰が消したか**は言いません。

⚪ **失われないもの** —— **決定は issue と PR に在ります**（撤去の理由・owner 裁定・witness）。**再発防止は「識別子ごとの注記」ではなく★一般の判別子**（owner の「相手が増えたらこちらも増えるか」）で、それは**個別の死んだ欄に貼るものではありません。**

## Test plan
- [x] `ruff check .` / `test_tier_audit.py --strict` / `verify_module_docstrings.py`
- [x] `mkdocs build --strict` / `check_doc_anchors.py`
- [x] `pytest tests/repo/test_config_reference_declared_in_4206.py` — 5 passed
- [x] (skipped — Visual 項目なし)

⚪ **TESTS-READ（B）が要ります**（`tests/` の docstring を触ります。assert は 1 行も変えていません）。
