### PR TITLE
fix(#5010): identifier_survives_in_src reads code, not string presence

### DIFF
--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -135,6 +135,7 @@ what broke.
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import keyword
 import re
@@ -495,18 +496,126 @@ def resolve_pr_shas(pr_number: int) -> "tuple[str, str]":
     return data["baseRefOid"], data["headRefOid"]
 
 
+def _blank_span(
+    lines: "list[str]", start: "tuple[int, int]", end: "tuple[int, int]",
+) -> None:
+    """Blank out the source span *start*..*end* (1-indexed line, 0-indexed
+    col — the shape both ``ast`` node positions and ``tokenize`` token
+    positions already use) IN PLACE on *lines*, replacing every redacted
+    character with a space so line/col positions of everything else are
+    unaffected — a caller never needs a remap, only a plain substring
+    search over the result."""
+    (start_line, start_col), (end_line, end_col) = start, end
+    if start_line == end_line:
+        line = lines[start_line - 1]
+        lines[start_line - 1] = line[:start_col] + " " * (end_col - start_col) + line[end_col:]
+        return
+    first = lines[start_line - 1]
+    body_len = len(first.rstrip("\n"))
+    lines[start_line - 1] = first[:start_col] + " " * (body_len - start_col) + first[body_len:]
+    for mid in range(start_line, end_line - 1):
+        body_len = len(lines[mid].rstrip("\n"))
+        lines[mid] = " " * body_len + lines[mid][body_len:]
+    last = lines[end_line - 1]
+    lines[end_line - 1] = " " * end_col + last[end_col:]
+
+
+def _redact_comments_and_docstrings(source: str) -> "str | None":
+    """Return *source* with every COMMENT token (``tokenize``) and every
+    real docstring — a module/class/function's own first statement, an
+    ``Expr(Constant(str))`` node (``ast``) — blanked out span-for-span.
+    Everything else, including ORDINARY string literals (``data.get(
+    "broker_identity")`` is a real, live use, not prose), is left
+    untouched.
+
+    Architect ruling (#5010, issuecomment-5380169887): the discriminator
+    this backs (:func:`identifier_survives_in_src`) was asking "does this
+    identifier appear as a STRING anywhere in src/" — unable to tell a
+    living code occurrence from a comment/docstring PROSE citation
+    recording that the identifier was removed (a correct, encouraged
+    practice this repo's own convention keeps — see this module's own
+    docstring on history-class docs for the doc-side analogue). Fixing
+    the SIDE that guesses (the identifier-survives check), not the
+    convention of leaving a removal note in place.
+
+    ``None`` if *source* fails to parse or tokenize (rare — this repo's
+    own ``src/`` is always valid Python) — a caller falls back to
+    counting the raw ``git grep`` hit as survives, logged to stderr,
+    never silently dropped."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    lines = source.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not node.body or not isinstance(node.body[0], ast.Expr):
+            continue
+        doc_value = node.body[0].value
+        if not (isinstance(doc_value, ast.Constant) and isinstance(doc_value.value, str)):
+            continue
+        doc_node = node.body[0]
+        if doc_node.end_lineno is None or doc_node.end_col_offset is None:
+            continue
+        _blank_span(
+            lines,
+            (doc_node.lineno, doc_node.col_offset),
+            (doc_node.end_lineno, doc_node.end_col_offset),
+        )
+    try:
+        for tok in tokenize.generate_tokens(StringIO(source).readline):
+            if tok.type == tokenize.COMMENT:
+                _blank_span(lines, tok.start, tok.end)
+    except (tokenize.TokenError, IndentationError, SyntaxError, OSError):
+        return None
+    return "".join(lines)
+
+
 def identifier_survives_in_src(identifier: str, src_root: Path) -> bool:
-    """True iff *identifier* still appears anywhere in the CURRENT (post-
-    diff) ``src/`` tree — i.e. this diff moved it rather than deleting it
-    from the codebase. Uses `git grep` scoped to the working tree so this
-    reads the checked-out post-diff state, not history."""
+    """True iff *identifier* still appears as CODE — a NAME token (a
+    definition or use) OR a string literal — anywhere in the CURRENT
+    (post-diff) ``src/`` tree, i.e. this diff moved it rather than
+    deleting it from the codebase. Excludes comment text and real
+    docstring prose (architect ruling, #5010: "in src/ as a STRING" →
+    "in src/ as CODE" — see :func:`_redact_comments_and_docstrings`'s own
+    docstring for the incident this closes). String literals ARE
+    counted — only comments and docstring nodes are excluded.
+
+    First narrows with a plain ``git grep`` (fast, scoped to the checked-
+    out working tree — reads post-diff state, not history) to the files
+    that contain *identifier* at all as raw text; only those candidates
+    are re-checked against their redacted content, so a file with no raw
+    occurrence is never even opened."""
     result = subprocess.run(
         ["git", "grep", "-lF", "--", identifier, "--", "src"],
         cwd=src_root,
         capture_output=True,
         text=True,
     )
-    return result.returncode == 0 and bool(result.stdout.strip())
+    if result.returncode != 0 or not result.stdout.strip():
+        return False
+    for rel_path in result.stdout.splitlines():
+        if not rel_path.strip():
+            continue
+        if not rel_path.endswith(".py"):
+            return True  # no comment/docstring model for non-Python src/ files
+        abs_path = src_root / rel_path
+        try:
+            source = abs_path.read_text(encoding="utf-8")
+        except OSError:
+            return True
+        redacted = _redact_comments_and_docstrings(source)
+        if redacted is None:
+            print(
+                f"WARN check_doc_drift: {rel_path!r} failed to parse/tokenize — "
+                f"counting its raw git-grep hit as survives",
+                file=sys.stderr,
+            )
+            return True
+        if identifier in redacted:
+            return True
+    return False
 
 
 def find_doc_files_containing(identifier: str, docs_root: Path) -> "set[str]":

--- a/tests/scripts/test_check_doc_drift_5003.py
+++ b/tests/scripts/test_check_doc_drift_5003.py
@@ -352,6 +352,47 @@ def test_identifier_survives_in_src_false_when_absent(tmp_path):
     assert m.identifier_survives_in_src("foo_bar_baz", repo) is False
 
 
+def test_identifier_survives_in_src_false_when_only_in_a_comment_or_docstring(tmp_path):
+    """Tier 1: #5010 (architect ruling, issuecomment-5380169887) — the
+    original `git grep -lF` counted a name mentioned only inside a
+    comment or a module/function docstring's removal-record PROSE as
+    "still present" (a STRING match), hiding a real removal whose only
+    surviving citation was record-keeping text, not living code. The
+    real incident: #5095 removed `AgentProfile.broker_identity`, leaving
+    only "removed by #5091"-shaped comments in profile.py/session.py —
+    the old check saw those and (wrongly) called the identifier present."""
+    repo = _init_repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / "src" / "x.py").write_text(
+        '"""only_a_prose_name was removed from here, see #1234."""\n'
+        "\n\n"
+        "def foo():\n"
+        "    # only_a_prose_name lived here once\n"
+        "    return 42\n",
+    )
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    assert m.identifier_survives_in_src("only_a_prose_name", repo) is False
+
+
+def test_identifier_survives_in_src_true_for_a_string_literal_use(tmp_path):
+    """Tier 1: #5010's own boundary case (architect: "文字列リテラルは
+    落とさないこと" — a string literal is NOT prose) — a bare `#`-comment
+    or docstring mention is excluded, but `data.get("a_dict_key_name")`
+    is a REAL, live use of that string and must still count as
+    surviving. Only comments and real docstring nodes are excluded;
+    ordinary string literals are not touched."""
+    repo = _init_repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / "src" / "x.py").write_text(
+        "def foo(data):\n"
+        '    return data.get("a_dict_key_name")\n',
+    )
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    assert m.identifier_survives_in_src("a_dict_key_name", repo) is True
+
+
 def test_find_doc_files_containing_excludes_history_class_dir(tmp_path):
     """Tier 1: the git-grep resolver itself applies exclusion 1 — a
     journal entry naming the identifier is not returned."""


### PR DESCRIPTION
**[docs-maintainer]** — issue #5010 の割当（issuecomment-5380192368、architect裁定 issuecomment-5380169887どおり）。

## やったこと
`identifier_survives_in_src`を「文字列として在るか」→「コードとして在るか」に変更。新ヘルパー`_redact_comments_and_docstrings`（`tokenize`のCOMMENTトークン + `ast`の実docstringノードをspan単位でblank）を追加。**文字列リテラルは除外しない**（architectの境界事例`data.get("broker_identity")`は生きた使用）。

## witness検証
`check_doc_drift.py --pr 5095` → **2件**報告（`reyn-yaml.md`, `reyn-yaml.ja.md`、file-level granularity）。lead-coderが挙げた4つの行番号（reyn-yaml.ja.md:35/66、reyn-yaml.md:37/72）は#5095の**マージコミット時点**の実際の行と完全一致することを独立に確認（`git show e802ad73a:...`で再検証）— これは2ファイル×2箇所ずつの手動カウント証拠であり、Findingオブジェクトの粒度（file単位）とは別軸。

strip-falsify: redaction呼び出しを外すと "OK"（0件）に戻ることを確認。

## 境界事例テスト（2本、両方独立にstrip-falsify済み）
- comment/docstringのみの言及 → survives=False（本来のバグ）
- 文字列リテラルのみの言及（dict `.get()`のキー）→ survives=True（architectの境界事例、素朴な「全文字列を落とす」修正だと壊れていたケース）

## 未対応（意図的、lead-coder dispatch通り）
warn-only→blockingの昇格は本PRではやりません（別PR）。4件が母集団の全部だとは主張していません（architect自身の留保どおり）。

## Gate
`ruff check`clean、`test_tier_audit.py --strict` 36/36 OK、`tests/scripts/` 904/904 green、`check_tests_path_literal_reference.py`/`mypy_ratchet.py` clean。

part of #5010
