### PR TITLE
feat(#5111): reyn agent new --project-context-path, mirrors --base-dir

### DIFF
--- a/src/reyn/interfaces/cli/commands/agent.py
+++ b/src/reyn/interfaces/cli/commands/agent.py
@@ -46,6 +46,16 @@ def register(sub) -> None:
             "workspace. Omitted -> inherits the project's own base_dir."
         ),
     )
+    p_new.add_argument(
+        "--project-context-path", default=None,
+        help=(
+            "REYN.md / AGENTS.md override for this agent (#5111/#5084 (2); "
+            "same restrict-only shape as --base-dir -- must resolve inside "
+            "the project workspace, rejected otherwise, never clamped). "
+            "Relative paths resolve against the project workspace. Omitted "
+            "-> falls through to the project-wide file."
+        ),
+    )
     p_new.set_defaults(func=_cmd_new)
 
     p_rm = inner.add_parser(
@@ -167,7 +177,10 @@ def _cmd_new(args: argparse.Namespace) -> None:
     target = _agents_dir() / args.name
     try:
         asyncio.run(
-            reg.create_agent(args.name, role=args.role, base_dir=args.base_dir)
+            reg.create_agent(
+                args.name, role=args.role, base_dir=args.base_dir,
+                project_context_path=args.project_context_path,
+            )
         )
     except ValueError as e:                       # invalid name
         print(f"Error: {e}", file=sys.stderr)

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -699,6 +699,7 @@ class AgentRegistry:
 
     def create(
         self, name: str, *, role: str = "", base_dir: "str | Path | None" = None,
+        project_context_path: "str | Path | None" = None,
     ) -> AgentProfile:
         """#5080: ``base_dir`` (optional) is #4206's axis ① (capability,
         restrict-only) applied to a "file zone" the agent layer had none
@@ -721,7 +722,13 @@ class AgentRegistry:
         the WORKSPACE ROOT here, not a spawner's own effective
         ``base_dir`` — owner's own resolution rule (issue #5080): an
         agent-spawn with nothing given defaults to the PROJECT base_dir,
-        not the spawner's."""
+        not the spawner's.
+
+        ``project_context_path`` (#5111): same shape, same bound
+        (``within_workspace``), same "restrict-only, reject rather than
+        clamp" — #5084's own goal witness names this as declarable ONLY
+        through this creation seam (no slash command), so this is the
+        one place it needs to land."""
         _validate_agent_name(name)
         if self.exists(name):
             raise FileExistsError(f"agent {name!r} already exists")
@@ -755,7 +762,39 @@ class AgentRegistry:
                     "project workspace."
                 )
             resolved_base_dir = str(candidate)
-        profile = AgentProfile.new(name, role=role, base_dir=resolved_base_dir)
+        resolved_project_context_path: "str | None" = None
+        if project_context_path is not None:
+            # #5111: mirrors ``base_dir`` immediately above, verbatim shape
+            # — #5084's own instruction (issue body, "①③" ordering note):
+            # ``project_context_path`` needs the IDENTICAL "⊆ workspace,
+            # restrict-only" bound ``base_dir`` already gets here, via the
+            # SAME ``within_workspace`` function (never a second,
+            # independently-written copy of the same check — the exact
+            # "same guard, different code" family #5057 closed three
+            # instances of already). The READ-side protection
+            # (``registry_bootstrap.resolve_agent_project_context``) is
+            # separate and already landed (#5086) — this is the WRITE-side
+            # twin, eager at creation time, same as ``base_dir``'s own.
+            from reyn.runtime.workspace_paths import within_workspace
+
+            candidate = Path(project_context_path)
+            if not candidate.is_absolute():
+                candidate = self._project_root / candidate
+            candidate = candidate.resolve()
+            workspace_resolved = self._project_root.resolve()
+            if not within_workspace(candidate, workspace_resolved):
+                raise ValueError(
+                    f"requested project_context_path {str(candidate)!r} "
+                    f"resolves outside the project workspace "
+                    f"{str(workspace_resolved)!r} — restrict-only: an "
+                    "agent's project_context_path must fall under the "
+                    "project workspace."
+                )
+            resolved_project_context_path = str(candidate)
+        profile = AgentProfile.new(
+            name, role=role, base_dir=resolved_base_dir,
+            project_context_path=resolved_project_context_path,
+        )
         profile.save(self._dir / name)
         return profile
 
@@ -939,6 +978,7 @@ class AgentRegistry:
     async def create_agent(
         self, name: str, *, role: str = "", parent: "str | None" = None,
         base_dir: "str | None" = None,
+        project_context_path: "str | None" = None,
     ) -> AgentProfile:
         """#2103 S2b: the action-layer CREATE seam — create the profile (sync) +
         emit ``agent_created`` so rewind can track / reconstruct / drop the agent
@@ -955,7 +995,10 @@ class AgentRegistry:
         escalation-on-rewind — so the carry+restore is a security linchpin (the emit
         AND the reconstruction-restore are both verified, the registered-but-unemitted
         → resurrection hazard class)."""
-        profile = self.create(name, role=role, base_dir=base_dir)
+        profile = self.create(
+            name, role=role, base_dir=base_dir,
+            project_context_path=project_context_path,
+        )
         if parent is not None:
             self._record_spawn_lineage(name, parent)
         # #2103 C2b: the parent's identity FROZEN at this spawn (the same value the edge

--- a/tests/cli/test_5111_agent_new_project_context_path.py
+++ b/tests/cli/test_5111_agent_new_project_context_path.py
@@ -1,0 +1,173 @@
+"""Tier 2: #5111 (lead-coder assignment, mirrors #5080's own ``--base-dir``
+precedent exactly) — ``reyn agent new`` gains a ``--project-context-path``
+flag reaching the SAME creation seam (``AgentRegistry.create_agent`` ->
+``create``) ``--base-dir`` already writes through.
+
+#5084's own owner-authored goal witness names the CREATION SEAM as the
+ONLY declaration surface ("2 coders declared/provisioned just by writing
+profile.yaml, no slash commands") — before this PR, ``base_dir`` was
+declarable that way and ``project_context_path`` was not (#5111's own
+finding, filed during #5084's live goal-witness verification). This
+closes that gap at CREATION time only — ``agent edit`` is explicitly out
+of scope (lead-coder's own instruction).
+
+The READ side (``registry_bootstrap.resolve_agent_project_context``, the
+``⊆workspace`` protect-at-use enforcement) is UNCHANGED and already
+covered by ``test_5084_agent_project_context_override.py`` — this file
+covers only the NEW write side: the CLI flag itself, and ``registry.
+create``'s own eager ⊆workspace rejection (mirrors #5080's own witness ④
+for ``base_dir``, same shape, same bound function).
+
+Real ``AgentRegistry``/argparse parser construction throughout — no mocks.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.interfaces.cli.commands import agent as agent_cmd  # noqa: E402
+from reyn.runtime.registry import AgentRegistry  # noqa: E402
+
+
+def _no_factory(profile):
+    raise RuntimeError("session factory not used in these write-side tests")
+
+
+def _profile_path(project_root: Path, name: str) -> Path:
+    return project_root / ".reyn" / "agents" / name / "profile.yaml"
+
+
+def _parse_agent_new(argv: "list[str]"):
+    """Build the REAL top-level argparse parser (the same ``register``
+    every CLI command module wires into) and parse ``argv`` — proves the
+    flag is reachable from an actual command line, not just that
+    ``_cmd_new`` accepts the kwarg when handed a hand-built Namespace."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="reyn")
+    sub = parser.add_subparsers(dest="<command>", metavar="<command>")
+    agent_cmd.register(sub)
+    return parser.parse_args(argv)
+
+
+# ── witness ① — the CLI flag itself is wired ────────────────────────────────
+
+
+def test_new_project_context_path_flag_is_parsed() -> None:
+    """Tier 2: ``reyn agent new x --project-context-path ...`` parses to a
+    real ``args.project_context_path`` attribute the SAME way
+    ``--base-dir`` already does — the flag genuinely exists on the
+    command line, not just as a ``create_agent`` keyword nobody can
+    reach.
+
+    Strip-falsifier: removing ``p_new.add_argument("--project-context-
+    path", ...)`` turns this red with an argparse ``SystemExit`` (unknown
+    argument) rather than a clean parse — verified locally."""
+    args = _parse_agent_new(
+        ["agent", "new", "coder1", "--project-context-path", "coder1-context.md"],
+    )
+    assert args.project_context_path == "coder1-context.md"
+
+
+def test_new_without_the_flag_defaults_to_none() -> None:
+    """Tier 2: regression guard — omitting the flag (every pre-#5111
+    caller) still parses, with ``project_context_path=None`` (byte-
+    identical to the pre-#5111 signature's implicit default)."""
+    args = _parse_agent_new(["agent", "new", "coder1"])
+    assert args.project_context_path is None
+
+
+# ── witness ② — _cmd_new writes the key through the real creation seam ──────
+
+
+def test_cmd_new_writes_project_context_path_to_profile(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: driving the REAL ``_cmd_new`` (the function ``reyn agent
+    new`` actually dispatches to) with a parsed ``args.project_context_
+    path`` writes a ``project_context_path:`` key into the created
+    agent's own ``profile.yaml`` — the full CLI-to-disk path, not just
+    the registry method in isolation (already covered elsewhere;
+    ``test_5084_agent_project_context_override.py``'s own witness ①
+    covers the create_agent->session resolution end)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+
+    args = _parse_agent_new(
+        ["agent", "new", "coder1", "--project-context-path", "coder1-context.md"],
+    )
+    args.func(args)
+
+    profile_path = _profile_path(tmp_path, "coder1")
+    assert profile_path.is_file()
+    text = profile_path.read_text(encoding="utf-8")
+    assert "project_context_path:" in text, (
+        f"no project_context_path: key was written to coder1's own "
+        f"profile.yaml; got: {text!r}"
+    )
+
+
+# ── witness ③ — the write-side ⊆workspace bound (mirrors #5080's own ④) ────
+
+
+@pytest.mark.asyncio
+async def test_project_context_path_outside_the_workspace_is_rejected_at_write(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the WRITE-side upper bound — a requested
+    ``project_context_path`` outside the project workspace is REJECTED
+    (a raised ``ValueError`` naming the boundary) at CREATE time, never
+    silently clamped or accepted then quietly ignored later — the SAME
+    shape ``base_dir`` already has (``test_5080_...::test_base_dir_
+    outside_the_workspace_is_rejected``), via the SAME
+    ``within_workspace`` bound function (#5084's own explicit
+    instruction: reuse, never a second copy).
+
+    This is the WRITE-side twin of ``test_5084_agent_project_context_
+    override.py``'s own ``test_project_context_path_outside_workspace_
+    is_rejected`` (the READ-side/protect-at-use test, for a value that
+    reached profile.yaml some OTHER way, e.g. a direct hand-edit) — that
+    test predates #5111 and is unaffected; this one is new, for the
+    seam #5111 added.
+
+    Strip-falsifier: removing the bound-check block this PR added to
+    ``registry.create`` (leaving the ``project_context_path`` write
+    unconditional) turns this green (accepted) instead of red —
+    verified locally."""
+    project_root = tmp_path / "project"
+    outside_file = tmp_path / "outside-the-workspace.md"
+
+    reg = AgentRegistry(project_root=project_root, session_factory=_no_factory)
+    with pytest.raises(ValueError, match="outside the project workspace"):
+        await reg.create_agent("coder1", project_context_path=str(outside_file))
+
+    # Rejected atomically: no partial state survives a rejected create.
+    assert not reg.exists("coder1")
+    assert not _profile_path(project_root, "coder1").exists()
+
+
+# ── witness ④ — omitting the flag writes no key (byte-identical) ───────────
+
+
+@pytest.mark.asyncio
+async def test_create_agent_without_project_context_path_writes_no_key(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: regression guard, registry level — omitting
+    ``project_context_path`` (every pre-#5111 caller) writes NO
+    ``project_context_path:`` key at all, mirroring #5080's own
+    ``test_agent_created_without_base_dir_writes_no_override_key``."""
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_no_factory)
+    await reg.create_agent("coder1")
+
+    profile_path = _profile_path(tmp_path, "coder1")
+    assert profile_path.is_file()
+    assert "project_context_path" not in profile_path.read_text(encoding="utf-8")

--- a/tests/runtime/test_5084_agent_project_context_override.py
+++ b/tests/runtime/test_5084_agent_project_context_override.py
@@ -56,22 +56,30 @@ async def test_agent_layer_project_context_path_replaces_the_project_wide_file(
     config = load_config()
     registry = build_agent_registry_from_project(project_root, config, non_interactive=True)
     try:
-        registry.create("coder1")
-        registry.create("coder2")
-        # Hand-edit each profile.yaml the way #5084's own target workflow
-        # does -- no create_agent(project_context_path=...) parameter
-        # exists (deliberately out of scope: the goal is a person writing
-        # the file directly).
-        p1 = AgentProfile.load(registry.agent_workspace_dir("coder1"))
-        AgentProfile(
-            name=p1.name, role=p1.role, created_at=p1.created_at,
-            project_context_path="${REYN_PROJECT_DIR}/coder1-context.md",
-        ).save(registry.agent_workspace_dir("coder1"))
-        p2 = AgentProfile.load(registry.agent_workspace_dir("coder2"))
-        AgentProfile(
-            name=p2.name, role=p2.role, created_at=p2.created_at,
-            project_context_path="${REYN_PROJECT_DIR}/coder2-context.md",
-        ).save(registry.agent_workspace_dir("coder2"))
+        # #5111: routes through the real creation seam now
+        # (``create_agent(..., project_context_path=...)``) rather than
+        # hand-editing profile.yaml — #5084's own goal ("declared just by
+        # writing profile.yaml, no slash commands") names the CREATION
+        # SEAM as the declaration surface, and that seam gained this
+        # parameter in #5111 (it did not exist when this test was
+        # written; the hand-edit below was a deliberate stand-in for it,
+        # not the target shape).
+        #
+        # A bare relative value here (not the ``${REYN_PROJECT_DIR}``
+        # token this file's OTHER tests use for a HAND-typed profile.yaml
+        # value) — the structured-API write side (``registry.create``)
+        # resolves a relative value against the project root and stores
+        # the RESULT as an absolute path, the same "structured parameter,
+        # never a token string" contract ``base_dir`` already has (see
+        # ``registry.create``'s own docstring). The read side
+        # (``resolve_agent_project_context``) accepts an absolute path
+        # directly — only a HAND-typed bare-relative value is rejected.
+        await registry.create_agent(
+            "coder1", project_context_path="coder1-context.md",
+        )
+        await registry.create_agent(
+            "coder2", project_context_path="coder2-context.md",
+        )
 
         session1 = registry.get_or_load("coder1")
         session2 = registry.get_or_load("coder2")


### PR DESCRIPTION
**[e2e-coder]** — part of #5111, part of #5084.

## What

`#5084`'s own owner-authored goal witness ("2 coders declared/provisioned just by writing profile.yaml, no slash commands") names the CREATION SEAM as the only declaration surface. `base_dir` was declarable that way (`--base-dir`, #5080); `project_context_path` was not — found during #5084's live goal-witness verification, filed as #5111, assigned back to me.

- `registry.py`: `create()`/`create_agent()` gain `project_context_path`, same shape as `base_dir` — a structured-API parameter (never a `${REYN_PROJECT_DIR}` token here, that's the hand-typed-YAML read-side's own vocabulary), validated eagerly ⊆ workspace via the SAME `within_workspace` function `base_dir` already uses.
- `agent.py` (CLI): `reyn agent new` gains `--project-context-path`, identical shape to `--base-dir`.
- `agent edit` explicitly NOT added (lead-coder's own scope cut).

Fixed a staleness the change created: `test_5084_agent_project_context_override.py`'s own witness ① hand-edited `profile.yaml` directly with a comment saying the parameter didn't exist — now routes through the real seam this PR adds.

READ side (`registry_bootstrap.resolve_agent_project_context`, the ⊆workspace protect-at-use enforcement) is UNCHANGED — landed via #5086; only the WRITE side (creation seam) is new here.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` (all changed/new test files, 0 Tier-4)
- [x] `python scripts/verify_module_docstrings.py` (changed src files)
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` (re-run post-rebase) / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] New witness `test_5111_agent_new_project_context_path.py`: ① CLI flag parses (real `argparse.ArgumentParser`) ② `_cmd_new` writes the key end-to-end ③ write-side ⊆workspace rejection (mirrors #5080's own witness ④) ④ omitting the flag writes no key. ①③ strip-falsified by hand (removed CLI arg → `SystemExit(2)`; removed bound check → `DID NOT RAISE`), both restored → green.
- [x] Full sweep filtered to `agent`/`registry`/`5084`/`5080`/`5111`: 1034 passed, 1 unrelated skip
- [ ] Live verification (per lead-coder's acceptance criteria — `--connect` reading a different REYN.md, raw log) — separate comment to follow before merge is requested.
- [ ] (Visual — standing waiver 2026-08-08)

part of #5111
part of #5084
