### PR TITLE
docs(cli/agent): reyn agent new's reference is missing 2 real flags

### DIFF
--- a/docs/reference/cli/agent.ja.md
+++ b/docs/reference/cli/agent.ja.md
@@ -35,17 +35,23 @@ researcher  2026-05-01 12:55  deep technical research, prefers primary sources
 writer      2026-04-30 18:20  concise long-form prose
 ```
 
-## `reyn agent new <name> [--role TEXT]`
+## `reyn agent new <name> [--role TEXT] [--base-dir PATH] [--project-context-path PATH]`
 
 `.reyn/agents/<name>/` 配下に新しい agent を作成します。ディレクトリは `profile.yaml` でプロビジョニングされます。`history.jsonl`、`events.jsonl`、`memory/`、`runs/` は最初のアクティビティ時に作成されます。
 
 ```bash
 reyn agent new researcher --role "deep technical research, prefers primary sources"
+reyn agent new worker --base-dir repos/worker
+reyn agent new coder1 --project-context-path coder1-context.md
 ```
 
 `<name>` は agent 名の正規表現に一致する必要があります: `[a-z0-9]` で始まる `[a-z0-9_-]` の 1〜32 文字。
 
-`--role` テキストは agent の LLM システムプロンプトに注入されます。短く具体的に書いてください。作成後に `allowed_mcp` や他のプロファイルフィールドを設定するには、`profile.yaml` を直接編集してください。profile-yaml リファレンス を参照してください。
+`--role` テキストは agent の LLM システムプロンプトに注入されます。短く具体的に書いてください。`allowed_mcp`・`preferences`・`bounding` には CLI からの宣言手段がまだ無いため、作成後に `profile.yaml` を直接編集してください。profile-yaml リファレンス を参照してください。
+
+`--base-dir`（#5080）は、この agent 自身の作業ディレクトリ override を設定します — restrict-only、プロジェクトワークスペース内に解決される必要があり（相対パスはそれを基準に解決）、範囲外は clamp されず拒否されます。省略時は、agent はプロジェクト自身の base_dir にフォールバックします。session-spawn 自身の `base_dir`（`spawn_session` の LLM 向け引数）は、両方が設定された場合この agent レベルの既定より優先されます。
+
+`--project-context-path`（#5111、`--base-dir` と同じ restrict-only 形状）は、この agent 自身の `REYN.md`/`AGENTS.md` override を設定し、この agent のセッションについてプロジェクト全体のファイルを置き換えます。省略時は、agent はプロジェクト全体のファイルにフォールスルーします。
 
 ## `reyn agent show <name>`
 

--- a/docs/reference/cli/agent.md
+++ b/docs/reference/cli/agent.md
@@ -35,20 +35,23 @@ researcher  2026-05-01 12:55  deep technical research, prefers primary sources
 writer      2026-04-30 18:20  concise long-form prose
 ```
 
-## `reyn agent new <name> [--role TEXT] [--base-dir PATH]`
+## `reyn agent new <name> [--role TEXT] [--base-dir PATH] [--project-context-path PATH]`
 
 Create a new agent under `.reyn/agents/<name>/`. The directory is provisioned with a `profile.yaml`; `history.jsonl`, `events.jsonl`, `memory/`, and `runs/` are created on first activity.
 
 ```bash
 reyn agent new researcher --role "deep technical research, prefers primary sources"
 reyn agent new worker --base-dir repos/worker
+reyn agent new coder1 --project-context-path coder1-context.md
 ```
 
 `<name>` must match the agent name regex: 1–32 characters of `[a-z0-9_-]` starting with `[a-z0-9]`.
 
-The `--role` text is injected into the agent's LLM system prompt — keep it short and specific. To configure `allowed_mcp` or any other profile field, edit `profile.yaml` directly after creation; see profile-yaml reference.
+The `--role` text is injected into the agent's LLM system prompt — keep it short and specific. `allowed_mcp`, `preferences`, and `bounding` have no CLI declaration surface yet — configure those by editing `profile.yaml` directly after creation; see profile-yaml reference.
 
 `--base-dir` (#5080) sets this agent's own working-directory override — restrict-only, must resolve inside the project workspace (relative paths resolve against it); a path outside is rejected, never clamped. Omitted, the agent falls back to the project's own base_dir. A session-spawn's own `base_dir` (`spawn_session`'s LLM-facing argument) still takes precedence over this agent-level default when both are set.
+
+`--project-context-path` (#5111, same restrict-only shape as `--base-dir`) sets this agent's own `REYN.md`/`AGENTS.md` override, replacing the project-wide file for this agent's sessions. Omitted, the agent falls through to the project-wide file.
 
 ## `reyn agent show <name>`
 


### PR DESCRIPTION
**[docs-maintainer]** — #5114のTESTS-READ(B)中に自力発見したdoc-drift。`docs/reference/cli/agent.md`の`reyn agent new`リファレンスが`--project-context-path`(#5111)に言及していません。`.ja.md`側は`--base-dir`(#5080)も`--project-context-path`もどちらも欠落 — 既存のen/jaパリティギャップで、両ミラーの「profile.yamlを直接編集」という文言自体が#5080/#5111がその2フィールドについて不要にした主張(CLAUDE.md rule 5該当)。

## 変更
- `agent.md`: synopsis行+例に`--project-context-path`追加、専用段落追加(`--base-dir`と同restrict-only形状)。`--role`のprose を「他の全プロファイルフィールド」→実際にまだhand-edit要る3つ(`allowed_mcp`/`preferences`/`bounding`)に限定。
- `agent.ja.md`: EN側と同等に更新(base-dir段落を新規追加+project-context-path段落追加+role prose訂正)。

`reyn-yaml.md:129`の`project_context_path`行(「REPLACING (not merging with)」)と整合確認済み。

## Gate
`mkdocs build --strict`(Aborted無し)→`check_doc_anchors.py`(dangling無し)→`check_retired_config_keys_denylist.py`(0 hits)、順序通り全clean。
