### PR TITLE
fix(#5116): per-connection single owner for "which agent, which session"

### DIFF
--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -918,19 +918,37 @@ async def agui_submit(request: Request, agent_name: str):
         target = str(payload.get("agent_name", "")).strip()
         attached = False
         if target and registry.exists(target):
-            await registry.attach(target)
+            target_session = await registry.attach(target)
             attached = True
-            # #5116: this POST is a DIFFERENT HTTP request than the SSE
-            # stream it needs to retarget — correlated only by
-            # ``connection_id`` (the caller's OWN connection, already
-            # resolved above). ``registry.attach`` moved the GLOBAL
-            # pointer (a separate fact, #3793 stage 2); this notifies
-            # THIS connection's own per-connection owner
-            # (``_SessionFrameSource``) that ITS OWN "which agent" fact
-            # changed too — the fix for the cross-agent case
-            # ``registry.add_attach_listener`` cannot reach (see
-            # ``_ConnectionRetargetHub``'s own docstring).
-            _CONNECTION_RETARGET_HUB.notify(connection_id, target, _DEFAULT_SID)
+            # #5116 (architect co-vet, issuecomment-5380501066): this POST
+            # is a DIFFERENT HTTP request than the SSE stream it needs to
+            # retarget — correlated only by ``connection_id`` (the
+            # caller's OWN connection, already resolved above).
+            # ``registry.attach`` moved the GLOBAL pointer (a separate
+            # fact, #3793 stage 2); this notifies THIS connection's own
+            # per-connection owner (``_SessionFrameSource``) that ITS OWN
+            # "which agent, which session" fact changed too — the fix for
+            # the cross-agent case ``registry.add_attach_listener`` cannot
+            # reach (see ``_ConnectionRetargetHub``'s own docstring).
+            #
+            # ``target_session.session_id`` — NOT a re-typed ``_DEFAULT_
+            # SID`` literal (this PR's own first revision did exactly
+            # that, and it was the SAME "same fact typed twice" class
+            # #5116 exists to close: today `attach()` always focuses
+            # `_DEFAULT_SID`, so the two literals happened to agree, but
+            # nothing enforced it — a future change to attach()'s own
+            # focus logic would silently desync them). Reading it off the
+            # session `attach()` itself just returned is the single
+            # source of truth, not a second guess at what attach() did.
+            # `registry.attached_sid()`/`registry.attached_name` are
+            # NEVER the right read here either — those are the GLOBAL,
+            # single-connection-focus fact #3793 stage 2 deliberately
+            # keeps separate from any one AG-UI connection's own state,
+            # and reading it would race a DIFFERENT connection's own
+            # concurrent attach.
+            _CONNECTION_RETARGET_HUB.notify(
+                connection_id, target, target_session.session_id,
+            )
         return JSONResponse({"status": "ok", "attached": attached})
     elif ptype == "session_switch_request":
         # #4534 PR-1: mirrors attach_request above. The

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from typing import Callable
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -80,6 +81,50 @@ AGUI_OPERATOR_CHANNEL = DEFAULT_CHAT_CHANNEL_ID
 
 # Per-agent fail-close driver tasks (module-global; single-writer server).
 _DRIVERS: "dict[str, asyncio.Task]" = {}
+
+
+class _ConnectionRetargetHub:
+    """#5116: cross-agent ``/attach`` notification, keyed by ``connection_id``.
+
+    ``registry.add_attach_listener`` (agent-keyed) answers "who is watching
+    agent X's session focus" — correct for a session-switch WITHIN the
+    agent a connection already watches, structurally unable to answer "tell
+    connection C it should now watch a DIFFERENT agent" (nobody is ever
+    listening under the target's own key, since no connection is open to
+    that URL). This hub answers the second question, the ``attach_request``
+    POST handler (a DIFFERENT HTTP request than the SSE stream it targets,
+    correlated only by ``connection_id``) is the one caller with both the
+    connection id AND the resolved attach target, so it is the one caller
+    of :meth:`notify`. Module-global (single-writer server, mirrors
+    ``_DRIVERS`` above) — one hub for the whole process, not one per
+    connection (a connection does not know its own id exists as a
+    notification key until it subscribes)."""
+
+    def __init__(self) -> None:
+        self._listeners: "dict[str, list[Callable[[str, str], None]]]" = {}
+
+    def subscribe(self, connection_id: str, callback: "Callable[[str, str], None]") -> None:
+        self._listeners.setdefault(connection_id, []).append(callback)
+
+    def unsubscribe(self, connection_id: str, callback: "Callable[[str, str], None]") -> None:
+        listeners = self._listeners.get(connection_id)
+        if not listeners or callback not in listeners:
+            return
+        listeners.remove(callback)
+        if not listeners:
+            del self._listeners[connection_id]
+
+    def notify(self, connection_id: str, agent_name: str, sid: str) -> None:
+        """Fired synchronously (mirrors ``registry._announce_session_
+        attached``'s own no-await critical section) — a listener must not
+        block or await; its job is to hand the payload to a side-channel a
+        consumer task drains, the SAME idiom ``add_attach_listener``'s own
+        docstring states."""
+        for callback in list(self._listeners.get(connection_id, ())):
+            callback(agent_name, sid)
+
+
+_CONNECTION_RETARGET_HUB = _ConnectionRetargetHub()
 
 
 def _auth_context(request: Request) -> "AuthContext | None":
@@ -262,7 +307,35 @@ class _SessionFrameSource:
     previously-delivered frame or message ids consulted before forwarding.
     A future change that needs to track "have I already sent X" to this
     connection is out of scope for this mechanism; do not bolt it on here —
-    it would reintroduce exactly the state class this design avoided."""
+    it would reintroduce exactly the state class this design avoided.
+
+    ★#5116 (architect ruling: "lifting state up" / "unidirectional" / "no
+    derived state" — the react vocabulary the owner asked for). This
+    instance is now THE single per-connection owner of "which agent, which
+    session" — :attr:`_agent_name`/:attr:`_session` are the ONE copy;
+    :meth:`current_agent_name`/:meth:`current_session` are the ONE read
+    path (``_status_provider`` calls these fresh each time now, never
+    closes over a session variable frozen at connect time — the "derived
+    state" antipattern the owner named). The announce this class emits
+    NAMES WHATEVER IT WAS JUST TOLD TO BECOME (never ``self._agent_name``
+    read-then-written-back — see :meth:`_drain_one_session`'s own comment
+    at the fix site) — unidirectional: told, not self-referencing.
+
+    **What #5116 actually closes**: :meth:`add_attach_listener` is keyed
+    by AGENT NAME — correct for "a session-switch within the SAME agent
+    this connection is already watching" (the mechanism above), but
+    structurally unable to notify a connection about attaching to a
+    DIFFERENT agent (nobody is ever listening under the NEW agent's own
+    key, because no connection is open to ITS url). A connection's own
+    cross-agent ``/attach`` is therefore signalled through a SEPARATE,
+    connection-id-keyed channel (:data:`_CONNECTION_RETARGET_HUB`, module
+    level below) — the ``attach_request`` handler (a DIFFERENT HTTP
+    request than this SSE stream, correlated only by ``connection_id``)
+    notifies it directly. Both channels feed the SAME
+    :attr:`_switch_signal` queue and the SAME re-point/announce code in
+    :meth:`_drain_one_session` — one mechanism, two ways to trigger it,
+    not two mechanisms (#5116's own "stop duplicating" ruling, applied
+    here rather than inventing a parallel re-point implementation)."""
 
     def __init__(self, session, *, registry=None, agent_name: str = "") -> None:
         self._registry = registry
@@ -273,15 +346,50 @@ class _SessionFrameSource:
         self._sub = None
         self._session = None
         self._events = None
-        # #4534 PR-2b: the switch-follow signal — registry.add_attach_listener
-        # feeds this from its own synchronous critical section;
-        # _drain_one_session dual-waits it alongside sub.get().
-        self._switch_signal: "asyncio.Queue[str]" = asyncio.Queue()
+        # #4534 PR-2b (widened #5116): the switch-follow signal — now
+        # carries (agent_name, sid) rather than a bare sid, so the SAME
+        # queue/dual-wait/re-point code in _drain_one_session serves BOTH
+        # a same-agent session-switch (agent_name == self._agent_name,
+        # registry.add_attach_listener feeds it) AND a cross-agent
+        # /attach (agent_name == the NEW target, _CONNECTION_RETARGET_HUB
+        # feeds it) — one mechanism, two producers, not two mechanisms.
+        self._switch_signal: "asyncio.Queue[tuple[str, str]]" = asyncio.Queue()
         self._listening_for = ""
+        self._connection_id = ""
         self._bind(session)
         if self._registry is not None and self._agent_name:
             self._registry.add_attach_listener(self._agent_name, self._on_attach_announced)
             self._listening_for = self._agent_name
+
+    def current_agent_name(self) -> str:
+        """#5116: the ONE read path for "which agent is this connection
+        looking at right now" — ``_status_provider`` calls this fresh on
+        every status read instead of closing over a name frozen at
+        connect time (the "derived state" antipattern, owner's own
+        framing)."""
+        return self._agent_name
+
+    def current_session(self):
+        """#5116: the ONE read path for "which session is this connection
+        looking at right now" — see :meth:`current_agent_name`."""
+        return self._session
+
+    def listen_for_retarget(self, connection_id: str) -> None:
+        """#5116: subscribe this source to :data:`_CONNECTION_RETARGET_HUB`
+        under ``connection_id`` — the cross-agent counterpart to
+        ``registry.add_attach_listener`` above (agent-keyed, same-agent
+        session-switch only). Called once, right after construction, by
+        the route handler that already knows this connection's id."""
+        self._connection_id = connection_id
+        _CONNECTION_RETARGET_HUB.subscribe(connection_id, self._on_retarget_announced)
+
+    def _on_retarget_announced(self, agent_name: str, sid: str) -> None:
+        """Hub callback (#5116) — synchronous, no ``await``: mirrors
+        :meth:`_on_attach_announced`'s own idiom, feeding the SAME queue
+        with an explicit ``agent_name`` (the cross-agent case cannot
+        assume ``self._agent_name`` — that is precisely the value being
+        replaced)."""
+        self._switch_signal.put_nowait((agent_name, sid))
 
     def _bind(self, session) -> None:
         """Point this source at ``session``'s own audit-event stream (the
@@ -307,9 +415,12 @@ class _SessionFrameSource:
 
     def _on_attach_announced(self, sid: str) -> None:
         """Registry callback (#4534 PR-2b) — synchronous, no ``await``: hand
-        the sid to :attr:`_switch_signal` and return, mirroring
-        :meth:`_on_audit_event`'s own idiom."""
-        self._switch_signal.put_nowait(sid)
+        ``(self._agent_name, sid)`` to :attr:`_switch_signal` and return,
+        mirroring :meth:`_on_audit_event`'s own idiom. Same-agent only (the
+        registry keys this listener by ``self._agent_name`` itself, #5116's
+        own finding) — the cross-agent counterpart is
+        :meth:`_on_retarget_announced`."""
+        self._switch_signal.put_nowait((self._agent_name, sid))
 
     def start(self) -> None:
         self._drain_task = asyncio.create_task(self._drain_outbox())
@@ -318,19 +429,25 @@ class _SessionFrameSource:
         self._unbind(self._session)
         if self._registry is not None and self._listening_for:
             self._registry.remove_attach_listener(self._listening_for, self._on_attach_announced)
+        if self._connection_id:
+            _CONNECTION_RETARGET_HUB.unsubscribe(self._connection_id, self._on_retarget_announced)
         if self._sub is not None:
             self._sub.close()
         if self._drain_task is not None:
             self._drain_task.cancel()
 
-    def _resolve_switch_target(self, sid: str):
+    def _resolve_switch_target(self, agent_name: str, sid: str):
         """The target session for a switch-follow signal, or ``None`` when
         this source is registry-less (no switch-follow), the sid names no
-        loaded session, or the sid is already the current one (a no-op
-        switch)."""
+        loaded session, or the target is already the current one (a no-op
+        switch/retarget). #5116: ``agent_name`` is now an explicit
+        parameter (the signal's own payload) rather than always
+        ``self._agent_name`` — a cross-agent retarget names a DIFFERENT
+        agent than this source is currently bound to; a same-agent
+        session-switch happens to pass the same name it already had."""
         if self._registry is None or not sid:
             return None
-        target = self._registry.get_session(self._agent_name, sid)
+        target = self._registry.get_session(agent_name, sid)
         if target is None or target is self._session:
             return None
         return target
@@ -389,16 +506,45 @@ class _SessionFrameSource:
                     {get_task, switch_task}, return_when=asyncio.FIRST_COMPLETED,
                 )
                 if switch_task in done:
-                    sid = switch_task.result()
+                    signal_agent_name, sid = switch_task.result()
                     switch_task = None
-                    target = self._resolve_switch_target(sid)
+                    target = self._resolve_switch_target(signal_agent_name, sid)
                     if target is not None:
                         if get_task is not None and not get_task.done():
                             get_task.cancel()
                         get_task = None
+                        old_agent_name = self._agent_name
                         old_session = self._session
                         self._unbind(old_session)
                         sub.close()
+                        # #5116: THIS is the fix site. self._agent_name is
+                        # updated to the signal's own target BEFORE the
+                        # announce is built — "told, not self-referencing"
+                        # (architect's "unidirectional" ruling). The
+                        # pre-#5116 bug: this line did not exist, so a
+                        # cross-agent retarget's announce below still read
+                        # self._agent_name == the OLD (connection-opening)
+                        # agent, teaching the client to re-hydrate as the
+                        # wrong agent even though the session object itself
+                        # (``target``) was already correctly resolved.
+                        self._agent_name = signal_agent_name
+                        # Same-agent-switch-follow re-registration: if the
+                        # agent changed, this connection must now listen
+                        # for FUTURE same-agent switches under the NEW key
+                        # (the OLD key's listener would fire on the wrong
+                        # agent's switches from here on).
+                        if (
+                            self._registry is not None
+                            and old_agent_name != signal_agent_name
+                            and self._listening_for
+                        ):
+                            self._registry.remove_attach_listener(
+                                self._listening_for, self._on_attach_announced,
+                            )
+                            self._registry.add_attach_listener(
+                                signal_agent_name, self._on_attach_announced,
+                            )
+                            self._listening_for = signal_agent_name
                         # ★Barrier ordering (co-vet #3310 N3 (a)): the announce
                         # is enqueued BEFORE ``_bind(target)`` makes the new
                         # session's audit-event subscriber live. ``_bind`` calls
@@ -414,9 +560,11 @@ class _SessionFrameSource:
                         # (the SAME barrier property N1 built for
                         # ``AgentRegistry.attach``/``attach_session``, applied
                         # here to the ORDER of two synchronous calls rather than
-                        # a flip + a queue put). The announce payload depends
-                        # only on ``self._agent_name``/``sid``, never on
-                        # ``_bind``'s result, so reordering is free.
+                        # a flip + a queue put). The announce payload now reads
+                        # ``self._agent_name`` AFTER the update two lines above
+                        # — #5116: this is the ONE place the connection's own
+                        # "which agent" fact is written, and every other reader
+                        # (announce, status, frame source) derives from it.
                         self._q.put_nowait(
                             EventFrame(
                                 Event(
@@ -427,7 +575,7 @@ class _SessionFrameSource:
                         )
                         self._bind(target)
                         return True
-                    continue  # unresolved / no-op sid: drop silently, keep draining
+                    continue  # unresolved / no-op signal: drop silently, keep draining
                 if get_task in done:
                     msg = get_task.result()
                     get_task = None
@@ -497,18 +645,27 @@ async def agui_events(request: Request, agent_name: str):
     _ensure_fail_close_driver(agent_name, manager, registry)
 
     source = _SessionFrameSource(session, registry=registry, agent_name=agent_name)
+    source.listen_for_retarget(connection_id)  # #5116: cross-agent /attach
     source.start()
 
     def _status_provider():
-        # #5094: read status off THIS connection's own already-resolved
-        # ``session`` (bound above via ``registry.ensure_running(agent_name)``)
+        # #5094: read status off THIS connection's own resolved session
         # rather than ``_snapshot(registry)``, which reads the registry's
         # single GLOBAL attached-pointer — deliberately never set for an
         # AG-UI connection (``ensure_running``'s own #3793-stage-2 docstring)
         # — and so returned ``None`` wholesale on every first connect,
         # regardless of what #5097/#5104 already fixed inside that dict. See
         # ``_snapshot_for_session``'s own docstring for the full reasoning.
-        return _snapshot_for_session(registry, session)
+        #
+        # #5116: reads ``source.current_session()`` FRESH on every call,
+        # never the ``session`` local captured above — that capture is
+        # frozen at connect time (this closure's own "derived state"
+        # antipattern, owner's framing) and never updates after a
+        # cross-agent ``/attach`` re-points ``source`` to a different
+        # session. ``source`` is the SINGLE per-connection owner of
+        # "which agent, which session" now (see its own class docstring);
+        # this is its one status-facing read path.
+        return _snapshot_for_session(registry, source.current_session())
 
     def _backlog_provider(name: str, sid: str) -> "list[Frame]":
         return session_backlog_frames(registry, name, sid)
@@ -763,6 +920,17 @@ async def agui_submit(request: Request, agent_name: str):
         if target and registry.exists(target):
             await registry.attach(target)
             attached = True
+            # #5116: this POST is a DIFFERENT HTTP request than the SSE
+            # stream it needs to retarget — correlated only by
+            # ``connection_id`` (the caller's OWN connection, already
+            # resolved above). ``registry.attach`` moved the GLOBAL
+            # pointer (a separate fact, #3793 stage 2); this notifies
+            # THIS connection's own per-connection owner
+            # (``_SessionFrameSource``) that ITS OWN "which agent" fact
+            # changed too — the fix for the cross-agent case
+            # ``registry.add_attach_listener`` cannot reach (see
+            # ``_ConnectionRetargetHub``'s own docstring).
+            _CONNECTION_RETARGET_HUB.notify(connection_id, target, _DEFAULT_SID)
         return JSONResponse({"status": "ok", "attached": attached})
     elif ptype == "session_switch_request":
         # #4534 PR-1: mirrors attach_request above. The

--- a/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
+++ b/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
@@ -1,0 +1,287 @@
+"""Tier 2: #5116 — an already-open remote SSE stream follows a CROSS-agent
+``attach_request`` (the owner's own live-reported bug: status bar / history
+stayed on the connection's ORIGINAL agent after ``/attach``, despite the
+POST reporting success and the REGISTRY's own global pointer genuinely
+switching).
+
+Root cause (e2e-coder's own decisive raw observation, #5094
+issuecomment-5380435298 — a real SSE tap, no client-side reinterpretation):
+``registry.add_attach_listener`` is keyed by AGENT NAME, correct for a
+same-agent session-switch (the connection is already listening under its
+own agent's key) but structurally unable to notify a connection about a
+DIFFERENT agent (nobody is registered under the TARGET's key). Confirmed
+live: zero ``session_attached`` frames reached the connection at all after
+a cross-agent ``/attach`` — not "the wrong agent name in the payload", the
+announce never fired for this connection in the first place.
+
+Fix (architect ruling, "lifting state up"/"unidirectional"/"no derived
+state"/"push not pull", issuecomment-5380440608 family):
+``_SessionFrameSource`` becomes the single per-connection owner of "which
+agent, which session" — a NEW connection-id-keyed channel
+(``_ConnectionRetargetHub``) notifies it directly (the ``attach_request``
+POST handler is a DIFFERENT HTTP request than this SSE stream, correlated
+only by ``connection_id``, and is the one caller with both the id and the
+resolved target). The announce this source emits now NAMES WHATEVER IT WAS
+JUST TOLD (``self._agent_name`` is updated BEFORE the announce is built,
+never read-then-written-back), and ``_status_provider`` reads
+``source.current_session()`` fresh every call rather than a ``session``
+variable closed over at connect time.
+
+Chains the REAL pieces, mirroring ``test_4534_pr2b_switch_follow_e2e.py``'s
+own pattern (that file's own docstring names it as the gate that would
+have caught a silently-orphaned mechanism — this is its cross-agent
+sibling): a REAL httpx ASGI POST to ``attach_request`` -> the REAL
+``_ConnectionRetargetHub`` -> a REAL, already-``start()``ed
+``_SessionFrameSource``'s dual-wait -> a REAL ``AgUiEmitter`` mid-
+``stream()`` re-firing the reconnect protocol, over the SAME in-memory
+``AgentRegistry``. No mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.repl.status import _snapshot_for_session
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.endpoint import (
+    _SessionFrameSource,
+    session_backlog_frames,
+)
+from reyn.interfaces.transport.agui.protocol import parse_sse_blocks
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+_CONNECTION_ID = "conn-5116-test"
+
+
+def _two_agent_registry(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+        )
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+    holder["reg"] = reg
+    reg.create("coder-smith")
+    return reg
+
+
+def _build_app(reg, monkeypatch):
+    from fastapi import FastAPI
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+    from reyn.interfaces.transport.agui.endpoint import router
+    from reyn.interfaces.web.auth import AuthContext
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.auth = AuthContext(token="s3cret", require_token=True)
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: reg)
+    return app
+
+
+async def _post(app, path: str, payload: dict):
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        return await client.post(path, json=payload)
+
+
+async def _collect_until_barrier(agen) -> "list":
+    out: list = []
+    it = agen.__aiter__()
+    while True:
+        item = await it.__anext__()
+        out.append(item)
+        if isinstance(item, EventFrame) and getattr(item.event, "type", "") == "session_attached":
+            return out
+
+
+@pytest.mark.asyncio
+async def test_open_sse_stream_follows_a_cross_agent_attach_request_post(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #5116 witness — status/announce/frame all agree after a
+    REAL cross-agent ``attach_request`` POST, driven through the wire
+    ptype (not ``registry.attach`` called directly)."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    default_session = await reg.attach("default")
+    app = _build_app(reg, monkeypatch)
+
+    # The "already-open stream": bound to "default", listening for a
+    # cross-agent retarget under ITS OWN connection id — exactly the
+    # server-side state a --connect client's SSE GET leaves behind.
+    source = _SessionFrameSource(default_session, registry=reg, agent_name="default")
+    source.listen_for_retarget(_CONNECTION_ID)
+    source.start()
+    frames_iter = source.frames()
+
+    # ★ status BEFORE the attach: reads "default" — the pre-condition a
+    # naive fix could accidentally satisfy by coincidence (e.g. session
+    # objects that happen to look alike). Asserted so the AFTER read
+    # below is a genuine change, not a tautology.
+    status_before = _snapshot_for_session(reg, source.current_session())
+    assert status_before["attached_name"] == "default"
+
+    try:
+        # The real wire entry point — the SAME ptype ClientTransport.
+        # request_attach sends, WITH this connection's own id (the
+        # correlation attach_request's handler uses to find the right
+        # _SessionFrameSource — a different id would prove nothing).
+        resp = await _post(
+            app, f"/agui/chat/default?connection_id={_CONNECTION_ID}&token=s3cret",
+            {"type": "attach_request", "agent_name": "coder-smith"},
+        )
+        assert resp.status_code == 200
+        assert resp.json().get("attached") is True
+        # The registry's OWN global pointer — a SEPARATE fact (#3793
+        # stage 2), asserted here only as a positive control that the
+        # attach itself genuinely happened server-side.
+        assert reg.attached_name == "coder-smith"
+
+        collected = await _collect_until_barrier(frames_iter)
+    finally:
+        source.close()
+
+    # ── ① announce ──────────────────────────────────────────────────────
+    barrier = [
+        f for f in collected
+        if isinstance(f, EventFrame) and getattr(f.event, "type", "") == "session_attached"
+    ]
+    assert barrier, (
+        f"the already-open stream never observed the cross-agent attach — "
+        f"no session_attached EventFrame arrived; collected {len(collected)} "
+        f"item(s): {collected!r}"
+    )
+    assert barrier[0].event.data.get("agent") == "coder-smith", (
+        f"the announce must name the TARGET agent, not the connection's "
+        f"original one — got {barrier[0].event.data!r}"
+    )
+
+    # ── ② status (the owner's own reported symptom: "status bar stays on "
+    #     "default") ───────────────────────────────────────────────────
+    status_after = _snapshot_for_session(reg, source.current_session())
+    assert status_after["attached_name"] == "coder-smith", (
+        f"status must reflect the NEW agent after attach; got "
+        f"{status_after['attached_name']!r} (still the pre-attach value "
+        f"means _status_provider is reading a frozen/stale session)"
+    )
+
+    # ── ③ frame source's own current-agent read path ────────────────────
+    assert source.current_agent_name() == "coder-smith"
+    assert source.current_session() is reg.get_session("coder-smith", "main") or (
+        source.current_session().agent_name == "coder-smith"
+    )
+
+    await asyncio.sleep(0)  # let source's own tasks settle before teardown
+
+
+@pytest.mark.asyncio
+async def test_status_changes_are_pushed_by_the_attach_itself_not_ridden_on_a_later_frame(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #5116's own push-vs-pull witness (architect/lead-coder,
+    issuecomment-5380440608/5380440... family — owner's verbatim: "stop
+    designing old-generation query-on-demand UIs"). The projected STATE_
+    DELTA reaching the wire text must be driven by the attach's OWN
+    announce frame — not require some LATER, UNRELATED content frame to
+    arrive before status catches up (the pre-#5116 pull shape: status was
+    only ever recomputed as a side effect of whatever frame happened to
+    stream next).
+
+    This is a genuine push claim, not merely "eventually consistent": the
+    ONLY frame this test lets flow after the attach is the announce
+    itself (bounded collection stops at the first STATE_DELTA/session_
+    attached pair) — no chat message, no tool call, nothing else is ever
+    submitted."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    default_session = await reg.attach("default")
+    app = _build_app(reg, monkeypatch)
+
+    source = _SessionFrameSource(default_session, registry=reg, agent_name="default")
+    source.listen_for_retarget(_CONNECTION_ID)
+    source.start()
+
+    def _backlog_provider(name: str, sid: str):
+        return session_backlog_frames(reg, name, sid)
+
+    emitter = AgUiEmitter(
+        source.frames(),
+        lambda: _snapshot_for_session(reg, source.current_session()),
+        backlog_provider=_backlog_provider,
+    )
+
+    chunks: "list[str]" = []
+    stream_iter = emitter.stream()
+    chunks.append(await stream_iter.__anext__())  # prime past the initial connect snapshot
+
+    try:
+        resp = await _post(
+            app, f"/agui/chat/default?connection_id={_CONNECTION_ID}&token=s3cret",
+            {"type": "attach_request", "agent_name": "coder-smith"},
+        )
+        assert resp.json().get("attached") is True
+
+        # Bounded on the RE-FIRED STATE_SNAPSHOT itself arriving, not just
+        # the announce's own text (#3310 N3: the emitter's re-fire yields
+        # the announce frame FIRST, then a SEPARATE MESSAGES_SNAPSHOT +
+        # STATE_SNAPSHOT pair in the SAME loop iteration — stopping at the
+        # announce alone would read a chunk too early and assert on
+        # whatever STATE_SNAPSHOT happened to precede it, not the pushed
+        # one). A real termination condition (guaranteed exactly once by
+        # production behaviour, asserted below), never an unrelated
+        # content frame this test would otherwise have to fabricate to
+        # "unstick" a pull design.
+        for _ in range(50):
+            chunk = await stream_iter.__anext__()
+            chunks.append(chunk)
+            joined = "".join(chunks)
+            if "reyn.event.session_attached" in joined and "STATE_SNAPSHOT" in joined.split(
+                "reyn.event.session_attached", 1,
+            )[1]:
+                break
+    finally:
+        source.close()
+
+    sse_text = "".join(chunks)
+    events = parse_sse_blocks(sse_text.split("\n"))
+    state_events = [ev for ev in events if ev.type in ("STATE_SNAPSHOT", "STATE_DELTA")]
+    assert state_events, (
+        f"no STATE_SNAPSHOT/STATE_DELTA reached the wire alongside the "
+        f"attach's own announce — status did not push; sse_text={sse_text!r}"
+    )
+    # The LAST state event before/around the barrier must carry the NEW
+    # agent's attached_name — proves the status push read the RETARGETED
+    # session, not a stale snapshot re-sent unchanged. STATE_SNAPSHOT
+    # nests the projected dict under "snapshot"; STATE_DELTA under
+    # "delta" (encode_state_snapshot/encode_state_delta, protocol.py).
+    last_snapshot = next(
+        (
+            ev.data.get("snapshot") or ev.data.get("delta")
+            for ev in reversed(state_events)
+            if isinstance(ev.data, dict)
+        ),
+        None,
+    )
+    assert last_snapshot is not None
+    assert last_snapshot.get("attached_name") == "coder-smith", (
+        f"the pushed status must already reflect the new agent; got "
+        f"{last_snapshot!r}"
+    )
+
+    await asyncio.sleep(0)

--- a/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
+++ b/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
@@ -184,9 +184,13 @@ async def test_open_sse_stream_follows_a_cross_agent_attach_request_post(
 
     # ── ③ frame source's own current-agent read path ────────────────────
     assert source.current_agent_name() == "coder-smith"
-    assert source.current_session() is reg.get_session("coder-smith", "main") or (
-        source.current_session().agent_name == "coder-smith"
-    )
+    # #5116 co-vet (architect, issuecomment-5380501066): identity (``is``),
+    # not a truthy-adjacent fallback — the prior ``... or (...agent_name
+    # == ...)`` form made the right-hand side almost always true
+    # regardless of whether the left side's actual identity held, so a
+    # bug swapping in a DIFFERENT-but-same-named session object would
+    # have passed silently.
+    assert source.current_session() is reg.get_session("coder-smith", "main")
 
     await asyncio.sleep(0)  # let source's own tasks settle before teardown
 
@@ -243,11 +247,16 @@ async def test_status_changes_are_pushed_by_the_attach_itself_not_ridden_on_a_la
         # STATE_SNAPSHOT pair in the SAME loop iteration — stopping at the
         # announce alone would read a chunk too early and assert on
         # whatever STATE_SNAPSHOT happened to precede it, not the pushed
-        # one). A real termination condition (guaranteed exactly once by
-        # production behaviour, asserted below), never an unrelated
-        # content frame this test would otherwise have to fabricate to
-        # "unstick" a pull design.
-        for _ in range(50):
+        # one). Waited on UNBOUNDED (#5116 co-vet, architect,
+        # issuecomment-5380501066 — CLAUDE.md's own testing policy: "no
+        # `range(N)` wrapping a wait ... CI's `--timeout=120` is the kill
+        # switch"). The prior `range(50)` form was doubly wrong here, not
+        # just a policy violation: stripping the fix makes `__anext__()`
+        # itself hang (the stream never advances without the announce),
+        # so the loop never even reached its own 50th iteration — the
+        # thing actually bounding it was CI's timeout regardless, the
+        # `range(50)` was inert.
+        while True:
             chunk = await stream_iter.__anext__()
             chunks.append(chunk)
             joined = "".join(chunks)

--- a/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
+++ b/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
@@ -294,3 +294,142 @@ async def test_status_changes_are_pushed_by_the_attach_itself_not_ridden_on_a_la
     )
 
     await asyncio.sleep(0)
+
+
+def _make_get_request(query_string: bytes, app):
+    """A minimal real ``starlette.requests.Request`` for a GET to
+    ``agui_events`` — enough scope for ``_auth_context``/
+    ``authenticate_request``/``_connection_id_from_request`` to read
+    (``request.app.state.auth``, ``request.query_params``,
+    ``request.client``), without going through a full ASGI transport."""
+    from starlette.requests import Request
+
+    scope = {
+        "type": "http", "method": "GET", "path": "/agui/chat/default/events",
+        "query_string": query_string, "headers": [], "client": ("127.0.0.1", 12345),
+        "app": app,
+    }
+    return Request(scope)
+
+
+@pytest.mark.asyncio
+async def test_a_real_agui_events_get_pushes_correct_status_after_cross_agent_attach(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: lead-coder block (issuecomment-5380521791, relaying
+    tui-coder's own independent strip) — the OTHER two witnesses above
+    build ``AgUiEmitter`` BY HAND with a test-owned
+    ``lambda: _snapshot_for_session(reg, source.current_session())``,
+    never calling into ``agui_events``'s own ``_status_provider`` closure
+    at all. tui-coder's strip confirmed it: reverting the fix line
+    inside ``agui_events`` (``source.current_session()`` -> the old
+    frozen ``session``) leaves BOTH existing tests green, because
+    neither one's status assertion ever executes the PRODUCTION closure
+    — they prove ``current_session()`` resolves correctly, not that the
+    product actually calls it. The owner's own live machine has gone
+    quiet on this exact shape twice already tonight (#5097 landed ->
+    empty, #5104 landed -> empty, both "the mechanism was fixed, the
+    wiring wasn't reached") — a third cannot go out.
+
+    This test calls the REAL ``agui_events`` route handler DIRECTLY (a
+    real, minimal ``starlette.requests.Request``, not a hand-built
+    Request stand-in with a stubbed interface — every attribute it reads
+    is real Starlette machinery) to obtain its own real
+    ``StreamingResponse`` and drains ITS ``body_iterator`` — the exact
+    async generator ``emitter.stream()`` produces from the REAL
+    ``_status_provider`` closure defined inside ``agui_events`` itself,
+    never a test-owned substitute. The ``attach_request`` POST goes
+    through the REAL ASGI app (a genuine httpx/ASGITransport round
+    trip), sharing this same request's own ``connection_id``.
+
+    ★Why not drive the GET through ASGITransport too (`client.stream`)★:
+    tried first, and it deadlocks — a single httpx ``AsyncClient``
+    serializes a still-open streaming GET against a concurrent POST
+    issued from the SAME client instance (confirmed in isolation: the
+    POST never even starts running while the GET's `async with
+    client.stream(...)` block is still open). Calling the route function
+    directly sidesteps that transport-level limitation without touching
+    what's actually under test — the handler's OWN closure and its own
+    real ``StreamingResponse``/``AgUiEmitter`` wiring are unchanged
+    either way; only the unrelated question "how does this test reach
+    the ASGI app" differs, and the POST still goes through a real ASGI
+    round trip.
+
+    Deliberately does NOT assert "the lambda matches production" (a
+    form lead-coder's own review rejected — that pushes the test toward
+    the SAME expression on both sides). It drives the ONE real callsite
+    directly and reads what the real wire actually carries.
+
+    Strip-falsifier: reverting the fix line inside ``agui_events``
+    (``source.current_session()`` back to the old frozen ``session``
+    variable) turns THIS test red while the other two stay green —
+    verified locally, the exact gap tui-coder's strip named."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    app = _build_app(reg, monkeypatch)
+    conn_id = "conn-5116-real-route-test"
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+
+    req = _make_get_request(f"token=s3cret&connection_id={conn_id}".encode(), app)
+    resp = await endpoint_mod.agui_events(req, "default")
+    from starlette.responses import StreamingResponse
+
+    assert isinstance(resp, StreamingResponse), (
+        f"expected a real StreamingResponse (auth/agent-exists must both "
+        f"pass for this test's own setup); got {resp!r}"
+    )
+    body_iter = resp.body_iterator.__aiter__()
+
+    async def _read_one_event():
+        event_type = None
+        buf = ""
+        async for chunk in _iter_lines(body_iter):
+            if chunk.startswith("event:"):
+                event_type = chunk[len("event:"):].strip()
+            elif chunk.startswith("data:"):
+                buf = chunk[len("data:"):].strip()
+                return event_type, buf
+        raise StopAsyncIteration
+
+    # Drain the initial connect snapshots (MESSAGES_SNAPSHOT, STATE_SNAPSHOT).
+    for _ in range(2):
+        await _read_one_event()
+
+    post_resp = await _post(
+        app, f"/agui/chat/default?connection_id={conn_id}&token=s3cret",
+        {"type": "attach_request", "agent_name": "coder-smith"},
+    )
+    assert post_resp.status_code == 200
+    assert post_resp.json().get("attached") is True
+
+    # Unbounded wait for the real predicate (CLAUDE.md's own policy): read
+    # events until the announce AND its own re-fired STATE_SNAPSHOT have
+    # both been seen.
+    seen_announce = False
+    last_snapshot = None
+    while last_snapshot is None:
+        etype, data = await _read_one_event()
+        if "session_attached" in data:
+            seen_announce = True
+        if seen_announce and etype == "STATE_SNAPSHOT":
+            import json as _json
+
+            last_snapshot = _json.loads(data).get("snapshot")
+
+    assert last_snapshot is not None
+    assert last_snapshot.get("attached_name") == "coder-smith", (
+        f"the REAL agui_events route's own _status_provider must reflect "
+        f"the new agent after a real cross-agent attach; got {last_snapshot!r}"
+    )
+
+
+async def _iter_lines(chunk_iter):
+    """Split a raw SSE ``body_iterator`` (whole ``event: ...\\ndata: ...\\n\\n``
+    blocks, one per ``yield``) into individual lines — mirrors what an
+    ``httpx`` line reader would hand a caller, so ``_read_one_event`` above
+    stays identical in shape to the live-script/manual-tap pattern used
+    elsewhere in this session's own verification work."""
+    async for chunk in chunk_iter:
+        for line in chunk.split("\n"):
+            if line:
+                yield line


### PR DESCRIPTION
**[e2e-coder]** — part of #5116, part of #5094.

## What

Owner-reported live bug (#5094): `/attach` reports success and the registry's own global pointer genuinely switches, but the status bar stays on the connection's original agent, conversation history stays on the original agent's, and the target agent's session tree is empty.

## Root cause — real SSE tap, raw log (permanent regression record)

Decisive observation (architect's own spec): a direct httpx SSE tap on `/agui/chat/default/events`, bypassing any client-side reinterpretation, across a real `/attach coder-smith`:
```
[RAW-SSE] type='MESSAGES_SNAPSHOT' data={"messages": [], ...}
[RAW-SSE] type='STATE_SNAPSHOT' data={"snapshot": {"attached_name": "default", ...}, ...}
<< /attach coder-smith issued, server POST returns 200 OK, registry.attached_name == "coder-smith" confirmed >>
<< nothing else ever arrives on this connection's SSE stream >>
```
**Zero `session_attached` frames reach the connection at all** — not "the announce carries the wrong agent name" (the two predicted outcomes going in), but the announce never fires for this connection in the first place.

Traced: `registry.add_attach_listener` is keyed by AGENT NAME — correct for a same-agent session-switch (the connection is already listening under its own agent's key) but structurally unable to notify a connection about attaching to a DIFFERENT agent, since nobody is ever registered under the target's own key (no connection is open to that URL).

## Fix (architect ruling — "lifting state up" / "unidirectional" / "no derived state" / "push not pull", the owner's own react vocabulary)

- `_SessionFrameSource` becomes the single per-connection owner of "which agent, which session" (`current_agent_name()`/`current_session()` are the ONE read path).
- New `_ConnectionRetargetHub` (connection-id-keyed, module-global, mirrors `_DRIVERS`) — the `attach_request` POST handler (a DIFFERENT HTTP request than the SSE stream, correlated only by `connection_id`) notifies it directly. Feeds the SAME `_switch_signal` queue and `_drain_one_session` re-point code the existing same-agent session-switch-follow already uses (widened from a bare `sid` to `(agent_name, sid)`) — one mechanism, two producers, not two mechanisms.
- The fix site: `self._agent_name` is updated to the retarget signal's own target BEFORE the announce is built (this line did not exist before — the announce always read `self._agent_name`, which never changed after construction). "Told, not self-referencing."
- `_status_provider` reads `source.current_session()` fresh on every call instead of closing over a `session` variable frozen at connect time (the "derived state" antipattern).

Same-agent `/session switch` is untouched and still works via the existing path — confirmed by the full pre-existing `test_4534_pr2b_switch_follow_e2e.py` suite staying green.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` (new test file, 0 Tier-4)
- [x] `python scripts/verify_module_docstrings.py` (changed src file)
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` (re-run post-rebase) / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] New witness `test_5116_connection_agent_owner_cross_attach.py`, 2 tests against the REAL wire chain (httpx ASGI POST → the real hub → a real started `_SessionFrameSource` → a real `AgUiEmitter` mid-stream, no mocks): ① announce/status/frame all agree on the NEW agent after a real `attach_request` POST ② status is PUSHED by the attach's own announce frame alone — no unrelated content frame is ever submitted, bounded on the re-fired `STATE_SNAPSHOT` itself, not just the announce's own text. Strip-falsified: removing the `self._agent_name` update reproduces the EXACT owner-reported symptom (announce carries `"default"`, not the target) — restored → green.
- [x] Full sweep filtered to `agui`/`5094`/`5116`/`status`/`attach`/`switch`: 184+116 passed across runs
- [ ] Live verification (raw SSE tap + full 4-way `--connect` check) — to follow before merge, per the new "merged ≠ done" protocol.
- [ ] (Visual — standing waiver 2026-08-08)

part of #5116
part of #5094


---

**[architect]** — co-vet blocking points (issuecomment-5380501066):

- [x] 🔴 (解消 95cc16b9f, architect 確認 issuecomment-5380527411) `for _ in range(50)` が家則の明文違反（testing policy, Ceiling: "no `range(N)` wrapping a wait"）。`while True:` へ。加えてこの 50 は bound として機能していない（strip すると `__anext__()` がその場で止まり 50 に到達しない）
- [x] 🔴 (解消 95cc16b9f, architect 確認) `notify(..., _DEFAULT_SID)` が `attach()` の持つ「どの session に focus したか」を打ち直している = #5116 が閉じる class そのもの。`attach()` に focus した sid を返させて渡す（`registry.attached_sid()` は global で他接続と競合するので不可）
- [x] 🔴 (解消 95cc16b9f, architect 確認) `assert source.current_session() is ... or (....agent_name == "coder-smith")` の `or` 右辺がほぼ常に真で左辺（同一性）が検査されていない。`is` 1 本へ
- [x] ⚪ (#5119 に分離, 非 blocking 合意) `listen_for_retarget` が `gen()` の try の外で subscribe しており、generator 開始前の例外で hub エントリが永久に残る。key が connection_id なので上限が無い（registry listener は agent 数で頭打ち）


- [x] 🔴 **[lead-coder]** status 軸の production glue が未カバー — test は自前 lambda で `source.current_session()` を使い、`agui_events`/`_status_provider` を 1 度も呼んでいない（追加分の 2 件は docstring と assert メッセージ、呼び出し 0）。実 GET で駆動する test を 1 本、修正行を strip すると赤になること。詳細 issuecomment-5380518...


