### PR TITLE
feat(#5039): a TESTS-READ note must name the tree it read

### DIFF
--- a/.github/workflows/check-tests-read-names-its-tree.yml
+++ b/.github/workflows/check-tests-read-names-its-tree.yml
@@ -1,0 +1,52 @@
+name: TESTS-READ names its tree
+
+# #5039: house rule 8 ("a PR touching tests/ does not self-merge until a
+# reviewer's TESTS-READ note lands") is satisfied by the note EXISTING —
+# nothing looks at WHICH tree the note is a claim about. Measured on one
+# evening (2026-08-22): four PRs each carried a note that read an earlier head
+# and then tests/ moved (#5090, #5095, #5096, #5038). All four read green.
+#
+# Same shape as check-pr-closing-intent.yml (the only other workflow that
+# inspects a PR's own text rather than its tree): a dedicated workflow, not
+# folded into test.yml, because it must re-run on `edited` — a reviewer who
+# adds the head to an existing note needs the gate to re-evaluate, and
+# `edited` is not a default pull_request event type. `synchronize` re-runs it
+# against the updated commit set, which is the whole point: a note that was
+# current becomes stale the moment tests/ moves.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  tests-read-names-its-tree:
+    name: TESTS-READ note names the tree it read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The check reads each PR commit's touched paths via `git show`, and
+          # refuses (loudly) rather than reporting a result computed from
+          # commits it could not read. A shallow checkout does not have them,
+          # so that refusal would fire on every PR — a false red, which is as
+          # bad as the false green this gate exists to remove.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      # scripts/check_tests_read_names_its_tree.py is stdlib-only
+      # (argparse / json / re / subprocess). No pip install needed.
+      - name: Check the TESTS-READ note names this PR's tree
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_tests_read_names_its_tree.py --pr "${{ github.event.pull_request.number }}"

--- a/.github/workflows/check-tests-read-names-its-tree.yml
+++ b/.github/workflows/check-tests-read-names-its-tree.yml
@@ -16,6 +16,13 @@ name: TESTS-READ names its tree
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  # The SUBJECT of this check is a PR comment, and `pull_request` does not
+  # fire when one is posted — measured on this workflow's own first PR
+  # (#5120): the reviewer's note landed, the check stayed red, and nothing
+  # would have re-run it short of another push. A gate that reads comments
+  # has to listen for them.
+  issue_comment:
+    types: [created, edited]
 
 permissions:
   contents: read
@@ -24,6 +31,9 @@ permissions:
 jobs:
   tests-read-names-its-tree:
     name: TESTS-READ note names the tree it read
+    # `issue_comment` fires for plain issues too; only pull requests have a
+    # `pull_request` key on the issue payload.
+    if: github.event_name == 'pull_request' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -49,4 +59,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          python scripts/check_tests_read_names_its_tree.py --pr "${{ github.event.pull_request.number }}"
+          # `pull_request` events carry the number on .pull_request; an
+          # `issue_comment` on a PR carries it on .issue.
+          python scripts/check_tests_read_names_its_tree.py \
+            --pr "${{ github.event.pull_request.number || github.event.issue.number }}"

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Fail a ``tests/``-touching PR whose TESTS-READ note does not name the tree
+it read, or names one that later commits to ``tests/`` have already left behind.
+
+#5039. House rule 8 says a PR touching ``tests/`` does not self-merge until a
+reviewer's TESTS-READ note lands on it. The rule is satisfied by the note
+*existing* — nothing looks at WHICH tree the note is a claim about. Measured on
+one evening (2026-08-22): four PRs each carried a TESTS-READ note that read an
+earlier head, and in every case ``tests/`` moved afterwards — #5090 (note at
+``a7c44eef6``; the gate tests landed 3 and 15 minutes later), #5095 (note at
+``e0dd40461``; the witness commit landed 13 minutes later), #5096 (note at
+10:32; test files changed at 10:48 and 10:59), #5038 (note read ``5c90f2ac4``
+while the PR head was ``6b5d587c0``, already merged). All four read green under
+rule 8.
+
+The class this closes is the one ``verification-hazards.md`` names as its root:
+**an observation does not name its own referent**. So the predicate is not "was
+the note any good" — nothing here reads the note's content. It is only:
+
+1. the note names a SHA at all (absent -> red), and
+2. no commit has touched ``tests/`` since that SHA (later commits -> red, with
+   the commits listed, so the ask is "top up the diff", not "read it again"),
+3. a ``tests/``-touching PR carries at least one note (none -> red) — rule 8
+   itself, which nothing has been checking mechanically.
+
+Deliberately NOT closed: an author can edit an old comment to swap in a newer
+SHA. That is outside a text predicate, and pretending otherwise would be the
+"a checklist item answered yes every time" shape CLAUDE.md already warns about.
+
+stdlib-only (argparse / json / re / subprocess), mirroring
+``scripts/check_pr_closing_intent.py`` so CI runs it dep-free.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+#: A TESTS-READ note is recognised by this marker appearing in a PR comment.
+#: Matched case-insensitively and tolerating the ``TESTS-READY`` typo that
+#: several sessions produce, because the gate must not turn a typo into
+#: "no note landed" (that would fail the PR for the wrong reason).
+_NOTE_MARKER = re.compile(r"TESTS-READ(?:Y)?", re.IGNORECASE)
+
+#: A 7-40 char hex run, the shape `git rev-parse` prints. Bounded on both sides
+#: by a non-hex boundary so a longer word containing hex letters is not read as
+#: a SHA. Backticks are the common wrapper in these notes and are not part of
+#: the token.
+_SHA = re.compile(r"(?<![0-9a-fA-F])([0-9a-fA-F]{7,40})(?![0-9a-fA-F])")
+
+#: Words that would otherwise pass `_SHA` — all-hex English that shows up in
+#: these notes. Compared lowercased.
+_SHA_FALSE_FRIENDS = frozenset({
+    "decade", "defaced", "faceted", "acceded", "effaced", "deface", "efface",
+})
+
+
+def find_note_shas(comment_body: str, known_oids: "list[str]") -> "list[str]":
+    """The SHA-shaped tokens in *comment_body* that are actually commits of
+    this PR (prefix-matched against *known_oids*).
+
+    Membership is the whole point, not a nicety: a bare hex pattern also
+    matches an issue-comment id (``5379476813`` is ten decimal digits, and
+    decimal digits are hex digits), an all-hex English word ("decade",
+    "faceted"), and any other long hex-ish run. Measured: the first live run of
+    this gate read a comment id as a tree name and passed a PR it should have
+    failed. A token that is not one of this PR's commits is not a claim about
+    this PR's tree, so it is not a SHA for this gate's purposes."""
+    out: "list[str]" = []
+    for cand in _SHA.findall(comment_body):
+        if cand.lower() in _SHA_FALSE_FRIENDS:
+            continue
+        if any(oid.startswith(cand) or cand.startswith(oid) for oid in known_oids if oid):
+            out.append(cand)
+    return out
+
+
+def tests_commits_after(sha: str, head: str, commits: "list[dict]") -> "list[dict]":
+    """The commits in *commits* that come strictly after *sha* and touch
+    ``tests/``.
+
+    *commits* is the PR's own commit list, oldest first, each with ``oid`` and
+    the paths it touched (``_tests_paths``, injected by the caller — this
+    function does no I/O so the fixture path and the live path share it).
+    An unknown *sha* (not one of the PR's commits, e.g. a note citing a
+    pre-branch base) yields every ``tests/``-touching commit: the note cannot
+    be shown to cover any of them."""
+    oids = [c.get("oid", "") for c in commits]
+    start = -1
+    for i, oid in enumerate(oids):
+        if oid.startswith(sha) or sha.startswith(oid):
+            start = i
+            break
+    tail = commits[start + 1:] if start >= 0 else commits
+    return [c for c in tail if c.get("_tests_paths")]
+
+
+def evaluate(pr: dict) -> "tuple[int, list[str]]":
+    """``(exit_code, lines)`` for one PR payload.
+
+    *pr* carries ``files`` (list of path strings), ``comments`` (list of
+    ``{'body':}``), ``commits`` (oldest first, each ``{'oid':, '_tests_paths':}``)
+    and ``headRefOid``. Pure — the live and fixture paths both build this
+    shape first, so the decision is testable without GitHub."""
+    touched_tests = [p for p in pr.get("files", []) if p.startswith("tests/")]
+    if not touched_tests:
+        return 0, ["OK — this PR does not touch tests/; rule 8 does not apply."]
+
+    notes = [c for c in pr.get("comments", []) if _NOTE_MARKER.search(c.get("body", ""))]
+    if not notes:
+        return 1, [
+            "RED — this PR touches tests/ but carries no TESTS-READ note.",
+            "  House rule 8: a PR touching tests/ does not self-merge until a",
+            "  reviewer's TESTS-READ note lands on it.",
+            f"  tests/ files touched: {len(touched_tests)}",
+        ]
+
+    commits = pr.get("commits", [])
+    oids = [c.get("oid", "") for c in commits] + [pr.get("headRefOid", "")]
+    head = pr.get("headRefOid", "")
+    lines: "list[str]" = []
+    for note in notes:
+        shas = find_note_shas(note.get("body", ""), oids)
+        if not shas:
+            continue
+        for sha in shas:
+            later = tests_commits_after(sha, head, commits)
+            if not later:
+                return 0, [
+                    f"OK — a TESTS-READ note names {sha}, and no commit has",
+                    "  touched tests/ since it.",
+                ]
+        lines.append(f"  note names {', '.join(shas)}")
+
+    if not lines:
+        return 1, [
+            "RED — a TESTS-READ note landed, but none of them names a commit of",
+            "  this PR. Add the head you read (e.g. `TESTS-READ (B) (head abc1234)`).",
+            "  An issue-comment id is not a tree name — it is hex-shaped, and this",
+            "  gate's first live run mistook one for a SHA.",
+            "  Without it, nothing can tell whether the note is a claim about THIS tree.",
+        ]
+
+    stale: "list[str]" = []
+    for note in notes:
+        for sha in find_note_shas(note.get("body", ""), oids):
+            for c in tests_commits_after(sha, head, commits):
+                stale.append(f"  {c.get('oid', '')[:9]} {c.get('messageHeadline', '')[:60]}")
+    return 1, [
+        "RED — every TESTS-READ note reads a tree that tests/ has moved past.",
+        *lines,
+        "  tests/ commits after it:",
+        *sorted(set(stale)),
+        "  Ask the same reviewer for a DIFFERENTIAL note over just these commits —",
+        "  re-reading the whole PR is not required.",
+    ]
+
+
+def fetch_pr(number: int) -> dict:
+    """Build the `evaluate` payload for a live PR via `gh`."""
+    raw = subprocess.run(
+        ["gh", "pr", "view", str(number), "--json",
+         "files,comments,commits,headRefOid"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    data = json.loads(raw)
+    commits = []
+    for c in data.get("commits", []):
+        oid = c.get("oid", "")
+        shown = subprocess.run(
+            ["git", "show", "--name-only", "--format=", oid],
+            capture_output=True, text=True,
+        )
+        if shown.returncode != 0:
+            # A commit this checkout cannot resolve (unfetched, or a squashed
+            # merge) would otherwise read as "touched no tests" — a green for
+            # the wrong reason, which is the exact shape this gate exists to
+            # reject. Say so and stop instead.
+            raise SystemExit(
+                f"check_tests_read_names_its_tree: cannot resolve commit {oid} "
+                f"in this checkout — fetch the PR's commits first "
+                f"(`git fetch origin pull/{number}/head`). Refusing to report a "
+                f"result computed from commits it could not read."
+            )
+        paths = shown.stdout.split()
+        commits.append({
+            "oid": oid,
+            "messageHeadline": c.get("messageHeadline", ""),
+            "_tests_paths": [p for p in paths if p.startswith("tests/")],
+        })
+    return {
+        "files": [f.get("path", "") for f in data.get("files", [])],
+        "comments": data.get("comments", []),
+        "commits": commits,
+        "headRefOid": data.get("headRefOid", ""),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail a tests/-touching PR whose TESTS-READ note does not name the "
+            "tree it read, or names one tests/ has moved past."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pr", type=int, metavar="N", help="Live PR number, via gh.")
+    group.add_argument(
+        "--fixture", metavar="PATH",
+        help=(
+            "JSON file with keys 'files' (paths), 'comments' ([{'body':}]), "
+            "'commits' (oldest first, [{'oid':, 'messageHeadline':, "
+            "'_tests_paths':}]) and 'headRefOid'. Lets this run offline."
+        ),
+    )
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = build_parser().parse_args(argv)
+    pr = (
+        json.loads(open(args.fixture, encoding="utf-8").read())
+        if args.fixture else fetch_pr(args.pr)
+    )
+    code, lines = evaluate(pr)
+    print("\n".join(lines))
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -118,7 +118,19 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
         ]
 
     commits = pr.get("commits", [])
-    oids = [c.get("oid", "") for c in commits] + [pr.get("headRefOid", "")]
+    if not commits:
+        return 1, [
+            "RED — this PR touches tests/ but its commit list is empty.",
+            "  Nothing here can be shown to have been read; refusing to pass a",
+            "  note that names a tree this check cannot locate.",
+        ]
+    # ONLY the PR's own commits — deliberately NOT headRefOid. A note quoting
+    # the head passes membership, and with an empty commit list there is then
+    # nothing for `tests_commits_after` to find, so the PR goes green with
+    # nothing read (docs-maintainer, #5120 B). The head is a commit of this PR
+    # whenever the PR has any, so including it separately buys nothing and
+    # costs exactly this hole.
+    oids = [c.get("oid", "") for c in commits]
     head = pr.get("headRefOid", "")
     lines: "list[str]" = []
     for note in notes:
@@ -158,6 +170,31 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     ]
 
 
+def commit_touched_paths(oid: str, number: int, repo_root: "str | None" = None) -> "list[str]":
+    """The paths *oid* touched, or stop the run if this checkout cannot read it.
+
+    Split out from :func:`fetch_pr` so the refusal is reachable with a real
+    ``git`` call on a real repository — no faked runner. *repo_root* makes the
+    repository an argument rather than the process's cwd, so a caller running
+    elsewhere cannot get a refusal that merely means "not in a git repo" — the
+    refusal would then be true for the wrong reason. A commit the checkout
+    cannot resolve (unfetched, or a squashed merge) would otherwise produce
+    empty output that reads as "touched no tests": a green computed from
+    commits never read, which is the shape this gate exists to reject."""
+    shown = subprocess.run(
+        ["git", "show", "--name-only", "--format=", oid],
+        capture_output=True, text=True, cwd=repo_root,
+    )
+    if shown.returncode != 0:
+        raise SystemExit(
+            f"check_tests_read_names_its_tree: cannot resolve commit {oid} "
+            f"in this checkout — fetch the PR's commits first "
+            f"(`git fetch origin pull/{number}/head`). Refusing to report a "
+            f"result computed from commits it could not read."
+        )
+    return shown.stdout.split()
+
+
 def fetch_pr(number: int) -> dict:
     """Build the `evaluate` payload for a live PR via `gh`."""
     raw = subprocess.run(
@@ -169,22 +206,7 @@ def fetch_pr(number: int) -> dict:
     commits = []
     for c in data.get("commits", []):
         oid = c.get("oid", "")
-        shown = subprocess.run(
-            ["git", "show", "--name-only", "--format=", oid],
-            capture_output=True, text=True,
-        )
-        if shown.returncode != 0:
-            # A commit this checkout cannot resolve (unfetched, or a squashed
-            # merge) would otherwise read as "touched no tests" — a green for
-            # the wrong reason, which is the exact shape this gate exists to
-            # reject. Say so and stop instead.
-            raise SystemExit(
-                f"check_tests_read_names_its_tree: cannot resolve commit {oid} "
-                f"in this checkout — fetch the PR's commits first "
-                f"(`git fetch origin pull/{number}/head`). Refusing to report a "
-                f"result computed from commits it could not read."
-            )
-        paths = shown.stdout.split()
+        paths = commit_touched_paths(oid, number)
         commits.append({
             "oid": oid,
             "messageHeadline": c.get("messageHeadline", ""),

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -1,0 +1,183 @@
+"""Tier 1: `scripts/check_tests_read_names_its_tree.py`'s own contract — a
+`tests/`-touching PR whose TESTS-READ note does not name the tree it read, or
+names one `tests/` has since moved past, is rejected.
+
+Contract, not OS invariant: the subject is a repo gate's decision function, and
+what it protects is house rule 8's blind spot (the rule is satisfied by a note
+EXISTING; nothing looks at which tree the note is a claim about). The four
+2026-08-22 instances the script's own docstring lists are the population this
+was written against — the reject-side cases below are those instances' shape.
+
+Payloads are built inline rather than fetched: `evaluate` is pure by design so
+the decision is testable without GitHub, and the fixtures here are the only
+callers that need to exist.
+"""
+from __future__ import annotations
+
+import importlib.util
+
+from tests._support.paths import REPO_ROOT
+
+_SPEC = importlib.util.spec_from_file_location(
+    "_check_tests_read",
+    REPO_ROOT / "scripts" / "check_tests_read_names_its_tree.py",
+)
+_MOD = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MOD)
+
+
+def _pr(*, files, comments, commits, head="ffffffff"):
+    return {"files": files, "comments": comments, "commits": commits, "headRefOid": head}
+
+
+def _commit(oid, headline="", tests=()):
+    return {"oid": oid, "messageHeadline": headline, "_tests_paths": list(tests)}
+
+
+# ── reject side ─────────────────────────────────────────────────────────────
+
+def test_note_without_a_sha_is_rejected():
+    """Tier 1: the #5096 shape — a note landed, but nothing in it says which tree."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "**[docs-maintainer]** — TESTS-READ (B: independent). Passing."}],
+        commits=[_commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
+    ))
+    assert code == 1
+    assert "names a commit of" in "\n".join(lines)
+
+
+def test_note_whose_sha_predates_a_later_tests_commit_is_rejected():
+    """Tier 1: the #5090 / #5095 shape — the note is real and names its head, and then
+    `tests/` moved. The failure names the commits so the ask is a differential
+    top-up, not a re-read."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "TESTS-READ (B: independent) (head `a7c44eef6`)."}],
+        commits=[
+            _commit("a7c44eef6", "docs: split the column"),
+            _commit("9ef30f95b", "test(#4206): CI-gate the Reload column too", ("tests/repo/test_config_reference_declared_in_4206.py",)),
+        ],
+    ))
+    assert code == 1
+    joined = "\n".join(lines)
+    assert "9ef30f95" in joined, "the offending commit is named, so the ask is scoped"
+    assert "DIFFERENTIAL" in joined.upper()
+
+
+def test_tests_touching_pr_with_no_note_at_all_is_rejected():
+    """Tier 1: rule 8 itself — nothing has been checking it mechanically."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "LGTM"}],
+        commits=[_commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
+    ))
+    assert code == 1
+    assert "no TESTS-READ note" in "\n".join(lines)
+
+
+# ── accept side ─────────────────────────────────────────────────────────────
+
+def test_note_naming_the_last_tests_commit_passes():
+    """Tier 1: the accept side — a note that names the newest tests/ commit is
+    a claim about the tree that is about to merge."""
+    code, _ = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "TESTS-READ (B) (head `bbbbbbbb`)"}],
+        commits=[
+            _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
+            _commit("bbbbbbbb", "test: fix", ("tests/scripts/test_check_doc_drift_5003.py",)),
+        ],
+    ))
+    assert code == 0
+
+
+def test_commits_after_the_note_that_do_not_touch_tests_pass():
+    """Tier 1: a docs-only or src-only commit after the note does not
+    invalidate it —
+    the note is a claim about `tests/`, so only `tests/` moving falsifies it."""
+    code, _ = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "TESTS-READ (B) (head `aaaaaaaa`)"}],
+        commits=[
+            _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
+            _commit("cccccccc", "docs: reword"),
+        ],
+    ))
+    assert code == 0
+
+
+def test_pr_not_touching_tests_is_out_of_scope():
+    """Tier 1: rule 8 binds only PRs that touch tests/ — a src- or docs-only PR
+    must not be asked for a note it does not owe."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["src/reyn/foo.py"], comments=[], commits=[_commit("aaaaaaaa", "fix")],
+    ))
+    assert code == 0
+    assert "does not touch tests/" in "\n".join(lines)
+
+
+def test_an_all_hex_english_word_is_not_read_as_a_sha():
+    """Tier 1: `decade`/`faceted` and friends match a bare hex pattern. Without the
+    false-friend filter a note saying "a decade of drift" would be read as
+    naming a tree, and this gate would pass a note that names nothing."""
+    oids = ["a7c44eef6"]
+    assert _MOD.find_note_shas("a decade of drift, faceted", oids) == []
+    assert _MOD.find_note_shas("head `a7c44eef6` here", oids) == ["a7c44eef6"]
+
+
+def test_an_issue_comment_id_is_not_read_as_a_sha():
+    """Tier 1: the gate's own first live run failed this way — run against PR #5090 it
+    read `5379476813` — an issue-comment id, ten decimal digits, and decimal
+    digits are hex digits — as the tree the note named, and passed a PR whose
+    note predated two later `tests/` commits.
+
+    Membership in the PR's own commit list is what rejects it; a hex SHAPE
+    cannot."""
+    oids = ["a7c44eef6", "9ef30f95b"]
+    assert _MOD.find_note_shas("see issuecomment-5379476813", oids) == []
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "TESTS-READ (B) — details in issuecomment-5379476813"}],
+        commits=[
+            _commit("a7c44eef6", "docs: split"),
+            _commit("9ef30f95b", "test: gate the column", ("tests/repo/test_config_reference_declared_in_4206.py",)),
+        ],
+    ))
+    assert code == 1, "a note citing only a comment id names no tree"
+
+
+def test_a_commit_this_checkout_cannot_resolve_is_not_reported_as_clean():
+    """Tier 1: `fetch_pr`'s other half of the same failure — `git show <oid>` on an
+    unfetched or squashed commit exits non-zero, and treating its (empty)
+    output as "touched no tests" is a green computed from commits the checkout
+    never read. The live run hit this too — the PR passed while its real
+    `tests/` commits were invisible."""
+    import subprocess as _sp
+
+    calls: "list[list[str]]" = []
+
+    def _fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[:2] == ["gh", "pr"]:
+            return _sp.CompletedProcess(
+                cmd, 0,
+                stdout='{"files":[{"path":"tests/scripts/test_check_doc_drift_5003.py"}],"comments":[],'
+                       '"commits":[{"oid":"deadbee1","messageHeadline":"x"}],'
+                       '"headRefOid":"deadbee1"}',
+            )
+        return _sp.CompletedProcess(cmd, 128, stdout="", stderr="bad object")
+
+    real_run = _MOD.subprocess.run
+    _MOD.subprocess.run = _fake_run
+    try:
+        raised = False
+        try:
+            _MOD.fetch_pr(5090)
+        except SystemExit as exc:
+            raised = True
+            assert "cannot resolve commit" in str(exc)
+        assert raised, "an unresolvable commit must stop the run, not read as clean"
+    finally:
+        _MOD.subprocess.run = real_run

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -148,36 +148,51 @@ def test_an_issue_comment_id_is_not_read_as_a_sha():
     assert code == 1, "a note citing only a comment id names no tree"
 
 
-def test_a_commit_this_checkout_cannot_resolve_is_not_reported_as_clean():
-    """Tier 1: `fetch_pr`'s other half of the same failure — `git show <oid>` on an
-    unfetched or squashed commit exits non-zero, and treating its (empty)
-    output as "touched no tests" is a green computed from commits the checkout
-    never read. The live run hit this too — the PR passed while its real
-    `tests/` commits were invisible."""
+def test_a_commit_this_checkout_cannot_resolve_stops_the_run():
+    """Tier 1: `fetch_pr`'s other half of the same failure — `git show` on an
+    unresolvable commit exits non-zero, and treating its empty output as
+    "touched no tests" is a green computed from a commit never read.
+
+    Driven with a REAL `git` call against this repository and a syntactically
+    valid oid that cannot exist, so nothing is faked (the earlier revision of
+    this test replaced `subprocess.run` wholesale — docs-maintainer, #5120 B)."""
+    import pytest
+
+    with pytest.raises(SystemExit) as exc:
+        _MOD.commit_touched_paths("0" * 40, 5120, repo_root=str(REPO_ROOT))
+    assert "cannot resolve commit" in str(exc.value)
+
+
+def test_a_resolvable_commit_reports_its_paths():
+    """Tier 1: the same seam's accept side, so the reject case above is not the
+    only thing exercised — a real HEAD resolves and yields its own paths."""
     import subprocess as _sp
 
-    calls: "list[list[str]]" = []
+    head = _sp.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True,
+        cwd=REPO_ROOT,
+    ).stdout.strip()
+    paths = _MOD.commit_touched_paths(head, 5120, repo_root=str(REPO_ROOT))
+    assert isinstance(paths, list)
 
-    def _fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        if cmd[:2] == ["gh", "pr"]:
-            return _sp.CompletedProcess(
-                cmd, 0,
-                stdout='{"files":[{"path":"tests/scripts/test_check_doc_drift_5003.py"}],"comments":[],'
-                       '"commits":[{"oid":"deadbee1","messageHeadline":"x"}],'
-                       '"headRefOid":"deadbee1"}',
-            )
-        return _sp.CompletedProcess(cmd, 128, stdout="", stderr="bad object")
 
-    real_run = _MOD.subprocess.run
-    _MOD.subprocess.run = _fake_run
-    try:
-        raised = False
-        try:
-            _MOD.fetch_pr(5090)
-        except SystemExit as exc:
-            raised = True
-            assert "cannot resolve commit" in str(exc)
-        assert raised, "an unresolvable commit must stop the run, not read as clean"
-    finally:
-        _MOD.subprocess.run = real_run
+def test_a_note_quoting_the_head_with_no_commits_does_not_pass():
+    """Tier 1: the vacuity gap docs-maintainer found in this gate's own B
+    (#5120) — `headRefOid` used to be appended to the membership list, so a
+    note quoting the head satisfied "names a commit of this PR" while an empty
+    commit list left `tests_commits_after` nothing to find. Green with nothing
+    read, which is the shape this gate exists to reject."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "TESTS-READ (B) (head `deadbee1`)"}],
+        commits=[],
+        head="deadbee1",
+    ))
+    assert code == 1
+    assert "commit list is empty" in "\n".join(lines)
+
+
+def test_the_head_alone_is_not_membership():
+    """Tier 1: the same gap at the predicate level — a SHA that is only the
+    head, with no commit carrying it, is not a commit of this PR."""
+    assert _MOD.find_note_shas("head `deadbee1`", []) == []


### PR DESCRIPTION
**[lead-coder]** — **part of #5039**（裁定は architect、issuecomment-5380484950）。

```
🔴 ★家則 rule 8 ──「a PR touching `tests/` does not self-merge until a reviewer's
   TESTS-READ note lands on it」── ★満たすのは「★note が★存在すること」
   ── ★★どの tree についての 主張かは ★誰も 見ていません
✅ ★実測（2026-08-22 の 1 晩、★4 件、★全て 私の発注で 起きました）
   ── ★#5090 ── note は `a7c44eef6` ── ★gate の test は★3 分後と 15 分後
   ── ★#5095 ── note は `e0dd40461` ── ★witness commit は★13 分後
   ── ★#5096 ── note は 10:32 ── ★test は 10:48 と 10:59
   ── ★#5038 ── note は `5c90f2ac4` ── ★head は `6b5d587c0`、★既に merged
   ── ★★4 件とも ★rule 8 では★緑
```

## ✅ 述語（★note の中身は★読みません）

**① note が★この PR の commit を 名指すか** ／ **② その後 `tests/` を触った commit が 無いか** ／ **③ `tests/` を触る PR に note が 在るか**（**rule 8 そのもの ── 今 機械で見ている人は 居ません**）。
⚪ **閉じる class** —— `verification-hazards.md` の根「**an observation does not name its own referent**」。**読んだかは検査しません** —— **どの tree の話かを 名乗らせるだけ**です。
⚠️ **閉じない穴**（明示）—— **古いコメントを編集して SHA を差し替えれば通ります。**文字列の述語の外側で、**「考慮したか」を訊く項目にすると毎回「はい」で通る**ので、足しません。

## 🔴 出荷前に実物で走らせて、自分の gate に欠陥が 2 つ出ました

```
🔴 ★① ★issuecomment の id を★SHA と 誤認 ── `5379476813` は★10 桁の 10 進数
   ── ★★10 進数は★16 進数として 妥当 ── ★#5090 を★★偽の緑で 通しました
   ── ✅ ★hex の「★形」では 拒めません ── ★★この PR 自身の commit 一覧への★所属で 拒みます
🔴 ★② `git show` が★解決できない commit を「★tests/ を触っていない」と 読む
   ── ★★読めなかった commit から 計算した 緑 ── ★★この gate が 拒む形 そのもの
   ── ✅ ★明示的に 停止します ── ★workflow は `fetch-depth: 0`（★CI で 偽の赤に しないため）
✅ ★どちらも★回帰事例として test に 在ります
```

✅ **実在の instance で確認** —— `--pr 5090` は **RED**、**後続の 4 commit を名指し**、exit 1。`--pr 5115`（docs のみ）は **OK**。

## Test plan
- [x] `pytest tests/scripts/` — **913 passed**
- [x] `ruff check .` ／ `test_tier_audit.py --strict`（Tier 4 違反 0）／ `verify_module_docstrings.py`
- [x] `mypy_ratchet.py` ／ `flat_tests_ratchet.py` ／ `check_bare_tests_import_reference.py`
- [x] `check_file_depth_reference.py` ／ `check_tests_path_literal_reference.py`
- [x] 実 PR 2 本（#5090 赤・#5115 緑）で端から端
- [x] (skipped — Visual 項目なし)

⚪ **TESTS-READ（B）が要ります。私が著者なので、名指しで別の方に出します。**
