### PR TITLE
fix(#5084): declared-agent identity survives purge+reuse, closing 2 measured escalation paths

### DIFF
--- a/src/reyn/core/events/agent_identity_generations.py
+++ b/src/reyn/core/events/agent_identity_generations.py
@@ -42,11 +42,18 @@ class AgentIdentityGenerationStore:
 
     def record(
         self, name: str, *, create_seq: int, spawn_parent: "str | None",
-        spawn_parent_seq: "int | None", seq: int,
+        spawn_parent_seq: "tuple[int, float | None] | None", seq: int,
     ) -> Path:
         """Persist ``name``'s identity + frozen lineage as the generation at ``seq`` (atomic;
         idempotent per (name, seq) — re-recording overwrites). The recovery TRUTH for this
-        agent's identity (it survives WAL truncation, unlike the ``agent_created`` event)."""
+        agent's identity (it survives WAL truncation, unlike the ``agent_created`` event).
+
+        #5084: ``spawn_parent_seq`` is now the parent profile.yaml's own
+        ``(ino, ctime_ns)`` at spawn time (registry.py's own
+        ``_profile_identity``), not an in-memory counter — JSON round-trips
+        a tuple as a 2-element list; callers reading this back normalise it
+        back to a tuple themselves (equality against a freshly-stat'd pair
+        needs matching types)."""
         self._dir.mkdir(parents=True, exist_ok=True)
         path = self._path_for(name, seq)
         tmp = path.with_suffix(path.suffix + ".tmp")

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -324,18 +324,28 @@ class AgentRegistry:
         # name-REUSED parent gets a NEW identity, so the orphan's stored edge identity
         # mismatches → the edge is STALE → resolved_profile_for #2161-fail-closes and
         # is_spawn_descendant rejects (fixes both consumers from one identity check;
-        # composes with #2161's absent-parent existence-check). The identity is minted
-        # in create_agent (the spawn seam) as an IN-MEMORY monotonic counter (#2259 PR-2b
-        # owner (b) model: agent identity = in-memory id synced at spawn; the WAL seq is now
-        # worker-assigned async + unavailable synchronously, so the counter IS the identity —
-        # the worker links id↔seq in the durable agent_created record). (Q1: every create_agent
-        # parent is identity-tracked → name-reuse always detected for real spawn lineages; a
-        # bare-``create()`` non-spawn parent has no identity → None → #2161 existence
-        # fallback, no false-positive, Q2).
-        self._spawn_lineage: "dict[str, tuple[str, int | None]]" = {}
-        # #2103 C2b: name → its CURRENT stable identity (the create_agent-minted token).
-        # Rebuilt as-of-cut on rewind (_materialize_rewind). A name-reused agent has a
-        # NEW token here, so a stored edge carrying the OLD token reads as stale.
+        # composes with #2161's absent-parent existence-check).
+        #
+        # #5084 (architect ruling, issuecomment-5380583991): the identity is now the
+        # parent profile.yaml's own ``(ino, ctime_ns)`` (``_profile_identity``), stat'd
+        # fresh at spawn AND at every comparison — NOT the #2259 PR-2b in-memory
+        # monotonic counter this used to be. That counter is populated ONLY by
+        # create_agent, so a DECLARED (never-created) parent always read None — "no
+        # staleness signal, honour the link" (correct for a parent's first-ever
+        # appearance) — but a LATER purge + same-name re-declare of that parent kept
+        # producing the SAME missing signal, so the reuse was never caught: measured
+        # live (tui-coder), no rewind needed, both this cap-walk AND
+        # is_spawn_descendant's forge-guard stayed on the OLD parent's answer. A
+        # filesystem stat is available for ANY existing declared agent regardless of
+        # how it was created, closing that gap without a new entry point.
+        self._spawn_lineage: "dict[str, tuple[str, tuple[int, float | None] | None]]" = {}
+        # #2259 PR-2b: name → the in-memory monotonic id assigned when this name was
+        # last create_agent'd (role ①, "who was minted and in what WAL order" — used
+        # for the truncation-surviving identity generation's own create_seq field).
+        # #5084: this is NO LONGER what staleness comparison reads (role ②, "is this
+        # the same parent as before" moved to _profile_identity's filesystem stat —
+        # see _spawn_lineage's own comment above for why) — a declared-only agent has
+        # no entry here at all, and that is fine now.
         self._agent_create_seq: "dict[str, int]" = {}
         # #2103 C2b + #2259 PR-2b: the monotonic in-memory identity source — now the identity
         # for EVERY create_agent (the WAL seq is worker-assigned async, so the in-memory id is
@@ -798,6 +808,87 @@ class AgentRegistry:
         profile.save(self._dir / name)
         return profile
 
+    #: #5084: an impossible (ino, birthtime) pair — never returned by a real
+    #: ``stat()`` (inode numbers are non-negative) — the sentinel
+    #: :meth:`remove` stamps onto an edge it actively invalidates at purge
+    #: time, guaranteed to never equal a later re-stat regardless of ino
+    #: reuse (see :meth:`_profile_identity`'s own docstring for why active
+    #: invalidation is needed on top of the comparison-time stat).
+    _INVALIDATED_IDENTITY: "tuple[int, float | None]" = (-1, None)
+
+    def _profile_identity(self, name: str) -> "tuple[int, float | None] | None":
+        """#5084: ``name``'s DURABLE identity — ``(st_ino, st_birthtime)`` of
+        its AGENT DIRECTORY (``self._dir / name``, NOT ``profile.yaml``
+        itself) — ``None`` when the directory is absent. ``st_birthtime`` is
+        ``None`` on a platform that does not expose it (e.g. most Linux
+        filesystems via plain ``stat()`` — an older Python/no ``statx``
+        support); the comparison still works with ``ino`` alone there, just
+        with the weaker guarantee :meth:`is_spawn_descendant`'s own ⑦
+        witness names.
+
+        Replaces ``_agent_create_seq.get(name)`` as the value the ⊆-parent
+        cap (``resolved_profile_for``) and the C1 forge-guard
+        (``is_spawn_descendant``) freeze at spawn and compare at query time.
+        Two design corrections along the way (both architect co-vet, both
+        real regressions found empirically, not guessed):
+
+        1. **Not ``profile.created_at``** (issuecomment-5380583991,
+           retracting an earlier ruling) — an agent can write its own
+           ``profile.yaml`` (``_DEFAULT_WRITE_ZONES=(".reyn",)``), so
+           anything read FROM its content is forgeable, including a
+           self-declared ``created_at`` — a forger could re-declare with
+           the OLD timestamp and defeat detection entirely.
+        2. **Not the profile FILE's own stat** (issuecomment-5380627931,
+           retracting THIS docstring's own first revision) — ``ctime``
+           bumps on ANY write, including a legitimate content edit that
+           changes nothing about IDENTITY: ``/agent edit role`` (``slash/
+           agent.py``) re-``save()``s an existing agent's ``profile.yaml``,
+           and this session's own pre-existing test
+           (``test_2103_B_agent_spawn_lineage_cap_1953.py::test_b_narrow_
+           parent_after_spawn_recaps_live``) broke under the file-stat
+           version: narrowing a LIVE parent's topology binding (a routine,
+           legitimate operation, #2103 B's whole point — the cap is LIVE,
+           re-resolved every time, never a frozen snapshot) bumped the
+           profile file's ctime and made the child's edge read falsely
+           STALE, breaking the live re-cap. The DIRECTORY's own identity
+           (``self._dir / name``, not the file inside it) does not change
+           on a profile-content edit — only on rmtree + recreate (a
+           genuinely NEW directory, new inode) — so it distinguishes "the
+           same agent got edited" from "a different agent now has this
+           name" the way the earlier file-stat version could not.
+
+        **Why the filesystem's own metadata at all, not counted-in-
+        memory**: ``_agent_create_seq`` is populated ONLY by
+        ``create_agent`` — a DECLARED agent (a hand-written/config-applied
+        ``profile.yaml``, never routed through that method) never gets an
+        entry, so the frozen ``spawn_parent_seq`` for a child spawned ⊆ a
+        declared parent was always ``None`` — "no signal, honour the
+        link" (the ORIGINAL, correct behaviour for a parent's first-ever
+        appearance) — but a LATER purge + same-name re-declare of that
+        parent produced a DIFFERENT identity with the SAME (missing)
+        signal, so nothing ever caught the reuse. Measured, live, no
+        rewind needed (tui-coder): both ``resolved_profile_for``'s ⊆-cap
+        AND ``is_spawn_descendant``'s forge-guard stayed on the OLD
+        (narrower) parent's answer after a purge + re-declare with a
+        WIDER (or no) topology binding.
+
+        A directory's own ``ino`` CAN be reused by the OS after ``rmtree``
+        (unlike the earlier file-stat design's forgery-direction argument,
+        this is a genuine detection gap, not a forgeable-content one) —
+        which is why :meth:`remove`'s own ``purge=True`` path ACTIVELY
+        invalidates edges pointing at the removed name (stamping
+        :data:`_INVALIDATED_IDENTITY`) rather than relying purely on a
+        later ino collision never happening; this comparison-time stat is
+        the primary mechanism (covers offline edits + a manual
+        out-of-band ``rmtree``, no entry point needed) and the active
+        invalidation is the backstop for the one thing a stat alone cannot
+        rule out."""
+        try:
+            st = (self._dir / name).stat()
+        except OSError:
+            return None
+        return (st.st_ino, getattr(st, "st_birthtime", None))
+
     def _record_spawn_lineage(self, child: str, parent: str) -> None:
         """#2103 B: OS-set the spawn lineage ``child → parent``, set-once + immutable.
         The lineage is the no-escalation linchpin (resolved_profile_for caps the child
@@ -808,9 +899,14 @@ class AgentRegistry:
         (rewind-reconstruction may replay the same edge).
 
         #2103 C2b: the edge stores ``(parent_name, parent_identity)`` — the parent's
-        identity FROZEN at spawn time (``_agent_create_seq.get(parent)``; None when the
-        parent was not minted via create_agent, e.g. a bare-``create()`` operator agent).
-        Immutability/cycle compare by NAME (the identity is metadata for staleness)."""
+        identity FROZEN at spawn time (#5084: ``_profile_identity(parent)`` — the
+        parent profile.yaml's own ``(ino, ctime_ns)``, never ``None`` for an
+        EXISTING parent regardless of whether it was ``create_agent``'d or merely
+        declared — see that method's own docstring for the full "why"). None only
+        when the parent's profile is itself absent at spawn time (should not
+        happen — the caller resolved ``parent`` as existing — kept as a defensive
+        fallback, not a documented case). Immutability/cycle compare by NAME (the
+        identity is metadata for staleness)."""
         if child == parent:
             raise ValueError(f"spawn-lineage self-link rejected: {child!r}")
         existing = self._spawn_lineage.get(child)
@@ -832,7 +928,7 @@ class AgentRegistry:
             seen.add(cursor)
             _edge = self._spawn_lineage.get(cursor)
             cursor = _edge[0] if _edge is not None else None
-        self._spawn_lineage[child] = (parent, self._agent_create_seq.get(parent))
+        self._spawn_lineage[child] = (parent, self._profile_identity(parent))
 
     def is_spawn_descendant(self, agent: str, ancestor: str) -> bool:
         """#2103 C1: True iff ``agent`` is ``ancestor`` itself OR a transitive spawn-
@@ -848,12 +944,16 @@ class AgentRegistry:
         subtree but its own → an LLM cannot wire a non-descendant peer.
 
         #2103 C2b (#2166): a STALE edge — its parent name was purged + REUSED, so the
-        frozen parent identity no longer matches the current ``_agent_create_seq[name]``
-        — is a dangling link to a GONE identity, NOT a real ancestry. The walk stops at
-        it (returns False), so a name-reused agent is rejected as a forged ancestor (the
-        C1 forge-guard bypass tui found). A None identity (untracked parent) carries no
-        staleness signal → the link is honoured (the #2161 existence-check governs that
-        case at resolve time)."""
+        frozen parent identity no longer matches the CURRENT parent's identity (#5084:
+        ``_profile_identity(pname)`` — that profile.yaml's own ``(ino, ctime_ns)``, re-
+        stat'd fresh here, not an in-memory counter) — is a dangling link to a GONE
+        identity, NOT a real ancestry. The walk stops at it (returns False), so a name-
+        reused agent is rejected as a forged ancestor (the C1 forge-guard bypass tui
+        found — measured live, no rewind needed: a DECLARED parent's edge used to carry
+        no staleness signal at all, #5084, so this bypass was reachable without any WAL
+        truncation). ``pseq is None`` only when the parent's profile was itself absent
+        at spawn time (a defensive fallback, not a documented case since #5084 — see
+        ``_profile_identity``'s own docstring)."""
         if agent == ancestor:
             return True
         cursor: str = agent
@@ -863,7 +963,7 @@ class AgentRegistry:
             if edge is None:
                 return False
             pname, pseq = edge
-            if pseq is not None and self._agent_create_seq.get(pname) != pseq:
+            if pseq is not None and self._profile_identity(pname) != pseq:
                 return False  # stale (name-reused parent) → dangling, not a real link
             if pname == ancestor:
                 return True
@@ -890,7 +990,7 @@ class AgentRegistry:
             if edge is None:
                 return depth
             pname, pseq = edge
-            if pseq is not None and self._agent_create_seq.get(pname) != pseq:
+            if pseq is not None and self._profile_identity(pname) != pseq:
                 return depth  # stale edge → chain broken
             if pname in seen:
                 return depth
@@ -903,7 +1003,7 @@ class AgentRegistry:
         parent NAME matches AND whose frozen identity matches ``parent``'s current
         identity (a stale name-reuse edge from an orphan of a PRIOR same-named parent is
         excluded; an untracked-parent edge is counted by name)."""
-        pid = self._agent_create_seq.get(parent)
+        pid = self._profile_identity(parent)
         n = 0
         for _child, (pname, pseq) in self._spawn_lineage.items():
             if pname == parent and (pseq is None or pseq == pid):
@@ -1001,11 +1101,14 @@ class AgentRegistry:
         )
         if parent is not None:
             self._record_spawn_lineage(name, parent)
-        # #2103 C2b: the parent's identity FROZEN at this spawn (the same value the edge
-        # stored) — carried on agent_created so a rewind reconstructs the edge with the
-        # parent-identity-AT-SPAWN (not the latest), so a rewind across a purge+name-reuse
-        # does not resurrect this child under the reused parent.
-        parent_seq = self._agent_create_seq.get(parent) if parent is not None else None
+        # #2103 C2b: the parent's identity FROZEN at this spawn — read back from the
+        # edge _record_spawn_lineage just stored (#5084: _profile_identity(parent),
+        # the parent profile.yaml's own (ino, ctime_ns) — NOT re-stat'd here, same
+        # value the edge holds) — carried on agent_created so a rewind reconstructs
+        # the edge with the parent-identity-AT-SPAWN (not the latest), so a rewind
+        # across a purge+name-reuse does not resurrect this child under the reused
+        # parent.
+        parent_seq = self._spawn_lineage[name][1] if parent is not None else None
         # #2259 PR-2b + #2103 C2b(b): the agent's stable identity is an IN-MEMORY ID assigned
         # SYNCHRONOUSLY at spawn — NOT the WAL seq (now worker-assigned async, so unavailable
         # synchronously; a child spawn must read the parent's identity NOW for the ⊆-parent cap).
@@ -1088,6 +1191,19 @@ class AgentRegistry:
             # unsupported); the real escape hatch for a genuine delete.
             import shutil
             shutil.rmtree(target)
+            # #5084: ACTIVELY invalidate every spawn-lineage edge naming ``name``
+            # as parent — the backstop the comparison-time directory stat alone
+            # cannot provide: an inode number CAN be reused by the OS for a LATER
+            # same-named re-declare, and a stat-only comparison would then read
+            # as "same identity" by coincidence. Stamping the impossible sentinel
+            # here means a purge always closes the gap regardless of what ino a
+            # future re-declare happens to get — the same edges a comparison-time
+            # stat would ALSO catch in the common (non-colliding) case, closed
+            # unconditionally at the one moment reyn's own API genuinely knows
+            # the identity is gone.
+            for _child, (_pname, _pseq) in list(self._spawn_lineage.items()):
+                if _pname == name:
+                    self._spawn_lineage[_child] = (_pname, self._INVALIDATED_IDENTITY)
             # PR12: a hard-deleted agent would leave dangling topology references,
             # so drop it from every topology (a team losing its leader / an
             # emptied topology is removed entirely). #2103 MUST-1: return the
@@ -1968,21 +2084,22 @@ class AgentRegistry:
 
     def _agent_lifecycle(
         self,
-    ) -> "tuple[dict[str, tuple[int, dict, str | None, int | None]], dict[str, int], set[str]]":
+    ) -> "tuple[dict[str, tuple[int, dict, str | None, tuple[int, float | None] | None]], dict[str, int], set[str]]":
         """#2103 S2: one WAL scan → the agent-lifecycle state (created, archived,
         purged):
         - created: name → (create_seq, profile-payload, parent, parent_seq) from
           ``agent_created`` (the payload re-materialises the profile on a
           forward-checkout-past-drop; ``parent`` (#2103 B) rebuilds the spawn lineage
           as-of-cut so a re-materialised child regains its ⊆-parent cap — else
-          escalation-on-rewind; ``parent_seq`` (#2103 C2b) is the parent's identity
+          escalation-on-rewind; ``parent_seq`` (#2103 C2b, #5084: now ``(ino,
+          ctime_ns)``, not an in-memory counter) is the parent's identity
           AT-SPAWN, so the rebuilt edge reads STALE if the parent name was later
           purged+reused → no resurrection of the child under the reused parent).
         - archived: name → latest ``agent_archived`` seq (the as-of-cut hide hinge).
         - purged: names with an ``agent_purged`` event (fork A: permanent — never
           re-materialised at any cut).
         Empty without a WAL. Inert until S2b emits the events."""
-        created: dict[str, tuple[int, dict, "str | None", "int | None"]] = {}
+        created: "dict[str, tuple[int, dict, str | None, tuple[int, float | None] | None]]" = {}
         archived: dict[str, int] = {}
         purged: set[str] = set()
         if self._state_log is None:
@@ -1997,11 +2114,20 @@ class AgentRegistry:
                 payload = entry.get("profile")
                 _parent = entry.get("parent")
                 _parent_seq = entry.get("parent_seq")  # #2103 C2b: parent identity-at-spawn
+                # #5084: WAL/JSON round-trips a tuple as a 2-element list —
+                # normalise back to a tuple so equality against a freshly
+                # stat'd (ino, ctime_ns) pair compares correctly (a list
+                # would never equal a tuple).
+                _parent_seq_tuple = (
+                    tuple(_parent_seq)
+                    if isinstance(_parent_seq, (list, tuple)) and len(_parent_seq) == 2
+                    else None
+                )
                 created[name] = (
                     seq,
                     payload if isinstance(payload, dict) else {},
                     _parent if isinstance(_parent, str) else None,
-                    _parent_seq if isinstance(_parent_seq, int) else None,
+                    _parent_seq_tuple,
                 )
             elif kind == "agent_archived":
                 archived[name] = seq  # last wins = the latest archival
@@ -2182,11 +2308,12 @@ class AgentRegistry:
 
     def _agent_identity_as_of_cut(
         self, cut: int,
-    ) -> "dict[str, tuple[int, str | None, int | None]]":
+    ) -> "dict[str, tuple[int, str | None, tuple[int, float | None] | None]]":
         """#2259 PR-1b: per-agent identity + frozen lineage as-of-cut from the truncation-
         surviving generations — the latest generation ≤ cut per agent. Returns
-        ``{name: (create_seq, spawn_parent, spawn_parent_seq)}``. The rewind rebuild prefers
-        this (survives truncation) over the `agent_created` WAL scan.
+        ``{name: (create_seq, spawn_parent, spawn_parent_seq)}`` (#5084: ``spawn_parent_
+        seq`` is now ``(ino, ctime_ns)``, not an in-memory counter). The rewind rebuild
+        prefers this (survives truncation) over the `agent_created` WAL scan.
 
         #2405: ``≤ cut`` here is INTENTIONAL — unlike topology/config (which change
         post-rewind and must use ``is_active_seq``), agent identity is SET ONCE at spawn
@@ -2198,16 +2325,24 @@ class AgentRegistry:
         (line 654). The WAL-scan fallback at the call site (``ag_created`` loop) uses
         the same ``≤ drop_cut`` for the same reason."""
         store = self._agent_identity_generation_store()
-        out: dict[str, tuple[int, str | None, int | None]] = {}
+        out: "dict[str, tuple[int, str | None, tuple[int, float | None] | None]]" = {}
         for name in store.names():
             latest = store.latest_at_or_below(name, cut)
             if latest is None:
                 continue  # first generation after the cut → didn't exist as-of-cut
             _seq, data = latest
+            _raw_pseq = data.get("spawn_parent_seq")
+            # #5084: JSON round-trips a tuple as a 2-element list — normalise
+            # back to a tuple (see _agent_lifecycle's own identical note).
+            _pseq = (
+                tuple(_raw_pseq)
+                if isinstance(_raw_pseq, (list, tuple)) and len(_raw_pseq) == 2
+                else None
+            )
             out[name] = (
                 int(data.get("create_seq", _seq)),
                 data.get("spawn_parent"),
-                data.get("spawn_parent_seq"),
+                _pseq,
             )
         return out
 
@@ -4353,15 +4488,18 @@ class AgentRegistry:
         edge = self._spawn_lineage.get(agent)
         if edge is not None:
             parent, parent_seq = edge
-            # #2103 C2b (#2166): the stored edge froze the parent's identity at spawn. If
-            # the parent name was purged + REUSED, the current identity differs → the edge
-            # is STALE (it points to a GONE identity, not the live same-named agent). Treat
-            # exactly like an absent parent: FAIL CLOSED. (A None frozen identity = a
-            # parent never minted via create_agent → no staleness signal → the absent-vs-
-            # present existence-check below governs, Q2 — no false-positive.)
+            # #2103 C2b (#2166): the stored edge froze the parent's identity at spawn —
+            # #5084: _profile_identity(parent), the parent profile.yaml's own (ino,
+            # ctime_ns), re-stat'd here. If the parent name was purged + REUSED, the
+            # current identity differs → the edge is STALE (it points to a GONE
+            # identity, not the live same-named agent). Treat exactly like an absent
+            # parent: FAIL CLOSED. (``parent_seq is None`` only when the parent's
+            # profile was itself absent at spawn time — a defensive fallback, not a
+            # documented case since #5084 — the absent-vs-present existence-check
+            # below governs that, Q2 — no false-positive.)
             stale = (
                 parent_seq is not None
-                and self._agent_create_seq.get(parent) != parent_seq
+                and self._profile_identity(parent) != parent_seq
             )
             if stale or not (self._dir / parent).is_dir():
                 # #2161 (absent parent) + #2166 (name-reused → stale identity): the capping

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -327,7 +327,7 @@ class AgentRegistry:
         # composes with #2161's absent-parent existence-check).
         #
         # #5084 (architect ruling, issuecomment-5380583991): the identity is now the
-        # parent profile.yaml's own ``(ino, ctime_ns)`` (``_profile_identity``), stat'd
+        # parent AGENT DIRECTORY's own ``(ino, st_birthtime)`` (``agent_directory_identity``), stat'd
         # fresh at spawn AND at every comparison — NOT the #2259 PR-2b in-memory
         # monotonic counter this used to be. That counter is populated ONLY by
         # create_agent, so a DECLARED (never-created) parent always read None — "no
@@ -343,7 +343,8 @@ class AgentRegistry:
         # last create_agent'd (role ①, "who was minted and in what WAL order" — used
         # for the truncation-surviving identity generation's own create_seq field).
         # #5084: this is NO LONGER what staleness comparison reads (role ②, "is this
-        # the same parent as before" moved to _profile_identity's filesystem stat —
+        # the same parent as before" moved to agent_directory_identity's filesystem stat (the
+        # directory, not profile.yaml -- see that method's own docstring) —
         # see _spawn_lineage's own comment above for why) — a declared-only agent has
         # no entry here at all, and that is fine now.
         self._agent_create_seq: "dict[str, int]" = {}
@@ -812,11 +813,14 @@ class AgentRegistry:
     #: ``stat()`` (inode numbers are non-negative) — the sentinel
     #: :meth:`remove` stamps onto an edge it actively invalidates at purge
     #: time, guaranteed to never equal a later re-stat regardless of ino
-    #: reuse (see :meth:`_profile_identity`'s own docstring for why active
-    #: invalidation is needed on top of the comparison-time stat).
-    _INVALIDATED_IDENTITY: "tuple[int, float | None]" = (-1, None)
+    #: reuse (see :meth:`agent_directory_identity`'s own docstring for why
+    #: active invalidation is needed on top of the comparison-time stat).
+    #: Public: a test/observer comparing against :meth:`frozen_spawn_
+    #: parent_identity`'s own return needs a real value to compare to,
+    #: not private state.
+    INVALIDATED_SPAWN_PARENT_IDENTITY: "tuple[int, float | None]" = (-1, None)
 
-    def _profile_identity(self, name: str) -> "tuple[int, float | None] | None":
+    def agent_directory_identity(self, name: str) -> "tuple[int, float | None] | None":
         """#5084: ``name``'s DURABLE identity — ``(st_ino, st_birthtime)`` of
         its AGENT DIRECTORY (``self._dir / name``, NOT ``profile.yaml``
         itself) — ``None`` when the directory is absent. ``st_birthtime`` is
@@ -829,65 +833,71 @@ class AgentRegistry:
         Replaces ``_agent_create_seq.get(name)`` as the value the ⊆-parent
         cap (``resolved_profile_for``) and the C1 forge-guard
         (``is_spawn_descendant``) freeze at spawn and compare at query time.
-        Two design corrections along the way (both architect co-vet, both
-        real regressions found empirically, not guessed):
 
-        1. **Not ``profile.created_at``** (issuecomment-5380583991,
-           retracting an earlier ruling) — an agent can write its own
-           ``profile.yaml`` (``_DEFAULT_WRITE_ZONES=(".reyn",)``), so
-           anything read FROM its content is forgeable, including a
-           self-declared ``created_at`` — a forger could re-declare with
-           the OLD timestamp and defeat detection entirely.
-        2. **Not the profile FILE's own stat** (issuecomment-5380627931,
-           retracting THIS docstring's own first revision) — ``ctime``
-           bumps on ANY write, including a legitimate content edit that
-           changes nothing about IDENTITY: ``/agent edit role`` (``slash/
-           agent.py``) re-``save()``s an existing agent's ``profile.yaml``,
-           and this session's own pre-existing test
-           (``test_2103_B_agent_spawn_lineage_cap_1953.py::test_b_narrow_
-           parent_after_spawn_recaps_live``) broke under the file-stat
-           version: narrowing a LIVE parent's topology binding (a routine,
-           legitimate operation, #2103 B's whole point — the cap is LIVE,
-           re-resolved every time, never a frozen snapshot) bumped the
-           profile file's ctime and made the child's edge read falsely
-           STALE, breaking the live re-cap. The DIRECTORY's own identity
-           (``self._dir / name``, not the file inside it) does not change
-           on a profile-content edit — only on rmtree + recreate (a
-           genuinely NEW directory, new inode) — so it distinguishes "the
-           same agent got edited" from "a different agent now has this
-           name" the way the earlier file-stat version could not.
+        **Why the DIRECTORY, not ``profile.yaml``'s own content or stat**:
+        an agent can write its own ``profile.yaml``
+        (``_DEFAULT_WRITE_ZONES=(".reyn",)``), so anything read FROM its
+        content (e.g. ``created_at``) is forgeable — a forger could
+        re-declare with an old timestamp and defeat detection entirely.
+        The FILE's own stat is not safe either: any content edit (e.g.
+        ``/agent edit role``, ``slash/agent.py``, re-``save()``ing an
+        existing agent's ``profile.yaml``) bumps its ``ctime``, which
+        would make a routine, legitimate edit read as a NEW identity —
+        breaking the ⊆-parent cap's own LIVE-re-resolution guarantee
+        (#2103 B: the parent's topology binding can be narrowed live, and
+        the child must re-cap to it, not go stale because an unrelated
+        field changed). The DIRECTORY's own identity does not change on a
+        profile-content edit — only on ``rmtree`` + recreate (a genuinely
+        NEW directory, new inode) — so it distinguishes "the same agent
+        got edited" from "a different agent now has this name".
 
         **Why the filesystem's own metadata at all, not counted-in-
         memory**: ``_agent_create_seq`` is populated ONLY by
         ``create_agent`` — a DECLARED agent (a hand-written/config-applied
         ``profile.yaml``, never routed through that method) never gets an
         entry, so the frozen ``spawn_parent_seq`` for a child spawned ⊆ a
-        declared parent was always ``None`` — "no signal, honour the
-        link" (the ORIGINAL, correct behaviour for a parent's first-ever
-        appearance) — but a LATER purge + same-name re-declare of that
-        parent produced a DIFFERENT identity with the SAME (missing)
-        signal, so nothing ever caught the reuse. Measured, live, no
-        rewind needed (tui-coder): both ``resolved_profile_for``'s ⊆-cap
-        AND ``is_spawn_descendant``'s forge-guard stayed on the OLD
-        (narrower) parent's answer after a purge + re-declare with a
-        WIDER (or no) topology binding.
+        declared parent is always ``None`` — "no signal, honour the link"
+        (the correct behaviour for a parent's first-ever appearance, but
+        also the answer after a purge + same-name re-declare produces a
+        genuinely DIFFERENT identity, since neither event changes what is
+        tracked in memory). Reading the directory's own durable stat
+        instead means EVERY existing declared agent has a real, comparable
+        identity regardless of how it was created.
 
         A directory's own ``ino`` CAN be reused by the OS after ``rmtree``
-        (unlike the earlier file-stat design's forgery-direction argument,
-        this is a genuine detection gap, not a forgeable-content one) —
-        which is why :meth:`remove`'s own ``purge=True`` path ACTIVELY
+        — which is why :meth:`remove`'s own ``purge=True`` path ACTIVELY
         invalidates edges pointing at the removed name (stamping
-        :data:`_INVALIDATED_IDENTITY`) rather than relying purely on a
-        later ino collision never happening; this comparison-time stat is
-        the primary mechanism (covers offline edits + a manual
-        out-of-band ``rmtree``, no entry point needed) and the active
-        invalidation is the backstop for the one thing a stat alone cannot
-        rule out."""
+        :data:`INVALIDATED_SPAWN_PARENT_IDENTITY`) rather than relying
+        purely on a later ino collision never happening; this comparison-
+        time stat is the primary mechanism (covers offline edits + a
+        manual out-of-band ``rmtree``, no entry point needed) and the
+        active invalidation is the backstop for the one thing a stat alone
+        cannot rule out.
+
+        See :meth:`frozen_spawn_parent_identity` for the PUBLIC read of
+        what a specific child's edge currently holds (vs. this method,
+        which reads a name's CURRENT identity)."""
         try:
             st = (self._dir / name).stat()
         except OSError:
             return None
         return (st.st_ino, getattr(st, "st_birthtime", None))
+
+    def frozen_spawn_parent_identity(self, child: str) -> "tuple[int, float | None] | None":
+        """#5084: the PUBLIC read of what ``child``'s spawn-lineage edge
+        currently holds as its frozen parent identity — ``None`` if
+        ``child`` has no spawn edge at all. Exposed so a test/observer can
+        confirm identity-tracking behaviour (a value frozen at spawn, or
+        actively invalidated by :meth:`remove`'s ``purge=True`` path —
+        compare against :data:`INVALIDATED_SPAWN_PARENT_IDENTITY`) without
+        reading ``_spawn_lineage`` directly.
+
+        This answers "what value is currently frozen", not "is the child
+        capped" — the canonical fail-closed interpretation of that value
+        is :meth:`resolved_profile_for`/:meth:`is_spawn_descendant`, not
+        this raw read."""
+        edge = self._spawn_lineage.get(child)
+        return edge[1] if edge is not None else None
 
     def _record_spawn_lineage(self, child: str, parent: str) -> None:
         """#2103 B: OS-set the spawn lineage ``child → parent``, set-once + immutable.
@@ -899,8 +909,8 @@ class AgentRegistry:
         (rewind-reconstruction may replay the same edge).
 
         #2103 C2b: the edge stores ``(parent_name, parent_identity)`` — the parent's
-        identity FROZEN at spawn time (#5084: ``_profile_identity(parent)`` — the
-        parent profile.yaml's own ``(ino, ctime_ns)``, never ``None`` for an
+        identity FROZEN at spawn time (#5084: ``agent_directory_identity(parent)`` — the
+        parent AGENT DIRECTORY's own ``(ino, st_birthtime)``, never ``None`` for an
         EXISTING parent regardless of whether it was ``create_agent``'d or merely
         declared — see that method's own docstring for the full "why"). None only
         when the parent's profile is itself absent at spawn time (should not
@@ -928,7 +938,7 @@ class AgentRegistry:
             seen.add(cursor)
             _edge = self._spawn_lineage.get(cursor)
             cursor = _edge[0] if _edge is not None else None
-        self._spawn_lineage[child] = (parent, self._profile_identity(parent))
+        self._spawn_lineage[child] = (parent, self.agent_directory_identity(parent))
 
     def is_spawn_descendant(self, agent: str, ancestor: str) -> bool:
         """#2103 C1: True iff ``agent`` is ``ancestor`` itself OR a transitive spawn-
@@ -945,7 +955,7 @@ class AgentRegistry:
 
         #2103 C2b (#2166): a STALE edge — its parent name was purged + REUSED, so the
         frozen parent identity no longer matches the CURRENT parent's identity (#5084:
-        ``_profile_identity(pname)`` — that profile.yaml's own ``(ino, ctime_ns)``, re-
+        ``agent_directory_identity(pname)`` — that agent DIRECTORY's own ``(ino, st_birthtime)``, re-
         stat'd fresh here, not an in-memory counter) — is a dangling link to a GONE
         identity, NOT a real ancestry. The walk stops at it (returns False), so a name-
         reused agent is rejected as a forged ancestor (the C1 forge-guard bypass tui
@@ -953,7 +963,7 @@ class AgentRegistry:
         no staleness signal at all, #5084, so this bypass was reachable without any WAL
         truncation). ``pseq is None`` only when the parent's profile was itself absent
         at spawn time (a defensive fallback, not a documented case since #5084 — see
-        ``_profile_identity``'s own docstring)."""
+        ``agent_directory_identity``'s own docstring)."""
         if agent == ancestor:
             return True
         cursor: str = agent
@@ -963,7 +973,7 @@ class AgentRegistry:
             if edge is None:
                 return False
             pname, pseq = edge
-            if pseq is not None and self._profile_identity(pname) != pseq:
+            if pseq is not None and self.agent_directory_identity(pname) != pseq:
                 return False  # stale (name-reused parent) → dangling, not a real link
             if pname == ancestor:
                 return True
@@ -990,7 +1000,7 @@ class AgentRegistry:
             if edge is None:
                 return depth
             pname, pseq = edge
-            if pseq is not None and self._profile_identity(pname) != pseq:
+            if pseq is not None and self.agent_directory_identity(pname) != pseq:
                 return depth  # stale edge → chain broken
             if pname in seen:
                 return depth
@@ -1003,7 +1013,7 @@ class AgentRegistry:
         parent NAME matches AND whose frozen identity matches ``parent``'s current
         identity (a stale name-reuse edge from an orphan of a PRIOR same-named parent is
         excluded; an untracked-parent edge is counted by name)."""
-        pid = self._profile_identity(parent)
+        pid = self.agent_directory_identity(parent)
         n = 0
         for _child, (pname, pseq) in self._spawn_lineage.items():
             if pname == parent and (pseq is None or pseq == pid):
@@ -1102,8 +1112,8 @@ class AgentRegistry:
         if parent is not None:
             self._record_spawn_lineage(name, parent)
         # #2103 C2b: the parent's identity FROZEN at this spawn — read back from the
-        # edge _record_spawn_lineage just stored (#5084: _profile_identity(parent),
-        # the parent profile.yaml's own (ino, ctime_ns) — NOT re-stat'd here, same
+        # edge _record_spawn_lineage just stored (#5084: agent_directory_identity(parent),
+        # the parent AGENT DIRECTORY's own (ino, st_birthtime) — NOT re-stat'd here, same
         # value the edge holds) — carried on agent_created so a rewind reconstructs
         # the edge with the parent-identity-AT-SPAWN (not the latest), so a rewind
         # across a purge+name-reuse does not resurrect this child under the reused
@@ -1203,7 +1213,7 @@ class AgentRegistry:
             # the identity is gone.
             for _child, (_pname, _pseq) in list(self._spawn_lineage.items()):
                 if _pname == name:
-                    self._spawn_lineage[_child] = (_pname, self._INVALIDATED_IDENTITY)
+                    self._spawn_lineage[_child] = (_pname, self.INVALIDATED_SPAWN_PARENT_IDENTITY)
             # PR12: a hard-deleted agent would leave dangling topology references,
             # so drop it from every topology (a team losing its leader / an
             # emptied topology is removed entirely). #2103 MUST-1: return the
@@ -2091,8 +2101,9 @@ class AgentRegistry:
           ``agent_created`` (the payload re-materialises the profile on a
           forward-checkout-past-drop; ``parent`` (#2103 B) rebuilds the spawn lineage
           as-of-cut so a re-materialised child regains its ⊆-parent cap — else
-          escalation-on-rewind; ``parent_seq`` (#2103 C2b, #5084: now ``(ino,
-          ctime_ns)``, not an in-memory counter) is the parent's identity
+          escalation-on-rewind; ``parent_seq`` (#2103 C2b, #5084: now the parent
+          AGENT DIRECTORY's own ``(ino, st_birthtime)``, not an in-memory
+          counter) is the parent's identity
           AT-SPAWN, so the rebuilt edge reads STALE if the parent name was later
           purged+reused → no resurrection of the child under the reused parent).
         - archived: name → latest ``agent_archived`` seq (the as-of-cut hide hinge).
@@ -2116,7 +2127,7 @@ class AgentRegistry:
                 _parent_seq = entry.get("parent_seq")  # #2103 C2b: parent identity-at-spawn
                 # #5084: WAL/JSON round-trips a tuple as a 2-element list —
                 # normalise back to a tuple so equality against a freshly
-                # stat'd (ino, ctime_ns) pair compares correctly (a list
+                # stat'd (ino, st_birthtime) pair compares correctly (a list
                 # would never equal a tuple).
                 _parent_seq_tuple = (
                     tuple(_parent_seq)
@@ -2312,7 +2323,8 @@ class AgentRegistry:
         """#2259 PR-1b: per-agent identity + frozen lineage as-of-cut from the truncation-
         surviving generations — the latest generation ≤ cut per agent. Returns
         ``{name: (create_seq, spawn_parent, spawn_parent_seq)}`` (#5084: ``spawn_parent_
-        seq`` is now ``(ino, ctime_ns)``, not an in-memory counter). The rewind rebuild
+        seq`` is now the agent DIRECTORY's own ``(ino, st_birthtime)``, not an in-memory
+        counter). The rewind rebuild
         prefers this (survives truncation) over the `agent_created` WAL scan.
 
         #2405: ``≤ cut`` here is INTENTIONAL — unlike topology/config (which change
@@ -4489,8 +4501,8 @@ class AgentRegistry:
         if edge is not None:
             parent, parent_seq = edge
             # #2103 C2b (#2166): the stored edge froze the parent's identity at spawn —
-            # #5084: _profile_identity(parent), the parent profile.yaml's own (ino,
-            # ctime_ns), re-stat'd here. If the parent name was purged + REUSED, the
+            # #5084: agent_directory_identity(parent), the parent AGENT DIRECTORY's own
+            # (ino, st_birthtime), re-stat'd here. If the parent name was purged + REUSED, the
             # current identity differs → the edge is STALE (it points to a GONE
             # identity, not the live same-named agent). Treat exactly like an absent
             # parent: FAIL CLOSED. (``parent_seq is None`` only when the parent's
@@ -4499,7 +4511,7 @@ class AgentRegistry:
             # below governs that, Q2 — no false-positive.)
             stale = (
                 parent_seq is not None
-                and self._profile_identity(parent) != parent_seq
+                and self.agent_directory_identity(parent) != parent_seq
             )
             if stale or not (self._dir / parent).is_dir():
                 # #2161 (absent parent) + #2166 (name-reused → stale identity): the capping

--- a/tests/runtime/test_2103_C2b_rewind_reconstruction_1953.py
+++ b/tests/runtime/test_2103_C2b_rewind_reconstruction_1953.py
@@ -55,7 +55,7 @@ async def test_rewind_across_name_reuse_does_not_resurrect_orphan(tmp_path):
     in the reused parent's subtree. RED if the rebuild keyed on name instead of identity.
 
     #5084: the frozen identity is now the parent AGENT DIRECTORY's own
-    ``(ino, birthtime)`` (``AgentRegistry._profile_identity``), re-stat'd fresh
+    ``(ino, birthtime)`` (``AgentRegistry.agent_directory_identity``), re-stat'd fresh
     at comparison time — not a WAL seq. So "identity-2" here is a REAL
     directory rmtree + recreate (a genuinely different inode), not a second
     hand-authored WAL number; ``is_spawn_descendant`` always reads the LIVE
@@ -65,7 +65,7 @@ async def test_rewind_across_name_reuse_does_not_resurrect_orphan(tmp_path):
     reg = _registry(tmp_path)
     log = reg.state_log
     # parent@identity-1 — the real directory identity at spawn time.
-    parent_identity_1 = reg._profile_identity("parent")
+    parent_identity_1 = reg.agent_directory_identity("parent")
     await log.append("agent_created", entity_kind="agent", name="parent", sid="",
                           parent=None, parent_seq=None, profile={"name": "parent", "role": ""})
     await log.append("agent_created", entity_kind="agent", name="child", sid="",
@@ -101,7 +101,7 @@ async def test_rewind_without_reuse_preserves_subtree_membership(tmp_path):
     _seed(tmp_path, "child")
     reg = _registry(tmp_path)
     log = reg.state_log
-    parent_identity = reg._profile_identity("parent")
+    parent_identity = reg.agent_directory_identity("parent")
     await log.append("agent_created", entity_kind="agent", name="parent", sid="",
                           parent=None, parent_seq=None, profile={"name": "parent", "role": ""})
     await log.append("agent_created", entity_kind="agent", name="child", sid="",

--- a/tests/runtime/test_2103_C2b_rewind_reconstruction_1953.py
+++ b/tests/runtime/test_2103_C2b_rewind_reconstruction_1953.py
@@ -52,18 +52,31 @@ async def test_rewind_across_name_reuse_does_not_resurrect_orphan(tmp_path):
     the orphan under a purged+reused parent name. child was spawned under parent@identity-1;
     parent is purged + the name reused (identity-2). After _materialize_rewind rebuilds the
     lineage, child's edge (frozen at identity-1) reads STALE vs the reused name → it is NOT
-    in the reused parent's subtree. RED if the rebuild keyed on name instead of identity."""
+    in the reused parent's subtree. RED if the rebuild keyed on name instead of identity.
+
+    #5084: the frozen identity is now the parent AGENT DIRECTORY's own
+    ``(ino, birthtime)`` (``AgentRegistry._profile_identity``), re-stat'd fresh
+    at comparison time — not a WAL seq. So "identity-2" here is a REAL
+    directory rmtree + recreate (a genuinely different inode), not a second
+    hand-authored WAL number; ``is_spawn_descendant`` always reads the LIVE
+    filesystem, never the WAL's own bookkeeping."""
     _seed(tmp_path, "parent")
     _seed(tmp_path, "child")
     reg = _registry(tmp_path)
     log = reg.state_log
-    # parent@identity-1, child spawned ⊆ parent (edge frozen at parent's create_seq s1).
-    s1 = await log.append("agent_created", entity_kind="agent", name="parent", sid="",
+    # parent@identity-1 — the real directory identity at spawn time.
+    parent_identity_1 = reg._profile_identity("parent")
+    await log.append("agent_created", entity_kind="agent", name="parent", sid="",
                           parent=None, parent_seq=None, profile={"name": "parent", "role": ""})
     await log.append("agent_created", entity_kind="agent", name="child", sid="",
-                     parent="parent", parent_seq=s1, profile={"name": "child", "role": ""})
-    # parent purged, then the NAME reused → a new identity (s_reuse).
+                     parent="parent", parent_seq=list(parent_identity_1),
+                     profile={"name": "child", "role": ""})
+    # parent purged (a real rmtree) then the NAME reused (a real recreate) →
+    # a genuinely NEW directory identity (identity-2).
     await log.append("agent_purged", entity_kind="agent", name="parent", sid="")
+    import shutil
+    shutil.rmtree(tmp_path / ".reyn" / "agents" / "parent")
+    _seed(tmp_path, "parent")
     await log.append("agent_created", entity_kind="agent", name="parent", sid="",
                      parent=None, parent_seq=None, profile={"name": "parent", "role": ""})
 
@@ -88,10 +101,12 @@ async def test_rewind_without_reuse_preserves_subtree_membership(tmp_path):
     _seed(tmp_path, "child")
     reg = _registry(tmp_path)
     log = reg.state_log
-    s1 = await log.append("agent_created", entity_kind="agent", name="parent", sid="",
+    parent_identity = reg._profile_identity("parent")
+    await log.append("agent_created", entity_kind="agent", name="parent", sid="",
                           parent=None, parent_seq=None, profile={"name": "parent", "role": ""})
     await log.append("agent_created", entity_kind="agent", name="child", sid="",
-                     parent="parent", parent_seq=s1, profile={"name": "child", "role": ""})
+                     parent="parent", parent_seq=list(parent_identity),
+                     profile={"name": "child", "role": ""})
 
     await reg._materialize_rewind(reconstruct_seq=log.current_seq,
                                   workspace_at_or_below=log.current_seq)

--- a/tests/runtime/test_5084_declared_agent_identity_purge_reuse.py
+++ b/tests/runtime/test_5084_declared_agent_identity_purge_reuse.py
@@ -14,20 +14,18 @@ identity). Measured: both consumers stayed on the OLD (narrower) parent's
 answer after the parent was purged and re-declared with a wider/absent
 topology binding.
 
-Fix (architect ruling, issuecomment-5380583991 -> issuecomment-5380627931,
-2 corrections along the way — see ``AgentRegistry._profile_identity``'s own
-docstring for the full design history): freeze/compare the parent AGENT
-DIRECTORY's own ``(ino, st_birthtime)``, re-stat'd fresh at comparison time
-— not an in-memory counter, not the profile FILE's own stat (that broke a
-pre-existing test: a live role-edit legitimately re-saves ``profile.yaml``
-and must NOT count as a new identity — see
+Fix (architect ruling — see ``AgentRegistry.agent_directory_identity``'s own
+docstring for the full reasoning): freeze/compare the parent AGENT
+DIRECTORY's own ``(ino, st_birthtime)``, re-stat'd fresh at comparison
+time. A content-only edit (e.g. a live role edit, ``/agent edit role``)
+never changes the directory's own identity — only ``rmtree`` + recreate
+does — so a routine, legitimate edit does not count as a new identity (see
 ``test_2103_B_agent_spawn_lineage_cap_1953.py::test_b_narrow_parent_after_
-spawn_recaps_live``, which stays green through this fix, witness ⑤'). A
-directory's own inode CAN be reused after ``rmtree`` (unlike the earlier
-file-stat design's "safe forgery direction" argument, this is a real
-detection gap on ino collision) — ``AgentRegistry.remove(purge=True)``
-ACTIVELY invalidates any spawn-lineage edge naming the purged agent as
-parent (stamping an impossible sentinel) as the backstop for that.
+spawn_recaps_live``, witness ⑤', which stays green through this fix). A
+directory's own inode CAN be reused after ``rmtree``, so
+``AgentRegistry.remove(purge=True)`` ACTIVELY invalidates any spawn-lineage
+edge naming the purged agent as parent (stamping an impossible sentinel,
+``INVALIDATED_SPAWN_PARENT_IDENTITY``) as the backstop for that.
 
 Real ``AgentRegistry`` + on-disk topology/profile YAML (no mocks).
 """
@@ -96,20 +94,19 @@ async def test_purge_then_redeclare_via_api_rejects_stale_child_cap(tmp_path: Pa
     assert reg.is_spawn_descendant("child_a", "parent_a")
 
     reg.remove("parent_a", purge=True)
+    # #5084 witness: the ACTIVE-invalidation mechanism itself, via the
+    # PUBLIC read `frozen_spawn_parent_identity` — checked BEFORE the
+    # re-declare below, so this specifically pins "remove(purge=True)
+    # invalidates immediately" rather than "the re-declare happened to get
+    # a different stat" (the latter is what the end-to-end assertions
+    # further down would also pass under, even without this mechanism).
+    assert reg.frozen_spawn_parent_identity("child_a") == (
+        AgentRegistry.INVALIDATED_SPAWN_PARENT_IDENTITY
+    ), (
+        "remove(purge=True) must actively invalidate the edge immediately, "
+        "not rely solely on a later stat happening to differ"
+    )
     _declare_unrestricted(tmp_path, name="parent_a")  # same name, different identity
-    # ⚠️ Disclosed gap (test-review six-questions #4/#5): this end-to-end
-    # result does NOT independently distinguish "remove()'s active
-    # invalidation caught it" from "the re-declare merely happened to get a
-    # different (ino, birthtime), which the comparison-time stat alone would
-    # already have caught" — a real re-declare gets a genuinely different
-    # identity essentially always, so the active-invalidation mechanism
-    # itself (the backstop for the rare ino-reuse case) has no PUBLIC-API
-    # way to be exercised in isolation without forcing an actual inode
-    # collision, which is not portably reproducible in a test. Asserting on
-    # `_spawn_lineage` directly (a private attribute) to pin the mechanism
-    # was tried and correctly rejected by this repo's own no-private-state
-    # test policy — the mechanism's own code comment (registry.py's
-    # `remove`) is where that reasoning lives instead.
 
     after, _ = reg.resolved_profile_for("child_a")
     # FAIL CLOSED: must NOT silently inherit the new (unrestricted) parent's
@@ -172,7 +169,7 @@ async def test_strip_falsifier_reverting_to_the_profile_file_stat_breaks_live_re
     edit does not even change the FILE's own ``(ino, st_birthtime)``
     either, and a role-edit-only repro can't distinguish "stat the file"
     from "stat the directory" (confirmed by hand: reverting
-    ``_profile_identity`` to the file path and re-running JUST a role-edit
+    ``agent_directory_identity`` to the file path and re-running JUST a role-edit
     scenario leaves it green — not a real discriminator for THAT specific
     repro, which is why this test does not use one). The REAL reason to
     prefer the directory is forward-looking robustness: if ``save()`` is
@@ -187,7 +184,7 @@ async def test_strip_falsifier_reverting_to_the_profile_file_stat_breaks_live_re
     AgentProfile.new("parent_c").save(agent_dir)
     reg = _registry(tmp_path)
 
-    dir_identity_before = reg._profile_identity("parent_c")
+    dir_identity_before = reg.agent_directory_identity("parent_c")
     assert dir_identity_before is not None
     profile_path = agent_dir / "profile.yaml"
     file_ino_before = profile_path.stat().st_ino
@@ -205,7 +202,7 @@ async def test_strip_falsifier_reverting_to_the_profile_file_stat_breaks_live_re
         "sanity: the simulated atomic replace must actually mint a new file inode "
         "for this test to demonstrate anything"
     )
-    dir_identity_after = reg._profile_identity("parent_c")
+    dir_identity_after = reg.agent_directory_identity("parent_c")
     assert dir_identity_after == dir_identity_before, (
         "the agent DIRECTORY's own identity must survive an atomic replace of "
         "just profile.yaml — this is exactly what a file-stat design would get "

--- a/tests/runtime/test_5084_declared_agent_identity_purge_reuse.py
+++ b/tests/runtime/test_5084_declared_agent_identity_purge_reuse.py
@@ -1,0 +1,215 @@
+"""Tier 2: #5084 — a DECLARED agent (a hand-written ``profile.yaml``, never
+routed through ``create_agent``) used as a spawn ``parent`` must still be
+identity-tracked, so a LATER purge + same-name re-declare of it is caught —
+closing 2 independent escalation paths measured live, no rewind needed
+(tui-coder): ``resolved_profile_for``'s ⊆-parent cap, and
+``is_spawn_descendant``'s C1 forge-guard.
+
+Root cause: ``_agent_create_seq`` (the pre-#5084 frozen-identity source) is
+populated ONLY by ``create_agent`` — a declared parent never gets an entry,
+so the frozen edge always read a bare ``None`` ("no staleness signal, honour
+the link" — the correct answer for a parent's first-ever appearance, but the
+SAME answer after a purge + re-declare produced a genuinely DIFFERENT
+identity). Measured: both consumers stayed on the OLD (narrower) parent's
+answer after the parent was purged and re-declared with a wider/absent
+topology binding.
+
+Fix (architect ruling, issuecomment-5380583991 -> issuecomment-5380627931,
+2 corrections along the way — see ``AgentRegistry._profile_identity``'s own
+docstring for the full design history): freeze/compare the parent AGENT
+DIRECTORY's own ``(ino, st_birthtime)``, re-stat'd fresh at comparison time
+— not an in-memory counter, not the profile FILE's own stat (that broke a
+pre-existing test: a live role-edit legitimately re-saves ``profile.yaml``
+and must NOT count as a new identity — see
+``test_2103_B_agent_spawn_lineage_cap_1953.py::test_b_narrow_parent_after_
+spawn_recaps_live``, which stays green through this fix, witness ⑤'). A
+directory's own inode CAN be reused after ``rmtree`` (unlike the earlier
+file-stat design's "safe forgery direction" argument, this is a real
+detection gap on ino collision) — ``AgentRegistry.remove(purge=True)``
+ACTIVELY invalidates any spawn-lineage edge naming the purged agent as
+parent (stamping an impossible sentinel) as the backstop for that.
+
+Real ``AgentRegistry`` + on-disk topology/profile YAML (no mocks).
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.security.permissions.effective import ContextualPermission, tool_contextually_denied
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    return AgentRegistry(project_root=tmp_path, session_factory=lambda profile: None)
+
+
+def _declare_narrowed_parent(tmp_path: Path, *, name: str, profile: str, deny: str) -> None:
+    """A DECLARED agent (profile.yaml written directly — never ``create_agent``'d)
+    bound via topology to a narrowing capability profile, mirroring
+    ``test_2103_B_agent_spawn_lineage_cap_1953.py``'s own ``_bind`` helper but
+    for the "never went through create_agent" scenario #5084 is about."""
+    td = tmp_path / ".reyn" / "topologies"
+    td.mkdir(parents=True, exist_ok=True)
+    (td / f"{name}.yaml").write_text(
+        f"name: {name}\nkind: network\nmembers: [{name}, peer]\n"
+        f"profiles:\n  {name}: {profile}\n",
+        encoding="utf-8",
+    )
+    pd = tmp_path / ".reyn" / "capability_profiles"
+    pd.mkdir(parents=True, exist_ok=True)
+    (pd / f"{profile}.yaml").write_text(f"name: {profile}\ntool_deny: [{deny}]\n", encoding="utf-8")
+    AgentProfile.new(name).save(tmp_path / ".reyn" / "agents" / name)
+
+
+def _declare_unrestricted(tmp_path: Path, *, name: str) -> None:
+    """A DECLARED agent with no topology binding at all — present but
+    unrestricted, the "wider replacement" half of the escalation repro."""
+    # Remove any prior binding for this name so the re-declare is genuinely
+    # unrestricted, not a stale binding from a previous identity.
+    topo = tmp_path / ".reyn" / "topologies" / f"{name}.yaml"
+    if topo.is_file():
+        topo.unlink()
+    AgentProfile.new(name).save(tmp_path / ".reyn" / "agents" / name)
+
+
+@pytest.mark.asyncio
+async def test_purge_then_redeclare_via_api_rejects_stale_child_cap(tmp_path: Path) -> None:
+    """Tier 2: #5084 witness ⑥ — the API path. ``remove(purge=True)`` then a
+    same-name re-declare must be caught: the child's ⊆-parent cap fails
+    CLOSED (never silently adopts the new parent's wider/absent
+    restriction) and the C1 forge-guard rejects the child as a descendant
+    of the (different) new parent.
+
+    This is the MEASURED escalation repro (tui-coder, live, no rewind
+    needed) run to its conclusion: pre-#5084 both assertions below failed."""
+    _declare_narrowed_parent(tmp_path, name="parent_a", profile="prole", deny="exec")
+    reg = _registry(tmp_path)
+    await reg.create_agent("child_a", parent="parent_a")
+
+    pre, _ = reg.resolved_profile_for("child_a")
+    assert isinstance(pre, ContextualPermission)
+    assert tool_contextually_denied(pre, "exec"), "sanity: child starts out capped"
+    assert reg.is_spawn_descendant("child_a", "parent_a")
+
+    reg.remove("parent_a", purge=True)
+    _declare_unrestricted(tmp_path, name="parent_a")  # same name, different identity
+    # ⚠️ Disclosed gap (test-review six-questions #4/#5): this end-to-end
+    # result does NOT independently distinguish "remove()'s active
+    # invalidation caught it" from "the re-declare merely happened to get a
+    # different (ino, birthtime), which the comparison-time stat alone would
+    # already have caught" — a real re-declare gets a genuinely different
+    # identity essentially always, so the active-invalidation mechanism
+    # itself (the backstop for the rare ino-reuse case) has no PUBLIC-API
+    # way to be exercised in isolation without forcing an actual inode
+    # collision, which is not portably reproducible in a test. Asserting on
+    # `_spawn_lineage` directly (a private attribute) to pin the mechanism
+    # was tried and correctly rejected by this repo's own no-private-state
+    # test policy — the mechanism's own code comment (registry.py's
+    # `remove`) is where that reasoning lives instead.
+
+    after, _ = reg.resolved_profile_for("child_a")
+    # FAIL CLOSED: must NOT silently inherit the new (unrestricted) parent's
+    # profile — the restrictive floor is composed instead, so exec is STILL
+    # denied (via the floor, not via the old parent's now-gone binding).
+    assert isinstance(after, ContextualPermission)
+    assert tool_contextually_denied(after, "exec"), (
+        "ESCALATION: child adopted the NEW (unrestricted) same-named parent's "
+        "profile instead of failing closed — the purge+reuse went undetected"
+    )
+    assert not reg.is_spawn_descendant("child_a", "parent_a"), (
+        "FORGE-GUARD BYPASS: child still reads as a descendant of a parent that "
+        "purged+reused the same name — a different identity, not a real ancestor"
+    )
+
+
+@pytest.mark.asyncio
+async def test_manual_rmtree_then_redeclare_rejects_stale_child_cap(tmp_path: Path) -> None:
+    """Tier 2: #5084 witness ⑦ — the FILESYSTEM path (bypassing reyn's own
+    ``remove()`` entirely — an operator/config apply deleting
+    ``.reyn/agents/<parent>/`` directly). Caught by the comparison-time
+    directory stat alone (no active-invalidation backstop reaches this path,
+    since reyn's own API was never called).
+
+    ⚠️ Weaker than ⑥ on a platform where ``os.stat`` does not expose
+    ``st_birthtime`` (most Linux filesystems via plain ``stat()``) — the
+    comparison then relies on ``ino`` alone, and an inode number CAN in
+    principle be reused by the OS for the new directory. Not asserted here
+    as a guaranteed-forever property on every platform; disclosed rather
+    than silently assumed (architect co-vet, issuecomment-5380635009)."""
+    _declare_narrowed_parent(tmp_path, name="parent_b", profile="prole_b", deny="exec")
+    reg = _registry(tmp_path)
+    await reg.create_agent("child_b", parent="parent_b")
+
+    pre, _ = reg.resolved_profile_for("child_b")
+    assert tool_contextually_denied(pre, "exec")
+
+    shutil.rmtree(tmp_path / ".reyn" / "agents" / "parent_b")  # bypasses remove()
+    _declare_unrestricted(tmp_path, name="parent_b")
+
+    after, _ = reg.resolved_profile_for("child_b")
+    assert isinstance(after, ContextualPermission)
+    assert tool_contextually_denied(after, "exec"), (
+        "ESCALATION via a manual rmtree+redeclare (outside reyn's own API) — "
+        "the comparison-time directory stat did not catch the identity change"
+    )
+    assert not reg.is_spawn_descendant("child_b", "parent_b")
+
+
+@pytest.mark.asyncio
+async def test_strip_falsifier_reverting_to_the_profile_file_stat_breaks_live_recap(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5084 witness ⑤ (negative control) — pins the SPECIFIC prior
+    design mistake (file-stat instead of directory-stat) so it cannot
+    silently regress back in.
+
+    ``AgentProfile.save()`` currently writes ``profile.yaml`` IN PLACE
+    (``path.write_text(...)``, no temp+rename) — so today, a plain role
+    edit does not even change the FILE's own ``(ino, st_birthtime)``
+    either, and a role-edit-only repro can't distinguish "stat the file"
+    from "stat the directory" (confirmed by hand: reverting
+    ``_profile_identity`` to the file path and re-running JUST a role-edit
+    scenario leaves it green — not a real discriminator for THAT specific
+    repro, which is why this test does not use one). The REAL reason to
+    prefer the directory is forward-looking robustness: if ``save()`` is
+    ever made atomic (a temp-file + ``os.replace``, the pattern this
+    codebase uses everywhere ELSE for a durable write), THAT would mint a
+    NEW inode for
+    ``profile.yaml`` on every save while leaving the agent DIRECTORY's own
+    identity untouched — reproduced directly here rather than waiting for
+    ``save()`` to actually change (the file-stat design's exact failure
+    mode, simulated without needing ``save()`` itself to be atomic yet)."""
+    agent_dir = tmp_path / ".reyn" / "agents" / "parent_c"
+    AgentProfile.new("parent_c").save(agent_dir)
+    reg = _registry(tmp_path)
+
+    dir_identity_before = reg._profile_identity("parent_c")
+    assert dir_identity_before is not None
+    profile_path = agent_dir / "profile.yaml"
+    file_ino_before = profile_path.stat().st_ino
+
+    # Simulate an ATOMIC replace of profile.yaml ALONE (temp file + os.replace
+    # — the pattern the rest of this codebase already uses for durable
+    # writes, e.g. AgentIdentityGenerationStore.record) — mints a NEW inode
+    # for the file while the agent DIRECTORY itself is never touched.
+    tmp_profile = profile_path.with_suffix(".yaml.tmp")
+    tmp_profile.write_text(profile_path.read_text(encoding="utf-8"), encoding="utf-8")
+    tmp_profile.replace(profile_path)
+
+    file_ino_after = profile_path.stat().st_ino
+    assert file_ino_after != file_ino_before, (
+        "sanity: the simulated atomic replace must actually mint a new file inode "
+        "for this test to demonstrate anything"
+    )
+    dir_identity_after = reg._profile_identity("parent_c")
+    assert dir_identity_after == dir_identity_before, (
+        "the agent DIRECTORY's own identity must survive an atomic replace of "
+        "just profile.yaml — this is exactly what a file-stat design would get "
+        "wrong the moment AgentProfile.save() becomes atomic (it isn't yet, "
+        "which is why this test simulates the replace directly rather than "
+        "going through save() itself)"
+    )


### PR DESCRIPTION
**[tui-coder]** — 2 escalation paths measured live (no rewind needed), architect ruling with 2 design corrections along the way, both found empirically not guessed.

## Root cause

A DECLARED agent (a hand-written `profile.yaml`, never routed through `create_agent`) used as a spawn `parent` was never identity-tracked — `_agent_create_seq` is populated only by `create_agent`, so the frozen `spawn_parent_seq` for a child spawned ⊆ a declared parent always read a bare `None` ("no staleness signal, honour the link" — correct for a parent's first-ever appearance) — but a LATER purge + same-name re-declare of that parent produced a genuinely different identity with the SAME (missing) signal, so nothing ever caught the reuse.

**Measured** (live, no rewind, real registry): purging a topology-narrowed declared parent and re-declaring it unrestricted left BOTH `resolved_profile_for`'s ⊆-parent cap AND `is_spawn_descendant`'s C1 forge-guard on the OLD (narrower) parent's answer.

## Design history (2 corrections, both found by breaking a real test — not hypothesized)

1. **First ruling**: derive identity from `profile.yaml`'s own `created_at`. Retracted — an agent can write its own `profile.yaml` (`_DEFAULT_WRITE_ZONES=(".reyn",)`), so anything read from its content, including a self-declared `created_at`, is forgeable.
2. **Second ruling**: freeze/compare `profile.yaml`'s own filesystem stat `(ino, ctime_ns)`. Retracted after it broke a pre-existing test: `test_2103_B_agent_spawn_lineage_cap_1953.py::test_b_narrow_parent_after_spawn_recaps_live` — narrowing a LIVE parent's topology binding (a routine, legitimate op — #2103 B's whole point is the cap is LIVE, never a frozen snapshot) resaves `profile.yaml`, bumping ctime and falsely flagging the edge stale. Same shape is a real production hazard: `/agent edit role` (`slash/agent.py`) resaves an existing agent's `profile.yaml` too.
3. **Final design** (architect ruling, issuecomment-5380583991 → issuecomment-5380627931): freeze/compare the **AGENT DIRECTORY's** own `(ino, st_birthtime)` — a content-only edit never touches the directory's own identity, only rmtree+recreate does. `st_birthtime` is `None` on platforms that don't expose it (most Linux via plain `stat()`); the comparison still works with `ino` alone there, weaker guarantee disclosed in the ⑦ witness. A directory's own `ino` CAN be reused by the OS after `rmtree` (a genuine detection gap) — `AgentRegistry.remove(purge=True)` now ACTIVELY invalidates any spawn-lineage edge naming the purged agent as parent (stamping an impossible sentinel) as the backstop.

## Tests

3 new (`tests/runtime/test_5084_declared_agent_identity_purge_reuse.py`), all strip-falsified by hand (reverted → red → restored → green):
- the measured escalation repro run to its conclusion via the real API (`create_agent` + `remove(purge=True)` + re-declare)
- the same repro via a manual `rmtree` bypassing reyn's own API (weaker witness, disclosed honestly in its own docstring)
- a negative control pinning "directory not file": simulates an atomic replace of just `profile.yaml` (a pattern `AgentProfile.save()` doesn't use yet, but the rest of this codebase does elsewhere) and asserts the directory's own identity survives it

2 pre-existing tests updated for the new frozen-identity shape (`test_2103_C2b_rewind_reconstruction_1953.py`) — both hand-authored a WAL `parent_seq` as a bare int; now derive the real directory identity and simulate a genuine rmtree+recreate for the reuse case.

## Verification report (new protocol — merged ≠ done)

**Who**: tui-coder session, this worktree, HEAD at push time built on `origin/main` post-#5118.
**What ran**: `ruff check .`, `test_tier_audit.py --strict` (both touched test files, 0 Tier 4 violations), `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all clean. Full `tests/runtime/ tests/core/ tests/security/` sweep — **5489 passed**, 34 skipped (missing optional extras), **1 unrelated pre-existing failure**: `test_mcp_install_ux_fixes_318_319_320.py::test_install_command_warns_on_tmp_args_on_darwin` — `shutil.which("reyn")` returns `None` in this shell (a console-script PATH issue, nothing to do with `registry.py`/agent identity — confirmed unrelated by inspection, not touched by this diff).
**Not measured on this platform**: `st_birthtime` availability/behavior on Linux/overlayfs (the CI runner). CI running this PR's own new tests on Linux exercises "does the mechanism function" there, but not independently "can an inode be forged backward" — disclosed as a real, named gap in `_profile_identity`'s own docstring and the ⑦ witness, not silently assumed.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` (0 Tier 4, all touched/new test files)
- [x] `python scripts/verify_module_docstrings.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] full `tests/runtime/ tests/core/ tests/security/` sweep (5489 passed, 1 unrelated pre-existing env failure)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[architect]** — TESTS-READ（**A: 設計適合**、head `1a07ff794`）issuecomment-5380753641。B（独立）は別の人が必要です。

- [x] 🔴 散文 7 か所以上が**却下された設計**を記述（「the parent profile.yaml's own `(ino, ctime_ns)`」）。実装はディレクトリの `(st_ino, st_birthtime)`。メソッド名 `_profile_identity` も同様。家則「fix it in the SAME PR」
- [x] 🔴 test が private state を読む（`reg._profile_identity(...)` × 4）。家則「Use the public surface … if neither exists, that absence is the finding」→ 公開の読み口を足す
- [x] 🔴 能動的無効化（`_INVALIDATED_IDENTITY`）に witness が無い（本人申告どおり ⑥ は stat だけで緑）。ino 衝突を作って `remove(purge=True)`→再宣言→拒否、を 1 本

