### PR TITLE
feat(#5117): DelegatingClientTransport, forward-by-default for wrappers

### DIFF
--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -487,6 +487,15 @@ class ClientTransportStub(ClientTransport):
     auto-forwarded NEW method would cross unmarshaled — trading "silently
     not delegated" for "silently delegated somewhere dangerous". Falling
     at construction, not at first (mis)use, is the point.
+
+    ⚠️ **Not the same finding as :class:`DelegatingClientTransport` below**
+    (#5117, class B) — that class is EXPLICIT forwarding (every method
+    written out, no ``__getattr__`` magic), for the narrower "a query
+    (:meth:`ClientTransport.state_ready`) has one honest default; a
+    command (:meth:`ClientTransport.clear_pending_command_ui`) does not"
+    distinction #5117 draws. This class's own rejected option ④ is about
+    a DIFFERENT hazard (marshaling), not about whether explicit-forward
+    is ever the right base — see that class's own docstring.
     """
 
     def attach_failed(self) -> bool:
@@ -518,6 +527,135 @@ class ClientTransportStub(ClientTransport):
 
     def reyn_state_root(self) -> "Path | None":
         return None
+
+
+class DelegatingClientTransport(ClientTransport):
+    """A base for a wrapper that HOLDS another :class:`ClientTransport` and
+    forwards to it — every method's default is "call the inner transport's
+    same-named method", not silence and not a fixed value. A subclass
+    overrides ONLY the methods it wants to intercept; everything else
+    reaches ``self._inner`` even if the subclass never mentions it.
+
+    #5117 (architect ruling, class B): ``ClientTransportStub``'s 9
+    convenience defaults answer with a FIXED value (``False``, ``[]``,
+    ``None``, …) — correct for a self-contained ``tests/`` fixture that
+    genuinely has nothing behind it, wrong for a wrapper that DOES have an
+    inner transport, because the fixed value is a claim the wrapper cannot
+    actually back. The two methods that motivated this split are the two
+    axes architect separated:
+
+    - :meth:`ClientTransport.state_ready` (a QUERY — "is your state
+      current") has one honest answer for a class with no inner transport
+      of its own (return immediately — ``ClientTransportStub``'s existing
+      default). A DELEGATING wrapper has no state of its own to be ready
+      about; the honest answer is whatever the inner transport says.
+    - :meth:`ClientTransport.clear_pending_command_ui` (a COMMAND — "do
+      this") has NO honest default that isn't "ask the layer that might
+      actually hold one" — a no-op default asserts "there is nothing to
+      clear here", a claim only the transport that OWNS the command-UI
+      state can make. A wrapper that no-ops it is speaking for a layer it
+      does not know the state of.
+
+    Both fixed defaults look equally harmless (#5117's own framing) but
+    for a delegating wrapper specifically, forwarding is the only answer
+    that is right regardless of what the inner transport is or does —
+    "forget to override" then costs nothing, rather than costing a
+    plausible-looking wrong answer (``ClientTransportStub``'s own hazard,
+    which stays correct for its actual audience: self-contained fixtures
+    with no inner transport to forward to).
+
+    Explicit forwarding, not ``__getattr__`` (see ``ClientTransportStub``'s
+    own docstring for why ``__getattr__`` auto-forwarding was rejected
+    there — a DIFFERENT hazard, marshaling, that does not apply here since
+    this class makes no thread-crossing claim): each method is written out
+    so ``ABCMeta`` sees a concrete implementation and a subclass overriding
+    one method still gets the other 18 for free, correctly, with no magic
+    attribute lookup to reason about.
+
+    NOT a home for ``ThreadedTransportProxy`` — that wrapper's job is
+    marshaling calls across a thread boundary, a per-method concern this
+    class's blind forwarding does not perform; it stays on the pure
+    ``ClientTransport`` contract, explicit about all 19 methods, unchanged
+    by this class's existence. A future wrapper whose job genuinely IS
+    plain forwarding (e.g. ``_ErrorWatchingTransport``, which today
+    hand-forwards all 19 to intercept only ``put_display``/``start``) is
+    this class's intended audience — migrating it is not part of this PR
+    (narrower scope: land the base, prove it with a zero-override
+    subclass)."""
+
+    def __init__(self, inner: "ClientTransport") -> None:
+        self._inner = inner
+
+    def start(self) -> None:
+        self._inner.start()
+
+    def close(self) -> None:
+        self._inner.close()
+
+    def frames(self) -> "AsyncIterator[Frame]":
+        return self._inner.frames()
+
+    async def submit_user_text(self, text: str) -> str:
+        return await self._inner.submit_user_text(text)
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return await self._inner.answer_intervention_text(
+            text, intervention_id=intervention_id
+        )
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return await self._inner.answer_intervention_choice(
+            choice_id, intervention_id=intervention_id
+        )
+
+    def has_session(self) -> bool:
+        return self._inner.has_session()
+
+    def attach_failed(self) -> bool:
+        return self._inner.attach_failed()
+
+    def pending_intervention_head(self) -> "object | None":
+        return self._inner.pending_intervention_head()
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self._inner.put_display(msg)
+
+    async def cancel_inflight(self) -> str:
+        return await self._inner.cancel_inflight()
+
+    async def run_slash_command(self, name: str, args: str) -> bool:
+        return await self._inner.run_slash_command(name, args)
+
+    async def cancel_queued(self, msg_id: str) -> bool:
+        return await self._inner.cancel_queued(msg_id)
+
+    async def request_attach(self, agent_name: str) -> bool:
+        return await self._inner.request_attach(agent_name)
+
+    async def request_session_switch(self, session_id: str) -> bool:
+        return await self._inner.request_session_switch(session_id)
+
+    async def request_artifact_list(self, *, agent: str) -> "tuple[list[dict], int]":
+        return await self._inner.request_artifact_list(agent=agent)
+
+    async def request_session_list(self) -> "list[dict]":
+        return await self._inner.request_session_list()
+
+    async def state_ready(self) -> None:
+        await self._inner.state_ready()
+
+    async def clear_pending_command_ui(self) -> None:
+        await self._inner.clear_pending_command_ui()
+
+    def reyn_state_root(self) -> "Path | None":
+        return self._inner.reyn_state_root()
+
+    async def shutdown(self) -> None:
+        await self._inner.shutdown()
 
 
 def pending_head_id(head: object, *, caller: str) -> "str | None":
@@ -570,4 +708,7 @@ def pending_head_id(head: object, *, caller: str) -> "str | None":
     return None
 
 
-__all__ = ["ClientTransport", "ClientTransportStub", "pending_head_id"]
+__all__ = [
+    "ClientTransport", "ClientTransportStub", "DelegatingClientTransport",
+    "pending_head_id",
+]

--- a/tests/interfaces/test_5117_delegating_client_transport.py
+++ b/tests/interfaces/test_5117_delegating_client_transport.py
@@ -1,0 +1,164 @@
+"""Tier 2: #5117 (architect ruling, class B) — ``DelegatingClientTransport``
+forwards to its inner transport by DEFAULT, for every method, even ones a
+subclass never mentions.
+
+The defect this closes: ``ClientTransportStub``'s 9 convenience defaults
+answer with a FIXED value (``False``/``[]``/``None``/…) — correct for a
+self-contained ``tests/`` fixture with nothing behind it, wrong for a
+wrapper that DOES have an inner transport, because the fixed value is a
+claim the wrapper cannot actually back (a no-op ``clear_pending_command_ui``
+asserts "nothing to clear" — only the layer that owns that state can say
+that). Acceptance (lead-coder): a wrapper that implements NOT A SINGLE
+method must still reach the inner transport.
+
+Real ``ClientTransportStub`` subclass as the inner transport throughout —
+no mocks. Distinguishing values (not ``ClientTransportStub``'s own
+defaults) prove genuine forwarding rather than two defaults coincidentally
+matching.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.transport.client_transport import (
+    ClientTransportStub,
+    DelegatingClientTransport,
+)
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _RecordingInner(ClientTransportStub):
+    """A real inner transport whose answers are DISTINCTIVE, not
+    ``ClientTransportStub``'s own defaults — so a passing assertion proves
+    the wrapper actually reached this instance, not that two unrelated
+    defaults happened to agree. Fills in the remaining (always-abstract on
+    ``ClientTransportStub`` too) methods with the same minimal shape
+    ``tests/_support/slash.py``'s own ``RecordingTransport`` uses."""
+
+    def __init__(self) -> None:
+        self.cleared = False
+        self.state_ready_called = False
+        self.displayed: "list[OutboxMessage]" = []
+
+    def start(self) -> None: ...
+    def close(self) -> None: ...
+
+    def frames(self) -> "AsyncIterator[object]":
+        raise NotImplementedError("not exercised by this test file")
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(self, text: str, *, intervention_id=None) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str, *, intervention_id=None) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    async def cancel_inflight(self) -> str:
+        return ""
+
+    async def shutdown(self) -> None: ...
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self.displayed.append(msg)
+
+    async def clear_pending_command_ui(self) -> None:
+        self.cleared = True
+
+    async def state_ready(self) -> None:
+        self.state_ready_called = True
+
+    def reyn_state_root(self) -> "Path | None":
+        return Path("/distinctive-marker")
+
+    async def request_session_list(self) -> "list[dict]":
+        return [{"sid": "distinctive-marker"}]
+
+
+class _ZeroOverrideWrapper(DelegatingClientTransport):
+    """Implements NOT A SINGLE method — the exact acceptance shape
+    (lead-coder): every call must still reach ``self._inner``."""
+
+
+@pytest.mark.asyncio
+async def test_zero_override_wrapper_reaches_the_inner_transport_command() -> None:
+    """Tier 2: the COMMAND case #5117 exists for — a wrapper that overrides
+    nothing still delivers ``clear_pending_command_ui`` to the inner
+    transport, rather than silently no-op'ing (``ClientTransportStub``'s
+    own default, which is right for a bare fixture, wrong here).
+
+    Strip-falsifier: reverting ``DelegatingClientTransport.clear_pending_
+    command_ui`` to ``return None`` (``ClientTransportStub``'s own body)
+    turns this red (``inner.cleared`` stays ``False``) — verified locally."""
+    inner = _RecordingInner()
+    wrapper = _ZeroOverrideWrapper(inner)
+
+    await wrapper.clear_pending_command_ui()
+
+    assert inner.cleared is True
+
+
+@pytest.mark.asyncio
+async def test_zero_override_wrapper_reaches_the_inner_transport_query() -> None:
+    """Tier 2: the QUERY case (``state_ready``) — same shape, the other
+    axis #5117 separates (architect: a query and a command are different
+    classes, both need forwarding for a wrapper specifically)."""
+    inner = _RecordingInner()
+    wrapper = _ZeroOverrideWrapper(inner)
+
+    await wrapper.state_ready()
+
+    assert inner.state_ready_called is True
+
+
+@pytest.mark.asyncio
+async def test_zero_override_wrapper_forwards_a_returned_value() -> None:
+    """Tier 2: forwarding also carries the inner transport's RETURN value
+    back out — not just a fire-and-forget call. Uses a distinctive value
+    (not ``ClientTransportStub``'s own ``[]`` default) so a pass cannot be
+    two unrelated defaults agreeing by coincidence."""
+    inner = _RecordingInner()
+    wrapper = _ZeroOverrideWrapper(inner)
+
+    assert await wrapper.request_session_list() == [{"sid": "distinctive-marker"}]
+    assert wrapper.reyn_state_root() == Path("/distinctive-marker")
+
+
+@pytest.mark.asyncio
+async def test_a_subclass_overriding_one_method_still_forwards_the_rest() -> None:
+    """Tier 2: the real-world shape (mirrors ``_ErrorWatchingTransport``,
+    the existing hand-written wrapper this class is meant to relieve) — a
+    subclass that overrides put_display to watch for errors must still get
+    every OTHER method forwarded for free, with no need to mention them."""
+
+    class _WatchingWrapper(DelegatingClientTransport):
+        def __init__(self, inner) -> None:
+            super().__init__(inner)
+            self.saw_error = False
+
+        def put_display(self, msg: "OutboxMessage") -> None:
+            if msg.kind == "error":
+                self.saw_error = True
+            self._inner.put_display(msg)
+
+    inner = _RecordingInner()
+    wrapper = _WatchingWrapper(inner)
+    msg = OutboxMessage(kind="error", text="boom")
+
+    wrapper.put_display(msg)
+    assert wrapper.saw_error is True
+    assert inner.displayed == [msg], "the overridden method must still forward to inner"
+
+    # The method it did NOT override still reaches the inner transport.
+    await wrapper.clear_pending_command_ui()
+    assert inner.cleared is True


### PR DESCRIPTION
**[docs-maintainer]** — issue #5117 の割当（class B、architect裁定どおり）。#5116着地済につき前提条件満たしています。class A(`state_ready`削除)は本PRではやりません(#5116のpush設計で呼び口0になってから、別PR)。

## やったこと
`DelegatingClientTransport`(`client_transport.py`)を`ClientTransport`直下の新basecクラスとして追加。19個のabstractmethod全てを`self._inner`へforwardする形で実装(`__getattr__`ではなく明示的 — `ClientTransportStub`のdocstringが既に述べているoption④拒否の理由(スレッドmarshaling)はここには適用されないため別軸である旨、既存docstringにも1段落追記)。

サブクラスが1メソッドもoverrideしなくても下位に届く(受入どおり) — overrideしたメソッドだけ差し替え、残りは自動的にforward。

## 検証
4本の新規test、全て実物`ClientTransportStub`サブクラス(distinctive戻り値)を使用、mock無し。**strip-falsify**: `clear_pending_command_ui`のforwardを`ClientTransportStub`と同じ`return None`に戻す → red確認、復元後green。

`tests/interfaces/`全体スイープ: 2000 passed, 8 skipped(optional dep), 0 failures — 既存機能への影響無し。

## 未対応(意図的、スコープ限定)
`_ErrorWatchingTransport`/`ThreadedTransportProxy`の移行はこのPRではやりません — 前者は将来の自然な移行候補としてdocstringに記録、後者はスレッドmarshalingのため対象外と明記。

## Gate
`ruff check`clean、`test_tier_audit.py --strict` 4/4 OK、`verify_module_docstrings.py`clean、`mypy_ratchet.py`clean。

part of #5117
