### PR TITLE
fix(#5058): remove the 17 remaining fastapi importorskip guards

### DIFF
--- a/tests/interfaces/test_5051_web_core_deps_import.py
+++ b/tests/interfaces/test_5051_web_core_deps_import.py
@@ -3,16 +3,16 @@
 reyn's own packaging contract, not an OS invariant: ``fastapi`` / ``starlette``
 / ``uvicorn`` / ``websockets`` moved from the (now-empty back-compat)
 ``[web]`` extra into ``[project].dependencies`` (#5051, `pyproject.toml`).
-17 test files across ``tests/web``/``tests/interfaces`` guard their own
-FastAPI-backed fixtures with ``pytest.importorskip("fastapi", ...)`` — a
-DELIBERATE decision, kept unchanged by #5051 (a #5058 follow-up owns
-whether that stays ``importorskip`` or becomes a hard import), so a broken
-install (one of these 4 genuinely missing, which after #5051 means a stale
-environment rather than a normal configuration) silently skips all 17
-rather than failing loud (CLAUDE.md's own six-questions Q4: "passes green
-having never run"). This ONE test is the loud voice: if any of the 4 is
-missing, THIS test fails hard (no importorskip), while the other 16 stay
-harmlessly skipped.
+
+17 test files across ``tests/web``/``tests/interfaces`` used to guard their
+own FastAPI-backed fixtures with ``pytest.importorskip("fastapi", ...)`` —
+kept unchanged by #5051 itself, then removed by the #5058 follow-up this
+docstring named as owning the question (architect ruling, generalized from
+the same-shaped `mcp` case: a core dep's absence is a broken install, not a
+normal absent-extra path, so the correct behavior is a loud failure, not a
+silent skip). All 17 now hard-import ``fastapi`` — this test is no longer
+the lone loud voice for a silently-skipped population; it now just adds a
+fast, standalone Tier-1 check that does not require booting the web app.
 
 Deliberately NOT derived from ``pyproject.toml``'s dependency list: a
 package name does not always equal its import name (``uvicorn[standard]``
@@ -30,9 +30,7 @@ def test_web_core_deps_import_cleanly():
     """Tier 1: fastapi/starlette/uvicorn/websockets (the 4 packages #5051
     moved off the [web] extra into core) all import without raising, in
     THIS interpreter -- a broken/stale install (one genuinely missing or
-    incompatible) fails this test loud, rather than silently skipping (the
-    fate of the 17 importorskip-guarded files this test exists to give a
-    voice to)."""
+    incompatible) fails this test loud, rather than silently skipping."""
     import fastapi  # noqa: F401
     import starlette  # noqa: F401
     import uvicorn  # noqa: F401

--- a/tests/interfaces/test_a2a_iv_kind_choices_267_gap4.py
+++ b/tests/interfaces/test_a2a_iv_kind_choices_267_gap4.py
@@ -31,10 +31,10 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
-
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus  # noqa: E402
 from reyn.interfaces.web.run_registry import RunRegistry  # noqa: E402
 from reyn.user_intervention import (  # noqa: E402

--- a/tests/interfaces/test_a2a_sse_producer_267_gap1.py
+++ b/tests/interfaces/test_a2a_sse_producer_267_gap1.py
@@ -33,10 +33,10 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
-
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 from reyn.core.events.events import EventLog  # noqa: E402
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus  # noqa: E402
 from reyn.interfaces.web.run_registry import RunRegistry  # noqa: E402

--- a/tests/interfaces/test_a2a_webhook_progress_267_gap2.py
+++ b/tests/interfaces/test_a2a_webhook_progress_267_gap2.py
@@ -36,10 +36,10 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
-
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 from reyn.core.events.events import EventLog  # noqa: E402
 from tests._support.paths import REPO_ROOT
 

--- a/tests/interfaces/test_channel_state_webhook_wire_269.py
+++ b/tests/interfaces/test_channel_state_webhook_wire_269.py
@@ -44,10 +44,10 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-import pytest
-
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
-
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 from reyn.core.events.events import EventLog  # noqa: E402
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus  # noqa: E402
 from reyn.interfaces.web.run_registry import RunRegistry  # noqa: E402

--- a/tests/interfaces/test_fp0001_a2a_endpoints.py
+++ b/tests/interfaces/test_fp0001_a2a_endpoints.py
@@ -32,8 +32,12 @@ _WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 
-# Skip the whole module if optional deps are missing.
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# Skip the whole module if httpx (TestClient dep) is missing -- fastapi
+# itself is no longer skip-guarded, see the #5058 comment below.
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
 
 

--- a/tests/interfaces/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/interfaces/test_fp0001_e2e_ask_user_roundtrip.py
@@ -51,7 +51,10 @@ if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 
 # Skip the whole module if optional web deps are missing.
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/interfaces/test_fp0009_b_web_lifespan.py
+++ b/tests/interfaces/test_fp0009_b_web_lifespan.py
@@ -25,9 +25,12 @@ import pytest
 
 from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
-# Skip entire module if fastapi / httpx are not installed (same guard as
-# the other web tests).
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here (this
+# file never had an httpx guard, so the module had exactly one) was a
+# silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed; no guard
+# remains in this module.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/interfaces/test_web_auth_lifespan_wiring.py
+++ b/tests/interfaces/test_web_auth_lifespan_wiring.py
@@ -15,13 +15,14 @@ from pathlib import Path
 
 import pytest
 
-from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
-
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
-
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 from fastapi import FastAPI  # noqa: E402
 
 from reyn.interfaces.web.auth import TOKEN_ENV_VAR, AuthContext  # noqa: E402
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _write_reyn_yaml(directory: Path, content: str) -> None:

--- a/tests/runtime/test_a2a_bus_stamping_268_phase2.py
+++ b/tests/runtime/test_a2a_bus_stamping_268_phase2.py
@@ -34,10 +34,10 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-import pytest
-
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
-
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus  # noqa: E402
 from reyn.interfaces.web.run_registry import RunRegistry  # noqa: E402
 from reyn.llm.llm import LLMToolCallResult  # noqa: E402

--- a/tests/web/test_4482_get_artifact_by_ref.py
+++ b/tests/web/test_4482_get_artifact_by_ref.py
@@ -21,7 +21,10 @@ _WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 
-fastapi = pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
 
 

--- a/tests/web/test_a2a.py
+++ b/tests/web/test_a2a.py
@@ -29,8 +29,12 @@ _WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 
-# Skip the whole module if optional deps are missing.
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# Skip the whole module if httpx (TestClient dep) is missing -- fastapi
+# itself is no longer skip-guarded, see the #5058 comment below.
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
 
 

--- a/tests/web/test_auth_gate_middleware.py
+++ b/tests/web/test_auth_gate_middleware.py
@@ -34,7 +34,10 @@ if str(_WORKTREE_SRC) not in sys.path:
 
 import pytest
 
-fastapi = pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
 
 from fastapi.testclient import TestClient  # noqa: E402

--- a/tests/web/test_mcp_sse.py
+++ b/tests/web/test_mcp_sse.py
@@ -32,8 +32,12 @@ _WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 
-# Skip the whole module if optional deps are missing.
-pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# Skip the whole module if httpx (TestClient dep) is missing -- fastapi
+# itself is no longer skip-guarded, see the #5058 comment below.
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
 # #5058 (group C): this file never imports the mcp SDK — both tests exercise
 # /mcp/messages purely over HTTP via TestClient, checking the mount's own 4xx

--- a/tests/web/test_openui_shell.py
+++ b/tests/web/test_openui_shell.py
@@ -24,9 +24,13 @@ if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 
 # ---------------------------------------------------------------------------
-# Guard: skip all tests if fastapi / httpx (TestClient dep) not installed.
+# Guard: skip all tests if httpx (TestClient dep) not installed --
+# fastapi itself is no longer skip-guarded, see the #5058 comment below.
 # ---------------------------------------------------------------------------
-fastapi = pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
 
 

--- a/tests/web/test_resources_router.py
+++ b/tests/web/test_resources_router.py
@@ -35,7 +35,10 @@ _WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 
-fastapi = pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
 
 

--- a/tests/web/test_smoke.py
+++ b/tests/web/test_smoke.py
@@ -28,9 +28,13 @@ if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 
 # ---------------------------------------------------------------------------
-# Guard: skip all tests if fastapi / httpx (TestClient dep) not installed.
+# Guard: skip all tests if httpx (TestClient dep) not installed --
+# fastapi itself is no longer skip-guarded, see the #5058 comment below.
 # ---------------------------------------------------------------------------
-fastapi = pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
 
 

--- a/tests/web/test_surface_registry.py
+++ b/tests/web/test_surface_registry.py
@@ -35,7 +35,10 @@ import pytest
 
 from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
-fastapi = pytest.importorskip("fastapi", reason="fastapi not installed (core dependency since #5051 -- stale environment)")
+# #5058: fastapi is a core dependency (#5051) -- an importorskip here
+# was a silent skip on a broken install, not a normal absent-extra path
+# (architect ruling, gh issue view 5058, generalized from the mcp class
+# to any core dep: "the correct behavior is red"). Removed.
 httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
 
 from fastapi.testclient import TestClient  # noqa: E402


### PR DESCRIPTION
**[e2e-coder]** — part of #5058 (the mcp 12-site body was already merged as #5061+#5062; this is the fastapi 17-site body, the same class, generalized per architect's ruling in the issue).

## What

`fastapi` became a core dependency in #5051 (PR #5055 fixed the `reason=` strings only, semantics unchanged). A core dep's absence is a broken install, not a normal absent-extra path — an `importorskip` guard against it silently skips rather than failing loud (CLAUDE.md six-questions Q4: "passes green having never run").

## Classification (architect's discriminator: is the `importorskip` argument in core dependencies?)

Both groups converge to the same fix — matching what the mcp precedent found (the prescription doesn't depend on the group):

- **A (direct fastapi SDK import, 3 files)**: `test_web_auth_lifespan_wiring.py`, `test_auth_gate_middleware.py`, `test_surface_registry.py`
- **B (indirect via `reyn.interfaces.web.*`, 14 files)**: the remainder — all import reyn's own web modules, which themselves import fastapi

No **C** (unused) group — every one of the 17 genuinely needs fastapi, directly or via `reyn.interfaces.web.*`.

## Also fixed in this PR

- 6 stale header comments ("skip if fastapi/httpx not installed") describing a guard this PR removes — 5 files kept their `httpx` guard (untouched — that's #5059's separate "undeclared dependency" scope) and needed the fastapi half of the sentence dropped; `tests/interfaces/test_fp0009_b_web_lifespan.py` had no httpx guard at all, so its header comment is dropped entirely (CLAUDE.md: a doc describing a mechanism is stale the moment that mechanism's code changes, same PR).
- `tests/interfaces/test_5051_web_core_deps_import.py`'s own docstring, which explicitly named this PR as owning the "importorskip vs hard import" question — now stale since the question is answered.

## Verification

- `ruff check .`, `test_tier_audit.py --strict` (135 tests inspected, 0 Tier-4 violations), `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `mypy_ratchet.py` — all green.
- The 17 changed files + the 2 docstring-updated files: 134 passed / 1 pre-existing unrelated skip (a separately-deferred F5 test).
- Broader sweep `tests/web/ tests/interfaces/ -k "a2a or web or fp0001 or fp0009"`: 292 passed / 1 pre-existing skip.
- Rebased onto latest `origin/main` (post-#5120), no file overlap with intervening commits, re-verified green after rebase.

## Test plan

- [x] All 17 sites' guards removed, tests still pass (fastapi genuinely installed in this env)
- [x] Stale prose (6 headers + 1 docstring) updated in the same PR
- [x] Full local gate suite green
- [x] Broader `a2a`/`web` regression sweep green
- [x] (skipped — no live/manual verification needed; this is a mechanical test-discipline fix, not a runtime behavior change)

⚠️ TESTS-READ note required (touches `tests/`) — per #5120, please include the reviewing commit SHA in the note (`head \`<sha>\``, matching this PR's own commit list, not an issuecomment id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
