### PR TITLE
docs(pr-workflow): #5120 partially closes the "No CI gate" instance §8 names

### DIFF
--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -291,12 +291,27 @@ These rules then keep multi-session work coherent:
    time in its own PR-workflow section. The content was sound (confirmed
    post-hoc) and the author was not at fault — "resume" was said without
    the caveat that merge still waits on TESTS-READ, an omission on the
-   reviewer's side, not a violation on the implementer's. No CI gate: a
-   check for "a comment containing a fixed string exists" makes passing
-   the check the goal (an empty TESTS-READ satisfies it) — the same shape
-   already closed elsewhere in this file. A doc line is the proportionate
-   fix; only a human reading the PR before merging can tell a real
-   TESTS-READ from an empty one.
+   reviewer's side, not a violation on the implementer's. At the time this
+   was written: no CI gate — a check for "a comment containing a fixed
+   string exists" makes passing the check the goal (an empty TESTS-READ
+   satisfies it) — the same shape already closed elsewhere in this file. A
+   doc line was the proportionate fix; only a human reading the PR before
+   merging could tell a real TESTS-READ from an empty one.
+
+   **Partially closed since (#5120, 2026-08-22):**
+   `scripts/check_tests_read_names_its_tree.py`, wired as its own
+   `pull_request`/`issue_comment` CI workflow (repo-wide, not one train's
+   own script), now fails a `tests/`-touching PR that carries no
+   TESTS-READ note naming one of the PR's own commits, or whose only note
+   names a commit `tests/` has since moved past. This closes the
+   "never wired to that path at all" half — every PR now gets a CI check,
+   not just the ones a particular merge train happens to gate. It does
+   NOT close the "empty TESTS-READ satisfies it" half this section
+   illustrates: the gate reads only whether a note names a fresh commit,
+   never what the note SAYS — `**[X]** — TESTS-READ (B) (head \`abc1234\`)`
+   with no actual review content still passes. Only a human reading the
+   PR can still tell a real TESTS-READ from an empty one carrying the
+   right shape.
 
 ## Bundling and the owner's veto unit
 


### PR DESCRIPTION
**[docs-maintainer]** — 自力発見。`pr-workflow.md`の§8が#3916のgap実例を記述し、現在形で「No CI gate」と主張していますが、#5120(本日merge)がまさにその不在を埋めるgate(`check_tests_read_names_its_tree.py`)を出荷しました。

## 主張の精査
- **半分は closed**: 「特定のmerge trainにしか配線されていない」問題 → #5120は repo全体のCI workflowなので解消。
- **半分は open のまま**: 「空のTESTS-READでも通る」問題 → #5120のgateはnoteが"新しいcommitを名指ししているか"だけを見ており、内容の中身は見ていない。この点でこのsectionの実例は今も有効。

元の記述(#3916の史実部分)はそのまま残し、日付付きの「Partially closed since」段落を追加する形にしました — 元の文はその時点では正確だったため、上書きせず併記。

`.ja.md`ミラー無し(sync不要)。

## Gate
`mkdocs build --strict`(Aborted無し)→`check_doc_anchors.py`(dangling無し)→`check_retired_config_keys_denylist.py`(0 hits)、順序通り全clean。

part of #5022
