### PR TITLE
fix(#5116): AgUiTransport._pump_sse's exception is no longer swallowed

### DIFF
--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -59,6 +59,29 @@ if TYPE_CHECKING:
 _SSE_DONE = object()
 
 
+class _SSEPumpError:
+    """#5126 (lead-coder catch on #5107, issuecomment-5380819283): a real
+    exception (e.g. ``httpx.ReadError`` — the connection dying mid-stream)
+    used to be indistinguishable from a clean end-of-stream: :meth:`_pump_sse`
+    enqueued the SAME :data:`_SSE_DONE` sentinel in its ``finally`` on every
+    exit, then let the exception propagate out of the untracked background
+    task — where nothing ever awaited it, so it became an asyncio
+    "exception was never retrieved" orphan, and :meth:`frames` (seeing only
+    ``_SSE_DONE``) returned exactly as if the stream had ended normally.
+
+    This wraps a genuine (non-cancellation) exception so it travels through
+    the SAME queue :data:`_SSE_DONE` does — the one channel a consumer
+    (:meth:`frames`) actually drains — instead of being silently dropped on
+    the task's own way out. :meth:`frames` re-raises it, so a real caller
+    (the TUI, or a test) sees the actual failure instead of a quiet, ordinary
+    end."""
+
+    __slots__ = ("exc",)
+
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
+
+
 class AgUiTransport(ClientTransport):
     """Decode a server AG-UI SSE stream into the renderer's ``Frame`` vocabulary."""
 
@@ -246,6 +269,20 @@ class AgUiTransport(ClientTransport):
         ``put_nowait`` cannot be interrupted mid-call, so the sentinel
         genuinely always lands, regardless of what ``self._display_queue``
         becomes later.
+
+        #5126: a genuine (non-cancellation) exception — the connection dying
+        mid-stream — is caught HERE and forwarded through the queue as a
+        :class:`_SSEPumpError`, ahead of the ``finally``'s own
+        :data:`_SSE_DONE`. Deliberately NOT re-raised after catching: this
+        task must exit cleanly (no exception left for asyncio to log as
+        "never retrieved") because the queue IS now the retrieval path —
+        :meth:`frames` reads the error back off it and raises it in the
+        CALLER's context, where a real caller can act on it. Cancellation
+        is exempt (bare ``except Exception``, not ``BaseException`` —
+        ``asyncio.CancelledError`` derives from ``BaseException`` since
+        Python 3.8): :meth:`close`'s own ``.cancel()`` is an intentional,
+        expected shutdown, not a failure to report back through the frame
+        stream.
         """
         try:
             block: list[str] = []
@@ -276,6 +313,12 @@ class AgUiTransport(ClientTransport):
                 for frame in self._consume_block(block):
                     await suspend_between_frames()  # #3570, same reason as above
                     await self._display_queue.put(frame)
+        except Exception as exc:  # noqa: BLE001 -- #5126: forwarded via the
+            # queue for `frames()` to re-raise, not re-raised here (see
+            # docstring above) -- deliberately broad: ANY failure reading or
+            # decoding the SSE stream must reach the caller as a real error,
+            # not vanish as an ordinary end-of-stream.
+            self._display_queue.put_nowait(_SSEPumpError(exc))
         finally:
             self._display_queue.put_nowait(_SSE_DONE)
 
@@ -288,6 +331,13 @@ class AgUiTransport(ClientTransport):
             self._sse_pump_task = asyncio.create_task(self._pump_sse())
         while True:
             frame = await self._display_queue.get()
+            if isinstance(frame, _SSEPumpError):
+                # #5126: the pump died (a real exception, not a clean end or
+                # an intentional close()); surface it HERE, in the caller's
+                # own context, instead of letting `_SSE_DONE` (queued right
+                # after this by the SAME `finally`) make it look like an
+                # ordinary end-of-stream.
+                raise frame.exc
             if frame is _SSE_DONE:
                 return
             # #3570 gate (test_stream_drain_yield_3570.py's own class gate):

--- a/tests/interfaces/test_5126_pump_sse_exception_not_swallowed.py
+++ b/tests/interfaces/test_5126_pump_sse_exception_not_swallowed.py
@@ -1,0 +1,105 @@
+"""Tier 2: #5126 (lead-coder catch on #5107, issuecomment-5380819283) — a
+genuine exception raised while ``AgUiTransport._pump_sse`` reads the SSE
+source (a connection dying mid-stream, e.g. ``httpx.ReadError``) used to be
+indistinguishable from a clean end-of-stream: ``_pump_sse``'s ``finally``
+enqueued the SAME ``_SSE_DONE`` sentinel on every exit, then let the raised
+exception propagate out of the untracked background task, where nothing
+ever awaited it (an asyncio "exception was never retrieved" orphan).
+``frames()``, seeing only ``_SSE_DONE``, returned exactly as if the stream
+had ended normally — a real connection failure vanished silently, mid-turn,
+with the caller (a TUI, or a test) none the wiser.
+
+Real ``AgUiTransport`` + a REAL ``AgUiEmitter``-encoded SSE stream throughout
+(the same production encoder that writes the wire format, not hand-rolled
+SSE text) — the failure is injected by raising out of the hand-fed async
+generator AFTER it has yielded genuine, correctly-encoded SSE lines, the
+same pattern every other ``AgUiTransport`` test in this suite uses for its
+SSE source (e.g. ``test_3300_p2a_queue_state_publish.py``'s ``_sse_lines``).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _InjectedFailure(RuntimeError):
+    """Stands in for a real transport-level failure (httpx.ReadError etc.)
+    — what actually raises is irrelevant to the property under test (the
+    pump must not swallow ANY exception), so a plain exception type avoids
+    coupling this test to httpx's own class hierarchy."""
+
+
+async def _one_display_frame():
+    yield DisplayFrame(OutboxMessage(kind="agent", text="hello"))
+
+
+def _status_provider():
+    return None
+
+
+async def _sse_lines_then_fail(sse_text: str):
+    for line in sse_text.split("\n"):
+        yield line
+    raise _InjectedFailure("connection dropped mid-stream")
+
+
+async def _noop_send(_payload: dict) -> "dict | None":
+    return None
+
+
+async def _build_real_sse_text() -> str:
+    """A REAL, production-encoded SSE stream (one display frame's worth) —
+    the same ``AgUiEmitter.stream()`` the actual server route uses."""
+    emitter = AgUiEmitter(_one_display_frame(), _status_provider)
+    return "".join([chunk async for chunk in emitter.stream()])
+
+
+@pytest.mark.asyncio
+async def test_a_pump_exception_reaches_the_frames_caller_not_swallowed():
+    """Tier 2: #5126's own witness — ``frames()`` must RAISE the real
+    exception, not return as if the stream ended cleanly.
+
+    Strip-falsifier: reverting ``_pump_sse``'s ``except Exception`` block
+    (and ``frames()``'s ``_SSEPumpError`` check) turns this red — the
+    ``async for`` below completes with NO exception raised (only the
+    STATE_SNAPSHOT/MESSAGES_SNAPSHOT reconnect frames, if any, then a
+    silent return), instead of raising ``_InjectedFailure``. Verified
+    locally."""
+    sse_text = await _build_real_sse_text()
+    transport = AgUiTransport(_sse_lines_then_fail(sse_text), _noop_send)
+
+    received = []
+    with pytest.raises(_InjectedFailure, match="connection dropped mid-stream"):
+        async for frame in transport.frames():
+            received.append(frame)
+
+    assert any(
+        isinstance(f, DisplayFrame) and f.message.text == "hello" for f in received
+    ), (
+        "sanity: the frame before the failure must still have been "
+        "delivered — this witness is about the FAILURE not being silently "
+        "dropped, not about losing frames that arrived before it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_clean_end_of_stream_still_returns_normally():
+    """Tier 2: regression guard — the fix must not turn an ORDINARY
+    end-of-stream (the source running dry, no exception) into a raise. Only
+    a genuine exception should surface; a clean end is still a clean
+    return."""
+    sse_text = await _build_real_sse_text()
+
+    async def _sse_lines_clean():
+        for line in sse_text.split("\n"):
+            yield line
+
+    transport = AgUiTransport(_sse_lines_clean(), _noop_send)
+    received = [frame async for frame in transport.frames()]
+    assert any(
+        isinstance(f, DisplayFrame) and f.message.text == "hello" for f in received
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5116 (lead-coder catch on #5107/PR #5110, issuecomment-5380819283; no issue filed — this PR is the record, per lead-coder's instruction).

## What

`_pump_sse`'s `try:`/`finally: put_nowait(_SSE_DONE)` (no `except`) let a genuine exception — e.g. `httpx.ReadError`, a connection dying mid-stream — propagate out of the untracked background task after its `finally` enqueued the SAME `_SSE_DONE` sentinel a clean end-of-stream uses. Nobody ever awaits `self._sse_pump_task` (`close()` only cancels it), so the exception became an asyncio "exception was never retrieved" orphan, and `frames()` — which only checks `frame is _SSE_DONE` — returned exactly as if the stream had ended normally. A real connection failure vanished silently, mid-turn, with no caller (TUI or test) ever finding out.

Surfaced by a genuine CI failure on #5126 (a docs-only PR whose CI happened to exercise this real-socket path): `tests/interfaces/test_3328_connect_remote_parity_witness.py` failed with an empty `renderer.messages`, and the same CI log showed `Task ... _pump_sse() ... exception=ReadError('')`.

## Fix

A new `_SSEPumpError` wrapper. `_pump_sse` catches any non-cancellation exception and forwards it through the SAME queue `_SSE_DONE` travels through (`put_nowait`, so it lands even under a concurrent `close()`); `frames()` checks for it BEFORE the `_SSE_DONE` check and re-raises it in the caller's own context. The pump task itself completes cleanly (no re-raise inside `_pump_sse`), so there is no unretrieved-exception orphan — the queue is now the sole retrieval path. `asyncio.CancelledError` is untouched (bare `except Exception`, not `BaseException`) — `close()`'s own cancel is an intentional, expected shutdown, not a failure to report.

**Explicitly NOT claimed by this PR** (per lead-coder): this does not diagnose or fix *why* the `ReadError` happened on #5126's CI run — that's tracked separately, no conflation. This closes the class of hole (any exception silently indistinguishable from a clean end), matching what #5107's own docstring already disclosed knowing about ("a raised exception... still runs `finally`") without noticing it fed the SAME sentinel a clean end does.

## Verification

- Strip-falsified: reverting both the `except` block in `_pump_sse` and the `_SSEPumpError` check in `frames()` turns the new witness red for the right reason ("DID NOT RAISE") — the CI log's own exact "exception was never retrieved" traceback reproduced locally. Restored, re-confirmed green.
- `ruff check .`, `test_tier_audit.py --strict` (0 Tier-4 violations), `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.
- `pytest tests/interfaces/ -k "agui or 3328 or 5107 or 5116 or 3300 or 3310"` — 198 passed.
- `tests/interfaces/test_3328_connect_remote_parity_witness.py` (the originally-failing test) — 2 passed, locally.

## Test plan

- [x] New tests pass (`tests/interfaces/test_5126_pump_sse_exception_not_swallowed.py`)
- [x] Strip-falsified (see above)
- [x] Broad `agui`/`3328`/`5107`/`5116`/`3300`/`3310` regression sweep green
- [x] The originally-failing test passes locally
- [x] (skipped — this fix doesn't itself claim to reproduce/fix the CI-specific `ReadError` trigger; no live/manual verification applies)

⚠️ TESTS-READ note required (touches `tests/`) — per #5120, please include the reviewing commit SHA in the note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
