### PR TITLE
fix(#5039): an issue_comment run checks out main, not the PR

### DIFF
--- a/.github/workflows/check-tests-read-names-its-tree.yml
+++ b/.github/workflows/check-tests-read-names-its-tree.yml
@@ -38,23 +38,17 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      # No checkout of the PR. The commit list and each commit's file names
+      # are read from the API as DATA (see the script's own
+      # `commit_touched_paths`), so a contributor's tree is never executed
+      # here and there is no `ref:` to get wrong — the conditional that used
+      # to live here is what reddened #5123/#5125/#5127 on `issue_comment`
+      # runs, which check out the DEFAULT BRANCH (architect's security lens
+      # on this PR: don't have that shape at all).
       - uses: actions/checkout@v6
         with:
-          # An `issue_comment` event checks out the DEFAULT BRANCH, not the PR
-          # — measured on this gate's own first days (#5123/#5125/#5127 all
-          # went red on `issue_comment` runs whose headSha was main's). The
-          # check reads each PR commit's touched paths via `git show`, so a
-          # main checkout cannot resolve them and the loud refusal fires: a
-          # red for the wrong reason, which is the same defect class as the
-          # false green this gate exists to remove. Name the PR's head
-          # explicitly; for `pull_request` events the default is already right.
-          ref: >-
-            ${{ github.event_name == 'issue_comment'
-                && format('refs/pull/{0}/head', github.event.issue.number)
-                || '' }}
-          # The refusal above also fires on a shallow checkout, which has the
-          # commits' tips but not their history.
-          fetch-depth: 0
+          # Only the script itself is needed, from the base branch.
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/check-tests-read-names-its-tree.yml
+++ b/.github/workflows/check-tests-read-names-its-tree.yml
@@ -40,11 +40,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # The check reads each PR commit's touched paths via `git show`, and
-          # refuses (loudly) rather than reporting a result computed from
-          # commits it could not read. A shallow checkout does not have them,
-          # so that refusal would fire on every PR — a false red, which is as
-          # bad as the false green this gate exists to remove.
+          # An `issue_comment` event checks out the DEFAULT BRANCH, not the PR
+          # — measured on this gate's own first days (#5123/#5125/#5127 all
+          # went red on `issue_comment` runs whose headSha was main's). The
+          # check reads each PR commit's touched paths via `git show`, so a
+          # main checkout cannot resolve them and the loud refusal fires: a
+          # red for the wrong reason, which is the same defect class as the
+          # false green this gate exists to remove. Name the PR's head
+          # explicitly; for `pull_request` events the default is already right.
+          ref: >-
+            ${{ github.event_name == 'issue_comment'
+                && format('refs/pull/{0}/head', github.event.issue.number)
+                || '' }}
+          # The refusal above also fires on a shallow checkout, which has the
+          # commits' tips but not their history.
           fetch-depth: 0
 
       - name: Set up Python

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -170,7 +170,7 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     ]
 
 
-def commit_touched_paths(oid: str, repo: str) -> "list[str]":
+def commit_touched_paths(oid: str, repo: str, run=subprocess.run) -> "list[str]":
     """The paths *oid* touched, read from GitHub rather than a checkout.
 
     Deliberately NOT ``git show``: reading the tree would force this workflow
@@ -184,8 +184,15 @@ def commit_touched_paths(oid: str, repo: str) -> "list[str]":
 
     Raises ``SystemExit`` rather than returning empty on an API failure: an
     empty list reads as "touched no tests", a green computed from a commit
-    this check could not read, which is the shape it exists to reject."""
-    result = subprocess.run(
+    this check could not read, which is the shape it exists to reject.
+
+    *run* is a seam, not a mock hook: an authenticated network call is not a
+    "cheaply constructible real instance", so the suite injects a small runner
+    here rather than reaching a live API. Measured why that matters — with the
+    real one, the reject-side test passed in CI because `gh` had no token, not
+    because the commit was bogus: green for the wrong reason, in the test for
+    the very behaviour this function exists to provide."""
+    result = run(
         ["gh", "api", f"repos/{repo}/commits/{oid}", "--jq", "[.files[].filename]"],
         capture_output=True, text=True,
     )

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -170,48 +170,57 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     ]
 
 
-def commit_touched_paths(oid: str, number: int, repo_root: "str | None" = None) -> "list[str]":
-    """The paths *oid* touched, or stop the run if this checkout cannot read it.
+def commit_touched_paths(oid: str, repo: str) -> "list[str]":
+    """The paths *oid* touched, read from GitHub rather than a checkout.
 
-    Split out from :func:`fetch_pr` so the refusal is reachable with a real
-    ``git`` call on a real repository — no faked runner. *repo_root* makes the
-    repository an argument rather than the process's cwd, so a caller running
-    elsewhere cannot get a refusal that merely means "not in a git repo" — the
-    refusal would then be true for the wrong reason. A commit the checkout
-    cannot resolve (unfetched, or a squashed merge) would otherwise produce
-    empty output that reads as "touched no tests": a green computed from
-    commits never read, which is the shape this gate exists to reject."""
-    shown = subprocess.run(
-        ["git", "show", "--name-only", "--format=", oid],
-        capture_output=True, text=True, cwd=repo_root,
+    Deliberately NOT ``git show``: reading the tree would force this workflow
+    to check the PR out, and an ``issue_comment`` run checks out the default
+    branch — measured, that is how this gate spent its first hour reddening
+    #5123/#5125/#5127 for a reason that had nothing to do with their notes
+    (architect's security lens on the same PR: checking out a contributor's
+    ref to run a script is a shape worth not having at all). The commit list
+    and its file names are DATA on the API side; taking them as data means the
+    PR's own tree is never executed here.
+
+    Raises ``SystemExit`` rather than returning empty on an API failure: an
+    empty list reads as "touched no tests", a green computed from a commit
+    this check could not read, which is the shape it exists to reject."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/commits/{oid}", "--jq", "[.files[].filename]"],
+        capture_output=True, text=True,
     )
-    if shown.returncode != 0:
+    if result.returncode != 0:
         raise SystemExit(
-            f"check_tests_read_names_its_tree: cannot resolve commit {oid} "
-            f"in this checkout — fetch the PR's commits first "
-            f"(`git fetch origin pull/{number}/head`). Refusing to report a "
-            f"result computed from commits it could not read."
+            f"check_tests_read_names_its_tree: cannot read commit {oid} from "
+            f"{repo} ({result.stderr.strip()[:200]}). Refusing to report a "
+            f"result computed from a commit it could not read."
         )
-    return shown.stdout.split()
+    return json.loads(result.stdout or "[]")
 
 
 def fetch_pr(number: int) -> dict:
-    """Build the `evaluate` payload for a live PR via `gh`."""
+    """Build the `evaluate` payload for a live PR via `gh` — no checkout."""
+    repo = subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
     raw = subprocess.run(
         ["gh", "pr", "view", str(number), "--json",
          "files,comments,commits,headRefOid"],
         capture_output=True, text=True, check=True,
     ).stdout
     data = json.loads(raw)
-    commits = []
-    for c in data.get("commits", []):
-        oid = c.get("oid", "")
-        paths = commit_touched_paths(oid, number)
-        commits.append({
-            "oid": oid,
+    commits = [
+        {
+            "oid": c.get("oid", ""),
             "messageHeadline": c.get("messageHeadline", ""),
-            "_tests_paths": [p for p in paths if p.startswith("tests/")],
-        })
+            "_tests_paths": [
+                f for f in commit_touched_paths(c.get("oid", ""), repo)
+                if f.startswith("tests/")
+            ],
+        }
+        for c in data.get("commits", [])
+    ]
     return {
         "files": [f.get("path", "") for f in data.get("files", [])],
         "comments": data.get("comments", []),

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -181,9 +181,12 @@ def test_a_readable_commit_reports_its_paths() -> None:
     would still pass the reject test."""
     paths = _MOD.commit_touched_paths(
         "abc1234", "tya5/reyn",
-        run=_runner(0, stdout='["src/reyn/a.py", "tests/scripts/b.py"]'),
+        run=_runner(0, stdout='["src/reyn/runtime/registry.py", "tests/scripts/test_check_doc_drift_5003.py"]'),
     )
-    assert paths == ["src/reyn/a.py", "tests/scripts/b.py"]
+    assert paths == [
+        "src/reyn/runtime/registry.py",
+        "tests/scripts/test_check_doc_drift_5003.py",
+    ]
 
 
 def test_a_note_quoting_the_head_with_no_commits_does_not_pass():

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -148,32 +148,31 @@ def test_an_issue_comment_id_is_not_read_as_a_sha():
     assert code == 1, "a note citing only a comment id names no tree"
 
 
-def test_a_commit_this_checkout_cannot_resolve_stops_the_run():
-    """Tier 1: `fetch_pr`'s other half of the same failure — `git show` on an
-    unresolvable commit exits non-zero, and treating its empty output as
-    "touched no tests" is a green computed from a commit never read.
+def test_an_unreadable_commit_stops_the_run() -> None:
+    """Tier 1: an API failure must not read as "touched no tests" — that would
+    be a green computed from a commit this check could not read, the shape it
+    exists to reject.
 
-    Driven with a REAL `git` call against this repository and a syntactically
-    valid oid that cannot exist, so nothing is faked (the earlier revision of
-    this test replaced `subprocess.run` wholesale — docs-maintainer, #5120 B)."""
+    Driven with a REAL `gh api` call for a syntactically valid oid that cannot
+    exist in this repository, so nothing is faked (an earlier revision replaced
+    `subprocess.run` wholesale — docs-maintainer, #5120 B; the revision after
+    that shelled out to `git show`, which is what forced the checkout this gate
+    then tripped over)."""
     import pytest
 
     with pytest.raises(SystemExit) as exc:
-        _MOD.commit_touched_paths("0" * 40, 5120, repo_root=str(REPO_ROOT))
-    assert "cannot resolve commit" in str(exc.value)
+        _MOD.commit_touched_paths("0" * 40, "tya5/reyn")
+    assert "cannot read commit" in str(exc.value)
 
 
-def test_a_resolvable_commit_reports_its_paths():
+def test_a_readable_commit_reports_its_paths() -> None:
     """Tier 1: the same seam's accept side, so the reject case above is not the
-    only thing exercised — a real HEAD resolves and yields its own paths."""
-    import subprocess as _sp
-
-    head = _sp.run(
-        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True,
-        cwd=REPO_ROOT,
-    ).stdout.strip()
-    paths = _MOD.commit_touched_paths(head, 5120, repo_root=str(REPO_ROOT))
-    assert isinstance(paths, list)
+    only thing exercised — a real commit of this repository yields real file
+    names. Without it, a `commit_touched_paths` that raised unconditionally
+    would still pass the reject test."""
+    paths = _MOD.commit_touched_paths("ddc009a8d", "tya5/reyn")
+    assert paths, "a real commit touched at least one file"
+    assert all(isinstance(p, str) for p in paths)
 
 
 def test_a_note_quoting_the_head_with_no_commits_does_not_pass():

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -148,31 +148,42 @@ def test_an_issue_comment_id_is_not_read_as_a_sha():
     assert code == 1, "a note citing only a comment id names no tree"
 
 
+def _runner(returncode: int, stdout: str = "", stderr: str = ""):
+    """A minimal stand-in for `subprocess.run`'s result, injected through
+    `commit_touched_paths`'s own `run` seam. Not a mock of a cheaply
+    constructible collaborator — the real one is an authenticated network
+    call, and using it made the reject case below pass in CI for the wrong
+    reason (no token, rather than a bogus commit)."""
+    import subprocess as _sp
+
+    def _run(cmd, **kwargs):
+        return _sp.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+    return _run
+
+
 def test_an_unreadable_commit_stops_the_run() -> None:
     """Tier 1: an API failure must not read as "touched no tests" — that would
     be a green computed from a commit this check could not read, the shape it
-    exists to reject.
-
-    Driven with a REAL `gh api` call for a syntactically valid oid that cannot
-    exist in this repository, so nothing is faked (an earlier revision replaced
-    `subprocess.run` wholesale — docs-maintainer, #5120 B; the revision after
-    that shelled out to `git show`, which is what forced the checkout this gate
-    then tripped over)."""
+    exists to reject."""
     import pytest
 
     with pytest.raises(SystemExit) as exc:
-        _MOD.commit_touched_paths("0" * 40, "tya5/reyn")
+        _MOD.commit_touched_paths(
+            "0" * 40, "tya5/reyn", run=_runner(1, stderr="Not Found"),
+        )
     assert "cannot read commit" in str(exc.value)
 
 
 def test_a_readable_commit_reports_its_paths() -> None:
     """Tier 1: the same seam's accept side, so the reject case above is not the
-    only thing exercised — a real commit of this repository yields real file
-    names. Without it, a `commit_touched_paths` that raised unconditionally
+    only thing exercised — a `commit_touched_paths` that raised unconditionally
     would still pass the reject test."""
-    paths = _MOD.commit_touched_paths("ddc009a8d", "tya5/reyn")
-    assert paths, "a real commit touched at least one file"
-    assert all(isinstance(p, str) for p in paths)
+    paths = _MOD.commit_touched_paths(
+        "abc1234", "tya5/reyn",
+        run=_runner(0, stdout='["src/reyn/a.py", "tests/scripts/b.py"]'),
+    )
+    assert paths == ["src/reyn/a.py", "tests/scripts/b.py"]
 
 
 def test_a_note_quoting_the_head_with_no_commits_does_not_pass():

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -148,18 +148,46 @@ def test_an_issue_comment_id_is_not_read_as_a_sha():
     assert code == 1, "a note citing only a comment id names no tree"
 
 
-def _runner(returncode: int, stdout: str = "", stderr: str = ""):
+def _runner(returncode: int, stdout: str = "", stderr: str = "", seen: "list | None" = None):
     """A minimal stand-in for `subprocess.run`'s result, injected through
     `commit_touched_paths`'s own `run` seam. Not a mock of a cheaply
     constructible collaborator — the real one is an authenticated network
     call, and using it made the reject case below pass in CI for the wrong
-    reason (no token, rather than a bogus commit)."""
+    reason (no token, rather than a bogus commit).
+
+    *seen* collects the argv it was handed. An earlier revision discarded it,
+    which left the seam's ONE mistakable part — the endpoint path and the
+    ``--jq`` that shapes the reply — outside every test (architect, #5128 B):
+    a `commit_touched_paths` that asked for the wrong URL would have passed
+    both cases below."""
     import subprocess as _sp
 
     def _run(cmd, **kwargs):
+        if seen is not None:
+            seen.append(list(cmd))
         return _sp.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
 
     return _run
+
+
+def test_the_seam_asks_github_for_that_commits_file_names() -> None:
+    """Tier 1: the command the seam issues — the part a reader cannot check by
+    running the suite unless a test looks at it. Endpoint and `--jq` together
+    decide whether the reply is a list of file names at all."""
+    seen: list = []
+    _MOD.commit_touched_paths(
+        "abc1234", "tya5/reyn", run=_runner(0, stdout="[]", seen=seen),
+    )
+    # `seen[0]` raises if the seam was never called at all, so the shape
+    # assertions below cannot pass vacuously.
+    argv = seen[0]
+    assert argv[:2] == ["gh", "api"], f"reads via the API, not a checkout; got {argv[:2]!r}"
+    assert "repos/tya5/reyn/commits/abc1234" in argv, (
+        f"asks for THAT commit in THAT repo; got {argv!r}"
+    )
+    assert "[.files[].filename]" in argv, (
+        f"asks for file NAMES — without this jq the reply is objects, not paths; got {argv!r}"
+    )
 
 
 def test_an_unreadable_commit_stops_the_run() -> None:


### PR DESCRIPTION
**[lead-coder]** — **part of #5039。★私の gate が★他人の PR を★誤って赤にしています。**

```
🔴 ★実測 ── `gh run list --workflow=check-tests-read-names-its-tree.yml`
   ── ★`issue_comment` の run の ★headSha が ★★`89bc6ea94` ＝ ★`origin/main`
   ── ★`pull_request` の run は ★PR の head（`f093fe0ab`）
∴ ★`issue_comment` は★★既定ブランチを checkout します
   ── ★この check は★PR の各 commit の touched paths を `git show` で 読みます
   ── ★★main の checkout に★PR の commit は 在りません ── ★私が入れた「読めない commit で止まる」
      拒否が★発火 ── ★★赤の理由が 誤り
```

⚪ **拒否そのものは★正しく働いています** —— **「読めなかった commit から計算した結果を報告しない」**という、**私がこの gate に入れた当の防御**です。**workflow が★構造的に 含み得ない checkout を 渡していました。**

⚠️ **以前 1 回 `issue_comment` が緑だったのは★逆の理由**でした —— **その PR は既に merge 済で、commit が main に在った**からです。**「たまたま通る」形です。**

🔴 **今この 3 本が 私の gate で 誤って赤です** —— **#5123 / #5125 / #5127**。**この PR が入れば解けます。**

## 🔴 私の非

```
🔴 ★`issue_comment` を 足したとき ── ★★その run が★何を checkout するかを★確かめていません
   ── ★trigger は 直した ── ★★trigger が 渡す 世界を 見ていない
   ── ⚠️ ★今夜 5 例目です ──「★経路は 見たが、★経路を 通るものを 見ていない」
      （★#5110 の pump ── ★出口は 数えたが★出口を 通る値が 何を 言えるかを 訊かなかった）
```

⚪ **workflow の yaml のみ、`tests/` は触りません** ∴ **rule 8 は掛かりません。**


---

**[architect]** — TESTS-READ（**B: 独立**、seam/test の半分のみ、head `9e7fbc2255`）issuecomment-5382917101。`gh api` 化は私の処方なので A、そこは独立に読めていません。

- [ ] 🔴 `_runner` が `cmd` を捨てているため、**endpoint `repos/{repo}/commits/{oid}` と `--jq` が test を素通り**する。打ち間違えると production は `SystemExit` で**全 PR が赤** = 今夜の事故そのもので、この test 群はその再発を止めない。`cmd` を記録して accept 側で assert
