### PR TITLE
fix(#5129): agui_submit/agui_seize resolve agent_name from the connection

### DIFF
--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -102,9 +102,33 @@ class _ConnectionRetargetHub:
 
     def __init__(self) -> None:
         self._listeners: "dict[str, list[Callable[[str, str], None]]]" = {}
+        # #5129: THE per-connection "what agent is this connection on right
+        # now" fact, addressable by a request that isn't the SSE stream
+        # itself (a POST, correlated only by connection_id — the same
+        # constraint that motivated this hub in the first place, #5116's own
+        # docstring). Seeded in :meth:`subscribe` (the connection's own URL
+        # agent, so a connection that never attaches still resolves) and
+        # kept current in :meth:`notify` (the same call that already tells
+        # this hub's listeners a retarget happened) — one write path each,
+        # not a second copy of the fact ``_SessionFrameSource.current_agent_
+        # name`` already owns for the SSE-stream reader itself.
+        self._current_agent: "dict[str, str]" = {}
 
-    def subscribe(self, connection_id: str, callback: "Callable[[str, str], None]") -> None:
+    def subscribe(
+        self, connection_id: str, callback: "Callable[[str, str], None]", agent_name: str = "",
+    ) -> None:
+        """*agent_name* seeds :meth:`current_agent` to THIS connection's own
+        URL agent — required so a connection that never sends
+        ``attach_request`` still resolves correctly (an empty/missing seed
+        would read as "unknown", and #5129's ``agui_submit`` fallback would
+        then fall back to ITS OWN URL param anyway — but future callers of
+        :meth:`current_agent` should not have to know that; the seed makes
+        the value simply always correct from the moment of subscribe). A
+        reconnect calls :meth:`subscribe` again (a fresh SSE GET), correctly
+        re-seeding to that connect's own URL agent."""
         self._listeners.setdefault(connection_id, []).append(callback)
+        if agent_name:
+            self._current_agent[connection_id] = agent_name
 
     def unsubscribe(self, connection_id: str, callback: "Callable[[str, str], None]") -> None:
         listeners = self._listeners.get(connection_id)
@@ -113,6 +137,11 @@ class _ConnectionRetargetHub:
         listeners.remove(callback)
         if not listeners:
             del self._listeners[connection_id]
+            # #5129: same lifetime as the listener entry it was seeded
+            # alongside — an unbounded dict keyed by connection_id was
+            # already #5119's own finding about this hub; this fact does
+            # not get a longer life than the subscription that seeded it.
+            self._current_agent.pop(connection_id, None)
 
     def notify(self, connection_id: str, agent_name: str, sid: str) -> None:
         """Fired synchronously (mirrors ``registry._announce_session_
@@ -120,6 +149,7 @@ class _ConnectionRetargetHub:
         block or await; its job is to hand the payload to a side-channel a
         consumer task drains, the SAME idiom ``add_attach_listener``'s own
         docstring states."""
+        self._current_agent[connection_id] = agent_name
         for callback in list(self._listeners.get(connection_id, ())):
             callback(agent_name, sid)
 
@@ -132,6 +162,16 @@ class _ConnectionRetargetHub:
         on private state — this method is the public surface that
         absence would otherwise BE the finding)."""
         return bool(self._listeners.get(connection_id))
+
+    def current_agent(self, connection_id: str) -> "str | None":
+        """#5129: the public read ``agui_submit`` (a DIFFERENT HTTP request
+        than the SSE stream that seeded/updates this) needs to resolve "what
+        agent is this connection ACTUALLY on", instead of trusting its own
+        URL path param — the fix for the 8th holder #5129 names. ``None``
+        for a connection this hub has never seen (no SSE stream ever
+        subscribed under this id) — the caller's own fallback is the URL,
+        never a guess made here."""
+        return self._current_agent.get(connection_id)
 
 
 _CONNECTION_RETARGET_HUB = _ConnectionRetargetHub()
@@ -147,6 +187,14 @@ def connection_retarget_has_subscribers(connection_id: str) -> bool:
     it, so the hub instance being module-private was itself the gap — not
     just :attr:`_ConnectionRetargetHub._listeners`)."""
     return _CONNECTION_RETARGET_HUB.has_subscribers(connection_id)
+
+
+def connection_current_agent(connection_id: str) -> "str | None":
+    """#5129: the module-level public surface ``agui_submit`` (and any test
+    of it) needs to resolve a connection's REAL current agent — mirrors
+    :func:`connection_retarget_has_subscribers`'s own reason for existing at
+    module level rather than requiring a private-global reach-in."""
+    return _CONNECTION_RETARGET_HUB.current_agent(connection_id)
 
 
 def _auth_context(request: Request) -> "AuthContext | None":
@@ -403,7 +451,9 @@ class _SessionFrameSource:
         session-switch only). Called once, right after construction, by
         the route handler that already knows this connection's id."""
         self._connection_id = connection_id
-        _CONNECTION_RETARGET_HUB.subscribe(connection_id, self._on_retarget_announced)
+        _CONNECTION_RETARGET_HUB.subscribe(
+            connection_id, self._on_retarget_announced, self._agent_name,
+        )
 
     def _on_retarget_announced(self, agent_name: str, sid: str) -> None:
         """Hub callback (#5116) — synchronous, no ``await``: mirrors
@@ -814,6 +864,13 @@ async def agui_seize(request: Request, agent_name: str):
     identity = authenticate_request(request, auth, connection_id=connection_id)
     if not identity.authenticated:
         return JSONResponse({"error": "authentication required"}, status_code=401)
+    # #5129 (architect, scope widened issuecomment-5382969115): this POST is,
+    # same as agui_submit, a DIFFERENT HTTP request than the SSE stream it
+    # seizes driver authority ON BEHALF OF — resolve from the connection,
+    # never the URL's own path param, or a post-attach seize grabs the
+    # ORIGINAL agent's surface instead of the one this connection is
+    # actually attached to now.
+    agent_name = connection_current_agent(connection_id) or agent_name
     manager = surface_registry().get(agent_name)
     if manager is None or not manager.seize(connection_id, identity.user_id, monotonic()):
         return JSONResponse({"seized": False, "error": "seize refused"}, status_code=409)
@@ -843,6 +900,23 @@ async def agui_submit(request: Request, agent_name: str):
     identity = authenticate_request(request, auth, connection_id=connection_id)
     if not identity.authenticated:
         return JSONResponse({"error": "authentication required"}, status_code=401)
+
+    # #5129: this POST is a DIFFERENT HTTP request than this connection's SSE
+    # stream, correlated only by ``connection_id`` — the URL's own
+    # ``agent_name`` is the agent this connection FIRST connected to and
+    # never updates after that (the client's own long-lived SSE URL), while
+    # ``_SessionFrameSource`` (the SSE stream's per-connection owner, #5116)
+    # is the one thing a cross-agent ``/attach`` actually re-points. Every
+    # decision below this line — the two heartbeat touches, ``exists``,
+    # ``ensure_running``, the TOOL_CALL_RESULT delegation, and the 3
+    # client-names-an-operation branches further down — reads THIS resolved
+    # value, never the raw path param again, so a stale attach cannot leave
+    # one of them still addressing the connection's original agent (the
+    # "sends but doesn't render" symptom a partial fix would reproduce in a
+    # different shape). Falls back to the URL when the hub has never seen
+    # this connection_id (no SSE stream subscribed under it — a POST that
+    # outraces its own connect, or a test driving this endpoint directly).
+    agent_name = connection_current_agent(connection_id) or agent_name
 
     try:
         payload = await request.json()

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -115,7 +115,7 @@ class _ConnectionRetargetHub:
         self._current_agent: "dict[str, str]" = {}
 
     def subscribe(
-        self, connection_id: str, callback: "Callable[[str, str], None]", agent_name: str = "",
+        self, connection_id: str, callback: "Callable[[str, str], None]", agent_name: str,
     ) -> None:
         """*agent_name* seeds :meth:`current_agent` to THIS connection's own
         URL agent — required so a connection that never sends
@@ -125,10 +125,20 @@ class _ConnectionRetargetHub:
         :meth:`current_agent` should not have to know that; the seed makes
         the value simply always correct from the moment of subscribe). A
         reconnect calls :meth:`subscribe` again (a fresh SSE GET), correctly
-        re-seeding to that connect's own URL agent."""
+        re-seeding to that connect's own URL agent.
+
+        No default (lead-coder co-vet, PR #5132 review): an optional
+        ``agent_name=""`` let a caller subscribe WITHOUT seeding, and
+        ``current_agent``'s ``None`` would then carry two meanings — "never
+        seen" and "subscribed, not seeded" — the second silently falling
+        back to the URL again, #5129's own symptom, with no red anywhere
+        (the #4996/#5093-family shape CLAUDE.md names: one value standing in
+        for two facts). This hub has exactly one caller
+        (:meth:`_SessionFrameSource.listen_for_retarget`); making the
+        parameter required closes the second meaning by construction rather
+        than by convention."""
         self._listeners.setdefault(connection_id, []).append(callback)
-        if agent_name:
-            self._current_agent[connection_id] = agent_name
+        self._current_agent[connection_id] = agent_name
 
     def unsubscribe(self, connection_id: str, callback: "Callable[[str, str], None]") -> None:
         listeners = self._listeners.get(connection_id)
@@ -148,8 +158,25 @@ class _ConnectionRetargetHub:
         attached``'s own no-await critical section) — a listener must not
         block or await; its job is to hand the payload to a side-channel a
         consumer task drains, the SAME idiom ``add_attach_listener``'s own
-        docstring states."""
-        self._current_agent[connection_id] = agent_name
+        docstring states.
+
+        Only records into :attr:`_current_agent` when ``connection_id`` has
+        a live subscription (architect/lead-coder co-vet, PR #5132 review):
+        the ``attach_request`` POST is a DIFFERENT request than the SSE
+        stream, correlated only by a CLIENT-SUPPLIED ``connection_id`` — a
+        client can POST ``attach_request`` repeatedly having never opened
+        (or after having closed) the matching SSE stream, and nothing here
+        requires it not to (a delayed attach after the SSE dropped is a
+        genuine, non-malicious case, not just a hostile one). Recording
+        unconditionally would create an entry :meth:`unsubscribe` — the
+        only removal path, gated on the listener list becoming empty — can
+        never reach, since no listener was ever added for that id: an
+        unbounded dict keyed by a value the client fully controls. Guarding
+        here means an entry only ever exists for a connection this hub
+        ALSO tracks a listener for, so it shares that entry's exact
+        lifetime — never longer."""
+        if connection_id in self._listeners:
+            self._current_agent[connection_id] = agent_name
         for callback in list(self._listeners.get(connection_id, ())):
             callback(agent_name, sid)
 

--- a/tests/interfaces/test_5129_submit_follows_connection_agent.py
+++ b/tests/interfaces/test_5129_submit_follows_connection_agent.py
@@ -39,7 +39,11 @@ import asyncio
 import pytest
 
 from reyn.core.events.state_log import StateLog
-from reyn.interfaces.transport.agui.endpoint import _SessionFrameSource
+from reyn.interfaces.transport.agui.endpoint import (
+    _SessionFrameSource,
+    connection_current_agent,
+    connection_retarget_has_subscribers,
+)
 from reyn.runtime.registry import AgentRegistry
 from reyn.user_intervention import UserIntervention
 from tests._async_wait import wait_until
@@ -241,3 +245,43 @@ async def test_answer_after_cross_agent_attach_resolves_against_the_target_sessi
         assert answer.text == "yes, proceed"
     finally:
         source.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_request_for_a_connection_with_no_open_sse_stream_leaves_nothing_behind(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: architect/lead-coder co-vet (PR #5132 review) — an
+    ``attach_request`` POST is a DIFFERENT request than the SSE stream it
+    targets, correlated only by a CLIENT-SUPPLIED ``connection_id``; a
+    client can send it for a ``connection_id`` with no live subscription
+    (SSE never opened, or already closed — not necessarily hostile: a
+    delayed attach after the stream dropped). Before the guard on
+    ``notify``, this created a ``_current_agent`` entry :meth:`unsubscribe`
+    could never reach (no listener was ever registered to remove) — an
+    unbounded dict keyed by a value the client fully controls. Sent 3 times
+    (not once) to pin "does not accumulate", not just "doesn't fail once".
+    """
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    await reg.attach("default")
+    app = _build_app(reg, monkeypatch)
+    orphan_connection_id = "conn-5129-no-sse-ever"
+
+    assert connection_current_agent(orphan_connection_id) is None
+    assert connection_retarget_has_subscribers(orphan_connection_id) is False
+
+    for _ in range(3):
+        resp = await _post(
+            app,
+            f"/agui/chat/default?connection_id={orphan_connection_id}&token=s3cret",
+            {"type": "attach_request", "agent_name": "coder-smith"},
+        )
+        assert resp.json().get("attached") is True  # the attach itself still succeeds
+
+    assert connection_current_agent(orphan_connection_id) is None, (
+        "notify recorded a current_agent for a connection with no live "
+        "subscription -- this entry has no removal path (unsubscribe only "
+        "fires for a connection that was actually subscribed), so it would "
+        "outlive every real connection this hub ever forgets"
+    )
+    assert connection_retarget_has_subscribers(orphan_connection_id) is False

--- a/tests/interfaces/test_5129_submit_follows_connection_agent.py
+++ b/tests/interfaces/test_5129_submit_follows_connection_agent.py
@@ -1,0 +1,243 @@
+"""Tier 2: #5129 — ``agui_submit`` resolves its ``agent_name`` from the
+connection, not from its own URL path param (the 8th holder of "which agent
+is this connection on" named in #5116's own count).
+
+Owner-reported live bug (verbatim): "attach で切り替えできるようになったのは
+良いけど、会話できないよ？メッセージ画面に会話更新されない。input messege は
+enter で消えるだけ". #5116/#5118 fixed the SSE stream's own per-connection
+"which agent" fact (``_SessionFrameSource.current_agent_name``) and made
+``_ConnectionRetargetHub`` the connection-id-keyed channel that tells it about
+a cross-agent ``/attach``. ``agui_submit`` is a SEPARATE HTTP request from
+that SSE stream (correlated only by ``connection_id``) and, before this fix,
+never consulted either — it decided every branch (heartbeat, ``exists``,
+``ensure_running``, the ``TOOL_CALL_RESULT`` delegation, and every
+client-names-an-operation branch below) off its OWN URL path param, which is
+fixed to whatever agent the client's long-lived SSE URL originally named and
+never updates. Input therefore kept reaching the connection's ORIGINAL agent
+after a cross-agent ``/attach`` succeeded — "sent, but nothing renders",
+exactly the owner's report (accepted by the ORIGINAL agent, not the one the
+status bar/announce now claim).
+
+Fix: ``_ConnectionRetargetHub`` gains a THIRD piece of state alongside its
+existing listener/notify machinery — ``current_agent(connection_id)``,
+seeded at ``subscribe`` time (so an untouched connection still resolves
+correctly — #5116's own witness ④) and kept current at ``notify`` time (the
+SAME call that already tells the SSE stream about a retarget).
+``agui_submit`` resolves this ONE value once, at the top, and every
+downstream branch reads it — never the raw path param again.
+
+Chains the REAL wire pieces (real ASGI POST -> the real
+``_ConnectionRetargetHub`` -> a real, started ``_SessionFrameSource`` ->
+real ``Session.submit_user_text`` -> a real ``user_submitted`` audit-event),
+mirroring ``test_5116_connection_agent_owner_cross_attach.py``'s own harness
+and constructor calls. No mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.transport.agui.endpoint import _SessionFrameSource
+from reyn.runtime.registry import AgentRegistry
+from reyn.user_intervention import UserIntervention
+from tests._async_wait import wait_until
+from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+_CONNECTION_ID = "conn-5129-test"
+_OTHER_CONNECTION_ID = "conn-5129-untouched"
+
+
+def _two_agent_registry(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+        )
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+    holder["reg"] = reg
+    reg.create("coder-smith")
+    return reg
+
+
+def _build_app(reg, monkeypatch):
+    from fastapi import FastAPI
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+    from reyn.interfaces.transport.agui.endpoint import router
+    from reyn.interfaces.web.auth import AuthContext
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.auth = AuthContext(token="s3cret", require_token=True)
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: reg)
+    return app
+
+
+async def _post(app, path: str, payload: dict):
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        return await client.post(path, json=payload)
+
+
+def _collect_events(session) -> "list":
+    collected: "list" = []
+    session.subscribe_audit_events(lambda ev: collected.append(ev))
+    return collected
+
+
+@pytest.mark.asyncio
+async def test_submit_after_cross_agent_attach_reaches_the_target_not_the_url_agent(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #5129 witness — a ``user_message`` POSTed to the connection's
+    ORIGINAL URL, after a real cross-agent ``attach_request`` on that same
+    connection_id, must produce a ``user_submitted`` audit-event on the
+    TARGET session — and NONE on the original ``default`` session (a
+    one-sided check would pass on "arrives everywhere")."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    default_session = await reg.attach("default")
+    app = _build_app(reg, monkeypatch)
+
+    default_events = _collect_events(default_session)
+
+    # The already-open stream: bound to "default", listening for a
+    # cross-agent retarget under ITS OWN connection id — same server-side
+    # state a --connect client's SSE GET leaves behind.
+    source = _SessionFrameSource(default_session, registry=reg, agent_name="default")
+    source.listen_for_retarget(_CONNECTION_ID)
+    source.start()
+
+    try:
+        resp = await _post(
+            app, f"/agui/chat/default?connection_id={_CONNECTION_ID}&token=s3cret",
+            {"type": "attach_request", "agent_name": "coder-smith"},
+        )
+        assert resp.json().get("attached") is True
+
+        target_session = reg.get_session("coder-smith", "main")
+        target_events = _collect_events(target_session)
+
+        # The client's own SSE URL never changes — it keeps POSTing to
+        # "default", exactly the owner's own live setup (attach switches,
+        # the connect URL does not).
+        submit_resp = await _post(
+            app, f"/agui/chat/default?connection_id={_CONNECTION_ID}&token=s3cret",
+            {"type": "user_message", "text": "hello coder-smith"},
+        )
+        assert submit_resp.status_code == 200
+        assert submit_resp.json().get("status") == "ok"
+
+        await asyncio.sleep(0)  # let the synchronous audit-event subscribers fire
+    finally:
+        source.close()
+
+    target_submits = [e for e in target_events if getattr(e, "type", "") == "user_submitted"]
+    default_submits = [e for e in default_events if getattr(e, "type", "") == "user_submitted"]
+
+    assert target_submits, (
+        "the target agent's own session never saw the submit -- input is "
+        "still reaching the connection's ORIGINAL agent after attach"
+    )
+    assert target_submits[0].data.get("text") == "hello coder-smith"
+    assert not default_submits, (
+        f"the ORIGINAL agent's session ALSO saw a user_submitted event "
+        f"({default_submits!r}) -- the submit is landing in two places, "
+        f"not exclusively at the attached target"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_connection_that_never_attached_still_submits_to_its_own_url_agent(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #5116 witness ④'s own sibling — a connection that never sent
+    ``attach_request`` (the hub has never seen its connection_id notified,
+    only subscribed) must resolve to its OWN URL agent, not silently break.
+    Pins the ``subscribe``-time seed: without it this connection would read
+    as "unknown" and depend entirely on the URL fallback happening to be
+    right, rather than the hub genuinely tracking it from the start."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    default_session = await reg.attach("default")
+    app = _build_app(reg, monkeypatch)
+    default_events = _collect_events(default_session)
+
+    source = _SessionFrameSource(default_session, registry=reg, agent_name="default")
+    source.listen_for_retarget(_OTHER_CONNECTION_ID)
+    source.start()
+
+    try:
+        resp = await _post(
+            app, f"/agui/chat/default?connection_id={_OTHER_CONNECTION_ID}&token=s3cret",
+            {"type": "user_message", "text": "still default"},
+        )
+        assert resp.status_code == 200
+        await asyncio.sleep(0)
+    finally:
+        source.close()
+
+    default_submits = [e for e in default_events if getattr(e, "type", "") == "user_submitted"]
+    assert default_submits and default_submits[0].data.get("text") == "still default"
+
+
+@pytest.mark.asyncio
+async def test_answer_after_cross_agent_attach_resolves_against_the_target_session(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #5129 scope-widen (architect, issuecomment-5382969115,
+    acceptance ⑥) — a ``TOOL_CALL_RESULT`` POST is delegated by ``agui_submit``
+    to ``_handle_answer`` with whatever ``agent_name`` ``agui_submit`` itself
+    resolved; since that resolution now reads the connection (this file's
+    first test), a HITL answer POSTed to the connection's original URL after
+    a cross-agent attach must resolve against the TARGET session's own
+    pending intervention — the #5050/#5064 regression surface architect
+    named."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    default_session = await reg.attach("default")
+    app = _build_app(reg, monkeypatch)
+
+    target_session = await reg.ensure_running("coder-smith")
+    target_session.register_intervention_listener("tui")
+    iv = UserIntervention(kind="ask_user", prompt="proceed?", run_id="r1")
+    iv.future = asyncio.get_running_loop().create_future()
+    iv_task = asyncio.ensure_future(target_session._dispatch_intervention(iv))
+    await wait_until(lambda: bool(target_session.interventions.list_active()))
+
+    source = _SessionFrameSource(default_session, registry=reg, agent_name="default")
+    source.listen_for_retarget(_CONNECTION_ID)
+    source.start()
+
+    try:
+        resp = await _post(
+            app, f"/agui/chat/default?connection_id={_CONNECTION_ID}&token=s3cret",
+            {"type": "attach_request", "agent_name": "coder-smith"},
+        )
+        assert resp.json().get("attached") is True
+
+        # Still POSTed to the connection's ORIGINAL URL ("default"), and
+        # naming the pending intervention's real id — exactly what a real
+        # remote client's answer_intervention_text round-trip sends.
+        answer_resp = await _post(
+            app, f"/agui/chat/default?connection_id={_CONNECTION_ID}&token=s3cret",
+            {"type": "TOOL_CALL_RESULT", "toolCallId": iv.id, "text": "yes, proceed"},
+        )
+        assert answer_resp.json().get("answered") is True, answer_resp.json()
+
+        answer = await asyncio.wait_for(iv_task, timeout=2.0)
+        assert answer.text == "yes, proceed"
+    finally:
+        source.close()

--- a/tests/interfaces/test_5129_submit_follows_connection_agent.py
+++ b/tests/interfaces/test_5129_submit_follows_connection_agent.py
@@ -270,6 +270,10 @@ async def test_attach_request_for_a_connection_with_no_open_sse_stream_leaves_no
     assert connection_current_agent(orphan_connection_id) is None
     assert connection_retarget_has_subscribers(orphan_connection_id) is False
 
+    # Repeats the POST 3x (not a wait-bound loop -- no await inside this
+    # loop blocks on anything the count is standing in for; each iteration
+    # is an independent, already-complete request, so CLAUDE.md's "no
+    # range(N) wrapping a wait" does not apply here).
     for _ in range(3):
         resp = await _post(
             app,


### PR DESCRIPTION
**[tui-coder]** — part of #5129 (owner "最優先" live bug: attach switches but conversation doesn't follow).

## What

`agui_submit` (and `agui_seize`) decided every branch off their own URL path param's `agent_name` — fixed to whatever agent the client's long-lived SSE URL originally named, never updated after a cross-agent `/attach`. #5116/#5118 already fixed the SSE stream's own per-connection fact (`_SessionFrameSource.current_agent_name`), but `agui_submit`/`agui_seize` are DIFFERENT HTTP requests, correlated only by `connection_id`, and never consulted it — the 8th holder of "which agent is this connection on" (#5116's own count).

## Fix

`_ConnectionRetargetHub` gains `current_agent(connection_id)` — seeded at `subscribe` (an untouched connection still resolves, #5116's own witness ④) and kept current at `notify` (the same call that already tells the SSE stream about a retarget). `agui_submit`/`agui_seize` resolve this ONE value once and every downstream branch reads it — never the raw path param again.

`connection_id` is already client-supplied and already trusted for this exact correlation before this change (heartbeat targeting, hub subscribe/notify); this fix adds a READ of the same already-trusted key, not a new trust boundary (architect's open question ③, measured not assumed — see `ConnectionIdentity`/`AuthContext.authenticate`, `connection_id` is carried as a label, no binding beyond the token check either before or after this PR).

## ⚠️ Limits of what this PR actually closes (architect ruling on #5129, condition ②, issuecomment-5383002248) — READ BEFORE ASSUMING "attach fixes conversation"

This PR fixes ONLY the plain case: **one connection attached, nobody else directly connected to the target agent.**

- **① input reaches the target, not default** — genuinely green, strip-falsified against the owner's real repro shape.
- **⑤ `/seize` after attach** — **NOT fixed here, still `409 seize refused`.** Cross-agent `/attach` never re-registers the connection in the target's own `SurfaceManager` (a separate holder, #5116's own item ②) — resolving WHICH agent name to ask (this PR) doesn't help if that agent's manager never has this connection as a surface. Follow-up: #5133.
- **⑥ HITL answer after attach** — green in THIS PR's own test, but **architect's re-derivation shows that green is conditional**: it holds only when nobody is directly connected to the target agent (so `SurfaceRegistry.get(target)` is `None` and `_handle_answer`'s `is_active_driver` guard is skipped). The **owner's actual configuration is the opposite** (`reyn chat --connect` × 2, the second connected directly to the target) — in that shape the target's manager DOES exist, the attached-via-`/attach` connection is NOT one of its surfaces, `is_active_driver` is `False`, and the answer is rejected. Not yet re-measured with a second connection open; tracked as acceptance ② of #5133.

Merging this PR closes the owner's most visible symptom (conversation not appearing at all) but does **not** mean "attach behaves identically to a direct connection" — #5133 is the tracking issue for what's left.

## Test plan

- [x] `tests/interfaces/test_5129_submit_follows_connection_agent.py` (3 tests, real ASGI POST → real hub → real `_SessionFrameSource` → real `Session`, no mocks)
- [x] Strip-falsified: reverting the resolution line reproduces the owner's exact symptom (target sees 0 `user_submitted` events); restored → green
- [x] `ruff check` / `test_tier_audit.py --strict` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all clean
- [x] Regression sweep: `test_5116_connection_agent_owner_cross_attach.py` + `test_5119*.py` + `test_4534*.py` + this PR's own file — 25 passed
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

⚠️ TESTS-READ note required (touches `tests/`).

part of #5116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

## 🔴 Reviewer's blocking points (lead-coder, issuecomment-5383006426)

- [x] 🔴 **`notify` writes `_current_agent[connection_id]` unconditionally**, but `unsubscribe`'s pop sits *inside* `if not listeners:` — so a `/attach` POST from a connection that never opened an SSE stream leaves an entry **nothing can ever remove**, keyed by a client-supplied string. This falsifies this PR's own comment, verbatim *"this fact does not get a longer life than the subscription that seeded it"*. Write only for a connection this hub actually has listeners for (six questions ⑤).
- [x] 🔴 **`subscribe(..., agent_name: str = "")` + `if agent_name:` lets `current_agent()` return `None` for two different reasons** — "never subscribed" and "subscribed without a seed" — and the second silently degrades to this issue's own symptom (submit falls back to the URL param). There is exactly one caller; make the parameter **required** so the second meaning cannot be expressed (#4996/#5093 family: one value carrying two meanings).


---

**[architect]** — TESTS-READ（**A: 設計適合**、head `accd4ac42d`）issuecomment。B（独立）は別の人が必要です。

- [x] 🔴 `notify` が購読の無い `connection_id` にも `_current_agent` を書き、`unsubscribe` は listeners が在った場合しか pop しない → **notify だけで生まれた entry を誰も消さない**（この PR 自身のコメントが主張する「subscription より長生きしない」が偽）。`if connection_id in self._listeners:` の時だけ記録する（生きた接続は必ず listener を持つので挙動不変）＋ witness 2 本



---

**[tui-coder]** — both block points fixed, head `fe837c701` (issuecomment-5383025881): ① `notify` now guards on `connection_id in self._listeners` ② `subscribe`'s `agent_name` is a required positional. New witness (3× attach_request against an orphan connection_id, asserting via the public reads nothing accumulates), strip-falsified. Local gate + regression sweep all green.
