### PR TITLE
docs(#5141): load_history names the on-demand extend path

### DIFF
--- a/src/reyn/runtime/history_tail_reader.py
+++ b/src/reyn/runtime/history_tail_reader.py
@@ -31,7 +31,10 @@ read.
 
 Older entries this reader doesn't return are NOT lost: ``history.jsonl`` is
 append-only, so anything left unread here is still on disk, reachable later
-via the extend-on-demand path (#4387 Phase B ②, not yet implemented).
+via the extend-on-demand path (#4387 Phase B ②):
+``Session.extend_history_backward`` / ``Session.extend_history_backward_
+async``, and ``ThreadedTransportProxy.extend_history_backward`` for a
+caller on the other side of a transport.
 
 #4476 Phase 1 adds a small, separate section at the end of this module:
 policy-independent measurement (bytes/line counts across every

--- a/src/reyn/runtime/history_tail_reader.py
+++ b/src/reyn/runtime/history_tail_reader.py
@@ -31,10 +31,10 @@ read.
 
 Older entries this reader doesn't return are NOT lost: ``history.jsonl`` is
 append-only, so anything left unread here is still on disk, reachable later
-via the extend-on-demand path (#4387 Phase B ②):
-``Session.extend_history_backward`` / ``Session.extend_history_backward_
-async``, and ``ThreadedTransportProxy.extend_history_backward`` for a
-caller on the other side of a transport.
+via the extend-on-demand path (#4387 Phase B ②): ``Session.extend_history_backward``,
+its async sibling ``Session.extend_history_backward_async``, and — for a
+caller on the other side of a transport —
+``ThreadedTransportProxy.extend_history_backward``.
 
 #4476 Phase 1 adds a small, separate section at the end of this module:
 policy-independent measurement (bytes/line counts across every

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4042,8 +4042,8 @@ class Session:
         later via the on-demand extend path (#4387 Phase B ②):
         :meth:`extend_history_backward`, its cross-thread-safe sibling
         :meth:`extend_history_backward_async`, and — for a caller on the
-        other side of a transport — :meth:`~reyn.interfaces.transport.
-        threaded.ThreadedTransportProxy.extend_history_backward`.
+        other side of a transport —
+        :meth:`~reyn.interfaces.transport.threaded.ThreadedTransportProxy.extend_history_backward`.
         """
         if not self.history_path.exists():
             return

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4039,8 +4039,11 @@ class Session:
 
         Entries this doesn't load are NOT lost: ``history.jsonl`` is
         append-only, so anything left unread here stays on disk, reachable
-        later via the on-demand extend path (#4387 Phase B ②, not yet
-        implemented).
+        later via the on-demand extend path (#4387 Phase B ②):
+        :meth:`extend_history_backward`, its cross-thread-safe sibling
+        :meth:`extend_history_backward_async`, and — for a caller on the
+        other side of a transport — :meth:`~reyn.interfaces.transport.
+        threaded.ThreadedTransportProxy.extend_history_backward`.
         """
         if not self.history_path.exists():
             return


### PR DESCRIPTION
**[lead-coder]** — `Session.load_history`'s docstring closed with: "reachable later via the on-demand extend path (#4387 Phase B ②, not yet implemented)." That claim is false on current main — the extend path is implemented and has three concrete call sites. An architect read the exact line, concluded the remote path had to build the extend mechanism from scratch, and had to retract the design once shown otherwise.

part of #5141

## What changed

`src/reyn/runtime/session.py::Session.load_history` docstring, closing paragraph.

**Old:**
```
Entries this doesn't load are NOT lost: ``history.jsonl`` is
append-only, so anything left unread here stays on disk, reachable
later via the on-demand extend path (#4387 Phase B ②, not yet
implemented).
```

**New:**
```
Entries this doesn't load are NOT lost: ``history.jsonl`` is
append-only, so anything left unread here stays on disk, reachable
later via the on-demand extend path (#4387 Phase B ②):
:meth:`extend_history_backward`, its cross-thread-safe sibling
:meth:`extend_history_backward_async`, and — for a caller on the
other side of a transport — :meth:`~reyn.interfaces.transport.
threaded.ThreadedTransportProxy.extend_history_backward`.
```

The `#4387 Phase B ②` reference is kept — it still identifies the mechanism (that's the label the three call sites' own docstrings use for it too), not just a retired plan.

## Falsification sweep

Ran:
```
git grep -rn "Phase B" -- src/ docs/
git grep -rn "not yet implemented" -- src/reyn/runtime/ src/reyn/interfaces/
git grep -rn "extend_history_backward\|_load_older_entries" -- src/ docs/
```

Found and fixed **one other site** carrying the identical false claim: `src/reyn/runtime/history_tail_reader.py`'s module docstring —

**Old:**
```
Older entries this reader doesn't return are NOT lost: ``history.jsonl`` is
append-only, so anything left unread here is still on disk, reachable later
via the extend-on-demand path (#4387 Phase B ②, not yet implemented).
```

**New:**
```
Older entries this reader doesn't return are NOT lost: ``history.jsonl`` is
append-only, so anything left unread here is still on disk, reachable later
via the extend-on-demand path (#4387 Phase B ②):
``Session.extend_history_backward`` / ``Session.extend_history_backward_
async``, and ``ThreadedTransportProxy.extend_history_backward`` for a
caller on the other side of a transport.
```

All other `Phase B` / `extend_history_backward` hits (`src/reyn/mcp/server.py`, `src/reyn/interfaces/repl/read_model.py`, `src/reyn/interfaces/inline/textual_chat/{app,restore}.py`, `src/reyn/runtime/services/router_history_buffer.py`, `docs/concepts/data-retrieval/chat-compaction.{md,ja.md}`) already describe the mechanism in the present tense as implemented — no other false "not yet implemented" claim found. `chain_manager.py`'s "not yet implemented" hit is an unrelated proposal (0067 P4/P7), out of scope.

**Left deliberately unfixed** (stale for a *different* reason, not this PR's scope): `src/reyn/mcp/server.py:101-103`'s `_history_baseline_seq` docstring says "...which Phase B's on-demand older-entry loading **will do** for other consumers" — future tense for a mechanism that now exists. It doesn't assert non-implementation the way the two fixed sites did, so it isn't falsified by this change, but it reads dated. Flagging for a separate pass rather than fixing here (different sentence, different failure mode, would widen this PR past the one false claim it's chartered to fix).

## Test plan

- [x] `ruff check .`
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/history_tail_reader.py` (second file this PR touches)
- [x] `python scripts/mypy_ratchet.py`
- [x] `python -m pytest tests/runtime -q -k "history"` — 96 passed, 1807 deselected
- [x] (skipped — no UI change)
- No `docs/` files changed, so the docs path-conditional gate (`mkdocs build --strict` etc.) does not apply.

**No new test added.** This is a docstring-only correction with no behavioural surface — the repo's testing policy forbids pinning docstring text (no snapshot/golden-file tests, no pinning exact whitespace), and there is no observable behaviour change for a Tier 1/2/3 test to bind to. `tests/runtime -k history` (96 passed) confirms the two touched modules' actual behaviour is unchanged.

### Real gate output

```
$ ruff check .
All checks passed!

$ python scripts/verify_module_docstrings.py src/reyn/runtime/session.py
OK: no module-docstring refactor narrative in src/reyn/runtime/session.py.

$ python scripts/verify_module_docstrings.py src/reyn/runtime/history_tail_reader.py
OK: no module-docstring refactor narrative in src/reyn/runtime/history_tail_reader.py.

$ python scripts/mypy_ratchet.py
mypy ratchet OK: 201 findings, all baselined (207 declared).

$ python -m pytest tests/runtime -q -k "history"
........................................................................ [ 75%]
........................                                                 [100%]
96 passed, 1807 deselected, 1 warning in 6.07s
```

(Run from an isolated `git worktree` branched off `origin/main`, with `PYTHONPATH` pointed at that worktree's `src/` so the interpreter resolved `reyn.__file__` to the worktree under test, not another checkout — verified with `python -c "import reyn; print(reyn.__file__)"` before trusting the pytest result.)


---

## 🔴 Reviewer's blocking point (lead-coder)

- [x] 🔴 **The wrapped identifiers defeat the reason this change exists.** Measured on this PR's own diff: `history_tail_reader.py` carries ``extend_history_backward_``+newline+``async``, and `session.py`'s cross-reference target is broken mid-path (`reyn.interfaces.transport.` / newline / `threaded.ThreadedTransportProxy...`). `git grep "extend_history_backward_async"` and `git grep "ThreadedTransportProxy.extend_history_backward"` do not find them in the files this PR touched. The paragraph exists because a reader concluded from "not yet implemented" that the mechanism had to be built; the way the next reader will check is by grepping the name. Keep each identifier whole on one line (do not shorten one to make it fit), and paste both `git grep` hits as the witness that the fix took.

⚠️ **CI is green on this PR.** That is the gate passing, not the change achieving its purpose — no check here reads whether an identifier survived line-wrapping.

