### PR TITLE
docs(agui-transport): {agent} is a fallback, not the destination (#5132)

### DIFF
--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -45,6 +45,13 @@ Reyn のチャットクライアントはストリームを消費する UI で�
 - `POST /agui/chat/{agent}/seize` — active-driver トークンを取得する(「Active driver and
   seize」参照)。
 
+`POST /agui/chat/{agent}` と `POST /agui/chat/{agent}/seize`(#5129)の `{agent}`
+は**fallback であり宛先ではない**: 両ルートとも、実際のターゲットはこの接続自身の
+`connection_id`(現在アタッチしているエージェント)から解決される — `{agent}` が参照
+されるのは、その接続に紐づくアタッチ記録がまだ無い場合のみ。したがって `--connect`
+した client 自身のクロスエージェント `/attach` は、client が POST 先の URL を変更
+しなくても、その次の `submit`/`seize` をリダイレクトする。
+
 client が server をシャットダウンすることは決してできない — shutdown メッセージは存在せず、
 client の `/quit` はローカルな切断にすぎない。server が唯一の writer である。
 

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -58,6 +58,14 @@ A2A; tools are MCP; observability export is OTEL. Those are separate surfaces.)
 - `POST /agui/chat/{agent}/seize` — take the active-driver token (see "Active
   driver and seize").
 
+`{agent}` on `POST /agui/chat/{agent}` and `POST /agui/chat/{agent}/seize`
+(#5129) is a **fallback, not the destination**: both routes resolve the real
+target from this connection's own `connection_id` (whichever agent it is
+currently attached to); `{agent}` is only consulted when the connection has
+no recorded attachment. A `--connect`ed client's own cross-agent `/attach`
+therefore redirects its NEXT `submit`/`seize` too, without the client having
+to change the URL it POSTs to.
+
 A client can never shut the server down — there is no shutdown message; a
 client's `/quit` is a local disconnect only. The server is the sole writer.
 


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder割当。#5132(merged 67ba60db9)が`agui-transport.md`を1箇所偽にしていました。

## 変更
`POST /agui/chat/{agent}`/`POST /agui/chat/{agent}/seize`のroute一覧直後に、`{agent}`が宛先ではなくfallback(hubがconnectionを知らない場合のみ参照)である旨を1行追記。変更履歴にはせず、現在の真実のみ記述(指示通り)。`endpoint.py`の`connection_current_agent()`/`notify()`実装で、cross-agent `/attach`が`_current_agent[connection_id]`を更新することを確認してから記述。

`.ja.md`ミラーも同じ偽claimを持っていたため同様に修正(CLAUDE.md rule 5該当 — mirror義務ではなくこのファイル自体がfalsifyされた主張を持つケース)。

## 追加sweep(lead-coderが引いていない面)
`concepts/`・`guide/`・`decisions/`・`cli-redesign.md`・`reyn-yaml.md`・`chat.md`・`feature-map.md`を確認。`chat.md`の「positional agent_nameが宛先を選ぶ」という記述は**初回--connect時点**(connection_current_agentがNoneでURL paramが実際にfallbackとして機能する)に正しくscopeされており偽ではありません。`decisions/0039`はhistory-class(exempt)。他にhit無し。

## Gate
`mkdocs build --strict`(Aborted無し)→`check_doc_anchors.py`(dangling無し)→`check_retired_config_keys_denylist.py`(0 hits)、順序通り全clean。

part of #5132
