### PR TITLE
gate(#5138): TESTS-READ's claim line moves from a PR comment to the PR body

### DIFF
--- a/.github/workflows/check-tests-read-names-its-tree.yml
+++ b/.github/workflows/check-tests-read-names-its-tree.yml
@@ -6,35 +6,56 @@ name: TESTS-READ names its tree
 # evening (2026-08-22): four PRs each carried a note that read an earlier head
 # and then tests/ moved (#5090, #5095, #5096, #5038). All four read green.
 #
-# Same shape as check-pr-closing-intent.yml (the only other workflow that
-# inspects a PR's own text rather than its tree): a dedicated workflow, not
-# folded into test.yml, because it must re-run on `edited` — a reviewer who
-# adds the head to an existing note needs the gate to re-evaluate, and
-# `edited` is not a default pull_request event type. `synchronize` re-runs it
-# against the updated commit set, which is the whole point: a note that was
-# current becomes stale the moment tests/ moves.
+# `pull_request` alone is not enough: a reviewer's note arrives as a new
+# COMMENT, and `pull_request` does not fire on one — measured on this
+# workflow's own first PR (#5120), the note landed and the check stayed red
+# with nothing to re-run it short of another push. So `issue_comment` is
+# listened on too.
 #
-# #5138: the note's CLAIM line lives in the PR BODY, not a comment, and this
-# workflow does NOT listen on `issue_comment` (it used to). GitHub attaches a
-# check run to the sha the triggering event carries; an `issue_comment` event
-# (fired by a posted comment) carries the DEFAULT BRANCH's sha, not the PR's
-# head, so a run it starts can never land on the PR's own check rollup —
-# measured, 4 of 4 PRs whose note arrived as a comment (#5127, #5128, #5132,
-# #5136) stayed red until a human re-ran the workflow by hand. `edited` fires
-# on a body edit and carries the PR's own head, which is what makes this work:
-# a reviewer who posts the claim line in the body gets a check that actually
-# reaches their PR.
+# #5138 (two rounds): a GitHub CHECK RUN attaches to the sha its triggering
+# event carries. `issue_comment` (fired by a posted comment) carries the
+# DEFAULT BRANCH's sha, not the PR's — a check run from that event can never
+# land on the PR's own rollup. Measured 4/4 (#5127, #5128, #5132, #5136)
+# stayed red until a human re-ran the workflow by hand. A first fix moved the
+# claim into the PR body (`pull_request: edited` carries the PR's own head),
+# but the body is one document serving many purposes — measured on #5144, the
+# PR that carried that fix: the body discussed TESTS-READ in prose and named
+# a real commit SHA elsewhere in that same prose, and the gate went green
+# with no reviewer note. Retracted (architect, #5138 comment 5383200442).
+#
+# Current shape: report via a GitHub commit STATUS posted to the PR's own
+# head sha (resolved via `gh pr view`, which works the same regardless of
+# which event triggered this run) — never a check run's own pass/fail. One
+# reporting channel, not two (a check run AND a status both encoding "did
+# this pass" is the exact class this repo spent an evening closing). `pending`
+# is posted BEFORE the script runs and `success`/`failure` AFTER — not
+# decoration: a job that is forced to always exit 0 (the alternative once
+# the check run itself is not read) goes silent if it dies mid-run; posting
+# `pending` first means a job that dies leaves the status `pending`, which
+# blocks merge, rather than leaving no signal at all.
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  issue_comment:
+    types: [created, edited]
 
 permissions:
   contents: read
   pull-requests: read
+  statuses: write
+
+env:
+  # Single fixed context so both triggers report to the SAME status slot —
+  # this is what "one reporting channel" means in practice: a branch
+  # protection rule names this string once.
+  STATUS_CONTEXT: tests-read-names-its-tree
 
 jobs:
   tests-read-names-its-tree:
     name: TESTS-READ note names the tree it read
+    # `issue_comment` fires for plain issues too; only pull requests have a
+    # `pull_request` key on the issue payload.
+    if: github.event_name == 'pull_request' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -57,11 +78,58 @@ jobs:
           python-version: "3.11"
           cache: pip
 
-      # scripts/check_tests_read_names_its_tree.py is stdlib-only
-      # (argparse / json / re / subprocess). No pip install needed.
-      - name: Check the TESTS-READ note names this PR's tree
+      - name: Resolve this PR's number and head sha
+        id: pr
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          python scripts/check_tests_read_names_its_tree.py \
-            --pr "${{ github.event.pull_request.number }}"
+          # `pull_request` events carry the number on .pull_request; an
+          # `issue_comment` on a PR carries it on .issue. Either way the
+          # HEAD SHA has to come from `gh pr view` — it is not on the
+          # `issue_comment` payload at all, and posting a status needs it.
+          NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          SHA="$(gh pr view "$NUMBER" --json headRefOid -q .headRefOid)"
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Post pending status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.sha }}" \
+            -f state=pending \
+            -f context="$STATUS_CONTEXT" \
+            -f description="Checking whether a TESTS-READ note names this tree..."
+
+      # scripts/check_tests_read_names_its_tree.py is stdlib-only
+      # (argparse / json / re / subprocess). No pip install needed.
+      - name: Check the TESTS-READ note names this PR's tree
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_tests_read_names_its_tree.py --pr "${{ steps.pr.outputs.number }}"
+
+      # `if: always()` is the whole point: this step must run whether the
+      # check step above passed, failed, or (if the runner itself dies
+      # first) never ran at all -- in that last case this step ALSO never
+      # runs, and the status posted above stays `pending` rather than
+      # silently vanishing. That is what answers "a job that dies mid-run
+      # must not go silent"; it is a property of these three steps existing
+      # in this order, not something a unit test can exercise.
+      - name: Post final status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ steps.check.outcome }}" = "success" ]; then
+            STATE=success
+            DESC="TESTS-READ note names this tree."
+          else
+            STATE=failure
+            DESC="TESTS-READ note missing or stale -- see the job log."
+          fi
+          gh api "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.sha }}" \
+            -f state="$STATE" \
+            -f context="$STATUS_CONTEXT" \
+            -f description="$DESC"

--- a/.github/workflows/check-tests-read-names-its-tree.yml
+++ b/.github/workflows/check-tests-read-names-its-tree.yml
@@ -13,16 +13,20 @@ name: TESTS-READ names its tree
 # `edited` is not a default pull_request event type. `synchronize` re-runs it
 # against the updated commit set, which is the whole point: a note that was
 # current becomes stale the moment tests/ moves.
+#
+# #5138: the note's CLAIM line lives in the PR BODY, not a comment, and this
+# workflow does NOT listen on `issue_comment` (it used to). GitHub attaches a
+# check run to the sha the triggering event carries; an `issue_comment` event
+# (fired by a posted comment) carries the DEFAULT BRANCH's sha, not the PR's
+# head, so a run it starts can never land on the PR's own check rollup —
+# measured, 4 of 4 PRs whose note arrived as a comment (#5127, #5128, #5132,
+# #5136) stayed red until a human re-ran the workflow by hand. `edited` fires
+# on a body edit and carries the PR's own head, which is what makes this work:
+# a reviewer who posts the claim line in the body gets a check that actually
+# reaches their PR.
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-  # The SUBJECT of this check is a PR comment, and `pull_request` does not
-  # fire when one is posted — measured on this workflow's own first PR
-  # (#5120): the reviewer's note landed, the check stayed red, and nothing
-  # would have re-run it short of another push. A gate that reads comments
-  # has to listen for them.
-  issue_comment:
-    types: [created, edited]
 
 permissions:
   contents: read
@@ -31,9 +35,6 @@ permissions:
 jobs:
   tests-read-names-its-tree:
     name: TESTS-READ note names the tree it read
-    # `issue_comment` fires for plain issues too; only pull requests have a
-    # `pull_request` key on the issue payload.
-    if: github.event_name == 'pull_request' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -62,7 +63,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # `pull_request` events carry the number on .pull_request; an
-          # `issue_comment` on a PR carries it on .issue.
           python scripts/check_tests_read_names_its_tree.py \
-            --pr "${{ github.event.pull_request.number || github.event.issue.number }}"
+            --pr "${{ github.event.pull_request.number }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Path-conditional gates:
 5. **No blanket en/ja mirror obligation.** Fix a `.ja.md` file only when the PR falsifies something it asserts.
 6. **Arc-closure remainder rule**: every remainder is **filed** or **explicitly dropped**, in the closing comment. "Next arc" is a third, silent state.
 7. **A reviewer's blocking point goes in the PR body** as `- [ ] 🔴 <point>`, not only in a review comment — `--request-changes` does not work here. Rule 4 applies to that edit too.
-8. **A PR touching `tests/` does not self-merge until a reviewer's TESTS-READ note lands on the PR.**
+8. **A PR touching `tests/` does not self-merge until a reviewer's TESTS-READ claim line lands in the PR body** (grounds may stay a comment — CI can only land the check on a body edit).
 9. **Arming auto-merge ends your reading of that PR** — a checkbox added afterwards is invisible to the merge. Do not arm while a reviewer's point is open, and re-check the body before arming.
 
 **Issue-triage label `blocked:external`** — needs owner judgment or an upstream

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Path-conditional gates:
 5. **No blanket en/ja mirror obligation.** Fix a `.ja.md` file only when the PR falsifies something it asserts.
 6. **Arc-closure remainder rule**: every remainder is **filed** or **explicitly dropped**, in the closing comment. "Next arc" is a third, silent state.
 7. **A reviewer's blocking point goes in the PR body** as `- [ ] 🔴 <point>`, not only in a review comment — `--request-changes` does not work here. Rule 4 applies to that edit too.
-8. **A PR touching `tests/` does not self-merge until a reviewer's TESTS-READ claim line lands in the PR body** (grounds may stay a comment — CI can only land the check on a body edit).
+8. **A PR touching `tests/` does not self-merge until a reviewer's TESTS-READ claim lands as a comment's FIRST line** (marker + head SHA together; grounds go from line 2 on).
 9. **Arming auto-merge ends your reading of that PR** — a checkbox added afterwards is invisible to the merge. Do not arm while a reviewer's point is open, and re-check the body before arming.
 
 **Issue-triage label `blocked:external`** — needs owner judgment or an upstream

--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -300,18 +300,30 @@ These rules then keep multi-session work coherent:
 
    **Partially closed since (#5120, 2026-08-22):**
    `scripts/check_tests_read_names_its_tree.py`, wired as its own
-   `pull_request`/`issue_comment` CI workflow (repo-wide, not one train's
-   own script), now fails a `tests/`-touching PR that carries no
-   TESTS-READ note naming one of the PR's own commits, or whose only note
-   names a commit `tests/` has since moved past. This closes the
-   "never wired to that path at all" half — every PR now gets a CI check,
-   not just the ones a particular merge train happens to gate. It does
-   NOT close the "empty TESTS-READ satisfies it" half this section
-   illustrates: the gate reads only whether a note names a fresh commit,
-   never what the note SAYS — `**[X]** — TESTS-READ (B) (head \`abc1234\`)`
-   with no actual review content still passes. Only a human reading the
-   PR can still tell a real TESTS-READ from an empty one carrying the
-   right shape.
+   `pull_request` CI workflow (repo-wide, not one train's own script), now
+   fails a `tests/`-touching PR that carries no TESTS-READ note naming one
+   of the PR's own commits, or whose only note names a commit `tests/` has
+   since moved past. This closes the "never wired to that path at all"
+   half — every PR now gets a CI check, not just the ones a particular
+   merge train happens to gate. It does NOT close the "empty TESTS-READ
+   satisfies it" half this section illustrates: the gate reads only
+   whether a note names a fresh commit, never what the note SAYS —
+   `**[X]** — TESTS-READ (B) (head \`abc1234\`)` with no actual review
+   content still passes. Only a human reading the PR can still tell a real
+   TESTS-READ from an empty one carrying the right shape.
+
+   **The note's claim line moved to the PR body since (#5138,
+   2026-08-23):** the workflow's first cut also listened on
+   `issue_comment` so a posted note re-ran the gate, but a check run
+   attaches to the sha its triggering event carries, and `issue_comment`
+   carries the DEFAULT BRANCH's sha, not the PR's — such a run's result
+   could never land on the PR's own check rollup. Measured 4/4 (#5127,
+   #5128, #5132, #5136) stayed red until a human re-ran the workflow by
+   hand. The claim line (`TESTS-READ (B) (head \`abc1234\`)`) now has to
+   land in the PR **body** — `pull_request: edited` fires on a body edit
+   and carries the PR's own head, so the check lands where it needs to.
+   The reviewer's write-up behind the claim (six-questions answers, scope,
+   limits) still belongs in a comment; only the one-line claim relocated.
 
 ## Bundling and the owner's veto unit
 

--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -300,30 +300,42 @@ These rules then keep multi-session work coherent:
 
    **Partially closed since (#5120, 2026-08-22):**
    `scripts/check_tests_read_names_its_tree.py`, wired as its own
-   `pull_request` CI workflow (repo-wide, not one train's own script), now
-   fails a `tests/`-touching PR that carries no TESTS-READ note naming one
-   of the PR's own commits, or whose only note names a commit `tests/` has
-   since moved past. This closes the "never wired to that path at all"
-   half — every PR now gets a CI check, not just the ones a particular
-   merge train happens to gate. It does NOT close the "empty TESTS-READ
-   satisfies it" half this section illustrates: the gate reads only
-   whether a note names a fresh commit, never what the note SAYS —
-   `**[X]** — TESTS-READ (B) (head \`abc1234\`)` with no actual review
-   content still passes. Only a human reading the PR can still tell a real
-   TESTS-READ from an empty one carrying the right shape.
+   `pull_request`/`issue_comment` CI workflow (repo-wide, not one train's
+   own script), now fails a `tests/`-touching PR that carries no
+   TESTS-READ note naming one of the PR's own commits, or whose only note
+   names a commit `tests/` has since moved past. This closes the
+   "never wired to that path at all" half — every PR now gets a CI check,
+   not just the ones a particular merge train happens to gate. It does
+   NOT close the "empty TESTS-READ satisfies it" half this section
+   illustrates: the gate reads only whether a note names a fresh commit,
+   never what the note SAYS — `**[X]** — TESTS-READ (B) (head \`abc1234\`)`
+   with no actual review content still passes. Only a human reading the
+   PR can still tell a real TESTS-READ from an empty one carrying the
+   right shape.
 
-   **The note's claim line moved to the PR body since (#5138,
-   2026-08-23):** the workflow's first cut also listened on
-   `issue_comment` so a posted note re-ran the gate, but a check run
-   attaches to the sha its triggering event carries, and `issue_comment`
-   carries the DEFAULT BRANCH's sha, not the PR's — such a run's result
-   could never land on the PR's own check rollup. Measured 4/4 (#5127,
-   #5128, #5132, #5136) stayed red until a human re-ran the workflow by
-   hand. The claim line (`TESTS-READ (B) (head \`abc1234\`)`) now has to
-   land in the PR **body** — `pull_request: edited` fires on a body edit
-   and carries the PR's own head, so the check lands where it needs to.
-   The reviewer's write-up behind the claim (six-questions answers, scope,
-   limits) still belongs in a comment; only the one-line claim relocated.
+   **Reporting reworked twice since (#5138):** a GitHub check run attaches
+   to the sha its triggering event carries, and `issue_comment` (fired by
+   a posted comment) carries the DEFAULT BRANCH's sha, not the PR's — a
+   check run from that event could never land on the PR's own rollup.
+   Measured 4/4 (#5127, #5128, #5132, #5136) stayed red until a human
+   re-ran the workflow by hand. A first fix moved the claim line into the
+   PR **body** (`pull_request: edited` carries the PR's own head, so a
+   body edit's check run lands correctly) — retracted days later
+   (architect, #5138 comment 5383200442) after it reproduced its own
+   failure mode on #5144: the body is one document with many purposes
+   (description, Test plan, blocking points), and that PR's body carried
+   both TESTS-READ prose and, elsewhere in the same text, a real commit
+   SHA — enough to pass with no reviewer note. The claim line moved back
+   to a comment, but now only that comment's FIRST LINE is read (marker
+   and head SHA co-located there; grounds from line 2 on), which excludes
+   a document merely discussing TESTS-READ SYNTACTICALLY rather than
+   statistically. Reporting moved off check runs entirely: the CI workflow
+   posts a GitHub commit STATUS to the PR's own head sha (resolved via
+   `gh pr view` regardless of which event triggered the run) — `pending`
+   before the script runs, `success`/`failure` after, so a job that dies
+   mid-run leaves the status `pending` (blocking merge) instead of going
+   silent. One reporting channel, not a check run and a status both
+   claiming the same fact.
 
 ## Bundling and the owner's veto unit
 

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -23,50 +23,47 @@ the note any good" — nothing here reads the note's content. It is only:
 3. a ``tests/``-touching PR carries at least one note (none -> red) — rule 8
    itself, which nothing has been checking mechanically.
 
-#5138: the note's CLAIM line lives in a PR **comment**, and only its FIRST
-LINE is ever read (see ``_NOTE_MARKER`` / ``evaluate``). That comment's line 1
-must carry the marker AND the head SHA together, e.g.
+The note's CLAIM line lives in a PR **comment**, and only its FIRST LINE is
+ever read (see ``_NOTE_MARKER`` / ``evaluate``). That comment's line 1 must
+carry the marker AND the head SHA together, e.g.
 ``**[e2e-coder]** — TESTS-READ (B: independent) (head 9cc100605)``. The
 GROUNDS behind the claim (six-questions answers, scope, limits) live from
 line 2 onward and are never read.
 
-This shape had two earlier revisions, both measured wrong:
+The claim is deliberately NOT read from anywhere in a comment (any line, not
+just the first): a document that merely *discusses* TESTS-READ — with an
+unrelated SHA-shaped token appearing nearby — would pass a whole-body search,
+because `find_note_shas` cannot distinguish a claim from a mention. Requiring
+the marker and the SHA to be co-located on the comment's OWN FIRST LINE
+excludes that: a document *about* TESTS-READ, rather than *stating* a
+TESTS-READ claim, does not put the marker there. This removes self-reference
+SYNTACTICALLY, not statistically — it is not that a marker-plus-SHA elsewhere
+in a multi-line comment is merely less likely to be read as a claim, it is
+structurally excluded, because ``evaluate`` never hands anything past a
+comment's first line to either the marker regex or the SHA search.
 
-- **Rev 1 (this file's own #5039 history):** the claim's home was ANY line of
-  ANY comment. `find_note_shas` read a whole comment body, so prose that
-  merely *discussed* TESTS-READ — with an unrelated SHA-shaped token nearby —
-  could pass.
-- **Rev 2 (#5138, briefly): the claim moved into the PR BODY.** A
-  ``pull_request: edited`` event carries the PR's own head sha, so a body
-  edit's check run lands where it needs to (an ``issue_comment`` run carries
-  the DEFAULT BRANCH's sha instead — measured 4/4, #5127/#5128/#5132/#5136
-  stayed red until a human re-ran the workflow by hand). But the PR body is
-  one document serving many purposes at once (description, Test plan,
-  reviewer blocking points, bootstrap notes) — measured on the PR that
-  introduced this exact revision (#5144): the body discussed TESTS-READ in
-  prose *and* a real commit SHA of the PR appeared elsewhere in that same
-  prose (a fixing-commit reference in a checked-off blocking point), and the
-  gate went green with no reviewer note at all. A comment is one document,
-  one purpose, and this predicate now additionally requires the marker and
-  the SHA to be co-located on that comment's OWN FIRST LINE — a document that
-  is *about* TESTS-READ, rather than *stating* a TESTS-READ claim, does not
-  put the marker there. This removes self-reference SYNTACTICALLY, not
-  statistically: it is not that a marker-plus-SHA elsewhere in a multi-line
-  comment is merely less likely to be read as a claim — it is structurally
-  excluded, because ``evaluate`` never looks past a comment's first line.
+The claim is also deliberately NOT read from the PR **body**. A body is one
+document serving many purposes at once — description, Test plan, reviewer
+blocking points, bootstrap notes — and a whole-body search cannot tell
+"stating a claim" from "describing this gate": measured, a PR body that
+discusses TESTS-READ in prose and separately quotes a real commit SHA of the
+PR (e.g. a fixing-commit reference in a checked-off blocking point) goes
+green with no reviewer note at all. A comment is one document with one
+purpose, which is what makes the first-line restriction meaningful there in
+a way it would not be for a body.
 
 Reporting: a check run attaches to the sha its *triggering event* carries,
 and ``issue_comment`` (fired when a comment is posted — the event that has to
 re-run this gate, since ``pull_request`` does not fire on a new comment)
-carries the default branch's sha, not the PR's. So the CI workflow does not
-rely on a check run at all; it posts a GitHub commit **status** to the PR's
-own head sha, resolved once via ``gh pr view`` regardless of which event
-triggered the run. One reporting channel, not two (architect's first
-objection to this shape, on an earlier round: a check run and a commit
-status both encoding "did this pass" is the exact class this repo spent an
-evening closing). The workflow posts `pending` before running this script and
-`success`/`failure` after — not decoration: it is what keeps a job that dies
-mid-run from going silent (architect's second objection: a job forced to
+carries the default branch's sha, not the PR's — measured 4/4,
+#5127/#5128/#5132/#5136 stayed red until a human re-ran the workflow by hand.
+So the CI workflow does not rely on a check run at all; it posts a GitHub
+commit **status** to the PR's own head sha, resolved once via ``gh pr view``
+regardless of which event triggered the run. One reporting channel, not two
+(a check run and a commit status both encoding "did this pass" is the exact
+class this repo spent an evening closing). The workflow posts `pending`
+before running this script and `success`/`failure` after — not decoration:
+it is what keeps a job that dies mid-run from going silent (a job forced to
 always exit 0 so it never reds is a gate that fires and says nothing). See
 ``check-tests-read-names-its-tree.yml`` for the three-step shape that
 provides this; it is not something a pure Python predicate can exercise, and

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -23,9 +23,23 @@ the note any good" — nothing here reads the note's content. It is only:
 3. a ``tests/``-touching PR carries at least one note (none -> red) — rule 8
    itself, which nothing has been checking mechanically.
 
-Deliberately NOT closed: an author can edit an old comment to swap in a newer
-SHA. That is outside a text predicate, and pretending otherwise would be the
-"a checklist item answered yes every time" shape CLAUDE.md already warns about.
+The note's CLAIM line (e.g. ``TESTS-READ (B) (head abc1234)``) lives in the PR
+**body**, not a comment. #5138: GitHub attaches a check run to the sha the
+triggering event carries, and an ``issue_comment`` event (fired when a
+comment is posted) carries the DEFAULT BRANCH's sha, not the PR's head — a run
+it starts can never land on the PR's own check rollup. Measured: 4 of 4 PRs
+whose note arrived as a comment (#5127, #5128, #5132, #5136) stayed red until
+a human re-ran the workflow by hand. A ``pull_request: edited`` event — which
+fires when the PR body changes — carries the PR's own head, so the check lands
+where it needs to. Comments remain the place for the note's GROUNDS (the
+four-section reviewer write-up: six-questions answers, scope, limits) — only
+the one-line claim moved. Comments are still fetched here, but only to give a
+precise diagnostic when a claim landed in the wrong place (see ``evaluate``).
+
+Deliberately NOT closed: an author can edit the body to swap in a newer SHA
+with no new review behind it. That is outside a text predicate, and
+pretending otherwise would be the "a checklist item answered yes every time"
+shape CLAUDE.md already warns about.
 
 stdlib-only (argparse / json / re / subprocess), mirroring
 ``scripts/check_pr_closing_intent.py`` so CI runs it dep-free.
@@ -38,10 +52,14 @@ import re
 import subprocess
 import sys
 
-#: A TESTS-READ note is recognised by this marker appearing in a PR comment.
-#: Matched case-insensitively and tolerating the ``TESTS-READY`` typo that
-#: several sessions produce, because the gate must not turn a typo into
-#: "no note landed" (that would fail the PR for the wrong reason).
+#: A TESTS-READ note's CLAIM line is recognised by this marker appearing in
+#: the PR **body** (#5138 — a check run lands on the sha the triggering event
+#: carries, and only ``pull_request: edited``, which fires on a body edit,
+#: carries the PR's own head; an ``issue_comment`` run carries the default
+#: branch's sha and its result can never reach the PR). Matched
+#: case-insensitively and tolerating the ``TESTS-READY`` typo that several
+#: sessions produce, because the gate must not turn a typo into "no note
+#: landed" (that would fail the PR for the wrong reason).
 _NOTE_MARKER = re.compile(r"TESTS-READ(?:Y)?", re.IGNORECASE)
 
 #: A 7-40 char hex run, the shape `git rev-parse` prints. Bounded on both sides
@@ -57,8 +75,8 @@ _SHA_FALSE_FRIENDS = frozenset({
 })
 
 
-def find_note_shas(comment_body: str, known_oids: "list[str]") -> "list[str]":
-    """The SHA-shaped tokens in *comment_body* that are actually commits of
+def find_note_shas(note_body: str, known_oids: "list[str]") -> "list[str]":
+    """The SHA-shaped tokens in *note_body* that are actually commits of
     this PR (prefix-matched against *known_oids*).
 
     Membership is the whole point, not a nicety: a bare hex pattern also
@@ -69,7 +87,7 @@ def find_note_shas(comment_body: str, known_oids: "list[str]") -> "list[str]":
     failed. A token that is not one of this PR's commits is not a claim about
     this PR's tree, so it is not a SHA for this gate's purposes."""
     out: "list[str]" = []
-    for cand in _SHA.findall(comment_body):
+    for cand in _SHA.findall(note_body):
         if cand.lower() in _SHA_FALSE_FRIENDS:
             continue
         if any(oid.startswith(cand) or cand.startswith(oid) for oid in known_oids if oid):
@@ -77,7 +95,7 @@ def find_note_shas(comment_body: str, known_oids: "list[str]") -> "list[str]":
     return out
 
 
-def tests_commits_after(sha: str, head: str, commits: "list[dict]") -> "list[dict]":
+def tests_commits_after(sha: str, commits: "list[dict]") -> "list[dict]":
     """The commits in *commits* that come strictly after *sha* and touch
     ``tests/``.
 
@@ -100,20 +118,38 @@ def tests_commits_after(sha: str, head: str, commits: "list[dict]") -> "list[dic
 def evaluate(pr: dict) -> "tuple[int, list[str]]":
     """``(exit_code, lines)`` for one PR payload.
 
-    *pr* carries ``files`` (list of path strings), ``comments`` (list of
-    ``{'body':}``), ``commits`` (oldest first, each ``{'oid':, '_tests_paths':}``)
-    and ``headRefOid``. Pure — the live and fixture paths both build this
-    shape first, so the decision is testable without GitHub."""
+    *pr* carries ``files`` (list of path strings), ``body`` (str — the PR
+    description, where the note's CLAIM line lives, #5138), ``comments``
+    (list of ``{'body':}`` — where the note's GROUNDS, the reviewer's
+    write-up, still lives, and read here only to produce a precise
+    diagnostic when a claim landed there instead), ``commits`` (oldest
+    first, each ``{'oid':, '_tests_paths':}``) and ``headRefOid``. Pure —
+    the live and fixture paths both build this shape first, so the decision
+    is testable without GitHub."""
     touched_tests = [p for p in pr.get("files", []) if p.startswith("tests/")]
     if not touched_tests:
         return 0, ["OK — this PR does not touch tests/; rule 8 does not apply."]
 
-    notes = [c for c in pr.get("comments", []) if _NOTE_MARKER.search(c.get("body", ""))]
+    body = pr.get("body", "") or ""
+    notes = [{"body": body}] if _NOTE_MARKER.search(body) else []
     if not notes:
+        comment_notes = [
+            c for c in pr.get("comments", []) if _NOTE_MARKER.search(c.get("body", ""))
+        ]
+        if comment_notes:
+            return 1, [
+                "RED — a TESTS-READ note landed in a comment, not the PR body.",
+                "  The claim line belongs in the body (e.g. `TESTS-READ (B) (head",
+                "  abc1234)`); the write-up behind it can stay a comment. Reason:",
+                "  a check run lands on the sha the triggering event carries, and",
+                "  only an event that carries THIS PR's head (a body edit) can put",
+                "  the result on this PR — a comment-triggered run's result lands",
+                "  on the default branch instead and never reaches this PR.",
+            ]
         return 1, [
             "RED — this PR touches tests/ but carries no TESTS-READ note.",
             "  House rule 8: a PR touching tests/ does not self-merge until a",
-            "  reviewer's TESTS-READ note lands on it.",
+            "  reviewer's TESTS-READ note lands on the PR body.",
             f"  tests/ files touched: {len(touched_tests)}",
         ]
 
@@ -131,14 +167,13 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     # whenever the PR has any, so including it separately buys nothing and
     # costs exactly this hole.
     oids = [c.get("oid", "") for c in commits]
-    head = pr.get("headRefOid", "")
     lines: "list[str]" = []
     for note in notes:
         shas = find_note_shas(note.get("body", ""), oids)
         if not shas:
             continue
         for sha in shas:
-            later = tests_commits_after(sha, head, commits)
+            later = tests_commits_after(sha, commits)
             if not later:
                 return 0, [
                     f"OK — a TESTS-READ note names {sha}, and no commit has",
@@ -158,7 +193,7 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     stale: "list[str]" = []
     for note in notes:
         for sha in find_note_shas(note.get("body", ""), oids):
-            for c in tests_commits_after(sha, head, commits):
+            for c in tests_commits_after(sha, commits):
                 stale.append(f"  {c.get('oid', '')[:9]} {c.get('messageHeadline', '')[:60]}")
     return 1, [
         "RED — every TESTS-READ note reads a tree that tests/ has moved past.",
@@ -213,7 +248,7 @@ def fetch_pr(number: int) -> dict:
     ).stdout.strip()
     raw = subprocess.run(
         ["gh", "pr", "view", str(number), "--json",
-         "files,comments,commits,headRefOid"],
+         "body,files,comments,commits,headRefOid"],
         capture_output=True, text=True, check=True,
     ).stdout
     data = json.loads(raw)
@@ -229,6 +264,7 @@ def fetch_pr(number: int) -> dict:
         for c in data.get("commits", [])
     ]
     return {
+        "body": data.get("body", ""),
         "files": [f.get("path", "") for f in data.get("files", [])],
         "comments": data.get("comments", []),
         "commits": commits,
@@ -248,7 +284,9 @@ def build_parser() -> argparse.ArgumentParser:
     group.add_argument(
         "--fixture", metavar="PATH",
         help=(
-            "JSON file with keys 'files' (paths), 'comments' ([{'body':}]), "
+            "JSON file with keys 'body' (the PR description, where the "
+            "note's claim line lives), 'files' (paths), 'comments' "
+            "([{'body':}], read only for the wrong-place diagnostic), "
             "'commits' (oldest first, [{'oid':, 'messageHeadline':, "
             "'_tests_paths':}]) and 'headRefOid'. Lets this run offline."
         ),

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -36,10 +36,22 @@ four-section reviewer write-up: six-questions answers, scope, limits) — only
 the one-line claim moved. Comments are still fetched here, but only to give a
 precise diagnostic when a claim landed in the wrong place (see ``evaluate``).
 
-Deliberately NOT closed: an author can edit the body to swap in a newer SHA
-with no new review behind it. That is outside a text predicate, and
-pretending otherwise would be the "a checklist item answered yes every time"
-shape CLAUDE.md already warns about.
+Deliberately NOT closed, and broader than "an author can edit the body to
+swap in a newer SHA with no new review behind it": moving the claim line from
+a comment to the body moved it onto the side rule 8 exists to check. A
+comment has an author distinct from the PR's; this gate could at least infer
+"someone other than the author wrote this" from that (weak, but a signal).
+The PR body has no such distinction — the PR's own author writes and edits it
+freely. So this gate establishes only that A CLAIM NAMES THIS TREE, never
+that a reviewer made the claim; that authorship signal is not weakened by
+this move, it is GONE. This is this repo's own named shape: a discriminator a
+trust decision reads must not come from the side being classified. Rule 8's
+actual review requirement rests on a human reading the PR before merging, not
+on this check — a green here is not evidence that review happened, only that
+some text in the body names a commit of this PR. Attempting to verify
+authorship with a text predicate is out of reach here and would produce
+exactly the "a checklist item answered yes every time" shape CLAUDE.md
+already warns about.
 
 stdlib-only (argparse / json / re / subprocess), mirroring
 ``scripts/check_pr_closing_intent.py`` so CI runs it dep-free.
@@ -125,7 +137,15 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     diagnostic when a claim landed there instead), ``commits`` (oldest
     first, each ``{'oid':, '_tests_paths':}``) and ``headRefOid``. Pure —
     the live and fixture paths both build this shape first, so the decision
-    is testable without GitHub."""
+    is testable without GitHub.
+
+    What a green return means, precisely: A CLAIM IN THE BODY NAMES A FRESH
+    COMMIT OF THIS PR. It does NOT mean a reviewer made that claim — the PR
+    body is written and edited by the PR's own author, with no distinct
+    authorship signal this function (or any text predicate) can read. Rule
+    8's actual review requirement is enforced by a human reading the PR
+    before merging, not by this check; treat a green here as "the tree is
+    named", never as "the tree was reviewed"."""
     touched_tests = [p for p in pr.get("files", []) if p.startswith("tests/")]
     if not touched_tests:
         return 0, ["OK — this PR does not touch tests/; rule 8 does not apply."]

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -23,34 +23,66 @@ the note any good" — nothing here reads the note's content. It is only:
 3. a ``tests/``-touching PR carries at least one note (none -> red) — rule 8
    itself, which nothing has been checking mechanically.
 
-The note's CLAIM line (e.g. ``TESTS-READ (B) (head abc1234)``) lives in the PR
-**body**, not a comment. #5138: GitHub attaches a check run to the sha the
-triggering event carries, and an ``issue_comment`` event (fired when a
-comment is posted) carries the DEFAULT BRANCH's sha, not the PR's head — a run
-it starts can never land on the PR's own check rollup. Measured: 4 of 4 PRs
-whose note arrived as a comment (#5127, #5128, #5132, #5136) stayed red until
-a human re-ran the workflow by hand. A ``pull_request: edited`` event — which
-fires when the PR body changes — carries the PR's own head, so the check lands
-where it needs to. Comments remain the place for the note's GROUNDS (the
-four-section reviewer write-up: six-questions answers, scope, limits) — only
-the one-line claim moved. Comments are still fetched here, but only to give a
-precise diagnostic when a claim landed in the wrong place (see ``evaluate``).
+#5138: the note's CLAIM line lives in a PR **comment**, and only its FIRST
+LINE is ever read (see ``_NOTE_MARKER`` / ``evaluate``). That comment's line 1
+must carry the marker AND the head SHA together, e.g.
+``**[e2e-coder]** — TESTS-READ (B: independent) (head 9cc100605)``. The
+GROUNDS behind the claim (six-questions answers, scope, limits) live from
+line 2 onward and are never read.
 
-Deliberately NOT closed, and broader than "an author can edit the body to
-swap in a newer SHA with no new review behind it": moving the claim line from
-a comment to the body moved it onto the side rule 8 exists to check. A
-comment has an author distinct from the PR's; this gate could at least infer
-"someone other than the author wrote this" from that (weak, but a signal).
-The PR body has no such distinction — the PR's own author writes and edits it
-freely. So this gate establishes only that A CLAIM NAMES THIS TREE, never
-that a reviewer made the claim; that authorship signal is not weakened by
-this move, it is GONE. This is this repo's own named shape: a discriminator a
-trust decision reads must not come from the side being classified. Rule 8's
-actual review requirement rests on a human reading the PR before merging, not
-on this check — a green here is not evidence that review happened, only that
-some text in the body names a commit of this PR. Attempting to verify
-authorship with a text predicate is out of reach here and would produce
-exactly the "a checklist item answered yes every time" shape CLAUDE.md
+This shape had two earlier revisions, both measured wrong:
+
+- **Rev 1 (this file's own #5039 history):** the claim's home was ANY line of
+  ANY comment. `find_note_shas` read a whole comment body, so prose that
+  merely *discussed* TESTS-READ — with an unrelated SHA-shaped token nearby —
+  could pass.
+- **Rev 2 (#5138, briefly): the claim moved into the PR BODY.** A
+  ``pull_request: edited`` event carries the PR's own head sha, so a body
+  edit's check run lands where it needs to (an ``issue_comment`` run carries
+  the DEFAULT BRANCH's sha instead — measured 4/4, #5127/#5128/#5132/#5136
+  stayed red until a human re-ran the workflow by hand). But the PR body is
+  one document serving many purposes at once (description, Test plan,
+  reviewer blocking points, bootstrap notes) — measured on the PR that
+  introduced this exact revision (#5144): the body discussed TESTS-READ in
+  prose *and* a real commit SHA of the PR appeared elsewhere in that same
+  prose (a fixing-commit reference in a checked-off blocking point), and the
+  gate went green with no reviewer note at all. A comment is one document,
+  one purpose, and this predicate now additionally requires the marker and
+  the SHA to be co-located on that comment's OWN FIRST LINE — a document that
+  is *about* TESTS-READ, rather than *stating* a TESTS-READ claim, does not
+  put the marker there. This removes self-reference SYNTACTICALLY, not
+  statistically: it is not that a marker-plus-SHA elsewhere in a multi-line
+  comment is merely less likely to be read as a claim — it is structurally
+  excluded, because ``evaluate`` never looks past a comment's first line.
+
+Reporting: a check run attaches to the sha its *triggering event* carries,
+and ``issue_comment`` (fired when a comment is posted — the event that has to
+re-run this gate, since ``pull_request`` does not fire on a new comment)
+carries the default branch's sha, not the PR's. So the CI workflow does not
+rely on a check run at all; it posts a GitHub commit **status** to the PR's
+own head sha, resolved once via ``gh pr view`` regardless of which event
+triggered the run. One reporting channel, not two (architect's first
+objection to this shape, on an earlier round: a check run and a commit
+status both encoding "did this pass" is the exact class this repo spent an
+evening closing). The workflow posts `pending` before running this script and
+`success`/`failure` after — not decoration: it is what keeps a job that dies
+mid-run from going silent (architect's second objection: a job forced to
+always exit 0 so it never reds is a gate that fires and says nothing). See
+``check-tests-read-names-its-tree.yml`` for the three-step shape that
+provides this; it is not something a pure Python predicate can exercise, and
+the test suite says so plainly rather than pretending to cover it.
+
+Deliberately NOT closed: this predicate proves only that a comment's first
+line names a fresh commit of this PR — never that a *reviewer* wrote it.
+Every session in this repo authenticates as the same ``gh`` user (house
+rule preamble, PR-workflow doc), so comment authorship cannot distinguish
+reviewer from author any more than body authorship could; the syntactic
+first-line restriction closes the #5144 false-green (a claim can no longer
+hide inside prose that merely discusses the marker), but it does not and
+cannot establish WHO posted the claim. Rule 8's actual review requirement is
+enforced by a human reading the PR before merging, not by this check. Text
+predicates over authorship are out of reach here, and pretending otherwise
+would be the "a checklist item answered yes every time" shape CLAUDE.md
 already warns about.
 
 stdlib-only (argparse / json / re / subprocess), mirroring
@@ -64,14 +96,12 @@ import re
 import subprocess
 import sys
 
-#: A TESTS-READ note's CLAIM line is recognised by this marker appearing in
-#: the PR **body** (#5138 — a check run lands on the sha the triggering event
-#: carries, and only ``pull_request: edited``, which fires on a body edit,
-#: carries the PR's own head; an ``issue_comment`` run carries the default
-#: branch's sha and its result can never reach the PR). Matched
-#: case-insensitively and tolerating the ``TESTS-READY`` typo that several
-#: sessions produce, because the gate must not turn a typo into "no note
-#: landed" (that would fail the PR for the wrong reason).
+#: A TESTS-READ note's claim line is recognised by this marker appearing on a
+#: comment's FIRST LINE (see ``_first_line`` / ``evaluate``) — never a line 2+
+#: only appearance, and never the PR body. Matched case-insensitively and
+#: tolerating the ``TESTS-READY`` typo that several sessions produce, because
+#: the gate must not turn a typo into "no note landed" (that would fail the
+#: PR for the wrong reason).
 _NOTE_MARKER = re.compile(r"TESTS-READ(?:Y)?", re.IGNORECASE)
 
 #: A 7-40 char hex run, the shape `git rev-parse` prints. Bounded on both sides
@@ -87,8 +117,20 @@ _SHA_FALSE_FRIENDS = frozenset({
 })
 
 
-def find_note_shas(note_body: str, known_oids: "list[str]") -> "list[str]":
-    """The SHA-shaped tokens in *note_body* that are actually commits of
+def _first_line(text: str) -> str:
+    """*text*'s first line, ``\\n``-delimited, with no trailing newline.
+
+    The gate's entire "read only the claim, not the grounds" boundary is
+    this one split: a comment's line 2 onward (the six-questions write-up,
+    scope, limits) is never passed to ``_NOTE_MARKER`` or ``find_note_shas``
+    at all — not filtered out after being read, but never handed to either
+    of them, which is what makes the exclusion syntactic rather than a
+    matter of degree."""
+    return text.split("\n", 1)[0]
+
+
+def find_note_shas(note_line: str, known_oids: "list[str]") -> "list[str]":
+    """The SHA-shaped tokens in *note_line* that are actually commits of
     this PR (prefix-matched against *known_oids*).
 
     Membership is the whole point, not a nicety: a bare hex pattern also
@@ -99,7 +141,7 @@ def find_note_shas(note_body: str, known_oids: "list[str]") -> "list[str]":
     failed. A token that is not one of this PR's commits is not a claim about
     this PR's tree, so it is not a SHA for this gate's purposes."""
     out: "list[str]" = []
-    for cand in _SHA.findall(note_body):
+    for cand in _SHA.findall(note_line):
         if cand.lower() in _SHA_FALSE_FRIENDS:
             continue
         if any(oid.startswith(cand) or cand.startswith(oid) for oid in known_oids if oid):
@@ -130,46 +172,43 @@ def tests_commits_after(sha: str, commits: "list[dict]") -> "list[dict]":
 def evaluate(pr: dict) -> "tuple[int, list[str]]":
     """``(exit_code, lines)`` for one PR payload.
 
-    *pr* carries ``files`` (list of path strings), ``body`` (str — the PR
-    description, where the note's CLAIM line lives, #5138), ``comments``
-    (list of ``{'body':}`` — where the note's GROUNDS, the reviewer's
-    write-up, still lives, and read here only to produce a precise
-    diagnostic when a claim landed there instead), ``commits`` (oldest
-    first, each ``{'oid':, '_tests_paths':}``) and ``headRefOid``. Pure —
-    the live and fixture paths both build this shape first, so the decision
-    is testable without GitHub.
+    *pr* carries ``files`` (list of path strings), ``comments`` (list of
+    ``{'body':}``), ``commits`` (oldest first, each ``{'oid':,
+    '_tests_paths':}``) and ``headRefOid``. Pure — the live and fixture paths
+    both build this shape first, so the decision is testable without GitHub.
 
-    What a green return means, precisely: A CLAIM IN THE BODY NAMES A FRESH
-    COMMIT OF THIS PR. It does NOT mean a reviewer made that claim — the PR
-    body is written and edited by the PR's own author, with no distinct
-    authorship signal this function (or any text predicate) can read. Rule
-    8's actual review requirement is enforced by a human reading the PR
-    before merging, not by this check; treat a green here as "the tree is
-    named", never as "the tree was reviewed"."""
+    A claim is a comment whose FIRST LINE (``_first_line``) matches
+    ``_NOTE_MARKER``; the SHA search (``find_note_shas``) also runs only over
+    that first line, never the rest of the comment. A comment that mentions
+    TESTS-READ only from its second line onward is not a claim at all — it
+    falls into the same "no note" bucket as a comment that never mentions it,
+    which is deliberate: a document *about* the marker is not a document
+    *stating* the marker.
+
+    What a green return means, precisely: A COMMENT'S FIRST LINE NAMES A
+    FRESH COMMIT OF THIS PR. It does NOT mean a reviewer made that claim —
+    every session here authenticates as the same ``gh`` user, so comment
+    authorship carries no reviewer/author distinction for this function (or
+    any text predicate) to read. Rule 8's actual review requirement is
+    enforced by a human reading the PR before merging, not by this check;
+    treat a green here as "the tree is named", never as "the tree was
+    reviewed"."""
     touched_tests = [p for p in pr.get("files", []) if p.startswith("tests/")]
     if not touched_tests:
         return 0, ["OK — this PR does not touch tests/; rule 8 does not apply."]
 
-    body = pr.get("body", "") or ""
-    notes = [{"body": body}] if _NOTE_MARKER.search(body) else []
+    notes = [
+        _first_line(c.get("body", ""))
+        for c in pr.get("comments", [])
+        if _NOTE_MARKER.search(_first_line(c.get("body", "")))
+    ]
     if not notes:
-        comment_notes = [
-            c for c in pr.get("comments", []) if _NOTE_MARKER.search(c.get("body", ""))
-        ]
-        if comment_notes:
-            return 1, [
-                "RED — a TESTS-READ note landed in a comment, not the PR body.",
-                "  The claim line belongs in the body (e.g. `TESTS-READ (B) (head",
-                "  abc1234)`); the write-up behind it can stay a comment. Reason:",
-                "  a check run lands on the sha the triggering event carries, and",
-                "  only an event that carries THIS PR's head (a body edit) can put",
-                "  the result on this PR — a comment-triggered run's result lands",
-                "  on the default branch instead and never reaches this PR.",
-            ]
         return 1, [
             "RED — this PR touches tests/ but carries no TESTS-READ note.",
             "  House rule 8: a PR touching tests/ does not self-merge until a",
-            "  reviewer's TESTS-READ note lands on the PR body.",
+            "  reviewer's TESTS-READ note lands on it — the marker and the head",
+            "  SHA must both be on a comment's FIRST line; a marker mentioned",
+            "  only from line 2 onward does not count as a note.",
             f"  tests/ files touched: {len(touched_tests)}",
         ]
 
@@ -189,7 +228,7 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     oids = [c.get("oid", "") for c in commits]
     lines: "list[str]" = []
     for note in notes:
-        shas = find_note_shas(note.get("body", ""), oids)
+        shas = find_note_shas(note, oids)
         if not shas:
             continue
         for sha in shas:
@@ -204,7 +243,8 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     if not lines:
         return 1, [
             "RED — a TESTS-READ note landed, but none of them names a commit of",
-            "  this PR. Add the head you read (e.g. `TESTS-READ (B) (head abc1234)`).",
+            "  this PR. Add the head you read (e.g. `TESTS-READ (B) (head abc1234)`),",
+            "  on the SAME first line as the marker.",
             "  An issue-comment id is not a tree name — it is hex-shaped, and this",
             "  gate's first live run mistook one for a SHA.",
             "  Without it, nothing can tell whether the note is a claim about THIS tree.",
@@ -212,7 +252,7 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
 
     stale: "list[str]" = []
     for note in notes:
-        for sha in find_note_shas(note.get("body", ""), oids):
+        for sha in find_note_shas(note, oids):
             for c in tests_commits_after(sha, commits):
                 stale.append(f"  {c.get('oid', '')[:9]} {c.get('messageHeadline', '')[:60]}")
     return 1, [
@@ -268,7 +308,7 @@ def fetch_pr(number: int) -> dict:
     ).stdout.strip()
     raw = subprocess.run(
         ["gh", "pr", "view", str(number), "--json",
-         "body,files,comments,commits,headRefOid"],
+         "files,comments,commits,headRefOid"],
         capture_output=True, text=True, check=True,
     ).stdout
     data = json.loads(raw)
@@ -284,7 +324,6 @@ def fetch_pr(number: int) -> dict:
         for c in data.get("commits", [])
     ]
     return {
-        "body": data.get("body", ""),
         "files": [f.get("path", "") for f in data.get("files", [])],
         "comments": data.get("comments", []),
         "commits": commits,
@@ -304,9 +343,8 @@ def build_parser() -> argparse.ArgumentParser:
     group.add_argument(
         "--fixture", metavar="PATH",
         help=(
-            "JSON file with keys 'body' (the PR description, where the "
-            "note's claim line lives), 'files' (paths), 'comments' "
-            "([{'body':}], read only for the wrong-place diagnostic), "
+            "JSON file with keys 'files' (paths), 'comments' ([{'body':}], "
+            "only each one's first line is read as a possible claim), "
             "'commits' (oldest first, [{'oid':, 'messageHeadline':, "
             "'_tests_paths':}]) and 'headRefOid'. Lets this run offline."
         ),

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -8,9 +8,9 @@ EXISTING; nothing looks at which tree the note is a claim about). The four
 2026-08-22 instances the script's own docstring lists are the population this
 was written against — the reject-side cases below are those instances' shape.
 
-#5138 (second round, architect comment 5383200442): the claim line stays a PR
-COMMENT, but only that comment's FIRST LINE is ever read — the marker and the
-head SHA must be co-located there. The tests below cover the architect's four
+The claim line is a PR COMMENT, and only that comment's FIRST LINE is ever
+read — the marker and the head SHA must be co-located there (architect,
+#5138 comment 5383200442). The tests below cover the architect's four
 acceptance cases:
 
 ① no claim line anywhere → red (`test_no_claim_line_at_all_is_rejected`).

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -8,6 +8,16 @@ EXISTING; nothing looks at which tree the note is a claim about). The four
 2026-08-22 instances the script's own docstring lists are the population this
 was written against — the reject-side cases below are those instances' shape.
 
+#5138 moved the note's CLAIM line from a PR comment to the PR body (a check
+run lands on the sha its triggering event carries, and only a body edit
+carries the PR's own head — a comment-triggered run's result can never reach
+the PR; measured 4/4). The tests below cover the architect's four acceptance
+cases for that move: ① a note in the body naming this PR's head passes, ② a
+note that landed only in a comment is rejected with a message naming the body
+as where the claim belongs, ③ no note anywhere is rejected with the existing
+rule-8 message, ④ a body note naming a sha that later tests/-touching commits
+moved past is rejected and lists those commits.
+
 Payloads are built inline rather than fetched: `evaluate` is pure by design so
 the decision is testable without GitHub, and the fixtures here are the only
 callers that need to exist.
@@ -27,8 +37,11 @@ assert _SPEC.loader is not None
 _SPEC.loader.exec_module(_MOD)
 
 
-def _pr(*, files, comments, commits, head="ffffffff"):
-    return {"files": files, "comments": comments, "commits": commits, "headRefOid": head}
+def _pr(*, files, body="", comments=(), commits, head="ffffffff"):
+    return {
+        "files": files, "body": body, "comments": list(comments),
+        "commits": commits, "headRefOid": head,
+    }
 
 
 def _commit(oid, headline="", tests=()):
@@ -38,10 +51,11 @@ def _commit(oid, headline="", tests=()):
 # ── reject side ─────────────────────────────────────────────────────────────
 
 def test_note_without_a_sha_is_rejected():
-    """Tier 1: the #5096 shape — a note landed, but nothing in it says which tree."""
+    """Tier 1: the #5096 shape — a note landed in the body, but nothing in it
+    says which tree."""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        comments=[{"body": "**[docs-maintainer]** — TESTS-READ (B: independent). Passing."}],
+        body="**[docs-maintainer]** — TESTS-READ (B: independent). Passing.",
         commits=[_commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
     ))
     assert code == 1
@@ -51,10 +65,10 @@ def test_note_without_a_sha_is_rejected():
 def test_note_whose_sha_predates_a_later_tests_commit_is_rejected():
     """Tier 1: the #5090 / #5095 shape — the note is real and names its head, and then
     `tests/` moved. The failure names the commits so the ask is a differential
-    top-up, not a re-read."""
+    top-up, not a re-read. (Architect's acceptance ④.)"""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        comments=[{"body": "TESTS-READ (B: independent) (head `a7c44eef6`)."}],
+        body="TESTS-READ (B: independent) (head `a7c44eef6`).",
         commits=[
             _commit("a7c44eef6", "docs: split the column"),
             _commit("9ef30f95b", "test(#4206): CI-gate the Reload column too", ("tests/repo/test_config_reference_declared_in_4206.py",)),
@@ -67,7 +81,8 @@ def test_note_whose_sha_predates_a_later_tests_commit_is_rejected():
 
 
 def test_tests_touching_pr_with_no_note_at_all_is_rejected():
-    """Tier 1: rule 8 itself — nothing has been checking it mechanically."""
+    """Tier 1: rule 8 itself — nothing has been checking it mechanically.
+    (Architect's acceptance ③.)"""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
         comments=[{"body": "LGTM"}],
@@ -77,14 +92,30 @@ def test_tests_touching_pr_with_no_note_at_all_is_rejected():
     assert "no TESTS-READ note" in "\n".join(lines)
 
 
+def test_note_only_in_a_comment_is_rejected_naming_the_body():
+    """Tier 1: #5138's own defect shape — a note posted as a comment (not the
+    body) is rejected, and the message names the body as where the claim
+    belongs, distinct from "no note anywhere". (Architect's acceptance ②.)"""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "TESTS-READ (B) (head `bbbbbbbb`)"}],
+        commits=[_commit("bbbbbbbb", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
+    ))
+    assert code == 1
+    joined = "\n".join(lines)
+    assert "not the PR body" in joined
+    assert "belongs in the body" in joined
+
+
 # ── accept side ─────────────────────────────────────────────────────────────
 
 def test_note_naming_the_last_tests_commit_passes():
-    """Tier 1: the accept side — a note that names the newest tests/ commit is
-    a claim about the tree that is about to merge."""
+    """Tier 1: the accept side — a note in the body that names the newest
+    tests/ commit is a claim about the tree that is about to merge.
+    (Architect's acceptance ①.)"""
     code, _ = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        comments=[{"body": "TESTS-READ (B) (head `bbbbbbbb`)"}],
+        body="TESTS-READ (B) (head `bbbbbbbb`)",
         commits=[
             _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
             _commit("bbbbbbbb", "test: fix", ("tests/scripts/test_check_doc_drift_5003.py",)),
@@ -99,7 +130,7 @@ def test_commits_after_the_note_that_do_not_touch_tests_pass():
     the note is a claim about `tests/`, so only `tests/` moving falsifies it."""
     code, _ = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        comments=[{"body": "TESTS-READ (B) (head `aaaaaaaa`)"}],
+        body="TESTS-READ (B) (head `aaaaaaaa`)",
         commits=[
             _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
             _commit("cccccccc", "docs: reword"),
@@ -112,7 +143,7 @@ def test_pr_not_touching_tests_is_out_of_scope():
     """Tier 1: rule 8 binds only PRs that touch tests/ — a src- or docs-only PR
     must not be asked for a note it does not owe."""
     code, lines = _MOD.evaluate(_pr(
-        files=["src/reyn/foo.py"], comments=[], commits=[_commit("aaaaaaaa", "fix")],
+        files=["src/reyn/foo.py"], commits=[_commit("aaaaaaaa", "fix")],
     ))
     assert code == 0
     assert "does not touch tests/" in "\n".join(lines)
@@ -139,16 +170,22 @@ def test_an_issue_comment_id_is_not_read_as_a_sha():
     assert _MOD.find_note_shas("see issuecomment-5379476813", oids) == []
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        comments=[{"body": "TESTS-READ (B) — details in issuecomment-5379476813"}],
+        body="TESTS-READ (B) — details in issuecomment-5379476813",
         commits=[
             _commit("a7c44eef6", "docs: split"),
             _commit("9ef30f95b", "test: gate the column", ("tests/repo/test_config_reference_declared_in_4206.py",)),
         ],
     ))
     assert code == 1, "a note citing only a comment id names no tree"
+    assert "names a commit of" in "\n".join(lines), (
+        "the rejection is for naming no commit, not for a missing note"
+    )
 
 
-def _runner(returncode: int, stdout: str = "", stderr: str = "", seen: "list | None" = None):
+def _runner(
+    returncode: int, stdout: str = "", stderr: str = "",
+    seen: "list | None" = None, kwargs_seen: "list | None" = None,
+):
     """A minimal stand-in for `subprocess.run`'s result, injected through
     `commit_touched_paths`'s own `run` seam. Not a mock of a cheaply
     constructible collaborator — the real one is an authenticated network
@@ -159,12 +196,19 @@ def _runner(returncode: int, stdout: str = "", stderr: str = "", seen: "list | N
     which left the seam's ONE mistakable part — the endpoint path and the
     ``--jq`` that shapes the reply — outside every test (architect, #5128 B):
     a `commit_touched_paths` that asked for the wrong URL would have passed
-    both cases below."""
+    both cases below.
+
+    *kwargs_seen* collects the keyword arguments the caller passed (e.g.
+    ``capture_output=``, ``text=``) — recorded, not silently swallowed, so a
+    caller that started passing `check=True` or a different `text=` would be
+    visible to a test rather than invisible to every test using this seam."""
     import subprocess as _sp
 
     def _run(cmd, **kwargs):
         if seen is not None:
             seen.append(list(cmd))
+        if kwargs_seen is not None:
+            kwargs_seen.append(dict(kwargs))
         return _sp.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
 
     return _run
@@ -175,8 +219,10 @@ def test_the_seam_asks_github_for_that_commits_file_names() -> None:
     running the suite unless a test looks at it. Endpoint and `--jq` together
     decide whether the reply is a list of file names at all."""
     seen: list = []
+    kwargs_seen: list = []
     _MOD.commit_touched_paths(
-        "abc1234", "tya5/reyn", run=_runner(0, stdout="[]", seen=seen),
+        "abc1234", "tya5/reyn",
+        run=_runner(0, stdout="[]", seen=seen, kwargs_seen=kwargs_seen),
     )
     # `seen[0]` raises if the seam was never called at all, so the shape
     # assertions below cannot pass vacuously.
@@ -188,6 +234,12 @@ def test_the_seam_asks_github_for_that_commits_file_names() -> None:
     assert "[.files[].filename]" in argv, (
         f"asks for file NAMES — without this jq the reply is objects, not paths; got {argv!r}"
     )
+    # capture_output/text together decide whether stdout comes back as a
+    # decoded string this function can json.loads — a caller that dropped
+    # either would still issue the right argv and still break at runtime.
+    kwargs = kwargs_seen[0]
+    assert kwargs.get("capture_output") is True, f"needs captured stdout/stderr; got {kwargs!r}"
+    assert kwargs.get("text") is True, f"needs str, not bytes, output; got {kwargs!r}"
 
 
 def test_an_unreadable_commit_stops_the_run() -> None:
@@ -225,7 +277,7 @@ def test_a_note_quoting_the_head_with_no_commits_does_not_pass():
     read, which is the shape this gate exists to reject."""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        comments=[{"body": "TESTS-READ (B) (head `deadbee1`)"}],
+        body="TESTS-READ (B) (head `deadbee1`)",
         commits=[],
         head="deadbee1",
     ))
@@ -237,3 +289,18 @@ def test_the_head_alone_is_not_membership():
     """Tier 1: the same gap at the predicate level — a SHA that is only the
     head, with no commit carrying it, is not a commit of this PR."""
     assert _MOD.find_note_shas("head `deadbee1`", []) == []
+
+
+def test_tests_commits_after_takes_no_head_argument():
+    """Tier 1: `tests_commits_after` decides membership from *sha* against
+    *commits* alone — a `head` parameter that the decision never consulted
+    would claim to participate without doing so (the shape a signature
+    should not carry). Its 2-argument form is the contract."""
+    later = _MOD.tests_commits_after(
+        "aaaaaaaa",
+        [
+            _commit("aaaaaaaa", "test: add"),
+            _commit("bbbbbbbb", "test: more", ("tests/scripts/test_check_doc_drift_5003.py",)),
+        ],
+    )
+    assert [c["oid"] for c in later] == ["bbbbbbbb"]

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -8,15 +8,28 @@ EXISTING; nothing looks at which tree the note is a claim about). The four
 2026-08-22 instances the script's own docstring lists are the population this
 was written against — the reject-side cases below are those instances' shape.
 
-#5138 moved the note's CLAIM line from a PR comment to the PR body (a check
-run lands on the sha its triggering event carries, and only a body edit
-carries the PR's own head — a comment-triggered run's result can never reach
-the PR; measured 4/4). The tests below cover the architect's four acceptance
-cases for that move: ① a note in the body naming this PR's head passes, ② a
-note that landed only in a comment is rejected with a message naming the body
-as where the claim belongs, ③ no note anywhere is rejected with the existing
-rule-8 message, ④ a body note naming a sha that later tests/-touching commits
-moved past is rejected and lists those commits.
+#5138 (second round, architect comment 5383200442): the claim line stays a PR
+COMMENT, but only that comment's FIRST LINE is ever read — the marker and the
+head SHA must be co-located there. The tests below cover the architect's four
+acceptance cases:
+
+① no claim line anywhere → red (`test_no_claim_line_at_all_is_rejected`).
+② a comment whose marker appears only from line 2 onward → red — the #5144
+   reproduction, built from that PR's actual shape: prose that discussed
+   TESTS-READ and happened to name a real commit of the PR elsewhere in the
+   same multi-purpose document, with no first-line claim at all
+   (`test_marker_only_from_line_two_onward_is_not_a_claim`).
+③ the CI job dying mid-run leaves the posted commit status `pending`, never
+   green. This is a property of the THREE-STEP workflow shape in
+   `check-tests-read-names-its-tree.yml` (`pending` before the script runs,
+   `success`/`failure` after, the final step gated on `if: always()`) — not
+   something `evaluate` or any other pure function here can exercise, so it
+   is deliberately NOT represented by a test in this file. Recorded here
+   rather than left silent: this file's own test-review discipline (six
+   questions, #4) treats an assertion that would pass vacuously as worse than
+   no assertion, and a Tier-1 test cannot reach into a GitHub Actions run.
+④ a claim naming a sha that later tests/-touching commits moved past → red,
+   listing those commits (`test_note_whose_sha_predates_a_later_tests_commit_is_rejected`).
 
 Payloads are built inline rather than fetched: `evaluate` is pure by design so
 the decision is testable without GitHub, and the fixtures here are the only
@@ -37,10 +50,10 @@ assert _SPEC.loader is not None
 _SPEC.loader.exec_module(_MOD)
 
 
-def _pr(*, files, body="", comments=(), commits, head="ffffffff"):
+def _pr(*, files, comments=(), commits, head="ffffffff"):
     return {
-        "files": files, "body": body, "comments": list(comments),
-        "commits": commits, "headRefOid": head,
+        "files": files, "comments": list(comments), "commits": commits,
+        "headRefOid": head,
     }
 
 
@@ -51,11 +64,11 @@ def _commit(oid, headline="", tests=()):
 # ── reject side ─────────────────────────────────────────────────────────────
 
 def test_note_without_a_sha_is_rejected():
-    """Tier 1: the #5096 shape — a note landed in the body, but nothing in it
-    says which tree."""
+    """Tier 1: the #5096 shape — a claim line landed on a comment's first
+    line, but nothing on it says which tree."""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        body="**[docs-maintainer]** — TESTS-READ (B: independent). Passing.",
+        comments=[{"body": "**[docs-maintainer]** — TESTS-READ (B: independent). Passing."}],
         commits=[_commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
     ))
     assert code == 1
@@ -68,7 +81,7 @@ def test_note_whose_sha_predates_a_later_tests_commit_is_rejected():
     top-up, not a re-read. (Architect's acceptance ④.)"""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        body="TESTS-READ (B: independent) (head `a7c44eef6`).",
+        comments=[{"body": "TESTS-READ (B: independent) (head `a7c44eef6`)."}],
         commits=[
             _commit("a7c44eef6", "docs: split the column"),
             _commit("9ef30f95b", "test(#4206): CI-gate the Reload column too", ("tests/repo/test_config_reference_declared_in_4206.py",)),
@@ -80,9 +93,9 @@ def test_note_whose_sha_predates_a_later_tests_commit_is_rejected():
     assert "DIFFERENTIAL" in joined.upper()
 
 
-def test_tests_touching_pr_with_no_note_at_all_is_rejected():
+def test_no_claim_line_at_all_is_rejected():
     """Tier 1: rule 8 itself — nothing has been checking it mechanically.
-    (Architect's acceptance ③.)"""
+    (Architect's acceptance ①.)"""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
         comments=[{"body": "LGTM"}],
@@ -92,30 +105,47 @@ def test_tests_touching_pr_with_no_note_at_all_is_rejected():
     assert "no TESTS-READ note" in "\n".join(lines)
 
 
-def test_note_only_in_a_comment_is_rejected_naming_the_body():
-    """Tier 1: #5138's own defect shape — a note posted as a comment (not the
-    body) is rejected, and the message names the body as where the claim
-    belongs, distinct from "no note anywhere". (Architect's acceptance ②.)"""
+def test_marker_only_from_line_two_onward_is_not_a_claim():
+    """Tier 1: the #5144 reproduction (architect's acceptance ②) — a
+    multi-purpose comment whose FIRST line is a plain role-prefixed opener,
+    and whose marker plus a real commit SHA of this PR only appear further
+    down, inside prose that is ABOUT TESTS-READ rather than STATING a
+    TESTS-READ claim. That is exactly the shape that made #5144's PR BODY
+    (a different multi-purpose document) go green with no reviewer note:
+    the marker and a real SHA were both present somewhere in the text, just
+    not co-located as a claim. This must be red, and — critically — for the
+    SAME reason as "no note at all", because the first line carries no
+    claim."""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        comments=[{"body": "TESTS-READ (B) (head `bbbbbbbb`)"}],
+        comments=[{
+            "body": (
+                "**[e2e-coder]** — 着手します。\n"
+                "\n"
+                "## Notes\n"
+                "\n"
+                "Reviewed the diff; will post TESTS-READ once done. Fixing "
+                "commit was `bbbbbbbb`, same tree this PR already has."
+            ),
+        }],
         commits=[_commit("bbbbbbbb", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
     ))
     assert code == 1
-    joined = "\n".join(lines)
-    assert "not the PR body" in joined
-    assert "belongs in the body" in joined
+    assert "no TESTS-READ note" in "\n".join(lines), (
+        "a marker appearing only from line 2 onward must fall into the same "
+        "bucket as no marker at all -- it must not be read as a claim"
+    )
 
 
 # ── accept side ─────────────────────────────────────────────────────────────
 
 def test_note_naming_the_last_tests_commit_passes():
-    """Tier 1: the accept side — a note in the body that names the newest
-    tests/ commit is a claim about the tree that is about to merge.
-    (Architect's acceptance ①.)"""
+    """Tier 1: the accept side — a claim on a comment's first line, naming
+    the newest tests/ commit, is a claim about the tree that is about to
+    merge."""
     code, _ = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        body="TESTS-READ (B) (head `bbbbbbbb`)",
+        comments=[{"body": "TESTS-READ (B) (head `bbbbbbbb`)"}],
         commits=[
             _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
             _commit("bbbbbbbb", "test: fix", ("tests/scripts/test_check_doc_drift_5003.py",)),
@@ -130,11 +160,31 @@ def test_commits_after_the_note_that_do_not_touch_tests_pass():
     the note is a claim about `tests/`, so only `tests/` moving falsifies it."""
     code, _ = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        body="TESTS-READ (B) (head `aaaaaaaa`)",
+        comments=[{"body": "TESTS-READ (B) (head `aaaaaaaa`)"}],
         commits=[
             _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
             _commit("cccccccc", "docs: reword"),
         ],
+    ))
+    assert code == 0
+
+
+def test_multiline_comment_with_the_claim_on_line_one_still_passes():
+    """Tier 1: the first-line restriction rejects a marker BELOW line 1 — it
+    must not also reject a well-formed claim that simply has grounds
+    written below it, which is the normal, expected shape (marker + SHA on
+    line 1, six-questions write-up on lines 2+)."""
+    code, _ = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{
+            "body": (
+                "**[architect]** — TESTS-READ (B: independent) (head `aaaaaaaa`)\n"
+                "\n"
+                "## Six questions\n"
+                "1. Tier 1, the same expression is not on both sides.\n"
+            ),
+        }],
+        commits=[_commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
     ))
     assert code == 0
 
@@ -170,7 +220,7 @@ def test_an_issue_comment_id_is_not_read_as_a_sha():
     assert _MOD.find_note_shas("see issuecomment-5379476813", oids) == []
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        body="TESTS-READ (B) — details in issuecomment-5379476813",
+        comments=[{"body": "TESTS-READ (B) — details in issuecomment-5379476813"}],
         commits=[
             _commit("a7c44eef6", "docs: split"),
             _commit("9ef30f95b", "test: gate the column", ("tests/repo/test_config_reference_declared_in_4206.py",)),
@@ -277,7 +327,7 @@ def test_a_note_quoting_the_head_with_no_commits_does_not_pass():
     read, which is the shape this gate exists to reject."""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
-        body="TESTS-READ (B) (head `deadbee1`)",
+        comments=[{"body": "TESTS-READ (B) (head `deadbee1`)"}],
         commits=[],
         head="deadbee1",
     ))


### PR DESCRIPTION
**[lead-coder]** — part of #5138

## What (reworked — see history below)

This PR went through three shapes. The current one is the architect's
option A rework (comment 5383200442), after option B (claim line in the
PR body) was retracted for reproducing a false green on THIS PR (history
preserved below, unedited, per house rule/ADR-style immutability for a
ruling record).

**Current design:**

- The TESTS-READ claim line lives in a PR **comment**, and only that
  comment's **first line** is ever read. A valid claim carries the role
  prefix, the marker, and the head SHA together on that first line, e.g.
  `**[e2e-coder]** — TESTS-READ (B: 独立) (head 9cc100605)`. Grounds (the
  four-section reviewer write-up) live from line 2 on and are never read.
  This excludes a document that merely *discusses* TESTS-READ
  **syntactically**, not statistically: `evaluate()` never hands line 2+
  to either the marker regex or the SHA search, so there is nothing
  probabilistic about the exclusion.
- Reporting no longer uses a GitHub check run at all. The workflow posts
  a GitHub commit **status** to the PR's own head sha, resolved once via
  `gh pr view` regardless of which event (`pull_request` or
  `issue_comment`) triggered the run. `pending` is posted before the
  script runs; `success`/`failure` after. One reporting channel — not a
  check run and a status both encoding "did this pass" (architect's first
  objection to option A, closed). A job that dies mid-run leaves the
  status `pending`, which blocks merge instead of going silent
  (architect's second objection, closed — this is a property of the
  workflow's three-step shape, not something a job that always exits 0
  could provide).
- `issue_comment` (with its job-level `if:` guard) is back alongside
  `pull_request`, since a comment — not `pull_request` — is what carries
  the claim now.

## Changes (current script/workflow/docs state)

- `scripts/check_tests_read_names_its_tree.py`
  - `evaluate(pr)` reads `pr["comments"]` again (not `pr["body"]`); each
    comment's body is reduced to its **first line** (`_first_line`)
    before either the marker check or `find_note_shas` ever see it.
  - `find_note_shas`'s parameter is `note_line` (a first line, not a
    whole comment body).
  - `fetch_pr` no longer fetches or returns `body` — unused now.
  - SHA membership against this PR's own commits, `_SHA_FALSE_FRIENDS`,
    `tests_commits_after`'s dating logic (2-arg, no `head` parameter —
    unrelated pyright fix from an earlier round, kept), the
    `commit_touched_paths` runner seam, the refusal to pass on an empty
    commit list, and the deliberate exclusion of `headRefOid` from the
    membership list are all UNCHANGED from #5039's original design.
  - Module docstring and `evaluate()`'s own docstring rewritten:
    present-tense mechanism, the measurements that justify each design
    choice (including the #5144-reproduction measurement below), and the
    two prior, retracted shapes named as history (not left as the current
    description). The "what a green return means" paragraph is retargeted:
    the reason authorship can't be established is now that every session
    here authenticates as the same `gh` user (house rule preamble /
    pr-workflow.md), not "the body is multi-purpose" — comments don't fix
    that reason either.
- `.github/workflows/check-tests-read-names-its-tree.yml`
  - `issue_comment: [created, edited]` restored, with the job-level `if:`
    guard for plain issues.
  - Three-step status shape: resolve PR number + head sha via `gh pr
    view` → post `pending` → run the script → `if: always()` post
    `success`/`failure` based on `steps.check.outcome`.
  - `permissions:` gains `statuses: write`; `contents: read` /
    `pull-requests: read` kept (checkout + `gh pr view`/`gh api` still
    need them).
  - Single fixed `STATUS_CONTEXT` env var used by both status posts.
  - No-checkout-of-the-PR shape and its security comment kept.
- `CLAUDE.md` rule 8: claim now described as a comment's first line
  (marker + head SHA together; grounds from line 2 on). `wc -w CLAUDE.md`
  → **2057** words.
- `docs/deep-dives/contributing/pr-workflow.md` §8: the #5138 paragraph
  rewritten to describe both rounds (retracted body attempt, then the
  current comment/first-line/status design) as history, and the #5120
  paragraph's "wired as its own `pull_request`" restored to
  "`pull_request`/`issue_comment`" (it always was both, until the
  retracted round briefly removed `issue_comment`).
- `tests/scripts/test_check_tests_read_names_its_tree_5039.py` rebuilt
  around the architect's four acceptance cases (see Test plan). Fixtures
  moved back from `body=` to `comments=`.

## History — what actually happened on this PR (kept, not edited)

**Round 1 (option B, architect ruling issuecomment-5383118933):** the
claim line moved into the PR body. Rationale and verification for that
round are preserved unedited below the `---` divider, including the
now-superseded blocking-point exchange.

**Round 2 (retraction, architect comment 5383200442):** architect
reproduced a false green on THIS PR — the body describes the gate (so
`TESTS-READ` appears in prose many times over) and a reviewer
blocking-point checkbox happened to quote a real commit of this PR
(`9cc100605`) elsewhere in that same document. Marker + a
membership-passing SHA anywhere in one multi-purpose document was
enough; nothing was reviewed. Retracted reasoning: "a PR body is one
document with many purposes... a comment is one document with one
purpose." This is the SAME shape as the already-closed authorship
finding, one level down: not just "a green doesn't prove a reviewer
wrote it" but "a green didn't even need a claim, only incidental
prose" — see the second (previously unaddressed) blocking-point item
below, now addressed by this round's rework.

**Round 3 (this round, option A with two fixes):** implemented above.

## Verification against reality (not merged, no write actions taken)

```
$ python scripts/check_tests_read_names_its_tree.py --pr 5144
RED — a TESTS-READ note landed, but none of them names a commit of
  this PR. Add the head you read (e.g. `TESTS-READ (B) (head abc1234)`),
  on the SAME first line as the marker.
  An issue-comment id is not a tree name — it is hex-shaped, and this
  gate's first live run mistook one for a SHA.
  Without it, nothing can tell whether the note is a claim about THIS tree.

$ python scripts/check_tests_read_names_its_tree.py --pr 5145
OK — a TESTS-READ note names 36fe599dde, and no commit has
  touched tests/ since it.
```

`--pr 5144` (this PR) is correctly RED under the reworked script: the
`docs-maintainer` comment's first line carries the marker with no SHA,
and the `architect` comment's TESTS-READ claim line does carry a head SHA
(`36fe599dde` — from a DIFFERENT PR, #5145) that is not a commit of THIS
PR, so it fails membership rather than passing on an unrelated SHA. No
comment on this PR yet satisfies the new predicate — the false green from
round 2 is gone, and it stayed gone for the right reason (membership),
not by accident. `--pr 5145` (a live, separate, `tests/`-touching PR
whose note is a comment) confirms the accept path still works: its
`architect` comment's first line is
`**[architect]** — ⚪ TESTS-READ（A: 設計適合）(head \`36fe599dde\`)`, and
that sha is genuinely one of #5145's own commits with no `tests/` commit
after it.

## Bootstrap note (unchanged in substance, relocated)

This PR touches `tests/` and therefore needs its own TESTS-READ note
under house rule 8 — and per the current rule, that note's claim line
must be a COMMENT's first line (not this body, and not buried past line
1 of a comment). Per the coordinator's explicit instruction this round,
**no claim line has been added by this session** — a reviewer will add
one.

## Test plan

- [x] `ruff check .` — All checks passed!
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_tests_read_names_its_tree_5039.py` — 16/16 OK, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py scripts/check_tests_read_names_its_tree.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK: 201 findings, all baselined (207 declared)
- [x] `python scripts/flat_tests_ratchet.py` — OK: 1 flat files, all baselined (1 declared)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK: 111 reference(s), all baselined (121 declared)
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python -m pytest tests/scripts/test_check_tests_read_names_its_tree_5039.py -q` — 16 passed
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (docs/ changed); pre-existing INFO-level ja-mirror anchor gaps only, none introduced by this PR
- [x] `python scripts/check_doc_anchors.py` — exit 0, "no dangling anchors into published pages" (pre-existing warnings unrelated to this PR)
- [x] Live verification (read-only): `--pr 5144` and `--pr 5145`, output above
- [x] Acceptance ③ (job dying mid-run leaves the status `pending`) is a
      property of the workflow's three-step shape and was **not**
      exercised by any test — said so plainly in the test file's own
      docstring rather than writing something that would pass vacuously.
      Not exercised live either (would require killing an in-flight
      Actions run against this PR, which was not done).
- [x] (skipped — no UI change)

## Not done / limits

- Did not touch `check_pr_closing_intent.py` or any other workflow — out
  of scope.
- Acceptance ③ is untested by design (see Test plan) — the coordinator's
  brief explicitly asked to say so rather than fake coverage.
- Did not trigger a live GitHub Actions run of the reworked workflow
  against this PR (it is unmerged; verification was via unit tests and
  `--pr` against two real PRs instead).


## Round 4 (docstring reframe, commit 00101b617)

Coordinator blocking point: the module docstring's "Rev 1 / Rev 2, both
measured wrong" framing was a changelog living in source -- the same
class the repo owner had 11 lines removed from `profile.py`/`session.py`
for, hours earlier. Fixed by framing, not deletion (comment policy's
K-inline class covers this content and says it stays inline): dropped
all chronology and ordering language; kept every rejected alternative as
a present-tense claim about the design (why the claim isn't read from
anywhere in a comment, why it isn't read from the PR body, the 4/4
issue_comment-sha measurement). Also reframed the equivalent phrase in
the test file's own module docstring.

**Gap found and reported, not fixed here (out of scope for this PR):**
re-ran `verify_module_docstrings.py` against BOTH the old Rev-1/Rev-2
text and the new text -- it passes both. That gate's own docstring says
its scope is deliberately narrow: an extract/move/split verb pointing at
a source module/file/"god-file"/"decomposition". A Rev-1/Rev-2-style
chronology that isn't phrased as a module *extraction* is outside that
pattern, so the gate does not catch this shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---

## History: round 1 body (unedited below this point except the blocking-point checkboxes, which are now resolved)

**[lead-coder]** — part of #5138

Option B from the architect's ruling (issuecomment-5383118933): the
TESTS-READ note's **claim line** (e.g. `TESTS-READ (B) (head abc1234)`)
now has to land in the PR **body**, not a comment. The note's **grounds**
(the four-section reviewer write-up: six-questions answers, scope,
limits) stay in a comment — only the one-line claim relocated.

Reason (measured, from #5138): GitHub attaches a check run to the sha its
*triggering event* carries. `issue_comment` (fired when a comment is
posted) carries the **default branch's** sha, not the PR's head, so a run
it starts can never land on the PR's own check rollup. 4 of 4 PRs whose
TESTS-READ note arrived as a comment (#5127, #5128, #5132, #5136) stayed
red until a human re-ran the workflow by hand. `pull_request: edited`
(fired on a body edit) carries the PR's own head, so the check lands
where it needs to.

Option A (a commit status on the PR head sha) was rejected by the
architect for two reasons preserved in `scripts/check_tests_read_names_its_tree.py`'s
docstring/comments: (1) it gives one fact two reporting channels — check
run + commit status — the exact class the repo spent an evening closing;
(2) it requires the job to always exit 0, so a dying job produces neither
red nor green but silence.

**⚠️ This section describes a design this PR no longer implements — see
"What (reworked)" above.**

### 🔴 Reviewer's blocking point (lead-coder)

- [x] 🔴 **Moving the claim from a comment to the body moves it onto the side rule 8 exists to check.** A comment has an author; a body line does not. Before this PR, the artifact the gate counted was written by a *reviewer* — weak evidence, but evidence. After it, the artifact is the PR description, which the **author** writes and edits freely, so a `tests/`-touching PR can go green with no reviewer having read anything. The docstring names only the narrower variant ("an author can edit the body to swap in a newer SHA"); it does not say that the authorship signal is now **gone**. This is the "a discriminator a trust decision reads must not come from the side being classified" shape. Record it: state plainly, in `evaluate`'s own docstring or beside `_NOTE_MARKER`, that this gate establishes *the claim names this tree* and **not** *a reviewer made it* — and that rule 8's reviewer requirement rests on people, not on this check. Do not add machinery to try to prove authorship (a text predicate cannot), and do not soften it into "the author is trusted". Addressed in commit 9cc100605 (round 1): the module docstring's "Deliberately NOT closed" paragraph and `evaluate`'s own docstring both stated plainly that a green return means "a claim names this tree", never "a reviewer made the claim". **Superseded in round 3**: the same statement now lives in the docstring, retargeted to the real reason (same `gh` user for every session), since the body-vs-comment distinction this checkbox was reasoning about no longer applies.

- [x] 🔴 **This PR's own body already passes this PR's own gate, with no reviewer involved.** Reproduced against the real PR:

  ```
  $ python3 <this PR's script> --pr 5144
  OK — a TESTS-READ note names 9cc100605, and no commit has
    touched tests/ since it.
  exit=0
  ```

  Nothing was reviewed. The body *describes* the gate (so `TESTS-READ` appears in prose many times over) and the reviewer-blocking-point checkbox happens to quote commit `9cc100605`. Marker + a membership-passing SHA anywhere in the same document is enough, so the two collided. A comment was a separate artifact; the body is where a PR explains itself, so a PR that touches this gate necessarily writes prose that matches it.

  This is not the same as the authorship point above (already closed) — that one said a green is not evidence a reviewer wrote the claim. This one says a green needs **no claim at all**, only incidental prose. Note that the current check on this PR is GREEN for exactly this reason, so the gate is currently lying about itself.

  **Do not design the fix here.** The ruling that moved the claim into the body is architect's (#5138); a defect found by running it goes back to them. Tightening the predicate (a line-leading marker with the SHA on that same line, say) is one candidate, but it reduces rather than removes self-reference, and that judgement is not mine to make alone.

  **Resolved in round 3**: architect retracted option B on this exact finding (comment 5383200442) and ruled option A (comment claim, first line only, reported via commit status) instead — implemented above. `--pr 5144` against the reworked script now reads RED (see "Verification against reality" above), for the correct reason (no comment's first line names a commit of this PR).


- [x] 🔴 **The module docstring now carries a changelog.** Verbatim on `19141d93e`: *"This shape had two earlier revisions, both measured wrong: — **Rev 1 (this file's own #5039 history)** … — **Rev 2 (#5138, briefly)** …"*. That is change history in source, which the repo owner ruled against in strong terms earlier today (11 lines of the same shape were removed from `profile.py`/`session.py` in #5112). **Do not delete the substance** — `comments.md` classes it K-inline (*"why something was NOT done / a hypothesis that was measured and rejected"*, **never moves, fixed inline**), and the measurement that a body-based predicate goes green on its own descriptive prose is the strongest justification this design has. Fix the framing: drop the chronology (`Rev 1`/`Rev 2`/"earlier revisions"/"briefly") and state each rejected alternative as a present-tense claim about the design — why the claim line is not read from anywhere in a comment, and why it is not read from the PR body — so a reader learns which alternatives are excluded and why, and nothing about the order this file was written in.


