### PR TITLE
fix(#5133): cross-agent /attach migrates this connection's SurfaceManager

### DIFF
--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -1064,6 +1064,70 @@ async def agui_submit(request: Request, agent_name: str):
         if target and registry.exists(target):
             target_session = await registry.attach(target)
             attached = True
+
+            # #5133 (architect ruling): this connection's SurfaceManager
+            # registration is a SEPARATE holder from the hub notify below —
+            # #5129 fixed WHICH agent name `agui_submit`/`agui_seize` ask,
+            # but neither of them registers this connection as a surface of
+            # the TARGET's own manager, so `/seize` 409s and a HITL answer's
+            # `is_active_driver` check reads the wrong (empty, or someone
+            # else's) surface set. No new semantics: a cross-agent /attach
+            # IS this connection's SurfaceManager attach(target) +
+            # detach(old), the same two primitives connect/disconnect
+            # already use (mirrors #5118's own "one mechanism, two
+            # producers, not two mechanisms" — reusing agui_events'/gen's
+            # own attach/detach side effects here rather than inventing a
+            # third "migrated" state).
+            #
+            # Order: ARRIVAL before DEPARTURE (architect, citing #3310 N3's
+            # own "the announce is enqueued BEFORE _bind" barrier) — the
+            # reverse would leave a window where this connection belongs to
+            # NO manager, and anything arriving in that window (a seize, an
+            # answer) has no surface to resolve against.
+            #
+            # (a) driver token: NEVER carried across. `SurfaceManager.
+            # attach` already encodes the right default (first surface on
+            # an otherwise-empty manager takes the token; an existing
+            # holder keeps it) — calling it unchanged on the target IS the
+            # "arrival competes normally, never seizes" rule, not a special
+            # case for it. `detach` on the old manager releases the token
+            # if this connection held it (a departure, same as a genuine
+            # disconnect) — regaining control post-attach is `/seize`,
+            # exactly the existing path, client-decided, never automatic.
+            new_manager = _surface_manager(target, auth)
+            now = monotonic()
+            new_first = not new_manager.has_surfaces()
+            new_manager.attach(connection_id, identity.user_id, now)
+            if new_first:
+                target_session.register_intervention_listener(AGUI_OPERATOR_CHANNEL)
+            target_session.emit_audit_event(
+                "client_attached",
+                auth_user_id=identity.user_id,
+                auth_connection_id=connection_id,
+                auth_tier=identity.tier.value,
+            )
+            _ensure_fail_close_driver(target, new_manager, registry)
+
+            # (b)/(c): the OLD agent's manager treats this exactly like an
+            # ordinary disconnect — no "special because it's a migration"
+            # branch (architect: that would give the same end state two
+            # arrival paths, only one of which gets fixed by a future
+            # change). `agent_name` here is still #5129's OWN resolution
+            # (the connection's agent BEFORE this attach), captured before
+            # `target` shadows it below.
+            old_manager = surface_registry().get(agent_name)
+            if old_manager is not None and old_manager is not new_manager:
+                old_session = await registry.ensure_running(agent_name)
+                old_manager.detach(connection_id, now)
+                if not old_manager.has_surfaces():
+                    old_session.unregister_intervention_listener(AGUI_OPERATOR_CHANNEL)
+                    _ensure_fail_close_driver(agent_name, old_manager, registry)
+                old_session.emit_audit_event(
+                    "client_detached",
+                    auth_user_id=identity.user_id,
+                    auth_connection_id=connection_id,
+                )
+
             # #5116 (architect co-vet, issuecomment-5380501066): this POST
             # is a DIFFERENT HTTP request than the SSE stream it needs to
             # retarget — correlated only by ``connection_id`` (the

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -1083,7 +1083,14 @@ async def agui_submit(request: Request, agent_name: str):
             # own "the announce is enqueued BEFORE _bind" barrier) — the
             # reverse would leave a window where this connection belongs to
             # NO manager, and anything arriving in that window (a seize, an
-            # answer) has no surface to resolve against.
+            # answer) has no surface to resolve against. This ordering's
+            # own consequence (architect co-vet): between `new_manager.
+            # attach` below and `old_manager.detach` further down, this
+            # connection briefly belongs to BOTH managers (the `await
+            # registry.ensure_running` in between yields the event loop).
+            # A concurrent HITL answer landing in that window is rejected
+            # by delivery-time re-authorization, not misdelivered — the
+            # safe default, not a bug.
             #
             # (a) driver token: NEVER carried across. `SurfaceManager.
             # attach` already encodes the right default (first surface on
@@ -1115,18 +1122,39 @@ async def agui_submit(request: Request, agent_name: str):
             # change). `agent_name` here is still #5129's OWN resolution
             # (the connection's agent BEFORE this attach), captured before
             # `target` shadows it below.
+            # lead-coder co-vet (issuecomment-5383186154): the prior draft
+            # `await`ed `registry.ensure_running(agent_name)` here — an
+            # exception/cancellation crossing that await between arrival
+            # (above) and this detach would leave this connection
+            # registered in BOTH managers FOREVER (detach never runs), so
+            # the old manager keeps counting a surface that already left;
+            # if it was the last real one, grace never arms — fail-close
+            # silently fails OPEN. `registry.get_session` (sync,
+            # non-loading, `None` if not currently running) removes that
+            # window entirely — no await between attach and detach means
+            # no suspension point for a cancellation to land in. (This
+            # request's own earlier, UNRELATED `session = await registry.
+            # ensure_running(agent_name)` — shared by every non-heartbeat/
+            # non-answer ptype, attach_request included — already booted
+            # the old agent by the time execution reaches here regardless;
+            # this change is about not adding a SECOND boot + a new crash
+            # window on top of that, not about whether the old agent ends
+            # up running.) `old_manager.detach`/`_ensure_fail_close_driver`
+            # never needed a session at all.
             old_manager = surface_registry().get(agent_name)
             if old_manager is not None and old_manager is not new_manager:
-                old_session = await registry.ensure_running(agent_name)
                 old_manager.detach(connection_id, now)
+                old_session = registry.get_session(agent_name)
                 if not old_manager.has_surfaces():
-                    old_session.unregister_intervention_listener(AGUI_OPERATOR_CHANNEL)
+                    if old_session is not None:
+                        old_session.unregister_intervention_listener(AGUI_OPERATOR_CHANNEL)
                     _ensure_fail_close_driver(agent_name, old_manager, registry)
-                old_session.emit_audit_event(
-                    "client_detached",
-                    auth_user_id=identity.user_id,
-                    auth_connection_id=connection_id,
-                )
+                if old_session is not None:
+                    old_session.emit_audit_event(
+                        "client_detached",
+                        auth_user_id=identity.user_id,
+                        auth_connection_id=connection_id,
+                    )
 
             # #5116 (architect co-vet, issuecomment-5380501066): this POST
             # is a DIFFERENT HTTP request than the SSE stream it needs to

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -1083,14 +1083,12 @@ async def agui_submit(request: Request, agent_name: str):
             # own "the announce is enqueued BEFORE _bind" barrier) — the
             # reverse would leave a window where this connection belongs to
             # NO manager, and anything arriving in that window (a seize, an
-            # answer) has no surface to resolve against. This ordering's
-            # own consequence (architect co-vet): between `new_manager.
-            # attach` below and `old_manager.detach` further down, this
-            # connection briefly belongs to BOTH managers (the `await
-            # registry.ensure_running` in between yields the event loop).
-            # A concurrent HITL answer landing in that window is rejected
-            # by delivery-time re-authorization, not misdelivered — the
-            # safe default, not a bug.
+            # answer) has no surface to resolve against. Every statement
+            # from `new_manager.attach` below through `old_manager.detach`
+            # further down runs without an `await` — a single-threaded
+            # event loop gives nothing else a chance to run in between, so
+            # this connection is never observably attached to both
+            # managers at once either.
             #
             # (a) driver token: NEVER carried across. `SurfaceManager.
             # attach` already encodes the right default (first surface on

--- a/tests/interfaces/test_5129_submit_follows_connection_agent.py
+++ b/tests/interfaces/test_5129_submit_follows_connection_agent.py
@@ -54,7 +54,16 @@ _CONNECTION_ID = "conn-5129-test"
 _OTHER_CONNECTION_ID = "conn-5129-untouched"
 
 
-def _two_agent_registry(tmp_path, monkeypatch):
+def _two_agent_registry(tmp_path, monkeypatch, origin_name: str, target_name: str):
+    """*origin_name*/*target_name* are per-TEST-unique (#5133's own
+    discipline, `test_5133_surface_migrates_on_cross_agent_attach.py`):
+    since #5133, a cross-agent ``attach_request`` touches the process-
+    global ``surface_registry()`` singleton (keyed by agent name) for BOTH
+    names — a literal "default"/"coder-smith" shared across this file's OWN
+    multiple test functions left driver-token/surface-count state from one
+    test bleeding into the next (measured: `test_answer_after_cross_agent_
+    attach_resolves_against_the_target_session` started 409ing once #5133
+    landed, purely from test run order, not from anything this PR broke)."""
     monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / "state.wal")
     (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
@@ -71,7 +80,8 @@ def _two_agent_registry(tmp_path, monkeypatch):
         project_root=tmp_path, session_factory=_factory, state_log=state_log,
     )
     holder["reg"] = reg
-    reg.create("coder-smith")
+    reg.create(origin_name)
+    reg.create(target_name)
     return reg
 
 
@@ -111,37 +121,38 @@ async def test_submit_after_cross_agent_attach_reaches_the_target_not_the_url_ag
     """Tier 2: #5129 witness — a ``user_message`` POSTed to the connection's
     ORIGINAL URL, after a real cross-agent ``attach_request`` on that same
     connection_id, must produce a ``user_submitted`` audit-event on the
-    TARGET session — and NONE on the original ``default`` session (a
+    TARGET session — and NONE on the original agent's session (a
     one-sided check would pass on "arrives everywhere")."""
-    reg = _two_agent_registry(tmp_path, monkeypatch)
-    default_session = await reg.attach("default")
+    origin, target = "5129-t1-origin", "5129-t1-target"
+    reg = _two_agent_registry(tmp_path, monkeypatch, origin, target)
+    origin_session = await reg.attach(origin)
     app = _build_app(reg, monkeypatch)
 
-    default_events = _collect_events(default_session)
+    origin_events = _collect_events(origin_session)
 
-    # The already-open stream: bound to "default", listening for a
+    # The already-open stream: bound to the origin agent, listening for a
     # cross-agent retarget under ITS OWN connection id — same server-side
     # state a --connect client's SSE GET leaves behind.
-    source = _SessionFrameSource(default_session, registry=reg, agent_name="default")
+    source = _SessionFrameSource(origin_session, registry=reg, agent_name=origin)
     source.listen_for_retarget(_CONNECTION_ID)
     source.start()
 
     try:
         resp = await _post(
-            app, f"/agui/chat/default?connection_id={_CONNECTION_ID}&token=s3cret",
-            {"type": "attach_request", "agent_name": "coder-smith"},
+            app, f"/agui/chat/{origin}?connection_id={_CONNECTION_ID}&token=s3cret",
+            {"type": "attach_request", "agent_name": target},
         )
         assert resp.json().get("attached") is True
 
-        target_session = reg.get_session("coder-smith", "main")
+        target_session = reg.get_session(target, "main")
         target_events = _collect_events(target_session)
 
-        # The client's own SSE URL never changes — it keeps POSTing to
-        # "default", exactly the owner's own live setup (attach switches,
-        # the connect URL does not).
+        # The client's own SSE URL never changes — it keeps POSTing to the
+        # ORIGIN agent's URL, exactly the owner's own live setup (attach
+        # switches, the connect URL does not).
         submit_resp = await _post(
-            app, f"/agui/chat/default?connection_id={_CONNECTION_ID}&token=s3cret",
-            {"type": "user_message", "text": "hello coder-smith"},
+            app, f"/agui/chat/{origin}?connection_id={_CONNECTION_ID}&token=s3cret",
+            {"type": "user_message", "text": "hello target"},
         )
         assert submit_resp.status_code == 200
         assert submit_resp.json().get("status") == "ok"
@@ -151,16 +162,16 @@ async def test_submit_after_cross_agent_attach_reaches_the_target_not_the_url_ag
         source.close()
 
     target_submits = [e for e in target_events if getattr(e, "type", "") == "user_submitted"]
-    default_submits = [e for e in default_events if getattr(e, "type", "") == "user_submitted"]
+    origin_submits = [e for e in origin_events if getattr(e, "type", "") == "user_submitted"]
 
     assert target_submits, (
         "the target agent's own session never saw the submit -- input is "
         "still reaching the connection's ORIGINAL agent after attach"
     )
-    assert target_submits[0].data.get("text") == "hello coder-smith"
-    assert not default_submits, (
+    assert target_submits[0].data.get("text") == "hello target"
+    assert not origin_submits, (
         f"the ORIGINAL agent's session ALSO saw a user_submitted event "
-        f"({default_submits!r}) -- the submit is landing in two places, "
+        f"({origin_submits!r}) -- the submit is landing in two places, "
         f"not exclusively at the attached target"
     )
 
@@ -175,27 +186,28 @@ async def test_a_connection_that_never_attached_still_submits_to_its_own_url_age
     Pins the ``subscribe``-time seed: without it this connection would read
     as "unknown" and depend entirely on the URL fallback happening to be
     right, rather than the hub genuinely tracking it from the start."""
-    reg = _two_agent_registry(tmp_path, monkeypatch)
-    default_session = await reg.attach("default")
+    origin, target = "5129-t2-origin", "5129-t2-target"
+    reg = _two_agent_registry(tmp_path, monkeypatch, origin, target)
+    origin_session = await reg.attach(origin)
     app = _build_app(reg, monkeypatch)
-    default_events = _collect_events(default_session)
+    origin_events = _collect_events(origin_session)
 
-    source = _SessionFrameSource(default_session, registry=reg, agent_name="default")
+    source = _SessionFrameSource(origin_session, registry=reg, agent_name=origin)
     source.listen_for_retarget(_OTHER_CONNECTION_ID)
     source.start()
 
     try:
         resp = await _post(
-            app, f"/agui/chat/default?connection_id={_OTHER_CONNECTION_ID}&token=s3cret",
-            {"type": "user_message", "text": "still default"},
+            app, f"/agui/chat/{origin}?connection_id={_OTHER_CONNECTION_ID}&token=s3cret",
+            {"type": "user_message", "text": "still origin"},
         )
         assert resp.status_code == 200
         await asyncio.sleep(0)
     finally:
         source.close()
 
-    default_submits = [e for e in default_events if getattr(e, "type", "") == "user_submitted"]
-    assert default_submits and default_submits[0].data.get("text") == "still default"
+    origin_submits = [e for e in origin_events if getattr(e, "type", "") == "user_submitted"]
+    assert origin_submits and origin_submits[0].data.get("text") == "still origin"
 
 
 @pytest.mark.asyncio
@@ -209,34 +221,41 @@ async def test_answer_after_cross_agent_attach_resolves_against_the_target_sessi
     first test), a HITL answer POSTed to the connection's original URL after
     a cross-agent attach must resolve against the TARGET session's own
     pending intervention — the #5050/#5064 regression surface architect
-    named."""
-    reg = _two_agent_registry(tmp_path, monkeypatch)
-    default_session = await reg.attach("default")
+    named. This connection is the TARGET's only surface (a fresh, unique
+    agent pair for this test, #5133's own discipline) so it genuinely takes
+    the driver token on arrival (`SurfaceManager.attach`'s existing
+    first-surface rule) — the scenario architect flagged as the ONE #5129
+    itself can claim; the "another connection already holds the target's
+    driver" scenario is `test_5133_surface_migrates_on_cross_agent_attach.
+    py`'s own acceptance ① (seize, not an automatic answer)."""
+    origin, target = "5129-t3-origin", "5129-t3-target"
+    reg = _two_agent_registry(tmp_path, monkeypatch, origin, target)
+    origin_session = await reg.attach(origin)
     app = _build_app(reg, monkeypatch)
 
-    target_session = await reg.ensure_running("coder-smith")
+    target_session = await reg.ensure_running(target)
     target_session.register_intervention_listener("tui")
     iv = UserIntervention(kind="ask_user", prompt="proceed?", run_id="r1")
     iv.future = asyncio.get_running_loop().create_future()
     iv_task = asyncio.ensure_future(target_session._dispatch_intervention(iv))
     await wait_until(lambda: bool(target_session.interventions.list_active()))
 
-    source = _SessionFrameSource(default_session, registry=reg, agent_name="default")
+    source = _SessionFrameSource(origin_session, registry=reg, agent_name=origin)
     source.listen_for_retarget(_CONNECTION_ID)
     source.start()
 
     try:
         resp = await _post(
-            app, f"/agui/chat/default?connection_id={_CONNECTION_ID}&token=s3cret",
-            {"type": "attach_request", "agent_name": "coder-smith"},
+            app, f"/agui/chat/{origin}?connection_id={_CONNECTION_ID}&token=s3cret",
+            {"type": "attach_request", "agent_name": target},
         )
         assert resp.json().get("attached") is True
 
-        # Still POSTed to the connection's ORIGINAL URL ("default"), and
-        # naming the pending intervention's real id — exactly what a real
-        # remote client's answer_intervention_text round-trip sends.
+        # Still POSTed to the connection's ORIGINAL URL, and naming the
+        # pending intervention's real id — exactly what a real remote
+        # client's answer_intervention_text round-trip sends.
         answer_resp = await _post(
-            app, f"/agui/chat/default?connection_id={_CONNECTION_ID}&token=s3cret",
+            app, f"/agui/chat/{origin}?connection_id={_CONNECTION_ID}&token=s3cret",
             {"type": "TOOL_CALL_RESULT", "toolCallId": iv.id, "text": "yes, proceed"},
         )
         assert answer_resp.json().get("answered") is True, answer_resp.json()
@@ -262,8 +281,9 @@ async def test_attach_request_for_a_connection_with_no_open_sse_stream_leaves_no
     unbounded dict keyed by a value the client fully controls. Sent 3 times
     (not once) to pin "does not accumulate", not just "doesn't fail once".
     """
-    reg = _two_agent_registry(tmp_path, monkeypatch)
-    await reg.attach("default")
+    origin, target = "5129-t4-origin", "5129-t4-target"
+    reg = _two_agent_registry(tmp_path, monkeypatch, origin, target)
+    await reg.attach(origin)
     app = _build_app(reg, monkeypatch)
     orphan_connection_id = "conn-5129-no-sse-ever"
 
@@ -277,8 +297,8 @@ async def test_attach_request_for_a_connection_with_no_open_sse_stream_leaves_no
     for _ in range(3):
         resp = await _post(
             app,
-            f"/agui/chat/default?connection_id={orphan_connection_id}&token=s3cret",
-            {"type": "attach_request", "agent_name": "coder-smith"},
+            f"/agui/chat/{origin}?connection_id={orphan_connection_id}&token=s3cret",
+            {"type": "attach_request", "agent_name": target},
         )
         assert resp.json().get("attached") is True  # the attach itself still succeeds
 

--- a/tests/interfaces/test_5133_surface_migrates_on_cross_agent_attach.py
+++ b/tests/interfaces/test_5133_surface_migrates_on_cross_agent_attach.py
@@ -1,0 +1,309 @@
+"""Tier 2: #5133 — a cross-agent ``/attach`` migrates this connection's
+``SurfaceManager`` registration, not just #5129's own "which agent name to
+ask" fact.
+
+#5129 fixed `agui_submit`/`agui_seize` to resolve `agent_name` from the
+connection instead of trusting their own URL path param. That closed the
+plain "input reaches the wrong agent" symptom, but left a SEPARATE holder
+untouched: `SurfaceRegistry.get(agent_name)` only returns a manager for an
+agent that has had an actual connection `attach()`ed to it (done only by
+`agui_events` at SSE-connect time) — a cross-agent `/attach` never
+re-registered this connection there, so `/seize` 409ed (unknown surface) and
+a HITL answer's `is_active_driver` check read whichever OTHER connection
+(if any) was already registered on the target.
+
+Architect ruling (issuecomment-5383089515, #5133): no new semantics — a
+cross-agent `/attach` IS `SurfaceManager.attach(target)` + `detach(old)`,
+the SAME two primitives `agui_events`' own connect/disconnect already use
+(mirrors #5118's "one mechanism, two producers, not two mechanisms").
+ARRIVAL before DEPARTURE (never a window where this connection belongs to
+no manager). The driver token is NEVER carried across — `attach()`'s own
+existing default (first surface on an empty manager takes it; an existing
+holder keeps it) already IS the right rule, so calling it unchanged is the
+fix, not a special case. The old agent's fail-close grace treats this
+exactly like an ordinary disconnect (arms only if this was its last
+surface); the target's treats arrival exactly like an ordinary connect
+(disarms an already-armed grace) — no "migration is special" branching on
+either side, architect's own explicit warning against giving the same end
+state two arrival paths.
+
+4 acceptance witnesses (architect's own ruling, each separate, never
+derived from a symptom):
+1. the target already has another driver -> the migrated connection does
+   NOT become driver, but an explicit /seize afterwards succeeds (ordinary
+   symmetric contention, not automatically stolen).
+2. the old agent still has another connection watching it -> its
+   fail-close grace is NOT armed by the migration.
+3. the old agent's LAST connection migrates away -> its grace arms
+   IDENTICALLY to an ordinary disconnect (measured in the SAME test, same
+   grace_seconds, same SurfaceManager class, against a real plain
+   disconnect for comparison — not just "does something get armed").
+4. the target's ALREADY-armed grace (its own last surface had already left)
+   is disarmed by the arriving connection, exactly like any ordinary
+   connect.
+
+Chains the real wire pieces (real ASGI POST -> real SurfaceManager/
+SurfaceRegistry -> real Session), mirroring
+test_5129_submit_follows_connection_agent.py's own harness. No mocks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.transport.agui.endpoint import _SessionFrameSource
+from reyn.interfaces.transport.agui.surface import monotonic, surface_registry
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _two_agent_registry(tmp_path, monkeypatch, origin_name: str, target_name: str):
+    """*origin_name*/*target_name* are per-TEST-unique (never "default" /
+    "coder-smith") -- ``surface_registry()`` is a process-global singleton
+    keyed by agent name (module-level ``_REGISTRY``, ``surface.py``), so a
+    literal shared across test functions in this file would carry leftover
+    surfaces from an earlier test into this one, exactly the false-red/
+    false-green trap this file's own tests exist to avoid in the endpoint
+    under test. Each test picks its own two names so this file's tests
+    cannot desync each other via that shared singleton."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+        )
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+    holder["reg"] = reg
+    reg.create(origin_name)
+    reg.create(target_name)
+    return reg
+
+
+def _build_app(reg, monkeypatch):
+    from fastapi import FastAPI
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+    from reyn.interfaces.transport.agui.endpoint import router
+    from reyn.interfaces.web.auth import AuthContext
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.auth = AuthContext(token="s3cret", require_token=True)
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: reg)
+    return app
+
+
+async def _post(app, path: str, payload: dict):
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        return await client.post(path, json=payload)
+
+
+def _authorized(user_id) -> bool:
+    return bool(user_id)
+
+
+@pytest.mark.asyncio
+async def test_migrating_into_a_manager_with_an_existing_driver_does_not_steal_it_but_seize_still_works(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: acceptance ① — architect's own explicit "arrival competes
+    normally, never seizes"."""
+    origin, target = "5133-t1-origin", "5133-t1-target"
+    reg = _two_agent_registry(tmp_path, monkeypatch, origin, target)
+    origin_session = await reg.attach(origin)
+    app = _build_app(reg, monkeypatch)
+
+    # connB: a SECOND, real connection already directly attached to the
+    # TARGET agent BEFORE connA migrates in -- it takes the driver token as
+    # any first surface would (SurfaceManager.attach's own existing rule).
+    mgr_target = surface_registry().for_agent(target, authorized=_authorized)
+    mgr_target.attach("conn-B", "userB", monotonic())
+    assert mgr_target.is_active_driver("conn-B")
+
+    conn_a = "conn-A-migrating"
+    mgr_origin = surface_registry().for_agent(origin, authorized=_authorized)
+    mgr_origin.attach(conn_a, "userA", monotonic())
+
+    source = _SessionFrameSource(origin_session, registry=reg, agent_name=origin)
+    source.listen_for_retarget(conn_a)
+    source.start()
+
+    try:
+        resp = await _post(
+            app, f"/agui/chat/{origin}?connection_id={conn_a}&token=s3cret",
+            {"type": "attach_request", "agent_name": target},
+        )
+        assert resp.json().get("attached") is True
+
+        # ① connA did NOT steal the token just by arriving.
+        assert mgr_target.is_active_driver("conn-B")
+        assert not mgr_target.is_active_driver(conn_a)
+
+        # An explicit /seize afterwards is the ordinary, un-special-cased
+        # contention path -- it succeeds because connA is now a genuinely
+        # registered surface of the target's own manager.
+        seize_resp = await _post(
+            app, f"/agui/chat/{origin}/seize?connection_id={conn_a}&token=s3cret", {},
+        )
+        assert seize_resp.status_code == 200
+        assert seize_resp.json().get("seized") is True
+        assert mgr_target.is_active_driver(conn_a)
+    finally:
+        source.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_does_not_arm_the_old_agents_grace_while_another_connection_remains(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: acceptance ② — the old agent still has a live watcher, so its
+    fail-close grace must NOT arm just because ONE connection left."""
+    origin, target = "5133-t2-origin", "5133-t2-target"
+    reg = _two_agent_registry(tmp_path, monkeypatch, origin, target)
+    origin_session = await reg.attach(origin)
+    app = _build_app(reg, monkeypatch)
+
+    conn_a = "conn-A-migrating"
+    conn_c = "conn-C-stays-on-origin"
+    mgr_origin = surface_registry().for_agent(origin, authorized=_authorized)
+    mgr_origin.attach(conn_a, "userA", monotonic())
+    mgr_origin.attach(conn_c, "userC", monotonic())
+
+    source = _SessionFrameSource(origin_session, registry=reg, agent_name=origin)
+    source.listen_for_retarget(conn_a)
+    source.start()
+
+    try:
+        resp = await _post(
+            app, f"/agui/chat/{origin}?connection_id={conn_a}&token=s3cret",
+            {"type": "attach_request", "agent_name": target},
+        )
+        assert resp.json().get("attached") is True
+
+        assert mgr_origin.surface_count() == 1, (
+            f"expected conn_a to have actually LEFT (only conn_c remaining), "
+            f"got {mgr_origin.surface_count()} surfaces -- a migration that "
+            f"never detaches conn_a would ALSO leave has_surfaces()/"
+            f"should_fail_close() looking exactly like this, so the count "
+            f"is the witness that departure genuinely happened, not just "
+            f"that grace happens not to be armed"
+        )
+        assert not mgr_origin.should_fail_close(monotonic() + mgr_origin.grace_seconds + 1.0), (
+            "the grace window armed even though another connection still "
+            "watches this agent -- a migration must not behave differently "
+            "from any other single-surface detach"
+        )
+    finally:
+        source.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_arms_the_old_agents_grace_identically_to_an_ordinary_disconnect(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: acceptance ③ — measured against a REAL plain disconnect in
+    the SAME test (architect: "if you claim 'the same', measure the
+    disconnect side with the same test too"), same grace_seconds, same
+    SurfaceManager class."""
+    origin, target = "5133-t3-origin", "5133-t3-target"
+    reg = _two_agent_registry(tmp_path, monkeypatch, origin, target)
+    origin_session = await reg.attach(origin)
+    app = _build_app(reg, monkeypatch)
+
+    conn_a = "conn-A-migrating"
+    mgr_origin = surface_registry().for_agent(origin, authorized=_authorized)
+    mgr_origin.attach(conn_a, "userA", monotonic())
+
+    source = _SessionFrameSource(origin_session, registry=reg, agent_name=origin)
+    source.listen_for_retarget(conn_a)
+    source.start()
+
+    try:
+        resp = await _post(
+            app, f"/agui/chat/{origin}?connection_id={conn_a}&token=s3cret",
+            {"type": "attach_request", "agent_name": target},
+        )
+        assert resp.json().get("attached") is True
+
+        assert not mgr_origin.has_surfaces(), "conn_a was the only surface"
+        past_grace = monotonic() + mgr_origin.grace_seconds + 1.0
+        assert mgr_origin.should_fail_close(past_grace), (
+            "migrating away the LAST surface must arm the grace window "
+            "exactly as an ordinary disconnect would"
+        )
+    finally:
+        source.close()
+
+    # The comparison: an UNRELATED agent's manager, one surface, an
+    # ORDINARY plain detach() (no attach_request, no /attach at all) --
+    # same grace_seconds (the manager's own default), same class, same
+    # `past_grace` offset. If migration's arming were somehow a DIFFERENT
+    # code path with different timing, this is where a divergence would
+    # show up.
+    mgr_plain = surface_registry().for_agent("5133-t3-plain-disconnect-control", authorized=_authorized)
+    mgr_plain.attach("conn-D-plain", "userD", monotonic())
+    mgr_plain.detach("conn-D-plain", monotonic())
+    assert not mgr_plain.has_surfaces()
+    assert mgr_plain.should_fail_close(monotonic() + mgr_plain.grace_seconds + 1.0), (
+        "sanity: an ordinary disconnect arms this exact same way -- "
+        "migration's own arming above is not a special, different timer"
+    )
+
+
+@pytest.mark.asyncio
+async def test_migration_disarms_the_targets_already_armed_grace(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: acceptance ④ — the target's grace was already armed (its
+    own last surface had already left); the arriving connection disarms it
+    exactly like any ordinary connect (SurfaceManager.attach's own existing
+    `self._last_empty_at = None`). No real waiting: `now` values are
+    supplied, never slept for."""
+    origin, target = "5133-t4-origin", "5133-t4-target"
+    reg = _two_agent_registry(tmp_path, monkeypatch, origin, target)
+    origin_session = await reg.attach(origin)
+    app = _build_app(reg, monkeypatch)
+
+    mgr_target = surface_registry().for_agent(target, authorized=_authorized)
+    mgr_target.attach("conn-D-left-already", "userD", monotonic())
+    mgr_target.detach("conn-D-left-already", monotonic())
+    armed_check_at = monotonic() + mgr_target.grace_seconds + 1.0
+    assert mgr_target.should_fail_close(armed_check_at), (
+        "setup sanity: the target's grace must be armed before the "
+        "arrival this test is actually about"
+    )
+
+    conn_a = "conn-A-migrating"
+    mgr_origin = surface_registry().for_agent(origin, authorized=_authorized)
+    mgr_origin.attach(conn_a, "userA", monotonic())
+
+    source = _SessionFrameSource(origin_session, registry=reg, agent_name=origin)
+    source.listen_for_retarget(conn_a)
+    source.start()
+
+    try:
+        resp = await _post(
+            app, f"/agui/chat/{origin}?connection_id={conn_a}&token=s3cret",
+            {"type": "attach_request", "agent_name": target},
+        )
+        assert resp.json().get("attached") is True
+
+        assert not mgr_target.should_fail_close(armed_check_at), (
+            "the arriving connection must disarm the target's already-"
+            "armed grace, exactly as an ordinary new connect would"
+        )
+    finally:
+        source.close()


### PR DESCRIPTION
**[tui-coder]** — Closes #5133 (architect ruling issuecomment-5383089515, following #5129/PR #5132's own disclosed limit).

## What

#5129 fixed `agui_submit`/`agui_seize` to resolve `agent_name` from the connection instead of trusting their own URL path param — closing the plain "input reaches the wrong agent" symptom. It left a separate holder untouched: `SurfaceRegistry.get(agent_name)` only returns a manager for an agent that has had an actual connection `attach()`ed to it (done only by `agui_events` at SSE-connect time). A cross-agent `/attach` never re-registered this connection there, so `/seize` 409ed and a HITL answer's `is_active_driver` check read whichever OTHER connection (if any) was already registered on the target — both measured live before this PR, not assumed.

## Fix (architect ruling — no new semantics)

A cross-agent `/attach` IS `SurfaceManager.attach(target)` + `detach(old)`, the SAME two primitives `agui_events`' own connect/disconnect already use (mirrors #5118's "one mechanism, two producers, not two mechanisms").

- **Order**: arrival before departure (cites #3310 N3's "the announce is enqueued BEFORE `_bind`") — the reverse leaves a window where this connection belongs to no manager.
- **Driver token**: never carried across. `attach()`'s own existing default (first surface on an empty manager takes it; an existing holder keeps it) already IS the right rule — calling it unchanged on the target is the fix, not a special case. Regaining control post-attach is `/seize`, the existing client-decided path, never automatic.
- **Fail-close grace**: the old agent's grace treats this exactly like an ordinary disconnect (arms only if this was its last surface); the target's treats arrival exactly like an ordinary connect (disarms an already-armed grace) — no "migration is special" branching on either side.

## Test plan

- [x] `tests/interfaces/test_5133_surface_migrates_on_cross_agent_attach.py` (4 tests, architect's own 4 acceptance criteria, each measured separately, never derived from a symptom):
  1. target already has another driver → migrated connection does NOT become driver, `/seize` afterwards succeeds (ordinary contention)
  2. old agent still watched by another connection → its grace does NOT arm (witnessed via `surface_count()`, not just `has_surfaces()`/`should_fail_close()` — those alone would ALSO pass if detach silently never happened, confirmed by my own strip)
  3. old agent's LAST connection migrates away → grace arms IDENTICALLY to a REAL plain disconnect measured in the SAME test
  4. target's ALREADY-armed grace is disarmed by the arriving connection, like any ordinary connect
- [x] Strip-falsified twice: whole migration block removed → all 4 fail; departure half alone disabled → exactly 2/3 fail (1/4 stay green — confirms independence, not "something happened"). Restored → green, `git diff` clean both times.
- [x] Also fixed `test_5129_submit_follows_connection_agent.py`'s own `"default"`/`"coder-smith"` literal agent names to per-test-unique pairs — `surface_registry()` is a process-global singleton keyed by agent name, and once `agui_submit`'s attach_request branch started touching it for both sides (this PR), that file's tests began leaking driver-token state into each other via those shared literals (measured directly: one of its own tests started 409ing purely from run order). Re-verified green in both file orders.
- [x] Full local gate (ruff / `test_tier_audit.py --strict` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`) — clean
- [x] Full sweep `tests/interfaces/ tests/web/`: 2096 passed, 9 skipped (pre-existing optional-dependency extras, unrelated)
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

⚠️ TESTS-READ note required (touches `tests/`).

part of #5116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

## 🔴 Reviewer's blocking points (lead-coder, issuecomment-5383186154)

- [x] 🔴 **An `await` sits between arrival and departure with nothing to unwind it.** The departure block opens with `old_session = await registry.ensure_running(agent_name)`; if that raises or the request is cancelled, the connection stays registered in BOTH managers and `detach` never runs. The old manager then still counts it as a surface, so the grace window does not arm when the last real operator surface is gone — a fail-close mechanism falling open. Arrival-before-departure is the right order, but it trades a belongs-to-no-manager window for a belongs-to-both window, and something has to close the second one.
- [x] 🔴 **Leaving an agent starts it.** `ensure_running` is called on the OLD agent solely to unregister an intervention listener and emit a detach audit-event — so attaching away from a stopped agent boots it, an effect nobody asked for and one that costs (band: cost/budget). A stopped agent has no listener to unregister and no "this connection left" worth recording. Read the session only if it is already running (`get_session`-style); `old_manager.detach` and `_ensure_fail_close_driver` need no session at all — which also removes the `await` behind the first point.

⚠️ Non-blocking, answer in the body: this migration lives in `agui_submit`'s `attach_request` branch only. If a cross-agent attach can arrive through any other door (`session_switch_request`, a REST attach, startup attach), those do not migrate. State the grounds for "one site is enough" — #5129 was the **8th** holder of "which agent is this connection on" precisely because nobody counted the doors.



---

**[tui-coder]** — both block points fixed, head `fe176ef02` (commit message has the full reasoning): `registry.get_session` (sync, non-loading) replaces the `await ensure_running` in the departure half -- no await between attach and detach means no cancellation window, and a stopped old agent is never booted just for this. Also added architect's requested 1-line clarification on the both-managers window.

**Non-blocking answer** — grepped the whole AG-UI endpoint module: `registry.attach(target)` (the cross-agent call) is invoked from exactly ONE site, `agui_submit`'s own `attach_request` branch (`endpoint.py:1065`). `session_switch_request` is a DIFFERENT operation (`registry.attach_session`, a same-agent session switch — no SurfaceManager migration needed, same agent = same manager already). The local CLI's own `registry.attach()` calls (`chat.py:119`/`853`) go through `InProcessTransport`, which has no `connection_id`/`SurfaceManager`/hub concept at all — a different transport, out of scope for this fix. There is no other AG-UI door that performs a cross-agent attach today; if one is added later, it needs this same migration (or to call this same code path), not a second copy of it.


- [x] 🔴 **The ordering comment still asserts an `await` that this PR removed.** On head `fe176ef02`, verbatim: *"between `new_manager.attach` below and `old_manager.detach` further down, this connection briefly belongs to BOTH managers (the `await registry.ensure_running` in between yields the event loop)"*. That `await` is gone — the fix for the first blocking point replaced it with the synchronous `registry.get_session`, and the block from `new_manager.attach` to `old_manager.detach` now contains no await at all. With no yield point, nothing can interleave there on a single-threaded event loop, so the both-managers window the paragraph describes does not open. The paragraph was true of the previous revision and is false of this one, in the same PR that made it false. Rewrite it to say what the code now does — the arrival-before-departure ordering and its reason stay; the yield-window consequence and the "a concurrent HITL answer landing in that window" sentence go, or are restated for whatever window genuinely remains. Do not add a note that it *used to* be there.



---

**[tui-coder]** — fixed, head `cd0a75fc7`: rewrote the comment to state the current, verified fact (no await anywhere between `new_manager.attach` and `old_manager.detach`, so nothing can interleave there on a single-threaded loop) — no "used to be" framing. Re-verified: ruff clean, all 8 tests green.

