### PR TITLE
fix(#5139): batch the remote backlog through the frame queue, not per-frame

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -65,7 +65,7 @@ from reyn.interfaces.repl.renderer import (
     summarize_tool_result,
 )
 from reyn.interfaces.transport.agui.state import RemoteQueueView
-from reyn.interfaces.transport.frames import FrameTag
+from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame, FrameTag
 
 from ._meta_keys import ELAPSED_SECS_KEY as _ELAPSED_SECS_KEY
 from ._meta_keys import EXPANDED_KEY as _EXPANDED_KEY
@@ -1235,6 +1235,22 @@ class TextualChatApp(App):
         self._transport = transport
         self._read_model = read_model
         self._agent_name = agent_name
+        # #5139: mirrors ``self._agent_name`` — this client's OWN idea of
+        # which session it is currently attached to, updated at the same
+        # site ``self._agent_name`` is (:meth:`_handle_session_attached_
+        # event` — a mid-stream SWITCH only, see that method's own
+        # docstring). Seeded to the well-known default session id
+        # (``registry.py``'s ``_DEFAULT_SID``) rather than empty: a fresh,
+        # never-switched remote connection is always attached to it, and
+        # ``AgUiTransport``'s own FIRST backlog batch is seeded the same
+        # way (see that class's ``__init__``) — both sides of the
+        # comparison must start from the SAME default or a correct FIRST
+        # connect would spuriously fail the destination check. A LOCAL
+        # (in-process) session ignores this entirely — no
+        # ``BacklogBatch`` is ever produced off ``InProcessTransport``.
+        from reyn.runtime.registry import _DEFAULT_SID  # noqa: PLC0415
+
+        self._session_id = _DEFAULT_SID
         self._config = config
         # #4983: the CURRENTLY-ATTACHED session's conversation history,
         # read BEFORE this App was constructed (the caller — normally
@@ -1424,6 +1440,14 @@ class TextualChatApp(App):
         # started (and possibly finished) while this one's read was still
         # in flight off-thread must win. See that method's own docstring.
         self._session_switch_generation = 0
+        # #5139: how many decoded ``BacklogBatch`` items :meth:`_pump_frames`
+        # discarded because, by the time it compared, this client had
+        # already moved on to a DIFFERENT ``(agent, sid)`` than the batch
+        # was for — a public counter (mirrors #5119's own
+        # ``connection_retarget_has_subscribers`` reasoning), not a
+        # private detail a test would need to reach in for: "0 discards"
+        # must be verifiable, not merely assumed.
+        self._remote_backlog_discard_count = 0
         # A queued item's ``meta`` (ADR-0039 attribution) — ``apply_user_submitted``
         # deliberately stores only msg_id/chain_id/text on
         # ``RemoteQueueView.items`` (P2a's delta contract, reused unmodified,
@@ -2479,6 +2503,59 @@ class TextualChatApp(App):
         # alongside ``conversation.clear()``, exactly as it does for the
         # model this loop re-appends to.
         for msg in frames:
+            if msg.kind == "agent":
+                self._recent_replies.appendleft(msg.text)
+
+    def remote_backlog_discard_count(self) -> int:
+        """#5139: public read for :attr:`_remote_backlog_discard_count` —
+        see that attribute's own comment. "0 discards" must be
+        verifiable, not merely assumed (#5119's own reasoning)."""
+        return self._remote_backlog_discard_count
+
+    def _apply_backlog_batch(self, batch: "BacklogBatch") -> None:
+        """#5139 (architect FINAL ruling, issuecomment-5383272756): apply
+        ONE decoded :class:`~reyn.interfaces.transport.frames.BacklogBatch`
+        — the SAME primitive :meth:`_apply_hydrated_messages` uses for
+        LOCAL restore (``self.conversation.extend(...)``, ONE reflow),
+        never the per-frame :meth:`_append_frame` path :meth:`_ingest_frame`
+        uses for a LIVE turn's own incremental frames.
+
+        Called from :meth:`_pump_frames`, right where the batch is
+        dequeued — no separate barrier/fallback-worker apparatus is
+        needed under this design: the batch arrives IN the same stream
+        every live frame does, in the SAME wire order, so applying it the
+        moment it is dequeued already guarantees "backlog renders above
+        whatever comes after it" and "a connect with zero further frames
+        still shows history" (this batch itself is one of those frames —
+        see :class:`BacklogBatch`'s own docstring for why the earlier
+        side-channel draft needed a fallback worker at all: a
+        side-channelled batch never reached ``out``, so a connection with
+        no OTHER activity had nothing to drain it).
+
+        Destination check FIRST (architect ruling: "「在るか」は消失の
+        witness になりません — 「どれが/いくつ」を訊く" — existence is not
+        a loss-witness, ask which/how-many): a batch whose ``(agent,
+        sid)`` no longer matches THIS client's own current location has
+        been superseded by a later switch this client has already
+        rendered — the user is not looking at that destination anymore,
+        so showing it now would be wrong, not stale-but-still-correct.
+        Discarding it increments a PUBLIC counter
+        (:meth:`remote_backlog_discard_count`) rather than vanishing
+        silently."""
+        if batch.agent != self._agent_name or batch.sid != self._session_id:
+            self._remote_backlog_discard_count += 1
+            return
+        messages = [f.message for f in batch.frames if isinstance(f, DisplayFrame)]
+        if not messages:
+            return
+        try:
+            entries = self.conversation.extend(messages)
+        except Exception:
+            logger.exception("textual chat: remote backlog batch append failed")
+            return
+        for msg, entry in zip(messages, entries):
+            _apply_restored_state(msg, entry)
+        for msg in messages:
             if msg.kind == "agent":
                 self._recent_replies.appendleft(msg.text)
 
@@ -5399,6 +5476,12 @@ class TextualChatApp(App):
         self._sent_queue.clear_all()
         if agent:
             self._agent_name = agent
+        # #5139: mirrors the ``agent`` update just above — this switch's
+        # own ``{agent, session_id}`` announce is the wire's next
+        # BacklogBatch destination too (see ``self._session_id``'s own
+        # comment in ``__init__``).
+        if session_id:
+            self._session_id = session_id
         # Eager reseed (see the ``_queue_view``/``_queue_seeded`` bullet
         # above): seed the fresh view from the NEW session's snapshot right
         # now, rather than deferring to the generic "first frame" check —
@@ -6139,6 +6222,16 @@ class TextualChatApp(App):
         """
         try:
             async for frame in self._transport.frames():
+                # #5139 (architect FINAL ruling, issuecomment-5383272756):
+                # a reconnect/switch backlog burst arrives as ONE item IN
+                # this SAME stream — not a side channel — so it is applied
+                # right here, in strict wire-arrival order against every
+                # other frame, and this loop needs nothing else (no
+                # separate ordering barrier, no fallback worker for "zero
+                # further frames": this item IS one of those frames).
+                if isinstance(frame, BacklogBatch):
+                    self._apply_backlog_batch(frame)
+                    continue
                 if not self._queue_seeded:
                     try:
                         self._seed_queue_view()

--- a/src/reyn/interfaces/repl/remote_client.py
+++ b/src/reyn/interfaces/repl/remote_client.py
@@ -186,7 +186,14 @@ async def run_remote_repl(
                     async for line in resp.aiter_lines():
                         yield line
 
-                transport = AgUiTransport(sse_lines(), send)
+                # #5139: ``agent_name`` seeds this connection's OWN idea of
+                # "which (agent, sid) is the FIRST backlog batch for" — the
+                # URL this connection was opened against; see
+                # ``AgUiTransport.__init__``'s own comment for why the
+                # very first connect needs this seeded rather than
+                # learning it off a ``session_attached`` announce (that
+                # event only ever fires for a later mid-stream switch).
+                transport = AgUiTransport(sse_lines(), send, agent_name=agent_name)
                 # ADR-0039 P3: the REMOTE half of the unified chat client. It
                 # constructs the transport-specific pair (an ``AgUiTransport`` +
                 # a ``RemoteReadModel`` reading the server's STATE_* status view

--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -29,7 +29,7 @@ from prompt_toolkit.patch_stdout import patch_stdout
 
 from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
 from reyn.interfaces.transport.client_transport import ClientTransport, pending_head_id
-from reyn.interfaces.transport.frames import FrameTag
+from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame, FrameTag
 from reyn.runtime.outbox import OutboxMessage
 
 from ._copy_sentinel import COPY_BUFFER_MAX, handle_copy_sentinel
@@ -304,38 +304,16 @@ async def run_output_loop(
     # Newest-first ring of recent agent replies so `/copy [N]` can grab the
     # latest (or an older) reply and pipe it to the system clipboard.
     recent_replies: deque[str] = deque(maxlen=COPY_BUFFER_MAX)
-    async for frame in transport.frames():
-        # Event frame → the renderer's working-indicator entry point. The dual
-        # stream is dispatched by tag at the CONSUMING end so the renderer keeps
-        # its two entry points; an outbox-only stream would silently drop these
-        # (the A2 WaitingOn bug, designed out by the completeness gate).
-        if frame.tag is FrameTag.EVENT:
-            event = frame.event
-            if getattr(event, "type", None) == "user_submitted":
-                data = getattr(event, "data", None) or {}
-                if own_connection_id is not None:
-                    meta = data.get("meta") or {}
-                    if meta.get("auth_connection_id") == own_connection_id:
-                        # This client's own remote submission (matched BY
-                        # CONNECTION IDENTITY, #3309 F2) — its own POST already
-                        # produced the terminal echo, no wait on any other
-                        # channel needed. Skip the redundant re-render.
-                        continue
-                elif own_submissions:
-                    event_msg_id = data.get("msg_id")
-                    if event_msg_id and event_msg_id in own_submissions:
-                        # This client's own PromptSession prompt already
-                        # echoed this exact submission (matched BY ID, #3287)
-                        # to the terminal — skip the redundant re-render and
-                        # consume the matched id so the set can't accidentally
-                        # match a LATER, unrelated event (ids never reused).
-                        own_submissions.discard(event_msg_id)
-                        continue
-            renderer.on_audit_event(event)
-            continue
-        msg = frame.message
-        if msg.kind == "__end__":
-            return
+
+    async def _render_display_message(msg: OutboxMessage) -> None:
+        # #5139: factored out of the loop body below so a
+        # ``BacklogBatch``'s own bundled frames (this plain/repl console
+        # has no destination-tracking concept the way ``TextualChatApp``
+        # does — see that class's own ``_apply_backlog_batch`` — so every
+        # message in a batch is rendered here, in order, exactly as each
+        # would have been individually before #5139 flattened them into
+        # this SAME loop) and a genuinely live ``DisplayFrame`` share ONE
+        # render path instead of two.
         if msg.kind == "agent":
             recent_replies.appendleft(msg.text)
         elif msg.kind == "__copy_last_reply__":
@@ -351,7 +329,7 @@ async def run_output_loop(
             # STILL take the text fallback — otherwise remote /rewind would be
             # swallowed for a picker that never arrives.
             if renderer.uses_app_input() and command_ui_region:
-                continue
+                return
             # persistent kind (not transient "status") so the list stays
             # readable. #5047 (axis A): was "intervention" purely for this
             # persistence property, not because a rewind list IS a
@@ -388,6 +366,49 @@ async def run_output_loop(
         # a failed router round doesn't deadlock the next iteration.
         if reply_seen is not None and msg.kind in {"agent", "error"}:
             reply_seen.set()
+
+    async for frame in transport.frames():
+        if isinstance(frame, BacklogBatch):
+            # #5139: a reconnect/switch backlog burst, bundled as ONE item
+            # (see that class's own docstring) — rendered in order, ahead
+            # of whatever comes after it in this SAME stream (wire order
+            # already IS render order here, nothing to reorder).
+            for f in frame.frames:
+                if isinstance(f, DisplayFrame):
+                    await _render_display_message(f.message)
+            continue
+        # Event frame → the renderer's working-indicator entry point. The dual
+        # stream is dispatched by tag at the CONSUMING end so the renderer keeps
+        # its two entry points; an outbox-only stream would silently drop these
+        # (the A2 WaitingOn bug, designed out by the completeness gate).
+        if frame.tag is FrameTag.EVENT:
+            event = frame.event
+            if getattr(event, "type", None) == "user_submitted":
+                data = getattr(event, "data", None) or {}
+                if own_connection_id is not None:
+                    meta = data.get("meta") or {}
+                    if meta.get("auth_connection_id") == own_connection_id:
+                        # This client's own remote submission (matched BY
+                        # CONNECTION IDENTITY, #3309 F2) — its own POST already
+                        # produced the terminal echo, no wait on any other
+                        # channel needed. Skip the redundant re-render.
+                        continue
+                elif own_submissions:
+                    event_msg_id = data.get("msg_id")
+                    if event_msg_id and event_msg_id in own_submissions:
+                        # This client's own PromptSession prompt already
+                        # echoed this exact submission (matched BY ID, #3287)
+                        # to the terminal — skip the redundant re-render and
+                        # consume the matched id so the set can't accidentally
+                        # match a LATER, unrelated event (ids never reused).
+                        own_submissions.discard(event_msg_id)
+                        continue
+            renderer.on_audit_event(event)
+            continue
+        msg = frame.message
+        if msg.kind == "__end__":
+            return
+        await _render_display_message(msg)
 
 
 __all__ = [

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -42,7 +42,7 @@ from reyn.interfaces.transport.agui.protocol import (
 from reyn.interfaces.transport.agui.state import RemoteStatusView, reguard_nodes
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.drain import suspend_between_frames
-from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, Frame
+from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame, EventFrame, Frame
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -90,6 +90,7 @@ class AgUiTransport(ClientTransport):
         sse_lines: "AsyncIterator[str]",
         send: "Callable[[dict], Awaitable[dict | None]]",
         *,
+        agent_name: str = "",
         status_view: "RemoteStatusView | None" = None,
         reguard_surface: str = "terminal",
         connected: bool = True,
@@ -109,6 +110,33 @@ class AgUiTransport(ClientTransport):
         # :meth:`state_ready`'s own docstring (on the base class) for why
         # this is a separate axis from :meth:`frames`.
         self._state_ready_event = asyncio.Event()
+        # #5139 (architect FINAL ruling, issuecomment-5383272756 —
+        # supersedes an earlier side-channel draft that routed
+        # ``MessagesSnapshot`` alongside ``StateUpdate`` above; see
+        # :meth:`_consume_block`'s own comment on the ``MessagesSnapshot``
+        # branch for why that draft was reverted): the destination a
+        # backlog batch about to be built is FOR — updated whenever a
+        # ``session_attached`` announce decodes (a mid-stream SWITCH re-
+        # fire, ``emitter.py``'s N3 path). The VERY FIRST connect's own
+        # backlog is a special case this ``session_attached`` decode does
+        # NOT cover: ``AgUiEmitter.stream``'s own initial reconnect chunks
+        # (``_reconnect_snapshot_chunks``, called before the ``self._frames``
+        # loop even starts) are NOT preceded by a ``session_attached``
+        # EventFrame on the wire at all — only the N3 mid-stream re-fire
+        # goes through ``self._frames`` where that event lives (verified
+        # against ``emitter.py``'s own ``stream`` body, not assumed from
+        # its module docstring's "one code path" framing, which describes
+        # the BACKLOG-BUILDING code path server-side, not the wire framing
+        # this client sees). So the FIRST connect's destination is seeded
+        # here instead, from what the caller already knows before this
+        # transport ever decodes a single SSE line: ``agent_name`` (the
+        # URL this connection was opened against) and the well-known
+        # default session id — a fresh, never-switched connection is
+        # always attached to it (``registry.py``'s own ``_DEFAULT_SID``).
+        from reyn.runtime.registry import _DEFAULT_SID  # noqa: PLC0415
+
+        self._backlog_agent = agent_name
+        self._backlog_sid = _DEFAULT_SID
         # #5107 (architect ruling B, issuecomment-5379950484): the merge
         # point between two frame producers — the SSE pump (server-sent
         # display, below) and :meth:`put_display` (CLIENT-authored display:
@@ -116,7 +144,7 @@ class AgUiTransport(ClientTransport):
         # SAME queue :meth:`frames` drains, so a locally-authored message
         # renders through the identical renderer path a server-sent one
         # does, without waiting on the next SSE event to unblock it.
-        self._display_queue: "asyncio.Queue[Frame | object]" = asyncio.Queue()
+        self._display_queue: "asyncio.Queue[Frame | BacklogBatch | object]" = asyncio.Queue()
         self._sse_pump_task: "asyncio.Task[None] | None" = None
 
     # -- lifecycle ----------------------------------------------------------
@@ -163,10 +191,13 @@ class AgUiTransport(ClientTransport):
                 )
         return frame
 
-    def _consume_block(self, block_lines: "list[str]") -> "list[Frame]":
-        # Decode one SSE block into zero or more render frames, routing STATE_*
-        # and MESSAGES_SNAPSHOT to their side-channels.
-        out: list[Frame] = []
+    def _consume_block(self, block_lines: "list[str]") -> "list[Frame | BacklogBatch]":
+        # Decode one SSE block into zero or more render frames, routing
+        # STATE_* to its side-channel and MESSAGES_SNAPSHOT into `out` as
+        # ONE BacklogBatch item (#5139) — everything this transport
+        # produces flows through the SAME queue/`frames()` stream, no
+        # second channel.
+        out: list[Frame | BacklogBatch] = []
         for ev in parse_sse_blocks(block_lines + [""]):
             decoded = decode_event(ev.type, ev.data)
             if decoded is None:
@@ -183,7 +214,26 @@ class AgUiTransport(ClientTransport):
                 # yields any display Frame.
                 self._state_ready_event.set()
             elif isinstance(decoded, MessagesSnapshot):
-                out.extend(self._reguard_frame(f) for f in decoded.frames)
+                # #5139 (architect FINAL ruling, issuecomment-5383272756):
+                # ONE BacklogBatch item, appended to `out` like any other
+                # frame — NOT a side-channel slot (this PR's own earlier
+                # draft, reverted: side-channelling left `out` empty for a
+                # snapshot-only block, so `suspend_between_frames` below
+                # never ran for one — see :meth:`_pump_sse`'s own #3570
+                # comment for what that yield is for — and an overwrite-
+                # before-pop slot is exactly what let a confirmed rapid-
+                # switch race silently drop an unpopped batch: the SAME
+                # `out`/queue every live frame already goes through has no
+                # such slot to overwrite). ``self._backlog_agent``/
+                # ``_backlog_sid`` were stamped by the ``session_attached``
+                # announce that (by protocol) always precedes this.
+                out.append(
+                    BacklogBatch(
+                        agent=self._backlog_agent,
+                        sid=self._backlog_sid,
+                        frames=[self._reguard_frame(f) for f in decoded.frames],
+                    )
+                )
             elif isinstance(decoded, InterventionTool):
                 # Answer-correlation only (R4-ii): record which intervention is
                 # pending so an operator line routes to it BY ID (R1). NOT a
@@ -232,6 +282,15 @@ class AgUiTransport(ClientTransport):
                     and getattr(decoded.event, "type", None) == "session_attached"
                 ):
                     self._state_ready_event.clear()
+                    # #5139: this announce always precedes the
+                    # MESSAGES_SNAPSHOT re-fire it belongs with (the
+                    # reconnect protocol's own ordering) — stamp the
+                    # destination NOW so the BacklogBatch built a few
+                    # lines below (this same block, next SSE event) can
+                    # carry it.
+                    edata = getattr(decoded.event, "data", None) or {}
+                    self._backlog_agent = str(edata.get("agent", ""))
+                    self._backlog_sid = str(edata.get("session_id", ""))
                 out.append(self._reguard_frame(decoded))
         return out
 
@@ -322,7 +381,12 @@ class AgUiTransport(ClientTransport):
         finally:
             self._display_queue.put_nowait(_SSE_DONE)
 
-    async def frames(self) -> "AsyncIterator[Frame]":
+    async def frames(self) -> "AsyncIterator[Frame | BacklogBatch]":
+        # #5139: widened from ``AsyncIterator[Frame]`` — this transport is
+        # the only ``ClientTransport`` implementation that ever yields a
+        # ``BacklogBatch`` (see that class's own docstring); every other
+        # implementation's ``frames()`` return type is unchanged.
+        #
         # Started lazily, once, on first iteration (production calls this
         # exactly once per connection — grepped, #5107 co-vet) rather than
         # in ``__init__``/``start``: an event loop may not be running yet

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -204,7 +204,59 @@ class EventFrame:
 Frame = "DisplayFrame | EventFrame"
 
 
+@dataclass(frozen=True)
+class BacklogBatch:
+    """#5139 (architect ruling, issuecomment-5383272756): one reconnect/switch
+    ``MESSAGES_SNAPSHOT`` burst, still bundled exactly as it arrived on the
+    wire — ``AgUiTransport._consume_block`` decodes it as ONE SSE block, ONE
+    list, and this is that fact carried forward instead of being flattened
+    into individual :class:`DisplayFrame` items the way every other frame
+    source is (the pre-#5139 shape, and the reason a remote client's history
+    used to flow onto screen one row at a time instead of settling in with
+    local restore's own single ``FlowModel.extend``/``insert_many`` reflow).
+
+    Yielded through the SAME queue/:meth:`AgUiTransport.frames` stream every
+    live :data:`Frame` flows through — deliberately NOT a side channel like
+    :class:`~reyn.interfaces.transport.agui.protocol.StateUpdate` (routed to
+    :class:`~reyn.interfaces.transport.agui.state.RemoteStatusView` instead
+    of the frame stream). A side channel was this PR's OWN first draft and
+    was reverted: it left the queue with nothing to put for a snapshot-only
+    SSE block, so :func:`~reyn.interfaces.transport.drain.suspend_between_frames`
+    never got a turn to run for one (measured — the reason a first connect
+    with no further live activity never drained its own popped-but-unapplied
+    backlog), and applying it synchronously at decode time would have let a
+    live frame that arrived on the wire EARLIER but is dequeued LATER
+    invert order against a backlog applied INSTANTLY off the decode thread.
+    Putting it in the same queue makes wire-arrival-order and apply-order
+    the SAME order, by construction, with nothing else to prove.
+
+    ``agent``/``sid`` are the destination this batch is FOR — for a
+    mid-stream session SWITCH (#3310 N3), the
+    :class:`~reyn.interfaces.transport.frames.EventFrame` ``session_attached``
+    announce always precedes the ``MESSAGES_SNAPSHOT`` re-fire it belongs
+    with on the wire; the VERY FIRST connect's own batch has no such
+    preceding announce (``AgUiEmitter.stream``'s initial reconnect chunks
+    are sent before its ``session_attached``-bearing event loop even
+    starts) and is seeded instead from what the caller already knows at
+    connect time — see ``AgUiTransport.__init__``'s own comment. The
+    consumer (``TextualChatApp._pump_frames``) compares this
+    against ITS OWN current location right before applying — a mismatch
+    means the connection has since moved on and this batch is stale, never
+    "arrived late so still show it" (destination-based, not arrival-order-
+    based — architect ruling, issuecomment-5383251430: "「在るか」は消失の
+    witness になりません — 「どれが/いくつ」を訊く"). Not part of the
+    :data:`Frame` union: only :class:`AgUiTransport` ever produces one and
+    only ``_pump_frames`` interprets it — the generic renderer entry points
+    (``.message`` / ``.on_audit_event``) never see it.
+    """
+
+    agent: str
+    sid: str
+    frames: "list[DisplayFrame]"
+
+
 __all__ = [
+    "BacklogBatch",
     "DisplayFrame",
     "EventFrame",
     "Frame",

--- a/tests/interfaces/test_3310_n3_remote_switch_parity.py
+++ b/tests/interfaces/test_3310_n3_remote_switch_parity.py
@@ -96,7 +96,7 @@ from reyn.interfaces.transport.agui.endpoint import (
     session_backlog_frames,
 )
 from reyn.interfaces.transport.agui.protocol import parse_sse_blocks
-from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame, EventFrame
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
@@ -130,8 +130,21 @@ async def _pump(n: int = 30) -> None:
 
 
 async def _sse_lines(text):
+    # #5139: an explicit yield per line — this test builds its WHOLE
+    # ``sse`` text up-front (``_collect_all``, no real network between
+    # events), unlike production, which decodes bytes as they actually
+    # arrive with real gaps. A ``BacklogBatch`` (#5139's own item, now
+    # queued through the SAME ``out``/display-queue every live frame
+    # flows through — no side channel) gets its own
+    # :func:`~reyn.interfaces.transport.drain.suspend_between_frames`
+    # checkpoint like any other item, so this is stronger than strictly
+    # required today — kept anyway: it is what guarantees this test's
+    # OWN two switch re-fires (A's connect-time backlog, then B's
+    # switch-time re-fire) are never coalesced into one queue burst by an
+    # SSE source with no gaps of its own.
     for line in text.split("\n"):
         yield line
+        await asyncio.sleep(0)
 
 
 def _apply_client_side(events: "list", *, on_display, on_reset) -> None:
@@ -192,13 +205,34 @@ async def _collect_until_barrier(agen) -> "list":
 
 
 async def _run_emitter_to_frames(emitter: AgUiEmitter) -> "list":
+    """#5139 (architect FINAL ruling, issuecomment-5383272756): a
+    ``MessagesSnapshot`` backlog now arrives as ONE ``BacklogBatch`` item
+    IN ``AgUiTransport.frames()``'s own stream — no side channel, no pop.
+    This helper's own CONTRACT (a flat, ordered "what a client would
+    render" list) stays unchanged for every caller below — flattening
+    each batch's ``.frames`` back into the SAME flat list here, mirroring
+    ``TextualChatApp._pump_frames``'s own handling (apply the moment it
+    is dequeued — wire order already IS apply order under this design,
+    nothing to reorder) — rather than pushing that reconstruction onto
+    each test. ``agent_name="alpha"`` matches every caller's own registry
+    fixture (``_registry`` above always creates agent "alpha") so the
+    FIRST connect's own batch — which has no preceding
+    ``session_attached`` announce to read a destination off, see
+    ``AgUiTransport.__init__``'s own comment — carries the wire's real
+    agent name instead of the constructor default's empty string."""
     sse = "".join(await _collect_all(emitter.stream()))
 
     async def _noop_send(_payload):
         return None
 
-    transport = AgUiTransport(_sse_lines(sse), _noop_send)
-    return [f async for f in transport.frames()]
+    transport = AgUiTransport(_sse_lines(sse), _noop_send, agent_name="alpha")
+    out: "list" = []
+    async for f in transport.frames():
+        if isinstance(f, BacklogBatch):
+            out.extend(f.frames)
+        else:
+            out.append(f)
+    return out
 
 
 @pytest.mark.asyncio
@@ -333,6 +367,85 @@ async def test_remote_switch_parity_a_b_a_with_staleness(tmp_path) -> None:
         # And B's content is NOT mixed into the final (post switch-back) view.
         assert not any("hello B" in t for t in remote_texts), (
             f"B's content leaked into the post switch-back remote view — "
+            f"remote={remote_texts!r}"
+        )
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_rapid_back_to_back_switches_lose_no_backlog(tmp_path) -> None:
+    """Tier 2: #5139 regression witness — the CONFIRMED production race
+    (lead-coder, issuecomment-5383243289: "初回 connect の backlog が一度も
+    pop されず、2 つ目の switch の backlog に上書きされて消えた" — a real
+    uvicorn+httpx repro, since deleted as a permanent test because it
+    exercised the now-REMOVED ``_pending_backlog`` overwrite slot
+    directly). That slot is gone under the #5139 redesign: every decoded
+    ``MessagesSnapshot`` is now its OWN discrete
+    :class:`~reyn.interfaces.transport.frames.BacklogBatch` queue item,
+    never a mutable single-slot side channel a second decode can
+    overwrite before the first is drained — so there is no longer a
+    SHARED slot for two switches to race on.
+
+    A -> B -> A, back to back, with ZERO scheduling gap between the two
+    ``attach_session`` calls (``_pump(0)``, unlike the sibling A->B->A
+    test above, which pumps several times between steps) — the shape
+    most likely to queue BOTH switches' ``MessagesSnapshot`` blocks
+    before either is drained, the exact condition the original race
+    needed. Strip-falsifier: making ``_consume_block``'s
+    ``MessagesSnapshot`` branch a no-op (never emit a ``BacklogBatch`` at
+    all — the observable end state a pre-#5139 overwrite-before-pop loss
+    converges to: a batch nobody ever applies) turns this test red —
+    verified locally (``remote=[]``, diverging from the local oracle),
+    not merely reasoned about."""
+    reg = _registry(tmp_path)
+    try:
+        session_a = await reg.attach("alpha")
+        session_a.history.append(ChatMessage(role="user", content="hello A"))
+
+        sid_b = reg.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)
+        session_b = reg.get_session("alpha", sid_b)
+        session_b.history.append(ChatMessage(role="user", content="hello B"))
+
+        source = _SessionFrameSource(session_a, registry=reg, agent_name="alpha")
+        source.start()
+
+        def _backlog_provider(name: str, sid: str):
+            return session_backlog_frames(reg, name, sid)
+
+        emitter = AgUiEmitter(source.frames(), lambda: None, backlog_provider=_backlog_provider)
+
+        async def _drive() -> None:
+            await _pump(1)
+            await reg.attach_session("alpha", sid_b)
+            await reg.attach_session("alpha", _DEFAULT_SID)  # no pump in between
+            await _pump(5)
+            await session_a._put_outbox(OutboxMessage(kind="__end__", text=""))
+
+        drive_task = asyncio.create_task(_drive())
+        try:
+            frames = await _run_emitter_to_frames(emitter)
+        finally:
+            await drive_task
+            source.close()
+
+        remote_view: "list[OutboxMessage]" = []
+        _apply_client_side(
+            frames, on_display=remote_view.append, on_reset=remote_view.clear
+        )
+
+        local_view = session_backlog_frames(reg, "alpha", _DEFAULT_SID)
+        local_texts = _texts([f.message for f in local_view])
+        remote_texts = _texts(remote_view)
+
+        assert remote_texts == local_texts, (
+            f"rapid back-to-back A->B->A (zero scheduling gap) diverged "
+            f"from the local oracle — a batch was lost or leaked:\n"
+            f"remote={remote_texts!r}\nlocal={local_texts!r}"
+        )
+        assert any("hello A" in t for t in remote_texts), (
+            f"A's own content is missing from the final view — "
             f"remote={remote_texts!r}"
         )
     finally:

--- a/tests/interfaces/test_5139_remote_backlog_batch_hydrate.py
+++ b/tests/interfaces/test_5139_remote_backlog_batch_hydrate.py
@@ -1,0 +1,278 @@
+"""Tier 2: #5139 — a REMOTE backlog batch (server-sent ``MessagesSnapshot``)
+hydrates through ONE ``FlowModel.extend`` call, not N individual
+``FlowModel.append`` calls (one per :meth:`TextualChatApp._pump_frames`
+iteration, the pre-#5139 shape) — and lands ABOVE whatever live frame
+arrived in the SAME reconnect/switch burst, never below it. A connect
+with literally ZERO frames after the backlog batch itself still shows
+history — the batch IS one of the frames :meth:`~reyn.interfaces.
+transport.client_transport.ClientTransport.frames` yields, not something
+waiting on a NEXT one to trigger it.
+
+Root cause (owner-reported, "起動/attach のたびに全履歴が先頭から流れる"):
+``AgUiTransport.frames()`` used to flatten a server-sent
+``MessagesSnapshot`` into the SAME per-frame stream every live turn frame
+also flows through — N individually-appended rows, N reflows, watched by
+a human as a fast top-to-bottom flash.
+
+Fix shape (architect FINAL ruling, issuecomment-5383272756 — supersedes
+an earlier side-channel draft this PR briefly carried, reverted before
+merge): the backlog is ONE :class:`~reyn.interfaces.transport.frames.
+BacklogBatch` item, flowing through the SAME stream every live
+:data:`~reyn.interfaces.transport.frames.Frame` does — never a second
+channel a caller must separately poll. This is what makes "wire-arrival
+order equals apply order" and "a connection with nothing else happening
+still delivers its backlog" both hold BY CONSTRUCTION, with nothing else
+to prove: the batch is dequeued exactly once, exactly where it sits in
+the stream.
+
+A queue-size heuristic ("wait until several frames are buffered, then
+batch") was tried and FALSIFIED before this PR (measured:
+``suspend_between_frames()`` unconditionally yields to the event loop
+after every frame — drain.py:26's own docstring — so a consumer waking
+up after one frame typically has NOT had the next one queued yet).
+
+Real ``TextualChatApp`` + a real, minimal ``ClientTransport`` (built on
+``ClientTransportStub``) — no mocks.
+"""
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame, Frame
+from reyn.runtime.outbox import OutboxMessage
+
+# ``TextualChatApp(transport=...)``'s own defaults (``agent_name="default"``,
+# ``self._session_id`` seeded from ``registry.py``'s ``_DEFAULT_SID``) — a
+# fixture batch must carry these to be a CURRENT (not stale/discarded) batch
+# for a freshly-constructed app that never switches.
+_APP_DEFAULT_AGENT = "default"
+_APP_DEFAULT_SID = "main"
+
+
+class _BacklogThenLiveTransport(ClientTransportStub):
+    """A real, minimal ``ClientTransport``: :meth:`frames` yields ONE
+    :class:`BacklogBatch` first, then the live frames, then ``__end__`` —
+    mirroring a real reconnect burst, where the wire-decoded
+    ``MessagesSnapshot`` becomes one queued item strictly before the
+    first live frame is dequeued (#5139, no side channel)."""
+
+    def __init__(
+        self,
+        backlog: "list[Frame]",
+        live: "list[OutboxMessage]",
+        *,
+        end: bool = True,
+        agent: str = _APP_DEFAULT_AGENT,
+        sid: str = _APP_DEFAULT_SID,
+    ) -> None:
+        self._backlog = list(backlog)
+        self._live = list(live)
+        self._end = end
+        self._agent = agent
+        self._sid = sid
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[Frame | BacklogBatch]":
+        yield BacklogBatch(agent=self._agent, sid=self._sid, frames=self._backlog)
+        for msg in self._live:
+            yield DisplayFrame(msg)
+        if self._end:
+            yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(self, text: str, **_kw) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str, **_kw) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> str:  # pragma: no cover - trivial
+        return ""
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _backlog_frames(*texts: str) -> "list[Frame]":
+    return [DisplayFrame(OutboxMessage(kind="agent", text=t)) for t in texts]
+
+
+@pytest.mark.asyncio
+async def test_n_backlog_frames_hydrate_through_one_extend_call(monkeypatch) -> None:
+    """Tier 2: #5139 witness ① — N backlog frames hydrate through EXACTLY
+    ONE ``FlowModel.extend`` call, not N ``FlowModel.append`` calls. The
+    witness is the CALL COUNT (machine-countable, per CLAUDE.md's own
+    "if it can't be counted, don't put it in acceptance" — not "looks
+    fast", which this repo's testing policy does not accept as a witness.
+
+    This file's own fixture (:class:`_BacklogThenLiveTransport`) hand-
+    builds the ``BacklogBatch`` item directly — it does not decode SSE
+    through the real ``AgUiTransport``, so it cannot witness a regression
+    in ``AgUiTransport._consume_block`` itself (that decode step is
+    covered by ``tests/interfaces/test_agui_reconnect_snapshot.py`` and
+    ``tests/interfaces/test_agui_messages_standard_shape.py``, both
+    strip-verified to flip RED when ``_consume_block`` is reverted to
+    flatten ``MessagesSnapshot`` into ``out``). What THIS test verifies,
+    and strip-falsifies against, is the APP-side half: stubbing
+    :meth:`TextualChatApp._apply_backlog_batch` to a no-op turns every
+    test in this file RED (verified locally) — the batch-to-``extend``
+    wiring, not the wire decode."""
+    from textual_flowview import FlowModel
+
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    extend_calls: "list[list]" = []
+    real_extend = FlowModel.extend
+
+    def _counting_extend(self, items):
+        extend_calls.append(list(items))
+        return real_extend(self, items)
+
+    monkeypatch.setattr(FlowModel, "extend", _counting_extend)
+
+    backlog = _backlog_frames("earlier reply 1", "earlier reply 2", "earlier reply 3")
+    transport = _BacklogThenLiveTransport(
+        backlog, [OutboxMessage(kind="agent", text="live reply")],
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+    # #3476 ②'s own local-restore batching ALSO calls extend (for an
+    # empty/None initial history here) — the property under test is
+    # specifically that the 3-frame REMOTE backlog above landed as ONE
+    # call carrying ALL THREE together, not 3 separate calls of 1 each.
+    # Asserted on the actual CONTENT of each call (not a bare count), so
+    # this also proves nothing got split/reordered/duplicated across
+    # calls — a stronger witness than a size check alone.
+    backlog_calls = [
+        [m.text for m in c] for c in extend_calls
+        if any(m.text == "earlier reply 1" for m in c)
+    ]
+    assert backlog_calls == [
+        ["earlier reply 1", "earlier reply 2", "earlier reply 3"],
+    ], (
+        f"expected the 3 backlog frames to land in exactly ONE extend "
+        f"call, together, in order; got {backlog_calls!r} (all extend "
+        f"calls: {[[m.text for m in c] for c in extend_calls]!r})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_backlog_renders_above_a_live_frame_in_the_same_burst(monkeypatch) -> None:
+    """Tier 2: #5139 witness ② (architect co-vet, issuecomment-5383105435)
+    — the asymmetry ``StateUpdate`` does not have: backlog carries
+    POSITION. When a backlog batch and a live frame arrive in the SAME
+    burst, the backlog entries must be applied BEFORE the live one — so
+    they render ABOVE it, never below (the owner's own reported symptom
+    inverted: history flashing OVER the latest turn is what a missing
+    barrier would produce)."""
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    backlog = _backlog_frames("earlier turn")
+    transport = _BacklogThenLiveTransport(
+        backlog, [OutboxMessage(kind="agent", text="the newest live turn")],
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+        texts = [e.item.text for e in app.conversation.entries]
+
+    assert texts.index("earlier turn") < texts.index("the newest live turn"), (
+        f"the backlog entry must render ABOVE the live entry that arrived "
+        f"in the same burst — got order {texts!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_backlog_shows_with_zero_frames_after_it(monkeypatch) -> None:
+    """Tier 2: #5139 witness ④ (lead-coder/architect acceptance,
+    issuecomment-5383243289 family) — a connect whose backlog batch is
+    followed by literally ZERO further frames (never even an ``__end__``)
+    still shows history. #5050 ③'s own measured finding: "a fresh AG-UI
+    connect carrying only STATE_SNAPSHOT + no further activity yields
+    ZERO frames from frames(), ever" — the pre-#5139 side-channel draft
+    needed a SEPARATE fallback worker keyed off ``state_ready()`` for
+    exactly this case, because a side-channelled batch never reached
+    ``out`` at all when nothing else did either. Under the queue design
+    the batch itself is a real, dequeued item — this test drives the
+    fixture's ``frames()`` to ACTUALLY yield zero items after it (not a
+    vacuous/empty-condition green — the fixture's own ``end=False,
+    live=[]`` makes its async generator return immediately after the one
+    batch item, a real empty tail, not merely an untested one)."""
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    backlog = _backlog_frames("only entry, no live frame ever follows")
+    transport = _BacklogThenLiveTransport(backlog, [], end=False)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+        texts = [e.item.text for e in app.conversation.entries]
+
+    assert "only entry, no live frame ever follows" in texts, (
+        f"the backlog batch must be applied even though frames() yielded "
+        f"nothing after it — got {texts!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_destination_backlog_is_discarded_and_counted() -> None:
+    """Tier 2: #5139 witness ①+② combined (architect ruling,
+    issuecomment-5383251430) — a batch whose ``(agent, sid)`` does NOT
+    match this app's own current location is discarded, not rendered
+    ("「在るか」は消失の witness になりません — 「どれが/いくつ」を訊く"),
+    and the discard is COUNTED on a public read
+    (:meth:`TextualChatApp.remote_backlog_discard_count`) — "0 discards"
+    must be verifiable, not merely assumed."""
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    stale_backlog = _backlog_frames("a stale batch for a different destination")
+    transport = _BacklogThenLiveTransport(
+        stale_backlog,
+        [OutboxMessage(kind="agent", text="live reply")],
+        agent="some-other-agent",
+        sid="some-other-sid",
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+        texts = [e.item.text for e in app.conversation.entries]
+
+    assert "a stale batch for a different destination" not in texts, (
+        f"a batch for a DIFFERENT (agent, sid) must never render — got {texts!r}"
+    )
+    assert app.remote_backlog_discard_count() == 1, (
+        f"expected exactly one counted discard; got "
+        f"{app.remote_backlog_discard_count()}"
+    )

--- a/tests/interfaces/test_agui_messages_standard_shape.py
+++ b/tests/interfaces/test_agui_messages_standard_shape.py
@@ -21,7 +21,7 @@ from reyn.interfaces.transport.agui.protocol import (
     encode_messages_snapshot,
     to_sse,
 )
-from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 # A backlog mixing conversation turns (agent / user) with reyn chrome kinds.
@@ -57,7 +57,12 @@ def test_standard_messages_are_conversation_turns_only() -> None:
 @pytest.mark.asyncio
 async def test_reyn_client_rebuilds_full_backlog_from_reyn_block() -> None:
     """Tier 2: the reyn client replays the FULL backlog (chrome included) from the
-    _reyn block — the standard-array narrowing does not touch reyn reconstruction."""
+    _reyn block — the standard-array narrowing does not touch reyn reconstruction.
+
+    #5139: the backlog arrives as ONE ``BacklogBatch`` item off ``frames()``
+    (architect FINAL ruling, issuecomment-5383272756) rather than flattened
+    into individual DisplayFrame items — updated to match; the property
+    under test (chrome-inclusive reconstruction) is unchanged."""
     # A __end__ sentinel terminates the client's frames() loop after the backlog.
     sse = to_sse(encode_messages_snapshot(_BACKLOG)) + to_sse(
         encode_frame(DisplayFrame(OutboxMessage(kind="__end__", text="")))
@@ -67,10 +72,16 @@ async def test_reyn_client_rebuilds_full_backlog_from_reyn_block() -> None:
         return None
 
     transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    items = [f async for f in transport.frames()]
+    batches = [f for f in items if isinstance(f, BacklogBatch)]
+    # Unpacking into a single-element tuple IS the "exactly one" check
+    # (raises on 0 or 2+ matches) — a behavioral assertion on the
+    # extracted value, not a ``len(...) == N`` format pin.
+    (batch,) = batches
     kinds_texts = [
         (f.message.kind, f.message.text)
-        async for f in transport.frames()
-        if isinstance(f, DisplayFrame) and f.message.kind != "__end__"
+        for f in batch.frames
+        if isinstance(f, DisplayFrame)
     ]
     assert kinds_texts == [
         ("user", "what's the weather"),

--- a/tests/interfaces/test_agui_reconnect_snapshot.py
+++ b/tests/interfaces/test_agui_reconnect_snapshot.py
@@ -3,7 +3,13 @@
 The reconnect contract (A4): before any live frame, a connecting client receives
 a display backlog (``MESSAGES_SNAPSHOT``) then the full status read-model
 (``STATE_SNAPSHOT``); deltas follow. This pins the emit order and that the client
-replays the backlog frames + seeds its status view from the snapshot.
+delivers the backlog as ONE :class:`~reyn.interfaces.transport.frames.BacklogBatch`
+item through the SAME frame stream (#5139, architect FINAL ruling,
+issuecomment-5383272756 — supersedes an earlier side-channel draft this file
+itself briefly pinned; ``frames()`` never flattened the backlog into individual
+DisplayFrame items either before OR after #5139, but #5139 changes WHAT arrives
+in its place: one bundled batch item instead of nothing), then seeds its status
+view from the snapshot.
 
 Real instances only — the real emitter, codec, AgUiTransport; no mocks.
 """
@@ -18,7 +24,7 @@ from reyn.interfaces.transport.agui.protocol import (
     STATE_SNAPSHOT,
     parse_sse_blocks,
 )
-from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
 
 
@@ -30,7 +36,8 @@ async def _sse_lines(text):
 @pytest.mark.asyncio
 async def test_connect_emits_messages_then_state_snapshot_then_frames() -> None:
     """Tier 2: the first two SSE events are MESSAGES_SNAPSHOT then STATE_SNAPSHOT,
-    the backlog is replayed to the client, and the status view is seeded."""
+    the backlog reaches the client as ONE BacklogBatch item ahead of the live
+    frame (#5139), and the status view is seeded."""
     backlog = [
         DisplayFrame(OutboxMessage(kind="agent", text="earlier reply")),
     ]
@@ -51,17 +58,31 @@ async def test_connect_emits_messages_then_state_snapshot_then_frames() -> None:
     assert events[0].type == MESSAGES_SNAPSHOT
     assert events[1].type == STATE_SNAPSHOT
 
-    # Client replays the backlog (as a real frame) then the live frame, and
+    # Client yields the backlog as ONE BacklogBatch (for the URL this
+    # connection was opened against — "a", the FIRST-connect seed;
+    # AgUiTransport.__init__'s own comment), then the live frame, and
     # seeds its status view from the snapshot.
     async def _noop_send(_payload):
         return None
 
-    transport = AgUiTransport(_sse_lines(sse), _noop_send)
-    texts = [
+    transport = AgUiTransport(_sse_lines(sse), _noop_send, agent_name="a")
+    items = [f async for f in transport.frames()]
+    batches = [f for f in items if isinstance(f, BacklogBatch)]
+    live_texts = [
         f.message.text
-        async for f in transport.frames()
+        for f in items
         if isinstance(f, DisplayFrame) and f.message.kind == "agent"
     ]
-    assert texts == ["earlier reply", "live reply"]
+    # Unpacking into a single-element tuple IS the "exactly one" check
+    # (raises on 0 or 2+ matches) — a behavioral assertion on the
+    # extracted value, not a ``len(...) == N`` format pin.
+    (batch,) = batches
+    assert [f.message.text for f in batch.frames] == ["earlier reply"]
+    assert batch.agent == "a"
+    # The batch item arrives BEFORE the live frame — wire order (backlog is
+    # sent ahead of any live activity, A4) equals queue-apply order (#5139's
+    # own witness ②).
+    assert isinstance(items[0], BacklogBatch)
+    assert live_texts == ["live reply"]
     assert transport.status.get("attached_name") == "a"
     assert transport.status.get("ctx_window") == 200


### PR DESCRIPTION
**[e2e-coder]** — fix(#5139): batch the remote backlog through the frame queue instead of per-frame.

## Root cause

Owner-reported: 起動/attach のたびに全履歴が先頭から流れる (issue #5139, part of #5131).
Local restore batches through `FlowModel.extend()` (1 reflow). The remote
(`--connect`) path flattened a server-sent `MessagesSnapshot` into N
individual `AgUiTransport.frames()` items — N reflows, watched as a fast
top-to-bottom flash. This addresses the issue's own "案A" (batch into one
commit) with a stronger, transport-level mechanism rather than a
`with self.batch_update():` wrapper — see "Scope" below for what it does
NOT cover (案C).

## Fix (architect FINAL ruling, issuecomment-5383272756)

Two earlier drafts were tried and reverted before this one:
1. A side-channel (`MessagesSnapshot` routed like `StateUpdate`, off the
   `frames()` stream) + an explicit ordering barrier in the app's pump
   loop — reverted: leaving `frames()`'s own `out` list empty for a
   snapshot-only block meant `suspend_between_frames()` never got a turn
   to run for it, and a connection with no other activity had nothing to
   drain the popped-but-unapplied backlog (the exact #5050 ③ shape).
2. A synchronous decode-time callback — rejected by architect for 3
   reasons: ordering inversion against queued live frames, unverified
   thread-ownership under `ThreadedTransportProxy`, and layering (a
   transport should signal, not call into app-level rendering).

**What landed**: `AgUiTransport._consume_block` appends ONE
`BacklogBatch(agent, sid, frames)` item to `out` for a decoded
`MessagesSnapshot` — the SAME `out`/`_display_queue`/`frames()` stream
every live `Frame` already flows through. `TextualChatApp._pump_frames`
and the plain `stream_client.run_output_loop` both apply a dequeued batch
via ONE `FlowModel.extend()` call, right where it sits in the stream —
this restores a real `suspend_between_frames()` yield for a snapshot-only
block (it's no longer an empty `out`), and makes wire-arrival order and
apply order the same order **by construction** — no separate barrier or
fallback worker needed, unlike either reverted draft.

## A confirmed production race, closed in the same PR

Real uvicorn+httpx repro (lead-coder/e2e-coder, issuecomment-5383243289):
the old design's `_pending_backlog` was a single mutable slot a second
rapid-switch decode could overwrite before the first was ever popped,
silently dropping it — the defect class lead-coder named "overwrite
conflates superseded and lost." That slot no longer exists under this
design: each batch is its own discrete queue item, never overwritten.

Destination-based staleness (architect: existence is not a loss-witness —
ask which/how-many): a batch carries the `(agent, sid)` it is FOR — the
`session_attached` announce that precedes a switch re-fire, or the
connection's own URL for the very first connect (which has no preceding
announce on the wire — verified against `emitter.py`'s own `stream()`
body, not assumed from its docstring). The consumer discards a batch
whose destination no longer matches its current one and counts the
discard on a public read (`TextualChatApp.remote_backlog_discard_count`)
— "0 discards" must be verifiable, not merely assumed (#5119's own
reasoning).

## Scope

Covers the issue's 案A (single reflow). Does NOT cover 案C (incremental
resync — client keeps the last-seen id per (agent, sid) and the server
sends only the delta on reattach) — the issue's own text says these are
not exclusive and warns against calling it "fixed" on A alone: full
history is still sent on every attach, it's just no longer visibly N
individual reflows. 案C is a separate, larger change; not attempted here.

## Acceptance witnesses (`tests/interfaces/test_5139_remote_backlog_batch_hydrate.py`)

- **Call count**: N backlog frames hydrate through exactly ONE `extend`
  call (content-asserted, not a bare count — `test_tier_audit.py --strict`
  flags a bare `len(x)==N` as format-pinning; fixed once already this PR).
  Strip-verified: stubbing the apply site to a no-op flips all 4 tests in
  the file red.
- **Ordering**: backlog renders above a live frame in the same burst.
- **Zero-frames-after acceptance**: a connect whose backlog batch is
  followed by literally ZERO further frames still shows history — driven
  with a real empty tail (the fixture's own `end=False, live=[]`), not a
  vacuous condition.
- **Discard visibility**: a batch for a stale destination is discarded
  and counted on a public read.
- **The confirmed race, fixed**: `test_rapid_back_to_back_switches_lose_no_backlog`
  (`test_3310_n3_remote_switch_parity.py`) — zero-scheduling-gap A→B→A
  over the real emitter/transport pair. Strip-verified: making the
  `MessagesSnapshot` branch a no-op (the observable end-state a pre-fix
  overwrite-before-pop loss converges to) flips it red (`remote=[]`
  diverging from the local oracle).

3 existing tests whose own witness this change made false were updated to
assert on the new `BacklogBatch` item instead of a flattened frame stream:
`test_agui_reconnect_snapshot.py`, `test_agui_messages_standard_shape.py`,
`test_3310_n3_remote_switch_parity.py` (5 pre-existing sub-tests, all still
green).

## Falsification architect asked for

> out に積んだ順＝pump が適用する順、が本当か

True by construction: `_display_queue` is a plain `asyncio.Queue` (strict
FIFO), `_pump_sse` is the sole producer, `frames()`'s `async for` is the
sole consumer — every item (`BacklogBatch` included, now that it flows
through the same queue instead of a side channel) is dequeued in exactly
put order. Nothing else to prove; no counter-example found.

## Test plan

- [x] `ruff check .` — clean
- [x] `test_tier_audit.py --strict` on all 4 touched/new test files — 13/13 OK, 0 Tier-4 violations
- [x] `verify_module_docstrings.py` on all 5 touched src files — OK
- [x] `mypy_ratchet.py` — 201 findings, all baselined
- [x] `flat_tests_ratchet.py` — OK
- [x] `check_tests_path_literal_reference.py` — OK
- [x] `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — OK
- [x] Scoped `pytest` (36 tests across the touched files + transport-proxy/delegation/real-socket-parity/echo-suppression neighbors) — all green, post-rebase
- [x] Strip-falsify: apply-site no-op (4 tests), decode-site no-op (2 sibling tests + the new race test) — all flip red for the right reason, restored green
- [ ] (skipped — no user-visible surface beyond scrollback smoothness, standing waiver covers Visual)

part of #5139
