### PR TITLE
fix(#5146): a purge does not leave the old identity's driver token behind

### DIFF
--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+import weakref
 from typing import Callable
 
 from fastapi import APIRouter, Request
@@ -281,6 +282,36 @@ def _surface_manager(agent_name: str, auth: AuthContext) -> SurfaceManager:
     return surface_registry().for_agent(
         agent_name, authorized=_authorized_predicate(auth)
     )
+
+
+# #5146: registries this process has already wired a purge-cleanup listener
+# for — a WeakSet (not a bare module-global bool) so wiring survives a
+# registry ever being swapped (tests construct a fresh AgentRegistry per
+# case) without silently skipping the SECOND registry's own wiring, and
+# without holding a strong ref that would keep an old registry alive past
+# its own test's teardown.
+_REMOVE_LISTENER_WIRED: "weakref.WeakSet" = weakref.WeakSet()
+
+
+def _ensure_remove_listener_wired(registry) -> None:
+    """#5146: subscribe :meth:`SurfaceRegistry.remove` to ``registry``'s own
+    purge notification, exactly once per registry instance.
+
+    Closes the #5084-class name-reuse hole for OPERATOR-DRIVER-TOKEN
+    identity (that fix closed the same class for spawn lineage): a purge
+    frees the agent name for immediate re-declaration, but
+    ``SurfaceRegistry`` keeps a purged name's ``SurfaceManager`` (with its
+    stale ``_active_driver``/surface set) forever without this — a
+    same-name re-declare's first connection would silently inherit the
+    OLD identity's operator authority. This module calls INTO
+    ``registry.add_remove_listener`` (already imports ``AgentRegistry``
+    indirectly via ``get_registry``); ``AgentRegistry`` itself never
+    imports or calls into transport (#5139's own layering ruling) — the
+    listener is the seam, wired from the transport side."""
+    if registry in _REMOVE_LISTENER_WIRED:
+        return
+    registry.add_remove_listener(surface_registry().remove)
+    _REMOVE_LISTENER_WIRED.add(registry)
 
 
 def _ensure_fail_close_driver(agent_name: str, manager: SurfaceManager, registry) -> None:
@@ -725,6 +756,7 @@ async def agui_events(request: Request, agent_name: str):
         return JSONResponse({"error": "authentication required"}, status_code=401)
 
     registry = get_registry()
+    _ensure_remove_listener_wired(registry)
     if not registry.exists(agent_name):
         return JSONResponse({"error": f"agent {agent_name!r} not found"}, status_code=404)
     session = await registry.ensure_running(agent_name)  # #3793 stage 2: boot-only, does not touch focus
@@ -902,6 +934,7 @@ async def agui_seize(request: Request, agent_name: str):
     if manager is None or not manager.seize(connection_id, identity.user_id, monotonic()):
         return JSONResponse({"seized": False, "error": "seize refused"}, status_code=409)
     registry = get_registry()
+    _ensure_remove_listener_wired(registry)
     if registry.exists(agent_name):
         session = await registry.ensure_running(agent_name)  # #3793 stage 2: boot-only, does not touch focus
         session.emit_audit_event(
@@ -970,6 +1003,7 @@ async def agui_submit(request: Request, agent_name: str):
         return JSONResponse({"status": "ok"})
 
     registry = get_registry()
+    _ensure_remove_listener_wired(registry)
     if not registry.exists(agent_name):
         return JSONResponse({"error": f"agent {agent_name!r} not found"}, status_code=404)
 

--- a/src/reyn/interfaces/transport/agui/surface.py
+++ b/src/reyn/interfaces/transport/agui/surface.py
@@ -218,6 +218,23 @@ class SurfaceRegistry:
             self._by_agent[agent_name] = mgr
         return mgr
 
+    def remove(self, agent_name: str) -> None:
+        """#5146: drop this name's own ``SurfaceManager`` entirely — the
+        AG-UI-side half of the #5084-class name-reuse fix (that one closed
+        spawn-lineage identity; this one closes operator-driver-token/
+        surface-set identity). Without this, a purge followed by an
+        immediate same-name re-declare hands the NEW identity's first
+        connection the OLD identity's stale ``_active_driver`` token and
+        surface set (the OLD manager, still keyed by the same name, is
+        just found and reused by :meth:`for_agent`). Meant to be wired as
+        the callback for ``AgentRegistry.add_remove_listener`` (this class
+        does not import ``AgentRegistry`` itself — the wiring lives at the
+        call site that already imports both, keeping this module's own
+        dependency direction unchanged). A no-op if the name was never
+        seen (``.pop(..., None)``) — a purge of an agent no connection
+        ever attached to is not an error here."""
+        self._by_agent.pop(agent_name, None)
+
     def get(self, agent_name: str) -> "SurfaceManager | None":
         return self._by_agent.get(agent_name)
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1232,8 +1232,29 @@ class AgentRegistry:
             # side effect that could reintroduce it). Synchronous, no await
             # crosses this loop — same barrier property add_attach_listener's
             # own docstring states.
+            #
+            # architect co-vet (issuecomment-5383416113): each callback is
+            # isolated — one listener raising must not stop the REST from
+            # running, and must not turn into remove() itself raising (this
+            # loop runs strictly AFTER `shutil.rmtree(target)` above already
+            # succeeded, so the agent is genuinely gone from disk regardless
+            # of what any listener does here — a listener's own failure
+            # destroys no evidence, CLAUDE.md's third gating question; the
+            # `rmtree` failing IS possible, but that raises further up, well
+            # before this loop is ever reached, a different and unrelated
+            # failure this method already lets propagate). A listener that
+            # raised simply did not get to run its own cleanup this time —
+            # for AG-UI's listener (SurfaceRegistry.remove, a single dict
+            # pop) that reopens exactly the bug this issue closes for that
+            # one purge, never a crash or a corrupted registry state.
             for _cb in list(self._remove_listeners):
-                _cb(name)
+                try:
+                    _cb(name)
+                except Exception:
+                    logger.exception(
+                        "AgentRegistry: a remove-listener raised for purged agent %r "
+                        "— continuing with the remaining listeners", name,
+                    )
             # PR12: a hard-deleted agent would leave dangling topology references,
             # so drop it from every topology (a team losing its leader / an
             # emptied topology is removed entirely). #2103 MUST-1: return the

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -421,6 +421,17 @@ class AgentRegistry:
         # registered for the switched agent, synchronously, from the SAME
         # no-await critical section as the ``repl_outbox`` barrier put.
         self._attach_listeners: "dict[str, list[Callable[[str], None]]]" = {}
+        # #5146: subscribers wanting to know "an agent name was just purged"
+        # — NOT agent-name-keyed like _attach_listeners above (a subscriber
+        # cannot pre-register per name; it wants every purge, whichever name).
+        # Fired from remove(purge=True) only (archive keeps the name taken,
+        # so no name-reuse risk there — see remove()'s own docstring on the
+        # archive/purge split). Exists so a transport-layer registry keyed by
+        # agent name (AG-UI's SurfaceRegistry, #5146) can drop ITS OWN
+        # bookkeeping for a purged name without this module reaching INTO
+        # transport (#5139's own "AgentRegistry does not call into interfaces"
+        # ruling) — the listener lets transport clean up after itself instead.
+        self._remove_listeners: "list[Callable[[str], None]]" = []
         # #3671 P3 (now #3793 stage 1: moved onto self._connection): the ONE
         # place a caller doing a BACKGROUND attach (P2's
         # `chat.py._background_attach`, running off the render path) can
@@ -1214,6 +1225,15 @@ class AgentRegistry:
             for _child, (_pname, _pseq) in list(self._spawn_lineage.items()):
                 if _pname == name:
                     self._spawn_lineage[_child] = (_pname, self.INVALIDATED_SPAWN_PARENT_IDENTITY)
+            # #5146: tell every remove-listener this name is gone, BEFORE the
+            # cascade below (a subscriber's own cleanup should not race a
+            # later re-declare of the same name — fire while "name" is
+            # unambiguously the just-purged identity, not after any other
+            # side effect that could reintroduce it). Synchronous, no await
+            # crosses this loop — same barrier property add_attach_listener's
+            # own docstring states.
+            for _cb in list(self._remove_listeners):
+                _cb(name)
             # PR12: a hard-deleted agent would leave dangling topology references,
             # so drop it from every topology (a team losing its leader / an
             # emptied topology is removed entirely). #2103 MUST-1: return the
@@ -3700,6 +3720,26 @@ class AgentRegistry:
         listeners.remove(callback)
         if not listeners:
             del self._attach_listeners[agent_name]
+
+    def add_remove_listener(self, callback: "Callable[[str], None]") -> None:
+        """#5146: subscribe to "an agent name was just purged" — ``callback``
+        is invoked with the purged ``name``, fired synchronously from inside
+        :meth:`remove` (purge only), same no-``await``-between critical-
+        section idiom as :meth:`add_attach_listener`. The intended (only,
+        today) consumer is AG-UI's ``SurfaceRegistry`` (#5146): a purge frees
+        the name for immediate re-declaration, but a stale ``SurfaceManager``
+        keyed by that name would otherwise hand the NEW identity's first
+        connection the OLD identity's ``_active_driver`` token and surface
+        set — the #5084 name-reuse class, for operator authority instead of
+        spawn lineage. This registry does not import or call into transport
+        itself (#5139's own layering ruling); the listener is the seam that
+        lets transport clean up its own bookkeeping instead."""
+        self._remove_listeners.append(callback)
+
+    def remove_remove_listener(self, callback: "Callable[[str], None]") -> None:
+        """Undo :meth:`add_remove_listener`. A no-op if already removed."""
+        if callback in self._remove_listeners:
+            self._remove_listeners.remove(callback)
 
     def _announce_session_attached(self, name: str, sid: str) -> None:
         """#3310 N1: notify the client a switch just happened, as a stream

--- a/tests/interfaces/test_5146_surface_manager_purge_lifecycle.py
+++ b/tests/interfaces/test_5146_surface_manager_purge_lifecycle.py
@@ -1,0 +1,237 @@
+"""Tier 2: #5146 — a purged agent's ``SurfaceManager`` does not survive a
+same-name re-declare, and the process does not otherwise grow one manager
+per URL-guessed name.
+
+#5133 fixed cross-agent ``/attach`` to migrate a connection's own
+``SurfaceManager`` registration. Reviewing it (architect, issuecomment-
+5383185709) surfaced a SEPARATE finding: ``SurfaceRegistry._by_agent`` has
+no removal path at all — measured, `for_agent` is only ever reached
+through `agui_events`/`agui_submit`/`agui_seize`, all of which 404 first
+via ``registry.exists(agent_name)``, so the manager COUNT is bounded by
+declared-agent-count, not unbounded (architect's own correction to the
+original finding's framing).
+
+The real defect (architect ruling, issuecomment-5383365332): a **purge**
+(``AgentRegistry.remove(name, purge=True)``) frees the agent name for
+IMMEDIATE re-declaration, but the stale ``SurfaceManager`` — still keyed by
+that same name, still holding the OLD identity's ``_active_driver`` token
+and surface set — is found and reused by `for_agent` for the NEW identity's
+first connection. The #5084-class name-reuse hole, this time for operator
+authority instead of spawn lineage.
+
+Fix: ``AgentRegistry.add_remove_listener`` (new, mirrors
+``add_attach_listener``'s own idiom) fires on every ``remove(purge=True)``;
+``AgentRegistry`` itself never imports or calls into ``interfaces``
+(#5139's own layering ruling, pinned here by acceptance ④) — the AG-UI
+endpoint module (which already depends on both) is what subscribes
+``SurfaceRegistry.remove`` to it, exactly once per registry instance
+(``_ensure_remove_listener_wired``).
+
+4 acceptance witnesses (architect's own ruling):
+1. purge -> same-name re-declare does NOT inherit the previous driver
+   token (the main one this issue exists for).
+2. a URL naming a NEVER-declared agent does not grow a manager (the
+   already-bounded-by-`exists()` population, pinned so a future change
+   can't silently remove that gate without a test noticing).
+3. N connections to the SAME agent share exactly 1 manager (no
+   accidental per-connection duplication).
+4. ``src/reyn/runtime/registry.py`` does not import
+   ``reyn.interfaces.transport.agui`` (the layering the fix deliberately
+   keeps — grep, not an import-time assertion, so it holds even if the
+   module is never imported in a given test run).
+
+Chains the real wire pieces (real ASGI POST -> real ``AgentRegistry`` ->
+real ``SurfaceRegistry``), mirroring
+``test_5133_surface_migrates_on_cross_agent_attach.py``'s own harness. No
+mocks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.transport.agui.surface import monotonic, surface_registry
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _registry(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+        )
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+    holder["reg"] = reg
+    return reg
+
+
+def _build_app(reg, monkeypatch):
+    from fastapi import FastAPI
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+    from reyn.interfaces.transport.agui.endpoint import router
+    from reyn.interfaces.web.auth import AuthContext
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.auth = AuthContext(token="s3cret", require_token=True)
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: reg)
+    return app
+
+
+async def _post(app, path: str, payload: dict):
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        return await client.post(path, json=payload)
+
+
+def _authorized(user_id) -> bool:
+    return bool(user_id)
+
+
+@pytest.mark.asyncio
+async def test_purge_then_same_name_redeclare_does_not_inherit_the_old_driver_token(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: acceptance ① — the main one. A connection holding the OLD
+    identity's driver token must not leave the NEW identity's manager
+    already claimed."""
+    name = "5146-t1-agent"
+    reg = _registry(tmp_path, monkeypatch)
+    reg.create(name)
+    app = _build_app(reg, monkeypatch)
+
+    conn_old = "conn-old-driver"
+    # A real POST (non-heartbeat) wires the purge-cleanup listener, exactly
+    # as a live connection's own first non-heartbeat traffic would.
+    resp = await _post(
+        app, f"/agui/chat/{name}?connection_id={conn_old}&token=s3cret",
+        {"type": "user_message", "text": "hello"},
+    )
+    assert resp.status_code == 200
+
+    # The old connection is this (only) surface -> holds the driver token,
+    # SurfaceManager.attach's own existing rule.
+    mgr_old = surface_registry().for_agent(name, authorized=_authorized)
+    mgr_old.attach(conn_old, "userOld", monotonic())
+    assert mgr_old.is_active_driver(conn_old)
+
+    reg.remove(name, purge=True)
+    reg.create(name)  # same name, a genuinely NEW identity
+
+    conn_new = "conn-new-arrival"
+    mgr_new = surface_registry().for_agent(name, authorized=_authorized)
+    assert mgr_new is not mgr_old, (
+        "the purge listener did not replace the stale manager -- for_agent "
+        "returned the SAME object for the new identity"
+    )
+    assert not mgr_new.is_active_driver(conn_old), (
+        "the OLD connection's driver token survived the purge -- the new "
+        "identity's first connection would find itself NOT the driver "
+        "(silently deposed) or the old connection would silently retain "
+        "authority over an agent it never attached to"
+    )
+    mgr_new.attach(conn_new, "userNew", monotonic())
+    assert mgr_new.is_active_driver(conn_new), (
+        "a genuinely fresh manager's first surface must take the driver "
+        "token, same as any ordinary first connect"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_never_declared_agent_name_never_grows_a_manager(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: acceptance ② — the population is bounded by declared agents
+    (the `registry.exists()` gate ahead of every `for_agent` call site),
+    not unbounded. Pinned so a future change can't silently drop that gate
+    without a test noticing (six questions ⑤'s answer for this file)."""
+    name = "5146-t2-agent"
+    never_declared = "5146-t2-never-declared"
+    reg = _registry(tmp_path, monkeypatch)
+    reg.create(name)
+    app = _build_app(reg, monkeypatch)
+
+    assert surface_registry().get(never_declared) is None
+
+    resp = await _post(
+        app, f"/agui/chat/{never_declared}?connection_id=conn-x&token=s3cret",
+        {"type": "user_message", "text": "hello"},
+    )
+    assert resp.status_code == 404, resp.text
+
+    assert surface_registry().get(never_declared) is None, (
+        "a request naming a never-declared agent grew a SurfaceManager for "
+        "it -- the exists() gate ahead of for_agent stopped doing its job"
+    )
+
+
+@pytest.mark.asyncio
+async def test_n_connections_to_the_same_agent_share_exactly_one_manager(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: acceptance ③ — no accidental per-connection duplication."""
+    name = "5146-t3-agent"
+    reg = _registry(tmp_path, monkeypatch)
+    reg.create(name)
+    app = _build_app(reg, monkeypatch)
+
+    for conn_id in ("conn-p", "conn-q", "conn-r"):
+        resp = await _post(
+            app, f"/agui/chat/{name}?connection_id={conn_id}&token=s3cret",
+            {"type": "user_message", "text": "hello"},
+        )
+        assert resp.status_code == 200
+
+    mgr = surface_registry().for_agent(name, authorized=_authorized)
+    for conn_id in ("conn-p", "conn-q", "conn-r"):
+        mgr.attach(conn_id, f"user-{conn_id}", monotonic())
+    same_mgr = surface_registry().for_agent(name, authorized=_authorized)
+    assert same_mgr is mgr
+    assert mgr.surface_count() == 3
+
+
+def test_runtime_registry_does_not_import_the_agui_transport_module() -> None:
+    """Tier 2: acceptance ④ — the layering #5146's fix deliberately keeps
+    (architect: "AgentRegistry does not call into transport", #5139's own
+    ruling reused here). Scoped to actual ``import`` statements (an ``ast``
+    walk, not a bare substring search) so a docstring cross-reference to
+    the AG-UI consumer class (legitimate, pre-existing prose elsewhere in
+    this file) cannot make this test a false red -- only a real dependency
+    would."""
+    import ast
+
+    from tests._support.paths import REPO_ROOT
+
+    src = REPO_ROOT / "src" / "reyn" / "runtime" / "registry.py"
+    tree = ast.parse(src.read_text(encoding="utf-8"), filename=str(src))
+    offenders = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            offenders.extend(
+                alias.name for alias in node.names
+                if alias.name.startswith("reyn.interfaces")
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module.startswith("reyn.interfaces.transport.agui"):
+                offenders.append(node.module)
+    assert not offenders, (
+        f"src/reyn/runtime/registry.py imports {offenders!r} -- AgentRegistry "
+        f"must not import or call into the AG-UI transport layer; the "
+        f"purge-notification seam (add_remove_listener) exists so transport "
+        f"can subscribe FROM its own side instead"
+    )

--- a/tests/interfaces/test_5146_surface_manager_purge_lifecycle.py
+++ b/tests/interfaces/test_5146_surface_manager_purge_lifecycle.py
@@ -152,6 +152,44 @@ async def test_purge_then_same_name_redeclare_does_not_inherit_the_old_driver_to
     )
 
 
+def test_a_raising_remove_listener_does_not_stop_the_others_or_remove_itself(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: architect co-vet (issuecomment-5383416113) — the notify loop
+    isolates each callback. Before this fix, one listener raising would
+    both skip every LATER listener AND make ``remove()`` itself raise,
+    even though the purge's own ``shutil.rmtree`` (earlier in the same
+    method) had already succeeded — a caller seeing an exception from
+    ``remove()`` here would have no way to tell "the purge itself failed"
+    from "a listener misbehaved after it already succeeded"."""
+    name = "5146-t5-agent"
+    reg = _registry(tmp_path, monkeypatch)
+    reg.create(name)
+
+    calls: "list[str]" = []
+
+    def _raising_listener(_name: str) -> None:
+        calls.append("raising")
+        raise RuntimeError("a listener that misbehaves")
+
+    def _second_listener(_name: str) -> None:
+        calls.append("second")
+
+    reg.add_remove_listener(_raising_listener)
+    reg.add_remove_listener(_second_listener)
+
+    reg.remove(name, purge=True)  # must not raise
+
+    assert calls == ["raising", "second"], (
+        f"the second listener must still run after the first raised; got "
+        f"{calls!r}"
+    )
+    assert not (tmp_path / ".reyn" / "agents" / name).exists(), (
+        "the purge itself (rmtree, BEFORE the listener loop) must have "
+        "already completed regardless of a later listener's own failure"
+    )
+
+
 @pytest.mark.asyncio
 async def test_a_never_declared_agent_name_never_grows_a_manager(
     tmp_path, monkeypatch,

--- a/tests/interfaces/test_agui_ignore_unknown_both_directions.py
+++ b/tests/interfaces/test_agui_ignore_unknown_both_directions.py
@@ -87,6 +87,12 @@ class _FakeRegistry:
         # fired, matching the production split.
         return self.session
 
+    def add_remove_listener(self, callback) -> None:
+        # #5146: endpoint.py's own _ensure_remove_listener_wired touches this
+        # on every request path this file drives — a no-op stub is enough
+        # here since this file's tests never purge an agent.
+        pass
+
 
 def _app(monkeypatch, registry: _FakeRegistry) -> FastAPI:
     app = FastAPI()


### PR DESCRIPTION
**[tui-coder]** — Closes #5146 (architect ruling issuecomment-5383365332, follow-up from #5133's TESTS-READY(A)).

## What

Reviewing #5133 surfaced a finding: `SurfaceRegistry._by_agent` has no removal path. Re-derived on review: the population is already bounded by declared-agent-count (`for_agent` is only reached after `registry.exists(agent_name)` 404s a nonexistent name) — **not** unbounded growth. The real defect is **name reuse**: `AgentRegistry.remove(name, purge=True)` frees the name for immediate re-declaration, but the stale `SurfaceManager` — still holding the OLD identity's `_active_driver` token and surface set — is found and reused by `for_agent` for the NEW identity's first connection. The #5084-class hole, this time for operator authority instead of spawn lineage.

## Fix (architect ruling)

`AgentRegistry.add_remove_listener` (new, mirrors `add_attach_listener`) fires on every `remove(purge=True)`, naming the purged agent. `AgentRegistry` itself never imports or calls into `interfaces` (#5139's own layering ruling, kept here too) — the AG-UI endpoint module (which already depends on both) subscribes `SurfaceRegistry.remove` to it, exactly once per registry instance. LRU/idle bounding is **not** needed — the population is already bounded once this lands; that reasoning is written down and pinned by a test rather than left as an unchecked docstring claim.

## Test plan

- [x] `tests/interfaces/test_5146_surface_manager_purge_lifecycle.py` (4 tests, architect's own 4 acceptance criteria):
  1. purge → same-name re-declare does NOT inherit the previous driver token
  2. a never-declared agent name does not grow a manager (the bounded population, pinned)
  3. N connections to the same agent share exactly 1 manager
  4. `registry.py` does not import `reyn.interfaces.transport.agui` (AST walk over real import statements, not a substring search — a pre-existing docstring cross-reference elsewhere in the file would otherwise false-red this)
- [x] Strip-falsified twice (endpoint-side wiring call, registry-side listener fire) — both reproduce the exact symptom (stale manager reused for the new identity); restored → green, `git diff` clean both times
- [x] Full local gate (ruff / `test_tier_audit.py --strict` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `verify_module_docstrings.py`) — clean
- [x] Scoped sweep (agui/surface/5116/5119/5129/5133/5146/4534 + 5084/purge/remove/2103): 254 passed
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

⚠️ TESTS-READ note required (touches `tests/`).

part of #5116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>



---

**[tui-coder]** — architect's non-blocking point (issuecomment-5383416113) addressed, head `f99203a3b`: each remove-listener now runs in its own try/except (one raising no longer stops the rest or makes `remove()` itself raise) + documented why (rmtree already ran before this loop, so a listener's own failure destroys no evidence). New witness (5 tests total now), strip-falsified. Re-verified: full gate clean, 255 passed.
