### PR TITLE
docs(contributing): add issue-management.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Path-conditional gates:
 3. **Broker is a hint; the PR is the contract.** It is in-memory, lags ~30s, has no ack. Put critical pause/block signals on the PR **and** broker. **Deliver every new assignment over broker** — one written only on the issue reaches nobody.
 4. **Never place a closing keyword next to an issue number** unless the PR really closes it — GitHub matches literally, negation and context included. Sub-PRs use `part of #X`; before writing `Closes #X`, enumerate open PRs with `part of #X`. The same matching applies to **commit messages** (a squash body concatenates them), and a body edit does not fix one.
 5. **No blanket en/ja mirror obligation.** Fix a `.ja.md` file only when the PR falsifies something it asserts.
-6. **Arc-closure remainder rule**: every remainder is **filed** or **explicitly dropped**, in the closing comment. "Next arc" is a third, silent state.
+6. **Arc-closure remainder rule**: every remainder is **filed** or **explicitly dropped**, in the closing comment. "Next arc" is a third, silent state. (`docs/deep-dives/contributing/issue-management.md`)
 7. **A reviewer's blocking point goes in the PR body** as `- [ ] 🔴 <point>`, not only in a review comment — `--request-changes` does not work here. Rule 4 applies to that edit too.
 8. **A PR touching `tests/` does not self-merge until a reviewer's TESTS-READ claim lands as a comment's FIRST line** (marker + head SHA together; grounds go from line 2 on).
 9. **Arming auto-merge ends your reading of that PR** — a checkbox added afterwards is invisible to the merge. Do not arm while a reviewer's point is open, and re-check the body before arming.
@@ -156,6 +156,7 @@ dominate in Y. Direct verification: 1/N."
 - **Verification hazards** (a green that means less, a red that overstates): `docs/deep-dives/contributing/verification-hazards.md`
 - **Tier-1 rules, full rationale** (Constitution, hard rules, comment policy, pre-conclusion): `docs/deep-dives/contributing/tier1-rationale.md`
 - **PR workflow, full rationale**: `docs/deep-dives/contributing/pr-workflow.md`
+- **Issue management** (what an issue is, consolidation, closing, priority axes, labels): `docs/deep-dives/contributing/issue-management.md`
 - **Six questions, full instances**: `docs/deep-dives/contributing/test-review-six-questions.md`
 - **Workspace** (single source of truth): `docs/concepts/runtime/workspace.md`
 - **Events / replay**: `docs/concepts/runtime/events.md`

--- a/docs/deep-dives/contributing/issue-management.md
+++ b/docs/deep-dives/contributing/issue-management.md
@@ -1,0 +1,142 @@
+# Issue management
+
+Normative for the lead-coder role. Decided by the repo owner 2026-08-22/23.
+
+## 1. What an issue is
+
+An issue is **one problem to be addressed in future**. It is not a record of
+what happened. Owner, verbatim: 「issue は将来対策すべき問題ごとに一つ作る
+べき」「単なる日記を起票すべきではない」.
+
+A body that is mostly a chronicle of an incident, with the future problem
+appearing in a single sentence or not at all, is not an issue — the
+chronicle belongs in the PR or a doc, and only the problem statement belongs
+in the issue. This keeps the backlog searchable as a list of problems, not a
+log of sessions.
+
+## 2. Consolidation
+
+**Issues that would be addressed in the same change are one issue.** Owner,
+verbatim: 「一緒に対策すべき問題を分散させるのは悪手」「同時に対策すべき
+issue は統合すべき」.
+
+The test is NOT "are these different problems" — that test passes too
+easily, and passing it too easily is exactly how issues get split that
+should not have been. The test is **"would fixing one force touching what
+the other is about"**.
+
+Measured instance: #5141 was split from #5139 on the grounds that one was
+about rendering and the other about wire volume — two different problems by
+the easy test. They were folded back after the architect's own note showed
+the #5139 fix creates the data structure (`BacklogBatch`) that #5141's
+limit/cursor has to live in — splitting them meant the second issue's fix
+would have rewritten the first's structure.
+
+Evidence for a grouping must be a **named artifact** — a file, function, or
+data structure both issues would change. A shared theme ("both about the
+TUI") is not evidence; a shared artifact is.
+
+## 3. The only axis for closing
+
+**An issue closes when its claim is no longer true** — fixed, superseded, or
+never real to begin with. Verify this against the code, not against the
+issue's own text.
+
+Explicitly NOT grounds for closing:
+
+- nobody plans to do it
+- nobody has picked it up
+- it is old
+- the backlog is long
+
+Owner, verbatim: 「計画ないものを落とすはダメでしょ。そもそも issue は計画で
+はない」. A backlog exists precisely to hold problems nobody has planned yet;
+closing the unplanned ones inverts its purpose — it would leave the backlog
+holding only what is already being worked, which is what a project board is
+for, not what a backlog is for.
+
+## 4. Priority is a judgement, and it is the lead's
+
+Ordering a backlog is not a sort key — someone has to judge, and the
+judgement has to be defensible or it is decoration. Owner, verbatim: 「順序に
+は優先順位を判断しなきゃいけないんだよ？」.
+
+The axes below are taken from the repo's own charter (`docs/concepts/architecture/charter.md`)
+rather than invented for this purpose, in order:
+
+1. **band** — violates the cross-cutting band (permission · audit-events ·
+   workspace-SSoT · crash-recovery/WAL · cost-budget/bounding). The charter
+   says a band failure does not ship, and band violations are exempt from
+   the count thresholds that otherwise suppress low-frequency work.
+2. **owner-hit** — the operator hits it in the shipped configuration.
+   Broken-in-reality outranks unclean-in-design.
+3. **silent** — a wrong answer arrives with no signal. Nothing turns red, so
+   it survives indefinitely unless someone goes looking for it.
+4. **blocks-others** — the absence of a mechanism stalls other sessions. One
+   defect here costs N people's time, not one.
+5. **thin areas** — Retrieval and Evaluation, which the charter names as the
+   areas where new work is most valuable.
+
+Demotion axis: **ours-only** — an issue whose only consumer is our own
+process (not the operator, not the product) ranks below product work.
+
+## 5. Labels carry the judgement so it can be made cheaply
+
+Owner, verbatim: 「その判断を効率化するためにタイトルやラベルを使うように
+してよ」. Triage must not require reading 35 bodies to re-derive an ordering
+that was already decided once.
+
+These labels exist in the repo now, carrying the meanings below:
+
+- `band`, `owner-hit`, `silent`, `blocks-others`, `ours-only`,
+  `thin:retrieval`, `thin:evaluation` — the axes from §4.
+- `priority:next` — the lead has judged this issue and it is next.
+  **Absence of `priority:next` means "not yet judged", NOT "low
+  priority"** — a scale with more levels than there are judgements
+  manufactures false precision, so there is no `priority:later` or
+  `priority:low` tier to fall back to.
+- `blocked:external` — needs owner judgement or an upstream dependency. An
+  open issue without it is pickable by any session. This label tells other
+  sessions not to touch the issue, so a stale one makes real work invisible:
+  #4364 carried the label after its own hold had been lifted and after
+  another session had already started the work — the label was still
+  telling readers to stay away from work already in progress.
+
+A new issue gets its axis label(s) when it is filed, not later. Deferring
+the label is how a backlog ends up with 35 issues at equal, unlabeled
+weight.
+
+## 6. What the lead owes the backlog
+
+Each of these is a duty, not a description — and each has a failure mode
+observed on 2026-08-22:
+
+- **Know who holds each issue and whether it moves.** Without this the lead
+  cannot answer "who is on #5010" without re-reading the issue from
+  scratch.
+- **Keep an order.** With 35 pickable issues at equal weight, nobody can
+  choose — the lead gets asked every time, and searches for an answer while
+  other sessions sit idle.
+- **Have the next thing decided before someone frees up.** Sessions went
+  idle repeatedly that night and work was found reactively, after the idle
+  time had already been spent.
+- **Notice what is not being filed.** Fourteen issues were filed in one
+  night and none touched Retrieval or Evaluation — the two areas the
+  charter names as thin. A backlog that only holds what the team tripped
+  over mirrors the team's own path through the code, not the product's
+  actual gaps.
+
+## 7. Priority over reviewing and implementing
+
+Owner, verbatim: 「リーダはレビューと作業よりも issue 管理を優先すべきで
+しょ。レビューは arch でもできるし、作業は coder/subagent にふれば良いだ
+け」.
+
+PR review — finding blocking points — defaults to the architect.
+Implementation goes to a coder session, or to a sonnet subagent when the
+work is mechanical and the design is already settled. The lead does not
+implement.
+
+What stays with the lead: issue management (§1–§6), deciding who gives the
+independent TESTS-READ note (house rule 8 — it cannot be the PR's author or
+the design's author), and merging.

--- a/docs/deep-dives/contributing/issue-management.md
+++ b/docs/deep-dives/contributing/issue-management.md
@@ -13,7 +13,7 @@ Normative for the lead-coder role. Decided by the repo owner 2026-08-22/23.
 
 An issue is **one problem to be addressed in future**. It is not a record of
 what happened. Owner, verbatim: 「issue は将来対策すべき問題ごとに一つ作る
-べき」「単なる日記を起票すべきではない」.
+べき」「単なる日記を〔起票〕すべきではない」.
 
 A body that is mostly a chronicle of an incident, with the future problem
 appearing in a single sentence or not at all, is not an issue — the

--- a/docs/deep-dives/contributing/issue-management.md
+++ b/docs/deep-dives/contributing/issue-management.md
@@ -1,3 +1,10 @@
+---
+type: contributing
+topic: issue-management
+audience: [human, agent]
+search_hints: [issue management, backlog, 起票, 統合, consolidation, close, closing, 閉じる, priority, 優先順位, label, labels, triage, blocked:external, priority:next, band, owner-hit, silent, blocks-others, ours-only, thin:retrieval, thin:evaluation, arc-closure remainder, diary, 日記, issue triage, priority axes]
+---
+
 # Issue management
 
 Normative for the lead-coder role. Decided by the repo owner 2026-08-22/23.

--- a/docs/deep-dives/contributing/issue-management.md
+++ b/docs/deep-dives/contributing/issue-management.md
@@ -2,7 +2,7 @@
 type: contributing
 topic: issue-management
 audience: [human, agent]
-search_hints: [issue management, backlog, 起票, 統合, consolidation, close, closing, 閉じる, priority, 優先順位, label, labels, triage, blocked:external, priority:next, band, owner-hit, silent, blocks-others, ours-only, thin:retrieval, thin:evaluation, arc-closure remainder, diary, 日記, issue triage, priority axes]
+search_hints: [issue management, backlog, 起票, 統合, consolidation, close, closing, 閉じる, priority, 優先順位, label, labels, triage, blocked:external, priority:next, band, owner-hit, silent, blocks-others, ours-only, thin:retrieval, thin:evaluation, no-axis, arc-closure remainder, diary, 日記, issue triage, priority axes]
 ---
 
 # Issue management
@@ -111,6 +111,11 @@ These labels exist in the repo now, carrying the meanings below:
   priority"** — a scale with more levels than there are judgements
   manufactures false precision, so there is no `priority:later` or
   `priority:low` tier to fall back to.
+- `no-axis` — judged, and none of the priority axes applies. It exists so
+  that an issue with no axis label means "not yet judged" rather than
+  "judged and found unimportant" — without it those two states are the
+  same absence, and a later reader cannot tell whether the backlog was
+  triaged or merely untouched.
 - `blocked:external` — needs owner judgement or an upstream dependency. An
   open issue without it is pickable by any session. This label tells other
   sessions not to touch the issue, so a stale one makes real work invisible:

--- a/docs/deep-dives/contributing/issue-management.md
+++ b/docs/deep-dives/contributing/issue-management.md
@@ -62,27 +62,36 @@ closing the unplanned ones inverts its purpose — it would leave the backlog
 holding only what is already being worked, which is what a project board is
 for, not what a backlog is for.
 
+No mechanism enforces this. There is no path that inspects the moment an
+issue is closed (measured, 2026-08-22). What holds it is a person.
+
 ## 4. Priority is a judgement, and it is the lead's
 
 Ordering a backlog is not a sort key — someone has to judge, and the
 judgement has to be defensible or it is decoration. Owner, verbatim: 「順序に
 は優先順位を判断しなきゃいけないんだよ？」.
 
-The axes below are taken from the repo's own charter (`docs/concepts/architecture/charter.md`)
-rather than invented for this purpose, in order:
+The axes below have five different sources — each is named plainly rather
+than folded into one blanket provenance claim, in order:
 
-1. **band** — violates the cross-cutting band (permission · audit-events ·
-   workspace-SSoT · crash-recovery/WAL · cost-budget/bounding). The charter
-   says a band failure does not ship, and band violations are exempt from
-   the count thresholds that otherwise suppress low-frequency work.
+1. **band** — the charter's own cross-cutting band (`docs/concepts/architecture/charter.md`):
+   permission · audit-events · workspace-SSoT · crash-recovery/WAL ·
+   cost-budget/bounding. The charter says a band failure does not ship, and
+   band violations are exempt from the count thresholds that otherwise
+   suppress low-frequency work.
 2. **owner-hit** — the operator hits it in the shipped configuration.
-   Broken-in-reality outranks unclean-in-design.
-3. **silent** — a wrong answer arrives with no signal. Nothing turns red, so
-   it survives indefinitely unless someone goes looking for it.
+   Derived from `CLAUDE.md`'s second gating question, "is this visible with
+   the shipped config?" — broken-in-reality outranks unclean-in-design.
+3. **silent** — a wrong answer arrives with no signal. Derived from
+   `CLAUDE.md`'s third gating question, "does the repair destroy the
+   evidence?" — a failure with no signal leaves nothing to repair from, so
+   nothing turns red and it survives indefinitely unless someone goes
+   looking for it.
 4. **blocks-others** — the absence of a mechanism stalls other sessions. One
-   defect here costs N people's time, not one.
-5. **thin areas** — Retrieval and Evaluation, which the charter names as the
-   areas where new work is most valuable.
+   defect here costs N people's time, not one. **This axis is the lead's own
+   addition** — it has no charter or `CLAUDE.md` basis.
+5. **thin areas** — Retrieval and Evaluation, which `CLAUDE.md` names as the
+   areas where new work is most valuable. (`CLAUDE.md`, not the charter.)
 
 Demotion axis: **ours-only** — an issue whose only consumer is our own
 process (not the operator, not the product) ranks below product work.

--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -247,7 +247,10 @@ These rules then keep multi-session work coherent:
    session's own memory) and rotted invisibly. A remainder belongs on the
    surface the merge gate actually reads (an open issue, an unchecked Test
    plan item) — not on a surface nobody re-checks (a broker message, a memory
-   pin, a comment's prose that never becomes a ticket).
+   pin, a comment's prose that never becomes a ticket). Filing the remainder
+   is the start of its life as backlog, not a decision about its priority or
+   its eventual close — both governed by
+   `docs/deep-dives/contributing/issue-management.md`.
 7. **A reviewer's blocking point goes in the PR body as an unchecked Test
    plan item, not only in a review comment.** `gh pr review --request-changes`
    does not work in this repo's setup: every session authenticates as the


### PR DESCRIPTION
**[lead-coder]** — New normative doc: `docs/deep-dives/contributing/issue-management.md`, recording the issue-management rules the repo owner decided tonight (2026-08-22/23) for the lead-coder role.

## What this documents

1. What an issue is — one future problem, not a chronicle.
2. Consolidation — the "would fixing one force touching what the other is about" test, with the #5141/#5139 measured instance.
3. The only axis for closing — claim no longer true, verified against code; explicitly not "unplanned" / "old" / "backlog is long". **No mechanism enforces this** — stated in the doc itself, see below.
4. Priority is a judgement (the lead's), on five axes with five different, individually-attributed sources (see below) — not a single blanket citation.
5. Labels that carry the judgement cheaply, including the `priority:next` absence-means-not-yet-judged distinction and the `blocked:external` staleness hazard (#4364).
6. What the lead owes the backlog, each duty with its observed 2026-08-22 failure mode.
7. Why issue management outranks review/implementation for the lead role.

## Reviewer blocking points — addressed

- [x] 🔴 **Provenance claim on §4's priority axes was false.** The doc said the axes were "taken from the repo's own charter … rather than invented." Measured by the reviewer against `origin/main`: `owner-hit` → charter 0, CLAUDE.md 0; `blocks-others` → charter 0, CLAUDE.md 0; "Retrieval and Evaluation" → charter 0, CLAUDE.md 1. Only `band` is actually in the charter; `thin:retrieval`/`thin:evaluation` are in `CLAUDE.md`, not the charter. Fixed: each axis now names its real source individually — `band` cited to the charter's cross-cutting band; `owner-hit` and `silent` marked "derived from" `CLAUDE.md`'s 2nd/3rd gating questions respectively (not "taken from"); `thin areas` attributed to `CLAUDE.md`, not the charter; **`blocks-others` stated plainly as the lead's own addition with no charter or `CLAUDE.md` basis** (not softened to "informed by"/"in the spirit of"). The blanket "rather than invented" phrasing was deleted.
- [x] 🔴 **§3 didn't disclose that closing has no enforced gate.** A reader assumes a mechanism exists unless told otherwise. Added to §3, verbatim as requested: "No mechanism enforces this. There is no path that inspects the moment an issue is closed (measured, 2026-08-22). What holds it is a person." Not turned into a plan to build a gate — the decision to ship without one is deliberate (the rule is semantic; a low-false-positive gate for it doesn't exist).

**Non-blocking, already settled — no doc change**: the reviewer's tree reported `wc -w CLAUDE.md` = 2044 against this PR body's stated 2071. Re-measured both directly: `origin/main` is 2057, this PR's head is 2071 (net +14 words for the two reference lines added in an earlier round). The PR body's number is correct; the reviewer's checkout was stale. Dropping this point — no action needed on it.

## Reachability

Three changes so the doc is reachable at the moment of the action, not only by someone already browsing the index:

1. **`search_hints:` frontmatter** on the new doc, following the shape at `docs/concepts/runtime/config-hot-reload.md:5` (`type` / `topic` / `audience` / `search_hints`). Hints include the title words and the words someone actually searches mid-task: issue, backlog, 起票, 統合, consolidation, close, closing, 閉じる, priority, 優先順位, label, triage, `blocked:external`, `priority:next`, band, owner-hit, silent, blocks-others, ours-only, `thin:retrieval`, `thin:evaluation`, arc-closure remainder, diary, 日記.
2. **`CLAUDE.md`'s own arc-closure rule (rule 6, PR-workflow section)** carries a bare reference to this doc, alongside the "When in doubt" index entry next to the PR-workflow pointer. No prose was added to `CLAUDE.md` beyond the two reference lines.
3. **`pr-workflow.md`'s own rule 6 (arc-closure remainder rule)** also points to this doc — it has no separate see-also list to extend, so the pointer sits where the file already discusses what happens to a remainder that doesn't land in the PR.

**Stated plainly, not overstated — accepted by the coordinator as a known, disclosed gap, not something this PR closes**: there is **no enforced path at the literal moment of `gh issue close` itself**. What exists is arc-closure rule 6 (fires when a session is settling a remainder, adjacent to but not identical with closing an existing issue) plus `search_hints` (reachable if the session searches first). A session that closes an issue directly and doesn't search is not routed here by any enforced mechanism. Closing that gap fully would need a CI check or an issue-close checklist item — out of scope for a docs-only PR.

## CLAUDE.md word count

`wc -w CLAUDE.md` → **2071** words at this PR's head (from 2057 on `origin/main` — net +14 words for the rule-6 reference and the "When in doubt" entry, both bare references, no inlined prose).

## Owner-verbatim quotations — verified against source

The coordinator (who has the actual owner conversation, which I do not have access to) checked all eight 「」-quoted owner lines in the doc against that source. **Seven of eight are verbatim as written.** **One was not**: §1's second quote — the owner's own message contained a typing slip, 気表 for 起票 — and the doc had silently normalized it to 起票 while still presenting the line inside full quotation marks, which is a silent correction dressed as a verbatim quote. Fixed by marking the corrected token explicitly: 「単なる日記を〔起票〕すべきではない」. No footnote was added explaining the slip, per instruction — the bracket states the correction as information about the text, not commentary on the typo.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, only pre-existing INFO-level ja-anchor notices (not this PR's files); re-run after every round of edits, most recently after the two blocking-point fixes
- [x] `python scripts/check_doc_anchors.py` — exit 0, "no dangling anchors into published pages"; re-run after every round of edits, most recently after the two blocking-point fixes
- [x] `python scripts/check_retired_config_keys_denylist.py` — exit 0, "retired-config-key denylist OK: 0 hits"
- [x] `ruff check .` — exit 0, "All checks passed!"
- [x] (skipped — docs only)

Does not touch `tests/`, so no TESTS-READ note is required for this PR.


## Update — `no-axis` label added to §5 (coordinator's addition, landed while PR was open)

The coordinator created the `no-axis` label after §5 was written, so the doc's label list would have gone stale on merge. Per this repo's own doc-drift rule, fixed in this same PR:

- Added `no-axis` to §5's label list: **judged, and none of the priority axes applies** — exists so an issue with no axis label means "not yet judged" rather than "judged and found unimportant"; without it those two states are the same absence, and a later reader can't tell whether the backlog was triaged or merely untouched.
- Added `no-axis` to the doc's `search_hints` frontmatter for consistency with the other axis labels.

**Label-existence check, as requested — done, not assumed**: `gh label list --repo tya5/reyn --json name --jq '.[].name'` (default, no `--limit`) returned only 30 rows and silently truncated — every axis label the doc names (`band`, `owner-hit`, `silent`, `blocks-others`, `ours-only`, `thin:retrieval`, `thin:evaluation`, `priority:next`, `blocked:external`) was **absent** from that truncated list, which would have read as "none of these exist." Re-ran with `gh label list --repo tya5/reyn --limit 200 --json name --jq '.[].name'`: all of them are present, plus `no-axis` itself. **No mismatch** — every label §5 currently names is real. Flagging the near-miss because it's the same failure shape as the coordinator's own `band`-created-twice story: a silent truncation/swallowed-error looks identical to "it doesn't exist" until you ask again without the default limit.

## Test plan (this round)

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, only pre-existing INFO-level ja-anchor notices (not this PR's files)
- [x] `python scripts/check_doc_anchors.py` — exit 0, "no dangling anchors into published pages"
- [x] `ruff check .` — exit 0, "All checks passed!"
