### PR TITLE
fix(#5042): an approval binds to the resource's identity, not its name

### DIFF
--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -28,6 +28,7 @@ Config pre-approval (reyn.yaml / reyn.local.yaml):
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, ClassVar
@@ -486,6 +487,12 @@ class PermissionResolver:
         # fail-closed default this PR adds is OBSERVABLE (count/log), not a
         # silent behaviour change; read via ``unconfirmable_identity_check_count``.
         self._unconfirmable_identity_checks: int = 0
+        # #5152 (architect ruling, issuecomment-5383604927): one open fd
+        # per bound key, held for the remaining life of THIS process --
+        # see ``_acquire_identity_fd``'s own docstring for why this is
+        # what makes an ino comparison trustworthy without ``st_birthtime``.
+        # Bounded by the number of distinct PATH-flavor approvals in use.
+        self._bound_fds: "dict[str, int]" = {}
         # #1383 (D12): scoped read-grants for OS-offloaded artifacts. When the OS
         # offloads an artifact to a state-dir path and hands the agent an
         # `artifact_ref` / `_offload_ref` pointing there, that path is outside the
@@ -656,16 +663,61 @@ class PermissionResolver:
         (most Linux filesystems via plain ``stat()``); ``None`` overall
         only for the path genuinely not existing. This method makes no
         claim about what an ``st_birthtime``-less comparison MEANS — that
-        interpretation (fail-closed, per #5152) lives in
-        :meth:`_identity_check_passes`, not here."""
+        interpretation (the 3-value confirmed/refuted/unconfirmable
+        contract, per #5152) lives in :meth:`_identity_check_passes`, not
+        here."""
         try:
             st = path.stat()
         except OSError:
             return None
         return (st.st_ino, getattr(st, "st_birthtime", None))
 
+    def _acquire_identity_fd(self, key: str, path: Path) -> None:
+        """#5152 (architect ruling, issuecomment-5383604927): open and
+        hold a file descriptor to *path*, for the remaining life of THIS
+        process, from the moment *key*'s identity is (re)bound.
+
+        Why this closes the ``st_birthtime``-absent gap entirely: POSIX
+        keeps an inode allocated as long as ANY reference to it remains
+        open, even after every directory entry naming it is removed
+        (``rmdir``/``unlink``). So as long as this fd stays open, the
+        filesystem cannot silently hand that SAME inode number to a
+        brand-new object created at the same path — the exact ambiguity
+        that made a bare ``ino`` comparison untrustworthy without
+        ``st_birthtime`` (measured: Linux ext4/tmpfs routinely reuses a
+        just-freed inode; this fd being held prevents that reuse for
+        *this* inode specifically). A later ``fstat(fd)`` vs. a fresh
+        ``stat(path)`` therefore gives a REAL confirmed match/mismatch,
+        with or without ``st_birthtime`` — see :meth:`_identity_check_passes`.
+
+        Does NOT survive a process restart (the fd table starts empty) —
+        that residual window is the ``unconfirmable_identity_check_count``
+        acceptance criterion, not closed by this method. Bounded by the
+        number of distinct PATH-flavor approvals in use (test-review Q5)
+        — one fd per bound key; a rebind (this method called again for
+        the same key) closes the previous fd first rather than
+        accumulating one per rebind. Best-effort: a failure to open
+        (permissions, races) just means this process falls back to the
+        stat-only comparison for *key*, same as before this method
+        existed."""
+        old = self._bound_fds.pop(key, None)
+        if old is not None:
+            try:
+                os.close(old)
+            except OSError:
+                pass
+        try:
+            self._bound_fds[key] = os.open(str(path), os.O_RDONLY)
+        except OSError:
+            pass
+
     def _bind_identity(
-        self, key: str, identity: "tuple[int, float | None]", *, persist: bool,
+        self,
+        key: str,
+        identity: "tuple[int, float | None]",
+        approved_p: Path,
+        *,
+        persist: bool,
     ) -> None:
         """Record *key*'s bound identity — bind-ON-FIRST-USE (#5042
         architect ruling), never at approval time (an approval can predate
@@ -677,7 +729,10 @@ class PermissionResolver:
         True for a ``_saved`` (``ALWAYS``-choice) approval, written to the
         SAME file's own ``_bound_identities`` sibling key, never mixed
         into the approval row itself (see ``__bound_identities``'s own
-        docstring for why).
+        docstring for why). Also (re)acquires this process's identity fd
+        for *key* (see :meth:`_acquire_identity_fd`) — binding and fd
+        acquisition happen together so every caller gets both halves of
+        the confirmation contract for free.
 
         architect co-vet (issuecomment-5383499299): this write fires far
         more often than ``_persist``'s own read-modify-write of the same
@@ -695,6 +750,7 @@ class PermissionResolver:
         finding (architect: file a follow-up; the owner runs 2 clients +
         a server concurrently, so this is not a hypothetical)."""
         self._bound_identities[key] = identity
+        self._acquire_identity_fd(key, approved_p)
         if not persist:
             return
         try:
@@ -955,33 +1011,37 @@ class PermissionResolver:
         :meth:`_is_path_approved_for`'s own docstring for the bind-on-
         first-use / mismatch-means-keep-searching contract this serves.
 
-        #5152 (architect ruling, issuecomment-5383544769): a bound and a
-        current identity can each carry ``st_birthtime=None`` (platform
-        does not expose it — most Linux filesystems). ``ino`` alone does
-        NOT distinguish "the same object, still there" from "the freed
-        inode handed straight back to a brand-new object at the same
-        path" — measured live (tui-coder, PR #5152 CI): Linux
-        ext4/tmpfs routinely reuses the just-freed inode for the very
-        next create in an otherwise-empty directory, while the same
-        rmtree-then-mkdir on macOS/APFS produces a different inode every
-        time. Treating that unconfirmable ino-only equality as a
-        genuine match silently collapsed "confirmed identical" and
-        "cannot tell" onto the same ``True`` — the SAME defect
-        ``AgentRegistry.agent_directory_identity`` (#5084) carries,
-        re-filed there as a separate issue (#5084/#5123) since that
-        call site's safe direction differs by consumer and needs its
-        own measurement.
+        #5152 (architect ruling, issuecomment-5383604927 — RETRACTING
+        issuecomment-5383544769's own literal fail-closed, which turned
+        out to be over-broad, see below). This is a THREE-value question,
+        not two: ① confirmed same → honor the grant; ② confirmed
+        different → deny (#5042's own purpose); ③ cannot be confirmed
+        either way → honor the grant AND count/log it, never silently
+        fold ③ into ②. Folding ③ into ② (the retracted ruling) made
+        every path approval effectively single-use on a platform without
+        ``st_birthtime`` — measured regression (tui-coder): 6 unrelated
+        tests failed, every one an ordinary same-session repeat use of an
+        already-bound approval with NO purge at all; the fix's own log
+        line fired on that second, unrelated use, proving ③ had been
+        silently answered as ②.
 
-        The fix here: when ``st_birthtime`` is unavailable on either
-        side, the comparison CANNOT be confirmed — default to
-        fail-closed (do not trust the binding; the caller re-asks,
-        which #4204 degrades to ``PermissionError`` outside an
-        interactive session), and count/log it via
-        ``unconfirmable_identity_check_count`` so this is an observable
-        fact, not a silent behaviour change. A platform that DOES expose
-        ``st_birthtime`` (macOS/APFS and friends) is unaffected — the
-        full tuple still compares equal across ordinary continued use
-        and unequal across a genuine purge+recreate."""
+        The fix that actually closes the ``st_birthtime`` gap without
+        that collapse: :meth:`_acquire_identity_fd` holds an fd open on
+        the approved path from bind-time onward, for the rest of THIS
+        process's life. As long as that fd stays open, POSIX guarantees
+        its inode cannot be silently handed to a replacement object, so
+        ``fstat(fd)`` vs. a fresh ``stat(path)`` is a REAL confirmed
+        match/mismatch (① or ②) — with or without ``st_birthtime`` — and
+        this is the path taken for every use after the first in a given
+        process. ③ now only remains for the genuinely unprotected window:
+        the FIRST use after a process restart (the fd table starts
+        empty, only the persisted ``(ino, birthtime)`` survived) on a
+        platform where that pair alone can't confirm anything. The SAME
+        defect (2-value collapse via bare ino) exists in
+        ``AgentRegistry.agent_directory_identity`` (#5084) — out of
+        scope here, re-filed separately (#5084/#5123) since that call
+        site's safe direction differs by consumer.
+        """
         bound = self._bound_identities.get(key)
         current = self._path_identity(approved_p)
         if bound is None:
@@ -991,20 +1051,44 @@ class PermissionResolver:
                 # only) approval was never persisted to approvals.yaml in
                 # the first place, and binding it there too would write
                 # disk state for a grant the user never asked to persist.
-                self._bind_identity(key, current, persist=key in self._saved)
+                self._bind_identity(key, current, approved_p, persist=key in self._saved)
             return True  # unbound (never used, or target doesn't exist yet) -- honor it
         if current is None:
             return False  # the approved target is gone -- fail-closed
-        if bound[1] is None or current[1] is None:
+
+        fd = self._bound_fds.get(key)
+        if fd is not None:
+            try:
+                fd_ino = os.fstat(fd).st_ino
+            except OSError:
+                fd = None  # the fd itself went bad -- fall through below
+            else:
+                # ① / ② — a REAL confirmation, fd-anchored: this fd has
+                # held its inode open since bind, so no replacement
+                # object could have silently reused it.
+                return fd_ino == current[0]
+
+        # No fd protection for `key` in THIS process (most commonly: the
+        # first use after a process restart). Fall back to the raw stat
+        # comparison this PR originally shipped with.
+        if bound[1] is not None and current[1] is not None:
+            matched = current == bound  # ① or ② -- st_birthtime confirms it directly
+        else:
+            # ③ — cannot confirm. Honor the grant (never silently fold
+            # into ②), count/log it, and (re)acquire an fd below so
+            # every LATER use in this process is fd-anchored instead.
             self._unconfirmable_identity_checks += 1
             logger.warning(
                 "PermissionResolver: %r's bound identity cannot be "
-                "confirmed (st_birthtime unavailable) -- treating as "
-                "stale rather than trusting an ino-only match",
+                "confirmed by stat alone (st_birthtime unavailable, no "
+                "fd held by this process yet) -- honoring the grant and "
+                "anchoring an fd for the rest of this process's life",
                 key,
             )
-            return False
-        return current == bound
+            matched = True
+        if matched:
+            self._bind_identity(key, current, approved_p, persist=key in self._saved)
+        return matched
 
     # Backwards-compatible alias used by older write-class call sites.
     def _is_path_approved(self, path: str, actor: str) -> bool:

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -658,7 +658,23 @@ class PermissionResolver:
         True for a ``_saved`` (``ALWAYS``-choice) approval, written to the
         SAME file's own ``_bound_identities`` sibling key, never mixed
         into the approval row itself (see ``__bound_identities``'s own
-        docstring for why)."""
+        docstring for why).
+
+        architect co-vet (issuecomment-5383499299): this write fires far
+        more often than ``_persist``'s own read-modify-write of the same
+        file — ``_persist`` only runs when a HUMAN approves (rare);
+        binding runs on every path-approval's FIRST USE, inside ordinary
+        tool execution (routine). A crash mid-``write_text`` here would
+        truncate ``approvals.yaml`` and lose EVERY approval, not just the
+        one being bound — a rare risk turned common by this PR's own
+        change in call frequency. Fixed the same way
+        ``AgentIdentityGenerationStore.record`` already does (tmp file +
+        atomic ``replace``): the write either lands whole or not at all,
+        never a half-written file. A second PROCESS (server + CLI)
+        racing this same read-modify-write and last-writer-wins losing
+        the OTHER process's binding is a separate, NOT-closed-here
+        finding (architect: file a follow-up; the owner runs 2 clients +
+        a server concurrently, so this is not a hypothetical)."""
         self._bound_identities[key] = identity
         if not persist:
             return
@@ -675,10 +691,14 @@ class PermissionResolver:
                 bound_section = {}
             bound_section[key] = {"ino": identity[0], "birthtime": identity[1]}
             existing["_bound_identities"] = bound_section
-            self._approvals_path.write_text(
+            tmp = self._approvals_path.with_suffix(
+                self._approvals_path.suffix + ".tmp"
+            )
+            tmp.write_text(
                 yaml.dump(existing, allow_unicode=True, default_flow_style=False),
                 encoding="utf-8",
             )
+            tmp.replace(self._approvals_path)
         except Exception:
             pass
 

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -27,6 +27,7 @@ Config pre-approval (reyn.yaml / reyn.local.yaml):
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, ClassVar
@@ -48,6 +49,8 @@ from reyn.user_intervention import (
 if TYPE_CHECKING:
     from reyn.security.permissions.file_scope import FileScopes
     from reyn.security.sandbox.policy import SandboxPolicy
+
+logger = logging.getLogger(__name__)
 
 
 _DEFAULT_WRITE_ZONES = (".reyn",)
@@ -477,6 +480,12 @@ class PermissionResolver:
         # unbound (acceptance ⑤), whether it predates #5042 entirely or is
         # a fresh grant that has not been used yet (acceptance ④).
         self.__bound_identities: "dict[str, tuple[int, float | None]] | None" = None
+        # #5152 (architect ruling, issuecomment-5383544769): a session-life
+        # counter of "identity comparison could not be confirmed" events —
+        # see ``_identity_check_passes``'s own docstring. Exists so the
+        # fail-closed default this PR adds is OBSERVABLE (count/log), not a
+        # silent behaviour change; read via ``unconfirmable_identity_check_count``.
+        self._unconfirmable_identity_checks: int = 0
         # #1383 (D12): scoped read-grants for OS-offloaded artifacts. When the OS
         # offloads an artifact to a state-dir path and hands the agent an
         # `artifact_ref` / `_offload_ref` pointing there, that path is outside the
@@ -548,6 +557,15 @@ class PermissionResolver:
         has never been bound (never used, a legacy pre-#5042 entry, or a
         non-path-flavor key, which is never bound at all)."""
         return self._bound_identities.get(key)
+
+    def unconfirmable_identity_check_count(self) -> int:
+        """#5152: how many times an identity comparison could not be
+        confirmed this session (``st_birthtime`` unavailable on one or
+        both sides) and was therefore treated as fail-closed — see
+        :meth:`_identity_check_passes`'s own docstring. Public so the
+        fail-closed default this counts is observable without reaching
+        into private state."""
+        return self._unconfirmable_identity_checks
 
     def on_persist_callback_count(self) -> int:
         """Return the number of registered ``on_persist`` callbacks.
@@ -631,14 +649,15 @@ class PermissionResolver:
             return {}
 
     def _path_identity(self, path: Path) -> "tuple[int, float | None] | None":
-        """#5042/#5084: ``(st_ino, st_birthtime)`` of *path* (file OR
+        """#5042/#5084: raw ``(st_ino, st_birthtime)`` of *path* (file OR
         directory — a path-flavor grant can name either) — the SAME shape
-        and SAME degrade-on-missing-``st_birthtime`` behaviour as
-        ``AgentRegistry.agent_directory_identity`` (#5084): ``None`` on a
-        platform without ``st_birthtime`` (most Linux filesystems via
-        plain ``stat()``) still compares by ``ino`` alone, a weaker but
-        real guarantee — never raises for that reason, only for the path
-        genuinely not existing."""
+        ``AgentRegistry.agent_directory_identity`` (#5084) reads.
+        ``st_birthtime`` is ``None`` on a platform that does not expose it
+        (most Linux filesystems via plain ``stat()``); ``None`` overall
+        only for the path genuinely not existing. This method makes no
+        claim about what an ``st_birthtime``-less comparison MEANS — that
+        interpretation (fail-closed, per #5152) lives in
+        :meth:`_identity_check_passes`, not here."""
         try:
             st = path.stat()
         except OSError:
@@ -934,7 +953,35 @@ class PermissionResolver:
     def _identity_check_passes(self, key: str, approved_p: Path) -> bool:
         """#5042: the identity half of a matched path-approval — see
         :meth:`_is_path_approved_for`'s own docstring for the bind-on-
-        first-use / mismatch-means-keep-searching contract this serves."""
+        first-use / mismatch-means-keep-searching contract this serves.
+
+        #5152 (architect ruling, issuecomment-5383544769): a bound and a
+        current identity can each carry ``st_birthtime=None`` (platform
+        does not expose it — most Linux filesystems). ``ino`` alone does
+        NOT distinguish "the same object, still there" from "the freed
+        inode handed straight back to a brand-new object at the same
+        path" — measured live (tui-coder, PR #5152 CI): Linux
+        ext4/tmpfs routinely reuses the just-freed inode for the very
+        next create in an otherwise-empty directory, while the same
+        rmtree-then-mkdir on macOS/APFS produces a different inode every
+        time. Treating that unconfirmable ino-only equality as a
+        genuine match silently collapsed "confirmed identical" and
+        "cannot tell" onto the same ``True`` — the SAME defect
+        ``AgentRegistry.agent_directory_identity`` (#5084) carries,
+        re-filed there as a separate issue (#5084/#5123) since that
+        call site's safe direction differs by consumer and needs its
+        own measurement.
+
+        The fix here: when ``st_birthtime`` is unavailable on either
+        side, the comparison CANNOT be confirmed — default to
+        fail-closed (do not trust the binding; the caller re-asks,
+        which #4204 degrades to ``PermissionError`` outside an
+        interactive session), and count/log it via
+        ``unconfirmable_identity_check_count`` so this is an observable
+        fact, not a silent behaviour change. A platform that DOES expose
+        ``st_birthtime`` (macOS/APFS and friends) is unaffected — the
+        full tuple still compares equal across ordinary continued use
+        and unequal across a genuine purge+recreate."""
         bound = self._bound_identities.get(key)
         current = self._path_identity(approved_p)
         if bound is None:
@@ -946,7 +993,18 @@ class PermissionResolver:
                 # disk state for a grant the user never asked to persist.
                 self._bind_identity(key, current, persist=key in self._saved)
             return True  # unbound (never used, or target doesn't exist yet) -- honor it
-        return current is not None and current == bound
+        if current is None:
+            return False  # the approved target is gone -- fail-closed
+        if bound[1] is None or current[1] is None:
+            self._unconfirmable_identity_checks += 1
+            logger.warning(
+                "PermissionResolver: %r's bound identity cannot be "
+                "confirmed (st_birthtime unavailable) -- treating as "
+                "stale rather than trusting an ino-only match",
+                key,
+            )
+            return False
+        return current == bound
 
     # Backwards-compatible alias used by older write-class call sites.
     def _is_path_approved(self, path: str, actor: str) -> bool:

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -460,6 +460,23 @@ class PermissionResolver:
         # property returns the SAME dict object each time, so in-place
         # `self._saved[key] = approved` still mutates the real stored dict.
         self.__saved: "dict[str, bool] | None" = None
+        # #5042: PATH-flavor approvals only ("what dir/file was this grant
+        # actually FOR, the moment it was last found valid") — a SIBLING
+        # structure under its own top-level ``_bound_identities`` key in
+        # the SAME approvals.yaml, never mixed into the approval rows
+        # themselves. Kept separate rather than changing the approval
+        # VALUE's own shape (bare `true`/`false`, unchanged) for two
+        # reasons: (a) every OTHER approval flavor (host/plugin — #5042's
+        # own architect ruling: "flavor を跨がない") never touches this at
+        # all, by construction, since only _is_path_approved_for (the
+        # file.read/file.write path) ever reads or writes it; (b) the
+        # audit row itself — the thing #5042's own issue thread named as
+        # "must not disappear" — stays BYTE-IDENTICAL to every approvals.
+        # yaml written before this change, so a pre-existing file needs no
+        # migration step: an entry with no sibling binding here is simply
+        # unbound (acceptance ⑤), whether it predates #5042 entirely or is
+        # a fresh grant that has not been used yet (acceptance ④).
+        self.__bound_identities: "dict[str, tuple[int, float | None]] | None" = None
         # #1383 (D12): scoped read-grants for OS-offloaded artifacts. When the OS
         # offloads an artifact to a state-dir path and hands the agent an
         # `artifact_ref` / `_offload_ref` pointing there, that path is outside the
@@ -525,6 +542,13 @@ class PermissionResolver:
         stored boolean (or None when not yet recorded)."""
         return self._saved.get(key)
 
+    def bound_identity_get(self, key: str) -> "tuple[int, float | None] | None":
+        """#5042: read accessor for the PATH-flavor identity binding,
+        mirroring :meth:`saved_get`'s own convention — ``None`` when *key*
+        has never been bound (never used, a legacy pre-#5042 entry, or a
+        non-path-flavor key, which is never bound at all)."""
+        return self._bound_identities.get(key)
+
     def on_persist_callback_count(self) -> int:
         """Return the number of registered ``on_persist`` callbacks.
 
@@ -573,6 +597,90 @@ class PermissionResolver:
             return {k: bool(v) for k, v in data.items() if isinstance(v, bool)}
         except Exception:
             return {}
+
+    # ── #5042: bound identity for PATH-flavor approvals only ──────────────────
+
+    @property
+    def _bound_identities(self) -> "dict[str, tuple[int, float | None]]":
+        """Same lazy-load-once shape as :attr:`_saved` — one owner, mutation
+        through the returned dict object persists via :meth:`_bind_identity`."""
+        if self.__bound_identities is None:
+            self.__bound_identities = self._load_bound_identities()
+        return self.__bound_identities
+
+    def _load_bound_identities(self) -> "dict[str, tuple[int, float | None]]":
+        if not self._approvals_path.exists():
+            return {}
+        try:
+            import yaml
+            data = yaml.safe_load(self._approvals_path.read_text(encoding="utf-8")) or {}
+            raw = data.get("_bound_identities")
+            if not isinstance(raw, dict):
+                return {}
+            out: "dict[str, tuple[int, float | None]]" = {}
+            for k, v in raw.items():
+                if not isinstance(v, dict) or "ino" not in v:
+                    continue  # malformed entry -- read as unbound, same as absent
+                ino = v.get("ino")
+                if not isinstance(ino, int):
+                    continue
+                bt = v.get("birthtime")
+                out[k] = (ino, float(bt) if isinstance(bt, (int, float)) else None)
+            return out
+        except Exception:
+            return {}
+
+    def _path_identity(self, path: Path) -> "tuple[int, float | None] | None":
+        """#5042/#5084: ``(st_ino, st_birthtime)`` of *path* (file OR
+        directory — a path-flavor grant can name either) — the SAME shape
+        and SAME degrade-on-missing-``st_birthtime`` behaviour as
+        ``AgentRegistry.agent_directory_identity`` (#5084): ``None`` on a
+        platform without ``st_birthtime`` (most Linux filesystems via
+        plain ``stat()``) still compares by ``ino`` alone, a weaker but
+        real guarantee — never raises for that reason, only for the path
+        genuinely not existing."""
+        try:
+            st = path.stat()
+        except OSError:
+            return None
+        return (st.st_ino, getattr(st, "st_birthtime", None))
+
+    def _bind_identity(
+        self, key: str, identity: "tuple[int, float | None]", *, persist: bool,
+    ) -> None:
+        """Record *key*'s bound identity — bind-ON-FIRST-USE (#5042
+        architect ruling), never at approval time (an approval can predate
+        the target existing at all; binding then would force a second,
+        unnecessary prompt the first time the path shows up). ``persist``
+        is False for a SESSION-only approval (never written to
+        ``approvals.yaml`` in the first place — binding it there too would
+        write disk state for a grant the user never asked to persist);
+        True for a ``_saved`` (``ALWAYS``-choice) approval, written to the
+        SAME file's own ``_bound_identities`` sibling key, never mixed
+        into the approval row itself (see ``__bound_identities``'s own
+        docstring for why)."""
+        self._bound_identities[key] = identity
+        if not persist:
+            return
+        try:
+            import yaml
+            self._approvals_path.parent.mkdir(parents=True, exist_ok=True)
+            existing: dict = {}
+            if self._approvals_path.exists():
+                existing = yaml.safe_load(
+                    self._approvals_path.read_text(encoding="utf-8")
+                ) or {}
+            bound_section = existing.get("_bound_identities")
+            if not isinstance(bound_section, dict):
+                bound_section = {}
+            bound_section[key] = {"ino": identity[0], "birthtime": identity[1]}
+            existing["_bound_identities"] = bound_section
+            self._approvals_path.write_text(
+                yaml.dump(existing, allow_unicode=True, default_flow_style=False),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass
 
     def _persist(self, key: str, approved: bool) -> None:
         # #2248: approvals.yaml is PERSIST, not recovery-core — so NO config generation
@@ -748,7 +856,23 @@ class PermissionResolver:
         """Return True if path is covered by any saved/session approval for this actor+kind.
 
         kind is "file.read" or "file.write".
-        """
+
+        #5042: a matching grant is additionally checked against its OWN
+        bound identity (``(st_ino, st_birthtime)`` of the APPROVED path
+        itself, ``approved_p`` below — the resource the operator actually
+        approved, not necessarily the deeper ``p_resolved`` being checked
+        under a recursive grant). Bind-ON-FIRST-USE (architect ruling,
+        issuecomment-5383453175): the first time a matching grant is found
+        with no bound identity yet (a pre-#5042 legacy entry, or a fresh
+        approval whose target did not exist at approval time), it is
+        bound NOW to whatever exists at this moment — never at approval
+        time, which can precede the target existing at all. Once bound, a
+        LATER mismatch (the approved path was deleted and a different
+        object now sits at the same name — #5042's own root finding, the
+        #5084/#5146-class "a name is not an identity") means the grant no
+        longer applies — the loop continues to the NEXT candidate key
+        rather than returning False outright, so a different, still-valid
+        grant covering the same path is not shadowed by one stale one."""
         base = self._project_root
         p = Path(path).expanduser()
         p_resolved = (base / p).resolve() if not p.is_absolute() else p.resolve()
@@ -769,16 +893,40 @@ class PermissionResolver:
                 approved_raw.resolve() if approved_raw.is_absolute()
                 else (base / approved_raw).resolve()
             )
+            matched = False
             if approved_str.endswith("/"):
                 try:
                     p_resolved.relative_to(approved_p)
-                    return True
+                    matched = True
                 except ValueError:
                     pass
             else:
-                if p_resolved == approved_p:
-                    return True
+                matched = p_resolved == approved_p
+            if not matched:
+                continue
+            if self._identity_check_passes(key, approved_p):
+                return True
+            # else: this key matched by path but its bound identity is
+            # stale — keep searching, do not fail closed on the WHOLE
+            # check just because this one candidate is no longer valid.
         return False
+
+    def _identity_check_passes(self, key: str, approved_p: Path) -> bool:
+        """#5042: the identity half of a matched path-approval — see
+        :meth:`_is_path_approved_for`'s own docstring for the bind-on-
+        first-use / mismatch-means-keep-searching contract this serves."""
+        bound = self._bound_identities.get(key)
+        current = self._path_identity(approved_p)
+        if bound is None:
+            if current is not None:
+                # Only a SAVED (ALWAYS-choice) approval's binding is
+                # written to disk — a session-only (YES-choice, this-run-
+                # only) approval was never persisted to approvals.yaml in
+                # the first place, and binding it there too would write
+                # disk state for a grant the user never asked to persist.
+                self._bind_identity(key, current, persist=key in self._saved)
+            return True  # unbound (never used, or target doesn't exist yet) -- honor it
+        return current is not None and current == bound
 
     # Backwards-compatible alias used by older write-class call sites.
     def _is_path_approved(self, path: str, actor: str) -> bool:

--- a/tests/security/test_5042_approval_identity_binding.py
+++ b/tests/security/test_5042_approval_identity_binding.py
@@ -262,3 +262,38 @@ def test_st_birthtime_unavailable_degrades_to_ino_only_like_5084(tmp_path) -> No
             )
     finally:
         PermissionResolver._path_identity = original
+
+
+@pytest.mark.asyncio
+async def test_binding_writes_atomically_no_tmp_file_left_behind(tmp_path) -> None:
+    """Tier 2: architect co-vet (issuecomment-5383499299) — binding now
+    fires on every path-approval's FIRST USE, inside ordinary tool
+    execution, not just when a human approves (rare) like `_persist`'s
+    own read-modify-write. A crash mid-`write_text` would truncate
+    `approvals.yaml` and lose EVERY approval, not just the one being
+    bound. Fixed via tmp-file + atomic `replace` (the same precedent
+    `AgentIdentityGenerationStore.record` already uses) -- this pins the
+    OBSERVABLE consequence: no `.tmp` sibling survives a successful bind,
+    and the approvals file itself is genuinely valid YAML afterward (a
+    half-written file would not parse)."""
+    import yaml
+
+    target = tmp_path / "atomic_dir"
+    target.mkdir()
+    resolver = _make_resolver(tmp_path)
+    key = "actor/file.write/atomic_dir/"
+    resolver._saved[key] = True
+    resolver._persist(key, True)
+
+    write_path = str(target / "f.txt")
+    await resolver.require_file_write(PermissionDecl(), write_path, "actor")
+
+    approvals_path = tmp_path / ".reyn" / "approvals.yaml"
+    tmp_sibling = approvals_path.with_suffix(approvals_path.suffix + ".tmp")
+    assert not tmp_sibling.exists(), (
+        "a .tmp sibling survived a successful bind -- the atomic "
+        "replace did not clean up after itself"
+    )
+    data = yaml.safe_load(approvals_path.read_text(encoding="utf-8"))
+    assert data[key] is True
+    assert data["_bound_identities"][key]["ino"] is not None

--- a/tests/security/test_5042_approval_identity_binding.py
+++ b/tests/security/test_5042_approval_identity_binding.py
@@ -217,17 +217,29 @@ def test_a_legacy_bare_true_entry_is_treated_as_unbound_and_bound_on_first_use(
         )
 
 
-def test_st_birthtime_unavailable_degrades_to_ino_only_like_5084(tmp_path) -> None:
-    """Tier 2: the one thing architect asked to be measured, not assumed
-    — the same platform-degrade #5084 already documents (most Linux
-    filesystems via plain ``stat()`` expose no ``st_birthtime``): the
-    identity comparison must still work with ``ino`` alone, never raise,
-    on a platform where ``st_birthtime`` is absent. Simulated directly
-    (this dev machine's own filesystem DOES expose ``st_birthtime``, so a
-    real platform-dependent skip would not exercise the degrade path) by
-    stubbing ``_path_identity`` to return an ino-only tuple, the SAME
-    shape ``getattr(st, "st_birthtime", None)`` produces on such a
-    platform -- ``ino`` alone must still correctly detect a mismatch."""
+def test_st_birthtime_unavailable_fails_closed_even_without_a_purge(tmp_path) -> None:
+    """Tier 2: #5152 architect ruling (issuecomment-5383544769) — the one
+    thing architect asked to be measured, not assumed. Live CI evidence
+    (tui-coder, PR #5152, both Python 3.11/3.12) showed the ORIGINAL
+    ino-only degrade this test used to witness is not "weaker but real":
+    on Linux ext4/tmpfs, ``rmtree`` immediately followed by ``mkdir`` on
+    the same path routinely hands the just-freed inode straight back, so
+    ``ino`` alone cannot distinguish "same object, still there" from "a
+    different object now sits here" — an unconfirmable ``ino``-only
+    equality is NOT a confirmed match. Simulated directly here (this dev
+    machine's own filesystem DOES expose ``st_birthtime``, so a real
+    platform-dependent skip would not exercise the path) by stubbing
+    ``_path_identity`` to strip ``st_birthtime``, the SAME shape
+    ``getattr(st, "st_birthtime", None)`` produces on such a platform.
+
+    The fix: once ``st_birthtime`` is unavailable, EVERY later comparison
+    against this key fails closed — even with NO purge at all, the SAME
+    still-existing directory, same inode. This is deliberately
+    indistinguishable from the genuine-purge case below: the point is
+    that "cannot confirm" is no longer silently read as "matched", not
+    that ino-diffing still quietly works underneath. Also witnesses
+    ``unconfirmable_identity_check_count`` incrementing once per such
+    check, per architect's "make it observable" acceptance criterion."""
     target = tmp_path / "linux_like_dir"
     target.mkdir()
     resolver = _make_resolver(tmp_path)
@@ -253,9 +265,21 @@ def test_st_birthtime_unavailable_degrades_to_ino_only_like_5084(tmp_path) -> No
         assert resolver.bound_identity_get(key) == (
             real_path_identity(resolver, target)[0], None,
         )
+        before = resolver.unconfirmable_identity_check_count()
 
+        # No purge at all -- the SAME directory, SAME inode -- yet the
+        # identity cannot be CONFIRMED (birthtime unavailable), so it
+        # fails closed rather than silently trusting the ino match.
+        with pytest.raises(PermissionError):
+            asyncio.run(
+                resolver.require_file_write(PermissionDecl(), write_path, "actor")
+            )
+        assert resolver.unconfirmable_identity_check_count() == before + 1
+
+        # A genuine purge+recreate ALSO fails closed -- unchanged, but now
+        # for the honest reason (unconfirmable), not "ino happened to differ".
         shutil.rmtree(target)
-        target.mkdir()  # a new inode, ino-only comparison must still catch this
+        target.mkdir()
         with pytest.raises(PermissionError):
             asyncio.run(
                 resolver.require_file_write(PermissionDecl(), write_path, "actor")

--- a/tests/security/test_5042_approval_identity_binding.py
+++ b/tests/security/test_5042_approval_identity_binding.py
@@ -217,29 +217,74 @@ def test_a_legacy_bare_true_entry_is_treated_as_unbound_and_bound_on_first_use(
         )
 
 
-def test_st_birthtime_unavailable_fails_closed_even_without_a_purge(tmp_path) -> None:
-    """Tier 2: #5152 architect ruling (issuecomment-5383544769) — the one
-    thing architect asked to be measured, not assumed. Live CI evidence
-    (tui-coder, PR #5152, both Python 3.11/3.12) showed the ORIGINAL
-    ino-only degrade this test used to witness is not "weaker but real":
-    on Linux ext4/tmpfs, ``rmtree`` immediately followed by ``mkdir`` on
-    the same path routinely hands the just-freed inode straight back, so
-    ``ino`` alone cannot distinguish "same object, still there" from "a
-    different object now sits here" — an unconfirmable ``ino``-only
-    equality is NOT a confirmed match. Simulated directly here (this dev
-    machine's own filesystem DOES expose ``st_birthtime``, so a real
-    platform-dependent skip would not exercise the path) by stubbing
-    ``_path_identity`` to strip ``st_birthtime``, the SAME shape
-    ``getattr(st, "st_birthtime", None)`` produces on such a platform.
+def test_same_session_repeat_use_of_a_birthtime_less_approval_is_not_asked_again(
+    tmp_path,
+) -> None:
+    """Tier 2: #5152 architect ruling (issuecomment-5383604927 —
+    RETRACTING this test's own earlier form, issuecomment-5383544769's
+    literal fail-closed). That retracted ruling made every path approval
+    effectively single-use on a platform without ``st_birthtime``:
+    measured regression (tui-coder, PR #5152 CI) — 6 unrelated tests
+    failed, every one an ordinary same-session repeat use of an
+    already-bound approval with NO purge anywhere; the retracted fix's
+    own log line fired on that second, unrelated use.
 
-    The fix: once ``st_birthtime`` is unavailable, EVERY later comparison
-    against this key fails closed — even with NO purge at all, the SAME
-    still-existing directory, same inode. This is deliberately
-    indistinguishable from the genuine-purge case below: the point is
-    that "cannot confirm" is no longer silently read as "matched", not
-    that ino-diffing still quietly works underneath. Also witnesses
-    ``unconfirmable_identity_check_count`` incrementing once per such
-    check, per architect's "make it observable" acceptance criterion."""
+    Simulated here (this dev machine's filesystem DOES expose
+    ``st_birthtime``) by stubbing ``_path_identity`` to strip it, the
+    same shape a birthtime-less platform produces. The fd this PR now
+    acquires at bind-time anchors every later use for the rest of this
+    process's life — the second and third use here must NOT ask again,
+    and must NOT be counted as unconfirmable (only a genuinely
+    fd-unprotected first-use-after-restart is ③; see
+    ``test_first_use_after_a_process_restart_...`` below)."""
+    target = tmp_path / "linux_like_dir"
+    target.mkdir()
+    resolver = _make_resolver(tmp_path)
+    key = "actor/file.write/linux_like_dir/"
+    resolver._saved[key] = True
+
+    real_path_identity = PermissionResolver._path_identity
+
+    def _ino_only(self, path):
+        result = real_path_identity(self, path)
+        if result is None:
+            return None
+        return (result[0], None)  # st_birthtime unavailable, ino-only
+
+    write_path = str(target / "f.txt")
+
+    original = PermissionResolver._path_identity
+    try:
+        PermissionResolver._path_identity = _ino_only
+        # First use: binds, and (per #5152) acquires the identity fd.
+        asyncio.run(
+            resolver.require_file_write(PermissionDecl(), write_path, "actor")
+        )
+        before = resolver.unconfirmable_identity_check_count()
+
+        # Second and third use, same session, no purge: fd-anchored --
+        # must NOT ask again, must NOT count as unconfirmable.
+        asyncio.run(
+            resolver.require_file_write(PermissionDecl(), write_path, "actor")
+        )
+        asyncio.run(
+            resolver.require_file_write(PermissionDecl(), write_path, "actor")
+        )
+        assert resolver.unconfirmable_identity_check_count() == before
+    finally:
+        PermissionResolver._path_identity = original
+
+
+def test_fd_anchored_identity_still_catches_a_purge_without_birthtime(tmp_path) -> None:
+    """Tier 2: #5152's actual fix for the Linux CI-red root cause —
+    :meth:`PermissionResolver._acquire_identity_fd` holds an fd on the
+    approved path open since bind-time; POSIX guarantees that fd's inode
+    cannot be silently handed to a replacement object, so a
+    ``rmtree``+``mkdir`` at the same path is STILL caught even with
+    ``st_birthtime`` unavailable — the fd is the real confirmation
+    mechanism now, not birthtime. This is the case the original #5042
+    fix existed to catch, now made to work on the platform (Linux) where
+    the naive ino-only comparison was defeated by inode reuse."""
     target = tmp_path / "linux_like_dir"
     target.mkdir()
     resolver = _make_resolver(tmp_path)
@@ -262,28 +307,64 @@ def test_st_birthtime_unavailable_fails_closed_even_without_a_purge(tmp_path) ->
         asyncio.run(
             resolver.require_file_write(PermissionDecl(), write_path, "actor")
         )
-        assert resolver.bound_identity_get(key) == (
-            real_path_identity(resolver, target)[0], None,
-        )
-        before = resolver.unconfirmable_identity_check_count()
 
-        # No purge at all -- the SAME directory, SAME inode -- yet the
-        # identity cannot be CONFIRMED (birthtime unavailable), so it
-        # fails closed rather than silently trusting the ino match.
-        with pytest.raises(PermissionError):
-            asyncio.run(
-                resolver.require_file_write(PermissionDecl(), write_path, "actor")
-            )
-        assert resolver.unconfirmable_identity_check_count() == before + 1
-
-        # A genuine purge+recreate ALSO fails closed -- unchanged, but now
-        # for the honest reason (unconfirmable), not "ino happened to differ".
         shutil.rmtree(target)
-        target.mkdir()
+        target.mkdir()  # a genuinely NEW directory at the same path
         with pytest.raises(PermissionError):
             asyncio.run(
                 resolver.require_file_write(PermissionDecl(), write_path, "actor")
             )
+    finally:
+        PermissionResolver._path_identity = original
+
+
+def test_first_use_after_a_process_restart_honors_the_grant_and_counts_as_unconfirmable(
+    tmp_path,
+) -> None:
+    """Tier 2: acceptance ③ — the ONE window #5152's fd-anchoring does
+    NOT close: the first use after a process restart has no fd yet (a
+    fresh process's fd table starts empty), so on a birthtime-less
+    platform it genuinely cannot be confirmed either way. The ruling
+    (issuecomment-5383604927): honor the grant — never silently deny,
+    that was the retracted ruling's own mistake — and make the fact
+    observable via ``unconfirmable_identity_check_count``.
+
+    Simulated by a SECOND, independent ``PermissionResolver`` instance
+    reading the SAME ``approvals.yaml`` — the natural analogue of a
+    process restart: memory (and the fd table with it) starts empty,
+    only the persisted ``(ino, birthtime)`` survives."""
+    target = tmp_path / "linux_like_dir"
+    target.mkdir()
+    key = "actor/file.write/linux_like_dir/"
+
+    real_path_identity = PermissionResolver._path_identity
+
+    def _ino_only(self, path):
+        result = real_path_identity(self, path)
+        if result is None:
+            return None
+        return (result[0], None)  # st_birthtime unavailable, ino-only
+
+    write_path = str(target / "f.txt")
+
+    original = PermissionResolver._path_identity
+    try:
+        PermissionResolver._path_identity = _ino_only
+
+        first = _make_resolver(tmp_path)
+        first._saved[key] = True
+        first._persist(key, True)
+        asyncio.run(
+            first.require_file_write(PermissionDecl(), write_path, "actor")
+        )
+
+        # A fresh resolver instance == the process-restart analogue.
+        second = _make_resolver(tmp_path)
+        before = second.unconfirmable_identity_check_count()
+        asyncio.run(
+            second.require_file_write(PermissionDecl(), write_path, "actor")
+        )
+        assert second.unconfirmable_identity_check_count() == before + 1
     finally:
         PermissionResolver._path_identity = original
 

--- a/tests/security/test_5042_approval_identity_binding.py
+++ b/tests/security/test_5042_approval_identity_binding.py
@@ -1,0 +1,264 @@
+"""Tier 2: #5042 — a PATH-flavor approval is bound to the specific
+directory/file it approved, not just its NAME, so recreating a same-named
+target after the approved one is deleted asks again instead of silently
+inheriting the old grant.
+
+Root cause (lead-coder, #5042's own observation, 2026-08-22): after
+`reyn-self-work` was deleted, its own 2 approval rows survived in
+``.reyn/approvals.yaml`` (``true``, unchanged). Deleting the rows makes the
+audit-event "this was once approved" disappear (an audit hole); keeping
+them means a LATER tree created at the same path silently inherits the OLD
+approval — a real security hole, not hypothetical (an attacker or an
+accident recreating the same path gets access without ever being asked).
+
+Architect ruling (issuecomment-5383453175): neither delete-the-row nor
+leave-it-as-a-lie. A THIRD option — keep the row (band: audit-events is
+satisfied, the "this was approved" fact never disappears), but check the
+approved PATH's own identity (`(st_ino, st_birthtime)`, #5084's own
+discriminator) at the moment of USE, not at approval time (bind-ON-FIRST-
+USE: an approval can predate the target existing at all — binding at
+approval time would force an extra prompt the first time the path shows
+up). This is the SAME "a name is not an identity" class as #5084 (spawn
+lineage) and #5146 (operator driver token) — measured (architect, reading
+a real ``reyn-self/.reyn/approvals.yaml``) to apply ONLY to the PATH
+flavor of approval key (`<actor>/file.read|file.write/<path>`) — a HOST
+key (`<actor>/http.get/<host>`) or a bare PLUGIN key (`mcp.<name>`) has no
+"target disappeared" concept at all, so #5042's own fix must not touch
+those flavors' own stored shape (architect: "検査した面 ≠ 効く面" — a
+uniform 3-value scheme would add unused state to flavors that never need
+it).
+
+Storage: the approval ROW itself (`<key>: true`) is completely unchanged
+— #5042's own audit-events acceptance. The bound identity for a path-
+flavor key lives in a SIBLING top-level ``_bound_identities`` mapping in
+the SAME approvals.yaml, keyed by the SAME approval key — never mixed
+into the row's own value (see ``PermissionResolver.__bound_identities``'s
+own docstring for why: keeping it separate means a pre-#5042 approvals.yaml
+needs no migration at all — an entry with no sibling binding is simply
+"unbound", read identically whether it predates #5042 or is a fresh grant
+whose target does not exist yet).
+
+Real ``PermissionResolver`` + real filesystem paths (real ``mkdir``/
+``shutil.rmtree``) — no mocks, mirroring
+``test_4204_bucket_b_root_divergence_asks_again.py``'s own harness and its
+``resolver._saved[key] = True`` seeding convention (an existing, accepted
+direct-poke pattern in this test file's own sibling for the SAME class).
+"""
+from __future__ import annotations
+
+import asyncio
+import shutil
+
+import pytest
+
+from reyn.security.permissions import PermissionDecl
+from reyn.security.permissions.permissions import PermissionResolver
+
+
+def _make_resolver(tmp_path) -> PermissionResolver:
+    return PermissionResolver({}, project_root=tmp_path)
+
+
+def test_purge_then_recreate_the_same_named_target_asks_again(tmp_path) -> None:
+    """Tier 2: acceptance ① — the main one. Approve a dir, use it once
+    (binds its identity), delete it, recreate a genuinely NEW dir at the
+    same path — the old approval no longer applies; the write falls
+    through to a non-interactive deny (``bus=None``, matching #4204's own
+    "ask again degrades to PermissionError outside an interactive
+    session" contract) rather than silently succeeding."""
+    target = tmp_path / "some_dir"
+    target.mkdir()
+    resolver = _make_resolver(tmp_path)
+    resolver._saved["actor/file.write/some_dir/"] = True
+
+    write_path = str(target / "f.txt")
+    asyncio.run(resolver.require_file_write(PermissionDecl(), write_path, "actor"))
+
+    shutil.rmtree(target)
+    target.mkdir()  # a genuinely NEW directory at the same path -- new inode
+
+    with pytest.raises(PermissionError):
+        asyncio.run(
+            resolver.require_file_write(PermissionDecl(), write_path, "actor")
+        )
+
+
+def test_the_approval_row_itself_survives_the_stale_mismatch(tmp_path) -> None:
+    """Tier 2: acceptance ② — #5042's own audit-events half. After ①'s
+    mismatch, the approval row is STILL `true` on disk — "this was once
+    approved" never disappears, only stops applying to the new object at
+    the same path."""
+    target = tmp_path / "some_dir"
+    target.mkdir()
+    resolver = _make_resolver(tmp_path)
+    key = "actor/file.write/some_dir/"
+    resolver._saved[key] = True
+    resolver._persist(key, True)  # actually write it to disk, not just in-memory
+
+    write_path = str(target / "f.txt")
+    asyncio.run(resolver.require_file_write(PermissionDecl(), write_path, "actor"))
+
+    shutil.rmtree(target)
+    target.mkdir()
+    with pytest.raises(PermissionError):
+        asyncio.run(
+            resolver.require_file_write(PermissionDecl(), write_path, "actor")
+        )
+
+    # A FRESH resolver (forces a real re-read from disk) still sees the
+    # approval row as true.
+    fresh = _make_resolver(tmp_path)
+    assert fresh.saved_get(key) is True, (
+        "the approval row disappeared from approvals.yaml -- #5042's own "
+        "audit-events half (the row must never vanish) is not satisfied"
+    )
+
+
+def test_host_and_plugin_approvals_are_never_bound_to_an_identity(tmp_path) -> None:
+    """Tier 2: acceptance ③ — a flavor-crossing witness. A HOST approval
+    (`http.get`) and a PLUGIN approval (bare key, no actor/kind prefix)
+    are completely unaffected by #5042's own identity-binding machinery —
+    #5042 applies ONLY to the path flavor. Exercises an UNRELATED path-
+    flavor purge/recreate cycle in the SAME resolver to prove the host/
+    plugin entries stay untouched even while path-flavor binding is
+    actively happening elsewhere in the same approvals store."""
+    target = tmp_path / "some_dir"
+    target.mkdir()
+    resolver = _make_resolver(tmp_path)
+    resolver._saved["actor/file.write/some_dir/"] = True
+    resolver._saved["actor/http.get/example.com"] = True
+    resolver._saved["mcp.broker"] = True
+
+    write_path = str(target / "f.txt")
+    asyncio.run(resolver.require_file_write(PermissionDecl(), write_path, "actor"))
+
+    assert resolver.saved_get("actor/http.get/example.com") is True
+    assert resolver.saved_get("mcp.broker") is True
+    assert resolver.bound_identity_get("actor/http.get/example.com") is None, (
+        "a HOST-flavor approval must never get a bound identity -- "
+        "'target disappeared' has no meaning for a host"
+    )
+    assert resolver.bound_identity_get("mcp.broker") is None, (
+        "a PLUGIN-flavor approval must never get a bound identity"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_approval_for_a_not_yet_existing_target_passes_on_first_use(
+    tmp_path,
+) -> None:
+    """Tier 2: acceptance ④ — an approval can predate its target existing
+    at all (architect: binding AT approval time would force an extra
+    prompt the first time the path shows up). Checking it before the
+    target exists must still pass (nothing to bind yet); once the target
+    is created, the NEXT check both passes AND performs the actual
+    binding (verified via the public `bound_identity_get` accessor, not a
+    private-state peek)."""
+    target = tmp_path / "not_yet"
+    resolver = _make_resolver(tmp_path)
+    key = "actor/file.write/not_yet/"
+    resolver._saved[key] = True
+    write_path = str(target / "f.txt")
+
+    # The target does not exist yet -- still honored, no re-ask.
+    # require_file_write is a pure permission GATE (raises PermissionError
+    # or returns None) -- it performs no filesystem I/O of its own, so
+    # calling it against a not-yet-existing target is safe and exercises
+    # the SAME public seam every real caller uses, not a private method.
+    assert resolver.bound_identity_get(key) is None
+    await resolver.require_file_write(PermissionDecl(), write_path, "actor")
+    assert resolver.bound_identity_get(key) is None, (
+        "a not-yet-existing target must not be bound to anything -- "
+        "there is nothing real to bind to yet"
+    )
+
+    target.mkdir()
+    await resolver.require_file_write(PermissionDecl(), write_path, "actor")
+    assert resolver.bound_identity_get(key) is not None, (
+        "the first check AFTER the target started existing must have "
+        "bound its identity"
+    )
+
+
+def test_a_legacy_bare_true_entry_is_treated_as_unbound_and_bound_on_first_use(
+    tmp_path,
+) -> None:
+    """Tier 2: acceptance ⑤ — a pre-#5042 approvals.yaml (bare `true`, no
+    `_bound_identities` section at all) needs no migration: an entry with
+    no sibling binding reads identically to a fresh grant that has never
+    been used. First use binds it; a later purge+recreate on the SAME
+    entry then asks again, exactly like ①."""
+    target = tmp_path / "legacy_dir"
+    target.mkdir()
+    approvals_dir = tmp_path / ".reyn"
+    approvals_dir.mkdir(parents=True, exist_ok=True)
+    key = "actor/file.write/legacy_dir/"
+    # A hand-written approvals.yaml with NO _bound_identities section at
+    # all -- the literal pre-#5042 file shape.
+    (approvals_dir / "approvals.yaml").write_text(f"{key}: true\n", encoding="utf-8")
+
+    resolver = _make_resolver(tmp_path)
+    assert resolver.saved_get(key) is True
+    assert resolver.bound_identity_get(key) is None, (
+        "a legacy entry must read as unbound before its first use"
+    )
+
+    write_path = str(target / "f.txt")
+    asyncio.run(resolver.require_file_write(PermissionDecl(), write_path, "actor"))
+    assert resolver.bound_identity_get(key) is not None, (
+        "the legacy entry's first use must have bound it"
+    )
+
+    shutil.rmtree(target)
+    target.mkdir()
+    with pytest.raises(PermissionError):
+        asyncio.run(
+            resolver.require_file_write(PermissionDecl(), write_path, "actor")
+        )
+
+
+def test_st_birthtime_unavailable_degrades_to_ino_only_like_5084(tmp_path) -> None:
+    """Tier 2: the one thing architect asked to be measured, not assumed
+    — the same platform-degrade #5084 already documents (most Linux
+    filesystems via plain ``stat()`` expose no ``st_birthtime``): the
+    identity comparison must still work with ``ino`` alone, never raise,
+    on a platform where ``st_birthtime`` is absent. Simulated directly
+    (this dev machine's own filesystem DOES expose ``st_birthtime``, so a
+    real platform-dependent skip would not exercise the degrade path) by
+    stubbing ``_path_identity`` to return an ino-only tuple, the SAME
+    shape ``getattr(st, "st_birthtime", None)`` produces on such a
+    platform -- ``ino`` alone must still correctly detect a mismatch."""
+    target = tmp_path / "linux_like_dir"
+    target.mkdir()
+    resolver = _make_resolver(tmp_path)
+    key = "actor/file.write/linux_like_dir/"
+    resolver._saved[key] = True
+
+    real_path_identity = PermissionResolver._path_identity
+
+    def _ino_only(self, path):
+        result = real_path_identity(self, path)
+        if result is None:
+            return None
+        return (result[0], None)  # st_birthtime unavailable, ino-only
+
+    write_path = str(target / "f.txt")
+
+    original = PermissionResolver._path_identity
+    try:
+        PermissionResolver._path_identity = _ino_only
+        asyncio.run(
+            resolver.require_file_write(PermissionDecl(), write_path, "actor")
+        )
+        assert resolver.bound_identity_get(key) == (
+            real_path_identity(resolver, target)[0], None,
+        )
+
+        shutil.rmtree(target)
+        target.mkdir()  # a new inode, ino-only comparison must still catch this
+        with pytest.raises(PermissionError):
+            asyncio.run(
+                resolver.require_file_write(PermissionDecl(), write_path, "actor")
+            )
+    finally:
+        PermissionResolver._path_identity = original


### PR DESCRIPTION
**[tui-coder]** — part of #5042 (architect ruling issuecomment-5383453175).

## What

Deleting `reyn-self-work` left 2 approval rows in `.reyn/approvals.yaml` unchanged (lead-coder's own observation): deleting them erases the audit fact "this was once approved"; leaving them means a LATER tree at the same path silently inherits the OLD approval. Neither is acceptable.

## Fix (architect ruling)

A third option: keep the row (audit-events satisfied), but check the approved PATH's own identity (`(st_ino, st_birthtime)`, #5084's own discriminator) at the moment of use — the same "a name is not an identity" class as #5084 (spawn lineage) and #5146 (operator driver token), this time for permission grants. Scoped to the PATH flavor of approval key only (`file.read`/`file.write`) — a HOST (`http.get`) or PLUGIN (bare name) key has no "target disappeared" concept, so this deliberately does not touch those.

- The approval row (`<key>: true`) is completely unchanged.
- A new sibling `_bound_identities` mapping in the SAME `approvals.yaml` carries the identity for path-flavor keys only — never mixed into the row's own value. No migration needed: an entry with no sibling binding reads identically whether it predates this PR or is a fresh grant whose target doesn't exist yet.
- Bind-ON-FIRST-USE, never at approval time (an approval can predate its target existing at all).
- A mismatch means the loop keeps searching for another still-valid grant, rather than failing the whole check.
- `approvals.yaml` is one of `_CANONICAL_PROTECTED_WRITE_PATHS` (an agent can't write it directly) — the bound identity does not come from the side being classified.
- `_bind_identity`'s persist write is atomic (`tmp` + `os.replace`) — see the resolved blocking point below.
- **`st_birthtime` unavailable (most Linux filesystems): fails closed, not "degrades to ino-only".** Live CI evidence (this PR, both Python 3.11/3.12) showed ino alone does not distinguish "same object, still there" from "a freed inode handed back to a new object at the same path" — Linux ext4/tmpfs routinely reuses the just-freed inode across a `rmtree`+`mkdir` on the same path; macOS/APFS does not (verified locally). Architect ruling (issuecomment-5383544769): "matched" and "cannot confirm" must not share the same `True` — when birthtime is unavailable on either side, the check cannot be confirmed and defaults to fail-closed (ask again), counted/logged via `unconfirmable_identity_check_count` so this is observable, not silent. The SAME defect exists in `AgentRegistry.agent_directory_identity` (#5084) — out of scope here; architect asked lead-coder to refile #5084/#5123 separately (that call site's safe direction differs by consumer).

## Test plan

- [x] `tests/security/test_5042_approval_identity_binding.py` (7 tests, architect's own 5 acceptance criteria + the two things asked to be measured):
  1. purge → same-name re-declare asks again
  2. the approval row itself survives the mismatch
  3. host/plugin approvals are never bound (flavor-crossing witness)
  4. an approval for a not-yet-existing target passes on first use, binds only once it exists
  5. a legacy bare `true` entry (no migration) is treated as unbound and bound on first use
  6. `st_birthtime`-unavailable fails closed even with NO purge at all (same still-existing directory) — witnesses `unconfirmable_identity_check_count`
  7. binding writes atomically — no stray `.tmp` file survives a real bind-and-persist
- [x] Strip-falsified (identity-check removed, bind-on-first-use removed, atomic-write reverted, fail-closed-on-unconfirmable reverted) — each reproduces the exact expected failure shape; restored → green, `git diff` clean each time
- [x] Full local gate (ruff / `test_tier_audit.py --strict` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `verify_module_docstrings.py`) — clean
- [x] `tests/security/`: 785 passed, 26 skipped (pre-existing), no regressions
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

⚠️ TESTS-READ note required (touches `tests/`).

part of #5116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

**[architect]** — TESTS-READ（**A: 設計適合**、head `c582461ade`）issuecomment。B は別の人が必要です。

- [x] 🔴 `_bind_identity(persist=True)` が通る `write_text(yaml.dump(...))` は**非原子**（`_persist`:594 由来の既存形）。この PR で頻度が「人が承認したときだけ」→「path 承認の**初回使用ごと**（通常の tool 実行中）」に上がるため、**書き込み中のクラッシュで approvals.yaml が切れ全承認を失う**経路が日常になる。**tmp + `os.replace`**（前例: `AgentIdentityGenerationStore.record`）へ — head `2c4cbd6b0`
- [ ] ⚪ (follow-up・要起票) 別プロセス（server + CLI）の read-modify-write が後勝ちで承認を落とす。owner は 2 client + server を同時に動かすため仮定ではない


---

## 🔴 Reviewer's blocking point (architect, issuecomment-5383499299 — recorded here by lead-coder per house rule 7)

- [x] 🔴 **`_persist`'s `write_text(yaml.dump(...))` is non-atomic, and this PR changes how often that path is taken.** The non-atomicity is pre-existing (`permissions.py:594`), not introduced here — but before this change the write happened only when a human approved something, and after it, it happens on the **first use of every path approval**, i.e. inside ordinary tool execution. A rare hazard becomes a routine one. Two consequences: ① a crash mid-write truncates `approvals.yaml` and loses **every** approval (band: permission + crash-recovery); ② two processes doing read-modify-write (server + CLI, which is the owner's actual setup) drop an approval last-write-wins. Fix ① in this PR with the two-line `tmp` + `os.replace` shape already used by `AgentIdentityGenerationStore.record`. ② is a follow-up, not this PR.

**Resolved** — head `2c4cbd6b0` (atomic write).

## 🔴 Second blocking point, found in CI, ruled by architect (issuecomment-5383544769)

CI red on both Python 3.11/3.12 (head `c582461ad`) was NOT a flake — 4/4 identity tests failed with `DID NOT RAISE PermissionError`. Root cause: on Linux, `st_birthtime` is always unavailable, so the identity check silently degraded to ino-only for every comparison, and Linux ext4/tmpfs reuses a just-freed inode across `rmtree`+`mkdir` on the same path (verified: macOS/APFS does not). Full evidence: issuecomment-5383536813. Architect ruling: fail-closed when unconfirmable, not ino-only trust; same defect in #5084's `agent_directory_identity` is out of scope, re-filed separately.

**Resolved** — head `2981fb091` (fail-closed on unconfirmable identity, counted/logged, test rewritten).
