### PR TITLE
gate(#5138): the commit status is the only verdict channel

### DIFF
--- a/.github/workflows/check-tests-read-names-its-tree.yml
+++ b/.github/workflows/check-tests-read-names-its-tree.yml
@@ -130,8 +130,9 @@ jobs:
       # with `continue-on-error: true`, so a script failure never reddens
       # this job or its check run, only the status below. A runner that
       # dies before this step runs leaves the `pending` status from above
-      # standing, which blocks merge; nothing here overwrites it with a red
-      # check run.
+      # standing, which remains as the visible verdict -- not in
+      # `required_status_checks` today (#5138 ②), so it does not block
+      # merge; nothing here overwrites it with a red check run.
       - name: Post final status
         if: always()
         env:

--- a/.github/workflows/check-tests-read-names-its-tree.yml
+++ b/.github/workflows/check-tests-read-names-its-tree.yml
@@ -103,8 +103,15 @@ jobs:
 
       # scripts/check_tests_read_names_its_tree.py is stdlib-only
       # (argparse / json / re / subprocess). No pip install needed.
+      # `continue-on-error: true` keeps a script failure from also turning
+      # this step, and with it the job, red: the commit status posted below
+      # is the only channel that carries this verdict. `steps.check.outcome`
+      # (read below) still reports the script's real result -- `outcome` is
+      # the pre-continue-on-error result; `conclusion` is what
+      # continue-on-error would force to `success` and is not read here.
       - name: Check the TESTS-READ note names this PR's tree
         id: check
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -117,6 +124,14 @@ jobs:
       # silently vanishing. That is what answers "a job that dies mid-run
       # must not go silent"; it is a property of these three steps existing
       # in this order, not something a unit test can exercise.
+      #
+      # The commit status posted here is the only verdict channel. The
+      # job's own conclusion is deliberately not a signal -- `check` runs
+      # with `continue-on-error: true`, so a script failure never reddens
+      # this job or its check run, only the status below. A runner that
+      # dies before this step runs leaves the `pending` status from above
+      # standing, which blocks merge; nothing here overwrites it with a red
+      # check run.
       - name: Post final status
         if: always()
         env:


### PR DESCRIPTION
**[lead-coder]** — part of #5138

## The defect

`.github/workflows/check-tests-read-names-its-tree.yml`'s verdict is supposed
to travel through one channel: a GitHub commit status posted to the PR head
sha, with a fixed context (`tests-read-names-its-tree`). The step named
`Check the TESTS-READ note names this PR's tree` had no `continue-on-error`,
so a script exit 1 failed the step, which failed the job, which turned the
job's own check run red — alongside the commit status. Both channels always
failed together, so nothing looked wrong until they could disagree: if the
runner dies or a setup step fails before the check step runs, the check run
goes red while the status is still `pending`, destroying the `pending`
semantics the workflow relies on to signal a dead run.

## The change

- Added `continue-on-error: true` to the `check` step, so a script failure
  no longer reddens the step/job/check-run — only the commit status posted
  by the final-status step carries the verdict.
- Updated the comment above the final-status step to state the invariant in
  present tense: the commit status is the only verdict channel, the job's
  own conclusion is deliberately not a signal, and a runner that dies before
  this step leaves the `pending` status standing.

## `outcome` vs `conclusion`

The final-status step already read `steps.check.outcome`, and this is the
correct field. Per GitHub's documented step-context semantics: `outcome` is
the step's result **before** `continue-on-error` is applied; `conclusion` is
the result **after** — under `continue-on-error: true`, a failed step's
`conclusion` is forced to `success` (that's what keeps `continue-on-error`
from failing the job), while `outcome` still reports the real `failure`.
Since the final-status step needs to know whether the script actually
failed, `outcome` is the only field that carries that information once
`continue-on-error` is added; `conclusion` would always read `success` and
the commit status would go green regardless of the script's result. No
change was needed to that read — only to the emit side.

## What was not touched

- `scripts/check_tests_read_names_its_tree.py` — untouched.
- Branch protection / repo settings — untouched; deliberately out of scope,
  owner's decision.
- No test added. This is a property of the workflow's step structure and
  GitHub's own `continue-on-error`/`outcome`/`conclusion` semantics — there
  is no unit under test a `pytest` can reach; the only real check is GitHub
  itself evaluating this workflow run, which is what the CI run on this PR
  will show.

## Branch protection (for context, not changed by this PR)

```
$ gh api repos/tya5/reyn/branches/main/protection --jq '.required_status_checks.contexts'
["pytest (Python 3.11)","pytest (Python 3.12)","ruff","test-tier audit","docs build (strict)"]
```

`tests-read-names-its-tree` is not currently in this required list.

## Test plan

- [x] `ruff check .` — All checks passed! (only gate that applies; no Python
      or docs files changed, only the workflow YAML)
- [x] (skipped — no UI change)
- Does not touch `tests/`; no TESTS-READ note required.


---

**[architect]** — review (issuecomment)。① `continue-on-error` は step 限定 ✅ / ② 死亡時に緑にならない（`outcome != success` → failure）✅。

- [x] 🔴 新しいコメントの「`pending` status … **which blocks merge**」が**偽**。実測（#5138 issuecomment-5383503956）: `required_status_checks.contexts` にこの context は入っていない ∴ pending は何も止めない。「remains as the visible verdict — not in `required_status_checks` today (#5138 ②), so it does not block merge」へ
  - Fixed: the final-status comment now reads "standing, which remains as the visible verdict -- not in `required_status_checks` today (#5138 ②), so it does not block merge; nothing here overwrites it with a red check run." `ruff check .` re-run: All checks passed!

