### PR TITLE
fix(#5155): test_3328's intervention witness waits on what it asserts

### DIFF
--- a/tests/interfaces/test_3328_connect_remote_parity_witness.py
+++ b/tests/interfaces/test_3328_connect_remote_parity_witness.py
@@ -294,6 +294,15 @@ async def test_connect_intervention_round_trip_matches_local_unfenced_answer(
     connect handler -> the dispatch task never resolved within the timeout
     (no listener -> nothing answers it) -> this test's ``asyncio.wait_for``
     raised -> RED -> reverted, GREEN.
+
+    #5155 scope note (architect, issuecomment-5383600060): this test
+    witnesses the prompt RENDERING (waits for ``renderer.messages`` to be
+    non-empty before answering) — it does NOT, and never did, witness
+    "an answer sent before the render cannot land": the test itself is the
+    only thing that calls :meth:`AgUiTransport.answer_intervention_text`,
+    and it always does so after its own wait resolves. A genuine
+    answer-before-render race in production is out of this witness's
+    scope, not disproven by it.
     """
     monkeypatch.chdir(tmp_path)
     registry = _registry(tmp_path)
@@ -348,10 +357,30 @@ async def test_connect_intervention_round_trip_matches_local_unfenced_answer(
                 remote_task = asyncio.ensure_future(
                     session._intervention_handler.dispatch(remote_iv)
                 )
-                await wait_until(
-                    lambda: transport.pending_intervention_head() is not None,
-                )
-                assert renderer.messages, "the intervention prompt must render before it is answered"
+                # #5155 (architect finding, issuecomment-5383600060): this
+                # used to wait on `pending_intervention_head()` and then
+                # bare-`assert renderer.messages` immediately after — two
+                # DIFFERENT conditions. `pending_intervention_head()` going
+                # non-None only means the transport decoded the intervention
+                # frontend-tool; it says nothing about whether the
+                # concurrently-running `output_task` (run_output_loop) has
+                # actually been scheduled far enough to append to
+                # `renderer.messages` yet — a bare `assert` right after a
+                # DIFFERENT wait is a race, not a witness (a variant of the
+                # "waited on A, asserted B" shape CLAUDE.md's six-questions
+                # Q4 names). Idle machine / few concurrent tests: the output
+                # task happens to get scheduled in time — green. Loaded
+                # machine / thousands of tests under -n auto: it may not —
+                # red, non-deterministically, exactly the shape observed on
+                # main (f7e9cc478) and PR #5148 the same night, never
+                # reproducing standalone. Waiting on the ACTUAL condition the
+                # assert depends on (unboundedly — CI's own --timeout=120 is
+                # the kill switch, no local ceiling) removes the race.
+                #
+                # This is a TEST defect, not a production ordering bug — see
+                # this PR's own scope note in the commit message for what
+                # this witness can and cannot show as a result.
+                await wait_until(lambda: bool(renderer.messages))
 
                 # The production remote answer path: the real AgUiTransport
                 # method a real client's input loop calls, over the real wire.


### PR DESCRIPTION
**[e2e-coder]** — fix(#5155): test_3328's intervention witness waits on what it asserts.

## Context

Found while diagnosing tonight's main-red (#5155). The investigation
started from a mistaken premise ("main's f7e9cc478 CI run failed 5
unrelated files") — corrected separately, via primary log-reading, not
by this PR. Once corrected, the actual signal was: main's f7e9cc478
failed exactly ONE test under pytest 3.11 `-n auto`, and PR #5148 hit
the SAME assertion, same file, the same night, unrelated to that PR's
own diff. Architect diagnosed the mechanism by reading the test code
directly (issuecomment-5383600060) — this PR implements the fix.

## Root cause

```python
await wait_until(lambda: transport.pending_intervention_head() is not None)
assert renderer.messages, "the intervention prompt must render before it is answered"
```

Two DIFFERENT conditions. `pending_intervention_head()` going non-None
means `AgUiTransport` decoded the intervention frontend-tool
(synchronous, at SSE decode time, inside `_pump_sse`). Whether the
CONCURRENTLY running `output_task` (`run_output_loop`, draining the
SAME transport's frame queue on its own schedule) has actually gotten a
turn to call `renderer.message()` yet is an unrelated scheduling
question. No happens-before relationship connects the two.

- Idle machine, few concurrent tests: `output_task` happens to get
  scheduled in time — green.
- CI under `-n auto` with ~12,000 tests: it may not — red,
  non-deterministically, on the exact same tree.

This is CLAUDE.md's six-questions Q4 shape ("waited on A, asserted B")
— the third instance named tonight in this codebase (#5079 / #5148 /
this one, per architect).

## Fix

```python
await wait_until(lambda: bool(renderer.messages))
```

Wait on the condition actually being asserted, unboundedly — CI's own
`--timeout=120` is the kill switch, no local ceiling (house rule). The
now-redundant `pending_intervention_head()` wait is dropped: the
emitter always encodes an intervention's frontend-tool announce and its
DisplayFrame in the SAME SSE block (`emitter.py`'s own per-frame loop),
so `_consume_block` decodes both before either is queued — waiting on
`renderer.messages` alone subsumes the earlier check, and
`pending_intervention_head()`'s return value was never otherwise used
in this test.

Scope note added to the test's own docstring (architect's own
correction of an over-claim risk I would otherwise have left implicit):
this test witnesses the prompt RENDERING before the test itself
answers — it never witnessed, and still doesn't, "an answer sent before
the render cannot land in production" (the test itself is the only
caller of `answer_intervention_text`, always after its own wait
resolves).

**This is a TEST defect only — no production ordering bug.**

## Verification (strip-flip, not a measurement)

An earlier "10/10 green" pass under `-n auto` was explicitly REJECTED as
evidence (architect's catch) — the old code was ALSO mostly green under
the same repeated-run protocol; green-count is a record of machine
speed, not proof the race is closed (six-questions Q4 again).

Instead, deterministic starvation (temporarily wrapped `run_output_loop`
with `await asyncio.sleep(2.0)` before its own loop starts — an
experiment tool, never committed, house rule: "no `sleep(N)` the
assertion depends on" in a committed test):

- **Old code** (bare assert immediately after the head-wait): **3/3
  deterministic RED** under the delay.
- **New code** (`wait_until` on the actual condition): unchanged
  **GREEN**, just slower by the delay — it waits the starvation out
  instead of racing it.

Also, on the actual failing commit (`f7e9cc478`, real CI): re-running
the SAME failed job on the SAME tree came back green — same-tree,
split-result is the non-determinism signature (not "it was flaky",
which would need a rerun to be dispositive of nothing — see the CI job
architect asked not to over-read either way).

## Test plan

- [x] `ruff check .` — clean
- [x] `test_tier_audit.py --strict tests/interfaces/test_3328_connect_remote_parity_witness.py` — 2/2 OK
- [x] `verify_module_docstrings.py` — OK
- [x] `mypy_ratchet.py` — 201 findings, all baselined
- [x] `flat_tests_ratchet.py` — OK
- [x] `check_tests_path_literal_reference.py` — OK
- [x] Standalone (`-n 0`) and repeated `-n auto` runs of the affected test — green throughout, both before and after (expected: the race needs real cross-suite scheduling pressure or artificial starvation to manifest, not standalone)
- [x] Strip-flip (see above) — the actual acceptance witness for this PR
- [ ] (skipped — no user-visible surface, standing waiver covers Visual)

## Not done / limits

- Did not attempt to reproduce the race under genuine full-suite `-n
  auto` load locally (house rule: full-suite runs are CI-only). The
  strip-flip above is the substitute deterministic witness.
- Did not investigate whether other tests in this repo share the same
  "wait on A, assert B" shape — out of scope for this PR; a sweep would
  be a separate, larger effort.

part of #5155
