### PR TITLE
fix(#5157): release the #5152 identity fd on approval revocation

### DIFF
--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -488,10 +488,22 @@ class PermissionResolver:
         # silent behaviour change; read via ``unconfirmable_identity_check_count``.
         self._unconfirmable_identity_checks: int = 0
         # #5152 (architect ruling, issuecomment-5383604927): one open fd
-        # per bound key, held for the remaining life of THIS process --
-        # see ``_acquire_identity_fd``'s own docstring for why this is
-        # what makes an ino comparison trustworthy without ``st_birthtime``.
-        # Bounded by the number of distinct PATH-flavor approvals in use.
+        # per bound key -- see ``_acquire_identity_fd``'s own docstring
+        # for why this is what makes an ino comparison trustworthy
+        # without ``st_birthtime``. #5157 (e2e-coder's TESTS-READY(B)
+        # finding on #5152, architect ruling issuecomment-5383671820):
+        # the population here is RATE-LIMITED BY A HUMAN, not machine-
+        # driven growth -- one fd per distinct path-flavor approval, and
+        # an approval is only ever created by a person granting it.
+        # Architect explicitly rejected an LRU cap (would routinely
+        # demote a still-protected key into the "cannot confirm" bucket,
+        # making pool SIZE decide the security guarantee's scope). The
+        # actual gap this PR closes: a same-key rebind was the ONLY
+        # release path -- see ``_persist``'s own revoke branch, which now
+        # also releases the fd (the same #5146-style "settle on
+        # disappearance" idiom, this time for approval revocation).
+        # ``bound_fd_count`` is the public read this issue's test-review
+        # Q5 asked for.
         self._bound_fds: "dict[str, int]" = {}
         # #1383 (D12): scoped read-grants for OS-offloaded artifacts. When the OS
         # offloads an artifact to a state-dir path and hands the agent an
@@ -566,13 +578,25 @@ class PermissionResolver:
         return self._bound_identities.get(key)
 
     def unconfirmable_identity_check_count(self) -> int:
-        """#5152: how many times an identity comparison could not be
-        confirmed this session (``st_birthtime`` unavailable on one or
-        both sides) and was therefore treated as fail-closed — see
-        :meth:`_identity_check_passes`'s own docstring. Public so the
-        fail-closed default this counts is observable without reaching
-        into private state."""
+        """#5152 (architect ruling, issuecomment-5383604927): how many
+        times an identity comparison could not be confirmed either way
+        this session (no fd held for the key yet, and ``st_birthtime``
+        unavailable) — the grant is HONORED, never denied, but counted
+        here so that fact is observable rather than silent. See
+        :meth:`_identity_check_passes`'s own docstring."""
         return self._unconfirmable_identity_checks
+
+    def bound_fd_count(self) -> int:
+        """#5157 (test-review Q5 — "what does this accumulate, and who
+        bounds it?"): how many identity fds this process currently
+        holds — one per distinct PATH-flavor approval a human has
+        granted and used at least once (architect ruling,
+        issuecomment-5383671820: rate-limited by human approval, not an
+        LRU cap — released on a rebind or on that approval's own
+        revocation, see :meth:`_release_identity_fd`). Public so the
+        real in-use count is observable without reaching into private
+        state."""
+        return len(self._bound_fds)
 
     def on_persist_callback_count(self) -> int:
         """Return the number of registered ``on_persist`` callbacks.
@@ -692,24 +716,50 @@ class PermissionResolver:
 
         Does NOT survive a process restart (the fd table starts empty) —
         that residual window is the ``unconfirmable_identity_check_count``
-        acceptance criterion, not closed by this method. Bounded by the
-        number of distinct PATH-flavor approvals in use (test-review Q5)
-        — one fd per bound key; a rebind (this method called again for
-        the same key) closes the previous fd first rather than
-        accumulating one per rebind. Best-effort: a failure to open
-        (permissions, races) just means this process falls back to the
-        stat-only comparison for *key*, same as before this method
-        existed."""
+        acceptance criterion, not closed by this method.
+
+        #5157 (e2e-coder's TESTS-READY(B) finding on #5152, test-review
+        Q5 — "what does this accumulate, and who bounds it?"). Architect
+        ruling (issuecomment-5383671820): the POPULATION here is
+        rate-limited by a human, not machine-driven growth — one fd per
+        distinct PATH-flavor approval, and an approval is only ever
+        created by a person granting it (reaching fd-table exhaustion,
+        ~1024+, needs on the order of 1000 individual human approvals).
+        An LRU cap was explicitly REJECTED: making eviction routine would
+        demote a still-protected key into the "cannot confirm" bucket as
+        a matter of course, making the pool SIZE decide the security
+        guarantee's scope, not the approval's own lifecycle. The actual
+        gap: a same-key REBIND was the ONLY release path this method
+        had — closed by :meth:`_release_identity_fd`, called from
+        :meth:`_persist`'s own revoke branch (the same #5146-style
+        "settle on disappearance" idiom, here triggered by a human
+        revoking the approval rather than a purge). ``bound_fd_count``
+        is the public read Q5 asked for, so the real in-use count is
+        observable if this population assumption ever needs revisiting.
+
+        Best-effort: a failure to open (permissions, races, an
+        already-exhausted fd table) just means this process falls back
+        to the stat-only comparison for *key*, same as before this
+        method existed."""
+        self._release_identity_fd(key)
+        try:
+            self._bound_fds[key] = os.open(str(path), os.O_RDONLY)
+        except OSError:
+            pass
+
+    def _release_identity_fd(self, key: str) -> None:
+        """#5157: close and forget *key*'s identity fd, if one is held.
+        Called on a rebind (a fresh fd replaces the old one) and from
+        :meth:`_persist`'s revoke branch (the approval disappearing is
+        exactly the disappearance-trigger #5146 already established for
+        this class of state — nothing left to protect once the grant
+        itself is gone)."""
         old = self._bound_fds.pop(key, None)
         if old is not None:
             try:
                 os.close(old)
             except OSError:
                 pass
-        try:
-            self._bound_fds[key] = os.open(str(path), os.O_RDONLY)
-        except OSError:
-            pass
 
     def _bind_identity(
         self,
@@ -785,6 +835,12 @@ class PermissionResolver:
         # `memory/`. Owner-confirmed reclassification (config → persist).
         self._saved[key] = approved
         self._session[key] = approved
+        if not approved:
+            # #5157 (architect ruling, issuecomment-5383671820): a human
+            # REVOKING this approval is the disappearance-trigger for its
+            # identity fd, same idiom as #5146's own settle-on-disappearance
+            # — nothing left to protect once the grant itself is gone.
+            self._release_identity_fd(key)
         try:
             import yaml
             self._approvals_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -836,11 +836,27 @@ class PermissionResolver:
         self._saved[key] = approved
         self._session[key] = approved
         if not approved:
-            # #5157 (architect ruling, issuecomment-5383671820): a human
-            # REVOKING this approval is the disappearance-trigger for its
-            # identity fd, same idiom as #5146's own settle-on-disappearance
-            # — nothing left to protect once the grant itself is gone.
+            # #5157 (architect ruling, issuecomment-5383671820, and a
+            # confirm-item catch on THIS fix's own TESTS-READY(A),
+            # issuecomment-5383698618): a human REVOKING this approval is
+            # the disappearance-trigger for its identity fd, same idiom
+            # as #5146's own settle-on-disappearance — nothing left to
+            # protect once the grant itself is gone. The BOUND IDENTITY
+            # RECORD is one more thing that must go with it, not just the
+            # fd: leaving `_bound_identities[key]` behind after revoke
+            # means a LATER re-approval of the SAME key starts with no fd
+            # (just released) but a STALE stat recorded from before the
+            # revoke -- if the target was deleted+recreated in between
+            # and the new object's (ino, birthtime) happens to coincide
+            # with the old one (inode reuse; or two creations landing in
+            # the same coarse-grained birthtime tick), the stale record
+            # would read as a CONFIRMED match — precisely the "a name is
+            # not an identity" shape #5042 exists to close, reopened by
+            # this PR's own fd-release path. Clearing the record forces
+            # the next use back through bind-ON-FIRST-USE, same as a
+            # never-before-seen key.
             self._release_identity_fd(key)
+            self._bound_identities.pop(key, None)
         try:
             import yaml
             self._approvals_path.parent.mkdir(parents=True, exist_ok=True)
@@ -850,6 +866,11 @@ class PermissionResolver:
                     self._approvals_path.read_text(encoding="utf-8")
                 ) or {}
             existing[key] = approved
+            if not approved:
+                bound_section = existing.get("_bound_identities")
+                if isinstance(bound_section, dict) and key in bound_section:
+                    bound_section.pop(key, None)
+                    existing["_bound_identities"] = bound_section
             self._approvals_path.write_text(
                 yaml.dump(existing, allow_unicode=True, default_flow_style=False),
                 encoding="utf-8",

--- a/tests/security/test_5157_identity_fd_release.py
+++ b/tests/security/test_5157_identity_fd_release.py
@@ -1,0 +1,110 @@
+"""Tier 2: #5157 — the #5152 identity fd has a real release trigger beyond
+a same-key rebind, and its in-use count is observable.
+
+Root cause (e2e-coder, #5152's own TESTS-READY(B), test-review Q5 — "what
+does this accumulate, and who bounds it?"): #5152's ``_acquire_identity_fd``
+held an fd open per bound key for the remaining life of the process, with a
+same-key rebind as the ONLY release path.
+
+Architect ruling (issuecomment-5383671820): the population here is
+rate-limited by a HUMAN, not machine-driven growth — one fd per distinct
+PATH-flavor approval, and an approval is only ever created by a person
+granting it. An LRU cap was explicitly REJECTED: making eviction routine
+would demote a still-protected key into the "cannot confirm" bucket as a
+matter of course, letting pool SIZE (not the approval's own lifecycle)
+decide the security guarantee's scope. The actual gap closed here: a human
+REVOKING an approval (``_persist(key, False)``) now also releases that key's
+fd — the same #5146-style "settle on disappearance" idiom, this time
+triggered by revocation rather than a purge — and the in-use count is now a
+public read (``bound_fd_count``) so the population assumption is checkable
+without reaching into private state.
+
+Real ``PermissionResolver`` + real filesystem paths — no mocks, same harness
+convention as ``test_5042_approval_identity_binding.py``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.security.permissions import PermissionDecl
+from reyn.security.permissions.permissions import PermissionResolver
+
+
+def _make_resolver(tmp_path) -> PermissionResolver:
+    return PermissionResolver({}, project_root=tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_bound_fd_count_reflects_distinct_bound_paths(tmp_path) -> None:
+    """Tier 2: #5157 acceptance ② — the in-use fd count is a public read,
+    and it counts distinct BOUND path-flavor keys, not distinct calls."""
+    resolver = _make_resolver(tmp_path)
+    assert resolver.bound_fd_count() == 0
+
+    for i in range(3):
+        d = tmp_path / f"dir{i}"
+        d.mkdir()
+        key = f"actor/file.write/dir{i}/"
+        resolver._saved[key] = True
+        await resolver.require_file_write(PermissionDecl(), str(d / "f.txt"), "actor")
+
+    assert resolver.bound_fd_count() == 3
+
+    # A SECOND use of an already-bound key does not grow the count.
+    await resolver.require_file_write(
+        PermissionDecl(), str((tmp_path / "dir0") / "g.txt"), "actor",
+    )
+    assert resolver.bound_fd_count() == 3
+
+
+@pytest.mark.asyncio
+async def test_revoking_an_approval_releases_its_identity_fd(tmp_path) -> None:
+    """Tier 2: #5157 acceptance ① — a human revoking a path approval
+    (``_persist(key, False)``) is the disappearance-trigger for its
+    identity fd: nothing left to protect once the grant itself is gone.
+    This is the actual gap the issue named ("a rebind was the ONLY
+    release path"); revocation is now a second one."""
+    resolver = _make_resolver(tmp_path)
+    target = tmp_path / "some_dir"
+    target.mkdir()
+    key = "actor/file.write/some_dir/"
+    resolver._saved[key] = True
+
+    await resolver.require_file_write(
+        PermissionDecl(), str(target / "f.txt"), "actor",
+    )
+    assert resolver.bound_fd_count() == 1
+
+    resolver._persist(key, False)  # the revoke surface (web/CLI) calls this
+    assert resolver.bound_fd_count() == 0, (
+        "revoking the approval must release its identity fd, not leak it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_revoking_one_key_does_not_release_a_different_keys_fd(
+    tmp_path,
+) -> None:
+    """Tier 2: #5157 — the release is scoped to the revoked KEY only; an
+    unrelated bound key's fd survives untouched."""
+    resolver = _make_resolver(tmp_path)
+
+    kept_dir = tmp_path / "kept_dir"
+    kept_dir.mkdir()
+    kept_key = "actor/file.write/kept_dir/"
+    resolver._saved[kept_key] = True
+    await resolver.require_file_write(
+        PermissionDecl(), str(kept_dir / "f.txt"), "actor",
+    )
+
+    revoked_dir = tmp_path / "revoked_dir"
+    revoked_dir.mkdir()
+    revoked_key = "actor/file.write/revoked_dir/"
+    resolver._saved[revoked_key] = True
+    await resolver.require_file_write(
+        PermissionDecl(), str(revoked_dir / "f.txt"), "actor",
+    )
+    assert resolver.bound_fd_count() == 2
+
+    resolver._persist(revoked_key, False)
+    assert resolver.bound_fd_count() == 1

--- a/tests/security/test_5157_identity_fd_release.py
+++ b/tests/security/test_5157_identity_fd_release.py
@@ -82,6 +82,51 @@ async def test_revoking_an_approval_releases_its_identity_fd(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_revoking_an_approval_also_clears_its_stale_identity_record(
+    tmp_path,
+) -> None:
+    """Tier 2: architect's confirm-item on this PR's own TESTS-READY(A)
+    (issuecomment-5383698618) — releasing the fd is not enough; the
+    STALE ``_bound_identities[key]`` record must go with it, both
+    in-memory and in the persisted ``approvals.yaml`` sibling section.
+
+    Left behind, a LATER re-approval of the SAME key would start with no
+    fd (just released) but a stale stat from before the revoke — if the
+    target was deleted+recreated in between and the new object's
+    ``(ino, birthtime)`` happens to coincide with the old one (inode
+    reuse, or two creations landing in the same coarse birthtime tick),
+    the stale record would read as a CONFIRMED match — the exact "a name
+    is not an identity" shape #5042 exists to close, reopened by this
+    PR's own fd-release path if the record survives revoke."""
+    resolver = _make_resolver(tmp_path)
+    target = tmp_path / "some_dir"
+    target.mkdir()
+    key = "actor/file.write/some_dir/"
+    resolver._saved[key] = True
+
+    await resolver.require_file_write(
+        PermissionDecl(), str(target / "f.txt"), "actor",
+    )
+    assert resolver.bound_identity_get(key) is not None
+
+    resolver._persist(key, False)
+    assert resolver.bound_identity_get(key) is None, (
+        "revoke must clear the in-memory bound-identity record, not just "
+        "the fd"
+    )
+
+    import yaml
+
+    approvals_path = tmp_path / ".reyn" / "approvals.yaml"
+    data = yaml.safe_load(approvals_path.read_text(encoding="utf-8"))
+    assert key not in data.get("_bound_identities", {}), (
+        "revoke must also clear the PERSISTED bound-identity record -- "
+        "otherwise it survives a process restart and a later re-approval "
+        "of the same key inherits the stale identity"
+    )
+
+
+@pytest.mark.asyncio
 async def test_revoking_one_key_does_not_release_a_different_keys_fd(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
**[tui-coder]** — part of #5157.

Stacked on #5152 (`fix/5042-approval-identity-binding`, not yet merged) — this diff will show #5152's own commits too until that lands; will rebase/shrink automatically once it merges. Do not merge this before #5152.

## What

e2e-coder's TESTS-READY(B) on #5152 (test-review Q5 — "what does this accumulate, and who bounds it?") found that a same-key rebind was the ONLY release path for the identity fd `_acquire_identity_fd` opens, and the web gateway's module-level singleton resolver (`interfaces/web/deps.py`) lives for the process's whole life. Left alone, distinct approved paths accumulated over a server's lifetime would grow the fd count without bound.

## Fix (architect ruling, issuecomment-5383671820)

- The population is rate-limited by a human, not machine-driven growth — one fd per distinct PATH-flavor approval, and an approval is only ever created by a person granting it (reaching fd-table exhaustion, ~1024+, needs on the order of 1000 individual human approvals).
- An LRU cap was explicitly REJECTED: making eviction routine would demote a still-protected key into the "cannot confirm" bucket as a matter of course, letting pool SIZE (not the approval's own lifecycle) decide the security guarantee's scope.
- The "exhaustion cascades into fail-open for every key at once" observation is explicitly NOT an owner escalation — it's a restatement of #5152's own already-ruled ③ (honor + count), just at scale; the reverse (deny on exhaustion) is the single-use regression #5152 already retracted, at scale.
- The actual fix: a human revoking a path approval (`_persist(key, False)`) now also releases that key's identity fd — the same #5146-style settle-on-disappearance idiom, this time triggered by revocation rather than a purge.
- `bound_fd_count()` is the public read the issue's own test-review Q5 asked for, so the "rate-limited by human approval" population assumption stays checkable, not just asserted.

## Test plan

- [x] `tests/security/test_5157_identity_fd_release.py` (3 tests): fd count reflects distinct bound paths (not distinct calls), revoking an approval releases its fd, revoking one key doesn't touch another key's fd
- [x] Strip-falsify: reverted the `_persist` revoke-branch release call → `test_revoking_an_approval_releases_its_identity_fd` reproduces exactly the expected failure (count stays 1); restored → green
- [x] Full local gate (ruff / `test_tier_audit.py --strict` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `verify_module_docstrings.py`) — clean
- [x] `tests/security/`: 790 passed, 26 skipped, no regressions
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

⚠️ TESTS-READ note required (touches `tests/`).

part of #5157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>