### PR TITLE
fix(#5140): per-agent hooks.yaml resolves ${REYN_AGENT_NAME} via expand_with_map

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -945,14 +945,60 @@ def load_per_agent_hooks(
     Same IN-set grain as the global ``.reyn/hooks.yaml`` (runtime-mutable,
     hot-reloadable) but scoped to one agent — read DIRECTLY here (not via
     :func:`load_hot_reload_config`, which is the top-level ``.reyn/*.yaml`` set),
-    mirroring how the per-agent ``profile.yaml`` is read. ``${VAR}`` interpolation is
-    applied to match the global layer. Returns the raw ``hooks:`` list (``[]`` when the
-    file or key is absent — a no-op layer, never an error).
-    """
+    mirroring how the per-agent ``profile.yaml`` is read. Returns the raw
+    ``hooks:`` list (``[]`` when the file or key is absent — a no-op layer,
+    never an error).
+
+    #5140 (architect ruling, issuecomment-5383725162): a per-agent
+    ``hooks.yaml``'s ``${REYN_AGENT_NAME}`` token used to go through
+    ``expand_env`` (``security/secrets/interpolation.py``) — an
+    ``os.environ``-backed expander (ADR-0030) meant for a SPAWNED CHILD
+    process's config-time env-injection. ``REYN_AGENT_NAME`` is only ever
+    set on a child process's own env (``hooks/shell_runner.py`` and
+    friends), never on this process's own ``os.environ``, so it was
+    ALWAYS undefined at config-load time — silently expanding to ``""``
+    (a `UserWarning`, then a syntactically-valid-but-wrong value the
+    caller cannot tell apart from a genuinely empty operator choice).
+    Hooks are not secrets, and the value this layer actually needs
+    (``agent_name``, the same string this function already receives as
+    an argument) is available right here — this is a layering mistake
+    (the wrong expander for the value), not a genuinely undefined
+    token, so the fix is :func:`reyn.plugins.tokens.expand_with_map`
+    (already used the same way by ``registry_bootstrap.py`` /
+    ``session.py`` for ``REYN_PROJECT_DIR``) with an explicit map,
+    never ``os.environ``.
+
+    Fail-close, scoped to reyn's OWN token vocabulary only (acceptance
+    ②/③): if a ``${REYN_*}``/``${CLAUDE_*}`` token remains unresolved
+    after expansion, that is reyn's own bug (a token reyn should always
+    be able to supply), not an operator's config choice — refuse to
+    load this hooks layer rather than register a matcher/config value
+    reyn silently got wrong. This is the "does the trigger fire on a
+    healthy path" test #5152's own retracted fail-closed ruling failed
+    (there, EVERY comparison on a birthtime-less platform triggered it);
+    here, a healthy config with reyn's tokens correctly supplied never
+    triggers it at all. An arbitrary NON-reyn ``${FOO}`` (an env var a
+    spawned child process resolves later) is deliberately NOT touched
+    by this check — see :func:`~reyn.plugins.tokens.find_unresolved_reyn_tokens`'s
+    own docstring."""
     root = (project_root or Path.cwd()).resolve()
     raw = _load_yaml(root / ".reyn" / "agents" / agent_name / "hooks.yaml")
-    from reyn.security.secrets.interpolation import expand_env
-    data = expand_env(raw)
+    from reyn.plugins.tokens import expand_with_map, find_unresolved_reyn_tokens
+    data = expand_with_map(
+        raw, {"REYN_PROJECT_DIR": str(root), "REYN_AGENT_NAME": agent_name}
+    )
+    unresolved = find_unresolved_reyn_tokens(data)
+    if unresolved:
+        import warnings
+        warnings.warn(
+            f"Per-agent hooks.yaml for {agent_name!r} left reyn token(s) "
+            f"{sorted(set(unresolved))} unresolved -- refusing to load "
+            "this hooks layer (this is reyn's own bug, not a config "
+            "choice to honor).",
+            UserWarning,
+            stacklevel=2,
+        )
+        return []
     hooks = data.get("hooks") if isinstance(data, dict) else None
     return hooks if isinstance(hooks, list) else []
 

--- a/src/reyn/plugins/tokens.py
+++ b/src/reyn/plugins/tokens.py
@@ -196,3 +196,43 @@ def expand_with_map(obj: Any, token_map: dict[str, str]) -> Any:
     "subset" purely by which keys it omits, not by a second code path.
     """
     return _expand(obj, token_map)
+
+
+# #5140: matches a REMAINING ``${REYN_*}``/``${CLAUDE_*}`` placeholder after
+# an expansion pass — i.e. reyn's OWN token vocabulary, never an arbitrary
+# caller-owned ``${VAR}`` (an env var meant for a spawned child process, a
+# pipeline ``ctx`` param, …). Deliberately narrower than ``_TOKEN_RE``: a
+# fail-close check built on the wrong regex here would refuse to load a
+# hooks.yaml over a token it was never reyn's job to resolve in the first
+# place (acceptance ③ — a non-reyn ``${FOO}`` must load exactly as before).
+_UNRESOLVED_REYN_TOKEN_RE = re.compile(r"\$\{((?:REYN|CLAUDE)_\w+)\}")
+
+
+def find_unresolved_reyn_tokens(obj: Any) -> list[str]:
+    """Recursively collect every REMAINING ``${REYN_*}``/``${CLAUDE_*}``
+    placeholder in *obj* (post-:func:`expand_with_map`, typically).
+
+    #5140: the fail-close half of that issue's ruling — reyn's own token
+    vocabulary left unresolved after reyn's own expansion pass means reyn
+    could not supply a value it owns, which is reyn's bug, not an
+    operator's config choice (contrast with an arbitrary ``${VAR}``, which
+    a downstream consumer — e.g. a spawned child process inheriting the
+    env — may legitimately resolve later; this function does not flag
+    those at all). A caller finding this list non-empty should refuse to
+    use the expanded structure rather than silently proceed with an
+    empty/wrong value standing in for an unresolved token — see
+    ``config/loader.py``'s ``load_per_agent_hooks`` for the reference
+    caller."""
+    if isinstance(obj, str):
+        return [m.group(0) for m in _UNRESOLVED_REYN_TOKEN_RE.finditer(obj)]
+    if isinstance(obj, dict):
+        found: list[str] = []
+        for v in obj.values():
+            found.extend(find_unresolved_reyn_tokens(v))
+        return found
+    if isinstance(obj, list):
+        found = []
+        for v in obj:
+            found.extend(find_unresolved_reyn_tokens(v))
+        return found
+    return []

--- a/tests/runtime/test_5140_per_agent_hooks_token_expansion.py
+++ b/tests/runtime/test_5140_per_agent_hooks_token_expansion.py
@@ -1,0 +1,140 @@
+"""Tier 2: #5140 — ``${REYN_AGENT_NAME}`` resolves in a per-agent hooks.yaml.
+
+Root cause (e2e-coder, found via #5091's own witness): ``load_per_agent_hooks``
+(``config/loader.py``) ran a per-agent ``hooks.yaml`` through ``expand_env``
+(``security/secrets/interpolation.py``, ADR-0030) — an ``os.environ``-backed
+expander meant for a SPAWNED CHILD process's config-time env-injection.
+``REYN_AGENT_NAME`` is only ever set on a child process's own env
+(``hooks/shell_runner.py`` and friends), never on this process's own
+``os.environ`` — so ``${REYN_AGENT_NAME}`` was ALWAYS undefined at config-load
+time, silently expanding to ``""`` (a ``UserWarning``, then a
+syntactically-valid-but-wrong value, e.g. ``broker://inbox/`` instead of
+``broker://inbox/coder-smith``, indistinguishable from an operator's genuine
+empty-suffix choice).
+
+Architect ruling (issuecomment-5383725162): this is a layering mistake, not a
+genuinely undefined token — the value (``agent_name``) is already an argument
+to this function. Fix: ``expand_with_map`` (``plugins/tokens.py``, #3629's own
+mechanism, already used by ``registry_bootstrap.py``/``session.py`` for
+``REYN_PROJECT_DIR``) with an explicit ``{"REYN_AGENT_NAME": agent_name, ...}``
+map — never ``os.environ``. Plus a fail-close SCOPED TO REYN'S OWN TOKEN
+VOCABULARY: a remaining ``${REYN_*}``/``${CLAUDE_*}`` placeholder after
+expansion is reyn's own bug (a token reyn should always be able to supply),
+so that hooks layer is refused rather than loaded with a wrong value — but a
+non-reyn ``${FOO}`` (an env var a spawned child process may resolve later)
+must NOT be caught by this check (the #5152 "does the trigger fire on a
+healthy path" test: here, a healthy config with reyn's own tokens correctly
+supplied never trips it).
+
+Real ``load_per_agent_hooks`` + real files on disk — no mocks.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+from reyn.config.loader import load_per_agent_hooks
+
+_AGENT = "coder-smith"
+
+
+def _write_per_agent_hooks(tmp_path: Path, body: str) -> None:
+    agent_dir = tmp_path / ".reyn" / "agents" / _AGENT
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "hooks.yaml").write_text(body, encoding="utf-8")
+
+
+def test_reyn_agent_name_resolves_to_the_real_agent_name(tmp_path: Path) -> None:
+    """Tier 2: acceptance ① — ${REYN_AGENT_NAME} resolves to the correct
+    per-agent name, not an empty string."""
+    _write_per_agent_hooks(
+        tmp_path,
+        "hooks:\n"
+        "  - on: turn_end\n"
+        "    template_push:\n"
+        "      message: broker://inbox/${REYN_AGENT_NAME}\n"
+        "      wake: true\n",
+    )
+    hooks = load_per_agent_hooks(tmp_path, _AGENT)
+    assert hooks, "the hooks layer must load, not come back empty"
+    assert hooks[0]["template_push"]["message"] == f"broker://inbox/{_AGENT}"
+
+
+def test_an_unresolved_reyn_token_refuses_to_load_the_hooks_layer(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: acceptance ② — a reyn-owned token this loader does NOT supply
+    a value for (simulated here via a token this map never populates,
+    ``${REYN_SKILL_DIR}`` — a location token with no meaning for a hooks
+    file) must refuse to load the WHOLE hooks layer, not silently register
+    a matcher with an empty/wrong value, and must surface why."""
+    _write_per_agent_hooks(
+        tmp_path,
+        "hooks:\n"
+        "  - on: turn_end\n"
+        "    template_push:\n"
+        "      message: ${REYN_SKILL_DIR}/note.txt\n"
+        "      wake: true\n",
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        hooks = load_per_agent_hooks(tmp_path, _AGENT)
+
+    assert hooks == [], (
+        "an unresolved reyn-owned token must refuse the WHOLE hooks layer, "
+        "not load a hook with a wrong/empty value"
+    )
+    assert any(
+        "REYN_SKILL_DIR" in str(w.message) and issubclass(w.category, UserWarning)
+        for w in caught
+    ), "the refusal must surface a reason, not fail silently"
+
+
+def test_a_non_reyn_token_is_left_untouched_and_still_loads(tmp_path: Path) -> None:
+    """Tier 2: acceptance ③ — a NON-reyn ``${FOO}`` (e.g. an env var meant
+    for a spawned child process to resolve) must load exactly as before:
+    left untouched, no fail-close. Without this, #5152's own retracted
+    fail-closed regression would repeat here (a healthy config tripping
+    the fail-close on every load)."""
+    _write_per_agent_hooks(
+        tmp_path,
+        "hooks:\n"
+        "  - on: turn_end\n"
+        "    exec:\n"
+        "      command: echo ${SOME_CHILD_PROCESS_VAR}\n"
+        "      wake: true\n",
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        hooks = load_per_agent_hooks(tmp_path, _AGENT)
+
+    assert hooks, "a non-reyn token must not cause the hooks layer to be refused"
+    assert hooks[0]["exec"]["command"] == "echo ${SOME_CHILD_PROCESS_VAR}"
+    assert not any(
+        issubclass(w.category, UserWarning) for w in caught
+    ), "a non-reyn token must not trip the fail-close or warn at all"
+
+
+def test_no_undefined_env_var_warning_fires_on_a_healthy_reyn_token(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: acceptance ④ — the OLD `warnings.warn("Config references
+    undefined environment variable…")` (expand_env's own, fired on every
+    single load because REYN_AGENT_NAME was never actually in os.environ)
+    is gone from this path: a healthy hooks.yaml with a correctly-supplied
+    reyn token produces NO warning at all."""
+    _write_per_agent_hooks(
+        tmp_path,
+        "hooks:\n"
+        "  - on: turn_end\n"
+        "    template_push:\n"
+        "      message: broker://inbox/${REYN_AGENT_NAME}\n"
+        "      wake: true\n",
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        load_per_agent_hooks(tmp_path, _AGENT)
+
+    assert not any(
+        "undefined environment variable" in str(w.message) for w in caught
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #5140 (architect ruling issuecomment-5383725162).

## What

Found by e2e-coder measuring #5091's own witness: `load_per_agent_hooks` (`config/loader.py`) ran a per-agent `hooks.yaml` through `expand_env` (`security/secrets/interpolation.py`, ADR-0030) — an `os.environ`-backed expander meant for a spawned child process's config-time env-injection. `REYN_AGENT_NAME` is only ever set on a CHILD process's own env (`hooks/shell_runner.py` and friends), never on this process's own `os.environ`, so `${REYN_AGENT_NAME}` was ALWAYS undefined at config-load time — silently expanding to `""` (a `UserWarning`, then a syntactically-valid-but-wrong value the caller can't tell apart from a genuinely empty operator choice).

## Fix (architect ruling)

This is a layering mistake, not a genuinely undefined token — the value (`agent_name`) is already an argument to `load_per_agent_hooks`. Moves to `expand_with_map` (`plugins/tokens.py`, #3629's own mechanism, already used the same way by `registry_bootstrap.py`/`session.py` for `REYN_PROJECT_DIR`) with an explicit `{"REYN_AGENT_NAME": agent_name, "REYN_PROJECT_DIR": ...}` map — never `os.environ`.

Fail-close, scoped to reyn's own token vocabulary only — this is the discriminator architect named against #5152's own retracted fail-closed regression: **does the trigger fire on a healthy path?** #5152's retracted version fired on EVERY Linux comparison; this one never fires on a healthy config. If a `${REYN_*}`/`${CLAUDE_*}` token remains unresolved after expansion, that's reyn's own bug (a token reyn should always be able to supply) — the whole hooks layer is refused rather than loaded with a wrong value. A non-reyn `${FOO}` (an env var a spawned child process resolves later) is untouched, no fail-close.

New `find_unresolved_reyn_tokens` (`plugins/tokens.py`) is the reusable detection primitive; `load_per_agent_hooks` is its reference caller.

## Test plan

- [x] `tests/runtime/test_5140_per_agent_hooks_token_expansion.py` (4 tests, architect's own 4 acceptance criteria): `${REYN_AGENT_NAME}` resolves to the real name; an unresolved reyn token refuses the whole hooks layer with a surfaced reason; a non-reyn `${FOO}` is left untouched and still loads (the #5152-regression-shaped acceptance criterion); the old "undefined environment variable" warning no longer fires on a healthy config
- [x] Strip-falsified (reverted to `expand_env`) — all 4 tests reproduce the exact expected failure; restored → green, `git diff` clean
- [x] Full local gate (ruff / `test_tier_audit.py --strict` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `verify_module_docstrings.py`) — clean (2 format-pinning `len()` assertions the audit flagged were removed, not suppressed)
- [x] `tests/runtime/` + `tests/config/` + `tests/plugins/`: 2174 passed, 7 skipped (pre-existing, optional extras), no regressions
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

⚠️ TESTS-READ note required (touches `tests/`).

part of #5140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>