### PR TITLE
fix(#5159): 4 sites wait on the real signal, not a clock

### DIFF
--- a/tests/core/test_1765_state_log_durability.py
+++ b/tests/core/test_1765_state_log_durability.py
@@ -41,28 +41,52 @@ async def test_iter_from_excludes_inflight_entry_during_fsync(tmp_path, monkeypa
     written-but-still-fsyncing (off-loop), a CONCURRENT iter_from must NOT expose it — it is
     not yet durable. After the fsync completes it becomes readable. RED if the `_inflight_seq`
     skip is removed (the concurrent read would see the non-durable entry — the surface that
-    reverted #1751)."""
+    reverted #1751).
+
+    #5159 (census finding): this used to fix the in-flight window open with a plain
+    `time.sleep(0.05)` inside `_slow_fsync` and race it against `await asyncio.sleep(0.01)`
+    on the test's own side — a CLOCK stand-in for the real condition ("has seq 2's write
+    actually reached fsync yet"), competing against a DIFFERENT clock (how long the fsync
+    itself takes) with no ordering guarantee between them: a loaded machine could let the
+    10ms window close before seq 2 ever reaches the fsync call (`during == []`), or let the
+    whole 50ms fsync complete before the 10ms sleep even fires (`during == [1, 2]`) — either
+    way a false pass or a false fail unrelated to the property under test. Replaced with a
+    `threading.Event` the (already monkeypatched) `_slow_fsync` itself sets the INSTANT it is
+    entered — waited on unboundedly (CI's own --timeout=120 is the kill switch) via
+    `asyncio.to_thread`, since the event is set from the worker thread `_do_wal_write` runs on,
+    not the event loop. This is a signal the TEST constructs and owns (not reyn's own private
+    state), the same class `wait_until(lambda: bool(renderer.messages))` already uses
+    elsewhere (#5156) — waiting on the ACTUAL condition (seq 2's write has reached the fsync
+    call, `_inflight_seq` is genuinely set) rather than a duration standing in for it."""
     import asyncio
     import os
-    import time
+    import threading
 
     orig_fsync = os.fsync
+    fsync_entered = threading.Event()
+    release_fsync = threading.Event()
 
     def _slow_fsync(fd):  # runs off-loop in to_thread → holds the in-flight window open
-        time.sleep(0.05)
+        fsync_entered.set()
+        release_fsync.wait()  # held open until the test's own check below releases it
         return orig_fsync(fd)
-
-    monkeypatch.setattr(os, "fsync", _slow_fsync)
 
     p = tmp_path / "wal.jsonl"
     sl = StateLog(p)
-    await sl.append("inbox_put", text="durable")  # seq 1 — durable
+    await sl.append("inbox_put", text="durable")  # seq 1 — durable, real fsync, unpatched
+    # Patched only AFTER seq 1 lands: patching before would also hold seq 1's own
+    # fsync open on `release_fsync`, which nothing releases until after this call
+    # already returned — a self-deadlock, not the race this test means to force.
+    monkeypatch.setattr(os, "fsync", _slow_fsync)
     appending = asyncio.create_task(sl.append("inbox_put", text="inflight"))  # seq 2
-    await asyncio.sleep(0.01)  # let seq 2 reach the file + enter the (slow) fsync
+    # Wait for the REAL condition the assertion below depends on: seq 2's write has
+    # genuinely reached the fsync call (so `_inflight_seq` is set) — not a duration.
+    await asyncio.to_thread(fsync_entered.wait)
 
     during = [e["seq"] for e in sl.iter_from(1)]
     assert during == [1], "a concurrent read must exclude the in-flight (non-durable) entry seq 2"
 
+    release_fsync.set()  # let the held-open fsync (and the append) complete
     await appending  # fsync completes → seq 2 is now durable
     after = [e["seq"] for e in sl.iter_from(1)]
     assert after == [1, 2], "after the fsync, the now-durable entry is readable"

--- a/tests/interfaces/test_4983_session_switch_off_thread.py
+++ b/tests/interfaces/test_4983_session_switch_off_thread.py
@@ -42,6 +42,7 @@ from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
 from reyn.runtime.session import Session
+from tests._async_wait import wait_until  # noqa: E402 — shared #1751 test wait helper
 from tests._support.agent_session import make_session
 
 
@@ -124,7 +125,18 @@ async def test_session_switch_reads_conversation_history_off_the_event_loop(
     the event loop's own main thread — reverting the fix (calling
     ``_hydrate_from_history`` synchronously again, as it did before this
     PR) turns this red: the call lands on the SAME thread the test
-    itself runs on."""
+    itself runs on.
+
+    #5159 (census finding): waiting for the switch's read via a flat
+    ``_settle(pilot)`` (``pilot.pause()`` — CPU idle time) instead of the
+    real condition ("has the read call actually been made yet") used to
+    risk a false ``assert switch_calls`` failure: `pilot.pause()`
+    determines idle from CPU time, and the switch's read is off-loop
+    I/O (``asyncio.to_thread``) that a busy machine may not have even
+    STARTED by the time the loop looks idle. Waits on the actual
+    condition instead — a public read (`len(call_threads)`, this test's
+    own recording list, not reyn's private state), unboundedly (CI's
+    own --timeout=120 is the kill switch)."""
     monkeypatch.chdir(tmp_path)
     reg = _registry(tmp_path)
     try:
@@ -150,7 +162,7 @@ async def test_session_switch_reads_conversation_history_off_the_event_loop(
             transport.push_event(
                 "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID},
             )
-            await _settle(pilot)
+            await wait_until(lambda: len(call_threads) > calls_at_mount)
 
         switch_calls = call_threads[calls_at_mount:]
         assert switch_calls, "the switch must have read conversation_history"
@@ -171,7 +183,17 @@ async def test_session_switch_still_hydrates_the_new_sessions_history(
     reset_hydrate.py`` already established, reconfirmed after the split:
     a turn produced on alpha while this client is on beta (durably
     persisted only, never delivered live) is present after switching
-    back to alpha."""
+    back to alpha.
+
+    #5159 (census finding): the final switch-back used to be settled via
+    a flat ``_settle(pilot)`` — a CPU-idle heuristic that can declare
+    "idle" before the switch's off-thread history read has landed and
+    been applied (same risk as the sibling test above, here for the
+    APPLIED content rather than just the call having been made). Waits
+    on the actual condition instead: the rendered rows matching what
+    this test asserts, unboundedly (CI's own --timeout=120 is the kill
+    switch) — this is the SAME condition the final `assert` already
+    checks, just waited on instead of asserted-after-a-duration."""
     monkeypatch.chdir(tmp_path)
     reg = _registry(tmp_path)
     try:
@@ -197,13 +219,21 @@ async def test_session_switch_still_hydrates_the_new_sessions_history(
             transport.push_event(
                 "session_attached", {"agent": "alpha", "session_id": _DEFAULT_SID},
             )
-            await _settle(pilot)
 
-            rows = [
-                (e.item.kind, e.item.text)
-                for e in app.query_one(FlowView).entries
-                if e.item.kind != "system"
-            ]
+            def _rows() -> "list[tuple[str, str]]":
+                return [
+                    (e.item.kind, e.item.text)
+                    for e in app.query_one(FlowView).entries
+                    if e.item.kind != "system"
+                ]
+
+            # Wait for the switch-back to have applied SOMETHING (the real
+            # condition — not a duration) before checking WHAT it applied,
+            # so a genuine content mismatch still fails with a real diff
+            # instead of a bare CI-timeout with no message.
+            await wait_until(lambda: bool(_rows()))
+
+            rows = _rows()
             assert rows == [("user", "turn while away")]
     finally:
         pass

--- a/tests/runtime/test_session_invariants.py
+++ b/tests/runtime/test_session_invariants.py
@@ -648,11 +648,24 @@ async def test_inbox_put_consume_emits_wal_events_with_monotonic_seq(tmp_path, m
     monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", stub)
 
     async def _run_one_turn():
-        """Process all three inbox messages then shutdown."""
-        # Start run() in background and shutdown after a brief moment.
+        """Process all three inbox messages then shutdown.
+
+        #5159 (census finding): this used to give the loop a flat
+        `await asyncio.sleep(0.05)` to consume all three messages before
+        calling `shutdown()` — a duration standing in for the real
+        condition ("has `run_task` actually drained the inbox yet"), with
+        no ordering guarantee against it: under load, `run_task` could
+        still not have run even once by the time the sleep elapses, and
+        `shutdown()` arriving first would end the run with messages never
+        consumed (`consume_events` empty — the assertion this test makes).
+        Waits on the real condition instead: the journal's own snapshot
+        `inbox` list emptying out (every submitted message has been
+        consumed), unboundedly (CI's own --timeout=120 is the kill
+        switch) — a PUBLIC read (`session.journal.snapshot().inbox`), not
+        reyn's private task-scheduling state."""
+        # Start run() in background and shutdown once the inbox is drained.
         run_task = asyncio.create_task(session.run())
-        # Give the event loop time to process all three messages.
-        await asyncio.sleep(0.05)
+        await wait_until(lambda: not session.journal.snapshot.inbox)
         await session.shutdown()
         try:
             await asyncio.wait_for(run_task, timeout=2.0)


### PR DESCRIPTION
**[e2e-coder]** — fix(#5159): 4 sites wait on the real signal, not a clock.

## What

Census finding (lead-coder, ~85 files read, `gh issue view 5159`): 4
sites where a duration stood in for the real condition an assertion
depends on, competing against an unrelated clock elsewhere with no
ordering guarantee between the two — CLAUDE.md's floor/ceiling rule
("no `sleep(N)` the assertion depends on"). All 4 get the same
prescription: wait on the actual condition, unboundedly (CI's own
`--timeout=120` is the kill switch), never a duration.

### `tests/core/test_1765_state_log_durability.py::test_iter_from_excludes_inflight_entry_during_fsync`

`await asyncio.sleep(0.01)` raced against an injected 50ms
`_slow_fsync`, in either direction (a loaded machine could close the
10ms window before seq 2 ever reaches fsync, or the fsync could
complete before the sleep even fires). Replaced with a
`threading.Event` the (already monkeypatched) `_slow_fsync` itself sets
the instant it is entered — waited on via `asyncio.to_thread` (the
event is set from the worker thread `_do_wal_write` runs on, not the
loop) — and held open by a second `Event` until the check completes, so
wire-arrival order is no longer a race at all.

### `tests/runtime/test_session_invariants.py::test_inbox_put_consume_emits_wal_events_with_monotonic_seq`

`await asyncio.sleep(0.05)` before `shutdown()`, with no guarantee
`run_task` had processed even one of the 3 queued messages by then.
Waits on the journal's own snapshot `inbox` list emptying instead — a
public read (`session.journal.snapshot.inbox`), not private
task-scheduling state.

### `tests/interfaces/test_4983_session_switch_off_thread.py` (2 tests)

`_settle(pilot)` (`pilot.pause()`, a CPU-idle heuristic) stood in for
"has the switch's off-thread history read landed" — blocking I/O
doesn't register as CPU-busy, so a loaded machine could declare idle
before the read even started (test 1: `assert switch_calls` on an empty
list) or before it had been applied (test 2: the switched-back content
missing). The file's own 3rd test already established the house
pattern (`threading.Event` + `asyncio.Event` gate, no duration) for a
DIFFERENT purpose (forcing ordering between two concurrent switches);
applied here to the simpler "just wait for it" case via `wait_until` on
the actual condition.

## Verification — 3 of 4 strip-verified, 1 disclosed as unforced

Each site's OLD clock-based code, run with an injected delay that
exceeds its original window, reproduces the EXACT predicted failure
deterministically (3/3 runs each):

- `test_1765` — **could not force the predicted failure locally**
  despite several delay-injection attempts (delaying `_do_wal_write`
  before the fsync call never widened the race window the way I
  expected; my best guess is the worker's own scheduling latency
  dominates in ways a single-process artificial delay doesn't
  reproduce — the same class of limitation as #5156's own
  `test_3328` strip-flip attempt, which also could not be reliably
  forced by a local, single-test delay). Disclosed, not concealed. The
  fix is structurally sound regardless — it waits on the exact
  condition `_inflight_seq` being set represents, removing the race by
  construction, independent of whether the old code's own failure mode
  could be forced open locally.
- `test_session_invariants` — 3/3 deterministic RED (`consume_events`
  empty) under a 100ms-per-call stub delay + `shutdown()`'s own 2s
  grace window; restored, green.
- `test_4983` (both tests) — 3/3 deterministic RED each
  (`assert switch_calls` empty / rows missing) under a 200ms read
  delay; restored, green.

## Test plan

- [x] `ruff check .` — clean
- [x] `test_tier_audit.py --strict` on all 3 touched files — 24/24 OK
- [x] `mypy_ratchet.py` — 201 findings, all baselined
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] Scoped `pytest` over the 3 touched files + a neighboring sibling (`test_3310_n2_reset_hydrate.py`) — 34 passed, post-rebase
- [x] Strip-verify (see above) — 3/4 genuine red→green, 1 disclosed limitation
- [ ] (skipped — no user-visible surface, standing waiver covers Visual)

part of #5159
