### PR TITLE
fix(#5140): composers: resolves reyn tokens like hooks: does

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5755,7 +5755,21 @@ class Session:
         #2880/#2881) — the ``composers:`` key of the SAME
         ``.reyn/agents/<name>/hooks.yaml`` file :meth:`_read_per_agent_hooks`
         reads its ``hooks:`` key from (same IN-set grain, scoped per agent).
-        ``[]`` when the file or key is absent."""
+        ``[]`` when the file or key is absent.
+
+        #5140 (part 2, sibling call site to ``load_per_agent_hooks``): this
+        used to expand ``${REYN_AGENT_NAME}`` via ``expand_env``
+        (``os.environ``-backed, ADR-0030) — always undefined at config-load
+        time for the SAME reason ``load_per_agent_hooks`` documents, so a
+        ``composers:`` entry using the token silently collapsed to ``""``.
+        Fixed the same way: :func:`reyn.plugins.tokens.expand_with_map` with
+        an explicit ``{REYN_PROJECT_DIR, REYN_AGENT_NAME}`` map, fail-closed
+        on any REMAINING ``${REYN_*}``/``${CLAUDE_*}`` token via
+        :func:`~reyn.plugins.tokens.find_unresolved_reyn_tokens` (reyn's own
+        bug, not an operator's config choice) — an arbitrary non-reyn
+        ``${FOO}`` is left untouched, for a spawned child process to resolve
+        later. See ``config/loader.py``'s ``load_per_agent_hooks`` for the
+        reference implementation this mirrors."""
         import yaml
         path = self._hot_reload_project_root() / ".reyn" / "agents" / self.agent_name / "hooks.yaml"
         if not path.is_file():
@@ -5766,8 +5780,21 @@ class Session:
             return []
         if not isinstance(raw, dict):
             return []
-        from reyn.security.secrets.interpolation import expand_env
-        data = expand_env(raw)
+        from reyn.plugins.tokens import expand_with_map, find_unresolved_reyn_tokens
+        root = self._hot_reload_project_root()
+        data = expand_with_map(
+            raw, {"REYN_PROJECT_DIR": str(root), "REYN_AGENT_NAME": self.agent_name}
+        )
+        unresolved = find_unresolved_reyn_tokens(data)
+        if unresolved:
+            logger.warning(
+                "Per-agent hooks.yaml for %r left reyn token(s) %s unresolved "
+                "in its composers: layer -- refusing to load this composers "
+                "layer (this is reyn's own bug, not a config choice to "
+                "honor).",
+                self.agent_name, sorted(set(unresolved)),
+            )
+            return []
         composers = data.get("composers") if isinstance(data, dict) else None
         return list(composers) if isinstance(composers, list) else []
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5757,19 +5757,19 @@ class Session:
         reads its ``hooks:`` key from (same IN-set grain, scoped per agent).
         ``[]`` when the file or key is absent.
 
-        #5140 (part 2, sibling call site to ``load_per_agent_hooks``): this
-        used to expand ``${REYN_AGENT_NAME}`` via ``expand_env``
-        (``os.environ``-backed, ADR-0030) — always undefined at config-load
-        time for the SAME reason ``load_per_agent_hooks`` documents, so a
-        ``composers:`` entry using the token silently collapsed to ``""``.
-        Fixed the same way: :func:`reyn.plugins.tokens.expand_with_map` with
-        an explicit ``{REYN_PROJECT_DIR, REYN_AGENT_NAME}`` map, fail-closed
-        on any REMAINING ``${REYN_*}``/``${CLAUDE_*}`` token via
-        :func:`~reyn.plugins.tokens.find_unresolved_reyn_tokens` (reyn's own
-        bug, not an operator's config choice) — an arbitrary non-reyn
-        ``${FOO}`` is left untouched, for a spawned child process to resolve
-        later. See ``config/loader.py``'s ``load_per_agent_hooks`` for the
-        reference implementation this mirrors."""
+        Expands reyn-owned tokens in this layer via
+        :func:`reyn.plugins.tokens.expand_with_map` with an explicit
+        ``{REYN_PROJECT_DIR, REYN_AGENT_NAME}`` map — not ``os.environ``:
+        ``REYN_AGENT_NAME`` exists only in a SPAWNED CHILD process's own env
+        (``hooks/shell_runner.py`` and friends), never in this process's own
+        ``os.environ``, so it is undefined at config-load time and an
+        ``os.environ``-backed expander cannot resolve it here. Fails closed
+        via :func:`~reyn.plugins.tokens.find_unresolved_reyn_tokens` on any
+        REMAINING ``${REYN_*}``/``${CLAUDE_*}`` token — reyn's own bug, not
+        an operator's config choice — while an arbitrary non-reyn ``${FOO}``
+        is left untouched, for a spawned child process to resolve later. See
+        ``config/loader.py``'s ``load_per_agent_hooks`` for the reference
+        implementation this mirrors."""
         import yaml
         path = self._hot_reload_project_root() / ".reyn" / "agents" / self.agent_name / "hooks.yaml"
         if not path.is_file():

--- a/tests/runtime/test_5140_per_agent_composers_token_expansion.py
+++ b/tests/runtime/test_5140_per_agent_composers_token_expansion.py
@@ -1,0 +1,141 @@
+"""Tier 2: #5140 (part 2) — ``${REYN_AGENT_NAME}`` resolves in a per-agent
+``hooks.yaml``'s ``composers:`` key, the sibling of the already-fixed
+``hooks:`` key (PR #5161, ``tests/runtime/test_5140_per_agent_hooks_token_expansion.py``).
+
+``Session._read_per_agent_composers`` (``runtime/session.py``) reads the SAME
+``.reyn/agents/<name>/hooks.yaml`` file :func:`~reyn.config.loader.load_per_agent_hooks`
+reads its ``hooks:`` key from, but its own ``composers:`` key — and it used
+to run that key through ``expand_env`` (``security/secrets/interpolation.py``,
+ADR-0030, ``os.environ``-backed). ``REYN_AGENT_NAME`` is only ever set on a
+SPAWNED CHILD process's own env, never on this process's own ``os.environ``,
+so ``${REYN_AGENT_NAME}`` was ALWAYS undefined at config-load time here too —
+silently expanding to ``""``, indistinguishable from an operator's genuine
+empty-suffix choice. This is the exact #5140 defect, in a sibling call site
+PR #5161 did not touch.
+
+Fix mirrors #5161 exactly: ``expand_with_map`` (``plugins/tokens.py``) with an
+explicit ``{REYN_PROJECT_DIR, REYN_AGENT_NAME}`` map, fail-closed (whole
+composers layer refused, not a wrong/empty value silently registered) on any
+REMAINING ``${REYN_*}``/``${CLAUDE_*}`` token via
+``find_unresolved_reyn_tokens`` — while a non-reyn ``${FOO}`` (a spawned
+child process's own env var) is left untouched and still loads (the #5152
+"healthy config must not trip the fail-close" shape).
+
+Deliberately its OWN test file, separate from the ``hooks:`` witness — each
+key's expansion is tested through the function that actually reads THAT key,
+so one half can never be silently empty while the other carries the file.
+
+Real ``Session`` (via ``tests._support.agent_session.make_session``) + real
+files on disk — no mocks. ``_hot_reload_project_root`` falls back to
+``Path.cwd()`` when the session is built with no registry (the usual case in
+tests) — matches the pattern already used by
+``tests/core/test_router_op_context_source_3607.py``.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from tests._support.agent_session import make_session
+
+_AGENT = "coder-smith"
+
+
+def _write_per_agent_hooks(project_root: Path, body: str) -> None:
+    agent_dir = project_root / ".reyn" / "agents" / _AGENT
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "hooks.yaml").write_text(body, encoding="utf-8")
+
+
+def _make_session_in(project_root: Path, monkeypatch, tmp_path: Path):
+    # ``_hot_reload_project_root`` falls back to cwd when no registry root is
+    # wired — that is the root ``_read_per_agent_composers`` re-reads
+    # ``hooks.yaml`` from.
+    monkeypatch.chdir(project_root)
+    return make_session(
+        agent_name=_AGENT,
+        workspace_base_dir=project_root,
+        workspace_state_dir=tmp_path / "state",
+    )
+
+
+def test_reyn_agent_name_resolves_to_the_real_agent_name_in_composers(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: acceptance ① — ${REYN_AGENT_NAME} in a ``composers:`` entry
+    resolves to the correct per-agent name, not an empty string."""
+    project = tmp_path / "proj"
+    _write_per_agent_hooks(
+        project,
+        "composers:\n"
+        "  - name: notify-${REYN_AGENT_NAME}\n"
+        "    on: turn_end\n"
+        "    template_push:\n"
+        "      message: broker://inbox/${REYN_AGENT_NAME}\n",
+    )
+    session = _make_session_in(project, monkeypatch, tmp_path)
+
+    composers = session._read_per_agent_composers()
+
+    assert composers, "the composers layer must load, not come back empty"
+    assert composers[0]["name"] == f"notify-{_AGENT}"
+    assert composers[0]["template_push"]["message"] == f"broker://inbox/{_AGENT}"
+
+
+def test_an_unresolved_reyn_token_refuses_to_load_the_composers_layer(
+    tmp_path, monkeypatch, caplog,
+) -> None:
+    """Tier 2: acceptance ② — a reyn-owned token this loader does NOT supply
+    a value for (``${REYN_SKILL_DIR}`` — a location token with no meaning for
+    a composers file) must refuse to load the WHOLE composers layer, not
+    silently register a composer with an empty/wrong value, and must surface
+    why."""
+    project = tmp_path / "proj"
+    _write_per_agent_hooks(
+        project,
+        "composers:\n"
+        "  - name: bad\n"
+        "    on: turn_end\n"
+        "    template_push:\n"
+        "      message: ${REYN_SKILL_DIR}/note.txt\n",
+    )
+    session = _make_session_in(project, monkeypatch, tmp_path)
+
+    with caplog.at_level(logging.WARNING):
+        composers = session._read_per_agent_composers()
+
+    assert composers == [], (
+        "an unresolved reyn-owned token must refuse the WHOLE composers "
+        "layer, not load a composer with a wrong/empty value"
+    )
+    assert any("REYN_SKILL_DIR" in r.getMessage() for r in caplog.records), (
+        "the refusal must surface a reason, not fail silently"
+    )
+
+
+def test_a_non_reyn_token_is_left_untouched_and_still_loads_in_composers(
+    tmp_path, monkeypatch, caplog,
+) -> None:
+    """Tier 2: acceptance ③ — a NON-reyn ``${FOO}`` (e.g. an env var meant
+    for a spawned child process to resolve) must load exactly as before:
+    left untouched, no fail-close. Without this, a future fail-close change
+    could kill the feature and nothing would catch it (the #5152 shape)."""
+    project = tmp_path / "proj"
+    _write_per_agent_hooks(
+        project,
+        "composers:\n"
+        "  - name: passthrough\n"
+        "    on: turn_end\n"
+        "    exec:\n"
+        "      command: echo ${SOME_CHILD_PROCESS_VAR}\n",
+    )
+    session = _make_session_in(project, monkeypatch, tmp_path)
+
+    with caplog.at_level(logging.WARNING):
+        composers = session._read_per_agent_composers()
+
+    assert composers, "a non-reyn token must not cause the composers layer to be refused"
+    assert composers[0]["exec"]["command"] == "echo ${SOME_CHILD_PROCESS_VAR}"
+    assert not any(
+        "unresolved" in r.getMessage() for r in caplog.records
+    ), "a non-reyn token must not trip the fail-close or warn at all"

--- a/tests/runtime/test_5140_per_agent_composers_token_expansion.py
+++ b/tests/runtime/test_5140_per_agent_composers_token_expansion.py
@@ -1,22 +1,20 @@
-"""Tier 2: #5140 (part 2) — ``${REYN_AGENT_NAME}`` resolves in a per-agent
-``hooks.yaml``'s ``composers:`` key, the sibling of the already-fixed
-``hooks:`` key (PR #5161, ``tests/runtime/test_5140_per_agent_hooks_token_expansion.py``).
+"""Tier 2: #5140 — ``${REYN_AGENT_NAME}`` resolves in a per-agent
+``hooks.yaml``'s ``composers:`` key, the sibling of the ``hooks:`` key
+witnessed by ``tests/runtime/test_5140_per_agent_hooks_token_expansion.py``.
 
 ``Session._read_per_agent_composers`` (``runtime/session.py``) reads the SAME
 ``.reyn/agents/<name>/hooks.yaml`` file :func:`~reyn.config.loader.load_per_agent_hooks`
-reads its ``hooks:`` key from, but its own ``composers:`` key — and it used
-to run that key through ``expand_env`` (``security/secrets/interpolation.py``,
-ADR-0030, ``os.environ``-backed). ``REYN_AGENT_NAME`` is only ever set on a
-SPAWNED CHILD process's own env, never on this process's own ``os.environ``,
-so ``${REYN_AGENT_NAME}`` was ALWAYS undefined at config-load time here too —
-silently expanding to ``""``, indistinguishable from an operator's genuine
-empty-suffix choice. This is the exact #5140 defect, in a sibling call site
-PR #5161 did not touch.
+reads its ``hooks:`` key from, but its own ``composers:`` key. It expands
+reyn-owned tokens in that key via ``expand_with_map`` (``plugins/tokens.py``)
+with an explicit ``{REYN_PROJECT_DIR, REYN_AGENT_NAME}`` map — not
+``expand_env`` (``security/secrets/interpolation.py``, ADR-0030,
+``os.environ``-backed): ``REYN_AGENT_NAME`` exists only in a SPAWNED CHILD
+process's own env, never in this process's own ``os.environ``, so an
+``os.environ``-backed expander can never resolve it here, regardless of
+operator config.
 
-Fix mirrors #5161 exactly: ``expand_with_map`` (``plugins/tokens.py``) with an
-explicit ``{REYN_PROJECT_DIR, REYN_AGENT_NAME}`` map, fail-closed (whole
-composers layer refused, not a wrong/empty value silently registered) on any
-REMAINING ``${REYN_*}``/``${CLAUDE_*}`` token via
+It fails closed (whole composers layer refused, not a wrong/empty value
+silently registered) on any REMAINING ``${REYN_*}``/``${CLAUDE_*}`` token via
 ``find_unresolved_reyn_tokens`` — while a non-reyn ``${FOO}`` (a spawned
 child process's own env var) is left untouched and still loads (the #5152
 "healthy config must not trip the fail-close" shape).


### PR DESCRIPTION
**[lead-coder]** — part of #5140

## The defect

`.reyn/agents/<name>/hooks.yaml` is read by two different functions, for two
different keys:

- `hooks:` — `config.loader.load_per_agent_hooks`, already fixed by #5161
  (`expand_with_map`, resolves `${REYN_AGENT_NAME}`).
- `composers:` — `Session._read_per_agent_composers`
  (`src/reyn/runtime/session.py`), still ran the file through `expand_env`
  (`security/secrets/interpolation.py`, `os.environ`-backed). `REYN_AGENT_NAME`
  is only ever set on a spawned CHILD process's own env, never on this
  process's own `os.environ`, so `${REYN_AGENT_NAME}` was always undefined at
  config-load time here too — silently expanding to `""`. Same defect,
  sibling call site, not touched by #5161.

Confirmed both functions on `origin/main` before editing — the description
above matched what was in the tree.

## The change

`Session._read_per_agent_composers` now mirrors `load_per_agent_hooks`'s
#5161 shape: `expand_with_map` (`reyn.plugins.tokens`) with the same
`{REYN_PROJECT_DIR, REYN_AGENT_NAME}` map, fail-closed via
`find_unresolved_reyn_tokens` on any remaining `${REYN_*}`/`${CLAUDE_*}`
token (refuse the whole `composers:` layer — reyn's own bug, not an
operator's config choice), while a non-reyn `${FOO}` is left untouched and
still loads (a spawned child process resolves it later).

**One genuine difference from `load_per_agent_hooks`**: `_read_per_agent_composers`
reads the file itself (it has no equivalent `load_per_agent_composers` in
`config/loader.py` to delegate to — `_read_per_agent_hooks` on the `session.py`
side is a one-line delegation to `load_per_agent_hooks`, but there is no
"composers" sibling function in `loader.py` at all), and it surfaces the
unresolved-token refusal via `logger.warning` (this module's own convention —
`_build_composer_defs`'s per-layer resilience already logs this way) rather
than `warnings.warn` (`loader.py`'s convention). The resolution mechanism and
policy (fail-close scoped to reyn's own token vocabulary only) are identical.

## Tests

New file `tests/runtime/test_5140_per_agent_composers_token_expansion.py` —
deliberately separate from #5161's `test_5140_per_agent_hooks_token_expansion.py`
so each key (`hooks:` / `composers:`) has its own witness that fails on its
own. Drives a real `Session` (`tests._support.agent_session.make_session`)
against real files on disk — no mocks.

- ① `${REYN_AGENT_NAME}` in a `composers:` entry resolves to the real agent name.
- ② An unresolved reyn-owned token (`${REYN_SKILL_DIR}`) refuses to load the
  whole composers layer, and warns why.
- ③ A non-reyn token (`${SOME_CHILD_PROCESS_VAR}`) is left untouched and the
  composers layer still loads — the #5152 "healthy config must not trip the
  fail-close" shape.

**Strip-falsify**: reverted `src/reyn/runtime/session.py`'s one-line
`expand_env` → `expand_with_map` swap, ran the new test file — all 3 tests
went red (① and ③ on wrong/mangled values, ② on the composers layer not
having been refused). Restored the fix — all 3 green again.

## Gates

- [x] `ruff check .` — All checks passed!
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5140_per_agent_composers_token_expansion.py` — 3 OK, 0 warnings, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (201 findings, all baselined)
- [x] `python scripts/flat_tests_ratchet.py` — OK (1 flat file, all baselined — unrelated pre-existing baseline)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python -m pytest tests/runtime/test_5140_per_agent_composers_token_expansion.py -q` — 3 passed

## Test plan

- [x] Ran the new test file — 3 passed
- [x] Strip-falsify — all 3 new tests red before the fix, green after
- [x] `ruff check .`, `mypy_ratchet.py`, `test_tier_audit.py --strict`, and the other listed gates all pass
- [x] (skipped — no UI change)

## Review note

Touches `tests/` — needs a TESTS-READ note from a reviewer before merge, per
`docs/deep-dives/contributing/pr-workflow.md` rule 8. Not self-merging; not
arming auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔴 Reviewer's blocking point (lead-coder)

- [x] 🔴 **The docstring carries change history.** Verbatim: *"#5140 (part 2, sibling call site …): this **used to** expand `${REYN_AGENT_NAME}` via `expand_env` … so a `composers:` entry using the token **silently collapsed** to `""`."* The repo owner ruled today that change history does not belong in source; 11 lines of this shape were removed from `profile.py`/`session.py` earlier the same day. **The omission is mine** — I left the constraint out of the implementer's brief, having stated it explicitly on two other PRs tonight. Rewrite as present tense: keep what the code does (reyn-owned tokens via `expand_with_map` with an explicit map; fail-close on a remaining `${REYN_*}`/`${CLAUDE_*}` because that indicates reyn's own bug, not an operator's config choice; a non-reyn `${FOO}` left untouched for a spawned child), **keep the reason `os.environ` cannot serve** (`REYN_AGENT_NAME` exists only in child-process environments, so it is undefined at config-load time — that is a claim about the mechanism, not a chronicle), and keep the pointer to `load_per_agent_hooks`. Remove "used to", "silently collapsed", "part 2", and any framing that narrates what changed. Same check on the new test file's docstrings.

⚪ Not blocking, recorded: reporting the genuine difference from `load_per_agent_hooks` (no `load_per_agent_composers` in `config/loader.py` to delegate to; `logger.warning` per this module's own convention) instead of forcing symmetry is what the brief asked for, and the three tests were strip-falsified separately so no one of them can carry another's weight.


⚪ **Closed** (lead-coder, verified on the PR head): the chronicle framing is gone from both the source docstring and the test module docstring — the implementer found the test file carried the same shape and fixed it unprompted. What survives is the part a future reader needs: `REYN_AGENT_NAME` exists only in a spawned child's env, never in this process's `os.environ`, so an `os.environ`-backed expander cannot resolve it here regardless of operator config.

⚠️ **Out of scope, measured and deliberately not widened here**: `session.py` still carries three unrelated "used to" narratives at lines 396 / 475 / 496, none of them touched by this PR. They belong to the same population as the change-history sweep discussed in #5147 — fixing them here would widen a one-function change into a file-wide edit.
