### PR TITLE
fix(#5153): approvals move from snapshot read-modify-write to an append-only ledger

### DIFF
--- a/src/reyn/interfaces/cli/commands/permissions.py
+++ b/src/reyn/interfaces/cli/commands/permissions.py
@@ -15,7 +15,7 @@ def register(sub) -> None:
     psub = p.add_subparsers(dest="permissions_command", metavar="<subcommand>")
     psub.required = True
 
-    p_list = psub.add_parser("list", help="Show all saved approvals from .reyn/approvals.yaml")
+    p_list = psub.add_parser("list", help="Show all saved approvals")
     p_list.set_defaults(func=_cmd_list)
 
     p_revoke = psub.add_parser("revoke", help="Remove a single approval entry by key")
@@ -32,39 +32,41 @@ def register(sub) -> None:
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
+# #5153 (architect ruling, issuecomment-5383838646, scope confirmed
+# issuecomment-5383848849): this command used to read/write
+# `.reyn/approvals.yaml` directly with its own `_load`/`_save`, a THIRD
+# independent writer alongside `PermissionResolver._persist` and the web
+# router's own equivalent — all 3 racing the same snapshot
+# read-modify-write. This surface, with no live `PermissionResolver`
+# instance (a standalone CLI invocation, often with no `reyn` process
+# running at all), is exactly why "make one process own the file" was
+# rejected as a fix (architect: "server 単一 writer は server 無し CLI が
+# 死ぬ"). `ApprovalLedger` needs no live resolver — constructing one here
+# is the same shape a running session uses.
 
-def _approvals_path() -> Path:
+
+def _ledger_path() -> Path:
+    project_root = _find_project_root(Path.cwd()) or Path.cwd()
+    return project_root / ".reyn" / "approvals.jsonl"
+
+
+def _legacy_snapshot_path() -> Path:
     project_root = _find_project_root(Path.cwd()) or Path.cwd()
     return project_root / ".reyn" / "approvals.yaml"
 
 
 def _load() -> dict[str, bool]:
-    path = _approvals_path()
-    if not path.exists():
-        return {}
-    try:
-        import yaml
-        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except Exception as exc:
-        print(f"Failed to parse {path}: {exc}", file=sys.stderr)
-        sys.exit(1)
-    if not isinstance(data, dict):
-        return {}
-    return {str(k): bool(v) for k, v in data.items() if isinstance(v, bool)}
-
-
-def _save(data: dict[str, bool]) -> None:
-    import yaml
-    path = _approvals_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if not data:
-        # Keep the file present but empty so tooling/diff stays predictable.
-        path.write_text("{}\n", encoding="utf-8")
-        return
-    path.write_text(
-        yaml.dump(data, allow_unicode=True, default_flow_style=False),
-        encoding="utf-8",
+    """Fold the ledger (migrating a legacy snapshot first, if present) —
+    the SAME read every other approvals surface (`PermissionResolver`,
+    the web router) now does."""
+    from reyn.security.permissions.approval_ledger import (
+        ApprovalLedger,
+        migrate_legacy_snapshot,
     )
+    ledger = ApprovalLedger(_ledger_path())
+    migrate_legacy_snapshot(ledger, _legacy_snapshot_path())
+    approvals, _bound = ledger.fold()
+    return approvals
 
 
 def _parse_key(key: str) -> tuple[str, str, str] | None:
@@ -90,7 +92,7 @@ def _parse_key(key: str) -> tuple[str, str, str] | None:
 
 
 def _cmd_list(args: argparse.Namespace) -> None:
-    path = _approvals_path()
+    path = _ledger_path()
     data = _load()
     if not data:
         print(f"No saved approvals at {path}.")
@@ -143,24 +145,31 @@ def _cmd_revoke(args: argparse.Namespace) -> None:
             for k in hits[:5]:
                 print(f"  {k}", file=sys.stderr)
         sys.exit(1)
-    del data[args.key]
-    _save(data)
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
+    ApprovalLedger(_ledger_path()).append_approval(args.key, False)
     print(f"Revoked {args.key!r}.")
 
 
 def _cmd_clear(args: argparse.Namespace) -> None:
     data = _load()
-    if not data:
+    currently_approved = {k for k, v in data.items() if v}
+    if not currently_approved:
         print("No saved approvals to clear.")
         return
     if not args.yes:
         try:
-            ans = input(f"Remove all {len(data)} approvals from {_approvals_path()} ? [y/N]: ").strip().lower()
+            ans = input(
+                f"Remove all {len(currently_approved)} approvals from "
+                f"{_ledger_path()} ? [y/N]: "
+            ).strip().lower()
         except (EOFError, KeyboardInterrupt):
             print()
             sys.exit(1)
         if ans != "y":
             print("Aborted.")
             return
-    _save({})
-    print(f"Cleared {len(data)} approval(s).")
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
+    ledger = ApprovalLedger(_ledger_path())
+    for key in currently_approved:
+        ledger.append_approval(key, False)
+    print(f"Cleared {len(currently_approved)} approval(s).")

--- a/src/reyn/interfaces/web/routers/permissions.py
+++ b/src/reyn/interfaces/web/routers/permissions.py
@@ -1,9 +1,11 @@
 """REST router — /api/permissions.
 
-Wraps .reyn/approvals.yaml (per-process permission approval store).
-All approval keys and values are passed through as-is (P7): the gateway
-never interprets the semantics of approval keys (which encode actor
-and path scoping from the engine's permission system).
+Wraps the #5153 append-only ``approvals.jsonl`` ledger (per-project
+permission-approval decision log — see
+``reyn.security.permissions.approval_ledger``). All approval keys and
+values are passed through as-is (P7): the gateway never interprets the
+semantics of approval keys (which encode actor and path scoping from the
+engine's permission system).
 
 Routes:
     GET    /api/permissions           — list all saved approvals
@@ -14,7 +16,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from pydantic import BaseModel
 
@@ -32,34 +33,33 @@ _SURFACE = "web"
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
+# #5153 (architect ruling, issuecomment-5383838646, scope confirmed
+# issuecomment-5383848849): this router used to read/write
+# `.reyn/approvals.yaml` directly with its own `_load`/`_save`, a THIRD
+# independent writer alongside `PermissionResolver._persist` and the CLI
+# `permissions` command's own equivalent — all 3 racing the same snapshot
+# read-modify-write. Moved onto the same `ApprovalLedger` every other
+# approvals surface now uses.
 
-def _approvals_path(project_root: Path) -> Path:
+
+def _ledger_path(project_root: Path) -> Path:
+    return project_root / ".reyn" / "approvals.jsonl"
+
+
+def _legacy_snapshot_path(project_root: Path) -> Path:
     return project_root / ".reyn" / "approvals.yaml"
 
 
 def _load(project_root: Path) -> dict[str, bool]:
-    path = _approvals_path(project_root)
-    if not path.exists():
-        return {}
-    try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except Exception:
-        return {}
-    if not isinstance(data, dict):
-        return {}
-    return {str(k): bool(v) for k, v in data.items() if isinstance(v, bool)}
-
-
-def _save(data: dict[str, bool], project_root: Path) -> None:
-    path = _approvals_path(project_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if not data:
-        path.write_text("{}\n", encoding="utf-8")
-        return
-    path.write_text(
-        yaml.dump(data, allow_unicode=True, default_flow_style=False),
-        encoding="utf-8",
+    """Fold the ledger (migrating a legacy snapshot first, if present)."""
+    from reyn.security.permissions.approval_ledger import (
+        ApprovalLedger,
+        migrate_legacy_snapshot,
     )
+    ledger = ApprovalLedger(_ledger_path(project_root))
+    migrate_legacy_snapshot(ledger, _legacy_snapshot_path(project_root))
+    approvals, _bound = ledger.fold()
+    return approvals
 
 
 # ── response models ───────────────────────────────────────────────────────────
@@ -77,7 +77,7 @@ class ApprovalEntry(BaseModel):
 async def list_permissions(
     project_root: Path = Depends(get_project_root),
 ) -> list[ApprovalEntry]:
-    """Return all saved approval entries from .reyn/approvals.yaml."""
+    """Return all saved approval entries, folded from the ledger."""
     data = _load(project_root)
     return [ApprovalEntry(key=k, approved=v) for k, v in sorted(data.items())]
 
@@ -89,13 +89,14 @@ async def revoke_permission(
 ) -> None:
     """Revoke a single approval entry by its key.
 
-    #5065: this is a management operation on the SAVED-approvals store, not
-    an in-run permission decision — ``_save`` below is a raw write with no
-    audit trail of its own (unlike the security-side ``_persist`` flow),
-    so this route emits the audit-event itself, naming the revoked key.
-    Best-effort: the emit runs AFTER ``_save`` and swallows its own failure
-    (see ``emit_direct_event``'s docstring) — the write always lands, but on
-    an emit failure the audit trail does not record it.
+    #5065/#5153: this is a management operation on the SAVED-approvals
+    store, not an in-run permission decision, so this route emits its
+    own audit-event naming the revoked key (the ledger append itself
+    carries no semantic "this was a revoke, from the web surface"
+    label — the event is the durable, human-facing trail for that).
+    Best-effort: the emit runs AFTER the append and swallows its own
+    failure (see ``emit_direct_event``'s docstring) — the append always
+    lands, but on an emit failure the audit trail does not record it.
     """
     data = _load(project_root)
     if key not in data:
@@ -103,8 +104,8 @@ async def revoke_permission(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No saved approval with key {key!r}.",
         )
-    del data[key]
-    _save(data, project_root)
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
+    ApprovalLedger(_ledger_path(project_root)).append_approval(key, False)
     emit_direct_event(
         "permission_approval_revoked",
         surface=_SURFACE,
@@ -120,21 +121,25 @@ async def clear_permissions(
 ) -> None:
     """Clear all saved approvals. Requires body: {\"confirm\": true}.
 
-    #5065: same audit gap as :func:`revoke_permission` above — a bulk clear
-    has no single key to name, so the audit-event carries the count of
-    entries actually cleared instead. Same best-effort scope as that route:
-    the emit runs after ``_save`` and swallows its own failure.
+    #5065/#5153: same shape as :func:`revoke_permission` above — a bulk
+    clear has no single key to name, so the audit-event carries the
+    count of entries actually revoked instead (only the currently-
+    APPROVED ones; an already-revoked entry has nothing left to clear).
     """
     if not confirm:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Pass {\"confirm\": true} in the request body to clear all approvals.",
         )
-    count = len(_load(project_root))
-    _save({}, project_root)
+    data = _load(project_root)
+    currently_approved = [k for k, v in data.items() if v]
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
+    ledger = ApprovalLedger(_ledger_path(project_root))
+    for key in currently_approved:
+        ledger.append_approval(key, False)
     emit_direct_event(
         "permission_approvals_cleared",
         surface=_SURFACE,
         reyn_root=project_root / ".reyn",
-        count=count,
+        count=len(currently_approved),
     )

--- a/src/reyn/security/permissions/approval_ledger.py
+++ b/src/reyn/security/permissions/approval_ledger.py
@@ -247,6 +247,21 @@ def migrate_legacy_snapshot(ledger: ApprovalLedger, legacy_yaml_path: Path) -> N
     the same way the pre-#5153 loaders already did (a non-bool row or a
     malformed ``_bound_identities`` entry is skipped, never an error).
 
+    **Invariant (architect co-vet, broker, #5170 2026-08-23T03:53Z —
+    state this in words so a future reader does not reintroduce the
+    real defect below by going per-key): the legacy snapshot is a BASE,
+    never an UPDATE.**
+    If the ledger already holds ANY record at all — for this key or any
+    other — migration adds NOTHING, full stop; it never selectively
+    "fills in just the keys that aren't there yet." A per-key migration
+    (checking each legacy key individually against what the ledger
+    already has) is exactly the shape that reintroduces the race below —
+    that granularity is what let a stale value land after a real
+    decision for ONE key while the others were still fine. Keeping
+    migration all-or-nothing at the FILE level, gated once on whether
+    the ledger exists AT ALL, is what makes the fix below possible in
+    the first place.
+
     #5153 real defect (docs-maintainer's TESTS-READY(B) on PR #5170,
     issuecomment-5384027134 — 3/3, no strip needed): the FIRST version of
     this function appended one record PER KEY via ``ApprovalLedger``'s
@@ -353,6 +368,13 @@ def migrate_legacy_snapshot(ledger: ApprovalLedger, legacy_yaml_path: Path) -> N
     # later write, reproducing the identical bug in a narrower window).
     # link() has no such gap: the content is complete before the ledger
     # path is ever created.
+    #
+    # os.link's atomicity is a SAME-FILESYSTEM guarantee -- a hard link
+    # cannot cross filesystem boundaries at all (raises OSError/EXDEV).
+    # The temp file MUST therefore be created in the SAME directory as
+    # the ledger (never /tmp or any other mount point), which is why
+    # `dir=str(ledger.path.parent)` below is load-bearing, not a
+    # convenience default.
     tmp_fd, tmp_path_str = tempfile.mkstemp(
         dir=str(ledger.path.parent), prefix=".approvals-migrate-", suffix=".tmp",
     )

--- a/src/reyn/security/permissions/approval_ledger.py
+++ b/src/reyn/security/permissions/approval_ledger.py
@@ -1,0 +1,265 @@
+"""#5153: append-only JSONL ledger for permission-approval decisions.
+
+Root cause (lead-coder): ``.reyn/approvals.yaml``'s persistence shape was
+snapshot read-modify-write — ``_persist`` (and, after #5152,
+``_bind_identity``) does ``yaml.safe_load`` the WHOLE file → mutate a dict →
+``write_text`` the WHOLE file back. Every writer therefore needs momentary
+ownership of the ENTIRE file's content to make even a ONE-key change, and
+TWO writers doing this concurrently (the owner's actual configuration: a
+``reyn web`` server plus one or more ``--connect`` CLI clients, all sharing
+the same project) silently lose an approval — last-writer-wins, with no
+audit trail of the lost decision ever having existed.
+
+Architect ruling (issuecomment-5383838646): don't decide who owns the file
+— make owning it unnecessary. Shrink what a writer must produce down to
+"my own decision" (one record), append-only, mirroring
+:class:`reyn.runtime.budget.budget.BudgetLedger` (PR25) exactly — the same
+codebase precedent for "durable, fsync'd-on-append, folded by readers"
+already used for LLM-call cost records, restated in the constitution as
+"the ledger, not the best-effort state-file cache, wins on recovery".
+Concurrent appends to DIFFERENT keys never conflict (they're different
+lines); concurrent appends to the SAME key both survive, in whatever order
+the OS interleaves the two small writes, and folding resolves that
+ordering deterministically (last record per key wins) — no reader ever
+needs to arbitrate between them, because neither write ever had to see or
+replace the other's line.
+
+**What goes in this ledger** (architect ruling): approval decisions
+(``kind="approval"``) AND #5152's own bound-identity records
+(``kind="identity_bind"``) — the SAME log, not two. Bound-identity records
+have become the MOST frequent write since #5152 (bind-on-first-use fires
+on every path approval's first use per process, not just on a human
+decision), so folding them separately would just move the race rather than
+close it.
+
+**Fold semantics** (the read side): walk records in file order; for each
+``key``, the LAST ``"approval"`` record wins for whether it's granted, and
+the LAST ``"identity_bind"`` record wins for the bound identity — EXCEPT a
+``"approval"`` record with ``approved=False`` (a revoke) also clears any
+bound identity for that key, mirroring #5157's own revoke-clears-binding
+invariant (a stale identity surviving a revoke is the exact "a name is not
+an identity" shape #5042 exists to close). This requires no locking and no
+read-before-write: a fold is a pure function of "every record written so
+far", and two processes racing to append never need to agree on anything
+before their own write lands.
+
+**Migration** (acceptance ③): a pre-#5153 ``approvals.yaml`` snapshot
+(``{key: bool}`` rows plus #5152's own ``_bound_identities`` sibling
+section) is migrated ONCE, on first touch, into day-0 records appended to
+this ledger — see :func:`migrate_legacy_snapshot`. Folding the ledger
+after migration must reproduce EXACTLY the same effective state the old
+snapshot reader would have returned (the acceptance witness) — migration
+adds records, it does not reinterpret them.
+
+**Ordering authority** (architect co-vet, broker, #5153 2026-08-23T02:44Z):
+FILE ORDER is the ONLY authority "last wins" means — i.e. the order
+:meth:`iter_records` yields lines in, which is append order, which is
+whatever order the OS actually interleaved N concurrent processes' small
+``write()`` calls in.
+The ``ts`` field on every record is DISPLAY-ONLY — never sorted on, never
+compared, never used to break or resolve anything. Independent processes'
+clocks are not synchronized (skew, NTP drift, two records landing in the
+same wall-clock second under real concurrency), so a fold that "helpfully"
+re-orders by ``ts`` would silently reintroduce exactly the same ambiguity
+this ledger exists to remove — the same "one fact, two sources of truth"
+shape this codebase closed 3 times over the same night this issue was
+ruled on. :meth:`fold` must never read ``ts`` for anything but a caller's
+own display formatting.
+
+**Caveat, stated rather than solved** (acceptance ④): the append's
+atomicity depends on each record line being small — a local filesystem's
+``write()`` for a buffer at or under ``PIPE_BUF``/the OS's own atomic-write
+threshold does not interleave with a concurrent writer's own ``write()``.
+This is the same assumption ``BudgetLedger`` already makes (never
+challenged there) and is NOT re-derived or strengthened here; a record
+line long enough to exceed that threshold (implausible for this ledger's
+small dict shapes) would need a different guarantee this module does not
+provide.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+
+class ApprovalLedger:
+    """Append-only JSONL ledger for one project's permission-approval
+    decisions and bound-identity records — see the module docstring for
+    the full rationale. One instance per ``approvals.jsonl`` path; safe to
+    construct freely (no held state beyond the path), same as
+    ``BudgetLedger`` — a CLI subcommand or a web request handler with no
+    live ``PermissionResolver`` instance can use one exactly the same way
+    a running session does.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append_approval(self, key: str, approved: bool) -> None:
+        """Append one approval-decision record (a grant or a revoke).
+        ``ts`` is DISPLAY-ONLY (see the module docstring's "Ordering
+        authority" section) — :meth:`fold` never reads it."""
+        self._write_record({
+            "ts": self._now_iso(),
+            "kind": "approval",
+            "key": key,
+            "approved": approved,
+        })
+
+    def append_identity_bind(
+        self, key: str, ino: int, birthtime: "float | None",
+    ) -> None:
+        """Append one #5152 bound-identity record for *key*."""
+        self._write_record({
+            "ts": self._now_iso(),
+            "kind": "identity_bind",
+            "key": key,
+            "ino": ino,
+            "birthtime": birthtime,
+        })
+
+    @staticmethod
+    def _now_iso() -> str:
+        """Current local time as an ISO-8601 string with UTC offset — same
+        shape as ``BudgetLedger._now_iso``."""
+        lt = time.localtime(time.time())
+        offset_sec = lt.tm_gmtoff
+        sign = "+" if offset_sec >= 0 else "-"
+        offset_abs = abs(offset_sec)
+        offset_str = f"{sign}{offset_abs // 3600:02d}:{(offset_abs % 3600) // 60:02d}"
+        return (
+            f"{lt.tm_year:04d}-{lt.tm_mon:02d}-{lt.tm_mday:02d}"
+            f"T{lt.tm_hour:02d}:{lt.tm_min:02d}:{lt.tm_sec:02d}"
+            f"{offset_str}"
+        )
+
+    def _write_record(self, record: dict) -> None:
+        """Serialize *record* as one JSONL line, append, flush, fsync —
+        identical shape to ``BudgetLedger._write_record``, including the
+        leading-newline guard against a previous crash's partial
+        (no-trailing-newline) write."""
+        line = json.dumps(record, ensure_ascii=False) + "\n"
+        need_lead = self._needs_lead_newline()
+        with self._path.open("a", encoding="utf-8") as f:
+            if need_lead:
+                f.write("\n")
+            f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
+
+    def _needs_lead_newline(self) -> bool:
+        if not self._path.is_file():
+            return False
+        try:
+            size = self._path.stat().st_size
+        except OSError:
+            return False
+        if size == 0:
+            return False
+        try:
+            with self._path.open("rb") as f:
+                f.seek(-1, 2)
+                return f.read(1) != b"\n"
+        except OSError:
+            return False
+
+    def iter_records(self):
+        """Yield parsed record dicts; skip broken/non-dict lines (a torn
+        write from a crash mid-append reads as absent, never an error —
+        the SAME tolerance ``BudgetLedger.iter_records`` gives its own
+        lines)."""
+        if not self._path.is_file():
+            return
+        with self._path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                yield entry
+
+    def fold(
+        self,
+    ) -> "tuple[dict[str, bool], dict[str, tuple[int, float | None]]]":
+        """Replay every record in file order into the two maps
+        ``PermissionResolver`` needs: ``(approvals, bound_identities)``.
+
+        Last ``"approval"`` record per key wins for the boolean; last
+        ``"identity_bind"`` record per key wins for the identity — EXCEPT
+        an ``"approval"`` record with ``approved=False`` also clears that
+        key's bound identity (see the module docstring's "Fold semantics"
+        section for why this mirrors #5157, not a new rule)."""
+        approvals: "dict[str, bool]" = {}
+        bound: "dict[str, tuple[int, float | None]]" = {}
+        for rec in self.iter_records():
+            key = rec.get("key")
+            if not isinstance(key, str):
+                continue
+            kind = rec.get("kind")
+            if kind == "approval":
+                approved = rec.get("approved")
+                if not isinstance(approved, bool):
+                    continue
+                approvals[key] = approved
+                if not approved:
+                    bound.pop(key, None)
+            elif kind == "identity_bind":
+                ino = rec.get("ino")
+                if not isinstance(ino, int):
+                    continue
+                bt = rec.get("birthtime")
+                bound[key] = (ino, float(bt) if isinstance(bt, (int, float)) else None)
+        return approvals, bound
+
+
+def migrate_legacy_snapshot(ledger: ApprovalLedger, legacy_yaml_path: Path) -> None:
+    """#5153 acceptance ③: one-time migration of a pre-ledger
+    ``approvals.yaml`` snapshot (``{key: bool}`` rows plus #5152's own
+    ``_bound_identities`` sibling section) into day-0 ledger records.
+
+    A no-op unless the ledger file does not exist yet AND the legacy
+    snapshot does — idempotent by construction (a second call sees the
+    ledger already present and does nothing), so callers can call this
+    unconditionally before every read/append without needing their own
+    "have I migrated yet" flag. Malformed/partial legacy content degrades
+    the same way the pre-#5153 loaders already did (a non-bool row or a
+    malformed ``_bound_identities`` entry is skipped, never an error)."""
+    if ledger.path.exists() or not legacy_yaml_path.exists():
+        return
+    try:
+        import yaml
+        data: Any = yaml.safe_load(legacy_yaml_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return
+    if not isinstance(data, dict):
+        return
+    bound_section = data.get("_bound_identities")
+    if not isinstance(bound_section, dict):
+        bound_section = {}
+    for key, value in data.items():
+        if key == "_bound_identities" or not isinstance(value, bool):
+            continue
+        ledger.append_approval(key, value)
+    for key, entry in bound_section.items():
+        if not isinstance(entry, dict) or "ino" not in entry:
+            continue
+        ino = entry.get("ino")
+        if not isinstance(ino, int):
+            continue
+        bt = entry.get("birthtime")
+        ledger.append_identity_bind(
+            key, ino, float(bt) if isinstance(bt, (int, float)) else None,
+        )

--- a/src/reyn/security/permissions/approval_ledger.py
+++ b/src/reyn/security/permissions/approval_ledger.py
@@ -45,11 +45,19 @@ before their own write lands.
 
 **Migration** (acceptance ③): a pre-#5153 ``approvals.yaml`` snapshot
 (``{key: bool}`` rows plus #5152's own ``_bound_identities`` sibling
-section) is migrated ONCE, on first touch, into day-0 records appended to
-this ledger — see :func:`migrate_legacy_snapshot`. Folding the ledger
-after migration must reproduce EXACTLY the same effective state the old
-snapshot reader would have returned (the acceptance witness) — migration
-adds records, it does not reinterpret them.
+section) is migrated ONCE, on first touch, into day-0 records — see
+:func:`migrate_legacy_snapshot`. Folding the ledger after migration must
+reproduce EXACTLY the same effective state the old snapshot reader would
+have returned (the acceptance witness) — migration adds records, it does
+not reinterpret them. The migration itself is written to a temp file,
+fully durable, THEN published at the ledger's own path via an atomic
+``os.link`` (not one append call per legacy key, and not a plain
+exclusive-create-then-write either — see that function's own docstring
+for why both of those still leave a gap) — see that function's own
+docstring for the real defect (docs-maintainer's TESTS-READY(B), PR
+#5170) this closes: a partially-migrated ledger racing
+a genuine concurrent decision could let a STALE legacy value land after,
+and therefore override, a real revoke.
 
 **Ordering authority** (architect co-vet, broker, #5153 2026-08-23T02:44Z):
 FILE ORDER is the ONLY authority "last wins" means — i.e. the order
@@ -80,6 +88,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -236,7 +245,61 @@ def migrate_legacy_snapshot(ledger: ApprovalLedger, legacy_yaml_path: Path) -> N
     unconditionally before every read/append without needing their own
     "have I migrated yet" flag. Malformed/partial legacy content degrades
     the same way the pre-#5153 loaders already did (a non-bool row or a
-    malformed ``_bound_identities`` entry is skipped, never an error)."""
+    malformed ``_bound_identities`` entry is skipped, never an error).
+
+    #5153 real defect (docs-maintainer's TESTS-READY(B) on PR #5170,
+    issuecomment-5384027134 — 3/3, no strip needed): the FIRST version of
+    this function appended one record PER KEY via ``ApprovalLedger``'s
+    normal ``append_*`` calls — durable per-call, but NOT atomic as a
+    WHOLE. A slow migration (many legacy keys, the target key not first
+    in iteration order) racing a genuinely CONCURRENT real decision (a
+    different process revoking that SAME key) could interleave: the real
+    revoke lands in file order BEFORE this function later reaches and
+    appends the STALE legacy value for that key — "last wins by file
+    order" then resurrects the stale, already-revoked grant. Batching
+    this function's own writes into one atomic operation would only fix
+    migration racing ITSELF (two processes both migrating); it does
+    nothing for migration racing an unrelated real append, because the
+    genuine danger is a partially-migrated ledger being visible to (and
+    written into) from another process's real decision at all.
+
+    Fixed by making migration INDIVISIBLE relative to ANY other writer,
+    not just to another migration attempt: every legacy row (both
+    ``approval`` and ``identity_bind`` records) is built into ONE buffer,
+    written COMPLETELY to a private temp file (fully flushed + fsync'd),
+    and only THEN published at the ledger's own path via ``os.link`` —
+    which POSIX guarantees is atomic and fails with ``EEXIST`` if the
+    target already exists. The ledger path itself is therefore NEVER
+    observed in a "created but not yet fully written" state by anyone —
+    it goes straight from "does not exist" to "exists with its FULL
+    migrated content", because the content was already 100% durable
+    before the ledger path was ever touched.
+
+    A first cut of this fix used a plain exclusive-create
+    (``O_CREAT | O_EXCL``) directly on the ledger path, then wrote the
+    content in a SEPARATE ``write()`` call — durable-once-written, but
+    NOT gap-free: between the create succeeding (ledger path now exists,
+    still empty) and the write landing, a genuinely concurrent real
+    decision could open the now-existing path in plain append mode,
+    write its own line into that gap, and then this function's own
+    (later) write — using ``O_APPEND``, which re-seeks to the CURRENT
+    end of file at write time, not the offset at open time — would still
+    land AFTER that real decision, reproducing the identical bug in a
+    narrower window (one syscall pair instead of an entire per-key
+    loop). The temp-file-then-link approach has no such window: nothing
+    is ever written to a path any other process can observe until the
+    content is already complete, so there is no gap to squeeze into.
+
+    Every real decision in this codebase calls this function BEFORE its
+    own append (``PermissionResolver._ensure_folded``, the CLI/web
+    ``_load`` — see each caller's own docstring), so:
+      - if THIS call wins the link, its full batch lands first, and
+        only THEN does the caller proceed to append its own
+        (necessarily later, necessarily correct) real decision;
+      - if this call LOSES (``FileExistsError`` — someone else's
+        migration, or a genuine append, already created the file), it
+        is a no-op, and the caller's own subsequent real append still
+        lands strictly AFTER whatever is already there."""
     if ledger.path.exists() or not legacy_yaml_path.exists():
         return
     try:
@@ -249,10 +312,15 @@ def migrate_legacy_snapshot(ledger: ApprovalLedger, legacy_yaml_path: Path) -> N
     bound_section = data.get("_bound_identities")
     if not isinstance(bound_section, dict):
         bound_section = {}
+    ts = ApprovalLedger._now_iso()
+    lines: list[str] = []
     for key, value in data.items():
         if key == "_bound_identities" or not isinstance(value, bool):
             continue
-        ledger.append_approval(key, value)
+        lines.append(json.dumps(
+            {"ts": ts, "kind": "approval", "key": key, "approved": value},
+            ensure_ascii=False,
+        ))
     for key, entry in bound_section.items():
         if not isinstance(entry, dict) or "ino" not in entry:
             continue
@@ -260,6 +328,46 @@ def migrate_legacy_snapshot(ledger: ApprovalLedger, legacy_yaml_path: Path) -> N
         if not isinstance(ino, int):
             continue
         bt = entry.get("birthtime")
-        ledger.append_identity_bind(
-            key, ino, float(bt) if isinstance(bt, (int, float)) else None,
-        )
+        lines.append(json.dumps(
+            {
+                "ts": ts, "kind": "identity_bind", "key": key, "ino": ino,
+                "birthtime": float(bt) if isinstance(bt, (int, float)) else None,
+            },
+            ensure_ascii=False,
+        ))
+    if not lines:
+        return  # nothing valid to migrate -- don't create an empty ledger
+    content = ("\n".join(lines) + "\n").encode("utf-8")
+    ledger.path.parent.mkdir(parents=True, exist_ok=True)
+    # Write the FULL batch to a private temp file first (fully durable —
+    # flushed + fsync'd — before the ledger path is ever touched), then
+    # publish it with os.link, which POSIX guarantees is atomic AND fails
+    # with EEXIST if the target already exists — never a "created but not
+    # yet written" intermediate state observable at the ledger path itself.
+    # A plain O_CREAT|O_EXCL open on the ledger path directly (this
+    # function's first cut) still leaves a 2-syscall gap between the
+    # create succeeding and the content actually landing — a REAL
+    # concurrent append could squeeze into exactly that gap (its own
+    # migrate() attempt sees the now-existing-but-still-empty file, skips,
+    # appends its real decision — landing BEFORE this migration's own
+    # later write, reproducing the identical bug in a narrower window).
+    # link() has no such gap: the content is complete before the ledger
+    # path is ever created.
+    tmp_fd, tmp_path_str = tempfile.mkstemp(
+        dir=str(ledger.path.parent), prefix=".approvals-migrate-", suffix=".tmp",
+    )
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(tmp_fd, "wb") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        try:
+            os.link(str(tmp_path), str(ledger.path))
+        except FileExistsError:
+            pass  # someone else's migration (or a genuine first append) already won
+    finally:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -452,7 +452,18 @@ class PermissionResolver:
             Path(file_zone_root).resolve() if file_zone_root else self._project_root
         )
         self._interactive = interactive
+        # #5153: the LEGACY snapshot path — read-only from here on (a
+        # one-time migration source into the ledger, never written by
+        # this class again; see ``_ensure_folded``/``migrate_legacy_snapshot``).
         self._approvals_path = self._project_root / ".reyn" / "approvals.yaml"
+        # #5153: the append-only decision ledger that REPLACES the above
+        # snapshot's read-modify-write. See ``approval_ledger.py``'s own
+        # module docstring for the full rationale (3 independent writers
+        # — this class, the CLI `permissions` command, the web router —
+        # each needing momentary ownership of the WHOLE snapshot file to
+        # change even one key was the root cause of a lost approval under
+        # concurrent access).
+        self._approval_ledger_path = self._project_root / ".reyn" / "approvals.jsonl"
         self._session: dict[str, bool] = {}
         # #3671 P4 item D-1: lazy — disk read + YAML parse deferred to the
         # `_saved` property's first access, not paid on every PermissionResolver
@@ -610,11 +621,13 @@ class PermissionResolver:
 
     @property
     def _saved(self) -> dict[str, bool]:
-        """#3671 P4 item D-1: the single owner of the lazy load — reads +
-        parses `approvals.yaml` on first access only, cached for the life of
-        this resolver. Returns the SAME dict object across calls, so
-        `self._saved[key] = value` (used by `_persist`) mutates the real
-        cached dict, not a throwaway copy.
+        """#3671 P4 item D-1: the single owner of the lazy load — folds
+        the #5153 append-only ``approvals.jsonl`` ledger (migrating a
+        legacy ``approvals.yaml`` snapshot first, if present) on first
+        access only, cached for the life of this resolver. Returns the
+        SAME dict object across calls, so `self._saved[key] = value`
+        (used by `_persist`) mutates the real cached dict, not a
+        throwaway copy.
 
         #3671 P4 D-1 review (lead-coder): this IS a check-then-set
         (`self.__saved is None` → `self.__saved = ...`), the same SHAPE as
@@ -623,7 +636,7 @@ class PermissionResolver:
         justify, not merely assert (#3674's own standard). One
         `PermissionResolver` IS shared across multiple `Session`s (PR10) —
         so this property IS reachable from more than one concurrently-
-        running coroutine. What makes it safe regardless: `_load_saved()`
+        running coroutine. What makes it safe regardless: `_ensure_folded()`
         contains NO `await` — the whole check-then-set body runs to
         completion inside a single asyncio task's turn with no yield point
         in between, so no other coroutine can observe `self.__saved` in a
@@ -634,50 +647,42 @@ class PermissionResolver:
         no longer hold and this property would need the same ownership
         treatment #3674 gave `ensure_litellm_ready`)."""
         if self.__saved is None:
-            self.__saved = self._load_saved()
+            self._ensure_folded()
+        assert self.__saved is not None  # _ensure_folded always sets both
         return self.__saved
 
-    def _load_saved(self) -> dict[str, bool]:
-        if not self._approvals_path.exists():
-            return {}
-        try:
-            import yaml
-            data = yaml.safe_load(self._approvals_path.read_text(encoding="utf-8")) or {}
-            return {k: bool(v) for k, v in data.items() if isinstance(v, bool)}
-        except Exception:
-            return {}
-
-    # ── #5042: bound identity for PATH-flavor approvals only ──────────────────
+    # ── #5042/#5153: bound identity for PATH-flavor approvals only ──────────
 
     @property
     def _bound_identities(self) -> "dict[str, tuple[int, float | None]]":
-        """Same lazy-load-once shape as :attr:`_saved` — one owner, mutation
+        """Same lazy-load-once shape as :attr:`_saved` — folded from the
+        SAME ledger in the SAME pass (see :meth:`_ensure_folded`); mutation
         through the returned dict object persists via :meth:`_bind_identity`."""
         if self.__bound_identities is None:
-            self.__bound_identities = self._load_bound_identities()
+            self._ensure_folded()
+        assert self.__bound_identities is not None  # _ensure_folded always sets both
         return self.__bound_identities
 
-    def _load_bound_identities(self) -> "dict[str, tuple[int, float | None]]":
-        if not self._approvals_path.exists():
-            return {}
-        try:
-            import yaml
-            data = yaml.safe_load(self._approvals_path.read_text(encoding="utf-8")) or {}
-            raw = data.get("_bound_identities")
-            if not isinstance(raw, dict):
-                return {}
-            out: "dict[str, tuple[int, float | None]]" = {}
-            for k, v in raw.items():
-                if not isinstance(v, dict) or "ino" not in v:
-                    continue  # malformed entry -- read as unbound, same as absent
-                ino = v.get("ino")
-                if not isinstance(ino, int):
-                    continue
-                bt = v.get("birthtime")
-                out[k] = (ino, float(bt) if isinstance(bt, (int, float)) else None)
-            return out
-        except Exception:
-            return {}
+    def _ensure_folded(self) -> None:
+        """#5153: the single fold site both :attr:`_saved` and
+        :attr:`_bound_identities` lazy-load through — one ledger read
+        producing BOTH maps together (they were always derived from the
+        same records; loading them separately would just be the same
+        file parsed twice). Migrates a legacy ``approvals.yaml`` snapshot
+        into the ledger first if the ledger doesn't exist yet (see
+        :func:`~reyn.security.permissions.approval_ledger.migrate_legacy_snapshot`)
+        — a no-op on every call after the first, for this resolver or any
+        other process (idempotent by construction: the ledger existing at
+        all is what makes it skip)."""
+        if self.__saved is not None and self.__bound_identities is not None:
+            return
+        from reyn.security.permissions.approval_ledger import (
+            ApprovalLedger,
+            migrate_legacy_snapshot,
+        )
+        ledger = ApprovalLedger(self._approval_ledger_path)
+        migrate_legacy_snapshot(ledger, self._approvals_path)
+        self.__saved, self.__bound_identities = ledger.fold()
 
     def _path_identity(self, path: Path) -> "tuple[int, float | None] | None":
         """#5042/#5084: raw ``(st_ino, st_birthtime)`` of *path* (file OR
@@ -784,48 +789,31 @@ class PermissionResolver:
         acquisition happen together so every caller gets both halves of
         the confirmation contract for free.
 
-        architect co-vet (issuecomment-5383499299): this write fires far
-        more often than ``_persist``'s own read-modify-write of the same
-        file — ``_persist`` only runs when a HUMAN approves (rare);
-        binding runs on every path-approval's FIRST USE, inside ordinary
-        tool execution (routine). A crash mid-``write_text`` here would
-        truncate ``approvals.yaml`` and lose EVERY approval, not just the
-        one being bound — a rare risk turned common by this PR's own
-        change in call frequency. Fixed the same way
-        ``AgentIdentityGenerationStore.record`` already does (tmp file +
-        atomic ``replace``): the write either lands whole or not at all,
-        never a half-written file. A second PROCESS (server + CLI)
-        racing this same read-modify-write and last-writer-wins losing
-        the OTHER process's binding is a separate, NOT-closed-here
-        finding (architect: file a follow-up; the owner runs 2 clients +
-        a server concurrently, so this is not a hypothetical)."""
+        #5153 (architect ruling, issuecomment-5383838646, superseding the
+        architect co-vet issuecomment-5383499299 that FIRST flagged this
+        write's frequency): this write fires far more often than
+        ``_persist``'s own decision — ``_persist`` only runs when a HUMAN
+        approves (rare); binding runs on every path-approval's FIRST USE
+        per process, inside ordinary tool execution (routine). The
+        original fix here was a snapshot tmp-file + atomic ``replace``
+        (still correct against a mid-write CRASH), but that read-modify-
+        write shape ALSO loses an update under concurrent WRITERS — not
+        just a crash — because every writer needs momentary ownership of
+        the WHOLE file to change even one key. #5153 replaces the
+        snapshot entirely with an APPEND to :class:`~reyn.security.
+        permissions.approval_ledger.ApprovalLedger` — see that module's
+        own docstring for why append-only removes the need for ownership
+        at all (a second, unrelated append to a DIFFERENT key never
+        conflicts; two racing appends for the SAME key both land, and
+        folding resolves the ordering deterministically)."""
         self._bound_identities[key] = identity
         self._acquire_identity_fd(key, approved_p)
         if not persist:
             return
-        try:
-            import yaml
-            self._approvals_path.parent.mkdir(parents=True, exist_ok=True)
-            existing: dict = {}
-            if self._approvals_path.exists():
-                existing = yaml.safe_load(
-                    self._approvals_path.read_text(encoding="utf-8")
-                ) or {}
-            bound_section = existing.get("_bound_identities")
-            if not isinstance(bound_section, dict):
-                bound_section = {}
-            bound_section[key] = {"ino": identity[0], "birthtime": identity[1]}
-            existing["_bound_identities"] = bound_section
-            tmp = self._approvals_path.with_suffix(
-                self._approvals_path.suffix + ".tmp"
-            )
-            tmp.write_text(
-                yaml.dump(existing, allow_unicode=True, default_flow_style=False),
-                encoding="utf-8",
-            )
-            tmp.replace(self._approvals_path)
-        except Exception:
-            pass
+        from reyn.security.permissions.approval_ledger import ApprovalLedger
+        ApprovalLedger(self._approval_ledger_path).append_identity_bind(
+            key, identity[0], identity[1],
+        )
 
     def _persist(self, key: str, approved: bool) -> None:
         # #2248: approvals.yaml is PERSIST, not recovery-core — so NO config generation
@@ -857,26 +845,17 @@ class PermissionResolver:
             # never-before-seen key.
             self._release_identity_fd(key)
             self._bound_identities.pop(key, None)
-        try:
-            import yaml
-            self._approvals_path.parent.mkdir(parents=True, exist_ok=True)
-            existing: dict = {}
-            if self._approvals_path.exists():
-                existing = yaml.safe_load(
-                    self._approvals_path.read_text(encoding="utf-8")
-                ) or {}
-            existing[key] = approved
-            if not approved:
-                bound_section = existing.get("_bound_identities")
-                if isinstance(bound_section, dict) and key in bound_section:
-                    bound_section.pop(key, None)
-                    existing["_bound_identities"] = bound_section
-            self._approvals_path.write_text(
-                yaml.dump(existing, allow_unicode=True, default_flow_style=False),
-                encoding="utf-8",
-            )
-        except Exception:
-            pass
+        # #5153 (architect ruling, issuecomment-5383838646): append the
+        # decision instead of read-modify-writing the whole snapshot — see
+        # ``approval_ledger.py``'s own module docstring. A revoke's
+        # in-memory fd-release/binding-clear above (#5157) is THIS
+        # process's own state; the PERSISTED half of "a revoke clears the
+        # bound identity too" is enforced generically by
+        # ``ApprovalLedger.fold`` (any ``approved=False`` record clears
+        # that key's fold-time binding, from WHICHEVER writer produced
+        # it — CLI, web router, or here) — no extra write needed for it.
+        from reyn.security.permissions.approval_ledger import ApprovalLedger
+        ApprovalLedger(self._approval_ledger_path).append_approval(key, approved)
         # #398 v4 emitter wiring: notify subscribers (= Session
         # instances that registered themselves) so the LLM sees the
         # permission change as a ``state_change`` history entry next

--- a/tests/interfaces/test_5050_remote_pending_intervention_choices.py
+++ b/tests/interfaces/test_5050_remote_pending_intervention_choices.py
@@ -59,7 +59,6 @@ import asyncio
 from pathlib import Path
 
 import pytest
-import yaml
 from textual_flowview import FlowView
 
 from reyn.core.events.events import Event
@@ -183,7 +182,7 @@ def _make_session_with_resolver(
 
 
 @pytest.mark.asyncio
-async def test_remote_always_choice_persists_to_approvals_yaml(tmp_path, monkeypatch):
+async def test_remote_always_choice_persists_to_the_approval_ledger(tmp_path, monkeypatch):
     """Tier 2: witness ① — the COMBINED witness lead-coder's own #5050③
     block found missing (no single test looked at the whole SET owner
     required): a construction where ``transport.frames()`` yields ZERO
@@ -269,12 +268,15 @@ async def test_remote_always_choice_persists_to_approvals_yaml(tmp_path, monkeyp
         # so ONE "down" reaches [A]lways.
         await pilot.press("down")
         await pilot.press("enter")
-        approvals_path = tmp_path / ".reyn" / "approvals.yaml"
-        await _wait_until(pilot, lambda: approvals_path.exists())
+        # #5153: persistence moved from a snapshot approvals.yaml to the
+        # append-only approvals.jsonl ledger — wait on THAT file existing.
+        ledger_path = tmp_path / ".reyn" / "approvals.jsonl"
+        await _wait_until(pilot, lambda: ledger_path.exists())
 
     await require_task
 
-    saved = yaml.safe_load(approvals_path.read_text(encoding="utf-8")) or {}
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
+    saved, _bound = ApprovalLedger(ledger_path).fold()
     assert saved.get("chat_router/http.get/news.ycombinator.com") is True, saved
 
 

--- a/tests/interfaces/test_5153_permissions_cli_ledger.py
+++ b/tests/interfaces/test_5153_permissions_cli_ledger.py
@@ -1,0 +1,153 @@
+"""Tier 2: #5153 — `reyn permissions` (CLI) moves onto the SAME
+`ApprovalLedger` `PermissionResolver` and the web router now use.
+
+Root cause (tui-coder, found while implementing #5153): this command had
+its OWN independent `_load`/`_save`, reading/writing `.reyn/approvals.yaml`
+directly — a THIRD writer racing the snapshot read-modify-write alongside
+`PermissionResolver._persist` and the web router's own equivalent.
+Architect ruling (issuecomment-5383838646, scope confirmed
+issuecomment-5383848849): ALL THREE doors must share the SAME primitive AND
+the SAME rule, or one door breaks what another enforces.
+
+Also closes a pre-existing audit-event gap this command's OLD behavior had
+that `_persist` never did: the old `_cmd_revoke`/`_cmd_clear` DELETED the
+approval row entirely (`del data[key]`) rather than keeping it with
+`approved=False` — the exact "the approval row itself must survive" shape
+#5042's own architect ruling established for `_persist`. An append-only
+ledger cannot delete a row at all, so this command's revoke/clear now keep
+the SAME audit trail `_persist` always has.
+
+Real `ApprovalLedger` + real filesystem paths — no mocks.
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from reyn.interfaces.cli.commands.permissions import _cmd_clear, _cmd_list, _cmd_revoke
+from reyn.security.permissions.approval_ledger import ApprovalLedger
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+
+def _ledger(tmp_path: Path) -> ApprovalLedger:
+    return ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl")
+
+
+def test_list_reads_from_the_ledger(tmp_path: Path, monkeypatch, capsys):
+    """Tier 2: `reyn permissions list` folds the ledger, not the legacy
+    approvals.yaml snapshot -- the visible surface of the storage move."""
+    monkeypatch.chdir(tmp_path)
+    _ledger(tmp_path).append_approval("actor/file.write/some_dir/", True)
+
+    _cmd_list(Namespace())
+
+    out = capsys.readouterr().out
+    assert "some_dir" in out
+    assert "Total: 1 entries" in out
+
+
+def test_revoke_appends_a_false_record_the_row_survives(tmp_path: Path, monkeypatch, capsys):
+    """Tier 2: the row must SURVIVE the revoke (as `approved=False`), not
+    disappear -- the old CLI behavior's own audit gap, closed here as a
+    structural consequence of the ledger being append-only."""
+    monkeypatch.chdir(tmp_path)
+    key = "actor/file.write/some_dir/"
+    _ledger(tmp_path).append_approval(key, True)
+
+    _cmd_revoke(Namespace(key=key))
+
+    out = capsys.readouterr().out
+    assert f"Revoked {key!r}" in out
+    saved, _bound = _ledger(tmp_path).fold()
+    assert key in saved, "the approval row must survive a revoke, not disappear"
+    assert saved[key] is False
+
+
+def test_revoke_of_an_unknown_key_exits_nonzero(tmp_path: Path, monkeypatch, capsys):
+    """Tier 2: revoking a key with no saved approval at all is a user
+    error (typo, wrong key) -- unchanged behavior from the pre-#5153
+    snapshot-backed command, now backed by the ledger's own fold."""
+    monkeypatch.chdir(tmp_path)
+    try:
+        _cmd_revoke(Namespace(key="actor/file.write/never_approved/"))
+        raised = False
+    except SystemExit as exc:
+        raised = True
+        assert exc.code != 0
+    assert raised, "revoking a key with no saved approval must exit non-zero"
+
+
+def test_clear_revokes_every_currently_approved_key(tmp_path: Path, monkeypatch, capsys):
+    """Tier 2: `reyn permissions clear` appends a revoke record for every
+    CURRENTLY-approved key -- the append-only analogue of the old
+    truncate-the-whole-file behavior, but auditable (every row survives)."""
+    monkeypatch.chdir(tmp_path)
+    ledger = _ledger(tmp_path)
+    ledger.append_approval("actor/file.write/a/", True)
+    ledger.append_approval("actor/file.write/b/", True)
+
+    _cmd_clear(Namespace(yes=True))
+
+    out = capsys.readouterr().out
+    assert "Cleared 2 approval(s)" in out
+    saved, _bound = ledger.fold()
+    assert saved == {"actor/file.write/a/": False, "actor/file.write/b/": False}
+
+
+def test_clear_does_not_touch_an_already_revoked_key_or_prompt(
+    tmp_path: Path, monkeypatch, capsys,
+):
+    """Tier 2: an already-``False`` key is not re-appended -- ``clear``
+    only revokes what is CURRENTLY approved."""
+    monkeypatch.chdir(tmp_path)
+    ledger = _ledger(tmp_path)
+    ledger.append_approval("actor/file.write/already_revoked/", False)
+    ledger.append_approval("actor/file.write/live/", True)
+
+    _cmd_clear(Namespace(yes=True))
+
+    out = capsys.readouterr().out
+    assert "Cleared 1 approval(s)" in out
+
+
+def test_cli_revoke_clears_the_bound_identity_a_live_resolver_would_have_held(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: #5153 acceptance ⑤ — the cross-writer witness architect
+    explicitly asked to be MEASURED, not assumed (issuecomment-5383848849):
+    a CLI revoke must not leave a stale bound-identity record behind for
+    the SAME "a name is not an identity" reason #5042/#5157 already
+    established. `ApprovalLedger.fold()`'s own rule (any `approved=False`
+    record clears that key's bound identity, from WHICHEVER writer
+    produced it) is what closes this generically -- verified here by
+    reading through a FRESH `PermissionResolver` (the process-boundary
+    analogue: a resolver that never saw the CLI's own in-process state,
+    only the ledger it wrote to)."""
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "some_dir"
+    target.mkdir()
+    key = "actor/file.write/some_dir/"
+
+    # A live resolver binds the identity (simulating the server process
+    # that originally approved and used this grant).
+    resolver = PermissionResolver({}, project_root=tmp_path)
+    resolver._saved[key] = True
+    resolver._persist(key, True)
+    import asyncio
+    asyncio.run(
+        resolver.require_file_write(PermissionDecl(), str(target / "f.txt"), "actor"),
+    )
+    assert resolver.bound_identity_get(key) is not None
+
+    # The CLI revokes it -- a SEPARATE process/door, no shared in-memory
+    # state with `resolver` above.
+    _cmd_revoke(Namespace(key=key))
+
+    # A FRESH resolver (the process-boundary analogue) must see NO bound
+    # identity for this key.
+    fresh = PermissionResolver({}, project_root=tmp_path)
+    assert fresh.bound_identity_get(key) is None, (
+        "a CLI revoke must clear the bound identity too, not just the "
+        "approval row -- otherwise a later re-approval of the same key "
+        "could inherit a stale identity from before the revoke"
+    )

--- a/tests/security/test_5042_approval_identity_binding.py
+++ b/tests/security/test_5042_approval_identity_binding.py
@@ -370,19 +370,20 @@ def test_first_use_after_a_process_restart_honors_the_grant_and_counts_as_unconf
 
 
 @pytest.mark.asyncio
-async def test_binding_writes_atomically_no_tmp_file_left_behind(tmp_path) -> None:
-    """Tier 2: architect co-vet (issuecomment-5383499299) — binding now
-    fires on every path-approval's FIRST USE, inside ordinary tool
-    execution, not just when a human approves (rare) like `_persist`'s
-    own read-modify-write. A crash mid-`write_text` would truncate
-    `approvals.yaml` and lose EVERY approval, not just the one being
-    bound. Fixed via tmp-file + atomic `replace` (the same precedent
-    `AgentIdentityGenerationStore.record` already uses) -- this pins the
-    OBSERVABLE consequence: no `.tmp` sibling survives a successful bind,
-    and the approvals file itself is genuinely valid YAML afterward (a
-    half-written file would not parse)."""
-    import yaml
-
+async def test_binding_writes_durably_no_tmp_file_ever_used(tmp_path) -> None:
+    """Tier 2: architect co-vet (issuecomment-5383499299) — binding fires
+    on every path-approval's FIRST USE, inside ordinary tool execution,
+    not just when a human approves (rare) like `_persist`'s own decision.
+    Originally fixed via tmp-file + atomic `replace` (the same precedent
+    `AgentIdentityGenerationStore.record` uses); #5153 (architect ruling,
+    issuecomment-5383838646) replaced that snapshot read-modify-write
+    (durable against a mid-write CRASH, but not against a concurrent
+    WRITER) with an APPEND to the `approvals.jsonl` ledger — see
+    `approval_ledger.py`. This pins the OBSERVABLE consequence of THAT
+    mechanism: no `.tmp` file is EVER created for a bind (there is
+    nothing to replace — the write is a single small ``fsync``'d
+    append), and folding the ledger correctly reflects the bound key's
+    value afterward."""
     target = tmp_path / "atomic_dir"
     target.mkdir()
     resolver = _make_resolver(tmp_path)
@@ -393,12 +394,13 @@ async def test_binding_writes_atomically_no_tmp_file_left_behind(tmp_path) -> No
     write_path = str(target / "f.txt")
     await resolver.require_file_write(PermissionDecl(), write_path, "actor")
 
-    approvals_path = tmp_path / ".reyn" / "approvals.yaml"
-    tmp_sibling = approvals_path.with_suffix(approvals_path.suffix + ".tmp")
+    ledger_path = tmp_path / ".reyn" / "approvals.jsonl"
+    tmp_sibling = ledger_path.with_suffix(ledger_path.suffix + ".tmp")
     assert not tmp_sibling.exists(), (
-        "a .tmp sibling survived a successful bind -- the atomic "
-        "replace did not clean up after itself"
+        "a .tmp sibling exists -- the append-only ledger should never "
+        "create one at all"
     )
-    data = yaml.safe_load(approvals_path.read_text(encoding="utf-8"))
-    assert data[key] is True
-    assert data["_bound_identities"][key]["ino"] is not None
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
+    saved, bound = ApprovalLedger(ledger_path).fold()
+    assert saved[key] is True
+    assert bound[key][0] is not None

--- a/tests/security/test_5153_approval_ledger.py
+++ b/tests/security/test_5153_approval_ledger.py
@@ -1,0 +1,188 @@
+"""Tier 2: #5153 — ``ApprovalLedger`` closes the read-modify-write race
+`.reyn/approvals.yaml`'s snapshot persistence had (lead-coder's own
+finding: ``_persist`` needed momentary ownership of the WHOLE file to
+change even one key, so two writers racing that same shape silently lost
+one's update).
+
+Architect ruling (issuecomment-5383838646) and its own explicit acceptance
+criteria (lead-coder's relay + architect's own message):
+  ① two processes concurrently approving DIFFERENT keys → both survive
+  ② a same-key grant→revoke race resolves by LOG ORDER (append order),
+     never by ``ts`` (display-only) — see ``approval_ledger.py``'s own
+     "Ordering authority" section
+  ③ folding the ledger after migrating a legacy ``approvals.yaml``
+     snapshot reproduces exactly what the OLD snapshot reader returned
+  ④ (documented, not tested — a stated caveat, not a behavior): append
+     atomicity depends on each record line staying under the OS's own
+     atomic-write threshold
+
+①/② are witnessed with REAL, SEPARATE OS processes (``multiprocessing``)
+writing to the SAME ledger file at the same time — lead-coder's own
+explicit instruction: "逐次に書いて通しても意味がありません" (sequential
+writes in one process would prove nothing about concurrent-writer safety;
+BudgetLedger has no such precedent test either, so this is the FIRST rigor
+check of this shape in this codebase for an append-only ledger).
+"""
+from __future__ import annotations
+
+import json
+import multiprocessing
+from pathlib import Path
+
+from reyn.security.permissions.approval_ledger import (
+    ApprovalLedger,
+    migrate_legacy_snapshot,
+)
+
+
+def _worker_append_many(path_str: str, key: str, n: int) -> None:
+    """Module-level (picklable) worker: append *n* alternating
+    grant/revoke records for *key* — run in a SEPARATE OS process."""
+    ledger = ApprovalLedger(Path(path_str))
+    for i in range(n):
+        ledger.append_approval(key, approved=(i % 2 == 0))
+
+
+def _worker_append_one(path_str: str, key: str, approved: bool) -> None:
+    ApprovalLedger(Path(path_str)).append_approval(key, approved)
+
+
+def test_two_real_processes_approving_different_keys_both_survive(tmp_path: Path) -> None:
+    """Tier 2: #5153 acceptance ① — two SEPARATE OS processes, each
+    appending its OWN key many times concurrently, must both fully land
+    (no lost lines, no corrupted lines) -- the exact shape the OLD
+    snapshot read-modify-write lost silently under this scenario."""
+    ledger_path = tmp_path / "approvals.jsonl"
+    n = 200
+
+    p1 = multiprocessing.Process(
+        target=_worker_append_many, args=(str(ledger_path), "actor/file.write/dir_a/", n),
+    )
+    p2 = multiprocessing.Process(
+        target=_worker_append_many, args=(str(ledger_path), "actor/file.write/dir_b/", n),
+    )
+    p1.start()
+    p2.start()
+    p1.join(timeout=60)
+    p2.join(timeout=60)
+    assert p1.exitcode == 0
+    assert p2.exitcode == 0
+
+    ledger = ApprovalLedger(ledger_path)
+    lines = list(ledger.path.read_text(encoding="utf-8").splitlines())
+    expected_total = 2 * n
+    written_total = len(lines)
+    assert written_total == expected_total, (
+        f"expected {expected_total} lines (no lost/dropped appends under "
+        f"real concurrent writers), got {written_total}"
+    )
+    for line in lines:
+        json.loads(line)  # every line parses -- no interleaved corruption
+
+    approvals, _bound = ledger.fold()
+    # n is even, so the LAST record each process wrote (index n-1, odd) is
+    # approved=False for both keys.
+    assert approvals["actor/file.write/dir_a/"] is False
+    assert approvals["actor/file.write/dir_b/"] is False
+
+
+def test_two_real_processes_racing_the_same_key_resolve_by_log_order(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5153 acceptance ② — two SEPARATE OS processes racing a
+    grant vs. a revoke for the SAME key: whichever one the OS actually
+    wrote LAST (file order) must be what ``fold()`` returns -- verified by
+    reading the ledger's own last line back, not by assuming a winner
+    (the whole point: the winner is legitimately nondeterministic under
+    real concurrency, and the ledger's job is to be INTERNALLY consistent
+    with whatever that real order was, not to predict it)."""
+    ledger_path = tmp_path / "approvals.jsonl"
+    key = "actor/file.write/contested/"
+
+    p1 = multiprocessing.Process(
+        target=_worker_append_one, args=(str(ledger_path), key, True),
+    )
+    p2 = multiprocessing.Process(
+        target=_worker_append_one, args=(str(ledger_path), key, False),
+    )
+    p1.start()
+    p2.start()
+    p1.join(timeout=30)
+    p2.join(timeout=30)
+    assert p1.exitcode == 0
+    assert p2.exitcode == 0
+
+    ledger = ApprovalLedger(ledger_path)
+    lines = [json.loads(line) for line in ledger.path.read_text(encoding="utf-8").splitlines()]
+    written_total = len(lines)
+    assert written_total == 2, "both processes' appends must survive -- neither lost"
+    last_record_approved = lines[-1]["approved"]
+
+    approvals, _bound = ledger.fold()
+    assert approvals[key] == last_record_approved, (
+        "fold() must agree with whatever the ledger's OWN last line says "
+        "for this key -- last wins by FILE ORDER, not by which process "
+        "happened to win the OS scheduler"
+    )
+
+
+def test_migration_witness_fold_matches_the_legacy_reader(tmp_path: Path) -> None:
+    """Tier 2: #5153 acceptance ③ — migrating a legacy approvals.yaml
+    snapshot into the ledger, then folding it, must reproduce EXACTLY
+    what the OLD (pre-#5153) snapshot reader returned -- migration adds
+    records, it does not reinterpret them."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    legacy_path = reyn_dir / "approvals.yaml"
+    legacy_path.write_text(
+        "actor/file.write/legacy_dir/: true\n"
+        "actor/file.write/legacy_revoked/: false\n"
+        "actor/http.get/example.com: true\n"
+        "_bound_identities:\n"
+        "  actor/file.write/legacy_dir/:\n"
+        "    ino: 12345\n"
+        "    birthtime: 1700000000.0\n",
+        encoding="utf-8",
+    )
+
+    # The OLD reader's own logic (mirrors _load_saved/_load_bound_identities
+    # exactly as they read before #5153 -- this is the "expected" side of
+    # the witness, not a re-derivation of the new code under test).
+    import yaml
+    raw = yaml.safe_load(legacy_path.read_text(encoding="utf-8")) or {}
+    expected_saved = {k: bool(v) for k, v in raw.items() if isinstance(v, bool)}
+    expected_bound_raw = raw.get("_bound_identities") or {}
+    expected_bound = {
+        k: (v["ino"], v.get("birthtime"))
+        for k, v in expected_bound_raw.items()
+        if isinstance(v, dict) and "ino" in v
+    }
+
+    ledger = ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl")
+    migrate_legacy_snapshot(ledger, legacy_path)
+    saved, bound = ledger.fold()
+
+    assert saved == expected_saved
+    assert bound == expected_bound
+
+
+def test_migration_is_idempotent_a_second_call_is_a_no_op(tmp_path: Path) -> None:
+    """Tier 2: #5153 — migration must not re-run once the ledger exists,
+    so every caller can call it unconditionally before every read/append
+    without needing its own "have I migrated" flag."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    legacy_path = reyn_dir / "approvals.yaml"
+    legacy_path.write_text("actor/file.write/dir/: true\n", encoding="utf-8")
+
+    ledger = ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl")
+    migrate_legacy_snapshot(ledger, legacy_path)
+    lines_after_first = ledger.path.read_text(encoding="utf-8").splitlines()
+
+    migrate_legacy_snapshot(ledger, legacy_path)
+    lines_after_second = ledger.path.read_text(encoding="utf-8").splitlines()
+
+    assert lines_after_first == lines_after_second, (
+        "a second migrate_legacy_snapshot call must be a no-op -- the "
+        "ledger already existing is what makes it skip"
+    )

--- a/tests/security/test_5153_approval_ledger.py
+++ b/tests/security/test_5153_approval_ledger.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import multiprocessing
+import os
 from pathlib import Path
 
 from reyn.security.permissions.approval_ledger import (
@@ -50,6 +51,17 @@ def _worker_append_one(path_str: str, key: str, approved: bool) -> None:
 def _worker_migrate(ledger_path_str: str, legacy_path_str: str) -> None:
     ledger = ApprovalLedger(Path(ledger_path_str))
     migrate_legacy_snapshot(ledger, Path(legacy_path_str))
+
+
+def _worker_revoke(ledger_path_str: str, legacy_path_str: str, key: str) -> None:
+    """Mirrors the REAL call pattern every caller in this codebase
+    follows (``PermissionResolver._ensure_folded``, the CLI/web
+    ``_load``): migrate first (win or lose), THEN append the real
+    decision -- never a bare append with no migrate attempt at all,
+    which no real call site does."""
+    ledger = ApprovalLedger(Path(ledger_path_str))
+    migrate_legacy_snapshot(ledger, Path(legacy_path_str))
+    ledger.append_approval(key, False)
 
 
 def test_two_real_processes_approving_different_keys_both_survive(tmp_path: Path) -> None:
@@ -234,3 +246,96 @@ def test_two_processes_racing_the_first_migration_still_fold_correctly(
         "actor/file.write/legacy_dir/": True,
         "actor/file.write/legacy_revoked/": False,
     }
+
+
+def test_a_slow_migration_racing_a_real_revoke_never_resurrects_the_stale_value(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5153 — docs-maintainer's TESTS-READY(B) finding on PR
+    #5170 (issuecomment-5384027134, 3/3, no strip needed): a slow
+    migration (many legacy keys, target key not first in iteration order)
+    racing a genuinely CONCURRENT real revoke of that SAME key must NOT
+    let the migration's stale legacy value land in file order AFTER the
+    real revoke -- that would make ``fold()`` resurrect an already-revoked
+    approval, straight at the permission band's own correctness.
+
+    Reproduced with a large legacy snapshot (many keys before the target,
+    so a per-key-append migration takes measurably longer than one fast
+    real append) and 2 REAL separate OS processes -- no artificial delay,
+    no strip needed to see this fail on the pre-fix (one-append-per-key)
+    migration; this test is the reproduction AND the fix's own witness."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    legacy_path = reyn_dir / "approvals.yaml"
+    target_key = "actor/file.write/target_dir/"
+
+    other_rows = "\n".join(
+        f"actor/file.write/other_{i}/: true" for i in range(3000)
+    )
+    legacy_path.write_text(
+        other_rows + f"\n{target_key}: true\n",
+        encoding="utf-8",
+    )
+    ledger_path = tmp_path / ".reyn" / "approvals.jsonl"
+
+    p_migrate = multiprocessing.Process(
+        target=_worker_migrate, args=(str(ledger_path), str(legacy_path)),
+    )
+    p_revoke = multiprocessing.Process(
+        target=_worker_revoke, args=(str(ledger_path), str(legacy_path), target_key),
+    )
+    p_migrate.start()
+    p_revoke.start()
+    p_migrate.join(timeout=60)
+    p_revoke.join(timeout=60)
+    assert p_migrate.exitcode == 0
+    assert p_revoke.exitcode == 0
+
+    saved, _bound = ApprovalLedger(ledger_path).fold()
+    assert saved[target_key] is False, (
+        "a real, concurrent revoke must never be resurrected by a slow "
+        "migration's stale legacy value landing after it in file order"
+    )
+
+
+def test_migration_publish_never_clobbers_a_decision_that_wins_first(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #5153 — a DETERMINISTIC proof of the exact invariant the
+    real-process test above only demonstrates probabilistically (OS
+    scheduling/spawn overhead makes forcing an exact interleave
+    unreliable to control from the outside). Forces a real decision to
+    land in the NARROWEST possible window — the instant before
+    ``migrate_legacy_snapshot``'s own ``os.link`` publish call, after its
+    temp file is already fully written — by monkeypatching ``os.link``
+    itself (the actual publish primitive, not a fake collaborator: the
+    ledger, the temp file, and the real decision are all real) to run one
+    real ``append_approval`` immediately before delegating to the real
+    ``os.link``. This is the tightest possible race this module can ever
+    face — if migration survives THIS without clobbering the real
+    decision, it survives any looser (real-world) timing too."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    legacy_path = reyn_dir / "approvals.yaml"
+    target_key = "actor/file.write/target_dir/"
+    legacy_path.write_text(f"{target_key}: true\n", encoding="utf-8")
+    ledger_path = tmp_path / ".reyn" / "approvals.jsonl"
+    ledger = ApprovalLedger(ledger_path)
+
+    real_link = os.link
+
+    def _real_decision_wins_the_narrowest_window(src, dst):
+        # The real decision creates the ledger path for the FIRST time,
+        # right before migration's own link() call would have.
+        ApprovalLedger(ledger_path).append_approval(target_key, False)
+        return real_link(src, dst)
+
+    monkeypatch.setattr(os, "link", _real_decision_wins_the_narrowest_window)
+    migrate_legacy_snapshot(ledger, legacy_path)
+
+    saved, _bound = ledger.fold()
+    assert saved[target_key] is False, (
+        "migration must never clobber a real decision, even one that "
+        "wins the ledger path's existence in the narrowest possible "
+        "window right before migration's own publish step"
+    )

--- a/tests/security/test_5153_approval_ledger.py
+++ b/tests/security/test_5153_approval_ledger.py
@@ -47,6 +47,11 @@ def _worker_append_one(path_str: str, key: str, approved: bool) -> None:
     ApprovalLedger(Path(path_str)).append_approval(key, approved)
 
 
+def _worker_migrate(ledger_path_str: str, legacy_path_str: str) -> None:
+    ledger = ApprovalLedger(Path(ledger_path_str))
+    migrate_legacy_snapshot(ledger, Path(legacy_path_str))
+
+
 def test_two_real_processes_approving_different_keys_both_survive(tmp_path: Path) -> None:
     """Tier 2: #5153 acceptance ① — two SEPARATE OS processes, each
     appending its OWN key many times concurrently, must both fully land
@@ -186,3 +191,46 @@ def test_migration_is_idempotent_a_second_call_is_a_no_op(tmp_path: Path) -> Non
         "a second migrate_legacy_snapshot call must be a no-op -- the "
         "ledger already existing is what makes it skip"
     )
+
+
+def test_two_processes_racing_the_first_migration_still_fold_correctly(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5153 — architect's TESTS-READ(A) note for the B reviewer
+    (issuecomment-5384009424): ``_load`` calls ``migrate_legacy_snapshot``
+    unconditionally on every touch, so two processes could both see "no
+    ledger yet" and both migrate at once. Measured (not assumed, per
+    architect's own "私は測っていません"): with REAL separate OS
+    processes racing the FIRST migration of the SAME legacy snapshot,
+    each migration only ever APPENDS (never truncates/replaces), so a
+    doubled set of day-0 records is, at worst, redundant -- ``fold()``'s
+    own last-wins-per-key semantics collapse duplicate identical records
+    to the same value, same as a single migration would have produced."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    legacy_path = reyn_dir / "approvals.yaml"
+    legacy_path.write_text(
+        "actor/file.write/legacy_dir/: true\n"
+        "actor/file.write/legacy_revoked/: false\n",
+        encoding="utf-8",
+    )
+    ledger_path = tmp_path / ".reyn" / "approvals.jsonl"
+
+    p1 = multiprocessing.Process(
+        target=_worker_migrate, args=(str(ledger_path), str(legacy_path)),
+    )
+    p2 = multiprocessing.Process(
+        target=_worker_migrate, args=(str(ledger_path), str(legacy_path)),
+    )
+    p1.start()
+    p2.start()
+    p1.join(timeout=30)
+    p2.join(timeout=30)
+    assert p1.exitcode == 0
+    assert p2.exitcode == 0
+
+    saved, _bound = ApprovalLedger(ledger_path).fold()
+    assert saved == {
+        "actor/file.write/legacy_dir/": True,
+        "actor/file.write/legacy_revoked/": False,
+    }

--- a/tests/security/test_5153_approval_ledger.py
+++ b/tests/security/test_5153_approval_ledger.py
@@ -22,6 +22,26 @@ explicit instruction: "逐次に書いて通しても意味がありません" (
 writes in one process would prove nothing about concurrent-writer safety;
 BudgetLedger has no such precedent test either, so this is the FIRST rigor
 check of this shape in this codebase for an append-only ledger).
+
+CI red (lead-coder, PR #5170, Python 3.12 only): one such test got 401
+lines instead of 400 -- an EXTRA line, not a lost one. The job's own
+warnings carried the actual cause: "This process (pid=...) is
+multi-threaded, use of fork() may lead to deadlocks in the child" --
+plain `multiprocessing.Process(...)` (this test's ORIGINAL form) with no
+explicit context uses the PLATFORM DEFAULT start method, which is
+"fork" on Linux (CPython's own
+docs: unsafe when the parent has more than one thread, exactly what a
+pytest-xdist worker is) but "spawn" on macOS (this dev machine, since
+Python 3.8) -- fork()ing a multi-threaded parent can leave the child
+with another thread's lock (buffering, import, etc.) held forever, or
+in another inconsistent state, with no thread present to release/fix
+it. This is why the failure never reproduced locally: it needs the
+Linux+multi-threaded-parent combination CI has and this machine does
+not. Fixed by using an EXPLICIT ``multiprocessing.get_context("spawn")``
+for every ``Process`` in this file -- ``spawn`` re-imports fresh in the
+child regardless of platform default, matching what already happened
+to work by accident on macOS, so the same safe behavior is now
+guaranteed everywhere this test runs, not just here.
 """
 from __future__ import annotations
 
@@ -34,6 +54,11 @@ from reyn.security.permissions.approval_ledger import (
     ApprovalLedger,
     migrate_legacy_snapshot,
 )
+
+# See the module docstring's "CI red" note: explicit spawn, never the
+# platform default, so this test's own correctness never depends on
+# whether the pytest worker that runs it happens to be single-threaded.
+_mp = multiprocessing.get_context("spawn")
 
 
 def _worker_append_many(path_str: str, key: str, n: int) -> None:
@@ -72,10 +97,10 @@ def test_two_real_processes_approving_different_keys_both_survive(tmp_path: Path
     ledger_path = tmp_path / "approvals.jsonl"
     n = 200
 
-    p1 = multiprocessing.Process(
+    p1 = _mp.Process(
         target=_worker_append_many, args=(str(ledger_path), "actor/file.write/dir_a/", n),
     )
-    p2 = multiprocessing.Process(
+    p2 = _mp.Process(
         target=_worker_append_many, args=(str(ledger_path), "actor/file.write/dir_b/", n),
     )
     p1.start()
@@ -116,10 +141,10 @@ def test_two_real_processes_racing_the_same_key_resolve_by_log_order(
     ledger_path = tmp_path / "approvals.jsonl"
     key = "actor/file.write/contested/"
 
-    p1 = multiprocessing.Process(
+    p1 = _mp.Process(
         target=_worker_append_one, args=(str(ledger_path), key, True),
     )
-    p2 = multiprocessing.Process(
+    p2 = _mp.Process(
         target=_worker_append_one, args=(str(ledger_path), key, False),
     )
     p1.start()
@@ -228,10 +253,10 @@ def test_two_processes_racing_the_first_migration_still_fold_correctly(
     )
     ledger_path = tmp_path / ".reyn" / "approvals.jsonl"
 
-    p1 = multiprocessing.Process(
+    p1 = _mp.Process(
         target=_worker_migrate, args=(str(ledger_path), str(legacy_path)),
     )
-    p2 = multiprocessing.Process(
+    p2 = _mp.Process(
         target=_worker_migrate, args=(str(ledger_path), str(legacy_path)),
     )
     p1.start()
@@ -278,10 +303,10 @@ def test_a_slow_migration_racing_a_real_revoke_never_resurrects_the_stale_value(
     )
     ledger_path = tmp_path / ".reyn" / "approvals.jsonl"
 
-    p_migrate = multiprocessing.Process(
+    p_migrate = _mp.Process(
         target=_worker_migrate, args=(str(ledger_path), str(legacy_path)),
     )
-    p_revoke = multiprocessing.Process(
+    p_revoke = _mp.Process(
         target=_worker_revoke, args=(str(ledger_path), str(legacy_path), target_key),
     )
     p_migrate.start()

--- a/tests/security/test_5157_identity_fd_release.py
+++ b/tests/security/test_5157_identity_fd_release.py
@@ -88,7 +88,14 @@ async def test_revoking_an_approval_also_clears_its_stale_identity_record(
     """Tier 2: architect's confirm-item on this PR's own TESTS-READY(A)
     (issuecomment-5383698618) — releasing the fd is not enough; the
     STALE ``_bound_identities[key]`` record must go with it, both
-    in-memory and in the persisted ``approvals.yaml`` sibling section.
+    in-memory and in whatever survives the revoke on disk — #5153
+    replaced the persisted ``_bound_identities`` YAML sibling this test
+    originally checked with the ``approvals.jsonl`` ledger, whose
+    ``fold()`` already clears a key's bound identity on any
+    ``approved=False`` record (see ``approval_ledger.py``'s own "Fold
+    semantics" section) — this test now folds the ledger to confirm that
+    generic rule actually closes THIS specific gap, not just the
+    in-memory half.
 
     Left behind, a LATER re-approval of the SAME key would start with no
     fd (just released) but a stale stat from before the revoke — if the
@@ -115,11 +122,11 @@ async def test_revoking_an_approval_also_clears_its_stale_identity_record(
         "the fd"
     )
 
-    import yaml
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
 
-    approvals_path = tmp_path / ".reyn" / "approvals.yaml"
-    data = yaml.safe_load(approvals_path.read_text(encoding="utf-8"))
-    assert key not in data.get("_bound_identities", {}), (
+    ledger_path = tmp_path / ".reyn" / "approvals.jsonl"
+    _saved, bound = ApprovalLedger(ledger_path).fold()
+    assert key not in bound, (
         "revoke must also clear the PERSISTED bound-identity record -- "
         "otherwise it survives a process restart and a later re-approval "
         "of the same key inherits the stale identity"

--- a/tests/security/test_permission_resolver_lazy_saved_3671_p4d1.py
+++ b/tests/security/test_permission_resolver_lazy_saved_3671_p4d1.py
@@ -1,6 +1,6 @@
 """Tier 2: #3671 P4 item D-1 — `PermissionResolver`'s persisted-approvals
-disk read (`approvals.yaml` → `self._saved`) is deferred to first actual
-use, not paid on every `reyn chat` startup construction.
+load is deferred to first actual use, not paid on every `reyn chat`
+startup construction.
 
 Before this fix, `__init__` unconditionally called `self._load_saved()` —
 disk I/O + YAML parse, cost scaling with the number of persisted approval
@@ -11,7 +11,15 @@ whichever of `saved_get()` / `_persist()` / the internal read sites reaches
 it first — there is no second call site that could forget to trigger it,
 unlike an optional constructor kwarg (rejected pattern, #3681).
 
-Witnessed via a call-through spy on `_load_saved` (real behavior still
+#5153: the load site is now `_ensure_folded` (folds the append-only
+`approvals.jsonl` ledger, migrating a legacy `approvals.yaml` snapshot
+first if present — see `approval_ledger.py`) rather than the old
+`_load_saved`'s direct YAML read, but the SAME deferred-until-first-access
+contract this issue established still holds; `_seed_approvals` below
+seeds the legacy snapshot format, which the migration step reads exactly
+as before.
+
+Witnessed via a call-through spy on `_ensure_folded` (real behavior still
 runs; only the call COUNT and its TIMING relative to construction are
 observed) — not a private-state peek at `self.__saved` itself.
 
@@ -41,22 +49,22 @@ def _seed_approvals(tmp_path, **entries) -> None:
 
 def test_construction_does_not_read_approvals_yaml(tmp_path, monkeypatch):
     """Tier 2: #3671 P4 item D-1 core witness — `PermissionResolver(...)`
-    itself never calls `_load_saved()`. A real approvals.yaml is seeded so
-    a call WOULD find real data if it fired."""
+    itself never calls `_ensure_folded()`. A real (legacy-format)
+    approvals.yaml is seeded so a call WOULD find real data if it fired."""
     _seed_approvals(tmp_path, **{"safe.key": True})
     calls = {"n": 0}
-    orig = PermissionResolver._load_saved
+    orig = PermissionResolver._ensure_folded
 
     def _spy(self):
         calls["n"] += 1
         return orig(self)
 
-    monkeypatch.setattr(PermissionResolver, "_load_saved", _spy)
+    monkeypatch.setattr(PermissionResolver, "_ensure_folded", _spy)
 
     PermissionResolver({}, project_root=tmp_path)
 
     assert calls["n"] == 0, (
-        f"_load_saved() was called {calls['n']} time(s) during construction — "
+        f"_ensure_folded() was called {calls['n']} time(s) during construction — "
         "expected 0 (deferred to first access)"
     )
 
@@ -66,13 +74,13 @@ def test_first_saved_get_triggers_exactly_one_load(tmp_path, monkeypatch):
     only once — a second call must not re-read the file."""
     _seed_approvals(tmp_path, **{"safe.key": True})
     calls = {"n": 0}
-    orig = PermissionResolver._load_saved
+    orig = PermissionResolver._ensure_folded
 
     def _spy(self):
         calls["n"] += 1
         return orig(self)
 
-    monkeypatch.setattr(PermissionResolver, "_load_saved", _spy)
+    monkeypatch.setattr(PermissionResolver, "_ensure_folded", _spy)
 
     resolver = PermissionResolver({}, project_root=tmp_path)
     assert calls["n"] == 0
@@ -91,13 +99,13 @@ def test_persist_also_triggers_lazy_load_exactly_once(tmp_path, monkeypatch):
     the one exercised above."""
     _seed_approvals(tmp_path, **{"other.key": False})
     calls = {"n": 0}
-    orig = PermissionResolver._load_saved
+    orig = PermissionResolver._ensure_folded
 
     def _spy(self):
         calls["n"] += 1
         return orig(self)
 
-    monkeypatch.setattr(PermissionResolver, "_load_saved", _spy)
+    monkeypatch.setattr(PermissionResolver, "_ensure_folded", _spy)
 
     resolver = PermissionResolver({}, project_root=tmp_path)
     assert calls["n"] == 0
@@ -133,7 +141,7 @@ async def test_saved_property_consistent_under_concurrent_coroutines(tmp_path):
     `_get_retryable_litellm_exceptions` in #3674): every concurrent accessor
     must observe the SAME dict object (not two independently-built dicts,
     which would mean a `_persist()` mutation on one could be invisible to a
-    reader holding the other) — safe because `_load_saved()` contains no
+    reader holding the other) — safe because `_ensure_folded()` contains no
     `await`, so the whole check-then-set body runs with no yield point a
     sibling coroutine could interleave into (asyncio's single-threaded
     cooperative scheduling — see the property's own docstring for the

--- a/tests/web/test_5065_permissions_router_emits_audit_event.py
+++ b/tests/web/test_5065_permissions_router_emits_audit_event.py
@@ -1,10 +1,13 @@
 """Tier 2: #5065 — the ``/api/permissions`` REST router's own management
 operations (revoke a single approval, clear all approvals) each emit a
 P6 audit-event, closing the band violation (permission x audit-events)
-this issue names: ``.reyn/approvals.yaml`` had two writers (the
-security-side ``_persist`` flow, which journals, and this router's own
-``_save``, a raw ``path.write_text`` with no audit trail of its own) and
-only one of them was observable through ``.reyn/events``.
+this issue names: the approvals store had multiple writers (the
+security-side ``_persist`` flow, and this router's own) and only one of
+them was observable through ``.reyn/events``. #5153 later moved BOTH onto
+the same ``ApprovalLedger`` (append-only ``approvals.jsonl``, replacing
+the ``.reyn/approvals.yaml`` snapshot's read-modify-write) — this test's
+seeding still uses the legacy YAML format, exercising the migration path
+``_load`` runs through on first touch.
 
 Real FastAPI TestClient + a real on-disk ``.reyn/`` tree throughout — no
 mocks. Witness reads the actual ``.reyn/events/`` files this PR's new
@@ -129,12 +132,14 @@ def test_revoke_permission_emits_one_audit_event_naming_the_key(tmp_project: Pat
     assert events[0]["data"]["key"] == "chat_router/http.get/example.com"
     assert events[0]["data"]["surface"] == "web"
 
-    # The write itself is unaffected by the audit addition -- approvals.yaml
-    # no longer carries the revoked key.
-    saved = yaml.safe_load(
-        (tmp_project / ".reyn" / "approvals.yaml").read_text(encoding="utf-8")
-    ) or {}
-    assert "chat_router/http.get/example.com" not in saved
+    # The write itself is unaffected by the audit addition -- #5153: folding
+    # the ledger no longer shows this key as approved (the row itself
+    # SURVIVES, as an explicit revoke record -- audit-events acceptance).
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
+    saved, _bound = ApprovalLedger(
+        tmp_project / ".reyn" / "approvals.jsonl"
+    ).fold()
+    assert saved.get("chat_router/http.get/example.com") is False
 
 
 # ── witness ② — clear_permissions ─────────────────────────────────────────
@@ -164,7 +169,59 @@ def test_clear_permissions_emits_one_audit_event_with_the_cleared_count(
     assert events[0]["data"]["count"] == 2
     assert events[0]["data"]["surface"] == "web"
 
-    saved = yaml.safe_load(
-        (tmp_project / ".reyn" / "approvals.yaml").read_text(encoding="utf-8")
-    ) or {}
-    assert saved == {}
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
+    saved, _bound = ApprovalLedger(
+        tmp_project / ".reyn" / "approvals.jsonl"
+    ).fold()
+    assert saved == {
+        "chat_router/http.get/a.example.com": False,
+        "chat_router/http.get/b.example.com": False,
+    }
+
+
+# ── #5153 acceptance ⑥ — cross-writer identity clear ─────────────────────
+
+
+def test_web_revoke_clears_the_bound_identity_a_live_resolver_would_have_held(
+    tmp_project: Path,
+):
+    """Tier 2: #5153 acceptance ⑥ — the cross-writer witness architect
+    explicitly asked to be MEASURED (issuecomment-5383848849), web's own
+    half of the SAME check #5153's CLI test makes: this router's
+    ``revoke_permission`` builds an ``ApprovalLedger`` directly from
+    ``project_root``, entirely bypassing ``deps._get_perm_resolver()``'s
+    own module-level singleton (the resolver a running session actually
+    gates permission checks through) — so a web-surface revoke must not
+    leave THAT resolver's own bound-identity record stale. Verified via a
+    FRESH ``PermissionResolver`` (the process-boundary analogue) reading
+    the SAME project after the HTTP revoke."""
+    import asyncio
+
+    from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+    key = "chat_router/file.write/some_dir/"
+    target = tmp_project / "some_dir"
+    target.mkdir()
+
+    # A live resolver binds the identity (simulating the server's own
+    # deps._get_perm_resolver() singleton having gated a real write).
+    resolver = PermissionResolver({}, project_root=tmp_project)
+    resolver._saved[key] = True
+    resolver._persist(key, True)
+    asyncio.run(
+        resolver.require_file_write(
+            PermissionDecl(), str(target / "f.txt"), "chat_router",
+        ),
+    )
+    assert resolver.bound_identity_get(key) is not None
+
+    response = _client().delete(
+        "/api/permissions/chat_router%2Ffile.write%2Fsome_dir%2F",
+    )
+    assert response.status_code == 204, response.text
+
+    fresh = PermissionResolver({}, project_root=tmp_project)
+    assert fresh.bound_identity_get(key) is None, (
+        "a web-surface revoke must clear the bound identity too, not "
+        "just the approval row"
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #5153 (architect ruling issuecomment-5383838646).

## What

`.reyn/approvals.yaml`'s persistence was snapshot read-modify-write — `_persist` (and, after #5152, `_bind_identity`) does `yaml.safe_load` the WHOLE file → mutate a dict → `write_text` the WHOLE file back. Every writer needed momentary ownership of the ENTIRE file's content to change even one key, and two writers doing this concurrently (the owner's actual configuration: a `reyn web` server plus one or more `--connect` CLI clients) silently lost an approval — last-writer-wins, with no audit trail of the lost decision ever having existed. #5152's own identity-binding write made this worse: binding now fires on every path approval's first use per process, not just a rare human decision.

**Scope grew mid-implementation**: `interfaces/cli/commands/permissions.py` and `interfaces/web/routers/permissions.py` each had their OWN independent `_load`/`_save`, completely bypassing `PermissionResolver` — a THIRD and FOURTH racy writer, not just the server+CLI-client scenario originally scoped. All three now share the same primitive and the same rule.

## Fix (architect ruling)

Don't decide who owns the file — make owning it unnecessary. Shrink what a writer must produce to "my own decision" (one record), append-only, mirroring `BudgetLedger` (`runtime/budget/budget.py:257`) exactly — fsync'd on append, folded by readers, no locking, no read-before-write. Folding resolves ordering by **file order only** — `ts` is display-only, never sorted on.

New `reyn/security/permissions/approval_ledger.py`:
- `ApprovalLedger.append_approval`/`append_identity_bind` — one fsync'd record per decision.
- `ApprovalLedger.fold()` — last `"approval"` record per key wins; last `"identity_bind"` wins EXCEPT an `approved=False` record also clears that key's bound identity (mirrors #5157's own revoke-clears-binding rule, generically, for ANY writer).
- `migrate_legacy_snapshot()` — one-time, idempotent migration of a pre-#5153 snapshot into day-0 records.

`PermissionResolver._ensure_folded` replaces `_load_saved`/`_load_bound_identities`; `_persist`/`_bind_identity` append instead of read-modify-write. The CLI command and web router build an `ApprovalLedger` directly (no live resolver required — keeps the CLI's no-server-running use case working, per architect's explicit rejection of a single-writer-via-server fix). Both now keep the approval row (`approved=False`) on revoke/clear instead of deleting it — closing a pre-existing audit gap those 2 surfaces had that `_persist` never did.

## Test plan

- [x] `tests/security/test_5153_approval_ledger.py` (4 tests, architect's own acceptance criteria ①②③): ① and ② with REAL separate OS processes (`multiprocessing`) writing to the same ledger concurrently — strip-falsified against a genuinely race-prone seek-then-write in place of `O_APPEND`, confirmed both tests catch the resulting corruption/loss; ③ migration witness matches the old snapshot reader exactly; migration idempotency
- [x] `tests/interfaces/test_5153_permissions_cli_ledger.py` (6 tests) + 2 new tests in `tests/web/test_5065_permissions_router_emits_audit_event.py`: cross-writer identity-clear acceptance criteria (⑤/⑥) architect asked to be MEASURED, not assumed — strip-falsified (all 3 fail together when the fold's revoke-clears-binding rule is removed)
- [x] Updated 5 pre-existing test files whose premise (the snapshot format, or the renamed `_load_saved`→`_ensure_folded` load site) the storage change made stale
- [x] Full local gate (ruff / `test_tier_audit.py --strict` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `verify_module_docstrings.py`) — clean
- [x] Broad sweep (`tests/security` + `tests/interfaces` + `tests/web` + `tests/runtime` + `tests/dev` + `tests/core/test_mcp_install_op.py`): 5076 passed, 43 skipped (pre-existing optional-extra skips), no regressions
- [x] (skipped — Visual, standing waiver 2026-08-08; N/A, no UI change)

⚠️ TESTS-READ note required (touches `tests/`).

part of #5153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

## 🔴 Reviewer's blocking point (docs-maintainer)

- [x] 🔴 **A real revoke can be silently reversed by another process's slow, concurrent first-time migration.** — Closed (docs-maintainer, head 579685b37): fixed via temp-file + atomic `os.link` publish. Independently re-verified: my original 6-run repro now consistently resolves correctly, plus a strip-falsified deterministic test (`test_migration_publish_never_clobbers_a_decision_that_wins_first`) confirms the EEXIST-safe backoff is load-bearing. Full account: issuecomment-5384097475. `migrate_legacy_snapshot` is a CHECK-then-MULTI-ACT (exists() check, then an append loop over every legacy key) — not a single atomic check-then-act. Measured with 2 real OS processes (not the new `test_two_processes_racing_the_first_migration_still_fold_correctly`, which only races two migrations writing the SAME legacy value): a slow migrating process (many legacy keys, target key not first in iteration order) can land its stale `approved=True` migration record AFTER a different, faster process's genuine `approved=False` revoke of that same key — `fold()`'s last-wins-by-file-order then resolves to the STALE value, silently reinstating a revoked approval. Reproduced 3/3, no strip needed. Full account: issuecomment-5384027134.

