### PR TITLE
fix(#5139-C): remote backlog is a bounded, client-pulled page (cursor = turn root id)

### DIFF
--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -362,11 +362,28 @@ remote のステータスパネルは常に server の値を反映する。
 
 接続(または再接続)時、server はどのライブ event よりも前に、以下を replay する:
 
-1. `MESSAGES_SNAPSHOT` — display のバックログ(既に生成されたメッセージ)。再接続する
+1. `MESSAGES_SNAPSHOT` — display のバックログ。再接続する
    client が自身の scrollback を再構築できるようにする。続いて
 2. `STATE_SNAPSHOT` — 上記のステータス read-model。
 
 その後にライブ event(および `STATE_DELTA`)が続く。
+
+**バックログは全履歴ではなく、1つの bounded page である(#5139 C)。** server が
+1回の `MESSAGES_SNAPSHOT` で送るのは最大 `HYDRATE_PAGE_FRAMES`(200 —
+local restore 自身の lazy scrollback paging と同じ値)フレームまでであり、
+ターン境界(`chain_id` で相関する連続 run)でのみ切られる — tool call/result
+のペアの途中で切ることは決してない(相関が静かに壊れるため)。`_reyn`
+ブロックには `messages` に加えて2つのキーが乗る: `has_more`(このページより
+古いターンがまだ存在するか)と `next_cursor`(その古いターン自身の
+`chain_id`、`has_more` が `False` のときちょうど `None`)。client がこの
+page の上端を超えてスクロールすると(`FlowView.ReachedTop`)、
+`{"type": "load_older_backlog_request", "session_id", "before_root_id":
+<next_cursor>}` を POST する。応答は同じ `MESSAGES_SNAPSHOT` エンコーディング
+を再利用する(もう1つの bounded page、独自の `has_more`/`next_cursor`)
+— 別の wire 語彙を新設しない。継続は常に CLIENT 主導の pull であり、
+server が要求なしに 2 ページ目を push することはない — この doc の他の
+typed request(`session_list_request` など)と同じ「1 要求 1 bound、
+2 回目の unbounded push はしない」という規律に従う。
 
 `MESSAGES_SNAPSHOT` の `messages` フィールドは、会話ターンのみからなる標準的な
 `[{role, content}]` **配列**である — `agent` → `assistant`、`user` → `user` — これは汎用

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -525,8 +525,8 @@ Adding any other field is an additive `STATE_*` key, not a client change.
 
 On connect (or reconnect) the server replays, before any live event:
 
-1. `MESSAGES_SNAPSHOT` — the display backlog (the messages already produced), so
-   a reconnecting client rebuilds its scrollback; then
+1. `MESSAGES_SNAPSHOT` — the display backlog, so a reconnecting client
+   rebuilds its scrollback; then
 2. `STATE_SNAPSHOT` — the status read-model above.
 
 Live events (and `STATE_DELTA`s) follow.
@@ -537,6 +537,25 @@ switch on an already-connected AG-UI stream re-fires this EXACT pair
 `reyn.event.session_attached` barrier is forwarded — see *the session-switch
 barrier* above. Connect-time and switch-time are one code path, not two
 byte-identical-by-hand copies.
+
+**The backlog is ONE bounded page, not the full history (#5139 C).** The
+server sends at most `HYDRATE_PAGE_FRAMES` (200 — the same bound local
+restore's own lazy scrollback paging already uses) frames per
+`MESSAGES_SNAPSHOT`, cut only at a turn boundary (a `chain_id`-correlated
+run — never inside a tool call/result pair, which would silently break
+its own correlation). The `_reyn` block carries two more keys alongside
+`messages`: `has_more` (whether an older turn still exists beyond this
+page) and `next_cursor` (that older turn's own `chain_id`, `None` exactly
+when `has_more` is `False`). A client that scrolls past this page's own
+top end (`FlowView.ReachedTop`) POSTs `{"type":
+"load_older_backlog_request", "session_id", "before_root_id":
+<next_cursor>}`; the response reuses this SAME `MESSAGES_SNAPSHOT`
+encoding (one more bounded page, its own `has_more`/`next_cursor`) rather
+than a second wire vocabulary. Continuation is always CLIENT-driven pull
+— the server never pushes a second page unprompted, the same "server
+owns the per-request bound, never a second unbounded send" discipline
+the rest of this doc's typed requests (`session_list_request` etc.)
+already follow.
 
 The `MESSAGES_SNAPSHOT` `messages` field is a **standard `[{role, content}]`
 array of conversation turns only** — `agent` → `assistant`, `user` → `user` — the

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -65,7 +65,12 @@ from reyn.interfaces.repl.renderer import (
     summarize_tool_result,
 )
 from reyn.interfaces.transport.agui.state import RemoteQueueView
-from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame, FrameTag
+from reyn.interfaces.transport.frames import (
+    HYDRATE_PAGE_FRAMES,
+    BacklogBatch,
+    DisplayFrame,
+    FrameTag,
+)
 
 from ._meta_keys import ELAPSED_SECS_KEY as _ELAPSED_SECS_KEY
 from ._meta_keys import EXPANDED_KEY as _EXPANDED_KEY
@@ -210,7 +215,10 @@ def empty_state_hint() -> "object":
 #: 200 frames ≈ a full page-in stays well under one frame budget at the
 #: measured ~1µs/entry handle cost, while covering far more than one viewport
 #: (so a single page-in absorbs several screens of scrolling before the next).
-_HYDRATE_PAGE_FRAMES = 200
+#: #5139 C: re-exported from :mod:`~reyn.interfaces.transport.frames` — the
+#: SAME bound the server now caps a REMOTE backlog page at, so local and
+#: remote paging can never drift apart into two different numbers.
+_HYDRATE_PAGE_FRAMES = HYDRATE_PAGE_FRAMES
 
 #: #4996 witness② marker — appended in :meth:`TextualChatApp.
 #: _apply_hydrated_messages` when a read model DECLARES it can never
@@ -1448,6 +1456,21 @@ class TextualChatApp(App):
         # private detail a test would need to reach in for: "0 discards"
         # must be verifiable, not merely assumed.
         self._remote_backlog_discard_count = 0
+        # #5139 C: the REMOTE counterpart of ``self._older_frames`` (#3476
+        # ④, local's own held-prefix) — a remote client holds no on-disk
+        # prefix to page from, so instead it tracks the LAST received
+        # backlog batch's own continuation state: whether an older page
+        # still exists, and that older page's own request key (a turn's
+        # ``chain_id``). ``None``/``False`` (never fetched, or the true
+        # start was already reached) means ``on_flow_view_reached_top``'s
+        # remote branch has nothing left to pull.
+        self._remote_backlog_has_more = False
+        self._remote_backlog_cursor: "str | None" = None
+        # Guards against firing a SECOND overlapping pull before the first's
+        # response has applied — ``ReachedTop`` re-arms on retreat (its own
+        # edge-trigger contract) and a fast double-scroll can re-fire before
+        # a prior pull's ``BacklogBatch`` has come back.
+        self._remote_backlog_pull_inflight = False
         # A queued item's ``meta`` (ADR-0039 attribution) — ``apply_user_submitted``
         # deliberately stores only msg_id/chain_id/text on
         # ``RemoteQueueView.items`` (P2a's delta contract, reused unmodified,
@@ -2545,16 +2568,41 @@ class TextualChatApp(App):
         if batch.agent != self._agent_name or batch.sid != self._session_id:
             self._remote_backlog_discard_count += 1
             return
+        # #5139 C: this batch's OWN continuation state — tracked regardless
+        # of whether it carries any frames (an empty page with
+        # ``has_more=False`` IS the "reached the true start" signal;
+        # ``on_flow_view_reached_top``'s remote branch below reads this,
+        # never re-derives it).
+        self._remote_backlog_has_more = batch.has_more
+        self._remote_backlog_cursor = batch.next_cursor
         messages = [f.message for f in batch.frames if isinstance(f, DisplayFrame)]
         if not messages:
             return
         try:
-            entries = self.conversation.extend(messages)
+            if batch.is_older_page:
+                # #5139 C: a ``ReachedTop`` pull's own page — PREPEND at the
+                # top (mirrors local's own ``on_flow_view_reached_top``:
+                # ``insert_many(0, page)``), never ``extend`` (append at the
+                # bottom), which would land older history AFTER whatever
+                # the user is currently reading.
+                entries = self.conversation.insert_many(0, messages)
+            else:
+                entries = self.conversation.extend(messages)
         except Exception:
             logger.exception("textual chat: remote backlog batch append failed")
             return
         for msg, entry in zip(messages, entries):
             _apply_restored_state(msg, entry)
+        if batch.is_older_page:
+            # #5139 C: an older PAGE-IN, never seeded into the ``/copy``
+            # ring — mirrors local's own ``on_flow_view_reached_top``,
+            # which likewise leaves ``_recent_replies`` untouched when
+            # paging an older prefix in (only the INITIAL hydrate/backlog
+            # seeds it, oldest-first — see #3362/#3486's own comment on
+            # that call site). Seeding here would ``appendleft`` OLDER
+            # replies ahead of already-shown newer ones, inverting the
+            # ring's own "1 = newest" contract.
+            return
         for msg in messages:
             if msg.kind == "agent":
                 self._recent_replies.appendleft(msg.text)
@@ -2681,9 +2729,39 @@ class TextualChatApp(App):
         exhausted this no longer concludes "nothing more exists" on the
         spot — it asks :meth:`_extend_older_frames_from_disk` for more of
         ``history.jsonl`` first, so a real conversation start and a merely
-        bounded in-memory load are no longer indistinguishable to the user."""
+        bounded in-memory load are no longer indistinguishable to the user.
+
+        #5139 C: a REMOTE session holds no on-disk prefix at all
+        (``self._read_model.capabilities.load_older_conversation_history``
+        is ``False``, and :meth:`_extend_older_frames_from_disk` always
+        returns ``False`` for it) — this method's own local page-in never
+        applies to it. Falls through instead to
+        :meth:`~reyn.interfaces.transport.client_transport.ClientTransport.request_older_backlog`,
+        which fetches asynchronously and applies its own page through the
+        SAME :meth:`_apply_backlog_batch` this frame pump already runs
+        every backlog through (``is_older_page=True`` — PREPEND). Guarded
+        by ``self._remote_backlog_has_more``: ``False`` means either no
+        remote batch has arrived yet (nothing to page from) or the true
+        start was already reached — either way, correctly a no-op, never a
+        request for a page that does not exist."""
         if not self._older_frames:
             if not self._extend_older_frames_from_disk():
+                if (
+                    self._remote_backlog_has_more
+                    and self._remote_backlog_cursor is not None
+                    and not self._remote_backlog_pull_inflight
+                ):
+                    self._remote_backlog_pull_inflight = True
+
+                    async def _pull() -> None:
+                        try:
+                            await self._transport.request_older_backlog(
+                                self._remote_backlog_cursor
+                            )
+                        finally:
+                            self._remote_backlog_pull_inflight = False
+
+                    self.run_worker(_pull(), name="remote-backlog-pull", exclusive=False)
                 return
         page = self._older_frames[-_HYDRATE_PAGE_FRAMES:]
         try:

--- a/src/reyn/interfaces/inline/textual_chat/restore.py
+++ b/src/reyn/interfaces/inline/textual_chat/restore.py
@@ -381,4 +381,103 @@ def project_restored_frames(
     return [divider, *frames]
 
 
-__all__ = ["RESTORED_META_KEY", "RESUME_DIVIDER", "project_restored_frames"]
+# A sentinel that never equals a real ``chain_id`` string (nor ``None``) —
+# forces a message with no ``chain_id`` at all to always start its OWN
+# singleton group, on both sides of it, rather than accidentally merging
+# with a neighbor that also happens to lack one.
+_NO_CHAIN = object()
+
+
+def _group_by_chain_id(history: "list[ChatMessage]") -> "list[list[ChatMessage]]":
+    """Split *history* into contiguous runs sharing one ``meta["chain_id"]``
+    (#5139 C) — router_loop.py stamps the SAME ``chain_id`` on every entry
+    one turn produces (user input, an assistant reply's own tool calls, and
+    each tool result), so a run is exactly one turn's worth of correlated
+    entries. This is the ONLY unit :func:`page_restored_history` ever cuts
+    a page boundary between — never inside one (see that function's own
+    docstring for why)."""
+    groups: "list[list[ChatMessage]]" = []
+    prev_key: object = _NO_CHAIN
+    for msg in history:
+        key = msg.meta.get("chain_id") if isinstance(msg.meta, dict) else None
+        if key is not None and key == prev_key:
+            groups[-1].append(msg)
+        else:
+            groups.append([msg])
+        prev_key = key if key is not None else _NO_CHAIN
+    return groups
+
+
+def page_restored_history(
+    history: "list[ChatMessage]",
+    *,
+    before_root_id: "str | None" = None,
+    limit: int,
+) -> "tuple[list[OutboxMessage], bool, str | None]":
+    """#5139 C: one server-side backlog PAGE — at most *limit* frames'
+    worth of the newest remaining turns, cut only at a ``chain_id``
+    (turn) boundary, never inside one.
+
+    ``before_root_id`` (``None`` = the newest page, i.e. the initial
+    connect/switch backlog): restricts the source to turns strictly OLDER
+    than the turn whose ``chain_id`` equals this value — the caller's own
+    previous page's oldest turn, so paging never re-sends what a prior
+    page already covered and never skips a turn between two pages either.
+    A ``before_root_id`` that names no known turn (a stale cursor — the
+    turn it pointed at rotated out of ``history`` between calls) degrades
+    to "nothing more" (``([], False, None)``) rather than silently
+    re-serving the newest page, which would look like new history to a
+    caller expecting strictly older content.
+
+    Returns ``(frames, has_more, next_cursor)``: ``frames`` is this page,
+    newest-last (the same order :func:`project_restored_frames` always
+    produces); ``has_more`` is whether an OLDER turn still exists beyond
+    this page (the caller's own "reached the true start" signal — ``False``
+    here is a hard "no more", never "didn't check"); ``next_cursor`` is
+    ``None`` exactly when ``has_more`` is ``False``, else the ``chain_id``
+    to pass as THIS call's ``before_root_id`` on the next page.
+
+    Bounded to walk only the groups this page and ``before_root_id``'s own
+    slice actually need — never the full history when only a page's worth
+    is being paged into a long-running conversation's tail."""
+    groups = _group_by_chain_id(history)
+    if before_root_id is not None:
+        cut = None
+        for i, g in enumerate(groups):
+            key = g[0].meta.get("chain_id") if isinstance(g[0].meta, dict) else None
+            if key == before_root_id:
+                cut = i
+                break
+        if cut is None:
+            return [], False, None
+        groups = groups[:cut]
+    selected: "list[ChatMessage]" = []
+    boundary = len(groups)
+    for i in range(len(groups) - 1, -1, -1):
+        selected = groups[i] + selected
+        boundary = i
+        if len(project_restored_frames(selected)) >= limit:
+            break
+    has_more = boundary > 0
+    next_cursor = None
+    if has_more:
+        root = groups[boundary][0]
+        next_cursor = root.meta.get("chain_id") if isinstance(root.meta, dict) else None
+    frames = project_restored_frames(selected)
+    # ``project_restored_frames`` unconditionally prepends ONE resume-divider
+    # row to any non-empty projection (its own docstring) — correct for the
+    # newest page (``before_root_id is None``, the one a client shows first),
+    # a would-be DUPLICATE on every OLDER page this same function projects
+    # independently per call. Mirrors ``_extend_older_frames_from_disk``'s
+    # identical dedup for local's own backward-extend.
+    if before_root_id is not None and frames and frames[0].kind == "system" and frames[0].text == RESUME_DIVIDER:
+        frames = frames[1:]
+    return frames, has_more, next_cursor
+
+
+__all__ = [
+    "RESTORED_META_KEY",
+    "RESUME_DIVIDER",
+    "page_restored_history",
+    "project_restored_frames",
+]

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -258,6 +258,9 @@ class _ErrorWatchingTransport(ClientTransport):
     async def request_session_list(self) -> "list[dict]":
         return await self._inner.request_session_list()
 
+    async def request_older_backlog(self, before_root_id: str) -> None:
+        await self._inner.request_older_backlog(before_root_id)
+
     async def run_slash_command(self, name: str, args: str) -> bool:
         return await self._inner.run_slash_command(name, args)
 

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -32,6 +32,7 @@ import asyncio
 from typing import TYPE_CHECKING, AsyncIterator, Awaitable, Callable
 
 from reyn.interfaces.transport.agui.protocol import (
+    MESSAGES_SNAPSHOT,
     InterventionTool,
     InterventionToolResult,
     MessagesSnapshot,
@@ -232,6 +233,8 @@ class AgUiTransport(ClientTransport):
                         agent=self._backlog_agent,
                         sid=self._backlog_sid,
                         frames=[self._reguard_frame(f) for f in decoded.frames],
+                        has_more=decoded.has_more,
+                        next_cursor=decoded.next_cursor,
                     )
                 )
             elif isinstance(decoded, InterventionTool):
@@ -515,6 +518,49 @@ class AgUiTransport(ClientTransport):
         result = await self._send({"type": "session_list_request"})
         sessions = (result or {}).get("sessions")
         return sessions if isinstance(sessions, list) else []
+
+    async def request_older_backlog(self, before_root_id: str) -> None:
+        """#5139 C: client-driven pull for the NEXT-older backlog page —
+        ``on_flow_view_reached_top``'s remote counterpart to local's
+        on-disk ``_extend_older_frames_from_disk``. POSTs a typed request
+        (mirrors ``request_session_list`` etc. above); the response reuses
+        the EXACT ``MESSAGES_SNAPSHOT`` wire shape a live reconnect/switch
+        already decodes (:func:`~reyn.interfaces.transport.agui.protocol.decode_event`),
+        so this reuses that same decode path rather than a second one.
+
+        The decoded page is wrapped as a :class:`BacklogBatch` with
+        ``is_older_page=True`` (PREPEND, not append —
+        ``TextualChatApp._apply_backlog_batch``'s own branch on that flag)
+        and fed into the SAME queue every other frame this transport
+        produces flows through (:meth:`put_display`'s own established
+        pattern) — a new PRODUCER onto the existing delivery path, not a
+        new one. A failed/empty response is silently dropped (never a
+        fabricated empty page — the caller's own ``has_more``/cursor state
+        is simply left as it was, so a transient failure retries on the
+        next ``ReachedTop`` rather than being mistaken for "reached the
+        true start")."""
+        result = await self._send(
+            {
+                "type": "load_older_backlog_request",
+                "session_id": self._backlog_sid,
+                "before_root_id": before_root_id,
+            },
+        )
+        if not result:
+            return
+        decoded = decode_event(MESSAGES_SNAPSHOT, result)
+        if not isinstance(decoded, MessagesSnapshot):
+            return
+        self._display_queue.put_nowait(
+            BacklogBatch(
+                agent=self._backlog_agent,
+                sid=self._backlog_sid,
+                frames=[self._reguard_frame(f) for f in decoded.frames],
+                has_more=decoded.has_more,
+                next_cursor=decoded.next_cursor,
+                is_older_page=True,
+            )
+        )
 
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None

--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -43,7 +43,7 @@ second source.
 """
 from __future__ import annotations
 
-from typing import AsyncIterator, Callable
+from typing import AsyncIterator, Awaitable, Callable
 
 from reyn.interfaces.transport.agui.protocol import (
     CONTROL_FILTER_KINDS,
@@ -90,7 +90,7 @@ class AgUiEmitter:
         backlog: "list[Frame] | None" = None,
         backlog_has_more: bool = False,
         backlog_next_cursor: "str | None" = None,
-        backlog_provider: "Callable[[str, str], tuple[list[Frame], bool, str | None]] | None" = None,
+        backlog_provider: "Callable[[str, str], Awaitable[tuple[list[Frame], bool, str | None]]] | None" = None,
     ) -> None:
         # ``frames`` is the unified frame stream (e.g. an InProcessTransport's
         # ``frames()``); ``status_provider`` returns the CUI status snapshot dict
@@ -205,7 +205,7 @@ class AgUiEmitter:
                 if etype == "session_attached" and self._backlog_provider is not None:
                     self._text_stream = TextStreamTracker()
                     self._waiting_on = None
-                    new_backlog, new_has_more, new_next_cursor = self._backlog_provider(
+                    new_backlog, new_has_more, new_next_cursor = await self._backlog_provider(
                         str(edata.get("agent", "")), str(edata.get("session_id", ""))
                     )
                     for chunk in self._reconnect_snapshot_chunks(

--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -88,19 +88,27 @@ class AgUiEmitter:
         status_provider: "Callable[[], dict | None]",
         *,
         backlog: "list[Frame] | None" = None,
-        backlog_provider: "Callable[[str, str], list[Frame]] | None" = None,
+        backlog_has_more: bool = False,
+        backlog_next_cursor: "str | None" = None,
+        backlog_provider: "Callable[[str, str], tuple[list[Frame], bool, str | None]] | None" = None,
     ) -> None:
         # ``frames`` is the unified frame stream (e.g. an InProcessTransport's
         # ``frames()``); ``status_provider`` returns the CUI status snapshot dict
         # (or None when no session is attached); ``backlog`` is the display
-        # history replayed on connect for reconnect (A4). ``backlog_provider``
+        # history replayed on connect for reconnect (A4), ALREADY bounded to one
+        # page by the caller (#5139 C — this class never pages on its own);
+        # ``backlog_has_more``/``backlog_next_cursor`` are that same page's own
+        # continuation state, encoded alongside it. ``backlog_provider``
         # (#3310 N3) is called with ``(agent, session_id)`` off a mid-stream
         # ``session_attached`` ``EventFrame`` to fetch the switched-to session's
-        # backlog for the re-fire; ``None`` means this connection never
-        # switches sessions (byte-identical to pre-N3 behavior).
+        # OWN bounded page (``(frames, has_more, next_cursor)``, #5139 C) for
+        # the re-fire; ``None`` means this connection never switches sessions
+        # (byte-identical to pre-N3 behavior).
         self._frames = frames
         self._status_provider = status_provider
         self._backlog = list(backlog or [])
+        self._backlog_has_more = backlog_has_more
+        self._backlog_next_cursor = backlog_next_cursor
         self._backlog_provider = backlog_provider
         self._model = StatusModel()
         self._waiting_on: str | None = None
@@ -113,19 +121,25 @@ class AgUiEmitter:
     def _project(self) -> dict:
         return project_status(self._status_provider(), waiting_on=self._waiting_on)
 
-    def _reconnect_snapshot_chunks(self, backlog: "list[Frame]") -> "list[str]":
+    def _reconnect_snapshot_chunks(
+        self, backlog: "list[Frame]", *, has_more: bool = False, next_cursor: "str | None" = None,
+    ) -> "list[str]":
         """The shared reconnect protocol (A4): backlog display, then full
         status — used identically at connect (``stream()`` start) and at a
         mid-stream session switch (#3310 N3), so the two are ONE code path,
-        not a byte-identical-by-hand duplicate."""
+        not a byte-identical-by-hand duplicate. ``has_more``/``next_cursor``
+        (#5139 C) are *backlog*'s own page-continuation state, riding the
+        SAME ``MESSAGES_SNAPSHOT`` event."""
         return [
-            to_sse(encode_messages_snapshot(backlog)),
+            to_sse(encode_messages_snapshot(backlog, has_more=has_more, next_cursor=next_cursor)),
             to_sse(encode_state_snapshot(self._model.snapshot(self._project()))),
         ]
 
     async def stream(self) -> AsyncIterator[str]:
         # Reconnect snapshots first (A4): backlog display, then full status.
-        for chunk in self._reconnect_snapshot_chunks(self._backlog):
+        for chunk in self._reconnect_snapshot_chunks(
+            self._backlog, has_more=self._backlog_has_more, next_cursor=self._backlog_next_cursor,
+        ):
             yield chunk
 
         async for frame in self._frames:
@@ -191,10 +205,12 @@ class AgUiEmitter:
                 if etype == "session_attached" and self._backlog_provider is not None:
                     self._text_stream = TextStreamTracker()
                     self._waiting_on = None
-                    new_backlog = self._backlog_provider(
+                    new_backlog, new_has_more, new_next_cursor = self._backlog_provider(
                         str(edata.get("agent", "")), str(edata.get("session_id", ""))
                     )
-                    for chunk in self._reconnect_snapshot_chunks(new_backlog):
+                    for chunk in self._reconnect_snapshot_chunks(
+                        new_backlog, has_more=new_has_more, next_cursor=new_next_cursor,
+                    ):
                         yield chunk
             delta = self._model.delta(self._project())
             if delta:

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -389,7 +389,7 @@ def session_backlog_frames(registry, name: str, sid: str) -> "list[Frame]":
     return [DisplayFrame(m) for m in project_restored_frames(history)]
 
 
-def session_backlog_page(
+async def session_backlog_page(
     registry, name: str, sid: str, *, before_root_id: "str | None" = None,
 ) -> "tuple[list[Frame], bool, str | None]":
     """#5139 C: ONE bounded backlog page — at most :data:`HYDRATE_PAGE_FRAMES`
@@ -402,17 +402,43 @@ def session_backlog_page(
     answer: the bound's OWNER is the server), continuation is client-pull,
     never a second server-initiated push.
 
+    **``target.history`` is only the in-memory tail, not the whole log**
+    (architect co-vet on this PR, issuecomment-5384101336): ``Session.
+    load_history()`` bounds its own startup read to a tail — "WITHOUT
+    necessarily reading the whole (potentially huge — owner's real
+    environment measured 500MB) file" (that method's own docstring) — so
+    a naive ``page_restored_history`` call over ``target.history`` alone
+    reports ``has_more=False`` the moment it reaches the front of what
+    happens to be LOADED, not the front of the conversation. A client
+    cannot tell the two apart, so this would silently truncate: "no
+    more" when there is, in fact, more on disk. Connects to the EXISTING
+    on-disk extend primitive local's own ``RegistryReadModel.
+    load_older_conversation_history`` already uses
+    (:meth:`~reyn.runtime.session.Session.extend_history_backward_async`,
+    the loop-safe sibling of ``extend_history_backward``) rather than
+    building a second one — the loop below re-asks ``page_restored_history``
+    after each successful extend (more groups are now in ``target.history``
+    for the SAME ``before_root_id`` to windup from), and only reports
+    ``has_more=False`` once an extend genuinely returns 0 (the true
+    physical start of ``history.jsonl``).
+
     Returns ``(frames, has_more, next_cursor)`` — see
     :func:`~reyn.interfaces.inline.textual_chat.restore.page_restored_history`,
     which this wraps, for what each means."""
     target = registry.get_session(name, sid)
     if target is None:
         return [], False, None
-    history = list(getattr(target, "history", []) or [])
-    frames, has_more, next_cursor = page_restored_history(
-        history, before_root_id=before_root_id, limit=HYDRATE_PAGE_FRAMES,
-    )
-    return [DisplayFrame(m) for m in frames], has_more, next_cursor
+    while True:
+        history = list(getattr(target, "history", []) or [])
+        frames, has_more, next_cursor = page_restored_history(
+            history, before_root_id=before_root_id, limit=HYDRATE_PAGE_FRAMES,
+        )
+        if has_more:
+            return [DisplayFrame(m) for m in frames], has_more, next_cursor
+        extend = getattr(target, "extend_history_backward_async", None)
+        extended = await extend() if extend is not None else 0
+        if extended <= 0:
+            return [DisplayFrame(m) for m in frames], False, None
 
 
 class _SessionFrameSource:
@@ -847,8 +873,8 @@ async def agui_events(request: Request, agent_name: str):
             # this is its one status-facing read path.
             return _snapshot_for_session(registry, source.current_session())
 
-        def _backlog_provider(name: str, sid: str) -> "tuple[list[Frame], bool, str | None]":
-            return session_backlog_page(registry, name, sid)
+        async def _backlog_provider(name: str, sid: str) -> "tuple[list[Frame], bool, str | None]":
+            return await session_backlog_page(registry, name, sid)
 
         # #3328: the INITIAL connect's `MESSAGES_SNAPSHOT` was silently empty —
         # `backlog_provider` (above) is only ever CALLED off a mid-stream
@@ -865,7 +891,7 @@ async def agui_events(request: Request, agent_name: str):
         # session's own history through the SAME projection the switch re-fire
         # and the local restore-on-restart path both use — one SSoT, populated
         # at both call sites now instead of only the second.
-        initial_backlog, initial_has_more, initial_next_cursor = session_backlog_page(
+        initial_backlog, initial_has_more, initial_next_cursor = await session_backlog_page(
             registry, agent_name, _DEFAULT_SID,
         )
         emitter = AgUiEmitter(
@@ -1326,7 +1352,7 @@ async def agui_submit(request: Request, agent_name: str):
         # no new wire vocabulary for this one request type.
         target_sid = str(payload.get("session_id", "")).strip() or _DEFAULT_SID
         cursor = payload.get("before_root_id")
-        page, has_more, next_cursor = session_backlog_page(
+        page, has_more, next_cursor = await session_backlog_page(
             registry, agent_name, target_sid,
             before_root_id=str(cursor) if cursor else None,
         )

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -46,9 +46,13 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from reyn.core.events.events import Event
-from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
+from reyn.interfaces.inline.textual_chat.restore import (
+    page_restored_history,
+    project_restored_frames,
+)
 from reyn.interfaces.repl.status import _snapshot_for_session
 from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.protocol import encode_messages_snapshot
 from reyn.interfaces.transport.agui.surface import (
     SurfaceManager,
     monotonic,
@@ -56,6 +60,7 @@ from reyn.interfaces.transport.agui.surface import (
 )
 from reyn.interfaces.transport.drain import suspend_between_frames
 from reyn.interfaces.transport.frames import (
+    HYDRATE_PAGE_FRAMES,
     DisplayFrame,
     EventFrame,
     Frame,
@@ -382,6 +387,32 @@ def session_backlog_frames(registry, name: str, sid: str) -> "list[Frame]":
         return []
     history = list(getattr(target, "history", []) or [])
     return [DisplayFrame(m) for m in project_restored_frames(history)]
+
+
+def session_backlog_page(
+    registry, name: str, sid: str, *, before_root_id: "str | None" = None,
+) -> "tuple[list[Frame], bool, str | None]":
+    """#5139 C: ONE bounded backlog page — at most :data:`HYDRATE_PAGE_FRAMES`
+    frames, cut only at a turn (``chain_id``) boundary. Unlike
+    :func:`session_backlog_frames` (unbounded, still used as the "what a
+    local hydrate would show" test oracle and the switch-follow re-fire's
+    own established shape), this is the one both the initial connect/switch
+    backlog AND a client-driven ``ReachedTop`` pull now go through — server
+    sends at most one page per request (architect's own six-questions⑤
+    answer: the bound's OWNER is the server), continuation is client-pull,
+    never a second server-initiated push.
+
+    Returns ``(frames, has_more, next_cursor)`` — see
+    :func:`~reyn.interfaces.inline.textual_chat.restore.page_restored_history`,
+    which this wraps, for what each means."""
+    target = registry.get_session(name, sid)
+    if target is None:
+        return [], False, None
+    history = list(getattr(target, "history", []) or [])
+    frames, has_more, next_cursor = page_restored_history(
+        history, before_root_id=before_root_id, limit=HYDRATE_PAGE_FRAMES,
+    )
+    return [DisplayFrame(m) for m in frames], has_more, next_cursor
 
 
 class _SessionFrameSource:
@@ -816,8 +847,8 @@ async def agui_events(request: Request, agent_name: str):
             # this is its one status-facing read path.
             return _snapshot_for_session(registry, source.current_session())
 
-        def _backlog_provider(name: str, sid: str) -> "list[Frame]":
-            return session_backlog_frames(registry, name, sid)
+        def _backlog_provider(name: str, sid: str) -> "tuple[list[Frame], bool, str | None]":
+            return session_backlog_page(registry, name, sid)
 
         # #3328: the INITIAL connect's `MESSAGES_SNAPSHOT` was silently empty —
         # `backlog_provider` (above) is only ever CALLED off a mid-stream
@@ -834,9 +865,14 @@ async def agui_events(request: Request, agent_name: str):
         # session's own history through the SAME projection the switch re-fire
         # and the local restore-on-restart path both use — one SSoT, populated
         # at both call sites now instead of only the second.
+        initial_backlog, initial_has_more, initial_next_cursor = session_backlog_page(
+            registry, agent_name, _DEFAULT_SID,
+        )
         emitter = AgUiEmitter(
             source.frames(), _status_provider,
-            backlog=session_backlog_frames(registry, agent_name, _DEFAULT_SID),
+            backlog=initial_backlog,
+            backlog_has_more=initial_has_more,
+            backlog_next_cursor=initial_next_cursor,
             backlog_provider=_backlog_provider,
         )
     except Exception:
@@ -1277,6 +1313,25 @@ async def agui_submit(request: Request, agent_name: str):
             for sid in registry.session_ids(agent_name)
         ]
         return JSONResponse({"status": "ok", "sessions": sessions})
+    elif ptype == "load_older_backlog_request":
+        # #5139 C: mirrors attach_request/session_switch_request/
+        # artifact_list_request/session_list_request above — client names
+        # an operation (the turn strictly older than its own last page's
+        # ``next_cursor``), server executes it against ITS OWN state (never
+        # a client-supplied history slice). One page per request (the bound
+        # architect's six-questions⑤ answer named the SERVER as the owner
+        # of) — reuses ``encode_messages_snapshot`` byte-for-byte, so the
+        # client decodes this response through the SAME ``MessagesSnapshot``
+        # path a live reconnect/switch ``MESSAGES_SNAPSHOT`` already does —
+        # no new wire vocabulary for this one request type.
+        target_sid = str(payload.get("session_id", "")).strip() or _DEFAULT_SID
+        cursor = payload.get("before_root_id")
+        page, has_more, next_cursor = session_backlog_page(
+            registry, agent_name, target_sid,
+            before_root_id=str(cursor) if cursor else None,
+        )
+        event_data = encode_messages_snapshot(page, has_more=has_more, next_cursor=next_cursor).data
+        return JSONResponse({"status": "ok", **event_data})
     return JSONResponse({"status": "ok"})
 
 

--- a/src/reyn/interfaces/transport/agui/protocol.py
+++ b/src/reyn/interfaces/transport/agui/protocol.py
@@ -226,9 +226,17 @@ class StateUpdate:
 
 @dataclass(frozen=True)
 class MessagesSnapshot:
-    """A decoded MESSAGES_SNAPSHOT — the reconnect display backlog (A4)."""
+    """A decoded MESSAGES_SNAPSHOT — the reconnect display backlog (A4).
+
+    #5139 C: ``has_more``/``next_cursor`` carry the server's own page
+    boundary — see :class:`~reyn.interfaces.transport.frames.BacklogBatch`'s
+    docstring for what each means; this is the wire-decoded form of the
+    same two fields, read straight through by
+    :meth:`~reyn.interfaces.transport.agui.client.AgUiTransport._consume_block`."""
 
     frames: list = field(default_factory=list)
+    has_more: bool = False
+    next_cursor: "str | None" = None
 
 
 @dataclass(frozen=True)
@@ -544,14 +552,23 @@ def encode_state_delta(delta: dict) -> AgUiEvent:
     )
 
 
-def encode_messages_snapshot(frames: "list[Frame]") -> AgUiEvent:
-    """MESSAGES_SNAPSHOT — the display backlog replayed on connect (A4).
+def encode_messages_snapshot(
+    frames: "list[Frame]", *, has_more: bool = False, next_cursor: "str | None" = None,
+) -> AgUiEvent:
+    """MESSAGES_SNAPSHOT — the display backlog replayed on connect (A4), a
+    switch re-fire (#3310 N3), or a client-driven older-page pull (#5139 C —
+    same encoder, same decoder, same :class:`MessagesSnapshot` shape; the
+    3 call sites differ only in which slice of history they pass in).
 
     The standard ``messages`` field is a ``[{role, content}]`` array of
     **conversation turns only** (P4) — the shape a generic AG-UI client expects;
     reyn chrome (status / error / present / intervention / trace) is NOT a
     conversation turn and is excluded. The reyn client rebuilds the FULL backlog
     (all display frames) from the ``_reyn`` block, so its scrollback is unchanged.
+
+    ``has_more``/``next_cursor`` (#5139 C) ride alongside inside the
+    ``_reyn`` block — see :class:`~reyn.interfaces.transport.frames.BacklogBatch`'s
+    docstring for what each means.
     """
     reyn_payload = [
         _encode_display(f).data[_REYN] for f in frames if isinstance(f, DisplayFrame)
@@ -563,7 +580,15 @@ def encode_messages_snapshot(frames: "list[Frame]") -> AgUiEvent:
     ]
     return AgUiEvent(
         type=MESSAGES_SNAPSHOT,
-        data={"messages": standard, _REYN: {"frame": "messages", "messages": reyn_payload}},
+        data={
+            "messages": standard,
+            _REYN: {
+                "frame": "messages",
+                "messages": reyn_payload,
+                "has_more": has_more,
+                "next_cursor": next_cursor,
+            },
+        },
     )
 
 
@@ -654,7 +679,11 @@ def decode_event(
             )
             for m in (reyn.get("messages") or [])
         ]
-        return MessagesSnapshot(frames=frames)
+        return MessagesSnapshot(
+            frames=frames,
+            has_more=bool(reyn.get("has_more", False)),
+            next_cursor=reyn.get("next_cursor"),
+        )
     if frame_tag == "intervention_tool":
         return InterventionTool(
             intervention_id=str(reyn.get("intervention_id") or ""),

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -345,6 +345,33 @@ class ClientTransport(ABC):
         :class:`ClientTransportStub`."""
 
     @abstractmethod
+    async def request_older_backlog(self, before_root_id: str) -> None:
+        """#5139 C: pull the NEXT-older backlog page — the client-driven
+        continuation ``ReachedTop`` triggers once a bounded initial/switch
+        page (:data:`~reyn.interfaces.transport.frames.HYDRATE_PAGE_FRAMES`)
+        is exhausted. ``before_root_id`` is the caller's own current page's
+        oldest turn id (a ``chain_id`` — see
+        :class:`~reyn.interfaces.transport.frames.BacklogBatch`'s docstring
+        for why a turn id, never a message's own ``seq``).
+
+        Fire-and-forget by design (returns ``None``, not the page itself):
+        the OWN local restore path (``InProcessTransport``) already answers
+        this query synchronously through :class:`ChatReadModel` instead
+        (``load_older_conversation_history``/``conversation_history``) — a
+        no-op here, never called by ``on_flow_view_reached_top`` for a
+        local session. A REMOTE transport instead delivers the fetched page
+        asynchronously as a :class:`~reyn.interfaces.transport.frames.BacklogBatch`
+        (``is_older_page=True``) through the SAME :meth:`frames` stream
+        every other frame this transport produces flows through — see
+        :meth:`~reyn.interfaces.transport.agui.client.AgUiTransport.request_older_backlog`'s
+        own docstring for the full reasoning.
+
+        Abstract (mirrors #5076's own reasoning for the OTHER typed ops on
+        this seam): a new subclass that forgets this fails to CONSTRUCT,
+        rather than silently degrading ``on_flow_view_reached_top``'s
+        remote paging to a permanent no-op nobody chose."""
+
+    @abstractmethod
     async def state_ready(self) -> None:
         """Return once this transport's own STATUS/state-read side-channel
         (whatever ``ChatReadModel.snapshot()``/``intervention_head()``/etc.
@@ -519,6 +546,9 @@ class ClientTransportStub(ClientTransport):
     async def request_session_list(self) -> "list[dict]":
         return []
 
+    async def request_older_backlog(self, before_root_id: str) -> None:
+        return None
+
     async def state_ready(self) -> None:
         return None
 
@@ -644,6 +674,9 @@ class DelegatingClientTransport(ClientTransport):
 
     async def request_session_list(self) -> "list[dict]":
         return await self._inner.request_session_list()
+
+    async def request_older_backlog(self, before_root_id: str) -> None:
+        await self._inner.request_older_backlog(before_root_id)
 
     async def state_ready(self) -> None:
         await self._inner.state_ready()

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -248,11 +248,35 @@ class BacklogBatch:
     :data:`Frame` union: only :class:`AgUiTransport` ever produces one and
     only ``_pump_frames`` interprets it — the generic renderer entry points
     (``.message`` / ``.on_audit_event``) never see it.
-    """
+
+    #5139 C (architect ruling, issuecomment-5383993909): ``has_more`` /
+    ``next_cursor`` carry the SAME server-side bound every OTHER reconnect
+    backlog now respects (:data:`HYDRATE_PAGE_FRAMES`) — the server sends
+    at most one page per request; ``has_more`` says whether an older page
+    still exists, ``next_cursor`` is that older page's own request key (a
+    turn's ``chain_id`` — the root id tool-call/result correlation, group
+    parenting, and sticky state are all keyed on, never a message's own
+    ``seq``, which a mid-turn cut would silently split). ``is_older_page``
+    distinguishes this batch's OWN apply direction: ``False`` (the
+    reconnect/switch snapshot, unchanged default) appends at the bottom;
+    ``True`` (a client-driven ``ReachedTop`` pull, #5139 C) prepends at the
+    top instead — see ``TextualChatApp._apply_backlog_batch``."""
 
     agent: str
     sid: str
     frames: "list[DisplayFrame]"
+    has_more: bool = False
+    next_cursor: "str | None" = None
+    is_older_page: bool = False
+
+
+#: The server sends at most this many frames per backlog page (reconnect
+#: snapshot, switch re-fire, or an older-page pull) — #5139 C reuses the
+#: SAME bound local restore's own lazy paging already uses
+#: (``textual_chat/app.py``'s ``_HYDRATE_PAGE_FRAMES``) rather than
+#: inventing a second number; both sides import this one constant so the
+#: two can never drift apart.
+HYDRATE_PAGE_FRAMES = 200
 
 
 __all__ = [
@@ -261,5 +285,6 @@ __all__ = [
     "EventFrame",
     "Frame",
     "FrameTag",
+    "HYDRATE_PAGE_FRAMES",
     "forwarded_frame_kinds",
 ]

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -284,6 +284,17 @@ class InProcessTransport(ClientTransport):
         focused = self._registry.attached_sid
         return [{"sid": sid, "attached": sid == focused} for sid in sids]
 
+    async def request_older_backlog(self, before_root_id: str) -> None:
+        # #5139 C: no-op — a local session's older-history paging goes
+        # through ``ChatReadModel.load_older_conversation_history`` (real
+        # disk, no wire hop) instead, exactly like ``conversation_history``
+        # already does. ``on_flow_view_reached_top`` never calls this for a
+        # local session (its ``self._read_model.capabilities`` already says
+        # so); this body exists only so the class constructs at all
+        # (``ClientTransport``'s own ``@abstractmethod``, #5076's
+        # discipline for this whole seam).
+        return None
+
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None
     ) -> bool:

--- a/src/reyn/interfaces/transport/session_bound.py
+++ b/src/reyn/interfaces/transport/session_bound.py
@@ -201,6 +201,15 @@ class SessionBoundTransport(ClientTransport):
         # class is a server-side seam) before it would ever reach here.
         return []
 
+    async def request_older_backlog(self, before_root_id: str) -> None:
+        # #5139 C: EXPLICITLY a no-op, same reasoning as
+        # request_session_list above — older-backlog paging is a
+        # client-driven READ query, structurally outside this send-side-only
+        # transport's own layer, and unreachable in practice for the same
+        # reason (this class is a server-side seam, never the CLIENT half
+        # ``on_flow_view_reached_top`` calls this on).
+        return None
+
     async def request_artifact_list(self, *, agent: str) -> "tuple[list[dict], int]":
         # #5094: EXPLICITLY implemented, not inherited — mirrors
         # InProcessTransport's own execution side (#4494 design C /

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -440,6 +440,9 @@ class ThreadedTransportProxy(ClientTransport):
     async def request_session_list(self) -> "list[dict]":
         return await self._call_on_worker("request_session_list")
 
+    async def request_older_backlog(self, before_root_id: str) -> None:
+        await self._call_on_worker("request_older_backlog", before_root_id=before_root_id)
+
     async def _cancel_pump_on_worker(self) -> None:
         """Runs ON THE WORKER LOOP (via ``run_coroutine_threadsafe``) so
         cancelling the pump task is properly awaited before this proxy asks

--- a/tests/interfaces/test_3310_n3_remote_switch_parity.py
+++ b/tests/interfaces/test_3310_n3_remote_switch_parity.py
@@ -315,7 +315,12 @@ async def test_remote_switch_parity_a_b_a_with_staleness(tmp_path) -> None:
         source.start()
 
         def _backlog_provider(name: str, sid: str):
-            return session_backlog_frames(reg, name, sid)
+            # #5139 C: AgUiEmitter's backlog_provider contract is now
+            # (frames, has_more, next_cursor) — this test's own oracle
+            # (session_backlog_frames, unbounded) has no pagination of its
+            # own, so it always reports "no more" (matches production's
+            # real ``session_backlog_page`` shape when a page fits whole).
+            return session_backlog_frames(reg, name, sid), False, None
 
         emitter = AgUiEmitter(source.frames(), lambda: None, backlog_provider=_backlog_provider)
 
@@ -412,7 +417,12 @@ async def test_rapid_back_to_back_switches_lose_no_backlog(tmp_path) -> None:
         source.start()
 
         def _backlog_provider(name: str, sid: str):
-            return session_backlog_frames(reg, name, sid)
+            # #5139 C: AgUiEmitter's backlog_provider contract is now
+            # (frames, has_more, next_cursor) — this test's own oracle
+            # (session_backlog_frames, unbounded) has no pagination of its
+            # own, so it always reports "no more" (matches production's
+            # real ``session_backlog_page`` shape when a page fits whole).
+            return session_backlog_frames(reg, name, sid), False, None
 
         emitter = AgUiEmitter(source.frames(), lambda: None, backlog_provider=_backlog_provider)
 
@@ -534,7 +544,12 @@ async def test_barrier_precedes_refire_on_the_wire(tmp_path) -> None:
         source.start()
 
         def _backlog_provider(name: str, sid: str):
-            return session_backlog_frames(reg, name, sid)
+            # #5139 C: AgUiEmitter's backlog_provider contract is now
+            # (frames, has_more, next_cursor) — this test's own oracle
+            # (session_backlog_frames, unbounded) has no pagination of its
+            # own, so it always reports "no more" (matches production's
+            # real ``session_backlog_page`` shape when a page fits whole).
+            return session_backlog_frames(reg, name, sid), False, None
 
         emitter = AgUiEmitter(source.frames(), lambda: None, backlog_provider=_backlog_provider)
 
@@ -600,7 +615,7 @@ async def test_connect_path_unaffected_by_backlog_provider_wiring(tmp_path) -> N
         yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
 
     without = AgUiEmitter(_frames(), lambda: None)
-    with_provider = AgUiEmitter(_frames(), lambda: None, backlog_provider=lambda a, s: [])
+    with_provider = AgUiEmitter(_frames(), lambda: None, backlog_provider=lambda a, s: ([], False, None))
 
     sse_without = "".join([c async for c in without.stream()])
     sse_with = "".join([c async for c in with_provider.stream()])

--- a/tests/interfaces/test_3310_n3_remote_switch_parity.py
+++ b/tests/interfaces/test_3310_n3_remote_switch_parity.py
@@ -314,12 +314,13 @@ async def test_remote_switch_parity_a_b_a_with_staleness(tmp_path) -> None:
         source = _SessionFrameSource(session_a, registry=reg, agent_name="alpha")
         source.start()
 
-        def _backlog_provider(name: str, sid: str):
+        async def _backlog_provider(name: str, sid: str):
             # #5139 C: AgUiEmitter's backlog_provider contract is now
-            # (frames, has_more, next_cursor) — this test's own oracle
-            # (session_backlog_frames, unbounded) has no pagination of its
-            # own, so it always reports "no more" (matches production's
-            # real ``session_backlog_page`` shape when a page fits whole).
+            # async, returning (frames, has_more, next_cursor) — this
+            # test's own oracle (session_backlog_frames, unbounded) has
+            # no pagination of its own, so it always reports "no more"
+            # (matches production's real ``session_backlog_page`` shape
+            # when a page fits whole).
             return session_backlog_frames(reg, name, sid), False, None
 
         emitter = AgUiEmitter(source.frames(), lambda: None, backlog_provider=_backlog_provider)
@@ -416,12 +417,13 @@ async def test_rapid_back_to_back_switches_lose_no_backlog(tmp_path) -> None:
         source = _SessionFrameSource(session_a, registry=reg, agent_name="alpha")
         source.start()
 
-        def _backlog_provider(name: str, sid: str):
+        async def _backlog_provider(name: str, sid: str):
             # #5139 C: AgUiEmitter's backlog_provider contract is now
-            # (frames, has_more, next_cursor) — this test's own oracle
-            # (session_backlog_frames, unbounded) has no pagination of its
-            # own, so it always reports "no more" (matches production's
-            # real ``session_backlog_page`` shape when a page fits whole).
+            # async, returning (frames, has_more, next_cursor) — this
+            # test's own oracle (session_backlog_frames, unbounded) has
+            # no pagination of its own, so it always reports "no more"
+            # (matches production's real ``session_backlog_page`` shape
+            # when a page fits whole).
             return session_backlog_frames(reg, name, sid), False, None
 
         emitter = AgUiEmitter(source.frames(), lambda: None, backlog_provider=_backlog_provider)
@@ -543,12 +545,13 @@ async def test_barrier_precedes_refire_on_the_wire(tmp_path) -> None:
         source = _SessionFrameSource(session_a, registry=reg, agent_name="alpha")
         source.start()
 
-        def _backlog_provider(name: str, sid: str):
+        async def _backlog_provider(name: str, sid: str):
             # #5139 C: AgUiEmitter's backlog_provider contract is now
-            # (frames, has_more, next_cursor) — this test's own oracle
-            # (session_backlog_frames, unbounded) has no pagination of its
-            # own, so it always reports "no more" (matches production's
-            # real ``session_backlog_page`` shape when a page fits whole).
+            # async, returning (frames, has_more, next_cursor) — this
+            # test's own oracle (session_backlog_frames, unbounded) has
+            # no pagination of its own, so it always reports "no more"
+            # (matches production's real ``session_backlog_page`` shape
+            # when a page fits whole).
             return session_backlog_frames(reg, name, sid), False, None
 
         emitter = AgUiEmitter(source.frames(), lambda: None, backlog_provider=_backlog_provider)
@@ -615,7 +618,10 @@ async def test_connect_path_unaffected_by_backlog_provider_wiring(tmp_path) -> N
         yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
 
     without = AgUiEmitter(_frames(), lambda: None)
-    with_provider = AgUiEmitter(_frames(), lambda: None, backlog_provider=lambda a, s: ([], False, None))
+    async def _empty_backlog_provider(a, s):
+        return [], False, None
+
+    with_provider = AgUiEmitter(_frames(), lambda: None, backlog_provider=_empty_backlog_provider)
 
     sse_without = "".join([c async for c in without.stream()])
     sse_with = "".join([c async for c in with_provider.stream()])

--- a/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
+++ b/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
@@ -221,10 +221,11 @@ async def test_status_changes_are_pushed_by_the_attach_itself_not_ridden_on_a_la
     source.listen_for_retarget(_CONNECTION_ID)
     source.start()
 
-    def _backlog_provider(name: str, sid: str):
-        # #5139 C: AgUiEmitter's backlog_provider contract is now
-        # (frames, has_more, next_cursor) — see test_3310's own identical
-        # comment for why ``False, None`` is the correct oracle answer here.
+    async def _backlog_provider(name: str, sid: str):
+        # #5139 C: AgUiEmitter's backlog_provider contract is now async,
+        # returning (frames, has_more, next_cursor) — see test_3310's own
+        # identical comment for why ``False, None`` is the correct oracle
+        # answer here.
         return session_backlog_frames(reg, name, sid), False, None
 
     emitter = AgUiEmitter(

--- a/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
+++ b/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
@@ -222,7 +222,10 @@ async def test_status_changes_are_pushed_by_the_attach_itself_not_ridden_on_a_la
     source.start()
 
     def _backlog_provider(name: str, sid: str):
-        return session_backlog_frames(reg, name, sid)
+        # #5139 C: AgUiEmitter's backlog_provider contract is now
+        # (frames, has_more, next_cursor) — see test_3310's own identical
+        # comment for why ``False, None`` is the correct oracle answer here.
+        return session_backlog_frames(reg, name, sid), False, None
 
     emitter = AgUiEmitter(
         source.frames(),

--- a/tests/interfaces/test_5119_retarget_hub_exception_cleanup.py
+++ b/tests/interfaces/test_5119_retarget_hub_exception_cleanup.py
@@ -17,7 +17,7 @@ was nobody, ever).
 
 Real ``AgentRegistry``/``Session`` + a real ``agui_events`` call throughout
 — no mocks. The failure is injected via a real ``monkeypatch.setattr`` on
-``session_backlog_frames`` (module-level, in the endpoint module's own
+``session_backlog_page`` (module-level, in the endpoint module's own
 namespace), not a fake collaborator standing in for a real one.
 """
 from __future__ import annotations
@@ -82,7 +82,7 @@ async def test_exception_before_gen_starts_does_not_leak_the_hub_subscription(
     connection's own hub subscription behind.
 
     Injects the failure at the LAST call in the vulnerable window
-    (``session_backlog_frames``, called to build ``AgUiEmitter``'s own
+    (``session_backlog_page``, called to build ``AgUiEmitter``'s own
     ``backlog=`` argument) — the latest possible failure point, so this
     witness covers the WHOLE window, not just an early step.
 
@@ -97,7 +97,11 @@ async def test_exception_before_gen_starts_does_not_leak_the_hub_subscription(
     def _raising_backlog(*_args, **_kwargs):
         raise RuntimeError("deliberate #5119 injected failure")
 
-    monkeypatch.setattr(endpoint_mod, "session_backlog_frames", _raising_backlog)
+    # #5139 C: the endpoint's own initial-backlog call site now goes through
+    # ``session_backlog_page`` (bounded, page-aware), not the unbounded
+    # ``session_backlog_frames`` this test used to target — the injection
+    # point moves to match, still the LAST call in the vulnerable window.
+    monkeypatch.setattr(endpoint_mod, "session_backlog_page", _raising_backlog)
 
     assert not endpoint_mod.connection_retarget_has_subscribers(conn_id), (
         "test precondition: the hub must start with no entry for this id"

--- a/tests/interfaces/test_5139c_older_backlog_wire_roundtrip.py
+++ b/tests/interfaces/test_5139c_older_backlog_wire_roundtrip.py
@@ -1,0 +1,130 @@
+"""Tier 2: #5139 C — the wire round-trip for a client-driven older-backlog
+pull: real ``session_backlog_page`` (server-side pagination) → real
+``encode_messages_snapshot`` → real ``AgUiTransport.request_older_backlog``
+(client-side decode). Complements ``test_5139c_page_restored_history.py``
+(the pure pagination logic, no wire) and
+``test_5139c_remote_reached_top_pull.py`` (the app-side ``ReachedTop``
+wiring, a fixture transport) — this file is the one that proves the ACTUAL
+encode/decode pair a real server response uses round-trips correctly,
+including a genuine 2-page split.
+
+Real ``AgentRegistry``/``Session``/``AgUiTransport``/``session_backlog_page``/
+``encode_messages_snapshot`` throughout — no mocks. The HTTP/ASGI POST layer
+itself is not driven here (``request_older_backlog``'s ``_send`` stub returns
+what a real endpoint handler would build via those same 2 real functions,
+matching this module's own established boundary — other typed-request tests
+in this suite stop at the same seam, e.g. ``test_3310``'s own module
+docstring)."""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.endpoint import session_backlog_page
+from reyn.interfaces.transport.agui.protocol import encode_messages_snapshot
+from reyn.interfaces.transport.frames import HYDRATE_PAGE_FRAMES, BacklogBatch
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path):
+    shared = BudgetTracker(CostConfig())
+
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=shared,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_request_older_backlog_decodes_a_real_second_page(tmp_path) -> None:
+    """Tier 2: a history long enough to force a genuine 3-page split: the FIRST
+    page (what a real connect/switch would send) reports ``has_more=True``
+    with a real cursor; POSTing that cursor through a real
+    :meth:`AgUiTransport.request_older_backlog` decodes the SECOND page —
+    which must ITSELF still report ``has_more=True`` with a real,
+    DIFFERENT cursor (a 3rd page still remains) — deliberately not the
+    all-defaults-are-already-False shape a final page would have, so a
+    stripped ``has_more``/``next_cursor`` decode (defaulting to
+    ``False``/``None``) is distinguishable from a correctly-decoded
+    ``True``/real-id (verified locally: reverting ``decode_event``'s
+    ``messages`` branch to the pre-#5139-C ``MessagesSnapshot(frames=frames)``
+    does NOT flip this test red for a final-page fixture, but DOES for
+    this one)."""
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        session = reg.get_session("alpha", _DEFAULT_SID)
+        assert session is not None
+        # 1 turn (user + assistant) projects to 2 frames — enough turns to
+        # span 3 pages (page 2 must itself still have a remainder).
+        n_turns = HYDRATE_PAGE_FRAMES + 20
+        for i in range(n_turns):
+            cid = f"turn-{i}"
+            session.history.append(
+                ChatMessage(role="user", content=f"msg {i}", meta={"chain_id": cid})
+            )
+            session.history.append(
+                ChatMessage(role="assistant", content=f"reply {i}", meta={"chain_id": cid})
+            )
+
+        page1_frames, has_more1, cursor1 = session_backlog_page(reg, "alpha", _DEFAULT_SID)
+        assert has_more1 is True, "test setup must force a real page split"
+        assert cursor1 is not None
+
+        async def _send(payload: dict) -> dict:
+            assert payload["type"] == "load_older_backlog_request"
+            assert payload["before_root_id"] == cursor1
+            page2_frames, has_more2, cursor2 = session_backlog_page(
+                reg, "alpha", _DEFAULT_SID, before_root_id=payload["before_root_id"],
+            )
+            event = encode_messages_snapshot(page2_frames, has_more=has_more2, next_cursor=cursor2)
+            return {"status": "ok", **event.data}
+
+        async def _no_sse():
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+        transport = AgUiTransport(_no_sse(), _send, agent_name="alpha")
+        # Seed the destination this transport's own BacklogBatch construction
+        # stamps (normally set by the ``session_attached`` announce that
+        # precedes a real MESSAGES_SNAPSHOT on the wire) so the resulting
+        # batch is not discarded as stale by whatever consumes it.
+        transport._backlog_sid = _DEFAULT_SID  # noqa: SLF001 - test seeds transport-internal destination state
+
+        await transport.request_older_backlog(cursor1)
+
+        # Drain exactly what request_older_backlog queued (no live SSE
+        # source is running here, so frames() would otherwise hang forever
+        # waiting on _pump_sse — reading the queue directly instead).
+        item = transport._display_queue.get_nowait()  # noqa: SLF001 - direct queue read, no live SSE source in this test
+        assert isinstance(item, BacklogBatch)
+        assert item.is_older_page is True
+        assert item.has_more is True, (
+            "test setup must leave a 3rd page remaining, so this assertion "
+            "distinguishes a correctly-decoded True from a stripped decode's "
+            "always-False default"
+        )
+        assert item.next_cursor is not None and item.next_cursor != cursor1
+        assert len(item.frames) > 0
+        # Content parity: the SAME messages session_backlog_page's own page 2
+        # produced, decoded back out the other side of the wire.
+        page2_frames, _, _ = session_backlog_page(reg, "alpha", _DEFAULT_SID, before_root_id=cursor1)
+        expected_texts = [f.message.text for f in page2_frames]
+        got_texts = [f.message.text for f in item.frames]
+        assert got_texts == expected_texts
+    finally:
+        await reg.shutdown()

--- a/tests/interfaces/test_5139c_older_backlog_wire_roundtrip.py
+++ b/tests/interfaces/test_5139c_older_backlog_wire_roundtrip.py
@@ -49,6 +49,28 @@ def _registry(tmp_path):
     return reg
 
 
+def _registry_with_disk_history(tmp_path):
+    """Mirrors ``test_4387_tui_paging_extends_from_disk.py``'s own
+    ``_registry`` — ``load_history()`` called at session-construction
+    time, same as a real attach, so ``_append_history`` below writes to
+    a REAL ``history.jsonl`` on disk (not just ``session.history`` in
+    memory) — required to exercise the tail-vs-disk divergence
+    acceptance⑤ (architect, issuecomment-5384101336) actually needs."""
+
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name, snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
 @pytest.mark.asyncio
 async def test_request_older_backlog_decodes_a_real_second_page(tmp_path) -> None:
     """Tier 2: a history long enough to force a genuine 3-page split: the FIRST
@@ -81,14 +103,14 @@ async def test_request_older_backlog_decodes_a_real_second_page(tmp_path) -> Non
                 ChatMessage(role="assistant", content=f"reply {i}", meta={"chain_id": cid})
             )
 
-        page1_frames, has_more1, cursor1 = session_backlog_page(reg, "alpha", _DEFAULT_SID)
+        page1_frames, has_more1, cursor1 = await session_backlog_page(reg, "alpha", _DEFAULT_SID)
         assert has_more1 is True, "test setup must force a real page split"
         assert cursor1 is not None
 
         async def _send(payload: dict) -> dict:
             assert payload["type"] == "load_older_backlog_request"
             assert payload["before_root_id"] == cursor1
-            page2_frames, has_more2, cursor2 = session_backlog_page(
+            page2_frames, has_more2, cursor2 = await session_backlog_page(
                 reg, "alpha", _DEFAULT_SID, before_root_id=payload["before_root_id"],
             )
             event = encode_messages_snapshot(page2_frames, has_more=has_more2, next_cursor=cursor2)
@@ -122,9 +144,66 @@ async def test_request_older_backlog_decodes_a_real_second_page(tmp_path) -> Non
         assert len(item.frames) > 0
         # Content parity: the SAME messages session_backlog_page's own page 2
         # produced, decoded back out the other side of the wire.
-        page2_frames, _, _ = session_backlog_page(reg, "alpha", _DEFAULT_SID, before_root_id=cursor1)
+        page2_frames, _, _ = await session_backlog_page(reg, "alpha", _DEFAULT_SID, before_root_id=cursor1)
         expected_texts = [f.message.text for f in page2_frames]
         got_texts = [f.message.text for f in item.frames]
         assert got_texts == expected_texts
+    finally:
+        await reg.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_has_more_extends_from_disk_past_the_in_memory_tail(tmp_path) -> None:
+    """Tier 2: acceptance⑤ (architect blocking finding on this PR,
+    issuecomment-5384101336) — ``target.history`` is only ``Session.
+    load_history()``'s own bounded STARTUP tail (#4387 Phase B ①,
+    "WITHOUT necessarily reading the whole (potentially huge) file"), not
+    the whole conversation. A page that reaches the front of that
+    in-memory tail must not report ``has_more=False`` ("the true start")
+    while MORE genuinely sits on disk — that would silently truncate
+    (the client shows "no more" and stops asking).
+
+    A short fixture would not tell this apart from the OLD (pre-fix)
+    behavior — both would happen to reach the true start on the FIRST in-
+    memory pass. This test deliberately bounds ``session.history`` to a
+    tiny in-memory tail (2 entries) while the REAL on-disk
+    ``history.jsonl`` (written via ``Session._append_history``, the same
+    seam ``test_4387_tui_paging_extends_from_disk.py`` uses) carries many
+    more turns, so a page that never extends from disk would silently
+    return a subset — not the genuinely-full conversation this test
+    compares against."""
+    reg = _registry_with_disk_history(tmp_path)
+    try:
+        await reg.attach("alpha")
+        session = reg.get_session("alpha", _DEFAULT_SID)
+        assert session is not None
+        for i in range(10):
+            session._append_history(ChatMessage(role="user", content=f"question {i}"))  # noqa: SLF001 - real durable-write seam, same as test_4387's own helper
+            session._append_history(ChatMessage(role="assistant", content=f"answer {i}"))  # noqa: SLF001
+        full_log = list(session.history)
+        session.history = session.history[-2:]  # bounded in-memory tail (#4387 Phase B ①)
+        assert len(session.history) < len(full_log), (
+            "test setup must genuinely bound the in-memory tail below the "
+            "full durable log, or there is nothing on disk left to extend "
+            "into — this would make the test vacuous"
+        )
+
+        frames, has_more, next_cursor = await session_backlog_page(reg, "alpha", _DEFAULT_SID)
+
+        assert has_more is False, (
+            "the TRUE start of history.jsonl was actually reached (all 10 "
+            "turns fit well under HYDRATE_PAGE_FRAMES) — has_more must "
+            "report False here, not just when the in-memory tail runs out"
+        )
+        assert next_cursor is None
+        from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
+
+        expected_texts = [f.text for f in project_restored_frames(full_log)]
+        got_texts = [f.message.text for f in frames]
+        assert got_texts == expected_texts, (
+            f"expected the FULL durable log ({len(expected_texts)} frames), "
+            f"not just the bounded in-memory tail — got {len(got_texts)} "
+            f"frames: {got_texts!r}"
+        )
     finally:
         await reg.shutdown()

--- a/tests/interfaces/test_5139c_page_restored_history.py
+++ b/tests/interfaces/test_5139c_page_restored_history.py
@@ -1,0 +1,153 @@
+"""Tier 1: #5139 C — ``page_restored_history`` bounds a remote backlog page
+without ever cutting a turn (``chain_id``-correlated run) in half.
+
+Root motivation (architect ruling, issuecomment-5383993909): a plain
+tail-N slice by MESSAGE would risk landing between an assistant's
+tool_calls message and its tool result — silently degrading the
+projection's own call/result correlation (``project_restored_frames``'s
+``calls_by_id`` is built from whatever slice is handed to it; a message
+outside that slice simply never contributes). ``page_restored_history``
+instead cuts only at a turn (``chain_id``) boundary, so a page's own
+message slice is always a union of WHOLE turns.
+
+Real ``ChatMessage``/``project_restored_frames`` throughout — no mocks;
+these are pure, session-independent functions."""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat._meta_keys import RESULT_KIND_KEY
+from reyn.interfaces.inline.textual_chat.restore import (
+    RESUME_DIVIDER,
+    page_restored_history,
+)
+from reyn.runtime.chat_message import ChatMessage
+
+
+def _turn_plain(chain_id: str, user_text: str, agent_text: str) -> "list[ChatMessage]":
+    """A 2-message turn: no tool call, just user + assistant reply."""
+    return [
+        ChatMessage(role="user", content=user_text, meta={"chain_id": chain_id}),
+        ChatMessage(role="assistant", content=agent_text, meta={"chain_id": chain_id}),
+    ]
+
+
+def _turn_with_tool_call(chain_id: str, tool_call_id: str) -> "list[ChatMessage]":
+    """A 2-message turn: an assistant tool_calls message + its tool result —
+    the exact pair whose correlation a mid-turn cut would silently break."""
+    return [
+        ChatMessage(
+            role="assistant",
+            content="",
+            meta={"chain_id": chain_id},
+            tool_calls=[
+                {"id": tool_call_id, "function": {"name": "search", "arguments": "{}"}}
+            ],
+        ),
+        ChatMessage(
+            role="tool",
+            content="3 results found",
+            tool_call_id=tool_call_id,
+            meta={"chain_id": chain_id},
+        ),
+    ]
+
+
+def test_a_small_limit_never_splits_a_tool_call_from_its_result() -> None:
+    """Tier 1: the turn boundary is a chain_id, not a message count — a
+    ``limit`` set BELOW a single turn's own frame count must still return
+    that turn whole, with the call/result correlation intact (never the
+    degraded "uncorrelated result, tool name only" shape
+    ``project_restored_frames`` falls back to when the assistant's own
+    tool_calls message is missing from the slice)."""
+    history = [
+        *_turn_plain("c1", "hi", "hello"),
+        *_turn_with_tool_call("c2", "tc-1"),
+    ]
+    # limit=1 is deliberately smaller than turn c2's own 1 projected frame
+    # (the tool call+result coalesce into ONE OutboxMessage) — forces the
+    # windowing loop to accept an "overshoot" rather than split the group.
+    frames, has_more, next_cursor = page_restored_history(history, limit=1)
+
+    # Tuple-unpacking IS the "exactly one" check (raises on 0 or 2+
+    # matches) — a behavioral assertion on the extracted value, not a
+    # ``len(...) == N`` format pin.
+    (tool_frame,) = [f for f in frames if f.kind == "tool_call_started"]
+    assert tool_frame.meta.get("tool") == "search", (
+        f"tool call must stay correlated (tool name resolved from the "
+        f"assistant's own tool_calls entry) even under a tight limit — "
+        f"got meta={tool_frame.meta!r}"
+    )
+    assert tool_frame.meta.get(RESULT_KIND_KEY) != "tool_call_failed"
+
+
+def test_has_more_and_next_cursor_walk_backward_across_pages() -> None:
+    """Tier 1: 3 turns, a limit that forces exactly 2 pages: page 1
+    (newest, ``before_root_id=None``) carries the newest turn(s) and
+    reports ``has_more=True`` with the older turn's own chain_id as
+    ``next_cursor``; page 2 (``before_root_id=<that cursor>``) carries
+    the remainder and reports ``has_more=False, next_cursor=None`` —
+    the "reached the true start" signal."""
+    history = [
+        *_turn_plain("c1", "first", "first reply"),
+        *_turn_plain("c2", "second", "second reply"),
+        *_turn_plain("c3", "third", "third reply"),
+    ]
+    # Each plain turn projects to 2 frames (user + agent); limit=2 should
+    # take exactly the newest turn (c3) as page 1.
+    page1, has_more1, cursor1 = page_restored_history(history, limit=2)
+    page1_texts = [f.text for f in page1 if f.kind in ("user", "agent")]
+    assert page1_texts == ["third", "third reply"], page1_texts
+    assert has_more1 is True
+    # ``next_cursor`` is THIS page's own oldest turn's id (c3) — the value
+    # the NEXT call passes back as ``before_root_id`` to exclude exactly
+    # what was already sent and continue strictly older, never that
+    # turn's own predecessor id (a caller never has to guess an offset).
+    assert cursor1 == "c3", f"next_cursor must be THIS page's own oldest turn id, got {cursor1!r}"
+
+    page2, has_more2, cursor2 = page_restored_history(
+        history, before_root_id=cursor1, limit=2,
+    )
+    page2_texts = [f.text for f in page2 if f.kind in ("user", "agent")]
+    assert page2_texts == ["second", "second reply"], page2_texts
+    assert has_more2 is True
+    assert cursor2 == "c2"
+
+    page3, has_more3, cursor3 = page_restored_history(
+        history, before_root_id=cursor2, limit=2,
+    )
+    page3_texts = [f.text for f in page3 if f.kind in ("user", "agent")]
+    assert page3_texts == ["first", "first reply"], page3_texts
+    assert has_more3 is False, "the true start must report has_more=False"
+    assert cursor3 is None, "has_more=False must carry next_cursor=None"
+
+
+def test_a_stale_cursor_degrades_to_nothing_more_not_a_resend() -> None:
+    """Tier 1: a ``before_root_id`` naming a turn no longer present in
+    *history* (rotated out between the caller's own two calls) must
+    answer "nothing more" — never silently re-serve the newest page,
+    which would look like NEW history to a caller that asked for
+    strictly OLDER content."""
+    history = [*_turn_plain("c1", "hi", "hello")]
+    frames, has_more, next_cursor = page_restored_history(
+        history, before_root_id="does-not-exist", limit=200,
+    )
+    assert frames == []
+    assert has_more is False
+    assert next_cursor is None
+
+
+def test_only_the_newest_page_carries_the_resume_divider() -> None:
+    """Tier 1: ``project_restored_frames`` unconditionally prepends ONE
+    resume divider to any non-empty projection — correct for the newest
+    page (what a client shows first) and a would-be DUPLICATE on every
+    older page this function projects independently per call."""
+    history = [
+        *_turn_plain("c1", "first", "first reply"),
+        *_turn_plain("c2", "second", "second reply"),
+    ]
+    newest, _, cursor = page_restored_history(history, limit=2)
+    assert newest[0].kind == "system" and newest[0].text == RESUME_DIVIDER
+
+    older, _, _ = page_restored_history(history, before_root_id=cursor, limit=2)
+    assert all(f.text != RESUME_DIVIDER for f in older), (
+        f"an OLDER page must not carry a second divider — got {older!r}"
+    )

--- a/tests/interfaces/test_5139c_remote_reached_top_pull.py
+++ b/tests/interfaces/test_5139c_remote_reached_top_pull.py
@@ -1,0 +1,183 @@
+"""Tier 2: #5139 C — a REMOTE session's ``FlowView.ReachedTop`` pulls the
+next-older backlog page over the wire instead of being a permanent no-op
+(the pre-#5139 C shape: ``RemoteReadModel.load_older_conversation_history``
+always returns 0, and local's own on-disk page-in path
+(:meth:`TextualChatApp._extend_older_frames_from_disk`) has nothing to
+extend for a remote session, so ``on_flow_view_reached_top`` silently did
+nothing past the initial bounded backlog).
+
+Root cause this closes (architect ruling, issuecomment-5383993909): a
+bounded initial/switch backlog (:data:`~reyn.interfaces.transport.frames.
+HYDRATE_PAGE_FRAMES`) is correct for the wire-send-amount half of #5139,
+but WITHOUT a continuation path it silently drops every turn older than
+that one page for a remote client — a real feature loss local restore
+does not have (:meth:`TextualChatApp.on_flow_view_reached_top`'s own
+local page-in). This file covers the CLIENT-DRIVEN pull half: the older
+page arrives as a second :class:`~reyn.interfaces.transport.frames.
+BacklogBatch` (``is_older_page=True``) through the SAME ``frames()``
+stream the initial one did, and is PREPENDED (never appended).
+
+Real ``TextualChatApp`` + a real, minimal ``ClientTransport`` (built on
+``ClientTransportStub``, queue-backed so :meth:`request_older_backlog`
+can genuinely push a second item onto the SAME stream
+``_pump_frames`` is still reading from) — no mocks. ``FlowView.ReachedTop``
+is fired by REAL scrolling (``flow.scroll_to_top()``), mirroring
+``test_4387_tui_paging_extends_from_disk.py``'s own established pattern,
+not a direct handler call.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame, Frame
+from reyn.runtime.outbox import OutboxMessage
+
+_APP_DEFAULT_AGENT = "default"
+_APP_DEFAULT_SID = "main"
+
+
+class _PagingTransport(ClientTransportStub):
+    """A real, minimal ``ClientTransport`` whose :meth:`frames` is a
+    genuinely LIVE queue (mirrors ``AgUiTransport``'s own architecture) so
+    :meth:`request_older_backlog` can push a SECOND item onto the exact
+    same stream :meth:`frames` is still being read from — never a
+    separate/second channel."""
+
+    def __init__(
+        self,
+        initial_batch: "BacklogBatch",
+        *,
+        older_batch: "BacklogBatch | None" = None,
+    ) -> None:
+        self._queue: "asyncio.Queue[Frame | BacklogBatch]" = asyncio.Queue()
+        self._queue.put_nowait(initial_batch)
+        self._older_batch = older_batch
+        self.pull_calls: "list[str]" = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[Frame | BacklogBatch]":
+        while True:
+            yield await self._queue.get()
+
+    async def request_older_backlog(self, before_root_id: str) -> None:
+        self.pull_calls.append(before_root_id)
+        if self._older_batch is not None:
+            self._queue.put_nowait(self._older_batch)
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(self, text: str, **_kw) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str, **_kw) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> str:  # pragma: no cover - trivial
+        return ""
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _batch(text: str, *, has_more: bool, next_cursor: "str | None", is_older_page: bool = False) -> "BacklogBatch":
+    return BacklogBatch(
+        agent=_APP_DEFAULT_AGENT,
+        sid=_APP_DEFAULT_SID,
+        frames=[DisplayFrame(OutboxMessage(kind="agent", text=text))],
+        has_more=has_more,
+        next_cursor=next_cursor,
+        is_older_page=is_older_page,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reached_top_pulls_the_next_older_page_and_prepends_it() -> None:
+    """Tier 2: acceptance② — reaching the top pulls the NEXT-older page
+    (the cursor the INITIAL batch itself carried) and PREPENDS it, never
+    appends (the entry must land ABOVE the initial batch's own entry, not
+    below it — an append would put "older" content after "newer",
+    silently inverting scrollback order)."""
+    initial = _batch("newest turn", has_more=True, next_cursor="turn-c1")
+    older = _batch("older turn", has_more=False, next_cursor=None, is_older_page=True)
+    transport = _PagingTransport(initial, older_batch=older)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        flow = app.query_one(FlowView)
+        for _ in range(4):
+            flow.scroll_to_top()
+            await pilot.pause()
+            await pilot.pause()
+            if transport.pull_calls:
+                break
+
+        assert transport.pull_calls == ["turn-c1"], (
+            f"expected exactly one pull for the initial batch's own cursor, "
+            f"got {transport.pull_calls!r}"
+        )
+        await pilot.pause()
+        await pilot.pause()
+        texts = [e.item.text for e in app.conversation.entries]
+
+    assert "older turn" in texts and "newest turn" in texts, texts
+    assert texts.index("older turn") < texts.index("newest turn"), (
+        f"the older page must PREPEND (render ABOVE the initial batch's "
+        f"own entry), never append — got order {texts!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_has_more_false_means_reaching_top_pulls_nothing() -> None:
+    """Tier 2: acceptance④ — ``has_more=False`` (the true start already
+    reached, or nothing ever received) must be a hard "no more", never a
+    request for a page that does not exist — even with a (malformed/
+    lingering) non-``None`` cursor still present, so this isolates the
+    ``has_more`` guard itself rather than piggy-backing on
+    ``next_cursor is None`` alone (production never pairs the two this
+    way, but the guard's OWN authority is what this test is for). Strip-
+    falsifier: replacing the ``self._remote_backlog_has_more`` guard in
+    ``on_flow_view_reached_top`` with a bare ``True`` turns this red — a
+    pull fires despite ``has_more=False`` (verified locally)."""
+    initial = _batch("only turn", has_more=False, next_cursor="stale-cursor-should-be-ignored")
+    transport = _PagingTransport(initial)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        flow = app.query_one(FlowView)
+        for _ in range(4):
+            flow.scroll_to_top()
+            await pilot.pause()
+            await pilot.pause()
+
+    assert transport.pull_calls == [], (
+        f"has_more=False must never trigger a pull — got {transport.pull_calls!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5139. Architect ruling (issuecomment-5383993909), implemented as designed — see that comment for the full form/acceptance derivation.

## Why cursor, not just a limit

A plain tail-N cap on the remote backlog would bound the wire send, but silently make remote strictly WEAKER than local: local already has scrollback-top lazy paging (`on_flow_view_reached_top` → `_extend_older_frames_from_disk`, #3476/#4387), so a limit-only remote fix would make everything older than N permanently unreachable on a remote client — exactly the axis reyn already carries multiple parity witnesses for. Cursor pagination closes that gap.

## Shape (architect's own 5 points)

1. Server sends **at most one page** (`HYDRATE_PAGE_FRAMES`, re-exported from `frames.py` so local and remote share the same number — never two that could drift) per `MESSAGES_SNAPSHOT`, whether that's the initial connect, a switch re-fire, or an older-page pull.
2. Continuation is **client-pull only** (`FlowView.ReachedTop`, already wired locally) — never a second server-initiated push.
3. The cursor is a **turn root id** (`chain_id`), never a message's own `seq` — a mid-turn cut would silently break tool call/result correlation, group parenting, and sticky state. `page_restored_history` (new, `restore.py`) cuts only at a `chain_id` boundary.
4. `N` reuses `HYDRATE_PAGE_FRAMES` (200) — not invented.
5. Carried in `BacklogBatch` (#5148) — `has_more` + `next_cursor` added to it and to the wire `MessagesSnapshot`/`encode_messages_snapshot`, no new wire vocabulary.

## What's new

- `page_restored_history` (restore.py): turn-boundary-safe windowing + divider dedup (an older page must not repeat the resume divider) + stale-cursor → "nothing more" (never a resend).
- `session_backlog_page` (endpoint.py): the bounded counterpart to `session_backlog_frames` (kept unbounded — still the test oracle 5 existing test files depend on).
- New POST type `load_older_backlog_request`, mirrors `session_list_request`'s own shape; reuses `encode_messages_snapshot`'s exact payload — the client decodes it through the SAME `decode_event`/`MessagesSnapshot` path a live reconnect already uses.
- `AgUiTransport.request_older_backlog`: POST + decode, pushes a `BacklogBatch(is_older_page=True)` onto the SAME internal queue `frames()` reads from (mirrors `put_display`'s established pattern) — no second delivery path.
- `ClientTransport.request_older_backlog`: new abstract op (6th of its kind, mirrors `request_session_list`). `InProcessTransport`/`session_bound.py` are no-ops (local paging goes through `ChatReadModel` instead); `threaded.py`/`dispatch.py` proxy through.
- `TextualChatApp._apply_backlog_batch`: branches on `is_older_page` — PREPEND (`insert_many(0, …)`) vs the existing append (`extend`), and does NOT seed the `/copy` ring for an older page-in (mirrors local's own `on_flow_view_reached_top`, which doesn't either — a self-caught bug during implementation, see commit history).
- `on_flow_view_reached_top`: falls through to the remote pull when local extend has nothing, guarded by `has_more`/an in-flight flag (no duplicate overlapping pulls).
- `docs/reference/runtime/agui-transport.{md,ja.md}`: the Reconnect section previously described the backlog as unbounded — fixed in this same PR (CLAUDE.md hard rule).

## Strip-verify (genuine, not claimed)

- Chain-boundary safety: naive per-message grouping → tool correlation degrades (`tool: None` instead of `"search"`) — confirmed RED, restored GREEN.
- `has_more=False` guard: replacing it with `True` → a pull fires despite a (deliberately) lingering stale cursor — confirmed RED, restored GREEN.
- Prepend-vs-append: forcing `extend` for `is_older_page=True` → order assertion flips — confirmed RED, restored GREEN.
- `has_more`/`next_cursor` wire decode: reverting `decode_event`'s `messages` branch to the pre-#5139-C shape → a 3-page fixture's page-2 assertion flips (a 2-page fixture did NOT flip red first try — a vacuous-witness self-catch, fixed before landing).

252 existing interface tests + 7 new ones green (`ruff`, `test_tier_audit.py --strict`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `verify_module_docstrings.py`, `mkdocs build --strict`, `check_doc_anchors.py`, `check_retired_config_keys_denylist.py` all clean).

## Test plan

- [x] `page_restored_history` unit tests (chain-boundary safety, has_more/cursor walk, stale cursor, divider dedup) — strip-verified
- [x] App-side `ReachedTop` → remote pull → prepend wiring, real `TextualChatApp` + queue-backed fixture transport — strip-verified
- [x] Real server-page → real encode → real client-decode round-trip (3-page synthetic history) — strip-verified
- [x] All 5 pre-existing tests whose `backlog_provider` contract changed shape, updated and re-verified green
- [ ] (Visual — standing waiver, owner 2026-08-08) actual scroll-to-top-and-back visual smoothness on a live TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[architect]** — TESTS-READ（**A: 設計適合**、head `81198ab2ed`）issuecomment。①〜⑤ は入っています。B は別の人が必要です。

- [x] 🔴 (解消 `7acabc25c`, architect 確認 issuecomment-5384131966) `has_more=False` が「履歴の先頭」ではなく「**起動時に読み込んだ tail の先頭**」を意味している（`endpoint.py:411` は `list(target.history)` を母集団にする / `load_history` は逐語「WITHOUT necessarily reading the whole (potentially huge — owner's real environment measured 500MB) file」）。client には区別できず「もう無い」と表示される＝**静かな切り詰め**。**A: tail 枯渇時に `extend_history_backward`（session.py:3947、既存）へ繋ぐ / B: `has_more=False` を使わず「この接続ではこれ以上遡れない」を別値で表す** のどちらか。受入⑤（長い history で上端まで遡る）を追加

