### PR TITLE
fix(#5173): #1199 write-gate carve-out never followed .reyn/approvals.jsonl

### DIFF
--- a/src/reyn/api/safe/file.py
+++ b/src/reyn/api/safe/file.py
@@ -124,7 +124,15 @@ def _canonical_protected_write_paths() -> "tuple[str, ...]":
     #5153/#5170 moved the live approval store to the append-only
     ``.reyn/approvals.jsonl`` ledger; #5173 found this carve-out never
     followed. ``approvals.yaml`` stays listed too (still read as the
-    one-time migration source)."""
+    one-time migration source).
+
+    LOAD-BEARING (architect co-vet, broker, #5175 2026-08-23T04:55Z):
+    "optimizing" this back to a module-level tuple silently disables
+    ``test_renaming_the_ledger_moves_both_carve_outs_with_it`` — the
+    monkeypatch it relies on stops reaching this function's own read the
+    moment the value is captured once at import time instead of read live.
+    That test is currently the ONLY thing that would catch a regression
+    back to a frozen tuple."""
     return (
         ".reyn/approvals.yaml",
         approval_ledger.RELATIVE_PATH,

--- a/src/reyn/api/safe/file.py
+++ b/src/reyn/api/safe/file.py
@@ -60,14 +60,12 @@ import os as _os
 import tempfile as _tempfile
 from typing import IO, Any
 
-# #5173: import the ledger's canonical relative path rather than re-typing
-# it — ``approval_ledger.py`` has zero reyn-internal imports, so this
-# subprocess-safe module can import just this constant even though it
-# cannot import the rest of ``security.permissions`` (see
-# ``_CANONICAL_PROTECTED_WRITE_PATHS`` below).
-from reyn.security.permissions.approval_ledger import (
-    RELATIVE_PATH as _APPROVAL_LEDGER_RELATIVE_PATH,
-)
+# #5173: import the MODULE (not a copied value) so a rename of
+# ``approval_ledger.RELATIVE_PATH`` is visible here on every call, not just
+# frozen at this file's own import time — see
+# ``_canonical_protected_write_paths`` below for why that distinction is the
+# actual fix, not a style choice.
+from reyn.security.permissions import approval_ledger
 
 # ── Internal state ─────────────────────────────────────────────────────────
 #
@@ -114,22 +112,23 @@ _RECOVERY_CORE_WRITE_PREFIXES = (
     ".reyn/state/",
 )
 
-_CANONICAL_PROTECTED_WRITE_PATHS = (
-    # #5153/#5170 moved the live approval store to the append-only
-    # ``.reyn/approvals.jsonl`` ledger; #5173 found this carve-out never
-    # followed — see the sibling copy's comment in ``permissions.py`` for
-    # the full bypass-class rationale. ``approvals.yaml`` stays listed (still
-    # read as the one-time migration source).
-    #
-    # The jsonl entry is the IMPORTED constant (``approval_ledger.py`` has
-    # zero reyn-internal imports, so this subprocess-safe module CAN import
-    # just that constant even though it cannot import the rest of the
-    # ``security.permissions`` package) — not a re-typed literal. #5173's own
-    # root cause was a hand-typed copy silently drifting from the live path;
-    # a shared constant cannot drift from itself.
-    ".reyn/approvals.yaml",
-    _APPROVAL_LEDGER_RELATIVE_PATH,
-)
+def _canonical_protected_write_paths() -> "tuple[str, ...]":
+    """The #571/#1199 canonical protected-write paths — mirrors
+    ``permissions.py``'s function of the same name; see that one's
+    docstring for why this is a FUNCTION reading ``approval_ledger.
+    RELATIVE_PATH`` live on every call rather than a module-level tuple
+    built once (#5173: a frozen tuple built from an imported *value* does
+    not follow a later rename of the constant it was built from — a live
+    module-attribute read does).
+
+    #5153/#5170 moved the live approval store to the append-only
+    ``.reyn/approvals.jsonl`` ledger; #5173 found this carve-out never
+    followed. ``approvals.yaml`` stays listed too (still read as the
+    one-time migration source)."""
+    return (
+        ".reyn/approvals.yaml",
+        approval_ledger.RELATIVE_PATH,
+    )
 
 
 def _set_permission_context(
@@ -248,7 +247,7 @@ def _is_canonical_protected_write(path: str) -> bool:
     """
     abs_path = _os.path.realpath(path)
     root = _project_root_for_gate()
-    for rel in _CANONICAL_PROTECTED_WRITE_PATHS:
+    for rel in _canonical_protected_write_paths():
         if abs_path == _os.path.realpath(_os.path.join(root, rel)):
             return True
     return False

--- a/src/reyn/api/safe/file.py
+++ b/src/reyn/api/safe/file.py
@@ -60,6 +60,15 @@ import os as _os
 import tempfile as _tempfile
 from typing import IO, Any
 
+# #5173: import the ledger's canonical relative path rather than re-typing
+# it — ``approval_ledger.py`` has zero reyn-internal imports, so this
+# subprocess-safe module can import just this constant even though it
+# cannot import the rest of ``security.permissions`` (see
+# ``_CANONICAL_PROTECTED_WRITE_PATHS`` below).
+from reyn.security.permissions.approval_ledger import (
+    RELATIVE_PATH as _APPROVAL_LEDGER_RELATIVE_PATH,
+)
+
 # ── Internal state ─────────────────────────────────────────────────────────
 #
 # These three module-globals are set once at python harness start-up via
@@ -106,7 +115,20 @@ _RECOVERY_CORE_WRITE_PREFIXES = (
 )
 
 _CANONICAL_PROTECTED_WRITE_PATHS = (
+    # #5153/#5170 moved the live approval store to the append-only
+    # ``.reyn/approvals.jsonl`` ledger; #5173 found this carve-out never
+    # followed — see the sibling copy's comment in ``permissions.py`` for
+    # the full bypass-class rationale. ``approvals.yaml`` stays listed (still
+    # read as the one-time migration source).
+    #
+    # The jsonl entry is the IMPORTED constant (``approval_ledger.py`` has
+    # zero reyn-internal imports, so this subprocess-safe module CAN import
+    # just that constant even though it cannot import the rest of the
+    # ``security.permissions`` package) — not a re-typed literal. #5173's own
+    # root cause was a hand-typed copy silently drifting from the live path;
+    # a shared constant cannot drift from itself.
     ".reyn/approvals.yaml",
+    _APPROVAL_LEDGER_RELATIVE_PATH,
 )
 
 

--- a/src/reyn/interfaces/cli/commands/permissions.py
+++ b/src/reyn/interfaces/cli/commands/permissions.py
@@ -46,8 +46,14 @@ def register(sub) -> None:
 
 
 def _ledger_path() -> Path:
+    # #5173: derived from the SAME constant PermissionResolver and the #1199
+    # write-gate carve-out use — a re-typed literal here is a 4th copy of the
+    # live path that could silently drift from the two the carve-out actually
+    # checks (exactly the class of gap #5173 found).
+    from reyn.security.permissions.approval_ledger import RELATIVE_PATH
+
     project_root = _find_project_root(Path.cwd()) or Path.cwd()
-    return project_root / ".reyn" / "approvals.jsonl"
+    return project_root / Path(RELATIVE_PATH)
 
 
 def _legacy_snapshot_path() -> Path:

--- a/src/reyn/interfaces/web/routers/permissions.py
+++ b/src/reyn/interfaces/web/routers/permissions.py
@@ -43,7 +43,13 @@ _SURFACE = "web"
 
 
 def _ledger_path(project_root: Path) -> Path:
-    return project_root / ".reyn" / "approvals.jsonl"
+    # #5173: derived from the SAME constant PermissionResolver and the #1199
+    # write-gate carve-out use — a re-typed literal here is a 3rd copy of the
+    # live path that could silently drift from the two the carve-out actually
+    # checks (exactly the class of gap #5173 found).
+    from reyn.security.permissions.approval_ledger import RELATIVE_PATH
+
+    return project_root / Path(RELATIVE_PATH)
 
 
 def _legacy_snapshot_path(project_root: Path) -> Path:

--- a/src/reyn/security/permissions/approval_ledger.py
+++ b/src/reyn/security/permissions/approval_ledger.py
@@ -93,6 +93,24 @@ import time
 from pathlib import Path
 from typing import Any
 
+#: Canonical project-relative path to the ledger file — the ONE name every
+#: other module builds a Path from: ``PermissionResolver.__init__``, and (#5173)
+#: the #1199 write-gate carve-out's ``_CANONICAL_PROTECTED_WRITE_PATHS`` in
+#: BOTH its copies (``security/permissions/permissions.py`` and
+#: ``api/safe/file.py`` — the latter imports this constant directly rather than
+#: re-typing it; it cannot import the rest of this security package's parent
+#: module, but this module has zero reyn-internal imports, so it is safe to).
+#:
+#: This constant is the fix for the actual root cause #5173 found: when
+#: persistence moved off ``approvals.yaml`` (#5153/#5170), the write-gate
+#: carve-out — a hand-typed literal at each of 2 use sites — silently did not
+#: follow, reopening #1199's own approval-injection bypass against the new
+#: live file. A literal can drift from what it names; a single constant that
+#: every dependent site imports cannot — renaming the ledger means changing
+#: this ONE line, and every dependent site (the resolver's own path AND the
+#: write-gate that protects it) moves together by construction.
+RELATIVE_PATH = ".reyn/approvals.jsonl"
+
 
 class ApprovalLedger:
     """Append-only JSONL ledger for one project's permission-approval

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -131,6 +131,14 @@ def _canonical_protected_write_paths() -> "tuple[str, ...]":
     than merely true today. See
     ``test_renaming_the_ledger_moves_both_carve_outs_with_it`` for the
     monkeypatch-based witness.
+
+    LOAD-BEARING (architect co-vet, broker, #5175 2026-08-23T04:55Z): "optimizing" this
+    back to a module-level tuple silently disables that witness — the
+    monkeypatch it relies on stops reaching this function's own read the
+    moment the value is captured once at import time instead of read live.
+    That test is currently the ONLY thing that would catch a regression
+    back to a frozen tuple — CLAUDE.md's "who stops this if it repeats?"
+    question has exactly one answer here, and this note names it.
     """
     from reyn.security.permissions import approval_ledger
 

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -42,6 +42,9 @@ from reyn.intervention_choices import (
     file_access_choices,
     generic_yn_choices,
 )
+from reyn.security.permissions.approval_ledger import (
+    RELATIVE_PATH as _APPROVAL_LEDGER_RELATIVE_PATH,
+)
 from reyn.user_intervention import (
     RequestBus,
     UserIntervention,
@@ -105,7 +108,23 @@ _CANONICAL_PROTECTED_WRITE_PATHS = (
     # user-approval gate + the audit, and (since approvals load once into
     # ``self._saved`` at startup) silently activating a never-approved grant on the
     # NEXT run = approval-audit bypass.
+    #
+    # #5153/#5170 moved the LIVE store from this snapshot to the append-only
+    # ``.reyn/approvals.jsonl`` ledger (``ApprovalLedger`` — see
+    # ``approval_ledger.py``) — #5173 found the carve-out was never updated to
+    # follow: a safe-mode write could append a fake ``{"kind": "approval", ...,
+    # "approved": true}`` record directly, the EXACT SAME bypass class #1199
+    # closed, reopened against the new file. ``approvals.yaml`` itself stays
+    # listed too — it is still read (one-time migration source,
+    # ``migrate_legacy_snapshot``) and a legacy tree may still carry it.
+    #
+    # The jsonl entry is the IMPORTED constant, not a re-typed literal (#5173's
+    # own root cause: a hand-typed copy of the live path is exactly what fell
+    # silently out of sync with it last time). Renaming the ledger means
+    # changing ``approval_ledger.RELATIVE_PATH`` once; this entry — and
+    # ``self._approval_ledger_path`` below — follow automatically.
     ".reyn/approvals.yaml",
+    _APPROVAL_LEDGER_RELATIVE_PATH,
 )
 
 
@@ -463,7 +482,7 @@ class PermissionResolver:
         # each needing momentary ownership of the WHOLE snapshot file to
         # change even one key was the root cause of a lost approval under
         # concurrent access).
-        self._approval_ledger_path = self._project_root / ".reyn" / "approvals.jsonl"
+        self._approval_ledger_path = self._project_root / Path(_APPROVAL_LEDGER_RELATIVE_PATH)
         self._session: dict[str, bool] = {}
         # #3671 P4 item D-1: lazy — disk read + YAML parse deferred to the
         # `_saved` property's first access, not paid on every PermissionResolver
@@ -608,6 +627,15 @@ class PermissionResolver:
         real in-use count is observable without reaching into private
         state."""
         return len(self._bound_fds)
+
+    @property
+    def approval_ledger_path(self) -> Path:
+        """#5173: the resolved path this resolver's :class:`ApprovalLedger`
+        reads/writes — public so a caller (or a test asserting the write-gate
+        carve-out actually covers the LIVE file, not a hand-picked string
+        that could silently drift from it) can read it without reaching into
+        ``self._approval_ledger_path`` directly."""
+        return self._approval_ledger_path
 
     def on_persist_callback_count(self) -> int:
         """Return the number of registered ``on_persist`` callbacks.

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -42,9 +42,7 @@ from reyn.intervention_choices import (
     file_access_choices,
     generic_yn_choices,
 )
-from reyn.security.permissions.approval_ledger import (
-    RELATIVE_PATH as _APPROVAL_LEDGER_RELATIVE_PATH,
-)
+from reyn.security.permissions import approval_ledger
 from reyn.user_intervention import (
     RequestBus,
     UserIntervention,
@@ -99,33 +97,47 @@ _RECOVERY_CORE_WRITE_PREFIXES = (
     ".reyn/state/",
 )
 
-_CANONICAL_PROTECTED_WRITE_PATHS = (
-    # #1199 security fix: the persisted approval store. It is written ONLY via
-    # the gated approval-decision mechanism (``_persist`` — which also emits the
-    # state_change audit signal). It is TOP-LEVEL (persist, #2248 A2-cont — not under
-    # the config/ recovery-core prefix), so it needs this explicit carve-out: without
-    # it a safe-mode file.write could inject an approval directly, bypassing the
-    # user-approval gate + the audit, and (since approvals load once into
-    # ``self._saved`` at startup) silently activating a never-approved grant on the
-    # NEXT run = approval-audit bypass.
-    #
-    # #5153/#5170 moved the LIVE store from this snapshot to the append-only
-    # ``.reyn/approvals.jsonl`` ledger (``ApprovalLedger`` — see
-    # ``approval_ledger.py``) — #5173 found the carve-out was never updated to
-    # follow: a safe-mode write could append a fake ``{"kind": "approval", ...,
-    # "approved": true}`` record directly, the EXACT SAME bypass class #1199
-    # closed, reopened against the new file. ``approvals.yaml`` itself stays
-    # listed too — it is still read (one-time migration source,
-    # ``migrate_legacy_snapshot``) and a legacy tree may still carry it.
-    #
-    # The jsonl entry is the IMPORTED constant, not a re-typed literal (#5173's
-    # own root cause: a hand-typed copy of the live path is exactly what fell
-    # silently out of sync with it last time). Renaming the ledger means
-    # changing ``approval_ledger.RELATIVE_PATH`` once; this entry — and
-    # ``self._approval_ledger_path`` below — follow automatically.
-    ".reyn/approvals.yaml",
-    _APPROVAL_LEDGER_RELATIVE_PATH,
-)
+def _canonical_protected_write_paths() -> "tuple[str, ...]":
+    """The #571/#1199 canonical protected-write paths.
+
+    #1199 security fix: the persisted approval store. It is written ONLY via
+    the gated approval-decision mechanism (``_persist`` — which also emits
+    the state_change audit signal). It is TOP-LEVEL (persist, #2248 A2-cont
+    — not under the config/ recovery-core prefix), so it needs this explicit
+    carve-out: without it a safe-mode file.write could inject an approval
+    directly, bypassing the user-approval gate + the audit, and (since
+    approvals load once into ``self._saved`` at startup) silently activating
+    a never-approved grant on the NEXT run = approval-audit bypass.
+
+    #5153/#5170 moved the LIVE store from this snapshot to the append-only
+    ``.reyn/approvals.jsonl`` ledger (``ApprovalLedger`` — see
+    ``approval_ledger.py``) — #5173 found the carve-out was never updated to
+    follow: a safe-mode write could append a fake ``{"kind": "approval", ...,
+    "approved": true}`` record directly, the EXACT SAME bypass class #1199
+    closed, reopened against the new file. ``approvals.yaml`` itself stays
+    listed too — it is still read (one-time migration source,
+    ``migrate_legacy_snapshot``) and a legacy tree may still carry it.
+
+    A FUNCTION reading ``approval_ledger.RELATIVE_PATH`` LIVE at call time —
+    not a module-level tuple built once at import time — is itself part of
+    #5173's fix, not a style choice: architect's own review of the first
+    draft (issuecomment-5384258107) found that a frozen tuple built from an
+    imported *value* (``from ... import RELATIVE_PATH as X``) satisfies
+    "derived from one constant" only in the SOURCE — a future rename of
+    ``approval_ledger.RELATIVE_PATH`` would silently NOT propagate here,
+    because the name binding captured the old string at import time. Reading
+    the module attribute live on every call is what makes acceptance ③ ("a
+    renamed ledger's protection follows automatically") actually true rather
+    than merely true today. See
+    ``test_renaming_the_ledger_moves_both_carve_outs_with_it`` for the
+    monkeypatch-based witness.
+    """
+    from reyn.security.permissions import approval_ledger
+
+    return (
+        ".reyn/approvals.yaml",
+        approval_ledger.RELATIVE_PATH,
+    )
 
 
 def _normalize_paths(v: object) -> list[str]:
@@ -145,7 +157,7 @@ def _is_canonical_protected_write(path_str: str, base: "Path | None" = None) -> 
     base = base or Path.cwd()
     p = Path(path_str).expanduser()
     resolved = (base / p).resolve() if not p.is_absolute() else p.resolve()
-    for rel in _CANONICAL_PROTECTED_WRITE_PATHS:
+    for rel in _canonical_protected_write_paths():
         if resolved == (base / rel).resolve():
             return True
     return False
@@ -172,7 +184,7 @@ def _in_default_write_zone(path_str: str, base: "Path | None" = None) -> bool:
     """Return True if path falls within a default-granted write zone (.reyn/).
 
     Exception: canonical protected paths (see
-    ``_CANONICAL_PROTECTED_WRITE_PATHS`` — ``.reyn/index/sources.yaml``
+    ``_canonical_protected_write_paths()`` — ``.reyn/index/sources.yaml``
     transitionally + ``.reyn/approvals.yaml``) return False here so the
     write is forced through its explicit ``file.write`` declaration / gated
     flow rather than the broad ``.reyn/`` zone. ``.reyn/mcp.yaml`` and
@@ -482,7 +494,7 @@ class PermissionResolver:
         # each needing momentary ownership of the WHOLE snapshot file to
         # change even one key was the root cause of a lost approval under
         # concurrent access).
-        self._approval_ledger_path = self._project_root / Path(_APPROVAL_LEDGER_RELATIVE_PATH)
+        self._approval_ledger_path = self._project_root / Path(approval_ledger.RELATIVE_PATH)
         self._session: dict[str, bool] = {}
         # #3671 P4 item D-1: lazy — disk read + YAML parse deferred to the
         # `_saved` property's first access, not paid on every PermissionResolver

--- a/tests/security/test_permission_collapse_phase2.py
+++ b/tests/security/test_permission_collapse_phase2.py
@@ -232,6 +232,38 @@ def test_safe_file_check_write_rejects_approvals_yaml(tmp_path, monkeypatch):
     safe_file._check_write(str(tmp_path / ".reyn" / "scratch_state.json"))
 
 
+def test_canonical_protected_paths_cover_the_real_live_approval_ledger(tmp_path, monkeypatch):
+    """Tier 2: #5173 — the drift-guard below (``test_canonical_protected_lists_
+    stay_in_sync``) only pins the two COPIES equal to each other; it says
+    nothing about whether either copy still names the actual live approval
+    file. #5153/#5170 moved persistence from ``.reyn/approvals.yaml`` to the
+    append-only ``.reyn/approvals.jsonl`` ledger without updating either
+    copy — both stayed correctly in sync with EACH OTHER while both pointed
+    at a file the live code no longer writes through the gated path. This
+    test closes that exact blind spot: it builds a REAL ``PermissionResolver``
+    (not a hand-picked string) and asserts the path it actually uses for the
+    ledger is one of the canonical protected paths — so a future rename of
+    the live file, done without touching this list, fails HERE instead of
+    only being discoverable by hand-running the #5173 repro.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    resolver = PermissionResolver({}, project_root=tmp_path)
+
+    live_ledger_path = resolver.approval_ledger_path.relative_to(tmp_path).as_posix()
+
+    assert live_ledger_path in _CANONICAL_PROTECTED_WRITE_PATHS, (
+        f"PermissionResolver's real approval-ledger path ({live_ledger_path!r}) "
+        f"is not in _CANONICAL_PROTECTED_WRITE_PATHS "
+        f"({_CANONICAL_PROTECTED_WRITE_PATHS!r}) — a safe-mode write to it "
+        f"would bypass the approval gate + audit (#1199's own bypass class, "
+        f"reopened by #5173)."
+    )
+    # And the write-gate itself actually denies it — not just list membership.
+    assert _in_default_write_zone(live_ledger_path) is False
+    assert _is_canonical_protected_write(live_ledger_path) is True
+
+
 def test_canonical_protected_lists_stay_in_sync():
     """Tier 2: the two _CANONICAL_PROTECTED_WRITE_PATHS copies must not drift.
 

--- a/tests/security/test_permission_collapse_phase2.py
+++ b/tests/security/test_permission_collapse_phase2.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 import pytest
 
 from reyn.security.permissions.permissions import (
-    _CANONICAL_PROTECTED_WRITE_PATHS,
     PermissionDecl,
     PermissionResolver,
+    _canonical_protected_write_paths,
     _in_default_write_zone,
     _is_canonical_protected_write,
 )
@@ -39,7 +39,7 @@ from reyn.security.permissions.permissions import (
 def test_canonical_protected_paths_excepted_from_default_zone(tmp_path, monkeypatch):
     """Tier 2: each canonical protected path returns False from _in_default_write_zone."""
     monkeypatch.chdir(tmp_path)
-    for rel in _CANONICAL_PROTECTED_WRITE_PATHS:
+    for rel in _canonical_protected_write_paths():
         assert _in_default_write_zone(rel) is False, (
             f"{rel!r} should be excepted from the default write zone (Gap A)"
         )
@@ -123,7 +123,7 @@ def test_explicit_file_write_no_canonical_implicit():
     })
     paths = {entry.get("path") for entry in decl.file_write if isinstance(entry, dict)}
     assert paths == {"/tmp/x"}
-    for canonical in _CANONICAL_PROTECTED_WRITE_PATHS:
+    for canonical in _canonical_protected_write_paths():
         assert canonical not in paths
 
 
@@ -251,37 +251,88 @@ def test_canonical_protected_paths_cover_the_real_live_approval_ledger(tmp_path,
     resolver = PermissionResolver({}, project_root=tmp_path)
 
     live_ledger_path = resolver.approval_ledger_path.relative_to(tmp_path).as_posix()
+    protected = _canonical_protected_write_paths()
 
-    assert live_ledger_path in _CANONICAL_PROTECTED_WRITE_PATHS, (
+    assert live_ledger_path in protected, (
         f"PermissionResolver's real approval-ledger path ({live_ledger_path!r}) "
-        f"is not in _CANONICAL_PROTECTED_WRITE_PATHS "
-        f"({_CANONICAL_PROTECTED_WRITE_PATHS!r}) — a safe-mode write to it "
-        f"would bypass the approval gate + audit (#1199's own bypass class, "
-        f"reopened by #5173)."
+        f"is not in _canonical_protected_write_paths() ({protected!r}) — a "
+        f"safe-mode write to it would bypass the approval gate + audit "
+        f"(#1199's own bypass class, reopened by #5173)."
     )
     # And the write-gate itself actually denies it — not just list membership.
     assert _in_default_write_zone(live_ledger_path) is False
     assert _is_canonical_protected_write(live_ledger_path) is True
 
 
-def test_canonical_protected_lists_stay_in_sync():
-    """Tier 2: the two _CANONICAL_PROTECTED_WRITE_PATHS copies must not drift.
+def test_renaming_the_ledger_moves_both_carve_outs_with_it(monkeypatch):
+    """Tier 2: #5173 acceptance ③ (architect, issuecomment-5384258107) — a
+    RENAMED live ledger file must carry the write-gate protection WITH it,
+    automatically, not just today's fixed name. The test above only proves
+    "today's name is covered" — that alone does not distinguish a real
+    derivation from two literals that both happen to still agree; architect's
+    own point (echoed by docs-maintainer): "agreement between two copies is
+    not evidence either is correct."
 
-    permissions.permissions and safe.file each define the list — the safe
-    module runs in the python-harness subprocess and cannot import the parent
-    permissions module, so the constant is duplicated. This drift-guard pins
-    them equal, so any future add/remove of a protected path must touch BOTH
-    copies. Closes the recurrence class behind the #1199 gap, where
+    Monkeypatches ``approval_ledger.RELATIVE_PATH`` itself (the ACTUAL
+    constant every dependent site reads, not a stand-in) and asserts BOTH
+    carve-out copies — ``permissions.py`` and ``api/safe/file.py`` — now
+    protect the RENAMED path and no longer protect the old one. This is only
+    meaningful because both copies read the constant as a live module
+    attribute lookup (``approval_ledger.RELATIVE_PATH``) inside a function
+    called fresh each time, rather than binding a frozen tuple once at each
+    module's own import time — see ``_canonical_protected_write_paths``'s own
+    docstring in both modules for why that distinction is the actual fix.
+    """
+    from reyn.api.safe.file import (
+        _canonical_protected_write_paths as safe_protected,
+    )
+    from reyn.security.permissions import approval_ledger
+
+    renamed = ".reyn/approvals-renamed-for-test.jsonl"
+    monkeypatch.setattr(approval_ledger, "RELATIVE_PATH", renamed)
+
+    assert renamed in _canonical_protected_write_paths(), (
+        "permissions.py's carve-out did not follow the renamed ledger path"
+    )
+    assert renamed in safe_protected(), (
+        "api/safe/file.py's carve-out did not follow the renamed ledger path"
+    )
+    assert ".reyn/approvals.jsonl" not in _canonical_protected_write_paths(), (
+        "the OLD ledger path is still listed after a rename — a stale, no-"
+        "longer-live path being protected is not itself a bug, but it means "
+        "this test isn't actually observing live derivation"
+    )
+
+
+def test_canonical_protected_lists_stay_in_sync():
+    """Tier 2: the two canonical-protected-paths copies must not drift.
+
+    permissions.permissions and safe.file each define the derivation — the
+    safe module runs in the python-harness subprocess and cannot import the
+    parent permissions module, so it is duplicated (each now derives its
+    jsonl entry from the SAME ``approval_ledger.RELATIVE_PATH``, but the
+    static ``.reyn/approvals.yaml`` entry and the function shape itself are
+    still two independent copies). This drift-guard pins the two functions'
+    OUTPUT equal, so any future add/remove of a protected path must touch
+    BOTH copies. Closes the recurrence class behind the #1199 gap, where
     approvals.yaml was added to the parent list only. #2248 PR-C: the same
     drift-guard now also pins the recovery-core PREFIX lists in sync.
+
+    (See ``test_renaming_the_ledger_moves_both_carve_outs_with_it`` for the
+    complementary check this one cannot make on its own: two copies agreeing
+    is not evidence either one is correct — #5173's own root cause was both
+    copies staying in sync while BOTH silently no longer named the live
+    file.)
     """
-    from reyn.api.safe.file import _CANONICAL_PROTECTED_WRITE_PATHS as safe_paths
     from reyn.api.safe.file import _RECOVERY_CORE_WRITE_PREFIXES as safe_prefixes
+    from reyn.api.safe.file import (
+        _canonical_protected_write_paths as safe_protected_write_paths,
+    )
     from reyn.security.permissions.permissions import (
         _RECOVERY_CORE_WRITE_PREFIXES as perm_prefixes,
     )
 
-    assert _CANONICAL_PROTECTED_WRITE_PATHS == safe_paths
+    assert _canonical_protected_write_paths() == safe_protected_write_paths()
     assert perm_prefixes == safe_prefixes
 
 


### PR DESCRIPTION
**[tui-coder]** — 🔴 severity:high security fix, #5173.

## Root cause
`_CANONICAL_PROTECTED_WRITE_PATHS` (both `security/permissions/permissions.py` and `api/safe/file.py`) still listed only `.reyn/approvals.yaml`. #5153/#5170 moved the LIVE approval store to the append-only `.reyn/approvals.jsonl` ledger without updating either copy — a safe-mode `file.write` could append a fake `{"kind": "approval", "key": ..., "approved": true}` record directly, bypassing the interactive approval gate + audit entirely. Same bypass class #1199 closed, reopened against the new file. Architect: "the protected side is the one no longer read (yaml); the open side is the one that's live (jsonl)."

Repro (docs-maintainer, confirmed):
```python
safe_file._check_write('.reyn/approvals.yaml')   # PermissionError (correct)
safe_file._check_write('.reyn/approvals.jsonl')  # allowed (the gap)
```

## Fix
1. Add `.reyn/approvals.jsonl` to both carve-out copies.
2. Per architect/lead-coder ruling (issuecomment-5384216119 / issuecomment-5384229017): don't re-type the path as a literal — a hand-typed copy is exactly what drifted last time, and the existing drift-guard test (`test_canonical_protected_lists_stay_in_sync`) only pins the two copies equal to EACH OTHER, which holds even when both are equally wrong. New `approval_ledger.RELATIVE_PATH` constant is now the single source: `PermissionResolver._approval_ledger_path`, both write-gate carve-out copies, and — found via an active `git grep -n "approvals.yaml" -- src` sweep (lead-coder's request; diff review can't see an absence) — two MORE hand-typed copies at `interfaces/web/routers/permissions.py` and `interfaces/cli/commands/permissions.py`'s own `_ledger_path()` helpers, a 3rd and 4th copy that would have reopened the identical gap independently. All four now derive from the one constant.

## Grep-sweep classification (`git grep -n "approvals.yaml" -- src tests docs`, ~70 hits)
- 2 live-code hits beyond this PR's own files (the web/CLI `_ledger_path()` helpers) — **fixed here**.
- Every remaining hit is either `_legacy_snapshot_path()`/`_approvals_path` (correctly still `.yaml`, the one-time migration source, never written again) or prose/docstring/doc mentions of the concept, not a live enforcement path.
- #5162 already migrated the drift-guard test + docs for the #5153 move; this PR is the write-gate carve-out those prior fixes left behind.

## Test
New `test_canonical_protected_paths_cover_the_real_live_approval_ledger`: builds a REAL `PermissionResolver`, asserts its actual ledger path (via the new public `approval_ledger_path` property — private-state access is forbidden by the testing policy, so this property is the fix, not just test convenience) is covered by the carve-out. Closes the specific blind spot #5173 named: agreement between two copies is not evidence either is correct.

Strip-falsified: reverted to the original single-file literal → red for the exact expected assertion; restored → green.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict tests/security/test_permission_collapse_phase2.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] `verify_module_docstrings.py` on every touched src file
- [x] Scoped regression: `tests/security/` + `tests/api/` + CLI/web ledger tests + audit-event kind vocabulary census — 911 passed, 26 skipped, no regressions
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[architect]** — TESTS-READ（**A: 設計適合**、head `15a30d836f`）issuecomment。①② は入っています。B は別の人が必要です。

- [x] 🔴 (解消 `c2d1221e3`, architect 再 A issuecomment-5384291351) 受入③（**名前を変えたら保護も追随する**）の witness が無い。現 test は「今の名前が carve-out に在る」までで、**`api/safe/file.py` 側だけリテラルに戻しても緑**。`monkeypatch.setattr(approval_ledger, "RELATIVE_PATH", ...)` して**両方の carve-out が追随する**ことを assert（「一致は同じ誤りの一致でも成立する」の残り 1 つ）

