### PR TITLE
fix(#5166): reyn tokens expand consistently across all 4 hooks.yaml layers

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -734,6 +734,27 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # key should not go unreported just because there's no project).
         unknown_config_keys_found = _warn_unknown_config_keys(merged)
 
+    # #5166: reyn's OWN token vocabulary (${REYN_PROJECT_DIR} — the only one
+    # this project-wide, agent-less load has a real value for;
+    # ${REYN_AGENT_NAME} has no meaning here and is deliberately NOT in this
+    # map, same as any other token this pass does not recognise) is expanded
+    # FIRST, via expand_with_map — never os.environ, the same reasoning
+    # load_per_agent_hooks/read_and_expand_hooks_yaml use. ORDER MATTERS:
+    # this must run BEFORE expand_env below. expand_with_map's own contract
+    # leaves anything absent from its map untouched (an MCP server's
+    # ${API_KEY} is not a reyn token, so this pass never touches it) — doing
+    # it in the other order would let expand_env's os.environ lookup consume
+    # ${REYN_PROJECT_DIR} first (undefined there, silently degrading to ""),
+    # exactly the #5140 failure shape one layer up. No fail-close here
+    # (unlike the per-agent/per-session hooks.yaml layers): an unresolved
+    # ${REYN_AGENT_NAME} in reyn.yaml itself has no agent context to supply
+    # it at this project-wide load — refusing the WHOLE config over one
+    # per-agent token would be a disproportionate blast radius this
+    # project-wide layer was never asked to take on (architect ruling on
+    # #5166 scopes fail-close to the 4 enumerated hooks.yaml layers only).
+    from reyn.plugins.tokens import expand_with_map
+    merged = expand_with_map(merged, {"REYN_PROJECT_DIR": str(project_root or cwd)})
+
     # ADR-0030: apply ${VAR} interpolation across all string fields of the
     # merged config dict.  At this point os.environ already contains values
     # loaded from ~/.reyn/secrets.env (see load_secrets_to_environ() above).
@@ -936,6 +957,64 @@ def load_hot_reload_config(project_root: "Path | None" = None) -> dict:
     return expand_env(merged)
 
 
+def read_and_expand_hooks_yaml(
+    path: Path, *, agent_name: str, project_root: Path,
+) -> "dict | None":
+    """#5166 (architect ruling, issuecomment-5384196419): the ONE read+expand
+    primitive EVERY hooks.yaml-shaped layer goes through — per-agent AND
+    per-session, the ``hooks:`` key AND the ``composers:`` key alike (same
+    file on disk, same 2 keys; only the caller's own key extraction
+    differs — see :meth:`~reyn.runtime.session.Session._hooks_yaml_layers`
+    for the enumerable registry of callers).
+
+    **Why one primitive, not "a rule everyone remembers"**: hooks get
+    copy-pasted between layers (the #5164 docstring's own "mirrors" —
+    architect's evidence this issue cites). A rule duplicated 4 times
+    means the NEXT copy only carries whichever half someone remembered —
+    exactly what happened here: #5161 fixed the per-agent ``hooks:``
+    reader, #5164 caught up the per-agent ``composers:`` reader, and the
+    2 per-session readers had NO expansion at all until this function
+    unified all 4 onto one implementation.
+
+    Expands reyn's OWN token vocabulary via
+    :func:`reyn.plugins.tokens.expand_with_map` with an explicit
+    ``{REYN_PROJECT_DIR, REYN_AGENT_NAME}`` map — never ``os.environ``
+    (``expand_env``, ADR-0030): that expander is for a SPAWNED CHILD
+    process's own config-time env-injection, and ``REYN_AGENT_NAME`` is
+    only ever set on a child's env, never on THIS process's own
+    ``os.environ`` — so it is always undefined here regardless of layer
+    (#5140's original finding). Fails closed via
+    :func:`~reyn.plugins.tokens.find_unresolved_reyn_tokens` on any
+    REMAINING ``${REYN_*}``/``${CLAUDE_*}`` token (reyn's own bug, not an
+    operator's config choice) — returns ``None`` (never ``{}``, so a
+    caller can tell "genuinely absent" from "refused" if it ever needs
+    to) — while an arbitrary non-reyn ``${FOO}`` is left untouched, for
+    whatever downstream (a spawned child process) resolves it later.
+
+    Returns ``None`` when the file is absent, malformed, or refused;
+    otherwise the parsed+expanded dict — the caller reads whichever key
+    (``hooks``/``composers``) it owns out of it."""
+    raw = _load_yaml(path)
+    if not raw:
+        return None
+    from reyn.plugins.tokens import expand_with_map, find_unresolved_reyn_tokens
+    data = expand_with_map(
+        raw, {"REYN_PROJECT_DIR": str(project_root), "REYN_AGENT_NAME": agent_name}
+    )
+    unresolved = find_unresolved_reyn_tokens(data)
+    if unresolved:
+        import warnings
+        warnings.warn(
+            f"{path} left reyn token(s) {sorted(set(unresolved))} "
+            "unresolved -- refusing to load this hooks.yaml layer (this "
+            "is reyn's own bug, not a config choice to honor).",
+            UserWarning,
+            stacklevel=2,
+        )
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def load_per_agent_hooks(
     project_root: "Path | None", agent_name: str
 ) -> list:
@@ -946,60 +1025,18 @@ def load_per_agent_hooks(
     hot-reloadable) but scoped to one agent — read DIRECTLY here (not via
     :func:`load_hot_reload_config`, which is the top-level ``.reyn/*.yaml`` set),
     mirroring how the per-agent ``profile.yaml`` is read. Returns the raw
-    ``hooks:`` list (``[]`` when the file or key is absent — a no-op layer,
-    never an error).
+    ``hooks:`` list (``[]`` when the file or key is absent, malformed, or
+    refused for an unresolved reyn token — a no-op layer, never an error
+    the caller has to handle specially).
 
-    #5140 (architect ruling, issuecomment-5383725162): a per-agent
-    ``hooks.yaml``'s ``${REYN_AGENT_NAME}`` token used to go through
-    ``expand_env`` (``security/secrets/interpolation.py``) — an
-    ``os.environ``-backed expander (ADR-0030) meant for a SPAWNED CHILD
-    process's config-time env-injection. ``REYN_AGENT_NAME`` is only ever
-    set on a child process's own env (``hooks/shell_runner.py`` and
-    friends), never on this process's own ``os.environ``, so it was
-    ALWAYS undefined at config-load time — silently expanding to ``""``
-    (a `UserWarning`, then a syntactically-valid-but-wrong value the
-    caller cannot tell apart from a genuinely empty operator choice).
-    Hooks are not secrets, and the value this layer actually needs
-    (``agent_name``, the same string this function already receives as
-    an argument) is available right here — this is a layering mistake
-    (the wrong expander for the value), not a genuinely undefined
-    token, so the fix is :func:`reyn.plugins.tokens.expand_with_map`
-    (already used the same way by ``registry_bootstrap.py`` /
-    ``session.py`` for ``REYN_PROJECT_DIR``) with an explicit map,
-    never ``os.environ``.
-
-    Fail-close, scoped to reyn's OWN token vocabulary only (acceptance
-    ②/③): if a ``${REYN_*}``/``${CLAUDE_*}`` token remains unresolved
-    after expansion, that is reyn's own bug (a token reyn should always
-    be able to supply), not an operator's config choice — refuse to
-    load this hooks layer rather than register a matcher/config value
-    reyn silently got wrong. This is the "does the trigger fire on a
-    healthy path" test #5152's own retracted fail-closed ruling failed
-    (there, EVERY comparison on a birthtime-less platform triggered it);
-    here, a healthy config with reyn's tokens correctly supplied never
-    triggers it at all. An arbitrary NON-reyn ``${FOO}`` (an env var a
-    spawned child process resolves later) is deliberately NOT touched
-    by this check — see :func:`~reyn.plugins.tokens.find_unresolved_reyn_tokens`'s
-    own docstring."""
+    #5140/#5166: token expansion is :func:`read_and_expand_hooks_yaml` — see
+    that function's own docstring for the full reasoning (why
+    ``expand_with_map`` not ``expand_env``, why fail-closed on reyn's own
+    tokens only)."""
     root = (project_root or Path.cwd()).resolve()
-    raw = _load_yaml(root / ".reyn" / "agents" / agent_name / "hooks.yaml")
-    from reyn.plugins.tokens import expand_with_map, find_unresolved_reyn_tokens
-    data = expand_with_map(
-        raw, {"REYN_PROJECT_DIR": str(root), "REYN_AGENT_NAME": agent_name}
-    )
-    unresolved = find_unresolved_reyn_tokens(data)
-    if unresolved:
-        import warnings
-        warnings.warn(
-            f"Per-agent hooks.yaml for {agent_name!r} left reyn token(s) "
-            f"{sorted(set(unresolved))} unresolved -- refusing to load "
-            "this hooks layer (this is reyn's own bug, not a config "
-            "choice to honor).",
-            UserWarning,
-            stacklevel=2,
-        )
-        return []
-    hooks = data.get("hooks") if isinstance(data, dict) else None
+    path = root / ".reyn" / "agents" / agent_name / "hooks.yaml"
+    data = read_and_expand_hooks_yaml(path, agent_name=agent_name, project_root=root)
+    hooks = (data or {}).get("hooks")
     return hooks if isinstance(hooks, list) else []
 
 

--- a/src/reyn/plugins/tokens.py
+++ b/src/reyn/plugins/tokens.py
@@ -198,33 +198,74 @@ def expand_with_map(obj: Any, token_map: dict[str, str]) -> Any:
     return _expand(obj, token_map)
 
 
-# #5140: matches a REMAINING ``${REYN_*}``/``${CLAUDE_*}`` placeholder after
-# an expansion pass — i.e. reyn's OWN token vocabulary, never an arbitrary
-# caller-owned ``${VAR}`` (an env var meant for a spawned child process, a
-# pipeline ``ctx`` param, …). Deliberately narrower than ``_TOKEN_RE``: a
-# fail-close check built on the wrong regex here would refuse to load a
-# hooks.yaml over a token it was never reyn's job to resolve in the first
-# place (acceptance ③ — a non-reyn ``${FOO}`` must load exactly as before).
+# #5140: matches a candidate ``${REYN_*}``/``${CLAUDE_*}`` placeholder —
+# the SYNTAX only. Deliberately narrower than ``_TOKEN_RE`` (any ``${VAR}``)
+# so a genuinely unrelated ``${VAR}`` never even reaches the vocabulary
+# check below, but this regex ALONE is not the fail-close decision — see
+# :data:`_KNOWN_REYN_TOKEN_NAMES` and #5176's own correction.
 _UNRESOLVED_REYN_TOKEN_RE = re.compile(r"\$\{((?:REYN|CLAUDE)_\w+)\}")
+
+# #5176 (architect TESTS-READ blocking finding on #5166, issuecomment-5384269296):
+# a REYN_/CLAUDE_ PREFIX is not the same thing as reyn's OWN token
+# VOCABULARY — real environment variables with this prefix exist and are
+# NOT reyn tokens: ``REYN_MCP_REGISTRY_URLS`` (config/loader.py's own
+# ``mcp.registries`` propagation), the SSRF-guard allowlist vars
+# (``security/ssrf_guard.py``), and ``CLAUDE_CODE_*`` (the Claude Code
+# harness's own env, unrelated to this module's ``CLAUDE_*`` alias
+# spellings). Before this fix, ``find_unresolved_reyn_tokens`` matched ANY
+# such-shaped placeholder by prefix alone — #5166's consolidation of every
+# hooks.yaml-shaped layer onto this ONE fail-close check widened the blast
+# radius from "the 1-2 layers #5140/#5164 originally touched" to "every
+# hooks.yaml layer any operator config can write", so a real,
+# previously-working ``${REYN_MCP_REGISTRY_URLS}`` reference (meant for
+# ``expand_env``/``os.environ``, never this module) would now be
+# misidentified as reyn's OWN unresolved token and refuse the whole layer
+# — a real config silently breaking, not a hypothetical.
+#
+# The fix: fail-close membership is the ACTUAL name set this module can
+# supply a value for — :data:`~reyn.plugins.tokens.CLAUDE_ALIAS_MAP`'s own
+# keys plus every ``PluginTokenContext.tokens()`` key, PLUS
+# ``REYN_AGENT_NAME`` (#5140's own addition — supplied via an explicit
+# map to :func:`expand_with_map`, never through ``PluginTokenContext``
+# itself, so it is not already in either of the above and must be listed
+# here too). Anything else — including a genuine reyn-shaped TYPO like
+# ``${REYN_AGNT_NAME}`` — passes through untouched, same as any other
+# non-reyn token: distinguishing "meant to be a reyn token, misspelled"
+# from "a real env var that happens to share reyn's prefix" is not
+# reliably decidable from the string alone (architect's own recommendation,
+# issuecomment-5384269296).
+_KNOWN_REYN_TOKEN_NAMES: frozenset[str] = frozenset(
+    {"REYN_PLUGIN_ROOT", "REYN_PROJECT_DIR", "REYN_SKILL_DIR", "REYN_AGENT_NAME"}
+    | set(CLAUDE_ALIAS_MAP)
+)
 
 
 def find_unresolved_reyn_tokens(obj: Any) -> list[str]:
-    """Recursively collect every REMAINING ``${REYN_*}``/``${CLAUDE_*}``
-    placeholder in *obj* (post-:func:`expand_with_map`, typically).
+    """Recursively collect every REMAINING placeholder in *obj*
+    (post-:func:`expand_with_map`, typically) whose name is in reyn's OWN
+    known token vocabulary (:data:`_KNOWN_REYN_TOKEN_NAMES`) — never a
+    bare ``${REYN_*}``/``${CLAUDE_*}`` PREFIX match (#5176's own
+    correction — see that constant's docstring for why a prefix match is
+    the wrong test).
 
     #5140: the fail-close half of that issue's ruling — reyn's own token
     vocabulary left unresolved after reyn's own expansion pass means reyn
     could not supply a value it owns, which is reyn's bug, not an
-    operator's config choice (contrast with an arbitrary ``${VAR}``, which
-    a downstream consumer — e.g. a spawned child process inheriting the
-    env — may legitimately resolve later; this function does not flag
-    those at all). A caller finding this list non-empty should refuse to
-    use the expanded structure rather than silently proceed with an
-    empty/wrong value standing in for an unresolved token — see
-    ``config/loader.py``'s ``load_per_agent_hooks`` for the reference
-    caller."""
+    operator's config choice (contrast with an arbitrary ``${VAR}`` — a
+    REYN_/CLAUDE_-shaped one included — which a downstream consumer (e.g.
+    ``expand_env``, or a spawned child process inheriting the env) may
+    legitimately resolve later; this function does not flag those at
+    all). A caller finding this list non-empty should refuse to use the
+    expanded structure rather than silently proceed with an empty/wrong
+    value standing in for an unresolved token — see
+    ``config/loader.py``'s ``read_and_expand_hooks_yaml`` for the
+    reference caller."""
     if isinstance(obj, str):
-        return [m.group(0) for m in _UNRESOLVED_REYN_TOKEN_RE.finditer(obj)]
+        return [
+            m.group(0)
+            for m in _UNRESOLVED_REYN_TOKEN_RE.finditer(obj)
+            if m.group(1) in _KNOWN_REYN_TOKEN_NAMES
+        ]
     if isinstance(obj, dict):
         found: list[str] = []
         for v in obj.values():

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5662,29 +5662,54 @@ class Session:
                 )
         return registry
 
+    def _hooks_yaml_layers(self) -> "list[tuple[str, Path]]":
+        """#5166 (architect ruling, issuecomment-5384196419): the enumerable
+        registry of every hooks.yaml-shaped layer this session reads — the
+        SAME 2 layers (per-agent, per-session) both ``hooks:`` and
+        ``composers:`` are read from. This is the "read+expand in ONE
+        place" ruling's own deliverable: a hand-written reader per (layer,
+        key) pair silently misses a 5th layer if one is ever added; walking
+        THIS list instead means a new entry here is automatically covered
+        by every caller that already walks it (:meth:`_read_hooks_yaml_layer_key`
+        and this repo's own #5166 registry-driven tests alike)."""
+        root = self._hot_reload_project_root()
+        return [
+            ("per-agent", root / ".reyn" / "agents" / self.agent_name / "hooks.yaml"),
+            ("per-session", Path(self._snapshot_path).parent / "hooks.yaml"),
+        ]
+
+    def _read_hooks_yaml_layer_key(self, path: Path, key: str) -> list:
+        """#5166: the ONE read+expand+extract step every per-agent/per-session
+        ``hooks:``/``composers:`` reader now goes through —
+        :func:`~reyn.config.loader.read_and_expand_hooks_yaml` does the
+        read+expand+fail-close (see its own docstring for the full
+        reasoning), this just extracts *key* from the result. ``[]`` when
+        the file is absent, malformed, refused (an unresolved reyn token),
+        or *key* itself is absent — a no-op layer, never a special case a
+        caller has to handle."""
+        from reyn.config.loader import read_and_expand_hooks_yaml
+        data = read_and_expand_hooks_yaml(
+            path, agent_name=self.agent_name, project_root=self._hot_reload_project_root(),
+        )
+        values = (data or {}).get(key)
+        return list(values) if isinstance(values, list) else []
+
     def _read_per_agent_hooks(self) -> list:
         """Read the per-agent runtime hooks layer for the COMBINE (#2073 per-agent
-        add-on) — ``.reyn/agents/<name>/hooks.yaml``, read directly (like the per-agent
-        profile.yaml, not via the top-level IN-set loader). ``[]`` when absent."""
-        from reyn.config.loader import load_per_agent_hooks
-        return load_per_agent_hooks(self._hot_reload_project_root(), self.agent_name)
+        add-on) — ``.reyn/agents/<name>/hooks.yaml``'s ``hooks:`` key. ``[]`` when
+        absent. #5166: routed through :meth:`_hooks_yaml_layers`/
+        :meth:`_read_hooks_yaml_layer_key`, the SAME primitive every other
+        hooks.yaml-shaped layer now uses."""
+        return self._read_hooks_yaml_layer_key(self._hooks_yaml_layers()[0][1], "hooks")
 
     def _read_per_session_hooks(self) -> list:
-        """#2285: read the per-SESSION hooks layer — ``<per-session state dir>/hooks.yaml`` (the 4th,
-        most-specific COMBINE layer). The per-session dir is the parent of this session's snapshot
-        path (set per (name, sid) by spawn_session). A hook defined here is visible ONLY to this
-        session. ``[]`` when absent (or the file is malformed — the loader's per-layer resilience
-        also guards)."""
-        import yaml
-        path = Path(self._snapshot_path).parent / "hooks.yaml"
-        if not path.is_file():
-            return []
-        try:
-            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-        except Exception:  # noqa: BLE001 — malformed → treat as absent
-            return []
-        hooks = data.get("hooks") if isinstance(data, dict) else None
-        return list(hooks) if isinstance(hooks, list) else []
+        """#2285: read the per-SESSION hooks layer — ``<per-session state dir>/hooks.yaml``'s
+        ``hooks:`` key (the 4th, most-specific COMBINE layer). The per-session dir is the
+        parent of this session's snapshot path (set per (name, sid) by spawn_session). A
+        hook defined here is visible ONLY to this session. ``[]`` when absent. #5166: now
+        expands reyn tokens (previously did not — the gap #5166 exists to close), via the
+        SAME primitive :meth:`_read_per_agent_hooks` uses."""
+        return self._read_hooks_yaml_layer_key(self._hooks_yaml_layers()[1][1], "hooks")
 
     def _build_composer_defs(self, in_set: "dict | None" = None) -> list:
         """Build the LAYERED ``ComposerDef`` list (Hook-Event Redesign Phase 4b/5,
@@ -5755,65 +5780,22 @@ class Session:
         #2880/#2881) — the ``composers:`` key of the SAME
         ``.reyn/agents/<name>/hooks.yaml`` file :meth:`_read_per_agent_hooks`
         reads its ``hooks:`` key from (same IN-set grain, scoped per agent).
-        ``[]`` when the file or key is absent.
-
-        Expands reyn-owned tokens in this layer via
-        :func:`reyn.plugins.tokens.expand_with_map` with an explicit
-        ``{REYN_PROJECT_DIR, REYN_AGENT_NAME}`` map — not ``os.environ``:
-        ``REYN_AGENT_NAME`` exists only in a SPAWNED CHILD process's own env
-        (``hooks/shell_runner.py`` and friends), never in this process's own
-        ``os.environ``, so it is undefined at config-load time and an
-        ``os.environ``-backed expander cannot resolve it here. Fails closed
-        via :func:`~reyn.plugins.tokens.find_unresolved_reyn_tokens` on any
-        REMAINING ``${REYN_*}``/``${CLAUDE_*}`` token — reyn's own bug, not
-        an operator's config choice — while an arbitrary non-reyn ``${FOO}``
-        is left untouched, for a spawned child process to resolve later. See
-        ``config/loader.py``'s ``load_per_agent_hooks`` for the reference
-        implementation this mirrors."""
-        import yaml
-        path = self._hot_reload_project_root() / ".reyn" / "agents" / self.agent_name / "hooks.yaml"
-        if not path.is_file():
-            return []
-        try:
-            raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-        except Exception:  # noqa: BLE001 — malformed → treat as absent
-            return []
-        if not isinstance(raw, dict):
-            return []
-        from reyn.plugins.tokens import expand_with_map, find_unresolved_reyn_tokens
-        root = self._hot_reload_project_root()
-        data = expand_with_map(
-            raw, {"REYN_PROJECT_DIR": str(root), "REYN_AGENT_NAME": self.agent_name}
-        )
-        unresolved = find_unresolved_reyn_tokens(data)
-        if unresolved:
-            logger.warning(
-                "Per-agent hooks.yaml for %r left reyn token(s) %s unresolved "
-                "in its composers: layer -- refusing to load this composers "
-                "layer (this is reyn's own bug, not a config choice to "
-                "honor).",
-                self.agent_name, sorted(set(unresolved)),
-            )
-            return []
-        composers = data.get("composers") if isinstance(data, dict) else None
-        return list(composers) if isinstance(composers, list) else []
+        ``[]`` when the file or key is absent. #5166: routed through the
+        SAME :meth:`_hooks_yaml_layers`/:meth:`_read_hooks_yaml_layer_key`
+        primitive :meth:`_read_per_agent_hooks` uses — no longer a hand
+        copy of that reader's own token-expansion rule (the exact "mirrors"
+        docstring #5166 itself cites as evidence of the copy-drift risk)."""
+        return self._read_hooks_yaml_layer_key(self._hooks_yaml_layers()[0][1], "composers")
 
     def _read_per_session_composers(self) -> list:
         """Read the per-SESSION composer layer (Hook-Event Redesign Phase 4b/5,
         #2880/#2881) — the ``composers:`` key of the SAME per-session
         ``hooks.yaml`` file :meth:`_read_per_session_hooks` reads its
         ``hooks:`` key from (#2285's 4th, most-specific layer). ``[]`` when
-        the file or key is absent (or the file is malformed)."""
-        import yaml
-        path = Path(self._snapshot_path).parent / "hooks.yaml"
-        if not path.is_file():
-            return []
-        try:
-            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-        except Exception:  # noqa: BLE001 — malformed → treat as absent
-            return []
-        composers = data.get("composers") if isinstance(data, dict) else None
-        return list(composers) if isinstance(composers, list) else []
+        the file or key is absent. #5166: now expands reyn tokens
+        (previously did not), via the SAME primitive every other
+        hooks.yaml-shaped layer uses."""
+        return self._read_hooks_yaml_layer_key(self._hooks_yaml_layers()[1][1], "composers")
 
     async def _reapply_hooks(self, in_set: dict) -> bool:
         """Reapply the hook layers (#2073 S2b + per-agent add-on) — re-read the global

--- a/tests/config/test_5166_load_config_reyn_token_before_env.py
+++ b/tests/config/test_5166_load_config_reyn_token_before_env.py
@@ -1,0 +1,80 @@
+"""Tier 2: #5166 acceptance③ — ``load_config``'s ``:741`` now runs a reyn-
+token pass (``expand_with_map``, ``${REYN_PROJECT_DIR}`` only — this
+project-wide, agent-less load has no ``${REYN_AGENT_NAME}`` value to
+supply) BEFORE ``expand_env`` (the ``os.environ``-backed pass MCP server
+``env:`` blocks and other real secrets rely on).
+
+Order is the whole point (lead-coder, #5166 supplement): reversing it
+would let ``expand_env``'s ``os.environ`` lookup consume
+``${REYN_PROJECT_DIR}`` first — undefined there, silently degrading to
+``""`` (the #5140 failure shape one layer up, at the project-wide config
+instead of a per-agent hooks.yaml).
+
+Real ``load_config`` + a real ``reyn.yaml`` on disk + a real env var — no
+mocks."""
+from __future__ import annotations
+
+from reyn.config.loader import load_config
+
+
+def test_reyn_project_dir_resolves_and_mcp_env_still_resolves_too(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: both passes must land: reyn's own ${REYN_PROJECT_DIR} AND a
+    real MCP server env var, in the SAME config load, neither one
+    breaking the other."""
+    monkeypatch.setenv("TEST_5166_MCP_API_KEY", "secret-value-123")
+    (tmp_path / "reyn.yaml").write_text(
+        "mcp:\n"
+        "  servers:\n"
+        "    myserver:\n"
+        "      type: stdio\n"
+        "      command: echo\n"
+        "      env:\n"
+        "        API_KEY: ${TEST_5166_MCP_API_KEY}\n"
+        "        PROJECT_TAG: ${REYN_PROJECT_DIR}\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_config(tmp_path)
+    env = cfg.mcp["servers"]["myserver"]["env"]
+
+    assert env["API_KEY"] == "secret-value-123", (
+        "a real MCP server env var (expand_env, os.environ-backed) must "
+        f"still resolve exactly as before — got {env!r}"
+    )
+    assert env["PROJECT_TAG"] == str(tmp_path.resolve()), (
+        "${REYN_PROJECT_DIR} must resolve to the real project root, not "
+        f"stay literal — got {env!r}"
+    )
+
+
+def test_a_non_reyn_var_degrades_exactly_as_expand_env_always_has(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: a non-reyn ``${FOO}`` the operator never set must reach
+    ``expand_env`` UNTOUCHED by the new reyn-token pass, so it degrades to
+    ``expand_env``'s own pre-existing behavior for a genuinely-undefined
+    var (``""``, verified directly against ``expand_env`` itself) — never
+    a NEW/different shape introduced by the reyn-token pass now running
+    first."""
+    monkeypatch.delenv("TOTALLY_UNSET_5166_VAR", raising=False)
+    (tmp_path / "reyn.yaml").write_text(
+        "mcp:\n"
+        "  servers:\n"
+        "    myserver:\n"
+        "      type: stdio\n"
+        "      command: echo\n"
+        "      env:\n"
+        "        SOME_VAR: ${TOTALLY_UNSET_5166_VAR}\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_config(tmp_path)
+    env = cfg.mcp["servers"]["myserver"]["env"]
+
+    assert env["SOME_VAR"] == "", (
+        f"a non-reyn undefined var must still degrade to expand_env's own "
+        f"pre-existing empty-string shape, unmodified by the reyn-token "
+        f"pass — got {env!r}"
+    )

--- a/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
+++ b/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
@@ -1,0 +1,69 @@
+"""Tier 1: #5176 (architect TESTS-READ blocking finding on #5166,
+issuecomment-5384269296) — ``find_unresolved_reyn_tokens``'s fail-close
+membership test is reyn's own KNOWN token vocabulary
+(``_KNOWN_REYN_TOKEN_NAMES``), never a bare ``${REYN_*}``/``${CLAUDE_*}``
+PREFIX match.
+
+Root cause: a REYN_/CLAUDE_ prefix is not the same thing as reyn's own
+token vocabulary — real environment variables with this prefix exist
+that are NOT reyn tokens (``REYN_MCP_REGISTRY_URLS``,
+``security/ssrf_guard.py``'s allowlist vars, ``CLAUDE_CODE_*``). #5166's
+consolidation of every hooks.yaml-shaped layer onto ONE fail-close check
+widened the blast radius of the pre-existing prefix-match bug from "the
+1-2 layers #5140/#5164 originally touched" to "every hooks.yaml layer any
+operator config can write" — a real, previously-working
+``${REYN_MCP_REGISTRY_URLS}`` reference would have silently stopped
+working (the whole layer refused) without this fix.
+
+Real ``find_unresolved_reyn_tokens`` — no mocks; a pure function."""
+from __future__ import annotations
+
+from reyn.plugins.tokens import find_unresolved_reyn_tokens
+
+
+def test_a_real_non_reyn_env_var_sharing_the_reyn_prefix_is_not_flagged() -> None:
+    """Tier 1: acceptance⑤ — ``${REYN_MCP_REGISTRY_URLS}`` (a real env var
+    ``config/loader.py`` itself propagates ``mcp.registries`` into, meant
+    for ``expand_env``/``os.environ``, never this module) must not be
+    treated as an unresolved reyn token."""
+    assert find_unresolved_reyn_tokens({"a": "${REYN_MCP_REGISTRY_URLS}"}) == []
+
+
+def test_claude_code_harness_env_is_not_flagged() -> None:
+    """Tier 1: ``CLAUDE_CODE_*`` (the Claude Code harness's own env,
+    unrelated to this module's ``CLAUDE_PLUGIN_ROOT``/``CLAUDE_SKILL_DIR``/
+    ``CLAUDE_PROJECT_DIR`` alias spellings) must not be flagged either."""
+    assert find_unresolved_reyn_tokens({"a": "${CLAUDE_CODE_SOME_VAR}"}) == []
+
+
+def test_a_reyn_shaped_typo_is_not_flagged() -> None:
+    """Tier 1: acceptance⑥ — a genuine reyn-token TYPO
+    (``${REYN_AGNT_NAME}``, missing the E) must pass through untouched,
+    not fail-close — "claims to be a reyn token by prefix, misspelled" is
+    not reliably distinguishable from "a real env var that happens to
+    share reyn's prefix" (architect's own recommendation,
+    issuecomment-5384269296; lead-coder concurred)."""
+    assert find_unresolved_reyn_tokens({"a": "${REYN_AGNT_NAME}"}) == []
+
+
+def test_every_real_reyn_token_name_is_still_flagged_when_unresolved() -> None:
+    """Tier 1: the fix must not overcorrect into never flagging anything —
+    every name this module ACTUALLY supplies a value for
+    (``REYN_PLUGIN_ROOT``/``REYN_PROJECT_DIR``/``REYN_SKILL_DIR`` via
+    ``PluginTokenContext``, ``REYN_AGENT_NAME`` via the #5140 hooks.yaml
+    map, and the ``CLAUDE_*`` alias spellings) is still caught unresolved."""
+    real_names = [
+        "REYN_PLUGIN_ROOT",
+        "REYN_PROJECT_DIR",
+        "REYN_SKILL_DIR",
+        "REYN_AGENT_NAME",
+        "CLAUDE_PLUGIN_ROOT",
+        "CLAUDE_SKILL_DIR",
+        "CLAUDE_PROJECT_DIR",
+    ]
+    for name in real_names:
+        found = find_unresolved_reyn_tokens({"a": f"${{{name}}}"})
+        assert found == [f"${{{name}}}"], (
+            f"{name}: a real reyn token name left unresolved must still be "
+            f"caught — got {found!r}"
+        )

--- a/tests/runtime/test_5140_per_agent_composers_token_expansion.py
+++ b/tests/runtime/test_5140_per_agent_composers_token_expansion.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+import pytest
+
 from tests._support.agent_session import make_session
 
 _AGENT = "coder-smith"
@@ -81,13 +83,19 @@ def test_reyn_agent_name_resolves_to_the_real_agent_name_in_composers(
 
 
 def test_an_unresolved_reyn_token_refuses_to_load_the_composers_layer(
-    tmp_path, monkeypatch, caplog,
+    tmp_path, monkeypatch,
 ) -> None:
     """Tier 2: acceptance ② — a reyn-owned token this loader does NOT supply
     a value for (``${REYN_SKILL_DIR}`` — a location token with no meaning for
     a composers file) must refuse to load the WHOLE composers layer, not
     silently register a composer with an empty/wrong value, and must surface
-    why."""
+    why.
+
+    #5166: the surfacing mechanism is now ``warnings.warn`` (the shared
+    ``read_and_expand_hooks_yaml`` primitive every hooks.yaml-shaped layer
+    goes through, matching ``config/loader.py``'s own established
+    convention), not ``logger.warning`` — this session-local reader used to
+    warn via the stdlib logger before the #5166 consolidation."""
     project = tmp_path / "proj"
     _write_per_agent_hooks(
         project,
@@ -99,15 +107,12 @@ def test_an_unresolved_reyn_token_refuses_to_load_the_composers_layer(
     )
     session = _make_session_in(project, monkeypatch, tmp_path)
 
-    with caplog.at_level(logging.WARNING):
+    with pytest.warns(UserWarning, match="REYN_SKILL_DIR"):
         composers = session._read_per_agent_composers()
 
     assert composers == [], (
         "an unresolved reyn-owned token must refuse the WHOLE composers "
         "layer, not load a composer with a wrong/empty value"
-    )
-    assert any("REYN_SKILL_DIR" in r.getMessage() for r in caplog.records), (
-        "the refusal must surface a reason, not fail silently"
     )
 
 

--- a/tests/runtime/test_5166_hooks_yaml_layer_registry.py
+++ b/tests/runtime/test_5166_hooks_yaml_layer_registry.py
@@ -1,0 +1,206 @@
+"""Tier 2: #5166 (architect ruling, issuecomment-5384196419) — EVERY
+hooks.yaml-shaped layer (per-agent AND per-session, ``hooks:`` AND
+``composers:``) expands reyn tokens through the SAME primitive
+(``Session._hooks_yaml_layers`` / ``_read_hooks_yaml_layer_key`` →
+``reyn.config.loader.read_and_expand_hooks_yaml``).
+
+Root cause this closes: hooks get copy-pasted between layers (#5164's own
+docstring self-describes as "mirrors" the per-agent ``hooks:`` reader) —
+#5161 fixed ONE reader, #5164 caught up a SECOND, and the 2 per-session
+readers had NO expansion at all until now. A rule duplicated 4 times means
+the next copy only carries whichever half someone remembered.
+
+**Registry-driven, not 4 hand-written tests** (architect's own explicit
+requirement — a hand-written test per (layer, key) pair silently misses a
+5th layer added later; walking ``Session._hooks_yaml_layers()`` instead
+means a NEW layer entry is automatically covered by every test here,
+without a single test file edit). Acceptance④'s own test proves this by
+literally adding a synthetic 3rd layer via monkeypatch and confirming
+the SAME test loop picks it up with zero code changes elsewhere.
+
+Real ``Session`` (via ``tests._support.agent_session.make_session``) + real
+files on disk — no mocks."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._support.agent_session import make_session
+
+_AGENT = "coder-smith"
+_KEYS = ("hooks", "composers")
+
+
+def _make_session_in(project_root: Path, monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(project_root)
+    return make_session(
+        agent_name=_AGENT,
+        workspace_base_dir=project_root,
+        workspace_state_dir=tmp_path / "state",
+    )
+
+
+def _write_yaml(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _entry(key: str) -> str:
+    """A minimal, valid entry for *key* (``hooks:`` or ``composers:``) whose
+    ONE string field carries the token under test — same shape both keys'
+    real schemas accept (a ``template_push.message``)."""
+    return (
+        f"{key}:\n"
+        "  - name: probe\n"
+        "    on: turn_end\n"
+        "    template_push:\n"
+        "      message: broker://inbox/${REYN_AGENT_NAME}\n"
+    )
+
+
+def _passthrough_entry(key: str) -> str:
+    return (
+        f"{key}:\n"
+        "  - name: probe\n"
+        "    on: turn_end\n"
+        "    exec:\n"
+        "      command: echo ${SOME_CHILD_PROCESS_VAR}\n"
+    )
+
+
+@pytest.mark.parametrize("key", _KEYS)
+def test_reyn_agent_name_resolves_in_every_registered_layer(
+    tmp_path, monkeypatch, key,
+) -> None:
+    """Tier 2: acceptance ① — ``${REYN_AGENT_NAME}`` resolves in *every*
+    layer :meth:`Session._hooks_yaml_layers` enumerates, for both the
+    ``hooks:`` and ``composers:`` key — driven from the registry itself,
+    never a hand-listed layer name."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    session = _make_session_in(project, monkeypatch, tmp_path)
+
+    for label, path in session._hooks_yaml_layers():
+        _write_yaml(path, _entry(key))
+        entries = session._read_hooks_yaml_layer_key(path, key)
+        assert entries, f"{label}/{key}: layer must load, not come back empty"
+        assert entries[0]["template_push"]["message"] == f"broker://inbox/{_AGENT}", (
+            f"{label}/{key}: ${{REYN_AGENT_NAME}} did not resolve to the "
+            f"real agent name — got {entries!r}"
+        )
+        path.unlink()  # isolate each layer's own probe from the next iteration
+
+
+@pytest.mark.parametrize("key", _KEYS)
+def test_a_non_reyn_token_passes_through_in_every_registered_layer(
+    tmp_path, monkeypatch, key,
+) -> None:
+    """Tier 2: acceptance ② — a non-reyn ``${FOO}`` (an env var meant for a
+    spawned child process) must load UNTOUCHED in every layer, never
+    fail-closed — the #5152-shaped regression this test is the detection
+    surface for (fail-close scoped too wide would turn a healthy config
+    red here)."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    session = _make_session_in(project, monkeypatch, tmp_path)
+
+    for label, path in session._hooks_yaml_layers():
+        _write_yaml(path, _passthrough_entry(key))
+        entries = session._read_hooks_yaml_layer_key(path, key)
+        assert entries, f"{label}/{key}: a non-reyn token must not be refused"
+        assert entries[0]["exec"]["command"] == "echo ${SOME_CHILD_PROCESS_VAR}", (
+            f"{label}/{key}: a non-reyn token must load untouched — got {entries!r}"
+        )
+        path.unlink()
+
+
+@pytest.mark.parametrize("key", _KEYS)
+def test_an_unresolved_reyn_token_refuses_the_layer_everywhere(
+    tmp_path, monkeypatch, key,
+) -> None:
+    """Tier 2: fail-close applies uniformly too — not just resolution.
+    Same registry walk, the OTHER half of "same字面, same意味"."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    session = _make_session_in(project, monkeypatch, tmp_path)
+
+    body = (
+        f"{key}:\n"
+        "  - name: bad\n"
+        "    on: turn_end\n"
+        "    template_push:\n"
+        "      message: ${REYN_SKILL_DIR}/note.txt\n"
+    )
+    for label, path in session._hooks_yaml_layers():
+        _write_yaml(path, body)
+        with pytest.warns(UserWarning, match="REYN_SKILL_DIR"):
+            entries = session._read_hooks_yaml_layer_key(path, key)
+        assert entries == [], (
+            f"{label}/{key}: an unresolved reyn token must refuse the whole "
+            f"layer, not load a wrong/empty value — got {entries!r}"
+        )
+        path.unlink()
+
+
+def test_the_four_named_reader_methods_delegate_through_the_shared_primitive(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: the OTHER half of #5166's own claim — walking
+    ``_hooks_yaml_layers()``/``_read_hooks_yaml_layer_key()`` directly (as
+    every OTHER test in this file does) proves the shared primitive itself
+    resolves reyn tokens correctly, but production code never calls that
+    primitive directly — ``_build_hook_registry``/``_build_composer_defs``
+    call the 4 NAMED methods (``_read_per_agent_hooks`` etc.). This is a
+    DIFFERENT claim (wiring, not layer-coverage) and deliberately names
+    all 4 — there are exactly 4 existing call sites production code uses,
+    not an open-ended set a registry could miss growing, so hand-naming
+    them here is the right shape (unlike the layer enumeration above,
+    which the #5166 registry exists precisely to avoid hand-naming)."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    session = _make_session_in(project, monkeypatch, tmp_path)
+
+    for label, path in session._hooks_yaml_layers():
+        for key in _KEYS:
+            _write_yaml(path, _entry(key))
+            method = getattr(session, f"_read_{label.replace('-', '_')}_{key}")
+            entries = method()
+            assert entries and entries[0]["template_push"]["message"] == f"broker://inbox/{_AGENT}", (
+                f"{label}.{method.__name__}(): must delegate through the "
+                f"shared primitive and resolve ${{REYN_AGENT_NAME}} — got {entries!r}"
+            )
+            path.unlink()
+
+
+def test_adding_a_layer_to_the_registry_is_automatically_covered(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: acceptance④ — the actual differentiator from "4 hand-written
+    tests": monkeypatch :meth:`Session._hooks_yaml_layers` to also report a
+    SYNTHETIC 3rd layer, and confirm the SAME registry-walk this file's
+    other tests already use picks it up with ZERO code changes anywhere
+    else — the concrete form of "a layer added later is not silently
+    missed" this issue's acceptance④ names."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    session = _make_session_in(project, monkeypatch, tmp_path)
+
+    synthetic_path = tmp_path / "synthetic-layer" / "hooks.yaml"
+    real_layers = session._hooks_yaml_layers()
+    monkeypatch.setattr(
+        session, "_hooks_yaml_layers",
+        lambda: [*real_layers, ("synthetic-3rd-layer", synthetic_path)],
+    )
+
+    layers = session._hooks_yaml_layers()
+    assert len(layers) == len(real_layers) + 1, "the monkeypatch itself must add exactly one layer"
+
+    for label, path in layers:
+        _write_yaml(path, _entry("hooks"))
+        entries = session._read_hooks_yaml_layer_key(path, "hooks")
+        assert entries and entries[0]["template_push"]["message"] == f"broker://inbox/{_AGENT}", (
+            f"{label}: a layer reached only through the registry (never "
+            f"hand-named in this test) must still resolve ${{REYN_AGENT_NAME}} "
+            f"— got {entries!r}"
+        )

--- a/tests/runtime/test_5166_hooks_yaml_layer_registry.py
+++ b/tests/runtime/test_5166_hooks_yaml_layer_registry.py
@@ -173,6 +173,46 @@ def test_the_four_named_reader_methods_delegate_through_the_shared_primitive(
             path.unlink()
 
 
+@pytest.mark.parametrize("key", _KEYS)
+def test_a_real_non_reyn_env_var_sharing_the_reyn_prefix_is_not_refused(
+    tmp_path, monkeypatch, key,
+) -> None:
+    """Tier 2: #5176 (architect TESTS-READ blocking finding on this PR,
+    issuecomment-5384269296) — acceptance⑤⑦, at the ACTUAL layer this
+    issue consolidated. ``${REYN_MCP_REGISTRY_URLS}`` is a real env var
+    (``config/loader.py`` propagates ``mcp.registries`` into it, meant for
+    ``expand_env``, never this module).
+
+    A REPAIR witness, not merely a prevention one (lead-coder's own
+    correction, acceptance⑦): the prefix-match bug this fixes already
+    ships on ``main`` via #5161/#5164's own fail-close call sites — a
+    per-agent ``hooks.yaml`` with ``${REYN_MCP_REGISTRY_URLS}`` is
+    refused TODAY, not merely something #5166's consolidation would have
+    newly broken. This test's own strip-verify (revert the
+    ``_KNOWN_REYN_TOKEN_NAMES`` filter) reproduces that exact CURRENT
+    ``main`` behavior — confirmed RED under the revert, restored GREEN."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    session = _make_session_in(project, monkeypatch, tmp_path)
+
+    body = (
+        f"{key}:\n"
+        "  - name: probe\n"
+        "    on: turn_end\n"
+        "    exec:\n"
+        "      command: echo ${REYN_MCP_REGISTRY_URLS}\n"
+    )
+    for label, path in session._hooks_yaml_layers():
+        _write_yaml(path, body)
+        entries = session._read_hooks_yaml_layer_key(path, key)
+        assert entries, (
+            f"{label}/{key}: a real env var sharing reyn's prefix must not "
+            f"refuse the whole layer — got {entries!r}"
+        )
+        assert entries[0]["exec"]["command"] == "echo ${REYN_MCP_REGISTRY_URLS}"
+        path.unlink()
+
+
 def test_adding_a_layer_to_the_registry_is_automatically_covered(
     tmp_path, monkeypatch,
 ) -> None:


### PR DESCRIPTION
**[e2e-coder]** — part of #5166. Architect ruling (issuecomment-5384196419), implemented as designed.

## Why (architect's own framing)

Not convenience — "the same literal means the same thing." Hooks get copy-pasted between layers: #5164's own docstring self-describes as "mirrors" the per-agent `hooks:` reader. A token-expansion rule duplicated 4 times means the next copy only carries whichever half someone remembered — exactly what happened: #5161 fixed per-agent `hooks:`, #5164 caught up per-agent `composers:`, and the 2 per-session readers (`hooks:`/`composers:`) had **no expansion at all**.

## What changed

- `config/loader.py`: new `read_and_expand_hooks_yaml(path, *, agent_name, project_root)` — the ONE read+expand+fail-close primitive every hooks.yaml-shaped layer now goes through. `load_per_agent_hooks` refactored to delegate to it (same public behavior).
- `session.py`: new `_hooks_yaml_layers()` (the enumerable per-agent/per-session path registry — this IS "read+expand in one place"'s own deliverable) + `_read_hooks_yaml_layer_key(path, key)`. All 4 readers (`_read_per_agent_hooks`/`_composers`, `_read_per_session_hooks`/`_composers`) are now 1-line delegations through the same registry+primitive.
- `config/loader.py` `:741` (`load_config`, acceptance③): a reyn-token pass (`expand_with_map`, `{REYN_PROJECT_DIR}` only — no agent context at this project-wide load) now runs **before** `expand_env`, so a real MCP server env var still resolves via `os.environ` while reyn's own tokens no longer silently degrade one layer up (the #5140 shape, recurring). **No fail-close at this layer** (unlike the 4 hooks.yaml layers) — refusing the whole project config over one unresolvable per-agent token (no agent context exists here) would be a disproportionate blast radius this project-wide load was never asked to take on; flagging this scoping choice explicitly for review.

## Tests — registry-driven, not 4 hand-written (architect's own explicit requirement)

- Walks `Session._hooks_yaml_layers()` for acceptance①②③ (resolve/pass-through/fail-close), never hand-lists a layer name.
- A dedicated acceptance④ test monkeypatches a **synthetic 3rd layer** onto `_hooks_yaml_layers()` and confirms the SAME test loop picks it up with zero code changes elsewhere — the literal "add a layer, coverage follows" witness.
- A separate, deliberately hand-named test covers the actual 4 production call sites (`_read_per_agent_hooks` etc.) — a DIFFERENT claim (wiring, not layer-coverage), and correctly hand-named since there are exactly 4 existing call sites, not an open set.
- `config/test_5166_load_config_reyn_token_before_env.py` covers acceptance③ (real MCP `${API_KEY}` + `${REYN_PROJECT_DIR}` in the same load).

## Strip-verify (genuine, not claimed)

- Reverted `_read_per_session_hooks` to its pre-#5166 (unwired) form → my own first test draft did NOT catch it (it called the shared primitive directly, not the named method) — caught and fixed before landing by adding a dedicated wiring test that calls the 4 named methods; that test correctly flips RED under the same revert.
- Reversed the `:741` expand order (`expand_env` before `expand_with_map`) → `${REYN_PROJECT_DIR}` silently degrades to `""`, confirmed RED, restored GREEN.

309+ existing tests in `tests/config/`/`tests/runtime/` scoped sweep green (2129 in the full directory sweep), plus 15 new. `ruff`/`test_tier_audit.py --strict`/`mypy_ratchet.py`/`flat_tests_ratchet.py`/doc-adjacent gates all clean (no doc currently asserts anything this PR falsifies — checked).

## Test plan

- [x] Registry-driven acceptance①②③④ (`test_5166_hooks_yaml_layer_registry.py`) — strip-verified
- [x] `:741` MCP-secret-order test (`test_5166_load_config_reyn_token_before_env.py`) — strip-verified
- [x] Existing `#5140` composers test updated for the new `warnings.warn` mechanism (was `logger.warning`), re-verified
- [ ] (Visual — standing waiver, owner 2026-08-08) N/A, no UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[architect]** — TESTS-READ（**A: 設計適合**、head `90566efc12`）issuecomment。裁定の形は全部入っています。B は別の人が必要です。

- [x] 🔴 (解消 `cb2ba2908`, architect 再 A issuecomment-5384291441／非 blocking 残は #5178) fail-close の判別が**接頭辞**（`\$\{((?:REYN|CLAUDE)_\w+)\}`）で、**語彙ではない**。`REYN_` で始まる**本物の環境変数**が実在する（`config/loader.py:744` 逐語「propagate `mcp.registries` config list into the **`REYN_MCP_REGISTRY_URLS`** env var」／`_ssrf_guard.py:55` も同型、`CLAUDE_CODE_*` も実在）→ **今まで `expand_env` が解決していた config が layer ごと拒否される**。`resolve_token_map`（tokens.py:174）の**名前集合に属するものだけ**を fail-close の対象に。受入⑤（`${REYN_MCP_REGISTRY_URLS}` を含む層が拒否されない）を追加

