### PR TITLE
fix(#5167): mcp_resource_updated hooks auto-subscribe at session start

### DIFF
--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -235,11 +235,34 @@ outside that loop: today, a subscribed MCP resource changing.
 ### `mcp_resource_updated`
 
 Fires when a server pushes a `resources/updated` notification for a resource
-this session subscribed to via `subscribe_mcp_resource` (see
+this session subscribed to (see
 [Resource subscriptions](../tools-integrations/mcp.md#resource-subscriptions-the-async-push-event-source)).
 Delivered from the MCP receive-loop task through a bounded queue drained on
 the session's own event loop — not from the agent's own turn/task machinery
 — so it can fire between turns, not only at a turn/task boundary.
+
+**Auto-subscribe at session start (#5167).** Declaring an `mcp_resource_updated`
+hook whose `matcher` names a CONCRETE `server` and a non-glob `uri` subscribes
+that resource automatically when the session starts — no `subscribe_mcp_resource`
+tool call, and no LLM turn, ever required. This closes a gap the mechanism
+originally shipped with: subscribing was previously reachable ONLY through the
+LLM-facing tool, so a declared hook whose agent happened never to call it
+silently never fired, with no warning anywhere — a declaration's effect
+depending on the agent's own turn-to-turn behaviour, the opposite of this
+system's usual "declared = honored deterministically" contract.
+
+A matcher with a *glob* `uri` (e.g. `{"server": "docs", "uri":
+"orch://job/*/progress"}`) is still valid and still narrows which pushes the
+hook reacts to — but it is not something reyn can auto-subscribe to (an MCP
+`resources/subscribe` request needs one exact URI). Same for a matcher missing
+`server`/`uri` entirely, or naming an unconfigured server. In every such case
+the agent's own explicit `subscribe_mcp_resource` tool call still works exactly
+as before; auto-subscribe never invents an ambiguous subscription, it only
+removes the LLM-turn dependency for the unambiguous case. Every case
+auto-subscribe cannot honor — including a genuine permission denial or a
+subscribe-level failure — emits a `mcp_hook_subscribe_not_applied` warning +
+audit-event naming the hook (see [Reference: events § MCP](../../reference/runtime/events.md#mcp)),
+so a declaration's non-effect is never silent.
 
 Template vars available to `template_push` / `pipeline_launch` rendering:
 

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -113,6 +113,7 @@ mcp_elicitation_auto_declined
 mcp_elicitation_requested
 mcp_elicitation_timed_out
 mcp_failed
+mcp_hook_subscribe_not_applied
 mcp_initialized
 mcp_install_cancelled
 mcp_install_probe_failed
@@ -418,6 +419,7 @@ op dispatch:
 | `mcp_elicitation_answered` | The request resolves to `accept` or `decline` (human choice, or a `decline` from `auto_decline` config). | `server`, `field_keys`, `action` (`"accept"` \| `"decline"`) |
 | `mcp_elicitation_timed_out` | No answer arrived before `elicitation_timeout_seconds`. | `server`, `field_keys` |
 | `mcp_elicitation_auto_declined` | Declined without prompting — `reason` distinguishes a server configured `elicitation: auto_decline` from a headless context (no live intervention listener). | `server`, `field_keys`, `reason` (`"server_configured"` \| `"headless"`) |
+| `mcp_hook_subscribe_not_applied` | #5167: a session-start `mcp_resource_updated` hook whose auto-subscribe attempt could not be honored (permission denied, an ambiguous/glob `uri` that names no concrete resource, an unconfigured server, or a subscribe-level failure). Never silent — see [Concepts: hooks § mcp_resource_updated](../../concepts/runtime/hooks.md#mcp_resource_updated). | `hook`, `server`, `uri` (may be `None` when the matcher never named one), `reason` |
 
 None of these events include the human's typed answer or any field *value* —
 only the requested schema's property names, matching the sensitive-field

--- a/src/reyn/builtin/skills/reactive-orchestration-plugins/references/incoming-events-coalescing-and-wake.md
+++ b/src/reyn/builtin/skills/reactive-orchestration-plugins/references/incoming-events-coalescing-and-wake.md
@@ -7,6 +7,17 @@ Subscribe call: `src/reyn/mcp/client.py`.
 The notification carries the **URI, not the resource body** -- the reacting
 side re-reads.
 
+**Getting subscribed (#5167).** A hook whose `matcher` names a CONCRETE
+`server` and a non-glob `uri` (e.g. `{"server": "docs", "uri":
+"orch://job/42/done"}`) is subscribed AUTOMATICALLY at session start -- no
+tool call needed on your plugin's part. A hook whose `matcher` globs `uri`
+(see below) is NOT auto-subscribed -- the agent still needs to call
+`subscribe_mcp_resource` explicitly for each concrete URI that pattern is
+meant to cover, since a glob names a SET of resources, not the one exact URI
+an MCP subscribe request requires. If your plugin's design depends on a
+specific URI firing without the agent ever having to call the tool, declare
+that URI literally rather than only under a glob matcher.
+
 **The URI is your signal namespace.** `matcher` glob-matches `uri` (see the
 glob-field set in `src/reyn/hooks/matcher.py`), so ONE hook point carries
 unlimited distinct signals: `orch://job/<id>/done`, `orch://job/<id>/failed`,

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -319,6 +319,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "mcp_elicitation_requested",
     "mcp_elicitation_timed_out",
     "mcp_failed",
+    "mcp_hook_subscribe_not_applied",
     "mcp_initialized",
     "mcp_install_cancelled",
     "mcp_install_probe_failed",

--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -147,6 +147,16 @@ class HookDispatcher:
         self._hook_cwd = hook_cwd
         self._hook_process_context = hook_process_context
 
+    @property
+    def registry(self) -> HookRegistry:
+        """The currently-live :class:`HookRegistry` (#5167). Read-only
+        introspection for a caller that needs to enumerate declared hooks
+        BEFORE any dispatch happens (e.g. ``Session``'s own session-start
+        auto-subscribe pass over declared ``mcp_resource_updated`` hooks) —
+        never reach into ``self._registry`` directly. Reflects
+        :meth:`replace_registry`'s live swap, same as ``dispatch()`` itself."""
+        return self._registry
+
     def _consent_bus_now(self) -> Any:
         """The consent bus iff a live intervention listener is attached, else None."""
         if self._consent_bus is None or self._consent_gate is None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -8695,16 +8695,32 @@ class Session:
         naming the hook, so a declaration's non-effect is never silent —
         see that kind's own docstring in ``event_schema.py``.
 
-        No-op for an ephemeral session (mirrors :meth:`_mcp_subscribe_resource`
-        itself: a subscription is only meaningful on a persistent connection)
-        and when no ``mcp_resource_updated`` hook is declared at all (the
-        common case — zero declared hooks means zero enumeration, zero
-        subscribe attempts, byte-identical to pre-#5167 startup).
+        Byte-identical to pre-#5167 startup when no ``mcp_resource_updated``
+        hook is declared at all (the common case — zero declared hooks means
+        zero enumeration, zero subscribe attempts, zero audit-events).
+
+        An EPHEMERAL session (architect non-blocking review, TESTS-READY(A) on
+        #5180, issuecomment-5384348643) still ENUMERATES its declared hooks and
+        reports each through the SAME ``mcp_hook_subscribe_not_applied`` path —
+        it does not silently early-return before looking. The refusal itself
+        is correct (mirrors :meth:`_mcp_subscribe_resource`'s own: a
+        subscription is only meaningful on a persistent connection, which an
+        ephemeral session never holds), but "correct AND silent" is exactly the
+        shape #5167 exists to close — a declared hook on an ephemeral session
+        would otherwise be accepted, never honored, and never explained,
+        indistinguishable from the original bug this whole method fixes.
         """
-        if self._ephemeral:
-            return
         hooks = self._hook_dispatcher.registry.hooks_for("mcp_resource_updated")
         for hook in hooks:
+            if self._ephemeral:
+                matcher = hook.matcher or {}
+                self._report_mcp_hook_subscribe_not_applied(
+                    hook.name or "mcp_resource_updated",
+                    matcher.get("server"), matcher.get("uri"),
+                    "session is ephemeral — a subscription is only "
+                    "meaningful on a persistent connection.",
+                )
+                continue
             await self._auto_subscribe_one_mcp_resource_hook(hook)
 
     async def _auto_subscribe_one_mcp_resource_hook(self, hook: "HookDef") -> None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from reyn.hooks.composed_consumer import ComposedEventConsumer
     from reyn.hooks.composer import ComposerRegistry
     from reyn.hooks.dispatcher import HookDispatcher
+    from reyn.hooks.schema import HookDef
     from reyn.interfaces.slash import SlashContext
     from reyn.mcp.connection_service import MCPConnectionService
     from reyn.runtime.fs_watcher import FsWatcher
@@ -6889,6 +6890,10 @@ class Session:
         # #2608 H4: start the filesystem watcher (no-op if no fs_watch.paths
         # configured or 'watchdog' isn't installed — see FsWatcher.start).
         await self._fs_watcher.start()
+        # #5167: auto-subscribe every declared mcp_resource_updated hook that
+        # names a concrete (server, uri) — no-op if none are declared, or if
+        # this is an ephemeral session (see the method's own docstring).
+        await self._auto_subscribe_mcp_resource_hooks()
         # Hook-Event Redesign Phase 5 part 1 (proposal 0059 §9 item 3 / #2881):
         # start every configured Composer (no-op — an empty list, the default
         # — spawns zero background tasks, byte-identical to pre-Composer-
@@ -8655,6 +8660,122 @@ class Session:
         async with MCPClientPool() as pool:
             ctx.mcp_pool = pool
             return await execute_op(op, ctx)
+
+    async def _auto_subscribe_mcp_resource_hooks(self) -> None:
+        """#5167: subscribe, at session start, to every declared
+        ``mcp_resource_updated`` hook whose ``matcher`` names a CONCRETE
+        ``(server, uri)`` — no LLM turn, no explicit ``subscribe_mcp_resource``
+        tool call, ever required.
+
+        Architect ruling (issuecomment-5384120494): declaring this hook used
+        to be pure INTENT — the only construction site for a subscribe was
+        the LLM-facing tool (``tools/mcp.py``), so a declared hook whose agent
+        never happened to call it silently never fired, with no warning or
+        audit-event anywhere. Charter lens 3 (deterministic, not stuffed into
+        the prompt) names exactly this: a declaration's effect must not
+        depend on the agent's own turn-to-turn behaviour.
+
+        **What counts as "concrete" here** (architect's own warning,
+        issuecomment-5384128053, re: a follow-up gate): a matcher can glob
+        ``uri`` (``reyn.hooks.matcher``'s own field), e.g. ``{"server":
+        "docs", "uri": "orch://job/*/progress"}`` — a real, useful pattern for
+        narrowing WHICH pushes a hook reacts to, but not a URI reyn can issue
+        an MCP ``resources/subscribe`` request for (the protocol subscribes to
+        one exact resource). A hook with no matcher, or a matcher missing
+        ``server``/``uri``, or a glob ``uri``, is left for the agent's own
+        explicit tool call exactly as before — this method never invents an
+        ambiguous subscription, it only removes the LLM-turn dependency for
+        the case where the declaration is already unambiguous.
+
+        **Silence, closed either way** (②, architect ruling — required even
+        with ① auto-subscribe, since ① has real failure paths: permission
+        denied, an unconfigured server, a subscribe-level fault, or a
+        deliberately-non-concrete matcher): every hook this method cannot
+        honor emits a ``mcp_hook_subscribe_not_applied`` warning + audit-event
+        naming the hook, so a declaration's non-effect is never silent —
+        see that kind's own docstring in ``event_schema.py``.
+
+        No-op for an ephemeral session (mirrors :meth:`_mcp_subscribe_resource`
+        itself: a subscription is only meaningful on a persistent connection)
+        and when no ``mcp_resource_updated`` hook is declared at all (the
+        common case — zero declared hooks means zero enumeration, zero
+        subscribe attempts, byte-identical to pre-#5167 startup).
+        """
+        if self._ephemeral:
+            return
+        hooks = self._hook_dispatcher.registry.hooks_for("mcp_resource_updated")
+        for hook in hooks:
+            await self._auto_subscribe_one_mcp_resource_hook(hook)
+
+    async def _auto_subscribe_one_mcp_resource_hook(self, hook: "HookDef") -> None:
+        """One declared hook's auto-subscribe attempt — see
+        :meth:`_auto_subscribe_mcp_resource_hooks`'s docstring for the full
+        design. Split out so each hook is isolated (one hook's failure never
+        skips the next) and so the warning/audit path has a single call
+        site."""
+        matcher = hook.matcher or {}
+        server = matcher.get("server")
+        uri = matcher.get("uri")
+        hook_label = hook.name or "mcp_resource_updated"
+
+        if not server or not uri:
+            self._report_mcp_hook_subscribe_not_applied(
+                hook_label, server, uri,
+                "matcher does not name both a concrete server and uri — "
+                "nothing to auto-subscribe to (the agent may still call "
+                "subscribe_mcp_resource itself).",
+            )
+            return
+        # #5167: reyn.hooks.matcher glob-matches `uri` via fnmatch — a
+        # pattern using any of fnmatch's special characters names a SET of
+        # resources, not the one concrete URI an MCP `resources/subscribe`
+        # request requires. `[` is included (fnmatch character classes),
+        # not just `*`/`?`.
+        if any(ch in uri for ch in "*?["):
+            self._report_mcp_hook_subscribe_not_applied(
+                hook_label, server, uri,
+                "matcher's uri is a glob pattern, not a concrete resource — "
+                "MCP subscribe requires one exact URI (the agent may still "
+                "call subscribe_mcp_resource itself for a resource that "
+                "matches this pattern).",
+            )
+            return
+
+        try:
+            result = await self._mcp_subscribe_resource(server, uri)
+        except PermissionError as exc:
+            self._report_mcp_hook_subscribe_not_applied(
+                hook_label, server, uri, f"permission denied: {exc}",
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — one hook's fault must never break startup or its siblings
+            self._report_mcp_hook_subscribe_not_applied(
+                hook_label, server, uri, f"unexpected error: {exc}",
+            )
+            return
+        if result.get("status") != "ok":
+            self._report_mcp_hook_subscribe_not_applied(
+                hook_label, server, uri,
+                str(result.get("error") or f"status={result.get('status')!r}"),
+            )
+
+    def _report_mcp_hook_subscribe_not_applied(
+        self, hook_label: str, server: "str | None", uri: "str | None", reason: str,
+    ) -> None:
+        """#5167 ②: the one place a declared ``mcp_resource_updated`` hook's
+        auto-subscribe non-effect becomes visible — mirrors the
+        ``sandbox_policy_not_applied`` shape (``hooks/shell_runner.py``) and
+        the loader's own "not applied" phrasing convention
+        (``config/loader.py``'s ``_warn_unknown_config_keys``): the consequence
+        is always named, never just the cause."""
+        logger.warning(
+            "mcp_resource_updated hook %r: auto-subscribe not applied — %s",
+            hook_label, reason,
+        )
+        self._audit_events.emit(
+            "mcp_hook_subscribe_not_applied",
+            hook=hook_label, server=server, uri=uri, reason=reason,
+        )
 
     async def _mcp_subscribe_resource(self, server: str, uri: str) -> dict:
         """Subscribe to server-pushed ``resources/updated`` for ``uri`` on

--- a/tests/runtime/test_5167_mcp_hook_auto_subscribe.py
+++ b/tests/runtime/test_5167_mcp_hook_auto_subscribe.py
@@ -1,0 +1,316 @@
+"""Tier 2: #5167 — declaring an ``mcp_resource_updated`` hook with a
+CONCRETE (server, uri) matcher auto-subscribes it at session start, with
+NO LLM turn ever required (architect ruling, issuecomment-5384120494).
+
+Before this: the only construction site for a resource subscription was
+the LLM-facing ``subscribe_mcp_resource`` tool (``tools/mcp.py``) — a
+declared hook whose agent never happened to call it silently never fired,
+with no warning anywhere. Charter lens 3 (deterministic, not stuffed into
+the prompt) names exactly this gap.
+
+Acceptance (architect, issuecomment-5384120494/5384128053):
+  ① declare -> session start -> never speak -> subscription exists.
+     Observed through ``Session.mcp_subscription_state()`` (#4686's public
+     read model over ``MCPConnectionService.subscribed_uris`` — #2597 s2b's
+     own observation point, reached here through the public surface rather
+     than the private connection-service attribute, per the testing policy).
+  ② unreachable/denied -> a ``mcp_hook_subscribe_not_applied`` warning +
+     audit-event names the hook — never silent.
+  ③ strip (revert the auto-subscribe call) -> ① goes red. Demonstrated by
+     the PR's own strip-falsify pass (this module's own witness IS ①;
+     there is no separate "strip" test — reverting ① and re-running it is
+     what proves ③, not a second copy of the same assertion).
+  ④ NONE of ①-③ requires an LLM turn. Structural here, not incidental:
+     every test below drives ``Session._auto_subscribe_mcp_resource_hooks``
+     directly (mirroring ``test_5091_broker_participation_via_per_session_
+     hooks.py``'s own convention of driving ``HookDispatcher.dispatch``
+     directly rather than the full ``run()`` loop) — no test in this module
+     ever calls ``run_one_iteration``/dispatches a router turn, so an LLM
+     call is structurally unreachable from any of them, not merely absent
+     by observation.
+
+Real ``Session`` + a real subscribable MCP server subprocess (the SAME
+support double ``test_2597_s2b_resource_subscriptions.py`` uses) — no
+mocks, per the testing policy.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
+from reyn.security.permissions.permissions import PermissionResolver
+from reyn.security.sandbox.noop_backend import NoopBackend
+from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
+from tests._support.paths import REPO_ROOT
+
+_SUPPORT_DIR = REPO_ROOT / "tests" / "_support"
+_SUBSCRIBABLE_SERVER = _SUPPORT_DIR / "mcp_subscribable_resources_server.py"
+_URI = "resource://counter"
+
+
+def _stdio_cfg(script: Path) -> dict:
+    return {"type": "stdio", "command": sys.executable, "args": [str(script)]}
+
+
+def _write_hooks_yaml(session: Session, *, server: "str | None", uri: "str | None") -> None:
+    snapshot_dir = Path(session._snapshot_path).parent
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    matcher_lines = ""
+    if server is not None:
+        matcher_lines += f"      server: {server}\n"
+    if uri is not None:
+        matcher_lines += f'      uri: "{uri}"\n'
+    matcher_block = f"    matcher:\n{matcher_lines}" if matcher_lines else ""
+    (snapshot_dir / "hooks.yaml").write_text(
+        "hooks:\n"
+        "  - on: mcp_resource_updated\n"
+        f"{matcher_block}"
+        "    template_push:\n"
+        '      message: "resource pushed"\n'
+        "      wake: true\n",
+        encoding="utf-8",
+    )
+
+
+def _make_session(
+    tmp_path: Path,
+    agent_name: str,
+    *,
+    mcp_servers: "dict | None" = None,
+    permission_resolver: "PermissionResolver | None" = None,
+) -> Session:
+    return make_session(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / f"{agent_name}.wal"),
+        snapshot_path=tmp_path / agent_name / "snap.json",
+        reactivity=ReactivityConfig(),
+        sandbox_backend=NoopBackend(),
+        mcp_servers=mcp_servers,
+        permission_resolver=permission_resolver,
+    )
+
+
+def _subscribed_uris(session: Session, server: str) -> list:
+    """The subscribed-URI set for *server*, read through the PUBLIC
+    ``Session.mcp_subscription_state()`` read model (#4686 — the same one
+    the status-bar/MCP-pane use) rather than reaching into
+    ``session._mcp_connection_service`` directly — the testing policy
+    forbids a private-state assertion, and this is the public surface that
+    exists for exactly this observation."""
+    for entry in session.mcp_subscription_state():
+        if entry["server"] == server:
+            return entry["uris"]
+    return []
+
+
+def _allow_all_resolver(tmp_path: Path, server: str) -> PermissionResolver:
+    """Non-interactive, config-pre-approved for *server* — no prompt ever
+    reachable (mirrors #2597 s2b's own ``interactive=False`` + config-approve
+    pattern), so a real subscribe succeeds with zero human/LLM involvement."""
+    return PermissionResolver(
+        config_permissions={"mcp": {server: "allow"}},
+        project_root=tmp_path,
+        interactive=False,
+    )
+
+
+# ── ① real subscribe, no LLM turn, no explicit tool call ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_declared_concrete_hook_is_subscribed_with_no_turn_and_no_tool_call(
+    tmp_path: Path,
+):
+    """Tier 2: acceptance ① — a concrete (server, uri) matcher subscribes
+    for real, driven only by session startup's own auto-subscribe pass.
+    Never calls run()/run_one_iteration/dispatches any router turn — the
+    LLM is structurally never in this call graph (acceptance ④)."""
+    resolver = _allow_all_resolver(tmp_path, "srv")
+    session = _make_session(
+        tmp_path, "coder-x",
+        mcp_servers={"srv": _stdio_cfg(_SUBSCRIBABLE_SERVER)},
+        permission_resolver=resolver,
+    )
+    _write_hooks_yaml(session, server="srv", uri=_URI)
+    session._hook_dispatcher.replace_registry(session._build_hook_registry())
+
+    try:
+        await session._auto_subscribe_mcp_resource_hooks()
+
+        assert _subscribed_uris(session, "srv") == [_URI], (
+            "declaring the hook did not produce a real subscription at "
+            "session start — the agent never called subscribe_mcp_resource "
+            "and no LLM turn ever ran"
+        )
+    finally:
+        await session.aclose_mcp_connections()
+
+
+@pytest.mark.asyncio
+async def test_no_declared_hook_means_no_subscribe_attempt(tmp_path: Path):
+    """Tier 2: regression guard mirroring #5091's own "absence must not
+    silently opt in" — a session with no mcp_resource_updated hook declared
+    at all subscribes nothing and touches the connection service not at all."""
+    resolver = _allow_all_resolver(tmp_path, "srv")
+    session = _make_session(
+        tmp_path, "coder-y",
+        mcp_servers={"srv": _stdio_cfg(_SUBSCRIBABLE_SERVER)},
+        permission_resolver=resolver,
+    )
+
+    await session._auto_subscribe_mcp_resource_hooks()
+
+    assert _subscribed_uris(session, "srv") == []
+
+
+# ── ② silence closed: every non-concrete/failed case is named, never mute ──
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_server_emits_warning_and_audit_event(tmp_path: Path):
+    """Tier 2: acceptance ② — a hook naming a server that isn't in
+    mcp_servers at all cannot be auto-subscribed; this must be VISIBLE
+    (warning + audit-event naming the hook), never a silent no-op."""
+    events = EventLog()
+    session = _make_session(tmp_path, "coder-z", mcp_servers={})
+    session._audit_events = events
+    _write_hooks_yaml(session, server="not-configured", uri=_URI)
+    session._hook_dispatcher.replace_registry(session._build_hook_registry())
+    collected = collect_events(events)
+
+    await session._auto_subscribe_mcp_resource_hooks()
+    await settle(events)
+
+    matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
+    assert matching, (
+        "an unconfigured-server hook produced no mcp_hook_subscribe_not_applied "
+        "audit-event — the declaration's non-effect went silent"
+    )
+    assert matching[0].data.get("server") == "not-configured"
+    assert matching[0].data.get("uri") == _URI
+    assert "not configured" in str(matching[0].data.get("reason", ""))
+
+
+@pytest.mark.asyncio
+async def test_permission_denied_emits_warning_and_audit_event(tmp_path: Path):
+    """Tier 2: acceptance ② second path — permission genuinely refused
+    (no config approval, non-interactive so no prompt can rescue it) also
+    surfaces via the SAME warning+audit-event path, not a raised exception
+    that could crash session startup."""
+    events = EventLog()
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    session = _make_session(
+        tmp_path, "coder-w",
+        mcp_servers={"srv": _stdio_cfg(_SUBSCRIBABLE_SERVER)},
+        permission_resolver=resolver,
+    )
+    session._audit_events = events
+    _write_hooks_yaml(session, server="srv", uri=_URI)
+    session._hook_dispatcher.replace_registry(session._build_hook_registry())
+    collected = collect_events(events)
+
+    await session._auto_subscribe_mcp_resource_hooks()
+    await settle(events)
+
+    matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
+    assert matching, "a permission-denied auto-subscribe must not fail silently"
+    assert matching[0].data.get("server") == "srv"
+    assert "permission" in str(matching[0].data.get("reason", "")).lower()
+    assert _subscribed_uris(session, "srv") == []
+
+
+@pytest.mark.asyncio
+async def test_glob_uri_matcher_is_not_auto_subscribed_but_is_reported(tmp_path: Path):
+    """Tier 2: a matcher's uri may glob (reyn.hooks.matcher's own field) —
+    a real, useful pattern for narrowing which pushes a hook reacts to, but
+    NOT a concrete resource an MCP subscribe request can name. Auto-
+    subscribe must never invent an ambiguous subscription; it reports the
+    non-effect the same way as any other unhonored case, and the agent's
+    own explicit subscribe_mcp_resource tool call is left as the path for
+    this case (unchanged from before #5167)."""
+    events = EventLog()
+    resolver = _allow_all_resolver(tmp_path, "srv")
+    session = _make_session(
+        tmp_path, "coder-v",
+        mcp_servers={"srv": _stdio_cfg(_SUBSCRIBABLE_SERVER)},
+        permission_resolver=resolver,
+    )
+    session._audit_events = events
+    _write_hooks_yaml(session, server="srv", uri="resource://job/*/progress")
+    session._hook_dispatcher.replace_registry(session._build_hook_registry())
+    collected = collect_events(events)
+
+    await session._auto_subscribe_mcp_resource_hooks()
+    await settle(events)
+
+    assert _subscribed_uris(session, "srv") == [], (
+        "a glob uri must never be auto-subscribed — it names a SET, not one "
+        "concrete resource"
+    )
+    matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
+    assert matching, "a glob-uri hook's non-effect must still be reported"
+    assert "glob" in str(matching[0].data.get("reason", "")).lower()
+
+
+@pytest.mark.asyncio
+async def test_matcher_missing_server_or_uri_is_reported_not_silently_skipped(
+    tmp_path: Path,
+):
+    """Tier 2: a hook with no matcher (or one missing server/uri) has
+    nothing concrete to auto-subscribe to — this is a LEGITIMATE
+    configuration (the agent may still call subscribe_mcp_resource itself
+    for whatever it decides to react to), but it must still be named, not
+    silently absorbed as "nothing to do here."""
+    events = EventLog()
+    resolver = _allow_all_resolver(tmp_path, "srv")
+    session = _make_session(
+        tmp_path, "coder-u",
+        mcp_servers={"srv": _stdio_cfg(_SUBSCRIBABLE_SERVER)},
+        permission_resolver=resolver,
+    )
+    session._audit_events = events
+    _write_hooks_yaml(session, server=None, uri=None)
+    session._hook_dispatcher.replace_registry(session._build_hook_registry())
+    collected = collect_events(events)
+
+    await session._auto_subscribe_mcp_resource_hooks()
+    await settle(events)
+
+    matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
+    assert matching, "a matcher-less hook's non-effect must still be reported"
+    assert matching[0].data.get("server") is None
+    assert matching[0].data.get("uri") is None
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_session_never_attempts_auto_subscribe(tmp_path: Path):
+    """Tier 2: mirrors _mcp_subscribe_resource's own ephemeral refusal — a
+    subscription is only meaningful on a persistent connection, so an
+    ephemeral session's auto-subscribe pass is a pure no-op (no warning,
+    no audit-event either — the session TYPE itself, not any one hook's
+    declaration, is why nothing happens here)."""
+    events = EventLog()
+    resolver = _allow_all_resolver(tmp_path, "srv")
+    session = _make_session(
+        tmp_path, "coder-t",
+        mcp_servers={"srv": _stdio_cfg(_SUBSCRIBABLE_SERVER)},
+        permission_resolver=resolver,
+    )
+    session._ephemeral = True
+    session._audit_events = events
+    _write_hooks_yaml(session, server="srv", uri=_URI)
+    session._hook_dispatcher.replace_registry(session._build_hook_registry())
+    collected = collect_events(events)
+
+    await session._auto_subscribe_mcp_resource_hooks()
+
+    assert collected == []

--- a/tests/runtime/test_5167_mcp_hook_auto_subscribe.py
+++ b/tests/runtime/test_5167_mcp_hook_auto_subscribe.py
@@ -292,12 +292,18 @@ async def test_matcher_missing_server_or_uri_is_reported_not_silently_skipped(
 
 
 @pytest.mark.asyncio
-async def test_ephemeral_session_never_attempts_auto_subscribe(tmp_path: Path):
-    """Tier 2: mirrors _mcp_subscribe_resource's own ephemeral refusal — a
-    subscription is only meaningful on a persistent connection, so an
-    ephemeral session's auto-subscribe pass is a pure no-op (no warning,
-    no audit-event either — the session TYPE itself, not any one hook's
-    declaration, is why nothing happens here)."""
+async def test_ephemeral_session_never_subscribes_but_still_reports_why(
+    tmp_path: Path,
+):
+    """Tier 2: architect non-blocking review on #5180 (TESTS-READY(A),
+    issuecomment-5384348643) — mirrors _mcp_subscribe_resource's own
+    ephemeral refusal (a subscription is only meaningful on a persistent
+    connection), but the refusal must NOT be a silent early-return before
+    even looking at declared hooks. A declared hook on an ephemeral session
+    that subscribed nothing and said nothing would be indistinguishable
+    from the original #5167 bug (declared, never honored, never
+    explained) — so this still enumerates and reports through the SAME
+    mcp_hook_subscribe_not_applied path every other unhonored case uses."""
     events = EventLog()
     resolver = _allow_all_resolver(tmp_path, "srv")
     session = _make_session(
@@ -314,4 +320,16 @@ async def test_ephemeral_session_never_attempts_auto_subscribe(tmp_path: Path):
     await session._auto_subscribe_mcp_resource_hooks()
     await settle(events)
 
-    assert collected == []
+    assert _subscribed_uris(session, "srv") == [], (
+        "an ephemeral session must never actually subscribe — no persistent "
+        "connection exists for a push to arrive on"
+    )
+    matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
+    assert matching, (
+        "an ephemeral session's declared hook produced no "
+        "mcp_hook_subscribe_not_applied audit-event — declared, never "
+        "honored, never explained is the exact #5167 bug shape"
+    )
+    assert matching[0].data.get("server") == "srv"
+    assert matching[0].data.get("uri") == _URI
+    assert "ephemeral" in str(matching[0].data.get("reason", "")).lower()

--- a/tests/runtime/test_5167_mcp_hook_auto_subscribe.py
+++ b/tests/runtime/test_5167_mcp_hook_auto_subscribe.py
@@ -312,5 +312,6 @@ async def test_ephemeral_session_never_attempts_auto_subscribe(tmp_path: Path):
     collected = collect_events(events)
 
     await session._auto_subscribe_mcp_resource_hooks()
+    await settle(events)
 
     assert collected == []


### PR DESCRIPTION
**[tui-coder]** — #5167, architect ruling (issuecomment-5384120494/5384128053).

## Problem
Subscribing to an MCP resource was reachable ONLY via the LLM-facing `subscribe_mcp_resource` tool — a declared `mcp_resource_updated` hook whose agent never happened to call it silently never fired, with no warning. Same class as #5140 (`${REYN_AGENT_NAME}`): a declaration reyn accepts but nothing honors. Charter lens 3 (deterministic, not stuffed into the prompt).

## Fix — two parts (both required per architect's general rule)
1. `Session.run()` calls a new `_auto_subscribe_mcp_resource_hooks()` right after starting the fs_watcher — enumerates every declared `mcp_resource_updated` hook (`HookDispatcher.registry`, new public property) and subscribes any whose matcher names a **concrete** `server`+`uri` (no glob chars) through the existing `_mcp_subscribe_resource` — same permission gate a tool call uses. No-op for ephemeral sessions / no declared hooks.
2. Every case that can't be honored (glob `uri`, missing `server`/`uri`, unconfigured server, permission denial, subscribe fault) emits a new `mcp_hook_subscribe_not_applied` warning + audit-event naming the hook — mirrors `sandbox_policy_not_applied`'s shape and the loader's "not applied" phrasing. Never silent, never a crash-startup exception.

## Test — 7 new tests, matching the 4 acceptance criteria
- ① a concrete hook subscribes for **real** against a live subscribable MCP server subprocess (same double `test_2597_s2b_resource_subscriptions.py` uses), observed via `Session.mcp_subscription_state()`'s public read model (no private-state assertion).
- ② unconfigured server / permission denial / glob uri / missing matcher fields all emit the audit-event.
- ③ strip-falsified: renamed the method away → ① fails with the expected `AttributeError`; restored green.
- ④ structural: every test drives `_auto_subscribe_mcp_resource_hooks` directly (mirrors `test_5091`'s own convention) — no test ever dispatches a router turn, so an LLM call is unreachable by construction, not merely unobserved.

## Docs (same PR, per house rule)
`concepts/runtime/hooks.md`'s `mcp_resource_updated` section, `reference/runtime/events.md`'s new-kind row, and the `reactive-orchestration-plugins` skill's "getting subscribed" note (flagged false by lead-coder during design) — all corrected here.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict tests/runtime/test_5167_mcp_hook_auto_subscribe.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] `check_bare_tests_import_reference.py`
- [x] `check_file_depth_reference.py`
- [x] `verify_module_docstrings.py`
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && check_doc_anchors.py && check_retired_config_keys_denylist.py` (docs/ touched)
- [x] Regression: `tests/runtime/` + `tests/core/test_2597_s2b_resource_subscriptions.py` + `tests/hooks/` + audit-event kind vocabulary census — 2263 passed, 7 skipped, no regressions
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)