### PR TITLE
fix(#5131): TUI down-flow (App->widget) moves to reactive/watch_

### DIFF
--- a/scripts/check_tui_reactive_ratchet.py
+++ b/scripts/check_tui_reactive_ratchet.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""#5131 gate B — the "down" reactive framework never shrinks, and App's
+imperative pushes into a widget never grow.
+
+Gate A (``check_tui_widget_boundary.py``) is structural and zero-FP: an
+import statement is unambiguous. Whether App→widget state flow actually
+goes through ``reactive``/``watch_`` instead of an imperative call is
+SEMANTIC — "did this migration duplicate state" is not something an AST
+census can answer, and this gate does not claim to. It answers a narrower,
+honest question instead: is the population of the two structural SIGNALS
+moving the right direction?
+
+  - ``reactive_count`` — every class-level ``reactive(...)`` assignment plus
+    every ``watch_*``/``watch__*`` method, across every ``.py`` file in
+    ``textual_chat/``. Ratchet FLOOR: must never DECREASE. A migration that
+    adds a new reactive/watcher raises the floor for free; nothing has to
+    be edited to let that count.
+  - ``imperative_push_count`` — call sites in ``app.py`` (the one file Gate
+    A lets touch widgets at all) shaped ``self.query_one(...).method(...)``
+    — the App reaching into a widget it just looked up and calling ANY
+    method on it directly. This is deliberately UNDER-selective, not
+    over-precise: it counts every such call, not only the ones that push
+    state (a pure-action call like ``.focus()`` counts the same as a
+    state-push like ``.update_status(...)``) — distinguishing the two
+    would be exactly the semantic "does this duplicate state" question
+    Gate A already declined to answer, restated one level down. Counting
+    the superset keeps the gate zero-FP at the cost of also flagging an
+    unrelated new ``.focus()`` call — cheap to clear (``--write-baseline``
+    + one PR line), and the baseline only grows when a human explicitly
+    says why. Ratchet CEILING: must never INCREASE for free; a
+    ``reactive``-based migration that REPLACES one of these sites makes
+    this count drop for free, with nothing to edit to let that count.
+
+Same baseline+``--write-baseline``+``--check-growth`` skeleton as
+``mypy_ratchet.py``/``flat_tests_ratchet.py`` (architect/#3726 precedent):
+a committed JSON baseline, re-measured live, red the moment either
+direction regresses. ``--check-growth BASE_REF`` additionally rejects a
+baseline edit that isn't backed by a real measured change (the same
+"hand-editing the baseline to fake progress" defense those two scripts
+already have).
+
+NOT a duplication detector, NOT a proof of sufficiency — a floor and a
+ceiling that stop this specific regression from being silent, nothing
+more. See ``src/reyn/interfaces/CLAUDE.md``'s own #5131 section for the
+4 rules this gate is a PARTIAL, structural witness for.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_PACKAGE_DIR = _ROOT / "src" / "reyn" / "interfaces" / "inline" / "textual_chat"
+_APP_PY = _PACKAGE_DIR / "app.py"
+_BASELINE_PATH = _ROOT / "scripts" / "tui_reactive_ratchet_baseline.json"
+
+
+def _is_reactive_call(node: ast.expr) -> bool:
+    """True if *node* is a call to ``reactive(...)`` (bare name, since
+    ``textual.reactive.reactive`` is always imported as the bare name in
+    this codebase — matches the import shape ``check_tui_widget_boundary``
+    itself assumes elsewhere)."""
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "reactive"
+
+
+def _reactive_count_in_file(path: Path) -> int:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError:
+        return 0
+    count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign) and node.value is not None and _is_reactive_call(node.value):
+            count += 1
+        elif isinstance(node, ast.Assign) and _is_reactive_call(node.value):
+            count += 1
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("watch_"):
+            count += 1
+    return count
+
+
+def measured_reactive_count(package_dir: Path = _PACKAGE_DIR) -> int:
+    """Total reactive-declaration + watch-method count across every ``.py``
+    file in *package_dir*. See the module docstring for exactly what
+    counts."""
+    return sum(_reactive_count_in_file(p) for p in sorted(package_dir.glob("*.py")))
+
+
+def _is_query_one_call(node: ast.expr) -> bool:
+    """True if *node* is ``self.query_one(...)`` — any argument shape."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "query_one"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+    )
+
+
+def measured_imperative_push_count(app_py: Path = _APP_PY) -> int:
+    """Call sites in *app_py* shaped ``self.query_one(...).method(...)`` —
+    App reaching into a widget it just looked up and calling a method on it
+    directly. See the module docstring for why this is the CEILING signal."""
+    if not app_py.is_file():
+        return 0
+    try:
+        tree = ast.parse(app_py.read_text(encoding="utf-8"), filename=str(app_py))
+    except SyntaxError:
+        return 0
+    count = 0
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and _is_query_one_call(node.func.value)
+        ):
+            count += 1
+    return count
+
+
+def _load_baseline(path: Path = _BASELINE_PATH) -> dict:
+    if not path.is_file():
+        return {"reactive_count": 0, "imperative_push_count": 0}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_baseline(reactive_count: int, imperative_push_count: int, path: Path = _BASELINE_PATH) -> None:
+    path.write_text(
+        json.dumps(
+            {"reactive_count": reactive_count, "imperative_push_count": imperative_push_count},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _git_show(base_ref: str, rel_path: str) -> "dict | None":
+    try:
+        raw = subprocess.run(
+            ["git", "show", f"{base_ref}:{rel_path}"],
+            cwd=_ROOT, capture_output=True, text=True, check=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write-baseline", action="store_true",
+        help="Overwrite the committed baseline with today's measured counts. "
+             "Legitimate for initial adoption or a real improvement — same "
+             "warning as mypy_ratchet.py: this can also be used to silently "
+             "paper over a regression, which is what --check-growth guards.",
+    )
+    parser.add_argument(
+        "--check-growth", metavar="BASE_REF",
+        help="Reject a baseline that moved in the WRONG direction relative "
+             "to BASE_REF (reactive_count decreased, or imperative_push_count "
+             "increased) without a matching real measured change.",
+    )
+    args = parser.parse_args()
+
+    reactive_count = measured_reactive_count()
+    imperative_push_count = measured_imperative_push_count()
+
+    if args.write_baseline:
+        _write_baseline(reactive_count, imperative_push_count)
+        print(
+            f"check_tui_reactive_ratchet: baseline written — "
+            f"reactive_count={reactive_count}, imperative_push_count={imperative_push_count}"
+        )
+        return 0
+
+    if args.check_growth:
+        base_baseline = _git_show(args.check_growth, "scripts/tui_reactive_ratchet_baseline.json")
+        if base_baseline is None:
+            print(
+                f"check_tui_reactive_ratchet: no baseline at {args.check_growth} — "
+                "nothing to compare, treating as OK (initial adoption).",
+            )
+        else:
+            current_baseline = _load_baseline()
+            if current_baseline["reactive_count"] < base_baseline["reactive_count"]:
+                print(
+                    "check_tui_reactive_ratchet FAILED: baseline reactive_count "
+                    f"dropped ({base_baseline['reactive_count']} -> "
+                    f"{current_baseline['reactive_count']}) at {args.check_growth} — "
+                    "a hand-edited baseline lowering the floor is exactly what "
+                    "this gate exists to catch.",
+                    file=sys.stderr,
+                )
+                return 1
+            if current_baseline["imperative_push_count"] > base_baseline["imperative_push_count"]:
+                print(
+                    "check_tui_reactive_ratchet FAILED: baseline imperative_push_count "
+                    f"rose ({base_baseline['imperative_push_count']} -> "
+                    f"{current_baseline['imperative_push_count']}) at {args.check_growth} — "
+                    "a hand-edited baseline raising the ceiling is exactly what "
+                    "this gate exists to catch.",
+                    file=sys.stderr,
+                )
+                return 1
+
+    baseline = _load_baseline()
+    failed = False
+    if reactive_count < baseline["reactive_count"]:
+        print(
+            f"check_tui_reactive_ratchet FAILED: reactive_count dropped "
+            f"({baseline['reactive_count']} -> {reactive_count}) — #5131's "
+            "down-flow framework usage may not have shrunk on purpose. If "
+            "this drop is real and intended, run --write-baseline.",
+            file=sys.stderr,
+        )
+        failed = True
+    if imperative_push_count > baseline["imperative_push_count"]:
+        print(
+            f"check_tui_reactive_ratchet FAILED: imperative_push_count rose "
+            f"({baseline['imperative_push_count']} -> {imperative_push_count}) — "
+            "a new self.query_one(...).method(...) site in app.py pushes "
+            "state into a widget imperatively instead of through a "
+            "reactive/watch_ pair (#5131). If this is genuinely necessary, "
+            "run --write-baseline and say why in the PR.",
+            file=sys.stderr,
+        )
+        failed = True
+
+    if failed:
+        return 1
+
+    print(
+        f"check_tui_reactive_ratchet OK: reactive_count={reactive_count} "
+        f"(floor {baseline['reactive_count']}), "
+        f"imperative_push_count={imperative_push_count} "
+        f"(ceiling {baseline['imperative_push_count']})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_tui_reactive_ratchet.py
+++ b/scripts/check_tui_reactive_ratchet.py
@@ -154,7 +154,7 @@ def _git_show(base_ref: str, rel_path: str) -> "dict | None":
         return None
 
 
-def main() -> int:
+def main(argv: "list[str] | None" = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--write-baseline", action="store_true",
@@ -169,13 +169,20 @@ def main() -> int:
              "to BASE_REF (reactive_count decreased, or imperative_push_count "
              "increased) without a matching real measured change.",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    reactive_count = measured_reactive_count()
-    imperative_push_count = measured_imperative_push_count()
+    # Name lookups (_PACKAGE_DIR / _APP_PY / _BASELINE_PATH), not the callees'
+    # own bound-default parameter values — a default is evaluated ONCE at
+    # def-time, so a test's monkeypatch.setattr(module, "_BASELINE_PATH", ...)
+    # would be invisible to a call that relied on the default. Same fix
+    # flat_tests_ratchet.py's own main() applies, for the same reason: this
+    # is what lets a test drive main()'s CLI behavior against a synthetic
+    # baseline/package without a real subprocess.
+    reactive_count = measured_reactive_count(_PACKAGE_DIR)
+    imperative_push_count = measured_imperative_push_count(_APP_PY)
 
     if args.write_baseline:
-        _write_baseline(reactive_count, imperative_push_count)
+        _write_baseline(reactive_count, imperative_push_count, _BASELINE_PATH)
         print(
             f"check_tui_reactive_ratchet: baseline written — "
             f"reactive_count={reactive_count}, imperative_push_count={imperative_push_count}"
@@ -190,7 +197,7 @@ def main() -> int:
                 "nothing to compare, treating as OK (initial adoption).",
             )
         else:
-            current_baseline = _load_baseline()
+            current_baseline = _load_baseline(_BASELINE_PATH)
             if current_baseline["reactive_count"] < base_baseline["reactive_count"]:
                 print(
                     "check_tui_reactive_ratchet FAILED: baseline reactive_count "
@@ -212,7 +219,7 @@ def main() -> int:
                 )
                 return 1
 
-    baseline = _load_baseline()
+    baseline = _load_baseline(_BASELINE_PATH)
     failed = False
     if reactive_count < baseline["reactive_count"]:
         print(

--- a/scripts/check_tui_widget_boundary.py
+++ b/scripts/check_tui_widget_boundary.py
@@ -45,12 +45,23 @@ def _imported_module_names(tree: ast.Module) -> "list[str]":
     return names
 
 
-def find_violations(package_dir: Path = _PACKAGE_DIR) -> "list[tuple[Path, str]]":
+def find_violations(package_dir: "Path | None" = None) -> "list[tuple[Path, str]]":
     """Return ``(file, offending_module)`` for every non-exempt widget
     module importing a forbidden prefix. AST-based (real ``Import``/
     ``ImportFrom`` nodes), not a substring search — a docstring or comment
     merely MENTIONING "transport" (this package's own module docstrings do)
-    must never false-positive here."""
+    must never false-positive here.
+
+    ``package_dir`` defaults to ``None`` — resolved to the module-level
+    ``_PACKAGE_DIR`` INSIDE the function body (a name lookup at CALL time),
+    not via a bound default-argument value (evaluated ONCE at def-time).
+    Same fix ``flat_tests_ratchet.py``'s own ``main()`` already applies —
+    a bound default is invisible to ``monkeypatch.setattr(module,
+    "_PACKAGE_DIR", ...)``, which is exactly how a test drives this
+    function against a synthetic fixture package without needing a real
+    subprocess."""
+    if package_dir is None:
+        package_dir = _PACKAGE_DIR
     violations: "list[tuple[Path, str]]" = []
     for path in sorted(package_dir.glob("*.py")):
         if path.name in _EXEMPT_FILENAMES:
@@ -66,15 +77,22 @@ def find_violations(package_dir: Path = _PACKAGE_DIR) -> "list[tuple[Path, str]]
 
 
 def main() -> int:
+    # Name lookups, not bound defaults — see find_violations's own docstring
+    # for why: a test monkeypatching _PACKAGE_DIR on this module must reach
+    # main() too, not just find_violations() called directly.
     if not _PACKAGE_DIR.is_dir():
         print(f"check_tui_widget_boundary: {_PACKAGE_DIR} not found", file=sys.stderr)
         return 1
-    violations = find_violations()
+    violations = find_violations(_PACKAGE_DIR)
     if violations:
         print("check_tui_widget_boundary FAILED:\n", file=sys.stderr)
         for path, module_name in violations:
+            try:
+                shown = path.relative_to(_ROOT)
+            except ValueError:
+                shown = path  # a fixture path outside _ROOT (test-only) — show it as-is
             print(
-                f"  {path.relative_to(_ROOT)} imports {module_name!r} — "
+                f"  {shown} imports {module_name!r} — "
                 "widget modules never touch transport/registry directly "
                 "(#5131); route through app.py instead.",
                 file=sys.stderr,

--- a/scripts/check_tui_widget_boundary.py
+++ b/scripts/check_tui_widget_boundary.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""#5131 gate A — a ``textual_chat/`` WIDGET module never imports transport
+or registry.
+
+Architect ruling (#5131): the "up" half of this arc's react discipline is
+already a framework (Textual ``Message`` subclasses, 10+ of them — widgets
+throw events upward, never touch the wire directly) — measured, not
+assumed: exactly ONE file in this package, ``app.py``, imports
+``reyn.interfaces.transport`` or ``reyn.runtime.registry``; every other
+module is already correctly widget-only. This gate PINS that boundary —
+structural, zero-FP (an import statement is unambiguous, unlike "does this
+duplicate state" — that's gate B, a ratchet, not this) — so it can never
+silently erode as new widget files land.
+
+``app.py`` itself is the ONE place transport/registry access belongs (it
+IS the seam between the wire and the widget tree) — excluded by name, not
+grandfathered by a baseline: this is a fixed architectural role, not a
+population of legacy violations to shrink over time.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_PACKAGE_DIR = _ROOT / "src" / "reyn" / "interfaces" / "inline" / "textual_chat"
+
+# The one file allowed to be the wire<->widget-tree seam.
+_EXEMPT_FILENAMES = frozenset({"app.py"})
+
+_FORBIDDEN_PREFIXES = (
+    "reyn.interfaces.transport",
+    "reyn.runtime.registry",
+)
+
+
+def _imported_module_names(tree: ast.Module) -> "list[str]":
+    names: "list[str]" = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.append(node.module)
+    return names
+
+
+def find_violations(package_dir: Path = _PACKAGE_DIR) -> "list[tuple[Path, str]]":
+    """Return ``(file, offending_module)`` for every non-exempt widget
+    module importing a forbidden prefix. AST-based (real ``Import``/
+    ``ImportFrom`` nodes), not a substring search — a docstring or comment
+    merely MENTIONING "transport" (this package's own module docstrings do)
+    must never false-positive here."""
+    violations: "list[tuple[Path, str]]" = []
+    for path in sorted(package_dir.glob("*.py")):
+        if path.name in _EXEMPT_FILENAMES:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue  # a real syntax error is caught by other CI gates, not this one
+        for module_name in _imported_module_names(tree):
+            if any(module_name.startswith(prefix) for prefix in _FORBIDDEN_PREFIXES):
+                violations.append((path, module_name))
+    return violations
+
+
+def main() -> int:
+    if not _PACKAGE_DIR.is_dir():
+        print(f"check_tui_widget_boundary: {_PACKAGE_DIR} not found", file=sys.stderr)
+        return 1
+    violations = find_violations()
+    if violations:
+        print("check_tui_widget_boundary FAILED:\n", file=sys.stderr)
+        for path, module_name in violations:
+            print(
+                f"  {path.relative_to(_ROOT)} imports {module_name!r} — "
+                "widget modules never touch transport/registry directly "
+                "(#5131); route through app.py instead.",
+                file=sys.stderr,
+            )
+        return 1
+    print("check_tui_widget_boundary OK: no widget module imports transport/registry.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tui_reactive_ratchet_baseline.json
+++ b/scripts/tui_reactive_ratchet_baseline.json
@@ -1,0 +1,4 @@
+{
+  "imperative_push_count": 10,
+  "reactive_count": 2
+}

--- a/src/reyn/interfaces/CLAUDE.md
+++ b/src/reyn/interfaces/CLAUDE.md
@@ -10,3 +10,34 @@ reyn ships a full-colour theme, so there is nothing to defer to.
 - **A colour is not a meaning.** "Error" is the meaning; red is one theme's rendering.
 - **One thing is forbidden**: a literal in a widget stylesheet. Every value goes through a token in `palette.py`, and stylesheets write a `@name@` marker.
 - `tests/interfaces/test_tui_colour_tokens.py` fails on any colour value named outside the palette. Textual's own `DEFAULT_CSS` and `interfaces/web/` are out of scope.
+
+## TUI state-flow discipline (`textual_chat/`) — #5131
+
+Architect ruling: "up" (widget→App) is already a framework — 10+ `Message`
+subclasses, a widget never touches the wire directly. "Down" (App→widget) was
+NOT — the App called widget setters imperatively at scattered sites/times,
+so status bar / history / agent tab / announce could show mismatched values
+after a session switch (the reported bug).
+
+1. **Down is `reactive` + `watch_` only.** The App never calls a widget
+   setter directly — it writes a `reactive` attribute and lets `watch_*`
+   propagate. One canonical trigger per piece of state, not N call sites
+   hoping to stay in sync.
+2. **Up stays `Message`-only.** Already true — this codifies it, doesn't
+   change it.
+3. **A widget holds no state of its own.** It renders the slice it is
+   given. Copying a prop into instance state to render from later (the
+   `#5116`-named anti-pattern) is forbidden — a copy is a second source of
+   truth the original can drift from.
+4. **Never query a live object mid-render.** Render from what you were
+   handed, not from re-fetching the current truth at draw time (owner:
+   "都度問い合わせる…旧世代UI設計はやめて").
+
+Gate A (`scripts/check_tui_widget_boundary.py`, structural, zero-FP):
+pins that only `app.py` imports `reyn.interfaces.transport`/
+`reyn.runtime.registry` — every other widget module must not. Gate B
+(`scripts/check_tui_reactive_ratchet.py`) is a ratchet, not a rule
+enforcement — see that script's own docstring for why the
+`reactive`/`watch_` count can only be pinned to never DECREASE, and the
+imperative-push count to never INCREASE, not proven sufficient on their
+own.

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -44,6 +44,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.message import Message
+from textual.reactive import reactive
 from textual.widgets import ContentSwitcher, OptionList, Static
 from textual_flowview import (
     Anchor,
@@ -1228,6 +1229,20 @@ class TextualChatApp(App):
         "_call_parents",
     )
 
+    #: #5131 (architect ruling): the FIRST "state down" migration target —
+    #: which agent this App is currently showing. A Textual ``reactive``,
+    #: not a plain attribute: every read site below is unchanged (the
+    #: descriptor is transparent to ``self._agent_name`` reads/writes), but
+    #: a WRITE now synchronously fires :meth:`watch__agent_name`, which
+    #: refreshes every consumer from ONE canonical trigger instead of
+    #: relying on the next per-frame :meth:`_refresh_live_chrome` call to
+    #: eventually catch up (the exact "stale until something else redraws"
+    #: gap #5131 names — idle between real server frames, nothing was
+    #: forcing an immediate refresh). ``init=False``: the constructor's own
+    #: assignment (below) must NOT fire the watcher before ``compose()``
+    #: has built the widget tree — see that watch method's own docstring.
+    _agent_name: "reactive[str]" = reactive("", init=False)
+
     def __init__(
         self,
         *,
@@ -1612,6 +1627,15 @@ class TextualChatApp(App):
         # one moved AWAY from is tracked here — it needs its gutter re-derived
         # too, otherwise the rail is left behind on it.
         self._marked_cursor: "Entry[OutboxMessage] | None" = None
+
+    @property
+    def agent_name(self) -> str:
+        """#5131: public read of :attr:`_agent_name` — which agent this App
+        is currently showing. Never reach into ``self._agent_name`` directly
+        from a test asserting on it (the testing policy forbids a
+        private-state assertion); this property is the public surface that
+        exists for exactly that observation."""
+        return self._agent_name
 
     @property
     def cursor_position(self) -> "Offset":
@@ -6502,6 +6526,41 @@ class TextualChatApp(App):
         except Exception:
             return  # not yet mounted
         menubar.update_status(self._status_text(snap))
+
+    def watch__agent_name(self, old_value: str, new_value: str) -> None:
+        """#5131: the App is now showing a DIFFERENT agent (init or a real
+        session switch — Textual's reactive default (``always_update=
+        False``) means this never fires for a same-value reassignment).
+        Refresh every consumer that derives its content from
+        :attr:`_agent_name` from this ONE canonical trigger, synchronously,
+        rather than waiting for the next :meth:`_refresh_live_chrome` per-
+        frame call to eventually catch up — closing the exact "stale
+        between real server frames" gap #5131 names for the status line
+        and the currently-open drawer pane (History/Agent/etc.). Mirrors
+        :meth:`_refresh_live_chrome`'s own two calls exactly, so this is
+        strictly an ADDITIONAL, earlier trigger for the SAME refresh path,
+        not a new one — no behavior change for a caller already relying on
+        the per-frame refresh.
+
+        Does not (yet) touch :attr:`_iv_panel` — #5131's own "announce"
+        consumer is a separate, NOT-yet-migrated follow-up (it has its own
+        parallel pending/answered state, not just a re-derivation of a
+        snapshot the way the status line and drawer panes are); folding it
+        in here would be a second, independent change bundled into this
+        one, not this migration's first slice.
+
+        No mount guard needed: both calls below already no-op safely pre-
+        mount via their own ``try: self.query_one(...) except Exception:
+        return`` (the exact same guard :meth:`_refresh_live_chrome` relies
+        on for the identical reason)."""
+        self._refresh_status()
+        try:
+            drawer = self.query_one("#drawer", ContentSwitcher)
+        except Exception:
+            return  # not yet mounted
+        open_tab = drawer.current
+        if drawer.display and open_tab:
+            self._refresh_pane(open_tab)
 
     async def on_composer_submitted(self, event: "Composer.Submitted") -> None:
         text = event.value.strip()

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -836,6 +836,64 @@ async def test_status_line_refreshes_on_event_frames_alone(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_name_reactive_refreshes_status_line_with_no_frame(
+    tmp_path,
+) -> None:
+    """Tier 2: #5131 — ``TextualChatApp._agent_name`` is now a Textual
+    ``reactive``; ASSIGNING it fires :meth:`TextualChatApp.watch__agent_name`
+    synchronously, refreshing :class:`StatusLine` with no server frame
+    involved at all.
+
+    This is the improvement the migration adds, not merely a
+    non-regression: before #5131, ``_agent_name`` was a plain attribute, and
+    nothing but the next :meth:`TextualChatApp._refresh_live_chrome` frame
+    tick would have picked up a change — a session switch sitting idle
+    between real frames would show a STALE agent name in the status line
+    until something else happened to redraw. Here there is no
+    ``transport.push_event`` and no extra ``pilot.pause()`` after the
+    assignment: if the watcher did not fire synchronously, the assertion
+    below would see the OLD name.
+
+    ``attached_name`` is cleared from the snapshot: ``status_line_text``
+    prefers ``snap["attached_name"]`` over the ``agent_name`` argument
+    (chrome.py's own ``agent = snap.get("attached_name") or agent_name``),
+    so leaving it set would let the snapshot's OWN agent field mask
+    whatever ``self._agent_name`` says — exactly the confound this test
+    must not have.
+
+    The replacement name is deliberately the SAME LENGTH as the original
+    (``MenuBar.update_status``'s ``changed_len`` branch remounts the whole
+    row via an async ``mount_all`` for a length change — a real effect, but
+    one that would force a ``pilot.pause()`` here for an unrelated reason,
+    diluting what this test is isolating). Same length takes the OTHER
+    branch — a direct, synchronous ``StatusLine.update(text)`` — so the
+    assertion below with NO intervening ``await`` is a clean witness of the
+    watcher firing synchronously off the plain assignment."""
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    snap, _session, _registry = await _real_snapshot(tmp_path)
+    snap["attached_name"] = None
+    read_model = _MutableSnapshotReadModel(snap)
+    transport = _EventOnlyTransport()
+    app = TextualChatApp(transport=transport, read_model=read_model)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        before = str(app.query_one(StatusLine).render())
+        assert app.agent_name in before, f"initial agent name missing: {before}"
+
+        new_name = "z" * len(app.agent_name)
+        assert new_name != app.agent_name
+        app._agent_name = new_name
+
+        after = str(app.query_one(StatusLine).render())
+        assert new_name in after, (
+            f"status line did not refresh synchronously off the reactive "
+            f"assignment (no frame arrived): {after}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_open_pane_updates_on_frame_and_closed_panes_do_not(tmp_path) -> None:
     """Tier 2: a drawer pane left OPEN keeps updating as frames land (it used to
     be built exactly once, at open time, and then froze) — AND a pane that is NOT

--- a/tests/scripts/test_5131_tui_reactive_ratchet.py
+++ b/tests/scripts/test_5131_tui_reactive_ratchet.py
@@ -1,0 +1,104 @@
+"""Tier 2: #5131 gate B — scripts/check_tui_reactive_ratchet.py.
+
+Placed in tests/scripts/ (not flat) — mirrors test_flat_tests_ratchet_3879.py's
+own placement rationale. Real files on a real tmp_path throughout (the
+functions under test are thin AST walks over the filesystem) — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_tui_reactive_ratchet import (
+    measured_imperative_push_count,
+    measured_reactive_count,
+)
+
+_REACTIVE_FILE = '''
+from textual.reactive import reactive
+
+
+class Widget:
+    _agent_name = reactive("")
+
+    def watch__agent_name(self, old_value, new_value):
+        pass
+'''
+
+_NO_REACTIVE_FILE = '''
+class Widget:
+    def __init__(self):
+        self._agent_name = ""
+'''
+
+_APP_PUSH_FILE = '''
+class App:
+    def refresh(self):
+        self.query_one("#status", Static).update("x")
+        self.query_one("#drawer", ContentSwitcher).focus()
+'''
+
+_APP_NO_PUSH_FILE = '''
+class App:
+    def refresh(self):
+        widget = self.query_one("#status", Static)
+        widget.update("x")
+'''
+
+
+def _write(tests_dir: Path, name: str, content: str) -> Path:
+    p = tests_dir / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_reactive_count_sums_declarations_and_watch_methods_across_files(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: one reactive() assignment + one watch_ method in ONE file ->
+    count 2; a sibling file with neither contributes 0 — the count sums
+    across every .py file in the package, not just one."""
+    _write(tmp_path, "widget.py", _REACTIVE_FILE)
+    _write(tmp_path, "other.py", _NO_REACTIVE_FILE)
+
+    assert measured_reactive_count(tmp_path) == 2
+
+
+def test_reactive_count_is_zero_with_no_reactive_usage(tmp_path: Path) -> None:
+    """Tier 2: a package with no reactive()/watch_ at all counts 0 — the
+    floor a from-scratch package starts at."""
+    _write(tmp_path, "other.py", _NO_REACTIVE_FILE)
+
+    assert measured_reactive_count(tmp_path) == 0
+
+
+def test_imperative_push_count_counts_every_query_one_method_call(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: BOTH self.query_one(...).update(...) (a state push) AND
+    self.query_one(...).focus() (a pure action) count — the gate is
+    deliberately UNDER-selective (see the script's own docstring for why:
+    distinguishing the two is the semantic question Gate A already
+    declined to answer)."""
+    app_py = _write(tmp_path, "app.py", _APP_PUSH_FILE)
+
+    assert measured_imperative_push_count(app_py) == 2
+
+
+def test_imperative_push_count_is_zero_when_widgets_are_looked_up_but_not_chained(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: query_one(...) assigned to a local variable, with the method
+    call on a SEPARATE line, is NOT counted — the gate's own narrow shape
+    (self.query_one(...).method(...) CHAINED on one expression) is a
+    deliberate proxy for "reach in and push immediately," not "look up a
+    widget for any reason."""
+    app_py = _write(tmp_path, "app.py", _APP_NO_PUSH_FILE)
+
+    assert measured_imperative_push_count(app_py) == 0
+
+
+def test_imperative_push_count_is_zero_for_a_missing_file(tmp_path: Path) -> None:
+    """Tier 2: a package with no app.py at all (shouldn't happen in
+    production, but the function must not raise) measures 0, not an
+    exception — mirrors measured_reactive_count's own empty-input safety."""
+    assert measured_imperative_push_count(tmp_path / "does_not_exist.py") == 0

--- a/tests/scripts/test_5131_tui_reactive_ratchet.py
+++ b/tests/scripts/test_5131_tui_reactive_ratchet.py
@@ -6,9 +6,12 @@ functions under test are thin AST walks over the filesystem) — no mocks.
 """
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import scripts.check_tui_reactive_ratchet as check_tui_reactive_ratchet
 from scripts.check_tui_reactive_ratchet import (
+    main,
     measured_imperative_push_count,
     measured_reactive_count,
 )
@@ -102,3 +105,82 @@ def test_imperative_push_count_is_zero_for_a_missing_file(tmp_path: Path) -> Non
     production, but the function must not raise) measures 0, not an
     exception — mirrors measured_reactive_count's own empty-input safety."""
     assert measured_imperative_push_count(tmp_path / "does_not_exist.py") == 0
+
+
+# ── main()'s own rejection path — the blocking gap itself ──────────────────
+#
+# Architect/lead-coder review (issuecomment-5384396179, broker 2026-08-23
+# 05:23Z): "correctly counting" and "fails when it worsens" are separate
+# claims — no test above drove main() far enough to hit the `failed = True`
+# branches. These monkeypatch the module's OWN globals (_PACKAGE_DIR /
+# _APP_PY / _BASELINE_PATH) — main() does a fresh NAME LOOKUP for each,
+# not a bound default (see the script's own main() docstring for why that
+# distinction is what makes this monkeypatch reach it at all).
+
+
+def _write_baseline_file(path: Path, *, reactive_count: int, imperative_push_count: int) -> None:
+    path.write_text(
+        json.dumps({"reactive_count": reactive_count, "imperative_push_count": imperative_push_count}),
+        encoding="utf-8",
+    )
+
+
+def test_main_rejects_a_reactive_count_drop_below_the_baseline_floor(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: measured reactive_count (0, an empty fixture package) below
+    the committed baseline's floor (1) must exit non-zero — the FLOOR
+    direction of the ratchet."""
+    package_dir = tmp_path / "pkg"
+    package_dir.mkdir()
+    _write(package_dir, "other.py", _NO_REACTIVE_FILE)  # 0 reactive usage
+    app_py = _write(package_dir, "app.py", _APP_NO_PUSH_FILE)  # 0 imperative pushes
+    baseline_path = tmp_path / "baseline.json"
+    _write_baseline_file(baseline_path, reactive_count=1, imperative_push_count=0)
+
+    monkeypatch.setattr(check_tui_reactive_ratchet, "_PACKAGE_DIR", package_dir)
+    monkeypatch.setattr(check_tui_reactive_ratchet, "_APP_PY", app_py)
+    monkeypatch.setattr(check_tui_reactive_ratchet, "_BASELINE_PATH", baseline_path)
+
+    assert main([]) == 1, "main() did not reject a reactive_count drop below the baseline floor"
+
+
+def test_main_rejects_an_imperative_push_count_rise_above_the_baseline_ceiling(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: measured imperative_push_count (2) above the committed
+    baseline's ceiling (0) must exit non-zero — the CEILING direction of
+    the ratchet."""
+    package_dir = tmp_path / "pkg"
+    package_dir.mkdir()
+    app_py = _write(package_dir, "app.py", _APP_PUSH_FILE)  # 2 imperative pushes
+    baseline_path = tmp_path / "baseline.json"
+    _write_baseline_file(baseline_path, reactive_count=0, imperative_push_count=0)
+
+    monkeypatch.setattr(check_tui_reactive_ratchet, "_PACKAGE_DIR", package_dir)
+    monkeypatch.setattr(check_tui_reactive_ratchet, "_APP_PY", app_py)
+    monkeypatch.setattr(check_tui_reactive_ratchet, "_BASELINE_PATH", baseline_path)
+
+    assert main([]) == 1, (
+        "main() did not reject an imperative_push_count rise above the baseline ceiling"
+    )
+
+
+def test_main_exits_zero_when_measured_counts_match_the_baseline(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: falsification contrast for the two tests above — measured
+    counts that match the baseline exactly pass through main()'s full CLI
+    path to exit 0, so the two red witnesses are pinned to the actual
+    mismatch, not to some other difference in the fixture setup."""
+    package_dir = tmp_path / "pkg"
+    package_dir.mkdir()
+    app_py = _write(package_dir, "app.py", _APP_PUSH_FILE)  # 2 imperative pushes
+    baseline_path = tmp_path / "baseline.json"
+    _write_baseline_file(baseline_path, reactive_count=0, imperative_push_count=2)
+
+    monkeypatch.setattr(check_tui_reactive_ratchet, "_PACKAGE_DIR", package_dir)
+    monkeypatch.setattr(check_tui_reactive_ratchet, "_APP_PY", app_py)
+    monkeypatch.setattr(check_tui_reactive_ratchet, "_BASELINE_PATH", baseline_path)
+
+    assert main([]) == 0

--- a/tests/scripts/test_5131_tui_widget_boundary.py
+++ b/tests/scripts/test_5131_tui_widget_boundary.py
@@ -1,0 +1,106 @@
+"""Tier 2: #5131 gate A — scripts/check_tui_widget_boundary.py.
+
+Architect/lead-coder review (issuecomment-5384396179, broker 2026-08-23
+05:23Z): the ratchet tests (test_5131_tui_reactive_ratchet.py) covered gate
+B; gate A had NO red witness — every existing check only confirmed the gate
+is green on the ALREADY-COMPLIANT current tree, which cannot distinguish
+"the gate is enforcing the boundary" from "the gate never runs at all" (a
+green with nothing to bite on wears the same colour either way — CLAUDE.md's
+own test-review question 4). This file closes that: a synthetic fixture
+widget module that DOES import transport, and asserts BOTH the underlying
+detector (find_violations) AND main()'s own CLI exit code catch it.
+
+Real files on a real tmp_path (mirrors test_flat_tests_ratchet_3879.py's own
+placement/no-mocks rationale) — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import scripts.check_tui_widget_boundary as check_tui_widget_boundary
+from scripts.check_tui_widget_boundary import find_violations, main
+
+
+def _write(package_dir: Path, name: str, content: str) -> None:
+    (package_dir / name).write_text(content, encoding="utf-8")
+
+
+def test_find_violations_catches_a_module_level_import(tmp_path: Path) -> None:
+    """Tier 2: the exact shape the gate exists to catch — a widget module
+    importing the forbidden transport prefix as a plain module-level
+    ``import``."""
+    _write(tmp_path, "some_widget.py", "import reyn.interfaces.transport.frames\n")
+
+    violations = find_violations(tmp_path)
+
+    assert violations == [
+        (tmp_path / "some_widget.py", "reyn.interfaces.transport.frames"),
+    ]
+
+
+def test_find_violations_catches_a_from_import(tmp_path: Path) -> None:
+    """Tier 2: the OTHER import shape — ``from reyn.runtime.registry import
+    X`` — both AST node types the detector walks (ast.Import / ast.ImportFrom)
+    need their own witness, not just one representative shape."""
+    _write(tmp_path, "other_widget.py", "from reyn.runtime.registry import AgentRegistry\n")
+
+    violations = find_violations(tmp_path)
+
+    assert violations == [
+        (tmp_path / "other_widget.py", "reyn.runtime.registry"),
+    ]
+
+
+def test_find_violations_ignores_app_py_by_name(tmp_path: Path) -> None:
+    """Tier 2: app.py is the ONE exempt file (it IS the wire<->widget-tree
+    seam) — the same forbidden import in a file literally named app.py must
+    NOT be flagged."""
+    _write(tmp_path, "app.py", "import reyn.interfaces.transport.frames\n")
+
+    assert find_violations(tmp_path) == []
+
+
+def test_find_violations_ignores_a_docstring_merely_mentioning_transport(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: AST-based, not substring — a docstring/comment that MENTIONS
+    "transport" in prose (this package's own module docstrings do) must
+    never false-positive. Falsification contrast to the module-level-import
+    test above: same word present in the file, opposite verdict."""
+    _write(
+        tmp_path, "prose_widget.py",
+        '"""This widget talks to the transport layer conceptually, but '
+        'imports nothing from it."""\n',
+    )
+
+    assert find_violations(tmp_path) == []
+
+
+def test_main_exits_nonzero_when_a_widget_module_violates_the_boundary(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the blocking gap itself (architect/lead-coder review) — a
+    green find_violations() result is not evidence main()'s own CLI wiring
+    ever reaches it. Monkeypatches the MODULE-LEVEL ``_PACKAGE_DIR`` (main()
+    does a fresh name lookup, not a bound default — see find_violations's
+    own docstring for why that distinction is load-bearing) and drives
+    main() itself, asserting the real CLI exit code."""
+    _write(tmp_path, "some_widget.py", "import reyn.interfaces.transport.frames\n")
+    monkeypatch.setattr(check_tui_widget_boundary, "_PACKAGE_DIR", tmp_path)
+
+    exit_code = main()
+
+    assert exit_code == 1, "main() did not reject a widget module importing transport"
+
+
+def test_main_exits_zero_on_a_compliant_fixture_package(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: falsification contrast for the test above — a fixture package
+    with NO violation still passes through main()'s full CLI path to exit 0,
+    so the red witness above is pinned to the violation, not to some other
+    difference between the fixture and the real package."""
+    _write(tmp_path, "clean_widget.py", "from textual.widgets import Static\n")
+    monkeypatch.setattr(check_tui_widget_boundary, "_PACKAGE_DIR", tmp_path)
+
+    assert main() == 0


### PR DESCRIPTION
**[tui-coder]** — #5131, architect ruling.

## Problem
TUI "up" (widget→App) is already a framework — 10+ `Message` subclasses, a widget never touches the wire directly. "Down" (App→widget) had ZERO `reactive`/`watch_` usage (measured: 0 hits across all 18 files in `textual_chat/`) — the App called widget setters imperatively at scattered call sites/times, so status bar / history / agent tab / announce could show mismatched values after a session switch (the reported bug).

## Rules (recorded in `src/reyn/interfaces/CLAUDE.md`)
1. Down is `reactive`+`watch_` only — App never calls a widget setter directly.
2. Up stays `Message`-only (already true, codified).
3. A widget holds no state of its own (the `#5116`-named anti-pattern is forbidden).
4. Never query a live object mid-render.

## This PR — first migration slice
Scoped narrowly per an Explore-subagent survey of every App→widget push site: **which agent the App is currently showing**.

- `TextualChatApp._agent_name` → Textual `reactive[str]` (`init=False`).
- New `watch__agent_name` mirrors `_refresh_live_chrome`'s existing two calls — an additional, earlier, *synchronous* trigger for the same refresh path, not a new one. The improvement: a session switch refreshes immediately instead of waiting for the next server frame.
- Does **not** yet touch `InterventionPanel`'s "announce" state — disclosed as a separate follow-up (its own parallel pending/answered state, not a snapshot re-derivation like the others).
- New public `TextualChatApp.agent_name` property — the testing policy forbids a private-state assertion, so this is what the new witness test reads through.

New witness test proves the actual improvement (not just non-regression): sets `_agent_name` directly with **no frame ever arriving**, asserts `StatusLine` already reflects it. Strip-falsified (renamed the watcher away → red for exactly the right reason; restored).

## Two CI gates
- **Gate A** (`scripts/check_tui_widget_boundary.py`, structural, zero-FP): AST census — only `app.py` may import `reyn.interfaces.transport`/`reyn.runtime.registry`. Verified clean on current tree; strip-falsified.
- **Gate B** (`scripts/check_tui_reactive_ratchet.py`, semantic, honest about its limits): a ratchet, not a proof. `reactive_count` (floor, must never decrease) + `imperative_push_count` (ceiling, must never increase, deliberately under-selective — counts `.focus()` the same as `.update_status()` rather than over-claim semantic precision it can't back up). Baseline: `reactive_count=2`, `imperative_push_count=10`.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] `check_bare_tests_import_reference.py`
- [x] `check_file_depth_reference.py`
- [x] `verify_module_docstrings.py`
- [x] Regression: `tests/interfaces/` + `tests/scripts/` — 2965 passed, 9 skipped (missing optional extras, unrelated), no regressions
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[architect]** — TESTS-READ（**A: 設計適合**、head `2217ae6734`）issuecomment。形は入っています。B は別の人が必要です。

- [x] 🔴 (解消 `f65b9de3f`, architect 差分 A) `check_tui_widget_boundary.py`（gate A）に**赤の witness が無い**。今日緑なのは境界が既に保たれているからで、**緑は「gate が効いている」を示さない**（不在と区別できない）。transport を import する合成 widget module の fixture で**非ゼロ終了**を 1 本
- [x] 🔴 (解消 `f65b9de3f`, architect 差分 A) ratchet の**拒否経路が未検査**（`:217-227` の `failed = True` を通る test が無い）。「正しく数える」と「悪化したら落ちる」は別の主張 → baseline を悪化させた入力で**非ゼロ終了**を 2 本（reactive 減 / imperative push 増）

