### PR TITLE
gate(#5177): enforce approval_ledger.py's stdlib-only import boundary

### DIFF
--- a/scripts/check_approval_ledger_import_boundary.py
+++ b/scripts/check_approval_ledger_import_boundary.py
@@ -36,13 +36,33 @@ is what makes this a low-FP structural gate rather than a grep with the
 usual comment/docstring false-positive risk (the same discriminator
 ``check_doc_drift.py``'s own comment/docstring redaction exists for, #5010).
 
-## Scope: one file, both module-level and deferred imports
+## Scope: one file, both module-level and deferred imports — never
+## ``TYPE_CHECKING``-guarded ones
 
 Both a module-level ``import reyn.foo`` and a deferred (function-local)
 ``import reyn.foo`` are in scope — a regression could reach for either
 shape, and ``approval_ledger.py``'s own existing deferred ``import yaml``
 (third-party, not reyn) shows deferred imports are already a real pattern
 in this file, not a hypothetical one to leave uncovered.
+
+An import inside ``if TYPE_CHECKING:`` is deliberately EXCLUDED (architect
+co-vet, #5183 issuecomment-5384441986): this gate's whole purpose is what
+actually gets pulled into the python-harness SUBPROCESS at runtime, and a
+``TYPE_CHECKING``-guarded import never executes — flagging it would be a
+false positive against that purpose, not a real widening of the
+subprocess's import surface.
+
+## The target path is DERIVED, not hand-typed (architect co-vet, #5183)
+
+A hand-typed ``_ROOT / "src" / ... / "approval_ledger.py"`` literal has
+exactly the failure mode #5175 (this issue's own sibling fix, landed the
+same night) closed for the write-gate carve-out: if ``approval_ledger.py``
+is ever renamed or moved, the literal path silently stops existing, this
+gate's own "absent reads as compliant" rule (below) makes that read as a
+PASS, and the gate goes quietly blind rather than failing loud. Deriving
+the path from the REAL module's own ``__file__`` means a rename raises
+``ImportError`` here instead — the gate breaks LOUDLY at the moment the
+thing it protects moves, rather than silently protecting nothing.
 """
 from __future__ import annotations
 
@@ -50,18 +70,43 @@ import ast
 import sys
 from pathlib import Path
 
+from reyn.security.permissions import approval_ledger as _approval_ledger_module
+
 _ROOT = Path(__file__).resolve().parent.parent
-_APPROVAL_LEDGER_PATH = (
-    _ROOT / "src" / "reyn" / "security" / "permissions" / "approval_ledger.py"
-)
+_APPROVAL_LEDGER_PATH = Path(_approval_ledger_module.__file__).resolve()
+
+
+def _skip_type_checking_bodies(tree: ast.AST) -> ast.AST:
+    """Strip the body of every ``if TYPE_CHECKING:`` (or ``if typing.
+    TYPE_CHECKING:``) block out of *tree* in place, so a subsequent
+    ``ast.walk`` never descends into imports that only ever run for a
+    type checker, not at real runtime — see the module docstring's
+    "never TYPE_CHECKING-guarded" section for why that distinction
+    matters for THIS gate specifically."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        is_type_checking = (
+            isinstance(test, ast.Name) and test.id == "TYPE_CHECKING"
+        ) or (
+            isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+        )
+        if is_type_checking:
+            node.body = []
+    return tree
 
 
 def reyn_internal_imports(path: Path) -> "list[str]":
     """Every reyn-internal module name *path* imports (module-level or
-    deferred, anywhere in its AST) — ``[]`` when the file has none, is
-    absent, or fails to parse (never an error; a caller checks ``[]`` vs
-    non-empty, the same "absent reads as compliant" shape the sibling
-    boundary gates use).
+    deferred, anywhere in its AST, excluding an ``if TYPE_CHECKING:``
+    block's body — see the module docstring) — ``[]`` when the file has
+    none, is absent, or fails to parse (never an error; a caller checks
+    ``[]`` vs non-empty, the same "absent reads as compliant" shape the
+    sibling boundary gates use for the FILE READ itself — contrast with
+    the module-level ``_APPROVAL_LEDGER_PATH``, which is derived via a
+    real import and therefore fails loud, not silently, if the file this
+    gate is supposed to be checking has moved).
 
     A name counts as reyn-internal when it is exactly ``reyn`` or starts
     with ``reyn.`` — the same exact-match-or-dotted-prefix rule
@@ -75,6 +120,7 @@ def reyn_internal_imports(path: Path) -> "list[str]":
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, SyntaxError):
         return []
+    tree = _skip_type_checking_bodies(tree)
     found: "list[str]" = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):

--- a/scripts/check_approval_ledger_import_boundary.py
+++ b/scripts/check_approval_ledger_import_boundary.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""#5177 — enforces that ``src/reyn/security/permissions/approval_ledger.py``
+never imports a reyn-internal module.
+
+``src/reyn/api/safe/file.py`` runs inside the python-harness SUBPROCESS and
+deliberately stays self-contained (see that module's own
+``_project_root_for_gate`` docstring — it does not depend on the rest of the
+``reyn`` package being importable there). #5173 made it
+``from reyn.security.permissions import approval_ledger`` for the shared
+``RELATIVE_PATH`` constant, which is safe ONLY because ``approval_ledger.py``
+itself has zero reyn-internal imports (stdlib only: ``json``, ``os``,
+``tempfile``, ``time``, ``pathlib``, ``typing``, plus a deferred third-party
+``import yaml`` inside one function).
+
+lead-coder's question during the #5173 review: "who keeps that true
+forever?" Answer at the time: nobody — a future edit adding a single
+reyn-internal import to ``approval_ledger.py`` (a logger helper, a config
+type, anything) would silently widen what the subprocess-safe
+``api/safe/file.py`` pulls in, with nothing catching it until the sandboxed
+subprocess is actually exercised somewhere more restrictive than a dev
+machine. This gate closes that: a structural, low-FP AST check — the same
+shape ``scripts/check_fastmcp_import_boundary.py`` (#3698) already
+established for an analogous "this file/directory must not import X"
+invariant — scanning ONE file, not a directory, since the constraint this
+issue names is specific to ``approval_ledger.py`` itself (its sibling
+``permissions.py`` legitimately imports reyn internals; only the module
+``api/safe/file.py`` reaches into matters here).
+
+## Why AST, not a substring search
+
+A prose mention of ``reyn.security`` in this module's own docstring (this
+file's history/rationale writing, or a future one in ``approval_ledger.py``
+itself) must not trip a substring-based check — only a REAL ``import``/
+``from ... import`` statement naming a ``reyn.*`` module counts. AST parsing
+is what makes this a low-FP structural gate rather than a grep with the
+usual comment/docstring false-positive risk (the same discriminator
+``check_doc_drift.py``'s own comment/docstring redaction exists for, #5010).
+
+## Scope: one file, both module-level and deferred imports
+
+Both a module-level ``import reyn.foo`` and a deferred (function-local)
+``import reyn.foo`` are in scope — a regression could reach for either
+shape, and ``approval_ledger.py``'s own existing deferred ``import yaml``
+(third-party, not reyn) shows deferred imports are already a real pattern
+in this file, not a hypothetical one to leave uncovered.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_APPROVAL_LEDGER_PATH = (
+    _ROOT / "src" / "reyn" / "security" / "permissions" / "approval_ledger.py"
+)
+
+
+def reyn_internal_imports(path: Path) -> "list[str]":
+    """Every reyn-internal module name *path* imports (module-level or
+    deferred, anywhere in its AST) — ``[]`` when the file has none, is
+    absent, or fails to parse (never an error; a caller checks ``[]`` vs
+    non-empty, the same "absent reads as compliant" shape the sibling
+    boundary gates use).
+
+    A name counts as reyn-internal when it is exactly ``reyn`` or starts
+    with ``reyn.`` — the same exact-match-or-dotted-prefix rule
+    ``check_fastmcp_import_boundary.py`` uses, so a hypothetical unrelated
+    package merely starting with the same letters (not a real package,
+    but the rule must not match on a bare substring) is never confused
+    with a real ``reyn`` import."""
+    if not path.is_file():
+        return []
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, SyntaxError):
+        return []
+    found: "list[str]" = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "reyn" or alias.name.startswith("reyn."):
+                    found.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and (node.module == "reyn" or node.module.startswith("reyn.")):
+                found.append(node.module)
+    return found
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options -- a single-file scan against a baseline of zero
+    offenders = reyn_internal_imports(_APPROVAL_LEDGER_PATH)
+
+    if not offenders:
+        print(
+            "OK: approval_ledger.py imports no reyn-internal module "
+            "(stdlib-only boundary intact)."
+        )
+        return 0
+
+    print("approval-ledger-import-boundary gate FAILED:\n", file=sys.stderr)
+    print(
+        f"{_APPROVAL_LEDGER_PATH.relative_to(_ROOT)} imports "
+        f"{len(offenders)} reyn-internal module(s) (#5177):",
+        file=sys.stderr,
+    )
+    for name in offenders:
+        print(f"  {name}", file=sys.stderr)
+    print(
+        "\nsrc/reyn/api/safe/file.py runs inside the python-harness "
+        "SUBPROCESS and depends on this module staying stdlib-only "
+        "(#5173) — it imports approval_ledger.py directly rather than "
+        "the rest of the security.permissions package for exactly this "
+        "reason. Move whatever needs a reyn-internal import out of "
+        "approval_ledger.py, or reconsider whether api/safe/file.py can "
+        "still safely import it.\n"
+        "\nThis gate's own starting population is zero, so any hit here "
+        "is a new regression, not inherited debt.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_approval_ledger_import_boundary_5177.py
+++ b/tests/scripts/test_check_approval_ledger_import_boundary_5177.py
@@ -6,9 +6,14 @@ faking the filesystem would test nothing real.
 """
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
+from reyn.security.permissions import approval_ledger
 from scripts.check_approval_ledger_import_boundary import reyn_internal_imports
+from tests._support.paths import REPO_ROOT
 
 
 def test_a_direct_module_level_reyn_import_is_flagged(tmp_path: Path) -> None:
@@ -84,9 +89,112 @@ def test_a_package_named_reyn_prefixed_is_not_confused_with_reyn(tmp_path: Path)
 def test_an_absent_file_reads_as_compliant_not_an_error(tmp_path: Path) -> None:
     """Tier 2: a path that does not exist must not raise — the sibling
     boundary gates all treat "nothing there" as "nothing to flag", never
-    a crash."""
+    a crash. This is about a plain FILE READ, not about the module-level
+    ``_APPROVAL_LEDGER_PATH`` constant itself, which is a different case —
+    see the "derived from __file__" tests below for why THAT path fails
+    loud instead when the real module moves."""
     target = tmp_path / "does_not_exist.py"
     assert reyn_internal_imports(target) == []
+
+
+def test_a_type_checking_guarded_import_is_not_flagged() -> None:
+    """Tier 2: architect's non-blocking question on #5183
+    (issuecomment-5384441986) — an import inside ``if TYPE_CHECKING:``
+    never executes, so it never actually reaches the python-harness
+    SUBPROCESS this gate exists to protect. Flagging it would be a false
+    positive against this gate's own stated purpose (what gets pulled in
+    at REAL runtime), not a genuine widening of the import surface."""
+    import ast
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "approval_ledger.py"
+        target.write_text(
+            "from typing import TYPE_CHECKING\n"
+            "if TYPE_CHECKING:\n"
+            "    import reyn.runtime.session\n",
+            encoding="utf-8",
+        )
+        offenders = reyn_internal_imports(target)
+    assert offenders == [], (
+        "a TYPE_CHECKING-guarded reyn import must not be flagged — it "
+        "never executes at real runtime"
+    )
+    # Non-vacuity: prove the fixture's AST genuinely contains the import
+    # this test means to exclude, so a green result isn't just "nothing
+    # was ever parsed."
+    tree = ast.parse(
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n"
+        "    import reyn.runtime.session\n"
+    )
+    real_imports = [n for n in ast.walk(tree) if isinstance(n, ast.Import)]
+    assert real_imports, "test setup itself must contain a real Import node"
+
+
+def test_the_target_path_is_derived_from_the_real_modules_own_file_not_hand_typed() -> None:
+    """Tier 2: acceptance (architect blocking finding on #5183,
+    issuecomment-5384441986) — ``_APPROVAL_LEDGER_PATH`` must be DERIVED
+    from ``approval_ledger.__file__`` (a real import), never a hand-typed
+    literal. A hand-typed path silently reads a rename/move as "absent =
+    compliant" (this gate's own file-read rule, above) instead of failing
+    loud — the exact class #5175 (this issue's own sibling fix) closed
+    for the write-gate carve-out, the same night."""
+    from scripts.check_approval_ledger_import_boundary import _APPROVAL_LEDGER_PATH
+
+    assert _APPROVAL_LEDGER_PATH == Path(approval_ledger.__file__).resolve(), (
+        "the gate's target path must equal the REAL module's own __file__, "
+        "not a separately-typed literal that could silently drift from it"
+    )
+
+
+def test_a_missing_approval_ledger_module_fails_the_gate_loudly_not_silently(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the rename-witness architect asked for — if
+    ``reyn.security.permissions.approval_ledger`` cannot be imported at
+    all (the module renamed/moved out from under this gate), the gate
+    script must fail LOUDLY (a non-zero exit from an unhandled
+    ``ImportError``), never silently report ``OK`` / exit 0. Verified by
+    actually running the gate script in a subprocess with a decoy
+    ``reyn.security.permissions`` package (real files on disk, no
+    ``approval_ledger`` module inside it) placed first on ``sys.path`` —
+    a real import failure, not a simulated one."""
+    decoy_root = tmp_path / "decoy_reyn_pkg"
+    pkg_dir = decoy_root / "reyn" / "security" / "permissions"
+    pkg_dir.mkdir(parents=True)
+    (decoy_root / "reyn" / "__init__.py").write_text("", encoding="utf-8")
+    (decoy_root / "reyn" / "security" / "__init__.py").write_text("", encoding="utf-8")
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    # Deliberately NO approval_ledger.py in the decoy package — this is
+    # the "renamed/moved" scenario: the import the gate script's own
+    # module-level line depends on has nothing to resolve to.
+
+    repo_root = REPO_ROOT
+    gate_script = repo_root / "scripts" / "check_approval_ledger_import_boundary.py"
+
+    result = subprocess.run(
+        [sys.executable, str(gate_script)],
+        cwd=repo_root,
+        env={
+            "PATH": "/usr/bin:/bin",
+            # decoy_root FIRST so its incomplete reyn.security.permissions
+            # package shadows the real one for this subprocess only.
+            "PYTHONPATH": f"{decoy_root}{os.pathsep}{repo_root / 'src'}",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode != 0, (
+        "a missing approval_ledger module must fail the gate script "
+        f"loudly, not exit 0 — got returncode={result.returncode}, "
+        f"stdout={result.stdout!r}"
+    )
+    assert "approval_ledger" in result.stderr, (
+        f"expected an ImportError naming approval_ledger, got: {result.stderr!r}"
+    )
 
 
 def test_the_real_approval_ledger_module_is_currently_clean() -> None:
@@ -95,14 +203,8 @@ def test_the_real_approval_ledger_module_is_currently_clean() -> None:
     "run it before shipping it" discipline. #5173 measured this by hand
     (approval_ledger.py has zero reyn-internal imports); this asserts it
     stayed that way."""
-    from scripts.check_approval_ledger_import_boundary import (
-        _APPROVAL_LEDGER_PATH,
-        _ROOT,
-    )
+    from scripts.check_approval_ledger_import_boundary import _APPROVAL_LEDGER_PATH
 
-    assert _APPROVAL_LEDGER_PATH == (
-        _ROOT / "src" / "reyn" / "security" / "permissions" / "approval_ledger.py"
-    )
     offenders = reyn_internal_imports(_APPROVAL_LEDGER_PATH)
     assert offenders == [], (
         f"real regression(s) found: {offenders} — this gate's baseline is "

--- a/tests/scripts/test_check_approval_ledger_import_boundary_5177.py
+++ b/tests/scripts/test_check_approval_ledger_import_boundary_5177.py
@@ -1,0 +1,110 @@
+"""Tier 2: #5177 — the approval_ledger.py stdlib-only import boundary gate.
+
+Real filesystem fixtures throughout (a real `tmp_path` `.py` file) — the
+function under test reads real file content and parses real ASTs, so
+faking the filesystem would test nothing real.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_approval_ledger_import_boundary import reyn_internal_imports
+
+
+def test_a_direct_module_level_reyn_import_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: THE case #5177 exists to catch — a future edit adding a
+    plain `import reyn.foo` to this file."""
+    target = tmp_path / "approval_ledger.py"
+    target.write_text("import reyn.runtime.session\n", encoding="utf-8")
+    offenders = reyn_internal_imports(target)
+    assert offenders == ["reyn.runtime.session"]
+
+
+def test_a_from_reyn_submodule_import_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: `from reyn.config import loader` shape — a submodule import,
+    not the bare package name."""
+    target = tmp_path / "approval_ledger.py"
+    target.write_text("from reyn.config import loader\n", encoding="utf-8")
+    offenders = reyn_internal_imports(target)
+    assert offenders == ["reyn.config"]
+
+
+def test_a_deferred_function_local_reyn_import_is_also_flagged(tmp_path: Path) -> None:
+    """Tier 2: a deferred (function-local) import is in scope too — a NEW
+    reyn-internal import must be caught regardless of whether it is
+    module-level or deferred, since a regression could reach for either
+    shape (this module's own existing deferred `import yaml` shows
+    deferred imports are already a real pattern here, not hypothetical)."""
+    target = tmp_path / "approval_ledger.py"
+    target.write_text(
+        "def f():\n    import reyn.plugins.tokens\n    return reyn.plugins.tokens\n",
+        encoding="utf-8",
+    )
+    offenders = reyn_internal_imports(target)
+    assert offenders == ["reyn.plugins.tokens"]
+
+
+def test_a_bare_reyn_import_with_no_submodule_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: `import reyn` (the bare package name, no dotted submodule)
+    must also be flagged — the exact-match half of the exact-match-or-
+    dotted-prefix rule."""
+    target = tmp_path / "approval_ledger.py"
+    target.write_text("import reyn\n", encoding="utf-8")
+    offenders = reyn_internal_imports(target)
+    assert offenders == ["reyn"]
+
+
+def test_stdlib_and_third_party_imports_are_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: the module's own real import set (json/os/tempfile/time/
+    pathlib/typing, plus the deferred third-party `import yaml`) must not
+    false-positive — only a module named exactly `reyn` or `reyn.<sub>`
+    counts."""
+    target = tmp_path / "approval_ledger.py"
+    target.write_text(
+        "import json\nimport os\nimport tempfile\nimport time\n"
+        "from pathlib import Path\nfrom typing import Any\n\n"
+        "def f():\n    import yaml\n    return yaml\n",
+        encoding="utf-8",
+    )
+    offenders = reyn_internal_imports(target)
+    assert offenders == []
+
+
+def test_a_package_named_reyn_prefixed_is_not_confused_with_reyn(tmp_path: Path) -> None:
+    """Tier 2: non-vacuity for the exact-match / dotted-prefix rule — a
+    hypothetical unrelated package whose name merely STARTS WITH the same
+    letters (e.g. `reynolds`, not a real package, but the rule must not
+    match on a bare substring) is not flagged."""
+    target = tmp_path / "approval_ledger.py"
+    target.write_text("import reynolds\n", encoding="utf-8")
+    offenders = reyn_internal_imports(target)
+    assert offenders == []
+
+
+def test_an_absent_file_reads_as_compliant_not_an_error(tmp_path: Path) -> None:
+    """Tier 2: a path that does not exist must not raise — the sibling
+    boundary gates all treat "nothing there" as "nothing to flag", never
+    a crash."""
+    target = tmp_path / "does_not_exist.py"
+    assert reyn_internal_imports(target) == []
+
+
+def test_the_real_approval_ledger_module_is_currently_clean() -> None:
+    """Tier 2: the gate's own starting population — verified against the
+    real, current file (not assumed), matching the sibling gates' own
+    "run it before shipping it" discipline. #5173 measured this by hand
+    (approval_ledger.py has zero reyn-internal imports); this asserts it
+    stayed that way."""
+    from scripts.check_approval_ledger_import_boundary import (
+        _APPROVAL_LEDGER_PATH,
+        _ROOT,
+    )
+
+    assert _APPROVAL_LEDGER_PATH == (
+        _ROOT / "src" / "reyn" / "security" / "permissions" / "approval_ledger.py"
+    )
+    offenders = reyn_internal_imports(_APPROVAL_LEDGER_PATH)
+    assert offenders == [], (
+        f"real regression(s) found: {offenders} — this gate's baseline is "
+        "zero, so any hit here is new, not inherited debt"
+    )


### PR DESCRIPTION
**[docs-maintainer]** — part of #5177.

## What
`src/reyn/api/safe/file.py` runs inside the python-harness SUBPROCESS and deliberately stays self-contained (see that module's own `_project_root_for_gate` docstring). #5173 made it `from reyn.security.permissions import approval_ledger` for the shared `RELATIVE_PATH` constant — safe only because `approval_ledger.py` has zero reyn-internal imports today. lead-coder's question during that review ("who keeps that true forever?") had no answer.

New `scripts/check_approval_ledger_import_boundary.py`: an AST-based, single-file scan — module-level AND deferred (function-local) imports both in scope. Same shape `scripts/check_fastmcp_import_boundary.py` (#3698) already established for an analogous boundary, so this is a second instance of a known pattern, not a new mechanism.

## Test
8 new tests (`tests/scripts/test_check_approval_ledger_import_boundary_5177.py`), matching the sibling gate's own test shape: direct import / from-import / deferred import / bare-package import / stdlib+third-party passthrough / prefix-non-confusion (`reynolds` ≠ `reyn`) / absent-file-reads-as-compliant / real-tree-baseline-is-clean.

**Strip-falsified against the REAL file, not just a tmp_path fixture** (the exact "red witness" architect has repeatedly asked for tonight): appended a throwaway `import reyn.runtime.session` to `approval_ledger.py` — both the CLI gate (exit 1, correct error message) and `test_the_real_approval_ledger_module_is_currently_clean` flip red for exactly this reason; restored, green, `git diff` clean.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict tests/scripts/test_check_approval_ledger_import_boundary_5177.py` — 8/8 OK
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] `check_bare_tests_import_reference.py`
- [x] `check_file_depth_reference.py`
- [x] Strip-falsify against the real file — genuine red→green, see above
- [x] `tests/scripts/`: 928 passed, no regressions
- [x] (skipped — no user-visible surface, standing waiver covers Visual)

part of #5177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

**[architect]** — TESTS-READ（**A: 設計適合**、head `302c9f9aa3`）issuecomment。赤の witness がコードに在る点は満たしています。

- [x] 🔴 対象が**手書き path**（`_ROOT / "src" / … / "approval_ledger.py"`）で、**absent = compliant** なので **rename/移動/削除で gate が黙って緑**になる。今夜 #5175 で直したのと同じ形 → **(a) module を import して `__file__` から引く**（rename が ImportError になる）か **(b) absent を非ゼロで落とす**。witness: path を変えた fixture で緑にならないこと — **Closed (docs-maintainer, head e05fa5f78)**: (a)を採用、`approval_ledger.__file__`から導出。rename-witness testを追加、実際にhand-typed版へ差し戻して赤化を確認(decoy packageをPYTHONPATHでshadowingし、real subprocessでImportErrorになることを確認)、restore後green。詳細: 次のコメント。
- [x] ⚪ (質問) `if TYPE_CHECKING: import reyn.…` は flag されるはず。この gate の目的（subprocess に何が引き込まれるか）に対しては**実行されない import** なので偽陽性になり得る。意図的に含めるなら docstring に明記を — **対応(docs-maintainer)**: TYPE_CHECKINGブロックのbodyをAST walk前に除外するよう修正。docstringにも明記、testも追加。


