### PR TITLE
docs(pr-workflow): a B note's independence claim must be one only its author can make

### DIFF
--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -316,6 +316,18 @@ These rules then keep multi-session work coherent:
    PR can still tell a real TESTS-READ from an empty one carrying the
    right shape.
 
+   **A B note claiming independence must say what only its author can
+   say.** B's whole value is that it was reached without A's framing, so
+   the note should state whether A had been read — but "I posted before
+   A" is the wrong form: posting order is measurable, and on 2026-08-23 a
+   B note claiming it was measured false (the A it claimed to precede was
+   posted 57 seconds earlier). Whether the reviewer *read* A is knowable
+   only to that reviewer, which is exactly why it has to be said rather
+   than inferred. The form that carries information is "written without
+   reading A (posted after it)". Either answer is fine; an unstated one
+   leaves the reader unable to weigh the note, and a falsifiable one
+   invites the reader to check the wrong thing.
+
    **Reporting reworked twice since (#5138):** a GitHub check run attaches
    to the sha its triggering event carries, and `issue_comment` (fired by
    a posted comment) carries the DEFAULT BRANCH's sha, not the PR's — a


### PR DESCRIPTION
**[lead-coder]** — **★B 注記の 独立性の 主張は、★★本人にしか 言えない 形で 書く。**⚪ **★docs のみ、★1 段落。**

## ✅ ★実例（★2026-08-23、★この 規則を 産んだ もの）

```
🔴 ★B 注記が「A より 前に★作成・投稿した」と 書きました
✅ ★architect が★★GitHub API の `created_at` で 実測
   ── ★A ── `2026-08-23T05:37:17Z`
   ── ★B ── `2026-08-23T05:38:14Z`
   ── ∴ ★★投稿は A が★57 秒 先 ── ★★主張は 偽 でした
⚪ ★中身は★強い B でした ── ★★独立性の 主張だけが★検証できる 形に なって いません でした
```

## ✅ ★何が 悪い 形か

```
🔴 ★「投稿が 先」── ★★測れます ── ∴ ★外から 反証されます
   ── ⚠️ ★しかも ── ★★測れた ところで★独立性を 示しません
      （★手元で 書き終えて から 貼る 順は★いくらでも 変わります）
✅ ★「★A を 読まずに 書いた（★投稿は A の 後）」── ★★本人にしか 言えません
   ── ⚪ ★★だから 1 行が 要ります ── ★推測できない から です
```

## ⚪ ★どちらでも 構いません

```
⚪ ★「読んだ 上で 書いた」も★正当な B です ── ★★重みが 違う だけ
⚪ ★書いて あれば ── ★★読む 側が 正しく 重み付け できます
🔴 ★書いて いないと ── ★読む 側は★★どちらか 分かりません
🔴 ★反証できる 形で 書くと ── ★★読む 側が 誤った ものを 検査しに 行きます
```

## ⚪ ★射程

```
⚪ ★`docs/deep-dives/contributing/pr-workflow.md` の★家則 8 節 ── ★1 段落
⚪ ★規則を 増やして いません ── ★★既に 在る「B は 独立」の★意味を 1 つ 定めた もの
🔴 ★機構は 作りません ── ★★読んだかは 機械に 見えません ── ★人が 名乗る しか ない
```

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml`
- [x] `python scripts/check_doc_anchors.py`
- [x] `python scripts/check_retired_config_keys_denylist.py`
- [x] (skipped — docs only ∴ 家則 8 の 対象外)
