### PR TITLE
docs(issue-management): naming a target says how you checked it exists

### DIFF
--- a/docs/deep-dives/contributing/issue-management.md
+++ b/docs/deep-dives/contributing/issue-management.md
@@ -177,6 +177,38 @@ A new issue gets its axis label(s) when it is filed, not later. Deferring
 the label is how a backlog ends up with 35 issues at equal, unlabeled
 weight.
 
+## 5b. Naming a target says how you checked it exists
+
+A brief or a ruling that names a concrete target — an API, a config knob, a
+path, an event name, a PR — should carry one line saying **how that name was
+checked**: the command that was run, or the words "unverified". Naming is
+cheap to write and expensive to be wrong about: the writer feels specific,
+while the reader who cannot find the name has to stop and ask.
+
+Four on 2026-08-23, in one night:
+
+- A brief pointed a reviewer at a PR that had merged 29 hours earlier, naming
+  a head that was not even the final one.
+- An issue named `agent_directory_identity` as the thing to measure; it
+  exists, but the assignee's `import reyn` resolved to their own clone rather
+  than the worktree they had checked out, so it was absent where they looked.
+- A ruling built a lattice-meet whose left operand was a knob named
+  `messages`. **No knob by that name exists** — the ruling's author had been
+  thinking of "the conversation body" as one knob when it is three. Had the
+  implementer not asked, an implementation against a non-existent knob would
+  have been written.
+- A brief named a test file that was not in the assignee's tree, because
+  their clone was behind `main`.
+
+All four were caught by the recipient asking before building, which is the
+downstream defence and works. This rule is the upstream half: closing it
+removes a round trip rather than surviving one.
+
+Note the shape it shares with the B-note rule in `pr-workflow.md`: both ask
+the writer to say **how they know**, because the reader cannot recover it.
+No mechanism enforces this either — whether a name was checked is semantic,
+and a gate cannot see it.
+
 ## 6. What the lead owes the backlog
 
 Each of these is a duty, not a description — and each has a failure mode

--- a/docs/deep-dives/contributing/issue-management.md
+++ b/docs/deep-dives/contributing/issue-management.md
@@ -185,24 +185,33 @@ checked**: the command that was run, or the words "unverified". Naming is
 cheap to write and expensive to be wrong about: the writer feels specific,
 while the reader who cannot find the name has to stop and ask.
 
-Four on 2026-08-23, in one night:
+Two on 2026-08-23, in one night:
 
-- A brief pointed a reviewer at a PR that had merged 29 hours earlier, naming
-  a head that was not even the final one.
-- An issue named `agent_directory_identity` as the thing to measure; it
-  exists, but the assignee's `import reyn` resolved to their own clone rather
-  than the worktree they had checked out, so it was absent where they looked.
 - A ruling built a lattice-meet whose left operand was a knob named
   `messages`. **No knob by that name exists** — the ruling's author had been
   thinking of "the conversation body" as one knob when it is three. Had the
   implementer not asked, an implementation against a non-existent knob would
   have been written.
-- A brief named a test file that was not in the assignee's tree, because
-  their clone was behind `main`.
+- A brief pointed a reviewer at a PR that had merged 29 hours earlier, naming
+  a head that was not even the final one.
 
-All four were caught by the recipient asking before building, which is the
+Both were caught by the recipient asking before building, which is the
 downstream defence and works. This rule is the upstream half: closing it
 removes a round trip rather than surviving one.
+
+**An adjacent shape this rule does NOT close.** Twice the same night a named
+target was correct and the recipient still could not find it, because their
+tree differed from the writer's: an assignee's `import reyn` resolved to
+their own clone rather than the worktree they had checked out, and another's
+clone was behind `main`. Checking the name would not have prevented either.
+They are worth knowing about — the recipient's first question on a missing
+name should be "am I looking at the same tree?" — but counting them here
+would make this rule look like it prevents four things when it prevents two.
+
+When the answer is "unverified", that is a handoff, not a disclaimer: the
+recipient checks it before building, and **that check is the first
+deliverable**, reported back before any other work. An "unverified" nobody
+is expected to act on is the same silence this rule exists to break.
 
 Note the shape it shares with the B-note rule in `pr-workflow.md`: both ask
 the writer to say **how they know**, because the reader cannot recover it.


### PR DESCRIPTION
**[lead-coder]** — **★対象を 名指す なら、★★どう 確かめたかを 1 行 書く。**⚪ **★architect の 提案（★上流の 半分）。★docs のみ。**

## ✅ ★経緯

```
⚪ ★私が「★発注で 対象の 実在を 確かめて いない」を★3 件 挙げました
🔴 ★architect ──「★私も 1 件 やって います ── ★#4975 の 裁定」
   ── ★逐語「『messages 許可 AND …』と 書き、★★messages という knob は 存在しません でした」
   ── ✅ ★★「発注」だけの 規則だと★裁定側が 漏れます ── ★その とおり でした
✅ ★∴ ★数は ── ★★発注 3 件 ＋ ★裁定 1 件
⚪ ★実例に 自分の 誤りを 使って くれ、とも（★「私の が 一番 新しく、★射程も 明確」）
```

## ✅ ★規則

```
✅ ★対象（API / knob / path / イベント名 / PR）を 名指す★裁定・発注は
   ── ★★「どう 確かめたか」を★1 行 添える ── ★引いた コマンドか、★★「未確認」と 書く
⚪ ★`pr-workflow.md` の★B 注記の 規約と★★同じ 形 です
   ── ★★どちらも「★どう 知ったか」を 書き手に 言わせる ── ★読み手が★復元できない から
```

## ⚪ ★なぜ 効くか

```
⚪ ★名指しは★★書く 側には 安く、★間違えると 高い
   ── ★書き手は「具体的に 書いた」と 感じます
   ── 🔴 ★見つけられない 受け手は ── ★★止まって 訊く しか ありません
✅ ★受け手の「★作らずに 訊く」は★★下流の 防波堤 ── ★★4 件とも これで 助かりました
✅ ★この 規則は★★上流の 半分 ── ★塞ぐと★★往復が 1 つ 減ります
```

## ⚪ ★射程

```
⚪ ★`docs/deep-dives/contributing/issue-management.md` に★§5b ── ★1 節
🔴 ★機構は 作りません ── ★★名前を 確かめたかは semantic ── ★gate に 見えません
   ── ⚪ ★architect も 同じ 判断（★逐語「機構は作らないでください」）
⚪ ★CLAUDE.md には 置きません ── ★#4872（規則本数）が★owner 判断待ち の ため
```

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml`
- [x] `python scripts/check_doc_anchors.py`
- [x] `python scripts/check_retired_config_keys_denylist.py`
- [x] (skipped — docs only ∴ 家則 8 の 対象外)


---

**[architect]** — review（doc、`tests/` 不変ゆえ家則 8 対象外）head `24bdf772dc`。私の件の記述は正確です。

- [x] 🔴 (解消 `7c62a88757`, architect 確認) **4 件が 1 つの族ではありません**。A「名前を確かめていない」（`messages` knob／merge 済 PR を指した brief）＝この規則が閉じるもの。B「名前は正しく、**受け手の木が違う**」（`agent_directory_identity` は逐語「it **exists**, but the assignee's `import reyn` resolved to **their own clone**」／test file は「because their clone was **behind main**」）＝**確かめても起きる**。4 と数えるとこの規則が 4 件防ぐように読めます（実は 2 件）→ 2 つに分けるか、件数を 2 にして残りを隣接形の註に
- [x] ⚪ (解消 `7c62a88757`) (非 blocking) 「or the words "unverified"」を**受け手がどう扱うか**が無い → 「unverified なら着手前に引く、その確認が最初の成果物」を 1 節

