### PR TITLE
fix(#5168): stdout/stderr are the TUI's own while it owns the screen

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -113,6 +113,7 @@ from .restore import RESUME_DIVIDER, project_restored_frames
 from .rewind_picker import RewindPicker
 from .search_bar import SearchBar
 from .sent_queue import SentQueue
+from .stray_output import StrayOutputCaptured, StrayOutputStats, capture_stray_output
 from .theme import REYN_THEME
 
 if TYPE_CHECKING:
@@ -1258,6 +1259,11 @@ class TextualChatApp(App):
         self._transport = transport
         self._read_model = read_model
         self._agent_name = agent_name
+        # #5168: set by run_textual_chat's own capture_stray_output window —
+        # None for any App constructed outside it (e.g. a bare
+        # TextualChatApp(...) in a test), in which case _status_text's own
+        # diagnostics_count read stays 0, byte-identical to before #5168.
+        self._stray_output_stats: "StrayOutputStats | None" = None
         # #5139: mirrors ``self._agent_name`` — this client's OWN idea of
         # which session it is currently attached to, updated at the same
         # site ``self._agent_name`` is (:meth:`_handle_session_attached_
@@ -2117,18 +2123,26 @@ class TextualChatApp(App):
         see ``_configured_gutter_visibility``'s own docstring for the
         pattern) — falls back to ``status_line_text``'s own module-default
         (:data:`~reyn.interfaces.inline.textual_chat.chrome.
-        CTX_WARN_PERCENT`) when unset."""
+        CTX_WARN_PERCENT`) when unset.
+
+        #5168: ``diagnostics_count`` reads ``self._stray_output_stats`` —
+        ``None`` whenever this App wasn't constructed inside
+        :func:`run_textual_chat`'s own ``capture_stray_output`` window (a
+        bare ``TextualChatApp(...)`` in a test, for instance), in which case
+        the count is always 0 — byte-identical status text to before #5168."""
         snapshot = self._snapshot() if snap is _UNSET else snap
         warn_percent = getattr(
             getattr(self._config, "tui", None),
             "context_usage_warn_percent",
             CTX_WARN_PERCENT,
         )
+        diagnostics_count = self._stray_output_stats.count if self._stray_output_stats else 0
         return status_line_text(
             snapshot,
             self._agent_name,
             attach_state=self._attach_state(),
             warn_percent=warn_percent,
+            diagnostics_count=diagnostics_count,
         )  # type: ignore[arg-type]
 
     async def _watch_loop_responsiveness(self) -> None:
@@ -2263,6 +2277,18 @@ class TextualChatApp(App):
                     "textual chat: %s",
                     stall_recovered_log_line(pump_ticks=self._pump_ticks),
                 )
+
+    def on_stray_output_captured(self, message: "StrayOutputCaptured") -> None:
+        """#5168: a stray ``stdout``/``stderr`` write was captured (a
+        third-party ``print(file=sys.stderr)``, a ``warnings.warn`` that
+        would otherwise have corrupted the live region — see
+        ``stray_output.py``). Re-reads the live count off
+        ``self._stray_output_stats`` rather than trusting anything on
+        *message* (see :class:`StrayOutputCaptured`'s own docstring for
+        why) and folds it into the SAME status-line refresh path every
+        other status-affecting event already uses — one row, updated in
+        place, never a line printed per occurrence."""
+        self._refresh_status()
 
     def on_mount(self) -> None:
         # #3505/#4840: #3504 made ``App``'s own background ``ansi_default``
@@ -6853,7 +6879,15 @@ async def run_textual_chat(
                 config=config,
                 initial_history_messages=_initial_history_messages,
             )
-        await app.run_async(inline=inline)
+        # #5168: sys.stdout/sys.stderr are the RENDERER's own from here until
+        # run_async returns — anything else writing to them (a third-party
+        # print(file=sys.stderr), a warnings.warn) corrupts the live region.
+        # See stray_output.py's own module docstring for the full rationale;
+        # __exit__ restores BOTH streams unconditionally, including a crash
+        # inside run_async, so the operator's terminal is never left mid-swap.
+        with capture_stray_output(app) as stray_output_stats:
+            app._stray_output_stats = stray_output_stats
+            await app.run_async(inline=inline)
     finally:
         if _stall_seconds is not None:
             _disarm_stall_trace()

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1727,6 +1727,8 @@ def status_line_text(
     *,
     attach_state: "str | None" = None,
     warn_percent: int = CTX_WARN_PERCENT,
+    diagnostics_count: int = 0,
+    diagnostics_log_path: "str | None" = None,
 ) -> str:
     """The Telemetry segment (#4542: ``model · agent    $cost  ctx%``, no
     ``│``/``|`` separators — position and text-style carry the grouping
@@ -1768,38 +1770,55 @@ def status_line_text(
     glyph can be added later without touching the mechanism, but a broken
     row on a still-forming feature would cast doubt on the mechanism
     itself.
+
+    #5168: ``diagnostics_count`` (default 0, byte-identical text when unset)
+    PREPENDS a ``diagnostics: N — <path>`` segment ahead of whatever this
+    function would otherwise return — the SAME "prepend, don't replace"
+    shape ``halted_reason`` already uses, and for the same reason: this is
+    the ONE always-visible row, so it is where an operator learns a
+    stray ``stdout``/``stderr`` write (a third-party ``print``, a
+    ``warnings.warn`` that would otherwise have corrupted the live region —
+    see ``stray_output.py``) was captured, without needing a modal or a
+    per-write printed line (the exact corruption this closes). Applied
+    LAST, after every other branch (``connecting``/``failed``/HALTED/base)
+    — diagnostics can coexist with any of those, so it is not folded into
+    any single branch's own return.
     """
     if attach_state == "connecting":
-        return f"connecting… · agent {agent_name}"
-    if attach_state == "failed":
-        return f"attach failed (see log) · agent {agent_name}"
-
-    # #2280: when ``snap["halted_reason"]`` is set (the session fail-stopped on
-    # a persistent durability failure — ``Session.halted_reason``), a
-    # ``HALTED`` banner segment is PREPENDED ahead of the usual values — this
-    # line is the ONE always-visible (never-collapsed) chrome region, so it is
-    # the surface an idle operator (not currently submitting anything) will
-    # proactively see the halt on, rather than only learning it from the next
-    # op's raised ``DurabilityHaltError``. Purely observability — the halt
-    # itself is already enforced synchronously elsewhere
-    # (``_fail_stop_if_durability_dead`` / ``run_one_iteration``); this never
-    # gates or delays anything.
-    snap = snap or {}
-    model = snap.get("model_active_class") or snap.get("model") or "—"
-    agent = snap.get("attached_name") or agent_name
-    ctx_pct = _ctx_pct(snap)
-    ctx_segment = ctx_pct
-    if ctx_pct.endswith("%"):
-        try:
-            if int(ctx_pct[:-1]) >= warn_percent:
-                ctx_segment = f"ctx {ctx_pct}"
-        except ValueError:
-            pass  # "—" (no completed call yet) — bare, never escalated
-    base = f"{model} · {agent}    {cost_figure(snap)}  {ctx_segment}"
-    halted_reason = snap.get("halted_reason")
-    if halted_reason:
-        return f"⚠ HALTED — {halted_reason} — agent stopped accepting ops · {base}"
-    return base
+        text = f"connecting… · agent {agent_name}"
+    elif attach_state == "failed":
+        text = f"attach failed (see log) · agent {agent_name}"
+    else:
+        # #2280: when ``snap["halted_reason"]`` is set (the session fail-stopped on
+        # a persistent durability failure — ``Session.halted_reason``), a
+        # ``HALTED`` banner segment is PREPENDED ahead of the usual values — this
+        # line is the ONE always-visible (never-collapsed) chrome region, so it is
+        # the surface an idle operator (not currently submitting anything) will
+        # proactively see the halt on, rather than only learning it from the next
+        # op's raised ``DurabilityHaltError``. Purely observability — the halt
+        # itself is already enforced synchronously elsewhere
+        # (``_fail_stop_if_durability_dead`` / ``run_one_iteration``); this never
+        # gates or delays anything.
+        snap = snap or {}
+        model = snap.get("model_active_class") or snap.get("model") or "—"
+        agent = snap.get("attached_name") or agent_name
+        ctx_pct = _ctx_pct(snap)
+        ctx_segment = ctx_pct
+        if ctx_pct.endswith("%"):
+            try:
+                if int(ctx_pct[:-1]) >= warn_percent:
+                    ctx_segment = f"ctx {ctx_pct}"
+            except ValueError:
+                pass  # "—" (no completed call yet) — bare, never escalated
+        base = f"{model} · {agent}    {cost_figure(snap)}  {ctx_segment}"
+        halted_reason = snap.get("halted_reason")
+        text = (
+            f"⚠ HALTED — {halted_reason} — agent stopped accepting ops · {base}"
+            if halted_reason else base
+        )
+    if diagnostics_count:
+        text = f"diagnostics: {diagnostics_count} — {diagnostics_log_path or '.reyn/logs/reyn.log'} · {text}"
+    return text
 
 
 #: #4357: how many unknown-key NAMES the chrome line shows inline before

--- a/src/reyn/interfaces/inline/textual_chat/stray_output.py
+++ b/src/reyn/interfaces/inline/textual_chat/stray_output.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import threading
 from dataclasses import dataclass
 
 from textual.message import Message
@@ -86,6 +87,45 @@ class StrayOutputCaptured(Message):
     the CURRENT total, not the count at post time)."""
 
 
+class _ReentrancyGuard:
+    """#5168 (architect blocking, issuecomment-...): shared between the
+    stdout AND stderr :class:`_CapturingStream` instances of one capture
+    window, so a stray write's own ``_log.warning`` call cannot recurse
+    back into ``write()``.
+
+    The hazard: ``_log.warning`` is routed through whatever handlers
+    ``logging`` has installed, and if any ``StreamHandler`` writes to
+    ``sys.stderr`` looked up LIVE (not bound at construction), that write
+    lands on THIS module's own ``_CapturingStream`` (now installed as
+    ``sys.stderr``) — ``write`` → ``_log.warning`` → handler write →
+    ``write`` → ... . Today this does not fire only because every handler
+    this codebase installs happens to bind its stream at construction
+    time, BEFORE the swap — an ordering accident, not a contract
+    (`logging.StreamHandler.__init__` defaults to the `sys.stderr` object
+    live AT THAT MOMENT, but nothing stops a future handler from being
+    added, or an existing one reconstructed, after the swap). "Works today"
+    and "no door left open" are different claims (architect: this exact
+    line recurred several times the same night this hazard was found).
+
+    ``threading.local``-backed because a stray write can originate from a
+    background thread a third-party library owns, not only the app's own
+    event loop — a global (non-thread-local) flag would let one thread's
+    in-flight write mask another thread's genuinely-new one."""
+
+    def __init__(self) -> None:
+        self._local = threading.local()
+
+    @property
+    def active(self) -> bool:
+        return getattr(self._local, "active", False)
+
+    def __enter__(self) -> None:
+        self._local.active = True
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._local.active = False
+
+
 class _CapturingStream:
     """A write-only file-like object that logs everything it receives
     instead of letting it reach the real terminal.
@@ -96,15 +136,36 @@ class _CapturingStream:
     (a library checking "am I on a real terminal before emitting ANSI
     codes" must see "no" here -- this is not one)."""
 
-    def __init__(self, stats: StrayOutputStats, poster: "MessagePump", stream_name: str) -> None:
+    def __init__(
+        self,
+        stats: StrayOutputStats,
+        poster: "MessagePump",
+        stream_name: str,
+        guard: _ReentrancyGuard,
+    ) -> None:
         self._stats = stats
         self._poster = poster
         self._stream_name = stream_name
+        self._guard = guard
 
     def write(self, s: str) -> int:
+        if self._guard.active:
+            # #5168: this is logging's OWN write of the record we are
+            # already in the middle of emitting (a StreamHandler pointed at
+            # what is now this captured stream) -- not a NEW stray write.
+            # Swallow silently: no recursive _log.warning call, no double
+            # count -- see _ReentrancyGuard's own docstring.
+            return len(s)
         if s and s.strip():
+            # A whitespace-only write (e.g. the bare "\n" terminator a
+            # print()/logging call issues as its own write() after the
+            # payload) is deliberately DISCARDED, not merely uncounted --
+            # it carries nothing worth a log line or a status-line bump.
             self._stats.count += 1
-            _log.warning("stray %s captured during TUI run: %s", self._stream_name, s.rstrip("\n"))
+            with self._guard:
+                _log.warning(
+                    "stray %s captured during TUI run: %s", self._stream_name, s.rstrip("\n"),
+                )
             try:
                 self._poster.post_message(StrayOutputCaptured())
             except Exception:  # noqa: BLE001 — a message-post fault must never crash the write() caller
@@ -138,8 +199,13 @@ class capture_stray_output:  # noqa: N801 — lowercase, contextlib-style naming
 
     def __enter__(self) -> StrayOutputStats:
         self._orig_stdout, self._orig_stderr = sys.stdout, sys.stderr
-        sys.stdout = _CapturingStream(self.stats, self._poster, "stdout")
-        sys.stderr = _CapturingStream(self.stats, self._poster, "stderr")
+        # One guard SHARED between both streams (not one each) -- a
+        # misdirected handler could in principle write the log record to
+        # either captured stream regardless of which one triggered it; see
+        # _ReentrancyGuard's own docstring.
+        guard = _ReentrancyGuard()
+        sys.stdout = _CapturingStream(self.stats, self._poster, "stdout", guard)
+        sys.stderr = _CapturingStream(self.stats, self._poster, "stderr", guard)
         return self.stats
 
     def __exit__(self, exc_type, exc, tb) -> None:

--- a/src/reyn/interfaces/inline/textual_chat/stray_output.py
+++ b/src/reyn/interfaces/inline/textual_chat/stray_output.py
@@ -1,0 +1,151 @@
+"""#5168: while a Textual app owns the screen, ``sys.stdout``/``sys.stderr``
+are the RENDERER's own — anything else writing to them corrupts the live
+region. Measured live (e2e-coder, real tmux TTY): a ``warnings.warn()`` fired
+mid-session left a garbled fragment durably stuck in the input composer's
+own rendered line (survived multiple ``capture-pane`` reads seconds apart,
+not a single transient redraw frame).
+
+Architect ruling (issuecomment-5384424061): the problem is not "what to do
+about warnings" — it is "who owns these streams while the app owns the
+screen." Two tty owners cannot coexist. Fixing only ``warnings`` (e.g.
+``logging.captureWarnings``, already installed for the CLI's own log
+redirect — see ``interfaces/cli/commands/chat.py``'s ``_setup_interactive_
+logging``) closes the ONE observed trigger but not the general path: a
+third party can bypass ``warnings`` entirely with a bare
+``print(..., file=sys.stderr)``, and the next one will corrupt the screen
+the same way (the exact #5164-doesn't-close-this shape e2e-coder's own
+report named).
+
+**Scope: the stream, not the writer.** ``capture_stray_output`` swaps
+``sys.stdout``/``sys.stderr`` themselves for the duration the app owns the
+screen. ``warnings.warn``'s default ``showwarning`` implementation writes to
+``sys.stderr`` looked up LIVE at call time (not bound at import), so it
+rides this swap automatically -- no separate ``warnings`` handling needed on
+this path (``logging.captureWarnings`` stays installed and correct for the
+CLI's OTHER, non-TUI callers of ``_setup_interactive_logging`` -- this
+module does not touch that).
+
+**Destination: reyn's own logging, never dropped.** Every captured write is
+logged via ``logging.getLogger(__name__)`` at WARNING level -- routed
+through whatever handler the interactive CLI already installed (a
+``.reyn/logs/reyn.log`` FileHandler, so ``--verbose``/log-tooling still sees
+it) rather than a raw, separately-invented file. ``filterwarnings("ignore")``
+is explicitly NOT an option here (architect ruling) -- that is the #5167
+shape this whole arc has been closing all night ("declared/received, never
+honored, never said"), generalized to output instead of a hook declaration.
+
+**Visibility: one line, never per-write.** A captured write bumps
+``StrayOutputStats.count`` and posts a ``StrayOutputCaptured`` message (NOT
+a direct method call -- posting is Textual's thread-safe primitive, and a
+stray write can originate from a background thread a third-party library
+owns, not only the app's own event loop) so the App can fold it into the
+ALREADY-EXISTING status-line refresh (``chrome.status_line_text``'s new
+``diagnostics_count``/``diagnostics_log_path`` params) -- one row, updated
+in place, never a line printed per occurrence (that repeated-line spam IS
+the corruption this closes) and never a modal (the ruling's own explicit
+"not a thing that stops operation").
+
+**Restore: unconditional, including a crash mid-run.** ``capture_stray_
+output`` is a context manager; ``__exit__`` runs on every exit path a
+``with`` block has -- a normal return, a Textual-internal exception, a
+KeyboardInterrupt during the run -- so an operator's terminal is never left
+mid-swap. The two assignments in ``__enter__`` are adjacent with no I/O or
+branching between them, so the only window a crash could land in is the
+attribute-store bytecode itself, which cannot raise -- there is no state
+between "neither swapped" and "both swapped" for an exception to observe.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass
+
+from textual.message import Message
+from textual.message_pump import MessagePump
+
+_log = logging.getLogger(__name__)
+
+
+@dataclass
+class StrayOutputStats:
+    """Live-mutated counter :func:`capture_stray_output` hands to its
+    caller. One instance per capture window (per TUI run) -- the App reads
+    ``.count`` at each status-line refresh; nothing here is Textual-specific,
+    so this dataclass alone is fully unit-testable with no App/widget
+    involved."""
+
+    count: int = 0
+
+
+class StrayOutputCaptured(Message):
+    """#5168: posted once per non-empty captured write. Carries no payload
+    deliberately -- a handler re-reads the live :class:`StrayOutputStats`
+    count rather than trusting a value that might already be stale by the
+    time Textual's message queue delivers it (several writes can be posted
+    before the App's handler runs; each handler invocation should reflect
+    the CURRENT total, not the count at post time)."""
+
+
+class _CapturingStream:
+    """A write-only file-like object that logs everything it receives
+    instead of letting it reach the real terminal.
+
+    Not a general-purpose stream proxy -- ``write`` is the only method a
+    ``print(...)``/``warnings.showwarning`` call actually needs; ``flush``
+    is a no-op (nothing buffered to flush) and ``isatty`` returns ``False``
+    (a library checking "am I on a real terminal before emitting ANSI
+    codes" must see "no" here -- this is not one)."""
+
+    def __init__(self, stats: StrayOutputStats, poster: "MessagePump", stream_name: str) -> None:
+        self._stats = stats
+        self._poster = poster
+        self._stream_name = stream_name
+
+    def write(self, s: str) -> int:
+        if s and s.strip():
+            self._stats.count += 1
+            _log.warning("stray %s captured during TUI run: %s", self._stream_name, s.rstrip("\n"))
+            try:
+                self._poster.post_message(StrayOutputCaptured())
+            except Exception:  # noqa: BLE001 — a message-post fault must never crash the write() caller
+                pass
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+    def isatty(self) -> bool:
+        return False
+
+
+class capture_stray_output:  # noqa: N801 — lowercase, contextlib-style naming (mirrors stdlib's own `contextlib.redirect_stdout`)
+    """Context manager: swap ``sys.stdout``/``sys.stderr`` to
+    :class:`_CapturingStream` instances for the duration ``poster`` (the
+    running :class:`~textual.app.App`) owns the screen. See the module
+    docstring for the full rationale.
+
+    ``poster`` is any ``MessagePump`` (Textual's ``App``/``Widget`` base --
+    ``post_message`` lives there, not on ``App`` specifically) -- typed as
+    the real Textual base rather than importing
+    ``reyn.interfaces.inline.textual_chat.app`` to avoid a circular import
+    (this module is imported BY ``app.py``)."""
+
+    def __init__(self, poster: "MessagePump") -> None:
+        self.stats = StrayOutputStats()
+        self._poster = poster
+        self._orig_stdout: "object | None" = None
+        self._orig_stderr: "object | None" = None
+
+    def __enter__(self) -> StrayOutputStats:
+        self._orig_stdout, self._orig_stderr = sys.stdout, sys.stderr
+        sys.stdout = _CapturingStream(self.stats, self._poster, "stdout")
+        sys.stderr = _CapturingStream(self.stats, self._poster, "stderr")
+        return self.stats
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        # Unconditional restore -- see the class docstring's own "Restore"
+        # paragraph for why this is safe even mid-crash.
+        if self._orig_stdout is not None:
+            sys.stdout = self._orig_stdout
+        if self._orig_stderr is not None:
+            sys.stderr = self._orig_stderr

--- a/tests/interfaces/test_5168_tui_stdio_capture.py
+++ b/tests/interfaces/test_5168_tui_stdio_capture.py
@@ -1,0 +1,312 @@
+"""Tier 2: #5168 — while a Textual app owns the screen, a stray
+``sys.stdout``/``sys.stderr`` write (a third-party ``print(file=sys.stderr)``,
+a ``warnings.warn``) must not corrupt the live region.
+
+Architect ruling (issuecomment-5384424061), 5 acceptance criteria:
+  ① a third-party-shaped ``print(file=sys.stderr)`` — NOT just ``warnings.warn``
+     — does not reach the real terminal while the app owns the screen.
+  ② the same content is still observable (routed to logging, never dropped).
+  ③ a screen indicator increases (never a silent capture).
+  ④ the streams are restored even if an exception is raised mid-block.
+  ⑤ a non-TUI run (capture never entered) keeps stderr behaving as before —
+     the layer boundary this closes must not leak into an unrelated caller.
+
+Real ``TextualChatApp`` + ``run_test()`` pilot for the end-to-end
+(status-line) witnesses; real (unstarted) Textual ``App``/``MessagePump``
+instances for the unit-level ``stray_output.py`` witnesses (a real
+``App()`` accepts ``post_message`` before ``run()`` — confirmed live, no
+mock needed). No mocks anywhere in this file, per the testing policy.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import sys
+from typing import AsyncIterator
+
+import pytest
+from textual.app import App
+
+from reyn.interfaces.inline.textual_chat.chrome import status_line_text
+from reyn.interfaces.inline.textual_chat.stray_output import (
+    StrayOutputStats,
+    _CapturingStream,
+    capture_stray_output,
+)
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+# ---------------------------------------------------------------------------
+# status_line_text — pure-function level (fast, no App)
+# ---------------------------------------------------------------------------
+
+
+def test_status_line_unaffected_when_diagnostics_count_is_zero():
+    """Tier 2: the default (``diagnostics_count=0``) is byte-identical to
+    the pre-#5168 text — no regression for the ordinary, nothing-captured
+    case (every existing status_line_text test already pins this shape;
+    this one just names the invariant explicitly for #5168's own diff)."""
+    text_before = status_line_text({"model_active_class": "opus"}, "alpha")
+    text_default = status_line_text({"model_active_class": "opus"}, "alpha", diagnostics_count=0)
+    assert text_before == text_default
+    assert "diagnostics" not in text_default
+
+
+def test_status_line_prepends_diagnostics_segment_when_count_is_nonzero():
+    """Tier 2: acceptance ③'s pure-function witness — a nonzero count
+    prepends a "diagnostics: N — <path>" segment naming both the count and
+    where to look, ahead of the ordinary text."""
+    text = status_line_text(
+        {"model_active_class": "opus"}, "alpha",
+        diagnostics_count=3, diagnostics_log_path=".reyn/logs/reyn.log",
+    )
+    assert text.startswith("diagnostics: 3 — .reyn/logs/reyn.log"), text
+    assert "opus" in text, "the ordinary status text must still follow, not be replaced"
+
+
+def test_status_line_diagnostics_coexists_with_the_halted_banner():
+    """Tier 2: diagnostics is applied LAST, after every other branch —
+    it must be able to coexist with the #2280 HALTED banner (both can be
+    true at once: the session halted AND a stray write happened), not
+    silently swallow one or the other."""
+    text = status_line_text(
+        {"halted_reason": "durability failure"}, "alpha", diagnostics_count=1,
+    )
+    assert text.startswith("diagnostics: 1")
+    assert "HALTED" in text
+
+
+# ---------------------------------------------------------------------------
+# stray_output.py — unit level (real, unstarted Textual App as the poster)
+# ---------------------------------------------------------------------------
+
+
+def test_capturing_stream_write_bumps_count_and_logs(caplog: pytest.LogCaptureFixture):
+    """Tier 2: acceptance ②/③'s unit witness — a non-empty write bumps the
+    live count AND is logged (never dropped)."""
+    stats = StrayOutputStats()
+    poster = App()
+    stream = _CapturingStream(stats, poster, "stderr")
+
+    with caplog.at_level(logging.WARNING, logger="reyn.interfaces.inline.textual_chat.stray_output"):
+        stream.write("a stray warning fragment\n")
+
+    assert stats.count == 1
+    assert any("a stray warning fragment" in r.message for r in caplog.records), (
+        "the captured content must be observable through logging, not silently dropped"
+    )
+
+
+def test_capturing_stream_ignores_whitespace_only_writes(caplog: pytest.LogCaptureFixture):
+    """Tier 2: falsification contrast — stdlib buffering machinery writes a
+    LOT of bare "\\n"/"" (e.g. print's own trailing newline as a SEPARATE
+    write call under some buffering modes); counting those would inflate
+    the diagnostic count for nothing an operator could act on."""
+    stats = StrayOutputStats()
+    poster = App()
+    stream = _CapturingStream(stats, poster, "stderr")
+
+    with caplog.at_level(logging.WARNING, logger="reyn.interfaces.inline.textual_chat.stray_output"):
+        stream.write("\n")
+        stream.write("")
+        stream.write("   ")
+
+    assert stats.count == 0
+    assert caplog.records == []
+
+
+def test_capturing_stream_posts_a_message_to_the_poster():
+    """Tier 2: the cross-thread-safe signal — a write posts
+    StrayOutputCaptured via post_message (thread-safe by construction, see
+    the module's own docstring), not a direct method call."""
+    stats = StrayOutputStats()
+    poster = App()
+    stream = _CapturingStream(stats, poster, "stderr")
+
+    posted = stream.write("something\n")
+
+    assert posted == len("something\n")
+    # A real, unstarted App still queues the message (confirmed live) —
+    # draining its own private queue directly would be a private-state
+    # assertion, so this test only pins the PUBLIC contract (write()
+    # succeeds, does not raise) rather than reaching into
+    # poster._message_queue.
+
+
+def test_capture_stray_output_swaps_and_restores_both_streams():
+    """Tier 2: acceptance ①'s mechanism-level witness — both streams are
+    swapped for the duration of the block and restored after."""
+    poster = App()
+    fake_real_stdout, fake_real_stderr = io.StringIO(), io.StringIO()
+    orig_stdout, orig_stderr = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = fake_real_stdout, fake_real_stderr
+        with capture_stray_output(poster) as stats:
+            assert sys.stdout is not fake_real_stdout
+            assert sys.stderr is not fake_real_stderr
+            print("stray", file=sys.stderr)
+            print("stray", file=sys.stdout)
+        assert sys.stdout is fake_real_stdout, "stdout must be restored after the block"
+        assert sys.stderr is fake_real_stderr, "stderr must be restored after the block"
+        assert fake_real_stdout.getvalue() == "", (
+            "the pre-swap stream must receive NOTHING while capture is active"
+        )
+        assert fake_real_stderr.getvalue() == "", (
+            "the pre-swap stream must receive NOTHING while capture is active"
+        )
+        assert stats.count == 2
+    finally:
+        sys.stdout, sys.stderr = orig_stdout, orig_stderr
+
+
+def test_capture_stray_output_restores_streams_even_on_exception():
+    """Tier 2: acceptance ④ — an exception raised INSIDE the `with` block
+    (mirrors a Textual-internal crash mid-run) must still restore both
+    streams; an operator's terminal must never be left mid-swap."""
+    poster = App()
+    fake_real_stdout, fake_real_stderr = io.StringIO(), io.StringIO()
+    orig_stdout, orig_stderr = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = fake_real_stdout, fake_real_stderr
+        with pytest.raises(RuntimeError, match="boom"):
+            with capture_stray_output(poster):
+                raise RuntimeError("boom")
+        assert sys.stdout is fake_real_stdout, "stdout must be restored even after a crash"
+        assert sys.stderr is fake_real_stderr, "stderr must be restored even after a crash"
+    finally:
+        sys.stdout, sys.stderr = orig_stdout, orig_stderr
+
+
+def test_stray_output_never_captured_when_the_context_manager_is_not_entered():
+    """Tier 2: acceptance ⑤ — a non-TUI caller that never enters
+    capture_stray_output at all keeps ordinary stderr behavior, byte-
+    identical to before #5168 (the layer boundary: this is scoped to the
+    TUI's own run window, not process-global)."""
+    fake_real_stderr = io.StringIO()
+    orig_stderr = sys.stderr
+    try:
+        sys.stderr = fake_real_stderr
+        print("ordinary stderr output", file=sys.stderr)
+        assert "ordinary stderr output" in fake_real_stderr.getvalue()
+    finally:
+        sys.stderr = orig_stderr
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — a real TextualChatApp, real run_test() pilot
+# ---------------------------------------------------------------------------
+
+
+class _StubTransport(ClientTransportStub):
+    """A real, minimal ClientTransport (mirrors _AttachStateTransport in
+    test_textual_chat_attach_state_3671_p3.py) — this test needs no attach
+    machinery at all, just an app that mounts and stays running."""
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def has_session(self) -> bool:
+        return True
+
+    def attach_failed(self) -> bool:
+        return False
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        import asyncio
+        await asyncio.Event().wait()
+        return
+        yield DisplayFrame(OutboxMessage(role="assistant", content=""))  # pragma: no cover — makes this a real async generator
+
+    async def submit_user_text(self, text: str) -> str:
+        return "msg-1"
+
+    async def answer_intervention_text(self, text: str, *, intervention_id=None) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str, *, intervention_id=None) -> bool:
+        return False
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+class _StubReadModel(ChatReadModel):
+    @property
+    def capabilities(self):
+        return LOCAL_CHAT_READ_CAPABILITIES
+
+    def snapshot(self, config=None):
+        return {"model_active_class": "opus"}
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    @property
+    def history_path(self):
+        from pathlib import Path
+        return Path("/tmp/reyn_5168_history")
+
+    def conversation_history(self, *, limit=None):
+        return []
+
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_a_stray_print_during_a_real_tui_run_updates_the_status_line():
+    """Tier 2: the full end-to-end witness — a real TextualChatApp mounted,
+    capture_stray_output entered exactly as run_textual_chat does it, a
+    third-party-shaped print(file=sys.stderr) fired (NOT warnings.warn —
+    acceptance ①'s own explicit "don't measure with warnings.warn alone"
+    requirement), and the StatusLine's rendered text reflects it (acceptance
+    ③) with the write never reaching the pre-swap stream (acceptance ①)."""
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    transport = _StubTransport()
+    app = TextualChatApp(transport=transport, read_model=_StubReadModel())
+
+    fake_real_stderr = io.StringIO()
+    orig_stderr = sys.stderr
+    try:
+        sys.stderr = fake_real_stderr
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            with capture_stray_output(app) as stats:
+                app._stray_output_stats = stats
+                print("a third-party library's own stray warning", file=sys.stderr)
+                await pilot.pause()
+
+                status_text = str(app.query_one(StatusLine).render())
+                assert "diagnostics: 1" in status_text, (
+                    f"status line did not surface the captured write: {status_text}"
+                )
+        assert fake_real_stderr.getvalue() == "", (
+            "the stray print must never have reached the pre-swap real stream"
+        )
+    finally:
+        sys.stderr = orig_stderr

--- a/tests/interfaces/test_5168_tui_stdio_capture.py
+++ b/tests/interfaces/test_5168_tui_stdio_capture.py
@@ -31,6 +31,7 @@ from reyn.interfaces.inline.textual_chat.chrome import status_line_text
 from reyn.interfaces.inline.textual_chat.stray_output import (
     StrayOutputStats,
     _CapturingStream,
+    _ReentrancyGuard,
     capture_stray_output,
 )
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
@@ -88,7 +89,7 @@ def test_capturing_stream_write_bumps_count_and_logs(caplog: pytest.LogCaptureFi
     live count AND is logged (never dropped)."""
     stats = StrayOutputStats()
     poster = App()
-    stream = _CapturingStream(stats, poster, "stderr")
+    stream = _CapturingStream(stats, poster, "stderr", _ReentrancyGuard())
 
     with caplog.at_level(logging.WARNING, logger="reyn.interfaces.inline.textual_chat.stray_output"):
         stream.write("a stray warning fragment\n")
@@ -106,7 +107,7 @@ def test_capturing_stream_ignores_whitespace_only_writes(caplog: pytest.LogCaptu
     the diagnostic count for nothing an operator could act on."""
     stats = StrayOutputStats()
     poster = App()
-    stream = _CapturingStream(stats, poster, "stderr")
+    stream = _CapturingStream(stats, poster, "stderr", _ReentrancyGuard())
 
     with caplog.at_level(logging.WARNING, logger="reyn.interfaces.inline.textual_chat.stray_output"):
         stream.write("\n")
@@ -117,13 +118,44 @@ def test_capturing_stream_ignores_whitespace_only_writes(caplog: pytest.LogCaptu
     assert caplog.records == []
 
 
+def test_capturing_stream_write_does_not_recurse_through_a_misdirected_handler():
+    """Tier 2: architect blocking finding (#5193 A, issuecomment-...) —
+    ``write()``'s own ``_log.warning`` call must not recurse back into
+    ``write()`` when a ``logging.StreamHandler`` happens to be bound to
+    THIS exact captured stream. That binding is exactly what would happen
+    if a handler were constructed/attached AFTER the stdout/stderr swap —
+    an ordering accident this codebase's own handlers happen not to hit
+    today, not a structural impossibility. RED if ``_ReentrancyGuard`` is
+    removed: this would recurse until ``RecursionError`` (a bare
+    ``StreamHandler.emit`` writing to a stream whose ``write`` calls
+    ``_log.warning`` again, forever)."""
+    stats = StrayOutputStats()
+    poster = App()
+    guard = _ReentrancyGuard()
+    stream = _CapturingStream(stats, poster, "stderr", guard)
+
+    logger = logging.getLogger("reyn.interfaces.inline.textual_chat.stray_output")
+    misdirected_handler = logging.StreamHandler(stream)  # bound to the captured stream itself
+    logger.addHandler(misdirected_handler)
+    logger.setLevel(logging.WARNING)
+    try:
+        stream.write("a stray fragment\n")  # must return, not recurse forever
+    finally:
+        logger.removeHandler(misdirected_handler)
+
+    assert stats.count == 1, (
+        f"the misdirected handler's own recursive write must be swallowed by the "
+        f"guard, not counted as a SECOND stray write -- got count={stats.count}"
+    )
+
+
 def test_capturing_stream_posts_a_message_to_the_poster():
     """Tier 2: the cross-thread-safe signal — a write posts
     StrayOutputCaptured via post_message (thread-safe by construction, see
     the module's own docstring), not a direct method call."""
     stats = StrayOutputStats()
     poster = App()
-    stream = _CapturingStream(stats, poster, "stderr")
+    stream = _CapturingStream(stats, poster, "stderr", _ReentrancyGuard())
 
     posted = stream.write("something\n")
 


### PR DESCRIPTION
**[tui-coder]** — #5168, architect ruling (issuecomment-5384424061).

## Problem
`warnings.warn()` (or a bare third-party `print(file=sys.stderr)`) writes straight to the tty the Textual app owns while it's running — corrupting the input composer's live-rendered line (e2e-coder's real-tmux repro: a garbled fragment survived multiple `capture-pane` reads seconds apart, not a transient redraw). #5164 removed the one observed trigger; the underlying path was untouched.

## Ruling — own the stream, not the writer
1. **Scope: the stream.** `capture_stray_output` swaps `sys.stdout`/`sys.stderr` for the duration `app.run_async(...)` runs. `warnings.warn`'s default `showwarning` resolves `sys.stderr` live at call time, so it rides the swap automatically.
2. **Destination: reyn's own logging, never dropped.** Every captured write routes through `logging.getLogger(__name__).warning(...)` — the same `.reyn/logs/reyn.log` handler the CLI's interactive-logging setup already installs. `filterwarnings("ignore")` was explicitly rejected (same silent-acceptance shape as #5167).
3. **Visibility: one status-line segment, never per-write.** A captured write bumps a counter and posts a `Message` (thread-safe — a stray write can come from a background thread); the status line prepends `diagnostics: N — <path>`, mirroring the #2280 HALTED banner's own "prepend, don't replace" shape.
4. **Restore: unconditional.** A context manager; `__exit__` runs on every exit path, including an exception mid-`run_async`.

## Test — 10 new tests, matching the 5 acceptance criteria
- ① a third-party-shaped `print(file=sys.stderr)` (not just `warnings.warn`) never reaches the pre-swap stream.
- ② the same content is logged (`caplog`).
- ③ the status line's rendered text grows a `diagnostics: N` segment, both at the pure-function and real-`TextualChatApp`+`run_test()` level.
- ④ an exception inside the `with` block still restores both streams.
- ⑤ a caller that never enters `capture_stray_output` sees unchanged stderr — the boundary is scoped to the TUI's own run window.

Real (unstarted) Textual `App` instances as the message poster for unit tests (`post_message` works pre-`run()`, confirmed live), a real `TextualChatApp` + pilot for the end-to-end witness. No mocks.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict tests/interfaces/test_5168_tui_stdio_capture.py`
- [x] `check_collect_events_settle.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] `check_bare_tests_import_reference.py`
- [x] `check_file_depth_reference.py`
- [x] `verify_module_docstrings.py`
- [x] Regression: `tests/interfaces/` — 2049 passed, 9 skipped (missing optional extras, unrelated), no regressions
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[architect]** — TESTS-READ（**A: 設計適合**、head `e5fda92b9f`）issuecomment。裁定①〜⑤は全て在ります。B は別の人が必要です。

- [x] 🔴 (解消 `654b88ced`, architect 差分 A) `write()` が `_log.warning(...)` を呼ぶため、**stderr に書く logging handler があると write→log→write の再帰**になる。今壊れないのは `StreamHandler` が**構築時の `sys.stderr` を保持**しているからで、**構築順を保証するものが無い**。**swap 後に stderr handler を足した状態で stray write → 再帰せず count は 1 だけ増える**、を 1 本
- [x] ⚪ (対応済 `654b88ced`) (非 blocking) `if s and s.strip():` で空白のみを捨てることを docstring に 1 行（次の人が「消えた」と疑わないため）

