### PR TITLE
fix(#5185): forward visibility_items/mcp_subscriptions onto the AG-UI wire

### DIFF
--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -324,8 +324,12 @@ WaitingOn ラベル)は**read-model**であり、ファイルミラーではな�
 する部分集合のみがストリームされる。
 
 - `STATE_SNAPSHOT` — **接続時**に発行される、read-model 全体。フィールド: `attached_name`、
-  `model`、`cost_agent`、`cost_total`、`agent_tokens`、`ctx_used`、`ctx_window`、
-  `waiting_on`、`queue`、`turn_active`、`halted_reason`。
+  `model`、`agent_names`、`session_tree`、`model_active_class`、`model_classes`
+  (#5094)、`visibility_items`、`mcp_subscriptions`(#5185)、`cost_agent`、
+  `cost_total`、`agent_tokens`、`ctx_used`、`ctx_window`、`waiting_on`、
+  `pending_intervention_head`(#5050)、`queue`、`turn_active`、`queue_seq`
+  (#3300 P2a)、`halted_reason`。この一覧の正本は `agui/state.py` 自身の
+  `project_status`(#5098)— このドキュメントの転記より、そちらを直接読むこと。
 - `STATE_DELTA` — **変更時**に発行され、変更されたキーのみを運ぶ。アイドルなストリームは
   delta を発行しない。
 

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -474,9 +474,14 @@ from the session's live cost / token / context accessors and the working-indicat
 state, and only the render-relevant subset is streamed.
 
 - `STATE_SNAPSHOT` — emitted **on connect**, the full read-model. Fields:
-  `attached_name`, `model`, `cost_agent`, `cost_total`, `agent_tokens`,
-  `ctx_used`, `ctx_window`, `waiting_on`, `queue`, `turn_active`,
-  `halted_reason`.
+  `attached_name`, `model`, `agent_names`, `session_tree`,
+  `model_active_class`, `model_classes` (#5094), `visibility_items`,
+  `mcp_subscriptions` (#5185), `cost_agent`, `cost_total`, `agent_tokens`,
+  `ctx_used`, `ctx_window`, `waiting_on`, `pending_intervention_head`
+  (#5050), `queue`, `turn_active`, `queue_seq` (#3300 P2a),
+  `halted_reason`. `agui/state.py`'s own `project_status` is the sole
+  declaration of this list (#5098) — read it directly rather than trusting
+  this doc's transcription to stay current.
 - `STATE_DELTA` — emitted **on change**, carrying only the changed keys. An idle
   stream emits no deltas.
 
@@ -511,14 +516,22 @@ the item by `msg_id` (unlike `turn_started`, which matches by `chain_id`).
 The client seeds its status view from the snapshot and merges each delta, so the
 remote status panel always reflects the server's values.
 
-These are exactly the **main status-line values** the interactive TUI renders, so a
+These are the **main status-line values** the interactive TUI renders, so a
 remote client on an interactive TTY draws the same status line as a local one
-(`agent` · `model` · `cost` · `ctx%`, plus the working indicator). The **drawer
-panes** behind that line (the cost breakdown and ctx/compaction detail, the
-`/model` class picker, the agent/session tree, the tool/mcp/skill/hook visibility
-and applicability toggles, the pipeline and cron listings) and the interactive
-intervention / `/rewind` **pickers** are session-local state, not on the wire — a
-remote client shows the streamed status values and degrades those to empty/`—`/0.
+(`agent` · `model` · `cost` · `ctx%`, plus the working indicator) — PLUS, as of
+#5094/#5185, a growing set of **drawer panes** that also reflect real
+server-side state: the `/model` class picker and agent/session tree (#5094),
+and the tool/mcp/skill visibility toggles (#5185, `visibility_items`) together
+with the mcp pane's own subscription rows (`mcp_subscriptions`) — see
+`ChatReadModelCapabilities`'s own docstring
+(`reyn.interfaces.repl.read_model`) for the full, authoritative list of which
+reads are genuinely wired vs. graceful-degrade; a hand-transcribed list here
+would drift the moment a new key is added, the same risk #5098 already named
+for the field list above. The REMAINING drawer panes (the cost breakdown and
+ctx/compaction detail, the hook applicability toggles, the pipeline and cron
+listings) and the interactive intervention / `/rewind` **pickers** are still
+session-local state, not on the wire — a remote client degrades those to
+empty/`—`/0/`"not reported on this connection"`, never a fabricated value.
 Adding any other field is an additive `STATE_*` key, not a client change.
 
 ## Reconnect

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -247,6 +247,34 @@ class ChatReadModelCapabilities:
     ``unknown_config_key_count``, ``unknown_config_keys``, ``ctx_source``)
     — see #5034's own issue thread for the per-key reasoning; not
     declared here because there is nothing to gate.
+
+    #5185 REVERSES #5034's clearance for 2 of those 6 —
+    ``visibility_items``/``mcp_subscriptions``. #5034's reasoning held for
+    the WIRE SHAPE at the time (both were hand-typed ``None``/``[]``
+    literals, and #5034 only asked "is the literal indistinguishable from
+    a genuinely empty local state" — for ``visibility_items`` the answer
+    was already "no", since #3378 made it ``None`` specifically so it
+    would NOT read as empty). What #5034 did not (and #5094's precedent
+    later showed matters): a hand-typed literal that never changes is
+    fabrication regardless of WHICH value it picks, once real per-session
+    data exists server-side and is simply never forwarded — owner
+    live-observed a real remote MCP pane showing "(not wired)" for a
+    session whose subscriptions were genuinely live (#5185). Both fields
+    now ride the wire for real (:func:`~reyn.interfaces.transport.agui.
+    state.project_status`), declared here so a producer that stops
+    forwarding either one fails to construct its declaration rather than
+    silently reverting to the old always-empty/always-None shape.
+    ``visibility_items_reported`` covers a SHARED key (tool/mcp/skill
+    panes all read it via ``chrome.py``'s ``_visibility_pane_rows``) —
+    genuinely one flag, since local and remote either both have the wire
+    channel or neither does; there is no way for one pane's visibility
+    read to be wired while another's is not. ``mcp_subscriptions_reported``
+    is its own separate flag (a different key, a different pane-local
+    read) even though #5185's acceptance criteria require the two land in
+    the SAME PR — landing together is an ORDERING requirement (a
+    subscription row has nothing to attach to without ``visibility_items``
+    supplying the server row first, see ``_mcp_pane_entries``'s own
+    docstring), not a reason to collapse them into one flag.
     """
 
     completion_source: bool
@@ -274,6 +302,10 @@ class ChatReadModelCapabilities:
     agent_roster_reported: bool  # covers `agent_names` + `session_tree` together
     model_catalog_reported: bool  # covers `model_classes` + `model_active_class` together
     attached_name_reported: bool
+    # #5185: see the class docstring's own section for why these reverse
+    # #5034's clearance and why they stay 2 fields despite landing together.
+    visibility_items_reported: bool  # covers `visibility_items` (tool/mcp/skill panes)
+    mcp_subscriptions_reported: bool  # covers `mcp_subscriptions` (mcp pane only)
 
 
 def reported_snapshot_keys(
@@ -327,6 +359,8 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     agent_roster_reported=True,
     model_catalog_reported=True,
     attached_name_reported=True,
+    visibility_items_reported=True,
+    mcp_subscriptions_reported=True,
 )
 
 #: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these
@@ -339,7 +373,11 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
 #: ``attached_name_reported`` (#5094, the same fix): those 5 snapshot keys
 #: now ride the SAME wire channel, so a remote agent tab / model-class
 #: picker reflects the server's real roster instead of an unconditional
-#: empty list. See the module docstring's "Frame-sufficiency" section.
+#: empty list. ``visibility_items_reported``/``mcp_subscriptions_reported``
+#: (#5185, the same fix again): a remote MCP/tool/skill pane now reflects
+#: the server's real visibility/subscription state instead of an
+#: unconditional "(not wired)"/empty subscription list. See the module
+#: docstring's "Frame-sufficiency" section.
 REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     completion_source=False,
     intervention_head=True,
@@ -356,6 +394,8 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     agent_roster_reported=True,
     model_catalog_reported=True,
     attached_name_reported=True,
+    visibility_items_reported=True,
+    mcp_subscriptions_reported=True,
 )
 
 
@@ -763,21 +803,29 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # pane, missed by #5009's original hand-enumerated key list).
         "hooks": [],
         "skills": [],
-        # #3378: None (not []) — a remote frame carries no visibility seam at all, and
-        # the renderer must say "not wired" rather than "(none)" (which would claim
-        # "nothing is narrowed", a statement this frame cannot support).
-        "visibility_items": None,
+        # #5185 (reverses #3378/#4686's own hand-typed literals below —
+        # see the ChatReadModelCapabilities docstring's own section):
+        # both keys now ride the wire for real
+        # (agui/state.py's own project_status, same channel #5094 used for
+        # agent_names etc). ``visibility_items`` is read straight off the
+        # wire, PRESERVING None — a bare `v.get(...)` with NO `[]` default,
+        # deliberately: defaulting to `[]` here would be the exact
+        # fabrication #3378 first existed to prevent, just moved from a
+        # permanent hand literal to a wire-miss default. `None` still means
+        # "this session wires no visibility seam" (`_visibility_pane_rows`'s
+        # own `raw is not None` check, unchanged) — now genuinely reflecting
+        # the SERVER's real per-session state instead of an unconditional
+        # remote-side constant.
+        "visibility_items": v.get("visibility_items"),
         # gated by ``hooks_reported`` alongside ``hooks`` above — one pane,
         # one field (#5034).
         "hook_items": [],
-        # #4686: session-local read (MCPConnectionService is process-local,
-        # not projected onto the wire) → [] for remote, same "empty" shape
-        # as ``mcp_servers``/``hooks``/``skills`` above — a remote client's
-        # mcp pane shows base rows with no subscription augmentation rather
-        # than raising (``_mcp_pane_entries`` treats a server absent from
-        # this list as "nothing to add", not "not wired", since the base
-        # row itself already came from ``visibility_items``).
-        "mcp_subscriptions": [],
+        # #5185: real wire data — `_session_mcp_subscriptions` always
+        # returns a list (never None, unlike `visibility_items` above; see
+        # its own docstring, "not a seam like visibility_items/hook_items"),
+        # so `[]` is the correct default for BOTH "genuinely no
+        # subscriptions" and "key not yet on the wire" here.
+        "mcp_subscriptions": v.get("mcp_subscriptions", []),
         # `[]` below is correct (pipeline registry is not on the wire);
         # gated by ``pipelines_reported`` above so `pipe_pane_lines`
         # renders "not reported" instead of its own `["(none)"]` fallback

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -71,6 +71,19 @@ def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) 
         "session_tree": snap.get("session_tree", []),
         "model_active_class": snap.get("model_active_class"),
         "model_classes": snap.get("model_classes", []),
+        # #5185: the same pattern #5094 used above — real per-session data
+        # already computed server-side (``status._snapshot``'s own
+        # ``_session_visibility_items``/``_session_mcp_subscriptions``) but
+        # never forwarded past this projection, so a remote MCP/tool/skill
+        # pane was unconditionally "(not wired)"/empty regardless of the
+        # session's real state (owner live-observed, #5185).
+        # ``visibility_items`` MUST default to ``None``, not ``[]`` — ``None``
+        # is itself a real, meaningful value here (#3378: "this session
+        # wires no visibility seam"), and defaulting it away would silently
+        # turn a genuine "can't say" into a fabricated "nothing is
+        # narrowed" the moment this key happened to be absent from `snap`.
+        "visibility_items": snap.get("visibility_items"),
+        "mcp_subscriptions": snap.get("mcp_subscriptions", []),
         "cost_agent": snap.get("cost_agent", 0.0),
         "cost_total": snap.get("cost_total", 0.0),
         "agent_tokens": snap.get("agent_tokens", 0),

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -138,6 +138,8 @@ def test_capabilities_dataclass_rejects_a_missing_field():
         agent_roster_reported=True,
         model_catalog_reported=True,
         attached_name_reported=True,
+        visibility_items_reported=True,
+        mcp_subscriptions_reported=True,
     )
     with pytest.raises(TypeError):
         ChatReadModelCapabilities(  # type: ignore[call-arg]
@@ -173,9 +175,10 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
     ``usage_breakdown_reported`` / ``ctx_compaction_reported`` (#5009) /
     ``hooks_reported`` / ``pipelines_reported`` (#5034) /
     ``agent_roster_reported`` / ``model_catalog_reported`` /
-    ``attached_name_reported`` (#5094) are the 9 fields NOT named after a
-    ``ChatReadModel`` method — see the class's own docstring for why they
-    live here anyway."""
+    ``attached_name_reported`` (#5094) /
+    ``visibility_items_reported`` / ``mcp_subscriptions_reported`` (#5185)
+    are the 11 fields NOT named after a ``ChatReadModel`` method — see the
+    class's own docstring for why they live here anyway."""
     names = {f.name for f in fields(ChatReadModelCapabilities)}
     assert names == {
         "completion_source",
@@ -193,6 +196,8 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
         "agent_roster_reported",
         "model_catalog_reported",
         "attached_name_reported",
+        "visibility_items_reported",
+        "mcp_subscriptions_reported",
     }
 
 

--- a/tests/interfaces/test_5185_remote_mcp_visibility_wire.py
+++ b/tests/interfaces/test_5185_remote_mcp_visibility_wire.py
@@ -1,0 +1,246 @@
+"""Tier 2: #5185 — a remote client's MCP/tool/skill visibility pane and
+MCP subscription rows reflect the SERVER's real state, not an
+unconditional "(not wired)"/empty literal.
+
+Owner live-observed: a real remote session's MCP pane showed
+``"(not wired)"`` even though the session's subscriptions were genuinely
+live. Root cause, measured (issuecomment-5384575651): ``agui/state.py``'s
+own ``project_status`` dict (the sole wire vocabulary, #5098) never
+forwarded ``visibility_items``/``mcp_subscriptions`` past the server's
+projection, even though ``status._snapshot``'s own
+``_session_visibility_items``/``_session_mcp_subscriptions`` calls
+already compute real values server-side — so
+``project_remote_snapshot`` (client-side) had nothing to read and fell
+back to hand-typed ``None``/``[]`` literals regardless of the session's
+real state.
+
+Architect ruling (issuecomment-5384583727 / issuecomment-5384627324),
+4 acceptance criteria:
+①remote and local render the same row for the same session state
+②a reader that genuinely cannot answer shows unknown ("(not wired)"),
+   never a fabricated "(none)" — ``visibility_items``'s ``None`` must
+   survive the wire, never collapse to ``[]``
+③a subscription row never appears without its server-row foundation
+   (``visibility_items`` supplies the row; ``mcp_subscriptions`` only
+   augments an EXISTING row)
+④a ``ChatReadModel`` that drops a declared capability key fails to
+   construct, not silently reverts to "unsupported"
+
+Same real, end-to-end pattern
+``test_5094_remote_agent_roster_and_model_catalog.py`` already
+establishes for this wire (real ``AgUiEmitter`` → real SSE →
+real ``AgUiTransport`` parsing it back) — extended through
+``project_remote_snapshot`` for these 2 keys instead.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat.chrome import _mcp_pane_entries, _visibility_pane_rows
+from reyn.interfaces.repl.read_model import project_remote_snapshot
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.state import project_status
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+async def _project_over_the_wire(server_snap: dict) -> dict:
+    """Drives the real emitter -> real SSE -> real transport -> the real
+    ``project_remote_snapshot`` projection the TUI's own chrome reads —
+    exactly the path a live ``--connect`` uses. ``server_snap`` stands in
+    for ``status._snapshot()``'s own dict; ``project_status`` (the SOLE
+    wire vocabulary, #5098) decides what actually crosses."""
+
+    def status_provider():
+        return dict(server_snap)
+
+    async def _display_frames():
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    emitter = AgUiEmitter(_display_frames(), status_provider)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_SNAPSHOT" in sse
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    async for _f in transport.frames():
+        pass  # draining applies STATE_SNAPSHOT to transport.status
+
+    return project_remote_snapshot(transport.status.values)
+
+
+# ── acceptance① / ② — real per-session state rides the wire honestly ────
+
+
+@pytest.mark.asyncio
+async def test_populated_visibility_and_subscriptions_ride_the_wire_end_to_end():
+    """Tier 2: acceptance① — a session with real, non-empty visibility
+    items and subscriptions produces the SAME data remote-side that
+    local's own ``status._snapshot()`` would have held server-side."""
+    visibility_items = [
+        {"kind": "mcp", "name": "broker", "on": True, "denied": False, "denied_reason": None},
+        {"kind": "mcp", "name": "some-server", "on": False, "denied": True, "denied_reason": "turn_context"},
+        {"kind": "tool", "name": "shell", "on": True, "denied": False, "denied_reason": None},
+    ]
+    mcp_subscriptions = [
+        {"server": "broker", "uris": ["broker://inbox/reyn-reviewer"], "unhonored": []},
+    ]
+    server_snap = {
+        "cost_agent": 0.0, "cost_total": 0.0, "ctx_used": 0, "ctx_window": 0,
+        "agent_tokens": 0, "attached_name": "default", "model": "m",
+        "visibility_items": visibility_items,
+        "mcp_subscriptions": mcp_subscriptions,
+    }
+
+    projected = await _project_over_the_wire(server_snap)
+
+    assert projected["visibility_items"] == visibility_items
+    assert projected["mcp_subscriptions"] == mcp_subscriptions
+    assert projected["visibility_items_reported"] is True
+    assert projected["mcp_subscriptions_reported"] is True
+
+    # ① — local and remote render the SAME row for the SAME state: feed
+    # the real snapshot dict, unmodified except for the wire round-trip,
+    # into the same rendering functions a local session's snap would hit.
+    local_rows = _visibility_pane_rows(server_snap, "mcp", "mcp_servers")
+    remote_rows = _visibility_pane_rows(projected, "mcp", "mcp_servers")
+    assert [(r.label, r.state, r.note) for r in local_rows] == [
+        (r.label, r.state, r.note) for r in remote_rows
+    ]
+    local_entries = _mcp_pane_entries(server_snap)
+    remote_entries = _mcp_pane_entries(projected)
+    assert local_entries == remote_entries
+    assert local_entries == [
+        ("[on] broker  · subscribed", "/visibility off mcp broker"),
+        ("    broker://inbox/reyn-reviewer", ""),
+        ("[--] some-server  · denied while untrusted content is in context", ""),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unwired_visibility_survives_the_wire_as_none_not_empty_list():
+    """Tier 2: acceptance② — the CRITICAL witness. A session whose
+    visibility seam is genuinely unwired (``visibility_items=None``,
+    #3378) must reach the remote projection as ``None``, never ``[]``.
+    Collapsing to ``[]`` would fabricate "nothing is narrowed"
+    (renders "(none)") where the true fact is "cannot say"
+    (renders "(not wired)") — exactly the lie #3378 exists to prevent,
+    now reachable through the wire path instead of only the local one."""
+    server_snap = {
+        "cost_agent": 0.0, "cost_total": 0.0, "ctx_used": 0, "ctx_window": 0,
+        "agent_tokens": 0, "attached_name": "default", "model": "m",
+        "visibility_items": None,
+        "mcp_subscriptions": [],
+    }
+
+    projected = await _project_over_the_wire(server_snap)
+
+    assert projected["visibility_items"] is None, (
+        f"None must survive the wire as None, got {projected['visibility_items']!r}"
+    )
+    assert projected["mcp_subscriptions"] == []
+
+    rows = _visibility_pane_rows(projected, "mcp", "mcp_servers")
+    assert [r.label for r in rows] == ["(not wired)"], (
+        "a genuinely unwired seam must render '(not wired)', not '(none)'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_wired_but_empty_visibility_renders_none_not_not_wired():
+    """Tier 2: acceptance②'s other half — a session whose seam IS wired
+    and genuinely has nothing narrowed (``visibility_items=[]``) must
+    render "(none)", distinguishably from the unwired "(not wired)" case
+    above — the two must never collapse to the same rendered text."""
+    server_snap = {
+        "cost_agent": 0.0, "cost_total": 0.0, "ctx_used": 0, "ctx_window": 0,
+        "agent_tokens": 0, "attached_name": "default", "model": "m",
+        "visibility_items": [],
+        "mcp_subscriptions": [],
+    }
+
+    projected = await _project_over_the_wire(server_snap)
+
+    assert projected["visibility_items"] == []
+    rows = _visibility_pane_rows(projected, "mcp", "mcp_servers")
+    assert [r.label for r in rows] == ["(none)"]
+
+
+# ── acceptance③ — a subscription row never appears without its server row ──
+
+
+@pytest.mark.asyncio
+async def test_subscriptions_without_a_visibility_foundation_render_nothing():
+    """Tier 2: acceptance③ — the ordering dependency lead-coder's own
+    measurement found (issuecomment-5384575651): ``mcp_subscriptions``
+    augments a row ``visibility_items`` must supply first. Real
+    subscription data with NO matching visibility item for that server
+    must not produce a floating/orphaned row."""
+    server_snap = {
+        "cost_agent": 0.0, "cost_total": 0.0, "ctx_used": 0, "ctx_window": 0,
+        "agent_tokens": 0, "attached_name": "default", "model": "m",
+        "visibility_items": None,  # unwired — no server rows to attach to
+        "mcp_subscriptions": [
+            {"server": "broker", "uris": ["broker://inbox/x"], "unhonored": []},
+        ],
+    }
+
+    projected = await _project_over_the_wire(server_snap)
+
+    entries = _mcp_pane_entries(projected)
+    assert entries == [("(not wired)", "")], (
+        "a subscription with no visibility-item foundation must not "
+        f"produce its own row; got {entries!r}"
+    )
+
+
+# ── strip-falsifier — same shape #5094's own test uses ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_strip_falsifier_absent_wire_keys_revert_to_the_old_shape():
+    """Tier 2: strip-falsifier — with the 2 keys absent from the server's
+    OWN status dict (simulating ``project_status`` reverted to not carry
+    them, the pre-#5185 shape), the client falls back to the SAME
+    graceful defaults the bug reproduced — confirming the positive
+    witnesses above genuinely depend on the wire carrying real data."""
+    server_snap = {
+        "cost_agent": 0.0, "cost_total": 0.0, "ctx_used": 0, "ctx_window": 0,
+        "agent_tokens": 0, "attached_name": "default", "model": "m",
+        # visibility_items/mcp_subscriptions deliberately absent — the
+        # pre-#5185 server-side shape.
+    }
+
+    projected = await _project_over_the_wire(server_snap)
+
+    assert projected["visibility_items"] is None
+    assert projected["mcp_subscriptions"] == []
+
+
+# ── the wire vocabulary itself (agui/state.py's project_status) ──────────
+
+
+def test_project_status_forwards_visibility_items_preserving_none():
+    """Tier 1: ``project_status`` (the sole wire vocabulary, #5098) must
+    itself carry ``visibility_items`` through with NO ``[]`` default —
+    a direct, no-transport-roundtrip pin of the exact line #5185 fixes,
+    independent of the emitter/transport machinery the tests above also
+    exercise."""
+    out = project_status({"visibility_items": None, "mcp_subscriptions": []})
+    assert "visibility_items" in out
+    assert out["visibility_items"] is None
+    assert out["mcp_subscriptions"] == []
+
+    real_items = [{"kind": "mcp", "name": "x", "on": True, "denied": False, "denied_reason": None}]
+    real_subs = [{"server": "x", "uris": [], "unhonored": None}]
+    out2 = project_status({"visibility_items": real_items, "mcp_subscriptions": real_subs})
+    assert out2["visibility_items"] == real_items
+    assert out2["mcp_subscriptions"] == real_subs


### PR DESCRIPTION
**[e2e-coder]** — part of #5185

Architect ruling (issuecomment-5384583727 / issuecomment-5384627324) on top of my own measurement (issuecomment-5384575651): owner live-observed a real remote MCP pane showing `"(not wired)"` for a session whose subscriptions were genuinely live. Root cause: `agui/state.py`'s `project_status` (the sole wire vocabulary, #5098) never forwarded `visibility_items`/`mcp_subscriptions` — `status._snapshot`'s own accessors already compute real values server-side, but `project_remote_snapshot` (client) had nothing to read and fell back to hand-typed `None`/`[]` literals regardless of the session's real state.

## Design (architect's 4 points)

- **① Don't collapse `None` to `[]`** — `visibility_items=None` is itself a real fact (#3378: "this session wires no visibility seam"), distinct from a wired-but-empty seam. Forwarded with a bare `.get(...)`, no `[]` default, at both `project_status` and `project_remote_snapshot`.
- **② Both keys land in this one PR** — `mcp_subscriptions` rows are additive augmentation keyed by a `visibility_items`-supplied row label (`_mcp_pane_entries`); landing them separately would leave subscriptions with nothing to attach to, a silent intermediate state.
- **③ #5094's capability-declaration pattern** — `visibility_items_reported`/`mcp_subscriptions_reported` declared on `ChatReadModelCapabilities` (both required fields, no defaults) — a producer that stops forwarding either fails to CONSTRUCT, not reverts silently.
- **④ No new hand-typed literal** — both new capability fields ride the existing generic `**reported_snapshot_keys(...)` spread already in `project_remote_snapshot`, the same mechanism #5094 used; no per-key wiring added.

## chrome.py is untouched

`_visibility_pane_rows`'s existing `raw is not None` check and `_mcp_pane_entries`'s existing row-label lookup were already correct — once the wire carries the SESSION's real value instead of an unconditional remote-side constant, local and remote render identically for free (verified by test). This matches the #5094 precedent exactly: `agent_roster_reported`/`model_catalog_reported`/`attached_name_reported` also needed zero chrome.py consumption once genuinely wired.

## Side effect, not scope creep

`visibility_items` is shared by the tool/skill panes too (`_visibility_pane_rows(snap, kind, ...)`), so this fixes the same `"(not wired)"` bug for those on remote as well — inherent to fixing the one shared field.

## Docs

`docs/reference/runtime/agui-transport.md`(`.ja.md`): the `STATE_SNAPSHOT` field list was already stale before this PR (missing #5094/#5050/#3300's own additions) and the "drawer panes... session-local" sentence already mischaracterized #5094's wired fields. Re-read the whole section (CLAUDE.md hard rule), repaired both rather than only appending this PR's own 2 keys.

## Strip-falsify

- Reverted `project_status`'s forwarding (wire vocabulary itself) → 3 tests correctly red (the wire-vocabulary pin test + 2 downstream e2e tests), restored green.
- Reverted `project_remote_snapshot`'s literals with `project_status` intact (client-side layer only) → 2 tests correctly red, restored green.
- Constructed `ChatReadModelCapabilities` omitting either new field → confirmed real `TypeError` at construction (acceptance④, not merely asserted by a test — a genuine dataclass-required-field guarantee).

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict <new/changed test files>` — 11/11 OK, 0 Tier-4
- [x] `python scripts/mypy_ratchet.py` — 201/207 baselined, no new
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` / `check_doc_anchors.py` / `check_retired_config_keys_denylist.py` (docs/ touched) — all clean
- [x] `pytest tests/interfaces/ -k "mcp or visibility or agui_state or read_model or 5094 or 5185 or 4996 or 3378 or 4686"` — 122/122 passed
- [x] (skipped — Visual, standing waiver, owner 2026-08-08)

Touches `tests/` and `docs/` — needs a TESTS-READ note before merge; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)