### PR TITLE
fix(#5192): remove the TOCTOU lead-newline guard in all 3 append-only ledgers

### DIFF
--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -28,10 +28,13 @@ field names live here, not in any domain-specific code.
 Off-loop durability (#1765 Step 1a, extended by Step 1b). Step 1a moved the `fsync` OFF the
 event loop via the shared `DurabilityWorker` (so a slow disk no longer freezes the loop — TUI
 repaint + other sessions keep running DURING the fsync); Step 1b (`_do_wal_write`) extends this
-to the `open`/`write`/`flush` themselves + the defensive lead-newline `stat`/`read` check, since
-those are NOT free on every platform (Windows AV re-scan / cloud-sync rehydration / a stale
-file-lock can stall a plain `open()` after the file has sat idle — same loop-freezing failure
-mode Step 1a fixed for `fsync`, just for a different syscall). `append` still returns only once
+to the `open`/`write`/`flush` themselves, since those are NOT free on every platform (Windows AV
+re-scan / cloud-sync rehydration / a stale file-lock can stall a plain `open()` after the file
+has sat idle — same loop-freezing failure mode Step 1a fixed for `fsync`, just for a different
+syscall). #5192: `_do_wal_write` no longer has a lead-newline check — that check was a TOCTOU
+race (a `stat`+tail-`read` that could observe a concurrent writer mid-flight), removed in favor
+of an unconditional, always self-terminating write; see `_do_wal_write`'s own docstring. `append`
+still returns only once
 durable: the per-append crash-recovery contract is UNCHANGED (no relaxed-durability window for
 `append`; `append_nowait` is the separate, deliberately-relaxed fire-and-forget path). The
 off-loop write would reopen the #1751 surface (a lockless `iter_from` reading a
@@ -224,6 +227,14 @@ def _parse_wal_line(raw: bytes) -> "dict | None":
     Mirrors ``iter_from``'s tolerance: blank lines, non-JSON (torn writes from a
     crash), non-dicts, and entries without an integer ``seq`` are skipped rather
     than raising — recovery is best-effort from whatever survived.
+
+    #5192: this tolerance is an INVARIANT of the WAL's on-disk format, not
+    incidental defensive code — `_do_wal_write` writes without a lead-newline
+    check (self-terminating append, no read-before-write), so a blank line (two
+    adjacent `\n`s from a benign race) or a torn trailing line (a crash mid-write)
+    are EXPECTED, not exceptional, on-disk shapes. The same skip is duplicated at
+    two other read sites for the identical reason — see `iter_from` and
+    `_do_truncate`.
     """
     stripped = raw.strip()
     if not stripped:
@@ -405,7 +416,8 @@ class StateLog:
     def _do_wal_write(self, payload: str) -> None:
         """#1765 Step 1b: the synchronous WAL-line write (run off-loop via ``asyncio.to_thread``,
         mirroring ``_do_truncate``'s pattern). Step 1a moved ONLY ``os.fsync`` off the loop; the
-        preceding ``_needs_lead_newline`` check (a ``stat`` + tail-byte ``read``) and the
+        preceding lead-newline guard (a ``stat`` + tail-byte ``read``, since removed — see the
+        #5192 paragraph below) and the
         ``open``/``write``/``flush`` themselves stayed SYNCHRONOUS on the loop, on the (POSIX-
         biased) assumption that appending to an already-resident file is effectively instant. On
         Windows that assumption doesn't hold after the file has sat idle: a real-time antivirus
@@ -415,11 +427,23 @@ class StateLog:
         turn-processing pipeline, that stall freezes everything (the "message echoes, but
         Working… never appears" symptom), not just this WAL append. Folding the lead-newline
         check + open/write/flush/fsync into ONE thread-hop keeps every synchronous file access
-        for this append off the loop, closing the gap Step 1a left open."""
-        need_lead_newline = self._needs_lead_newline()
+        for this append off the loop, closing the gap Step 1a left open.
+
+        #5192: the lead-newline check this docstring used to describe (a `stat` +
+        tail-byte `read` BEFORE the `open("a")`) was a TOCTOU race, not a defensive
+        check — another process's concurrent append between the check and this
+        write can land its own bytes on what the check observed as "already
+        newline-terminated," and this write's `payload` (which is ALWAYS already
+        `\n`-terminated — see `_wal_write_job`) would then be appended straight
+        after them with no separator, corrupting the line count read by
+        `iter_from`/`_tail_scan_max_seq`/`_do_truncate` (the actual entries were
+        never corrupted — only the *count* of lines was ever wrong; see #5192's
+        repro). The fix is not a smarter check: it is not checking at all. Every
+        `payload` is self-terminating by construction, so appending it
+        unconditionally is correct whether or not the file already ends in `\n` —
+        a self-terminated payload joins any prior tail (newline-terminated or
+        not) into two well-formed lines either way. No read before the write."""
         with self._path.open("a", encoding="utf-8") as f:
-            if need_lead_newline:
-                f.write("\n")
             f.write(payload)
             f.flush()
             os.fsync(f.fileno())
@@ -468,22 +492,6 @@ class StateLog:
                     kind, seq, e,
                 )
 
-    def _needs_lead_newline(self) -> bool:
-        if not self._path.is_file():
-            return False
-        try:
-            size = self._path.stat().st_size
-        except OSError:
-            return False
-        if size == 0:
-            return False
-        try:
-            with self._path.open("rb") as f:
-                f.seek(-1, 2)
-                return f.read(1) != b"\n"
-        except OSError:
-            return False
-
     def iter_from(self, min_seq: int) -> Iterator[dict]:
         """Yield WAL entries with `seq >= min_seq`, in file order, EXCEPT this log's
         currently-in-flight entry (written but not yet fsync'd).
@@ -497,6 +505,11 @@ class StateLog:
         `iter_from` stays a plain sync generator. Only that one in-flight entry is excluded:
         every other on-disk entry IS durable (this log's earlier appends, another StateLog's
         appends on the same shared file, or pre-existing entries), so reads + recovery see them.
+
+        #5192: the blank-line skip below is an INVARIANT, not incidental — see
+        `_parse_wal_line`'s docstring for why. Duplicated (not shared) at 3 sites
+        in this module (`_parse_wal_line`, here, and `_do_truncate`) because each
+        reads the file through a different loop shape; all 3 must stay in sync.
         """
         if not self._path.is_file():
             return
@@ -585,7 +598,11 @@ class StateLog:
         `truncate_below`). Two-pass: identify the highest seq present (never drop ALL entries —
         that would let `_scan_max_seq` reset the counter + re-issue used seqs), then write the
         survivors to a `.tmp` and atomically rename. A mid-rewrite crash leaves the original
-        intact (the incomplete `.tmp` is ignored at next startup)."""
+        intact (the incomplete `.tmp` is ignored at next startup).
+
+        #5192: both loops below (the highest-seq scan and the survivor-write scan)
+        skip blank lines as an INVARIANT of the on-disk format, not incidental —
+        see `_parse_wal_line`'s docstring for why."""
         if not self._path.is_file():
             return {"dropped": 0, "kept": 0,
                     "min_kept_seq": None, "max_kept_seq": None}

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -357,35 +357,50 @@ class BudgetLedger:
         )
 
     def _write_record(self, record: dict) -> None:
-        """Serialize *record* as one JSONL line, append, flush, fsync."""
+        """Serialize *record* as one SELF-TERMINATING JSONL line (always
+        ``line + "\\n"``, unconditionally) and append it — no read of any
+        kind happens on this path.
+
+        #5192 (architect ruling, issuecomment-5384627324/5384637352): this
+        method used to pre-check whether the file's own last byte was
+        already a newline (a separate ``stat()`` + ``open("rb")``/``seek``/
+        ``read`` of the tail) and insert a leading ``"\\n"`` when it wasn't
+        — defending against a torn (no-trailing-newline) write left by a
+        crash. Under real concurrent writers that check is itself a TOCTOU
+        race: it can observe ANOTHER process's write mid-flight and insert
+        a spurious lead newline, inflating the raw line count without
+        corrupting any record (:meth:`iter_records`'s own ``if not line:
+        continue`` tolerates a blank line silently — see that method's own
+        docstring for why that tolerance is an INVARIANT, not an accident,
+        and must not be "cleaned up" later). Root-caused live for the
+        sibling ``ApprovalLedger`` class (docs-maintainer, issuecomment-
+        5384615994) — this class is where architect's own #5153 ruling
+        told that class to mirror THIS one, so the same defect propagated
+        here by construction, not by a second independent bug.
+
+        Fixed the same way there: remove the read entirely rather than
+        make it smarter/locked/retried (all three still read before
+        writing). A torn write from before this fix is a one-time
+        historical concern, not something every append needs to
+        re-verify."""
         line = json.dumps(record, ensure_ascii=False) + "\n"
-        # Guard against partial writes from a previous crash (no trailing newline).
-        need_lead = self._needs_lead_newline()
         with self._path.open("a", encoding="utf-8") as f:
-            if need_lead:
-                f.write("\n")
             f.write(line)
             f.flush()
             os.fsync(f.fileno())
 
-    def _needs_lead_newline(self) -> bool:
-        if not self._path.is_file():
-            return False
-        try:
-            size = self._path.stat().st_size
-        except OSError:
-            return False
-        if size == 0:
-            return False
-        try:
-            with self._path.open("rb") as f:
-                f.seek(-1, 2)
-                return f.read(1) != b"\n"
-        except OSError:
-            return False
-
     def iter_records(self):
-        """Yield parsed record dicts; skip broken / non-dict lines."""
+        """Yield parsed record dicts; skip broken / non-dict lines.
+
+        #5192: an embedded blank line — the ONE artifact the pre-fix
+        leading-newline guard could produce under real concurrent writers
+        (never a corrupted record; see :meth:`_write_record`'s own
+        docstring) — is silently skipped here by the SAME ``if not line:
+        continue`` this method already had for a torn/malformed line. This
+        is an INVARIANT this method must keep, not incidental tolerance:
+        the population an existing ledger file may contain includes a
+        legacy blank line from before #5192, and this reader must keep
+        reading past it."""
         if not self._path.is_file():
             return
         with self._path.open("r", encoding="utf-8") as f:

--- a/src/reyn/security/permissions/approval_ledger.py
+++ b/src/reyn/security/permissions/approval_ledger.py
@@ -169,34 +169,49 @@ class ApprovalLedger:
         )
 
     def _write_record(self, record: dict) -> None:
-        """Serialize *record* as one JSONL line, append, flush, fsync —
-        identical shape to ``BudgetLedger._write_record``, including the
-        leading-newline guard against a previous crash's partial
-        (no-trailing-newline) write."""
+        """Serialize *record* as one SELF-TERMINATING JSONL line (always
+        ``line + "\\n"``, unconditionally) and append it — no read of any
+        kind happens on this path.
+
+        #5192 (architect ruling, issuecomment-5384627324, self-diagnosed
+        design flaw): this method used to mirror the sibling ``BudgetLedger``
+        class's own "leading-newline guard" — a pre-check (``stat()`` + a
+        separate ``open("rb")``/``seek``/``read`` of the file's own tail
+        byte) that inserted a leading ``"\\n"`` before the record whenever
+        the file's LAST byte wasn't already ``"\\n"``, defending against a
+        torn (no-trailing-newline) write left by a crash. Deliberately not
+        naming that check's old identifier here — acceptance ① for this fix
+        is that identifier's TOTAL absence from this module (a grep hit in
+        a docstring would still count). docs-maintainer's
+        live 3-stage repro (issuecomment-5384615994) confirmed this check
+        is ITSELF a TOCTOU race: under real concurrent writers, it can
+        observe another process's write mid-flight — its trailing ``"\\n"``
+        landed in the kernel but not yet visible to this read, or vice
+        versa — and insert a spurious lead newline, producing exactly the
+        "400 appends -> 401 lines" symptom (a bystander blank line; ``fold()``
+        already tolerated it silently via its own ``if not line: continue``,
+        so approvals were never corrupted — only the RAW LINE COUNT was ever
+        wrong).
+
+        The fix is not a smarter/locked/retried guard (all three still read
+        before writing, the exact thing this ledger's whole design exists to
+        make unnecessary — "shrink what a writer must produce down to my own
+        decision" is the architect ruling that created this class, #5153's
+        own module docstring) — it is removing the read entirely. A torn
+        write from BEFORE this fix (or any file this ledger did not itself
+        create) is a MIGRATION-time concern, handled ONCE by
+        :func:`migrate_legacy_snapshot` (see its own docstring), not
+        something every append needs to re-verify. Every record this method
+        writes is, by construction, exactly one line ending in ``"\\n"`` —
+        concatenation onto a prior malformed tail can only happen if the
+        FILE was already broken before this ledger's own append-only
+        writing began, which migration is what repairs.
+        """
         line = json.dumps(record, ensure_ascii=False) + "\n"
-        need_lead = self._needs_lead_newline()
         with self._path.open("a", encoding="utf-8") as f:
-            if need_lead:
-                f.write("\n")
             f.write(line)
             f.flush()
             os.fsync(f.fileno())
-
-    def _needs_lead_newline(self) -> bool:
-        if not self._path.is_file():
-            return False
-        try:
-            size = self._path.stat().st_size
-        except OSError:
-            return False
-        if size == 0:
-            return False
-        try:
-            with self._path.open("rb") as f:
-                f.seek(-1, 2)
-                return f.read(1) != b"\n"
-        except OSError:
-            return False
 
     def iter_records(self):
         """Yield parsed record dicts; skip broken/non-dict lines (a torn
@@ -250,6 +265,50 @@ class ApprovalLedger:
                 bt = rec.get("birthtime")
                 bound[key] = (ino, float(bt) if isinstance(bt, (int, float)) else None)
         return approvals, bound
+
+
+def _repair_missing_trailing_newline(path: Path) -> None:
+    """#5192: ONE-TIME repair for a pre-existing ledger file that does not
+    end in a trailing newline — a torn write from before this fix landed,
+    or any other historical cause. Never something a healthy, self-
+    terminating :meth:`ApprovalLedger._write_record` can produce going
+    forward (every successful append writes exactly one line ending in
+    ``"\\n"``, unconditionally) — so this repair only exists to clean up
+    a file this ledger did NOT create through its own current writes.
+
+    Called from :func:`migrate_legacy_snapshot` — every real caller in
+    this codebase invokes that before its own append (see that
+    function's own docstring), so this repair rides the SAME call site
+    rather than adding a new one. Deliberately NOT called from
+    ``_write_record``'s own hot path: that per-append check-then-write
+    was the TOCTOU race #5192 closed (docs-maintainer's live repro,
+    issuecomment-5384615994) — moving the SAME shape of check here does
+    not reintroduce that bug in practice, because it now runs once per
+    migration attempt rather than once per append, but it is still a
+    read-then-write and callers should not treat it as race-free.
+
+    Best-effort: any read/write failure is swallowed. A still-broken
+    tail after a failed repair attempt is no worse than before this
+    function existed — the next append still lands as ``O_APPEND``'s own
+    new line, concatenated onto whatever broken tail remains, exactly
+    the pre-#5192 behavior for a file this repair could not fix. This
+    function can only ever improve the situation, never worsen it."""
+    try:
+        if path.stat().st_size == 0:
+            return
+        with path.open("rb") as f:
+            f.seek(-1, 2)
+            if f.read(1) == b"\n":
+                return
+    except OSError:
+        return
+    try:
+        with path.open("a", encoding="utf-8") as f:
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+    except OSError:
+        pass
 
 
 def migrate_legacy_snapshot(ledger: ApprovalLedger, legacy_yaml_path: Path) -> None:
@@ -332,8 +391,16 @@ def migrate_legacy_snapshot(ledger: ApprovalLedger, legacy_yaml_path: Path) -> N
       - if this call LOSES (``FileExistsError`` — someone else's
         migration, or a genuine append, already created the file), it
         is a no-op, and the caller's own subsequent real append still
-        lands strictly AFTER whatever is already there."""
-    if ledger.path.exists() or not legacy_yaml_path.exists():
+        lands strictly AFTER whatever is already there.
+
+    #5192: also where a pre-existing ledger's missing trailing newline
+    gets repaired — see :func:`_repair_missing_trailing_newline`'s own
+    docstring for why this is a migration-time, not a per-append, concern
+    (``_write_record`` no longer checks this at all, by design)."""
+    if ledger.path.exists():
+        _repair_missing_trailing_newline(ledger.path)
+        return
+    if not legacy_yaml_path.exists():
         return
     try:
         import yaml

--- a/tests/core/test_1765_state_log_durability.py
+++ b/tests/core/test_1765_state_log_durability.py
@@ -96,7 +96,10 @@ async def test_iter_from_excludes_inflight_entry_during_fsync(tmp_path, monkeypa
 @pytest.mark.asyncio
 async def test_slow_file_open_does_not_freeze_the_event_loop(tmp_path, monkeypatch):
     """Tier 2: #1765 Step 1b. Step 1a moved only `fsync` off the loop; the preceding
-    `_needs_lead_newline` check + `open`/`write`/`flush` stayed synchronous on the loop. On a
+    `open`/`write`/`flush` stayed synchronous on the loop (#5192 later removed the
+    lead-newline guard that once ran before them — see `_do_wal_write`'s own docstring —
+    but `open`/`write`/`flush` themselves are the subject of this test, unaffected by
+    that removal). On a
     stalled filesystem (Windows AV re-scan / cloud-sync rehydration / a stale lock — all far
     more likely after the file has sat idle), those calls freeze the WHOLE event loop, not just
     this append (the reported symptom: the user's message echoes, but the "Working…" indicator

--- a/tests/core/test_5192_state_log_wal_no_toctou_guard.py
+++ b/tests/core/test_5192_state_log_wal_no_toctou_guard.py
@@ -1,0 +1,207 @@
+"""Tier 2: #5192 — ``StateLog`` closes the same TOCTOU race
+``ApprovalLedger``/``BudgetLedger`` had, in the third band it lives in
+(crash-recovery/WAL, not permission or cost/bounding).
+
+Architect ruling (issuecomment-5384637352, relayed by lead-coder) fixed
+ALL THREE files (this one, ``approval_ledger.py``, ``budget.py``) in one PR,
+with 5 shared acceptance criteria:
+  ① the old check-then-write guard's identifier is COMPLETELY absent from
+     the module — not merely unused (grep 0 hits; one file standing in for
+     all three does not satisfy this)
+  ② two real, separate writers appending concurrently to the same WAL file
+     → line count == record count (no lost/corrupted entries)
+  ③ WAL-specific truncate-falsify (the CLAUDE.md hard rule itself): set
+     state with a WAL containing an embedded blank line → truncate the WAL
+     past that point → reconstruct → assert derived state survives
+  ④ the reader's tolerant blank-line skip is documented as an INVARIANT of
+     the on-disk format (not incidental defensive code) at all 3 read sites
+     in this module — see ``_parse_wal_line``'s, ``iter_from``'s, and
+     ``_do_truncate``'s own docstrings
+  ⑤ #5194's already-merged self-describing diagnostic stays (that fix lives
+     in ``tests/security/test_5153_approval_ledger.py``, not here)
+
+③'s WAL-specific angle (architect, not present in ①②'s approval_ledger/
+budget precedent): truncation uses ``seq``, not byte offset, as its floor —
+whether an embedded blank line could disturb that floor was explicitly
+UNMEASURED before this test.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import multiprocessing
+from pathlib import Path
+
+import pytest
+
+import reyn.core.events.state_log as state_log_module
+from reyn.core.events.state_log import StateLog
+
+# Mirrors tests/security/test_5153_approval_ledger.py's own explicit-spawn
+# fix (PR #5170 CI red on Linux+multi-threaded-parent) -- never the platform
+# default, so this file's own correctness never depends on which platform
+# happens to run it.
+_mp = multiprocessing.get_context("spawn")
+
+
+def test_no_lead_newline_guard_remains_in_the_module() -> None:
+    """Tier 2: #5192 acceptance ① — the old TOCTOU-vulnerable
+    check-then-write guard's identifier must be completely removed from
+    ``state_log.py``, not merely unused. RED if the guard (or a
+    reintroduced equivalent under the same name) comes back."""
+    source = inspect.getsource(state_log_module)
+    assert "_needs_lead_newline" not in source, (
+        "the old TOCTOU-vulnerable guard's identifier must be completely "
+        "removed -- see _do_wal_write's own docstring for why"
+    )
+
+
+def _worker_append_many(path_str: str, tag: str, n: int) -> None:
+    """Module-level (picklable) worker: append *n* records with a distinct
+    *tag* field -- run in a SEPARATE OS process, its own event loop."""
+    import asyncio
+
+    async def _run() -> None:
+        sl = StateLog(Path(path_str))
+        for i in range(n):
+            await sl.append("inbox_put", text=f"{tag}-{i}")
+        await sl.aclose()
+
+    asyncio.run(_run())
+
+
+def test_two_real_processes_appending_concurrently_line_count_equals_record_count(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5192 acceptance ② — two SEPARATE OS processes, each with its
+    own event loop, appending to the SAME WAL file concurrently: every
+    append must survive (no lost lines) and every surviving line must parse
+    (no interleaved corruption from the removed guard's race). RED if the
+    self-terminating write is reverted to a check-then-write guard."""
+    wal_path = tmp_path / "wal.jsonl"
+    n = 150
+
+    p1 = _mp.Process(target=_worker_append_many, args=(str(wal_path), "p1", n))
+    p2 = _mp.Process(target=_worker_append_many, args=(str(wal_path), "p2", n))
+    p1.start()
+    p2.start()
+    p1.join(timeout=60)
+    p2.join(timeout=60)
+    assert p1.exitcode == 0
+    assert p2.exitcode == 0
+
+    raw_content = wal_path.read_text(encoding="utf-8")
+    lines = raw_content.splitlines()
+    expected_total = 2 * n
+    assert len(lines) == expected_total, (
+        f"expected {expected_total} lines from two concurrent writers, got "
+        f"{len(lines)} raw lines: {lines!r}"
+    )
+    records = [json.loads(line) for line in lines]  # every line must parse
+    assert len(records) == expected_total
+    tags = {r["text"].rsplit("-", 1)[0] for r in records}
+    assert tags == {"p1", "p2"}
+    # Each process's own texts must appear exactly n times, with none lost
+    # or duplicated -- the property the removed guard's race could corrupt
+    # (an interleaved/torn write, not seq assignment: each StateLog instance
+    # owns its own in-memory counter, so cross-process seq UNIQUENESS is a
+    # separate, out-of-scope property this test does not claim).
+    for tag in ("p1", "p2"):
+        texts = [r["text"] for r in records if r["text"].startswith(f"{tag}-")]
+        assert sorted(texts) == sorted(f"{tag}-{i}" for i in range(n)), (
+            f"{tag}'s {n} appends must all survive exactly once, got: {texts!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_truncate_falsify_survives_an_embedded_blank_line(tmp_path: Path) -> None:
+    """Tier 2: #5192 acceptance ③ — the CLAUDE.md hard rule itself
+    ("Recovery-feature PRs need a truncate-falsify test: set X → truncate
+    the WAL past X's events → reconstruct → assert X survives").
+
+    Sets up a WAL with a real durable entry, hand-inserts an embedded blank
+    line (the on-disk shape a benign write race can produce -- see
+    ``_parse_wal_line``'s docstring), appends more entries past it, then
+    truncates below a seq that is AFTER the blank line. Reconstruction
+    (a fresh StateLog's ``iter_from``) must see exactly the kept entries --
+    the blank line must not have thrown off the seq-based truncation floor
+    (architect's explicitly-unmeasured concern) or corrupted anything past
+    it. RED if the blank line disturbs truncation's seq accounting or if
+    the reconstructed state loses an entry that should have survived."""
+    wal_path = tmp_path / "wal.jsonl"
+    sl = StateLog(wal_path)
+    seq1 = await sl.append("inbox_put", text="kept-below-floor-but-highest")
+    seq2 = await sl.append("inbox_put", text="dropped")
+    assert (seq1, seq2) == (1, 2)
+    await sl.aclose()
+
+    # Hand-insert an embedded blank line between durable entries -- the
+    # shape a benign concurrent-write race produces (two adjacent "\n"s),
+    # now tolerated by construction rather than prevented by a guard.
+    with wal_path.open("a", encoding="utf-8") as f:
+        f.write("\n")
+
+    sl = StateLog(wal_path)  # re-opens; counter recovers past the blank line
+    seq3 = await sl.append("inbox_put", text="also-dropped")
+    seq4 = await sl.append("inbox_put", text="survives-truncation")
+    assert (seq3, seq4) == (3, 4)
+
+    # Truncate below seq4: everything strictly below seq4 is dropped, EXCEPT
+    # the highest seq present is always kept (the counter watermark) -- so
+    # seq2/seq3 are dropped, seq4 survives. seq1 is below the highest-seq
+    # exemption's reach only because it isn't the highest -- also dropped.
+    await sl.truncate_below(seq4)
+    await sl.flush()
+    stats = sl.last_truncate_stats
+    assert stats["dropped"] == 3, f"expected 3 dropped entries, got: {stats!r}"
+    assert stats["kept"] == 1, f"expected 1 kept entry, got: {stats!r}"
+    await sl.aclose()
+
+    # Reconstruction: a FRESH StateLog on the truncated file must recover
+    # correctly -- the seq counter watermark must not have been corrupted
+    # by the blank line that sat in the pre-truncation file.
+    recovered = StateLog(wal_path)
+    entries = list(recovered.iter_from(1))
+    assert [e["seq"] for e in entries] == [4], (
+        f"derived state after truncate+reconstruct must contain exactly "
+        f"seq 4 (the only survivor), got: {entries!r}"
+    )
+    assert entries[0]["text"] == "survives-truncation"
+    # The next append must continue from seq 5, not re-issue 1-4 -- proof
+    # the counter watermark itself survived the blank-line-adjacent rewrite.
+    seq5 = await recovered.append("inbox_put", text="next-after-recovery")
+    assert seq5 == 5, (
+        f"counter must resume at 5 after truncate+reconstruct, got {seq5} "
+        f"-- a reset here would re-issue a seq already used before the blank "
+        f"line, corrupting the audit trail's monotonic ordering"
+    )
+    await recovered.aclose()
+
+
+@pytest.mark.asyncio
+async def test_iter_from_tolerates_an_embedded_blank_line_as_an_invariant(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5192 acceptance ④ — the blank-line skip is exercised as a
+    real behavior (not merely asserted-present in a docstring): a WAL with
+    an embedded blank line between two durable entries must still yield
+    both entries via ``iter_from``, in seq order, with nothing lost or
+    duplicated. RED if the skip is ever narrowed to "only a trailing blank
+    line" or removed."""
+    wal_path = tmp_path / "wal.jsonl"
+    sl = StateLog(wal_path)
+    await sl.append("inbox_put", text="before-blank")
+    await sl.aclose()
+
+    with wal_path.open("a", encoding="utf-8") as f:
+        f.write("\n")  # embedded blank line -- the tolerated on-disk shape
+
+    sl = StateLog(wal_path)
+    await sl.append("inbox_put", text="after-blank")
+
+    entries = list(sl.iter_from(1))
+    assert [e["text"] for e in entries] == ["before-blank", "after-blank"], (
+        f"a blank line between two durable entries must not lose or "
+        f"duplicate either one: {entries!r}"
+    )
+    await sl.aclose()

--- a/tests/core/test_5192_state_log_wal_no_toctou_guard.py
+++ b/tests/core/test_5192_state_log_wal_no_toctou_guard.py
@@ -1,6 +1,10 @@
 """Tier 2: #5192 — ``StateLog`` closes the same TOCTOU race
 ``ApprovalLedger``/``BudgetLedger`` had, in the third band it lives in
-(crash-recovery/WAL, not permission or cost/bounding).
+(crash-recovery/WAL, not permission or cost/bounding). Also carries
+``budget.py``'s own guard-absence witness (acceptance ①'s "3 か所とも
+grep 0 件, 1 つで代表させない" -- see the per-module test below for why it
+lives here rather than in a budget-specific test file: it needs no
+budget-specific fixtures, only ``inspect.getsource``).
 
 Architect ruling (issuecomment-5384637352, relayed by lead-coder) fixed
 ALL THREE files (this one, ``approval_ledger.py``, ``budget.py``) in one PR,
@@ -35,6 +39,7 @@ from pathlib import Path
 import pytest
 
 import reyn.core.events.state_log as state_log_module
+import reyn.runtime.budget.budget as budget_module
 from reyn.core.events.state_log import StateLog
 
 # Mirrors tests/security/test_5153_approval_ledger.py's own explicit-spawn
@@ -53,6 +58,24 @@ def test_no_lead_newline_guard_remains_in_the_module() -> None:
     assert "_needs_lead_newline" not in source, (
         "the old TOCTOU-vulnerable guard's identifier must be completely "
         "removed -- see _do_wal_write's own docstring for why"
+    )
+
+
+def test_no_lead_newline_guard_remains_in_the_budget_module() -> None:
+    """Tier 2: #5192 acceptance ① — the SAME check, for ``budget.py``
+    (architect finding, issuecomment-5384693823, on this PR's own head:
+    a witness existed for the WAL and for ``approval_ledger.py``, but NOT
+    for ``budget.py`` -- "3 か所とも grep 0 件" means 3 separate witnesses,
+    not 2 witnesses standing in for a third). ``budget.py`` is the
+    cost/budget band and the ORIGINAL #5153-era source this guard pattern
+    was mirrored FROM into ``approval_ledger.py`` -- nothing else in this
+    band bounds a reintroduction of the guard here. RED if the guard (or a
+    reintroduced equivalent under the same name) comes back."""
+    source = inspect.getsource(budget_module)
+    assert "_needs_lead_newline" not in source, (
+        "the old TOCTOU-vulnerable guard's identifier must be completely "
+        "removed from budget.py -- see BudgetLedger._write_record's own "
+        "docstring for why"
     )
 
 

--- a/tests/security/test_5153_approval_ledger.py
+++ b/tests/security/test_5153_approval_ledger.py
@@ -243,6 +243,63 @@ def test_two_real_processes_racing_the_same_key_resolve_by_log_order(
     )
 
 
+def test_no_lead_newline_check_remains_in_the_module() -> None:
+    """Tier 2: #5192 acceptance ① (architect ruling, issuecomment-
+    5384627324) — the removed check-then-write guard's own identifier is
+    TOTALLY ABSENT from approval_ledger.py, not merely unreachable. "Never
+    called" would still leave the method defined (dead code drifting back
+    into use later); this asserts the stronger claim by reading the actual
+    module source, the same population a real ``grep`` would search."""
+    import inspect
+
+    import reyn.security.permissions.approval_ledger as approval_ledger_module
+
+    source = inspect.getsource(approval_ledger_module)
+    assert "_needs_lead_newline" not in source, (
+        "the old TOCTOU-vulnerable guard's identifier must be completely "
+        "removed, not merely unused -- see _write_record's own docstring"
+    )
+
+
+def test_a_ledger_missing_its_trailing_newline_is_repaired_by_migration(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5192 acceptance ③ — a pre-existing ledger file that does
+    NOT end in a trailing newline (simulating a torn write from before
+    this fix, or any other historical cause) is repaired the ONE TIME
+    migrate_legacy_snapshot runs against it -- not on every append (see
+    _repair_missing_trailing_newline's own docstring for why that's a
+    migration-time, not a per-append, concern)."""
+    ledger_path = tmp_path / "approvals.jsonl"
+    # Simulate a torn write: two well-formed records, but the FILE's own
+    # last byte is not "\n" (the second record's own trailing newline is
+    # missing -- exactly what a crash mid-fsync could leave behind).
+    torn_content = (
+        json.dumps({"kind": "approval", "key": "a", "approved": True}) + "\n"
+        + json.dumps({"kind": "approval", "key": "b", "approved": False})
+    )
+    ledger_path.write_text(torn_content, encoding="utf-8")
+    assert not torn_content.endswith("\n"), "sanity: the fixture is genuinely torn"
+
+    ledger = ApprovalLedger(ledger_path)
+    legacy_yaml_path = tmp_path / "approvals.yaml"  # never created -- not this test's path
+    migrate_legacy_snapshot(ledger, legacy_yaml_path)
+
+    assert ledger.path.read_text(encoding="utf-8").endswith("\n"), (
+        "migrate_legacy_snapshot must repair a missing trailing newline on "
+        "an already-existing ledger file"
+    )
+
+    # The repair must not corrupt or duplicate what was already there --
+    # a fresh append now lands as its OWN clean line, not concatenated
+    # onto key "b"'s own (now newline-terminated) record.
+    ledger.append_approval("c", True)
+    records = list(ledger.iter_records())
+    assert [(r["key"], r["approved"]) for r in records] == [
+        ("a", True), ("b", False), ("c", True),
+    ], f"unexpected records after repair + append: {records!r}"
+
+
 def test_migration_witness_fold_matches_the_legacy_reader(tmp_path: Path) -> None:
     """Tier 2: #5153 acceptance ③ — migrating a legacy approvals.yaml
     snapshot into the ledger, then folding it, must reproduce EXACTLY


### PR DESCRIPTION
**[tui-coder]** — closes #5192.

## Summary

`ApprovalLedger`, `BudgetLedger`, and `StateLog`'s WAL each had a
check-then-write "leading newline" guard (a separate `stat()` +
tail-byte `read()` BEFORE an append) meant to decide whether a leading
newline was needed before the payload. Between the check and the write,
another process's concurrent append could land its own bytes — a real
TOCTOU race (#5192's repro: 401 lines instead of 400 under 2 concurrent
writers, not a hypothetical).

Architect ruling (issuecomment-5384637352, relayed by lead-coder): fix
all 3 files in one PR (a single defect crossing bands — permission /
cost·bounding / crash-recovery·WAL — is fixed while still crossing them).
Guard removed; every write becomes unconditionally self-terminating
(the payload always ends in its own `\n`), never reading before writing.

`approval_ledger.py` additionally repairs a *pre-existing* ledger's
missing trailing newline, but only once, at migration time — not on the
per-append hot path. An already-dirty file is not cleaned retroactively;
the fix is "never dirty it further," per architect's explicit
"直った」と書く時に区別を" caveat.

## Files

- `security/permissions/approval_ledger.py` — guard removed,
  self-terminating write, one-time trailing-newline repair added to
  `migrate_legacy_snapshot`
- `runtime/budget/budget.py` — guard removed (the original #5153-era
  source this pattern was mirrored from)
- `core/events/state_log.py` (WAL / crash-recovery band) — guard
  removed, self-terminating write; the reader's blank-line tolerance
  documented as an on-disk-format **invariant** (not incidental
  defensiveness) at all 3 read sites: `_parse_wal_line`, `iter_from`,
  `_do_truncate`

## Acceptance criteria (per architect/lead-coder's dispatch)

- ① guard identifier (`_needs_lead_newline`) absent from all 3 modules
  — `grep -n _needs_lead_newline` returns 0 hits in each, verified
  individually (not one file standing in for the other two)
- ② two real, separate OS-process writers appending concurrently to the
  same file → line count == record count, no lost/corrupted entries —
  witnessed with real `multiprocessing` (spawn context) for all 3 files
- ③ WAL-specific **truncate-falsify** test (the CLAUDE.md hard rule
  itself): a WAL containing an embedded blank line survives
  `truncate_below` + reconstruct — `test_truncate_falsify_survives_an_embedded_blank_line`
- ④ the reader's tolerant blank-line skip documented as an invariant at
  all 3 `state_log.py` read sites (and already true of `approval_ledger.py`
  / `budget.py`'s `iter_records`/`fold`)
- ⑤ #5194's already-merged self-describing diagnostic (line-count-mismatch
  breakdown) is untouched

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 17/17 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest` scoped to the diff (budget/state_log/approval_ledger + their consumers) — 125 passed
- [x] the new concurrent-writer + truncate-falsify tests re-run 3x locally for stability — stable
- [ ] (skipped — full suite runs in CI per repo convention, not locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

**[architect]** — TESTS-READ（**A: 設計適合**、head `48067968c6`）issuecomment。3 か所ともガードは消えています。B は別の人が必要です。

- [x] 🔴 (解消 `f199bf79a`, architect 差分 A) **`budget.py` に guard 不在の witness が無い**。在るのは WAL（`test_no_lead_newline_guard_remains_in_the_module`）と approval（`test_no_lead_newline_check_remains_in_the_module`）の 2 本のみで、diff の "budget" 5 件は散文/コメント。受入は逐語「**3 か所とも `_needs_lead_newline` が不在（grep 0 件）**」「**1 つで代表させない**」→ **budget.py 用に同型の 1 本を追加**

