### PR TITLE
fix(#5197): TESTS-READ gate quantifies over EVERY note, not just one

### DIFF
--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -352,6 +352,37 @@ These rules then keep multi-session work coherent:
    silent. One reporting channel, not a check run and a status both
    claiming the same fact.
 
+   **Existential quantification closed to universal (#5197, 2026-08-23):**
+   `evaluate` used to return green the instant ANY ONE note named a fresh
+   commit of the PR — an existential check ("does a note naming the current
+   tree exist"), not the universal one rule 8 actually needs ("does EVERY
+   note naming a commit of the PR name a fresh one"). Measured live on
+   #5196: architect's A note named the new head; docs-maintainer's B note
+   still named the PREVIOUS head, because a fresh witness commit (the fix
+   for architect's own blocking finding) had landed to `tests/` in
+   between — and the gate went green having read only the A note, since it
+   stopped looking the moment it found one success. Rule 8 requires B
+   specifically; A is architect's own operational practice, not something
+   this gate (or any other mechanism) may come to require in its place —
+   so the fix is a plain ∀ over every note's own SHA, never a role parse.
+   `evaluate` now reds a PR the moment ANY note names a commit `tests/` has
+   moved past, and names that note's own first-line text in the failure so
+   the ask is "post a fresh note" scoped to the reviewer who owns it, not
+   "read the PR again". A single-note PR (the ordinary case) is unaffected
+   — the tightening only bites when multiple notes exist and disagree.
+
+   **This does not close, and was never meant to close, a second, separate
+   limit:** the gate reads no role marker at all — it cannot tell an A note
+   from a B note, or a B note from a third opinion, only that a comment's
+   first line names the marker and a fresh SHA. #5187 gave a note's first
+   line a role-disclosing shape parseable in principle, but adding a role
+   parse here would make "A ran" a requirement this gate enforces, when
+   only "B ran" is a house rule that exists — a new rule invented by the
+   gate, not a reflection of one that does. Whether the RIGHT roles
+   reviewed a PR remains a human's judgment reading the PR before merging,
+   same as it always was; a green here means "every note that names a tree
+   names a fresh one," never "the tree was reviewed by the right people."
+
 ## Bundling and the owner's veto unit
 
 A doc PR that exists to give the owner a veto opportunity should ship alone.

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -166,6 +166,35 @@ def tests_commits_after(sha: str, commits: "list[dict]") -> "list[dict]":
     return [c for c in tail if c.get("_tests_paths")]
 
 
+def _note_verdict(
+    note: str, oids: "list[str]", commits: "list[dict]",
+) -> "tuple[str, str, list[dict]] | None":
+    """One note's verdict: ``None`` if it names no commit of this PR (not a
+    claim this predicate can evaluate at all — the caller's "none resolved"
+    bucket); otherwise ``(note, sha, later)`` where *sha* is the FIRST fresh
+    SHA the note names, and *later* is empty when fresh.
+
+    A note naming several SHA-shaped tokens (rare, but ``find_note_shas``
+    returns every membership hit on the line) passes as a whole the moment
+    ANY one of them is fresh — mirrors the per-note short-circuit the old
+    single-note code path already had, just no longer let one note's own
+    fresh candidate excuse a DIFFERENT note (see ``evaluate``'s own
+    docstring, #5197). When every candidate on this note is stale, *sha*/
+    *later* report the FIRST one, so the red output names one concrete
+    offending commit set rather than every candidate's own list."""
+    shas = find_note_shas(note, oids)
+    if not shas:
+        return None
+    first_later: "list[dict]" = []
+    for sha in shas:
+        later = tests_commits_after(sha, commits)
+        if not later:
+            return note, sha, []
+        if not first_later:
+            first_later = later
+    return note, shas[0], first_later
+
+
 def evaluate(pr: dict) -> "tuple[int, list[str]]":
     """``(exit_code, lines)`` for one PR payload.
 
@@ -182,14 +211,39 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     which is deliberate: a document *about* the marker is not a document
     *stating* the marker.
 
-    What a green return means, precisely: A COMMENT'S FIRST LINE NAMES A
-    FRESH COMMIT OF THIS PR. It does NOT mean a reviewer made that claim —
-    every session here authenticates as the same ``gh`` user, so comment
-    authorship carries no reviewer/author distinction for this function (or
-    any text predicate) to read. Rule 8's actual review requirement is
-    enforced by a human reading the PR before merging, not by this check;
-    treat a green here as "the tree is named", never as "the tree was
-    reviewed"."""
+    #5197 (architect ruling, following lead-coder's #5196 measurement): the
+    verdict is a UNIVERSAL quantification over every note that names a
+    commit of this PR, not an existential one. The predicate used to return
+    green the instant ANY ONE note named a fresh commit — measured live on
+    #5196: architect's A note named the new head, docs-maintainer's B note
+    still named the PREVIOUS head (a fresh witness commit had landed to
+    tests/ between them), and the gate went green having read only the A
+    note, because it stopped looking the moment it found one success. House
+    rule 8 requires B specifically (the A role is architect's own
+    operational practice, not something this gate — or anything else — may
+    come to require; see the paragraph below). Now EVERY note naming a
+    commit of this PR must name a FRESH one for the PR to pass — one fresh
+    note no longer excuses a different, stale note.
+
+    Deliberately does NOT parse which review role (A/B/etc.) wrote a note —
+    only "B is required" is a house rule this gate can enforce; making A
+    load-bearing here would be a new rule invented by this predicate, not a
+    reflection of one that exists. #5187 fixed the note's first line into a
+    parseable shape (role disclosed), which is what would make role-parsing
+    POSSIBLE if the universal quantification above ever proves insufficient
+    on its own — not a reason to add it preemptively (CLAUDE.md: "would
+    removing this cause a mistake?").
+
+    What a green return means, precisely: EVERY comment whose first line
+    names a commit of this PR names a FRESH one. It does NOT mean a
+    reviewer made that claim, and it does NOT mean every required ROLE
+    weighed in — every session here authenticates as the same ``gh`` user,
+    so comment authorship carries no reviewer/author distinction for this
+    function (or any text predicate) to read, and this function reads no
+    role marker at all. Rule 8's actual review requirement is enforced by a
+    human reading the PR before merging, not by this check; treat a green
+    here as "every note that names a tree names a fresh one", never as
+    "the tree was reviewed" or "the right roles reviewed it"."""
     touched_tests = [p for p in pr.get("files", []) if p.startswith("tests/")]
     if not touched_tests:
         return 0, ["OK — this PR does not touch tests/; rule 8 does not apply."]
@@ -223,21 +277,19 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     # whenever the PR has any, so including it separately buys nothing and
     # costs exactly this hole.
     oids = [c.get("oid", "") for c in commits]
-    lines: "list[str]" = []
-    for note in notes:
-        shas = find_note_shas(note, oids)
-        if not shas:
-            continue
-        for sha in shas:
-            later = tests_commits_after(sha, commits)
-            if not later:
-                return 0, [
-                    f"OK — a TESTS-READ note names {sha}, and no commit has",
-                    "  touched tests/ since it.",
-                ]
-        lines.append(f"  note names {', '.join(shas)}")
 
-    if not lines:
+    resolved_count = 0
+    stale: "list[tuple[str, str, list[dict]]]" = []
+    for note in notes:
+        verdict = _note_verdict(note, oids, commits)
+        if verdict is None:
+            continue
+        resolved_count += 1
+        note_text, sha, later = verdict
+        if later:
+            stale.append((note_text, sha, later))
+
+    if not resolved_count:
         return 1, [
             "RED — a TESTS-READ note landed, but none of them names a commit of",
             "  this PR. Add the head you read (e.g. `TESTS-READ (B) (head abc1234)`),",
@@ -247,18 +299,27 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
             "  Without it, nothing can tell whether the note is a claim about THIS tree.",
         ]
 
-    stale: "list[str]" = []
-    for note in notes:
-        for sha in find_note_shas(note, oids):
-            for c in tests_commits_after(sha, commits):
-                stale.append(f"  {c.get('oid', '')[:9]} {c.get('messageHeadline', '')[:60]}")
-    return 1, [
-        "RED — every TESTS-READ note reads a tree that tests/ has moved past.",
-        *lines,
-        "  tests/ commits after it:",
-        *sorted(set(stale)),
-        "  Ask the same reviewer for a DIFFERENTIAL note over just these commits —",
-        "  re-reading the whole PR is not required.",
+    if stale:
+        lines = [
+            "RED — a TESTS-READ note reads a tree that tests/ has moved past.",
+            "  (∀ EVERY note naming a commit of this PR must name a FRESH one —",
+            "  one fresh note does not excuse a different, stale note. #5197.)",
+        ]
+        for note_text, sha, later in stale:
+            lines.append(f"  stale note (first line): {note_text!r}")
+            lines.append(f"    names {sha}")
+            lines.append("    tests/ commits after it:")
+            for c in later:
+                lines.append(f"      {c.get('oid', '')[:9]} {c.get('messageHeadline', '')[:60]}")
+        lines.append(
+            "  Ask the same reviewer for a DIFFERENTIAL note over just these commits —"
+        )
+        lines.append("  re-reading the whole PR is not required.")
+        return 1, lines
+
+    return 0, [
+        "OK — every TESTS-READ note names a commit of this PR, and no commit",
+        "  has touched tests/ since it.",
     ]
 
 

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -105,6 +105,76 @@ def test_no_claim_line_at_all_is_rejected():
     assert "no TESTS-READ note" in "\n".join(lines)
 
 
+def test_a_fresh_a_note_does_not_excuse_a_stale_b_note():
+    """Tier 1: #5197 (architect ruling) — the existential-quantification gap
+    measured live on #5196 itself. architect's A note named the NEW head;
+    docs-maintainer's B note still named the PREVIOUS head, and a fresh
+    ``tests/`` commit (the witness the blocking finding needed) had landed
+    in between. The old predicate returned green the instant it found ONE
+    fresh note (A) — it never looked at B, though house rule 8 requires B
+    specifically. Reproduced from #5196's own actual shape: two notes, one
+    fresh, one one commit stale. Must be red — a fresh note no longer
+    excuses a different, stale note (architect's acceptance ①)."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/core/test_5192_state_log_wal_no_toctou_guard.py"],
+        comments=[
+            {"body": "**[architect]** — TESTS-READ (A: design conformance) (head `f199bf79a`)"},
+            {"body": "**[docs-maintainer]** — TESTS-READ (B: independent) (head `48067968c`)"},
+        ],
+        commits=[
+            _commit("48067968c", "fix(#5192): remove the guard in 2 of 3 files"),
+            _commit("f199bf79a", "fix(#5192): add budget.py's own guard-absence witness",
+                     ("tests/core/test_5192_state_log_wal_no_toctou_guard.py",)),
+        ],
+    ))
+    assert code == 1, "a stale B note must not be excused by a fresh A note"
+    joined = "\n".join(lines)
+    assert "f199bf79a" in joined, "the offending witness commit is named, so the ask is scoped"
+
+
+def test_the_red_message_names_which_note_is_stale():
+    """Tier 1: #5197 acceptance ② — the red output must name WHICH note went
+    stale (its own first-line text), not just that some note somewhere did —
+    the ask a reviewer gets is "post a fresh note", and they need to know
+    it's THEIRS, not the other reviewer's, that's being asked for."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[
+            {"body": "**[architect]** — TESTS-READ (A) (head `bbbbbbbb`)"},
+            {"body": "**[docs-maintainer]** — TESTS-READ (B) (head `aaaaaaaa`)"},
+        ],
+        commits=[
+            _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
+            _commit("bbbbbbbb", "test: fix", ("tests/scripts/test_check_doc_drift_5003.py",)),
+        ],
+    ))
+    assert code == 1
+    joined = "\n".join(lines)
+    assert "docs-maintainer" in joined, (
+        "the stale note's own first-line text (naming its author role) must "
+        f"appear in the output so the ask is scoped to the right reviewer; got {joined!r}"
+    )
+    assert "architect" not in joined, (
+        "the FRESH note must not be reported as if it were the problem"
+    )
+
+
+def test_a_single_note_naming_the_current_head_still_passes():
+    """Tier 1: #5197 acceptance ③ — the common case (one required B note,
+    naming the PR's current head) must keep passing under the universal
+    quantification; #5197 only tightens the "one is enough" case where
+    MULTIPLE notes exist and disagree, not the ordinary single-note PR."""
+    code, _ = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "**[docs-maintainer]** — TESTS-READ (B) (head `bbbbbbbb`)"}],
+        commits=[
+            _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
+            _commit("bbbbbbbb", "test: fix", ("tests/scripts/test_check_doc_drift_5003.py",)),
+        ],
+    ))
+    assert code == 0
+
+
 def test_marker_only_from_line_two_onward_is_not_a_claim():
     """Tier 1: the #5144 reproduction (architect's acceptance ②) — a
     multi-purpose comment whose FIRST line is a plain role-prefixed opener,


### PR DESCRIPTION
**[docs-maintainer]** — #5197, architect ruling (relayed by lead-coder).

## Problem
`check_tests_read_names_its_tree.py`'s `evaluate()` returned green the instant ANY ONE note named a fresh commit of the PR — an existential check ("does a note naming the current tree exist"), not the universal one house rule 8 needs ("does EVERY note naming a commit of the PR name a fresh one"). Measured live on #5196: architect's A note named the new head; docs-maintainer's B note still named the previous head (a fresh witness commit — the fix for architect's own blocking finding — had landed to `tests/` in between). The gate went green having read only the A note, since it stopped looking the moment it found one success.

## Fix — ∀, not ∃
`evaluate()` now checks every note that names a commit of this PR; if ANY of them names a commit `tests/` has since moved past, the PR reds — and the failure names that note's own first-line text, so the ask is scoped to the reviewer who owns it ("post a fresh note"), not "read the PR again". A single-note PR (the ordinary case) is unaffected.

Deliberately does NOT parse which review role (A/B/etc.) wrote a note — only "B is required" is a house rule this gate can enforce; making A load-bearing here would be a new rule invented by this predicate, not a reflection of one that exists (#5187 gave a note's first line a role-disclosing shape, which is what would make role-parsing *possible* if the ∀ ever proves insufficient — not a reason to add it preemptively).

## Strip-falsify
Ran the OLD (pre-fix) `evaluate()` against #5196's own actual comment/commit shape (architect's A at `f199bf79a`, docs-maintainer's B at the stale `48067968c`, one `tests/`-touching commit between them) — it returns **green**, reproducing the exact bug. The new `evaluate()` reds it and names the stale B note in the output.

## Docs
`docs/deep-dives/contributing/pr-workflow.md`'s existing #5120/#5138 TESTS-READ gate section gets a new paragraph recording the ∃→∀ fix, plus a paragraph stating explicitly that the gate still reads no role marker at all (a separate, un-closed limit — per architect's acceptance④, "doesn't read content" and "doesn't read which role" are different limits and both need to be on the record).

## Test plan
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_tests_read_names_its_tree_5039.py` — 19/19 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py scripts/check_tests_read_names_its_tree.py` — OK
- [x] `python scripts/mypy_ratchet.py` — 201/207 baselined, no new
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` / `check_doc_anchors.py` / `check_retired_config_keys_denylist.py` (docs/ touched) — all clean
- [x] `pytest tests/scripts/test_check_tests_read_names_its_tree_5039.py -q` — 19 passed (16 pre-existing + 3 new, all pass under the new ∀)
- [x] (skipped — Visual, standing waiver 2026-08-08)

Touches `tests/` — needs a TESTS-READ note before merge; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
