### PR TITLE
feat(#5190): gate hook kinds declarable but reachable only via an LLM turn

### DIFF
--- a/scripts/check_hooks_declared_reachable.py
+++ b/scripts/check_hooks_declared_reachable.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""#5190 — a hook `on:` kind ``hooks.yaml`` can DECLARE must have at least
+one real code path that reaches it WITHOUT requiring an LLM turn.
+
+## The bug class this closes (#5167)
+
+Before #5167, ``mcp_resource_updated`` was a fully declarable ``on:``
+value (present in ``reyn.hooks.schema_registry.BUILTIN_HOOK_SCHEMAS``) with
+exactly ONE construction site for the subscription that would ever fire
+it — the LLM-facing ``subscribe_mcp_resource`` tool. A ``hooks.yaml`` entry
+declaring this hook was schema-VALID and silently, permanently inert for
+any agent whose model never happened to call that tool. Nothing caught
+this: the schema advertised the kind, a real ``build_hook_payload``/
+``HookDispatcher.dispatch`` call site existed in the source tree (so an
+"emit-site census" alone would have called it reachable), and the only
+thing actually missing was a NON-LLM way to reach that call site at all.
+
+Architect's ruling (issuecomment-5384661356, on #5190): this is a
+STRUCTURAL defect, not a case-by-case one, and there is no legitimate
+"intentionally declare-only, no reachability yet" state — a schema is an
+ADVERTISEMENT (owner ruling on #5167, "honor できない宣言は load で大きな
+声で落とす" — a declaration reyn cannot honor must fail loud, never be
+silently accepted), so a kind that is declarable but reaches nothing IS
+the defect this gate exists to catch, not a legitimate degrade to leave
+alone.
+
+## Why "an emit call site exists" is NOT the check
+
+The #5167 trap: ``build_hook_payload("mcp_resource_updated", ...)`` DID
+exist in the source tree the whole time (inside the ``subscribe_mcp_
+resource`` tool's own implementation) — a naive AST census of "does a
+``build_hook_payload(kind, ...)`` call site exist for this kind" would
+have read #5167 as compliant. The actual defect was that the ONLY path to
+that call site required an LLM to decide to call a specific tool first.
+So this gate does not (and structurally cannot) derive "reachable without
+an LLM turn" from an AST scan — that requires the same kind of human
+judgment ``reyn.core.events.event_schema.DYNAMIC_KIND_EMIT_SITES``
+already exercises for audit-event blind spots (a classified, reviewed,
+hand-maintained registry, not a scanner). ``REACHABLE_WITHOUT_LLM_TURN``
+below is that registry for hook kinds: one citation per declarable kind,
+to the real non-LLM code path that dispatches it, verified against the
+source tree at the time each entry was written (see the entry's own
+comment) — not verified BY this script at runtime, the same trust
+boundary ``DYNAMIC_KIND_EMIT_SITES`` already accepts.
+
+"Reachable without an LLM turn" (architect's own definition, mirroring
+#5167 acceptance④): a code path that fires WITHOUT the model ever needing
+to decide to invoke a tool first — session lifecycle, the turn-loop
+itself (regardless of whether a given turn happens to call the LLM),
+config-driven ingress (fs watcher / cron / webhook), or an auto-wiring
+mechanism like #5167's own fix. A path gated behind runtime CONFIGURATION
+(e.g. only fires when an MCP server is actually configured) still counts
+— the code path exists unconditionally; whether it fires on a given
+deployment is an operational fact, not a reachability one. Only "requires
+an LLM to choose a tool call" disqualifies a citation.
+
+## The only 2 remedies (architect ruling — no allowlist, ever)
+
+When ``BUILTIN_HOOK_SCHEMAS`` gains a kind with no matching entry here,
+this gate goes RED. There are exactly two ways to fix that:
+
+  (a) build the reachability path — do what #5167 did — and add the
+      citation here in the SAME PR, or
+  (b) the kind isn't ready to be advertised yet — remove it from
+      ``BUILTIN_HOOK_SCHEMAS`` until (a) is done.
+
+An allowlist / "expected empty" exemption list is explicitly rejected
+(architect, issuecomment-5384661356): that would make "advertised but
+permanently unreachable" a PERMANENT, sanctioned state — exactly what
+this gate exists to make impossible, not merely detectable. There is no
+third option this gate's failure message may ever suggest.
+
+## Baseline: the diff is currently empty, and must always be
+
+Unlike the approval-ledger / TUI-widget boundary gates (whose baseline
+population is a COUNT of forbidden things, zero), this gate's invariant
+is set-theoretic: declared ⊆ reachable-without-LLM. Landing #5190 with
+today's 9 declarable kinds and today's 9 registered citations makes the
+diff empty NOW — every future kind added to the schema must arrive with
+its own citation in the SAME PR, or this gate fails.
+"""
+from __future__ import annotations
+
+import sys
+
+from reyn.hooks.schema_registry import BUILTIN_HOOK_SCHEMAS
+
+# ---------------------------------------------------------------------------
+# The hand-maintained reachability registry — one entry per declarable kind
+# (mirrors reyn.core.events.event_schema.DYNAMIC_KIND_EMIT_SITES's own
+# "classified, reviewed, not scanner-derived" discipline). Each value is a
+# one-line citation to the real non-LLM-turn code path, verified against
+# the source tree as of #5190.
+# ---------------------------------------------------------------------------
+
+REACHABLE_WITHOUT_LLM_TURN: "dict[str, str]" = {
+    "builtin:lifecycle:session_start": (
+        "session.py:6872, Session.run() — unconditional session-boot "
+        "lifecycle dispatch, no LLM call anywhere on this path"
+    ),
+    "builtin:lifecycle:session_end": (
+        "session.py:6956, Session.run()'s own teardown — fires on every "
+        "session shutdown regardless of any LLM activity"
+    ),
+    "builtin:lifecycle:turn_start": (
+        "session.py:6553 — fires from the turn-loop's own trigger "
+        "handling BEFORE any model call; a turn can originate from user "
+        "input, a hook self-continuation push, cron, or a webhook, none "
+        "of which require the LLM to have run first"
+    ),
+    "builtin:lifecycle:turn_end": (
+        "session.py:9264 — wraps every turn unconditionally, regardless "
+        "of whether that particular turn happened to invoke the LLM"
+    ),
+    "builtin:external:mcp_resource_updated": (
+        "session.py:8648, Session._auto_subscribe_mcp_resource_hooks() "
+        "(#5167) — called unconditionally from Session.run() at "
+        "session.py:6880 for every declared hook whose matcher names a "
+        "concrete (server, uri); the fix THIS gate's own bug class "
+        "names — no LLM tool call needed"
+    ),
+    "builtin:external:file_changed": (
+        "hooks/ingress.py:237, FsIngressAdapter.to_event — purely "
+        "config-driven (fs_watch.paths in reyn.yaml) via the watchdog "
+        "thread; the code path is unconditional, whether it FIRES on a "
+        "given deployment depends on config, not on an LLM turn"
+    ),
+    "builtin:external:cron_fired": (
+        "hooks/ingress.py:280, CronIngressAdapter.to_event — purely "
+        "config-driven cron: schedule, resolved out-of-process via "
+        "reyn.runtime.cron.routing; no LLM call on this path"
+    ),
+    "builtin:external:webhook_received": (
+        "hooks/ingress.py:319, WebhookIngressAdapter.to_event — fires "
+        "from inbound HTTP via reyn.runtime.webhook_routing; no LLM "
+        "call on this path"
+    ),
+    "builtin:task:task_settled": (
+        "runtime/services/pipeline_executor_driver.py:474, "
+        "PipelineExecutorDriver._finish() — settles when a Pipeline run "
+        "launched via the config-driven `pipeline_launch` hook action "
+        "(attachable to any non-LLM hook point, e.g. cron_fired) "
+        "reaches a terminal disposition. Deliberately NOT "
+        "inter_agent_messaging.py:655's own producer, which settles "
+        "only via run_prompt(collect=\"async\") — an LLM-tool-invoked "
+        "path that would be exactly the #5167 trap if used as this "
+        "kind's sole witness"
+    ),
+}
+
+
+def find_undeclared_reachability(schemas=None, registry=None) -> "list[str]":
+    """The declarable kinds (*schemas*, defaults to the real
+    ``BUILTIN_HOOK_SCHEMAS``) with no entry in *registry* (defaults to
+    the real :data:`REACHABLE_WITHOUT_LLM_TURN`) — the failure set,
+    sorted for a stable diagnostic order. Both parameters are injectable
+    (resolved by name lookup below, not bound defaults) so a test can
+    monkeypatch either module-level constant and still reach this
+    function through :func:`main`."""
+    if schemas is None:
+        schemas = BUILTIN_HOOK_SCHEMAS
+    if registry is None:
+        registry = REACHABLE_WITHOUT_LLM_TURN
+    return sorted(set(schemas) - set(registry))
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options — a whole-registry set diff, no target to name
+    offenders = find_undeclared_reachability()
+
+    if not offenders:
+        print(
+            f"OK: all {len(BUILTIN_HOOK_SCHEMAS)} declarable hook kinds "
+            "have a registered non-LLM-turn reachability witness."
+        )
+        return 0
+
+    print("hooks-declared-reachable gate FAILED:\n", file=sys.stderr)
+    print(
+        f"{len(offenders)} hook kind(s) are declarable in hooks.yaml "
+        "(present in reyn.hooks.schema_registry.BUILTIN_HOOK_SCHEMAS) "
+        "but have NO registered non-LLM-turn reachability witness in "
+        "scripts/check_hooks_declared_reachable.py's own "
+        "REACHABLE_WITHOUT_LLM_TURN (#5190):",
+        file=sys.stderr,
+    )
+    for kind in offenders:
+        print(f"  {kind}", file=sys.stderr)
+    print(
+        "\nA hook config can declare an `on:` value for one of these "
+        "kinds and it will silently never fire for any agent whose "
+        "model never happens to call a specific tool — the exact #5167 "
+        "defect class. There are exactly 2 ways to fix this, no other:\n"
+        "\n"
+        "  (a) build a real code path that reaches this kind WITHOUT "
+        "requiring an LLM turn (session lifecycle / turn loop / "
+        "config-driven ingress / an auto-wiring mechanism, see #5167's "
+        "own fix), then add a citation to REACHABLE_WITHOUT_LLM_TURN "
+        "in the SAME PR; or\n"
+        "  (b) remove the kind from BUILTIN_HOOK_SCHEMAS until (a) is "
+        "done — an advertised-but-unreachable kind must not ship.\n"
+        "\n"
+        "An allowlist / exemption is not a third option (architect "
+        "ruling, #5190) — that would make 'advertised but permanently "
+        "unreachable' a sanctioned state instead of a caught defect.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_hooks_declared_reachable_5190.py
+++ b/tests/scripts/test_check_hooks_declared_reachable_5190.py
@@ -1,0 +1,223 @@
+"""Tier 2: #5190 — the hooks declared-vs-reachable-without-an-LLM-turn
+gate.
+
+Real registries throughout — the real ``BUILTIN_HOOK_SCHEMAS`` and the
+real ``REACHABLE_WITHOUT_LLM_TURN`` (except where a test deliberately
+constructs a synthetic dict to exercise a specific diff shape, matching
+the ``check_approval_ledger_import_boundary`` test file's own pattern of
+real-file-then-synthetic-fixture).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from reyn.hooks.schema_registry import BUILTIN_HOOK_SCHEMAS
+from scripts.check_hooks_declared_reachable import (
+    REACHABLE_WITHOUT_LLM_TURN,
+    find_undeclared_reachability,
+)
+from tests._support.paths import REPO_ROOT
+
+# ── acceptance① — the real registry, right now, has an empty diff ────────
+
+
+def test_the_real_registries_diff_is_currently_empty() -> None:
+    """Tier 2: acceptance① — landed on main, every declarable kind has a
+    registered reachability witness. This gate's own starting population
+    is zero, so any hit here is a new regression (a schema addition that
+    forgot its citation), not inherited debt."""
+    offenders = find_undeclared_reachability()
+    assert offenders == [], (
+        f"real regression(s) found: {offenders} — a kind was added to "
+        "BUILTIN_HOOK_SCHEMAS with no matching REACHABLE_WITHOUT_LLM_TURN "
+        "citation"
+    )
+
+
+def test_every_declarable_kind_is_covered_one_to_one() -> None:
+    """Tier 2: non-vacuity for① — pins that the real registry is not
+    merely a superset that happens to swallow the diff (e.g. stale
+    entries for kinds no longer declarable masking a real gap); asserts
+    the two key-sets are IDENTICAL, not just that the subtraction above
+    is empty by coincidence of one side being huge."""
+    assert set(REACHABLE_WITHOUT_LLM_TURN) == set(BUILTIN_HOOK_SCHEMAS)
+
+
+# ── acceptance② — a new schema kind with no citation goes red ────────────
+
+
+def test_a_new_schema_kind_with_no_citation_is_flagged() -> None:
+    """Tier 2: acceptance② — the exact #5167 shape reproduced
+    synthetically: a hypothetical 10th declarable kind
+    (`builtin:external:new_thing`) with NO matching registry entry must
+    appear in the diff. Without this check, a future PR could add a
+    schema entry and this gate would stay silently green ("empty today"
+    read as "always empty"), the architect's own named risk
+    (issuecomment-5384661356: "これが無いと『今空だから緑』")."""
+    schemas = dict(BUILTIN_HOOK_SCHEMAS)
+    schemas["builtin:external:new_thing"] = frozenset({"point"})
+    offenders = find_undeclared_reachability(schemas=schemas)
+    assert offenders == ["builtin:external:new_thing"]
+
+
+def test_a_new_schema_kind_with_a_citation_is_not_flagged() -> None:
+    """Tier 2: the accept-side of② — adding BOTH the schema entry and its
+    citation in the same change clears the gate, proving the check is a
+    genuine set diff and not an unconditional "any change to schemas
+    fails" trip-wire."""
+    schemas = dict(BUILTIN_HOOK_SCHEMAS)
+    schemas["builtin:external:new_thing"] = frozenset({"point"})
+    registry = dict(REACHABLE_WITHOUT_LLM_TURN)
+    registry["builtin:external:new_thing"] = "some/real/path.py:1 — real witness"
+    offenders = find_undeclared_reachability(schemas=schemas, registry=registry)
+    assert offenders == []
+
+
+# ── acceptance③ — an LLM-tool-only producer must not count as reachable ──
+
+
+def test_task_settled_citation_is_not_the_llm_tool_only_producer() -> None:
+    """Tier 2: acceptance③, the #5167-trap witness — `task_settled` has
+    TWO real producers (inter_agent_messaging.py's run_prompt(collect=
+    "async") settle branch, LLM-tool-invoked; pipeline_executor_driver.py's
+    Pipeline-settle branch, config-driven). The registered citation must
+    point at the config-driven one, NOT the LLM-tool-invoked one — citing
+    the wrong producer here would silently reproduce #5167's own defect
+    one kind later, just with the gate reporting green over it."""
+    citation = REACHABLE_WITHOUT_LLM_TURN["builtin:task:task_settled"]
+    assert citation.startswith("runtime/services/pipeline_executor_driver.py"), (
+        f"task_settled's citation must be ANCHORED on the config-driven "
+        f"pipeline settle path (not merely mention it in passing), got: "
+        f"{citation!r}"
+    )
+    assert 'run_prompt(collect="async")' in citation and "LLM-tool-invoked" in citation, (
+        "the citation must explicitly name and reject the LLM-tool-gated "
+        f"producer, not merely omit it — got: {citation!r}"
+    )
+
+
+def test_a_citation_naming_only_an_llm_gated_path_would_not_be_caught_mechanically() -> None:
+    """Tier 2: disclosed limitation, not a defect — this gate's registry
+    is HAND-maintained (mirrors DYNAMIC_KIND_EMIT_SITES's own trust
+    boundary, see the gate module's own docstring); it cannot mechanically
+    verify a citation's PROSE is truthful, only that a citation EXISTS.
+    A reviewer misreading an LLM-gated call site as a valid witness would
+    still pass this gate — the previous test is what actually holds
+    task_settled's citation honest, not this mechanism. Documented here
+    so the boundary is explicit, not implied."""
+    registry = {"builtin:task:task_settled": "a plausible-looking but wrong citation"}
+    offenders = find_undeclared_reachability(
+        schemas={"builtin:task:task_settled": frozenset()}, registry=registry,
+    )
+    assert offenders == [], (
+        "the mechanism only checks presence, not truthfulness — by design, "
+        "see this test's own docstring"
+    )
+
+
+# ── acceptance④ — config-dependent reachability is NOT a false positive ──
+
+
+def test_config_dependent_kinds_have_registered_witnesses() -> None:
+    """Tier 2: acceptance④ — file_changed/cron_fired/webhook_received/
+    mcp_resource_updated only actually FIRE under specific operator
+    configuration (fs_watch.paths set, a cron job scheduled, a webhook
+    configured, a concrete-matcher hook declared) — but the CODE PATH is
+    unconditional, so all 4 must be present in the registry (the gate
+    must not treat "config-gated" as equivalent to "LLM-gated")."""
+    config_dependent = {
+        "builtin:external:file_changed",
+        "builtin:external:cron_fired",
+        "builtin:external:webhook_received",
+        "builtin:external:mcp_resource_updated",
+    }
+    assert config_dependent <= set(REACHABLE_WITHOUT_LLM_TURN)
+    # Non-vacuity: confirm these are real declarable kinds too, not a
+    # set this test invented independently of the schema.
+    assert config_dependent <= set(BUILTIN_HOOK_SCHEMAS)
+
+
+# ── acceptance⑤ — the failure message names exactly 2 remedies, never an allowlist ──
+
+
+def test_failure_message_names_exactly_two_remedies_never_an_allowlist() -> None:
+    """Tier 2: acceptance⑤ — architect ruling (issuecomment-5384661356):
+    the only 2 legitimate repairs are (a) build reachability or (b) drop
+    the kind from the declarable schema; an allowlist/exemption must
+    never be offered as a way out. Drives the real `main()` with a
+    monkeypatched schema (a synthetic gap) and reads the real printed
+    message."""
+    import io
+    from contextlib import redirect_stderr, redirect_stdout
+
+    import scripts.check_hooks_declared_reachable as gate_module
+
+    original = gate_module.BUILTIN_HOOK_SCHEMAS
+    try:
+        gate_module.BUILTIN_HOOK_SCHEMAS = dict(original) | {
+            "builtin:external:new_thing": frozenset({"point"}),
+        }
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = gate_module.main()
+    finally:
+        gate_module.BUILTIN_HOOK_SCHEMAS = original
+
+    assert code == 1
+    message = err.getvalue()
+    assert "builtin:external:new_thing" in message
+    assert "(a)" in message and "(b)" in message, (
+        f"expected exactly 2 lettered remedies in the failure message, "
+        f"got: {message!r}"
+    )
+    assert "(c)" not in message
+    assert "allowlist" in message.lower(), (
+        "the message must explicitly name and reject allowlist as a "
+        "non-option, not merely omit it"
+    )
+    assert "not a third option" in message or "not an option" in message.lower() or (
+        "allowlist" in message.lower() and "not" in message.lower()
+    )
+
+
+def test_a_clean_registry_reports_ok_and_exits_zero() -> None:
+    """Tier 2: accept-side of⑤ — the real, unmodified registries print an
+    OK line and exit 0, driven through the real `main()`."""
+    import io
+    from contextlib import redirect_stdout
+
+    from scripts.check_hooks_declared_reachable import main
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        code = main()
+    assert code == 0
+    assert "OK" in out.getvalue()
+
+
+# ── the gate script actually runs cleanly as a subprocess ────────────────
+
+
+def test_the_gate_script_runs_clean_as_a_real_subprocess() -> None:
+    """Tier 2: the same "run it before shipping it" discipline the
+    approval-ledger/TUI-widget boundary gates use — a real subprocess
+    invocation, not just an in-process function call, since that's how
+    CI actually exercises this script."""
+    gate_script = REPO_ROOT / "scripts" / "check_hooks_declared_reachable.py"
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT / "src")
+    result = subprocess.run(
+        [sys.executable, str(gate_script)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"gate script failed as a real subprocess: stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout


### PR DESCRIPTION
**[e2e-coder]** — part of #5190

Architect ruling (issuecomment-5384661356): a hook `on:` kind `hooks.yaml` can declare (`reyn.hooks.schema_registry.BUILTIN_HOOK_SCHEMAS`) with no code path that reaches it WITHOUT an LLM turn is the exact #5167 defect class — a schema-valid hook that silently never fires for any agent whose model never happens to call a specific tool. "Intentionally declare-only, no reachability yet" is not a legitimate state — a schema is an advertisement, and reyn must not advertise what it cannot honor.

## The gate

`scripts/check_hooks_declared_reachable.py`:

- **set A**: `BUILTIN_HOOK_SCHEMAS`'s own keys (the 9 declarable kinds) — imported directly, never hand-duplicated.
- **set B**: `REACHABLE_WITHOUT_LLM_TURN`, a hand-maintained, cited registry (one entry per kind, real file:line + reachability class) mirroring `event_schema.DYNAMIC_KIND_EMIT_SITES`'s own "classified, reviewed, not scanner-derived" trust boundary. "Reachable without an LLM turn" needs the same human judgment #5167 itself needed — a real `build_hook_payload` call site existed for `mcp_resource_updated` the whole time; the defect was that its ONLY path required the LLM to choose a specific tool first, invisible to an AST emit-site census.
- **gate** = A − B; a member of A missing from B fails, printing exactly 2 remedies (build reachability / drop from the declarable schema) and explicitly naming-and-rejecting an allowlist as a non-option — never offered, per architect's ruling that a sanctioned "advertised but permanently unreachable" state is the defect itself, not an acceptable degrade.

Today's diff is empty: all 9 kinds have a real, cited non-LLM path (session lifecycle, the turn loop itself, config-driven ingress — fs_watch/cron/webhook — or #5167's own auto-subscribe fix for `mcp_resource_updated`).

## The #5167-trap witness (acceptance③)

`task_settled` has two real producers — `InterAgentMessaging`'s `run_prompt(collect="async")` settle branch (LLM-tool-invoked) and `PipelineExecutorDriver`'s config-driven settle branch (a Pipeline launched via the `pipeline_launch` hook action, attachable to any non-LLM hook point). The registered citation is deliberately anchored on the latter — citing the LLM-tool-invoked producer as the sole witness would silently reproduce #5167's own trap one kind later, just with this gate reporting green over it. A dedicated test asserts the citation names the right producer.

## No new workflow file

Mirrors `check_approval_ledger_import_boundary.py`'s own precedent (no standalone `.github/workflows/*.yml` either) — exercised through the test suite's real subprocess + in-process calls, the same as that gate.

## Strip-falsify

Removed `mcp_resource_updated`'s citation (the real, historically-defective kind) — 7/10 tests correctly flipped red, and a direct script run correctly flagged exactly that kind. Restored to green.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_hooks_declared_reachable_5190.py` — 10/10 OK, 0 Tier-4
- [x] `python scripts/mypy_ratchet.py` — 201/207 baselined, no new
- [x] `python scripts/verify_module_docstrings.py scripts/check_hooks_declared_reachable.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] `pytest tests/scripts/` — 955/955 passed (whole tree, no regressions)
- [x] `pytest -k "5167 or hooks_schema or schema_registry"` — 16/16 passed
- [x] (skipped — Visual, standing waiver, owner 2026-08-08)

Touches `tests/` — needs a TESTS-READ note before merge; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)