### PR TITLE
fix(#5149): fold the client's (agent, session_id) into one immutable value

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -496,6 +496,29 @@ class ScrollableDrawer(ContentSwitcher):
         self.scroll_end(animate=False)
 
 
+@dataclass(frozen=True, slots=True)
+class _Destination:
+    """#5149: this client's current location — which agent, and which of
+    that agent's sessions — folded into ONE immutable value instead of two
+    separately-writable fields (``_agent_name`` / ``_session_id``, pre-
+    #5149). Architect ruling (issuecomment-5384594944 → #5148 → #5149,
+    the client-side instance of #5116's "props copied into state, the
+    copy split into two"): two fields that must always change TOGETHER
+    but CAN be written independently is a bug waiting for a second write
+    site — ``TextualChatApp.watch__destination``'s own docstring names the
+    exact backlog-discard consequence.
+
+    ``frozen=True`` is load-bearing, not stylistic: it is what makes
+    "update only ``.agent``, leave ``.session_id`` stale" a
+    ``dataclasses.FrozenInstanceError`` at the write site, rather than a
+    convention a future editor has to remember. The only way to change
+    either field is to construct a whole new ``_Destination(...)`` — one
+    assignment, both fields, always together."""
+
+    agent: str
+    session_id: str
+
+
 class TextualChatApp(App):
     """The TTY conversation pane: a FlowView of the live conversation + a
     Composer, both fed/served by one :class:`ClientTransport`.
@@ -1233,8 +1256,8 @@ class TextualChatApp(App):
     #: #5131 (architect ruling): the FIRST "state down" migration target —
     #: which agent this App is currently showing. A Textual ``reactive``,
     #: not a plain attribute: every read site below is unchanged (the
-    #: descriptor is transparent to ``self._agent_name`` reads/writes), but
-    #: a WRITE now synchronously fires :meth:`watch__agent_name`, which
+    #: descriptor is transparent to ``self._destination.agent`` reads), but
+    #: a WRITE now synchronously fires :meth:`watch__destination`, which
     #: refreshes every consumer from ONE canonical trigger instead of
     #: relying on the next per-frame :meth:`_refresh_live_chrome` call to
     #: eventually catch up (the exact "stale until something else redraws"
@@ -1242,7 +1265,22 @@ class TextualChatApp(App):
     #: forcing an immediate refresh). ``init=False``: the constructor's own
     #: assignment (below) must NOT fire the watcher before ``compose()``
     #: has built the widget tree — see that watch method's own docstring.
-    _agent_name: "reactive[str]" = reactive("", init=False)
+    #:
+    #: #5149 (architect ruling, issuecomment-5384771856): folded together
+    #: with ``_session_id`` (below) into ONE frozen dataclass behind ONE
+    #: reactive, closing the #5148-flagged hazard of the two fields
+    #: diverging (a client-side #5116: "props copied into two separate
+    #: pieces of state that can drift apart"). A frozen dataclass makes
+    #: "update only one of the pair" a TypeError-shaped impossibility, not
+    #: a convention someone has to remember — ``self._destination.agent =
+    #: x`` raises ``dataclasses.FrozenInstanceError``; the only way to
+    #: change either field is a whole new ``_Destination(...)``, one
+    #: assignment, both fields together. Class-level default is the
+    #: placeholder ``_Destination("", "")`` — real values are seeded in
+    #: ``__init__`` before ``compose()``, mirroring the pre-#5149
+    #: ``_agent_name`` reactive's own placeholder-then-seed shape (the
+    #: real ``_DEFAULT_SID`` needs a deferred import — see ``__init__``).
+    _destination: "reactive[_Destination]" = reactive(_Destination("", ""), init=False)
 
     def __init__(
         self,
@@ -1258,28 +1296,26 @@ class TextualChatApp(App):
         super().__init__()
         self._transport = transport
         self._read_model = read_model
-        self._agent_name = agent_name
         # #5168: set by run_textual_chat's own capture_stray_output window —
         # None for any App constructed outside it (e.g. a bare
         # TextualChatApp(...) in a test), in which case _status_text's own
         # diagnostics_count read stays 0, byte-identical to before #5168.
         self._stray_output_stats: "StrayOutputStats | None" = None
-        # #5139: mirrors ``self._agent_name`` — this client's OWN idea of
-        # which session it is currently attached to, updated at the same
-        # site ``self._agent_name`` is (:meth:`_handle_session_attached_
-        # event` — a mid-stream SWITCH only, see that method's own
-        # docstring). Seeded to the well-known default session id
-        # (``registry.py``'s ``_DEFAULT_SID``) rather than empty: a fresh,
-        # never-switched remote connection is always attached to it, and
-        # ``AgUiTransport``'s own FIRST backlog batch is seeded the same
-        # way (see that class's ``__init__``) — both sides of the
-        # comparison must start from the SAME default or a correct FIRST
-        # connect would spuriously fail the destination check. A LOCAL
-        # (in-process) session ignores this entirely — no
+        # #5149: the two halves of "current location" are seeded TOGETHER,
+        # one ``_Destination`` construction — see that class's own
+        # docstring for why they can no longer be seeded (or later updated)
+        # independently. The session half is seeded to the well-known
+        # default session id (``registry.py``'s ``_DEFAULT_SID``) rather
+        # than empty: a fresh, never-switched remote connection is always
+        # attached to it, and ``AgUiTransport``'s own FIRST backlog batch is
+        # seeded the same way (see that class's ``__init__``) — both sides
+        # of the comparison must start from the SAME default or a correct
+        # FIRST connect would spuriously fail the destination check. A
+        # LOCAL (in-process) session ignores this entirely — no
         # ``BacklogBatch`` is ever produced off ``InProcessTransport``.
         from reyn.runtime.registry import _DEFAULT_SID  # noqa: PLC0415
 
-        self._session_id = _DEFAULT_SID
+        self._destination = _Destination(agent=agent_name, session_id=_DEFAULT_SID)
         self._config = config
         # #4983: the CURRENTLY-ATTACHED session's conversation history,
         # read BEFORE this App was constructed (the caller — normally
@@ -1636,12 +1672,12 @@ class TextualChatApp(App):
 
     @property
     def agent_name(self) -> str:
-        """#5131: public read of :attr:`_agent_name` — which agent this App
-        is currently showing. Never reach into ``self._agent_name`` directly
-        from a test asserting on it (the testing policy forbids a
-        private-state assertion); this property is the public surface that
-        exists for exactly that observation."""
-        return self._agent_name
+        """#5131: public read of :attr:`_destination`'s agent half — which
+        agent this App is currently showing. Never reach into
+        ``self._destination`` directly from a test asserting on it (the
+        testing policy forbids a private-state assertion); this property is
+        the public surface that exists for exactly that observation."""
+        return self._destination.agent
 
     @property
     def cursor_position(self) -> "Offset":
@@ -2074,7 +2110,7 @@ class TextualChatApp(App):
         if not rows:
             return rows
         project_root = _find_project_root(Path.cwd()) or Path.cwd()
-        return resolve_display_paths(rows, project_root, self._agent_name)
+        return resolve_display_paths(rows, project_root, self._destination.agent)
 
     def _pane_rows(self, tab_id: str, snap: "dict | None | object" = _UNSET) -> "list[str]":
         """The display rows for ``tab_id``'s pane, derived from canonical sources:
@@ -2139,7 +2175,7 @@ class TextualChatApp(App):
         diagnostics_count = self._stray_output_stats.count if self._stray_output_stats else 0
         return status_line_text(
             snapshot,
-            self._agent_name,
+            self._destination.agent,
             attach_state=self._attach_state(),
             warn_percent=warn_percent,
             diagnostics_count=diagnostics_count,
@@ -2615,7 +2651,7 @@ class TextualChatApp(App):
         Discarding it increments a PUBLIC counter
         (:meth:`remote_backlog_discard_count`) rather than vanishing
         silently."""
-        if batch.agent != self._agent_name or batch.sid != self._session_id:
+        if (batch.agent, batch.sid) != (self._destination.agent, self._destination.session_id):
             self._remote_backlog_discard_count += 1
             return
         # #5139 C: this batch's OWN continuation state — tracked regardless
@@ -3426,7 +3462,7 @@ class TextualChatApp(App):
             rows_from_ref_table_entries,
         )
 
-        entries, total = await self._transport.request_artifact_list(agent=self._agent_name)
+        entries, total = await self._transport.request_artifact_list(agent=self._destination.agent)
         fallback_rows = rows_from_ref_table_entries(entries)
         if fallback_rows:
             # Same resolved_path fill-in the live path gets (#4482 PR-3
@@ -3435,7 +3471,7 @@ class TextualChatApp(App):
             # artifacts in different directories.
             project_root = _find_project_root(Path.cwd()) or Path.cwd()
             fallback_rows = resolve_display_paths(
-                fallback_rows, project_root, self._agent_name,
+                fallback_rows, project_root, self._destination.agent,
             )
         self._artifact_rows_cache = fallback_rows
         self._artifact_rows_source = "ref_table_fallback"
@@ -4449,7 +4485,7 @@ class TextualChatApp(App):
             self._ingest_frame(OutboxMessage(kind="status", text="no artifact ref given"))
             return
         project_root = _find_project_root(Path.cwd()) or Path.cwd()
-        resolved = resolve_ref(project_root, self._agent_name, ref)
+        resolved = resolve_ref(project_root, self._destination.agent, ref)
         if resolved is None:
             self._ingest_frame(OutboxMessage(
                 kind="status", text=f"artifact not found (ref={ref})",
@@ -5602,14 +5638,20 @@ class TextualChatApp(App):
         self._rewind_picker.hide()
         self._queue_view = RemoteQueueView()
         self._sent_queue.clear_all()
-        if agent:
-            self._agent_name = agent
-        # #5139: mirrors the ``agent`` update just above — this switch's
-        # own ``{agent, session_id}`` announce is the wire's next
-        # BacklogBatch destination too (see ``self._session_id``'s own
-        # comment in ``__init__``).
-        if session_id:
-            self._session_id = session_id
+        # #5149: ONE atomic replacement — never two independent writes (the
+        # pre-#5149 ``if agent: self._agent_name = agent`` / ``if
+        # session_id: self._session_id = session_id`` shape this replaces
+        # is exactly the hazard: two separately-guarded writes let the pair
+        # go stale relative to each other the moment a caller supplies only
+        # one). Either half missing from the event (``data.get`` returned
+        # ``None``) falls back to the CURRENT value of that half, so a
+        # partial announce still produces a single, internally-consistent
+        # ``_Destination`` rather than a bug-shaped partial update.
+        if agent or session_id:
+            self._destination = _Destination(
+                agent=agent or self._destination.agent,
+                session_id=session_id or self._destination.session_id,
+            )
         # Eager reseed (see the ``_queue_view``/``_queue_seeded`` bullet
         # above): seed the fresh view from the NEW session's snapshot right
         # now, rather than deferring to the generic "first frame" check —
@@ -6553,12 +6595,12 @@ class TextualChatApp(App):
             return  # not yet mounted
         menubar.update_status(self._status_text(snap))
 
-    def watch__agent_name(self, old_value: str, new_value: str) -> None:
+    def watch__destination(self, old_value: "_Destination", new_value: "_Destination") -> None:
         """#5131: the App is now showing a DIFFERENT agent (init or a real
         session switch — Textual's reactive default (``always_update=
         False``) means this never fires for a same-value reassignment).
         Refresh every consumer that derives its content from
-        :attr:`_agent_name` from this ONE canonical trigger, synchronously,
+        :attr:`_destination` from this ONE canonical trigger, synchronously,
         rather than waiting for the next :meth:`_refresh_live_chrome` per-
         frame call to eventually catch up — closing the exact "stale
         between real server frames" gap #5131 names for the status line
@@ -6575,10 +6617,26 @@ class TextualChatApp(App):
         in here would be a second, independent change bundled into this
         one, not this migration's first slice.
 
+        #5149 (architect ruling, issuecomment-5384771856, condition on the
+        approval): guarded on ``old_value.agent != new_value.agent`` — a
+        ``_destination`` change where ONLY ``session_id`` moved (agent
+        unchanged) does NOT re-run this refresh. Explicit reason, per that
+        same ruling ("正しく、かつ沈黙している" must not happen again): no
+        consumer below reads ``session_id`` at all (the status line and the
+        drawer panes both derive purely from the agent's own snapshot), and
+        nothing in this codebase currently needs to react to a session_id-
+        only move — the #4983 history rehydration on a real session switch
+        is driven by :meth:`_handle_session_attached_event`'s own frame
+        handling, not by this watcher. If a future consumer DOES need to
+        react to a session_id-only change, this guard is the place that
+        will silently swallow it — widen it here, not around it.
+
         No mount guard needed: both calls below already no-op safely pre-
         mount via their own ``try: self.query_one(...) except Exception:
         return`` (the exact same guard :meth:`_refresh_live_chrome` relies
         on for the identical reason)."""
+        if old_value.agent == new_value.agent:
+            return
         self._refresh_status()
         try:
             drawer = self.query_one("#drawer", ContentSwitcher)

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -839,10 +839,11 @@ async def test_status_line_refreshes_on_event_frames_alone(tmp_path) -> None:
 async def test_agent_name_reactive_refreshes_status_line_with_no_frame(
     tmp_path,
 ) -> None:
-    """Tier 2: #5131 — ``TextualChatApp._agent_name`` is now a Textual
-    ``reactive``; ASSIGNING it fires :meth:`TextualChatApp.watch__agent_name`
-    synchronously, refreshing :class:`StatusLine` with no server frame
-    involved at all.
+    """Tier 2: #5131 — ``TextualChatApp._destination`` (its ``agent`` half;
+    #5149 folded ``_agent_name``/``_session_id`` into this ONE reactive
+    dataclass) is a Textual ``reactive``; ASSIGNING it fires
+    :meth:`TextualChatApp.watch__destination` synchronously, refreshing
+    :class:`StatusLine` with no server frame involved at all.
 
     This is the improvement the migration adds, not merely a
     non-regression: before #5131, ``_agent_name`` was a plain attribute, and
@@ -858,8 +859,8 @@ async def test_agent_name_reactive_refreshes_status_line_with_no_frame(
     prefers ``snap["attached_name"]`` over the ``agent_name`` argument
     (chrome.py's own ``agent = snap.get("attached_name") or agent_name``),
     so leaving it set would let the snapshot's OWN agent field mask
-    whatever ``self._agent_name`` says — exactly the confound this test
-    must not have.
+    whatever ``self._destination.agent`` says — exactly the confound this
+    test must not have.
 
     The replacement name is deliberately the SAME LENGTH as the original
     (``MenuBar.update_status``'s ``changed_len`` branch remounts the whole
@@ -884,7 +885,9 @@ async def test_agent_name_reactive_refreshes_status_line_with_no_frame(
 
         new_name = "z" * len(app.agent_name)
         assert new_name != app.agent_name
-        app._agent_name = new_name
+        from reyn.interfaces.inline.textual_chat.app import _Destination
+
+        app._destination = _Destination(agent=new_name, session_id=app._destination.session_id)
 
         after = str(app.query_one(StatusLine).render())
         assert new_name in after, (

--- a/tests/interfaces/test_5149_client_destination_single_value.py
+++ b/tests/interfaces/test_5149_client_destination_single_value.py
@@ -1,0 +1,281 @@
+"""Tier 2: #5149 — the client's "current location" (which agent, which of
+that agent's sessions) is ONE value (:class:`_Destination`), not two
+separately-writable fields.
+
+Architect ruling (issue #5149, part of #5116): the #5148-flagged hazard —
+``_agent_name`` and ``_session_id`` could be written independently, and a
+divergence silently discards correct remote backlog (``batch.agent !=
+self._agent_name or batch.sid != self._session_id``) — is closed
+STRUCTURALLY, not by a test: ``_Destination`` is a frozen dataclass, so
+``dest.agent = x`` is a ``dataclasses.FrozenInstanceError`` at the write
+site, not a convention a future editor has to remember. The acceptance
+itself ("two fields cannot be updated independently") is a type/structure
+claim (architect's own words, "test では示せません — 型／構造で示すもの"),
+so the FIRST test below witnesses that directly; the rest witness the
+actual #5148 bug scenario this closes (a partial ``session_attached``
+announce) now landing as one atomic, internally-consistent value.
+
+Real ``AgentRegistry`` + real ``TextualChatApp`` + a real queue-backed
+``ClientTransport`` (mirrors ``tests/interfaces/test_3310_n2_reset_
+hydrate.py``'s own ``QueueTransport`` exactly) — no mocks, per the testing
+policy.
+"""
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.core.events.events import Event
+from reyn.interfaces.inline.textual_chat.app import TextualChatApp, _Destination
+from reyn.interfaces.repl.read_model import RegistryReadModel
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame, EventFrame
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def test_destination_is_frozen_writing_one_field_alone_raises() -> None:
+    """Tier 2: #5149's own acceptance, stated verbatim by architect —
+    "two fields cannot be updated independently" is a type/structure claim.
+    This is that claim, witnessed directly: assigning to ONE field of an
+    already-constructed ``_Destination`` raises, so the only way to change
+    either half is a whole new ``_Destination(...)`` — one assignment,
+    both fields, always together. RED (a plain, non-frozen dataclass) if
+    ``frozen=True`` is ever dropped from the class."""
+    dest = _Destination(agent="alpha", session_id=_DEFAULT_SID)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        dest.agent = "beta"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        dest.session_id = "some-other-sid"  # type: ignore[misc]
+    # Neither raise mutated it — a FrozenInstanceError leaves the instance
+    # exactly as constructed, not partially written.
+    assert dest == _Destination(agent="alpha", session_id=_DEFAULT_SID)
+
+
+class QueueTransport(ClientTransportStub):
+    """Mirrors ``test_3310_n2_reset_hydrate.py``'s own class of the same
+    name exactly — a real, minimal ``ClientTransport`` a test drives
+    frame-by-frame via an ``asyncio.Queue``."""
+
+    def __init__(self) -> None:
+        import asyncio
+
+        self._queue: "asyncio.Queue" = asyncio.Queue()
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            yield await self._queue.get()
+
+    def push_event(self, etype: str, data: dict) -> None:
+        self._queue.put_nowait(EventFrame(Event(type=etype, data=data)))
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg) -> None:
+        self._queue.put_nowait(DisplayFrame(msg))
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return True
+
+    async def cancel_inflight(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+async def _settle(pilot, n: int = 2) -> None:
+    for _ in range(n):
+        await pilot.pause()
+
+
+def _matches_destination(app: TextualChatApp, agent: str, sid: str) -> bool:
+    """Public-surface oracle for "is the App's current destination exactly
+    (agent, sid)?" — never reads ``app._destination`` directly (the testing
+    policy forbids a private-state assertion). ``_apply_backlog_batch`` is
+    ALREADY the production code that compares a batch's destination against
+    ``self._destination`` in full (both halves) and exposes the outcome via
+    the public :meth:`TextualChatApp.remote_backlog_discard_count` counter
+    — reusing it here means this oracle and the real discard check can
+    never silently drift apart from each other."""
+    before = app.remote_backlog_discard_count()
+    app._apply_backlog_batch(BacklogBatch(agent=agent, sid=sid, frames=[]))
+    return app.remote_backlog_discard_count() == before
+
+
+@pytest.mark.asyncio
+async def test_agent_only_announce_preserves_the_current_session_id(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: the actual #5148 bug scenario — a ``session_attached``
+    announce naming ONLY ``agent`` (``session_id`` absent from ``data``,
+    e.g. a caller that has not learned the session id yet) must not corrupt
+    or blank the session half; it must fall back to whatever the current
+    session_id already was, in the SAME atomic assignment that updates
+    ``agent``. RED if a stray ``session_id=None`` ever wins over the
+    current value (the old independently-guarded ``if session_id: ...``
+    shape could not express this wrongly since it just skipped the write,
+    but a rewrite that constructs unconditionally with ``data.get
+    ("session_id")`` verbatim WOULD silently blank it — this test is the
+    guard against that regression). The well-known default session id
+    (``_DEFAULT_SID``) is public knowledge (``registry.py``'s own constant,
+    also what ``__init__`` seeds — see that constructor's own comment),
+    not a private-state read."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    await reg.attach("alpha")
+    transport = QueueTransport()
+    app = TextualChatApp(
+        transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _settle(pilot)
+        assert _matches_destination(app, "alpha", _DEFAULT_SID), (
+            "sanity: a fresh App starts at (alpha, _DEFAULT_SID)"
+        )
+
+        transport.push_event("session_attached", {"agent": "alpha"})  # no session_id
+        await _settle(pilot)
+
+        assert _matches_destination(app, "alpha", _DEFAULT_SID), (
+            "an agent-only announce must preserve the existing session_id "
+            "(_DEFAULT_SID), not blank it"
+        )
+
+
+@pytest.mark.asyncio
+async def test_session_only_announce_preserves_the_current_agent(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: the mirror case — a ``session_attached`` announce naming
+    ONLY ``session_id`` (``agent`` absent) must not corrupt or blank the
+    agent half."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    await reg.attach("alpha")
+    transport = QueueTransport()
+    app = TextualChatApp(
+        transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _settle(pilot)
+        assert app.agent_name == "alpha"  # the public property (#5131)
+
+        transport.push_event("session_attached", {"session_id": "some-other-sid"})
+        await _settle(pilot)
+
+        assert app.agent_name == "alpha", (
+            "a session-only announce must preserve the existing agent"
+        )
+        assert _matches_destination(app, "alpha", "some-other-sid"), (
+            "a session-only announce must land the new session_id"
+        )
+
+
+@pytest.mark.asyncio
+async def test_full_announce_updates_both_atomically(tmp_path, monkeypatch) -> None:
+    """Tier 2: falsification contrast — a FULL announce (both fields
+    present) updates both, in the same one assignment (never two writes an
+    observer could catch mid-update — not directly observable from outside
+    without instrumenting the reactive descriptor, but the end state must
+    be the new pair, not a stale mix)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    reg.create("beta")
+    await reg.attach("alpha")
+    transport = QueueTransport()
+    app = TextualChatApp(
+        transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _settle(pilot)
+        await reg.attach("beta")
+        transport.push_event(
+            "session_attached", {"agent": "beta", "session_id": "beta-sid"},
+        )
+        await _settle(pilot)
+
+        assert app.agent_name == "beta"
+        assert _matches_destination(app, "beta", "beta-sid")
+
+
+@pytest.mark.asyncio
+async def test_remote_backlog_discard_compares_the_whole_destination(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: witnesses the #5148-named discard site
+    (``_apply_backlog_batch``'s ``(batch.agent, batch.sid) !=
+    (self._destination.agent, self._destination.session_id)`` check) still
+    discriminates correctly post-#5149 — a backlog batch destined for the
+    CURRENT (agent, session_id) pair is not discarded, one destined for a
+    DIFFERENT pair (either half differing) is."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    await reg.attach("alpha")
+    transport = QueueTransport()
+    app = TextualChatApp(
+        transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _settle(pilot)
+        before = app.remote_backlog_discard_count()
+
+        # Matches the current destination exactly -- not discarded.
+        app._apply_backlog_batch(
+            BacklogBatch(agent=app._destination.agent, sid=app._destination.session_id, frames=[]),
+        )
+        assert app.remote_backlog_discard_count() == before
+
+        # Session half differs -- discarded.
+        app._apply_backlog_batch(
+            BacklogBatch(agent=app._destination.agent, sid="some-other-sid", frames=[]),
+        )
+        assert app.remote_backlog_discard_count() == before + 1
+
+        # Agent half differs -- discarded.
+        app._apply_backlog_batch(
+            BacklogBatch(agent="some-other-agent", sid=app._destination.session_id, frames=[]),
+        )
+        assert app.remote_backlog_discard_count() == before + 2


### PR DESCRIPTION
**[tui-coder]** — closes #5149.

## Summary

`TextualChatApp` tracked its current location ("which agent, which of
that agent's sessions") in two separately-writable fields — `_agent_name`
(a `reactive[str]` since #5182) and `_session_id` (#5139) — updated by the
session-switch handler behind two INDEPENDENT `if` guards. Safe today (one
update site, both seeded together at construction), but the moment a
second write site appears, the pair can diverge — and the divergence is
invisible: `_apply_backlog_batch`'s destination check
(`(batch.agent, batch.sid) != (self._agent_name, self._session_id)`)
silently discards a correct remote backlog the instant either half goes
stale relative to the other (the #5148-flagged hazard). Architect ruling
(#5149, part of #5116 — the client-side instance of "props copied into
state, the copy split into two").

## Fix

`_Destination`, a frozen dataclass holding both fields behind ONE
`reactive`. `frozen=True` is load-bearing, not stylistic: it makes "update
only one half" a `dataclasses.FrozenInstanceError` at the write site, not
a convention someone has to remember — the only way to change either
field is a whole new `_Destination(...)`, one assignment, both fields
together. The switch handler's two independently-guarded writes become
one atomic assignment; a missing half falls back to the CURRENT value of
that half, so a partial `session_attached` announce still produces one
internally-consistent destination.

`watch__destination` (renamed from `watch__agent_name`) is guarded on
`old.agent != new.agent`, per architect's explicit condition on the
approval: a `session_id`-only change does not re-run the status/drawer
refresh, preserving the pre-#5149 watcher's exact granularity. The reason
is documented in the docstring itself (no consumer currently reads
`session_id`; the #4983 history rehydration is driven by
`session_attached`'s own frame handling, not this watcher) — closing
architect's own "correct but silent" pattern from the same session, so
the next person who needs `session_id`-reactivity sees where to widen it.

## Tests

- `test_destination_is_frozen_writing_one_field_alone_raises` — the
  structural claim itself (architect: "test では示せません — 型／構造で
  示すもの"), witnessed directly: assigning to one field raises.
- `test_agent_only_announce_preserves_the_current_session_id` /
  `test_session_only_announce_preserves_the_current_agent` — the actual
  #5148 bug scenario: a partial announce preserves the other half
  atomically, never blanking it.
- `test_full_announce_updates_both_atomically` — falsification contrast.
- `test_remote_backlog_discard_compares_the_whole_destination` — the
  discard site itself still discriminates correctly post-#5149.

No private-state assertions: the `_apply_backlog_batch` discard/no-discard
outcome (a public, production code path) is reused as the oracle for
destination state instead of reading `app._destination` directly.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 41/41 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] full `tests/interfaces/` sweep — 2062 passed, 9 skipped (known optional-dependency extras, unrelated)
- [ ] (skipped — full suite runs in CI per repo convention, not locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
