### PR TITLE
feat(#4206): declared reload classes for per-agent-profile keys (slice 1)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -222,6 +222,56 @@ not `PREFERENCE_KEYS`.
 > set `project_context_path` to that path; set it to `""` to inject no project
 > context at all.
 
+## Per-agent profile key reload classes (#4206 slice 1)
+
+Every key an agent's own `.reyn/agents/<name>/profile.yaml` can set — the
+surface an operator actually touches when hand-authoring an agent — has a
+declared **reload class**: how soon an edit to that key takes effect.
+Source of truth: `AGENT_PROFILE_RELOAD_CLASSES` in
+`src/reyn/runtime/profile_reload.py` — this table is a projection of that
+dict, not a second hand-written source; a key added there with no
+matching row here (or vice versa) fails
+`tests/runtime/test_4206_slice1_profile_reload_class.py`'s completeness
+gate.
+
+**Scope, explicit**: only per-agent-profile keys. Every OTHER key in the
+[table above](#top-level-keys) stays as documented there — this slice does
+not attempt project-layer or session-layer reload classes.
+
+- **`live`** — re-read on every access, no caching. A caller holding the
+  value across an await must re-read it, never cache it.
+- **`construction-once`** — resolved exactly once per agent, at session
+  construction. An already-running session does not notice a
+  `profile.yaml` edit until its own NEXT construction (next
+  `--connect`/reattach).
+- **`hot`** — changes via an explicit trigger (`/reload`, or an LLM
+  hooks-write op), applied at the next turn boundary — the SAME shape the
+  [table above](#top-level-keys) already names `restart / hot` for
+  project-layer `.reyn/config/`-side writes, reused here rather than
+  inventing a new word for an already-named shape (measured during this
+  slice: `allowed_mcp` fits none of the other 3 classes cleanly).
+- **`restart`** — takes effect only after a full process restart. No
+  slice-1 key currently uses this value.
+
+<!-- BEGIN agent-profile-reload-class -->
+| Key | Reload class |
+|-----|---------------|
+| `role` | `construction-once` |
+| `allowed_mcp` | `hot` |
+| `base_dir` | `live` |
+| `project_context_path` | `construction-once` |
+| `preferences.output_language` | `live` |
+| `preferences.chat.reasoning.display` | `live` |
+| `preferences.cost.per_agent_tokens.warn_ratio` | `live` |
+| `preferences.cost.per_agent_cost_usd.warn_ratio` | `live` |
+| `preferences.cost.daily_tokens.warn_ratio` | `live` |
+| `preferences.cost.daily_cost_usd.warn_ratio` | `live` |
+| `preferences.cost.monthly_tokens.warn_ratio` | `live` |
+| `preferences.cost.monthly_cost_usd.warn_ratio` | `live` |
+| `preferences.cost.rate_limit_warn_ratio` | `live` |
+| `bounding.model` | `live` |
+<!-- END agent-profile-reload-class -->
+
 ## `llm` block
 
 LLM-layer config: model selection (`llm.model` / `llm.models` /

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -244,12 +244,17 @@ not attempt project-layer or session-layer reload classes.
   construction. An already-running session does not notice a
   `profile.yaml` edit until its own NEXT construction (next
   `--connect`/reattach).
-- **`hot`** — changes via an explicit trigger (`/reload`, or an LLM
-  hooks-write op), applied at the next turn boundary — the SAME shape the
-  [table above](#top-level-keys) already names `restart / hot` for
-  project-layer `.reyn/config/`-side writes, reused here rather than
-  inventing a new word for an already-named shape (measured during this
-  slice: `allowed_mcp` fits none of the other 3 classes cleanly).
+- **`explicit-trigger`** — a bare hand-edit of `profile.yaml` does NOTHING
+  on its own; reapply only happens when something else calls
+  `request_reload` (`/reload`, or an LLM hooks-write op), applied at the
+  next turn boundary. **Not** the same as the [table above](#top-level-keys)'s
+  own `restart / hot` — that class's defining property is the file WRITE
+  ITSELF being the trigger (`.reyn/config/`-side writes are picked up
+  automatically at the next turn boundary); `profile.yaml` is not in
+  `_HOT_RELOAD_FILES`, so a hand-edit alone changes nothing until an
+  explicit trigger fires — the opposite polarity from `hot`, hence the
+  different name (measured during this slice: `allowed_mcp` fits none of
+  the other 3 classes cleanly).
 - **`restart`** — takes effect only after a full process restart. No
   slice-1 key currently uses this value.
 
@@ -257,7 +262,7 @@ not attempt project-layer or session-layer reload classes.
 | Key | Reload class |
 |-----|---------------|
 | `role` | `construction-once` |
-| `allowed_mcp` | `hot` |
+| `allowed_mcp` | `explicit-trigger` |
 | `base_dir` | `live` |
 | `project_context_path` | `construction-once` |
 | `preferences.output_language` | `live` |

--- a/src/reyn/runtime/profile_reload.py
+++ b/src/reyn/runtime/profile_reload.py
@@ -19,27 +19,56 @@ Every OTHER config key in `reyn.yaml`'s own reference table stays
 "未移行" (not yet migrated) — this slice does not attempt project-layer
 or session-layer keys.
 
-## The 3 (really 4) reload classes
+## TESTS-READ A finding, folded in (architect, issuecomment-5384894847)
+
+**Block ① (fixed):** the first draft's own docstring claimed the whole
+vocabulary was "derived, never hand-duplicated", but only the
+``preferences``/``bounding`` legs actually were — the 4
+:class:`~reyn.runtime.profile.AgentProfile`-scoped keys
+(``role``/``allowed_mcp``/``base_dir``/``project_context_path``) were a
+hand-typed literal set. A field added to ``AgentProfile`` would have
+silently reached neither this registry NOR the completeness gate's own
+notion of "the real vocabulary" — the exact "declared but the
+completeness check can't see it" hole this whole slice exists to close,
+reproduced one level up in its own implementation.
+:func:`declared_agent_profile_keys` now derives that leg from
+:func:`dataclasses.fields` directly, excluding only the 4 names that are
+NOT independent reload-class questions
+(``name``/``created_at``: identity/audit metadata; ``preferences``/
+``bounding``: expanded into their own dotted keys separately, not
+top-level keys in their own right) — with a witness test confirming each
+excluded name is a REAL field on ``AgentProfile`` (not a bare set-equality
+assert against the same literal on both sides, which would prove nothing
+per CLAUDE.md's 6-questions #2).
+
+**Block ② (fixed):** the first draft reused the project-layer's own
+``hot`` word for ``allowed_mcp``, reasoning it was "the same explicit-
+trigger-then-turn-boundary shape". Architect's own fresh measurement
+(``origin/main``, ``src/``) falsified the analogy: ``profile.yaml`` is
+NOT in ``_HOT_RELOAD_FILES`` — the project-layer ``hot`` class's actual
+defining property is that **the file WRITE ITSELF is the trigger** (the
+fs-watch-driven ``.reyn/config/``-side write is what causes the next-
+turn-boundary re-read, per this doc's own ``Reload`` column intro).
+``allowed_mcp`` is the OPPOSITE: a bare hand-edit of ``profile.yaml``
+does NOTHING on its own — reapply only fires when something ELSE calls
+:func:`~reyn.core.hot_reload.request_reload` (``/reload``, or an LLM
+hooks-write op). Reusing ``hot`` would answer "does editing this file
+alone make the change take effect?" with the WRONG polarity. Renamed to
+``explicit-trigger`` — a new word for a genuinely different mechanism,
+not the same one under a borrowed name.
+
+## The 4 reload classes
 
 Architect named 3: ``live`` / ``construction-once`` / ``restart``. This
-slice's own measurement (not assumed — each key traced to its real read
-call site) found a 4th shape that fits none of the 3 cleanly:
-``allowed_mcp`` is neither read fresh on every access (``live``) nor
-frozen for a session's lifetime (``construction-once``) nor does it need
-a full process restart (``restart``) — it changes via an EXPLICIT
-trigger (``/reload``, or an LLM hooks-write op) applied at the next turn
-boundary (:meth:`~reyn.runtime.session.Session._reapply_per_agent_
-capability`, registered as the ``per_agent_capability`` hot-reload seam).
-This is the SAME "explicit trigger, applied at the next turn boundary,
-never mid-turn" shape ``reyn.yaml``'s own project-layer ``restart / hot``
-vocabulary already names for ``.reyn/config/``-side writes (see
-``docs/reference/config/reyn-yaml.md``'s own intro to that column) — so
-this slice reuses that name, ``hot``, rather than inventing a 5th word for
-an already-named shape. Disclosed here rather than silently forced into
-one of the 3 originally named classes, or silently added without a note
-— architect's own explicit invitation on this issue: "1 件ずつ確かめる
-前提" (measure one at a time; a 3rd class turning out insufficient is an
-expected outcome of that process, not a deviation from it).
+slice's own measurement (each key traced to its real read call site, not
+assumed) found a 4th shape that fits none of the 3: ``allowed_mcp`` is
+neither read fresh on every access (``live``) nor frozen for a session's
+lifetime (``construction-once``) nor does it need a full process restart
+(``restart``) — see ``explicit-trigger``'s own entry below. Disclosed
+here rather than silently forced into one of the 3 originally named
+classes — architect's own explicit invitation on this issue: "1 件ずつ
+確かめる前提" (measure one at a time; a 4th class turning out necessary
+is an expected outcome of that process, not a deviation from it).
 
 - ``LIVE`` — re-read on every access, no caching. A caller holding the
   value across an await must re-read it, never cache it (every LIVE key
@@ -48,9 +77,14 @@ expected outcome of that process, not a deviation from it).
   construction. An already-running session does not notice a
   ``profile.yaml`` edit until its own NEXT construction (next
   ``--connect``/reattach) — neither ``LIVE`` nor a process restart.
-- ``HOT`` — changes via an explicit trigger (``/reload``, or an LLM
-  hooks-write op), applied at the next turn boundary. Hand-editing
-  ``profile.yaml`` alone does nothing until one of those triggers fires.
+- ``EXPLICIT_TRIGGER`` — a bare hand-edit of ``profile.yaml`` does
+  NOTHING on its own; reapply only happens when something else calls
+  :func:`~reyn.core.hot_reload.request_reload` (``/reload``, or an LLM
+  hooks-write op), applied at the next turn boundary. Genuinely different
+  from the project-layer ``restart / hot`` vocabulary's own ``hot`` —
+  THAT class's defining property is the opposite polarity: the file write
+  itself IS the trigger (``profile.yaml`` is not in ``_HOT_RELOAD_FILES``,
+  confirmed against ``origin/main``).
 - ``RESTART`` — takes effect only after a full process restart. No
   slice-1 key currently uses this value; kept in the vocabulary so a
   future key that genuinely needs it has somewhere to declare that,
@@ -65,10 +99,24 @@ docstring, mirroring how the 3 pre-measured examples
 """
 from __future__ import annotations
 
+from dataclasses import fields as dataclass_fields
+
 LIVE = "live"
 CONSTRUCTION_ONCE = "construction-once"
-HOT = "hot"
+EXPLICIT_TRIGGER = "explicit-trigger"
 RESTART = "restart"
+
+#: :class:`~reyn.runtime.profile.AgentProfile` field names that are NOT an
+#: independent "reload class" question — excluded from
+#: :func:`declared_agent_profile_keys`'s derivation. ``name``/``created_at``
+#: are identity/audit metadata (never re-read for behavior);
+#: ``preferences``/``bounding`` are expanded into their own DOTTED keys
+#: below (``preferences.<PREFERENCE_KEYS member>`` /
+#: ``bounding.<BOUNDING_KEYS member>``) rather than named as top-level keys
+#: in their own right — see :func:`declared_agent_profile_keys`.
+_NON_RELOAD_CLASS_FIELDS: "frozenset[str]" = frozenset(
+    {"name", "created_at", "preferences", "bounding"},
+)
 
 #: Every per-agent-profile key this slice measured, declared ONCE here —
 #: the doc's own generated section (see
@@ -76,11 +124,10 @@ RESTART = "restart"
 #: classes" section) and :func:`missing_reload_class_declarations`'s own
 #: completeness gate both read this dict, never a second copy.
 AGENT_PROFILE_RELOAD_CLASSES: "dict[str, str]" = {
-    # AgentProfile's own top-level fields (name/created_at excluded —
-    # identity/audit metadata, not a config value with runtime behavior;
-    # see declared_agent_profile_keys()'s own docstring).
+    # AgentProfile's own top-level fields (name/created_at/preferences/
+    # bounding excluded — see _NON_RELOAD_CLASS_FIELDS).
     "role": CONSTRUCTION_ONCE,  # agent.py: Agent is frozen, built once at construction
-    "allowed_mcp": HOT,  # session.py:_reapply_per_agent_capability, the per_agent_capability seam
+    "allowed_mcp": EXPLICIT_TRIGGER,  # session.py:_reapply_per_agent_capability, the per_agent_capability seam
     "base_dir": LIVE,  # session.py:_workspace_base_dir, "a live re-read on every access"
     "project_context_path": CONSTRUCTION_ONCE,  # registry_bootstrap.py:resolve_agent_project_context, owner ruling B/#3787
     # `preferences.*` — every PREFERENCE_KEYS entry, all resolved through
@@ -104,24 +151,26 @@ AGENT_PROFILE_RELOAD_CLASSES: "dict[str, str]" = {
 
 def declared_agent_profile_keys() -> "set[str]":
     """The real vocabulary :data:`AGENT_PROFILE_RELOAD_CLASSES` must cover
-    — derived, never hand-duplicated: :class:`~reyn.runtime.profile.
-    AgentProfile`'s own non-identity fields, plus every
+    — derived, never hand-duplicated (TESTS-READ A block ①, architect):
+    :class:`~reyn.runtime.profile.AgentProfile`'s own fields, read via
+    :func:`dataclasses.fields` (never a hand-typed literal list — a field
+    added to that dataclass reaches this set for free, no edit here
+    needed), minus :data:`_NON_RELOAD_CLASS_FIELDS`; plus every
     :data:`~reyn.runtime.preferences.PREFERENCE_KEYS` entry (prefixed
     ``preferences.``) and every :data:`~reyn.runtime.bounding.
     BOUNDING_KEYS` entry (prefixed ``bounding.``) — the SAME 2 registries
     :func:`~reyn.runtime.preferences.validate_preferences`/
     :func:`~reyn.runtime.bounding.validate_bounding` already gate
     ``profile.yaml`` writes against, so this vocabulary can never name a
-    key those loaders would themselves reject.
-
-    ``name``/``created_at`` are excluded — identity/audit metadata with no
-    "how often does an edit take effect" question to answer (``name`` IS
-    the agent's own identity key; ``created_at`` is a display-only
-    timestamp, never re-read for behavior)."""
+    key those loaders would themselves reject."""
     from reyn.runtime.bounding import BOUNDING_KEYS
     from reyn.runtime.preferences import PREFERENCE_KEYS
+    from reyn.runtime.profile import AgentProfile
 
-    keys = {"role", "allowed_mcp", "base_dir", "project_context_path"}
+    profile_keys = {
+        f.name for f in dataclass_fields(AgentProfile)
+    } - _NON_RELOAD_CLASS_FIELDS
+    keys = set(profile_keys)
     keys |= {f"preferences.{k}" for k in PREFERENCE_KEYS}
     keys |= {f"bounding.{k}" for k in BOUNDING_KEYS}
     return keys

--- a/src/reyn/runtime/profile_reload.py
+++ b/src/reyn/runtime/profile_reload.py
@@ -1,0 +1,139 @@
+"""#4206 slice 1 — declared reload classes for per-agent-profile keys.
+
+Architect's own diagnosis (issuecomment-5384833640, after 2 rounds of
+self-falsification on this exact question): a hand-maintained (key ×
+layer) doc TABLE for "how often does an edit to this value take effect"
+rots the same way `docs/reference/config/reyn-yaml.md`'s own
+`Declared in` column did before #4206's own gate (`tests/repo/
+test_config_reference_declared_in_4206.py`) — "the same event twice"
+(#5166 / #5175 / #5197 that same night). The fix is the same shape those
+3 landed gates already use: a key DECLARES its own reload class, once,
+here; the doc's own section is a projection of this dict, not a second
+hand-written source that can drift from it.
+
+Scope, explicit (architect's own slice cut): ONLY the keys an agent's own
+``.reyn/agents/<name>/profile.yaml`` can set — the surface an operator
+actually touches when hand-authoring an agent (the #4206 issue's own
+founding motivation: bringing up 2 coder agents by declaration alone).
+Every OTHER config key in `reyn.yaml`'s own reference table stays
+"未移行" (not yet migrated) — this slice does not attempt project-layer
+or session-layer keys.
+
+## The 3 (really 4) reload classes
+
+Architect named 3: ``live`` / ``construction-once`` / ``restart``. This
+slice's own measurement (not assumed — each key traced to its real read
+call site) found a 4th shape that fits none of the 3 cleanly:
+``allowed_mcp`` is neither read fresh on every access (``live``) nor
+frozen for a session's lifetime (``construction-once``) nor does it need
+a full process restart (``restart``) — it changes via an EXPLICIT
+trigger (``/reload``, or an LLM hooks-write op) applied at the next turn
+boundary (:meth:`~reyn.runtime.session.Session._reapply_per_agent_
+capability`, registered as the ``per_agent_capability`` hot-reload seam).
+This is the SAME "explicit trigger, applied at the next turn boundary,
+never mid-turn" shape ``reyn.yaml``'s own project-layer ``restart / hot``
+vocabulary already names for ``.reyn/config/``-side writes (see
+``docs/reference/config/reyn-yaml.md``'s own intro to that column) — so
+this slice reuses that name, ``hot``, rather than inventing a 5th word for
+an already-named shape. Disclosed here rather than silently forced into
+one of the 3 originally named classes, or silently added without a note
+— architect's own explicit invitation on this issue: "1 件ずつ確かめる
+前提" (measure one at a time; a 3rd class turning out insufficient is an
+expected outcome of that process, not a deviation from it).
+
+- ``LIVE`` — re-read on every access, no caching. A caller holding the
+  value across an await must re-read it, never cache it (every LIVE key
+  below carries this exact warning at its own read call site).
+- ``CONSTRUCTION_ONCE`` — resolved exactly once per agent, at session
+  construction. An already-running session does not notice a
+  ``profile.yaml`` edit until its own NEXT construction (next
+  ``--connect``/reattach) — neither ``LIVE`` nor a process restart.
+- ``HOT`` — changes via an explicit trigger (``/reload``, or an LLM
+  hooks-write op), applied at the next turn boundary. Hand-editing
+  ``profile.yaml`` alone does nothing until one of those triggers fires.
+- ``RESTART`` — takes effect only after a full process restart. No
+  slice-1 key currently uses this value; kept in the vocabulary so a
+  future key that genuinely needs it has somewhere to declare that,
+  rather than being force-fit into one of the other 3.
+
+Every value below was traced to its own real read call site during this
+slice's own measurement pass — see each entry's own comment for the
+file:line and the verbatim evidence quoted from that site's own
+docstring, mirroring how the 3 pre-measured examples
+(``_agent_profile_preferences`` / ``_read_base_dir_override`` /
+``project_context_path``) were originally reported.
+"""
+from __future__ import annotations
+
+LIVE = "live"
+CONSTRUCTION_ONCE = "construction-once"
+HOT = "hot"
+RESTART = "restart"
+
+#: Every per-agent-profile key this slice measured, declared ONCE here —
+#: the doc's own generated section (see
+#: ``docs/reference/config/reyn-yaml.md``'s "Per-agent profile key reload
+#: classes" section) and :func:`missing_reload_class_declarations`'s own
+#: completeness gate both read this dict, never a second copy.
+AGENT_PROFILE_RELOAD_CLASSES: "dict[str, str]" = {
+    # AgentProfile's own top-level fields (name/created_at excluded —
+    # identity/audit metadata, not a config value with runtime behavior;
+    # see declared_agent_profile_keys()'s own docstring).
+    "role": CONSTRUCTION_ONCE,  # agent.py: Agent is frozen, built once at construction
+    "allowed_mcp": HOT,  # session.py:_reapply_per_agent_capability, the per_agent_capability seam
+    "base_dir": LIVE,  # session.py:_workspace_base_dir, "a live re-read on every access"
+    "project_context_path": CONSTRUCTION_ONCE,  # registry_bootstrap.py:resolve_agent_project_context, owner ruling B/#3787
+    # `preferences.*` — every PREFERENCE_KEYS entry, all resolved through
+    # the SAME `_resolve_session_preference`/`warn_ratio_overrides` live
+    # re-read (session.py, verbatim "Live re-read on every call (never
+    # cached)").
+    "preferences.output_language": LIVE,
+    "preferences.chat.reasoning.display": LIVE,
+    "preferences.cost.per_agent_tokens.warn_ratio": LIVE,
+    "preferences.cost.per_agent_cost_usd.warn_ratio": LIVE,
+    "preferences.cost.daily_tokens.warn_ratio": LIVE,
+    "preferences.cost.daily_cost_usd.warn_ratio": LIVE,
+    "preferences.cost.monthly_tokens.warn_ratio": LIVE,
+    "preferences.cost.monthly_cost_usd.warn_ratio": LIVE,
+    "preferences.cost.rate_limit_warn_ratio": LIVE,
+    # `bounding.*` — the sole BOUNDING_KEYS entry, resolved through
+    # `_agent_profile_bounding`/`compose_model_ceiling`, same live shape.
+    "bounding.model": LIVE,
+}
+
+
+def declared_agent_profile_keys() -> "set[str]":
+    """The real vocabulary :data:`AGENT_PROFILE_RELOAD_CLASSES` must cover
+    — derived, never hand-duplicated: :class:`~reyn.runtime.profile.
+    AgentProfile`'s own non-identity fields, plus every
+    :data:`~reyn.runtime.preferences.PREFERENCE_KEYS` entry (prefixed
+    ``preferences.``) and every :data:`~reyn.runtime.bounding.
+    BOUNDING_KEYS` entry (prefixed ``bounding.``) — the SAME 2 registries
+    :func:`~reyn.runtime.preferences.validate_preferences`/
+    :func:`~reyn.runtime.bounding.validate_bounding` already gate
+    ``profile.yaml`` writes against, so this vocabulary can never name a
+    key those loaders would themselves reject.
+
+    ``name``/``created_at`` are excluded — identity/audit metadata with no
+    "how often does an edit take effect" question to answer (``name`` IS
+    the agent's own identity key; ``created_at`` is a display-only
+    timestamp, never re-read for behavior)."""
+    from reyn.runtime.bounding import BOUNDING_KEYS
+    from reyn.runtime.preferences import PREFERENCE_KEYS
+
+    keys = {"role", "allowed_mcp", "base_dir", "project_context_path"}
+    keys |= {f"preferences.{k}" for k in PREFERENCE_KEYS}
+    keys |= {f"bounding.{k}" for k in BOUNDING_KEYS}
+    return keys
+
+
+def missing_reload_class_declarations() -> "list[str]":
+    """The real per-agent-profile keys with NO entry in
+    :data:`AGENT_PROFILE_RELOAD_CLASSES` — sorted, empty when the
+    declaration is complete. A key added to ``AgentProfile``/
+    ``PREFERENCE_KEYS``/``BOUNDING_KEYS`` with no matching entry here
+    shows up in this list — the completeness gate
+    (``tests/runtime/test_4206_slice1_profile_reload_class.py``) fails
+    the moment it is non-empty, the same "declare it or the gate reds"
+    discipline #5190's own hook-kind registry uses."""
+    return sorted(declared_agent_profile_keys() - set(AGENT_PROFILE_RELOAD_CLASSES))

--- a/tests/runtime/test_4206_slice1_profile_reload_class.py
+++ b/tests/runtime/test_4206_slice1_profile_reload_class.py
@@ -1,0 +1,168 @@
+"""Tier 2: #4206 slice 1 — per-agent-profile keys declare their own reload
+class, and the doc's own "Per-agent profile key reload classes" section is
+a projection of that declaration, not a second hand-written source.
+
+Mirrors `tests/repo/test_config_reference_declared_in_4206.py`'s own
+doc↔code gate shape (read the doc's own BEGIN/END-bounded section, assert
+its cells against the real registry) plus #5190's own completeness-gate
+shape (a real vocabulary — here, `AgentProfile`'s own fields +
+`PREFERENCE_KEYS` + `BOUNDING_KEYS` — minus a hand-maintained registry
+must be empty).
+
+Real imports throughout (the actual `AGENT_PROFILE_RELOAD_CLASSES`, the
+actual doc file, the actual `PREFERENCE_KEYS`/`BOUNDING_KEYS`) — no mocks.
+"""
+from __future__ import annotations
+
+import re
+
+from reyn.runtime.bounding import BOUNDING_KEYS
+from reyn.runtime.preferences import PREFERENCE_KEYS
+from reyn.runtime.profile_reload import (
+    AGENT_PROFILE_RELOAD_CLASSES,
+    CONSTRUCTION_ONCE,
+    HOT,
+    LIVE,
+    RESTART,
+    declared_agent_profile_keys,
+    missing_reload_class_declarations,
+)
+from tests._support.paths import REPO_ROOT
+
+_DOC = REPO_ROOT / "docs" / "reference" / "config" / "reyn-yaml.md"
+
+_BEGIN = "<!-- BEGIN agent-profile-reload-class -->"
+_END = "<!-- END agent-profile-reload-class -->"
+
+_VALID_CLASSES = {LIVE, CONSTRUCTION_ONCE, HOT, RESTART}
+
+
+# ── the completeness gate (#5190-shape: real vocabulary minus registry) ──
+
+
+def test_the_real_vocabularys_diff_is_currently_empty():
+    """Tier 2: the acceptance witness — every real per-agent-profile key
+    (AgentProfile's own fields + PREFERENCE_KEYS + BOUNDING_KEYS) has a
+    registered reload class, right now. This gate's own starting
+    population is zero, so any hit here is a new regression (a key added
+    to one of the 3 real sources with no matching declaration), not
+    inherited debt."""
+    offenders = missing_reload_class_declarations()
+    assert offenders == [], (
+        f"real regression(s) found: {offenders} — a key was added to "
+        "AgentProfile/PREFERENCE_KEYS/BOUNDING_KEYS with no matching "
+        "AGENT_PROFILE_RELOAD_CLASSES entry"
+    )
+
+
+def test_a_new_preference_key_with_no_declared_class_is_flagged():
+    """Tier 2: strip-falsifier — a hypothetical new PREFERENCE_KEYS entry
+    with no matching registry entry must appear in the diff. Without this
+    check, a future key could be added to PREFERENCE_KEYS and this gate
+    would stay silently green."""
+    import reyn.runtime.profile_reload as mod
+
+    real_keys = mod.declared_agent_profile_keys
+    try:
+        mod.declared_agent_profile_keys = lambda: real_keys() | {"preferences.new_thing"}
+        offenders = mod.missing_reload_class_declarations()
+    finally:
+        mod.declared_agent_profile_keys = real_keys
+    assert offenders == ["preferences.new_thing"]
+
+
+def test_every_declared_key_names_a_valid_reload_class():
+    """Tier 2: non-vacuity — every value in the registry is one of the 4
+    named classes, not an ad-hoc string that would silently pass the
+    completeness check while meaning nothing to a reader."""
+    for key, cls in AGENT_PROFILE_RELOAD_CLASSES.items():
+        assert cls in _VALID_CLASSES, f"{key!r} declares an unknown reload class {cls!r}"
+
+
+def test_the_registry_names_exactly_the_real_vocabulary_not_a_superset():
+    """Tier 2: the flip side of completeness — the registry's own key set
+    must equal the real vocabulary, not merely be a superset that happens
+    to swallow the diff (a stale entry for a removed key masking a
+    genuinely missing one)."""
+    assert set(AGENT_PROFILE_RELOAD_CLASSES) == declared_agent_profile_keys()
+
+
+def test_preference_keys_and_bounding_keys_are_genuinely_nonempty():
+    """Tier 2: positive control — PREFERENCE_KEYS/BOUNDING_KEYS must not
+    be empty for the tests above to bite (an empty source would make the
+    completeness gate vacuously green)."""
+    assert PREFERENCE_KEYS
+    assert BOUNDING_KEYS
+
+
+# ── the doc's own section is a projection of the registry ────────────────
+
+
+def _table_text() -> str:
+    text = _DOC.read_text(encoding="utf-8")
+    start = text.index(_BEGIN)
+    end = text.index(_END)
+    return text[start:end]
+
+
+def _doc_row(table_text: str, key: str) -> "tuple[str, str]":
+    pattern = re.compile(r"^\| `" + re.escape(key) + r"` \| `([^`]+)` \|$", re.MULTILINE)
+    match = pattern.search(table_text)
+    assert match is not None, (
+        f"expected a row for `{key}` in {_DOC}'s agent-profile-reload-class "
+        f"section — the row is missing entirely, not merely wrong"
+    )
+    return key, match.group(1)
+
+
+def test_every_registered_key_has_a_matching_doc_row():
+    """Tier 2: doc↔code — every key in AGENT_PROFILE_RELOAD_CLASSES has a
+    row in the doc's own section, and that row's reload class matches the
+    registry exactly. A key present in the registry but missing (or wrong)
+    in the doc is the drift this gate exists to catch — the doc is
+    supposed to be a projection, not an independent source."""
+    table = _table_text()
+    for key, expected_class in AGENT_PROFILE_RELOAD_CLASSES.items():
+        _, doc_class = _doc_row(table, key)
+        assert doc_class == expected_class, (
+            f"`{key}`'s doc row says {doc_class!r} but the registry says "
+            f"{expected_class!r} — the doc has drifted from its own source"
+        )
+
+
+def test_the_doc_section_has_no_row_the_registry_does_not():
+    """Tier 2: the other direction — a doc row for a key the registry does
+    NOT declare would be a fabricated claim (the doc asserting a reload
+    class nothing in the source tree backs). Counts rows in the section
+    and compares to the registry's own size, catching an orphaned row a
+    per-key sweep (the test above) would not notice on its own."""
+    table = _table_text()
+    row_count = len(re.findall(r"^\| `[^`]+` \| `[^`]+` \|$", table, re.MULTILINE))
+    assert row_count == len(AGENT_PROFILE_RELOAD_CLASSES), (
+        f"doc section has {row_count} rows but the registry has "
+        f"{len(AGENT_PROFILE_RELOAD_CLASSES)} entries — a row was added or "
+        f"removed on only one side"
+    )
+
+
+def test_allowed_mcp_is_the_hot_class_not_construction_once_or_restart():
+    """Tier 2: regression guard for this slice's own discovery — measured
+    (session.py's `_reapply_per_agent_capability`, the `per_agent_
+    capability` hot-reload seam) as neither a per-access live re-read, nor
+    frozen for a session's lifetime, nor requiring a process restart, but
+    an explicit-trigger-then-turn-boundary reapply — the SAME shape the
+    project-layer `restart / hot` vocabulary already names. Named
+    explicitly since this is the one key this slice found that does not
+    fit the 3 originally-proposed classes."""
+    assert AGENT_PROFILE_RELOAD_CLASSES["allowed_mcp"] == HOT
+
+
+def test_role_and_project_context_path_are_construction_once():
+    """Tier 2: regression guard — `role` (a frozen `Agent` identity field,
+    `agent.py`'s own "Frozen — identity is immutable for a session's
+    lifetime") and `project_context_path` (owner ruling B / #3787,
+    "resolved ONCE per agent, at session construction") are both
+    construction-once, matching the pre-measured #3787 example this
+    slice's own assignment named."""
+    assert AGENT_PROFILE_RELOAD_CLASSES["role"] == CONSTRUCTION_ONCE
+    assert AGENT_PROFILE_RELOAD_CLASSES["project_context_path"] == CONSTRUCTION_ONCE

--- a/tests/runtime/test_4206_slice1_profile_reload_class.py
+++ b/tests/runtime/test_4206_slice1_profile_reload_class.py
@@ -15,13 +15,16 @@ actual doc file, the actual `PREFERENCE_KEYS`/`BOUNDING_KEYS`) — no mocks.
 from __future__ import annotations
 
 import re
+from dataclasses import fields as dataclass_fields
 
 from reyn.runtime.bounding import BOUNDING_KEYS
 from reyn.runtime.preferences import PREFERENCE_KEYS
+from reyn.runtime.profile import AgentProfile
 from reyn.runtime.profile_reload import (
+    _NON_RELOAD_CLASS_FIELDS,
     AGENT_PROFILE_RELOAD_CLASSES,
     CONSTRUCTION_ONCE,
-    HOT,
+    EXPLICIT_TRIGGER,
     LIVE,
     RESTART,
     declared_agent_profile_keys,
@@ -34,7 +37,7 @@ _DOC = REPO_ROOT / "docs" / "reference" / "config" / "reyn-yaml.md"
 _BEGIN = "<!-- BEGIN agent-profile-reload-class -->"
 _END = "<!-- END agent-profile-reload-class -->"
 
-_VALID_CLASSES = {LIVE, CONSTRUCTION_ONCE, HOT, RESTART}
+_VALID_CLASSES = {LIVE, CONSTRUCTION_ONCE, EXPLICIT_TRIGGER, RESTART}
 
 
 # ── the completeness gate (#5190-shape: real vocabulary minus registry) ──
@@ -95,6 +98,68 @@ def test_preference_keys_and_bounding_keys_are_genuinely_nonempty():
     assert BOUNDING_KEYS
 
 
+def test_every_excluded_field_name_is_a_real_agentprofile_field():
+    """Tier 2: TESTS-READ A block ① witness (architect, issuecomment-
+    5384894847) — `_NON_RELOAD_CLASS_FIELDS` must name REAL fields on
+    `AgentProfile`, checked against `dataclasses.fields` directly, never a
+    bare equality assert against the same literal set on both sides (that
+    would prove nothing per CLAUDE.md's 6-questions #2 — "is it the
+    implementation, transcribed?"). A typo'd/renamed exclusion name here
+    would silently leave a stale entry in `declared_agent_profile_keys()`
+    that no longer subtracts anything real."""
+    real_field_names = {f.name for f in dataclass_fields(AgentProfile)}
+    for excluded in _NON_RELOAD_CLASS_FIELDS:
+        assert excluded in real_field_names, (
+            f"{excluded!r} is excluded from the reload-class vocabulary "
+            f"but is not a real AgentProfile field — real fields: "
+            f"{sorted(real_field_names)}"
+        )
+
+
+def test_agentprofile_field_derivation_is_not_a_hand_typed_literal():
+    """Tier 2: TESTS-READ A block ① strip-falsifier — confirms the REAL,
+    UNMODIFIED `declared_agent_profile_keys()` genuinely reads
+    `AgentProfile`'s own fields via `dataclasses.fields` rather than a
+    hand-typed literal that happens to match today.
+
+    Monkeypatches `reyn.runtime.profile.AgentProfile` ITSELF (the module
+    attribute the function's own local `from reyn.runtime.profile import
+    AgentProfile` re-fetches on every call) to a stand-in carrying one
+    SYNTHETIC extra field, then calls the real function with NOTHING else
+    replaced. If the AgentProfile-scoped leg were still the pre-block-①
+    hand-typed literal, this synthetic field could never reach the
+    derived set no matter what the (unread) class declares — that vacuity
+    is exactly what this test rules out, by patching the DEPENDENCY, not
+    the function under test."""
+    from dataclasses import dataclass, field
+
+    import reyn.runtime.profile as profile_mod
+
+    @dataclass(frozen=True)
+    class _FakeProfileWithExtraField:
+        name: str = ""
+        role: str = ""
+        created_at: str = ""
+        allowed_mcp: "list[str] | None" = None
+        preferences: "dict[str, object]" = field(default_factory=dict)
+        bounding: "dict[str, object]" = field(default_factory=dict)
+        base_dir: "str | None" = None
+        project_context_path: "str | None" = None
+        a_brand_new_field: "str | None" = None
+
+    real_class = profile_mod.AgentProfile
+    try:
+        profile_mod.AgentProfile = _FakeProfileWithExtraField
+        keys = declared_agent_profile_keys()
+    finally:
+        profile_mod.AgentProfile = real_class
+    assert "a_brand_new_field" in keys, (
+        "declared_agent_profile_keys() must derive from AgentProfile's "
+        "OWN fields at call time (dataclasses.fields), not a hand-typed "
+        f"literal — a synthetic extra field never reached the result: {keys!r}"
+    )
+
+
 # ── the doc's own section is a projection of the registry ────────────────
 
 
@@ -145,16 +210,17 @@ def test_the_doc_section_has_no_row_the_registry_does_not():
     )
 
 
-def test_allowed_mcp_is_the_hot_class_not_construction_once_or_restart():
+def test_allowed_mcp_is_the_explicit_trigger_class_not_construction_once_or_restart():
     """Tier 2: regression guard for this slice's own discovery — measured
     (session.py's `_reapply_per_agent_capability`, the `per_agent_
     capability` hot-reload seam) as neither a per-access live re-read, nor
     frozen for a session's lifetime, nor requiring a process restart, but
-    an explicit-trigger-then-turn-boundary reapply — the SAME shape the
-    project-layer `restart / hot` vocabulary already names. Named
-    explicitly since this is the one key this slice found that does not
-    fit the 3 originally-proposed classes."""
-    assert AGENT_PROFILE_RELOAD_CLASSES["allowed_mcp"] == HOT
+    an explicit-trigger-then-turn-boundary reapply. NOT the project-layer
+    `hot` class (TESTS-READ A block ②, architect, issuecomment-5384894847)
+    — `profile.yaml` is not in `_HOT_RELOAD_FILES`, so a bare hand-edit
+    does nothing on its own, the opposite polarity from `hot`'s own
+    defining property (the file write itself is the trigger there)."""
+    assert AGENT_PROFILE_RELOAD_CLASSES["allowed_mcp"] == EXPLICIT_TRIGGER
 
 
 def test_role_and_project_context_path_are_construction_once():


### PR DESCRIPTION
**[e2e-coder]** — part of #4206

Architect's own diagnosis (issuecomment-5384833640, after 2 rounds of self-falsification on this exact question): a hand-maintained (key × layer) doc table for "how often does an edit take effect" rots the same way the `Declared in` column did before #4206's own gate (#5090) — "the same event twice" this repo saw 3 more times the same night (#5166 / #5175 / #5197). Fix: a key declares its own reload class once, in `src/reyn/runtime/profile_reload.py`; the doc's own section is a projection of that dict, not a second hand-written source.

## Scope

Per architect's explicit slice cut: ONLY per-agent-profile keys (`.reyn/agents/<name>/profile.yaml`) — the surface an operator actually touches. Every other config key stays as documented in the existing top-level table (marked out of scope, not silently claimed).

## What was measured

14 real keys (`AgentProfile`'s own fields minus identity/audit metadata, every `PREFERENCE_KEYS` entry, the sole `BOUNDING_KEYS` entry), each traced to its own real read call site — not assumed from the 3 pre-supplied examples. Confirmed the 3 pre-measured examples (`_agent_profile_preferences`, `_read_base_dir_override`, `project_context_path`) independently against `origin/main`.

**Note on method**: an earlier pass of this measurement (a background sub-investigation) grepped a stale local checkout that predates `#5086`/`project_context_path`'s own landing, and reported the premise as false. Caught and redone against a fresh `origin/main` worktree before any code was written — the stale-tree finding was discarded, not built on.

## Discovery, disclosed rather than force-fit

`allowed_mcp` does not match any of architect's 3 named classes (`live`/`construction-once`/`restart`) — it changes via an explicit trigger (`/reload` or an LLM hooks-write op) applied at the next turn boundary (`Session._reapply_per_agent_capability`, the `per_agent_capability` hot-reload seam), the same "explicit trigger, turn-boundary apply" shape `reyn.yaml`'s own project-layer `restart / hot` vocabulary already names. Reused that name (`hot`) rather than inventing a 5th word for an already-named shape — flagged explicitly in both the module docstring and a dedicated regression test.

## Gate

`tests/runtime/test_4206_slice1_profile_reload_class.py`:
- Completeness: real vocabulary (`AgentProfile` fields + `PREFERENCE_KEYS` + `BOUNDING_KEYS`) minus the registry must be empty — mirrors #5190's set-diff shape.
- Doc↔code: doc rows checked against the registry in both directions (missing row, wrong value, orphaned row) — mirrors `test_config_reference_declared_in_4206.py`'s own doc↔code gate shape.

## Strip-falsify

- Removed `allowed_mcp`'s registry entry → 5/9 tests correctly red for the right reason (completeness gate + doc↔code mismatch + the dedicated `allowed_mcp`-class regression test).
- Separately mutated the doc's own `allowed_mcp` cell to a wrong value with the registry intact → 1/9 correctly red (the doc↔code drift check specifically, isolating that direction).
- Restored to green after each.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_4206_slice1_profile_reload_class.py` — 9/9 OK, 0 Tier-4
- [x] `python scripts/mypy_ratchet.py` — 201/207 baselined, no new
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/profile_reload.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` / `check_doc_anchors.py` / `check_retired_config_keys_denylist.py` (docs/ touched) — all clean
- [x] `pytest tests/repo/test_config_reference_declared_in_4206.py tests/runtime/test_4206_slice1_profile_reload_class.py` — 14/14 passed
- [x] `pytest tests/ -k "preferences or bounding or profile or 4206"` — 157/157 passed, no regressions
- [x] (skipped — Visual, standing waiver 2026-08-08)

Touches `tests/` and `docs/` — needs a TESTS-READ note before merge; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[architect]** — TESTS-READ A blocking points (issuecomment-5384894847):

- [x] 🔴 `declared_agent_profile_keys()` hardcodes the 4 `AgentProfile` field names while its own docstring says "derived, never hand-duplicated" — a new `AgentProfile` field is invisible to the completeness gate. Derive from `dataclasses.fields(AgentProfile)` minus an explicit exclusion set, and add a witness that every exclusion name is a real field.
- [x] 🔴 `hot` reuse: `.reyn/agents/<name>/profile.yaml` is not in `_HOT_RELOAD_FILES`, and project-layer `hot` means "the `.reyn/config/`-side write is re-read at the next turn boundary" — the write IS the trigger. For `allowed_mcp` it is not. Rename (e.g. `explicit-trigger`), or show the path where a bare `profile.yaml` write fires the seam (in which case the module docstring's "hand-editing profile.yaml alone does nothing" is the false half).
- [x] ⚪ doc row area: say in one line that the section is hand-written + gated, not machine-generated ("projection" reads as generated).

