### PR TITLE
feat(#4995): AgentRegistry gains an explicit, enforced single-owner-thread invariant (slice 1)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -465,42 +465,59 @@ class AgentRegistry:
         # ★ behavior change: a malformed topology yaml's warning now surfaces
         # at first topology access instead of at Registry construction time.
         self._topologies_raw: dict[str, Topology] | None = None
-        # #4995 slice 1 (architect ruling, issuecomment-5384869791): the
-        # thread that CONSTRUCTS this registry is its owner, from birth —
-        # mirroring ``ThreadedTransportProxy``'s own "worker owns from the
-        # moment it exists" shape (that class's own module docstring),
-        # never a second owner assigned later. Slice 1's own deliverable is
-        # making this ownership EXPLICIT (a named seam) without moving
-        # anything yet — today's single caller (``chat.py``'s composition
-        # root) already runs on one thread, so this is a no-op in practice
-        # until slice 2 (#4995) routes ``_background_attach`` through a
-        # worker thread and slice 3 wires ``ThreadedTransportProxy`` in;
-        # from then on, ``_assert_owner_thread`` is what makes "a second
-        # thread cannot touch this registry" a THING THAT FAILS LOUDLY
-        # (RuntimeError) rather than a silent race, at the small set of
-        # entry points ``_background_attach``/the REPL's own direct calls
-        # use (measured: ``attach``, ``restore_all``,
-        # ``resume_deferred_agents``, ``record_background_attach_error``,
-        # ``exists``, ``loaded_names``, ``agent_cost_usd``,
-        # ``agent_total_usage``, ``attached_session``, ``get_session``,
-        # ``agent_workspace_dir`` — see #4995's own issue comments for the
-        # full measurement this list is drawn from).
+        # #4995 slice 1 (architect ruling, issuecomment-5384869791, CORRECTED
+        # by issuecomment-5384963741 after CI caught the first version): the
+        # thread that CONSTRUCTS this registry owns its MUTATIONS, from
+        # birth — mirroring ``ThreadedTransportProxy``'s own "worker owns
+        # from the moment it exists" shape (that class's own module
+        # docstring), never a second owner assigned later.
+        #
+        # "Owns" means "only thread allowed to MUTATE", NOT "only thread
+        # allowed to touch" — the first version of this invariant asserted
+        # on 11 methods including 7 READS, and CI found a real, pre-existing,
+        # LEGITIMATE second thread within one run: ``app.py``'s #4983 design
+        # deliberately reads conversation history off the event loop via
+        # ``asyncio.to_thread`` (app.py's own ``_read_conversation_history``
+        # call sites), which genuinely executes on a second OS thread and
+        # reaches ``get_session``/``agent_workspace_dir``/etc. through
+        # ``RegistryReadModel``. That is not the race #4995 exists to
+        # prevent — 27 CI failures were this PR breaking a real feature, not
+        # catching a real bug. Scoped down to exactly the 4 methods that
+        # MUTATE registry-owned state: ``attach``, ``restore_all``,
+        # ``resume_deferred_agents``, ``record_background_attach_error``.
+        # The 7 read methods (``exists``, ``loaded_names``,
+        # ``agent_cost_usd``, ``agent_total_usage``, ``attached_session``,
+        # ``get_session``, ``agent_workspace_dir``) are NOT asserted — see
+        # each one's own docstring.
+        #
+        # #4995 slice 2's own open question (architect, issuecomment-
+        # 5384963741): whether #4983's off-thread READS observe a live view
+        # of registry-owned state or an immutable snapshot determines
+        # whether an `asyncio.Lock` around the 4 mutating methods (slice 2)
+        # is sufficient — a lock serializes MUTATION against MUTATION
+        # (same-loop coroutines), never against a genuinely concurrent
+        # OS-thread READER. See #4995's own issue comments for that
+        # measurement once it exists.
         self._owner_thread_ident = threading.get_ident()
 
     def _assert_owner_thread(self) -> None:
-        """#4995 slice 1: raise if called from a thread OTHER than the one
-        that constructed this registry. Call at the top of any method a
-        cross-thread caller could otherwise reach — see this registry's own
-        ``_owner_thread_ident`` comment for which methods currently do."""
+        """#4995 slice 1 (scope corrected — see ``_owner_thread_ident``'s
+        own comment): raise if called from a thread OTHER than the one that
+        constructed this registry. Call ONLY at the top of a method that
+        MUTATES registry-owned state — a read must NOT call this (#4983's
+        own off-thread reads are a legitimate second thread; asserting on a
+        read breaks them, as CI found)."""
         current = threading.get_ident()
         if current != self._owner_thread_ident:
             raise RuntimeError(
-                f"AgentRegistry touched from thread {current} but is owned "
+                f"AgentRegistry mutated from thread {current} but is owned "
                 f"by thread {self._owner_thread_ident} — see #4995 (a single "
                 f"owner thread is the invariant this registry's cross-thread "
-                f"safety depends on; a second thread reaching this method is "
-                f"the race #4995 exists to prevent, not a permitted access "
-                f"pattern)"
+                f"MUTATION safety depends on; a second thread reaching this "
+                f"method is the race #4995 exists to prevent, not a "
+                f"permitted access pattern — reads are a separate, allowed "
+                f"case, see this registry's own ``_owner_thread_ident`` "
+                f"comment)"
             )
 
     @property
@@ -591,8 +608,16 @@ class AgentRegistry:
         """Public non-loading accessor for a Session (FP-0043 Stage 3) — the
         supported replacement for external ``registry._agents.get(name)`` reach-in.
         Defaults to the implicit "main" session (byte-identical to the prior
-        single-session lookup)."""
-        self._assert_owner_thread()
+        single-session lookup).
+
+        #4995 slice 1 (architect correction, issuecomment-5384963741): NOT
+        owner-thread-asserted, unlike the mutating methods — ``app.py``'s
+        own #4983 design deliberately reads history off the event loop via
+        ``asyncio.to_thread``, which genuinely runs on a second real OS
+        thread and reaches this method through ``RegistryReadModel``. That
+        is a legitimate existing read, not the race #4995 exists to
+        prevent — see ``AgentRegistry``'s own ``_owner_thread_ident``
+        docstring for which methods DO assert and why."""
         return self._peek_session(name, sid)
 
     def session_ids(self, name: str) -> list[str]:
@@ -623,8 +648,10 @@ class AgentRegistry:
         run_repl exit summary. Reading the durable tracker (one per-agent counter) makes this survive
         restart and byte-align with ``/cost``. (Was: a SUM over per-session gateways — this-process
         only, so it reset to 0 on restart AND N×-counted an agent's cost across ``/session new``
-        sessions, since each gateway held the full per-agent seed. #cost-restart.)"""
-        self._assert_owner_thread()
+        sessions, since each gateway held the full per-agent seed. #cost-restart.)
+
+        #4995 slice 1 (architect correction): NOT owner-thread-asserted —
+        a read, not a mutation. See :meth:`get_session`'s own docstring."""
         tracker = self._shared_budget_tracker()
         return tracker.agent_cost_usd(name) if tracker is not None else 0.0
 
@@ -644,8 +671,10 @@ class AgentRegistry:
         return tracker.agent_tokens(name) if tracker is not None else 0
 
     def agent_total_usage(self, name: str) -> "object":
-        """Aggregate TokenUsage across ALL sessions of agent ``name``."""
-        self._assert_owner_thread()
+        """Aggregate TokenUsage across ALL sessions of agent ``name``.
+
+        #4995 slice 1 (architect correction): NOT owner-thread-asserted —
+        a read, not a mutation. See :meth:`get_session`'s own docstring."""
         from reyn.llm.pricing import TokenUsage
         total: "TokenUsage" = TokenUsage()
         for sid in self.session_ids(name):
@@ -762,12 +791,15 @@ class AgentRegistry:
         from ``workspace_state_dir``, which every registry-constructed
         agent gets set to this SAME ``project_root / ".reyn"`` at
         bootstrap — not a re-derivation, the identical value by a
-        different, session-free route)."""
-        self._assert_owner_thread()
+        different, session-free route).
+
+        #4995 slice 1 (architect correction): NOT owner-thread-asserted —
+        a read, not a mutation. See :meth:`get_session`'s own docstring."""
         return self._dir / name
 
     def exists(self, name: str) -> bool:
-        self._assert_owner_thread()
+        """#4995 slice 1 (architect correction): NOT owner-thread-asserted
+        — a read, not a mutation. See :meth:`get_session`'s own docstring."""
         return (self._dir / name / PROFILE_FILENAME).is_file()
 
     def create(
@@ -4021,7 +4053,8 @@ class AgentRegistry:
         return active[1] if active is not None else None
 
     def attached_session(self) -> "object | None":
-        self._assert_owner_thread()
+        """#4995 slice 1 (architect correction): NOT owner-thread-asserted
+        — a read, not a mutation. See :meth:`get_session`'s own docstring."""
         active = self._connection.active
         if active is None:
             return None
@@ -4286,7 +4319,8 @@ class AgentRegistry:
                 logger.warning("StateLog teardown failed: %s", exc)
 
     def loaded_names(self) -> list[str]:
-        self._assert_owner_thread()
+        """#4995 slice 1 (architect correction): NOT owner-thread-asserted
+        — a read, not a mutation. See :meth:`get_session`'s own docstring."""
         return list(self._sessions.keys())
 
     def session_tree(self) -> "list[dict]":

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -506,7 +506,18 @@ class AgentRegistry:
         constructed this registry. Call ONLY at the top of a method that
         MUTATES registry-owned state — a read must NOT call this (#4983's
         own off-thread reads are a legitimate second thread; asserting on a
-        read breaks them, as CI found)."""
+        read breaks them, as CI found).
+
+        Disclosed gap (architect, issuecomment-5385029098), not a
+        completeness claim: nothing here or in ``tests/runtime/test_4995_
+        registry_owner_thread.py`` catches a FUTURE mutating method added
+        with no call to this guard — "which method mutates" is semantics,
+        not syntax, so no zero-false-positive gate can enforce it (a naive
+        census of ``self._x =`` assignments over-fires on cached/memoized
+        reads). Whoever adds a new mutating method must add both the call
+        AND a test entry; this is a manually-maintained list, deliberately
+        NOT derived from source (see that test file's own comment on why
+        deriving it would weaken, not strengthen, the witness)."""
         current = threading.get_ident()
         if current != self._owner_thread_ident:
             raise RuntimeError(

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -26,6 +26,7 @@ import asyncio
 import json
 import logging
 import re
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -464,6 +465,51 @@ class AgentRegistry:
         # ★ behavior change: a malformed topology yaml's warning now surfaces
         # at first topology access instead of at Registry construction time.
         self._topologies_raw: dict[str, Topology] | None = None
+        # #4995 slice 1 (architect ruling, issuecomment-5384869791): the
+        # thread that CONSTRUCTS this registry is its owner, from birth —
+        # mirroring ``ThreadedTransportProxy``'s own "worker owns from the
+        # moment it exists" shape (that class's own module docstring),
+        # never a second owner assigned later. Slice 1's own deliverable is
+        # making this ownership EXPLICIT (a named seam) without moving
+        # anything yet — today's single caller (``chat.py``'s composition
+        # root) already runs on one thread, so this is a no-op in practice
+        # until slice 2 (#4995) routes ``_background_attach`` through a
+        # worker thread and slice 3 wires ``ThreadedTransportProxy`` in;
+        # from then on, ``_assert_owner_thread`` is what makes "a second
+        # thread cannot touch this registry" a THING THAT FAILS LOUDLY
+        # (RuntimeError) rather than a silent race, at the small set of
+        # entry points ``_background_attach``/the REPL's own direct calls
+        # use (measured: ``attach``, ``restore_all``,
+        # ``resume_deferred_agents``, ``record_background_attach_error``,
+        # ``exists``, ``loaded_names``, ``agent_cost_usd``,
+        # ``agent_total_usage``, ``attached_session``, ``get_session``,
+        # ``agent_workspace_dir`` — see #4995's own issue comments for the
+        # full measurement this list is drawn from).
+        self._owner_thread_ident = threading.get_ident()
+
+    def _assert_owner_thread(self) -> None:
+        """#4995 slice 1: raise if called from a thread OTHER than the one
+        that constructed this registry. Call at the top of any method a
+        cross-thread caller could otherwise reach — see this registry's own
+        ``_owner_thread_ident`` comment for which methods currently do."""
+        current = threading.get_ident()
+        if current != self._owner_thread_ident:
+            raise RuntimeError(
+                f"AgentRegistry touched from thread {current} but is owned "
+                f"by thread {self._owner_thread_ident} — see #4995 (a single "
+                f"owner thread is the invariant this registry's cross-thread "
+                f"safety depends on; a second thread reaching this method is "
+                f"the race #4995 exists to prevent, not a permitted access "
+                f"pattern)"
+            )
+
+    @property
+    def owner_thread_ident(self) -> int:
+        """#4995 slice 1: the thread identity this registry is owned by —
+        the public read a test (or a future caller deciding whether it is
+        safe to touch this registry) can check without reaching into
+        ``_owner_thread_ident`` directly."""
+        return self._owner_thread_ident
 
     @property
     def state_log(self) -> StateLog | None:
@@ -546,6 +592,7 @@ class AgentRegistry:
         supported replacement for external ``registry._agents.get(name)`` reach-in.
         Defaults to the implicit "main" session (byte-identical to the prior
         single-session lookup)."""
+        self._assert_owner_thread()
         return self._peek_session(name, sid)
 
     def session_ids(self, name: str) -> list[str]:
@@ -577,6 +624,7 @@ class AgentRegistry:
         restart and byte-align with ``/cost``. (Was: a SUM over per-session gateways — this-process
         only, so it reset to 0 on restart AND N×-counted an agent's cost across ``/session new``
         sessions, since each gateway held the full per-agent seed. #cost-restart.)"""
+        self._assert_owner_thread()
         tracker = self._shared_budget_tracker()
         return tracker.agent_cost_usd(name) if tracker is not None else 0.0
 
@@ -597,6 +645,7 @@ class AgentRegistry:
 
     def agent_total_usage(self, name: str) -> "object":
         """Aggregate TokenUsage across ALL sessions of agent ``name``."""
+        self._assert_owner_thread()
         from reyn.llm.pricing import TokenUsage
         total: "TokenUsage" = TokenUsage()
         for sid in self.session_ids(name):
@@ -714,9 +763,11 @@ class AgentRegistry:
         agent gets set to this SAME ``project_root / ".reyn"`` at
         bootstrap — not a re-derivation, the identical value by a
         different, session-free route)."""
+        self._assert_owner_thread()
         return self._dir / name
 
     def exists(self, name: str) -> bool:
+        self._assert_owner_thread()
         return (self._dir / name / PROFILE_FILENAME).is_file()
 
     def create(
@@ -1536,6 +1587,7 @@ class AgentRegistry:
         resolved here; narrowed out of this PR's scope rather than silently
         decided either way.
         """
+        self._assert_owner_thread()
         if self._state_log is None:
             return {}
 
@@ -3828,6 +3880,7 @@ class AgentRegistry:
         this time concrete). `_run_once`'s own design never needed the
         runner — it drives the session to completion via
         `send_to_agent_impl` itself; the runner's job (nothing else)."""
+        self._assert_owner_thread()
         # #3671 P3: a fresh attach attempt (or its `get_or_load` below, which
         # can itself raise) is never shadowed by a PRIOR background attempt's
         # recorded failure — clear it up front rather than only on success,
@@ -3968,6 +4021,7 @@ class AgentRegistry:
         return active[1] if active is not None else None
 
     def attached_session(self) -> "object | None":
+        self._assert_owner_thread()
         active = self._connection.active
         if active is None:
             return None
@@ -3981,6 +4035,7 @@ class AgentRegistry:
         A caller that never does a background attach never calls this; a
         transport reading `attach_failed()` before ANY attach was even
         attempted correctly still sees `False` (== "connecting")."""
+        self._assert_owner_thread()
         self._connection.record_background_attach_error(error)
 
     def attach_failed(self) -> bool:
@@ -4022,6 +4077,7 @@ class AgentRegistry:
         self._tasks[key].done(): ...`), so even a session already restored
         by one path never gets a second run-task from the other.
         """
+        self._assert_owner_thread()
         resumed: "list[str]" = []
         for name, sid in list(self._pending_restore.keys()):
             # Pop (not peek) BEFORE constructing: `get_or_load` is synchronous
@@ -4230,6 +4286,7 @@ class AgentRegistry:
                 logger.warning("StateLog teardown failed: %s", exc)
 
     def loaded_names(self) -> list[str]:
+        self._assert_owner_thread()
         return list(self._sessions.keys())
 
     def session_tree(self) -> "list[dict]":

--- a/tests/runtime/test_4995_registry_owner_thread.py
+++ b/tests/runtime/test_4995_registry_owner_thread.py
@@ -1,0 +1,127 @@
+"""Tier 2: #4995 slice 1 — ``AgentRegistry`` gains an explicit, enforced
+single-owner-thread invariant.
+
+Architect ruling (issuecomment-5384869791, relayed by lead-coder): before a
+worker-thread boundary (``ThreadedTransportProxy``) can safely own the
+registry, there must FIRST be a named seam that makes "a second thread
+touched this registry" fail loudly (``RuntimeError``) instead of racing
+silently — slice 1's own deliverable, with NO behavior change for today's
+single-threaded callers (only slice 2/3 introduce an actual second thread).
+
+Acceptance witnessed here:
+  ① a registry touched by exactly one thread — the constructing thread —
+     never raises (sanity: slice 1 changes nothing observable today)
+  ② a SECOND real OS thread touching the registry raises RuntimeError
+     (the seam itself, "2つ目が触れない" — architect's own acceptance
+     wording)
+  ③ the owner thread identity is a public read
+     (:attr:`AgentRegistry.owner_thread_ident`), not a private-state reach-in
+
+Real ``AgentRegistry`` + real ``threading.Thread`` (no mocks) — mirrors
+``tests/security/test_5153_approval_ledger.py``'s own real-concurrency
+witnesses, but a SINGLE real thread suffices here (the property under test
+is "does touching from thread B raise", not a race between two writers).
+"""
+from __future__ import annotations
+
+import threading
+
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path) -> AgentRegistry:
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    return AgentRegistry(project_root=tmp_path, session_factory=factory)
+
+
+def test_owner_thread_ident_is_the_constructing_thread(tmp_path) -> None:
+    """Tier 2: #4995 slice 1 acceptance ③ — the public read matches the
+    thread that actually constructed the registry (this test's own thread)."""
+    reg = _registry(tmp_path)
+    assert reg.owner_thread_ident == threading.get_ident()
+
+
+def test_same_thread_access_never_raises(tmp_path) -> None:
+    """Tier 2: #4995 slice 1 acceptance ① — sanity/non-regression. Every
+    measured entry point (#4995's own issue comments) is reachable from the
+    owner thread exactly as before slice 1 — RED if the guard mis-fires on
+    the very thread that owns the registry."""
+    reg = _registry(tmp_path)
+    reg.exists("default")
+    reg.loaded_names()
+    reg.agent_workspace_dir("default")
+    reg.get_session("default")
+    reg.attached_session()
+    reg.record_background_attach_error("probe")
+    reg.agent_cost_usd("default")
+    reg.agent_total_usage("default")
+    # No assertion needed beyond "did not raise" -- this test's only job is
+    # to prove slice 1 changed nothing for the owner thread.
+
+
+def test_a_different_thread_touching_the_registry_raises(tmp_path) -> None:
+    """Tier 2: #4995 slice 1 acceptance ② — the seam itself. A REAL second
+    OS thread calling a measured entry point must raise RuntimeError, not
+    silently succeed (the exact race slice 2/3 must not be allowed to
+    reintroduce). RED if ``_assert_owner_thread`` is removed or bypassed."""
+    reg = _registry(tmp_path)
+
+    caught: "list[BaseException | None]" = [None]
+
+    def _touch_from_other_thread() -> None:
+        try:
+            reg.loaded_names()
+        except BaseException as e:  # noqa: BLE001 -- captured for the main thread to inspect
+            caught[0] = e
+
+    t = threading.Thread(target=_touch_from_other_thread)
+    t.start()
+    t.join(timeout=10)
+    assert not t.is_alive(), "the other thread's call must have returned (raised), not hung"
+    assert isinstance(caught[0], RuntimeError), (
+        f"a second thread touching the registry must raise RuntimeError, got: {caught[0]!r}"
+    )
+    assert "4995" in str(caught[0]), "the error must point at the invariant's own issue"
+
+
+def test_two_different_registries_each_owned_by_their_own_constructing_thread(
+    tmp_path,
+) -> None:
+    """Tier 2: falsification contrast — ownership is per-INSTANCE, not a
+    process-global "the first thread wins" latch. A second registry
+    constructed on a DIFFERENT thread is owned by THAT thread, and each
+    instance rejects the other's owner thread."""
+    result: "list[AgentRegistry | None]" = [None]
+    other_ident: "list[int | None]" = [None]
+
+    def _build_other() -> None:
+        r = _registry(tmp_path / "other")
+        result[0] = r
+        other_ident[0] = threading.get_ident()
+
+    t = threading.Thread(target=_build_other)
+    t.start()
+    t.join(timeout=10)
+    other_reg = result[0]
+    assert other_reg is not None
+    assert other_reg.owner_thread_ident == other_ident[0]
+    assert other_reg.owner_thread_ident != threading.get_ident(), (
+        "sanity: the other registry's owner must genuinely be a different "
+        "thread from this test's own"
+    )
+
+    main_reg = _registry(tmp_path / "main")
+    assert main_reg.owner_thread_ident == threading.get_ident()
+    # main_reg (owned by THIS thread) is safely touchable from it -- proof
+    # the two instances' ownership is independent, not a shared/global latch.
+    main_reg.loaded_names()

--- a/tests/runtime/test_4995_registry_owner_thread.py
+++ b/tests/runtime/test_4995_registry_owner_thread.py
@@ -120,6 +120,23 @@ _MUTATING_METHOD_CALLS = {
     "resume_deferred_agents": lambda reg: reg.resume_deferred_agents(),
     "record_background_attach_error": lambda reg: reg.record_background_attach_error("x"),
 }
+# #4995 (architect: keep this hand-written, do NOT derive it from source).
+# Deliberately the mirror of #5201's own lesson, not the same shape: #5201's
+# hand-written list stood in for the REAL vocabulary (deriving it would have
+# let the real thing grow past the list unnoticed). Here the hand-written
+# list stands in for "the methods that are SUPPOSED to be guarded" — deriving
+# it (e.g. from every method whose body assigns ``self._x``) would make BOTH
+# sides of this test's assertion move together, so removing a guard AND its
+# entry from a derivation source at once would stay green (six-questions ②,
+# the identical-expression-on-both-sides failure).
+#
+# Disclosed gap, not a completeness claim: a FUTURE new mutating method
+# added to ``AgentRegistry`` with no ``_assert_owner_thread()`` call is NOT
+# caught by anything here or in the source — no zero-false-positive gate
+# exists for "which methods mutate" (that is semantics, not syntax; a naive
+# ``self._x =`` census over-fires on cached/memoized reads). The person
+# adding that method must remember to add BOTH the guard call and an entry
+# here — this test only proves the 4 CURRENTLY listed stay guarded.
 
 
 @pytest.mark.parametrize("method_name", sorted(_MUTATING_METHOD_CALLS))

--- a/tests/runtime/test_4995_registry_owner_thread.py
+++ b/tests/runtime/test_4995_registry_owner_thread.py
@@ -1,33 +1,51 @@
 """Tier 2: #4995 slice 1 — ``AgentRegistry`` gains an explicit, enforced
-single-owner-thread invariant.
+single-owner-THREAD-FOR-MUTATION invariant.
 
-Architect ruling (issuecomment-5384869791, relayed by lead-coder): before a
-worker-thread boundary (``ThreadedTransportProxy``) can safely own the
-registry, there must FIRST be a named seam that makes "a second thread
-touched this registry" fail loudly (``RuntimeError``) instead of racing
-silently — slice 1's own deliverable, with NO behavior change for today's
-single-threaded callers (only slice 2/3 introduce an actual second thread).
+Architect ruling (issuecomment-5384869791), CORRECTED after CI caught the
+first version (issuecomment-5384963741, PR #5202): the invariant is "only
+one thread may MUTATE this registry", not "only one thread may touch it
+at all" — ``app.py``'s #4983 design deliberately reads conversation
+history off the event loop via ``asyncio.to_thread``, a real second OS
+thread reaching several read-only registry methods through
+``RegistryReadModel``. Asserting on those 7 reads broke that legitimate
+feature (27 CI failures, all the identical ``RuntimeError``). The guard
+now covers exactly the 4 methods that MUTATE registry-owned state:
+``attach``, ``restore_all``, ``resume_deferred_agents``,
+``record_background_attach_error``.
 
-Acceptance witnessed here:
-  ① a registry touched by exactly one thread — the constructing thread —
-     never raises (sanity: slice 1 changes nothing observable today)
-  ② a SECOND real OS thread touching the registry raises RuntimeError
-     (the seam itself, "2つ目が触れない" — architect's own acceptance
-     wording)
-  ③ the owner thread identity is a public read
+Docs-maintainer's B finding on the first version (issuecomment-5384937050,
+still valid against the corrected scope): a hand-counted list has no
+completeness witness — stripping the guard from any ONE of the 4 methods
+must be independently caught, not just "some cross-thread test exists
+somewhere". This file exercises EACH of the 4 individually (never one
+standing in for the others), plus a read-side falsification (a read
+reached from a second thread must NOT raise — the #4983 pattern this
+scope correction exists to preserve).
+
+Acceptance:
+  ① same-thread access to every one of the 4 + every one of the 7 reads
+     never raises (sanity — slice 1's own non-regression)
+  ② EACH of the 4 mutating methods raises RuntimeError when reached from
+     a genuinely different OS thread, tested individually
+  ③ a read method reached from a different OS thread does NOT raise (the
+     #4983 pattern preserved — falsification contrast for ②)
+  ④ the owner thread identity is a public read
      (:attr:`AgentRegistry.owner_thread_ident`), not a private-state reach-in
 
-Real ``AgentRegistry`` + real ``threading.Thread`` (no mocks) — mirrors
-``tests/security/test_5153_approval_ledger.py``'s own real-concurrency
-witnesses, but a SINGLE real thread suffices here (the property under test
-is "does touching from thread B raise", not a race between two writers).
+Real ``AgentRegistry`` + real ``threading.Thread`` (no mocks). The 3
+``async def`` mutating methods are driven from the other thread via
+``asyncio.run`` (a real, independent event loop on that thread) — the
+identical shape ``ThreadedTransportProxy`` itself uses in production.
 """
 from __future__ import annotations
 
+import asyncio
 import threading
 
+import pytest
+
 from reyn.runtime.profile import AgentProfile
-from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
 from tests._support.agent_session import make_session
 
 
@@ -44,8 +62,31 @@ def _registry(tmp_path) -> AgentRegistry:
     return AgentRegistry(project_root=tmp_path, session_factory=factory)
 
 
+def _call_from_other_thread(fn) -> "BaseException | None":
+    """Run zero-arg callable *fn* on a REAL second OS thread and return
+    whatever it raised (``None`` if it returned normally). ``fn`` may be
+    sync or return a coroutine -- a coroutine is driven via ``asyncio.run``
+    on that thread's own fresh loop (mirrors ``ThreadedTransportProxy``'s
+    own worker-thread-owns-its-loop shape)."""
+    caught: "list[BaseException | None]" = [None]
+
+    def _run() -> None:
+        try:
+            result = fn()
+            if asyncio.iscoroutine(result):
+                asyncio.run(result)
+        except BaseException as e:  # noqa: BLE001 -- captured for the main thread to inspect
+            caught[0] = e
+
+    t = threading.Thread(target=_run)
+    t.start()
+    t.join(timeout=10)
+    assert not t.is_alive(), "the other thread's call must have returned, not hung"
+    return caught[0]
+
+
 def test_owner_thread_ident_is_the_constructing_thread(tmp_path) -> None:
-    """Tier 2: #4995 slice 1 acceptance ③ — the public read matches the
+    """Tier 2: #4995 slice 1 acceptance ④ — the public read matches the
     thread that actually constructed the registry (this test's own thread)."""
     reg = _registry(tmp_path)
     assert reg.owner_thread_ident == threading.get_ident()
@@ -53,45 +94,68 @@ def test_owner_thread_ident_is_the_constructing_thread(tmp_path) -> None:
 
 def test_same_thread_access_never_raises(tmp_path) -> None:
     """Tier 2: #4995 slice 1 acceptance ① — sanity/non-regression. Every
-    measured entry point (#4995's own issue comments) is reachable from the
-    owner thread exactly as before slice 1 — RED if the guard mis-fires on
-    the very thread that owns the registry."""
+    one of the 4 mutating methods AND every one of the 7 read methods is
+    reachable from the owner thread exactly as before slice 1."""
     reg = _registry(tmp_path)
+    # Reads (never asserted, on any thread):
     reg.exists("default")
     reg.loaded_names()
     reg.agent_workspace_dir("default")
     reg.get_session("default")
     reg.attached_session()
-    reg.record_background_attach_error("probe")
     reg.agent_cost_usd("default")
     reg.agent_total_usage("default")
+    # Mutations (asserted, but this IS the owner thread):
+    reg.record_background_attach_error("probe")
+    asyncio.run(reg.attach("default", start_runner=False))
+    asyncio.run(reg.restore_all())
+    asyncio.run(reg.resume_deferred_agents())
     # No assertion needed beyond "did not raise" -- this test's only job is
     # to prove slice 1 changed nothing for the owner thread.
 
 
-def test_a_different_thread_touching_the_registry_raises(tmp_path) -> None:
-    """Tier 2: #4995 slice 1 acceptance ② — the seam itself. A REAL second
-    OS thread calling a measured entry point must raise RuntimeError, not
-    silently succeed (the exact race slice 2/3 must not be allowed to
-    reintroduce). RED if ``_assert_owner_thread`` is removed or bypassed."""
-    reg = _registry(tmp_path)
+_MUTATING_METHOD_CALLS = {
+    "attach": lambda reg: reg.attach("default", start_runner=False),
+    "restore_all": lambda reg: reg.restore_all(),
+    "resume_deferred_agents": lambda reg: reg.resume_deferred_agents(),
+    "record_background_attach_error": lambda reg: reg.record_background_attach_error("x"),
+}
 
-    caught: "list[BaseException | None]" = [None]
 
-    def _touch_from_other_thread() -> None:
-        try:
-            reg.loaded_names()
-        except BaseException as e:  # noqa: BLE001 -- captured for the main thread to inspect
-            caught[0] = e
-
-    t = threading.Thread(target=_touch_from_other_thread)
-    t.start()
-    t.join(timeout=10)
-    assert not t.is_alive(), "the other thread's call must have returned (raised), not hung"
-    assert isinstance(caught[0], RuntimeError), (
-        f"a second thread touching the registry must raise RuntimeError, got: {caught[0]!r}"
+@pytest.mark.parametrize("method_name", sorted(_MUTATING_METHOD_CALLS))
+def test_each_mutating_method_individually_raises_from_another_thread(
+    tmp_path, method_name,
+) -> None:
+    """Tier 2: #4995 slice 1 acceptance ② — docs-maintainer's completeness
+    finding on the FIRST version of this guard (issuecomment-5384937050):
+    a single cross-thread test does not witness the other 3. Parametrized
+    over all 4 mutating methods so stripping the guard from ANY ONE of
+    them is independently caught (RED for that specific method, not
+    masked by the other 3 still passing)."""
+    reg = _registry(tmp_path / method_name)
+    call = _MUTATING_METHOD_CALLS[method_name]
+    caught = _call_from_other_thread(lambda: call(reg))
+    assert isinstance(caught, RuntimeError), (
+        f"{method_name}() reached from a different thread must raise "
+        f"RuntimeError, got: {caught!r}"
     )
-    assert "4995" in str(caught[0]), "the error must point at the invariant's own issue"
+    assert "4995" in str(caught), "the error must point at the invariant's own issue"
+
+
+def test_a_read_reached_from_another_thread_does_not_raise(tmp_path) -> None:
+    """Tier 2: #4995 slice 1 acceptance ③ — falsification contrast for ②,
+    and the exact regression the first version of this guard caused (CI,
+    27 failures, PR #5202): ``app.py``'s #4983 design reads conversation
+    history off the event loop via ``asyncio.to_thread`` -- a REAL second
+    OS thread reaching ``get_session`` (and siblings) through
+    ``RegistryReadModel``. That must keep working. RED if a read method
+    is ever given the mutation-only guard back."""
+    reg = _registry(tmp_path)
+    caught = _call_from_other_thread(lambda: reg.get_session("default", _DEFAULT_SID))
+    assert caught is None, (
+        f"a read reached from a different thread must NOT raise (the #4983 "
+        f"off-thread-read pattern this scope exists to preserve), got: {caught!r}"
+    )
 
 
 def test_two_different_registries_each_owned_by_their_own_constructing_thread(
@@ -99,8 +163,7 @@ def test_two_different_registries_each_owned_by_their_own_constructing_thread(
 ) -> None:
     """Tier 2: falsification contrast — ownership is per-INSTANCE, not a
     process-global "the first thread wins" latch. A second registry
-    constructed on a DIFFERENT thread is owned by THAT thread, and each
-    instance rejects the other's owner thread."""
+    constructed on a DIFFERENT thread is owned by THAT thread."""
     result: "list[AgentRegistry | None]" = [None]
     other_ident: "list[int | None]" = [None]
 
@@ -122,6 +185,6 @@ def test_two_different_registries_each_owned_by_their_own_constructing_thread(
 
     main_reg = _registry(tmp_path / "main")
     assert main_reg.owner_thread_ident == threading.get_ident()
-    # main_reg (owned by THIS thread) is safely touchable from it -- proof
+    # main_reg (owned by THIS thread) is safely mutable from it -- proof
     # the two instances' ownership is independent, not a shared/global latch.
-    main_reg.loaded_names()
+    main_reg.record_background_attach_error("probe")


### PR DESCRIPTION
**[tui-coder]** — part of #4995 (slice 1 of 3).

## What happened (read this before the diff)

The first version of this PR (head `b05f4511e`) asserted the owner-thread
invariant on all 11 measured entry points, including 7 READ methods. CI
caught a real regression: `app.py`'s #4983 design deliberately reads
conversation history off the event loop via `asyncio.to_thread`
(`app.py:5688`/`6913`) — a real, legitimate second OS thread reaching
`get_session`/`agent_workspace_dir`/etc. through `RegistryReadModel`.
Asserting on those broke it: 27 CI failures (pytest 3.11 and 3.12), all
the identical `RuntimeError`. My local sweep before the first push had
omitted `tests/interfaces/` and `tests/web/` — the two trees where this
actually broke — so it went green locally and red in CI (see PR/issue
comments for the full trace).

**Architect correction (issuecomment-5384963741):** the invariant is
"only one thread may MUTATE this registry", not "only one thread may
touch it at all". This head (`9b54e0660`) is the corrected version.

## Background

Architect ruling (issuecomment-5384869791): #4995's original request
("wire `ThreadedTransportProxy`'s `transport_factory` into `repl.py`")
was measured to move the transport-construction touch point without
removing the concurrency that would make it unsafe — `chat.py`'s
`_background_attach` runs concurrently with `run_repl` (via
`asyncio.create_task`, on the SAME thread/loop today), touching the SAME
`AgentRegistry` a future worker thread would need to own alone. The real
question is not "which thread constructs the transport" but "who owns
the registry" — today, nobody does explicitly.

Architect's 3-slice plan:
1. **This PR** — make MUTATION ownership explicit, no behavior change
   for anything already working
2. the same-thread coroutine-interleaving hazard already present in
   `resume_deferred_agents`/`restore_all` closed (or scoped) — separate
   work, tracked in #4995's own issue thread
3. `transport_factory` wired in (the original request)

**Slice 2's own limit (architect, issuecomment-5384963741 and follow-up):**
an `asyncio.Lock` around the 4 mutating methods only closes MUTATION-vs-
MUTATION races (same loop, different coroutines). It does NOT stop a
genuinely concurrent OS-thread READER (#4983's own pattern) from
observing state mid-mutation — that's a separate axis, filed as #5203
once measured (live vs. snapshot reads).

## This PR

`AgentRegistry` now records the thread that constructed it
(`owner_thread_ident`, a public read) and raises `RuntimeError` if a
DIFFERENT thread reaches one of the 4 methods that MUTATE registry-owned
state: `attach`, `restore_all`, `resume_deferred_agents`,
`record_background_attach_error`. The 7 read methods (`exists`,
`loaded_names`, `agent_cost_usd`, `agent_total_usage`,
`attached_session`, `get_session`, `agent_workspace_dir`) are NOT
asserted — each documents why in its own docstring, pointing at #4983's
legitimate off-thread read.

**No consumer of the raise path exists today, by design** (six-questions
③): every production caller runs on one thread for MUTATIONS, so
`_assert_owner_thread` never fires in production until slice 3
introduces a second real thread that mutates. This PR's own witness
tests construct that second thread directly (real `threading.Thread`,
not a mock).

## Tests

- `test_owner_thread_ident_is_the_constructing_thread` — sanity
- `test_same_thread_access_never_raises` — non-regression, all 11 methods
- `test_each_mutating_method_individually_raises_from_another_thread` —
  **parametrized over all 4 mutating methods individually** (docs-
  maintainer's completeness finding on the first version,
  issuecomment-5384937050: a single cross-thread test doesn't witness the
  other 3 — stripping the guard from any ONE method is now independently
  caught)
- `test_a_read_reached_from_another_thread_does_not_raise` —
  falsification contrast, and the exact #4983 pattern this scope
  correction exists to preserve
- `test_two_different_registries_each_owned_by_their_own_constructing_thread`
  — per-instance ownership, not a global latch

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 5/5 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] full `tests/core+runtime+security+llm+interfaces+web` sweep — **8434
      passed**, 1 pre-existing unrelated failure (`shutil.which("reyn")`
      returning `None`, a console-script/PATH environment issue) — this
      time including the two trees the first version's sweep omitted
- [ ] (skipped — full suite runs in CI per repo convention, not locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
