### PR TITLE
fix(#5204): TESTS-READ gate compares against the current head, not "any commit"/"every note"

### DIFF
--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -352,36 +352,46 @@ These rules then keep multi-session work coherent:
    silent. One reporting channel, not a check run and a status both
    claiming the same fact.
 
-   **Existential quantification closed to universal (#5197, 2026-08-23):**
+   **Existential quantification closed to universal, then corrected back to
+   existential over the CURRENT HEAD (#5197 → #5204, both 2026-08-23):**
    `evaluate` used to return green the instant ANY ONE note named a fresh
    commit of the PR — an existential check ("does a note naming the current
-   tree exist"), not the universal one rule 8 actually needs ("does EVERY
-   note naming a commit of the PR name a fresh one"). Measured live on
-   #5196: architect's A note named the new head; docs-maintainer's B note
-   still named the PREVIOUS head, because a fresh witness commit (the fix
-   for architect's own blocking finding) had landed to `tests/` in
-   between — and the gate went green having read only the A note, since it
-   stopped looking the moment it found one success. Rule 8 requires B
-   specifically; A is architect's own operational practice, not something
-   this gate (or any other mechanism) may come to require in its place —
-   so the fix is a plain ∀ over every note's own SHA, never a role parse.
-   `evaluate` now reds a PR the moment ANY note names a commit `tests/` has
-   moved past, and names that note's own first-line text in the failure so
-   the ask is "post a fresh note" scoped to the reviewer who owns it, not
-   "read the PR again". A single-note PR (the ordinary case) is unaffected
-   — the tightening only bites when multiple notes exist and disagree.
+   tree exist"), where "a fresh commit" meant merely "not stale relative to
+   `tests/`". Measured live on #5196: architect's A note named the new head;
+   docs-maintainer's B note still named the PREVIOUS head, because a fresh
+   witness commit (the fix for architect's own blocking finding) had landed
+   to `tests/` in between — and the gate went green having read only the A
+   note, since it stopped looking the moment it found one success. #5197's
+   own fix over-corrected to a ∀ over every note that names ANY commit of
+   the PR: reds the moment any note is stale relative to `tests/`, no matter
+   how many other notes exist. That broke on #5201, live: a first B note
+   went stale after a fix landed, the SAME reviewer posted a second,
+   differential B note correctly naming the new head — and the PR stayed
+   red FOREVER, because a comment thread only grows and the first note's own
+   stale SHA never stops existing to fail the ∀. #5204 (architect,
+   correcting #5197's own ruling) replaced the comparison target: the
+   predicate is existential over the PR's CURRENT `headRefOid` specifically
+   — "does some note name THIS commit" — not "any commit of the PR" (#5196's
+   hole) and not "every note ever posted" (#5197's hole). An old note naming
+   an old SHA simply doesn't match the (moving) target and is left exactly
+   where it is, never edited or deleted; a single fresh note matching the
+   current head is enough regardless of how many superseded notes sit above
+   it. One behavior change worth naming: because the target is now the
+   EXACT head rather than "no `tests/` commit landed since", a commit that
+   moves the head without touching `tests/` (e.g. a docs-only fixup) still
+   requires a fresh note — the pre-#5204 `tests/`-only leniency is gone.
 
    **This does not close, and was never meant to close, a second, separate
    limit:** the gate reads no role marker at all — it cannot tell an A note
    from a B note, or a B note from a third opinion, only that a comment's
-   first line names the marker and a fresh SHA. #5187 gave a note's first
-   line a role-disclosing shape parseable in principle, but adding a role
-   parse here would make "A ran" a requirement this gate enforces, when
+   first line names the marker and the current head. #5187 gave a note's
+   first line a role-disclosing shape parseable in principle, but adding a
+   role parse here would make "A ran" a requirement this gate enforces, when
    only "B ran" is a house rule that exists — a new rule invented by the
    gate, not a reflection of one that does. Whether the RIGHT roles
    reviewed a PR remains a human's judgment reading the PR before merging,
-   same as it always was; a green here means "every note that names a tree
-   names a fresh one," never "the tree was reviewed by the right people."
+   same as it always was; a green here means "some note names the exact
+   tree about to merge," never "the tree was reviewed by the right people."
 
 ## Bundling and the owner's veto unit
 

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Fail a ``tests/``-touching PR whose TESTS-READ note does not name the tree
-it read, or names one that later commits to ``tests/`` have already left behind.
+"""Fail a ``tests/``-touching PR whose TESTS-READ note does not name the PR's
+CURRENT head, or carries no such note at all.
 
 #5039. House rule 8 says a PR touching ``tests/`` does not self-merge until a
 reviewer's TESTS-READ note lands on it. The rule is satisfied by the note
@@ -11,17 +11,27 @@ earlier head, and in every case ``tests/`` moved afterwards — #5090 (note at
 ``e0dd40461``; the witness commit landed 13 minutes later), #5096 (note at
 10:32; test files changed at 10:48 and 10:59), #5038 (note read ``5c90f2ac4``
 while the PR head was ``6b5d587c0``, already merged). All four read green under
-rule 8.
+rule 8; all four also fail the CURRENT algorithm below (a note naming an
+earlier SHA cannot satisfy the existential over the current head either) —
+the population these 4 real instances name did not change across #5197/#5204,
+only the shape of the check that catches them.
 
 The class this closes is the one ``verification-hazards.md`` names as its root:
 **an observation does not name its own referent**. So the predicate is not "was
 the note any good" — nothing here reads the note's content. It is only:
 
-1. the note names a SHA at all (absent -> red), and
-2. no commit has touched ``tests/`` since that SHA (later commits -> red, with
-   the commits listed, so the ask is "top up the diff", not "read it again"),
-3. a ``tests/``-touching PR carries at least one note (none -> red) — rule 8
-   itself, which nothing has been checking mechanically.
+1. a ``tests/``-touching PR carries at least one TESTS-READ note (none -> red)
+   — rule 8 itself, which nothing has been checking mechanically.
+2. that note names a SHA at all, and the SHA is a real commit of this PR
+   (absent/unresolvable -> red — an issue-comment id, e.g., is hex-shaped but
+   not a commit).
+3. #5204 (architect ruling, correcting #5197's own ∀ — see ``evaluate``'s own
+   docstring for the full history): SOME resolvable note names the PR's
+   CURRENT head specifically (none does -> red, naming both the stale note's
+   own SHA and the current head, so the ask is "post a fresh note naming
+   THIS head" — never "read the PR again", and never "edit or delete the
+   old note", which stays exactly where it is as history of what was
+   actually read at the time).
 
 The note's CLAIM line lives in a PR **comment**, and only its FIRST LINE is
 ever read (see ``_NOTE_MARKER`` / ``evaluate``). That comment's line 1 must
@@ -70,7 +80,7 @@ provides this; it is not something a pure Python predicate can exercise, and
 the test suite says so plainly rather than pretending to cover it.
 
 Deliberately NOT closed: this predicate proves only that a comment's first
-line names a fresh commit of this PR — never that a *reviewer* wrote it.
+line names the PR's current head — never that a *reviewer* wrote it.
 Every session in this repo authenticates as the same ``gh`` user (house
 rule preamble, PR-workflow doc), so comment authorship cannot distinguish
 reviewer from author any more than body authorship could; the syntactic

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -166,33 +166,16 @@ def tests_commits_after(sha: str, commits: "list[dict]") -> "list[dict]":
     return [c for c in tail if c.get("_tests_paths")]
 
 
-def _note_verdict(
-    note: str, oids: "list[str]", commits: "list[dict]",
-) -> "tuple[str, str, list[dict]] | None":
-    """One note's verdict: ``None`` if it names no commit of this PR (not a
-    claim this predicate can evaluate at all — the caller's "none resolved"
-    bucket); otherwise ``(note, sha, later)`` where *sha* is the FIRST fresh
-    SHA the note names, and *later* is empty when fresh.
-
-    A note naming several SHA-shaped tokens (rare, but ``find_note_shas``
-    returns every membership hit on the line) passes as a whole the moment
-    ANY one of them is fresh — mirrors the per-note short-circuit the old
-    single-note code path already had, just no longer let one note's own
-    fresh candidate excuse a DIFFERENT note (see ``evaluate``'s own
-    docstring, #5197). When every candidate on this note is stale, *sha*/
-    *later* report the FIRST one, so the red output names one concrete
-    offending commit set rather than every candidate's own list."""
-    shas = find_note_shas(note, oids)
-    if not shas:
-        return None
-    first_later: "list[dict]" = []
-    for sha in shas:
-        later = tests_commits_after(sha, commits)
-        if not later:
-            return note, sha, []
-        if not first_later:
-            first_later = later
-    return note, shas[0], first_later
+def _note_names_head(note: str, head: str, oids: "list[str]") -> bool:
+    """Does *note* (a comment's first line) name *head* specifically —
+    ``head`` prefix-matched against every SHA-shaped token *note* names
+    that is also a real commit of this PR (:func:`find_note_shas`'s own
+    membership filter). The comparison TARGET, not merely "any commit" —
+    see :func:`evaluate`'s own docstring, #5204."""
+    return any(
+        head.startswith(sha) or sha.startswith(head)
+        for sha in find_note_shas(note, oids)
+    )
 
 
 def evaluate(pr: dict) -> "tuple[int, list[str]]":
@@ -211,39 +194,48 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     which is deliberate: a document *about* the marker is not a document
     *stating* the marker.
 
-    #5197 (architect ruling, following lead-coder's #5196 measurement): the
-    verdict is a UNIVERSAL quantification over every note that names a
-    commit of this PR, not an existential one. The predicate used to return
-    green the instant ANY ONE note named a fresh commit — measured live on
-    #5196: architect's A note named the new head, docs-maintainer's B note
-    still named the PREVIOUS head (a fresh witness commit had landed to
-    tests/ between them), and the gate went green having read only the A
-    note, because it stopped looking the moment it found one success. House
-    rule 8 requires B specifically (the A role is architect's own
-    operational practice, not something this gate — or anything else — may
-    come to require; see the paragraph below). Now EVERY note naming a
-    commit of this PR must name a FRESH one for the PR to pass — one fresh
-    note no longer excuses a different, stale note.
+    #5204 (architect ruling, correcting #5197's own ∀ — issuecomment-
+    5384996017): the verdict is an EXISTENTIAL quantification over the
+    CURRENT HEAD specifically — "does a note exist naming THIS commit" —
+    not "any commit of this PR" (#5196's own bug: a stale B note satisfied
+    plain commit-membership, so a fresh A + a stale B still went green) and
+    NOT a universal quantification over every note ever posted (#5197's own
+    overcorrection, which #5204 replaces): a comment thread only grows, so
+    under ∀ a single stale note from an EARLIER round of review permanently
+    reds a PR that has since gained a fresh one — #5201 is the live
+    counter-example architect measured (a first B note went stale after a
+    fix landed; a second, differential B note correctly named the new head;
+    ∀ still reported red forever, because the FIRST note never stops
+    existing and never stops naming its own now-stale SHA).
+
+    Comparing against the CURRENT head fixes both holes at once: an old
+    note naming an old SHA simply does not match the (moving) target and is
+    left exactly where it is — this predicate never asks anyone to edit or
+    delete a prior note (CLAUDE.md's 3rd cross-cutting question, "does the
+    repair destroy the evidence" — here, no: every earlier note stays
+    intact as history of what was actually read at the time). A single
+    fresh note matching the current head is enough to pass, regardless of
+    how many earlier, now-superseded notes sit above it in the same thread.
 
     Deliberately does NOT parse which review role (A/B/etc.) wrote a note —
     only "B is required" is a house rule this gate can enforce; making A
     load-bearing here would be a new rule invented by this predicate, not a
     reflection of one that exists. #5187 fixed the note's first line into a
     parseable shape (role disclosed), which is what would make role-parsing
-    POSSIBLE if the universal quantification above ever proves insufficient
-    on its own — not a reason to add it preemptively (CLAUDE.md: "would
-    removing this cause a mistake?").
+    POSSIBLE if the existential check above ever proves insufficient on its
+    own — not a reason to add it preemptively (CLAUDE.md: "would removing
+    this cause a mistake?").
 
-    What a green return means, precisely: EVERY comment whose first line
-    names a commit of this PR names a FRESH one. It does NOT mean a
-    reviewer made that claim, and it does NOT mean every required ROLE
-    weighed in — every session here authenticates as the same ``gh`` user,
-    so comment authorship carries no reviewer/author distinction for this
-    function (or any text predicate) to read, and this function reads no
-    role marker at all. Rule 8's actual review requirement is enforced by a
-    human reading the PR before merging, not by this check; treat a green
-    here as "every note that names a tree names a fresh one", never as
-    "the tree was reviewed" or "the right roles reviewed it"."""
+    What a green return means, precisely: SOME comment's first line names
+    the PR's CURRENT head. It does NOT mean a reviewer made that claim, and
+    it does NOT mean every required ROLE weighed in — every session here
+    authenticates as the same ``gh`` user, so comment authorship carries no
+    reviewer/author distinction for this function (or any text predicate)
+    to read, and this function reads no role marker at all. Rule 8's actual
+    review requirement is enforced by a human reading the PR before
+    merging, not by this check; treat a green here as "a note names the
+    exact tree about to merge", never as "the tree was reviewed" or "the
+    right roles reviewed it"."""
     touched_tests = [p for p in pr.get("files", []) if p.startswith("tests/")]
     if not touched_tests:
         return 0, ["OK — this PR does not touch tests/; rule 8 does not apply."]
@@ -270,24 +262,25 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
             "  Nothing here can be shown to have been read; refusing to pass a",
             "  note that names a tree this check cannot locate.",
         ]
-    # ONLY the PR's own commits — deliberately NOT headRefOid. A note quoting
-    # the head passes membership, and with an empty commit list there is then
-    # nothing for `tests_commits_after` to find, so the PR goes green with
-    # nothing read (docs-maintainer, #5120 B). The head is a commit of this PR
-    # whenever the PR has any, so including it separately buys nothing and
-    # costs exactly this hole.
     oids = [c.get("oid", "") for c in commits]
+    head = pr.get("headRefOid", "")
+    if not head:
+        return 1, [
+            "RED — this PR's headRefOid is empty; cannot verify a note names",
+            "  the current tree.",
+        ]
 
     resolved_count = 0
-    stale: "list[tuple[str, str, list[dict]]]" = []
+    other: "list[tuple[str, str, list[dict]]]" = []
     for note in notes:
-        verdict = _note_verdict(note, oids, commits)
-        if verdict is None:
+        shas = find_note_shas(note, oids)
+        if not shas:
             continue
         resolved_count += 1
-        note_text, sha, later = verdict
-        if later:
-            stale.append((note_text, sha, later))
+        if _note_names_head(note, head, oids):
+            return 0, [f"OK — a TESTS-READ note names the current head {head}."]
+        sha = shas[0]
+        other.append((note, sha, tests_commits_after(sha, commits)))
 
     if not resolved_count:
         return 1, [
@@ -299,28 +292,21 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
             "  Without it, nothing can tell whether the note is a claim about THIS tree.",
         ]
 
-    if stale:
-        lines = [
-            "RED — a TESTS-READ note reads a tree that tests/ has moved past.",
-            "  (∀ EVERY note naming a commit of this PR must name a FRESH one —",
-            "  one fresh note does not excuse a different, stale note. #5197.)",
-        ]
-        for note_text, sha, later in stale:
-            lines.append(f"  stale note (first line): {note_text!r}")
-            lines.append(f"    names {sha}")
-            lines.append("    tests/ commits after it:")
-            for c in later:
-                lines.append(f"      {c.get('oid', '')[:9]} {c.get('messageHeadline', '')[:60]}")
-        lines.append(
-            "  Ask the same reviewer for a DIFFERENTIAL note over just these commits —"
-        )
-        lines.append("  re-reading the whole PR is not required.")
-        return 1, lines
-
-    return 0, [
-        "OK — every TESTS-READ note names a commit of this PR, and no commit",
-        "  has touched tests/ since it.",
+    lines = [
+        f"RED — no TESTS-READ note names the current head {head}.",
+        "  (∃ over the CURRENT head, #5204 — an older note naming an earlier",
+        "  commit does not count against a PR that has since moved. Post a",
+        "  FRESH note naming this head; earlier notes stay exactly as posted,",
+        "  nothing here asks you to edit or delete them.)",
     ]
+    for note_text, sha, later in other:
+        suffix = (
+            f" — {len(later)} tests/ commit(s) landed since"
+            if later else " — not the current head"
+        )
+        lines.append(f"  note (first line): {note_text!r}")
+        lines.append(f"    names {sha}{suffix}")
+    return 1, lines
 
 
 def commit_touched_paths(oid: str, repo: str, run=subprocess.run) -> "list[str]":

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -31,6 +31,17 @@ acceptance cases:
 ④ a claim naming a sha that later tests/-touching commits moved past → red,
    listing those commits (`test_note_whose_sha_predates_a_later_tests_commit_is_rejected`).
 
+#5204 (architect ruling, correcting #5197's own ∀): the comparison target
+is the PR's CURRENT HEAD specifically, not "any commit of this PR" (#5196's
+own bug) and not "every note ever posted must be fresh" (#5197's own
+overcorrection — a note thread only grows, so a stale note from an EARLIER
+review round permanently reds a PR that has since gained a fresh note;
+#5201 is the live counter-example architect measured). Every `_pr()` call
+below now passes an explicit `head=` matching the fixture's own intended
+"current" commit — the old default (`"ffffffff"`, matching nothing) would
+silently red every accept-side case under the new head-specific comparison,
+which is itself part of what this file now must not let happen invisibly.
+
 Payloads are built inline rather than fetched: `evaluate` is pure by design so
 the decision is testable without GitHub, and the fixtures here are the only
 callers that need to exist.
@@ -76,9 +87,11 @@ def test_note_without_a_sha_is_rejected():
 
 
 def test_note_whose_sha_predates_a_later_tests_commit_is_rejected():
-    """Tier 1: the #5090 / #5095 shape — the note is real and names its head, and then
-    `tests/` moved. The failure names the commits so the ask is a differential
-    top-up, not a re-read. (Architect's acceptance ④.)"""
+    """Tier 1: the #5090 / #5095 shape — the note is real and names an
+    EARLIER commit, and `tests/` has since moved past it (the PR's current
+    head is the LATER commit). The failure names the stale SHA and the
+    current head so the ask is a differential top-up, not a re-read.
+    (Architect's acceptance ④.)"""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
         comments=[{"body": "TESTS-READ (B: independent) (head `a7c44eef6`)."}],
@@ -86,11 +99,12 @@ def test_note_whose_sha_predates_a_later_tests_commit_is_rejected():
             _commit("a7c44eef6", "docs: split the column"),
             _commit("9ef30f95b", "test(#4206): CI-gate the Reload column too", ("tests/repo/test_config_reference_declared_in_4206.py",)),
         ],
+        head="9ef30f95b",
     ))
     assert code == 1
     joined = "\n".join(lines)
-    assert "9ef30f95" in joined, "the offending commit is named, so the ask is scoped"
-    assert "DIFFERENTIAL" in joined.upper()
+    assert "a7c44eef6" in joined, "the note's own stale SHA is named"
+    assert "9ef30f95b" in joined, "the current head it must instead name is named"
 
 
 def test_no_claim_line_at_all_is_rejected():
@@ -105,65 +119,96 @@ def test_no_claim_line_at_all_is_rejected():
     assert "no TESTS-READ note" in "\n".join(lines)
 
 
-def test_a_fresh_a_note_does_not_excuse_a_stale_b_note():
-    """Tier 1: #5197 (architect ruling) — the existential-quantification gap
-    measured live on #5196 itself. architect's A note named the NEW head;
-    docs-maintainer's B note still named the PREVIOUS head, and a fresh
-    ``tests/`` commit (the witness the blocking finding needed) had landed
-    in between. The old predicate returned green the instant it found ONE
-    fresh note (A) — it never looked at B, though house rule 8 requires B
-    specifically. Reproduced from #5196's own actual shape: two notes, one
-    fresh, one one commit stale. Must be red — a fresh note no longer
-    excuses a different, stale note (architect's acceptance ①)."""
-    code, lines = _MOD.evaluate(_pr(
+def test_a_fresh_note_passes_even_with_an_older_stale_note_present():
+    """Tier 1: #5204 (architect ruling, correcting #5197's own ∀) — the
+    live #5201 counter-example. A first B note went stale after a fix
+    landed; the SAME reviewer then posted a second, differential B note
+    correctly naming the new head — but the first note never disappears
+    (a comment thread only grows). Under #5197's ∀, this PR reported red
+    FOREVER, because the old note's own stale SHA never stops existing.
+    Under #5204's ∃-over-current-head, the fresh note alone is sufficient
+    — the old note is simply irrelevant to the CURRENT head, not a second
+    vote that has to also agree. Reproduced from #5196/#5201's own actual
+    shape: two notes from the SAME author, one now-stale, one fresh."""
+    code, _ = _MOD.evaluate(_pr(
         files=["tests/core/test_5192_state_log_wal_no_toctou_guard.py"],
         comments=[
-            {"body": "**[architect]** — TESTS-READ (A: design conformance) (head `f199bf79a`)"},
             {"body": "**[docs-maintainer]** — TESTS-READ (B: independent) (head `48067968c`)"},
+            {"body": "**[docs-maintainer]** — TESTS-READ 再B (head `f199bf79a`)"},
         ],
         commits=[
             _commit("48067968c", "fix(#5192): remove the guard in 2 of 3 files"),
             _commit("f199bf79a", "fix(#5192): add budget.py's own guard-absence witness",
                      ("tests/core/test_5192_state_log_wal_no_toctou_guard.py",)),
         ],
+        head="f199bf79a",
     ))
-    assert code == 1, "a stale B note must not be excused by a fresh A note"
-    joined = "\n".join(lines)
-    assert "f199bf79a" in joined, "the offending witness commit is named, so the ask is scoped"
+    assert code == 0, (
+        "a fresh note naming the current head must pass even with an "
+        "older, now-superseded note from an earlier review round still "
+        "sitting in the same thread"
+    )
 
 
-def test_the_red_message_names_which_note_is_stale():
-    """Tier 1: #5197 acceptance ② — the red output must name WHICH note went
-    stale (its own first-line text), not just that some note somewhere did —
-    the ask a reviewer gets is "post a fresh note", and they need to know
-    it's THEIRS, not the other reviewer's, that's being asked for."""
+def test_the_red_message_names_the_stale_note_and_the_current_head():
+    """Tier 1: #5204 acceptance ② — with NO note naming the current head
+    (only a stale one), the red output must name both the stale note's own
+    content and the head it fails to name, so the ask is "post a note
+    naming THIS head", not merely "something is wrong"."""
     code, lines = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
         comments=[
-            {"body": "**[architect]** — TESTS-READ (A) (head `bbbbbbbb`)"},
             {"body": "**[docs-maintainer]** — TESTS-READ (B) (head `aaaaaaaa`)"},
         ],
         commits=[
             _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
             _commit("bbbbbbbb", "test: fix", ("tests/scripts/test_check_doc_drift_5003.py",)),
         ],
+        head="bbbbbbbb",
     ))
     assert code == 1
     joined = "\n".join(lines)
     assert "docs-maintainer" in joined, (
-        "the stale note's own first-line text (naming its author role) must "
-        f"appear in the output so the ask is scoped to the right reviewer; got {joined!r}"
+        "the stale note's own first-line text must appear in the output"
     )
-    assert "architect" not in joined, (
-        "the FRESH note must not be reported as if it were the problem"
+    assert "bbbbbbbb" in joined, "the current head the note fails to name must be named"
+
+
+def test_repair_only_adds_a_note_never_needs_to_touch_the_stale_one():
+    """Tier 1: #5204 acceptance ③ — "repair does not destroy evidence"
+    (CLAUDE.md's 3rd cross-cutting question), witnessed directly: the SAME
+    stale-note fixture from the red case above, with ONE note APPENDED
+    (never editing or removing the first), flips straight to green. The
+    old note is never touched."""
+    stale_comment = {"body": "**[docs-maintainer]** — TESTS-READ (B) (head `aaaaaaaa`)"}
+    commits = [
+        _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
+        _commit("bbbbbbbb", "test: fix", ("tests/scripts/test_check_doc_drift_5003.py",)),
+    ]
+    red_code, _ = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[stale_comment],
+        commits=commits, head="bbbbbbbb",
+    ))
+    assert red_code == 1, "sanity: the stale-only fixture is red on its own"
+
+    green_code, _ = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[
+            stale_comment,  # untouched, still present, still names the old SHA
+            {"body": "**[docs-maintainer]** — TESTS-READ 再B (head `bbbbbbbb`)"},
+        ],
+        commits=commits, head="bbbbbbbb",
+    ))
+    assert green_code == 0, (
+        "appending a fresh note — without editing or removing the stale "
+        "one — must be enough to pass"
     )
 
 
 def test_a_single_note_naming_the_current_head_still_passes():
-    """Tier 1: #5197 acceptance ③ — the common case (one required B note,
-    naming the PR's current head) must keep passing under the universal
-    quantification; #5197 only tightens the "one is enough" case where
-    MULTIPLE notes exist and disagree, not the ordinary single-note PR."""
+    """Tier 1: the common case (one required B note, naming the PR's
+    current head) passes."""
     code, _ = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
         comments=[{"body": "**[docs-maintainer]** — TESTS-READ (B) (head `bbbbbbbb`)"}],
@@ -171,6 +216,7 @@ def test_a_single_note_naming_the_current_head_still_passes():
             _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
             _commit("bbbbbbbb", "test: fix", ("tests/scripts/test_check_doc_drift_5003.py",)),
         ],
+        head="bbbbbbbb",
     ))
     assert code == 0
 
@@ -211,8 +257,8 @@ def test_marker_only_from_line_two_onward_is_not_a_claim():
 
 def test_note_naming_the_last_tests_commit_passes():
     """Tier 1: the accept side — a claim on a comment's first line, naming
-    the newest tests/ commit, is a claim about the tree that is about to
-    merge."""
+    the newest tests/ commit (the PR's current head), is a claim about the
+    tree that is about to merge."""
     code, _ = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
         comments=[{"body": "TESTS-READ (B) (head `bbbbbbbb`)"}],
@@ -220,14 +266,21 @@ def test_note_naming_the_last_tests_commit_passes():
             _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
             _commit("bbbbbbbb", "test: fix", ("tests/scripts/test_check_doc_drift_5003.py",)),
         ],
+        head="bbbbbbbb",
     ))
     assert code == 0
 
 
-def test_commits_after_the_note_that_do_not_touch_tests_pass():
-    """Tier 1: a docs-only or src-only commit after the note does not
-    invalidate it —
-    the note is a claim about `tests/`, so only `tests/` moving falsifies it."""
+def test_a_note_naming_an_older_commit_reds_even_when_the_newer_one_is_docs_only():
+    """Tier 1: #5204's own behavior change from the pre-#5204 leniency —
+    the comparison target is the CURRENT HEAD specifically, not "the
+    newest tests/-touching commit". A docs-only commit landing after the
+    note still MOVES THE HEAD, so a note naming the earlier commit no
+    longer names the current tree, even though nothing in tests/ itself
+    changed. (The pre-#5204 predicate tolerated this via `tests_commits_
+    after`'s tests/-only filter; #5204 dropped that leniency in favor of
+    "does a note name headRefOid, full stop" — see the module docstring's
+    own #5204 section, "just fix the comparison target".)"""
     code, _ = _MOD.evaluate(_pr(
         files=["tests/scripts/test_check_doc_drift_5003.py"],
         comments=[{"body": "TESTS-READ (B) (head `aaaaaaaa`)"}],
@@ -235,8 +288,12 @@ def test_commits_after_the_note_that_do_not_touch_tests_pass():
             _commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",)),
             _commit("cccccccc", "docs: reword"),
         ],
+        head="cccccccc",
     ))
-    assert code == 0
+    assert code == 1, (
+        "a note naming a non-head commit must red, even when the commit "
+        "that moved the head touched no tests/ file"
+    )
 
 
 def test_multiline_comment_with_the_claim_on_line_one_still_passes():
@@ -255,6 +312,7 @@ def test_multiline_comment_with_the_claim_on_line_one_still_passes():
             ),
         }],
         commits=[_commit("aaaaaaaa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
+        head="aaaaaaaa",
     ))
     assert code == 0
 


### PR DESCRIPTION
**[docs-maintainer]** — #5204, architect ruling (issuecomment-5384996017), correcting #5197's own ruling.

## Problem

#5197's own fix (my #5198) over-corrected: universally quantifying over EVERY note that names any commit of the PR breaks live on #5201 — a first B note went stale after a fix landed, the same reviewer posted a second, differential B note correctly naming the new head, and the PR stayed red **forever**, because a comment thread only grows and the first note's own stale SHA never stops existing to fail the ∀. Confirmed against the actual live PR: `tests-read-names-its-tree` currently fails on #5201 despite a fresh B note naming its current head.

## Fix

Existential quantification over the PR's **current `headRefOid`** specifically — "does some note name THIS commit" — not "any commit of the PR" (#5196's original hole) and not "every note ever posted" (#5197's overcorrection). An old note naming an old SHA simply doesn't match the moving target and is left exactly where it is, never edited or deleted (CLAUDE.md's 3rd cross-cutting question: the repair does not destroy the evidence). A single fresh note matching the current head is enough regardless of how many superseded notes sit above it.

**Behavior change worth naming**: since the target is now the exact head rather than "no `tests/` commit landed since", a commit that moves the head without touching `tests/` (a docs-only fixup) now also requires a fresh note — the pre-#5204 `tests/`-only leniency is gone, per architect's explicit "just fix the comparison target to the current head".

## Verified against the live, currently-failing PR directly

```
$ python scripts/check_tests_read_names_its_tree.py --pr 5201
OK — a TESTS-READ note names the current head 35eae1996e8e9ec3d5991f592fc9f8c53e23f221.
```
(this command currently returns non-zero / fails CI on `main`'s own #5198 code — confirmed before this fix, and again as the strip-falsify below)

## Strip-falsify

- Reran the exact #5196 mixed-note shape (fresh A + stale B) as a synthetic fixture: green (A alone satisfies ∃-over-head) — the #5196 hole stays closed.
- A stale-B-only fixture (no note anywhere names the current head): red.
- The live #5201 PR: OK (see above), where the pre-fix code reds it forever.

## Docs

`docs/deep-dives/contributing/pr-workflow.md`'s #5197 section (my own #5198 PR) is now itself stale — the whole "∃→∀" story it told is half-corrected here; rewrote the section to record #5197→#5204 as one continuous story rather than silently overwriting what #5198 said.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_tests_read_names_its_tree_5039.py` — 20/20 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py scripts/check_tests_read_names_its_tree.py` — OK
- [x] `python scripts/mypy_ratchet.py` — 201/207 baselined, no new
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` / `check_doc_anchors.py` / `check_retired_config_keys_denylist.py` (docs/ touched) — all clean
- [x] `pytest tests/scripts/test_check_tests_read_names_its_tree_5039.py -q` — 20 passed
- [x] (skipped — Visual, standing waiver 2026-08-08)

- [x] 🔴 **[e2e-coder]** module docstring top summary (line 2-3, list items 1-3) still describes the pre-#5204 algorithm ("no commit has touched tests/ since that SHA") — evaluate()'s own docstring and pr-workflow.md are correct, only the file-top summary is stale. See issuecomment-5385044827. **[docs-maintainer] fixed at `f58f05e08`** — re-read the whole opening section (not just the numbered list), also fixed one more stale phrase ("names a fresh commit" -> "names the PR's current head") in the "Deliberately NOT closed" paragraph. All gates green.

Touches `tests/` — needs a TESTS-READ note before merge; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



