### PR TITLE
gate(#5093): a graceful-degrade placeholder in project_remote_snapshot needs a declared axis, structurally

### DIFF
--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -97,6 +97,7 @@ from pathlib import Path
 
 from reyn.interfaces.repl import read_model as read_model_module
 from reyn.interfaces.repl.read_model import _WIRE_KEYS, ChatReadModelCapabilities
+from reyn.interfaces.transport.agui import state as agui_state_module
 
 #: #5093 — keys whose placeholder-shaped value is covered by ONE declared
 #: axis that does not share its own name (a single boolean gating more than
@@ -148,6 +149,7 @@ _CLEARED_NON_FABRICATING_KEYS = {
 }
 
 _PACKAGE_DIR = Path(read_model_module.__file__).resolve()
+_AGUI_STATE_PATH = Path(agui_state_module.__file__).resolve()
 
 
 def _is_placeholder_literal(node: "ast.expr") -> bool:
@@ -176,36 +178,79 @@ def _get_call_placeholder_key(node: "ast.expr") -> "str | None":
     return key_arg.value
 
 
-def find_violations(package_dir: "Path | None" = None) -> "list[str]":
-    """Return a message per placeholder-shaped dict key in
-    ``project_remote_snapshot`` with none of the 3 remedies. Empty = clean."""
-    if package_dir is None:
-        package_dir = _PACKAGE_DIR
+def _find_function_return_dict(
+    package_dir: Path, func_name: str,
+) -> "tuple[ast.Dict | None, str | None]":
+    """Parse *package_dir* and return the ``ast.Dict`` node backing *func_name*'s
+    return value — shared by both this gate's checks
+    (``project_remote_snapshot``'s own placeholder scan, and
+    ``project_status``'s unconditional-key-set scan for
+    :func:`find_wire_keys_violations`). Handles both ``return {...}``
+    directly AND ``out = {...}; return out`` (``project_status``'s own
+    shape) — the LAST top-level assignment to the returned name before the
+    ``return`` statement, matching how a reader would resolve it by eye.
+    Returns ``(None, error_message)`` if the function, its return, or the
+    dict literal it resolves to could not be found."""
     source = package_dir.read_text(encoding="utf-8")
     tree = ast.parse(source, filename=str(package_dir))
 
     func_node = None
     for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == "project_remote_snapshot":
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
             func_node = node
             break
     if func_node is None:
-        return [
-            "check_remote_snapshot_placeholder_declared: could not find "
-            "project_remote_snapshot in read_model.py -- has it been renamed "
-            "or moved? Update this gate's function-name lookup."
-        ]
+        return None, (
+            f"check_remote_snapshot_placeholder_declared: could not find "
+            f"{func_name} in {package_dir} -- has it been renamed or moved? "
+            f"Update this gate's function-name lookup."
+        )
 
-    return_dict = None
+    return_node = None
     for node in ast.walk(func_node):
-        if isinstance(node, ast.Return) and isinstance(node.value, ast.Dict):
-            return_dict = node.value
+        if isinstance(node, ast.Return):
+            return_node = node
             break
+    if return_node is None:
+        return None, (
+            f"check_remote_snapshot_placeholder_declared: {func_name} has no "
+            f"return statement -- update this gate."
+        )
+
+    if isinstance(return_node.value, ast.Dict):
+        return return_node.value, None
+
+    if isinstance(return_node.value, ast.Name):
+        returned_name = return_node.value.id
+        return_dict = None
+        for node in func_node.body:
+            if (
+                isinstance(node, ast.Assign)
+                and isinstance(node.value, ast.Dict)
+                and any(
+                    isinstance(t, ast.Name) and t.id == returned_name
+                    for t in node.targets
+                )
+            ):
+                return_dict = node.value  # last assignment wins (top-to-bottom walk)
+        if return_dict is not None:
+            return return_dict, None
+
+    return None, (
+        f"check_remote_snapshot_placeholder_declared: {func_name}'s return "
+        f"value does not resolve to a dict literal (neither `return {{...}}` "
+        f"nor `<name> = {{...}}; return <name>`) -- update this gate."
+    )
+
+
+def find_violations(package_dir: "Path | None" = None) -> "list[str]":
+    """Return a message per placeholder-shaped dict key in
+    ``project_remote_snapshot`` with none of the 3 remedies. Empty = clean."""
+    if package_dir is None:
+        package_dir = _PACKAGE_DIR
+    return_dict, error = _find_function_return_dict(package_dir, "project_remote_snapshot")
     if return_dict is None:
-        return [
-            "check_remote_snapshot_placeholder_declared: project_remote_snapshot's "
-            "return statement is not a dict literal -- update this gate."
-        ]
+        return [error or "unknown error locating project_remote_snapshot"]
 
     axis_field_names = {f.name for f in _dataclass_field_names()}
     violations: "list[str]" = []
@@ -247,19 +292,65 @@ def _dataclass_field_names():
     return dataclasses.fields(ChatReadModelCapabilities)
 
 
+def find_wire_keys_violations(agui_state_path: "Path | None" = None) -> "list[str]":
+    """#5093 (architect blocking finding, issuecomment-5385179961, PR #5206
+    A #1): ``_WIRE_KEYS`` was a hand-typed ASSERTION with no producer code
+    reading it -- "these keys are genuinely, unconditionally on the wire"
+    was never checked against the actual wire emitter. This closes that:
+    ``_WIRE_KEYS`` must be a SUBSET of the keys ``agui/state.py``'s
+    ``project_status`` unconditionally emits (every key in ITS OWN return
+    dict, since every value there is a ``snap.get(key, default)`` call with
+    a default -- the key is always present in the output regardless of
+    ``snap``'s own contents). A key later removed from ``project_status``
+    but left in ``_WIRE_KEYS`` now goes RED here -- the exact gap the
+    architect finding named (the PR body's prior claim that a key falling
+    off the wire "re-enters the gate's scope with no second edit" was false
+    until this function existed to make it true)."""
+    if agui_state_path is None:
+        agui_state_path = _AGUI_STATE_PATH
+    return_dict, error = _find_function_return_dict(agui_state_path, "project_status")
+    if return_dict is None:
+        return [error or "unknown error locating project_status"]
+
+    unconditional_keys = {
+        key_node.value
+        for key_node in return_dict.keys
+        if isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)
+    }
+    missing = sorted(_WIRE_KEYS - unconditional_keys)
+    return [
+        f'"{key}" is in read_model._WIRE_KEYS but project_status no longer '
+        f"unconditionally emits it -- remove it from _WIRE_KEYS (it needs a "
+        f"declared ChatReadModelCapabilities axis instead, like any other "
+        f"key that can be absent from the wire)"
+        for key in missing
+    ]
+
+
 def main() -> int:
     violations = find_violations(_PACKAGE_DIR)
-    if violations:
-        print(
-            "check_remote_snapshot_placeholder_declared: "
-            f"{len(violations)} undeclared placeholder(s) in "
-            "project_remote_snapshot's return dict:\n"
-        )
-        for v in violations:
-            print(f"  - {v}")
+    wire_key_violations = find_wire_keys_violations(_AGUI_STATE_PATH)
+    if violations or wire_key_violations:
+        if violations:
+            print(
+                "check_remote_snapshot_placeholder_declared: "
+                f"{len(violations)} undeclared placeholder(s) in "
+                "project_remote_snapshot's return dict:\n"
+            )
+            for v in violations:
+                print(f"  - {v}")
+        if wire_key_violations:
+            print(
+                "check_remote_snapshot_placeholder_declared: "
+                f"{len(wire_key_violations)} _WIRE_KEYS entry(ies) no longer "
+                "backed by project_status:\n"
+            )
+            for v in wire_key_violations:
+                print(f"  - {v}")
         return 1
     print("check_remote_snapshot_placeholder_declared: OK, every placeholder-shaped "
-          "key is covered by _WIRE_KEYS, a declared axis, or a cited exemption.")
+          "key is covered by _WIRE_KEYS, a declared axis, or a cited exemption, and "
+          "_WIRE_KEYS is a verified subset of project_status's unconditional keys.")
     return 0
 
 

--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""#5093 — a graceful-degrade placeholder in ``project_remote_snapshot``'s
+return dict must have a declared axis (or a cited, permanent exemption),
+never a hand-typed literal a producer can silently forget to update.
+
+## The bug class this closes
+
+``project_remote_snapshot`` (``reyn/interfaces/repl/read_model.py``) is
+the ONE place a remote client's status snapshot gets built. Several of
+its dict values are graceful-degrade PLACEHOLDERS — ``None``/``[]``/``0``
+for a key the remote transport genuinely cannot report (session-local
+state never projected onto the wire). #5009/#5034/#5094/#5185 each found
+the SAME shape independently, each time only after an operator actually
+hit the blank pane: a placeholder value is, by construction,
+indistinguishable from "genuinely empty right now" — the caller cannot
+tell "nothing to show" from "this producer cannot show it" unless a
+SEPARATE boolean axis (:class:`~reyn.interfaces.repl.read_model.
+ChatReadModelCapabilities`) says so. #5093's own architect ruling: stop
+finding these one operator-hit at a time — a placeholder with no
+declared axis and no cited exemption is a STRUCTURAL defect, catch it in
+CI.
+
+## What counts as a "placeholder" here (lead-coder's corrected definition,
+## PR #5097 review — a hand-typed literal moved to ``v.get(key, [])`` is
+## STILL a placeholder, not a fix, if the key can genuinely be absent from
+## an older server's wire payload)
+
+A dict value is a placeholder if its AST is EITHER:
+  (a) a bare literal constant — ``None``/``[]``/``{}``/``0``/``0.0``/``""``/``False``, or
+  (b) a call of the shape ``<name>.get(<key-literal>, <placeholder-literal>)``
+      (the SAME placeholder shapes as (a), as the 2nd positional arg)
+
+Both shapes share the identical caller-visible defect: the caller cannot
+distinguish "the read genuinely produced this value" from "there was
+nothing to read". A ``.get(key)`` call with NO default (bare optional
+read, e.g. ``v.get("attached_name")``) does NOT match — its default is
+Python's own ``None`` supplied by the language, not a placeholder someone
+chose to paper over an unsupported case; a producer that wires the key at
+all gets whatever the wire actually said, `None` included, uniformly.
+
+## The only 3 remedies (no allowlist that grows unbounded)
+
+For each placeholder-shaped key found, exactly one of these must hold, or
+the gate is RED:
+
+1. **Genuinely, unconditionally on the wire — cite ``_WIRE_KEYS``.**
+   ``read_model._WIRE_KEYS`` (imported here, never re-typed — architect's
+   explicit condition, issuecomment-5384873023: a key that later falls off
+   the wire protocol automatically re-enters this gate's scope, no second
+   edit needed) is the set of ``.get()`` KEY ARGUMENTS with no possible
+   "not yet on the wire" state. Matched against the ``.get()`` call's own
+   key argument (not necessarily the dict's own output key — e.g.
+   ``cost_usd``'s call reads the ``"cost_agent"`` wire key).
+2. **A declared axis exists.** ``ChatReadModelCapabilities`` has a field
+   named ``f"{key}_reported"``, OR the key is one of the hand-maintained
+   grouped pairings below (a boolean covering more than one dict key —
+   cited to the PR/issue that established the grouping, same discipline
+   ``REACHABLE_WITHOUT_LLM_TURN`` in ``check_hooks_declared_reachable.py``
+   uses for its own non-1:1 mapping).
+3. **Cited as a deliberately-cleared non-fabricating literal.** A SMALL,
+   hand-maintained, cited set (#5034's own "cleared, not fabricating"
+   list) — a placeholder value here does NOT need its own axis because
+   #5034 already reasoned through why it never differs meaningfully from
+   a genuine local empty state. Adding to this set is a design decision
+   with its own citation, not a way to silence the gate.
+
+## Why this is AST, not intent
+
+The gate does not ask "did the author mean to add a graceful degrade" —
+it asks a purely syntactic question (does this value match one of the two
+placeholder shapes) and then checks 3 syntactic/lookup facts (membership
+in ``_WIRE_KEYS``, a matching dataclass field, membership in the cited
+non-fabricating set). Zero false positives on the CURRENT dict (verified
+by this script's own test suite); a NEW placeholder-shaped key added
+without touching one of the 3 remedies goes red immediately, the same
+turn it is written.
+
+## Disclosed gap (not a completeness claim)
+
+The 2 placeholder shapes above cover a bare literal and a single ``.get``
+call — they do NOT recurse into a ``Tuple``/``List`` of sub-expressions
+(``"usage": (0, 0, v.get("agent_tokens", 0))`` and
+``"ctx_recent_usage": (0, 0)`` are both this shape today, and neither is
+seen by this gate at all, silently). Both are already covered by a
+declared axis in the source (``usage_breakdown_reported``/
+``cache_usage_reported`` respectively) via a hand-written comment, not
+this gate's own enforcement — a FUTURE change to either that drops the
+axis check would not be caught here. Widening the AST walk to recurse
+into container literals is future work, not attempted in this PR (#5093's
+own scope: the placeholder shapes actually observed at #5009/#5034/#5094's
+own findings, all of which were shape (a)/(b), not a nested tuple)."""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+from reyn.interfaces.repl import read_model as read_model_module
+from reyn.interfaces.repl.read_model import _WIRE_KEYS, ChatReadModelCapabilities
+
+#: #5093 — keys whose placeholder-shaped value is covered by ONE declared
+#: axis that does not share its own name (a single boolean gating more than
+#: one dict key, or a dict key whose name differs from its axis field).
+#: Each entry cites the PR/issue that established the grouping — see
+#: ``ChatReadModelCapabilities``'s own docstring for the full reasoning.
+_GROUPED_AXIS_KEYS = {
+    # #5094/#5097: one flag covers both halves of the agent roster.
+    "agent_names": "agent_roster_reported",
+    "session_tree": "agent_roster_reported",
+    # #5094/#5097: one flag covers both halves of the model-class catalog.
+    "model_classes": "model_catalog_reported",
+    "model_active_class": "model_catalog_reported",
+    # #5009: cache-hit accounting shares 1 axis with "session_cached_tokens"
+    # below (the axis docstring's own "covers two snapshot() dict KEYS
+    # instead" note); "ctx_recent_usage" itself is a tuple-shaped value this
+    # gate's shape detector does not parse (see module docstring's own
+    # disclosed gap) so it never reaches this mapping today.
+    "session_cached_tokens": "cache_usage_reported",
+    # #5034: the hook-pane's 2nd dict key rides the same axis as "hooks".
+    "hook_items": "hooks_reported",
+    # #5009: the compaction-status callable slot is explicitly "gated by
+    # ctx_compaction_reported" per project_remote_snapshot's own inline
+    # comment at this key -- the axis name differs from the dict key name.
+    "ctx_compaction_status_fn": "ctx_compaction_reported",
+    # #4996/#5050: this key predates the *_reported convention (named
+    # "intervention_head" on the capabilities class, not
+    # "pending_intervention_head_reported") — the METHOD-axis field, not a
+    # snapshot-key-suffix one; see ChatReadModelCapabilities's own field.
+    "pending_intervention_head": "intervention_head",
+}
+
+#: #5034 (architect co-vet, its own issue thread) — keys whose placeholder
+#: value was explicitly reasoned through and cleared as NOT fabricating: an
+#: empty/zero value here never differs meaningfully from a genuinely empty
+#: LOCAL state, so no axis is needed to distinguish "unsupported" from
+#: "empty". Citing #4194/#4357 for the 2 keys #5034 itself didn't cover.
+_CLEARED_NON_FABRICATING_KEYS = {
+    "skills",  # #5034: an empty skill list reads identically either way
+    "mcp_servers",  # #5034: same reasoning as "skills"
+    "unknown_config_key_count",  # #4194: remote has no client-local reyn.yaml to report
+    "unknown_config_keys",  # #4357: same as unknown_config_key_count
+    "ctx_source",  # #5034: a label, not a fabricatable figure (defensive:
+    # its CURRENT value ("remote") isn't placeholder-shaped at all, so this
+    # entry only matters if a future edit narrows it to a bare "")
+    "turn_usage_fn",  # #3283 ④: a callable slot (not a data figure), always
+    # None remotely -- "the right gutter renders '—' rather than a
+    # fabricated figure" per this key's own inline comment
+}
+
+_PACKAGE_DIR = Path(read_model_module.__file__).resolve()
+
+
+def _is_placeholder_literal(node: "ast.expr") -> bool:
+    """Shape (a): a bare ``None``/``[]``/``{}``/``0``/``0.0``/``""``/``False``."""
+    if isinstance(node, ast.Constant):
+        return node.value in (None, 0, 0.0, "", False) or node.value is None
+    if isinstance(node, (ast.List, ast.Dict)):
+        return len(getattr(node, "elts", getattr(node, "keys", []))) == 0
+    return False
+
+
+def _get_call_placeholder_key(node: "ast.expr") -> "str | None":
+    """Shape (b): ``<name>.get(<key-literal>, <placeholder-literal>)`` — returns
+    the key-literal string if *node* matches, else ``None``."""
+    if not isinstance(node, ast.Call):
+        return None
+    if not isinstance(node.func, ast.Attribute) or node.func.attr != "get":
+        return None
+    if len(node.args) != 2:
+        return None
+    key_arg, default_arg = node.args
+    if not (isinstance(key_arg, ast.Constant) and isinstance(key_arg.value, str)):
+        return None
+    if not _is_placeholder_literal(default_arg):
+        return None
+    return key_arg.value
+
+
+def find_violations(package_dir: "Path | None" = None) -> "list[str]":
+    """Return a message per placeholder-shaped dict key in
+    ``project_remote_snapshot`` with none of the 3 remedies. Empty = clean."""
+    if package_dir is None:
+        package_dir = _PACKAGE_DIR
+    source = package_dir.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(package_dir))
+
+    func_node = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "project_remote_snapshot":
+            func_node = node
+            break
+    if func_node is None:
+        return [
+            "check_remote_snapshot_placeholder_declared: could not find "
+            "project_remote_snapshot in read_model.py -- has it been renamed "
+            "or moved? Update this gate's function-name lookup."
+        ]
+
+    return_dict = None
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Dict):
+            return_dict = node.value
+            break
+    if return_dict is None:
+        return [
+            "check_remote_snapshot_placeholder_declared: project_remote_snapshot's "
+            "return statement is not a dict literal -- update this gate."
+        ]
+
+    axis_field_names = {f.name for f in _dataclass_field_names()}
+    violations: "list[str]" = []
+    for key_node, value_node in zip(return_dict.keys, return_dict.values):
+        if key_node is None:  # a ``**spread`` entry -- exempt by definition
+            continue
+        if not (isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)):
+            continue  # a non-string-literal key (none exist today) -- not this gate's shape
+        dict_key = key_node.value
+
+        wire_key = _get_call_placeholder_key(value_node)
+        if wire_key is not None:
+            if wire_key in _WIRE_KEYS:
+                continue  # remedy ① -- genuinely, unconditionally on the wire
+        elif not _is_placeholder_literal(value_node):
+            continue  # not a placeholder shape at all -- not this gate's concern
+
+        if dict_key in _CLEARED_NON_FABRICATING_KEYS:
+            continue  # remedy ③
+        if f"{dict_key}_reported" in axis_field_names:
+            continue  # remedy ②, direct suffix match
+        if _GROUPED_AXIS_KEYS.get(dict_key) in axis_field_names:
+            continue  # remedy ②, grouped/renamed match
+
+        violations.append(
+            f'"{dict_key}": a placeholder-shaped value with no declared axis, no '
+            f'_WIRE_KEYS membership, and no cited non-fabricating exemption. Fix: '
+            f'add a `{dict_key}_reported` field to ChatReadModelCapabilities (or an '
+            f'entry to _GROUPED_AXIS_KEYS if it shares an axis with another key), OR '
+            f'add "{dict_key}" to _WIRE_KEYS in read_model.py if it is genuinely, '
+            f'unconditionally always on the wire, OR cite a reason and add it to '
+            f'_CLEARED_NON_FABRICATING_KEYS here.'
+        )
+    return violations
+
+
+def _dataclass_field_names():
+    import dataclasses
+    return dataclasses.fields(ChatReadModelCapabilities)
+
+
+def main() -> int:
+    violations = find_violations(_PACKAGE_DIR)
+    if violations:
+        print(
+            "check_remote_snapshot_placeholder_declared: "
+            f"{len(violations)} undeclared placeholder(s) in "
+            "project_remote_snapshot's return dict:\n"
+        )
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+    print("check_remote_snapshot_placeholder_declared: OK, every placeholder-shaped "
+          "key is covered by _WIRE_KEYS, a declared axis, or a cited exemption.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -704,6 +704,36 @@ class RegistryReadModel(ChatReadModel):
         return extend()
 
 
+#: #5093 (architect ruling, issuecomment-5384873023): the ``STATE_*`` wire
+#: keys that ``project_remote_snapshot`` reads via a ``v.get(key, <placeholder>)``
+#: call where the placeholder is genuinely unreachable — these keys have NO
+#: "unsupported"/"not yet on the wire" state to declare (unlike
+#: ``agent_names``/``model_classes``/etc, which DO — see
+#: ``ChatReadModelCapabilities.agent_roster_reported``/``model_catalog_reported``
+#: — and unlike a bare non-``.get`` literal like ``cron_jobs: []``, which
+#: needs its own declared axis). ``scripts/check_remote_snapshot_placeholder_
+#: declared.py`` imports this SAME constant rather than re-typing the key
+#: list — architect's explicit condition on approving the exclusion at all:
+#: "5件をgate側に書き写さない... 将来keyがwireから外れたとき、gateは除外した
+#: ままで穴が開く" (same comment as above, issuecomment-5384873023) — a key
+#: removed from here automatically re-enters the gate's scope, no second
+#: edit required.
+#:
+#: ``cost_usd`` is NOT listed separately: its own ``.get(...)`` call reads
+#: the ``"cost_agent"`` wire key (an intentional alias, see the dict below),
+#: so the gate matches on the ``.get()`` call's own key ARGUMENT, not the
+#: dict's output key name — one membership check covers both.
+#:
+#: ``queue``/``turn_active``/``queue_seq`` (#3300 P2b/#5098) are the
+#: server-authoritative sent-queue state, folded onto the wire the same way
+#: the cost/ctx figures are — see ``project_remote_snapshot``'s own inline
+#: comment at those 3 keys for the citation.
+_WIRE_KEYS = frozenset({
+    "cost_agent", "cost_total", "agent_tokens", "ctx_used", "ctx_window",
+    "queue", "turn_active", "queue_seq",
+})
+
+
 def project_remote_snapshot(values: "dict | None") -> dict:
     """Project a :class:`RemoteStatusView`'s wire values into the ``_snapshot``
     dict shape the inline chips read.

--- a/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
+++ b/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
@@ -1,0 +1,157 @@
+"""Tier 2: #5093 — scripts/check_remote_snapshot_placeholder_declared.py.
+
+Architect ruling (issuecomment-5384873023): a graceful-degrade placeholder
+in ``project_remote_snapshot``'s return dict must have a declared axis
+(``ChatReadModelCapabilities``), a ``_WIRE_KEYS`` membership, or a cited
+non-fabricating exemption — never a bare hand-typed literal a producer can
+silently forget to update. Real ``project_remote_snapshot``/
+``ChatReadModelCapabilities``/``_WIRE_KEYS`` for acceptance①; synthetic
+fixture files (mirrors ``test_5131_tui_widget_boundary.py``'s own pattern)
+for the falsification witnesses — a gate that only confirms green on the
+ALREADY-COMPLIANT current tree cannot distinguish "enforcing" from
+"never runs at all" (CLAUDE.md's own test-review question 4).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_remote_snapshot_placeholder_declared import find_violations
+
+# ── acceptance① — the real source, right now, has zero violations ────────
+
+
+def test_the_real_source_has_zero_violations() -> None:
+    """Tier 2: acceptance① — landed on main, every placeholder-shaped key
+    in the real ``project_remote_snapshot`` is covered by one of the 3
+    remedies. Any hit here is a real regression, not inherited debt."""
+    violations = find_violations()
+    assert violations == [], f"real regression(s) found: {violations}"
+
+
+# ── acceptance② — a new undeclared placeholder key is flagged ────────────
+
+
+def _write_module(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "fixture_read_model.py"
+    path.write_text(
+        "def project_remote_snapshot(values):\n"
+        "    v = values or {}\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_a_bare_literal_placeholder_with_no_remedy_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: acceptance② shape (a) — a bare ``[]`` literal for a key with
+    no matching ``ChatReadModelCapabilities`` field, no ``_WIRE_KEYS``
+    membership, and no cited exemption. The exact PRE-#5097 shape witness①
+    in #5093's own issue thread describes."""
+    path = _write_module(
+        tmp_path,
+        '    return {"totally_new_placeholder_key": []}\n',
+    )
+
+    violations = find_violations(path)
+
+    assert any("totally_new_placeholder_key" in v for v in violations), violations
+
+
+def test_a_get_call_placeholder_with_no_remedy_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: acceptance② shape (b) — ``v.get(key, [])`` for an
+    undeclared key. This is the shape lead-coder's corrected placeholder
+    definition (PR #5097 review) exists to still catch even AFTER a bare
+    literal is moved to a ``.get`` call — the wire-read shape alone does
+    not prove the key can never be absent."""
+    path = _write_module(
+        tmp_path,
+        '    return {"another_new_key": v.get("another_new_key", [])}\n',
+    )
+
+    violations = find_violations(path)
+
+    assert any("another_new_key" in v for v in violations), violations
+
+
+def test_a_get_call_with_no_default_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: falsification contrast — ``v.get(key)`` with NO default arg
+    (like real ``attached_name``/``pending_intervention_head``'s bare
+    reads) is not a placeholder shape at all; must never be flagged."""
+    path = _write_module(
+        tmp_path,
+        '    return {"bare_optional_key": v.get("bare_optional_key")}\n',
+    )
+
+    assert find_violations(path) == []
+
+
+def test_a_non_placeholder_value_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: falsification contrast — a non-empty string constant (a
+    genuine label, not a degrade placeholder) must never be flagged."""
+    path = _write_module(
+        tmp_path,
+        '    return {"a_real_label": "some-real-value"}\n',
+    )
+
+    assert find_violations(path) == []
+
+
+# ── acceptance③ — declaring the key (any of the 3 remedies) clears it ────
+
+
+def test_declaring_a_wire_keys_member_clears_the_flag(tmp_path: Path) -> None:
+    """Tier 2: acceptance③ remedy① — a key whose ``.get()`` call reads a
+    ``_WIRE_KEYS`` member is exempt. Uses a REAL ``_WIRE_KEYS`` entry
+    (``cost_agent``) rather than a synthetic one, since that set is
+    imported from the real module, not parameterizable per-test."""
+    path = _write_module(
+        tmp_path,
+        '    return {"cost_agent_alias": v.get("cost_agent", 0.0)}\n',
+    )
+
+    assert find_violations(path) == []
+
+
+def test_declaring_a_direct_suffix_axis_clears_the_flag(tmp_path: Path) -> None:
+    """Tier 2: acceptance③ remedy② (direct suffix match) — a key whose
+    name, with ``_reported`` appended, matches a real
+    ``ChatReadModelCapabilities`` field (``hooks_reported``)."""
+    path = _write_module(
+        tmp_path,
+        '    return {"hooks": []}\n',
+    )
+
+    assert find_violations(path) == []
+
+
+def test_an_undeclared_key_sharing_a_name_with_a_cleared_key_is_not_flagged(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: acceptance③ remedy③ — a key in the real
+    ``_CLEARED_NON_FABRICATING_KEYS`` set (``skills``) is exempt without
+    needing its own axis."""
+    path = _write_module(
+        tmp_path,
+        '    return {"skills": []}\n',
+    )
+
+    assert find_violations(path) == []
+
+
+# ── strip-falsify — the gate script itself, as a subprocess ──────────────
+
+
+def test_main_exits_nonzero_when_a_violation_exists(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: the CLI entry point (not just the underlying detector) must
+    fail loudly — mirrors the other 2026-08-23 gate test files' own
+    main()-level witness (test_5131_tui_widget_boundary.py's own
+    rationale: a detector-only test can pass while main() itself is wired
+    wrong, e.g. an exit-code inversion)."""
+    import scripts.check_remote_snapshot_placeholder_declared as gate_module
+
+    fixture = _write_module(tmp_path, '    return {"totally_undeclared": []}\n')
+    monkeypatch.setattr(gate_module, "_PACKAGE_DIR", fixture)
+
+    exit_code = gate_module.main()
+
+    assert exit_code == 1

--- a/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
+++ b/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
@@ -10,12 +10,22 @@ fixture files (mirrors ``test_5131_tui_widget_boundary.py``'s own pattern)
 for the falsification witnesses — a gate that only confirms green on the
 ALREADY-COMPLIANT current tree cannot distinguish "enforcing" from
 "never runs at all" (CLAUDE.md's own test-review question 4).
+
+``TestWireKeysBackedByProjectStatus`` (below) is the follow-up architect
+blocking finding (issuecomment-5385179961, PR #5206 A #1): ``_WIRE_KEYS``
+was a hand-typed ASSERTION with no producer code reading it — nothing
+checked that its members were genuinely, unconditionally on the wire.
+``find_wire_keys_violations`` closes that by AST-checking ``_WIRE_KEYS ⊆``
+the keys ``agui/state.py``'s ``project_status`` unconditionally emits.
 """
 from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.check_remote_snapshot_placeholder_declared import find_violations
+from scripts.check_remote_snapshot_placeholder_declared import (
+    find_violations,
+    find_wire_keys_violations,
+)
 
 # ── acceptance① — the real source, right now, has zero violations ────────
 
@@ -155,3 +165,61 @@ def test_main_exits_nonzero_when_a_violation_exists(tmp_path: Path, monkeypatch)
     exit_code = gate_module.main()
 
     assert exit_code == 1
+
+
+# ── _WIRE_KEYS ⊆ project_status's unconditional keys (architect blocking
+# finding, issuecomment-5385179961) ───────────────────────────────────────
+
+
+def _write_status_module(tmp_path: Path, keys: "list[str]") -> Path:
+    path = tmp_path / "fixture_agui_state.py"
+    body_lines = "\n".join(f'        "{k}": snap.get("{k}"),' for k in keys)
+    path.write_text(
+        "def project_status(snapshot, *, waiting_on=None):\n"
+        "    snap = snapshot or {}\n"
+        "    out = {\n"
+        f"{body_lines}\n"
+        "    }\n"
+        "    return out\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_the_real_wire_keys_are_a_verified_subset_of_project_status() -> None:
+    """Tier 2: acceptance① — landed on main, every ``_WIRE_KEYS`` member is
+    genuinely one of ``project_status``'s own unconditionally-emitted keys."""
+    violations = find_wire_keys_violations()
+    assert violations == [], f"real regression(s) found: {violations}"
+
+
+def test_a_wire_key_dropped_from_project_status_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: acceptance② — the exact architect finding: a key present in
+    ``_WIRE_KEYS`` but no longer emitted by ``project_status`` (e.g. removed
+    from the wire protocol) must be flagged, not silently trusted. Uses a
+    REAL ``_WIRE_KEYS`` member (``cost_agent``) with a synthetic
+    ``project_status`` fixture that omits it -- the exact "wire protocol
+    changed but the hand-typed assertion didn't move" shape."""
+    fixture = _write_status_module(
+        tmp_path,
+        # every real _WIRE_KEYS member EXCEPT "cost_agent"
+        ["cost_total", "agent_tokens", "ctx_used", "ctx_window", "queue",
+         "turn_active", "queue_seq"],
+    )
+
+    violations = find_wire_keys_violations(fixture)
+
+    assert any("cost_agent" in v for v in violations), violations
+
+
+def test_project_status_emitting_every_wire_key_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: falsification contrast — a fixture that DOES emit every real
+    ``_WIRE_KEYS`` member (plus an unrelated extra key, proving the check is
+    a subset test, not an exact-set one) produces zero violations."""
+    fixture = _write_status_module(
+        tmp_path,
+        ["cost_agent", "cost_total", "agent_tokens", "ctx_used", "ctx_window",
+         "queue", "turn_active", "queue_seq", "some_unrelated_extra_key"],
+    )
+
+    assert find_wire_keys_violations(fixture) == []


### PR DESCRIPTION
**[tui-coder]** — closes #5093.

## Background

Owner (2026-08-22): "穴を実測でなく構造で検出できるようにならないの？" — #5050,
⑦-a, and #4200 were all the same shape: a snapshot producer returning a
placeholder value indistinguishable from "genuinely empty", found only
after an operator hit the blank pane. `ChatReadModelCapabilities` already
solves the DECLARATION half; nothing enforced that a new placeholder-shaped
key actually gets declared.

Full design discussion (placeholder definition correction, `_WIRE_KEYS`
exclusion scoping, version-skew follow-up split) is in the issue's own
comment thread — architect's final approval: issuecomment-5384873023.

## What this adds

An AST-based gate (`scripts/check_remote_snapshot_placeholder_declared.py`)
over `project_remote_snapshot`'s return dict. A value counts as a
placeholder if it's a bare literal constant, or a `.get(key, <placeholder>)`
call — the corrected definition from PR #5097's own review (lead-coder): a
hand-typed literal moved to a wire read does NOT by itself prove the key
can never be absent (a server too old to send it still hits the same
default, indistinguishable from "0 agents").

Three remedies, checked structurally:
1. **`_WIRE_KEYS`** (new constant in `read_model.py`, imported by the gate
   — never re-typed, so a key that later falls off the wire protocol
   re-enters the gate's scope with no second edit) — keys genuinely,
   unconditionally on the wire, no "unsupported" state possible.
2. **A declared `ChatReadModelCapabilities` axis** — direct
   `f"{key}_reported"` suffix match, or a cited grouped/renamed pairing
   for the N:1 cases (`agent_names`/`session_tree` → `agent_roster_reported`,
   etc.).
3. **A small, cited allowlist** of keys #5034 already reasoned through as
   not fabricating anything (`skills`, `unknown_config_*`, etc).

## Scope, disclosed

The shape detector covers a bare literal and a single `.get()` call — it
does NOT recurse into a `Tuple`/`List` of sub-expressions (`"usage": (0, 0,
v.get(...))` and `"ctx_recent_usage": (0, 0)` are both this shape and are
silently not seen). Both are already covered by a declared axis via a
hand-written comment, not this gate's own enforcement. Documented in the
gate's own module docstring as future work, not attempted here (#5093's
own scope was the shapes actually observed at #5009/#5034/#5094).

Version-skew (a capability that's statically `True` even when the actual
connection is too old to carry the key) is a separate, already-filed
concern (see the issue thread) — this gate is static analysis over source,
it cannot know at CI time whether a given key is dynamically present on a
given wire connection.

## Tests

- `test_the_real_source_has_zero_violations` — the real gate, right now,
  zero false positives
- shape-detection witnesses for both placeholder AST shapes (bare literal,
  `.get()` call) and their falsification contrasts (no-default `.get()`,
  a real non-empty label)
- one witness per remedy (`_WIRE_KEYS` membership, direct suffix axis,
  cited non-fabricating exemption)
- `main()`-level CLI exit-code witness (not just the underlying detector)

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 9/9 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] full `tests/interfaces/ tests/scripts/` sweep — 3032 passed, 9 skipped (known optional-dependency extras)
- [ ] (skipped — full suite runs in CI per repo convention, not locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

**[architect]** — TESTS-READ A blocking point (see the review comment):

- [x] 🔴 `_WIRE_KEYS` is asserted, not derived — no production code reads it, so "a key that later falls off the wire protocol re-enters the gate's scope with no second edit" (this body) is false as built. Add a check that `_WIRE_KEYS` is a subset of the keys `agui/state.py`'s `project_status` emits unconditionally (all 8 are there today), with a witness: remove one from a `project_status` fixture → red.

