### PR TITLE
**[coder-brown]** — derive token vocabulary from explicit SSoT

### DIFF
--- a/src/reyn/plugins/tokens.py
+++ b/src/reyn/plugins/tokens.py
@@ -202,7 +202,7 @@ def expand_with_map(obj: Any, token_map: dict[str, str]) -> Any:
 # the SYNTAX only. Deliberately narrower than ``_TOKEN_RE`` (any ``${VAR}``)
 # so a genuinely unrelated ``${VAR}`` never even reaches the vocabulary
 # check below, but this regex ALONE is not the fail-close decision — see
-# :data:`_KNOWN_REYN_TOKEN_NAMES` and #5176's own correction.
+# the explicit :data:`REYN_TOKEN_NAMES` vocabulary and #5176's own correction.
 _UNRESOLVED_REYN_TOKEN_RE = re.compile(r"\$\{((?:REYN|CLAUDE)_\w+)\}")
 
 # #5176 (architect TESTS-READ blocking finding on #5166, issuecomment-5384269296):
@@ -222,28 +222,22 @@ _UNRESOLVED_REYN_TOKEN_RE = re.compile(r"\$\{((?:REYN|CLAUDE)_\w+)\}")
 # misidentified as reyn's OWN unresolved token and refuse the whole layer
 # — a real config silently breaking, not a hypothetical.
 #
-# The fix: fail-close membership is the ACTUAL name set this module can
-# supply a value for — :data:`~reyn.plugins.tokens.CLAUDE_ALIAS_MAP`'s own
-# keys plus every ``PluginTokenContext.tokens()`` key, PLUS
-# ``REYN_AGENT_NAME`` (#5140's own addition — supplied via an explicit
-# map to :func:`expand_with_map`, never through ``PluginTokenContext``
-# itself, so it is not already in either of the above and must be listed
-# here too). Anything else — including a genuine reyn-shaped TYPO like
-# ``${REYN_AGNT_NAME}`` — passes through untouched, same as any other
-# non-reyn token: distinguishing "meant to be a reyn token, misspelled"
-# from "a real env var that happens to share reyn's prefix" is not
-# reliably decidable from the string alone (architect's own recommendation,
-# issuecomment-5384269296).
-_KNOWN_REYN_TOKEN_NAMES: frozenset[str] = frozenset(
-    {"REYN_PLUGIN_ROOT", "REYN_PROJECT_DIR", "REYN_SKILL_DIR", "REYN_AGENT_NAME"}
-    | set(CLAUDE_ALIAS_MAP)
+# The token vocabulary is deliberately separate from any one resolver map:
+# a map is only a projection for one context and cannot contain agent-scoped
+# values supplied by a caller such as the hooks runner.
+CONTEXT_TOKEN_NAMES: frozenset[str] = frozenset(
+    {"REYN_PLUGIN_ROOT", "REYN_PROJECT_DIR", "REYN_SKILL_DIR"}
+)
+AGENT_SCOPED_TOKEN_NAMES: frozenset[str] = frozenset({"REYN_AGENT_NAME"})
+REYN_TOKEN_NAMES: frozenset[str] = frozenset(
+    CONTEXT_TOKEN_NAMES | AGENT_SCOPED_TOKEN_NAMES | set(CLAUDE_ALIAS_MAP)
 )
 
 
 def find_unresolved_reyn_tokens(obj: Any) -> list[str]:
     """Recursively collect every REMAINING placeholder in *obj*
     (post-:func:`expand_with_map`, typically) whose name is in reyn's OWN
-    known token vocabulary (:data:`_KNOWN_REYN_TOKEN_NAMES`) — never a
+    known token vocabulary (:data:`REYN_TOKEN_NAMES`) — never a
     bare ``${REYN_*}``/``${CLAUDE_*}`` PREFIX match (#5176's own
     correction — see that constant's docstring for why a prefix match is
     the wrong test).
@@ -264,7 +258,7 @@ def find_unresolved_reyn_tokens(obj: Any) -> list[str]:
         return [
             m.group(0)
             for m in _UNRESOLVED_REYN_TOKEN_RE.finditer(obj)
-            if m.group(1) in _KNOWN_REYN_TOKEN_NAMES
+            if m.group(1) in REYN_TOKEN_NAMES
         ]
     if isinstance(obj, dict):
         found: list[str] = []

--- a/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
+++ b/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
@@ -18,7 +18,14 @@ working (the whole layer refused) without this fix.
 Real ``find_unresolved_reyn_tokens`` — no mocks; a pure function."""
 from __future__ import annotations
 
-from reyn.plugins.tokens import find_unresolved_reyn_tokens
+from reyn.plugins.tokens import (
+    AGENT_SCOPED_TOKEN_NAMES,
+    CONTEXT_TOKEN_NAMES,
+    REYN_TOKEN_NAMES,
+    PluginTokenContext,
+    find_unresolved_reyn_tokens,
+    resolve_token_map,
+)
 
 
 def test_a_real_non_reyn_env_var_sharing_the_reyn_prefix_is_not_flagged() -> None:
@@ -44,6 +51,25 @@ def test_a_reyn_shaped_typo_is_not_flagged() -> None:
     share reyn's prefix" (architect's own recommendation,
     issuecomment-5384269296; lead-coder concurred)."""
     assert find_unresolved_reyn_tokens({"a": "${REYN_AGNT_NAME}"}) == []
+
+
+def test_token_vocabularies_are_disjoint_and_complete(tmp_path) -> None:
+    """Tier 1: context and agent-scoped token sets form the full vocabulary."""
+    context = PluginTokenContext(tmp_path, tmp_path)
+    assert not CONTEXT_TOKEN_NAMES & AGENT_SCOPED_TOKEN_NAMES
+    assert CONTEXT_TOKEN_NAMES | AGENT_SCOPED_TOKEN_NAMES <= REYN_TOKEN_NAMES
+    assert set(resolve_token_map(context)) == CONTEXT_TOKEN_NAMES - {"REYN_SKILL_DIR"}
+
+
+def test_an_added_token_name_is_checked_automatically(monkeypatch) -> None:
+    """Tier 1: a token added to the vocabulary is part of fail-close checks."""
+    monkeypatch.setattr(
+        "reyn.plugins.tokens.REYN_TOKEN_NAMES",
+        frozenset({"REYN_NEW_TOKEN"}),
+    )
+    assert find_unresolved_reyn_tokens({"a": "${REYN_NEW_TOKEN}"}) == [
+        "${REYN_NEW_TOKEN}"
+    ]
 
 
 def test_every_real_reyn_token_name_is_still_flagged_when_unresolved() -> None:

--- a/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
+++ b/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
@@ -79,7 +79,6 @@ def test_token_vocabularies_are_disjoint_and_complete(tmp_path) -> None:
         and node.value in AGENT_SCOPED_TOKEN_NAMES
     }
     assert supplied_names == AGENT_SCOPED_TOKEN_NAMES
-    assert agent_sources
 
 
 def test_an_added_token_name_is_checked_automatically(monkeypatch) -> None:

--- a/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
+++ b/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
@@ -18,6 +18,11 @@ working (the whole layer refused) without this fix.
 Real ``find_unresolved_reyn_tokens`` — no mocks; a pure function."""
 from __future__ import annotations
 
+import inspect
+
+from reyn.config import loader
+from reyn.environment import container_backend
+from reyn.hooks import shell_runner
 from reyn.plugins.tokens import (
     AGENT_SCOPED_TOKEN_NAMES,
     CONTEXT_TOKEN_NAMES,
@@ -59,6 +64,14 @@ def test_token_vocabularies_are_disjoint_and_complete(tmp_path) -> None:
     assert not CONTEXT_TOKEN_NAMES & AGENT_SCOPED_TOKEN_NAMES
     assert CONTEXT_TOKEN_NAMES | AGENT_SCOPED_TOKEN_NAMES <= REYN_TOKEN_NAMES
     assert set(resolve_token_map(context)) == CONTEXT_TOKEN_NAMES - {"REYN_SKILL_DIR"}
+    agent_sources = (
+        inspect.getsource(loader)
+        + inspect.getsource(container_backend)
+        + inspect.getsource(shell_runner)
+    )
+    assert AGENT_SCOPED_TOKEN_NAMES <= {
+        name for name in AGENT_SCOPED_TOKEN_NAMES if name in agent_sources
+    }
 
 
 def test_an_added_token_name_is_checked_automatically(monkeypatch) -> None:

--- a/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
+++ b/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
@@ -70,14 +70,30 @@ def test_token_vocabularies_are_disjoint_and_complete(tmp_path) -> None:
         inspect.getsource(container_backend),
         inspect.getsource(shell_runner),
     )]
-    supplied_names = {
-        node.value
-        for tree in trees
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Constant)
-        and isinstance(node.value, str)
-        and node.value in AGENT_SCOPED_TOKEN_NAMES
-    }
+    supplied_names: set[str] = set()
+    for tree in trees:
+        parents = {
+            child: parent
+            for parent in ast.walk(tree)
+            for child in ast.iter_child_nodes(parent)
+        }
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and node.value in AGENT_SCOPED_TOKEN_NAMES
+            ):
+                continue
+            parent = parents.get(node)
+            if isinstance(parent, ast.Dict):
+                supplied_names.add(node.value)
+                continue
+            if isinstance(parent, ast.JoinedStr):
+                ancestor = parents.get(parent)
+                while ancestor is not None and not isinstance(ancestor, ast.Call):
+                    ancestor = parents.get(ancestor)
+                if isinstance(ancestor, ast.Call):
+                    supplied_names.add(node.value)
     assert supplied_names == AGENT_SCOPED_TOKEN_NAMES
 
 

--- a/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
+++ b/tests/plugins/test_5176_reyn_token_vocabulary_not_prefix.py
@@ -18,6 +18,7 @@ working (the whole layer refused) without this fix.
 Real ``find_unresolved_reyn_tokens`` — no mocks; a pure function."""
 from __future__ import annotations
 
+import ast
 import inspect
 
 from reyn.config import loader
@@ -64,14 +65,21 @@ def test_token_vocabularies_are_disjoint_and_complete(tmp_path) -> None:
     assert not CONTEXT_TOKEN_NAMES & AGENT_SCOPED_TOKEN_NAMES
     assert CONTEXT_TOKEN_NAMES | AGENT_SCOPED_TOKEN_NAMES <= REYN_TOKEN_NAMES
     assert set(resolve_token_map(context)) == CONTEXT_TOKEN_NAMES - {"REYN_SKILL_DIR"}
-    agent_sources = (
-        inspect.getsource(loader)
-        + inspect.getsource(container_backend)
-        + inspect.getsource(shell_runner)
-    )
-    assert AGENT_SCOPED_TOKEN_NAMES <= {
-        name for name in AGENT_SCOPED_TOKEN_NAMES if name in agent_sources
+    trees = [ast.parse(source) for source in (
+        inspect.getsource(loader),
+        inspect.getsource(container_backend),
+        inspect.getsource(shell_runner),
+    )]
+    supplied_names = {
+        node.value
+        for tree in trees
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value in AGENT_SCOPED_TOKEN_NAMES
     }
+    assert supplied_names == AGENT_SCOPED_TOKEN_NAMES
+    assert agent_sources
 
 
 def test_an_added_token_name_is_checked_automatically(monkeypatch) -> None:


### PR DESCRIPTION
**[coder-brown]** — Replace the hand-written unresolved-token vocabulary with explicit `REYN_TOKEN_NAMES` SSoT, split into context and agent-scoped token names. Add Tier 1 witnesses for disjoint/completeness invariants and automatic fail-close coverage for added token names.

part of #5178

Checks: `.venv/bin/ruff check .`; `.venv/bin/python -m pytest tests/plugins/ -q` (54 passed); Tier audit (6 inspected, 0 errors).


---

**[docs-maintainer]** — TESTS-READ B blocking point (issuecomment-5385258000):

- [x] 🔴 The new `AGENT_SCOPED_TOKEN_NAMES` cross-check (`inspect.getsource(...)` + `name in agent_sources`) checks bare substring presence, not real supply. Strip-falsified: added a fake ungrounded name + a comment mentioning it (never actually supplied) in `shell_runner.py` — still 6/6 green, undetected. The CONTEXT side's `resolve_token_map(context)` check is a real functional cross-check (calls the resolver, compares output) with no such hole. Fix: AST-check for the name appearing as an actual dict-literal key (or f-string/format argument), not a raw substring of the concatenated source. **[docs-maintainer] resolved at `0a669feb`** — now AST-based (`ast.Constant` walk), comment-only mentions correctly excluded (comments aren't AST nodes), verified with a positive control (a fully-ungrounded name still reds).

- [x] 🔴 **[docs-maintainer]** New finding, same head: the AST walk matches ANY `ast.Constant` string node regardless of position — a bare, docstring-shaped no-op string statement whose value exactly equals the token name (never an actual dict key or supply argument) still passes. Strip-falsified: added `"REYN_EXACT_DOCSTRING_FAKE"` as a standalone statement in `shell_runner.py` (not assigned, not a dict value) — 6/6 still green. See issuecomment-5385281465 for the fix suggestion (require the constant's parent to be a `Dict` value or `Call` argument, not any `ast.Constant` position).



**Known coverage boundary:** `container_backend.py` supplies `REYN_AGENT_NAME` in a list-level `JoinedStr`, while this witness recognizes Dict values and Call-contained JoinedStr. Current coverage remains true because loader and shell_runner provide redundant Dict-shaped supplies; removing those would create a false negative. This is disclosed rather than treated as full producer coverage.
