### PR TITLE
fix(#4573): an unresolvable model class warns at load, still raises at use, and no longer blocks startup or /model

### DIFF
--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -477,6 +477,47 @@ class ModelResolver:
                     _name, _spec.model,
                 )
 
+        # #4573 (architect ruling): WARN at LOAD time — not raise — for a
+        # class-position value this resolver cannot resolve. Load-bearing
+        # ``resolve()`` (below) still raises at USE time, unchanged — #3368's
+        # own intent (a legible, load-bearing error instead of a confusing
+        # provider-side one) is preserved there. What this closes is the GAP
+        # #3368 never addressed: NOTHING previously warned that ``llm.model``
+        # (or a ``model_class_by_purpose`` entry) was already broken, at the
+        # one point reyn actually knows it — construction. A typo'd
+        # ``llm.model`` used to surface only via whatever code path first
+        # happened to call ``resolve()`` on it (#4573's own observed
+        # symptom — a lazy, incidental turn-budget-estimation call, NOT a
+        # real LLM call — crashed the whole session before the operator
+        # ever got a chance to see why or run ``/model`` to fix it). This
+        # warning fires unconditionally at construction, so the operator
+        # sees the actionable message on the FIRST render, not buried
+        # behind whichever internal call site happens to touch the value
+        # first (see this module's own docstring's "not applied" phrasing
+        # convention, mirrored in the message below).
+        _class_position_values = {
+            "default_class": default_class,
+            **{
+                f"model_class_by_purpose.{purpose}": cls
+                for purpose, cls in self._purpose_classes.items()
+            },
+        }
+        for _field_label, _value in _class_position_values.items():
+            if "/" in _value or _value in self._resolved:
+                continue
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "llm.%s %r does not match any declared model class (%s) and "
+                "is not a literal provider/model string — this model is "
+                "NOT APPLIED until fixed: any use of it will fail with a "
+                "load-bearing error (not silently fall back). Check "
+                "reyn.yaml/reyn.local.yaml's `llm.models:` section for a "
+                "typo or a load failure, or run `/model <class>` to switch "
+                "to a working one for this session.",
+                _field_label, _value, ", ".join(sorted(self._resolved)) or "none",
+            )
+
     def resolve(self, name: str) -> ModelSpec:
         """Return the ModelSpec for *name*.
 

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -318,6 +318,30 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return result
 
 
+class UnresolvableModelClassError(ValueError):
+    """#4573 (architect blocking finding, issuecomment-5385388810, PR #5212
+    A): raised by :meth:`ModelResolver.resolve` for a class-position value
+    that resolves to neither a declared class nor a literal
+    ``provider/model`` name — a TYPED discriminator, not a bare
+    ``ValueError``, so a caller distinguishing "this specific, expected
+    failure mode" from "some OTHER ValueError I did not anticipate" can do
+    so by type instead of by string-matching the message (reyn's own
+    typed-discriminated-union preference, applied to exceptions the same
+    way #4996/``ChatReadModelCapabilities`` applies it to capabilities).
+
+    Concretely: :func:`~reyn.services.turn_budget.try_build_default_turn_
+    budget_engine` catches ONLY this subclass (never bare ``ValueError``)
+    around its own ``resolver.resolve(model)`` call — before this class
+    existed, a bare ``except ValueError`` there caught the SHAPE of the
+    failure, not the CAUSE: any future, unrelated ``ValueError`` from
+    somewhere else in that call chain would have ALSO silently degraded to
+    ``None`` (a context-window display going quietly wrong, not raising),
+    with nothing to catch the over-broad catch itself. A subclass of
+    ``ValueError`` (not a sibling exception type) so every EXISTING bare
+    ``except ValueError`` elsewhere in the codebase that already wraps a
+    ``resolve()`` call keeps working unchanged."""
+
+
 class ModelClassExceedsCeilingError(ValueError):
     """#4206 T1: raised by :func:`reyn.llm.llm.recorded_acompletion` when a
     call's declared ``model_class`` exceeds the caller's effective
@@ -548,7 +572,7 @@ class ModelResolver:
             return self._resolved[name]
         if "/" in name:
             return ModelSpec(model=name, kwargs={})
-        raise ValueError(
+        raise UnresolvableModelClassError(
             f"model class {name!r} not found among known classes "
             f"({', '.join(sorted(self._resolved)) or 'none'}). Check reyn.yaml/"
             "reyn.local.yaml's `llm.models:` section for a typo or a load "

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -677,10 +677,14 @@ class RouterHostAdapter:
         once — #3671 follow-up).
 
         A cached ``None`` (a tiny-context model that genuinely cannot
-        support force-close, per ``try_build_default_turn_budget_engine``'s
-        own contract) is a valid, permanent answer — distinguished from
-        "not computed yet" by the ``_TURN_BUDGET_ENGINE_UNSET`` sentinel, not
-        by ``None`` itself."""
+        support force-close, OR — #4573 — a currently-unresolvable model
+        class, per ``try_build_default_turn_budget_engine``'s own contract)
+        is a valid, permanent answer — distinguished from "not computed
+        yet" by the ``_TURN_BUDGET_ENGINE_UNSET`` sentinel, not by ``None``
+        itself. The unresolvable-class case is not permanent in the
+        session's OWN lifetime, though: ``/model`` rebuilds this cache
+        directly (:meth:`set_turn_budget_engine`), so switching to a valid
+        class overwrites a stale ``None`` from a broken initial state."""
         if self._turn_budget_engine is _TURN_BUDGET_ENGINE_UNSET:
             factory = self._turn_budget_engine_factory
             self._turn_budget_engine = factory() if factory is not None else None

--- a/src/reyn/services/turn_budget/engine.py
+++ b/src/reyn/services/turn_budget/engine.py
@@ -321,6 +321,9 @@ def try_build_default_turn_budget_engine(
 ) -> "TurnBudgetEngine | None":
     """:func:`build_default_turn_budget_engine`, but returns ``None`` instead of
     raising when the model's context is too small to satisfy the by-construction
+    force-close floor, OR (#4573) when *model* is a class the resolver cannot
+    resolve — see the ``ValueError`` paragraph below for why the second case
+    belongs in this same degrade, not a crash.
     force-close floor (``output_reserve + offload_cap < force_close_threshold``).
 
     Such a model genuinely CANNOT support force-close termination by construction
@@ -335,11 +338,30 @@ def try_build_default_turn_budget_engine(
 
     The viability gate is exactly the engine's own construction-time
     ``assert_turn_budget_bounds`` — caught here so the result is None, not a raise;
-    no bounds logic is duplicated (which would drift from the engine's measure)."""
+    no bounds logic is duplicated (which would drift from the engine's measure).
+
+    #4573 (architect ruling, issuecomment on that issue): ALSO catches
+    ``ValueError`` — the SAME shape ``ModelResolver.resolve()`` raises for an
+    unresolvable model CLASS (a typo'd ``llm.model``, e.g.), which this
+    engine's own ``resolver.resolve(model)`` call (inside
+    ``TurnBudgetEngine.__init__``) propagates unchanged. This call site is
+    LAZY (``RouterHostAdapter._ensure_turn_budget_engine``, first reference
+    — a status/context-window read, not a real LLM call) and its whole
+    return contract is already "``None`` is a legitimate, permanent
+    degrade" (the small-context case above) — an unresolvable model class is
+    the SAME shape of degrade for the SAME caller, not a reason to crash the
+    session before the operator ever gets a chance to run ``/model`` and
+    fix it (#4573's own observed symptom: a typo'd ``llm.model`` made
+    ``reyn chat`` unusable, including the ``/model`` escape hatch, because
+    THIS lazy build ran before any turn and before any user input). The
+    REAL turn-dispatch path (``RouterLoop``'s own ``resolve_model`` calls)
+    is untouched by this — a genuine turn attempt with an unresolved model
+    still raises the full, load-bearing error (#4573 acceptance③); only
+    this budget-ESTIMATION path degrades."""
     try:
         return build_default_turn_budget_engine(
             model, resolver=resolver, use_chars4=use_chars4,
             max_inline_bytes=max_inline_bytes, events=events,
         )
-    except AssertionError:
+    except (AssertionError, ValueError):
         return None

--- a/src/reyn/services/turn_budget/engine.py
+++ b/src/reyn/services/turn_budget/engine.py
@@ -340,28 +340,44 @@ def try_build_default_turn_budget_engine(
     ``assert_turn_budget_bounds`` — caught here so the result is None, not a raise;
     no bounds logic is duplicated (which would drift from the engine's measure).
 
-    #4573 (architect ruling, issuecomment on that issue): ALSO catches
-    ``ValueError`` — the SAME shape ``ModelResolver.resolve()`` raises for an
-    unresolvable model CLASS (a typo'd ``llm.model``, e.g.), which this
-    engine's own ``resolver.resolve(model)`` call (inside
-    ``TurnBudgetEngine.__init__``) propagates unchanged. This call site is
-    LAZY (``RouterHostAdapter._ensure_turn_budget_engine``, first reference
-    — a status/context-window read, not a real LLM call) and its whole
-    return contract is already "``None`` is a legitimate, permanent
-    degrade" (the small-context case above) — an unresolvable model class is
-    the SAME shape of degrade for the SAME caller, not a reason to crash the
-    session before the operator ever gets a chance to run ``/model`` and
-    fix it (#4573's own observed symptom: a typo'd ``llm.model`` made
-    ``reyn chat`` unusable, including the ``/model`` escape hatch, because
-    THIS lazy build ran before any turn and before any user input). The
-    REAL turn-dispatch path (``RouterLoop``'s own ``resolve_model`` calls)
-    is untouched by this — a genuine turn attempt with an unresolved model
-    still raises the full, load-bearing error (#4573 acceptance③); only
-    this budget-ESTIMATION path degrades."""
+    #4573 (architect ruling, corrected per issuecomment-5385388810, PR
+    #5212 A blocking finding): ALSO catches
+    :class:`~reyn.llm.model_resolver.UnresolvableModelClassError` — the
+    TYPED exception ``ModelResolver.resolve()`` raises for an unresolvable
+    model CLASS (a typo'd ``llm.model``, e.g.), which this engine's own
+    ``resolver.resolve(model)`` call (inside ``TurnBudgetEngine.__init__``)
+    propagates unchanged. This call site is LAZY (``RouterHostAdapter.
+    _ensure_turn_budget_engine``, first reference — a status/context-window
+    read, not a real LLM call) and its whole return contract is already
+    "``None`` is a legitimate, permanent degrade" (the small-context case
+    above) — an unresolvable model class is the SAME shape of degrade for
+    the SAME caller, not a reason to crash the session before the operator
+    ever gets a chance to run ``/model`` and fix it (#4573's own observed
+    symptom: a typo'd ``llm.model`` made ``reyn chat`` unusable, including
+    the ``/model`` escape hatch, because THIS lazy build ran before any
+    turn and before any user input).
+
+    Deliberately a NARROW except (this specific subclass, not bare
+    ``ValueError``) — the architect finding on the first version of this
+    fix: catching bare ``ValueError`` here catches the SHAPE of the known
+    failure, not its CAUSE, so a future, UNRELATED ``ValueError`` from
+    anywhere else in this call chain would ALSO silently degrade to
+    ``None`` (a context-window display going quietly wrong instead of
+    raising), with nothing to catch the over-broad catch itself. Since
+    ``UnresolvableModelClassError`` is a ``ValueError`` subclass, every
+    EXISTING bare ``except ValueError`` elsewhere that already wraps a
+    ``resolve()`` call is unaffected by this narrowing.
+
+    The REAL turn-dispatch path (``RouterLoop``'s own ``resolve_model``
+    calls) is untouched by this — a genuine turn attempt with an
+    unresolved model still raises the full, load-bearing error (#4573
+    acceptance③); only this budget-ESTIMATION path degrades."""
+    from reyn.llm.model_resolver import UnresolvableModelClassError
+
     try:
         return build_default_turn_budget_engine(
             model, resolver=resolver, use_chars4=use_chars4,
             max_inline_bytes=max_inline_bytes, events=events,
         )
-    except (AssertionError, ValueError):
+    except (AssertionError, UnresolvableModelClassError):
         return None

--- a/tests/llm/test_4573_model_resolver_load_warn_use_raise.py
+++ b/tests/llm/test_4573_model_resolver_load_warn_use_raise.py
@@ -1,0 +1,193 @@
+"""Tier 2: #4573 — an unresolvable model CLASS in a class-position config
+value (``llm.model``, ``llm.model_class_by_purpose.<purpose>``) warns at
+LOAD time and still raises at USE time.
+
+Architect ruling: two prior rulings looked like they conflicted (loader.py's
+"warn, never hard-fail, anywhere" for unknown CONFIG KEYS vs #3368's
+intentional hard-raise for an unresolvable model CLASS VALUE) — resolved not
+by picking a side but by moving WHEN the raise happens, not whether:
+
+  ① load  — warn (names the value, states the consequence: "NOT APPLIED
+     until fixed")
+  ② /model — a valid class switch works even from a broken initial state
+  ③ use   — a genuine turn attempt with the unresolved value still fails,
+     loudly, with the value and how to fix it (never silently degrades)
+  ④ strip — reverting the try/except in ``try_build_default_turn_budget_
+     engine`` back to catching only ``AssertionError`` must make ①'s own
+     witness go RED (the crash #4573 reports, reproduced exactly)
+
+Real ``ModelResolver``/``TurnBudgetEngine`` — no mocks, per the testing
+policy. ``caplog`` for ①'s warning witness (the public, intended observation
+surface for a logged warning — not a private-state read).
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from reyn.llm.model_resolver import ModelResolver
+from reyn.services.turn_budget import try_build_default_turn_budget_engine
+
+# ── acceptance① — load-time warn, not raise ───────────────────────────────
+
+
+def test_construction_with_an_unresolvable_default_class_does_not_raise(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: #4573's own reported crash — ``ModelResolver(...,
+    default_class="gemini-2.5-flash-lite")`` where that string is neither a
+    declared class nor a provider-prefixed name — must NOT raise at
+    construction. RED pre-#4573 fix: this used to be silent (no crash here
+    either, since #3368's raise lives in ``resolve()``, not ``__init__`` —
+    but nothing warned, so the operator had no signal until whatever code
+    happened to call ``resolve()`` first crashed instead)."""
+    with caplog.at_level(logging.WARNING, logger="reyn.llm.model_resolver"):
+        ModelResolver(
+            {"light": "openai/gpt-4o-mini", "standard": "openai/gpt-4o"},
+            default_class="gemini-2.5-flash-lite",
+        )
+    assert any(
+        "gemini-2.5-flash-lite" in r.message and "NOT APPLIED" in r.message
+        for r in caplog.records
+    ), f"expected a warning naming the value and its consequence, got: {[r.message for r in caplog.records]}"
+
+
+def test_construction_with_an_unresolvable_purpose_class_also_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: the SAME class-position shape, for a
+    ``model_class_by_purpose`` entry — not just ``default_class``. Both are
+    class positions ``resolve()`` treats identically; the load-time warn
+    must too."""
+    with caplog.at_level(logging.WARNING, logger="reyn.llm.model_resolver"):
+        ModelResolver(
+            {"light": "openai/gpt-4o-mini"},
+            default_class="light",
+            purpose_classes={"router": "typo-d-class"},
+        )
+    assert any("typo-d-class" in r.message for r in caplog.records), (
+        f"expected a warning naming the bad purpose-class value, got: "
+        f"{[r.message for r in caplog.records]}"
+    )
+
+
+def test_construction_with_a_valid_default_class_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: falsification contrast — a resolvable ``default_class``
+    produces NO class-position warning (the existing bare-name-position
+    warning, #1454 PR-B, is a separate concern and not asserted against
+    here)."""
+    with caplog.at_level(logging.WARNING, logger="reyn.llm.model_resolver"):
+        ModelResolver(
+            {"light": "openai/gpt-4o-mini", "standard": "openai/gpt-4o"},
+            default_class="standard",
+        )
+    assert not any("NOT APPLIED" in r.message for r in caplog.records), (
+        f"a valid default_class must not warn, got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_construction_with_a_slash_prefixed_default_class_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: falsification contrast — a literal name-position value
+    (contains '/') is a legitimate passthrough, not an unresolved class;
+    must not warn."""
+    with caplog.at_level(logging.WARNING, logger="reyn.llm.model_resolver"):
+        ModelResolver(
+            {"light": "openai/gpt-4o-mini"},
+            default_class="anthropic/claude-opus-4",
+        )
+    assert not any("NOT APPLIED" in r.message for r in caplog.records)
+
+
+# ── acceptance④ (checked first — it's the strip-falsify baseline the
+# other engine-level tests below implicitly rely on) ──────────────────────
+
+
+def test_try_build_degrades_to_none_for_an_unresolvable_model_class() -> None:
+    """Tier 2: #4573's actual crash site — ``TurnBudgetEngine.__init__``
+    calls ``resolver.resolve(model)`` directly, and (pre-fix)
+    ``try_build_default_turn_budget_engine`` only caught ``AssertionError``,
+    letting the ``ValueError`` from an unresolved class propagate straight
+    through this LAZY, non-essential budget-estimation call — crashing the
+    whole session before the operator could even reach ``/model``. Must now
+    degrade to ``None`` (the same "legitimate permanent degrade" contract
+    this function already has for a too-small-context model).
+
+    Strip-falsify (acceptance④, done by hand rather than as an automated
+    monkeypatch — see this test's own docstring for why): reverting
+    ``except (AssertionError, ValueError)`` back to ``except AssertionError``
+    in ``engine.py`` makes THIS test raise ``ValueError`` instead of
+    returning ``None`` — verified manually before this PR (not re-verified
+    by a second, redundant test here — CLAUDE.md's own "same expression on
+    both sides" caution about testing exactly the code under test)."""
+    resolver = ModelResolver(
+        {"light": "openai/gpt-4o-mini", "standard": "openai/gpt-4o"},
+        default_class="gemini-2.5-flash-lite",
+    )
+    engine = try_build_default_turn_budget_engine(
+        "gemini-2.5-flash-lite", resolver=resolver,
+    )
+    assert engine is None
+
+
+def test_try_build_still_builds_normally_for_a_resolvable_class() -> None:
+    """Tier 2: falsification contrast — a VALID class still produces a real
+    engine (the fix does not silently degrade legitimate models too)."""
+    resolver = ModelResolver(
+        {"light": "openai/gpt-4o-mini", "standard": "openai/gpt-4o"},
+        default_class="standard",
+    )
+    engine = try_build_default_turn_budget_engine("standard", resolver=resolver)
+    assert engine is not None
+
+
+# ── acceptance② — /model can reach a valid class from a broken initial
+# state ────────────────────────────────────────────────────────────────────
+
+
+def test_switching_from_a_broken_default_to_a_valid_class_builds_a_real_engine() -> None:
+    """Tier 2: acceptance② — the exact #4573 recovery path: a resolver
+    constructed with an unresolvable ``default_class`` (the broken initial
+    state) must still let a caller build a real engine for a VALID class
+    (what ``/model <class>`` does via ``_rebuild_derived_model_engines_
+    for_model``'s own ``try_build_default_turn_budget_engine`` call) — the
+    broken default must not poison resolution of an UNRELATED, valid class
+    on the SAME resolver instance."""
+    resolver = ModelResolver(
+        {"light": "openai/gpt-4o-mini", "standard": "openai/gpt-4o"},
+        default_class="gemini-2.5-flash-lite",
+    )
+    # the broken default degrades (acceptance④'s own witness) ...
+    assert try_build_default_turn_budget_engine(
+        "gemini-2.5-flash-lite", resolver=resolver,
+    ) is None
+    # ... but switching to a real class on the SAME resolver instance works.
+    engine = try_build_default_turn_budget_engine("standard", resolver=resolver)
+    assert engine is not None
+
+
+# ── acceptance③ — a genuine turn attempt with the unresolved value still
+# fails loudly, naming the value and how to fix it ─────────────────────────
+
+
+def test_resolve_still_raises_for_a_genuine_use_attempt() -> None:
+    """Tier 2: acceptance③ — #3368's own load-bearing raise, UNCHANGED.
+    #4573 only moves WHEN the operator first learns about the problem
+    (load-time warn) and closes an INCIDENTAL crash site (the lazy budget
+    estimate) — it does not touch ``resolve()`` itself, which is what a
+    REAL turn-dispatch call (``RouterHostAdapter.resolve_model`` /
+    ``RouterLoop``'s own calls) still goes through. A silent degrade here
+    would be WORSE than #4573's original bug (per architect's own
+    ``起動はするが何も言わない`` (starts but says nothing) is worse) —
+    this test is the guard
+    against that regression."""
+    resolver = ModelResolver(
+        {"light": "openai/gpt-4o-mini", "standard": "openai/gpt-4o"},
+        default_class="gemini-2.5-flash-lite",
+    )
+    with pytest.raises(ValueError, match="gemini-2.5-flash-lite"):
+        resolver.resolve("gemini-2.5-flash-lite")

--- a/tests/llm/test_4573_model_resolver_load_warn_use_raise.py
+++ b/tests/llm/test_4573_model_resolver_load_warn_use_raise.py
@@ -118,12 +118,12 @@ def test_try_build_degrades_to_none_for_an_unresolvable_model_class() -> None:
     this function already has for a too-small-context model).
 
     Strip-falsify (acceptance④, done by hand rather than as an automated
-    monkeypatch — see this test's own docstring for why): reverting
-    ``except (AssertionError, ValueError)`` back to ``except AssertionError``
-    in ``engine.py`` makes THIS test raise ``ValueError`` instead of
-    returning ``None`` — verified manually before this PR (not re-verified
-    by a second, redundant test here — CLAUDE.md's own "same expression on
-    both sides" caution about testing exactly the code under test)."""
+    monkeypatch — see this test's own docstring for why): reverting the
+    ``except`` clause in ``engine.py`` back to ``except AssertionError``
+    alone makes THIS test raise instead of returning ``None`` — verified
+    manually before this PR (not re-verified by a second, redundant test
+    here — CLAUDE.md's own "same expression on both sides" caution about
+    testing exactly the code under test)."""
     resolver = ModelResolver(
         {"light": "openai/gpt-4o-mini", "standard": "openai/gpt-4o"},
         default_class="gemini-2.5-flash-lite",
@@ -143,6 +143,36 @@ def test_try_build_still_builds_normally_for_a_resolvable_class() -> None:
     )
     engine = try_build_default_turn_budget_engine("standard", resolver=resolver)
     assert engine is not None
+
+
+def test_an_unrelated_value_error_still_propagates_through(monkeypatch) -> None:
+    """Tier 2: architect blocking finding on the FIRST version of this fix
+    (issuecomment-5385388810, PR #5212 A): ``except (AssertionError,
+    ValueError)`` caught the SHAPE of the known failure (a bare
+    ``ValueError``), not its CAUSE — a future, UNRELATED ``ValueError``
+    raised anywhere else inside ``build_default_turn_budget_engine``'s own
+    call chain would have ALSO silently degraded to ``None`` instead of
+    propagating. Narrowed to
+    :class:`~reyn.llm.model_resolver.UnresolvableModelClassError`
+    specifically (a ``ValueError`` subclass, so this test injects a
+    DIFFERENT ``ValueError`` — not that subclass — via
+    ``estimate_tokens`` (called right after the now-successful
+    ``resolver.resolve()`` inside ``TurnBudgetEngine.__init__``) to prove
+    it is NOT swallowed."""
+    import reyn.services.turn_budget.engine as engine_module
+
+    resolver = ModelResolver(
+        {"light": "openai/gpt-4o-mini", "standard": "openai/gpt-4o"},
+        default_class="standard",
+    )
+
+    def _boom(*args, **kwargs):
+        raise ValueError("an unrelated failure, not an unresolvable model class")
+
+    monkeypatch.setattr(engine_module, "estimate_tokens", _boom)
+
+    with pytest.raises(ValueError, match="an unrelated failure"):
+        try_build_default_turn_budget_engine("standard", resolver=resolver)
 
 
 # ── acceptance② — /model can reach a valid class from a broken initial


### PR DESCRIPTION
**[tui-coder]** — closes #4573.

## Root cause (traced empirically, not guessed)

A raw model string in `llm.model` (instead of a declared class) crashed
`reyn chat` before the operator could even reach `/model` to fix it.
Reproduced with a minimal script (config → registry → session →
`wrap_up_output_reserve`) and got the exact traceback:

```
TurnBudgetEngine.__init__ → resolver.resolve(model)  [raises ValueError]
  ← build_default_turn_budget_engine
    ← try_build_default_turn_budget_engine  [only caught AssertionError]
      ← RouterHostAdapter._ensure_turn_budget_engine  [LAZY, first reference]
        ← wrap_up_output_reserve
```

`try_build_default_turn_budget_engine` only caught `AssertionError` (the
too-small-context-model degrade); the `ValueError` from an unresolved
class propagated straight through this incidental, non-essential
budget-estimation call and crashed the whole session — before any real
turn was ever attempted, and before the operator got a chance to run
`/model`.

## Ruling (architect)

Two prior rulings looked like they conflicted (`loader.py`'s "warn, never
hard-fail, anywhere" for unknown config KEYS vs #3368's intentional
hard-raise for an unresolvable model class VALUE) — resolved by moving
WHEN the raise happens, not whether:

1. **load** — `ModelResolver.__init__` now warns (names the value, states
   the consequence: "NOT APPLIED until fixed") for an unresolvable
   `default_class`/`model_class_by_purpose` entry.
2. **`/model`** — unaffected by a broken initial state: verified a switch
   to a valid class on the SAME resolver instance still builds a real
   engine, even after the broken default already degraded.
3. **use** — `resolve()` itself is UNCHANGED — a genuine turn-dispatch
   attempt (`RouterLoop`'s own `resolve_model` calls) still raises the
   full, load-bearing error #3368 added. Silently degrading here would be
   WORSE than the original bug (architect: "起動はするが何も言わない is
   worse").
4. **strip** — verified by hand: reverting the `except` clause in
   `engine.py` back to catching only `AssertionError` flips 2 of the new
   tests red immediately.

`try_build_default_turn_budget_engine` now also catches `ValueError` —
the same "legitimate permanent degrade" contract it already has for a
too-small-context model — scoped to this ONE lazy, incidental call site,
never `resolve()` itself.

## A collision found while running the full suite

The new load-time warning's wording originally contained the substring
`"no provider prefix"`, which an UNRELATED existing test (#1454 PR-B's
bare-name-position warning) greps for — a false-positive match. Reworded
before it could ship (caught by the full `tests/llm/` sweep, not by the
new tests themselves).

## Tests

- load-time warn: fires for an unresolvable `default_class`, fires for an
  unresolvable `model_class_by_purpose` entry, does NOT fire for a valid
  class or a literal `provider/model` string
- `try_build_default_turn_budget_engine` degrades to `None` for an
  unresolvable class (falsification contrast: still builds normally for a
  valid one)
- switching to a valid class on a resolver whose default is broken still
  builds a real engine (acceptance②)
- `resolve()` itself still raises for a genuine use attempt (acceptance③)

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 8/8 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] full `tests/llm/ tests/runtime/ tests/services/` sweep — 2835 passed, 7 skipped (known optional-dependency extras)
- [x] manual strip-falsify (reverted the `except` clause by hand, confirmed 2 tests go red, restored)
- [ ] (skipped — full suite runs in CI per repo convention, not locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---

**[architect]** — TESTS-READ A blocking point (see the review comment):

- [x] 🔴 `except (AssertionError, ValueError)` catches a *shape*, not a *cause*. Today `resolver.resolve()` is the only ValueError source inside that try, but nothing enforces it — a future unrelated `ValueError` would silently degrade to `None` (context-window reporting dies quietly). Introduce a dedicated `UnresolvableModelClass(ValueError)` raised by `resolve()` and catch only that (a ValueError subtype, so existing catches keep working). Witness: a fixture raising an unrelated `ValueError` inside `try_build_default_turn_budget_engine` must propagate, not be swallowed.

