### PR TITLE
fix(#5203): hoist registry-touching history read onto the loop, restore owner-thread guard on 7 reads

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1321,8 +1321,10 @@ class TextualChatApp(App):
         # read BEFORE this App was constructed (the caller — normally
         # ``run_textual_chat``'s own pre-``run_async`` step — reads it off
         # the event loop, e.g. via ``asyncio.to_thread``) so ``on_mount``
-        # never has to make its own synchronous disk read to hydrate the
-        # first frame. ``None`` means "no pre-fetched history was given" —
+        # never has to make its own synchronous registry/session read to
+        # hydrate the first frame (#5203: not a disk read — see
+        # ``_read_conversation_history``'s own docstring for why).
+        # ``None`` means "no pre-fetched history was given" —
         # a real caller that just has nothing to restore passes ``[]``,
         # not ``None`` (``ChatReadModel.conversation_history`` never
         # returns ``None`` on success) — so ``on_mount`` can tell "read
@@ -2392,7 +2394,7 @@ class TextualChatApp(App):
             # #4983: prefer the history this App was CONSTRUCTED with (the
             # caller already read it OFF the event loop — see
             # ``__init__``'s own ``initial_history_messages`` docstring) —
-            # step ② only, no new disk read here. ``None`` (nothing was
+            # step ② only, no new registry/session read here. ``None`` (nothing was
             # pre-fetched — most existing construction sites, tests
             # included) falls back to the old synchronous do-both call,
             # unchanged: this method must still hydrate correctly for a
@@ -2474,12 +2476,25 @@ class TextualChatApp(App):
     def _read_conversation_history(
         self, *, agent: "str | None" = None, session_id: "str | None" = None
     ) -> "list | None":
-        """#4983 step ① — the actual disk read (``history.jsonl`` via
-        :meth:`~reyn.interfaces.repl.read_model.ChatReadModel.
-        conversation_history`), split out of :meth:`_hydrate_from_history`
-        so a caller can choose HOW this specific step runs without also
-        touching step ② (:meth:`_apply_hydrated_messages`, pure in-memory
-        projection). Deliberately still a PLAIN synchronous method, not
+        """#4983 step ① — the registry/session read (:meth:`~reyn.interfaces.
+        repl.read_model.ChatReadModel.conversation_history`), split out of
+        :meth:`_hydrate_from_history` so a caller can choose HOW this
+        specific step runs without also touching step ② (:meth:`_apply_
+        hydrated_messages`, pure in-memory projection).
+
+        **Not a disk read** (#5203 measurement, docs-maintainer/architect-
+        confirmed issuecomment-5385460393): ``conversation_history`` reads
+        ``Session.history``, a plain in-memory list populated once by
+        ``Session.load_history`` at session-construction time — this method
+        never touches ``history.jsonl`` itself. #4983's ORIGINAL "real disk
+        I/O" framing (this docstring's own prior wording) was already wrong
+        by the time #5203 measured it; that finding is not new work this
+        PR did, just a stale claim this PR is the first to correct here.
+        The reason this step still deserves to run off the loop is
+        different from "disk I/O": see :meth:`_resolve_history_source`'s
+        own docstring for the real one (a bounded but non-zero in-memory
+        list copy, worth keeping off the loop for a large history).
+        Deliberately still a PLAIN synchronous method, not
         ``async def`` — architect ruling (#4983): the two call sites need
         DIFFERENT answers for "run this off the event loop or not" (mount
         reads before the loop's own ``run_async`` even starts; a live
@@ -5496,8 +5511,9 @@ class TextualChatApp(App):
         #4983 (owner ruling, 2026-08-21: "セッション切り替えの見た目許容" —
         a brief blank-then-refill on switch is accepted; NOT "history
         never arrives" or "order changes"): ``async def``, not ``def``,
-        so the NEW session's ``conversation_history()`` disk read
-        (:meth:`_read_conversation_history`, step ①) can run OFF the
+        so the NEW session's ``conversation_history()`` read
+        (:meth:`_read_conversation_history`, step ① — not disk I/O, #5203;
+        see that method's own docstring) can run OFF the
         event loop via ``asyncio.to_thread`` — see this method's own
         tail for where. Deliberately does NOT make :meth:`_hydrate_from_
         history` itself async (architect ruling, #4983: that would push
@@ -5727,10 +5743,12 @@ class TextualChatApp(App):
             ),
             name="hydrated-iv-head-switch", exclusive=False,
         )
-        # #4983: step ① (the disk read) runs OFF the event loop — the
-        # measured defect this issue exists for (a synchronous
-        # `conversation_history()` call blocking the TUI's own event
-        # loop, here on every session switch, not just at mount) —
+        # #4983: step ① (the registry/session read — NOT disk I/O, #5203
+        # measurement; see `_read_conversation_history`'s own docstring)
+        # runs OFF the event loop — the measured defect this issue exists
+        # for (a synchronous `conversation_history()` call blocking the
+        # TUI's own event loop, here on every session switch, not just at
+        # mount, via a bounded in-memory list copy, not disk latency) —
         # step ② (projection + apply) stays on the loop, unchanged. See
         # this method's own docstring for why `_hydrate_from_history`
         # itself is not what's called here.

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2505,6 +2505,55 @@ class TextualChatApp(App):
             logger.exception("textual chat: conversation-history read failed")
             return None
 
+    def _resolve_history_source(
+        self, *, agent: "str | None" = None, session_id: "str | None" = None
+    ):
+        """#5203 — the registry-TOUCHING half of the #4983 off-thread read,
+        split out so it can be called ON THE LOOP, BEFORE the
+        ``asyncio.to_thread`` hop at this method's own 2 call sites
+        (``_handle_session_attached_event`` and :func:`run_textual_chat`'s
+        mount-time pre-fetch). #4995's owner-thread guard is restored onto
+        ``AgentRegistry.get_session``/``attached_session`` in this SAME PR
+        (see that class's own ``_assert_owner_thread`` docstring) — a
+        worker thread calling back into either would now raise, which is
+        exactly the defect this split closes: the accidental safety #5203
+        measured (only ``Session.history`` happened to already be hydrated
+        before a session becomes registry-visible — a fact about today's
+        field, not a designed guarantee, architect issuecomment-
+        5385152402) is replaced with a REAL one — the registry is never
+        touched off its owner thread at all, by construction.
+
+        Returns the plain VALUE :meth:`~reyn.interfaces.repl.read_model.
+        ChatReadModel.resolve_conversation_history_source` produces (never
+        a live ``Session``/registry handle) — safe to hand to
+        :meth:`_history_from_source` across the thread boundary. ``None``
+        on `self._read_model` being unset OR the resolve raising (already
+        logged here), mirroring :meth:`_read_conversation_history`'s own
+        error-handling shape."""
+        if self._read_model is None:
+            return None
+        try:
+            return self._read_model.resolve_conversation_history_source(
+                agent=agent, session_id=session_id
+            )
+        except Exception:
+            logger.exception("textual chat: conversation-history source-resolve failed")
+            return None
+
+    def _history_from_source(self, source) -> "list | None":
+        """#5203 — the thread-SAFE half. *source* is whatever
+        :meth:`_resolve_history_source` returned (already resolved ON THE
+        LOOP) — this method touches no registry and is safe to run inside
+        ``asyncio.to_thread``, the actual off-thread step #4983 exists
+        for."""
+        if source is None or self._read_model is None:
+            return None
+        try:
+            return self._read_model.conversation_history_from_source(source)
+        except Exception:
+            logger.exception("textual chat: conversation-history read failed")
+            return None
+
     def _apply_hydrated_messages(self, messages: "list | None") -> None:
         """#4983 step ② — project *messages* (already read by :meth:`_read_
         conversation_history`, step ①) into the retained model so the pane
@@ -5685,9 +5734,13 @@ class TextualChatApp(App):
         # step ② (projection + apply) stays on the loop, unchanged. See
         # this method's own docstring for why `_hydrate_from_history`
         # itself is not what's called here.
-        messages = await asyncio.to_thread(
-            self._read_conversation_history, agent=agent, session_id=session_id,
-        )
+        #
+        # #5203: the registry TOUCH (resolving `agent`/`session_id` to a
+        # Session) happens HERE, still on the loop, BEFORE the thread hop
+        # — only the plain-value slice below crosses into `to_thread`. See
+        # `_resolve_history_source`'s own docstring for why.
+        source = self._resolve_history_source(agent=agent, session_id=session_id)
+        messages = await asyncio.to_thread(self._history_from_source, source)
         # #4983 supersede guard — see this method's own docstring. A LATER
         # switch may have claimed a newer generation (and already applied
         # its own hydrate) while the read above was still in flight; this
@@ -6899,19 +6952,24 @@ async def run_textual_chat(
     # ``[]``, in that case (``on_mount`` needs to tell "nothing to read"
     # apart from "read it yourself").
     #
-    # Deliberately does NOT touch the session-switch rehydrate path
-    # (``TextualChatApp._handle_session_attached_event``, live, mid-
-    # session) — that call site still makes the SAME synchronous read it
-    # always did. Its own event-loop-block question is a separate,
-    # still-open UX question (a live switch would trade "TUI freezes
-    # briefly" for "the pane goes blank for a beat, then refills") that
-    # needs its own owner-facing ruling before it changes — see #4983's
-    # own issue thread. Do not read this fix as covering that path too.
+    # #5203: this call site and ``TextualChatApp._handle_session_attached_
+    # event``'s (the session-switch rehydrate, live, mid-session) are now
+    # the SAME shape — both resolve the target session EXPLICITLY (``agent=
+    # agent_name`` here, matching the switch path's own ``agent``/
+    # ``session_id``, rather than this call's former implicit "whichever
+    # session is attached") and both hoist the registry touch onto the
+    # LOOP, before their own ``asyncio.to_thread`` hop, so neither ever
+    # reaches ``AgentRegistry.get_session``/``attached_session`` from the
+    # worker thread anymore. See ``ChatReadModel.resolve_conversation_
+    # history_source``'s own docstring for why.
     _initial_history_messages = None
     if read_model is not None:
         try:
+            _history_source = read_model.resolve_conversation_history_source(
+                agent=agent_name
+            )
             _initial_history_messages = await asyncio.to_thread(
-                read_model.conversation_history
+                read_model.conversation_history_from_source, _history_source,
             )
         except Exception:
             # Fully guarded, same discipline as the pre-#4983 synchronous

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -745,9 +745,14 @@ class RegistryReadModel(ChatReadModel):
             return []
         # The Session's ``history`` list IS the ChatMessage log loaded from
         # ``history.jsonl`` by ``Session.load_history`` at load time — read it
-        # straight (no audit-event path). A shallow copy, so neither this
-        # caller nor a later ``conversation_history_from_source`` slice can
-        # mutate the live session history.
+        # straight (no audit-event path). ``list(...)`` is a shallow copy: the
+        # LIST is a new object, so neither this caller nor a later
+        # ``conversation_history_from_source`` slice/append can add or drop
+        # entries in the live session history. The ELEMENTS (``ChatMessage``
+        # instances) are the SAME objects, shared with the live list — an
+        # in-place mutation of one WOULD reach the live session. Nothing on
+        # this path does that today (docs-maintainer's #5215 B confirmed), so
+        # this is a documentation-accuracy note, not a live hazard.
         return list(getattr(s, "history", []) or [])
 
     def conversation_history_from_source(

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -506,6 +506,55 @@ class ChatReadModel(ABC):
         method's; passing a target here on a remote client is accepted but
         inert."""
 
+    def resolve_conversation_history_source(
+        self, *, agent: "str | None" = None, session_id: "str | None" = None,
+    ) -> "list[ChatMessage]":
+        """#5203: the registry-TOUCHING half of :meth:`conversation_history`
+        — MUST be called on the registry's OWNER thread
+        (:attr:`~reyn.runtime.registry.AgentRegistry.owner_thread_ident`,
+        #4995) by an implementation that genuinely touches one. Returns a
+        plain VALUE (never a live ``Session``/registry handle) safe to
+        hand across a thread boundary to :meth:`conversation_history_
+        from_source`.
+
+        **Concrete, not abstract** — the default delegates straight to
+        :meth:`conversation_history` (``limit=None``, the whole log),
+        treating its return value AS the "source". This keeps every
+        EXISTING :class:`ChatReadModel` implementation (test doubles that
+        only ever implemented the single combined method — this is a
+        pre-#5203 interface, not a new requirement on them) working
+        unchanged: their ``conversation_history`` has no thread-safety
+        concern to begin with, so the default split is a no-op split.
+
+        :class:`RegistryReadModel` OVERRIDES this with the REAL split (the
+        registry touch, nothing else) — the ONE implementation ``app.py``'s
+        #4983 off-loop read (``asyncio.to_thread``) actually calls this
+        way, from a genuine second OS thread reaching
+        ``AgentRegistry.get_session``/``attached_session`` — #4995 slice 1
+        restores the owner-thread guard onto exactly those 2 registry
+        methods (the 7-read set #5202 first excluded then #5203
+        re-covers) in this SAME PR, so the registry touch must happen on
+        the loop, BEFORE the thread hop, not inside it. Every OTHER
+        implementation is free to keep using this default — there is
+        nothing to hoist when there is no registry to protect."""
+        return self.conversation_history(agent=agent, session_id=session_id)
+
+    def conversation_history_from_source(
+        self, source: "list[ChatMessage]", *, limit: "int | None" = None,
+    ) -> "list[ChatMessage]":
+        """#5203: the thread-SAFE half — *source* is whatever
+        :meth:`resolve_conversation_history_source` returned. **Concrete,
+        not abstract** — the default just applies ``limit`` to *source*
+        (already the full resolved log, from the default resolve above);
+        see that method's own docstring for why this default is safe for
+        every implementation that does not override the split.
+        :class:`RegistryReadModel` overrides this too, so the ``limit``
+        slice it does here matches this default's own shape exactly —
+        kept as one definition, not duplicated, by inheriting it."""
+        if limit is not None and limit >= 0:
+            return list(source)[-limit:]
+        return list(source)
+
     @abstractmethod
     def load_older_conversation_history(
         self,
@@ -649,12 +698,32 @@ class RegistryReadModel(ChatReadModel):
         limit: "int | None" = None,
         agent: "str | None" = None,
         session_id: "str | None" = None,
-    ):
-        # The Session's ``history`` list IS the ChatMessage log loaded from
-        # ``history.jsonl`` by ``Session.load_history`` at load time — read it
-        # straight (no audit-event path). Return a shallow copy so a caller can
-        # not mutate the live session history. ``None`` = whole log (resume-
-        # equivalent); a positive ``limit`` keeps the most-recent N.
+    ) -> "list[ChatMessage]":
+        # #5203: the synchronous do-both convenience — a caller that does
+        # not cross a thread boundary (this is most callers) has no reason
+        # to split the 2 halves itself. Byte-identical to this method's own
+        # pre-#5203 single-piece body; the ONLY caller that DOES cross a
+        # thread boundary (``app.py``'s #4983 off-loop read) calls the 2
+        # halves directly instead — see ``resolve_conversation_history_
+        # source``'s own docstring immediately below.
+        source = self.resolve_conversation_history_source(agent=agent, session_id=session_id)
+        return self.conversation_history_from_source(source, limit=limit)
+
+    def resolve_conversation_history_source(
+        self, *, agent: "str | None" = None, session_id: "str | None" = None,
+    ) -> "list[ChatMessage]":
+        # #5203: the ONLY registry-touching half of conversation_history's
+        # own former single-piece body — split out so a caller crossing a
+        # thread boundary (``asyncio.to_thread``, ``app.py``'s #4983 off-
+        # loop read) can call THIS half on the registry's OWNER thread and
+        # hand the plain VALUE this returns across to the worker thread,
+        # instead of letting the worker thread call back into
+        # ``AgentRegistry.get_session``/``attached_session`` itself (#4995's
+        # own owner-thread invariant, restored onto exactly these 2 methods
+        # in the SAME PR — see ``registry.py``'s own ``_assert_owner_thread``
+        # call sites). The returned list IS the plain value: a shallow copy
+        # of the resolved session's ``history``, no live ``Session``/
+        # registry reference retained past this call.
         #
         # #3310 N2: ``agent`` given → resolve THAT session (not necessarily the
         # attached one) via ``AgentRegistry.get_session`` — the same
@@ -674,10 +743,24 @@ class RegistryReadModel(ChatReadModel):
             s = self._attached()
         if s is None:
             return []
-        history = list(getattr(s, "history", []) or [])
+        # The Session's ``history`` list IS the ChatMessage log loaded from
+        # ``history.jsonl`` by ``Session.load_history`` at load time — read it
+        # straight (no audit-event path). A shallow copy, so neither this
+        # caller nor a later ``conversation_history_from_source`` slice can
+        # mutate the live session history.
+        return list(getattr(s, "history", []) or [])
+
+    def conversation_history_from_source(
+        self, source: "list[ChatMessage]", *, limit: "int | None" = None,
+    ) -> "list[ChatMessage]":
+        # #5203: the thread-safe half — *source* is already a plain value
+        # (whatever :meth:`resolve_conversation_history_source` returned),
+        # never a live ``Session``/registry handle, so this method touches
+        # neither ``self._registry`` nor any ``Session`` attribute — safe
+        # to call from ANY thread, including inside ``asyncio.to_thread``.
         if limit is not None and limit >= 0:
-            return history[-limit:]
-        return history
+            return source[-limit:]
+        return list(source)
 
     def load_older_conversation_history(
         self,
@@ -919,13 +1002,16 @@ class RemoteReadModel(ChatReadModel):
         limit: "int | None" = None,
         agent: "str | None" = None,
         session_id: "str | None" = None,
-    ):
-        # Frame-sufficiency: a remote client holds no session and the past-turn
-        # ChatMessage log is NOT projected onto the wire (like the dropdown
-        # expansions / rewind picker). Degrade gracefully to empty — never a
-        # fabricated turn, regardless of a targeted (agent, session_id) — remote
-        # switch-hydrate is #3310 N3's job, not this accessor's. Restore-on-
-        # restart / switch-rehydrate is a local-attach affordance today.
+    ) -> "list[ChatMessage]":
+        # #5203: no registry to touch on this side — a remote client holds
+        # no session. Frame-sufficiency: the past-turn ChatMessage log is
+        # NOT projected onto the wire (like the dropdown expansions /
+        # rewind picker). Degrade gracefully to empty — never a fabricated
+        # turn, regardless of a targeted (agent, session_id) — remote
+        # switch-hydrate is #3310 N3's job, not this accessor's. No
+        # override of resolve_conversation_history_source/conversation_
+        # history_from_source needed: the base class's own defaults
+        # delegate straight to this method and already produce [] → [].
         return []
 
     def load_older_conversation_history(

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -472,36 +472,60 @@ class AgentRegistry:
         # from the moment it exists" shape (that class's own module
         # docstring), never a second owner assigned later.
         #
-        # "Owns" means "only thread allowed to MUTATE OR READ", enforced on
-        # every method that touches registry-owned state (the 4 mutators
-        # PLUS 7 reads — see below).
+        # "Owns" means "only thread allowed to MUTATE", NOT "only thread
+        # allowed to touch" — the first version of this invariant asserted
+        # on 11 methods including 7 READS, and CI found a real, pre-existing,
+        # LEGITIMATE second thread within one run: ``app.py``'s #4983 design
+        # deliberately reads conversation history off the event loop via
+        # ``asyncio.to_thread`` (app.py's own ``_read_conversation_history``
+        # call sites), which genuinely executes on a second OS thread and
+        # reaches ``get_session``/``agent_workspace_dir``/etc. through
+        # ``RegistryReadModel``. That is not the race #4995 exists to
+        # prevent — 27 CI failures were this PR breaking a real feature, not
+        # catching a real bug. Scoped down to exactly the 4 methods that
+        # MUTATE registry-owned state: ``attach``, ``restore_all``,
+        # ``resume_deferred_agents``, ``record_background_attach_error``.
+        # The 7 read methods (``exists``, ``loaded_names``,
+        # ``agent_cost_usd``, ``agent_total_usage``, ``attached_session``,
+        # ``get_session``, ``agent_workspace_dir``) are NOT asserted — see
+        # each one's own docstring.
         #
-        # History (#5203, restoring what #5202 first landed then had to
-        # narrow): the first version of this invariant asserted on 11
-        # methods including these 7 READS, and CI found a real,
-        # pre-existing second thread within one run: ``app.py``'s #4983
-        # design read conversation history off the event loop via
-        # ``asyncio.to_thread`` (``app.py``'s own ``_read_conversation_
-        # history``/mount-time call sites), which genuinely executed on a
-        # second OS thread and reached ``get_session``/``attached_session``
-        # through ``RegistryReadModel``. #5202 scoped the guard down to
-        # exactly the 4 mutators to stop breaking that legitimate feature
-        # (27 CI failures) — architect's own follow-up ruling
-        # (issuecomment-5385152402) named the safety that left in place as
-        # ACCIDENTAL, not designed: the window (``get_or_load``, between
-        # ``_store_session`` and its own later ``load_persisted_toggles``/
-        # ``restore_state``) is real, and the ONLY reason nothing broke was
-        # that the one field ``app.py``'s off-thread reads actually consume
-        # (``Session.history``) happens to be hydrated before a session is
-        # ever stored — a fact about today's field, not a guarantee. #5203
-        # (same PR as this comment) moved ``app.py``'s 2 ``asyncio.to_
-        # thread`` call sites to resolve the registry-touching half ON THE
-        # LOOP first, handing the worker thread a plain, already-resolved
-        # value instead — closing the "偶然" (accidental) dependency by
-        # construction rather than merely documenting it, which is what
-        # makes restoring the guard onto all 7 reads (including
-        # ``get_session``/``attached_session``) safe again: nothing
-        # legitimate touches ANY of them off this thread anymore.
+        # #5203 tried to restore the guard onto the 7 reads too (architect
+        # issuecomment-5385152402, reasoning ``app.py``'s hoist below closed
+        # the ONLY legitimate off-thread reader) — WITHDRAWN by the same
+        # architect (issuecomment-5385481839, then reaffirmed against a
+        # narrower "just `exists()`" alternative, issuecomment-5385499177)
+        # for 2 INDEPENDENT reasons, not one:
+        #   (a) CI caught 2 MORE legitimate off-thread readers this PR
+        #       never enumerated: the web server's A2A (``resolve_a2a_
+        #       session`` → ``resolve_session`` → ``get_session``) and
+        #       artifact-by-ref (``registry.exists``) routes.
+        #   (b) even with every current caller enumerated, "one owner
+        #       thread" is topology-dependent, not a real invariant — the
+        #       web server structurally runs a SYNC endpoint via FastAPI's
+        #       own threadpool, and Starlette's own TestClient dispatches
+        #       through its own background portal thread. Narrowing to
+        #       "only `exists()` needs excluding" (the 6 OTHER reads
+        #       currently having no known off-thread caller) is SHALLOW
+        #       reasoning — "safe because nothing off-thread touches it
+        #       TODAY" is exactly the assumption that broke twice already
+        #       here (#5202's first version, then #5203's own restoration
+        #       attempt); it is a fact about today's callers, not a
+        #       structural guarantee, and a 3rd unenumerated caller would
+        #       be the same mistake a 3rd time. This is the SAME judgment
+        #       that withdrew #4995 slice 2's own lock proposal.
+        # #5203's real fix (a SEPARATE PR, not this one) is at the actual
+        # accidental-safety window instead: ``get_or_load`` (below) calls
+        # ``_store_session`` — publishing the session to this registry's
+        # map — BEFORE its own later ``load_persisted_toggles``/``restore_
+        # state`` finish constructing it. Moving ``_store_session`` to run
+        # LAST (publish only once complete) means any thread that finds a
+        # session in the map at all finds a COMPLETE one — no guard needed
+        # on the reads (there is nothing left for a read-side guard to
+        # strip-to-red once publication order is fixed), and A2A/web need
+        # no changes either. ``app.py``'s own hoist (below) stays in THIS
+        # PR regardless — independently correct hygiene (the registry
+        # touch happening on the loop, not because a guard depends on it).
         #
         # #4995 slice 2's own open question (architect, issuecomment-
         # 5384963741): whether #4983's off-thread READS observe a live view
@@ -509,26 +533,20 @@ class AgentRegistry:
         # whether an `asyncio.Lock` around the 4 mutating methods (slice 2)
         # is sufficient — a lock serializes MUTATION against MUTATION
         # (same-loop coroutines), never against a genuinely concurrent
-        # OS-thread READER. #5203 does not answer this — see #4995's own
-        # issue comments for that measurement (superseded by an
-        # uninterruptibility test per issuecomment-5385115588, out of this
-        # PR's scope).
+        # OS-thread READER. See #4995's own issue comments for that
+        # measurement once it exists.
         self._owner_thread_ident = threading.get_ident()
 
     def _assert_owner_thread(self) -> None:
-        """#4995 slice 1, scope RESTORED to its original 11 methods by
-        #5203 (see ``_owner_thread_ident``'s own comment for the full
-        history): raise if called from a thread OTHER than the one that
-        constructed this registry. Call at the top of every method that
-        MUTATES OR READS registry-owned state (``self._sessions`` and
-        friends) — the 4 mutators AND the 7 reads
-        (``exists``/``loaded_names``/``agent_cost_usd``/``agent_total_
-        usage``/``attached_session``/``get_session``/``agent_workspace_
-        dir``). Safe to assert on the reads again because #5203 (same PR)
-        moved the one legitimate off-thread caller (``app.py``'s #4983
-        ``asyncio.to_thread`` reads) to resolve the registry-touching half
-        on the loop BEFORE crossing the thread boundary — nothing
-        remaining legitimately reaches this registry off its owner thread.
+        """#4995 slice 1 (scope corrected — see ``_owner_thread_ident``'s
+        own comment): raise if called from a thread OTHER than the one that
+        constructed this registry. Call ONLY at the top of a method that
+        MUTATES registry-owned state — a read must NOT call this (#4983's
+        own off-thread reads are a legitimate second thread; asserting on a
+        read breaks them, as CI found — and, per #5215's own withdrawn
+        attempt, so does the web server's A2A/artifact-by-ref reads, plus
+        the web server's structural use of a threadpool for sync endpoints;
+        see ``_owner_thread_ident``'s own comment for the full history).
 
         Disclosed gap (architect, issuecomment-5385029098), not a
         completeness claim: nothing here or in ``tests/runtime/test_4995_
@@ -543,10 +561,10 @@ class AgentRegistry:
         current = threading.get_ident()
         if current != self._owner_thread_ident:
             raise RuntimeError(
-                f"AgentRegistry touched from thread {current} but is owned "
+                f"AgentRegistry mutated from thread {current} but is owned "
                 f"by thread {self._owner_thread_ident} — see #4995 (a single "
                 f"owner thread is the invariant this registry's cross-thread "
-                f"safety depends on; a second thread reaching this "
+                f"MUTATION safety depends on; a second thread reaching this "
                 f"method is the race #4995 exists to prevent, not a "
                 f"permitted access pattern — reads are a separate, allowed "
                 f"case, see this registry's own ``_owner_thread_ident`` "
@@ -643,15 +661,12 @@ class AgentRegistry:
         Defaults to the implicit "main" session (byte-identical to the prior
         single-session lookup).
 
-        #4995 slice 1, owner-thread-asserted again as of #5203 (see
-        ``AgentRegistry``'s own ``_owner_thread_ident``/``_assert_owner_
-        thread`` docstrings for the full history) — ``app.py``'s #4983
-        off-thread read now resolves the session on the LOOP via
-        :meth:`~reyn.interfaces.repl.read_model.RegistryReadModel.
-        resolve_conversation_history_source` before ever crossing into
-        ``asyncio.to_thread``, so this method is no longer legitimately
-        reached from a second OS thread."""
-        self._assert_owner_thread()
+        #4995 slice 1 (architect correction): NOT owner-thread-asserted —
+        a read, not a mutation. See ``AgentRegistry``'s own
+        ``_owner_thread_ident`` docstring for which methods DO assert and
+        why (#5215's attempt to restore this for #5203 was withdrawn —
+        the web server's A2A/artifact-by-ref routes reach this method the
+        same way ``app.py``'s off-thread reads do)."""
         return self._peek_session(name, sid)
 
     def session_ids(self, name: str) -> list[str]:
@@ -684,9 +699,8 @@ class AgentRegistry:
         only, so it reset to 0 on restart AND N×-counted an agent's cost across ``/session new``
         sessions, since each gateway held the full per-agent seed. #cost-restart.)
 
-        #4995 slice 1, owner-thread-asserted again as of #5203 — see
-        :meth:`get_session`'s own docstring for the full history."""
-        self._assert_owner_thread()
+        #4995 slice 1 (architect correction): NOT owner-thread-asserted —
+        a read, not a mutation. See :meth:`get_session`'s own docstring."""
         tracker = self._shared_budget_tracker()
         return tracker.agent_cost_usd(name) if tracker is not None else 0.0
 
@@ -708,9 +722,8 @@ class AgentRegistry:
     def agent_total_usage(self, name: str) -> "object":
         """Aggregate TokenUsage across ALL sessions of agent ``name``.
 
-        #4995 slice 1, owner-thread-asserted again as of #5203 — see
-        :meth:`get_session`'s own docstring for the full history."""
-        self._assert_owner_thread()
+        #4995 slice 1 (architect correction): NOT owner-thread-asserted —
+        a read, not a mutation. See :meth:`get_session`'s own docstring."""
         from reyn.llm.pricing import TokenUsage
         total: "TokenUsage" = TokenUsage()
         for sid in self.session_ids(name):
@@ -829,15 +842,13 @@ class AgentRegistry:
         bootstrap — not a re-derivation, the identical value by a
         different, session-free route).
 
-        #4995 slice 1, owner-thread-asserted again as of #5203 — see
-        :meth:`get_session`'s own docstring for the full history."""
-        self._assert_owner_thread()
+        #4995 slice 1 (architect correction): NOT owner-thread-asserted —
+        a read, not a mutation. See :meth:`get_session`'s own docstring."""
         return self._dir / name
 
     def exists(self, name: str) -> bool:
-        """#4995 slice 1, owner-thread-asserted again as of #5203 — see
-        :meth:`get_session`'s own docstring for the full history."""
-        self._assert_owner_thread()
+        """#4995 slice 1 (architect correction): NOT owner-thread-asserted
+        — a read, not a mutation. See :meth:`get_session`'s own docstring."""
         return (self._dir / name / PROFILE_FILENAME).is_file()
 
     def create(
@@ -4091,9 +4102,8 @@ class AgentRegistry:
         return active[1] if active is not None else None
 
     def attached_session(self) -> "object | None":
-        """#4995 slice 1, owner-thread-asserted again as of #5203 — see
-        :meth:`get_session`'s own docstring for the full history."""
-        self._assert_owner_thread()
+        """#4995 slice 1 (architect correction): NOT owner-thread-asserted
+        — a read, not a mutation. See :meth:`get_session`'s own docstring."""
         active = self._connection.active
         if active is None:
             return None
@@ -4358,9 +4368,8 @@ class AgentRegistry:
                 logger.warning("StateLog teardown failed: %s", exc)
 
     def loaded_names(self) -> list[str]:
-        """#4995 slice 1, owner-thread-asserted again as of #5203 — see
-        :meth:`get_session`'s own docstring for the full history."""
-        self._assert_owner_thread()
+        """#4995 slice 1 (architect correction): NOT owner-thread-asserted
+        — a read, not a mutation. See :meth:`get_session`'s own docstring."""
         return list(self._sessions.keys())
 
     def session_tree(self) -> "list[dict]":

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -472,23 +472,36 @@ class AgentRegistry:
         # from the moment it exists" shape (that class's own module
         # docstring), never a second owner assigned later.
         #
-        # "Owns" means "only thread allowed to MUTATE", NOT "only thread
-        # allowed to touch" — the first version of this invariant asserted
-        # on 11 methods including 7 READS, and CI found a real, pre-existing,
-        # LEGITIMATE second thread within one run: ``app.py``'s #4983 design
-        # deliberately reads conversation history off the event loop via
-        # ``asyncio.to_thread`` (app.py's own ``_read_conversation_history``
-        # call sites), which genuinely executes on a second OS thread and
-        # reaches ``get_session``/``agent_workspace_dir``/etc. through
-        # ``RegistryReadModel``. That is not the race #4995 exists to
-        # prevent — 27 CI failures were this PR breaking a real feature, not
-        # catching a real bug. Scoped down to exactly the 4 methods that
-        # MUTATE registry-owned state: ``attach``, ``restore_all``,
-        # ``resume_deferred_agents``, ``record_background_attach_error``.
-        # The 7 read methods (``exists``, ``loaded_names``,
-        # ``agent_cost_usd``, ``agent_total_usage``, ``attached_session``,
-        # ``get_session``, ``agent_workspace_dir``) are NOT asserted — see
-        # each one's own docstring.
+        # "Owns" means "only thread allowed to MUTATE OR READ", enforced on
+        # every method that touches registry-owned state (the 4 mutators
+        # PLUS 7 reads — see below).
+        #
+        # History (#5203, restoring what #5202 first landed then had to
+        # narrow): the first version of this invariant asserted on 11
+        # methods including these 7 READS, and CI found a real,
+        # pre-existing second thread within one run: ``app.py``'s #4983
+        # design read conversation history off the event loop via
+        # ``asyncio.to_thread`` (``app.py``'s own ``_read_conversation_
+        # history``/mount-time call sites), which genuinely executed on a
+        # second OS thread and reached ``get_session``/``attached_session``
+        # through ``RegistryReadModel``. #5202 scoped the guard down to
+        # exactly the 4 mutators to stop breaking that legitimate feature
+        # (27 CI failures) — architect's own follow-up ruling
+        # (issuecomment-5385152402) named the safety that left in place as
+        # ACCIDENTAL, not designed: the window (``get_or_load``, between
+        # ``_store_session`` and its own later ``load_persisted_toggles``/
+        # ``restore_state``) is real, and the ONLY reason nothing broke was
+        # that the one field ``app.py``'s off-thread reads actually consume
+        # (``Session.history``) happens to be hydrated before a session is
+        # ever stored — a fact about today's field, not a guarantee. #5203
+        # (same PR as this comment) moved ``app.py``'s 2 ``asyncio.to_
+        # thread`` call sites to resolve the registry-touching half ON THE
+        # LOOP first, handing the worker thread a plain, already-resolved
+        # value instead — closing the "偶然" (accidental) dependency by
+        # construction rather than merely documenting it, which is what
+        # makes restoring the guard onto all 7 reads (including
+        # ``get_session``/``attached_session``) safe again: nothing
+        # legitimate touches ANY of them off this thread anymore.
         #
         # #4995 slice 2's own open question (architect, issuecomment-
         # 5384963741): whether #4983's off-thread READS observe a live view
@@ -496,17 +509,26 @@ class AgentRegistry:
         # whether an `asyncio.Lock` around the 4 mutating methods (slice 2)
         # is sufficient — a lock serializes MUTATION against MUTATION
         # (same-loop coroutines), never against a genuinely concurrent
-        # OS-thread READER. See #4995's own issue comments for that
-        # measurement once it exists.
+        # OS-thread READER. #5203 does not answer this — see #4995's own
+        # issue comments for that measurement (superseded by an
+        # uninterruptibility test per issuecomment-5385115588, out of this
+        # PR's scope).
         self._owner_thread_ident = threading.get_ident()
 
     def _assert_owner_thread(self) -> None:
-        """#4995 slice 1 (scope corrected — see ``_owner_thread_ident``'s
-        own comment): raise if called from a thread OTHER than the one that
-        constructed this registry. Call ONLY at the top of a method that
-        MUTATES registry-owned state — a read must NOT call this (#4983's
-        own off-thread reads are a legitimate second thread; asserting on a
-        read breaks them, as CI found).
+        """#4995 slice 1, scope RESTORED to its original 11 methods by
+        #5203 (see ``_owner_thread_ident``'s own comment for the full
+        history): raise if called from a thread OTHER than the one that
+        constructed this registry. Call at the top of every method that
+        MUTATES OR READS registry-owned state (``self._sessions`` and
+        friends) — the 4 mutators AND the 7 reads
+        (``exists``/``loaded_names``/``agent_cost_usd``/``agent_total_
+        usage``/``attached_session``/``get_session``/``agent_workspace_
+        dir``). Safe to assert on the reads again because #5203 (same PR)
+        moved the one legitimate off-thread caller (``app.py``'s #4983
+        ``asyncio.to_thread`` reads) to resolve the registry-touching half
+        on the loop BEFORE crossing the thread boundary — nothing
+        remaining legitimately reaches this registry off its owner thread.
 
         Disclosed gap (architect, issuecomment-5385029098), not a
         completeness claim: nothing here or in ``tests/runtime/test_4995_
@@ -521,10 +543,10 @@ class AgentRegistry:
         current = threading.get_ident()
         if current != self._owner_thread_ident:
             raise RuntimeError(
-                f"AgentRegistry mutated from thread {current} but is owned "
+                f"AgentRegistry touched from thread {current} but is owned "
                 f"by thread {self._owner_thread_ident} — see #4995 (a single "
                 f"owner thread is the invariant this registry's cross-thread "
-                f"MUTATION safety depends on; a second thread reaching this "
+                f"safety depends on; a second thread reaching this "
                 f"method is the race #4995 exists to prevent, not a "
                 f"permitted access pattern — reads are a separate, allowed "
                 f"case, see this registry's own ``_owner_thread_ident`` "
@@ -621,14 +643,15 @@ class AgentRegistry:
         Defaults to the implicit "main" session (byte-identical to the prior
         single-session lookup).
 
-        #4995 slice 1 (architect correction, issuecomment-5384963741): NOT
-        owner-thread-asserted, unlike the mutating methods — ``app.py``'s
-        own #4983 design deliberately reads history off the event loop via
-        ``asyncio.to_thread``, which genuinely runs on a second real OS
-        thread and reaches this method through ``RegistryReadModel``. That
-        is a legitimate existing read, not the race #4995 exists to
-        prevent — see ``AgentRegistry``'s own ``_owner_thread_ident``
-        docstring for which methods DO assert and why."""
+        #4995 slice 1, owner-thread-asserted again as of #5203 (see
+        ``AgentRegistry``'s own ``_owner_thread_ident``/``_assert_owner_
+        thread`` docstrings for the full history) — ``app.py``'s #4983
+        off-thread read now resolves the session on the LOOP via
+        :meth:`~reyn.interfaces.repl.read_model.RegistryReadModel.
+        resolve_conversation_history_source` before ever crossing into
+        ``asyncio.to_thread``, so this method is no longer legitimately
+        reached from a second OS thread."""
+        self._assert_owner_thread()
         return self._peek_session(name, sid)
 
     def session_ids(self, name: str) -> list[str]:
@@ -661,8 +684,9 @@ class AgentRegistry:
         only, so it reset to 0 on restart AND N×-counted an agent's cost across ``/session new``
         sessions, since each gateway held the full per-agent seed. #cost-restart.)
 
-        #4995 slice 1 (architect correction): NOT owner-thread-asserted —
-        a read, not a mutation. See :meth:`get_session`'s own docstring."""
+        #4995 slice 1, owner-thread-asserted again as of #5203 — see
+        :meth:`get_session`'s own docstring for the full history."""
+        self._assert_owner_thread()
         tracker = self._shared_budget_tracker()
         return tracker.agent_cost_usd(name) if tracker is not None else 0.0
 
@@ -684,8 +708,9 @@ class AgentRegistry:
     def agent_total_usage(self, name: str) -> "object":
         """Aggregate TokenUsage across ALL sessions of agent ``name``.
 
-        #4995 slice 1 (architect correction): NOT owner-thread-asserted —
-        a read, not a mutation. See :meth:`get_session`'s own docstring."""
+        #4995 slice 1, owner-thread-asserted again as of #5203 — see
+        :meth:`get_session`'s own docstring for the full history."""
+        self._assert_owner_thread()
         from reyn.llm.pricing import TokenUsage
         total: "TokenUsage" = TokenUsage()
         for sid in self.session_ids(name):
@@ -804,13 +829,15 @@ class AgentRegistry:
         bootstrap — not a re-derivation, the identical value by a
         different, session-free route).
 
-        #4995 slice 1 (architect correction): NOT owner-thread-asserted —
-        a read, not a mutation. See :meth:`get_session`'s own docstring."""
+        #4995 slice 1, owner-thread-asserted again as of #5203 — see
+        :meth:`get_session`'s own docstring for the full history."""
+        self._assert_owner_thread()
         return self._dir / name
 
     def exists(self, name: str) -> bool:
-        """#4995 slice 1 (architect correction): NOT owner-thread-asserted
-        — a read, not a mutation. See :meth:`get_session`'s own docstring."""
+        """#4995 slice 1, owner-thread-asserted again as of #5203 — see
+        :meth:`get_session`'s own docstring for the full history."""
+        self._assert_owner_thread()
         return (self._dir / name / PROFILE_FILENAME).is_file()
 
     def create(
@@ -4064,8 +4091,9 @@ class AgentRegistry:
         return active[1] if active is not None else None
 
     def attached_session(self) -> "object | None":
-        """#4995 slice 1 (architect correction): NOT owner-thread-asserted
-        — a read, not a mutation. See :meth:`get_session`'s own docstring."""
+        """#4995 slice 1, owner-thread-asserted again as of #5203 — see
+        :meth:`get_session`'s own docstring for the full history."""
+        self._assert_owner_thread()
         active = self._connection.active
         if active is None:
             return None
@@ -4330,8 +4358,9 @@ class AgentRegistry:
                 logger.warning("StateLog teardown failed: %s", exc)
 
     def loaded_names(self) -> list[str]:
-        """#4995 slice 1 (architect correction): NOT owner-thread-asserted
-        — a read, not a mutation. See :meth:`get_session`'s own docstring."""
+        """#4995 slice 1, owner-thread-asserted again as of #5203 — see
+        :meth:`get_session`'s own docstring for the full history."""
+        self._assert_owner_thread()
         return list(self._sessions.keys())
 
     def session_tree(self) -> "list[dict]":

--- a/tests/interfaces/test_4387_read_model_load_older_conversation_history.py
+++ b/tests/interfaces/test_4387_read_model_load_older_conversation_history.py
@@ -142,3 +142,24 @@ def test_remote_read_model_always_degrades_to_zero() -> None:
 
     assert rm.load_older_conversation_history() == 0
     assert rm.load_older_conversation_history(agent="anything", session_id="main") == 0
+
+
+def test_remote_read_model_split_methods_agree_with_conversation_history() -> None:
+    """Tier 1: #5215 — ``RemoteReadModel`` carries NO override of
+    ``resolve_conversation_history_source``/``conversation_history_from_
+    source`` (unlike ``RegistryReadModel``, the one implementation with a
+    real thread-safety concern to split for) — the base ``ChatReadModel``'s
+    own default (delegate straight to ``conversation_history()``) is relied
+    on silently. Explicit witness that the default produces the SAME
+    frame-sufficiency degrade (``[]``) as calling ``conversation_history()``
+    directly, so a future base-class default change is caught here rather
+    than only by this class's silence (six-questions ④)."""
+    rm = RemoteReadModel(transport=None)
+
+    assert rm.resolve_conversation_history_source() == []
+    assert rm.conversation_history_from_source([]) == []
+    assert (
+        rm.conversation_history_from_source(rm.resolve_conversation_history_source())
+        == rm.conversation_history()
+        == []
+    )

--- a/tests/interfaces/test_4983_mount_hydrate_off_loop.py
+++ b/tests/interfaces/test_4983_mount_hydrate_off_loop.py
@@ -1,14 +1,25 @@
 """Tier 2: #4983 — ``on_mount()`` no longer makes its own synchronous
-``history.jsonl`` disk read.
+``conversation_history()`` registry/session read.
 
 Root cause: ``TextualChatApp.on_mount()`` is not ``async def``, and used to
 call ``self._hydrate_from_history()`` unconditionally, which synchronously
-called ``self._read_model.conversation_history()`` — real disk I/O, directly
-on the event loop, with no ``await`` anywhere in the chain. Found while
-investigating #4834's CI `pump heartbeat +0` stalls; confirmed as a real
-defect independent of that investigation's own open question (whether it
-explains CI's specific 2-second symptom — it may not, given CI's own small
-test fixtures — see #4834's own thread).
+called ``self._read_model.conversation_history()`` directly on the event
+loop, with no ``await`` anywhere in the chain. Found while investigating
+#4834's CI `pump heartbeat +0` stalls; confirmed as a real defect
+independent of that investigation's own open question (whether it explains
+CI's specific 2-second symptom — it may not, given CI's own small test
+fixtures — see #4834's own thread).
+
+**Not disk I/O** (#5203 measurement, docs-maintainer/architect-confirmed
+issuecomment-5385460393, corrected here — same PR that discovered the
+stale claim): ``conversation_history`` reads ``Session.history``, a plain
+in-memory list populated once by ``Session.load_history`` at session-
+construction time — it never touches ``history.jsonl`` itself. The
+"real disk I/O" framing above was #4983's ORIGINAL (wrong) understanding
+of the defect; the real defect is still real — a synchronous call
+blocking the event loop — the blocking source is a bounded in-memory list
+copy, not disk latency, which is why moving it off-loop still matters for
+a large history without being "an I/O fix" in the literal sense.
 
 Architect's design (c), issue #4983: read the CURRENTLY-ATTACHED session's
 history OFF the event loop, BEFORE the App exists at all (``run_textual_

--- a/tests/interfaces/test_4983_mount_hydrate_off_loop.py
+++ b/tests/interfaces/test_4983_mount_hydrate_off_loop.py
@@ -81,6 +81,20 @@ class _CountingReadModel(ChatReadModel):
         self.call_count += 1
         return list(self.messages)
 
+    def resolve_conversation_history_source(self, *, agent=None, session_id=None):
+        # #5203: the split half `run_textual_chat`'s own mount-time
+        # pre-fetch now calls DIRECTLY (bypassing `conversation_history`
+        # above entirely — see that call site's own docstring) — counts
+        # the same way, so `call_count` still means "a real read happened"
+        # regardless of which entry point a given call site uses.
+        self.call_count += 1
+        return list(self.messages)
+
+    def conversation_history_from_source(self, source, *, limit=None):
+        if limit is not None and limit >= 0:
+            return list(source)[-limit:]
+        return list(source)
+
     def load_older_conversation_history(self, *, agent=None, session_id=None):
         return 0
 
@@ -161,26 +175,32 @@ async def test_mount_without_prefetch_falls_back_to_the_synchronous_read() -> No
 async def test_run_textual_chat_prefetches_off_thread_before_construction(
     monkeypatch,
 ) -> None:
-    """Tier 2: ``run_textual_chat`` itself must call ``conversation_history``
-    BEFORE constructing the App (mirrors ``test_3671_stall_trace_startup_
+    """Tier 2: ``run_textual_chat`` itself must call ``resolve_conversation_
+    history_source``/``conversation_history_from_source`` BEFORE
+    constructing the App (mirrors ``test_3671_stall_trace_startup_
     wiring.py``'s own technique — stub ``TextualChatApp.run_async`` to raise
     immediately, so only pre-construction wiring is observed).
 
+    #5203: recording moved to ``conversation_history_from_source`` — the
+    specific half that still crosses ``asyncio.to_thread`` (the registry
+    touch, ``resolve_conversation_history_source``, now runs on the loop
+    first, per that call site's own docstring in ``app.py``).
+
     Also confirms the read runs OFF the calling task via a real
-    ``asyncio.to_thread``: records the thread identity ``conversation_
-    history`` was called from and asserts it differs from the main
-    event-loop thread's own identity."""
+    ``asyncio.to_thread``: records the thread identity that call was made
+    from and asserts it differs from the main event-loop thread's own
+    identity."""
     main_thread = threading.current_thread()
     call_threads: "list[threading.Thread]" = []
     messages = _fixture_messages()
     read_model = _CountingReadModel(messages)
-    real_conversation_history = read_model.conversation_history
+    real_from_source = read_model.conversation_history_from_source
 
     def _recording(*args, **kwargs):
         call_threads.append(threading.current_thread())
-        return real_conversation_history(*args, **kwargs)
+        return real_from_source(*args, **kwargs)
 
-    monkeypatch.setattr(read_model, "conversation_history", _recording)
+    monkeypatch.setattr(read_model, "conversation_history_from_source", _recording)
 
     construct_order: "list[str]" = []
     real_init = TextualChatApp.__init__
@@ -206,7 +226,7 @@ async def test_run_textual_chat_prefetches_off_thread_before_construction(
 
     assert read_model.call_count == 1
     assert construct_order == ["construct"], "the App must have been constructed"
-    assert call_threads, "conversation_history must have been called"
+    assert call_threads, "conversation_history_from_source must have been called"
     assert call_threads[0] is not main_thread, (
         "the read must run off the event-loop thread (asyncio.to_thread), "
         "not inline on the same thread run_textual_chat itself runs on"

--- a/tests/interfaces/test_4983_session_switch_off_thread.py
+++ b/tests/interfaces/test_4983_session_switch_off_thread.py
@@ -1,5 +1,10 @@
 """Tier 2: #4983 — the session-switch rehydrate no longer makes its
-synchronous ``history.jsonl`` disk read on the event loop.
+synchronous ``conversation_history()`` registry/session read on the event
+loop. **Not disk I/O** (#5203 measurement, docs-maintainer/architect-
+confirmed issuecomment-5385460393): ``conversation_history`` reads
+``Session.history``, a plain in-memory list, never ``history.jsonl``
+directly — this module's own earlier text claiming "disk read" was
+stale/wrong, corrected here in the same PR that discovered it.
 
 Owner ruling (2026-08-21, "セッション切り替えの見た目許容"): a brief
 blank-then-refill on switch is the ACCEPTED trade — NOT "history never
@@ -10,9 +15,10 @@ Architect's design: split by WORK, not by function — ``_hydrate_from_
 history`` itself stays synchronous (mount, #4985's own untouched
 fallback path, still uses it byte-identically); ONLY
 ``_handle_session_attached_event`` (the live switch barrier) is now
-``async def`` and runs step ① (``_read_conversation_history``, the I/O)
-via ``asyncio.to_thread`` before applying step ② (``_apply_hydrated_
-messages``, pure in-memory) on the loop, exactly as it always has.
+``async def`` and runs step ① (``_read_conversation_history``, the
+registry/session read) via ``asyncio.to_thread`` before applying step ②
+(``_apply_hydrated_messages``, pure in-memory) on the loop, exactly as it
+always has.
 
 Witness is "does the I/O run off the event loop" (real thread-identity
 check, mirroring ``test_4983_mount_hydrate_off_loop.py``'s own

--- a/tests/interfaces/test_4983_session_switch_off_thread.py
+++ b/tests/interfaces/test_4983_session_switch_off_thread.py
@@ -121,11 +121,20 @@ async def test_session_switch_reads_conversation_history_off_the_event_loop(
     tmp_path, monkeypatch,
 ) -> None:
     """Tier 2: the measured defect's own falsifier. The switch barrier's
-    ``conversation_history()`` call must run on a DIFFERENT thread than
-    the event loop's own main thread — reverting the fix (calling
-    ``_hydrate_from_history`` synchronously again, as it did before this
-    PR) turns this red: the call lands on the SAME thread the test
-    itself runs on.
+    off-thread step must run on a DIFFERENT thread than the event loop's
+    own main thread — reverting the fix (calling ``_hydrate_from_history``
+    synchronously again, as it did before this PR) turns this red: the
+    call lands on the SAME thread the test itself runs on.
+
+    #5203: recording moved from ``conversation_history()`` (the combined,
+    synchronous convenience — no longer what the switch call site invokes
+    at all) to ``conversation_history_from_source()`` — the specific half
+    #5203 kept inside ``asyncio.to_thread`` (the registry TOUCH,
+    ``resolve_conversation_history_source()``, now runs on the loop
+    instead, per that method's own docstring). This test's own subject —
+    "does step ① genuinely run off-thread" — is still answered by
+    watching whichever call is the one still crossing the thread
+    boundary.
 
     #5159 (census finding): waiting for the switch's read via a flat
     ``_settle(pilot)`` (``pilot.pause()`` — CPU idle time) instead of the
@@ -144,13 +153,13 @@ async def test_session_switch_reads_conversation_history_off_the_event_loop(
         read_model = RegistryReadModel(reg)
         main_thread = threading.current_thread()
         call_threads: "list[threading.Thread]" = []
-        real_conversation_history = read_model.conversation_history
+        real_from_source = read_model.conversation_history_from_source
 
         def _recording(*args, **kwargs):
             call_threads.append(threading.current_thread())
-            return real_conversation_history(*args, **kwargs)
+            return real_from_source(*args, **kwargs)
 
-        monkeypatch.setattr(read_model, "conversation_history", _recording)
+        monkeypatch.setattr(read_model, "conversation_history_from_source", _recording)
 
         transport = QueueTransport()
         app = TextualChatApp(transport=transport, read_model=read_model, agent_name="alpha")
@@ -165,7 +174,7 @@ async def test_session_switch_reads_conversation_history_off_the_event_loop(
             await wait_until(lambda: len(call_threads) > calls_at_mount)
 
         switch_calls = call_threads[calls_at_mount:]
-        assert switch_calls, "the switch must have read conversation_history"
+        assert switch_calls, "the switch must have read conversation_history_from_source"
         assert all(t is not main_thread for t in switch_calls), (
             "the session-switch read must run off the event-loop thread "
             "(asyncio.to_thread), not inline on the test's own thread"
@@ -294,15 +303,26 @@ async def test_session_switch_supersede_guard_lets_the_later_switch_win(
             loop = asyncio.get_running_loop()
             release_beta_read = threading.Event()
             beta_read_started = asyncio.Event()
-            real_read = app._read_conversation_history
+            real_from_source = app._history_from_source
 
-            def _gated_read(*, agent=None, session_id=None):
-                if agent == "beta":
+            # #5203: the gate moves from `_read_conversation_history`
+            # (which no longer runs at all on this call path — the
+            # registry touch is now `_resolve_history_source`, hoisted
+            # onto the loop, and `agent`/`session_id` are no longer
+            # available at the point that crosses into `to_thread`) to
+            # `_history_from_source`, keyed on the resolved history's own
+            # CONTENT rather than the agent name — beta's and gamma's
+            # seeded turns are distinguishable by content alone, so no
+            # extra plumbing is needed to tell which switch's read this is.
+            def _gated_from_source(source):
+                if source and any(
+                    getattr(m, "content", None) == "beta's own turn" for m in source
+                ):
                     loop.call_soon_threadsafe(beta_read_started.set)
                     release_beta_read.wait()
-                return real_read(agent=agent, session_id=session_id)
+                return real_from_source(source)
 
-            monkeypatch.setattr(app, "_read_conversation_history", _gated_read)
+            monkeypatch.setattr(app, "_history_from_source", _gated_from_source)
 
             await reg.attach("beta")
             beta_task = asyncio.create_task(

--- a/tests/runtime/test_4995_registry_owner_thread.py
+++ b/tests/runtime/test_4995_registry_owner_thread.py
@@ -1,7 +1,6 @@
 """Tier 2: #4995 slice 1 — ``AgentRegistry`` gains an explicit, enforced
-single-owner-thread invariant, RESTORED to its original scope (all 11
-methods — 4 mutators + 7 reads) by #5203, after #5202 had to narrow it to
-just the 4 mutators.
+single-owner-thread invariant, scoped to exactly the 4 methods that MUTATE
+registry-owned state.
 
 ## History (read this before touching any test below)
 
@@ -13,56 +12,45 @@ second OS thread reaching 7 read-only registry methods through
 ``RegistryReadModel``. #5202 scoped the guard down to just the 4 mutators
 (``attach``, ``restore_all``, ``resume_deferred_agents``,
 ``record_background_attach_error``) to stop breaking that (27 CI
-failures, all the identical ``RuntimeError``).
+failures, all the identical ``RuntimeError``). The 7 reads (``exists``,
+``loaded_names``, ``agent_cost_usd``, ``agent_total_usage``,
+``attached_session``, ``get_session``, ``agent_workspace_dir``) are NOT
+asserted — see each one's own docstring.
 
-Architect's OWN follow-up ruling (issuecomment-5385152402), after
-e2e-coder's #5203 measurement: the safety #5202 left in place for the 7
-reads was ACCIDENTAL, not designed — a real partial-construction window
-exists in ``AgentRegistry.get_or_load`` (between ``_store_session`` and
-its own later ``load_persisted_toggles``/``restore_state``), and the ONLY
-reason nothing broke was that the ONE field ``app.py``'s off-thread reads
-actually consume (``Session.history``) happens to already be hydrated
-before a session is ever stored — a fact about today's field shape, not a
-guarantee. #5203 (same PR as this file's own changes) closes that by
-CONSTRUCTION instead of leaving it accidental: ``app.py``'s 2
-``asyncio.to_thread`` call sites now resolve the registry-touching half
-ON THE LOOP first (:meth:`~reyn.interfaces.repl.read_model.
-ChatReadModel.resolve_conversation_history_source`), handing the worker
-thread an already-resolved PLAIN VALUE
-(:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.
-conversation_history_from_source`) instead of letting it call back into
-the registry. With that hoist in place, NOTHING legitimately reaches this
-registry off its owner thread anymore — so the guard goes back onto all 7
-reads, in this SAME PR (architect's own acceptance ①: "①が入らないなら
-やらないでください" — this restoration IS the PR's own body, not an
-optional extra).
+#5203 tried to restore the guard onto the 7 reads too (architect
+issuecomment-5385152402, reasoning that app.py's own hoist — see
+``read_model.py``'s ``resolve_conversation_history_source``/
+``conversation_history_from_source`` — closed the ONLY legitimate
+off-thread reader). **WITHDRAWN by the same architect the same day**
+(issuecomment-5385481839, PR #5215): CI caught 2 MORE legitimate
+off-thread readers this restoration never enumerated — the web server's
+A2A (``resolve_a2a_session`` → ``resolve_session`` → ``get_session``) and
+artifact-by-ref (``registry.exists``) routes. Worse: for the web server,
+"one owner thread" is not even a real invariant to begin with — FastAPI
+runs a sync endpoint via its own threadpool, so no guard here can hold
+structurally for that transport. The real fix belongs at the actual
+accidental-safety window instead (a SEPARATE PR, not #5215): ``get_or_
+load`` publishes a session to the registry's map (``_store_session``)
+BEFORE its own later ``load_persisted_toggles``/``restore_state`` finish
+constructing it — moving the publish to run LAST means any thread that
+finds a session at all finds a complete one, and no read-side guard is
+needed anywhere.
 
 Docs-maintainer's B finding on the first version of this guard
-(issuecomment-5384937050) still applies, now to BOTH groups: a
-hand-counted list has no completeness witness — stripping the guard from
-any ONE of the 11 methods must be independently caught, not just "some
-cross-thread test exists somewhere". This file exercises EACH of the 4
-mutators AND EACH of the 7 reads individually (never one standing in for
-the others).
+(issuecomment-5384937050) still applies: a hand-counted list has no
+completeness witness — stripping the guard from any ONE of the 4 mutators
+must be independently caught, not just "some cross-thread test exists
+somewhere". This file exercises EACH of the 4 mutators individually
+(never one standing in for the others).
 
-Acceptance (#5203, architect issuecomment-5385152402):
-  ① restore ``_assert_owner_thread()`` onto the 7 reads #5202 excluded, in
-     the SAME PR as the ``app.py`` hoist (this file's own subject).
-  ② with the guard restored, CI stays green (the 27-failure regression
-     does NOT reappear) — a read reached from another thread now DOES
-     raise, but ``app.py`` no longer legitimately reaches it that way.
-  ③ strip: reverting the ``app.py`` hoist (simulating the pre-#5203
-     call shape — a worker thread calling the combined
-     ``conversation_history()`` directly) flips a read to RED — proving
-     the hoist, not luck, is what keeps this green. This file's own
-     ``test_each_read_method_individually_raises_from_another_thread``
-     IS that flip: it fails on the pre-#5203 combined-call shape and
-     passes once the guard covers all 7 (see this file's own git history
-     around #5202 for the exact before/after).
-  ④ the owner thread identity is a public read
+Acceptance (#4995 slice 1, architect issuecomment-5384963741):
+  ① guard covers exactly the 4 mutators — not the 7 reads (see History
+     above for why a second attempt at the reads, #5203/#5215, was
+     withdrawn).
+  ② the owner thread identity is a public read
      (:attr:`AgentRegistry.owner_thread_ident`), not a private-state reach-in
 
-Real ``AgentRegistry`` + real ``threading.Thread`` (no mocks). The 3
+Real ``AgentRegistry`` + real ``threading.Thread`` (no mocks). The 4
 ``async def`` mutating methods are driven from the other thread via
 ``asyncio.run`` (a real, independent event loop on that thread) — the
 identical shape ``ThreadedTransportProxy`` itself uses in production.
@@ -124,11 +112,15 @@ def test_owner_thread_ident_is_the_constructing_thread(tmp_path) -> None:
 
 def test_same_thread_access_never_raises(tmp_path) -> None:
     """Tier 2: #4995 slice 1 acceptance ① — sanity/non-regression. Every
-    one of the 4 mutating methods AND every one of the 7 read methods is
-    reachable from the owner thread — the guard only ever fires against a
-    DIFFERENT thread, never against the one that constructed the registry."""
+    one of the 4 mutating methods is reachable from the owner thread — the
+    guard only ever fires against a DIFFERENT thread, never against the one
+    that constructed the registry. The 7 reads are exercised too (never
+    asserted, on any thread — see History in this file's own module
+    docstring for why they stay unguarded), so a same-thread call staying
+    silent is not itself informative for them; they are here for parity
+    with the mutators' own coverage, not as a guard witness."""
     reg = _registry(tmp_path)
-    # Reads (asserted as of #5203, but this IS the owner thread):
+    # Reads (never asserted, on any thread — see module docstring):
     reg.exists("default")
     reg.loaded_names()
     reg.agent_workspace_dir("default")
@@ -169,11 +161,12 @@ _MUTATING_METHOD_CALLS = {
 # adding that method must remember to add BOTH the guard call and an entry
 # here — this test only proves the 4 CURRENTLY listed stay guarded.
 #
-# #5203: the guard's own scope grew from 4 to 11 (4 mutators + 7 reads,
-# restored). This dict stays MUTATORS-ONLY, not because the 7 reads are less
-# important, but because they are a semantically distinct group (reads, not
-# writes) — see ``_READ_METHOD_CALLS`` below, its own sibling dict, same
-# hand-written discipline, same disclosed gap.
+# A guard-restoration attempt on the 7 reads was tried and WITHDRAWN
+# (#5203/#5215, see this file's own module docstring's History section) —
+# this dict stays MUTATORS-ONLY, not a placeholder for a sibling that will
+# return: the reads are not merely "less important", the invariant itself
+# does not hold for them given the web server's threadpool-per-sync-
+# endpoint topology.
 
 
 @pytest.mark.parametrize("method_name", sorted(_MUTATING_METHOD_CALLS))
@@ -192,58 +185,6 @@ def test_each_mutating_method_individually_raises_from_another_thread(
     assert isinstance(caught, RuntimeError), (
         f"{method_name}() reached from a different thread must raise "
         f"RuntimeError, got: {caught!r}"
-    )
-    assert "4995" in str(caught), "the error must point at the invariant's own issue"
-
-
-_READ_METHOD_CALLS = {
-    "exists": lambda reg: reg.exists("default"),
-    "loaded_names": lambda reg: reg.loaded_names(),
-    "agent_workspace_dir": lambda reg: reg.agent_workspace_dir("default"),
-    "get_session": lambda reg: reg.get_session("default"),
-    "attached_session": lambda reg: reg.attached_session(),
-    "agent_cost_usd": lambda reg: reg.agent_cost_usd("default"),
-    "agent_total_usage": lambda reg: reg.agent_total_usage("default"),
-}
-# #5203 — the SAME hand-written, not-derived-from-source discipline
-# ``_MUTATING_METHOD_CALLS`` above uses, applied to the 7 reads the guard is
-# restored onto in this PR. These are EXACTLY the 7 names #5202's own PR
-# body/commit history excluded when it narrowed the guard from 11 methods
-# down to 4 — see this file's own module docstring for the full history.
-#
-# Disclosed gap, not a completeness claim: a FUTURE new read method added
-# to ``AgentRegistry`` with no ``_assert_owner_thread()`` call is NOT
-# caught by anything here or in the source, same limitation
-# ``_MUTATING_METHOD_CALLS``'s own comment names for mutators.
-
-
-@pytest.mark.parametrize("method_name", sorted(_READ_METHOD_CALLS))
-def test_each_read_method_individually_raises_from_another_thread(
-    tmp_path, method_name,
-) -> None:
-    """Tier 2: #5203 acceptance ①②③ — the read-side counterpart of
-    ``test_each_mutating_method_individually_raises_from_another_thread``,
-    parametrized over all 7 reads so stripping the guard from ANY ONE is
-    independently caught. This is also the concrete realization of
-    acceptance③'s strip-test: with ``app.py``'s hoist landed (this same
-    PR), nothing legitimately calls any of these 7 off the owner thread
-    anymore, so a genuine cross-thread call — the exact shape ``app.py``
-    used to make, pre-#5203 — correctly raises. Reverting ``app.py``'s own
-    hoist (going back to calling the combined ``conversation_history()``
-    from inside ``asyncio.to_thread``) makes a REAL run hit this exact
-    RuntimeError in production — independently demonstrated by hand for
-    this PR: reverting ``_handle_session_attached_event``'s call site to
-    the pre-#5203 shape flips all 3 of ``test_4983_session_switch_off_
-    thread.py``'s tests to this same ``RuntimeError``, not just this
-    unit-level one (not itself checked in, since it duplicates the revert
-    this parametrization already covers structurally)."""
-    reg = _registry(tmp_path / method_name)
-    call = _READ_METHOD_CALLS[method_name]
-    caught = _call_from_other_thread(lambda: call(reg))
-    assert isinstance(caught, RuntimeError), (
-        f"{method_name}() reached from a different thread must raise "
-        f"RuntimeError now that #5203 hoists the registry touch onto the "
-        f"loop, got: {caught!r}"
     )
     assert "4995" in str(caught), "the error must point at the invariant's own issue"
 

--- a/tests/runtime/test_4995_registry_owner_thread.py
+++ b/tests/runtime/test_4995_registry_owner_thread.py
@@ -1,34 +1,64 @@
 """Tier 2: #4995 slice 1 — ``AgentRegistry`` gains an explicit, enforced
-single-owner-THREAD-FOR-MUTATION invariant.
+single-owner-thread invariant, RESTORED to its original scope (all 11
+methods — 4 mutators + 7 reads) by #5203, after #5202 had to narrow it to
+just the 4 mutators.
+
+## History (read this before touching any test below)
 
 Architect ruling (issuecomment-5384869791), CORRECTED after CI caught the
-first version (issuecomment-5384963741, PR #5202): the invariant is "only
-one thread may MUTATE this registry", not "only one thread may touch it
-at all" — ``app.py``'s #4983 design deliberately reads conversation
-history off the event loop via ``asyncio.to_thread``, a real second OS
-thread reaching several read-only registry methods through
-``RegistryReadModel``. Asserting on those 7 reads broke that legitimate
-feature (27 CI failures, all the identical ``RuntimeError``). The guard
-now covers exactly the 4 methods that MUTATE registry-owned state:
-``attach``, ``restore_all``, ``resume_deferred_agents``,
-``record_background_attach_error``.
+first version (issuecomment-5384963741, PR #5202): the guard broke a
+legitimate feature — ``app.py``'s #4983 design deliberately read
+conversation history off the event loop via ``asyncio.to_thread``, a real
+second OS thread reaching 7 read-only registry methods through
+``RegistryReadModel``. #5202 scoped the guard down to just the 4 mutators
+(``attach``, ``restore_all``, ``resume_deferred_agents``,
+``record_background_attach_error``) to stop breaking that (27 CI
+failures, all the identical ``RuntimeError``).
 
-Docs-maintainer's B finding on the first version (issuecomment-5384937050,
-still valid against the corrected scope): a hand-counted list has no
-completeness witness — stripping the guard from any ONE of the 4 methods
-must be independently caught, not just "some cross-thread test exists
-somewhere". This file exercises EACH of the 4 individually (never one
-standing in for the others), plus a read-side falsification (a read
-reached from a second thread must NOT raise — the #4983 pattern this
-scope correction exists to preserve).
+Architect's OWN follow-up ruling (issuecomment-5385152402), after
+e2e-coder's #5203 measurement: the safety #5202 left in place for the 7
+reads was ACCIDENTAL, not designed — a real partial-construction window
+exists in ``AgentRegistry.get_or_load`` (between ``_store_session`` and
+its own later ``load_persisted_toggles``/``restore_state``), and the ONLY
+reason nothing broke was that the ONE field ``app.py``'s off-thread reads
+actually consume (``Session.history``) happens to already be hydrated
+before a session is ever stored — a fact about today's field shape, not a
+guarantee. #5203 (same PR as this file's own changes) closes that by
+CONSTRUCTION instead of leaving it accidental: ``app.py``'s 2
+``asyncio.to_thread`` call sites now resolve the registry-touching half
+ON THE LOOP first (:meth:`~reyn.interfaces.repl.read_model.
+ChatReadModel.resolve_conversation_history_source`), handing the worker
+thread an already-resolved PLAIN VALUE
+(:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.
+conversation_history_from_source`) instead of letting it call back into
+the registry. With that hoist in place, NOTHING legitimately reaches this
+registry off its owner thread anymore — so the guard goes back onto all 7
+reads, in this SAME PR (architect's own acceptance ①: "①が入らないなら
+やらないでください" — this restoration IS the PR's own body, not an
+optional extra).
 
-Acceptance:
-  ① same-thread access to every one of the 4 + every one of the 7 reads
-     never raises (sanity — slice 1's own non-regression)
-  ② EACH of the 4 mutating methods raises RuntimeError when reached from
-     a genuinely different OS thread, tested individually
-  ③ a read method reached from a different OS thread does NOT raise (the
-     #4983 pattern preserved — falsification contrast for ②)
+Docs-maintainer's B finding on the first version of this guard
+(issuecomment-5384937050) still applies, now to BOTH groups: a
+hand-counted list has no completeness witness — stripping the guard from
+any ONE of the 11 methods must be independently caught, not just "some
+cross-thread test exists somewhere". This file exercises EACH of the 4
+mutators AND EACH of the 7 reads individually (never one standing in for
+the others).
+
+Acceptance (#5203, architect issuecomment-5385152402):
+  ① restore ``_assert_owner_thread()`` onto the 7 reads #5202 excluded, in
+     the SAME PR as the ``app.py`` hoist (this file's own subject).
+  ② with the guard restored, CI stays green (the 27-failure regression
+     does NOT reappear) — a read reached from another thread now DOES
+     raise, but ``app.py`` no longer legitimately reaches it that way.
+  ③ strip: reverting the ``app.py`` hoist (simulating the pre-#5203
+     call shape — a worker thread calling the combined
+     ``conversation_history()`` directly) flips a read to RED — proving
+     the hoist, not luck, is what keeps this green. This file's own
+     ``test_each_read_method_individually_raises_from_another_thread``
+     IS that flip: it fails on the pre-#5203 combined-call shape and
+     passes once the guard covers all 7 (see this file's own git history
+     around #5202 for the exact before/after).
   ④ the owner thread identity is a public read
      (:attr:`AgentRegistry.owner_thread_ident`), not a private-state reach-in
 
@@ -45,7 +75,7 @@ import threading
 import pytest
 
 from reyn.runtime.profile import AgentProfile
-from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from reyn.runtime.registry import AgentRegistry
 from tests._support.agent_session import make_session
 
 
@@ -95,9 +125,10 @@ def test_owner_thread_ident_is_the_constructing_thread(tmp_path) -> None:
 def test_same_thread_access_never_raises(tmp_path) -> None:
     """Tier 2: #4995 slice 1 acceptance ① — sanity/non-regression. Every
     one of the 4 mutating methods AND every one of the 7 read methods is
-    reachable from the owner thread exactly as before slice 1."""
+    reachable from the owner thread — the guard only ever fires against a
+    DIFFERENT thread, never against the one that constructed the registry."""
     reg = _registry(tmp_path)
-    # Reads (never asserted, on any thread):
+    # Reads (asserted as of #5203, but this IS the owner thread):
     reg.exists("default")
     reg.loaded_names()
     reg.agent_workspace_dir("default")
@@ -111,7 +142,7 @@ def test_same_thread_access_never_raises(tmp_path) -> None:
     asyncio.run(reg.restore_all())
     asyncio.run(reg.resume_deferred_agents())
     # No assertion needed beyond "did not raise" -- this test's only job is
-    # to prove slice 1 changed nothing for the owner thread.
+    # to prove the guard changes nothing for the owner thread.
 
 
 _MUTATING_METHOD_CALLS = {
@@ -137,6 +168,12 @@ _MUTATING_METHOD_CALLS = {
 # ``self._x =`` census over-fires on cached/memoized reads). The person
 # adding that method must remember to add BOTH the guard call and an entry
 # here — this test only proves the 4 CURRENTLY listed stay guarded.
+#
+# #5203: the guard's own scope grew from 4 to 11 (4 mutators + 7 reads,
+# restored). This dict stays MUTATORS-ONLY, not because the 7 reads are less
+# important, but because they are a semantically distinct group (reads, not
+# writes) — see ``_READ_METHOD_CALLS`` below, its own sibling dict, same
+# hand-written discipline, same disclosed gap.
 
 
 @pytest.mark.parametrize("method_name", sorted(_MUTATING_METHOD_CALLS))
@@ -159,20 +196,56 @@ def test_each_mutating_method_individually_raises_from_another_thread(
     assert "4995" in str(caught), "the error must point at the invariant's own issue"
 
 
-def test_a_read_reached_from_another_thread_does_not_raise(tmp_path) -> None:
-    """Tier 2: #4995 slice 1 acceptance ③ — falsification contrast for ②,
-    and the exact regression the first version of this guard caused (CI,
-    27 failures, PR #5202): ``app.py``'s #4983 design reads conversation
-    history off the event loop via ``asyncio.to_thread`` -- a REAL second
-    OS thread reaching ``get_session`` (and siblings) through
-    ``RegistryReadModel``. That must keep working. RED if a read method
-    is ever given the mutation-only guard back."""
-    reg = _registry(tmp_path)
-    caught = _call_from_other_thread(lambda: reg.get_session("default", _DEFAULT_SID))
-    assert caught is None, (
-        f"a read reached from a different thread must NOT raise (the #4983 "
-        f"off-thread-read pattern this scope exists to preserve), got: {caught!r}"
+_READ_METHOD_CALLS = {
+    "exists": lambda reg: reg.exists("default"),
+    "loaded_names": lambda reg: reg.loaded_names(),
+    "agent_workspace_dir": lambda reg: reg.agent_workspace_dir("default"),
+    "get_session": lambda reg: reg.get_session("default"),
+    "attached_session": lambda reg: reg.attached_session(),
+    "agent_cost_usd": lambda reg: reg.agent_cost_usd("default"),
+    "agent_total_usage": lambda reg: reg.agent_total_usage("default"),
+}
+# #5203 — the SAME hand-written, not-derived-from-source discipline
+# ``_MUTATING_METHOD_CALLS`` above uses, applied to the 7 reads the guard is
+# restored onto in this PR. These are EXACTLY the 7 names #5202's own PR
+# body/commit history excluded when it narrowed the guard from 11 methods
+# down to 4 — see this file's own module docstring for the full history.
+#
+# Disclosed gap, not a completeness claim: a FUTURE new read method added
+# to ``AgentRegistry`` with no ``_assert_owner_thread()`` call is NOT
+# caught by anything here or in the source, same limitation
+# ``_MUTATING_METHOD_CALLS``'s own comment names for mutators.
+
+
+@pytest.mark.parametrize("method_name", sorted(_READ_METHOD_CALLS))
+def test_each_read_method_individually_raises_from_another_thread(
+    tmp_path, method_name,
+) -> None:
+    """Tier 2: #5203 acceptance ①②③ — the read-side counterpart of
+    ``test_each_mutating_method_individually_raises_from_another_thread``,
+    parametrized over all 7 reads so stripping the guard from ANY ONE is
+    independently caught. This is also the concrete realization of
+    acceptance③'s strip-test: with ``app.py``'s hoist landed (this same
+    PR), nothing legitimately calls any of these 7 off the owner thread
+    anymore, so a genuine cross-thread call — the exact shape ``app.py``
+    used to make, pre-#5203 — correctly raises. Reverting ``app.py``'s own
+    hoist (going back to calling the combined ``conversation_history()``
+    from inside ``asyncio.to_thread``) makes a REAL run hit this exact
+    RuntimeError in production — independently demonstrated by hand for
+    this PR: reverting ``_handle_session_attached_event``'s call site to
+    the pre-#5203 shape flips all 3 of ``test_4983_session_switch_off_
+    thread.py``'s tests to this same ``RuntimeError``, not just this
+    unit-level one (not itself checked in, since it duplicates the revert
+    this parametrization already covers structurally)."""
+    reg = _registry(tmp_path / method_name)
+    call = _READ_METHOD_CALLS[method_name]
+    caught = _call_from_other_thread(lambda: call(reg))
+    assert isinstance(caught, RuntimeError), (
+        f"{method_name}() reached from a different thread must raise "
+        f"RuntimeError now that #5203 hoists the registry touch onto the "
+        f"loop, got: {caught!r}"
     )
+    assert "4995" in str(caught), "the error must point at the invariant's own issue"
 
 
 def test_two_different_registries_each_owned_by_their_own_constructing_thread(


### PR DESCRIPTION
**[e2e-coder]** — part of #5203

## Summary (revised — see History below)

`app.py`'s #4983 off-thread history read (`asyncio.to_thread`) used to call the combined `ChatReadModel.conversation_history()` from a genuine second OS thread, reaching `AgentRegistry.get_session`/`attached_session` through it. This PR:

- `ChatReadModel` gains 2 new methods, `resolve_conversation_history_source` (the registry TOUCH) and `conversation_history_from_source` (the thread-safe slice) — **concrete on the base class** with default implementations that delegate to `conversation_history()` (still abstract, unchanged shape), so every existing hand-authored test double across the TUI suite keeps working with zero changes. `RegistryReadModel` overrides both with the real split; `RemoteReadModel` needs no override at all (relies on the base default — witnessed by a new test).
- `app.py`'s 2 real off-thread call sites (`_handle_session_attached_event`, `run_textual_chat`'s mount-time pre-fetch) now resolve the registry touch ON THE LOOP first, then hand only the plain-value slice into `asyncio.to_thread`. **This hoist is independently correct hygiene and stays in the PR regardless of the guard history below.**
- A stale "disk read" claim in `app.py`'s own docstring (falsified by this PR's own measurement — `conversation_history` reads `Session.history`, a plain in-memory list, never `history.jsonl` directly) was corrected in the same PR, per CLAUDE.md's doc-drift rule.

## History — the guard restoration attempt, withdrawn

An earlier version of this PR also restored `AgentRegistry._assert_owner_thread()` onto the 7 reads #5202 had excluded, reasoning the app.py hoist above closed the only legitimate off-thread caller. **Architect withdrew this** ([issuecomment-5385481839](https://github.com/tya5/reyn/issues/5203#issuecomment-5385481839), reaffirmed against a narrower "exclude only `exists()`" alternative, issuecomment-5385499177) for 2 independent reasons:

1. **Incomplete caller census**: CI caught 2 more legitimate off-thread readers this restoration never enumerated — the web server's A2A (`resolve_a2a_session` → `resolve_session` → `get_session`) and artifact-by-ref (`registry.exists`) routes.
2. **The invariant itself is topology-dependent**: even a complete census wouldn't fix the underlying problem — the web server structurally runs sync endpoints via FastAPI's own threadpool (and Starlette's `TestClient` dispatches via its own portal thread), so "one owner thread" cannot hold structurally for that transport regardless of caller count.

The real fix belongs in a **separate PR**, at the actual accidental-safety window: `AgentRegistry.get_or_load` currently publishes a session (`_store_session`) BEFORE its own later `load_persisted_toggles`/`restore_state` finish constructing it. Moving the publish to run LAST means any thread that finds a session at all finds a complete one — no read-side guard needed anywhere, and A2A/web need no changes.

This PR now scopes down to: the `app.py`/`read_model.py` hoist (kept, independently correct), the prose fix (kept), and the mutating-4 guard exactly as #5202 left it (untouched).

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on all changed test files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/verify_module_docstrings.py` on all changed src files
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Scoped `pytest`: `test_4995_registry_owner_thread.py`, `test_4983_session_switch_off_thread.py`, `test_4983_mount_hydrate_off_loop.py`, `test_4996_read_model_capabilities.py`, `test_4387_read_model_load_older_conversation_history.py`, `test_fp0001_a2a_endpoints.py`, `test_4482_get_artifact_by_ref.py` — all green (the last 2 were the CI-red signal that led to the withdrawal above; confirmed fixed by the revert)
- [ ] (skipped — Visual, standing waiver, owner 2026-08-08)

Cannot self-merge — touches `tests/`, needs TESTS-READ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)