### PR TITLE
fix(#5213): hook disable is origin-aware — a session layer cannot silence a startup hook

### DIFF
--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -230,8 +230,15 @@ def _parse_entry(
     raw: object,
     entry_index: int,
     composed_schemas: "dict[str, frozenset[str]] | None" = None,
+    *,
+    origin: str = "unknown",
 ) -> HookDef:
-    """Validate one raw hooks list entry and return a ``HookDef``."""
+    """Validate one raw hooks list entry and return a ``HookDef``.
+
+    ``origin`` (#5213): the config layer this entry came from, threaded
+    straight onto the returned ``HookDef`` — see that field's own
+    docstring. Defaults to ``"unknown"`` (every pre-#5213 caller's
+    unchanged behavior)."""
     if not isinstance(raw, dict):
         raise HookConfigError(
             f"hooks[{entry_index}] must be a mapping, "
@@ -557,6 +564,7 @@ def _parse_entry(
         subprocess=subprocess_raw,
         network=network_raw,
         write_paths=write_paths_raw,
+        origin=origin,
     )
 
 
@@ -568,6 +576,8 @@ def _parse_entry(
 def load_hooks(
     raw: object,
     composed_schemas: "dict[str, frozenset[str]] | None" = None,
+    *,
+    origin: str = "unknown",
 ) -> HookRegistry:
     """Parse and validate the ``hooks:`` value from a reyn.yaml dict.
 
@@ -587,6 +597,17 @@ def load_hooks(
         composer. ``None`` (the default) skips both checks — the pre-#2889
         permissive posture, for callers with no composer configuration to
         thread (most direct ``load_hooks(raw)`` test calls).
+    origin:
+        #5213 — the config layer *raw* came from (one of
+        ``reyn.hooks.schema.HOOK_ORIGIN_ORDER``), stamped onto every
+        resulting ``HookDef``. A SINGLE call always stamps the SAME origin
+        on every entry — a caller composing MULTIPLE layers (``Session.
+        _build_hook_registry``) calls this once PER LAYER and merges the
+        resulting registries, rather than concatenating raw dicts first
+        (which would lose provenance the moment two layers' entries sit in
+        the same list). Defaults to ``"unknown"`` — every pre-#5213 caller
+        that does not pass this keeps the SAME ``HookDef.origin`` value
+        (``"unknown"``) it always implicitly had.
 
     Returns
     -------
@@ -612,6 +633,6 @@ def load_hooks(
 
     defs: list[HookDef] = []
     for idx, entry in enumerate(raw):
-        defs.append(_parse_entry(entry, idx, composed_schemas))
+        defs.append(_parse_entry(entry, idx, composed_schemas, origin=origin))
 
     return HookRegistry(defs)

--- a/src/reyn/hooks/registry.py
+++ b/src/reyn/hooks/registry.py
@@ -29,6 +29,16 @@ class HookRegistry:
     # Query
     # ------------------------------------------------------------------
 
+    def all_defs(self) -> list[HookDef]:
+        """#5213: every ``HookDef`` in this registry, registration order —
+        the public surface a caller composing MULTIPLE ``HookRegistry``
+        instances (one per config LAYER, so each entry keeps its own
+        ``HookDef.origin``) needs to merge them into one combined registry,
+        without reaching into ``self._defs`` directly (the testing
+        policy's own "no private-state reach-in" discipline, applied here
+        to production code composing this class, not just tests)."""
+        return list(self._defs)
+
     def hooks_for(self, point: str) -> list[HookDef]:
         """Return all hooks registered for *point* in registration order.
 

--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -313,6 +313,37 @@ class HookDef:
         Together with ``subprocess`` and ``network`` this completes the per-site
         sandbox triad an operator already has on a stdio MCP server, so the same
         three axes are expressible at every per-site sandbox surface.
+    origin:
+        #5213: which config LAYER declared this hook — one of
+        ``HOOK_ORIGIN_ORDER`` (``"startup"``/``"runtime"``/``"per-agent"``/
+        ``"per-session"``), threaded through by
+        :func:`~reyn.hooks.loader.load_hooks`'s ``origin=`` parameter, or
+        ``"unknown"`` (the default) for a ``HookDef`` constructed directly
+        without threading one through (test fixtures, most existing
+        callers).
+
+        Exists because the ``hooks:`` COMBINE loop
+        (``Session._build_hook_registry``) used to concatenate every
+        layer's raw dicts into one flat list before parsing — provenance
+        was discarded at concatenation, so nothing downstream could ask
+        "which layer declared this hook?". That question matters for
+        exactly one predicate: ``disabled:`` (a SEPARATE, layer-agnostic
+        axis, persisted at the per-session state file) used to disable a
+        hook by NAME ALONE, with no origin check — so any agent that can
+        write its own per-session state (every agent) could silently
+        neutralise a project-layer hook the operator declared specifically
+        because that layer is the one the agent CANNOT write (#5213's own
+        motivating example: #5041's supervision hook). See
+        :func:`hook_origin_is_at_least_as_specific_as` for the rule this
+        field makes askable.
+
+        ``"unknown"`` is deliberately NOT in ``HOOK_ORIGIN_ORDER`` and is
+        treated as the MOST specific origin (freely disableable) —
+        fail-OPEN for this one default, matching every pre-#5213
+        test/direct-construction call site's behavior exactly (nothing
+        regresses); the protection this field exists to provide only
+        applies to a ``HookDef`` that actually went through the real
+        session composition path, which always sets a real origin.
     """
 
     on: str
@@ -325,3 +356,68 @@ class HookDef:
     subprocess: bool | None = field(default=None)
     network: bool | None = field(default=None)
     write_paths: "tuple[str, ...] | None" = field(default=None)
+    origin: str = field(default="unknown")
+
+
+#: #5213: the 4 config layers ``hooks:`` composes across, in ORDER FROM LEAST
+#: TO MOST specific (trust runs the same direction, most-to-least) —
+#: ``Session._build_hook_registry``'s own combine loop's real layer order:
+#: ``startup`` (reyn.yaml, the operator's, trusted) → ``runtime``
+#: (``.reyn/hooks.yaml``) → ``per-agent`` (``.reyn/agents/<name>/hooks.yaml``)
+#: → ``per-session`` (session-defined, read from the SAME per-session state
+#: file ``disabled:`` itself is persisted to). Deliberately NOT re-derived
+#: from that loop's own string literals (a second hand-typed copy would be
+#: the exact "same fact in 2 places" risk this session's own #5202/#5206
+#: work flagged repeatedly) — this IS the one declared vocabulary; the
+#: combine loop's own labels must match these 4 strings exactly, or a hook
+#: silently gets treated as more-specific-than-it-is by
+#: :func:`hook_origin_is_at_least_as_specific_as` (fail-open, per that
+#: function's own "unrecognized origin" branch).
+HOOK_ORIGIN_ORDER = ("startup", "runtime", "per-agent", "per-session")
+
+
+def hook_origin_is_at_least_as_specific_as(origin: str, layer: str) -> bool:
+    """#5213 (architect ruling): the rule that closes the ``disabled:``
+    layer-bypass hole — "a layer's ``disabled:`` may only disable hooks
+    whose origin is that layer or below [more specific]". Returns whether
+    *origin* is *layer* itself or a MORE SPECIFIC layer (later in
+    :data:`HOOK_ORIGIN_ORDER`).
+
+    Concretely, ``Session``'s own ``is_hook_disabled`` predicate calls this
+    with ``layer="per-agent"``, NOT ``"per-session"`` and NOT ``"runtime"``
+    — the real boundary (verified: ``_canonical_protected_write_paths()``
+    and ``_RECOVERY_CORE_WRITE_PREFIXES``) is the WRITE ZONE, not the file
+    ``disabled:`` happens to be persisted to. ``.reyn/agents/<name>/hooks.yaml``
+    (per-agent) and the per-session state file are BOTH agent-writable —
+    disabling a hook at either origin grants no power an agent didn't
+    already have (it could edit that same file directly to remove the hook
+    entirely). ``runtime`` (the IN-set's ``hooks:`` key, physically
+    ``.reyn/config/hooks.yaml``) is under ``_RECOVERY_CORE_WRITE_PREFIXES``
+    (``.reyn/config/``, ``.reyn/state/``) — NOT in an agent's default write
+    zone, a raw ``file.write`` there is denied — and ``startup``
+    (reyn.yaml/reyn.local.yaml, read once at boot, never re-read from a
+    writable path) is restart-only. Both genuinely differ from per-agent/
+    per-session, so ``"per-agent"`` is the correct threshold — everything
+    less specific than per-agent (``startup``, ``runtime``) stays
+    protected. An earlier version of this threshold used ``"runtime"``,
+    treating ``.reyn/config/hooks.yaml`` as agent-writable on the strength
+    of a stale pre-#2073-file-split filename (``.reyn/hooks.yaml``, which
+    still appears in a few docstrings elsewhere in this codebase) — caught
+    in #5218 review before merge. Expressed as a general order comparison
+    (not a hardcoded membership test) so the check keeps working for free
+    if the write-zone boundary ever moves again, or a SECOND
+    ``disabled:``-shaped axis is added at a different layer.
+
+    Fail-OPEN (returns ``True``, i.e. "disableable") for either argument
+    NOT in :data:`HOOK_ORIGIN_ORDER` — covers ``HookDef.origin``'s own
+    ``"unknown"`` default (every test/direct-construction call site that
+    predates #5213, preserved byte-identical) and protects against a typo'd
+    *layer* argument silently becoming "nothing is ever disableable" instead
+    of a loud failure — this function's OWN contract is permissive-by-
+    default, matching ``disabled:`` being a legitimate feature this issue
+    narrows the SCOPE of, not a security boundary it tightens to
+    fail-closed (see #5213's own issue thread: "disabled: 自体は正当な機能
+    なので消さず射程を切る")."""
+    if origin not in HOOK_ORIGIN_ORDER or layer not in HOOK_ORIGIN_ORDER:
+        return True
+    return HOOK_ORIGIN_ORDER.index(origin) >= HOOK_ORIGIN_ORDER.index(layer)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -57,6 +57,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.status_classify import classify_op_status
 from reyn.core.pipeline.registry import PipelineNotFoundError, PipelineRegistry
 from reyn.core.turn_scope import active_turn
+from reyn.hooks.schema import hook_origin_is_at_least_as_specific_as
 from reyn.hooks.schema_registry import build_hook_payload
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.agent import Agent
@@ -4530,7 +4531,36 @@ class Session:
             launch_pipeline=self._launch_pipeline_from_hook,
             # #2285: per-session hook applicability gate — skip a hook this session disabled. A
             # callable (not a snapshot) so a toggle applies live to the next dispatch.
-            is_hook_disabled=lambda hook: hook.name is not None and hook.name in self._disabled_hooks,
+            # #5213: the origin check closes the layer-bypass hole — `self._disabled_hooks`
+            # is persisted to THIS session's own state dir (`_persist_hook_disabled`), a
+            # WRITE ZONE every agent already has (`_DEFAULT_WRITE_ZONES = (".reyn",)`,
+            # confirmed via `_canonical_protected_write_paths()`). Two layers are agent-writable
+            # this way: `per-agent` (`.reyn/agents/<name>/hooks.yaml`) and `per-session` (this
+            # session's own state dir) — an agent disabling a hook that originates there grants
+            # no NEW power, since it could edit that same writable file directly to remove the
+            # hook entirely. Two layers are NOT agent-writable and stay protected: `startup`
+            # (reyn.yaml/reyn.local.yaml, the OUT-set — read ONCE at boot, never re-read from a
+            # writable path at runtime, #5041's own supervision-hook placement rationale) and
+            # `runtime` (the IN-set's `hooks:` key, physically `.reyn/config/hooks.yaml` — under
+            # `_RECOVERY_CORE_WRITE_PREFIXES` (`.reyn/config/`, `.reyn/state/`), which
+            # `_in_default_write_zone` explicitly excludes from the broad `.reyn/` grant; a raw
+            # `file.write` there is denied, it goes through a dedicated WAL-emitting op instead.
+            # architect correction, #5218 review: an earlier version of this threshold used
+            # "runtime" — i.e. treated `.reyn/config/hooks.yaml` as agent-writable, echoing a
+            # stale pre-#2073-file-split filename (`.reyn/hooks.yaml`) that survives in several
+            # docstrings elsewhere in this codebase. That threshold left #5041's own supervision
+            # hook (placed at the runtime layer specifically because it is protected) one
+            # `disabled:` entry away from being switched off by the party it supervises).
+            # Threshold is therefore "per-agent or below [more specific]" — `per-agent` and
+            # `per-session` only. See
+            # `reyn.hooks.schema.hook_origin_is_at_least_as_specific_as`'s own docstring for why
+            # this is a general order check, not a hardcoded membership test — general enough to
+            # extend for free if the write-zone boundary ever moves again.
+            is_hook_disabled=lambda hook: (
+                hook.name is not None
+                and hook.name in self._disabled_hooks
+                and hook_origin_is_at_least_as_specific_as(hook.origin, "per-agent")
+            ),
             sandbox_config=self._sandbox_config,
             sandbox_backend=self._sandbox_backend,
             # #2095: route a not-yet-allowlisted shell-hook's consent prompt
@@ -5639,15 +5669,30 @@ class Session:
         fail loud), then each untrusted layer is try-added INDEPENDENTLY: a bad runtime
         keeps startup ∪ per-agent; a bad per-agent keeps startup ∪ runtime; each bad
         layer is dropped + warned. (On the reload path validate-before-apply also rejects
-        a bad runtime layer up front; this is the boot + defence-in-depth guard.)"""
+        a bad runtime layer up front; this is the boot + defence-in-depth guard.)
+
+        #5213: each layer is now parsed by its OWN ``load_hooks`` call
+        (``origin=<label>``), and the resulting registries' ``HookDef``
+        lists are MERGED — never concatenated as raw dicts first (the
+        pre-#5213 shape, which discarded provenance the moment two layers'
+        entries sat in the same list before parsing, closing off the
+        question "which layer declared this hook?" the ``disabled:``
+        layer-bypass hole needed answered — see
+        ``reyn.hooks.schema.HookDef.origin``'s own docstring). Per-layer
+        boot resilience (previous paragraph) is unchanged: each layer is
+        still validated and skipped independently on its own
+        ``HookConfigError``, just without re-parsing every earlier layer's
+        entries each time (a side benefit, not the point of this change)."""
         from reyn.hooks.loader import HookConfigError, load_hooks
         runtime = (in_set or {}).get("hooks") or []
         runtime_list = list(runtime) if isinstance(runtime, list) else []
         per_agent_list = self._read_per_agent_hooks()
         per_session_list = self._read_per_session_hooks()  # #2285: the 4th, most-specific layer
-        combined = list(self._startup_hooks_raw)
         composed_schemas = getattr(self, "_composed_schemas", None)
-        registry = load_hooks(combined, composed_schemas)  # trusted startup must load — else fail loud
+        # trusted startup must load — else fail loud (unchanged from pre-#5213).
+        defs = load_hooks(
+            list(self._startup_hooks_raw), composed_schemas, origin="startup",
+        ).all_defs()
         for label, layer in (
             ("runtime", runtime_list),
             ("per-agent", per_agent_list),
@@ -5656,14 +5701,15 @@ class Session:
             if not layer:
                 continue
             try:
-                registry = load_hooks(combined + layer, composed_schemas)
-                combined = combined + layer
+                defs = defs + load_hooks(layer, composed_schemas, origin=label).all_defs()
             except HookConfigError as exc:
                 logger.warning(
                     "config hot-reload: malformed %s hooks layer — skipped, keeping "
                     "the valid hook layers: %s", label, exc,
                 )
-        return registry
+        from reyn.hooks.registry import HookRegistry
+
+        return HookRegistry(defs)
 
     def _hooks_yaml_layers(self) -> "list[tuple[str, Path]]":
         """#5166 (architect ruling, issuecomment-5384196419): the enumerable

--- a/tests/runtime/test_5213_hook_disable_layer_bypass.py
+++ b/tests/runtime/test_5213_hook_disable_layer_bypass.py
@@ -1,0 +1,235 @@
+"""Tier 2: #5213 — a per-session ``disabled:`` entry may only disable a
+hook whose origin is per-agent or per-session, never a startup or runtime
+(project-level) hook.
+
+Root cause (architect ruling, issue #5213): ``hooks:`` composition used to
+concatenate every layer's raw dicts into ONE flat list before parsing —
+provenance was discarded at concatenation, so ``Session._hook_dispatcher``'s
+``is_hook_disabled`` predicate had no way to ask "which layer declared this
+hook?". Any agent that can write its own per-session state (every agent —
+``<state dir>/hooks.yaml``'s ``disabled:`` list is inside
+``_DEFAULT_WRITE_ZONES``) could therefore silently neutralise a
+project-level (startup or runtime) hook the operator declared specifically
+because those two layers are the ones the agent cannot write (#5213's own
+motivating example: #5041's supervision hook, placed at the runtime layer —
+``.reyn/config/hooks.yaml`` — precisely because it is protected).
+
+Fix: ``HookDef`` now carries ``origin`` (the config layer), and
+``is_hook_disabled`` checks
+``hook_origin_is_at_least_as_specific_as(hook.origin, "per-agent")`` in
+addition to the name match — ``startup`` and ``runtime`` stay protected;
+``per-agent`` and ``per-session`` remain disableable (both are inside every
+agent's default write zone, so ``disabled:`` grants no new power there).
+Real ``Session``/``AgentRegistry``/``HookDispatcher`` — no mocks, mirrors
+``test_hook_applicability_2285.py``'s own real-seam pattern.
+
+Threshold correction (#5218 review): an earlier version of the fix used
+``"runtime"`` as the threshold, on the (incorrect) assumption that
+``.reyn/hooks.yaml`` — a stale, pre-#2073-file-split filename — was the
+runtime layer's actual file and was agent-writable. The runtime layer is
+actually ``.reyn/config/hooks.yaml``, which sits under
+``_RECOVERY_CORE_WRITE_PREFIXES`` and is NOT agent-writable — the
+``"runtime"`` threshold left #5041's supervision hook one ``disabled:``
+entry away from being switched off by the party it supervises. See
+``test_a_runtime_layer_hook_remains_protected`` below for the corrected
+acceptance witness.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
+from tests._support.agent_session import make_session
+
+_STARTUP_HOOK_NAME = "project-supervision-hook"
+_STARTUP_HOOKS = [
+    {
+        "on": "turn_end",
+        "name": _STARTUP_HOOK_NAME,
+        "template_push": {"message": "startup fired", "wake": True},
+    },
+]
+
+
+def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
+    return make_session(
+        agent_name="alice",
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "alice" / "state" / "snapshot.json",
+        reactivity=ReactivityConfig(hooks_config=hooks_config),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_project_layer_hook_still_fires_after_a_session_layer_disable(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: acceptance — the exact #5213 witness. A ``disabled:`` entry
+    at the session layer naming a project(startup)-layer hook must NOT
+    stop it from firing — the origin check rejects the name match because
+    the hook's origin (``startup``) is LESS specific than the disabling
+    layer (``per-session``)."""
+    monkeypatch.chdir(tmp_path)
+    s = _make_session(tmp_path, hooks_config=_STARTUP_HOOKS)
+
+    # The agent writes ITS OWN per-session disabled-set naming the
+    # project-layer hook — exactly what #5213 describes: any agent that
+    # can write its own state can do this today, pre-fix.
+    s.set_hook_enabled(_STARTUP_HOOK_NAME, False)
+
+    await s._hook_dispatcher.dispatch("turn_end", {})
+
+    assert s.inbox.qsize() >= 1, (
+        "a project-layer hook must still fire even after the session "
+        "layer's own disabled: list names it — the origin check must "
+        "reject this cross-layer disable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_per_session_layer_hook_can_still_disable_itself(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: falsification contrast — the SAME disable mechanism must
+    still work for a hook that genuinely originates at the per-session
+    layer — #5213 narrows the SCOPE of ``disabled:`` (only ``startup`` and
+    ``runtime`` are protected — see ``is_hook_disabled``'s own comment), it
+    does not remove the feature."""
+    import yaml
+
+    monkeypatch.chdir(tmp_path)
+    s = _make_session(tmp_path, hooks_config=None)
+    per_session_hooks_path = Path(s._snapshot_path).parent / "hooks.yaml"
+    per_session_hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    per_session_hooks_path.write_text(
+        yaml.safe_dump({
+            "hooks": [
+                {
+                    "on": "turn_end",
+                    "name": "session-own-hook",
+                    "template_push": {"message": "session fired", "wake": True},
+                },
+            ],
+        }),
+        encoding="utf-8",
+    )
+    await s._reapply_hooks({})  # re-read all layers, including the new per-session file
+
+    s.set_hook_enabled("session-own-hook", False)
+    await s._hook_dispatcher.dispatch("turn_end", {})
+
+    assert s.inbox.qsize() == 0, (
+        "a genuinely per-session-origin hook must still be disableable by "
+        "its own layer's disabled: list"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_per_agent_layer_hook_remains_disableable(tmp_path, monkeypatch) -> None:
+    """Tier 2: falsification contrast — the write-zone boundary
+    (``per-agent``/``per-session`` are BOTH in ``_DEFAULT_WRITE_ZONES``,
+    confirmed via ``_canonical_protected_write_paths()``: the agent could
+    edit ``.reyn/agents/<name>/hooks.yaml`` directly to remove this hook
+    anyway, so ``disabled:`` grants no new power here). Mirrors
+    ``test_hook_applicability_2285.py``'s own pre-existing per-agent-hook
+    disable tests — this is the exact real-world case #5213's fix must NOT
+    break (found by running the full suite, not guessed)."""
+    import yaml
+
+    monkeypatch.chdir(tmp_path)
+    s = _make_session(tmp_path, hooks_config=None)
+    per_agent_hooks_path = tmp_path / ".reyn" / "agents" / "alice" / "hooks.yaml"
+    per_agent_hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    per_agent_hooks_path.write_text(
+        yaml.safe_dump({
+            "hooks": [
+                {
+                    "on": "turn_end",
+                    "name": "agent-own-hook",
+                    "template_push": {"message": "agent fired", "wake": True},
+                },
+            ],
+        }),
+        encoding="utf-8",
+    )
+    await s._reapply_hooks({})
+
+    s.set_hook_enabled("agent-own-hook", False)
+    await s._hook_dispatcher.dispatch("turn_end", {})
+
+    assert s.inbox.qsize() == 0, (
+        "a per-agent-origin hook must remain disableable — the agent "
+        "already has write access to the file that declares it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_layer_hook_remains_protected(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — the CORRECTED write-zone boundary (architect
+    finding, #5218 review). The ``runtime`` layer (the IN-set's ``hooks:``
+    key, physically ``.reyn/config/hooks.yaml``) sits under
+    ``_RECOVERY_CORE_WRITE_PREFIXES`` (``.reyn/config/``, ``.reyn/state/``),
+    which ``_in_default_write_zone`` excludes from the broad ``.reyn/``
+    grant — a raw ``file.write`` there is denied, so it is NOT agent-
+    writable the way ``per-agent``/``per-session`` are. A per-session
+    ``disabled:`` entry naming a runtime-origin hook must therefore NOT
+    stop it from firing, same as the startup case — this is the exact
+    #5041 threat an earlier ("runtime") threshold left open (a runtime-
+    origin supervision hook one ``disabled:`` line away from being
+    switched off by the party it supervises). Constructs the runtime
+    layer directly via ``in_set={"hooks": [...]}`` (mirrors
+    ``Session._build_hook_registry``'s own ``(in_set or {}).get("hooks")``
+    read, session.py:5679) rather than writing
+    ``.reyn/config/hooks.yaml`` + exercising the full hot-reload file-read
+    path — the origin-check boundary being tested here is downstream of
+    that read, not the read itself."""
+    monkeypatch.chdir(tmp_path)
+    s = _make_session(tmp_path, hooks_config=None)
+    await s._reapply_hooks({
+        "hooks": [
+            {
+                "on": "turn_end",
+                "name": "runtime-own-hook",
+                "template_push": {"message": "runtime fired", "wake": True},
+            },
+        ],
+    })
+
+    s.set_hook_enabled("runtime-own-hook", False)
+    await s._hook_dispatcher.dispatch("turn_end", {})
+
+    assert s.inbox.qsize() >= 1, (
+        "a runtime-origin hook must still fire even after the session "
+        "layer's own disabled: list names it — runtime is under "
+        "_RECOVERY_CORE_WRITE_PREFIXES, not agent-writable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strip_the_origin_check_reproduces_the_bypass(tmp_path, monkeypatch) -> None:
+    """Tier 2: strip-falsify (architect's own witness prescription) — with
+    the origin check removed from the predicate (mirroring the pre-#5213
+    shape: name match alone), the project-layer hook IS disabled by the
+    session-layer entry. Manually reconstructs the OLD predicate against
+    the SAME real dispatcher/registry, rather than monkeypatching internal
+    session state, so this test exercises the real HookDispatcher.dispatch
+    path exactly like the fixed-behavior test above — only the predicate
+    passed to it differs."""
+    monkeypatch.chdir(tmp_path)
+    s = _make_session(tmp_path, hooks_config=_STARTUP_HOOKS)
+    s.set_hook_enabled(_STARTUP_HOOK_NAME, False)
+
+    old_predicate = lambda hook: hook.name is not None and hook.name in s._disabled_hooks  # noqa: E731
+    s._hook_dispatcher._is_hook_disabled = old_predicate
+
+    await s._hook_dispatcher.dispatch("turn_end", {})
+
+    assert s.inbox.qsize() == 0, (
+        "the OLD (origin-blind) predicate must reproduce the bypass — if "
+        "this assertion fails, the strip did not actually revert to the "
+        "pre-#5213 shape"
+    )


### PR DESCRIPTION
**[tui-coder]** — closes #5213

## Background

#5213: `hooks:` composition concatenates every layer's (startup → runtime →
per-agent → per-session) raw dicts into one flat list before parsing, so
provenance is discarded at concatenation. `Session`'s `is_hook_disabled`
predicate (feeding `HookDispatcher`) matched a `disabled:` entry by name
alone, with no way to ask "which layer declared this hook?".

Since a per-session `disabled:` list is persisted to `<state dir>/hooks.yaml`
— a file every agent already has write access to — any agent could silently
neutralise a project-level hook the operator declared *specifically because*
that layer is one the agent cannot write. #5041's supervision hook (placed
at the runtime layer precisely because it is protected) is the motivating
real example.

## Ruling / fix

`HookDef` gains an `origin` field naming its config layer. `load_hooks` /
`_parse_entry` take a keyword-only `origin=`, and `Session._build_hook_registry`
now parses each layer separately (one `load_hooks()` call per layer) and
merges the resulting `HookDef` lists via the new `HookRegistry.all_defs()`
public accessor, instead of concatenating raw dicts and re-parsing the whole
growing list each iteration. `is_hook_disabled` now additionally requires
`hook_origin_is_at_least_as_specific_as(hook.origin, "per-agent")` — so
`disabled:` reaches only `per-agent` and `per-session`-origin hooks;
`startup` and `runtime` stay protected.

**Threshold correction during review** — recorded here since it's the one
nontrivial judgment call in this PR, and I got it wrong twice before landing
on the right boundary:

1. First pass used `"per-session"` — reasoning that since `disabled:` is
   physically persisted at the per-session state file, that was the natural
   boundary. Running the FULL `tests/hooks/ tests/runtime/` suite (not just
   my own new tests) showed this broke 2 real pre-existing tests in
   `test_hook_applicability_2285.py` that legitimately disable a
   per-agent-origin hook via `Session.set_hook_enabled`.
2. Corrected to `"runtime"` — investigated the write-zone boundary via
   `_canonical_protected_write_paths()` and (mistakenly) treated
   `.reyn/hooks.yaml` as the runtime layer's file and concluded it was
   agent-writable. **Architect/lead-coder review caught this**: the runtime
   layer's actual file is `.reyn/config/hooks.yaml` (`session.py:5679` →
   `load_hot_reload_config` → `loader._HOT_RELOAD_FILES` includes
   `"config/hooks.yaml"`), which sits under `_RECOVERY_CORE_WRITE_PREFIXES`
   (`.reyn/config/`, `.reyn/state/`) — `_in_default_write_zone` explicitly
   excludes that prefix from the broad `.reyn/` grant, so a raw
   `file.write` there is denied. `.reyn/hooks.yaml` is a stale,
   pre-#2073-file-split filename that still survives in a few docstrings
   elsewhere in this codebase (`session.py:5642`, `schema.py:366`/`:389` —
   left untouched here per reviewer guidance, worth a separate cleanup PR).
   The `"runtime"` threshold left #5041's supervision hook exactly one
   `disabled:` entry away from being switched off by the party it
   supervises — the precise hole this PR exists to close.
3. Corrected to `"per-agent"` (final) — `.reyn/agents/<name>/hooks.yaml`
   (per-agent) and the per-session state file are both genuinely inside
   every agent's default write zone; `startup` and `runtime` are both
   genuinely outside it. `disabled:` grants no new power at per-agent/
   per-session (the agent could edit that same file directly to remove
   the hook), which is exactly the boundary that matters.

## Tests

`tests/runtime/test_5213_hook_disable_layer_bypass.py` — Tier 2, real
`Session`/`AgentRegistry`/`HookDispatcher`, no mocks:

- `test_a_project_layer_hook_still_fires_after_a_session_layer_disable` —
  acceptance, the exact #5213 witness (startup layer).
- `test_a_runtime_layer_hook_remains_protected` — acceptance, the corrected
  boundary's other protected layer (the case the `"runtime"` threshold got
  wrong; strip-falsified manually by reverting to `"runtime"` and confirming
  this test goes red, then restoring).
- `test_a_per_session_layer_hook_can_still_disable_itself` — falsification
  contrast, the feature still works for its genuine scope.
- `test_a_per_agent_layer_hook_remains_disableable` — falsification
  contrast, the case that broke with the first, overly-strict `"per-session"`
  threshold.
- `test_strip_the_origin_check_reproduces_the_bypass` — strip-falsify:
  reinstalling the old name-only predicate on the real `HookDispatcher`
  reproduces the bypass.

## Not touched (disclosed, not filed yet)

`Session.hook_state()` has its own separate re-derivation of hook "scope"
from raw layer dicts (reaching into `registry._defs`, most-specific-layer-
wins dict semantics) that duplicates what `HookDef.origin` now carries
directly. It is a READ-only status-bar display path — `enabled` there is
computed the same name-only way `is_hook_disabled` used to be, so it can
show a misleading `enabled: false` for a hook whose `disabled:` entry the
origin check actually rejects — but it is never consulted by dispatch/
enforcement, so this does not reopen the bypass this PR claims to
close. Left alone here to avoid scope creep and a precedence-order bug in
the existing "most specific wins" semantics — a genuine follow-up
(display accuracy, not security), will file separately after this lands.

## Verification

- `ruff check .` — clean
- `python scripts/test_tier_audit.py --strict tests/runtime/test_5213_hook_disable_layer_bypass.py` — 5/5 OK
- `python scripts/verify_module_docstrings.py` on all 4 changed src files — OK
- `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- `python scripts/flat_tests_ratchet.py` — OK
- `python scripts/check_tests_path_literal_reference.py` — OK
- Full sweep on the rebased, corrected tree: `pytest tests/hooks/ tests/runtime/ tests/core/test_emit_hook_event_0059_phase5_part2.py` → **2310 passed, 1 skipped**, zero failures/regressions.
- Manual strip-falsify: reverted the threshold string to `"runtime"`,
  confirmed `test_a_runtime_layer_hook_remains_protected` goes red, restored,
  confirmed green again.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on the new test file
- [x] `verify_module_docstrings.py` on changed src files
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] Full local sweep of `tests/hooks/ tests/runtime/ tests/core/test_emit_hook_event_0059_phase5_part2.py` (2310 passed, 1 skipped)
- [x] Manual strip-falsify (threshold reverted to `"runtime"` → new witness test red; restored → green)
- [ ] (skipped — Visual, standing waiver 2026-08-08) no TUI/visual surface touched by this change

This PR touches `tests/` — needs an independent TESTS-READY(B) on the
current head before I self-merge (rule 8). I will verify `gh pr checks`
myself before merging and will not rely on a broker status report alone for
that signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
