### PR TITLE
fix(#5216): don't swallow programming errors as "no history" at app.py's read boundary

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2402,7 +2402,19 @@ class TextualChatApp(App):
             if self._initial_history_messages is not None:
                 self._apply_hydrated_messages(self._initial_history_messages)
             else:
-                self._hydrate_from_history()
+                # #5216: THIS try/except is now where "a hydrate failure
+                # must never stop the app from mounting" actually lives —
+                # moved OUT of ``_read_conversation_history`` itself (that
+                # method no longer swallows; see its own docstring for
+                # why catching there silently hid programming errors as
+                # "no history"). Mounting with an unhydrated pane on a
+                # genuine failure is the same degrade the old inner catch
+                # produced — only the LOG is clearer now (points at
+                # ``on_mount`` hydrate, not a generic "read failed").
+                try:
+                    self._hydrate_from_history()
+                except Exception:
+                    logger.exception("textual chat: on_mount hydrate-from-history failed")
         # The running-blink gutter animates off FlowView's NATIVE animation clock
         # (``animation_fps`` wired in :meth:`compose`), not an app-side timer — so
         # there is nothing to start/pause here. The blink is ADDITIVE: a frozen
@@ -2504,21 +2516,31 @@ class TextualChatApp(App):
         site. Each caller decides that for itself — this method only does
         the read.
 
-        Returns ``None`` on `self._read_model` being unset OR the read
-        raising (already logged here) — the caller's :meth:`_apply_
-        hydrated_messages` treats ``None`` as "nothing to hydrate", same
-        behavior as the pre-split method's own early-return did."""
+        Returns ``None`` on `self._read_model` being unset — the caller's
+        :meth:`_apply_hydrated_messages` treats ``None`` as "nothing to
+        hydrate". **Does NOT catch a read failure** (#5216, reversing this
+        method's own prior shape): the enumerated call chain
+        (``ChatReadModel.conversation_history`` → ``RegistryReadModel``'s
+        real implementation, a bare dict lookup plus an in-memory list
+        copy; ``RemoteReadModel``'s trivial ``[]``) has no legitimate
+        "there is genuinely no history to show" failure mode among either
+        production implementation — every exception reaching this point is
+        a programming error (a broken invariant, an incompatible
+        ``self._read_model``), and #5216 found the PRIOR ``except
+        Exception: ... return None`` here silently degraded that into the
+        SAME value as "nothing to hydrate" (a real bug and "no history"
+        collapsed into one observable — #5215's own strip-falsify hit
+        exactly this, and the resulting failure mode was an unbounded
+        ``wait_until`` hang, not a legitimate CLAUDE.md witness). This
+        method's ONLY caller, :meth:`_hydrate_from_history`, is itself
+        only ever called from :meth:`on_mount`'s own guarded call site —
+        see that call site's own comment for where "must never crash
+        mount" now actually lives."""
         if self._read_model is None:
             return None
-        try:
-            if agent is not None or session_id is not None:
-                return self._read_model.conversation_history(
-                    agent=agent, session_id=session_id
-                )
-            return self._read_model.conversation_history()
-        except Exception:
-            logger.exception("textual chat: conversation-history read failed")
-            return None
+        if agent is not None or session_id is not None:
+            return self._read_model.conversation_history(agent=agent, session_id=session_id)
+        return self._read_model.conversation_history()
 
     def _resolve_history_source(
         self, *, agent: "str | None" = None, session_id: "str | None" = None
@@ -2527,47 +2549,54 @@ class TextualChatApp(App):
         split out so it can be called ON THE LOOP, BEFORE the
         ``asyncio.to_thread`` hop at this method's own 2 call sites
         (``_handle_session_attached_event`` and :func:`run_textual_chat`'s
-        mount-time pre-fetch). #4995's owner-thread guard is restored onto
-        ``AgentRegistry.get_session``/``attached_session`` in this SAME PR
-        (see that class's own ``_assert_owner_thread`` docstring) — a
-        worker thread calling back into either would now raise, which is
-        exactly the defect this split closes: the accidental safety #5203
-        measured (only ``Session.history`` happened to already be hydrated
-        before a session becomes registry-visible — a fact about today's
-        field, not a designed guarantee, architect issuecomment-
-        5385152402) is replaced with a REAL one — the registry is never
-        touched off its owner thread at all, by construction.
+        mount-time pre-fetch).
+
+        This split closes the accidental safety #5203 measured (only
+        ``Session.history`` happened to already be hydrated before a
+        session becomes registry-visible — a fact about today's field, not
+        a designed guarantee, architect issuecomment-5385152402) by
+        CONSTRUCTION instead: the registry touch simply never happens off
+        this thread, regardless of what does or doesn't assert. #4995's
+        own owner-thread guard is NOT restored onto ``AgentRegistry.
+        get_session``/``attached_session`` — a #5215 attempt to do so was
+        withdrawn (the web server's A2A/artifact-by-ref routes reach them
+        the same way, and structurally cannot honor a single-owner-thread
+        invariant at all — see ``registry.py``'s own ``_owner_thread_
+        ident`` comment for the full history). This hoist is independently
+        correct hygiene regardless of that guard's own fate.
 
         Returns the plain VALUE :meth:`~reyn.interfaces.repl.read_model.
         ChatReadModel.resolve_conversation_history_source` produces (never
         a live ``Session``/registry handle) — safe to hand to
         :meth:`_history_from_source` across the thread boundary. ``None``
-        on `self._read_model` being unset OR the resolve raising (already
-        logged here), mirroring :meth:`_read_conversation_history`'s own
-        error-handling shape."""
+        only on `self._read_model` being unset. **Does NOT catch a resolve
+        failure** (#5216 — see :meth:`_read_conversation_history`'s own
+        docstring for the enumeration this shares: nothing in the current
+        call chain legitimately raises for "no history", so swallowing here
+        only ever hid a programming error). This method's ONLY caller,
+        :meth:`_handle_session_attached_event`, is itself only ever called
+        from inside the event-frame loop's own ``except Exception:
+        logger.exception(...)`` wrapper (see that loop's own
+        ``session_attached`` branch) — a raise here surfaces there, with a
+        clearer message than the swallow-and-hang this replaces, and the
+        frame loop continues to the next frame exactly as before."""
         if self._read_model is None:
             return None
-        try:
-            return self._read_model.resolve_conversation_history_source(
-                agent=agent, session_id=session_id
-            )
-        except Exception:
-            logger.exception("textual chat: conversation-history source-resolve failed")
-            return None
+        return self._read_model.resolve_conversation_history_source(
+            agent=agent, session_id=session_id
+        )
 
     def _history_from_source(self, source) -> "list | None":
         """#5203 — the thread-SAFE half. *source* is whatever
         :meth:`_resolve_history_source` returned (already resolved ON THE
         LOOP) — this method touches no registry and is safe to run inside
         ``asyncio.to_thread``, the actual off-thread step #4983 exists
-        for."""
+        for. **Does NOT catch a slice failure** (#5216) — same reasoning
+        and same caller/boundary as :meth:`_resolve_history_source`'s own
+        docstring."""
         if source is None or self._read_model is None:
             return None
-        try:
-            return self._read_model.conversation_history_from_source(source)
-        except Exception:
-            logger.exception("textual chat: conversation-history read failed")
-            return None
+        return self._read_model.conversation_history_from_source(source)
 
     def _apply_hydrated_messages(self, messages: "list | None") -> None:
         """#4983 step ② — project *messages* (already read by :meth:`_read_
@@ -2579,8 +2608,9 @@ class TextualChatApp(App):
         splitting it further would buy nothing while adding a second
         cross-thread handoff for no reason.
 
-        A no-op when *messages* is ``None`` (step ① found nothing to read,
-        or failed — already logged there).
+        A no-op when *messages* is ``None`` (step ① found no read model
+        configured — a genuine failure there now propagates instead, see
+        :meth:`_read_conversation_history`'s own docstring, #5216).
 
         Appends each projected frame to ``self.conversation``
         (:func:`.restore.project_restored_frames`). Every restored entry is

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -509,13 +509,10 @@ class ChatReadModel(ABC):
     def resolve_conversation_history_source(
         self, *, agent: "str | None" = None, session_id: "str | None" = None,
     ) -> "list[ChatMessage]":
-        """#5203: the registry-TOUCHING half of :meth:`conversation_history`
-        — MUST be called on the registry's OWNER thread
-        (:attr:`~reyn.runtime.registry.AgentRegistry.owner_thread_ident`,
-        #4995) by an implementation that genuinely touches one. Returns a
-        plain VALUE (never a live ``Session``/registry handle) safe to
-        hand across a thread boundary to :meth:`conversation_history_
-        from_source`.
+        """#5203: the registry-TOUCHING half of :meth:`conversation_history`.
+        Returns a plain VALUE (never a live ``Session``/registry handle)
+        safe to hand across a thread boundary to :meth:`conversation_
+        history_from_source`.
 
         **Concrete, not abstract** — the default delegates straight to
         :meth:`conversation_history` (``limit=None``, the whole log),
@@ -530,13 +527,17 @@ class ChatReadModel(ABC):
         registry touch, nothing else) — the ONE implementation ``app.py``'s
         #4983 off-loop read (``asyncio.to_thread``) actually calls this
         way, from a genuine second OS thread reaching
-        ``AgentRegistry.get_session``/``attached_session`` — #4995 slice 1
-        restores the owner-thread guard onto exactly those 2 registry
-        methods (the 7-read set #5202 first excluded then #5203
-        re-covers) in this SAME PR, so the registry touch must happen on
-        the loop, BEFORE the thread hop, not inside it. Every OTHER
-        implementation is free to keep using this default — there is
-        nothing to hoist when there is no registry to protect."""
+        ``AgentRegistry.get_session``/``attached_session``. #4995's own
+        owner-thread guard does NOT cover these 2 methods (a #5215
+        attempt to restore it was withdrawn — the web server's A2A/
+        artifact-by-ref routes reach them the same way, and structurally
+        cannot honor a single-owner-thread invariant at all — see
+        ``registry.py``'s own ``_owner_thread_ident`` comment for the
+        full history); this hoist is independently correct hygiene
+        regardless — the registry touch happening on the loop, not
+        because a guard depends on it. Every OTHER implementation is
+        free to keep using this default — there is nothing to hoist
+        when there is no registry to protect."""
         return self.conversation_history(agent=agent, session_id=session_id)
 
     def conversation_history_from_source(
@@ -718,12 +719,14 @@ class RegistryReadModel(ChatReadModel):
         # loop read) can call THIS half on the registry's OWNER thread and
         # hand the plain VALUE this returns across to the worker thread,
         # instead of letting the worker thread call back into
-        # ``AgentRegistry.get_session``/``attached_session`` itself (#4995's
-        # own owner-thread invariant, restored onto exactly these 2 methods
-        # in the SAME PR — see ``registry.py``'s own ``_assert_owner_thread``
-        # call sites). The returned list IS the plain value: a shallow copy
-        # of the resolved session's ``history``, no live ``Session``/
-        # registry reference retained past this call.
+        # ``AgentRegistry.get_session``/``attached_session`` itself. #4995's
+        # own owner-thread invariant does NOT cover these 2 methods — a
+        # #5215 attempt to restore it was withdrawn (see ``registry.py``'s
+        # own ``_owner_thread_ident`` comment for the full history) — this
+        # hoist stays anyway as independently correct hygiene, not because
+        # a guard depends on it. The returned list IS the plain value: a
+        # shallow copy of the resolved session's ``history``, no live
+        # ``Session``/registry reference retained past this call.
         #
         # #3310 N2: ``agent`` given → resolve THAT session (not necessarily the
         # attached one) via ``AgentRegistry.get_session`` — the same

--- a/tests/interfaces/test_4983_mount_hydrate_off_loop.py
+++ b/tests/interfaces/test_4983_mount_hydrate_off_loop.py
@@ -257,3 +257,46 @@ async def test_run_textual_chat_with_no_read_model_prefetches_nothing(monkeypatc
 
     with pytest.raises(RuntimeError, match="simulated"):
         await run_textual_chat(transport=QueueTransport(), read_model=None)
+
+
+# ── #5216: a real programming error mounts anyway, logged distinctly ────────
+
+
+class _BrokenReadModel(_CountingReadModel):
+    """A :class:`_CountingReadModel` whose ``conversation_history`` raises a
+    genuine programming error — #5216's own subject, distinguished from
+    "no history to show"."""
+
+    def conversation_history(self, *, limit=None, agent=None, session_id=None):
+        self.call_count += 1
+        raise RuntimeError("simulated: a real bug in conversation_history")
+
+
+@pytest.mark.asyncio
+async def test_mount_without_prefetch_survives_a_real_read_bug(caplog) -> None:
+    """Tier 2: #5216 — the fallback synchronous path
+    (:meth:`on_mount`'s own no-prefetch branch) must still mount the app
+    on a genuine programming error, exactly as it did before #5216 — but
+    the swallow now lives at ``on_mount``'s own call site, not inside
+    ``_read_conversation_history`` itself (see that method's own
+    docstring). Real assertion on the LOG boundary that now actually
+    catches it, not a duration: reverting #5216's move (putting the
+    ``except Exception`` back inside ``_read_conversation_history``)
+    would still mount correctly (masking the difference at THIS level),
+    which is exactly why ``test_4983_session_switch_off_thread.py``'s own
+    ``test_a_programming_error_in_the_switch_read_propagates_not_swallowed``
+    is the real strip-witness — this test only confirms the mount path's
+    own, deliberately-different "never crash startup" contract still
+    holds."""
+    import logging
+
+    read_model = _BrokenReadModel(_fixture_messages())
+    app = TextualChatApp(transport=QueueTransport(), read_model=read_model)
+    with caplog.at_level(logging.ERROR):
+        async with app.run_test(size=(80, 24)):
+            assert not app.conversation, (
+                "a real read bug must leave the pane unhydrated, not fabricate turns"
+            )
+    assert any(
+        "on_mount hydrate-from-history failed" in r.message for r in caplog.records
+    ), "the error must be logged at on_mount's own boundary, not silently dropped"

--- a/tests/interfaces/test_4983_session_switch_off_thread.py
+++ b/tests/interfaces/test_4983_session_switch_off_thread.py
@@ -366,3 +366,117 @@ async def test_session_switch_supersede_guard_lets_the_later_switch_win(
             )
     finally:
         pass
+
+
+@pytest.mark.asyncio
+async def test_a_programming_error_in_the_switch_read_propagates_not_swallowed(
+    tmp_path, monkeypatch, caplog,
+) -> None:
+    """Tier 2: #5216 — the read boundary must not collapse a genuine
+    programming error and "no history to show" into the same observable
+    (``None`` + a swallowed log). A real assertion on the RAISED error,
+    not a duration: reverting #5216 (wrapping ``_resolve_history_source``/
+    ``_history_from_source`` back in ``except Exception: ... return
+    None``) turns this red — the raised ``RuntimeError`` would never reach
+    ``pytest.raises`` below, and the switch would instead silently apply
+    ``None``/hang on whatever the caller was waiting for, exactly #5215's
+    own strip-falsify symptom (a pytest-timeout, not a legitimate
+    witness — CLAUDE.md's no-duration rule)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        read_model = RegistryReadModel(reg)
+
+        def _broken_resolve(*, agent=None, session_id=None):
+            raise RuntimeError("simulated: a real bug in the resolve step")
+
+        monkeypatch.setattr(
+            read_model, "resolve_conversation_history_source", _broken_resolve,
+        )
+
+        transport = QueueTransport()
+        app = TextualChatApp(transport=transport, read_model=read_model, agent_name="alpha")
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            await reg.attach("beta")
+            with pytest.raises(RuntimeError, match="simulated: a real bug"):
+                await app._handle_session_attached_event(
+                    Event(
+                        type="session_attached",
+                        data={"agent": "beta", "session_id": _DEFAULT_SID},
+                    )
+                )
+    finally:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_the_frame_loop_logs_and_continues_past_a_switch_read_error(
+    tmp_path, monkeypatch, caplog,
+) -> None:
+    """Tier 2: #5216's accept side — the SAME raise, driven through the
+    real event-frame pump (not called directly) instead of directly,
+    confirming the frame loop's own pre-existing ``except Exception:
+    logger.exception(...)`` around ``session_attached`` is where the
+    error actually surfaces (not a new catch this PR adds), and that the
+    pump keeps draining subsequent frames rather than dying itself."""
+    import logging
+
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        read_model = RegistryReadModel(reg)
+        real_resolve = read_model.resolve_conversation_history_source
+
+        def _broken_only_for_beta(*, agent=None, session_id=None):
+            if agent == "beta":
+                raise RuntimeError("simulated: a real bug in the resolve step")
+            return real_resolve(agent=agent, session_id=session_id)
+
+        monkeypatch.setattr(
+            read_model, "resolve_conversation_history_source", _broken_only_for_beta,
+        )
+
+        transport = QueueTransport()
+        app = TextualChatApp(transport=transport, read_model=read_model, agent_name="alpha")
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            await reg.attach("beta")
+            with caplog.at_level(logging.ERROR):
+                transport.push_event(
+                    "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID},
+                )
+                await wait_until(
+                    lambda: any(
+                        "session_attached reset+hydrate failed" in r.message
+                        for r in caplog.records
+                    )
+                )
+            # The pump must still be alive — a THIRD switch after the
+            # error-carrying one must still be processed normally (real
+            # content assertion, not "did not crash"). Gamma's own resolve
+            # is NOT patched to raise, so this switch takes the real path.
+            from reyn.runtime.chat_message import ChatMessage
+
+            await reg.attach("gamma")
+            reg.get_session("gamma")._append_history(
+                ChatMessage(role="user", content="gamma's own turn"),
+            )
+            transport.push_event(
+                "session_attached", {"agent": "gamma", "session_id": _DEFAULT_SID},
+            )
+
+            def _rows() -> "list[tuple[str, str]]":
+                return [
+                    (e.item.kind, e.item.text)
+                    for e in app.query_one(FlowView).entries
+                    if e.item.kind != "system"
+                ]
+
+            await wait_until(lambda: ("user", "gamma's own turn") in _rows())
+    finally:
+        pass


### PR DESCRIPTION
**[e2e-coder]** — Closes #5216

## Summary

`app.py`'s history-read boundary (`_read_conversation_history`, `_resolve_history_source`, `_history_from_source`) caught every exception, logged it, and returned `None` — the SAME value #5215's own strip-falsify found "no history to show" also produces. A programming error and a legitimate degrade were one value, two facts; the only way to tell them apart was a **duration** (hang until pytest-timeout), which CLAUDE.md forbids as a witness.

## Enumeration (the issue's own "not measured" item)

Traced the actual call chain: `RegistryReadModel.resolve_conversation_history_source` is a bare dict lookup (`AgentRegistry._peek_session`) plus an in-memory list copy; `RemoteReadModel` trivially returns `[]`. **Neither has a legitimate "there is genuinely no history" failure mode** among the concrete implementations — every exception reaching this boundary is a programming error. So the fix removes the catch entirely from the 3 read methods, rather than narrowing to a guessed exception tuple (the issue's own explicit warning: narrowing from memory would repeat the mistake at a smaller size).

## Where "must never crash" now actually lives

- `_handle_session_attached_event`'s call site already sits inside the frame-processing loop's pre-existing `except Exception: logger.exception(...)` around the `session_attached` branch (unchanged by this PR) — a raise now surfaces there, with a clearer message, and the loop keeps draining subsequent frames.
- `on_mount`'s own call to `_hydrate_from_history()` (the only caller of `_read_conversation_history`) gets a **new** try/except, since `on_mount` previously had none of its own — this is where "must never stop the app from mounting" now actually lives, not inside the pure read.
- `run_textual_chat`'s own mount-time pre-fetch (a separate, already well-reasoned "never block startup" boundary calling `read_model`'s methods directly) is untouched — out of scope.

## Also fixed: doc-drift that survived #5215's own withdrawal

3 stale docstring claims (`app.py`'s `_resolve_history_source`, `read_model.py`'s 2 split methods) still described `AgentRegistry`'s owner-thread guard as restored onto `get_session`/`attached_session` — #5215's own final withdrawal reverted that, but these 3 spots were missed. Caught while working this same area.

## Strip-falsify

Reverting either catch back to `except Exception: ...; return None` flips `test_a_programming_error_in_the_switch_read_propagates_not_swallowed`, `test_the_frame_loop_logs_and_continues_past_a_switch_read_error`, and `test_mount_without_prefetch_survives_a_real_read_bug` to **RED via a raised assertion** — not #5215's own masked hang→timeout — verified by hand, then restored to green.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on both changed test files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/verify_module_docstrings.py` on both changed src files
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Scoped `pytest`: `test_4983_session_switch_off_thread.py`, `test_4983_mount_hydrate_off_loop.py`, `test_4995_registry_owner_thread.py`, `test_4996_read_model_capabilities.py`, `test_textual_chat_phase5_3273.py` — 40 passed
- [x] Strip-falsify (both boundaries) — reverted by hand, confirmed RED, restored, confirmed green
- [ ] (skipped — Visual, standing waiver, owner 2026-08-08)

Cannot self-merge — touches `tests/`, needs TESTS-READ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)