### PR TITLE
fix(#5217): get_or_load publishes a session only after construction completes

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3323,7 +3323,23 @@ class AgentRegistry:
         replaces (#5215 tried enforcing the OLD window with a guard on the
         READERS; withdrawn once found to be topology-dependent — this fix is
         the one architect named as the real one, closing the WRITER's own
-        window instead)."""
+        window instead).
+
+        Reorder safety: a GREP for a direct registry reach (registry/
+        get_session/attached_session/_peek/self._reg) inside ``load_
+        persisted_toggles``/``restore_state`` finds none — but this PR's
+        own TESTS-READ B (tui-coder) found a real INDIRECT one a grep
+        cannot see: ``load_persisted_toggles`` → ``CapabilityVisibility.
+        reapply_visibility_override`` → ``self.resolved_profile_for``
+        (THIS class's own method, below). Independently confirmed
+        harmless for the reorder: ``resolved_profile_for`` reads topology
+        bindings and capability-profile YAML files only — it never
+        touches ``self._sessions``/the session map, ``get_session``,
+        ``attached_session``, ``_peek_session``, or ``_pending_restore``
+        (same grep, same zero hits, re-run over its own body). Left here
+        because grep alone missed it once already — the next person
+        reordering something similar should trace the actual call graph
+        one level deeper than the direct-hit search, not just repeat it."""
         existing = self._peek_session(name)
         if existing is not None:
             return existing

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3303,7 +3303,27 @@ class AgentRegistry:
         A2A request path). It is recorded on FIRST construction (a cache hit
         returns the existing session unchanged) and drives the unbound-delegate
         default-deny in ``resolved_profile_for``. Default False = a top-level /
-        non-delegation load (byte-identical to pre-#2081)."""
+        non-delegation load (byte-identical to pre-#2081).
+
+        #5217: ``_store_session`` (PUBLISH) runs LAST, after toggle-restore and
+        state-restore (COMPLETE), not before. Before this fix, a session was
+        publicly visible in the registry's own map for the 3 lines between
+        ``_store_session`` and ``restore_state`` — any OTHER thread reaching
+        this registry in that window (``get_session``/``attached_session``)
+        could observe a half-built ``Session`` (toggles/pending-state not yet
+        applied). #5203 measured that this window happened to be harmless
+        TODAY only because the one field its own off-thread readers consumed
+        (``Session.history``) is populated earlier, inside ``_construct_
+        session``'s own factory call — an accidental safety, not a designed
+        one (architect issuecomment-5385481839). Publishing only once
+        construction is COMPLETE makes it structural instead: any thread that
+        finds a session in the map at all now finds a fully-built one, or
+        finds nothing — never a partial one. See ``AgentRegistry``'s own
+        ``_owner_thread_ident`` comment for the read-guard history this
+        replaces (#5215 tried enforcing the OLD window with a guard on the
+        READERS; withdrawn once found to be topology-dependent — this fix is
+        the one architect named as the real one, closing the WRITER's own
+        window instead)."""
         existing = self._peek_session(name)
         if existing is not None:
             return existing
@@ -3313,7 +3333,6 @@ class AgentRegistry:
             )
         profile = self.load_profile(name)
         session = self._construct_session(profile, is_delegate=is_delegate)
-        self._store_session(name, session)
         # #2285 step2: restore persisted visibility/hook toggles for the MAIN session (spawned
         # sessions load in spawn_session after the per-session path re-key). First-construction only
         # — cache-hits return above — so this runs once per session lifetime, incl. on restart.
@@ -3329,6 +3348,8 @@ class AgentRegistry:
         pending = self._pending_restore.pop((name, _DEFAULT_SID), None)
         if pending is not None:
             session.restore_state(pending)
+        # #5217: PUBLISH last — see this method's own docstring for why.
+        self._store_session(name, session)
         return session
 
     def _construct_session(

--- a/tests/runtime/test_5217_publish_after_complete.py
+++ b/tests/runtime/test_5217_publish_after_complete.py
@@ -69,7 +69,12 @@ def test_a_session_under_construction_is_never_visible_half_built(
 
     def _gated_load_persisted_toggles(self) -> None:
         started.set()
-        release.wait(timeout=10)
+        # #5216-adjacent note, CLAUDE.md floor/ceiling rule (architect
+        # issuecomment-5385725693): wait on the condition UNBOUNDED — no
+        # inline timeout=. CI's own --timeout is the sole kill switch; an
+        # inline ceiling here would risk a false RED (and a misleading
+        # message) on a genuinely slow machine, not a real defect.
+        release.wait()
         real_load(self)
 
     monkeypatch.setattr(
@@ -87,7 +92,7 @@ def test_a_session_under_construction_is_never_visible_half_built(
     t = threading.Thread(target=_construct)
     t.start()
     try:
-        assert started.wait(timeout=10), "construction never reached load_persisted_toggles"
+        started.wait()
         # The constructing thread is now PAUSED inside load_persisted_
         # toggles — get_or_load has not returned, so #5217's own claim is:
         # nothing is published yet. get_session (FP-0043 Stage 3) is the
@@ -98,8 +103,7 @@ def test_a_session_under_construction_is_never_visible_half_built(
         )
     finally:
         release.set()
-        t.join(timeout=10)
-    assert not t.is_alive(), "the constructing thread must have finished"
+        t.join()
     assert caught[0] is None, f"construction must not raise, got: {caught[0]!r}"
 
     # Now that construction has completed, the session IS visible via the

--- a/tests/runtime/test_5217_publish_after_complete.py
+++ b/tests/runtime/test_5217_publish_after_complete.py
@@ -1,0 +1,128 @@
+"""Tier 2: #5217 — ``AgentRegistry.get_or_load`` publishes a session to its
+own map ONLY after construction is COMPLETE, never before.
+
+Architect (issuecomment-5385481839, during #5215's own review): the
+accidental safety #5203 measured — a session was visible in the registry's
+own map for the 3 lines between ``_store_session`` and ``restore_state``,
+and nothing broke ONLY because the one field #4983's off-thread readers
+actually consumed (``Session.history``) happens to already be hydrated
+before that window opens — is replaced here by a STRUCTURAL guarantee: any
+thread that finds a session in the registry's map at all now finds a
+FULLY-BUILT one (toggles loaded, pending state restored), or finds
+NOTHING. Never a half-built one.
+
+#5215 tried to close the SAME gap from the reader's side (an owner-thread
+guard on the 7 reads) — withdrawn once found to be topology-dependent (the
+web server structurally cannot honor a single-owner-thread invariant for
+sync endpoints). This is the fix architect actually prescribed: move the
+WRITER's own publish point instead, so no reader-side guard is needed at
+all.
+
+Real ``AgentRegistry`` + a real ``Session`` (``make_session``) + a real
+second OS thread gating ``Session.load_persisted_toggles`` with a
+``threading.Event`` (a controllable seam, never a sleep — CLAUDE.md's
+floor/ceiling rule) — no mocks.
+"""
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path) -> AgentRegistry:
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+def test_a_session_under_construction_is_never_visible_half_built(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #5217's own falsifier. Gates ``Session.load_persisted_
+    toggles`` (the FIRST of the 2 steps #5217 moved ``_store_session``
+    past) mid-call on a real second OS thread; while it is held open, the
+    constructing thread has not returned from ``get_or_load`` yet — the
+    registry's own map must show NOTHING for this name, never a
+    partially-built ``Session``. Reverting #5217 (moving ``_store_session``
+    back to BEFORE these 2 steps, #5215's own pre-fix shape) turns this
+    red: the gated read would then observe a real, live (but half-built)
+    ``Session`` instance instead of ``None``."""
+    reg = _registry(tmp_path)
+    real_load = Session.load_persisted_toggles
+    started = threading.Event()
+    release = threading.Event()
+
+    def _gated_load_persisted_toggles(self) -> None:
+        started.set()
+        release.wait(timeout=10)
+        real_load(self)
+
+    monkeypatch.setattr(
+        Session, "load_persisted_toggles", _gated_load_persisted_toggles,
+    )
+
+    caught: "list[BaseException | None]" = [None]
+
+    def _construct() -> None:
+        try:
+            reg.get_or_load("alpha")
+        except BaseException as e:  # noqa: BLE001 — inspected on the main thread
+            caught[0] = e
+
+    t = threading.Thread(target=_construct)
+    t.start()
+    try:
+        assert started.wait(timeout=10), "construction never reached load_persisted_toggles"
+        # The constructing thread is now PAUSED inside load_persisted_
+        # toggles — get_or_load has not returned, so #5217's own claim is:
+        # nothing is published yet. get_session (FP-0043 Stage 3) is the
+        # SUPPORTED public accessor for this — not a private reach-in.
+        assert reg.get_session("alpha") is None, (
+            "a session under construction must not be visible in the "
+            "registry's own map yet — #5217's whole point"
+        )
+    finally:
+        release.set()
+        t.join(timeout=10)
+    assert not t.is_alive(), "the constructing thread must have finished"
+    assert caught[0] is None, f"construction must not raise, got: {caught[0]!r}"
+
+    # Now that construction has completed, the session IS visible via the
+    # same public accessor.
+    assert reg.get_session("alpha") is not None, (
+        "construction must publish the session once complete"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_or_load_still_returns_the_fully_built_session(tmp_path) -> None:
+    """Tier 2: accept-side, no gating — the ordinary (single-thread,
+    ungated) path must still work byte-identically: ``get_or_load``
+    returns a real, usable ``Session``, same-thread, same call shape as
+    before #5217."""
+    reg = _registry(tmp_path)
+    session = reg.get_or_load("alpha")
+    assert session is not None
+    assert reg.get_session("alpha") is session, (
+        "the returned session must be the SAME object now stored in the registry"
+    )
+
+    # A second get_or_load for the same name is a cache hit (byte-identical
+    # to pre-#5217): no re-construction, no re-publish.
+    session_again = reg.get_or_load("alpha")
+    assert session_again is session


### PR DESCRIPTION
**[e2e-coder]** — Closes #5217

## Summary

`get_or_load` published a session to the registry's own map (`_store_session`) **before** its own later `load_persisted_toggles`/`restore_state` finished constructing it — a real window where another thread reaching the registry (`AgentRegistry.get_session`/`attached_session`) could observe a half-built `Session`. #5203's own measurement found nothing broke ONLY because the one field #4983's off-thread readers actually consumed (`Session.history`) happens to already be hydrated earlier, inside `_construct_session`'s own factory call — an accidental safety, not a designed one (architect issuecomment-5385481839).

#5215 tried to close this from the **reader's** side (an owner-thread guard restored onto the 7 reads) — withdrawn once found to be topology-dependent: the web server structurally cannot honor a single-owner-thread invariant for sync endpoints (FastAPI's own threadpool), so no reader-side guard could ever hold there regardless of caller count.

This is the fix architect actually prescribed: move the **writer's** own publish point instead. `_store_session` now runs LAST, after `load_persisted_toggles` and `restore_state` both complete. Any thread that finds a session in the registry's map at all now finds a fully-built one, or finds nothing — never a partial one — **by construction**, not by today's field shape. No reader-side guard needed anywhere; A2A/web need no changes.

## Verified safe to reorder

Neither `load_persisted_toggles` (`session.py:2920`) nor `restore_state` (`session.py:6365`) touches the registry, directly or through any synchronously-invoked helper (grepped both method bodies for `registry`/`get_session`/`attached_session`/`_peek`/`self._reg` — zero hits; `restore_state`'s own scheduled asyncio tasks run after `get_or_load` returns, well after the new `_store_session` call, so no re-entrancy concern either).

## Strip-falsify

Reverting the reorder (moving `_store_session` back before the 2 steps) flips `test_a_session_under_construction_is_never_visible_half_built` to RED — the gated read observes a real, live, half-built `Session` instead of `None` — verified by hand, then restored to green.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on the new test file
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/verify_module_docstrings.py` on the changed src file
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Scoped `pytest`: `test_4995_registry_owner_thread.py`, `test_registry_restore_all_only_names_3671_p4c1.py`, `test_2081_s2_delegate_default_deny.py`, `test_2708_p31_spawn_bridge_present.py`, pipeline IS2/IS4/IS5/IS6 — 79 passed
- [x] Full local sweep `tests/runtime/ + tests/core/` (4787 tests): 4782 passed, 5 skipped, 1 failed — the 1 failure (`test_install_command_warns_on_tmp_args_on_darwin`) reproduces identically with this change fully reverted (a pre-existing venv/environment issue, unrelated to this PR)
- [x] Strip-falsify — reverted by hand, confirmed RED, restored, confirmed green
- [ ] (skipped — Visual, standing waiver, owner 2026-08-08)

Cannot self-merge — touches `tests/`, needs TESTS-READ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[architect]** — TESTS-READ A blocking point (see the review comment):

- [x] 🔴 Three bounded waits in `tests/runtime/test_5217_publish_after_complete.py` — `release.wait(timeout=10)` (:72), `assert started.wait(timeout=10)` (:90), `t.join(timeout=10)` (:101). CLAUDE.md's ceiling rule: wait on the condition unboundedly, CI's `--timeout=120` is the kill switch. The `:90` one is the worst: the assertion depends on the bound, so a slow machine produces a false red whose message ("construction never reached load_persisted_toggles") points at the wrong cause. Drop all three timeouts.

