### PR TITLE
docs(#5220): hooks runtime layer is .reyn/config/hooks.yaml, not .reyn/hooks.yaml

### DIFF
--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -259,7 +259,7 @@ lambdas.
 The config-derivation this builder takes as inputs is resolved inline, BEFORE the builder
 call:
 - Hooks are LAYERED (#2073 S2b): the `reyn.yaml` startup layer (OUT-set, captured once as
-  `_startup_hooks_raw`, never re-read on reload) ∪ the `.reyn/hooks.yaml` runtime layer
+  `_startup_hooks_raw`, never re-read on reload) ∪ the `.reyn/config/hooks.yaml` runtime layer
   (IN-set, hot-reloadable; the LLM-op writes it in S3). `_build_hook_registry` combines
   them; the boot registry includes the runtime layer too (active from session start,
   mirroring `.reyn/mcp.yaml`), and the hooks-reapply seam re-reads only the runtime layer +
@@ -297,7 +297,7 @@ call:
 
 After the bundle returns, `self._hot_reloader` is published as the process-wide active
 reloader (#2073 S3: `set_active_hot_reloader`) so the hooks-write LLM-op can
-`request_reload` after writing `.reyn/hooks.yaml` (mirrors `set_active_scheduler`;
+`request_reload` after writing `.reyn/config/hooks.yaml` (mirrors `set_active_scheduler`;
 multi-session = last-registered wins, a known cron caveat). `_register_hot_reload_seams`
 (#2073 S2) then registers the per-component hot-reload reapply seams once the
 sub-components they orchestrate (`router_host` etc., built later by Family 6a) exist —

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -1021,7 +1021,7 @@ def load_per_agent_hooks(
     """Load the per-agent runtime hooks layer (#2073 per-agent-hooks add-on) — ONLY
     ``.reyn/agents/<name>/hooks.yaml``.
 
-    Same IN-set grain as the global ``.reyn/hooks.yaml`` (runtime-mutable,
+    Same IN-set grain as the global ``.reyn/config/hooks.yaml`` (runtime-mutable,
     hot-reloadable) but scoped to one agent — read DIRECTLY here (not via
     :func:`load_hot_reload_config`, which is the top-level ``.reyn/*.yaml`` set),
     mirroring how the per-agent ``profile.yaml`` is read. Returns the raw

--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -363,7 +363,7 @@ class HookDef:
 #: TO MOST specific (trust runs the same direction, most-to-least) —
 #: ``Session._build_hook_registry``'s own combine loop's real layer order:
 #: ``startup`` (reyn.yaml, the operator's, trusted) → ``runtime``
-#: (``.reyn/hooks.yaml``) → ``per-agent`` (``.reyn/agents/<name>/hooks.yaml``)
+#: (``.reyn/config/hooks.yaml``) → ``per-agent`` (``.reyn/agents/<name>/hooks.yaml``)
 #: → ``per-session`` (session-defined, read from the SAME per-session state
 #: file ``disabled:`` itself is persisted to). Deliberately NOT re-derived
 #: from that loop's own string literals (a second hand-typed copy would be
@@ -401,9 +401,10 @@ def hook_origin_is_at_least_as_specific_as(origin: str, layer: str) -> bool:
     less specific than per-agent (``startup``, ``runtime``) stays
     protected. An earlier version of this threshold used ``"runtime"``,
     treating ``.reyn/config/hooks.yaml`` as agent-writable on the strength
-    of a stale pre-#2073-file-split filename (``.reyn/hooks.yaml``, which
-    still appears in a few docstrings elsewhere in this codebase) — caught
-    in #5218 review before merge. Expressed as a general order comparison
+    of a stale pre-#2073-file-split filename (``.reyn/hooks.yaml``) — caught
+    in #5218 review before merge; #5220 swept the remaining bare mentions
+    of that stale filename (this one deliberately kept, as the historical
+    record of what was caught and why). Expressed as a general order comparison
     (not a hardcoded membership test) so the check keeps working for free
     if the write-zone boundary ever moves again, or a SECOND
     ``disabled:``-shaped axis is added at a different layer.

--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -153,7 +153,7 @@ def validate_in_set(in_set: "dict") -> "str | None":
     hooks = in_set.get("hooks")
     if hooks is not None:
         # #2073 S2b: validate the runtime hooks shape via the real loader so a
-        # malformed .reyn/hooks.yaml rejects the whole reload (atomic) rather than
+        # malformed .reyn/config/hooks.yaml rejects the whole reload (atomic) rather than
         # raising inside the reapply seam.
         from reyn.hooks import HookConfigError, load_hooks
         try:
@@ -434,7 +434,7 @@ class HotReloader:
 
 # ── process-wide active HotReloader (#2073 S3) ──────────────────────────────
 # The LLM-op hooks-write tool reaches the reloader to ``request_reload`` after
-# writing .reyn/hooks.yaml. Mirrors ``set_active_scheduler`` / ``get_active_scheduler``
+# writing .reyn/config/hooks.yaml. Mirrors ``set_active_scheduler`` / ``get_active_scheduler``
 # (cron). NOTE (multi-session caveat, same as cron's single-scheduler): this is the
 # last-registered session's reloader; a per-session route (via ToolContext) is a
 # noted beauty-follow-up, out of S3 scope.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4547,8 +4547,9 @@ class Session:
             # `file.write` there is denied, it goes through a dedicated WAL-emitting op instead.
             # architect correction, #5218 review: an earlier version of this threshold used
             # "runtime" — i.e. treated `.reyn/config/hooks.yaml` as agent-writable, echoing a
-            # stale pre-#2073-file-split filename (`.reyn/hooks.yaml`) that survives in several
-            # docstrings elsewhere in this codebase. That threshold left #5041's own supervision
+            # stale pre-#2073-file-split filename (`.reyn/hooks.yaml`) — #5220 swept the
+            # remaining bare mentions of it (this one kept as the historical record).
+            # That threshold left #5041's own supervision
             # hook (placed at the runtime layer specifically because it is protected) one
             # `disabled:` entry away from being switched off by the party it supervises).
             # Threshold is therefore "per-agent or below [more specific]" — `per-agent` and
@@ -5623,7 +5624,7 @@ class Session:
         HotReloader (#2073 S2). Called once at construction after router_host and
         other sub-components exist. Each seam reapplies one IN-set component live at
         the turn boundary; the Session orchestrates them (it owns the sub-components).
-        Hooks = S2b (global .reyn/hooks.yaml); per-agent-hooks add-on = a separate
+        Hooks = S2b (global .reyn/config/hooks.yaml); per-agent-hooks add-on = a separate
         decision."""
         hr = self._hot_reloader
         # validate-before-apply is the HotReloader's built-in structural check
@@ -5647,7 +5648,7 @@ class Session:
 
         - **startup** — the reyn.yaml hooks (``self._startup_hooks_raw``, captured once
           at boot, the restart-only OUT-set, never re-read on a reload);
-        - **runtime** — the global ``.reyn/hooks.yaml`` (from the IN-set);
+        - **runtime** — the global ``.reyn/config/hooks.yaml`` (from the IN-set);
         - **per-agent** — ``.reyn/agents/<name>/hooks.yaml`` (read directly here, same
           IN-set grain but scoped per agent).
 
@@ -5663,7 +5664,7 @@ class Session:
 
         **Per-LAYER boot resilience (the add-on refinement):** ``load_hooks`` raises
         ``HookConfigError`` on a malformed layer, and BOTH boot AND the reload path call
-        this — a malformed persisted ``.reyn/hooks.yaml`` or per-agent file must NOT
+        this — a malformed persisted ``.reyn/config/hooks.yaml`` or per-agent file must NOT
         crash boot, NOR may one bad UNTRUSTED layer drop a good sibling. So the trusted
         startup layer (reyn.yaml — the operator's) must load (a failure propagates =
         fail loud), then each untrusted layer is try-added INDEPENDENTLY: a bad runtime
@@ -5848,7 +5849,7 @@ class Session:
 
     async def _reapply_hooks(self, in_set: dict) -> bool:
         """Reapply the hook layers (#2073 S2b + per-agent add-on) — re-read the global
-        .reyn/hooks.yaml (IN-set) AND the per-agent .reyn/agents/<name>/hooks.yaml,
+        .reyn/config/hooks.yaml (IN-set) AND the per-agent .reyn/agents/<name>/hooks.yaml,
         re-combine with the FIXED reyn.yaml startup layer, and swap the dispatcher's
         registry. The dispatcher reads its registry fresh per dispatch, so the swap
         propagates to every holder. The startup layer is never re-read (safety

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -242,7 +242,7 @@ def get_default_registry() -> ToolRegistry:
     registry.register(CRON_ENABLE)
     registry.register(CRON_DISABLE)
     # #2073 S3: the hooks-write self-reload tool (the agent adds its own runtime
-    # hooks to .reyn/hooks.yaml + reloads at the turn boundary). Router-only.
+    # hooks to .reyn/config/hooks.yaml + reloads at the turn boundary). Router-only.
     registry.register(HOOKS_ADD)
     # Hook-Event Redesign Phase 5 part 2 (proposal 0059 §8): LLM-authored
     # hook-event emission onto the caller's own HookBus. Router-only (the


### PR DESCRIPTION
**[docs-maintainer]** — #5220, lead-coder dispatch.

## Problem

The #2073 file split moved the hooks runtime layer from `.reyn/hooks.yaml` to `.reyn/config/hooks.yaml` — `config/loader.py`'s own `_HOT_RELOAD_FILES` already had this right (`"config/hooks.yaml"`), but 8 prose sites across 5 files kept using the pre-split bare name.

**Confirmed pure doc/naming drift, not a functional defect** (checked before starting the fix, per lead-coder's explicit ask): grepped every actual path-construction site (`Path(...)`, `_load_yaml(...)`, etc.) — none of them build `.reyn/hooks.yaml` as a real path anywhere in `src/reyn/`. Every hit was inside a comment or docstring.

**This drift had a real, measured consequence** — it wasn't purely cosmetic: architect's #5218 review caught tui-coder treating the runtime layer as agent-writable on the strength of this exact stale name, which would have left #5041's own supervision hook one `disabled:` line away from being switched off by the party it supervises.

## Fix

Corrected the 8 uncritical bare mentions:
- `src/reyn/config/loader.py`
- `src/reyn/runtime/hot_reload.py` (×2)
- `src/reyn/tools/__init__.py`
- `src/reyn/runtime/session.py` (×4)
- `src/reyn/hooks/schema.py`

Plus the docs mirrors:
- `docs/reference/runtime/session-construction.md` (×2)

## Left untouched, deliberately

- `docs/reference/runtime/reyn-dir-layout.md`'s "Was → Now" migration table — correctly documents the OLD name as old, nothing to fix.
- `session.py:4550` and `hooks/schema.py:404` — #5218's own new commentary, which already correctly cites `.reyn/hooks.yaml` as *"a stale pre-#2073-file-split filename"*, not as fact. Updated both (same PR, since CLAUDE.md's hard rule applies to a doc changing what it mirrors too) to note this PR swept the remaining mentions — their own "survives in several docstrings elsewhere" claim would otherwise go stale the moment this PR lands.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/verify_module_docstrings.py` on all 5 changed src files — OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean (no Aborted line)
- [x] `python scripts/check_doc_anchors.py` — no dangling anchors into published pages
- [x] `python scripts/check_retired_config_keys_denylist.py` — OK
- [x] `pytest tests/hooks/ tests/runtime/test_5213_hook_disable_layer_bypass.py -q` — 343 passed
- [x] (skipped — Visual, standing waiver 2026-08-08)

Prose-only change, no `tests/` touched by this PR — no TESTS-READ required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
