### PR TITLE
fix(#5222): hook_state() reports enabled using the real dispatch predicate, not bare name-membership

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2963,38 +2963,53 @@ class Session:
         """#2285: the status-bar's hook read model — each NAMED hook in this session's merged
         registry (startup ∪ runtime ∪ per-agent ∪ per-session) as ``{name, scope, enabled}``.
         ``scope`` = the most-specific layer that defines the name; a hook with no name is omitted
-        (it can't be individually toggled). ``enabled`` = not in this session's disabled-set."""
-        runtime_hooks: list = []
-        try:
-            from reyn.runtime.hot_reload import load_hot_reload_config
-            runtime_hooks = (load_hot_reload_config(self._hot_reload_project_root()) or {}).get("hooks") or []
-        except Exception:  # noqa: BLE001 — scope is best-effort display metadata
-            runtime_hooks = []
-        scope_by_name: "dict[str, str]" = {}
-        for scope, raw in (
-            ("startup", self._startup_hooks_raw),
-            ("runtime", runtime_hooks),
-            ("per-agent", self._read_per_agent_hooks()),
-            ("per-session", self._read_per_session_hooks()),
-        ):
-            for hook_cfg in (raw or []):
-                n = hook_cfg.get("name") if isinstance(hook_cfg, dict) else None
-                if n:
-                    scope_by_name[n] = scope  # more-specific layer wins (later in this order)
+        (it can't be individually toggled). ``enabled`` reflects the SAME predicate the real
+        dispatcher enforces (:func:`hook_origin_is_at_least_as_specific_as`), not name-membership
+        alone — see #5222 below.
 
-        registry = getattr(self._hook_dispatcher, "_registry", None)
+        #5222 (follow-up from #5218's own "Not touched" disclosure): this used to re-derive
+        ``scope`` from a SEPARATE raw-dict scan of the 4 config layers (re-reading
+        ``.reyn/config/hooks.yaml`` + the per-agent/per-session files a SECOND time, purely for
+        display) and computed ``enabled`` as bare name-membership in ``self._disabled_hooks`` —
+        both duplicating logic #5213 already made unnecessary: every ``HookDef`` in the merged
+        registry now carries its own ``origin`` directly. Reading ``origin`` off the SAME
+        ``HookDef`` list the dispatcher itself uses (via the public
+        :attr:`~reyn.hooks.dispatcher.HookDispatcher.registry` property and
+        :meth:`~reyn.hooks.registry.HookRegistry.all_defs`, never the private ``_defs``) means
+        display can no longer disagree with enforcement the way it could pre-#5222: before this
+        fix, a ``startup``- or ``runtime``-origin hook a session tried to disable via
+        ``disabled:`` was still PROTECTED (#5213) but this method reported ``enabled: false``
+        anyway, since it only checked name-membership — misleading exactly where it matters most
+        (#5041's own supervision hook: reads as neutralized when it is not).
+
+        Precedence: ``all_defs()`` is ordered startup → runtime → per-agent → per-session (see
+        ``Session._build_hook_registry``), the SAME least-to-most-specific order the old raw-dict
+        scan iterated in. Iterating forward and overwriting a per-name dict entry on every
+        occurrence reproduces "most-specific-layer-wins" without re-deriving it: the LAST write
+        for a given name is necessarily its most-specific origin. (The old code additionally kept
+        the FIRST-encountered ``HookDef`` instance for a name's OTHER fields via its own separate
+        ``seen`` set — since ``_defs``/``all_defs()`` iterate in the same least-to-most-specific
+        order, that was the LEAST specific instance, silently inconsistent with the "most specific
+        wins" scope it displayed alongside. Overwriting per name here fixes both fields from the
+        same walk, consistently.)
+
+        A name declared at two DIFFERENT origins (e.g. both startup and per-session) collapses to
+        one displayed row, same simplification as before #5222 — the real dispatcher still fires
+        BOTH independently underlying ``HookDef`` instances; this display shows only the most
+        specific one's own enabled/disabled verdict. Not solved here (out of scope) — flagged in
+        the #5222 issue for whoever revisits it."""
+        by_name: "dict[str, HookDef]" = {}
+        for hook in self._hook_dispatcher.registry.all_defs():
+            if hook.name is not None:
+                by_name[hook.name] = hook  # last write = most specific (see docstring)
+
         out: "list[dict]" = []
-        seen: "set[str]" = set()
-        for hook in getattr(registry, "_defs", []) if registry is not None else []:
-            n = getattr(hook, "name", None)
-            if n is None or n in seen:
-                continue
-            seen.add(n)
-            out.append({
-                "name": n,
-                "scope": scope_by_name.get(n, "unknown"),
-                "enabled": n not in self._disabled_hooks,
-            })
+        for name, hook in by_name.items():
+            enabled = not (
+                name in self._disabled_hooks
+                and hook_origin_is_at_least_as_specific_as(hook.origin, "per-agent")
+            )
+            out.append({"name": name, "scope": hook.origin, "enabled": enabled})
         return out
 
     async def dispatch_external_event(self, point: str, template_vars: dict) -> None:

--- a/tests/runtime/test_5222_hook_state_origin_aware.py
+++ b/tests/runtime/test_5222_hook_state_origin_aware.py
@@ -1,0 +1,205 @@
+"""Tier 2: #5222 — ``Session.hook_state()`` (the status-bar's hook read model)
+reports ``enabled`` using the SAME predicate the real ``HookDispatcher``
+enforces, not bare name-membership in ``self._disabled_hooks``.
+
+Root cause (follow-up filed from #5218's own "Not touched" disclosure):
+before this fix, ``hook_state()`` re-derived hook ``scope`` from a SEPARATE
+raw-dict scan of the 4 config layers (re-reading ``.reyn/config/hooks.yaml``
++ the per-agent/per-session files a SECOND time, purely for display) and
+computed ``enabled`` as bare ``name not in self._disabled_hooks`` — both
+duplicating logic #5213 already made unnecessary (every ``HookDef`` in the
+merged registry carries its own ``origin`` directly) and, worse,
+INCONSISTENT with what #5213 actually enforces: a ``startup``- or
+``runtime``-origin hook a session tried to disable via ``disabled:`` is
+PROTECTED (#5213) and still fires, but pre-#5222 ``hook_state()`` reported
+``enabled: false`` for it anyway — misleading exactly where it matters most
+(#5041's own supervision hook: status bar reads as neutralized when it is
+not).
+
+Fix: ``hook_state()`` now reads ``HookDef.origin`` directly off
+``self._hook_dispatcher.registry.all_defs()`` (the public accessors, never
+the private ``registry._defs`` reach-in the old code used) and computes
+``enabled`` via the SAME ``hook_origin_is_at_least_as_specific_as`` check
+``is_hook_disabled`` uses. ``all_defs()`` is ordered least-to-most-specific
+(startup → runtime → per-agent → per-session, see
+``Session._build_hook_registry``); overwriting a per-name dict entry while
+iterating forward reproduces "most-specific-layer-wins" for both ``scope``
+and ``enabled`` from ONE walk, fixing a subtle inconsistency the old code
+had: it computed ``scope`` as most-specific (via a similar forward-overwrite
+loop) but picked its OTHER fields (via a separate ``seen`` set keeping the
+FIRST-encountered ``HookDef``) from the LEAST-specific instance instead.
+
+Real ``Session``/``HookDispatcher`` — no mocks, mirrors
+``test_5213_hook_disable_layer_bypass.py``'s own real-seam pattern.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
+from tests._support.agent_session import make_session
+
+_STARTUP_HOOK_NAME = "project-supervision-hook"
+_STARTUP_HOOKS = [
+    {
+        "on": "turn_end",
+        "name": _STARTUP_HOOK_NAME,
+        "template_push": {"message": "startup fired", "wake": True},
+    },
+]
+
+
+def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
+    return make_session(
+        agent_name="alice",
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "alice" / "state" / "snapshot.json",
+        reactivity=ReactivityConfig(hooks_config=hooks_config),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_protected_startup_hook_disabled_via_per_session_shows_enabled_true(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: acceptance — the exact #5222 witness. A per-session
+    ``disabled:`` entry naming a startup-origin hook does not actually
+    disable it (#5213) — ``hook_state()`` must say so (``enabled: True``),
+    not the misleading ``enabled: False`` bare name-membership gave."""
+    monkeypatch.chdir(tmp_path)
+    s = _make_session(tmp_path, hooks_config=_STARTUP_HOOKS)
+
+    s.set_hook_enabled(_STARTUP_HOOK_NAME, False)
+
+    state = {h["name"]: h for h in s.hook_state()}
+    assert state[_STARTUP_HOOK_NAME]["scope"] == "startup"
+    assert state[_STARTUP_HOOK_NAME]["enabled"] is True, (
+        "a startup-origin hook is protected from a per-session disable "
+        "(#5213) — hook_state() must not report it as disabled"
+    )
+
+    # Corroborate against the REAL dispatch outcome, not just the display.
+    await s._hook_dispatcher.dispatch("turn_end", {})
+    assert s.inbox.qsize() >= 1, "the hook actually still fires — display must agree"
+
+
+@pytest.mark.asyncio
+async def test_a_genuine_per_session_hook_disable_shows_enabled_false(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: falsification contrast — a hook that genuinely originates at
+    the per-session layer IS disableable (#5213 narrows scope, does not
+    remove the feature), and ``hook_state()`` must still say so."""
+    monkeypatch.chdir(tmp_path)
+    s = _make_session(tmp_path, hooks_config=None)
+    per_session_hooks_path = Path(s._snapshot_path).parent / "hooks.yaml"
+    per_session_hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    per_session_hooks_path.write_text(
+        yaml.safe_dump({
+            "hooks": [
+                {
+                    "on": "turn_end",
+                    "name": "session-own-hook",
+                    "template_push": {"message": "session fired", "wake": True},
+                },
+            ],
+        }),
+        encoding="utf-8",
+    )
+    await s._reapply_hooks({})
+
+    s.set_hook_enabled("session-own-hook", False)
+
+    state = {h["name"]: h for h in s.hook_state()}
+    assert state["session-own-hook"]["scope"] == "per-session"
+    assert state["session-own-hook"]["enabled"] is False, (
+        "a genuinely per-session-origin hook is disableable — hook_state() "
+        "must reflect that"
+    )
+
+    await s._hook_dispatcher.dispatch("turn_end", {})
+    assert s.inbox.qsize() == 0, "the hook is actually suppressed — display must agree"
+
+
+@pytest.mark.asyncio
+async def test_scope_reports_the_most_specific_layer_when_a_name_repeats(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: precedence — the SAME name declared at both the startup
+    layer and the per-agent layer must report the MORE SPECIFIC origin
+    (``per-agent``), not the least-specific one a naive first-occurrence
+    walk over ``all_defs()`` (startup-first order) would pick."""
+    monkeypatch.chdir(tmp_path)
+    shared_name = "shared-hook-name"
+    s = _make_session(tmp_path, hooks_config=[
+        {
+            "on": "turn_end",
+            "name": shared_name,
+            "template_push": {"message": "startup copy", "wake": True},
+        },
+    ])
+    per_agent_hooks_path = tmp_path / ".reyn" / "agents" / "alice" / "hooks.yaml"
+    per_agent_hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    per_agent_hooks_path.write_text(
+        yaml.safe_dump({
+            "hooks": [
+                {
+                    "on": "turn_end",
+                    "name": shared_name,
+                    "template_push": {"message": "per-agent copy", "wake": True},
+                },
+            ],
+        }),
+        encoding="utf-8",
+    )
+    await s._reapply_hooks({})
+
+    state = {h["name"]: h for h in s.hook_state()}
+    assert state[shared_name]["scope"] == "per-agent", (
+        "the most-specific origin for a repeated name must win — a "
+        "first-occurrence walk over the least-to-most-specific order "
+        "would wrongly report 'startup'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strip_the_origin_aware_enabled_check_reproduces_the_stale_display(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: strip-falsify — reconstructing the OLD bare name-membership
+    ``enabled`` computation (mirroring pre-#5222) against the same real
+    session/dispatcher must reproduce the misleading ``enabled: False`` for
+    a hook that is actually still firing."""
+    monkeypatch.chdir(tmp_path)
+    s = _make_session(tmp_path, hooks_config=_STARTUP_HOOKS)
+    s.set_hook_enabled(_STARTUP_HOOK_NAME, False)
+
+    def _old_hook_state(self) -> "list[dict]":
+        out = []
+        seen = set()
+        for hook in self._hook_dispatcher.registry.all_defs():
+            n = hook.name
+            if n is None or n in seen:
+                continue
+            seen.add(n)
+            out.append({
+                "name": n,
+                "scope": hook.origin,
+                "enabled": n not in self._disabled_hooks,
+            })
+        return out
+
+    import types
+    s.hook_state = types.MethodType(_old_hook_state, s)
+
+    state = {h["name"]: h for h in s.hook_state()}
+    assert state[_STARTUP_HOOK_NAME]["enabled"] is False, (
+        "the OLD bare name-membership check must reproduce the stale, "
+        "misleading display — if this assertion fails, the strip did not "
+        "actually revert to the pre-#5222 shape"
+    )


### PR DESCRIPTION
**[tui-coder]** — closes #5222

## Background

`Session.hook_state()` is the status bar's hook read model. It used to
re-derive hook `scope` from a SEPARATE raw-dict scan of the 4 config layers
(re-reading `.reyn/config/hooks.yaml` + the per-agent/per-session files a
SECOND time, purely for display) and computed `enabled` as bare
`name not in self._disabled_hooks` — both duplicating logic #5213 already
made unnecessary (every `HookDef` in the merged registry carries its own
`origin` directly), and, worse, inconsistent with what #5213 actually
enforces: a `startup`- or `runtime`-origin hook a session tried to disable
via `disabled:` is PROTECTED (#5213) and still fires, but `hook_state()`
reported `enabled: false` for it anyway — misleading exactly where it
matters most (#5041's own supervision hook: the status bar reads as
neutralized when it is not).

**Severity correction, on my own earlier filing**: I originally filed this
as "cosmetic, no security impact." Lead-coder corrected that: the status
bar is the surface a human uses to judge "is supervision in effect," and a
false `enabled: false` for a supervision hook could read as "neutralized"
to a person watching it, even though the real dispatch was never affected.
Not a security bypass (#5213 already closed that; this PR is display-only)
but a genuine trust/observability issue, not merely cosmetic.

## Fix

`hook_state()` now reads `HookDef.origin` directly off
`self._hook_dispatcher.registry.all_defs()` — the dispatcher's own public
`.registry` property and `HookRegistry.all_defs()`, never the private
`registry._defs` reach-in the old code used — and computes `enabled` via
the SAME `hook_origin_is_at_least_as_specific_as` check `is_hook_disabled`
uses.

`all_defs()` is ordered least-to-most-specific (startup → runtime →
per-agent → per-session, see `Session._build_hook_registry`). Overwriting a
per-name dict entry while iterating forward reproduces
"most-specific-layer-wins" for BOTH `scope` and `enabled` from one walk —
which also fixes a subtle pre-existing inconsistency: the old code computed
`scope` as most-specific (via a similar forward-overwrite loop) but picked
its OTHER fields (via a separate `seen` set keeping the FIRST-encountered
`HookDef`) from the LEAST-specific instance instead. `scope` and `enabled`
could silently disagree about which layer's definition they were
describing.

**Not solved here** (documented in the new docstring, left as a further
follow-up if anyone wants it): a name declared at two DIFFERENT origins
(e.g. both startup and per-session) still collapses to one displayed row —
the real dispatcher fires BOTH underlying `HookDef` instances
independently; this display shows only the most specific one's own
enabled/disabled verdict. This simplification pre-dates #5222 and isn't new
here — flagging rather than expanding scope.

## Tests

`tests/runtime/test_5222_hook_state_origin_aware.py` — Tier 2, real
`Session`/`HookDispatcher`, no mocks:

- `test_a_protected_startup_hook_disabled_via_per_session_shows_enabled_true`
  — acceptance, the exact #5222 witness, corroborated against the real
  dispatch outcome (not just the display).
- `test_a_genuine_per_session_hook_disable_shows_enabled_false` —
  falsification contrast, the feature still works for its genuine scope.
- `test_scope_reports_the_most_specific_layer_when_a_name_repeats` —
  precedence: a name declared at both startup and per-agent layers must
  report the more specific origin, not a first-occurrence walk's least
  specific one.
- `test_strip_the_origin_aware_enabled_check_reproduces_the_stale_display`
  — strip-falsify: reinstalling the old bare name-membership check
  reproduces the misleading display.

## Verification

- `ruff check .` — clean
- `python scripts/test_tier_audit.py --strict tests/runtime/test_5222_hook_state_origin_aware.py` — 4/4 OK
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK
- `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- `python scripts/flat_tests_ratchet.py` — OK
- `python scripts/check_tests_path_literal_reference.py` — OK
- Manual strip-falsify: reverted the `enabled` computation to bare name-membership, confirmed the acceptance test goes red with the exact misleading value (`False`), restored, confirmed green.
- Full sweep on the rebased tree (`tests/hooks/ tests/runtime/ tests/interfaces/test_3595_s4_slash_handler_seam.py`): **2300 passed, 1 skipped**, zero regressions.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on the new test file
- [x] `verify_module_docstrings.py` on the changed src file
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] Full local sweep of `tests/hooks/ tests/runtime/ tests/interfaces/test_3595_s4_slash_handler_seam.py` (2300 passed, 1 skipped)
- [x] Manual strip-falsify (bare name-membership restored → acceptance test red with the exact stale value; restored → green)
- [ ] (skipped — Visual, standing waiver 2026-08-08) status-bar rendering itself not touched, only the read model

This PR touches `tests/` — needs an independent TESTS-READY(B) before I
self-merge (rule 8). I will verify `gh pr checks` myself before merging and
will not rely on a broker status report alone for that signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
