### PR TITLE
fix(#5210): exec_capture output is capped from a real budget, never truncated

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -92,6 +92,7 @@ class HookDispatcher:
         bus: "HookBus | None" = None,
         hook_cwd: "Callable[[], str | None] | None" = None,
         hook_process_context: "Callable[[], Any] | None" = None,
+        resolve_exec_capture_output_cap: "Callable[[], tuple[int, str] | None] | None" = None,
     ) -> None:
         self._registry = registry
         # Hook-Event Redesign Phase 4a (proposal 0059 §3.2/§3.3): the optional
@@ -146,6 +147,15 @@ class HookDispatcher:
         # cwd, same as always).
         self._hook_cwd = hook_cwd
         self._hook_process_context = hook_process_context
+        # #5210: same "live callable, not a value frozen at construction time"
+        # idiom as hook_cwd/hook_process_context above — the context budget
+        # a live Session/TurnBudgetEngine derives can change across this
+        # dispatcher's lifetime (a model switch, e.g.). None (the default —
+        # every pre-#5210 call site) → no cap applied, byte-identical to
+        # before this parameter existed (exec_capture's returned stdout is
+        # unbounded, same as always — see shell_runner.run_shell_hook's own
+        # docstring for why #5210 does not invent a fallback number here).
+        self._resolve_exec_capture_output_cap = resolve_exec_capture_output_cap
 
     @property
     def registry(self) -> HookRegistry:
@@ -349,6 +359,14 @@ class HookDispatcher:
                 hook_process_context=(
                     self._hook_process_context()
                     if self._hook_process_context is not None
+                    else None
+                ),
+                # #5210: live-resolved (cap_tokens, model) or None — see
+                # shell_runner.run_shell_hook's own docstring for the
+                # explicit-failure-not-truncation contract this enforces.
+                output_token_cap=(
+                    self._resolve_exec_capture_output_cap()
+                    if self._resolve_exec_capture_output_cap is not None
                     else None
                 ),
             )

--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -22,6 +22,14 @@ Contract
 * **Timeout** (default 60 s, overridable per-hook via ``timeout_seconds``).
   Timeout / non-zero exit → log + return ``None``; the runner NEVER crashes the
   agent.
+* **Output size** (``exec_capture`` only, #5210): the returned/parsed stdout
+  is unbounded by default (``output_token_cap=None``, byte-identical to
+  every pre-#5210 caller) — the LOGGED copy has always been capped at 200
+  bytes (see ``:200`` below) but the RETURNED value, which ends up as an
+  inbox message and ultimately a prompt, was not. A caller that supplies
+  ``output_token_cap`` gets an explicit, recorded failure (never a silent
+  truncation — see ``run_shell_hook``'s own docstring) when the decoded
+  stdout exceeds it.
 
 Sandbox (CRITICAL)
 ------------------
@@ -435,6 +443,7 @@ async def run_shell_hook(
     consent_bus: "RequestBus | None" = None,
     hook_name: str | None = None,
     emit_event: "Callable[..., Any] | None" = None,
+    output_token_cap: "tuple[int, str] | None" = None,
 ) -> str | None:
     """Run an exec/exec_capture HookDef argv under the sandbox + consent gate.
 
@@ -518,13 +527,31 @@ async def run_shell_hook(
         (allowlisted / accepted) hook, otherwise a silent side-effect, surfaces in
         the TUI events tab. NOT called when consent is refused or the command is
         skipped (then nothing ran). Best-effort: a sink error never breaks the run.
+    output_token_cap:
+        #5210 — ``(cap_tokens, model)`` for ``capture_stdout=True`` runs only;
+        ``None`` (default) applies NO cap, matching every pre-#5210 caller's
+        behavior unchanged. When set, the decoded stdout's estimated token
+        count (:func:`~reyn.services.compaction.engine.estimate_tokens`,
+        against *model*) is checked BEFORE the caller ever sees or parses it —
+        exceeding *cap_tokens* is an EXPLICIT failure (logged, recorded via
+        *emit_event* with ``denial_class="exec_capture_output_cap_exceeded"``,
+        return ``None``), never a truncation: a truncated JSON push-directive
+        fails to parse and is indistinguishable from a clean no-push run at
+        the dispatcher (the exact "two silences" shape #5041 already closed
+        once for a different cause). *cap_tokens* is deliberately not invented
+        here — the caller derives it from a real, live context-budget source
+        (``HookDispatcher``'s own ``resolve_exec_capture_output_cap``,
+        wired from ``Session``'s ``TurnBudgetEngine.budget.output_reserve``)
+        and passes ``None`` when no such source is available, rather than
+        supplying an arbitrary fallback number.
 
     Returns
     -------
     str | None
-        The decoded stdout when ``capture_stdout=True`` and the run succeeded;
-        otherwise ``None`` (always ``None`` for ``capture_stdout=False``, and on
-        any failure in either mode).
+        The decoded stdout when ``capture_stdout=True`` and the run succeeded
+        AND (if *output_token_cap* is set) is within it; otherwise ``None``
+        (always ``None`` for ``capture_stdout=False``, and on any failure in
+        either mode, including exceeding *output_token_cap*).
 
     Notes
     -----
@@ -637,6 +664,41 @@ async def run_shell_hook(
         # run_and_classify (#3823 ①) — reused here, not re-derived.
         denial_class = launched.denial_class
 
+        # #5210: computed HERE — before the single unconditional emit_event
+        # call below — so an over-cap rejection rides that SAME event
+        # (architect's own prescription: reuse denial_class, no new event
+        # surface) rather than firing a second, separate one. Only relevant
+        # for a would-be-successful capture_stdout run; an already-failed
+        # run (non-zero exit) is unaffected — that path's own denial_class
+        # (e.g. DENIAL_FORK) takes priority below, unchanged.
+        cap_exceeded = False
+        if (
+            capture_stdout
+            and result.returncode == 0
+            and output_token_cap is not None
+        ):
+            cap_tokens, cap_model = output_token_cap
+            from reyn.services.compaction.engine import estimate_tokens  # noqa: PLC0415
+
+            decoded_stdout_for_cap = result.stdout.decode("utf-8", errors="replace")
+            actual_tokens = estimate_tokens(decoded_stdout_for_cap, cap_model)
+            if actual_tokens > cap_tokens:
+                cap_exceeded = True
+                denial_class = "exec_capture_output_cap_exceeded"
+                # #5210 (architect ruling, issue #5210): NEVER truncate — a
+                # cut JSON push-directive fails to parse at the dispatcher
+                # and is indistinguishable from a clean, deliberate no-push
+                # run (the exact "two silences" #5041 already closed once).
+                # Reject outright, loudly, and record it (below) — never
+                # silently degrade.
+                _log.warning(
+                    "shell-hook %r exec_capture output (%d estimated tokens) "
+                    "exceeds the context-budget-derived cap (%d tokens) — push "
+                    "skipped, NOT truncated (a truncated JSON directive would "
+                    "silently fail to parse instead).",
+                    command, actual_tokens, cap_tokens,
+                )
+
         if emit_event is not None:
             try:
                 emit_event(
@@ -694,10 +756,13 @@ async def run_shell_hook(
             return None  # fail-safe: a failed command yields no push-directive
 
         # Success. capture_stdout (exec_capture) → return decoded stdout for the
-        # caller to parse; otherwise (exec) output is ignored.
-        if capture_stdout:
-            return result.stdout.decode("utf-8", errors="replace")
-        return None
+        # caller to parse; otherwise (exec) output is ignored. #5210: a
+        # cap_exceeded verdict (computed above, before the emit_event call,
+        # so the rejection rides that SAME event) still returns None here —
+        # never a truncated prefix of the real output.
+        if not capture_stdout or cap_exceeded:
+            return None
+        return result.stdout.decode("utf-8", errors="replace")
 
     except Exception as exc:
         _log.error("shell-hook %r: unexpected error: %s", command, exc)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4602,6 +4602,12 @@ class Session:
                 ).resolve(),
                 agent_name=self.agent_name,
             ),
+            # #5210: same deferred-lambda-over-live-state idiom as hook_cwd/
+            # hook_process_context above — the model (and therefore the
+            # budget) can change across this dispatcher's lifetime (a
+            # ``/model`` switch), so this is resolved fresh at each
+            # exec_capture dispatch, never frozen here at construction.
+            resolve_exec_capture_output_cap=self._resolve_exec_capture_output_cap,
         )
         # #2608 H4: the session-owned filesystem watcher (see
         # reyn.runtime.fs_watcher's module docstring for the thread->async
@@ -5615,6 +5621,27 @@ class Session:
             agent_name=self.agent_name,
         )
         return mcp_connection_service
+
+    def _resolve_exec_capture_output_cap(self) -> "tuple[int, str] | None":
+        """#5210: ``(cap_tokens, model)`` for ``HookDispatcher``'s
+        ``exec_capture`` output-cap check, or ``None`` when no real budget
+        is available — see ``shell_runner.run_shell_hook``'s own docstring
+        for why this deliberately never falls back to an invented number.
+
+        ``self._router_host.wrap_up_output_reserve`` is the SAME live,
+        model-derived token budget ``RouterLoop._force_close_call`` already
+        hard-caps the wrap-up consolidation call to (#1092 PR-F1) — reused
+        here rather than a second, independent budget computation for
+        exec_capture specifically. ``None`` when the chat axis has no
+        turn_budget engine (an unresolvable model class, #4573 — see that
+        issue's own load-warn/use-raise ruling; this path degrades to "no
+        cap" rather than raising, matching #5210's own "no bounding subject
+        available" disclosure, not a hard dependency on #4573 being fixed
+        first)."""
+        output_reserve = self._router_host.wrap_up_output_reserve
+        if output_reserve is None:
+            return None
+        return output_reserve, self.model
 
     # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──
 

--- a/tests/hooks/test_5210_exec_capture_output_cap.py
+++ b/tests/hooks/test_5210_exec_capture_output_cap.py
@@ -310,3 +310,25 @@ async def test_session_resolves_a_real_cap_from_its_own_turn_budget_engine(
     cap_tokens, model = resolved
     assert isinstance(cap_tokens, int) and cap_tokens > 0
     assert model == s.model
+
+
+@pytest.mark.asyncio
+async def test_session_with_no_engine_resolves_no_cap(tmp_path: Path) -> None:
+    """Tier 2: falsification contrast — the None-path (B review non-blocking
+    note, #5229). An unresolvable model CLASS (#4573's own degrade: the
+    resolver's lazy, non-essential ``TurnBudgetEngine`` build catches the
+    typed ``UnresolvableModelClassError`` and returns ``None`` rather than
+    crashing the session) means ``RouterHostAdapter.wrap_up_output_reserve``
+    is ``None`` — ``_resolve_exec_capture_output_cap`` must degrade to
+    ``None`` too, matching pre-#5210 (unbounded) behavior, not raise."""
+    from tests._support.agent_session import make_session
+
+    s = make_session(
+        agent_name="alice",
+        model="gemini-2.5-flash-lite",  # #4573's own unresolvable-class fixture
+        snapshot_path=tmp_path / "s" / "snapshot.json",
+    )
+
+    resolved = s._resolve_exec_capture_output_cap()
+
+    assert resolved is None

--- a/tests/hooks/test_5210_exec_capture_output_cap.py
+++ b/tests/hooks/test_5210_exec_capture_output_cap.py
@@ -1,0 +1,312 @@
+"""Tier 2: #5210 — exec_capture's returned stdout is bounded when a caller
+supplies a real, context-budget-derived cap; unbounded (byte-identical to
+pre-#5210) when it does not.
+
+Architect ruling (issue #5210): the LOGGED copy of a shell-hook's stdout has
+always been capped at 200 bytes (``shell_runner.py``'s own ``[:200]`` slices);
+the RETURNED copy — the ``exec_capture`` push directive, whose ``message``
+field lands in an inbox and ultimately a prompt — was not. Do NOT truncate:
+a truncated JSON push-directive fails to parse and is indistinguishable from
+a clean, deliberate no-push run at the dispatcher (the exact "two silences"
+shape #5041 already closed once). Exceeding the cap is an EXPLICIT failure
+(no push, recorded via the existing ``hook_shell_executed`` event's
+``denial_class`` field), never a silent truncation. The cap itself is never
+invented — it is derived from a real, live context-budget source
+(``RouterHostAdapter.wrap_up_output_reserve``, the SAME token budget the
+force-close wrap-up call is already hard-capped to).
+
+Level 1 (``run_shell_hook`` itself): REAL subprocesses (``python -c``
+one-liners), mirroring ``test_1800_hook_shell_runner.py``'s own established
+pattern — no mocks.
+Level 2 (``HookDispatcher`` wiring): a real ``HookDispatcher`` with a
+recording ``run_shell`` seam, mirroring ``test_hook_shell_push_2069.py``'s
+own established pattern for this exact seam.
+Level 3 (``Session`` wiring): a real ``Session``/``AgentRegistry`` — no
+mocks, per the testing policy.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookDef
+from reyn.security.sandbox import NoopBackend, SandboxPolicy
+
+_PY = sys.executable
+
+
+def _noop_backend() -> NoopBackend:
+    return NoopBackend()
+
+
+def _policy(timeout: int = 10) -> SandboxPolicy:
+    return SandboxPolicy(network=False, deny_subprocess=True, timeout_seconds=timeout)
+
+
+# ── Level 1 — run_shell_hook itself, real subprocesses ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_output_within_cap_is_returned_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: falsification contrast — output that fits inside the cap is
+    returned exactly as before #5210 (the cap check is a rejection, not a
+    modification, of anything that passes it)."""
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+    directive = {"push_when": True, "wake": True, "message": "go"}
+    script = f"import json,sys; sys.stdout.write(json.dumps({directive!r}))"
+
+    result = await run_shell_hook(
+        [_PY, "-c", script],
+        event_context={"event": "turn_end"},
+        timeout_seconds=10,
+        sandbox_backend=_noop_backend(),
+        sandbox_policy=_policy(),
+        allowlist_path=tmp_path / "allowlist.json",
+        capture_stdout=True,
+        output_token_cap=(1000, "openai/gpt-4o-mini"),
+    )
+
+    assert result is not None
+    assert json.loads(result) == directive
+
+
+@pytest.mark.asyncio
+async def test_output_exceeding_the_cap_is_rejected_not_truncated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog,
+) -> None:
+    """Tier 2: acceptance — the #5210 witness itself. A real subprocess whose
+    stdout genuinely exceeds a small token cap must return ``None`` (an
+    EXPLICIT rejection), not a truncated prefix of its own output — a
+    truncated JSON string would fail ``json.loads`` at the dispatcher and be
+    indistinguishable from a clean no-push run, exactly the silent-failure
+    shape this issue exists to prevent."""
+    import logging
+
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+    # A long, repetitive string — genuinely large, real subprocess output,
+    # not a synthetic in-process value.
+    script = "import sys; sys.stdout.write('x' * 20000)"
+
+    events: "list[dict]" = []
+
+    def _emit_event(event_type: str, **data) -> None:
+        events.append({"event_type": event_type, **data})
+
+    with caplog.at_level(logging.WARNING):
+        result = await run_shell_hook(
+            [_PY, "-c", script],
+            event_context={"event": "turn_end"},
+            timeout_seconds=10,
+            sandbox_backend=_noop_backend(),
+            sandbox_policy=_policy(),
+            allowlist_path=tmp_path / "allowlist.json",
+            capture_stdout=True,
+            emit_event=_emit_event,
+            output_token_cap=(5, "openai/gpt-4o-mini"),
+        )
+
+    assert result is None, (
+        "output genuinely exceeding the cap must be rejected outright, "
+        "never truncated into a shorter (and likely unparseable) string"
+    )
+    assert any(
+        "exceeds the context-budget-derived cap" in r.message for r in caplog.records
+    ), "the rejection must be logged, not silent"
+    (event,) = events  # raises if not exactly 1: the rejection must ride the
+    # SAME single hook_shell_executed event the run already emits, not fire
+    # a second, separate one.
+    assert event["event_type"] == "hook_shell_executed"
+    assert event["mode"] == "exec_capture"
+    assert event["returncode"] == 0
+    assert event["denial_class"] == "exec_capture_output_cap_exceeded", (
+        "the rejection must be recorded on the existing hook_shell_executed "
+        "event's denial_class field (architect's own prescription: reuse "
+        "denial_class, no new surface needed) so a future reader (#5041's "
+        f"own design) can see it — got {event!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_cap_supplied_is_unbounded_matching_pre_5210(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: non-regression — every pre-#5210 caller passes no
+    ``output_token_cap`` (the default, ``None``) and must see EXACTLY the
+    old behavior: a large output returned whole, no rejection. #5210 adds a
+    capability; it does not change default behavior for a caller that
+    doesn't opt in."""
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+    payload = "x" * 20000
+    script = f"import sys; sys.stdout.write({payload!r})"
+
+    result = await run_shell_hook(
+        [_PY, "-c", script],
+        event_context={"event": "turn_end"},
+        timeout_seconds=10,
+        sandbox_backend=_noop_backend(),
+        sandbox_policy=_policy(),
+        allowlist_path=tmp_path / "allowlist.json",
+        capture_stdout=True,
+        # output_token_cap omitted -- the default
+    )
+
+    assert result == payload, (
+        "the full, unmodified payload must come back — no truncation, no "
+        "rejection, exactly the pre-#5210 shape for a caller that supplies "
+        "no cap"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strip_the_cap_check_reproduces_the_original_defect(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: strip-falsify — mirrors the real check by hand: with a cap
+    supplied but a genuinely-oversized output, if the cap enforcement were
+    removed the function would return the full string instead of None. This
+    test pins that a cap being SUPPLIED changes the outcome versus not being
+    supplied (contrasted against the previous test), which is what proves
+    the check in shell_runner.py's own return-point logic is load-bearing,
+    not decorative."""
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+    payload = "x" * 20000
+    script = f"import sys; sys.stdout.write({payload!r})"
+
+    no_cap_result = await run_shell_hook(
+        [_PY, "-c", script],
+        event_context={"event": "turn_end"},
+        timeout_seconds=10,
+        sandbox_backend=_noop_backend(),
+        sandbox_policy=_policy(),
+        allowlist_path=tmp_path / "allowlist.json",
+        capture_stdout=True,
+    )
+    with_cap_result = await run_shell_hook(
+        [_PY, "-c", script],
+        event_context={"event": "turn_end"},
+        timeout_seconds=10,
+        sandbox_backend=_noop_backend(),
+        sandbox_policy=_policy(),
+        allowlist_path=tmp_path / "allowlist.json",
+        capture_stdout=True,
+        output_token_cap=(5, "openai/gpt-4o-mini"),
+    )
+
+    assert no_cap_result == payload
+    assert with_cap_result is None, (
+        "the SAME oversized output must be treated differently depending "
+        "on whether a cap was supplied — proving the cap check actually "
+        "gates the return value"
+    )
+
+
+# ── Level 2 — HookDispatcher wiring ────────────────────────────────────────
+
+
+class _RecordingShell:
+    """A recording async ``run_shell`` seam (real callable, not a mock) —
+    mirrors ``test_hook_shell_push_2069.py``'s own ``_ReturningShell``
+    pattern exactly, extended to also record the kwargs it was called
+    with (needed here to verify ``output_token_cap`` was actually threaded
+    through, not just that SOME call happened)."""
+
+    def __init__(self, stdout: "str | None") -> None:
+        self._stdout = stdout
+        self.calls: "list[tuple[tuple, dict]]" = []
+
+    async def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self._stdout
+
+
+def _dispatcher(hooks: "list[HookDef]", *, run_shell, resolve_cap=None) -> HookDispatcher:
+    registry = HookRegistry(list(hooks))
+
+    async def _noop_put_inbox(*args, **kwargs) -> None:
+        return None
+
+    async def _noop_stage(*args, **kwargs) -> None:
+        return None
+
+    return HookDispatcher(
+        registry,
+        put_inbox=_noop_put_inbox,
+        stage_next_turn_context=_noop_stage,
+        run_shell=run_shell,
+        resolve_exec_capture_output_cap=resolve_cap,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_threads_the_resolved_cap_into_run_shell() -> None:
+    """Tier 2: acceptance — ``HookDispatcher`` calls its live
+    ``resolve_exec_capture_output_cap`` callable at DISPATCH time (not
+    construction time, matching ``hook_cwd``/``hook_process_context``'s own
+    established idiom) and forwards its result to ``run_shell`` as
+    ``output_token_cap``."""
+    shell = _RecordingShell(json.dumps({"push_when": False, "wake": False, "message": "x"}))
+    hook = HookDef(on="turn_end", exec_capture=("emit.sh",))
+    disp = _dispatcher(
+        [hook], run_shell=shell, resolve_cap=lambda: (42, "openai/gpt-4o-mini"),
+    )
+
+    await disp.dispatch("turn_end", {})
+
+    (_args, kwargs), = shell.calls
+    assert kwargs["output_token_cap"] == (42, "openai/gpt-4o-mini")
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_with_no_resolver_passes_none_cap() -> None:
+    """Tier 2: non-regression — ``resolve_exec_capture_output_cap=None``
+    (the default, every pre-#5210 ``HookDispatcher`` construction site)
+    passes ``output_token_cap=None`` through unchanged, matching #5210's own
+    "does not invent a fallback number" ruling — no cap source means no cap,
+    not a guessed one."""
+    shell = _RecordingShell(json.dumps({"push_when": False, "wake": False, "message": "x"}))
+    hook = HookDef(on="turn_end", exec_capture=("emit.sh",))
+    disp = _dispatcher([hook], run_shell=shell)  # resolve_cap omitted
+
+    await disp.dispatch("turn_end", {})
+
+    (_args, kwargs), = shell.calls
+    assert kwargs["output_token_cap"] is None
+
+
+# ── Level 3 — Session wiring ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_session_resolves_a_real_cap_from_its_own_turn_budget_engine(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: acceptance — a real ``Session`` with a resolvable model
+    derives a genuine ``(cap_tokens, model)`` pair from
+    ``RouterHostAdapter.wrap_up_output_reserve`` — the SAME live budget the
+    force-close wrap-up call is already hard-capped to (#1092 PR-F1), not a
+    second, independent computation."""
+    from tests._support.agent_session import make_session
+
+    s = make_session(agent_name="alice", snapshot_path=tmp_path / "s" / "snapshot.json")
+
+    resolved = s._resolve_exec_capture_output_cap()
+
+    assert resolved is not None
+    cap_tokens, model = resolved
+    assert isinstance(cap_tokens, int) and cap_tokens > 0
+    assert model == s.model


### PR DESCRIPTION
**[docs-maintainer]** — implements architect's #5210 prescription.

## What

`exec_capture` shell-hook stdout was unbounded in size but only its LOGGED
copy was ever capped (200 bytes) — the RETURNED value, which ends up as an
inbox message and ultimately a prompt, was not. A huge return value could
blow the context budget silently.

Per architect's design (issue #5210 body):

- Never truncate. A cut JSON push-directive fails to parse and is
  indistinguishable from a clean, deliberate no-push run — the exact "two
  silences" shape #5041 already closed once for a different cause.
- An over-cap output is an EXPLICIT, recorded failure via the EXISTING
  `hook_shell_executed` audit-event's `denial_class` field
  (`exec_capture_output_cap_exceeded`) — no new event surface.
- The cap value comes from a REAL, live context-budget source, never an
  invented byte number: `RouterHostAdapter.wrap_up_output_reserve`, the same
  live budget the force-close wrap-up call is already hard-capped to
  (#1092 PR-F1).

## How

- `run_shell_hook` (`shell_runner.py`) gains `output_token_cap: tuple[int,
  str] | None = None`. `None` (default) is byte-identical to every
  pre-#5210 caller. When set, the decoded stdout's estimated token count
  (`estimate_tokens`, against the supplied model) is checked BEFORE the
  caller ever parses it. Computed before the function's single existing
  `emit_event` call so the rejection rides that SAME event rather than
  firing a second one.
- `HookDispatcher.__init__` gains `resolve_exec_capture_output_cap:
  Callable[[], tuple[int, str] | None] | None = None` — a deferred callable
  mirroring the existing `hook_cwd`/`hook_process_context` idiom (live
  state, resolved fresh per dispatch, not frozen at construction). Wired
  into the `exec_capture` branch's `run_shell` call.
- `Session._resolve_exec_capture_output_cap` derives `(cap_tokens, model)`
  from `RouterHostAdapter.wrap_up_output_reserve`, returning `None` when no
  real budget is available (no fallback number invented). `session.py` is
  the only place with access to both `self._router_host` (for
  `wrap_up_output_reserve`) and `self.model` — the new method lives there
  and is wired into `HookDispatcher.__init__` at construction
  (`resolve_exec_capture_output_cap=self._resolve_exec_capture_output_cap`).

## Lenses

Security (fail-closed, explicit denial, never a silent truncation) ·
Observability (rides the existing audited event, no new surface) ·
Reliability (default `None` path is byte-identical to pre-#5210 — no
behavior change for any existing caller).

## Test plan

- [x] `pytest tests/hooks/test_5210_exec_capture_output_cap.py -q` — 8/8
  pass (Level 1: `run_shell_hook` real-subprocess; Level 2: `HookDispatcher`
  wiring with a real recording `run_shell` seam; Level 3: `Session` wiring
  with a real `make_session`, resolvable-model AND #4573's own
  unresolvable-model-class None-path).
- [x] `pytest tests/hooks/ -q` — full regression, 346/346 pass.
- [x] `ruff check` on the 3 changed src files — clean.
- [x] `scripts/test_tier_audit.py --strict tests/hooks/test_5210_exec_capture_output_cap.py` — 8/8 OK, 0 Tier-4 violations.
- [x] `scripts/verify_module_docstrings.py` on the 3 changed src files — OK.
- [x] `scripts/mypy_ratchet.py` — OK, no new findings.
- [x] `scripts/flat_tests_ratchet.py` — OK.
- [x] `scripts/check_tests_path_literal_reference.py` — OK.
- [x] `scripts/check_bare_tests_import_reference.py` — OK.
- [x] `scripts/check_file_depth_reference.py` — OK.
- [ ] (skipped — no UI surface) Visual

`tests/` are touched — needs a TESTS-READ (B) review from someone other than
me (I'm the author).

**B review (tui-coder)**: no blocking — all 4 of architect's prescription
axes independently verified against source (never-truncate confirmed by
strip-falsify, explicit-failure-via-existing-event by reading the emit-event
ordering, no-invented-number by tracing the full chain to a real
`TurnBudgetEngine`, the subprocess concern resolved structurally — budget
resolution happens caller-side, before the subprocess runs). 2 non-blocking
notes, both addressed: added the dedicated `_resolve_exec_capture_output_cap`
None-path test above, and the "why session.py" note in **How** above.

**Production consumers today**: 0 — no built-in `exec_capture` hook exists
yet in this codebase; #5041's own supervision-hook work will be the first
real caller. This cap exists ahead of that caller by design (architect's
#5210 prescription), not reactively to an observed overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

