### PR TITLE
docs(cli): /hook off names its origin-protection gap (#5213/#5218/#5222)

### DIFF
--- a/docs/reference/cli/chat.ja.md
+++ b/docs/reference/cli/chat.ja.md
@@ -88,7 +88,7 @@ reyn chat researcher
 | `/cost` | このagentのトークン + USD コスト概要 |
 | `/exit` | チャットを終了(alias: `/quit`、Ctrl+D) |
 | `/help [<cmd>]` | スラッシュコマンドのヘルプ — 全件一覧、または特定コマンドに絞る |
-| `/hook on\|off <name>` | このセッションでの hook の有効/無効を切り替え(次回 dispatch から有効; セッションスコープ — agent の他セッションでは引き続き発火。再起動後も持続) |
+| `/hook on\|off <name>` | このセッションでの hook の有効/無効を切り替え(次回 dispatch から有効; セッションスコープ — agent の他セッションでは引き続き発火。再起動後も持続)。`off` が実際に効くのは per-agent / per-session origin の hook のみ — startup / runtime origin の hook(agent が書き込めない config 層)は保護されており、無効化しても発火し続ける(#5213/#5218)。保護された hook に対する `/hook off` は、実際には無効化されていないにもかかわらず今も「now disabled」と応答する(既知のギャップ、#5230)。一方 status bar の Hook タブはこのギャップを共有していない — その `enabled` は dispatcher が実際に強制するのと同じ判定を示し、単純な name-in-disabled-set ではない(#5222) |
 | `/image <path>`(alias `/img`) | 次のユーザーメッセージに画像を添付(マルチモーダル入力; png/jpg/jpeg/gif/webp/svg) |
 | `/list` | 保留中の介入を一覧表示 |
 | `/memory [list\|view <name>]` | プロジェクトメモリのエントリを確認([concepts/memory](../../concepts/data-retrieval/memory.md) 参照) |

--- a/docs/reference/cli/chat.md
+++ b/docs/reference/cli/chat.md
@@ -87,7 +87,7 @@ While a session is active, lines starting with `/` are intercepted and never rou
 | `/cost` | Quick token + USD cost summary for this agent |
 | `/exit` | Exit the chat (alias: `/quit`, Ctrl+D) |
 | `/help [<cmd>]` | Slash command help — list all, or focus on one |
-| `/hook on\|off <name>` | Enable/disable a hook for this session (live at the next dispatch; session-scoped — the hook still fires in the agent's other sessions; persists across restart) |
+| `/hook on\|off <name>` | Enable/disable a hook for this session (live at the next dispatch; session-scoped — the hook still fires in the agent's other sessions; persists across restart). `off` only takes effect for a per-agent- or per-session-origin hook; a startup- or runtime-origin hook (config-file layers the agent cannot write) is protected — it keeps firing regardless (#5213/#5218). `/hook off` on a protected hook still replies "now disabled" (known gap, #5230) even though the hook is unaffected; the status bar's Hook tab does NOT share that gap — its `enabled` names the SAME predicate the dispatcher enforces, not bare name-in-disabled-set (#5222) |
 | `/image <path>` (alias `/img`) | Attach an image to the next user message (multimodal input; png/jpg/jpeg/gif/webp/svg) |
 | `/list` | List pending interventions |
 | `/memory [list\|view <name>]` | Inspect project memory entries (see [concepts/memory](../../concepts/data-retrieval/memory.md)) |


### PR DESCRIPTION
**[docs-maintainer]** — doc-drift found while doc-syncing #5222's PR (#5227, merged).

## What

`docs/reference/cli/chat.md`'s `/hook on|off <name>` row described
unconditional enable/disable with no caveat — stale since #5213/#5218
landed real origin-based disable-protection (a startup- or runtime-origin
hook can't actually be disabled per-session; `/hook off` on one is a no-op
at dispatch, by design — #5041's own supervision hook must not be
disableable by the party it supervises). #5222/#5227 fixed the status-bar
Hook tab's `enabled` field to reflect this predicate but the CLI reference
row was never touched — addition-axis doc drift, same shape as the #5022
family (#5015→#5017, #5027→#5030, #5034→prior PR).

Also filed #5230 along the way: the `/hook off` slash command itself still
unconditionally replies "now disabled" even when the target is protected —
worse than a silent no-op. Named as a known gap in the doc rather than
glossed over; not fixed here (out of docs-maintainer scope, needs its own
implementation PR).

`chat.ja.md` asserted the same stale claim — fixed in this PR per house
rule 5 (fix a `.ja.md` only when the PR falsifies something it asserts).

## Lenses

Product Think (predictable/legible — the doc now matches what the command
actually does) · Observability (names the exact PRs/issue behind the gap
rather than a vague caveat).

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean (only
  pre-existing, unrelated INFO-level cross-anchor mismatches).
- [x] `scripts/check_doc_anchors.py` — "no dangling anchors into published
  pages".
- [x] `scripts/check_retired_config_keys_denylist.py` — 0 hits.
- [ ] (skipped — docs-only, no UI surface) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
