### PR TITLE
fix(#5188): make the manual-rmtree identity witness platform-independent

### DIFF
--- a/tests/runtime/test_2103_C2b_rewind_reconstruction_1953.py
+++ b/tests/runtime/test_2103_C2b_rewind_reconstruction_1953.py
@@ -57,9 +57,25 @@ async def test_rewind_across_name_reuse_does_not_resurrect_orphan(tmp_path):
     #5084: the frozen identity is now the parent AGENT DIRECTORY's own
     ``(ino, birthtime)`` (``AgentRegistry.agent_directory_identity``), re-stat'd fresh
     at comparison time — not a WAL seq. So "identity-2" here is a REAL
-    directory rmtree + recreate (a genuinely different inode), not a second
-    hand-authored WAL number; ``is_spawn_descendant`` always reads the LIVE
-    filesystem, never the WAL's own bookkeeping."""
+    directory rmtree + recreate, not a second hand-authored WAL number;
+    ``is_spawn_descendant`` always reads the LIVE filesystem, never the
+    WAL's own bookkeeping.
+
+    #5188 (lead-coder co-vet on PR #5235, same hazard/same fix as that PR's
+    own #5084 witness): whether the real rmtree+recreate actually mints a
+    genuinely different inode is OS-dependent — on most Linux filesystems
+    (no ``st_birthtime``, the comparison degrades to bare ``ino``) an
+    inode CAN be reused for a freshly created directory, which would make
+    ``is_spawn_descendant`` here silently NOT reject and this test flaky
+    on Linux CI for a reason unrelated to the rewind-reconstruction logic
+    under test. Same fix as #5235: after the real rmtree + real recreate,
+    force ``agent_directory_identity("parent")`` to return a value
+    guaranteed different from the identity actually frozen into the WAL
+    (``parent_identity_1``, already captured below) — this still drives
+    the real ``_materialize_rewind`` reconstruction and the real
+    ``is_spawn_descendant`` comparison unmodified, it just stops gambling
+    on what the OS's free-inode allocator does in the gap. Reads
+    ``st_ino``/``st_birthtime`` nowhere in this test's own code."""
     _seed(tmp_path, "parent")
     _seed(tmp_path, "child")
     reg = _registry(tmp_path)
@@ -71,8 +87,7 @@ async def test_rewind_across_name_reuse_does_not_resurrect_orphan(tmp_path):
     await log.append("agent_created", entity_kind="agent", name="child", sid="",
                      parent="parent", parent_seq=list(parent_identity_1),
                      profile={"name": "child", "role": ""})
-    # parent purged (a real rmtree) then the NAME reused (a real recreate) →
-    # a genuinely NEW directory identity (identity-2).
+    # parent purged (a real rmtree) then the NAME reused (a real recreate).
     await log.append("agent_purged", entity_kind="agent", name="parent", sid="")
     import shutil
     shutil.rmtree(tmp_path / ".reyn" / "agents" / "parent")
@@ -83,6 +98,20 @@ async def test_rewind_across_name_reuse_does_not_resurrect_orphan(tmp_path):
     # forward-checkout past everything → rebuild lineage from the WAL as-of-cut.
     await reg._materialize_rewind(reconstruct_seq=log.current_seq,
                                   workspace_at_or_below=log.current_seq)
+
+    # #5188: force the post-recreate identity to be deterministically
+    # different from parent_identity_1 (the value actually frozen into the
+    # WAL above), instead of trusting the OS to have minted a different
+    # inode. Guaranteed to differ from any real (ino, birthtime) pair, so
+    # it cannot coincide with parent_identity_1 by chance either.
+    real_identity = reg.agent_directory_identity
+
+    def _identity_with_forced_reuse_mismatch(name: str):
+        if name == "parent":
+            return (-2, None)
+        return real_identity(name)
+
+    reg.agent_directory_identity = _identity_with_forced_reuse_mismatch  # type: ignore[method-assign]
 
     # no resurrection: child's frozen edge does not match the reused parent identity.
     assert not reg.is_spawn_descendant("child", "parent"), (

--- a/tests/runtime/test_5084_declared_agent_identity_purge_reuse.py
+++ b/tests/runtime/test_5084_declared_agent_identity_purge_reuse.py
@@ -131,12 +131,46 @@ async def test_manual_rmtree_then_redeclare_rejects_stale_child_cap(tmp_path: Pa
     directory stat alone (no active-invalidation backstop reaches this path,
     since reyn's own API was never called).
 
-    ⚠️ Weaker than ⑥ on a platform where ``os.stat`` does not expose
-    ``st_birthtime`` (most Linux filesystems via plain ``stat()``) — the
-    comparison then relies on ``ino`` alone, and an inode number CAN in
-    principle be reused by the OS for the new directory. Not asserted here
-    as a guaranteed-forever property on every platform; disclosed rather
-    than silently assumed (architect co-vet, issuecomment-5380635009)."""
+    #5188: this witness's own discriminator was, until now, "does
+    ``shutil.rmtree`` + recreate happen to mint a NEW inode for the
+    replacement directory" — genuinely OS-dependent, and on most Linux
+    filesystems (no ``st_birthtime``, comparison degrades to bare ``ino``)
+    an inode CAN be reused for a freshly-created directory, especially one
+    recreated immediately after removal in the same test process. That
+    made this witness NON-DETERMINISTIC on Linux CI — it does not assert a
+    duration, but it silently depended on one (how the OS's free-inode
+    allocator happens to behave right now), which is the same class of
+    problem CLAUDE.md's floor/ceiling rule names for time: the outcome
+    should not depend on incidental timing/allocation the test does not
+    control. Confirmed unrelated to any reyn PR (tui-coder's own #5180
+    analysis: the call stack that failed never constructs a ``Session`` at
+    all — ``AgentRegistry(session_factory=lambda profile: None)`` — so it
+    cannot intersect with anything ``Session.run()``-scoped).
+
+    Fix: stop depending on whether the OS actually reused the inode.
+    ``resolved_profile_for``/``is_spawn_descendant`` (the consumers under
+    test) both make their fail-closed decision by comparing the FROZEN
+    identity against ``self.agent_directory_identity(pname)`` called FRESH
+    at query time (``registry.py``'s own ``is_spawn_descendant`` docstring)
+    — this witness's real subject is "does that comparison correctly rail
+    when the two sides differ", not "does ``rmtree``+recreate reliably
+    produce two different stats on every platform" (a DIFFERENT, disclosed,
+    genuinely platform-dependent property of the production mechanism
+    itself — #5188 records that weakness as still real and does not
+    resolve it here; narrowing/hardening ``agent_directory_identity`` is
+    explicitly out of this fix's scope, architect's own call, #5042/#5152).
+    So: monkeypatch ``agent_directory_identity`` to return a value that is
+    UNCONDITIONALLY different for the re-declared ``parent_b`` — this
+    still drives the SAME real filesystem operations (a genuine
+    ``shutil.rmtree`` + a genuine re-declare) and the SAME real consumer
+    code path (``resolved_profile_for``/``is_spawn_descendant``'s own
+    comparison, unmodified), it just no longer gambles on what the OS's
+    free-inode allocator decides to do in the gap between them. Reads
+    ``st_ino``/``st_birthtime`` NOWHERE in this test — the monkeypatch
+    replaces the whole method, never inspects what it returns, so this
+    witness is now platform-independent BY CONSTRUCTION, not by luck: a
+    reviewer can confirm that from this file's own text, without needing
+    to run it on Linux."""
     _declare_narrowed_parent(tmp_path, name="parent_b", profile="prole_b", deny="exec")
     reg = _registry(tmp_path)
     await reg.create_agent("child_b", parent="parent_b")
@@ -146,6 +180,25 @@ async def test_manual_rmtree_then_redeclare_rejects_stale_child_cap(tmp_path: Pa
 
     shutil.rmtree(tmp_path / ".reyn" / "agents" / "parent_b")  # bypasses remove()
     _declare_unrestricted(tmp_path, name="parent_b")
+
+    # #5188: force the "the OS gave the new directory a different identity"
+    # postcondition deterministically, instead of trusting the OS's
+    # free-inode allocator to have actually done so. Every OTHER name still
+    # resolves through the real method (unwrapped) — only "parent_b" (the
+    # one this witness rmtree'd+recreated) is overridden, and only to a
+    # value guaranteed to differ from whatever was frozen at spawn time
+    # above (an impossible ino, mirroring the shape of the registry's own
+    # ``INVALIDATED_SPAWN_PARENT_IDENTITY`` sentinel — never a value a real
+    # ``os.stat()`` could produce, so it cannot coincide with the frozen
+    # identity by chance either).
+    real_identity = reg.agent_directory_identity
+
+    def _identity_with_forced_reuse_mismatch(name: str):
+        if name == "parent_b":
+            return (-2, None)
+        return real_identity(name)
+
+    reg.agent_directory_identity = _identity_with_forced_reuse_mismatch  # type: ignore[method-assign]
 
     after, _ = reg.resolved_profile_for("child_b")
     assert isinstance(after, ContextualPermission)


### PR DESCRIPTION
**[e2e-coder]** — Closes #5188

## Summary

`test_manual_rmtree_then_redeclare_rejects_stale_child_cap`'s own correctness used to depend on `shutil.rmtree` + recreate happening to mint a NEW inode for the replacement directory — genuinely OS-dependent, and on most Linux filesystems (no `st_birthtime`, `agent_directory_identity`'s comparison degrades to bare `ino`) an inode CAN be reused for a freshly created directory. That made this witness non-deterministic on Linux CI: tui-coder's #5180 analysis confirmed a real, unrelated PR got blocked by it (and confirmed, structurally, that the failing call stack never constructs a `Session` at all, so it cannot intersect with anything `Session.run()`-scoped).

Per lead-coder/architect's scoping: rewrite the **test's own discriminator** (option ①), not `agent_directory_identity` itself (option ③, explicitly out of scope — that's a production-mechanism call touching #5042/#5152, architect's domain), and not a platform skip (option ②, explicitly rejected — "skip wears green's color").

## Fix

The witness's real subject is "does `resolved_profile_for`/`is_spawn_descendant` correctly fail closed when the frozen identity differs from the current one" — not "does `rmtree`+recreate reliably produce two different stats on every platform" (a different, disclosed, genuinely platform-dependent property of the production mechanism that this fix does **NOT** resolve — #5188 stays open on that as architect's own future call).

So the test now monkeypatches `AgentRegistry.agent_directory_identity` to force a guaranteed-different return value for the re-declared name, after the same real `rmtree` + real re-declare filesystem operations, driving the exact same real consumer code path unmodified. Reads `st_ino`/`st_birthtime` nowhere in the test's own executable code (confirmed: all 4 `st_birthtime` mentions in the file are prose/docstring, not code) — platform-independent by construction, not by luck.

**lead-coder co-vet found a second file with the same hazard** — `test_2103_C2b_rewind_reconstruction_1953.py::test_rewind_across_name_reuse_does_not_resurrect_orphan`'s own final assertion is the exact same shape (`assert not reg.is_spawn_descendant(...)`), depending on the same real-rmtree-mints-a-new-inode assumption. Fixed with the identical technique in this same PR. `git grep -ln "agent_directory_identity" -- tests/` now confirms these are the ONLY 2 files calling it, and both are fixed.

## Disclosed remainder (CLAUDE.md rule 6 — recorded, not silently dropped)

lead-coder's own observation: before this PR, 1 test in the `#5084`/`#2103 C2b` family (the now-fixed `..._manual_rmtree_...` witness) genuinely asserted "a real `rmtree`+recreate mints a different directory identity" against the live filesystem. After this fix, that property has **zero** live witnesses across both files — the remaining 2 fixed tests now assert "the consumer correctly reacts when identity differs" (a controlled, forced condition), not "the OS actually produces that condition". This is not a regression this PR introduced silently; it's the necessary cost of removing OS-timing dependence from these 2 witnesses. Strengthening `agent_directory_identity` (option ③, architect's own domain, #5042/#5152) is the only way to restore a real end-to-end witness for that specific property — not filed as a new issue tonight per the owner's budget directive; recorded here as the open item.

## Verification

**Not from a local run** — local is macOS/APFS, which has `st_birthtime` and cannot reproduce the Linux race at all, so a local green proves nothing about this fix. Instead: wrote standalone scripts simulating the exact Linux failure mode (force `agent_directory_identity` to return the FROZEN value unchanged after rmtree+recreate — a real inode-reuse collision) against both the OLD and NEW designs, for both fixed tests.

```
#5084 witness — OLD design under simulated inode reuse: denied=None, is_descendant=True   # the exact CI symptom
#5084 witness — NEW design (forced override):           denied=True, is_descendant=False  # correctly rejects the stale link

#2103 C2b witness — same simulated-reuse override → assert not True (identical shape to the CI symptom), restored → green
```

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on both changed test files
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] Local sweep: both fixed files + the 4 related #2103 B lineage-cap test files — 22 passed
- [x] `git grep -ln "agent_directory_identity" -- tests/` — confirms exactly 2 files, both fixed
- [x] Strip-falsify (both fixed tests, simulated inode-reuse collision, not a normal run — see Verification above): reproduced the exact CI failure shape against both, confirmed the fix is immune, restored to green
- [ ] (skipped — Visual, standing waiver, owner 2026-08-08)

Cannot self-merge — touches `tests/`, needs TESTS-READ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
