### PR TITLE
feat(#5184): a spawning policy carries a writable temp_dir

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -92,6 +92,7 @@ class HookDispatcher:
         bus: "HookBus | None" = None,
         hook_cwd: "Callable[[], str | None] | None" = None,
         hook_process_context: "Callable[[], Any] | None" = None,
+        hook_temp_dir: "Callable[[], str | None] | None" = None,
         resolve_exec_capture_output_cap: "Callable[[], tuple[int, str] | None] | None" = None,
     ) -> None:
         self._registry = registry
@@ -147,6 +148,7 @@ class HookDispatcher:
         # cwd, same as always).
         self._hook_cwd = hook_cwd
         self._hook_process_context = hook_process_context
+        self._hook_temp_dir = hook_temp_dir
         # #5210: same "live callable, not a value frozen at construction time"
         # idiom as hook_cwd/hook_process_context above — the context budget
         # a live Session/TurnBudgetEngine derives can change across this
@@ -325,6 +327,7 @@ class HookDispatcher:
                 # #5084 ④: read live, same as consent_bus_now() above — a
                 # relative exec argv resolves inside the agent's OWN tree.
                 cwd=self._hook_cwd() if self._hook_cwd is not None else None,
+                temp_dir=self._hook_temp_dir() if self._hook_temp_dir is not None else None,
                 hook_process_context=(
                     self._hook_process_context()
                     if self._hook_process_context is not None
@@ -356,6 +359,7 @@ class HookDispatcher:
                 emit_event=self._emit_event,
                 # #5084 ④: same live cwd/env source as the exec branch above.
                 cwd=self._hook_cwd() if self._hook_cwd is not None else None,
+                temp_dir=self._hook_temp_dir() if self._hook_temp_dir is not None else None,
                 hook_process_context=(
                     self._hook_process_context()
                     if self._hook_process_context is not None

--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -431,6 +431,7 @@ async def run_shell_hook(
     *,
     timeout_seconds: int = 60,
     cwd: str | None = None,
+    temp_dir: str | None = None,
     hook_process_context: "HookProcessContext | None" = None,
     sandbox_backend: "SandboxBackend | None" = None,
     sandbox_config: "SandboxConfig | None" = None,
@@ -614,6 +615,8 @@ async def run_shell_hook(
             deny_subprocess=not allow_subprocess if allow_subprocess is not None else True,
             write_paths=list(write_paths) if write_paths is not None else [],
             timeout_seconds=timeout_seconds,
+            temp_dir=temp_dir or "",
+            temp_source="session",
         )
         # #3005: the agent-level ``reyn.yaml sandbox.policy`` never reaches this
         # policy — it is resolved on the op path only. That scoping is

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -2126,7 +2126,7 @@ class MCPClient:
             write_paths=[cwd, *extra],
             # #5184 part 1: MCP intentionally inherits the SDK environment;
             # part 2 will replace this bool with the three-value mode.
-            temp_dir_required=False,
+            temp_source="inherited",
             # #3901 PR-B ④ (owner ruling B): SandboxPolicy's own dataclass
             # defaults for read_deny_paths/write_deny_paths are now empty
             # (full compat) — but an MCP server is untrusted THIRD-PARTY code,

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -2124,6 +2124,9 @@ class MCPClient:
             # backend (expand_policy_path) — NOT here, so every backend applies
             # one shared contract instead of each caller pre-expanding (#2976).
             write_paths=[cwd, *extra],
+            # #5184 part 1: MCP intentionally inherits the SDK environment;
+            # part 2 will replace this bool with the three-value mode.
+            temp_dir_required=False,
             # #3901 PR-B ④ (owner ruling B): SandboxPolicy's own dataclass
             # defaults for read_deny_paths/write_deny_paths are now empty
             # (full compat) — but an MCP server is untrusted THIRD-PARTY code,

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -192,6 +192,12 @@ def build_router_op_context(
         default_sandbox_policy=resolve_sandbox_policy(
             sandbox_policy,
             write_paths=[str(workspace.base_dir)],
+            temp_dir=(
+                str(workspace.state_dir / "cache" / "tmp" / session_id)
+                if workspace.state_dir is not None and session_id is not None
+                else ""
+            ),
+            temp_dir_required=True,
         ),
         cancel_event=cancel_event,
         ephemeral=ephemeral,

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -89,6 +89,7 @@ def build_router_op_context(
     threat_scan: Any = None,  # FP-0050/#1822 S5 (EP4): exec command-scan config
     contextual_permission: Any = None,  # #1827 S3: per-session capability narrowing → OpContext
     session_id: str | None = None,
+    child_temp_dir: str = "",
     hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
     hook_bus: Any = None,  # Hook-Event Redesign Phase 5 part 2: the Session's HookBus → emit_hook_event
     turn_origin: str | None = None,  # proposal 0060 Phase 1 (A7): OS-derived turn provenance → install-op stamping (A9)
@@ -192,12 +193,8 @@ def build_router_op_context(
         default_sandbox_policy=resolve_sandbox_policy(
             sandbox_policy,
             write_paths=[str(workspace.base_dir)],
-            temp_dir=(
-                str(workspace.state_dir / "cache" / "tmp" / session_id)
-                if workspace.state_dir is not None and session_id is not None
-                else ""
-            ),
-            temp_dir_required=True,
+            temp_dir=child_temp_dir,
+            temp_source="session",
         ),
         cancel_event=cancel_event,
         ephemeral=ephemeral,
@@ -291,6 +288,7 @@ class RouterOpContextSource:
         threat_scan: Any,
         contextual_permission_fn: Any,
         session_id_fn: Any,
+        child_temp_dir: str,
         hook_dispatcher: Any,
         hook_bus: Any,
         turn_origin_fn: Any,
@@ -328,6 +326,7 @@ class RouterOpContextSource:
         self._threat_scan = threat_scan
         self._contextual_permission_fn = contextual_permission_fn
         self._session_id_fn = session_id_fn
+        self._child_temp_dir = child_temp_dir
         self._hook_dispatcher = hook_dispatcher
         self._hook_bus = hook_bus
         self._turn_origin_fn = turn_origin_fn
@@ -401,6 +400,7 @@ class RouterOpContextSource:
             threat_scan=self._threat_scan,
             contextual_permission=self._resolve(self._contextual_permission_fn),
             session_id=self._resolve(self._session_id_fn),
+            child_temp_dir=self._child_temp_dir,
             hook_dispatcher=self._hook_dispatcher,
             hook_bus=self._hook_bus,
             turn_origin=self._resolve(self._turn_origin_fn),

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import re
+import tempfile
 from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
@@ -1130,6 +1131,10 @@ class Session:
 
         # WAL + per-agent snapshot for crash recovery via SnapshotJournal; snapshot_path kept only for diagnostics (PR21 / PR-refactor-session-1, see session-construction.md#family-2-recovery-wal-journal)
         self._session_id = session_id
+        # #5184: session-owned child-process scratch lives outside the workspace
+        # so sandbox write grants never widen recovery-core permissions.
+        self._child_temp_dir = Path(tempfile.gettempdir()) / "reyn" / session_id
+        self._child_temp_dir.mkdir(parents=True, exist_ok=True)
         # #3705: pass the resolved state root through so an explicitly-
         # supplied workspace_state_dir isn't silently ignored (only used
         # when the caller didn't already override snapshot_path itself).
@@ -4672,6 +4677,7 @@ class Session:
             ),
             sandbox_config=self._sandbox_config,
             sandbox_backend=self._sandbox_backend,
+            hook_temp_dir=lambda: str(self._child_temp_dir),
             # #2095: route a not-yet-allowlisted shell-hook's consent prompt
             # through this session's RequestBus, but ONLY when a live
             # intervention listener is attached (TUI / web / A2A-override) —
@@ -5120,6 +5126,7 @@ class Session:
             # #1953: live — a spawned session's real id is assigned after this
             # constructor runs, and ops must namespace under the real one.
             session_id_fn=lambda: self._session_id,
+            child_temp_dir=str(self._child_temp_dir),
             hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c
             hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2
             # proposal 0060 Phase 1 (A7): live — ``_current_turn_origin`` carries
@@ -7166,6 +7173,13 @@ class Session:
                 # event delivery never arrived — closing here removes
                 # that failure mode from Session's own lifecycle).
                 await self._audit_events.stop_dispatch()
+                # #5184: the session owns this scratch lifetime. Teardown is
+                # best-effort so cleanup cannot block shutdown.
+                try:
+                    import shutil
+                    shutil.rmtree(self._child_temp_dir)
+                except Exception:  # noqa: BLE001
+                    logger.warning("session temp cleanup failed", exc_info=True)
 
     async def _drain_on_shutdown(self) -> None:
         """Cancel any in-flight background work, then tear down on shutdown.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1133,7 +1133,9 @@ class Session:
         self._session_id = session_id
         # #5184: session-owned child-process scratch lives outside the workspace
         # so sandbox write grants never widen recovery-core permissions.
-        self._child_temp_dir = Path(tempfile.gettempdir()) / "reyn" / session_id
+        self._child_temp_dir = (
+            Path(tempfile.gettempdir()) / "reyn" / self._agent.agent_name / session_id
+        )
         self._child_temp_dir.mkdir(parents=True, exist_ok=True)
         # #3705: pass the resolved state root through so an explicitly-
         # supplied workspace_state_dir isn't silently ignored (only used

--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -150,11 +150,26 @@ def resolve_passthrough_env(policy: "SandboxPolicy") -> dict[str, str]:
     deny = set(policy.env_deny_names)
     if policy.allow_env_names is not None:
         allow = set(policy.allow_env_names)
-        return {
+        env = {
             name: value for name, value in os.environ.items()
             if name in allow and name not in deny
         }
-    return {name: value for name, value in os.environ.items() if name not in deny}
+    else:
+        env = {name: value for name, value in os.environ.items() if name not in deny}
+    # #5184: a child-launching policy must carry a real writable directory;
+    # fail at the spawn boundary rather than allowing tempfile to fall back to cwd.
+    if policy.temp_dir_required:
+        if not policy.temp_dir:
+            raise ValueError("sandbox child launch requires a writable temp_dir")
+        temp_path = Path(policy.temp_dir)
+        if not temp_path.is_dir() or not os.access(temp_path, os.W_OK):
+            raise ValueError(
+                f"sandbox child launch temp_dir is not writable: {policy.temp_dir!r}"
+            )
+        env["TMPDIR"] = policy.temp_dir
+    elif policy.temp_dir:
+        env["TMPDIR"] = policy.temp_dir
+    return env
 
 
 # The network default lives in ONE place so the owner can flip it trivially
@@ -353,6 +368,15 @@ class SandboxPolicy:
     # `None` rather than a sentinel large int.
     background_max_timeout_seconds: "int | None" = DEFAULT_BACKGROUND_MAX_EXEC_TIMEOUT_SECONDS
     max_output_bytes: int = MAX_SUBPROCESS_OUTPUT_BYTES
+    # #5184: session-owned temporary directory for child-process artifacts.
+    # The owner resolves this path while constructing the policy; env builders
+    # only read the value and never derive session identity themselves.
+    temp_dir: str = ""
+    # #5184: callers that launch a child through ``run`` opt into the
+    # spawn-site invariant; command-level MCP wrapping intentionally does not.
+    # Temporary bool bridge for #5184 part 1. Part 2 replaces this with a
+    # discriminated mode (session-owned / no-spawn / intentional-inherit).
+    temp_dir_required: bool = True
 
 
 def deny_narrowed_write_grants(policy: SandboxPolicy) -> list[tuple[str, str]]:
@@ -704,6 +728,8 @@ def resolve_sandbox_policy(
     config_policy: dict | None,
     *,
     write_paths: list[str] | None = None,
+    temp_dir: str = "",
+    temp_dir_required: bool = True,
     mode: str = "compat",
 ) -> dict:
     """Resolve the effective agent-level sandbox policy as a dict.
@@ -742,9 +768,14 @@ def resolve_sandbox_policy(
     semantics make the "explicit-empty vs omitted" distinction the whole fix
     hinges on directly representable — no separate sentinel is needed.
     """
+    effective_write_paths = list(write_paths or [])
+    if temp_dir and temp_dir not in effective_write_paths:
+        effective_write_paths.append(temp_dir)
     floor: dict = {
         "network": DEFAULT_SANDBOX_NETWORK,
-        "write_paths": list(write_paths or []),
+        "write_paths": effective_write_paths,
+        "temp_dir": temp_dir,
+        "temp_dir_required": temp_dir_required,
     }
     explicit = _translate_sandbox_policy_config(config_policy)
     if mode == "strict":

--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -376,7 +376,7 @@ class SandboxPolicy:
     temp_dir: str = ""
     # #5184 part 1 bridge; part 2 will make this a required discriminated
     # source. Values: session, none, inherited.
-    temp_source: str = "session"
+    temp_source: str = "inherited"
 
 
 def deny_narrowed_write_grants(policy: SandboxPolicy) -> list[tuple[str, str]]:
@@ -729,7 +729,7 @@ def resolve_sandbox_policy(
     *,
     write_paths: list[str] | None = None,
     temp_dir: str = "",
-    temp_source: str = "session",
+    temp_source: str = "inherited",
     mode: str = "compat",
 ) -> dict:
     """Resolve the effective agent-level sandbox policy as a dict.

--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -158,17 +158,19 @@ def resolve_passthrough_env(policy: "SandboxPolicy") -> dict[str, str]:
         env = {name: value for name, value in os.environ.items() if name not in deny}
     # #5184: a child-launching policy must carry a real writable directory;
     # fail at the spawn boundary rather than allowing tempfile to fall back to cwd.
-    if policy.temp_dir_required:
+    if policy.temp_source == "session":
         if not policy.temp_dir:
-            raise ValueError("sandbox child launch requires a writable temp_dir")
+            raise ValueError("session temp source requires a writable temp_dir")
         temp_path = Path(policy.temp_dir)
         if not temp_path.is_dir() or not os.access(temp_path, os.W_OK):
             raise ValueError(
-                f"sandbox child launch temp_dir is not writable: {policy.temp_dir!r}"
+                f"session temp_dir is not writable: {policy.temp_dir!r}"
             )
         env["TMPDIR"] = policy.temp_dir
-    elif policy.temp_dir:
-        env["TMPDIR"] = policy.temp_dir
+    elif policy.temp_source == "none":
+        raise ValueError("sandbox child launch is forbidden for temp_source='none'")
+    elif policy.temp_source != "inherited":
+        raise ValueError(f"unknown sandbox temp_source: {policy.temp_source!r}")
     return env
 
 
@@ -372,11 +374,9 @@ class SandboxPolicy:
     # The owner resolves this path while constructing the policy; env builders
     # only read the value and never derive session identity themselves.
     temp_dir: str = ""
-    # #5184: callers that launch a child through ``run`` opt into the
-    # spawn-site invariant; command-level MCP wrapping intentionally does not.
-    # Temporary bool bridge for #5184 part 1. Part 2 replaces this with a
-    # discriminated mode (session-owned / no-spawn / intentional-inherit).
-    temp_dir_required: bool = True
+    # #5184 part 1 bridge; part 2 will make this a required discriminated
+    # source. Values: session, none, inherited.
+    temp_source: str = "session"
 
 
 def deny_narrowed_write_grants(policy: SandboxPolicy) -> list[tuple[str, str]]:
@@ -729,7 +729,7 @@ def resolve_sandbox_policy(
     *,
     write_paths: list[str] | None = None,
     temp_dir: str = "",
-    temp_dir_required: bool = True,
+    temp_source: str = "session",
     mode: str = "compat",
 ) -> dict:
     """Resolve the effective agent-level sandbox policy as a dict.
@@ -769,13 +769,11 @@ def resolve_sandbox_policy(
     hinges on directly representable — no separate sentinel is needed.
     """
     effective_write_paths = list(write_paths or [])
-    if temp_dir and temp_dir not in effective_write_paths:
-        effective_write_paths.append(temp_dir)
     floor: dict = {
         "network": DEFAULT_SANDBOX_NETWORK,
         "write_paths": effective_write_paths,
         "temp_dir": temp_dir,
-        "temp_dir_required": temp_dir_required,
+        "temp_source": temp_source,
     }
     explicit = _translate_sandbox_policy_config(config_policy)
     if mode == "strict":

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -6,6 +6,7 @@ mocks) used as the adapter's action ports when a test only needs construction.
 """
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 
 from reyn.core.events.events import EventLog
@@ -48,6 +49,7 @@ _INERT_OP_CONTEXT_SOURCE_FIELDS: dict = {
     "threat_scan": None,
     "contextual_permission_fn": None,
     "session_id_fn": None,
+    "child_temp_dir": "",
     "hook_dispatcher": None,
     "hook_bus": None,
     "turn_origin_fn": None,
@@ -64,10 +66,15 @@ def make_op_context_source(**overrides: object) -> RouterOpContextSource:
     """A REAL RouterOpContextSource with everything inert but *overrides*.
 
     The real class, not a stand-in: it is a plain object with no I/O, so a test
-    that needs one builds one."""
+    that needs one builds one. The test harness owns its temporary directory.
+    """
     unknown = set(overrides) - set(_INERT_OP_CONTEXT_SOURCE_FIELDS)
     assert not unknown, f"not RouterOpContextSource fields: {sorted(unknown)}"
-    return RouterOpContextSource(**{**_INERT_OP_CONTEXT_SOURCE_FIELDS, **overrides})
+    scratch = tempfile.TemporaryDirectory()
+    fields = {**_INERT_OP_CONTEXT_SOURCE_FIELDS, "child_temp_dir": scratch.name, **overrides}
+    source = RouterOpContextSource(**fields)
+    source._test_temp_dir = scratch
+    return source
 
 
 async def null_file_read(path: str) -> dict:

--- a/tests/hooks/test_1800_hook_shell_runner.py
+++ b/tests/hooks/test_1800_hook_shell_runner.py
@@ -48,8 +48,14 @@ def _noop_backend() -> NoopBackend:
     return NoopBackend()
 
 
-def _policy(timeout: int = 10) -> SandboxPolicy:
-    return SandboxPolicy(network=False, deny_subprocess=True, timeout_seconds=timeout)
+def _policy(timeout: int = 10, temp_dir: str = "") -> SandboxPolicy:
+    return SandboxPolicy(
+        network=False,
+        deny_subprocess=True,
+        timeout_seconds=timeout,
+        temp_dir=temp_dir,
+        temp_source="session",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +101,7 @@ async def test_output_ignored_returns_none(
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(),
+        sandbox_policy=_policy(temp_dir=str(tmp_path)),
         allowlist_path=allowlist,
     )
 
@@ -128,7 +134,7 @@ async def test_capture_stdout_returns_decoded_stdout(
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(),
+        sandbox_policy=_policy(temp_dir=str(tmp_path)),
         allowlist_path=allowlist,
         capture_stdout=True,
     )
@@ -157,7 +163,7 @@ async def test_capture_stdout_nonzero_exit_returns_none(
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(),
+        sandbox_policy=_policy(temp_dir=str(tmp_path)),
         allowlist_path=allowlist,
         capture_stdout=True,
     )
@@ -198,7 +204,7 @@ async def test_json_context_delivered_on_stdin(
         event_context={"event": "skill_end", "skill": "my-skill"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(),
+        sandbox_policy=_policy(temp_dir=str(tmp_path)),
         allowlist_path=allowlist,
     )
 
@@ -232,7 +238,7 @@ async def test_timeout_returns_none_no_crash(
         event_context={"event": "session_end"},
         timeout_seconds=1,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(timeout=1),
+        sandbox_policy=_policy(timeout=1, temp_dir=str(tmp_path)),
         allowlist_path=allowlist,
     )
 
@@ -269,7 +275,7 @@ async def test_nonapproved_command_nontty_refused(
         event_context={"event": "session_start"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(),
+        sandbox_policy=_policy(temp_dir=str(tmp_path)),
         allowlist_path=allowlist,
     )
 

--- a/tests/hooks/test_2095_shell_hook_consent_bus.py
+++ b/tests/hooks/test_2095_shell_hook_consent_bus.py
@@ -57,8 +57,14 @@ class _RecordingBus:
         return InterventionAnswer(choice_id=self._choice_id)
 
 
-def _policy() -> SandboxPolicy:
-    return SandboxPolicy(network=False, deny_subprocess=True, timeout_seconds=10)
+def _policy(temp_dir: str = "") -> SandboxPolicy:
+    return SandboxPolicy(
+        network=False,
+        deny_subprocess=True,
+        timeout_seconds=10,
+        temp_dir=temp_dir,
+        temp_source="session",
+    )
 
 
 def _marker_argv(marker: Path) -> list[str]:
@@ -72,7 +78,7 @@ async def _run(argv: list[str], allowlist: Path, **kw) -> None:
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=NoopBackend(),
-        sandbox_policy=_policy(),
+        sandbox_policy=_policy(temp_dir=str(allowlist.parent)),
         allowlist_path=allowlist,
         **kw,
     )

--- a/tests/hooks/test_5084_hook_process_context.py
+++ b/tests/hooks/test_5084_hook_process_context.py
@@ -167,6 +167,7 @@ async def test_relative_exec_argv_runs_inside_the_dispatching_agents_own_tree(tm
         stage_next_turn_context=lambda *a, **k: None,
         sandbox_backend=NoopBackend(),
         hook_cwd=lambda: str(agent_dir),
+        hook_temp_dir=lambda: str(tmp_path),
     )
     await dispatcher.dispatch("turn_end", {})
 

--- a/tests/hooks/test_5210_exec_capture_output_cap.py
+++ b/tests/hooks/test_5210_exec_capture_output_cap.py
@@ -44,8 +44,14 @@ def _noop_backend() -> NoopBackend:
     return NoopBackend()
 
 
-def _policy(timeout: int = 10) -> SandboxPolicy:
-    return SandboxPolicy(network=False, deny_subprocess=True, timeout_seconds=timeout)
+def _policy(timeout: int = 10, temp_dir: str = "") -> SandboxPolicy:
+    return SandboxPolicy(
+        network=False,
+        deny_subprocess=True,
+        timeout_seconds=timeout,
+        temp_dir=temp_dir,
+        temp_source="session",
+    )
 
 
 # ── Level 1 — run_shell_hook itself, real subprocesses ────────────────────
@@ -69,7 +75,7 @@ async def test_output_within_cap_is_returned_unchanged(
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(),
+        sandbox_policy=_policy(temp_dir=str(tmp_path)),
         allowlist_path=tmp_path / "allowlist.json",
         capture_stdout=True,
         output_token_cap=(1000, "openai/gpt-4o-mini"),
@@ -109,7 +115,7 @@ async def test_output_exceeding_the_cap_is_rejected_not_truncated(
             event_context={"event": "turn_end"},
             timeout_seconds=10,
             sandbox_backend=_noop_backend(),
-            sandbox_policy=_policy(),
+            sandbox_policy=_policy(temp_dir=str(tmp_path)),
             allowlist_path=tmp_path / "allowlist.json",
             capture_stdout=True,
             emit_event=_emit_event,
@@ -157,7 +163,7 @@ async def test_no_cap_supplied_is_unbounded_matching_pre_5210(
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(),
+        sandbox_policy=_policy(temp_dir=str(tmp_path)),
         allowlist_path=tmp_path / "allowlist.json",
         capture_stdout=True,
         # output_token_cap omitted -- the default
@@ -192,7 +198,7 @@ async def test_strip_the_cap_check_reproduces_the_original_defect(
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(),
+        sandbox_policy=_policy(temp_dir=str(tmp_path)),
         allowlist_path=tmp_path / "allowlist.json",
         capture_stdout=True,
     )
@@ -201,7 +207,7 @@ async def test_strip_the_cap_check_reproduces_the_original_defect(
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(),
+        sandbox_policy=_policy(temp_dir=str(tmp_path)),
         allowlist_path=tmp_path / "allowlist.json",
         capture_stdout=True,
         output_token_cap=(5, "openai/gpt-4o-mini"),

--- a/tests/security/test_sandbox_temp_dir_5184.py
+++ b/tests/security/test_sandbox_temp_dir_5184.py
@@ -1,0 +1,22 @@
+"""Tier 2: #5184 child-process temp source invariant."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.security.sandbox.policy import SandboxPolicy, resolve_passthrough_env
+
+
+def test_session_temp_source_requires_a_real_writable_directory(tmp_path: Path) -> None:
+    """Tier 2: session-owned child policy supplies TMPDIR from an existing directory."""
+    policy = SandboxPolicy(temp_dir=str(tmp_path), temp_source="session")
+    env = resolve_passthrough_env(policy)
+    assert env["TMPDIR"] == str(tmp_path)
+
+
+def test_session_temp_source_without_a_directory_is_rejected(tmp_path: Path) -> None:
+    """Tier 2: a spawning policy without writable temp fails before child launch."""
+    policy = SandboxPolicy(temp_dir=str(tmp_path / "missing"), temp_source="session")
+    with pytest.raises(ValueError, match="not writable"):
+        resolve_passthrough_env(policy)


### PR DESCRIPTION
**[coder-smith]** — Add a session-owned temporary source for sandbox child launches.

part of #5184

## What changed
- Add `temp_source` (`session` / `none` / `inherited`) to the sandbox policy bridge; session-owned children receive a writable temp directory outside the workspace, and session teardown removes it best-effort.
- Thread the session temp through router OpContext and hook dispatcher/shell execution. MCP stdio explicitly uses `inherited` because its SDK-owned environment is intentional.
- Remove the attempted `write_paths` widening; recovery-core security floors remain unchanged.
- Repair nine hook unit tests with explicit `tmp_path` scaffolding. The Tier 2 witnesses verify a real writable session temp and rejection before child launch when it is missing.

## Scope and limits
- The invariant is limited to execution paths that carry a `SandboxPolicy`: such paths must carry a writable temp source before spawning.
- Fifteen other spawn sites do not currently carry `SandboxPolicy`; their complete population is not yet established and remains outside this PR as a separate follow-up concern.
- No dedicated test is added for MCP `inherited`: it intentionally preserves the SDK's environment contract, and there is no Reyn-owned temp invariant to assert for that mode.
- Auto-merge is intentionally not armed; this PR touches tests and requires an independent TESTS-READ(B).


---

Resolved in commits `6473313ed` and `7bd87159a`: agent-scoped temp paths, inherited default with explicit session opt-in, and affected test harnesses.

**[lead-coder]** — blocking points (rule 7), from the A review (see the comment above):

- [x] 🔴 `/tmp/reyn/<sid>` collides across agents: `registry.py:117` `_DEFAULT_SID = "main"`, so every agent's default session lands in the same `/tmp/reyn/main`. Two agents then share one scratch dir, and whichever `Session.run()` tears down first `rmtree`s the other's live children's temp. Include the agent name: `/tmp/reyn/<agent_name>/<sid>`.
  → Fixed by namespacing the owner path as `/tmp/reyn/<agent_name>/<sid>` in commit `6473313ed`.
- [x] 🔴 `temp_source: str = "session"` makes every existing `SandboxPolicy` (14 in src, 161 in tests) claim a session-owned temp, so `resolve_passthrough_env` raises `ValueError` on the empty `temp_dir`. CI is red on the sandbox boundary tests (`Landlock/seccomp deny must fire`, `sandbox boundary is load-method independent`) — the scoped pytest run did not cover them. Either default to `"inherited"` (recommended — this PR's scope is "the invariant bites on one path", not "migrate every policy"), or make it a `Literal` with no default and migrate src's 14 sites here, leaving tests to the `policy_for_test` factory of the separate follow-up.
  → Fixed by defaulting to `"inherited"` and explicitly selecting `"session"` for router/session-owned paths in commit `6473313ed`; targeted suite now passes.

Non-blocking observation, for the body: `Session.__init__` calls `mkdir(parents=True, exist_ok=True)`, so merely constructing a `Session` mutates the filesystem, and the cleanup only runs in `run()`'s `finally` — a construct-only path leaves the directory behind.


