### PR TITLE
**[coder-brown]** — surface hook messages on live outbox

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -7029,10 +7029,16 @@ class Session:
         name = payload.get("name", "hook")
         text = payload.get("text", "")
         chain_id = payload.get("chain_id") or new_chain_id()
+        attributed = _format_ride_along_attribution(TurnOrigin.HOOK, name, text)
         self._append_history(ChatMessage(
             role="system",
-            content=_format_ride_along_attribution(TurnOrigin.HOOK, name, text),
+            content=attributed,
             ts=_now_iso(),
+            meta={"chain_id": chain_id},
+        ))
+        await self._put_outbox(OutboxMessage(
+            kind="system",
+            text=attributed,
             meta={"chain_id": chain_id},
         ))
         try:

--- a/tests/core/test_hook_loop_valve_1800_7.py
+++ b/tests/core/test_hook_loop_valve_1800_7.py
@@ -74,6 +74,24 @@ async def _push_user(session: Session, text: str) -> None:
     await session._put_inbox("user", {"text": text, "wake": True, "chain_id": "c"})
 
 
+@pytest.mark.asyncio
+async def test_hook_message_is_fanned_out_to_live_outbox(tmp_path):
+    """Tier 2: a hook ride-along is visible on the live outbox, not only history."""
+    session = _make_session(tmp_path, cap=2)
+    subscription = session.outbox_hub.subscribe()
+    async def _noop(*_args):
+        return None
+
+    session._run_router_loop = _noop  # type: ignore[method-assign]
+
+    await session._handle_hook_message({"name": "probe", "text": "injected", "wake": True})
+    message = await subscription.get()
+    assert message is not None
+    assert message.kind == "system"
+    assert "[hook:probe]" in message.text
+    subscription.close()
+
+
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
**[coder-brown]** — Make hook-originated ride-along messages visible on the live TUI outbox alongside their existing history entry.

part of #5240

- [x] `session_start`/hook-originated message is emitted as `OutboxMessage(kind="system")` with the same attribution.
- [x] Tier 2 witness observes `[hook:probe]` on a live `OutboxHub` subscription.
- [ ] `wake=false` ride-along semantics remain out of scope.
- [ ] cron/webhook routes remain out of scope.

Checks: ruff; `pytest tests/core/test_hook_loop_valve_1800_7.py -q` (5 passed); Tier audit (5 inspected, 0 errors); diff check. TESTS-READ B required before merge; auto-merge not enabled.