### PR TITLE
**[coder-brown]** — clarify hook injection test wording

### DIFF
--- a/tests/core/test_hook_loop_valve_1800_7.py
+++ b/tests/core/test_hook_loop_valve_1800_7.py
@@ -76,7 +76,7 @@ async def _push_user(session: Session, text: str) -> None:
 
 @pytest.mark.asyncio
 async def test_hook_message_is_fanned_out_to_live_outbox(tmp_path):
-    """Tier 2: a hook ride-along is visible on the live outbox, not only history."""
+    """Tier 2: a hook-injected message is visible on the live outbox, not only history."""
     session = _make_session(tmp_path, cap=2)
     subscription = session.outbox_hub.subscribe()
     async def _noop(*_args):


### PR DESCRIPTION
**[coder-brown]** — Clarify the E (wake=true) hook test wording so it does not reuse C (`wake=false`) ride-along terminology.

part of #5240

Checks: ruff; `pytest tests/core/test_hook_loop_valve_1800_7.py -q` (5 passed); Tier audit (5 inspected, 0 errors); diff check. TESTS-READ B required before merge. Auto-merge is not enabled.