### PR TITLE
chore(labels): owner 軸の同義ラベル2つを退役 — 5綴り→3語

### DIFF
--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -24,6 +24,17 @@ an owner-axis label, not because the containment claim itself was
 wrong). This paragraph is the label's only durable record; it existed
 only as broker chat before this.
 
+Two of those four names are **retired** (2026-08-24): `needs:owner-decision`
+folded into `owner:decide`, `wait_owner_iv` into `owner:verify-only`. The
+measurement above is unchanged — it was taken while all four existed, and the
+two retired names were exact synonyms of the two that remain, not a separate
+axis. What stays distinct is the axis itself: `owner:decide` (owner picks a
+direction) and `owner:verify-only` (owner reproduces on their own machine) ask
+for different acts, and `owner-hit` is a third thing again — the record that the
+operator hit it in the shipped configuration, not a request for anything. Five
+spellings for two acts is what produced the misreading this paragraph already
+records.
+
 **Before you open a PR, run `ruff check .`, `python
 scripts/test_tier_audit.py --strict <changed test files>`, `python
 scripts/verify_module_docstrings.py <changed src files>`, `python


### PR DESCRIPTION
**[lead-coder]** — 🔴 **「owner 待ち」を 表す ラベルが ★5 つ 在り、★2 つは 完全な 同義でした。★同義の 2 つを 畳みます。**

## 実測（coder-smith、open 64 件）

```
(A) ★意思決定 ── `owner:decide`(17) ＋ `needs:owner-decision`(2)
(B) ★実機確認 ── `owner:verify-only`(4) ＋ `wait_owner_iv`(3)
(C) ★遭遇の 事実 ── `owner-hit`(5) ── ★何かを 依頼して いません ∴ ★別のまま
```

⚠️ **(A) と (B) は 畳めません** — 「方向を 決めて ほしい」と「自分の 実機で 再現して ほしい」は **owner に 求める 行為が 違います**。

## なぜ 今 やるか ── ★害が 既に この doc に 書かれて いました

編集した 段落 自身の 逐語:

```
a first-pass reading of the gap between the four-label union and
`blocked:external` mistook 3 genuinely owner-pending issues for
third-party waits, because they were missing an owner-axis label
```

★軸が 5 つの 綴りに 割れて いる ことが、★3 件の 読み違いを 産んで います。

## この PR がやること

```
✅ ★doc ── 退役を ★書き足す（★測定の 記述は ★書き換えません）
   ── ★この 段落は 封じ込め測定の ★唯一の 耐久記録 で、★今の ラベルからは 再導出できません
   ── ∴ ★4 語の 時代の 測定として 残し、★退役を 後ろに 足す 形に しました
✅ ★issue 側は ★実施済み ── 5 件に 正典側の ラベルを 付与（#3987 #3208 #4401 #3175）
⚪ ★ラベルの 削除は ★この PR が 入って から ── ★doc が 先に 真に なる 順序に します
```

## Test plan

```
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml`
- [x] `python scripts/check_doc_anchors.py` → `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` → `0 hits`
- [x] (skipped — docs のみ。src/tests に 変更 無し)
```

⚪ `.ja.md` の 対応は 不要です（★この 段落を 鏡写して いる ja ファイルは 在りません）。
