### PR TITLE
fix(#5184): lazy session temp creation

### DIFF
--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -90,6 +90,7 @@ def build_router_op_context(
     contextual_permission: Any = None,  # #1827 S3: per-session capability narrowing → OpContext
     session_id: str | None = None,
     child_temp_dir: str = "",
+    child_temp_dir_fn: Any = None,
     hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
     hook_bus: Any = None,  # Hook-Event Redesign Phase 5 part 2: the Session's HookBus → emit_hook_event
     turn_origin: str | None = None,  # proposal 0060 Phase 1 (A7): OS-derived turn provenance → install-op stamping (A9)
@@ -193,7 +194,7 @@ def build_router_op_context(
         default_sandbox_policy=resolve_sandbox_policy(
             sandbox_policy,
             write_paths=[str(workspace.base_dir)],
-            temp_dir=child_temp_dir,
+            temp_dir=child_temp_dir_fn() if child_temp_dir_fn is not None else child_temp_dir,
             temp_source="session",
         ),
         cancel_event=cancel_event,
@@ -289,6 +290,7 @@ class RouterOpContextSource:
         contextual_permission_fn: Any,
         session_id_fn: Any,
         child_temp_dir: str,
+        child_temp_dir_fn: Any = None,
         hook_dispatcher: Any,
         hook_bus: Any,
         turn_origin_fn: Any,
@@ -327,6 +329,7 @@ class RouterOpContextSource:
         self._contextual_permission_fn = contextual_permission_fn
         self._session_id_fn = session_id_fn
         self._child_temp_dir = child_temp_dir
+        self._child_temp_dir_fn = child_temp_dir_fn
         self._hook_dispatcher = hook_dispatcher
         self._hook_bus = hook_bus
         self._turn_origin_fn = turn_origin_fn
@@ -401,6 +404,7 @@ class RouterOpContextSource:
             contextual_permission=self._resolve(self._contextual_permission_fn),
             session_id=self._resolve(self._session_id_fn),
             child_temp_dir=self._child_temp_dir,
+            child_temp_dir_fn=self._child_temp_dir_fn,
             hook_dispatcher=self._hook_dispatcher,
             hook_bus=self._hook_bus,
             turn_origin=self._resolve(self._turn_origin_fn),

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1132,11 +1132,12 @@ class Session:
         # WAL + per-agent snapshot for crash recovery via SnapshotJournal; snapshot_path kept only for diagnostics (PR21 / PR-refactor-session-1, see session-construction.md#family-2-recovery-wal-journal)
         self._session_id = session_id
         # #5184: session-owned child-process scratch lives outside the workspace
-        # so sandbox write grants never widen recovery-core permissions.
+        # so sandbox write grants never widen recovery-core permissions. The
+        # directory is created lazily by the first child launch; construction
+        # alone must not leave an artifact that only run() can clean up.
         self._child_temp_dir = (
             Path(tempfile.gettempdir()) / "reyn" / self._agent.agent_name / session_id
         )
-        self._child_temp_dir.mkdir(parents=True, exist_ok=True)
         # #3705: pass the resolved state root through so an explicitly-
         # supplied workspace_state_dir isn't silently ignored (only used
         # when the caller didn't already override snapshot_path itself).
@@ -4679,7 +4680,7 @@ class Session:
             ),
             sandbox_config=self._sandbox_config,
             sandbox_backend=self._sandbox_backend,
-            hook_temp_dir=lambda: str(self._child_temp_dir),
+            hook_temp_dir=lambda: self._ensure_child_temp_dir(),
             # #2095: route a not-yet-allowlisted shell-hook's consent prompt
             # through this session's RequestBus, but ONLY when a live
             # intervention listener is attached (TUI / web / A2A-override) —
@@ -5129,6 +5130,7 @@ class Session:
             # constructor runs, and ops must namespace under the real one.
             session_id_fn=lambda: self._session_id,
             child_temp_dir=str(self._child_temp_dir),
+            child_temp_dir_fn=self._ensure_child_temp_dir,
             hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c
             hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2
             # proposal 0060 Phase 1 (A7): live — ``_current_turn_origin`` carries
@@ -7188,6 +7190,11 @@ class Session:
                     shutil.rmtree(self._child_temp_dir)
                 except Exception:  # noqa: BLE001
                     logger.warning("session temp cleanup failed", exc_info=True)
+
+    def _ensure_child_temp_dir(self) -> str:
+        """Create the session-owned child scratch directory on first use."""
+        self._child_temp_dir.mkdir(parents=True, exist_ok=True)
+        return str(self._child_temp_dir)
 
     async def _drain_on_shutdown(self) -> None:
         """Cancel any in-flight background work, then tear down on shutdown.

--- a/tests/runtime/test_5184_session_temp_lifetime.py
+++ b/tests/runtime/test_5184_session_temp_lifetime.py
@@ -1,0 +1,27 @@
+"""Tier 2: #5184 session-owned child temp lifetime."""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from reyn.core.events.state_log import StateLog
+from tests._support.agent_session import make_session
+
+
+def test_constructing_a_session_does_not_create_child_temp_dir(tmp_path: Path) -> None:
+    """Tier 2: construction alone leaves no session child-temp artifact."""
+    session_id = "construct-only-5184"
+    temp_dir = Path(tempfile.gettempdir()) / "reyn" / "test-agent" / session_id
+    if temp_dir.exists():
+        import shutil
+
+        shutil.rmtree(temp_dir)
+
+    session = make_session(
+        agent_name="test-agent",
+        session_id=session_id,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "test-agent" / "state" / "snapshot.json",
+    )
+
+    assert not temp_dir.exists()

--- a/tests/runtime/test_5184_session_temp_lifetime.py
+++ b/tests/runtime/test_5184_session_temp_lifetime.py
@@ -25,3 +25,9 @@ def test_constructing_a_session_does_not_create_child_temp_dir(tmp_path: Path) -
     )
 
     assert not temp_dir.exists()
+    session.router_host.make_router_op_context()
+    assert temp_dir.is_dir()
+
+    import shutil
+
+    shutil.rmtree(temp_dir)


### PR DESCRIPTION
**[coder-smith]** — Lazily create session-owned child temp directories.

part of #5184

Construction alone no longer leaves a temp artifact; the first child-temp consumer creates it. Added a Tier 2 regression test and verified the old mkdir with strip-falsify (1 failed). No closing keyword; auto-merge not armed.

---

**[lead-coder]** — 🔴 **BLOCK 1 件（★家則 7 ∴ 本文に 置きます）。**

- [x] 🔴 **witness が ★不存在 方向 ★1 本 だけ ── ★存在する 方向を 足す こと。** `test_5184_session_temp_lifetime.py:27` の `assert not temp_dir.exists()` が 唯一の assert。**★`_ensure_child_temp_dir()` を 呼ぶ 経路を 通した 後の `assert temp_dir.exists()` が 要ります。** 無いと **★「作る 機能を まるごと 消した」でも 緑の まま** で、**「掃除された」と「最初から 壊れて いる」を 区別 しません**（六問④）。⚠️ ★#5228 が ★空の hook 一覧で 静かに 通った のと ★同じ 形 です。
- [x] 🔴 **②の strip を 実施し、★①②の 両方を 本文に 逐語で 書く こと。** ★`_ensure_child_temp_dir()` の 呼び出しを 消して ②が 赤に なる こと。
- ⚠️ **★実体が 安く 作れない 場合、`MagicMock` で 埋めない こと。** ★「起動 経路を 駆動する 口が 無い」なら ★★それ 自体が finding です ── ★報告して ください。



⚪ **[lead-coder]** — ★BLOCK 2 件 ★解消（[issuecomment-5396320700](https://github.com/tya5/reyn/pull/5249#issuecomment-5396320700) に TESTS-READ(B) と 六問）。★auto-merge を 武装します。
