### PR TITLE
**[coder-brown]** — honor false push_when before message validation

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -506,14 +506,17 @@ def _parse_exec_push(stdout: str | None) -> ResolvedPush | None:
 
     # Required-field + type checks (bool first — bool is an int subclass, so the
     # isinstance(..., bool) guard correctly rejects an integer 1/0).
+    if not isinstance(push_when, bool):
+        _log.warning("exec_capture directive 'push_when' must be a JSON bool — push skipped.")
+        return None
+    if not push_when:
+        _log.debug("exec_capture directive declined push_when=false; push skipped.")
+        return ResolvedPush(message="", wake=False, push_when=False, session=None)
     if not isinstance(message, str) or not message.strip():
         _log.warning("exec_capture directive 'message' must be a non-empty string — push skipped.")
         return None
     if not isinstance(wake, bool):
         _log.warning("exec_capture directive 'wake' must be a JSON bool — push skipped.")
-        return None
-    if not isinstance(push_when, bool):
-        _log.warning("exec_capture directive 'push_when' must be a JSON bool — push skipped.")
         return None
     if session is not None and not isinstance(session, str):
         _log.warning("exec_capture directive 'session' must be a string or null — push skipped.")

--- a/tests/core/test_hook_loop_valve_1800_7.py
+++ b/tests/core/test_hook_loop_valve_1800_7.py
@@ -76,7 +76,7 @@ async def _push_user(session: Session, text: str) -> None:
 
 @pytest.mark.asyncio
 async def test_hook_message_is_fanned_out_to_live_outbox(tmp_path):
-    """Tier 2: a hook ride-along is visible on the live outbox, not only history."""
+    """Tier 2: a hook-injected message is visible on the live outbox, not only history."""
     session = _make_session(tmp_path, cap=2)
     subscription = session.outbox_hub.subscribe()
     async def _noop(*_args):

--- a/tests/hooks/test_hook_shell_push_2069.py
+++ b/tests/hooks/test_hook_shell_push_2069.py
@@ -197,6 +197,21 @@ async def test_exec_capture_parse_failure_skips_push() -> None:
     assert seams["stage_next_turn_context"].calls == []
 
 
+def test_exec_capture_false_with_empty_message_is_observed_without_warning(caplog) -> None:
+    """Tier 2: push_when=false with an empty message is a valid declined push."""
+    caplog.set_level("WARNING")
+    rp = _parse_exec_push(json.dumps({"push_when": False, "wake": False, "message": ""}))
+    assert rp == ResolvedPush(message="", wake=False, push_when=False, session=None)
+    assert not caplog.records
+
+
+def test_exec_capture_true_with_empty_message_still_warns(caplog) -> None:
+    """Tier 2: push_when=true still requires a non-empty message."""
+    caplog.set_level("WARNING")
+    assert _parse_exec_push(json.dumps({"push_when": True, "wake": False, "message": ""})) is None
+    assert any("message" in record.message for record in caplog.records)
+
+
 @pytest.mark.asyncio
 async def test_exec_capture_push_when_false_skips_push() -> None:
     """Tier 2: a directive with push_when=false is the conditional-push guard —


### PR DESCRIPTION
**[coder-brown]** — Read `push_when` before validating `message` in exec_capture directives. A false conditional with an empty message now returns an observable declined `ResolvedPush` without WARNING; true with an empty message retains the existing WARNING/fail-safe behavior.

part of #5245

Checks: `.venv/bin/ruff check src/reyn/hooks/dispatcher.py tests/hooks/test_hook_shell_push_2069.py`; `.venv/bin/python -m pytest tests/hooks/test_hook_shell_push_2069.py -q` (23 passed); Tier audit (12 inspected, 0 errors).