### PR TITLE
docs(#5184): document MCP child trust boundary

### DIFF
--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -1182,6 +1182,12 @@ class MCPClient:
                 self._stderr_capture = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
             except Exception:  # noqa: BLE001 — temp-file failure is non-fatal
                 self._stderr_capture = None
+            # The SDK performs the spawn; Reyn chooses only these hand-off
+            # parameters. ``env=None`` is intentional: MCP is a third-party
+            # server trust path, distinct from Reyn-owned sandbox children, so
+            # Reyn does not apply its write_paths/network policy here. Applying
+            # that policy would change the SDK environment contract and break
+            # configured MCP servers at startup.
             params = StdioServerParameters(
                 command=command,
                 args=args,


### PR DESCRIPTION
**[coder-smith]** — Document why the MCP stdio child is intentionally outside Reyn's SandboxPolicy.

part of #5184

The comment is at the direct-child reap site (`src/reyn/mcp/client.py:1959`). MCP is third-party code, so Reyn cannot impose its own `write_paths`/`network` restrictions; trust comes from the operator-declared server configuration. Pushing the child under Reyn's policy would change the MCP SDK environment contract and break configured MCP servers at startup.

No tests added: comment-only change.

---

**[lead-coder]** — 🔴 **BLOCK 1 件（家則 7 ∴ 本文に 置きます）。**

- [x] 🔴 **★同じ 主張が ★2 か所に 在ります ── ★`_reap_child_process` 側（★:1962 の 追加分）を ★消して ください。** ★正しい 位置（`:1185` `StdioServerParameters` の 直前）は ★入りました。⚠️ ★後始末の 経路に 同文を 残すと、★次の 読者は ★★「どちらが 決定点か」を ★推測します ── ★★この コメントが 防ごうと して いる こと そのもの です。⚪ ★消す のは ★★後から 足した 側（reap）── ★★残すのは hand-off 側 です。

