### PR TITLE
**[coder-brown]** — gate open blocking PR checkboxes

### DIFF
--- a/.github/workflows/check-open-blocking-checkboxes.yml
+++ b/.github/workflows/check-open-blocking-checkboxes.yml
@@ -1,0 +1,42 @@
+name: Open blocking-checkbox check
+
+# #5135: house rule 7 puts a reviewer's blocking point in the PR body as
+# `- [ ] 🔴 <point>`, and rule 9 says arming auto-merge ends the reviewer's
+# reading of that PR — a box ticked afterwards is invisible to the merge.
+# Neither rule had any enforcement: on 2026-08-24 a PR went green with an
+# open `- [ ] 🔴` in its body and auto-merge armed; the only thing that
+# stopped it was a human noticing. This gate is that enforcement.
+#
+# A dedicated workflow (not folded into test.yml) for the same reason
+# check-pr-closing-intent.yml is one: the body is edited *after* opening —
+# a reviewer adds the box, the author ticks it — and `edited` is not one of
+# the default pull_request event types.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  open-blocking-checkbox:
+    name: no open blocking checkbox in the PR body
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      # scripts/check_open_blocking_checkboxes.py is stdlib-only.
+      - name: Check the PR body for an open blocking checkbox
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_open_blocking_checkboxes.py --pr "${{ github.event.pull_request.number }}"

--- a/scripts/check_open_blocking_checkboxes.py
+++ b/scripts/check_open_blocking_checkboxes.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fail when a PR body contains an open red blocking checkbox (#5135)."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_OPEN_BLOCK = "- [ ] 🔴"
+
+
+def evaluate_body(body: object) -> tuple[int, str]:
+    """Return a failure for missing/non-string PR bodies or open blockers."""
+    if not isinstance(body, str):
+        return 2, "PR body could not be fetched"
+    if _OPEN_BLOCK in body:
+        return 1, "PR body contains an open blocking checkbox (- [ ] 🔴)"
+    return 0, "PR body has no open blocking checkbox"
+
+
+def fetch_body(pr: int) -> str:
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr), "--json", "body"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+    body = data.get("body")
+    if not isinstance(body, str):
+        raise ValueError("PR body is missing or not a string")
+    return body
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pr", type=int)
+    group.add_argument("--fixture", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        body = fetch_body(args.pr) if args.pr is not None else json.loads(
+            args.fixture.read_text(encoding="utf-8")
+        ).get("body")
+        code, message = evaluate_body(body)
+    except (OSError, ValueError, json.JSONDecodeError, subprocess.CalledProcessError) as exc:
+        print(f"PR body fetch failed: {exc}", file=sys.stderr)
+        return 2
+    print(message)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_open_blocking_checkboxes.py
+++ b/scripts/check_open_blocking_checkboxes.py
@@ -4,19 +4,21 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
-_OPEN_BLOCK = "- [ ] 🔴"
+_OPEN_BLOCK = re.compile(r"^\s*[-*+]\s*\[\s*\]\s*(?:\*\*\s*)*🔴", re.MULTILINE)
 
 
 def evaluate_body(body: object) -> tuple[int, str]:
     """Return a failure for missing/non-string PR bodies or open blockers."""
     if not isinstance(body, str):
         return 2, "PR body could not be fetched"
-    if _OPEN_BLOCK in body:
-        return 1, "PR body contains an open blocking checkbox (- [ ] 🔴)"
+    if _OPEN_BLOCK.search(body):
+        return 1, "PR body contains an open blocking checkbox"
     return 0, "PR body has no open blocking checkbox"
 
 
@@ -34,22 +36,29 @@ def fetch_body(pr: int) -> str:
     return body
 
 
+def run_gate(body_supplier: Callable[[], object]) -> int:
+    """Evaluate a supplied PR body, keeping retrieval as an explicit seam."""
+    try:
+        body = body_supplier()
+    except Exception as exc:  # noqa: BLE001 - the gate must fail closed
+        print(f"PR body fetch failed: {exc}", file=sys.stderr)
+        return 2
+    code, message = evaluate_body(body)
+    print(message)
+    return code
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--pr", type=int)
     group.add_argument("--fixture", type=Path)
     args = parser.parse_args(argv)
-    try:
-        body = fetch_body(args.pr) if args.pr is not None else json.loads(
-            args.fixture.read_text(encoding="utf-8")
-        ).get("body")
-        code, message = evaluate_body(body)
-    except (OSError, ValueError, json.JSONDecodeError, subprocess.CalledProcessError) as exc:
-        print(f"PR body fetch failed: {exc}", file=sys.stderr)
-        return 2
-    print(message)
-    return code
+    if args.pr is not None:
+        return run_gate(lambda: fetch_body(args.pr))
+    return run_gate(
+        lambda: json.loads(args.fixture.read_text(encoding="utf-8")).get("body")
+    )
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_check_open_blocking_checkboxes.py
+++ b/tests/scripts/test_check_open_blocking_checkboxes.py
@@ -1,0 +1,43 @@
+"""Tier 1: PR bodies must reject open red blocking checkboxes."""
+from __future__ import annotations
+
+import json
+import subprocess
+
+from scripts.check_open_blocking_checkboxes import evaluate_body, main
+
+
+def test_open_blocking_checkbox_fails() -> None:
+    """Tier 1: an open red blocking checkbox fails the gate."""
+    code, _ = evaluate_body("- [ ] 🔴 unresolved")
+    assert code != 0
+
+
+def test_checked_blocking_checkbox_passes() -> None:
+    """Tier 1: a checked red blocking checkbox passes the gate."""
+    code, _ = evaluate_body("- [x] 🔴 resolved")
+    assert code == 0
+
+
+def test_missing_body_fails_closed() -> None:
+    """Tier 1: a missing PR body fails closed rather than passing vacuously."""
+    code, _ = evaluate_body(None)
+    assert code != 0
+
+
+def test_live_fetch_failure_fails_closed(monkeypatch) -> None:
+    """Tier 1: a failed body fetch returns nonzero."""
+    def fail(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0], stderr="network down")
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    assert main(["--pr", "123"]) != 0
+
+
+def test_fixture_cli_supports_both_states(tmp_path) -> None:
+    """Tier 1: the CLI reports both open and checked fixture bodies."""
+    fixture = tmp_path / "pr.json"
+    fixture.write_text(json.dumps({"body": "- [x] 🔴 done"}), encoding="utf-8")
+    assert main(["--fixture", str(fixture)]) == 0
+    fixture.write_text(json.dumps({"body": "- [ ] 🔴 todo"}), encoding="utf-8")
+    assert main(["--fixture", str(fixture)]) != 0

--- a/tests/scripts/test_check_open_blocking_checkboxes.py
+++ b/tests/scripts/test_check_open_blocking_checkboxes.py
@@ -2,15 +2,20 @@
 from __future__ import annotations
 
 import json
-import subprocess
 
-from scripts.check_open_blocking_checkboxes import evaluate_body, main
+from scripts.check_open_blocking_checkboxes import evaluate_body, main, run_gate
 
 
-def test_open_blocking_checkbox_fails() -> None:
-    """Tier 1: an open red blocking checkbox fails the gate."""
-    code, _ = evaluate_body("- [ ] 🔴 unresolved")
-    assert code != 0
+def test_open_blocking_checkbox_variants_fail() -> None:
+    """Tier 1: supported list markers and formatting fail closed."""
+    for body in (
+        "- [ ] 🔴 unresolved",
+        "  - [ ] 🔴 nested",
+        "* [ ]🔴 compact",
+        "+ [ ] **🔴** decorated",
+    ):
+        code, _ = evaluate_body(body)
+        assert code != 0
 
 
 def test_checked_blocking_checkbox_passes() -> None:
@@ -25,13 +30,12 @@ def test_missing_body_fails_closed() -> None:
     assert code != 0
 
 
-def test_live_fetch_failure_fails_closed(monkeypatch) -> None:
-    """Tier 1: a failed body fetch returns nonzero."""
-    def fail(*args, **kwargs):
-        raise subprocess.CalledProcessError(1, args[0], stderr="network down")
+def test_body_supplier_failure_fails_closed() -> None:
+    """Tier 1: a failed body supplier returns nonzero without patching."""
+    def fail():
+        raise OSError("network down")
 
-    monkeypatch.setattr(subprocess, "run", fail)
-    assert main(["--pr", "123"]) != 0
+    assert run_gate(fail) != 0
 
 
 def test_fixture_cli_supports_both_states(tmp_path) -> None:


### PR DESCRIPTION
**[coder-brown]** — Add a fail-closed script gate for open `- [x] 🔴` checkboxes in PR bodies. Checked boxes pass; missing or failed body fetches return nonzero. Includes fixture-based Tier 1 witnesses for both states and fetch failure.

part of #5135

Checks: `.venv/bin/ruff check scripts/check_open_blocking_checkboxes.py tests/scripts/test_check_open_blocking_checkboxes.py`; `.venv/bin/python -m pytest tests/scripts/test_check_open_blocking_checkboxes.py -q` (5 passed); Tier audit (5 inspected, 0 errors).

---

**[lead-coder]** — 🔴 **BLOCK 2 件（家則 7 ∴ 本文に 置きます）。★fail-closed の 設計は ★正しい です。**

- [x] 🔴 **★見つける 形が ★狭すぎます ── ★★この gate が 一番 やっては いけない 失敗 です。** 現状は 逐語 `- [x] 🔴` の ★完全一致 のみ。⚠️ ★以下は ★★全部 素通りします ── `  - [x] 🔴`(★字下げ ── ★入れ子の 箇条書きで 普通に 出ます) ／ `* [ ] 🔴` ／ `- [ ]🔴`(★空白 無し) ／ `- [ ] **🔴**`。🔴 ★正規表現に して ください ── ★行頭 空白 任意 ／ `-` `*` `+` ／ `[ ]` 前後の 空白 ／ 🔴 の 前の 装飾。✅ ★test も ★その 変種 ごとに 1 本ずつ。⚪ **★「今 私が 書いて いる 形」に 合わせるのでは なく ★★家則 7 が 許す 形 全部 に 合わせて ください。**

- [x] 🔴 **★`monkeypatch.setattr(subprocess, "run", fail)` ── ★家則 違反です。** 逐語「Never fake a collaborator ... no `MagicMock`/`AsyncMock`/`patch`」。🔴 ★直し方は ★mock を 別の 何かに 替える ことでは なく ★★seam を 作る こと ── ★`fetch_body` / `main` に ★body の 取得口(callable)を ★引数で 渡せる ように する。✅ ★そうすれば ★★失敗する 取得口を ★普通に 渡す だけ で ★偽装が 要りません。⚪ ★家則の 逐語 ──「if neither exists, ★that absence is the finding」── ★★今回は ★seam の 不在が finding です。

⚠️ **★私の 側の 未了（★開示）** — ★この script は ★★まだ どこからも 呼ばれて いません。★workflow への 配線は ★私が やります（★あなたの push 権限では 落ちる ため）。⚠️ **★配線が 済むまで ★この gate は ★1 度も 走りません** ── ★★#5138 と 同じ 形（★gate は 在るが 結果が PR に 載らない）に ★しない ため、★★ここに 書いて 残します。

---

**[lead-coder]** — 🔴 **BLOCK 追加（★3 件目）── ★★この PR は 今 ★merge 済の 仕事を ★2 本 巻き戻します。**

- [x] 🔴 **★base が 古い ── ★`origin/main` から ★gate の 2 file だけ で 積み直して ください。** ★二点差分 `git diff origin/main origin/issue-5135 --stat` の 逐語:

```
 scripts/check_open_blocking_checkboxes.py          | 65 ++++++++++
 src/reyn/mcp/client.py                             |  6 --
 src/reyn/runtime/router_op_context.py              |  6 +-
 src/reyn/runtime/session.py                        | 13 +----
 tests/runtime/test_5184_session_temp_lifetime.py   | 33 -------
 tests/scripts/test_check_open_blocking_checkboxes.py | 47 +++++++
```

🔴 ★`src/` 3 file の 変更と ★test 1 file の ★★削除 は ★この PR の 仕事では ありません ── ★#5249(lazy temp)と #5252(MCP trust コメント)が ★main に 入った 後の 姿を ★巻き戻して います。⚪ **★gate の 2 file ★以外の 差分が ★0 に なる のが 条件です。**

⚪ **★coder-brown が ★自分の A-read で ★これを 見つけました** ── ★★二点差分の 規律を 渡した 直後 です。⚪ **★私が merge 前に 気付いた のでは なく、★受け手が 止めました。**
---

**[lead-coder]** — ✅ **BLOCK 3 件 ★全て 解消。★①は ★私が やりました（★coder-brown が 止まって いた ため）。**

```
✅ ① base ── ★`origin/main` に ★gate の 2 commit を cherry-pick
   ── ★二点差分 `git diff origin/main origin/issue-5135 --stat` ── ★★3 file・★★削除 0
✅ ② 検出の 形 ── coder-brown が 正規表現に
   `^\s*[-*+]\s*\[\s*\]\s*(?:\*\*\s*)*🔴`  (MULTILINE)
   ── ★実機 probe ── `  - [ ] 🔴 indented` → ★★exit 1（★字下げを 捕まえます）
✅ ③ seam ── `run_gate(body_supplier)` ── ★`monkeypatch` は ★消えました
✅ 配線 ── `.github/workflows/check-open-blocking-checkboxes.yml` を ★私が 追加
   ── ★`types: [opened, edited, synchronize, reopened]` ── ★`edited` が 要ります
```

⚠️ **★この PR 自身が ★gate の 最初の 被験者 です** — 上の 3 つが `- [ ] 🔴` の まま なら ★★この gate は 自分の PR を 落とします。⚪ **★今 閉じた ので 通ります。**

## ⚪ 実行した もの

```
✅ `ruff check` ── `All checks passed!`
✅ `pytest tests/scripts/test_check_open_blocking_checkboxes.py` ── `5 passed`
✅ `python scripts/test_tier_audit.py --strict <上記>` ── `Exit code: 0`
✅ ★字下げ variant の 実機 probe ── `exit=1`
```
