### PR TITLE
fix(#5100): preserve malformed hooks YAML status

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -1010,9 +1010,13 @@ def read_and_expand_hooks_yaml(
     to) — while an arbitrary non-reyn ``${FOO}`` is left untouched, for
     whatever downstream (a spawned child process) resolves it later.
 
-    Returns ``None`` when the file is absent, malformed, or refused;
-    otherwise the parsed+expanded dict — the caller reads whichever key
-    (``hooks``/``composers``) it owns out of it."""
+    Returns ``None`` when the file is absent or refused; otherwise the
+    parsed+expanded dict — the caller reads whichever key
+    (``hooks``/``composers``) it owns out of it. A file that EXISTS but
+    does not parse raises :class:`HookYamlReadError` instead of joining
+    the ``None`` cases (#5100): collapsing it there made "this layer
+    declares no hooks" and "this layer could not be read" the same value,
+    so no caller could tell them apart or report the difference."""
     raw = _load_hooks_yaml(path)
     if not raw:
         return None

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -46,6 +46,10 @@ from reyn.config.observability import (
 from reyn.config.root import ReynConfig  # #1682 #3 cross-section
 
 
+class HookYamlReadError(ValueError):
+    """A hooks.yaml file exists but could not be read as a mapping."""
+
+
 def _load_yaml(path: Path) -> dict:
     if not path.exists():
         return {}
@@ -957,6 +961,21 @@ def load_hot_reload_config(project_root: "Path | None" = None) -> dict:
     return expand_env(merged)
 
 
+def _load_hooks_yaml(path: Path) -> dict:
+    """Read a hooks layer while preserving parse failure for its caller."""
+    if not path.exists():
+        return {}
+    try:
+        import yaml
+        with path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception as exc:
+        import logging
+        logging.getLogger(__name__).warning("failed to parse %s: %s", path, exc)
+        raise HookYamlReadError(str(exc)) from exc
+    return data if isinstance(data, dict) else {}
+
+
 def read_and_expand_hooks_yaml(
     path: Path, *, agent_name: str, project_root: Path,
 ) -> "dict | None":
@@ -994,7 +1013,7 @@ def read_and_expand_hooks_yaml(
     Returns ``None`` when the file is absent, malformed, or refused;
     otherwise the parsed+expanded dict — the caller reads whichever key
     (``hooks``/``composers``) it owns out of it."""
-    raw = _load_yaml(path)
+    raw = _load_hooks_yaml(path)
     if not raw:
         return None
     from reyn.plugins.tokens import expand_with_map, find_unresolved_reyn_tokens

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5883,10 +5883,14 @@ class Session:
         the file is absent, malformed, refused (an unresolved reyn token),
         or *key* itself is absent — a no-op layer, never a special case a
         caller has to handle."""
-        from reyn.config.loader import read_and_expand_hooks_yaml
-        data = read_and_expand_hooks_yaml(
-            path, agent_name=self.agent_name, project_root=self._hot_reload_project_root(),
-        )
+        from reyn.config.loader import HookYamlReadError, read_and_expand_hooks_yaml
+        try:
+            data = read_and_expand_hooks_yaml(
+                path, agent_name=self.agent_name, project_root=self._hot_reload_project_root(),
+            )
+        except HookYamlReadError as exc:
+            logger.warning("hooks layer %s could not be read: %s", path, exc)
+            return []
         values = (data or {}).get(key)
         return list(values) if isinstance(values, list) else []
 

--- a/tests/runtime/test_5100_hooks_yaml_read_status.py
+++ b/tests/runtime/test_5100_hooks_yaml_read_status.py
@@ -1,0 +1,23 @@
+"""Tier 2: #5100 preserves malformed-vs-absent hooks YAML status."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.config.loader import HookYamlReadError, read_and_expand_hooks_yaml
+
+
+def test_malformed_hooks_yaml_is_distinguishable_from_absent_hooks_yaml(tmp_path: Path) -> None:
+    """Tier 2: malformed existing YAML raises a typed read error, while an absent file returns None."""
+    malformed = tmp_path / "malformed.yaml"
+    malformed.write_text("hooks: [turn_end\n", encoding="utf-8")
+
+    try:
+        read_and_expand_hooks_yaml(malformed, agent_name="alice", project_root=tmp_path)
+    except HookYamlReadError:
+        pass
+    else:
+        raise AssertionError("malformed hooks YAML must preserve a read failure")
+
+    assert read_and_expand_hooks_yaml(
+        tmp_path / "absent.yaml", agent_name="alice", project_root=tmp_path,
+    ) is None


### PR DESCRIPTION
**[coder-smith]** — Preserve malformed hooks YAML as a typed read failure instead of collapsing it to an empty layer.

part of #5100

Malformed existing hooks YAML now raises `HookYamlReadError`; absent files still return `None`. Session layer readers catch the typed error and retain the existing no-op layer behavior while callers can distinguish the read failure. Added a real temporary-file Tier 2 witness for malformed vs absent, and strip-falsified the typed raise (`1 failed`).

No closing keyword; auto-merge not armed.

---

**[lead-coder]** — 🔴 **BLOCK 2 件（家則 7 ∴ 本文に 置きます）。★seam の 設計 自体は ★正しい です。**

- [x] 🔴 **★この PR が ★★自分の docstring を ★偽に して います。** `src/reyn/config/loader.py` の `read_and_expand_hooks_yaml` 逐語 ── **`Returns ``None`` when the file is absent, malformed, or refused`**。🔴 ★malformed は ★★もう `None` を 返しません ── ★raise します。⚪ 家則 ──「★機構を 記述した doc は ★その 機構が 変わった 瞬間に 陳腐化する ── ★★同じ PR で 直す」。✅ ★近くの 語を ★1 行 だけ 見るのでは なく ★★節 全体を 読み直して ください。

- [x] 🔴 **★本文に ★★「operator が 見る ものは 変わって いない」と 書いて ください。** `session.py:5891-5893` は typed error を 捕まえて ★`return []` ── ∴ ★★Session の 外から 見ると ★「読めなかった」も「書いて いない」も ★同じ `[]` の ままです。⚠️ ★今の 本文「callers can distinguish the read failure」は ★★loader の 面 では 真ですが、★operator の 面 では ★何も 変わりません。⚪ **★それで 良い です** ── ★★但し ★#5100 を「直った」と 読ませない ため、★残る 半分を ★明示して ください。

⚪ **★観察（block では ありません）** — ★`_load_hooks_yaml` は ★`_load_yaml` の ★ほぼ 複製 で、★`_load_yaml` は ★今も 握り潰します。⚪ ★hooks 経路だけに 絞った 判断は ★妥当（★全 config tier に 波及させない）── ⚠️ ★但し ★片方 だけ 直す 修理が ★もう 1 つ 増えました。

⚪ **★良かった 点** — ★base が 綺麗（`git diff origin/main HEAD --stat` が ★3 file・★削除 0）／★実 tmp file の witness・★mock 無し／★strip で `1 failed` を 実測。
---

**[lead-coder]** — ✅ **BLOCK 2 件 ★解消。★私が やりました（★coder-smith は ★gpt の quota 切れ で 停止中 ── #5256）。**

## 🔴 ★この PR が ★何を して いないか（★要件②の 開示）

```
🔴 ★operator が 見る ものは ★★この PR の 前後で ★変わって いません
   ── `session.py:5891-5893` ── typed error を 捕まえ ★`return []`
   ── ∴ ★Session の 外から 見ると ★「読めなかった」も「書いて いない」も ★同じ `[]`
✅ ★出来た のは ★seam ── ★loader の 面で ★分岐 できる ように なりました
⚠️ ★∴ ★#5100 は ★★閉じません ── ★出し分けの 半分が 残ります
```

## ✅ ①docstring ── ★この PR 自身が 偽に して いた もの

```
❌ 旧 ── `Returns ``None`` when the file is absent, malformed, or refused;`
✅ 新 ── absent / refused → `None`、★malformed → ★`HookYamlReadError` を raise
   ── ⚪ ★「なぜ そう したか」も 1 文 ── ★同じ 値に 潰すと ★呼び手が 区別 できない
🔴 ★語 1 つの 置換では なく ★節 全体を 読み直しました
   ── ⚪ ★直近に「a caller can tell 'genuinely absent' from 'refused'」という
      ★★同じ 趣旨の 記述が 既に 在り、★整合させて います
```

## ⚪ 実行した もの（★head `90b02c81a`）

```
✅ `ruff check src/reyn/config/loader.py` ── `All checks passed!`
✅ `pytest tests/runtime/test_5100_hooks_yaml_read_status.py` ── `1 passed`
✅ `python scripts/verify_module_docstrings.py src/reyn/config/loader.py` ── `OK`
```
