### PR TITLE
test(mcp): SDK 自身の tool-error 文面を assert していたため全 PR の CI が赤

### DIFF
--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -341,8 +341,11 @@ def test_call_tool_propagates_tool_error_not_transport_crash() -> None:
     # which turned every PR's CI red on an in-range bump (`mcp>=2.0,<3.0`).
     # What reyn owns here is the shape -- a tool error arrives as a RESULT
     # with isError set, never as a raised MCPError -- so that is what is
-    # asserted. Asserting the string again re-pins a third party's wording.
-    assert isinstance(result["content"][0]["text"], str)
+    # asserted, together with the failure having reached the model at all.
+    # Reading INTO content (its shape, its wording) re-pins the same third
+    # party a different way -- mcp 3.x renaming "text" would go red for the
+    # same non-reason.
+    assert result["content"]
 
 
 def test_call_tool_propagates_transport_errors_as_mcp_error() -> None:

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -335,7 +335,14 @@ def test_call_tool_propagates_tool_error_not_transport_crash() -> None:
 
     result = asyncio.run(_run_it())
     assert result["isError"] is True
-    assert "simulated tool failure" in result["content"][0]["text"]
+    # The text inside ``content`` is the SDK's own rendering of a server-side
+    # tool exception, not reyn's: mcp 2.x changed it from the raised message
+    # ("simulated tool failure") to a generic "Error executing tool <name>",
+    # which turned every PR's CI red on an in-range bump (`mcp>=2.0,<3.0`).
+    # What reyn owns here is the shape -- a tool error arrives as a RESULT
+    # with isError set, never as a raised MCPError -- so that is what is
+    # asserted. Asserting the string again re-pins a third party's wording.
+    assert isinstance(result["content"][0]["text"], str)
 
 
 def test_call_tool_propagates_transport_errors_as_mcp_error() -> None:


### PR DESCRIPTION
**[lead-coder]** — 🔴 **★全 PR の CI が 赤に なって います。★原因は ★第三者の 文字列を ★assert して いた こと です。**

## 実測

```
🔴 `tests/mcp/test_mcp_client.py:338`
   逐語 `assert "simulated tool failure" in result["content"][0]["text"]`
🔴 CI（3.11 / 3.12 とも）
   逐語 `AssertionError: assert 'simulated tool failure' in 'Error executing tool boom'`
⚪ ★手元では 通ります ── ★私の venv は `mcp 2.0.0`
   ── ★`pyproject.toml:236` は `mcp>=2.0,<3.0` ── ★★範囲内の bump で CI 側が 新しく なりました
```

## 🔴 これは ★六問①の 形 です

```
🔴 「★第三者の property」── ★★`content[0]["text"]` の 中身は ★SDK が 決める もの です
   ── ★reyn が 変わって いない のに ★★SDK が 語を 変えた だけ で 落ちます
   ── ⚠️ ★★落ちても ★reyn の 誰も 困って いません ── ★★誰の bug でも ありません
✅ ★reyn が 持って いる 契約は ★★形 の 方 です
   ── ★「tool の 失敗が ★★result(isError) で 来る ── ★★raise では 来ない」
   ── ★docstring 自身が そう 言って います
      逐語「not an MCPError — matching the pre-swap contract
            (``call_tool_mcp`` never raises on ``isError``)」
```

## ✅ この PR

```
✅ ★文字列の assert を ★外し、★★理由を その場に 残しました
   ── ★「変えるな」でなく ★「★なぜ ここに 書かないか」
✅ ★`isError is True` は ★そのまま ── ★★契約の 本体 です
⚠️ ★弱く なる 点 ── ★★「どの tool が 落ちたか」は ★もう 見て いません
   ── ⚪ ★★それを 見る なら ★reyn 側の 値で 見る べきで、★SDK の 文面 では ありません
```

## ⚠️ 残る 問い（★この PR では 閉じません）

```
⚠️ ★同種の assert が ★他に あるか ── ★★未測定
   ── ★私は ★この 1 件を ★CI の 赤から 辿った だけ です
⚠️ ★`mcp>=2.0,<3.0` を ★狭めるか ── ★★別 の 判断
   ── ⚪ ★憲章「第三者の 責務を 奪うな」に 照らすと ★★狭める 方向は 慎重に
```

## Test plan

```
- [x] `pytest tests/mcp/test_mcp_client.py` → `16 passed`
- [x] `ruff check tests/mcp/test_mcp_client.py` → `All checks passed!`
- [x] `python scripts/test_tier_audit.py --strict tests/mcp/test_mcp_client.py` → `Exit code: 0`
- [x] (skipped — Visual 項目 無し)
```
