### PR TITLE
feat(chat): streamed-reply の repaint 予算に config の口を足す（既定は不変）

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -750,6 +750,7 @@ chat:
   image_url_schemes: []   # opt-in scheme allowlist for present's image src fetch
   empty_stop_retry: false # opt-in resend on an empty router response
   theme: null              # override the TUI's Textual theme name (default: reyn's own)
+  stream_repaint_min_interval: 0.0333  # seconds between repaints of a streamed reply
 ```
 
 ### `chat.render_mode`
@@ -896,6 +897,34 @@ carries its own copy of Textual's theme registry to keep in sync.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `theme` | str \| null | `null` | Textual theme name for the interactive TUI. `null` keeps reyn's own default (`"reyn"`). |
+
+### `chat.stream_repaint_min_interval`
+
+The minimum wall-clock gap, in **seconds**, between two repaints of the
+same streamed reply in the TTY conversation pane (#3570's repaint budget,
+made reachable). Deltas arrive at the provider's rate — measured up to
+~1000/s through a proxy that packs many SSE events into one read — and
+each repaint costs a present plus a strip render of the whole accumulated
+body, so painting every delta spends the loop redrawing frames no eye
+separates.
+
+The default is the knee measured on one terminal (2000 deltas, 60 KB
+reply): `set_item` 1979 → 75, wall-clock 16.1 s → 3.3 s. That measurement
+is the reason this knob ships with the value it does — and the reason the
+knob exists: a slower terminal (SSH, a multiplexer, a remote desktop) has
+a different knee, and before this field the only way to reach it was to
+edit source.
+
+Raising it trades update smoothness for loop time. It can never lose
+text: the reply's accumulation is unconditional, and a catch-up timer
+bounds every deferral to one interval. A non-positive value falls back to
+the default instead of disabling the budget — `0` means "repaint on every
+delta", the pre-#3570 behaviour the measurement above exists to keep
+operators out of.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `stream_repaint_min_interval` | float | `0.0333` (1/30) | Seconds between two repaints of the same streamed reply. Non-positive falls back to the default. |
 
 ### `chat.reasoning` fields
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -915,6 +915,8 @@ knob exists: a slower terminal (SSH, a multiplexer, a remote desktop) has
 a different knee, and before this field the only way to reach it was to
 edit source.
 
+Seconds, not the milliseconds its `events:` sibling (`agent_delta_coalesce_interval_ms`) uses: the measured value is `1/30`, and a whole-millisecond field would round it — moving the shipped default as a side effect of picking a unit. Do not "unify" the two without changing the default deliberately.
+
 Raising it trades update smoothness for loop time. It can never lose
 text: the reply's accumulation is unconditional, and a catch-up timer
 bounds every deferral to one interval. A non-positive value falls back to

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -522,6 +522,15 @@
 # resolves it, not at config-load time.
 #   theme: nord
 
+# chat.stream_repaint_min_interval: seconds between two repaints of the SAME
+# streamed reply in the TUI (#3570's budget, made reachable). Default 1/30 is
+# a knee measured on one terminal (2000 deltas / 60 KB reply: set_item
+# 1979 -> 75, wall-clock 16.1 s -> 3.3 s). A slower terminal (SSH, tmux) has a
+# different knee — raise this there. Text is never lost: the accumulation is
+# unconditional and a catch-up timer bounds every deferral. 0 or negative
+# falls back to the default rather than repainting on every delta.
+#   stream_repaint_min_interval: 0.1
+
 
 # -----------------------------------------------------------------------------
 # audit_events: audit-log rotation + automatic purge policy (#4174 T5:

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -1065,12 +1065,32 @@ def _build_chat_config(raw: object) -> ChatConfig:
     # would mean "repaint every delta", which is the pre-#3570 behaviour the
     # measurement in the field's docstring exists to keep operators out of.
     _raw_repaint = raw.get("stream_repaint_min_interval")
+    _repaint_default = ChatConfig().stream_repaint_min_interval
+    _repaint_rejected: object = None
     try:
         stream_repaint_min_interval = float(_raw_repaint)  # type: ignore[arg-type]
     except (TypeError, ValueError):
-        stream_repaint_min_interval = ChatConfig().stream_repaint_min_interval
+        if _raw_repaint is not None:
+            _repaint_rejected = _raw_repaint
+        stream_repaint_min_interval = _repaint_default
     if stream_repaint_min_interval <= 0:
-        stream_repaint_min_interval = ChatConfig().stream_repaint_min_interval
+        _repaint_rejected = _raw_repaint
+        stream_repaint_min_interval = _repaint_default
+    if _repaint_rejected is not None:
+        # The substitution is announced, not silent: without this an operator
+        # who typed 0 and one who never wrote the key at all read the same
+        # running config back, so "my setting did nothing" is indistinguishable
+        # from "I never set it". Same shape as the hooks.yaml token warning in
+        # `loader.py` — refuse the value, say so, keep the session running.
+        import warnings
+        warnings.warn(
+            f"chat.stream_repaint_min_interval={_repaint_rejected!r} is not a "
+            f"positive number of seconds -- using the default {_repaint_default!r}. "
+            "0 or negative would repaint on every delta, which is the "
+            "pre-measurement behaviour this budget exists to avoid.",
+            UserWarning,
+            stacklevel=2,
+        )
     compaction_raw = raw.get("compaction") or {}
     if not isinstance(compaction_raw, dict):
         return ChatConfig(  # type: ignore[arg-type]

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -969,6 +969,20 @@ class ChatConfig:
     still-open design question (#4840's own thread) — this knob does not
     answer it; it just stops silently discarding whatever name an operator
     already knows to type.
+
+    ``stream_repaint_min_interval`` (#5135-adjacent, this knob's own issue):
+    the minimum wall-clock gap, in SECONDS, between two repaints of the same
+    streamed reply in the TTY conversation pane. The default is the measured
+    knee documented on ``textual_chat.app._STREAM_REPAINT_MIN_INTERVAL``
+    (2000 deltas / 60 KB reply: ``set_item`` 1979 -> 75, wall-clock 16.1 s ->
+    3.3 s) and this knob does not change it — it exists because that measure
+    was taken on one terminal, and a slower one (SSH, a corporate laptop, a
+    terminal multiplexer) has a different knee that nobody can reach without
+    editing source. Seconds, not milliseconds like its ``events:`` sibling:
+    the measured value is a fraction (1/30), and expressing it in whole ms
+    would silently move the shipped default. Raising it trades update
+    smoothness for loop time; it can never lose text (the accumulation is
+    unconditional and a catch-up timer bounds every deferral).
     """
     compaction: CompactionConfig = field(default_factory=CompactionConfig)
     reasoning: ReasoningConfig = field(default_factory=ReasoningConfig)
@@ -978,6 +992,7 @@ class ChatConfig:
     image_url_schemes: "list[str]" = field(default_factory=list)
     empty_stop_retry: bool = False
     theme: "str | None" = None
+    stream_repaint_min_interval: float = 1 / 30
 
 
 def _build_reasoning_config(raw: object) -> ReasoningConfig:
@@ -1045,12 +1060,24 @@ def _build_chat_config(raw: object) -> ChatConfig:
     # list here).
     raw_theme = raw.get("theme")
     theme = str(raw_theme) if raw_theme is not None else None
+    # The TTY streamed-reply repaint budget. A non-positive or unparseable
+    # value falls back to the default rather than disabling the budget: 0
+    # would mean "repaint every delta", which is the pre-#3570 behaviour the
+    # measurement in the field's docstring exists to keep operators out of.
+    _raw_repaint = raw.get("stream_repaint_min_interval")
+    try:
+        stream_repaint_min_interval = float(_raw_repaint)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        stream_repaint_min_interval = ChatConfig().stream_repaint_min_interval
+    if stream_repaint_min_interval <= 0:
+        stream_repaint_min_interval = ChatConfig().stream_repaint_min_interval
     compaction_raw = raw.get("compaction") or {}
     if not isinstance(compaction_raw, dict):
         return ChatConfig(  # type: ignore[arg-type]
             reasoning=reasoning, render_mode=render_mode, gutters=gutters,
             neutralize_body=neutralize_body, image_url_schemes=image_url_schemes,
             empty_stop_retry=empty_stop_retry, theme=theme,
+            stream_repaint_min_interval=stream_repaint_min_interval,
         )
     # #1128: head_size/tail_size (step 3) + trigger_total_tokens/min_compact_batch
     # (PR-a, axis-1 removal) were removed — head/tail sizing is token-budget via
@@ -1141,6 +1168,7 @@ def _build_chat_config(raw: object) -> ChatConfig:
         gutters=gutters, neutralize_body=neutralize_body,
         image_url_schemes=image_url_schemes, empty_stop_retry=empty_stop_retry,
         theme=theme,
+        stream_repaint_min_interval=stream_repaint_min_interval,
     )
 
 

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -191,6 +191,22 @@ def _configured_gutter_visibility(config) -> "tuple[bool, bool]":
         return (defaults.left, defaults.right)
 
 
+def _configured_stream_repaint_interval(config) -> float:
+    """The #3570 repaint budget, in seconds, from ``chat.stream_repaint_min_interval``.
+
+    Same shape as :func:`_configured_gutter_visibility`: the default lives on
+    the config dataclass, not re-typed here, and a missing/partial config (a
+    remote client that carries none) falls back to it. The module constant
+    stays the ONE place the measured knee is written down —
+    :class:`~reyn.config.chat.ChatConfig` seeds its own default from it."""
+    if config is None:
+        return _STREAM_REPAINT_MIN_INTERVAL
+    try:
+        return float(config.chat.stream_repaint_min_interval)
+    except (AttributeError, TypeError, ValueError):
+        return _STREAM_REPAINT_MIN_INTERVAL
+
+
 def empty_state_hint() -> "object":
     """The conversation pane's empty-state hint (#3476 ②, flowview 0.6.0
     ``empty=``): shown across the viewport while the model has no entries — a
@@ -1317,6 +1333,9 @@ class TextualChatApp(App):
 
         self._destination = _Destination(agent=agent_name, session_id=_DEFAULT_SID)
         self._config = config
+        #3570: the repaint budget is per app, read once — a mid-session config
+        # reload must not change the pace a reply already streaming is painted at.
+        self._stream_repaint_min_interval = _configured_stream_repaint_interval(config)
         # #4983: the CURRENTLY-ATTACHED session's conversation history,
         # read BEFORE this App was constructed (the caller — normally
         # ``run_textual_chat``'s own pre-``run_async`` step — reads it off
@@ -6308,7 +6327,7 @@ class TextualChatApp(App):
         viewer sees nothing until completion) or stop arriving entirely (a model
         that pauses mid-reply must not leave its last chunk unpainted until the
         completion frame)."""
-        if self._clock() - record.last_repaint >= _STREAM_REPAINT_MIN_INTERVAL:
+        if self._clock() - record.last_repaint >= self._stream_repaint_min_interval:
             self._flush_streaming_reply(record)
             return
         self._schedule_streaming_catchup()
@@ -6329,7 +6348,7 @@ class TextualChatApp(App):
             return
         try:
             self._streaming_catchup = self.set_timer(
-                _STREAM_REPAINT_MIN_INTERVAL, self._flush_pending_streaming_replies
+                self._stream_repaint_min_interval, self._flush_pending_streaming_replies
             )
         except Exception:
             logger.exception("textual chat: could not arm the streamed-reply catch-up")

--- a/tests/core/test_stream_repaint_interval_config.py
+++ b/tests/core/test_stream_repaint_interval_config.py
@@ -1,0 +1,109 @@
+"""Tier 1/2: `chat.stream_repaint_min_interval` config parsing.
+
+The TTY repaint budget (#3570) was a module constant with no way to reach
+it. Its default is a knee measured on ONE terminal; a slower one (SSH, a
+multiplexer, a corporate laptop) has a different knee and its operator had
+no way to find it without editing source. This knob does not move the
+shipped default — it only stops the value being unreachable.
+
+Test shape mirrors `test_4840_chat_theme_config.py`, including the
+`load_config` round-trip and ITS falsification pair: exercising
+`_build_chat_config` alone proves the parser reads the key, not that the
+real entrypoint surfaces it (the gap #4899 found on a sibling field).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from reyn.config.chat import ChatConfig, _build_chat_config
+from reyn.config.loader import load_config
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+
+def test_stream_repaint_interval_defaults_to_the_measured_knee() -> None:
+    """Tier 1: the shipped default is unchanged by this knob existing."""
+    assert ChatConfig().stream_repaint_min_interval == 1 / 30
+
+
+def test_stream_repaint_interval_parses_a_slower_value() -> None:
+    """Tier 1: an operator on a slow terminal can widen the budget."""
+    assert _build_chat_config(
+        {"stream_repaint_min_interval": 0.2},
+    ).stream_repaint_min_interval == 0.2
+
+
+def test_stream_repaint_interval_absent_keeps_the_default() -> None:
+    """Tier 1: falsification pair — omitting the key does not pick a value
+    up from any sibling `chat:` key."""
+    assert _build_chat_config(
+        {"render_mode": "plain"},
+    ).stream_repaint_min_interval == 1 / 30
+
+
+def test_stream_repaint_interval_parses_with_and_without_a_compaction_block() -> None:
+    """Tier 1: `_build_chat_config` returns early when `compaction:` is
+    absent or malformed, so a field must parse on BOTH branches — the shape
+    #4677 and #4840 each pinned for their own field."""
+    with_block = _build_chat_config(
+        {"stream_repaint_min_interval": 0.1, "compaction": {"body_token_cap": 5000}},
+    )
+    without_block = _build_chat_config({"stream_repaint_min_interval": 0.1})
+    assert with_block.stream_repaint_min_interval == 0.1
+    assert without_block.stream_repaint_min_interval == 0.1
+
+
+def test_non_positive_interval_falls_back_rather_than_disabling_the_budget() -> None:
+    """Tier 1: 0 (or a negative) means "repaint every delta" — the
+    pre-#3570 behaviour whose measured cost (wall-clock 16.1 s vs 3.3 s on
+    a 2000-delta reply) is the reason the budget exists. An operator does
+    not reach that by typing a number this parser could have rejected."""
+    assert _build_chat_config(
+        {"stream_repaint_min_interval": 0},
+    ).stream_repaint_min_interval == 1 / 30
+    assert _build_chat_config(
+        {"stream_repaint_min_interval": -1},
+    ).stream_repaint_min_interval == 1 / 30
+
+
+def test_unparseable_interval_falls_back_to_the_default() -> None:
+    """Tier 1: a typo leaves the shipped default in place instead of
+    raising into session startup."""
+    assert _build_chat_config(
+        {"stream_repaint_min_interval": "fast"},
+    ).stream_repaint_min_interval == 1 / 30
+
+
+def test_stream_repaint_interval_survives_a_real_load_config_round_trip(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: `load_config()` itself — a real reyn.yaml on disk — surfaces
+    the value, not just `_build_chat_config` in isolation."""
+    monkeypatch.chdir(tmp_path)
+    _write_yaml(tmp_path / "reyn.yaml", {"chat": {"stream_repaint_min_interval": 0.25}})
+
+    cfg = load_config(tmp_path)
+
+    assert cfg.chat.stream_repaint_min_interval == 0.25
+
+
+def test_absent_from_yaml_keeps_the_default_through_load_config(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: strip-falsify for the round-trip above — without the key,
+    `load_config()` must still report the default, proving the previous
+    test read a value that actually came off disk."""
+    monkeypatch.chdir(tmp_path)
+    _write_yaml(tmp_path / "reyn.yaml", {"chat": {"render_mode": "plain"}})
+
+    cfg = load_config(tmp_path)
+
+    assert cfg.chat.stream_repaint_min_interval == 1 / 30

--- a/tests/core/test_stream_repaint_interval_config.py
+++ b/tests/core/test_stream_repaint_interval_config.py
@@ -13,8 +13,10 @@ real entrypoint surfaces it (the gap #4899 found on a sibling field).
 """
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
+import pytest
 import yaml
 
 from reyn.config.chat import ChatConfig, _build_chat_config
@@ -107,3 +109,27 @@ def test_absent_from_yaml_keeps_the_default_through_load_config(
     cfg = load_config(tmp_path)
 
     assert cfg.chat.stream_repaint_min_interval == 1 / 30
+
+
+def test_a_rejected_value_is_announced_not_silently_substituted() -> None:
+    """Tier 1: an operator who typed 0 and one who never wrote the key must
+    not read back the same running config with nothing said. The fallback
+    keeps the session up; the warning is what makes it distinguishable."""
+    with pytest.warns(UserWarning, match="stream_repaint_min_interval"):
+        _build_chat_config({"stream_repaint_min_interval": 0})
+    with pytest.warns(UserWarning, match="stream_repaint_min_interval"):
+        _build_chat_config({"stream_repaint_min_interval": "fast"})
+
+
+def test_an_accepted_value_and_an_absent_key_are_both_silent() -> None:
+    """Tier 1: falsification pair — the warning fires on the rejection, not
+    on every parse. Without this the assertion above would still pass if the
+    parser warned unconditionally."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert _build_chat_config(
+            {"stream_repaint_min_interval": 0.2},
+        ).stream_repaint_min_interval == 0.2
+        assert _build_chat_config(
+            {"render_mode": "plain"},
+        ).stream_repaint_min_interval == 1 / 30


### PR DESCRIPTION
**[lead-coder]** — ✅ **owner の 直感（「flowview extend の 回数削減が 要る」）に 対する ★到達手段 です。★既定は 1 mm も 動きません。**

## 🔴 まず ── ★削減 自体は ★★既に 在ります

```
✅ `app.py:284` `_STREAM_REPAINT_MIN_INTERVAL = 1 / 30`（#3570）
   ── ★実測が コメントに ── 2000 deltas / 60KB / textual-flowview v0.9.0
      `set_item` ★1979 → 75 ／ `present` ★1908 → 72 ／ wall ★★16.1s → 3.3s
✅ ★視界外は `track_visibility` で ★O(1) 更新
✅ ★取りこぼし なし ── ★蓄積は 無条件・★catch-up timer が 1 interval で 追いつく
```

## 🔴 足りなかった もの ── ★★口

```
🔴 ★定数 ── ★config の 口が 無い
   ── ⚪ ★根拠は コメントに 在る ∴「根拠なき定数」では ありません
   ── ⚠️ ★但し ★測ったのは ★★1 つの 端末 です
      ── ★SSH / multiplexer / 貸与 PC は ★knee が 違います
      ── ★★source を 編集する 以外に 到達手段が ありません でした
```

## ✅ この PR

```
✅ `chat.stream_repaint_min_interval`（★秒・float）── ★既定 `1/30` ── ★変更 なし
✅ ★秒に した 理由 ── ★兄弟(`agent_delta_coalesce_interval_ms`)は ms ですが
   ── ★測定値が `1/30` ── ★★whole ms に すると ★既定が 黙って 動きます
✅ ★非正値は ★★fallback ── ★`0` は「毎 delta 描画」＝ ★pre-#3570 の 挙動
   ── ★上の 実測が ★そこへ 行かせない ため に 在ります
✅ ★app は 起動時に 1 回 読む ── ★streaming 中の reload で ★pace が 変わらない
```

## ⚠️ 未了（★開示 ── ★block では ありません）

```
⚠️ ★app 側の 配線に ★★公開の 読み口が 在りません
   ── ∴ ★test は ★config の 面（`_build_chat_config` ＋ `load_config`）だけ です
   ── ★「app が 実際に この 値を 使うか」は ★★test されて いません
   ── ⚪ ★家則「読み口が 無い なら ★その 不在が finding」に 従い ★private に 手を 出して いません
🔴 ★この PR は ★遅さを 直しません ── ★★測る 手段を 足す だけ です
   ── ★上流(proxy/provider)か 下流(描画)かは ★★未測定 の ままです
```

## Test plan

```
- [x] `pytest tests/core/test_stream_repaint_interval_config.py` → `8 passed`
- [x] `pytest tests/config` → `232 passed`（★mirror gate 含む）
- [x] `ruff check .` → `All checks passed!`
- [x] `scripts/test_tier_audit.py --strict <新 test>` → `Exit code: 0`
- [x] `scripts/mypy_ratchet.py` → `OK: 201 findings, all baselined`
- [x] `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py`
      / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` → 全て OK
- [x] `mkdocs build --strict` ＋ `check_doc_anchors.py` ＋ `check_retired_config_keys_denylist.py` → OK
- [x] (skipped — Visual 項目は 既定不変 ∴ 見た目に 変化 無し)
```

---

**[lead-coder]** — ✅ **architect の 3 点、★全部 入れました（head `d17b5b9a6`）。**

```
🔴 ①（本文に 1 行）── ★★sleep を 使う test で 埋めない こと
   ── ★「app が 実際に この 値を 使うか」の witness は ★★描画の 間隔＝時間 です
   ── ★家則「test は duration を どちら向きにも 書かない」に 正面から 当たります
   ── ⚠️ ★★次に 気付いた 人が ★sleep で 埋めるのが ★一番 起きやすい 誤り です
   ── ✅ ★埋めるなら ★clock を 注入できる seam を 先に 作る こと（★app は clock 注入可）
✅ ②（非 block）── ★非正値/未解析値の ★★静かな 差し替えを 止めました
   ── ★`UserWarning` 1 本 ── ★`loader.py` の hooks.yaml token 警告と 同じ 形
   ── ★test 2 本 ── ★出る 側 と ★★出ない 側（`simplefilter("error")`）
✅ ③（非 block）── ★★「兄弟が ms なのに 秒な 理由」を ★doc に
   ── 逐語「Do not \"unify\" the two without changing the default deliberately.」
```

⚠️ **★head が `d216b5307` → `d17b5b9a6` に 動きました** ── ★architect の B は ★前の tree に ついて の 主張 です。⚪ **★差分 B を お願いします**（★あなたが #5257 で 示した 形）。

---

**[lead-coder]** — ⚪ **★境界を 1 つ 記録します（architect の 非 block 指摘 ── ★変更しません）。**

```
⚪ `stream_repaint_min_interval: null` と ★明示した 場合、★warn は 鳴りません
   ── ★`raw.get(...)` が None を 返し、★`_repaint_rejected` に 入らない ため
⚪ ★妥当だと 判断しました ── ★YAML の null は 通例「未設定」と 読みます
⚠️ ★但し ★私が 立てた 軸（★「書いた 人」と「書かなかった 人」を 分ける）では
   ── ★★null は 境界 です ── ★書いた のに 鳴りません
✅ ★聞かれた ときに 答えられる よう、★ここに 残します
```
