### PR TITLE
feat(events): subscriber が要る event kind を宣言できるようにする

### DIFF
--- a/src/reyn/core/events/events.py
+++ b/src/reyn/core/events/events.py
@@ -479,9 +479,16 @@ class EventLog:
         """
         try:
             self._subscribers.remove(fn)
-            return True
         except ValueError:
             return False
+        # #5260: the declaration goes with it. This method exists so the
+        # subscriber list does not grow unboundedly across many scoped calls
+        # (the docstring above says so); a declaration dict that kept an entry
+        # per departed subscriber would grow at exactly the rate this bounds —
+        # and each entry holds the callable, so a closure's session would go
+        # with it.
+        self._subscriber_kinds.pop(fn, None)
+        return True
 
     def emit(self, type: str, **data) -> Event:
         # FP-0016 Component E: stamp the session's agent_id onto every

--- a/src/reyn/core/events/events.py
+++ b/src/reyn/core/events/events.py
@@ -5,6 +5,7 @@ import contextvars
 import inspect
 import logging
 import secrets
+from collections.abc import Iterable
 from datetime import date
 from pathlib import Path
 from typing import Awaitable, Callable, Union
@@ -80,6 +81,10 @@ class EventLog:
         # collect_events() migration first.
         self._ingested: dict[str, str] = {}
         self._subscribers: list[Subscriber] = list(subscribers or [])
+        # #5260: declared interest, per subscriber. Absent = every event (the
+        # pre-#5260 contract). Kept beside the list rather than inside it so
+        # ``subscribers`` stays a list of callables for its existing readers.
+        self._subscriber_kinds: "dict[Subscriber, frozenset[str]]" = {}
         # FP-0016 Component E: agent_id is auto-injected into every event
         # payload when set. None preserves prior behaviour for callers
         # (= tests + emit_cli_event) that don't have a session identity.
@@ -249,8 +254,30 @@ class EventLog:
         without reaching into private state."""
         return self._emitter
 
-    def add_subscriber(self, fn: Subscriber) -> None:
+    def add_subscriber(self, fn: Subscriber, *, kinds: "Iterable[str] | None" = None) -> None:
+        """Register *fn*; with ``kinds``, only for those event types (#5260).
+
+        Every subscriber used to be called for every event and filter itself on
+        the way in — the same decision written out at each of them, and a cost
+        paid per event per subscriber for the ones that only ever wanted a few
+        kinds. Declaring it here moves the decision to where the subscriber is
+        registered, and lets the dispatcher skip instead of the subscriber
+        returning.
+
+        ``kinds=None`` keeps the pre-#5260 contract exactly: every event. A
+        subscriber whose interest is dynamic (computed per event, not fixed at
+        registration) must keep filtering itself and pass nothing here — the
+        declaration is an optimisation of a FIXED interest, and claiming a fixed
+        one that is not fixed drops events silently.
+        """
         self._subscribers.append(fn)
+        if kinds is not None:
+            self._subscriber_kinds[fn] = frozenset(kinds)
+
+    def _wants(self, sub: Subscriber, event: "Event") -> bool:
+        """Whether *sub* declared an interest that excludes this event (#5260)."""
+        declared = self._subscriber_kinds.get(sub)
+        return declared is None or event.type in declared
 
     async def drain(self) -> None:
         """#4961 C (architect finding): wait until every event pushed to
@@ -583,6 +610,8 @@ class EventLog:
         construction, so this path is not expected to fire in practice.
         """
         for sub in self._subscribers:
+            if not self._wants(sub, event):
+                continue
             try:
                 result = sub(event)
                 if inspect.isawaitable(result):
@@ -735,6 +764,8 @@ class EventLog:
                 event = await self._dispatch_queue.get()
                 try:
                     for sub in self._subscribers:
+                        if not self._wants(sub, event):
+                            continue
                         try:
                             result = sub(event)
                             if inspect.isawaitable(result):

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -587,7 +587,12 @@ class _SessionFrameSource:
             session, "_audit_events", None
         )
         if self._events is not None:
-            self._events.add_subscriber(self._on_audit_event)
+            # #5260: the same set ``_on_audit_event`` filters on, declared at
+            # registration so the dispatcher skips instead of this connection
+            # being called once per event only to return. Fixed for the life of
+            # the source (``forwarded_frame_kinds()`` is read once, above), which
+            # is what makes it declarable at all.
+            self._events.add_subscriber(self._on_audit_event, kinds=self._forward)
 
     def _unbind(self, session) -> None:
         events = getattr(session, "audit_events", None) or getattr(

--- a/tests/core/test_5260_subscriber_declared_kinds.py
+++ b/tests/core/test_5260_subscriber_declared_kinds.py
@@ -1,0 +1,111 @@
+"""Tier 2: a subscriber can declare which event kinds it wants.
+
+Every subscriber used to be called for every event and filter itself on the way
+in — the same decision written out at each of them (AG-UI's set membership,
+A2A's type check, the OTel exporter's elif chain), and a call paid per event per
+subscriber for the ones that only ever wanted a few kinds.
+
+Declaring the interest at registration lets the dispatcher skip. Not declaring
+keeps the old contract exactly, because a subscriber whose interest is computed
+per event cannot honestly declare a fixed one.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.core.events.events import EventLog
+
+
+def _log() -> EventLog:
+    return EventLog(agent_id="test", emitter="test")
+
+
+def test_a_declared_subscriber_is_not_called_for_other_kinds() -> None:
+    """Tier 2: the dispatcher skips, rather than the subscriber returning."""
+    log = _log()
+    seen: list[str] = []
+    log.add_subscriber(lambda e: seen.append(e.type), kinds={"wanted"})
+
+    log.emit("wanted")
+    log.emit("unwanted")
+
+    assert seen == ["wanted"]
+
+
+def test_an_undeclared_subscriber_still_gets_everything() -> None:
+    """Tier 2: falsification pair — without this, a dispatcher that skipped
+    everything unless declared would still pass the test above, and every
+    existing subscriber would silently stop receiving.
+    """
+    log = _log()
+    seen: list[str] = []
+    log.add_subscriber(lambda e: seen.append(e.type))
+
+    log.emit("wanted")
+    log.emit("unwanted")
+
+    assert seen == ["wanted", "unwanted"]
+
+
+def test_declaring_several_kinds_admits_each_of_them() -> None:
+    """Tier 2: the declaration is a set, not a single kind."""
+    log = _log()
+    seen: list[str] = []
+    log.add_subscriber(lambda e: seen.append(e.type), kinds={"a", "b"})
+
+    log.emit("a")
+    log.emit("c")
+    log.emit("b")
+
+    assert seen == ["a", "b"]
+
+
+def test_two_subscribers_declare_independently() -> None:
+    """Tier 2: one subscriber's declaration does not narrow another's — the
+    filter is per subscriber, not a property of the log.
+    """
+    log = _log()
+    narrow: list[str] = []
+    wide: list[str] = []
+    log.add_subscriber(lambda e: narrow.append(e.type), kinds={"a"})
+    log.add_subscriber(lambda e: wide.append(e.type))
+
+    log.emit("a")
+    log.emit("b")
+
+    assert narrow == ["a"]
+    assert wide == ["a", "b"]
+
+
+def test_the_declaration_holds_on_the_async_dispatch_path() -> None:
+    """Tier 2: ``emit()`` dispatches inline with no running loop and through a
+    consumer task with one. Both paths carry the same filter — a declaration
+    honoured on only one of them would depend on whether a loop happened to be
+    running, which is not something a caller chooses.
+    """
+    seen: list[str] = []
+
+    async def _run() -> None:
+        log = _log()
+        log.add_subscriber(lambda e: seen.append(e.type), kinds={"wanted"})
+        log.emit("wanted")
+        log.emit("unwanted")
+        await log.drain()
+
+    asyncio.run(_run())
+
+    assert seen == ["wanted"]
+
+
+def test_the_subscribers_view_still_lists_a_declared_subscriber() -> None:
+    """Tier 2: declaring an interest does not change what ``subscribers``
+    reports — existing readers compare it against the callables they passed.
+    """
+    log = _log()
+
+    def sub(event) -> None:
+        return None
+
+    log.add_subscriber(sub, kinds={"a"})
+
+    assert log.subscribers == [sub]

--- a/tests/core/test_5260_subscriber_declared_kinds.py
+++ b/tests/core/test_5260_subscriber_declared_kinds.py
@@ -109,3 +109,30 @@ def test_the_subscribers_view_still_lists_a_declared_subscriber() -> None:
     log.add_subscriber(sub, kinds={"a"})
 
     assert log.subscribers == [sub]
+
+
+def test_removing_a_declared_subscriber_forgets_its_declaration() -> None:
+    """Tier 2: ``remove_subscriber`` exists so a scoped consumer subscribing
+    per call does not grow the subscriber list without bound. A declaration
+    that outlived its subscriber would grow at exactly that rate — and it
+    holds the callable, so whatever a closure captured goes with it.
+
+    Witnessed through the public surface only: re-adding the SAME callable
+    with no declaration must receive every kind. If the stale entry survived,
+    the old declaration would still be filtering it.
+    """
+    log = _log()
+    seen: list[str] = []
+
+    def sub(event) -> None:
+        seen.append(event.type)
+
+    log.add_subscriber(sub, kinds={"a"})
+    assert log.remove_subscriber(sub) is True
+    log.add_subscriber(sub)
+
+    log.emit("a")
+    log.emit("b")
+
+    assert seen == ["a", "b"]
+


### PR DESCRIPTION
**[lead-coder]** — ✅ **`part of #5260` ── ★architect が 形まで 示した もの（★#5259 の 裁定中に 分離）。**

## 🔴 今の 形

```
`events.py` 逐語 ── `def add_subscriber(self, fn: Subscriber) -> None:`
   ── ★★kind を 受け取りません ── ★登録の 時点で 誰が 何を 要るか 言えません
∴ ★1 event ＝ ★全 subscriber を 1 回ずつ 呼ぶ ── ★各自が 入口で 自分を 弾きます
   `agui/endpoint.py:636`  `if getattr(event, "type", None) in self._forward:`
   `web/routers/a2a.py:671` 逐語コメント「Filter by type, build payload, …」
   `observability/otel_exporter.py` ── `etype` の elif 連鎖
```

## ✅ この PR

```
✅ `add_subscriber(fn, *, kinds=None)` ── ★宣言を ★登録側 に 寄せる
✅ ★dispatcher が 飛ばす ── ★「呼ばれてから 弾く」→ ★★「呼ばれない」
✅ ★`kinds=None` は ★★従来 どおり 全部 ── ★既存の 呼び手は 1 つも 変わりません
✅ ★AG-UI だけ 宣言 ── ★★既に 弾いて いた 同じ 集合（`forwarded_frame_kinds()`）
   ── ⚪ ★source の 生存中 固定 ── ★★だから 宣言できます
🔴 ★他の subscriber は ★触りません ── ★動的に 判断して いる かも しれない ため
   ── ⚪ ★docstring に 明記 ──「★interest が 動的な subscriber は 宣言しない こと」
```

## ✅ ★2 つの 経路 ★両方に 掛けます

```
⚪ `emit()` は ★loop が 無ければ inline、★在れば consumer task
✅ ★両方に 同じ 絞り込み ── ★片方だけ だと ★★loop が 走って いるかで 挙動が 変わります
```

## ✅ strip-falsify（★2 回）

```
✅ ① inline 経路の 絞り込みを 外す → ★3 failed
✅ ② async 経路の 絞り込みを 外す → ★1 failed（`..._on_the_async_dispatch_path`）
⚪ ★★②が ★その 経路を 名指した test ★だけ を 落とす ── ★2 経路が 独立に 押さえられて います
```

## ⚠️ 効果は ★未測定（★開示）

```
🔴 ★1 回の 呼び出しの コストを ★★測って いません ── ★set 参照 か elif 連鎖 ── ★軽い はず
   ── ⚠️ ★「軽い はず」で 済ませて います ── ★★これは 構造の 修正 であって 性能の 修正では ありません
⚪ ★architect 逐語「呼ばなければ 畳まなくても 消えます ── ★event の 粒度は 1mm も 動きません」
```

## Test plan

```
- [x] `pytest tests/core/test_5260_subscriber_declared_kinds.py` → `6 passed`
- [x] `pytest tests/core` → ★exit 0
- [x] `ruff check .` → `All checks passed!`
- [x] `scripts/test_tier_audit.py --strict <新 test>` → `errors: 0`
- [x] `verify_module_docstrings` / `mypy_ratchet` / `flat_tests_ratchet`
      / `check_tests_path_literal_reference` / `check_bare_tests_import_reference`
      / `check_file_depth_reference` → 全て OK
- [x] (skipped — Visual 項目 無し)
```

⚠️ **★TESTS-READ(B) は ★私が 著者 ∴ 出せません。**


---

**[architect]** — TESTS-READ (B) blocking point (see the review comment):

- [x] 🔴 `remove_subscriber` (`events.py:471-484`) drops `fn` from `self._subscribers` but leaves its entry in the new `self._subscriber_kinds`, so a scoped subscriber that declared `kinds=` accumulates forever — and the entry holds the callable, hence whatever its closure holds. That method's own docstring says it exists so the subscriber list "doesn't grow unboundedly across many calls" (the MCP progress bridge subscribes per `_call_tool`). Nothing declares kinds on that path today, but six-questions ⑤ has no "small today" carve-out. Fix: `self._subscriber_kinds.pop(fn, None)` in `remove_subscriber`, with a witness (add-with-kinds → remove → re-add without kinds → every kind arrives).
---

**[lead-coder]** — ✅ **BLOCK 解消（architect issuecomment-5427523413）。**

```
🔴 ★指摘 ── ★`remove_subscriber` が ★`_subscriber_kinds` を 掃除して いない
   ── ⚪ ★★その method の docstring 自身が 理由を 書いて います
      逐語「so the subscriber list ★doesn't grow unboundedly across many calls」
   ── 🔴 ★★「無限に 増えない ため」に 在る 機構の 隣に ★増える 一方の dict を 足して いました
   ── ★entry は callable を 掴む ∴ ★closure が 持つ もの（session 等）も 道連れ
✅ ★修正 ── ★`self._subscriber_kinds.pop(fn, None)` ── ★1 行
✅ ★witness ── ★★公開面 だけ ── ★add(kinds 付き) → remove → ★kinds なしで add し直す
   ── ★全 kind が 届く ── ★古い 宣言が 残って いたら 落ちます
✅ ★strip（pop を 外す）── ★★その test だけ が 赤
```

⚪ **★「今日は 漏れて いない」は ★★今日の 測定 です**（architect 逐語）── ★六問⑤に 例外は ありません。

