### PR TITLE
perf(agui): run を集める間も loop に制御を返す

### DIFF
--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -829,7 +829,7 @@ class _SessionFrameSource:
             # nothing is held at all: an empty queue yields exactly what a
             # pre-#5259 reader saw. A merged run is bounded by what the
             # provider already produced, so it cannot outgrow one reply.
-            frame, held = self._drain_delta_run(frame)
+            frame, held = await self._drain_delta_run(frame)
             # #3570, the server-side instance of the same shape as
             # ``InProcessTransport.frames``: ``_q`` is fed by SYNCHRONOUS
             # ``put_nowait`` callers (the audit-event subscriber, the forwarder),
@@ -853,7 +853,7 @@ class _SessionFrameSource:
                 if isinstance(held, DisplayFrame) and held.message.kind == "__end__":
                     return
 
-    def _drain_delta_run(self, first):
+    async def _drain_delta_run(self, first):
         """Collect the ``agent_delta`` run that ``first`` starts, if it starts one.
 
         Returns ``(frame_to_emit, frame_that_ended_the_run_or_None)``. A run is
@@ -887,6 +887,15 @@ class _SessionFrameSource:
                 break
             if _is_delta_frame(nxt) and _same_delta_run(run[-1], nxt):
                 run.append(nxt)
+                # AFTER collecting one, before reaching for the next: the
+                # collecting is what this loop does INSTEAD of encoding and
+                # writing each frame, but it is still work, and a long enough
+                # run would hold the loop for its whole length — the starvation
+                # #3570 named. Suspending here and not at the top of the loop
+                # means the turn that finds the queue empty, and the first
+                # reach, cost nothing: control is returned once per frame
+                # actually taken, never for deciding there are none.
+                await suspend_between_frames()
                 continue
             held = nxt
             break

--- a/tests/interfaces/test_5259_agui_delta_run_merge.py
+++ b/tests/interfaces/test_5259_agui_delta_run_merge.py
@@ -186,24 +186,23 @@ def test_the_drain_returns_control_while_it_collects() -> None:
     server's loop for its whole length, which is the starvation #3570 named
     (other connections' writes, the fail-close driver's timers).
 
-    Witnessed by a competing task that can only advance when this loop hands
-    control back: it must advance MORE THAN ONCE while a multi-frame run is
-    collected. Without the suspension it advances at most once, whatever the
-    run's length — so this does not measure how long anything took, only
-    whether control was returned at all.
+    Witnessed by a competing task that needs TWO turns to finish. One turn it
+    gets either way: ``frames()`` already suspended once before yielding its
+    frame, and that alone is what this test must not mistake for the property.
+    A SECOND turn exists only if the collecting loop handed control back too —
+    so the witness is whether that task ran to completion, not how long
+    anything took nor how many turns were counted.
     """
     source = _source_with([_delta("a"), _delta("b"), _delta("c"), _delta("d")])
-    ticks: list[int] = []
+    reached_its_second_turn = asyncio.Event()
 
     async def _run() -> None:
         async def _competitor() -> None:
-            while True:
-                await asyncio.sleep(0)
-                ticks.append(1)
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            reached_its_second_turn.set()
 
         rival = asyncio.create_task(_competitor())
-        await asyncio.sleep(0)
-        ticks.clear()
         agen = source.frames()
         await agen.__anext__()
         rival.cancel()
@@ -211,5 +210,4 @@ def test_the_drain_returns_control_while_it_collects() -> None:
 
     asyncio.run(_run())
 
-    assert len(ticks) > 1
-
+    assert reached_its_second_turn.is_set()

--- a/tests/interfaces/test_5259_agui_delta_run_merge.py
+++ b/tests/interfaces/test_5259_agui_delta_run_merge.py
@@ -178,3 +178,38 @@ def test_an_end_sentinel_that_ends_a_run_still_terminates() -> None:
     out = _drain(source)
 
     assert [f.event.data["text"] for f in out] == ["ab"]
+
+
+def test_the_drain_returns_control_while_it_collects() -> None:
+    """Tier 2: collecting a run is what this connection does INSTEAD of
+    encoding each frame, but it is still work — a long run would hold the
+    server's loop for its whole length, which is the starvation #3570 named
+    (other connections' writes, the fail-close driver's timers).
+
+    Witnessed by a competing task that can only advance when this loop hands
+    control back: it must advance MORE THAN ONCE while a multi-frame run is
+    collected. Without the suspension it advances at most once, whatever the
+    run's length — so this does not measure how long anything took, only
+    whether control was returned at all.
+    """
+    source = _source_with([_delta("a"), _delta("b"), _delta("c"), _delta("d")])
+    ticks: list[int] = []
+
+    async def _run() -> None:
+        async def _competitor() -> None:
+            while True:
+                await asyncio.sleep(0)
+                ticks.append(1)
+
+        rival = asyncio.create_task(_competitor())
+        await asyncio.sleep(0)
+        ticks.clear()
+        agen = source.frames()
+        await agen.__anext__()
+        rival.cancel()
+        await agen.aclose()
+
+    asyncio.run(_run())
+
+    assert len(ticks) > 1
+


### PR DESCRIPTION
**[lead-coder]** — 🔴 **#5262 が ★★譲る 回数も 減らして いました。★戻します。**

## 🔴 見落として いた こと

```
⚪ ★私は #5262 の 本文に こう 書きました
   ──「★減らすのは ★encode / 送信 の 回数 だけ ── ★譲る 回数 では ありません」
🔴 ★★`frames()` の yield 前は 譲って いました ── ★★drain の 中は 譲って いません でした
   ── ★N 個 集める 間、★loop を 握った ままです
   ── ⚪ ★これは #3570 が 名指した 飢餓 そのもの
      逐語「other connections' writes, the fail-close driver's timers」
```

## ✅ この PR

```
✅ ★1 frame 取る ごとに ★`suspend_between_frames()`
🔴 ★置き場 ── ★★取った 後・★次に 手を 伸ばす 前（owner 指定）
   ── ⚪ ★loop の 先頭に 置くと ── ★★空だと 分かる 周回でも 譲ります
   ── ⚪ ★最初の 一手 の 前にも 譲る ことに なります
   ── ✅ ★★「実際に 取った 1 個に つき 1 回」── ★数える 対象が 揃います
```

## ✅ witness

```
✅ ★競合 task が ★★2 回以上 進む こと
   ── ★譲りが 無ければ ★どれだけ 長い run でも ★★高々 1 回 しか 進みません
   ── ⚪ ★★時間を 測って いません ── ★「制御が 戻ったか」だけ
✅ strip（★譲りを 外す）── ★★その test だけ が 赤
```

## Test plan

```
- [x] `pytest tests/interfaces/test_5259_agui_delta_run_merge.py` → `10 passed`
- [x] `pytest tests/interfaces/test_stream_drain_yield_3570.py` → `5 passed`
- [x] `ruff check .` → `All checks passed!`
- [x] `scripts/test_tier_audit.py --strict <該当 test>` → `errors: 0`
- [x] `verify_module_docstrings` / `mypy_ratchet` / `flat_tests_ratchet`
      / `check_tests_path_literal_reference` / `check_bare_tests_import_reference`
      / `check_file_depth_reference` → 全て OK
- [x] `pytest tests/interfaces` → ★別途 実行（結果は 下の comment）
- [x] (skipped — Visual: ★見た目は 不変。★譲る 頻度 だけ)
```

⚠️ **★TESTS-READ(B) は ★私が 著者 ∴ 出せません。**
