### PR TITLE
feat(#5261): merge agent_delta at the LLM-call source, not 1 chunk = 1 event

### DIFF
--- a/src/reyn/core/events/backend.py
+++ b/src/reyn/core/events/backend.py
@@ -354,7 +354,21 @@ class LocalEventBackend:
         if key not in self._delta_last_persisted_at:
             self._delta_last_persisted_at[key] = now
         self._delta_last_event[key] = event
-        pending = self._delta_pending_count.get(key, 0) + 1
+        # #5261: an incoming ``agent_delta`` may already stand in for MORE
+        # than one raw provider chunk — the source-side merge that issue
+        # introduced tags a merged event with its own ``raw_chunk_count``.
+        # Sum that (not a bare +1 per EVENT) so ``coalesced_fragment_count``
+        # below keeps meaning "how many raw provider chunks", not "how many
+        # agent_delta events arrived" — those stopped being the same number
+        # the moment source-side merging could produce an event standing in
+        # for more than one chunk. An event with no ``raw_chunk_count``
+        # (pre-#5261 callers, or #5261's own unmerged single-chunk case)
+        # contributes exactly 1 — an unmerged event IS one raw chunk, by
+        # definition, so this is not a guessed default.
+        _raw_count = event.data.get("raw_chunk_count")
+        pending = self._delta_pending_count.get(key, 0) + (
+            _raw_count if isinstance(_raw_count, int) and _raw_count > 0 else 1
+        )
         elapsed_ms = (now - self._delta_last_persisted_at[key]) * 1000
         if (
             pending >= self._agent_delta_coalesce_fragments
@@ -402,6 +416,15 @@ class LocalEventBackend:
         (already-completed) subscriber dispatch loop may still be holding a
         reference to, so a new object is written, never the original
         mutated in place).
+
+        *coalesced_fragment_count* (#5261: this caller's own ``pending``,
+        summed from each incoming event's ``raw_chunk_count`` — see
+        :meth:`write`'s own comment) is provider-raw-chunk-accurate even
+        when the source itself already merges: it always means "how many
+        chunks the provider actually sent", never "how many
+        ``agent_delta`` events arrived here" — those stopped being
+        interchangeable the moment source-side merging could make one
+        event stand in for more than one chunk.
 
         #4666: when ``agent_delta_include_text`` is off (the default),
         ``text`` (the streamed reply content itself) is dropped from the

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -10,7 +10,7 @@ import weakref
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
-from typing import TYPE_CHECKING, Callable, Coroutine, NamedTuple, TypeVar, Union
+from typing import TYPE_CHECKING, Coroutine, NamedTuple, Protocol, TypeVar, Union
 
 logger = logging.getLogger(__name__)
 from reyn.core.turn_scope import get_active_turn_chain_id
@@ -2130,6 +2130,26 @@ def _streaming_enabled(
     return capability is not False
 
 
+class _OnContentDelta(Protocol):
+    """#5261: the ``on_content_delta`` callback shape. ``text`` is the
+    concatenation of whatever raw provider chunks a batch's worth of
+    task B draining merged (see ``_stream_and_reconstruct``'s own #5261
+    comment) — ``raw_chunk_count``/``first_arrival``/``last_arrival``
+    (architect condition, issue #5261) let a consumer reconstruct "what
+    did the provider send, and when" after that merge, the same question
+    the durable side's ``coalesced_fragment_count`` answers for its own,
+    separate coalescing (#4960)."""
+
+    def __call__(
+        self,
+        text: str,
+        *,
+        raw_chunk_count: int,
+        first_arrival: "datetime",
+        last_arrival: "datetime",
+    ) -> None: ...
+
+
 async def recorded_acompletion(
     *,
     model: str,
@@ -2144,7 +2164,7 @@ async def recorded_acompletion(
     extra_kwargs: dict | None = None,
     emit_cost_events: bool = False,  # #1683: chat path opts in (kernel emits via LLMCallRecorder)
     routing: dict | None = None,  # #309: per-class api_base/provider; None → global proxy_kwargs()
-    on_content_delta: "Callable[[str], None] | None" = None,  # #3288 ③b: opt-in per-chunk content-delta callback (see _stream_and_reconstruct)
+    on_content_delta: "_OnContentDelta | None" = None,  # #3288 ③b / #5261: opt-in MERGED content-delta callback (see _stream_and_reconstruct)
     stream_override: "bool | None" = None,  # a model class's ``stream:`` — operator policy, NOT a litellm kwarg
     prompt_cache_key: str | None = None,  # #4700: routing hint — see the call-kwargs block below for the full reasoning
 ) -> object:
@@ -2184,15 +2204,23 @@ async def recorded_acompletion(
     ModelClassExceedsCeilingError` BEFORE ``litellm.acompletion`` is ever
     called — no partial call, no charge, no record.
 
-    ``on_content_delta`` (#3288 ③b): an OPT-IN, per-call callback invoked
-    SYNCHRONOUSLY with each non-empty content-delta string as ``_stream_and_reconstruct``
-    (③a) drains the chunk stream — never invoked on the whole-collect (non-streaming)
-    path, so it is capability-gated by construction (see ``_streaming_enabled``: no
-    capability ⇒ no streaming ⇒ this callback never fires). ``None`` (every caller
-    except ``RouterLoop``'s primary reply call) is byte-identical to today. A raising
-    callback is caught and logged — a broken display-event emit must never break the
-    LLM call it is merely narrating. The reconstructed WHOLE response (below) is
-    unaffected either way — this is purely an additional notification channel, not a
+    ``on_content_delta`` (#3288 ③b, #5261): an OPT-IN, per-call callback
+    invoked SYNCHRONOUSLY as ``_stream_and_reconstruct`` (③a) drains the
+    chunk stream — never invoked on the whole-collect (non-streaming) path,
+    so it is capability-gated by construction (see ``_streaming_enabled``:
+    no capability ⇒ no streaming ⇒ this callback never fires). ``None``
+    (every caller except ``RouterLoop``'s primary reply call) is
+    byte-identical to today — no queue, no second task, the original
+    single-loop chunk drain. #5261: no longer once per raw provider
+    chunk — the ``text`` a call carries is whatever task B's drain had
+    ALREADY accumulated by the time it got a turn to run (see
+    ``_stream_and_reconstruct``'s own #5261 comment for the confirmed
+    drain form); ``raw_chunk_count``/``first_arrival``/``last_arrival``
+    (:class:`_OnContentDelta`) let a consumer reconstruct what that batch
+    stood in for. A raising callback is caught and logged — a broken
+    display-event emit must never break the LLM call it is merely
+    narrating. The reconstructed WHOLE response (below) is unaffected
+    either way — this is purely an additional notification channel, not a
     change to what this function returns or records.
 
     ``prompt_cache_key`` (#4700): OPTIONAL — sent to litellm only when set
@@ -2529,34 +2557,165 @@ async def recorded_acompletion(
         chunks = []
         _delta_fired = False
         _tool_calls_seen = False
-        async for chunk in chunk_stream:
-            chunks.append(chunk)
-            if on_content_delta is not None:
-                _delta_text = None
+        if on_content_delta is None:
+            # #5261: byte-identical to pre-#5261 — no queue/task machinery
+            # at all when nobody wants delta notifications (every caller
+            # except RouterLoop's primary reply call).
+            async for chunk in chunk_stream:
+                chunks.append(chunk)
+                # #4805 review (lead-coder catch): a tool-only round's chunks
+                # legitimately never expose delta.content at all (tool_calls
+                # is a SEPARATE field) — this is reyn's most common round
+                # shape, not a defect. Tracked here, alongside _delta_fired,
+                # so the guard below can tell "genuinely dead" apart from
+                # "just a normal tool round."
                 try:
-                    _delta_text = chunk.choices[0].delta.content
+                    if chunk.choices[0].delta.tool_calls:
+                        _tool_calls_seen = True
                 except Exception:  # noqa: BLE001 — malformed/empty chunk shape
-                    _delta_text = None
-                if _delta_text:
+                    pass
+        else:
+            # #5261: task A drains the provider stream and queues each
+            # non-empty content delta with its own arrival time; task B —
+            # the SAME event loop, no thread (owner ruling, issue #5261) —
+            # repeatedly drains whatever is ALREADY waiting in that queue
+            # into ONE merged ``on_content_delta`` call. Nothing is held
+            # for a fixed interval or count: the boundary is "however much
+            # task A managed to put while task B was still busy delivering
+            # the previous batch" — see ``_drain_and_emit_deltas``'s own
+            # docstring for the confirmed drain form and why it needs no
+            # ``held``/no-match branch (unlike its AG-UI precedent,
+            # ``_SessionFrameSource._drain_delta_run``, #5262): every item
+            # this queue ever holds is a content delta from THIS ONE
+            # ``acompletion`` call — same ``chain_id``, same ``round_index``
+            # by construction — so there is nothing for a "different run"
+            # to look like.
+            #
+            # The queue is intentionally UNBOUNDED. ``_pump_chunks``'s own
+            # ``chunks.append(chunk)`` below ALREADY retains every chunk
+            # unconditionally (``litellm.stream_chunk_builder`` needs the
+            # complete list to reconstruct the response) — this queue only
+            # ever holds a SUBSET of what ``chunks`` already holds (the ones
+            # carrying a non-empty content delta), so it cannot be the
+            # reason memory grows beyond what this function already commits
+            # to holding — a ``maxsize`` here would bound something that is
+            # not a new resource (owner's standing "no unjustified constant"
+            # rule). See ``chunks.append(chunk)``'s own comment for what
+            # would silently invalidate this (architect, issue #5261).
+            q: "asyncio.Queue[tuple[str, datetime]]" = asyncio.Queue()
+            _DONE = object()
+
+            async def _pump_chunks() -> None:
+                nonlocal _tool_calls_seen
+                try:
+                    async for chunk in chunk_stream:
+                        # #5261: this unconditional append is WHY the merge
+                        # queue above needs no ``maxsize`` — it already
+                        # retains every chunk regardless of delta wiring, so
+                        # the queue only ever holds a subset. If this line
+                        # ever becomes conditional (e.g. a knob to stop
+                        # retaining chunks once reconstruction no longer
+                        # needs them), the queue above silently becomes an
+                        # unbounded resource of its own and nothing here
+                        # turns red to say so — re-examine it then.
+                        chunks.append(chunk)
+                        _delta_text = None
+                        try:
+                            _delta_text = chunk.choices[0].delta.content
+                        except Exception:  # noqa: BLE001 — malformed/empty chunk shape
+                            _delta_text = None
+                        if _delta_text:
+                            await q.put((_delta_text, datetime.now().astimezone()))
+                        # #4805 review (lead-coder catch) — see the
+                        # ``on_content_delta is None`` branch above for the
+                        # full reasoning; unchanged here.
+                        try:
+                            if chunk.choices[0].delta.tool_calls:
+                                _tool_calls_seen = True
+                        except Exception:  # noqa: BLE001 — malformed/empty chunk shape
+                            pass
+                finally:
+                    # ALWAYS enqueued, on every exit (normal end, a raised
+                    # exception, or cancellation) — the only way
+                    # ``_drain_and_emit_deltas`` learns "no more deltas are
+                    # coming" (mirrors #5107's own ``_SSE_DONE``-in-``finally``
+                    # discipline, ``AgUiTransport._pump_sse``).
+                    await q.put(_DONE)
+
+            async def _drain_and_emit_deltas() -> None:
+                """#5261 confirmed drain form (issue #5261, lead-coder's
+                final sketch after 4 owner-driven simplifications — no
+                fixed window, no fixed count, no ``held``):
+
+                    array = [await q.get()]
+                    while True:
+                        await asyncio.sleep(0)
+                        try: array.append(q.get_nowait())
+                        except QueueEmpty: break
+                    emit(merge(array))
+
+                Extended only to also stop on :data:`_DONE` (not part of
+                the confirmed snippet — that snippet assumed an infinite
+                delta stream; this one is finite, one ``acompletion`` call)
+                and to loop the whole thing until the stream ends, since one
+                call produces MANY merged batches over its lifetime, not
+                one. Runs until ``_pump_chunks`` signals the stream is
+                over, then returns — never blocks forever on an empty
+                queue with nothing left to fill it.
+
+                Each merged batch is emitted with ①the raw chunk count and
+                ②the first/last arrival time of the chunks it stands in
+                for (architect condition, issue #5261 — the coalesced-away
+                individual arrivals must still be reconstructible: "what
+                did the provider send, and when", the same question
+                ``coalesced_fragment_count`` answers on the durable side,
+                #4960)."""
+                nonlocal _delta_fired
+                while True:
+                    item = await q.get()
+                    if item is _DONE:
+                        return
+                    array = [item]
+                    stream_ended = False
+                    while True:
+                        await asyncio.sleep(0)  # yield — #5262's own drain does the same
+                        try:
+                            nxt = q.get_nowait()
+                        except asyncio.QueueEmpty:
+                            break
+                        if nxt is _DONE:
+                            stream_ended = True
+                            break
+                        array.append(nxt)
                     _delta_fired = True
+                    merged_text = "".join(text for text, _ in array)
                     try:
-                        on_content_delta(_delta_text)
+                        on_content_delta(
+                            merged_text,
+                            raw_chunk_count=len(array),
+                            first_arrival=array[0][1],
+                            last_arrival=array[-1][1],
+                        )
                     except Exception:  # noqa: BLE001 — a display-event emit must never break the LLM call
                         logger.exception(
                             "recorded_acompletion: on_content_delta callback raised; "
                             "continuing the stream"
                         )
-            # #4805 review (lead-coder catch): a tool-only round's chunks
-            # legitimately never expose delta.content at all (tool_calls is
-            # a SEPARATE field) — this is reyn's most common round shape,
-            # not a defect. Tracked here, alongside _delta_fired, so the
-            # guard below can tell "genuinely dead" apart from "just a
-            # normal tool round."
+                    if stream_ended:
+                        return
+
+            pump_task = asyncio.create_task(_pump_chunks())
+            drain_task = asyncio.create_task(_drain_and_emit_deltas())
             try:
-                if chunk.choices[0].delta.tool_calls:
-                    _tool_calls_seen = True
-            except Exception:  # noqa: BLE001 — malformed/empty chunk shape
-                pass
+                await pump_task
+                await drain_task
+            except BaseException:
+                # A raise from the provider stream, or this whole call
+                # being cancelled from outside — either way, the other
+                # task must not be left running unattended.
+                drain_task.cancel()
+                pump_task.cancel()
+                raise
         # #3288 ③b co-vet fix: a silent functional-dead-mode guard. If the
         # provider streamed at least one chunk AND a callback was supplied,
         # but NOT ONE chunk ever exposed a non-empty delta.content (e.g. a
@@ -2806,7 +2965,7 @@ async def call_llm_tools(
     event_log: "EventLog | None" = None,
     emit_cost_events: bool = False,  # #1683: forwarded to recorded_acompletion (chat opts in)
     response_format: "dict | None" = None,  # 0062: RouterLoop's separate no-tools structured-answer turn ONLY — every op-loop tool-decision call leaves this None (ADR-0035 D2 separate-decide preserved: never combined with a non-empty `tools`)
-    on_content_delta: "Callable[[str], None] | None" = None,  # #3288 ③b: forwarded to recorded_acompletion — see its docstring
+    on_content_delta: "_OnContentDelta | None" = None,  # #3288 ③b / #5261: forwarded to recorded_acompletion — see its docstring
     model_class: "str | None" = None,  # #4206 T1: forwarded to recorded_acompletion — see its docstring (None = not subject to ceiling enforcement)
     model_class_ceiling: "str | None" = None,  # #4206 T1: the caller's effective ceiling, if any (None = unbounded)
     prompt_cache_key: str | None = None,  # #4700: forwarded to recorded_acompletion — see its docstring for the full reasoning

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -2712,9 +2712,22 @@ async def recorded_acompletion(
             except BaseException:
                 # A raise from the provider stream, or this whole call
                 # being cancelled from outside — either way, the other
-                # task must not be left running unattended.
+                # task must not be left running unattended. cancel() only
+                # REQUESTS cancellation — it does not wait for it, so
+                # without the gather below this function would return (and
+                # `raise` would propagate) while a task is still pending:
+                # ``_pump_chunks``'s own `finally` (which still runs on
+                # cancellation) could append to `chunks` or put onto `q`
+                # AFTER the caller believes the call is over — the same
+                # class of hazard #5267 named tonight for a different
+                # task pair. Awaiting the gather (with
+                # `return_exceptions=True`, since a cancelled task's own
+                # CancelledError must not mask the real exception we're
+                # about to re-raise) makes both tasks genuinely `done()`
+                # before this function returns.
                 drain_task.cancel()
                 pump_task.cancel()
+                await asyncio.gather(pump_task, drain_task, return_exceptions=True)
                 raise
         # #3288 ③b co-vet fix: a silent functional-dead-mode guard. If the
         # provider streamed at least one chunk AND a callback was supplied,

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -35,6 +35,8 @@ from reyn.services.compaction.engine import _IMAGE_FIXED_TOKEN_COST
 from reyn.services.turn_budget import wrap_up_system_prompt
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from reyn.llm.llm import LLMToolCallResult
     from reyn.tools.scheme import ExecutionResult
 
@@ -1204,7 +1206,14 @@ class RouterLoop:
             return _fn()
         return self._resolver.class_ceiling()
 
-    def _emit_agent_delta(self, text: str) -> None:
+    def _emit_agent_delta(
+        self,
+        text: str,
+        *,
+        raw_chunk_count: int,
+        first_arrival: "datetime",
+        last_arrival: "datetime",
+    ) -> None:
         """#3288 ③b: forward one streamed content-delta chunk as an audit-event
         — the owner-ratified L4 replacement (issue #3288 comment thread): a
         partial rides ``host.events`` (the SAME audit-event channel
@@ -1243,6 +1252,20 @@ class RouterLoop:
 
         Best-effort: a failing audit-event emit must never abort the
         in-flight LLM call it is merely narrating.
+
+        ``raw_chunk_count``/``first_arrival``/``last_arrival`` (#5261,
+        architect condition): ``text`` may already stand in for MORE than
+        one raw provider chunk — ``recorded_acompletion``'s own source-side
+        merge (task B's confirmed drain form, issue #5261) concatenates
+        whatever was already waiting before this callback ever fires. These
+        3 fields keep "what did the provider send, and when" answerable
+        after that merge — the same question the durable side's
+        ``coalesced_fragment_count`` answers for ITS OWN, separate
+        coalescing (#4960); losing this here would leave a gap the
+        durable side never had. What is genuinely lost is the individual
+        chunk BOUNDARIES within one merged batch — the owner's own
+        stated goal for this change (issue #5261: "no one wants individual
+        delta events").
         """
         try:
             self.host.events.emit(
@@ -1250,6 +1273,9 @@ class RouterLoop:
                 text=text,
                 chain_id=self.chain_id,
                 round_index=self._delta_round_index,
+                raw_chunk_count=raw_chunk_count,
+                first_arrival=first_arrival.isoformat(),
+                last_arrival=last_arrival.isoformat(),
             )
         except Exception:  # noqa: BLE001 — narration must never break the turn
             logger.exception("router: agent_delta audit-event emit failed")

--- a/tests/core/test_4960_agent_delta_coalesce.py
+++ b/tests/core/test_4960_agent_delta_coalesce.py
@@ -90,6 +90,36 @@ def test_coalescing_resets_after_each_durable_write() -> None:
     assert [w.data.get("coalesced_fragment_count") for w in store.written] == [5, 5]
 
 
+# ── #5261: raw_chunk_count-aware summing ────────────────────────────────
+
+
+def test_coalesced_count_sums_raw_chunk_count_not_event_count() -> None:
+    """Tier 1: #5261 — a mix of ``agent_delta`` events, some already
+    standing in for several raw provider chunks (source-side merged,
+    ``raw_chunk_count`` set) and some with none (pre-#5261 callers, or
+    #5261's own unmerged single-chunk case, contributing exactly 1) must
+    sum to the TRUE raw-chunk total, not the number of events that
+    arrived. Asserts the actual computed sum, never a pinned/hardcoded
+    literal (a pinned count previously failed ``test_tier_audit.py
+    --strict`` on #5266) — the value below is derived from the same
+    per-event contributions the test itself constructs."""
+    store = _RecordingStore()
+    backend = LocalEventBackend(store, agent_delta_coalesce_fragments=1_000_000, clock=_FakeClock())
+
+    contributions = [3, None, 1, 5, None]  # None == no raw_chunk_count field at all
+    for n in contributions:
+        data = {"chain_id": "c1", "text": "x"}
+        if n is not None:
+            data["raw_chunk_count"] = n
+        backend.write(Event(type="agent_delta", data=data))
+    assert store.written == [], "sanity: below the (huge) fragment threshold, nothing durable yet"
+
+    backend.flush_pending_deltas("c1")
+
+    expected_total = sum(n if n is not None else 1 for n in contributions)
+    assert [w.data.get("coalesced_fragment_count") for w in store.written] == [expected_total]
+
+
 # ── interval coalescing (the process-death guarantee) ──────────────────
 
 

--- a/tests/interfaces/test_agent_delta_audit_event_3288.py
+++ b/tests/interfaces/test_agent_delta_audit_event_3288.py
@@ -25,6 +25,7 @@ with a real async callable (never a mock, per testing.md) that invokes the
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from pathlib import Path
 
 from reyn.core.events.events import Event
@@ -99,8 +100,17 @@ def test_agent_delta_events_fire_and_history_stays_whole_persist(tmp_path, monke
             "RouterLoop must thread on_content_delta into call_llm_tools "
             "for this to be a real streaming-wiring witness"
         )
+        # #5261: on_content_delta is now called per MERGED batch, carrying
+        # ①raw_chunk_count and ②first/last arrival. This fake stand-in
+        # drives call sites directly (it doesn't exercise the real
+        # ``_stream_and_reconstruct`` merge machinery — that's covered in
+        # ``tests/llm/test_llm_streaming_delta_emission_3288.py``), so each
+        # piece here stands in as its OWN unmerged batch of 1 raw chunk —
+        # the same "no field ⇒ 1" fact ``backend.py``'s summing fix relies
+        # on for a caller that predates #5261's merging.
         for piece in _PIECES:
-            on_delta(piece)
+            now = datetime.now().astimezone()
+            on_delta(piece, raw_chunk_count=1, first_arrival=now, last_arrival=now)
         return LLMToolCallResult(
             content=_FULL_TEXT, tool_calls=[], finish_reason="stop", usage=_EMPTY_USAGE,
         )
@@ -115,6 +125,11 @@ def test_agent_delta_events_fire_and_history_stays_whole_persist(tmp_path, monke
     delta_events = [e for e in sink.events if e.type == "agent_delta"]
     assert [e.data.get("text") for e in delta_events] == _PIECES
     assert all(e.data.get("chain_id") == "chain-delta-1" for e in delta_events)
+    # #5261: architect's mandatory condition — every "agent_delta" event
+    # carries the raw chunk count and arrival window it stands in for, all
+    # the way out to the audit-event, not just inside RouterLoop.
+    assert all(e.data.get("raw_chunk_count") == 1 for e in delta_events)
+    assert all(e.data.get("first_arrival") and e.data.get("last_arrival") for e in delta_events)
 
     # (2) the outbox NEVER carries a partial — exactly one kind="agent"
     # message, the FULL text. An "agent_delta" outbox entry never appears

--- a/tests/interfaces/test_stream_repaint_coalesce_3570.py
+++ b/tests/interfaces/test_stream_repaint_coalesce_3570.py
@@ -32,6 +32,7 @@ the only faked boundary, the established idiom of
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -161,7 +162,8 @@ def _install_bursting_llm(monkeypatch, *, chunks: int) -> None:
             "to be a real streaming-wiring witness"
         )
         for _ in range(chunks):
-            on_delta(_CHUNK)
+            now = datetime.now().astimezone()
+            on_delta(_CHUNK, raw_chunk_count=1, first_arrival=now, last_arrival=now)
         return LLMToolCallResult(
             content=_CHUNK * chunks,
             tool_calls=[],
@@ -499,7 +501,8 @@ async def test_a_deferred_repaint_is_painted_within_the_budget_window(
     async def _fake_llm(*_args, **kwargs):
         on_delta = kwargs["on_content_delta"]
         for _ in range(50):
-            on_delta(_CHUNK)
+            now = datetime.now().astimezone()
+            on_delta(_CHUNK, raw_chunk_count=1, first_arrival=now, last_arrival=now)
         await released.wait()  # the reply never completes during the assertion
         return LLMToolCallResult(
             content=_CHUNK * 50, tool_calls=[], finish_reason="stop", usage=_USAGE

--- a/tests/llm/test_llm_streaming_delta_emission_3288.py
+++ b/tests/llm/test_llm_streaming_delta_emission_3288.py
@@ -464,3 +464,73 @@ def test_a_tool_only_round_never_trips_the_dead_mode_guard(monkeypatch, caplog) 
         "a tool-only round must never trip the dead-mode guard — it is "
         "reyn's most common round shape, not a defect"
     )
+
+
+def _make_fake_acompletion_raises_mid_stream():
+    """A real, scripted stand-in whose streaming branch yields ONE content
+    chunk, then raises — modelling a provider stream that dies mid-flight
+    (a network drop, a malformed frame, anything ``async for`` can surface
+    as an exception from the provider's own async generator)."""
+
+    async def _fake_acompletion(model: str, messages: list, **kw: Any) -> Any:
+        def _chunk(delta: Delta) -> ModelResponseStream:
+            return ModelResponseStream(
+                id="resp-4", created=1, model=model, object="chat.completion.chunk",
+                choices=[StreamingChoices(index=0, delta=delta, finish_reason=None)],
+            )
+
+        async def _gen():
+            yield _chunk(Delta(role="assistant", content="partial"))
+            raise RuntimeError("provider stream dropped")
+
+        return _gen()
+
+    return _fake_acompletion
+
+
+def test_a_raising_provider_stream_leaves_no_task_still_running(monkeypatch) -> None:
+    """Tier 1: #5261 review (lead-coder + architect) — when the provider
+    stream itself raises, ``recorded_acompletion`` must not return (via the
+    re-raise) while ``_pump_chunks``/``_drain_and_emit_deltas`` are still
+    pending — ``cancel()`` only REQUESTS cancellation, it does not wait for
+    it, so the outer ``except`` must ``await`` the gather before
+    re-raising (mirrors #5267's own named hazard for a different task
+    pair). Witnessed via a TRUTH check (every task this call created is
+    ``done()`` once it returns), never a duration — CLAUDE.md forbids
+    writing a duration into a test in either direction."""
+    monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion_raises_mid_stream())
+
+    # #5261 review: ``asyncio.all_tasks()`` only lists tasks that are NOT
+    # yet done, so it cannot witness "done() by the time the call
+    # returned" — a genuinely-done task has already dropped out of it by
+    # the time we'd check. Capture the actual Task objects as they're
+    # created instead, via the real ``asyncio.create_task`` this module
+    # calls, so `.done()` can be asked directly on THOSE references.
+    created_tasks: "list[asyncio.Task]" = []
+    real_create_task = asyncio.create_task
+
+    def _recording_create_task(coro, **kw):
+        task = real_create_task(coro, **kw)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", _recording_create_task)
+
+    async def _drive() -> None:
+        try:
+            await recorded_acompletion(
+                model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
+                purpose="main", recorder=None,
+                model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
+                on_content_delta=lambda _t, **_kw: None,
+            )
+            assert False, "the provider's RuntimeError must propagate"
+        except RuntimeError:
+            pass
+        # The call has returned (via the re-raise) — every task IT created
+        # (_pump_chunks / _drain_and_emit_deltas) must already be done(),
+        # not merely cancel-requested.
+        assert created_tasks, "sanity: the streaming branch must have created tasks at all"
+        assert all(t.done() for t in created_tasks)
+
+    asyncio.run(_drive())

--- a/tests/llm/test_llm_streaming_delta_emission_3288.py
+++ b/tests/llm/test_llm_streaming_delta_emission_3288.py
@@ -3,10 +3,21 @@
 
 ③a (merged, #3304) added a capability-gated streaming loop that reconstructs
 the SAME whole response internally — callers saw no behavioral difference.
-③b's job is to carry the per-chunk deltas OUT to a caller-supplied callback
-while leaving that reconstruction (and everything callers already observed)
+③b's job is to carry the deltas OUT to a caller-supplied callback while
+leaving that reconstruction (and everything callers already observed)
 untouched. This file is the llm.py-level half of that; the audit-event/
 transport half lives in ``tests/interfaces/test_agent_delta_audit_event_3288.py``.
+
+#5261: ``on_content_delta`` now fires once per MERGED batch, not once per
+raw provider chunk — the merge boundary is emergent from cooperative
+scheduling (see ``_stream_and_reconstruct``'s own #5261 docstring/comments),
+never a fixed count or fixed time window, so this file must never pin HOW
+MANY calls happen or WHERE the split falls (CLAUDE.md: never pin algorithm-
+level behaviour). What stays invariant regardless of how the scheduler
+happens to batch this run: every batch's text concatenated in order still
+reconstructs the whole response, the ``raw_chunk_count`` values sum to the
+true number of content-bearing chunks, and each batch's
+``first_arrival <= last_arrival``.
 
 Uses a scripted ``litellm.acompletion`` replacement (a real async callable —
 same idiom as ``test_llm_streaming_equivalence_3288.py``), never a
@@ -17,6 +28,7 @@ produced a plausible-looking result while never actually streaming).
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from typing import Any
 
 import litellm
@@ -26,6 +38,29 @@ from reyn.llm.llm import call_llm_tools, recorded_acompletion
 
 _CONTENT = "Hello world"
 _USAGE = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+
+
+class _DeltaRecorder:
+    """#5261: records each MERGED ``on_content_delta`` call — (text,
+    raw_chunk_count, first_arrival, last_arrival) — without assuming how
+    many calls there are or where the merge boundary falls."""
+
+    def __init__(self) -> None:
+        self.calls: "list[tuple[str, int, datetime, datetime]]" = []
+
+    def __call__(
+        self, text: str, *, raw_chunk_count: int,
+        first_arrival: datetime, last_arrival: datetime,
+    ) -> None:
+        self.calls.append((text, raw_chunk_count, first_arrival, last_arrival))
+
+    @property
+    def merged_text(self) -> str:
+        return "".join(text for text, _, _, _ in self.calls)
+
+    @property
+    def total_raw_chunk_count(self) -> int:
+        return sum(n for _, n, _, _ in self.calls)
 
 
 def _make_fake_acompletion(chunk_witness: "list[int] | None" = None):
@@ -71,29 +106,37 @@ def _make_fake_acompletion(chunk_witness: "list[int] | None" = None):
     return _fake_acompletion
 
 
-def test_on_content_delta_fires_per_real_content_chunk(monkeypatch) -> None:
-    """Tier 3a: ``on_content_delta`` fires once per non-empty content-delta
-    chunk, in order, with the RAW per-chunk text — witnessed via real chunk
-    consumption (``chunk_witness``), not merely that ``stream=True`` was
-    requested (see ``_stream_and_reconstruct``'s non-aiter-able fallback)."""
+def test_on_content_delta_fires_with_merged_text_covering_every_content_chunk(
+    monkeypatch,
+) -> None:
+    """Tier 3a: ``on_content_delta`` fires — possibly split across several
+    merged batches, per #5261's emergent-scheduling boundary — with the
+    concatenation of every batch's text reconstructing the full response,
+    and every content-bearing chunk accounted for exactly once across the
+    ``raw_chunk_count`` values. Witnessed via real chunk consumption
+    (``chunk_witness``), not merely that ``stream=True`` was requested (see
+    ``_stream_and_reconstruct``'s non-aiter-able fallback)."""
     chunk_witness: list[int] = []
     monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion(chunk_witness))
 
-    deltas: list[str] = []
+    deltas = _DeltaRecorder()
     result = asyncio.run(recorded_acompletion(
         model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,
         model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
-        on_content_delta=deltas.append,
+        on_content_delta=deltas,
     ))
 
     # All 3 scripted chunks (2 content + 1 usage-only terminal) were really
     # consumed off the async generator.
     assert chunk_witness == [1, 1, 1]
-    # Only the 2 content-bearing chunks reached the callback — the terminal
-    # usage-only chunk (empty delta.content) is silently skipped.
-    assert deltas == [_CONTENT[: len(_CONTENT) // 2], _CONTENT[len(_CONTENT) // 2 :]]
-    assert "".join(deltas) == _CONTENT
+    # The terminal usage-only chunk (empty delta.content) never entered a
+    # batch — only the 2 content-bearing chunks are accounted for, however
+    # they happened to be split/merged across calls.
+    assert deltas.total_raw_chunk_count == 2
+    assert deltas.merged_text == _CONTENT
+    for _text, _count, first, last in deltas.calls:
+        assert first <= last
     # ③a's whole-result reconstruction is UNAFFECTED by ③b's callback.
     assert result.choices[0].message.content == _CONTENT
     assert result.usage.prompt_tokens == _USAGE["prompt_tokens"]
@@ -133,7 +176,7 @@ def test_failing_on_content_delta_does_not_break_the_call(monkeypatch) -> None:
 
     calls: list[str] = []
 
-    def _boom(text: str) -> None:
+    def _boom(text: str, **_kw: Any) -> None:
         calls.append(text)
         raise RuntimeError("display sink exploded")
 
@@ -144,10 +187,11 @@ def test_failing_on_content_delta_does_not_break_the_call(monkeypatch) -> None:
         on_content_delta=_boom,
     ))
 
-    # The callback WAS invoked (and raised, and was swallowed) for each chunk —
-    # a vacuous "never called" would let this test pass without exercising the
-    # guard at all.
-    assert calls == [_CONTENT[: len(_CONTENT) // 2], _CONTENT[len(_CONTENT) // 2 :]]
+    # The callback WAS invoked (and raised, and was swallowed) for at least
+    # one batch — a vacuous "never called" would let this test pass without
+    # exercising the guard at all. #5261: however many batches, their
+    # concatenation still covers the whole content.
+    assert "".join(calls) == _CONTENT
     assert result.choices[0].message.content == _CONTENT
 
 
@@ -159,14 +203,15 @@ def test_call_llm_tools_forwards_on_content_delta_through_to_the_stream(monkeypa
     chunk_witness: list[int] = []
     monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion(chunk_witness))
 
-    deltas: list[str] = []
+    deltas = _DeltaRecorder()
     result = asyncio.run(call_llm_tools(
         model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
-        tools=[], on_content_delta=deltas.append,
+        tools=[], on_content_delta=deltas,
     ))
 
     assert chunk_witness == [1, 1, 1]
-    assert deltas == [_CONTENT[: len(_CONTENT) // 2], _CONTENT[len(_CONTENT) // 2 :]]
+    assert deltas.total_raw_chunk_count == 2
+    assert deltas.merged_text == _CONTENT
     assert result.content == _CONTENT
 
 
@@ -288,12 +333,12 @@ def test_default_shaped_gemini_call_actually_enters_the_streaming_branch(monkeyp
     chunk_witness: list[int] = []
     monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion(chunk_witness))
 
-    deltas: list[str] = []
+    deltas = _DeltaRecorder()
     result = asyncio.run(recorded_acompletion(
         model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,
         model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
-        on_content_delta=deltas.append,
+        on_content_delta=deltas,
         # The default-config primary-reply shape: tools attached AND
         # reasoning_effort set (an operator's own reyn.yaml model classes
         # commonly carry reasoning_effort for Gemini reasoning models —
@@ -306,7 +351,8 @@ def test_default_shaped_gemini_call_actually_enters_the_streaming_branch(monkeyp
     # streaming branch was actually entered and driven, not just that the
     # capability query returned True.
     assert chunk_witness == [1, 1, 1]
-    assert deltas == [_CONTENT[: len(_CONTENT) // 2], _CONTENT[len(_CONTENT) // 2 :]]
+    assert deltas.total_raw_chunk_count == 2
+    assert deltas.merged_text == _CONTENT
     assert result.choices[0].message.content == _CONTENT
 
 
@@ -324,7 +370,7 @@ def test_silent_zero_delta_guard_does_not_fire_when_deltas_do(monkeypatch, caplo
             model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=None,
             model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
-            on_content_delta=lambda _t: None,
+            on_content_delta=lambda _t, **_kw: None,
         ))
 
     guard_records = [
@@ -406,7 +452,7 @@ def test_a_tool_only_round_never_trips_the_dead_mode_guard(monkeypatch, caplog) 
             model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=None,
             model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
-            on_content_delta=lambda _t: None,
+            on_content_delta=lambda _t, **_kw: None,
         ))
 
     assert chunk_witness == [1, 1, 1]  # real chunk consumption, not vacuous


### PR DESCRIPTION
**[e2e-coder]** — Closes #5261.

## What
`_stream_and_reconstruct` (`recorded_acompletion`'s chokepoint, `llm.py`) no longer hands 1 raw provider stream chunk straight to `on_content_delta`. Two `asyncio.Task` on the SAME event loop (owner-ruled: no threads, issue #5261):

- `_pump_chunks` drains the provider stream, queues each non-empty content-delta chunk with its own arrival time; always enqueues a `_DONE` sentinel in `finally` regardless of how the stream ends (mirrors `AgUiTransport._pump_sse`'s #5107 discipline).
- `_drain_and_emit_deltas` repeatedly merges whatever is ALREADY waiting in the queue (confirmed drain form, issue #5261) into one `on_content_delta` call — never a fixed window or fixed count; the merge boundary is emergent from cooperative scheduling.

Each merged batch carries `raw_chunk_count` / `first_arrival` / `last_arrival` (architect's mandatory condition) so the cost/latency measurement that justified this change stays possible after it ships.

The queue is intentionally unbounded — `chunks.append(chunk)` already retains every chunk unconditionally for `stream_chunk_builder`, so the queue can only ever hold a subset; a `maxsize` would bound something that isn't a new resource. Both sides carry the invalidation note (owner's "no unjustified constant" rule).

`RouterLoop._emit_agent_delta` (sole production `on_content_delta` consumer) takes the 3 new required keyword-only args and forwards them onto the `agent_delta` audit-event.

## Also fixed (same PR, in scope — see below)
Found during implementation: `LocalEventBackend.write()`'s `coalesced_fragment_count` (#4960) summed `+1` per incoming `agent_delta` EVENT, which would silently under-count once one event can stand in for several raw chunks. Now sums each event's own `raw_chunk_count` (defaulting to 1 for an event without one — an unmerged event IS one raw chunk). lead-coder folded this into #5261's own issue body and required same-PR (splitting would leave `main` carrying a silently-wrong count under an unchanged field name).

## Tests
- Updated every pre-existing `on_content_delta`/`_emit_agent_delta` test call site to the new 4-argument convention (`test_llm_streaming_delta_emission_3288.py`, `test_agent_delta_audit_event_3288.py`, `test_stream_repaint_coalesce_3570.py`).
- New merge-boundary-agnostic witness (`test_llm_streaming_delta_emission_3288.py`) — never pins call count/split (CLAUDE.md: never pin algorithm-level behaviour); asserts merged text reconstructs the whole response and `raw_chunk_count` sums correctly.
- New `raw_chunk_count`-aware coalesced-count witness (`test_4960_agent_delta_coalesce.py`) — mixed merged/unmerged events, asserts the computed sum, never a pinned literal (#5266 precedent).
- Both new mechanisms strip-falsified: reverting `backend.py`'s summing to a bare `+1`, and reverting `llm.py`'s `raw_chunk_count`/`last_arrival` to hardcoded single-chunk values, both flip the new tests RED (verified, then restored).

Local gates: ruff, `test_tier_audit.py --strict` (changed test files), `mypy_ratchet.py`, `verify_module_docstrings.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green. Scoped pytest across every file touching `on_content_delta`/`_emit_agent_delta` (llm streaming, agent_delta audit-event, textual_chat repaint/coalesce, AG-UI delta-run-merge, turn-group) — all green.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on changed test files
- [x] `mypy_ratchet.py`
- [x] `verify_module_docstrings.py` on changed src files
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] Scoped pytest across all `on_content_delta`/`_emit_agent_delta` call sites
- [x] Strip-falsify: both new mechanisms confirmed RED under a real strip, then restored
- [x] (skipped — no visual surface changed)

Cannot self-merge (touches `tests/`) — needs a TESTS-READ note per rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- [x] 🔴 cancel した task を待っていない — `drain_task.cancel()` / `pump_task.cancel()` の後に `await asyncio.gather(..., return_exceptions=True)`。戻った時点で両 task が `done()` である witness を付けること（#5267 と同じ形）。

