### PR TITLE
feat(#5267): task-funnel-bypass gate (Family A) — warn-only

### DIFF
--- a/.github/workflows/task-funnel-bypass-gate.yml
+++ b/.github/workflows/task-funnel-bypass-gate.yml
@@ -1,0 +1,58 @@
+name: task-funnel-bypass gate
+
+# #5267 (Family A): a module that owns a TrackedTaskSet (receives one as
+# a required constructor param, or constructs one directly) must route
+# every background spawn through it, never a raw asyncio.create_task —
+# such a task is invisible to the funnel's own cancel-then-await
+# discipline (TrackedTaskSet.aclose()'s asyncio.gather(...,
+# return_exceptions=True)), the exact shape #5267's own chain (Session.
+# run_one_iteration's _turn_owner_task) and #5268 (same night, a
+# different ad hoc task pair in llm.py) both hit. See
+# scripts/check_task_funnel_bypass.py's module docstring for the full
+# design rationale, the derived (not hand-enumerated) scope, and the
+# promotion/removal conditions.
+#
+# WARN-ONLY (architect ruling, #5267) — nobody has measured this AST
+# shape's false-positive rate against the real tree yet. The promotion
+# condition (0 new false positives across 20 consecutive PRs touching an
+# in-scope file -> promote to blocking) is written in the script's own
+# module docstring NOW, at gate creation, specifically so this does not
+# repeat #5010's own fate (a warn-only gate nobody ever wrote a
+# promotion condition for, so it never had a moment anyone could call
+# "now" and stayed warn-only indefinitely).
+on:
+  pull_request:
+    paths:
+      - "src/reyn/**"
+
+permissions:
+  contents: read
+
+jobs:
+  task-funnel-bypass:
+    name: task-funnel-bypass gate (warn-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_task_funnel_bypass.py is stdlib-only (ast / pathlib
+      # / sys). No pip install needed.
+      - name: Check no TrackedTaskSet-owning module bypasses its own funnel
+        run: |
+          set +e
+          python scripts/check_task_funnel_bypass.py > funnel_bypass_output.txt 2>&1
+          exit_code=$?
+          cat funnel_bypass_output.txt
+          if [ "$exit_code" -ne 0 ]; then
+            while IFS= read -r line; do
+              echo "::warning::${line}"
+            done < <(grep "^  src/" funnel_bypass_output.txt)
+          fi
+          exit 0

--- a/scripts/check_task_funnel_bypass.py
+++ b/scripts/check_task_funnel_bypass.py
@@ -95,16 +95,48 @@ is a candidate for removal rather than indefinite warn status — a
 warn-only gate nobody ever promotes is indistinguishable, in effect,
 from no gate at all, and #5010 is the standing example of exactly that
 non-outcome.
+
+## The baseline — where a false positive gets COUNTED (lead-coder review)
+
+The 20-PR/2-week conditions above need a denominator: something that
+actually COUNTS a false positive when one fires, distinct from a real
+defect. The first draft's own test (a bare "the tree has exactly this
+one disclosed hit" pin) failed that job — its own failure message told
+a person to "update this pin," which silently absorbs a genuinely NEW
+hit (false positive OR real defect, indistinguishable) into the pin
+with zero record that anything happened. Zero false positives could
+ever get counted that way, so the 20-PR promotion condition could never
+be evaluated either — not because none occurred, but because nothing
+was built to notice.
+
+``task_funnel_bypass_baseline.json`` is the fix — the same
+declared-baseline idiom this repo already uses for exactly this problem
+(``mypy_ratchet.py``'s ``(file, code)`` pairs, ``flat_tests_ratchet.py``'s
+filename set): every CURRENTLY accepted offender is a declared entry,
+keyed by file path, each carrying its own ``"type"`` (``"defect"`` — a
+real hazard tracked for its own fix PR, same as ``session.py`` today —
+or ``"false_positive"`` — the gate is wrong about this one) and a
+``"note"`` explaining which and why. The test
+(``tests/scripts/test_check_task_funnel_bypass_5267.py``) asserts the
+REAL tree's offenders match the declared set exactly; a new,
+undeclared offender fails that test (a real, already-blocking CI signal
+via the normal pytest job — no separate always-blocking workflow
+needed), forcing whoever introduced it to add a declared entry and
+classify it BEFORE the PR is green. That one required action is what
+makes ``"false_positive"`` entries countable: they are not a "same as
+before" default that requires nobody to write anything down.
 """
 from __future__ import annotations
 
 import ast
+import json
 import sys
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[1]
 _SRC_DIR = _ROOT / "src" / "reyn"
 _TRACKED_TASKS_MODULE = _SRC_DIR / "runtime" / "tracked_tasks.py"
+_BASELINE_PATH = _ROOT / "scripts" / "task_funnel_bypass_baseline.json"
 
 
 def _annotation_text(node: "ast.expr | None") -> str:
@@ -211,6 +243,15 @@ def offending_files(src_dir: Path) -> "list[tuple[Path, list[int]]]":
         if hits:
             offenders.append((path, hits))
     return offenders
+
+
+def load_declared_baseline(path: Path = _BASELINE_PATH) -> "dict[str, dict[str, str]]":
+    """The committed record of every offender CURRENTLY accepted, keyed by
+    a ``src/reyn/...``-relative path string, each carrying its own
+    ``type`` (``"defect"`` / ``"false_positive"``) and ``note`` — see this
+    module's own "The baseline" docstring section for why this exists
+    instead of a bare pinned count."""
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def main(argv: "list[str] | None" = None) -> int:

--- a/scripts/check_task_funnel_bypass.py
+++ b/scripts/check_task_funnel_bypass.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""#5267 (Family A) — a static gate against a raw ``asyncio.create_task``
+call inside a module that OWNS a :class:`~reyn.runtime.tracked_tasks.
+TrackedTaskSet`, bypassing the single funnel #4759 built for exactly this
+("SpawnTracker and OutboxHub made task_tracker a REQUIRED constructor
+param ... skipping the funnel there is now a TypeError, not a silent
+gap" — but, per that same issue's own words, "where it's optional, it is
+still a discipline, not a guarantee" for every OTHER caller).
+
+## The failure this closes
+
+#5267's own chain: ``Session.run_one_iteration()`` spawns a turn's body
+via a bare ``asyncio.create_task`` (``session.py``), never through
+``TrackedTaskSet``. ``Task.cancel()`` only requests cancellation at the
+task's current await point — it does not, and cannot, stop a background
+thread (or any other still-running work) a cancelled task's own
+``finally`` may still be spawning/writing through. A turn cancelled
+mid-flight can leave background work racing the NEXT turn over the same
+mutable session state, with nothing red anywhere: cancellation is a
+human action (Ctrl-C, a slash command), not something a test suite
+presses on its own. #5268 (same night) found a second, independent
+instance of the identical shape in ``llm.py``'s own ad hoc task pair.
+
+The fix this gate exists to make structural (not a one-off patch) is
+routing every such spawn through ``TrackedTaskSet.spawn()`` instead of a
+bare ``asyncio.create_task`` — the funnel already awaits its own tasks'
+cancellation properly (``aclose()``'s ``asyncio.gather(..., return_
+exceptions=True)``), so a module that spawns exclusively through it gets
+that discipline for free, the same way #4759 already made it a
+``TypeError`` (not a silent gap) to construct ``SpawnTracker``/
+``OutboxHub`` without one.
+
+## Scope — derived, not enumerated by hand
+
+A hand-typed module list is a census: "the modules I noticed today", not
+"the modules that are actually exposed" — a 9th case that arrives via a
+FUTURE PR, adding a module that owns a ``TrackedTaskSet``, would silently
+sit outside a frozen list forever (nothing here would turn red to say
+so). Scope is derived from two independent, both mechanical, ownership
+shapes — verified against the real tree the night this gate was written
+(#5267 comment thread: the first draft, "required constructor param"
+only, undercounted to 2 files and structurally EXCLUDED ``session.py`` —
+the very file #5267's own chain names — because ``Session`` does not
+RECEIVE a ``TrackedTaskSet``, it CONSTRUCTS one):
+
+1. **Receives one as a required constructor param** — an ``__init__``
+   parameter whose annotation names ``TrackedTaskSet`` with no
+   ``None``-tolerant union and no default value (``outbox_hub.py``,
+   ``spawn_tracker.py`` today). ``ChainManager`` deliberately keeps this
+   OPTIONAL (``TrackedTaskSet | None = None``, documented in its own
+   ``__init__`` — 12 pre-existing test call sites never exercise #4759's
+   teardown property, and forcing all 12 to thread a tracker through
+   would touch files unrelated to any single PR's own concern) — it is
+   correctly OUT of this gate's scope; see that constructor's own
+   docstring for the exact condition under which it would need to
+   re-enter scope.
+2. **Constructs one itself** — a ``TrackedTaskSet(...)`` call anywhere in
+   the module (``session.py``'s own ``self._background_tasks =
+   TrackedTaskSet()``). Construction is the strongest form of ownership;
+   a module that builds the funnel and then bypasses it for some OTHER
+   spawn is the exact defect #5267 found, so this criterion is what
+   brings ``session.py`` itself into scope.
+
+Both are AST-derived facts about the file's own text, not a judgment
+call — a module that starts receiving/constructing a ``TrackedTaskSet``
+tomorrow enters scope automatically; one that stops (drops the param,
+inlines a different task owner) leaves it automatically. ``tracked_
+tasks.py`` itself is excluded unconditionally — it IS the funnel;
+``TrackedTaskSet.spawn()``'s own ``asyncio.create_task`` call is the
+one legitimate call site this whole gate exists to fence everything
+else away from.
+
+## Warn-only (architect ruling, #5267) — promotion condition stated now
+
+This gate starts at WARN (the CI workflow always exits 0; see
+``.github/workflows/task-funnel-bypass-gate.yml``) because nobody has
+measured this specific AST shape's false-positive rate against the real
+tree yet. #5010's own history is the reason a promotion condition is
+written HERE, NOW, rather than left for later: #5010 stayed warn-only
+indefinitely because nobody wrote down what "ready to promote" meant,
+so there was never a moment anyone could point to and say "now" — it
+just accumulated as a gate that looks like it protects something while
+promoting nothing.
+
+**Promotion condition**: 0 new false positives, across 20 consecutive
+PRs that touch an in-scope file, promotes this to a blocking (error-exit)
+gate. (20, not a time window — a time-based count depends on this
+project's own PR pace, which this gate has no reason to track; 20 is
+enough PRs to hit the in-scope files, which are a small, named-by-
+construction subset of ``src/``, several times over.)
+
+**Removal condition**: if 2 weeks pass with the promotion condition
+still unmet (i.e. a false positive fired within that window), this gate
+is a candidate for removal rather than indefinite warn status — a
+warn-only gate nobody ever promotes is indistinguishable, in effect,
+from no gate at all, and #5010 is the standing example of exactly that
+non-outcome.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC_DIR = _ROOT / "src" / "reyn"
+_TRACKED_TASKS_MODULE = _SRC_DIR / "runtime" / "tracked_tasks.py"
+
+
+def _annotation_text(node: "ast.expr | None") -> str:
+    """Best-effort source text of an annotation node — this repo writes
+    these as quoted forward refs (``"TrackedTaskSet"`` / ``"TrackedTaskSet
+    | None"``) as often as bare expressions, so a plain ``ast.unparse``
+    (which would just re-quote the string constant) is not enough; peel
+    one layer of ``ast.Constant`` string first."""
+    if node is None:
+        return ""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    try:
+        return ast.unparse(node)
+    except Exception:  # noqa: BLE001 — best-effort only, never fatal
+        return ""
+
+
+def _is_required_tracked_task_set_param(arg: ast.arg, has_default: bool) -> bool:
+    """True if *arg* is annotated as (a non-Optional) ``TrackedTaskSet``
+    and has no default value — criterion ① in the module docstring."""
+    text = _annotation_text(arg.annotation)
+    if "TrackedTaskSet" not in text:
+        return False
+    if "None" in text or "Optional" in text:
+        return False  # None-tolerant — e.g. ChainManager's own param
+    return not has_default
+
+
+def _init_has_required_tracker_param(cls: ast.ClassDef) -> bool:
+    for node in cls.body:
+        if not (isinstance(node, ast.FunctionDef) and node.name == "__init__"):
+            continue
+        args = node.args
+        # Positional-or-keyword args: only the tail (len(defaults)) have
+        # defaults; align from the right, same as Python's own binding.
+        posargs = args.args
+        pos_defaults = [None] * (len(posargs) - len(args.defaults)) + list(args.defaults)
+        for a, d in zip(posargs, pos_defaults):
+            if _is_required_tracked_task_set_param(a, d is not None):
+                return True
+        # Keyword-only args: aligned 1:1 with kw_defaults (None entry = no default).
+        for a, d in zip(args.kwonlyargs, args.kw_defaults):
+            if _is_required_tracked_task_set_param(a, d is not None):
+                return True
+    return False
+
+
+def _module_constructs_tracked_task_set(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else (
+            func.attr if isinstance(func, ast.Attribute) else None
+        )
+        if name == "TrackedTaskSet":
+            return True
+    return False
+
+
+def _is_raw_create_task_call(node: ast.Call) -> bool:
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr == "create_task":
+        return isinstance(func.value, ast.Name) and func.value.id == "asyncio"
+    if isinstance(func, ast.Name) and func.id == "create_task":
+        return True  # `from asyncio import create_task` shape
+    return False
+
+
+def in_scope_files(src_dir: Path) -> "list[Path]":
+    """Every file that OWNS a ``TrackedTaskSet`` (criterion ① or ②),
+    excluding the funnel's own implementation file — the mechanical scope
+    this gate's own module docstring describes. Directly testable in
+    isolation from the offender scan below."""
+    scoped: "list[Path]" = []
+    for path in sorted(src_dir.rglob("*.py")):
+        if path == _TRACKED_TASKS_MODULE:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, SyntaxError):
+            continue
+        if _module_constructs_tracked_task_set(tree):
+            scoped.append(path)
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and _init_has_required_tracker_param(node):
+                scoped.append(path)
+                break
+    return scoped
+
+
+def offending_files(src_dir: Path) -> "list[tuple[Path, list[int]]]":
+    """The gate's whole decision, isolated from CLI/printing — directly
+    testable, mirrors ``check_cancel_swallow.py``'s own split."""
+    offenders: "list[tuple[Path, list[int]]]" = []
+    for path in in_scope_files(src_dir):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        hits = sorted(
+            node.lineno for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and _is_raw_create_task_call(node)
+        )
+        if hits:
+            offenders.append((path, hits))
+    return offenders
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options — a whole-tree scan against a derived scope
+    offenders = offending_files(_SRC_DIR)
+
+    if not offenders:
+        print(
+            "OK: no raw asyncio.create_task() call found inside a module "
+            "that owns a TrackedTaskSet."
+        )
+        return 0
+
+    print("task-funnel-bypass gate FAILED (WARN-ONLY — see module docstring):\n", file=sys.stderr)
+    print(
+        f"{len(offenders)} file(s) own a TrackedTaskSet (receive one as a "
+        "required constructor param, or construct one directly) but spawn "
+        "at least one background task with a raw asyncio.create_task() "
+        "instead of routing it through TrackedTaskSet.spawn() (#4759) — "
+        "such a task is invisible to the funnel's own teardown/cancel-"
+        "then-await discipline (#5267):",
+        file=sys.stderr,
+    )
+    for path, hits in offenders:
+        rel = path.relative_to(_ROOT)
+        for line in hits:
+            print(f"  {rel}:{line}: raw asyncio.create_task() in a TrackedTaskSet-owning module", file=sys.stderr)
+
+    print(
+        "\nFix: route the spawn through this module's own TrackedTaskSet "
+        "instance's .spawn() instead of asyncio.create_task() directly "
+        "(see outbox_hub.py / spawn_tracker.py for the accepted shape).\n"
+        "\nWarn-only for now — promotion/removal conditions are in this "
+        "script's own module docstring.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_task_funnel_bypass.py
+++ b/scripts/check_task_funnel_bypass.py
@@ -96,6 +96,16 @@ warn-only gate nobody ever promotes is indistinguishable, in effect,
 from no gate at all, and #5010 is the standing example of exactly that
 non-outcome.
 
+**Who counts, and how**: a human, at promotion-decision time — not a
+new script. ``git log -p -- scripts/task_funnel_bypass_baseline.json``
+shows every commit that added an entry; the commit(s) adding a
+``"false_positive"`` entry ARE the false-positive count, in order,
+against the PRs that touched an in-scope file over that stretch. #5010
+stalled because nobody wrote down what "ready to promote" meant, not
+because nothing counted it automatically — writing the one-line
+derivation above, at promotion time, is enough; building a counter for
+it would be solving a problem #5010 never actually had.
+
 ## The baseline — where a false positive gets COUNTED (lead-coder review)
 
 The 20-PR/2-week conditions above need a denominator: something that

--- a/scripts/task_funnel_bypass_baseline.json
+++ b/scripts/task_funnel_bypass_baseline.json
@@ -1,0 +1,6 @@
+{
+  "src/reyn/runtime/session.py": {
+    "type": "defect",
+    "note": "#5267's own chain (Session.run_one_iteration's _turn_owner_task) — a real hazard, tracked for its own separate fix PR, not a gate false positive."
+  }
+}

--- a/src/reyn/runtime/services/chain_manager.py
+++ b/src/reyn/runtime/services/chain_manager.py
@@ -224,6 +224,13 @@ class ChainManager:
         # `cancel_timeout`) stays the primary bookkeeping either way; this is
         # an ADDITIONAL registration for teardown-reachability, not a
         # replacement for it.
+        #
+        # #5267: this optionality is WHY scripts/check_task_funnel_bypass.py
+        # does not scope this class in — if a future change makes this
+        # class spawn turn-crossing background work WITHOUT the funnel
+        # (today's watchdog timers are drop-safe/reversible, not turn-
+        # crossing state-writers), that gate's scope needs revisiting, not
+        # just this comment.
         self._task_tracker = task_tracker
 
         self._chains: dict[str, _PendingChain] = {}

--- a/tests/scripts/test_check_task_funnel_bypass_5267.py
+++ b/tests/scripts/test_check_task_funnel_bypass_5267.py
@@ -1,0 +1,164 @@
+"""Tier 2: #5267 (Family A) — the task-funnel-bypass gate itself.
+
+Real filesystem fixtures throughout (a real ``tmp_path`` tree of ``.py``
+files) — the function under test reads real file content and parses real
+ASTs, so faking the filesystem would test nothing real. Mirrors this
+repo's own established convention for a static gate's own test file
+(``tests/scripts/test_check_cancel_swallow_4988.py``).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_task_funnel_bypass import in_scope_files, offending_files
+
+
+def test_a_required_constructor_param_module_is_in_scope(tmp_path: Path) -> None:
+    """Tier 2: criterion ① — a module whose ``__init__`` takes
+    ``task_tracker`` as a required (no default, non-Optional)
+    ``TrackedTaskSet``-typed param is in scope, the ``outbox_hub.py`` /
+    ``spawn_tracker.py`` shape."""
+    (tmp_path / "hub.py").write_text(
+        "class Hub:\n"
+        "    def __init__(self, *, task_tracker: \"TrackedTaskSet\") -> None:\n"
+        "        self._task_tracker = task_tracker\n",
+        encoding="utf-8",
+    )
+    assert in_scope_files(tmp_path) == [tmp_path / "hub.py"]
+
+
+def test_an_optional_tracker_param_module_is_not_in_scope(tmp_path: Path) -> None:
+    """Tier 2: accept-side — ``ChainManager``'s own deliberately
+    None-tolerant ``task_tracker: TrackedTaskSet | None = None`` must NOT
+    bring a module into scope; forcing every optional-tracker caller to
+    thread one through was explicitly rejected (architect/lead-coder,
+    #5267 comment thread) as out of proportion to this gate's own
+    concern."""
+    (tmp_path / "chain_manager.py").write_text(
+        "class ChainManager:\n"
+        "    def __init__(self, *, task_tracker: \"TrackedTaskSet | None\" = None) -> None:\n"
+        "        self._task_tracker = task_tracker\n"
+        "\n"
+        "    def start(self) -> None:\n"
+        "        import asyncio\n"
+        "        self._t = asyncio.create_task(self._watch())\n",
+        encoding="utf-8",
+    )
+    assert in_scope_files(tmp_path) == []
+    assert offending_files(tmp_path) == []
+
+
+def test_a_module_that_constructs_its_own_tracker_is_in_scope(tmp_path: Path) -> None:
+    """Tier 1: criterion ② — THE case #5267 exists for. ``session.py``
+    does not RECEIVE a ``TrackedTaskSet``, it CONSTRUCTS one
+    (``self._background_tasks = TrackedTaskSet()``); criterion ① alone
+    structurally excludes exactly the file #5267's own chain names — this
+    is the falsifier for that gap (architect self-correction, #5267)."""
+    (tmp_path / "session.py").write_text(
+        "from reyn.runtime.tracked_tasks import TrackedTaskSet\n"
+        "\n"
+        "class Session:\n"
+        "    def __init__(self) -> None:\n"
+        "        self._background_tasks = TrackedTaskSet()\n",
+        encoding="utf-8",
+    )
+    assert in_scope_files(tmp_path) == [tmp_path / "session.py"]
+
+
+def test_a_raw_create_task_in_a_tracker_owning_module_is_flagged(tmp_path: Path) -> None:
+    """Tier 1: the gate's own reason to exist — a module that owns a
+    TrackedTaskSet but spawns via a bare ``asyncio.create_task`` instead
+    of routing through it. This is the exact shape of #5267's own chain
+    (``Session.run_one_iteration``'s ``_turn_owner_task``)."""
+    (tmp_path / "session.py").write_text(
+        "import asyncio\n"
+        "from reyn.runtime.tracked_tasks import TrackedTaskSet\n"
+        "\n"
+        "class Session:\n"
+        "    def __init__(self) -> None:\n"
+        "        self._background_tasks = TrackedTaskSet()\n"
+        "\n"
+        "    async def run_one_iteration(self):\n"
+        "        self._turn_owner_task = asyncio.create_task(self._run_turn_body())\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == [(tmp_path / "session.py", [9])]
+
+
+def test_routing_through_the_funnels_own_spawn_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 1: accept-side — the ACTUAL fix this gate prescribes
+    (``self._task_tracker.spawn(...)``, the ``outbox_hub.py`` /
+    ``spawn_tracker.py`` shape) must not itself be flagged; a gate that
+    flags its own prescribed fix would be self-defeating."""
+    (tmp_path / "hub.py").write_text(
+        "class Hub:\n"
+        "    def __init__(self, *, task_tracker: \"TrackedTaskSet\") -> None:\n"
+        "        self._task_tracker = task_tracker\n"
+        "\n"
+        "    def start(self) -> None:\n"
+        "        self._drain_task = self._task_tracker.spawn(self._drain(), name='drain')\n",
+        encoding="utf-8",
+    )
+    assert offending_files(tmp_path) == []
+
+
+def test_a_module_with_no_tracker_at_all_is_not_in_scope_regardless_of_create_task(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: non-vacuity — a module with plenty of raw ``asyncio.
+    create_task`` calls but NO ``TrackedTaskSet`` ownership at all (most
+    of ``src/`` — architect's own explicit warning against scoping this
+    to "everything", #5267 comment thread) must never be flagged; this
+    gate's whole point is the funnel-bypass, not raw ``create_task`` in
+    general."""
+    (tmp_path / "unrelated.py").write_text(
+        "import asyncio\n"
+        "\n"
+        "async def fire_and_forget():\n"
+        "    asyncio.create_task(do_work())\n",
+        encoding="utf-8",
+    )
+    assert in_scope_files(tmp_path) == []
+    assert offending_files(tmp_path) == []
+
+
+def test_the_funnels_own_implementation_file_is_excluded_from_scope(tmp_path: Path) -> None:
+    """Tier 1: ``tracked_tasks.py`` itself constructs no ``TrackedTaskSet``
+    (it defines the class) and its own ``spawn()`` method's ``asyncio.
+    create_task`` call is the one legitimate call site this whole gate
+    exists to fence everything else away from — the real file's own path
+    is excluded unconditionally in the source (a name match, not a
+    tmp_path fixture, since the exclusion is keyed off the real repo
+    path)."""
+    from scripts.check_task_funnel_bypass import _TRACKED_TASKS_MODULE
+
+    assert _TRACKED_TASKS_MODULE.name == "tracked_tasks.py"
+    real_text = _TRACKED_TASKS_MODULE.read_text(encoding="utf-8")
+    assert "asyncio.create_task(coro, name=name)" in real_text, (
+        "sanity: the real funnel file must still contain its own "
+        "legitimate create_task call for this exclusion to matter at all"
+    )
+
+
+def test_the_real_repo_tree_has_exactly_the_one_disclosed_pre_existing_hit() -> None:
+    """Tier 2: the gate's own starting population against the real tree —
+    verified, not assumed (matching the sibling gates' own "run it before
+    shipping it" discipline). This PR is the family remedy (the gate)
+    only; #5267's own comment thread explicitly scoped the 4 real defect
+    sites (including this one, ``session.py``'s ``_turn_owner_task``) to
+    their OWN separate PRs, not this one — so this gate's baseline is
+    NOT zero, and pinning it to the one disclosed pre-existing hit (never
+    a bare "the tree is clean") is what makes a genuinely NEW regression
+    (a 2nd hit appearing) visible as a diff against this test, rather than
+    silently absorbed into an already-nonzero warn count."""
+    from scripts.check_task_funnel_bypass import _SRC_DIR
+
+    offenders = offending_files(_SRC_DIR)
+    assert [str(p.relative_to(_SRC_DIR.parents[1])) for p, _ in offenders] == [
+        "src/reyn/runtime/session.py",
+    ], (
+        f"population changed: {offenders} — if this is a NEW module bypassing "
+        "the funnel, fix it (route through TrackedTaskSet.spawn()); if it is "
+        "the disclosed session.py hit moving line numbers, update this pin"
+    )

--- a/tests/scripts/test_check_task_funnel_bypass_5267.py
+++ b/tests/scripts/test_check_task_funnel_bypass_5267.py
@@ -8,9 +8,16 @@ repo's own established convention for a static gate's own test file
 """
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from scripts.check_task_funnel_bypass import in_scope_files, offending_files
+from scripts.check_task_funnel_bypass import (
+    _BASELINE_PATH,
+    _SRC_DIR,
+    in_scope_files,
+    load_declared_baseline,
+    offending_files,
+)
 
 
 def test_a_required_constructor_param_module_is_in_scope(tmp_path: Path) -> None:
@@ -141,24 +148,80 @@ def test_the_funnels_own_implementation_file_is_excluded_from_scope(tmp_path: Pa
     )
 
 
-def test_the_real_repo_tree_has_exactly_the_one_disclosed_pre_existing_hit() -> None:
+def test_the_real_repo_tree_matches_the_declared_baseline_exactly() -> None:
     """Tier 2: the gate's own starting population against the real tree —
     verified, not assumed (matching the sibling gates' own "run it before
-    shipping it" discipline). This PR is the family remedy (the gate)
-    only; #5267's own comment thread explicitly scoped the 4 real defect
-    sites (including this one, ``session.py``'s ``_turn_owner_task``) to
-    their OWN separate PRs, not this one — so this gate's baseline is
-    NOT zero, and pinning it to the one disclosed pre-existing hit (never
-    a bare "the tree is clean") is what makes a genuinely NEW regression
-    (a 2nd hit appearing) visible as a diff against this test, rather than
-    silently absorbed into an already-nonzero warn count."""
-    from scripts.check_task_funnel_bypass import _SRC_DIR
+    shipping it" discipline). #5267's own comment thread explicitly
+    scoped the 4 real defect sites (including this one, ``session.py``'s
+    ``_turn_owner_task``) to their OWN separate PRs, not this one — so
+    this gate's baseline is NOT zero.
 
+    lead-coder review (#5270): a bare "the tree has exactly this one
+    disclosed hit" pin, whose own failure message says "update this pin,"
+    silently absorbs a NEW hit — defect or false positive,
+    indistinguishable — with no record that anything happened, which
+    means the module docstring's own "0 new false positives across 20
+    PRs" promotion condition could never be evaluated (nothing ever
+    counts a false positive when one fires). Comparing against the
+    DECLARED baseline instead (``task_funnel_bypass_baseline.json``)
+    means a new, undeclared offender fails THIS test — forcing whoever
+    introduced it to add a classified (``"defect"`` / ``"false_positive"``)
+    entry before the PR is green, the same declared-baseline idiom this
+    repo already uses for exactly this problem (``mypy_ratchet.py``,
+    ``flat_tests_ratchet.py``)."""
     offenders = offending_files(_SRC_DIR)
-    assert [str(p.relative_to(_SRC_DIR.parents[1])) for p, _ in offenders] == [
-        "src/reyn/runtime/session.py",
-    ], (
-        f"population changed: {offenders} — if this is a NEW module bypassing "
-        "the funnel, fix it (route through TrackedTaskSet.spawn()); if it is "
-        "the disclosed session.py hit moving line numbers, update this pin"
+    measured = {str(p.relative_to(_SRC_DIR.parents[1])) for p, _ in offenders}
+    declared = set(load_declared_baseline().keys())
+    new = measured - declared
+    assert not new, (
+        f"undeclared offender(s): {new} — add an entry to "
+        f"{_BASELINE_PATH.name} classifying each as \"defect\" (a real "
+        "hazard, tracked for its own fix PR) or \"false_positive\" (the "
+        "gate is wrong about this one), with a one-line note explaining "
+        "which and why"
+    )
+    # A declared entry that no longer measures (fixed, or the module
+    # changed shape) is allowed to silently drop — same as mypy_ratchet's
+    # own "a fix just stops appearing" behavior; only NEW, undeclared
+    # growth needs a person to act.
+
+
+def test_load_declared_baseline_round_trips_a_classified_entry(tmp_path: Path) -> None:
+    """Tier 1: ``load_declared_baseline`` reads back exactly what a real
+    declaration writes — the ``type``/``note`` fields the ratchet's own
+    failure message tells a person to add."""
+    fixture = tmp_path / "baseline.json"
+    fixture.write_text(
+        json.dumps({"src/reyn/example.py": {"type": "false_positive", "note": "reason"}}),
+        encoding="utf-8",
+    )
+    declared = load_declared_baseline(fixture)
+    assert declared == {"src/reyn/example.py": {"type": "false_positive", "note": "reason"}}
+
+
+def test_an_undeclared_offender_is_what_the_ratchet_exists_to_catch(tmp_path: Path) -> None:
+    """Tier 1: the exact regression lead-coder's review found in the first
+    draft — a NEW offender not present in the declared baseline must be
+    distinguishable from "the same accepted population as before", via a
+    plain set difference against the real baseline file's own declared
+    keys (the same check ``test_the_real_repo_tree_matches_the_declared_
+    baseline_exactly`` runs against the real tree)."""
+    (tmp_path / "new_offender.py").write_text(
+        "import asyncio\n"
+        "from reyn.runtime.tracked_tasks import TrackedTaskSet\n"
+        "\n"
+        "class NewOwner:\n"
+        "    def __init__(self) -> None:\n"
+        "        self._t = TrackedTaskSet()\n"
+        "\n"
+        "    def go(self) -> None:\n"
+        "        asyncio.create_task(self._work())\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    measured = {str(p.relative_to(tmp_path)) for p, _ in offenders}
+    declared = set(load_declared_baseline(_BASELINE_PATH).keys())  # the real repo's own baseline
+    assert measured - declared == {"new_offender.py"}, (
+        "a synthetic new offender, absent from the real declared baseline, "
+        "must show up as undeclared growth"
     )


### PR DESCRIPTION
**[e2e-coder]** — part of #5267 (Family A only; the 4 real defect sites — including this PR's own disclosed `session.py` hit — are each their own separate PR per the issue thread's own scoping).

## What
A module that OWNS a `TrackedTaskSet` (receives one as a required constructor param, or constructs one directly) must route every background spawn through it, never a raw `asyncio.create_task` — such a task is invisible to the funnel's own cancel-then-await discipline (`TrackedTaskSet.aclose()`'s `gather(..., return_exceptions=True)`), the exact shape #5267's own chain (`Session.run_one_iteration`'s `_turn_owner_task`) and #5268 (a different ad hoc task pair in `llm.py`, same night) both hit.

`scripts/check_task_funnel_bypass.py` — AST, zero-FP, scope **derived**, not enumerated:
- ① required `TrackedTaskSet` constructor param (non-Optional, no default) — `outbox_hub.py`, `spawn_tracker.py`
- ② constructs a `TrackedTaskSet` itself — `session.py`

① alone (the original design, and my own first draft) undercounted to those same 2 files and structurally excluded `session.py` — the very file #5267's own chain names — because `Session` doesn't RECEIVE a `TrackedTaskSet`, it CONSTRUCTS one. Caught by asking before implementing rather than trusting the originally-claimed "5 modules" (which turned out to be a `git grep -l task_tracker` mention-count, not a required-param count — verified directly: `registry.py` has no `task_tracker` param at all, `chain_manager.py`'s is deliberately optional). Both architect and lead-coder confirmed the corrected 2-criterion scope in the issue thread.

`chain_manager.py` stays out of scope (documented, deliberate optional dependency — 12 pre-existing test call sites, zero behavioural gain forcing them to thread a tracker through) with a 1-line note added on what would bring it back into scope.

## Warn-only
Architect ruling — `.github/workflows/task-funnel-bypass-gate.yml` always exits 0, same shape as `check-doc-drift.yml`. Promotion condition stated **now**, in the script's own module docstring: 0 new false positives across 20 consecutive PRs touching an in-scope file → promote to error; 2 weeks unmet → consider removal. This is specifically to avoid repeating #5010's own fate (warn-only indefinitely because nobody ever wrote down what "ready to promote" meant).

## The one real hit
The real tree's only current offender is `session.py`'s own `_turn_owner_task` — #5267's own named chain. Left **unfixed in this PR by design** (the issue thread scoped the 4 real defect sites to their own separate PRs; this PR is the family remedy only) and pinned **by file name, not line number**, in the gate's own test, so a genuinely NEW hit shows up as a diff against the test rather than silently blending into an already-nonzero warn count.

## Tests
New file `tests/scripts/test_check_task_funnel_bypass_5267.py` — both scope criteria, the offender detector, the funnel's own accepted fix shape (not self-flagged), non-vacuity (a tracker-less module with raw `create_task` is not in scope), the funnel's own implementation file exclusion, and the real-tree pin. Both derivation criteria and the offender-detector strip-falsified (each flips RED when disabled, confirmed then restored).

Local gates: ruff, `test_tier_audit.py --strict`, `mypy_ratchet.py`, `verify_module_docstrings.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on the new test file
- [x] `mypy_ratchet.py`
- [x] `verify_module_docstrings.py` on changed src/scripts files
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] New gate's own test file, including strip-falsify of both scope criteria and the offender detector
- [x] YAML syntax-checked
- [x] (skipped — no visual surface changed)

Cannot self-merge (touches `tests/`) — needs a TESTS-READ note per rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- [x] 🔴 昇格条件（20 連続 PR で新規偽陽性 0）を測る分母が、`test_the_real_repo_tree_has_exactly_the_one_disclosed_pre_existing_hit` で潰れる — 偽陽性が「赤い test」として現れ、pin 更新で消える。①偽陽性を数えられる場所（ratchet の declared 数が先例）か ②test を「開示済み hit が含まれる」に弱める、のどちらかを。推奨は①。

