### PR TITLE
feat(#5100): show malformed hooks warning in config chrome

### DIFF
--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -140,7 +140,6 @@ _CLEARED_NON_FABRICATING_KEYS = {
     "mcp_servers",  # #5034: same reasoning as "skills"
     "unknown_config_key_count",  # #4194: remote has no client-local reyn.yaml to report
     "unknown_config_keys",  # #4357: same as unknown_config_key_count
-    "hooks_config_warnings",  # #5100: remote has no client-local per-session hooks.yaml to report
     "ctx_source",  # #5034: a label, not a fabricatable figure (defensive:
     # its CURRENT value ("remote") isn't placeholder-shaped at all, so this
     # entry only matters if a future edit narrows it to a bare "")

--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -140,6 +140,7 @@ _CLEARED_NON_FABRICATING_KEYS = {
     "mcp_servers",  # #5034: same reasoning as "skills"
     "unknown_config_key_count",  # #4194: remote has no client-local reyn.yaml to report
     "unknown_config_keys",  # #4357: same as unknown_config_key_count
+    "hooks_config_warnings",  # #5100: remote has no client-local per-session hooks.yaml to report
     "ctx_source",  # #5034: a label, not a fabricatable figure (defensive:
     # its CURRENT value ("remote") isn't placeholder-shaped at all, so this
     # entry only matters if a future edit narrows it to a bare "")

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -49,6 +49,11 @@ from reyn.config.root import ReynConfig  # #1682 #3 cross-section
 class HookYamlReadError(ValueError):
     """A hooks.yaml file exists but could not be read as a mapping."""
 
+    def __init__(self, message: str, *, line: int | None = None, column: int | None = None) -> None:
+        super().__init__(message)
+        self.line = line
+        self.column = column
+
 
 def _load_yaml(path: Path) -> dict:
     if not path.exists():
@@ -972,7 +977,12 @@ def _load_hooks_yaml(path: Path) -> dict:
     except Exception as exc:
         import logging
         logging.getLogger(__name__).warning("failed to parse %s: %s", path, exc)
-        raise HookYamlReadError(str(exc)) from exc
+        mark = getattr(exc, "problem_mark", None)
+        raise HookYamlReadError(
+            str(exc),
+            line=getattr(mark, "line", None),
+            column=getattr(mark, "column", None),
+        ) from exc
     return data if isinstance(data, dict) else {}
 
 

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1935,10 +1935,16 @@ class TextualChatApp(App):
             # #4357: `keys=` passes the actual `{key: hint}` dict so the line
             # names the offending keys (and destinations, where known)
             # instead of only a bare count.
+            _snap = self._snapshot() or {}
             config_warning = config_warning_text(
                 getattr(self._config, "unknown_config_key_count", 0),
                 keys=getattr(self._config, "unknown_config_keys", None),
-                hooks_warnings=(self._snapshot() or {}).get("hooks_config_warnings", []),
+                hooks_warnings=_snap.get("hooks_config_warnings", []),
+                # #5100/#5272: default True — a producer that hasn't wired
+                # this key at all (older server) reads as "reported", the
+                # pre-#5272 behavior; only an EXPLICIT False (a connection
+                # that positively knows it can't report) shows the new line.
+                hooks_warnings_reported=_snap.get("hooks_config_warnings_reported", True),
             )
             if config_warning is not None:
                 yield ConfigWarningLine(config_warning, id="config-warning")

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1938,6 +1938,7 @@ class TextualChatApp(App):
             config_warning = config_warning_text(
                 getattr(self._config, "unknown_config_key_count", 0),
                 keys=getattr(self._config, "unknown_config_keys", None),
+                hooks_warnings=(self._snapshot() or {}).get("hooks_config_warnings", []),
             )
             if config_warning is not None:
                 yield ConfigWarningLine(config_warning, id="config-warning")

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1911,10 +1911,14 @@ def config_warning_text(count: int, keys: "dict | None" = None, hooks_warnings: 
     ``⚠`` matches the existing ``HALTED`` banner glyph above (same
     single-cell-width class of symbol, same "something needs attention"
     register) rather than introducing a new one."""
-    if hooks_warnings:
-        return f"⚠ {hooks_warnings[0]}"
-    if not count:
+    warning_parts = list(hooks_warnings or [])
+    if not count and not warning_parts:
         return None
+    if warning_parts:
+        base = f"⚠ {'; '.join(warning_parts)}"
+        if count:
+            base += f" · {count} config key{'s' if count != 1 else ''} not applied"
+        return base
     plural = "" if count == 1 else "s"
     base = f"⚠ {count} config key{plural} not applied"
     if not keys:

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1865,7 +1865,7 @@ def status_line_text(
 _CONFIG_WARNING_INLINE_KEY_CAP = 3
 
 
-def config_warning_text(count: int, keys: "dict | None" = None) -> "str | None":
+def config_warning_text(count: int, keys: "dict | None" = None, hooks_warnings: "list[str] | None" = None) -> "str | None":
     """The bottom-chrome config-warning indicator's text, or ``None`` when
     there is nothing to show (#4194).
 
@@ -1911,6 +1911,8 @@ def config_warning_text(count: int, keys: "dict | None" = None) -> "str | None":
     ``⚠`` matches the existing ``HALTED`` banner glyph above (same
     single-cell-width class of symbol, same "something needs attention"
     register) rather than introducing a new one."""
+    if hooks_warnings:
+        return f"⚠ {hooks_warnings[0]}"
     if not count:
         return None
     plural = "" if count == 1 else "s"

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1865,9 +1865,26 @@ def status_line_text(
 _CONFIG_WARNING_INLINE_KEY_CAP = 3
 
 
-def config_warning_text(count: int, keys: "dict | None" = None, hooks_warnings: "list[str] | None" = None) -> "str | None":
+def config_warning_text(
+    count: int,
+    keys: "dict | None" = None,
+    hooks_warnings: "list[str] | None" = None,
+    hooks_warnings_reported: bool = True,
+) -> "str | None":
     """The bottom-chrome config-warning indicator's text, or ``None`` when
     there is nothing to show (#4194).
+
+    ``hooks_warnings_reported`` (#5100/#5272, default ``True`` — every
+    caller before this connection-awareness existed, and every LOCAL
+    session today, gets the pre-existing behavior byte-identical):
+    ``False`` means the CONNECTION cannot report per-session hooks.yaml
+    warnings at all (a remote client — see
+    ``ChatReadModelCapabilities.hooks_config_warnings_reported``), not
+    that the server-side session has none. Distinct from ``hooks_warnings
+    == []``, which means the connection COULD report and genuinely found
+    nothing — the same "unsupported vs empty" distinction #5034 already
+    drew for the Hook/Pipe panes, applied here to the ONE remaining
+    caller (this line) that read `hooks_config_warnings` unconditionally.
 
     Architect's ruling (#4194 issue thread, 2026-08-11) fixes exactly THREE
     properties, form left to the implementer: ①doesn't
@@ -1912,6 +1929,14 @@ def config_warning_text(count: int, keys: "dict | None" = None, hooks_warnings: 
     single-cell-width class of symbol, same "something needs attention"
     register) rather than introducing a new one."""
     warning_parts = list(hooks_warnings or [])
+    # #5100/#5272: an unreported connection with an EMPTY hooks_warnings list
+    # cannot be distinguished from "genuinely healthy" without this — say so,
+    # rather than silently falling through to the `None` (no row at all)
+    # case below, which a remote operator would misread as "no problem".
+    # Genuine warning content (a non-empty list) always wins regardless of
+    # the reported flag — real content is never suppressed.
+    if not hooks_warnings_reported and not warning_parts:
+        warning_parts = ["hooks config warnings not reported on this connection"]
     if not count and not warning_parts:
         return None
     if warning_parts:

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -306,6 +306,18 @@ class ChatReadModelCapabilities:
     # #5034's clearance and why they stay 2 fields despite landing together.
     visibility_items_reported: bool  # covers `visibility_items` (tool/mcp/skill panes)
     mcp_subscriptions_reported: bool  # covers `mcp_subscriptions` (mcp pane only)
+    # #5100/#5272 (lead-coder correction, issuecomment on #5272): unlike
+    # `unknown_config_key_count`/`unknown_config_keys` (genuinely client-
+    # local — a remote's OWN reyn.yaml, structurally absent on that
+    # connection), `hooks_config_warnings`'s value is SESSION state
+    # (`status.py`'s snapshot reads `getattr(s, "hooks_config_warnings",
+    # [])` off the live Session) — the SERVER side genuinely has a
+    # per-session hooks.yaml and may genuinely have parsed it with a real
+    # warning. `project_remote_snapshot`'s `[]` is "not wired onto the
+    # wire yet", not "structurally cannot exist" — the same fabrication
+    # shape `hooks_reported` above closes for the Hook pane, not the
+    # `_CLEARED_NON_FABRICATING_KEYS` shape its two siblings are.
+    hooks_config_warnings_reported: bool
 
 
 def reported_snapshot_keys(
@@ -361,6 +373,7 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     attached_name_reported=True,
     visibility_items_reported=True,
     mcp_subscriptions_reported=True,
+    hooks_config_warnings_reported=True,
 )
 
 #: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these
@@ -396,6 +409,10 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     attached_name_reported=True,
     visibility_items_reported=True,
     mcp_subscriptions_reported=True,
+    # #5100/#5272: not yet wired onto the AG-UI wire (no producer projects
+    # the server session's real hooks_config_warnings for a remote
+    # client to read) -- False, not True; see the field's own docstring.
+    hooks_config_warnings_reported=False,
 )
 
 
@@ -987,6 +1004,13 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # count-only (here, no-indicator-at-all) fallback in
         # config_warning_text, never a fabricated key list.
         "unknown_config_keys": {},
+        # `[]` below is correct (per-session hooks.yaml parsing lives on the
+        # SERVER's Session, not projected onto the wire); gated by
+        # `hooks_config_warnings_reported` above so `config_warning_text`
+        # can tell "genuinely no warnings" apart from "this connection
+        # can't report them" — unlike `unknown_config_key_count`/
+        # `unknown_config_keys` just above, which name the CLIENT's own
+        # reyn.yaml and are structurally absent on a remote connection.
         "hooks_config_warnings": [],
     }
 

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -987,6 +987,7 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # count-only (here, no-indicator-at-all) fallback in
         # config_warning_text, never a fabricated key list.
         "unknown_config_keys": {},
+        "hooks_config_warnings": [],
     }
 
 

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -714,6 +714,7 @@ def _snapshot_for_session(registry, s, config=None):
         "unknown_config_keys": (
             getattr(config, "unknown_config_keys", {}) if config is not None else {}
         ),
+        "hooks_config_warnings": getattr(s, "hooks_config_warnings", []),
         # #2285: session-scoped capability visibility + hook applicability toggles.
         # #3378: ``visibility_items`` is ``None`` when the session wires no visibility
         # seam (or it raised) and a possibly-empty LIST when it does — the renderer

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6230,7 +6230,6 @@ class Session:
                 if exc.line is not None and exc.column is not None
                 else "unknown location"
             )
-            warning = f"hooks.yaml could not be read: {path.name} ({location})"
             self._hooks_config_warnings[path.name] = location
             logger.warning("hooks layer %s could not be read: %s", path, exc)
             return []

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1024,6 +1024,7 @@ class Session:
         # CapabilityVisibility, constructed below (see #3121 step3 Extract Class).
         # Session-scoped hook APPLICABILITY override, per-session by construction (#2285, see session-construction.md#capability-permission-visibility)
         self._disabled_hooks: "set[str]" = set()
+        self._hooks_config_warnings: list[str] = []
         # Per-message tool-call budget for the MAIN chat RouterLoop (#187, see session-construction.md#safety-limits-interactive-mode)
         self._router_max_iterations = int(router_max_iterations)
         # Run-once mode: the router SP must not ask a clarifying question nobody can answer (#1439 Fix #1, see session-construction.md#safety-limits-interactive-mode)
@@ -6224,10 +6225,17 @@ class Session:
                 path, agent_name=self.agent_name, project_root=self._hot_reload_project_root(),
             )
         except HookYamlReadError as exc:
+            line = next((line for line in str(exc).splitlines() if "line " in line), "unknown")
+            self._hooks_config_warnings.append(f"hooks.yaml could not be read: {path.name} ({line})")
             logger.warning("hooks layer %s could not be read: %s", path, exc)
             return []
         values = (data or {}).get(key)
         return list(values) if isinstance(values, list) else []
+
+    @property
+    def hooks_config_warnings(self) -> list[str]:
+        """Warnings for hooks layers that could not be parsed."""
+        return list(self._hooks_config_warnings)
 
     def _read_per_agent_hooks(self) -> list:
         """Read the per-agent runtime hooks layer for the COMBINE (#2073 per-agent

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1024,7 +1024,7 @@ class Session:
         # CapabilityVisibility, constructed below (see #3121 step3 Extract Class).
         # Session-scoped hook APPLICABILITY override, per-session by construction (#2285, see session-construction.md#capability-permission-visibility)
         self._disabled_hooks: "set[str]" = set()
-        self._hooks_config_warnings: list[str] = []
+        self._hooks_config_warnings: dict[str, str] = {}
         # Per-message tool-call budget for the MAIN chat RouterLoop (#187, see session-construction.md#safety-limits-interactive-mode)
         self._router_max_iterations = int(router_max_iterations)
         # Run-once mode: the router SP must not ask a clarifying question nobody can answer (#1439 Fix #1, see session-construction.md#safety-limits-interactive-mode)
@@ -6225,8 +6225,13 @@ class Session:
                 path, agent_name=self.agent_name, project_root=self._hot_reload_project_root(),
             )
         except HookYamlReadError as exc:
-            line = next((line for line in str(exc).splitlines() if "line " in line), "unknown")
-            self._hooks_config_warnings.append(f"hooks.yaml could not be read: {path.name} ({line})")
+            location = (
+                f"line {exc.line + 1}, column {exc.column + 1}"
+                if exc.line is not None and exc.column is not None
+                else "unknown location"
+            )
+            warning = f"hooks.yaml could not be read: {path.name} ({location})"
+            self._hooks_config_warnings[path.name] = location
             logger.warning("hooks layer %s could not be read: %s", path, exc)
             return []
         values = (data or {}).get(key)
@@ -6235,7 +6240,7 @@ class Session:
     @property
     def hooks_config_warnings(self) -> list[str]:
         """Warnings for hooks layers that could not be parsed."""
-        return list(self._hooks_config_warnings)
+        return [f"hooks.yaml could not be read: {name} ({location})" for name, location in self._hooks_config_warnings.items()]
 
     def _read_per_agent_hooks(self) -> list:
         """Read the per-agent runtime hooks layer for the COMBINE (#2073 per-agent

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -519,7 +519,24 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: full paragraph above — the SAME question (same-time vs different-time
 #: write, private-vs-public, member-vs-constructor-arg) applies to your
 #: own case too, not just #5336's.
-_PUBLIC_MEMBER_CEILING = 117
+#: Raised 117 -> 118 for #5100/#5272: ``hooks_config_warnings`` — a NEW
+#: read-only property.
+#: ① What was added: a list of "this hooks.yaml layer failed to parse"
+#: messages, accumulated during hooks reads over the session's own
+#: lifetime — no new mutation surface, just a read of existing internal
+#: state (``self._hooks_config_warnings``).
+#: ② Why not private: genuinely consumed from OUTSIDE Session —
+#: ``interfaces/repl/status.py``'s config-chrome snapshot
+#: (``getattr(s, "hooks_config_warnings", [])``) and the TUI's own
+#: rendering (``inline/textual_chat/app.py``) both read it across the
+#: module boundary; the whole point of #5100 is surfacing this warning
+#: in the chrome an operator actually looks at, not a slash handler
+#: reaching into session internals (#3595 S4's own failure mode).
+#: ③ Why not a constructor argument: the warnings are DISCOVERED, not
+#: supplied — they accumulate as hooks.yaml layers are read (possibly
+#: repeatedly, across hot-reloads) over the session's own lifetime, not
+#: known at construction time.
+_PUBLIC_MEMBER_CEILING = 118
 
 
 def test_session_public_surface_does_not_grow() -> None:

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -140,6 +140,7 @@ def test_capabilities_dataclass_rejects_a_missing_field():
         attached_name_reported=True,
         visibility_items_reported=True,
         mcp_subscriptions_reported=True,
+        hooks_config_warnings_reported=True,
     )
     with pytest.raises(TypeError):
         ChatReadModelCapabilities(  # type: ignore[call-arg]
@@ -176,8 +177,9 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
     ``hooks_reported`` / ``pipelines_reported`` (#5034) /
     ``agent_roster_reported`` / ``model_catalog_reported`` /
     ``attached_name_reported`` (#5094) /
-    ``visibility_items_reported`` / ``mcp_subscriptions_reported`` (#5185)
-    are the 11 fields NOT named after a ``ChatReadModel`` method — see the
+    ``visibility_items_reported`` / ``mcp_subscriptions_reported`` (#5185) /
+    ``hooks_config_warnings_reported`` (#5100/#5272)
+    are the 12 fields NOT named after a ``ChatReadModel`` method — see the
     class's own docstring for why they live here anyway."""
     names = {f.name for f in fields(ChatReadModelCapabilities)}
     assert names == {
@@ -198,6 +200,7 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
         "attached_name_reported",
         "visibility_items_reported",
         "mcp_subscriptions_reported",
+        "hooks_config_warnings_reported",
     }
 
 

--- a/tests/runtime/test_5100_hooks_config_warning.py
+++ b/tests/runtime/test_5100_hooks_config_warning.py
@@ -1,0 +1,31 @@
+"""Tier 2: #5100 malformed hooks warnings reach the existing chrome."""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.chrome import config_warning_text
+
+
+def test_malformed_hooks_warning_is_visible_without_hiding_config_warning() -> None:
+    """Tier 2: both independent warning facts remain visible in one line."""
+    text = config_warning_text(
+        2,
+        hooks_warnings=["hooks.yaml could not be read: hooks.yaml (line 3, column 9)"],
+    )
+    assert "hooks.yaml" in text
+    assert "line 3" in text
+    assert "2 config keys not applied" in text
+    assert "turn_end" not in text
+
+
+def test_all_hooks_warning_paths_are_visible() -> None:
+    """Tier 2: a bounded path-keyed warning collection is not reduced to its first item."""
+    text = config_warning_text(
+        0,
+        hooks_warnings=["hooks.yaml could not be read: a.yaml (line 1, column 1)", "hooks.yaml could not be read: b.yaml (line 2, column 1)"],
+    )
+    assert "a.yaml" in text
+    assert "b.yaml" in text
+
+
+def test_healthy_hooks_have_no_warning_line() -> None:
+    """Tier 2: no malformed hooks warning preserves the existing no-indicator behavior."""
+    assert config_warning_text(0, hooks_warnings=[]) is None

--- a/tests/runtime/test_5100_hooks_config_warning.py
+++ b/tests/runtime/test_5100_hooks_config_warning.py
@@ -29,3 +29,41 @@ def test_all_hooks_warning_paths_are_visible() -> None:
 def test_healthy_hooks_have_no_warning_line() -> None:
     """Tier 2: no malformed hooks warning preserves the existing no-indicator behavior."""
     assert config_warning_text(0, hooks_warnings=[]) is None
+
+
+def test_unreported_connection_with_empty_warnings_says_so() -> None:
+    """Tier 2: #5100/#5272 (lead-coder correction) — an empty hooks_warnings
+    list on a connection that CANNOT report them (hooks_warnings_reported=
+    False, e.g. a remote AG-UI connection) must not read as "healthy" — a
+    genuinely empty list and an unreportable one are different facts.
+    Real incident this closes: a broken per-session hooks.yaml on the
+    server side of a remote connection previously showed no indicator at
+    all, indistinguishable from a clean config."""
+    text = config_warning_text(0, hooks_warnings=[], hooks_warnings_reported=False)
+    assert text is not None
+    assert "not reported" in text
+
+
+def test_default_reported_true_preserves_pre_5272_behavior() -> None:
+    """Tier 2: callers that don't pass hooks_warnings_reported (every call
+    site before #5272, and every LOCAL session today) get the exact
+    pre-#5272 behavior — no new line appears out of nowhere for an
+    unmodified caller."""
+    assert config_warning_text(0, hooks_warnings=[]) is None
+    assert config_warning_text(0, hooks_warnings=[]) == config_warning_text(
+        0, hooks_warnings=[], hooks_warnings_reported=True,
+    )
+
+
+def test_real_warning_content_wins_over_unreported_marker() -> None:
+    """Tier 2: genuine warning content is never suppressed by the
+    unreported marker, even if a caller passes hooks_warnings_reported=
+    False alongside real content (a real warning always outranks "can't
+    tell")."""
+    text = config_warning_text(
+        0,
+        hooks_warnings=["hooks.yaml could not be read: a.yaml (line 1, column 1)"],
+        hooks_warnings_reported=False,
+    )
+    assert "a.yaml" in text
+    assert "not reported" not in text

--- a/tests/runtime/test_5100_hooks_session_witness.py
+++ b/tests/runtime/test_5100_hooks_session_witness.py
@@ -19,8 +19,10 @@ def test_session_reads_malformed_per_session_hooks_and_records_location(tmp_path
 
     session._read_per_session_hooks()
     warnings = session.hooks_config_warnings
-    assert warnings == [f"hooks.yaml could not be read: {path.name} (line 2, column 1)"]
+    assert len(warnings) == 1
+    assert path.name in warnings[0]
     assert "turn_end" not in warnings[0]
+    assert "line " in warnings[0] and "column " in warnings[0]
 
     session._read_per_session_hooks()
     assert session.hooks_config_warnings == warnings

--- a/tests/runtime/test_5100_hooks_session_witness.py
+++ b/tests/runtime/test_5100_hooks_session_witness.py
@@ -17,12 +17,12 @@ def test_session_reads_malformed_per_session_hooks_and_records_location(tmp_path
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("hooks: [turn_end\n", encoding="utf-8")
 
-    assert session._read_per_session_hooks() == []
+    session._read_per_session_hooks()
     warnings = session.hooks_config_warnings
     assert warnings == [f"hooks.yaml could not be read: {path.name} (line 2, column 1)"]
     assert "turn_end" not in warnings[0]
 
-    assert session._read_per_session_hooks() == []
+    session._read_per_session_hooks()
     assert session.hooks_config_warnings == warnings
 
 
@@ -37,5 +37,5 @@ def test_healthy_per_session_hooks_have_no_warning(tmp_path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("hooks: []\n", encoding="utf-8")
 
-    assert session._read_per_session_hooks() == []
+    session._read_per_session_hooks()
     assert session.hooks_config_warnings == []

--- a/tests/runtime/test_5100_hooks_session_witness.py
+++ b/tests/runtime/test_5100_hooks_session_witness.py
@@ -19,7 +19,9 @@ def test_session_reads_malformed_per_session_hooks_and_records_location(tmp_path
 
     session._read_per_session_hooks()
     warnings = session.hooks_config_warnings
-    assert len(warnings) == 1
+    # #5266's tier audit rejects len(x)==N as a form pin; this is the
+    # Reyn-owned semantic claim that one malformed file yields one warning.
+    assert warnings[1:] == []
     assert path.name in warnings[0]
     assert "turn_end" not in warnings[0]
     assert "line " in warnings[0] and "column " in warnings[0]

--- a/tests/runtime/test_5100_hooks_session_witness.py
+++ b/tests/runtime/test_5100_hooks_session_witness.py
@@ -1,0 +1,41 @@
+"""Tier 2: #5100 malformed per-session hooks reach the existing warning seam."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests._support.agent_session import make_session
+
+
+def test_session_reads_malformed_per_session_hooks_and_records_location(tmp_path: Path) -> None:
+    """Tier 2: a real Session reads malformed YAML, records only file and location, and replaces on reread."""
+    session = make_session(
+        agent_name="hooks-warning",
+        workspace_base_dir=tmp_path,
+        workspace_state_dir=tmp_path / "state",
+    )
+    path = session._hooks_yaml_layers()[1][1]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("hooks: [turn_end\n", encoding="utf-8")
+
+    assert session._read_per_session_hooks() == []
+    warnings = session.hooks_config_warnings
+    assert warnings == [f"hooks.yaml could not be read: {path.name} (line 2, column 1)"]
+    assert "turn_end" not in warnings[0]
+
+    assert session._read_per_session_hooks() == []
+    assert session.hooks_config_warnings == warnings
+
+
+def test_healthy_per_session_hooks_have_no_warning(tmp_path: Path) -> None:
+    """Tier 2: a valid per-session hooks file does not create a warning."""
+    session = make_session(
+        agent_name="healthy-hooks",
+        workspace_base_dir=tmp_path,
+        workspace_state_dir=tmp_path / "state",
+    )
+    path = session._hooks_yaml_layers()[1][1]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("hooks: []\n", encoding="utf-8")
+
+    assert session._read_per_session_hooks() == []
+    assert session.hooks_config_warnings == []


### PR DESCRIPTION
**[coder-smith]** — Surface malformed per-session hooks YAML through the existing `ConfigWarningLine`.

part of #5100

Session records only the hooks YAML filename and parser line, never YAML contents. The existing ChatReadModel snapshot carries the warning to TextualChatApp, which supplies it to the existing config chrome line; no second UI entry point is introduced. Absent/empty hooks layers remain silent.

Verified: `ruff check` passed; config warning chrome tests: 12 passed.

No closing keyword; auto-merge not armed.

- [x] 🔴 ① test が 0 件 — public property / snapshot key / 描画の分岐 / Session の状態、どれにも witness が無い。必要: ①行が出る ②内容が出ない ③健全時は出ない。
- [x] 🔴 ② `if hooks_warnings: return ...` が `unknown_config_key_count` の警告を黙って隠す。2 つの事実が 1 行を奪い合っている。
- [x] 🔴 ③ `hooks_warnings[0]` — 2 件目以降が silent に消える。切り詰めるなら開示すること。
- [x] 🔴 ④ `str(exc)` の文面を構文解析して行番号を取っている。`yaml.YAMLError.problem_mark` (.line/.column) を使うこと。
- [x] 🔴 ⑤ `_hooks_config_warnings.append` が hot-reload ごとに積まれる。path をキーに置き換える形に。
- [x] 🔴 ⑥ hooks 読み込みが compose より前かを本文に 1 行（`app.py:1929-1933` の「no later render tick」前提）。


---

## ✅ lead-coder の裁定（この節が指示です。broker ではなくここを読んでください）

**rebase は不要です。cherry-pick も force push も不要です。**

`git diff HEAD origin/main` は「HEAD から見て main に何が無いか」を出します。あなたの Session
変更は PR branch にしか無いので、main に無いのは当然です。**消えたのではなく、まだ入っていない
だけ**です。確かめ方はこの 2 つで足ります:

- `git log origin/main --oneline -3` に あなたの commit が無いこと
- `git show 47dfd5edc:src/reyn/runtime/session.py | grep hooks_config_warnings` に在ること

**残っている作業は次の 1 点だけです。**

- [x] 🔴 `tests/runtime/test_5100_hooks_session_witness.py` の line 20 と line 40 の
  `assert session._read_per_session_hooks() == []` を削除する。private state への直接 assert は
  家則で Tier 4（書いてはいけない）。読み込みを起こすために `_read_per_session_hooks()` を
  **呼ぶ**のは構いませんが、**戻り値を assert しない**こと。見たい振る舞いは
  「呼んだ結果として public な `session.hooks_config_warnings` に warning が入る」です。
  他の 2 ファイル（`test_5100_hooks_config_warning.py` / `test_5100_hooks_yaml_read_status.py`）は
  audit 通過済みです。

直したら報告してください。self-merge しないでください。




### ✅ ⑥ の答え（lead-coder が実測。coder-smith の resume ループで往復が滞ったため私が引きました）

**hooks は compose より前に読まれます。** ∴ この行に警告は載ります。

呼び出し順（`origin/main` を引いた file:line）:

1. `src/reyn/runtime/session.py:4633` — `self._build_hook_registry(boot_in_set)` が
   `_build_hook_event_bundle` の中で呼ばれる（**Session 構築時**）
2. `src/reyn/runtime/session.py:5837` — その中で
   `per_session_list = self._read_per_session_hooks()`（＝warning が記録される箇所）
3. `src/reyn/interfaces/inline/textual_chat/app.py:7058` — `TextualChatApp(...)` は
   **既に構築済みの** `transport` / `read_model` を受け取って構築される
4. `src/reyn/interfaces/inline/textual_chat/app.py:1938` — `compose()` 時に
   `config_warning_text(...)` が呼ばれる

∴ 1→2 は 3→4 より**厳密に前**です。`app.py:1929-1933` の
「is fixed for the whole session … no later render tick」という前提は満たされており、
refresh 機構は不要です。


### ⚠️ 開示（architect の求めにより lead-coder が記載）

**per-session hooks の再読込を公開面から起こす口がありません。** そのため
`tests/runtime/test_5100_hooks_session_witness.py` は `session._read_per_session_hooks()` を
**呼んで**駆動しています（assert は公開 property `session.hooks_config_warnings` のみ）。
家則の言う「その不在こそが finding」に当たる形なので、隠さずここに書きます。この PR では
seam を新設しません（#5100 の scope は警告の可視化であって、hooks 再読込の公開 API ではない）。


- [x] 🔴 `tests/runtime/test_5100_hooks_session_witness.py:22` の `assert len(warnings) == 1` が tier audit で Tier 4（format pinning）になります。私も #5266 で同じ形を弾かれました。大きさではなく値で書いてください: `assert warnings[1:] == []`（「2件目が無い」を値の比較として言う）。`path.name in warnings[0]` / `"turn_end" not in warnings[0]` / `"line " in ... and "column " in ...` はそのままで結構です。 あわせて **1 行コメントで理由を残してください**（architect の条件）: 「tier audit は `len(x)==N` を形式 pin として弾く。ここは意味（1 file → 1 警告 = reyn の規則）だが gate は区別しないので、同じ主張を値の比較で述べる」。理由が無いと次の人に「変な書き方」として戻されます。




- [x] 🔴 CI `pytest (Python 3.12)` が本物の赤です（`tests/scripts/test_5093_remote_snapshot_placeholder_declared.py`）。`project_remote_snapshot` に足した `"hooks_config_warnings": []` が「軸の宣言が無い placeholder」として検出されています。**gate の指摘は正しい** — remote client には server 側 session の hooks 警告が無く、空リストは「警告なし」と「報告できない」を潰します。直し方は隣の兄弟と同じ形で: `scripts/check_remote_snapshot_placeholder_declared.py:138` の `_CLEARED_NON_FABRICATING_KEYS` に `"hooks_config_warnings",  # #5100: remote has no client-local per-session hooks.yaml to report（`unknown_config_key_count` #4194 と同じ理由）` を足してください。`unknown_config_key_count`(#4194) / `unknown_config_keys`(#4357) がすぐ上に在り、**同じ理由・同じ形**です。（capability 軸を新設する案もありますが、兄弟 2 つが exemption を選んでいるので合わせてください。）



## ⚠️ 訂正 → ✅ 対応完了（docs-maintainer）

**最初の対応（③除外）は撤回しました**（reverted commit `773411702`）。lead-coder の指摘どおり、`hooks_config_warnings` は siblings と同型ではありません — `status.py` で `getattr(s, "hooks_config_warnings", [])` として **session（server側）から** 読んでおり、client-local な reyn.yaml とは異なります。**①（axis 宣言）で対応し直しました。**

### 実装

- `ChatReadModelCapabilities` に `hooks_config_warnings_reported: bool` を追加（local=True / remote=False）。#5034 が `hooks_reported`/`pipelines_reported` にやった形と同じ。`reported_snapshot_keys()` が自動投影。
- `config_warning_text` に `hooks_warnings_reported: bool = True` を追加。**False かつ空リストのとき**、「healthy」に見えず `"hooks config warnings not reported on this connection"` を表示します（既存の `⚠` 行に乗る形、#5034 の hook/pipe pane と同じ文言規約）。**default=True で既存呼び出し元は byte-identical**（後方互換）。本物の警告内容は reported の値に関わらず常に優先されます。
- `app.py` の呼び出し箇所がスナップショットの新キーを配線。

### ⚠️ 明示する設計判断（レビューで押し戻しやすいように）

**すべての remote 接続で、この行が「恒久的に」表示され続けます**（config key 数が 0 でも）。これは #5034 が hook/pipe **pane**（operator が明示的にそのタブを開いたときだけ見える）で採った形より露出が大きい選択です — この行は**常時表示の bottom-chrome 行**だからです。architect の懸念（「問題なし」と区別できない）を実際に閉じるには、この露出が必要だと判断しましたが、**「毎回出続けるのはノイズではないか」は妥当な反論です**。別案（例: pane 相当の場所にだけ出す）に倒すべきと判断されれば、その方が良いかもしれません。

### Test plan（更新）

- `pytest tests/runtime/test_5100_hooks_config_warning.py -v` — 6/6 pass（新規3件含む）
- `pytest tests/interfaces/test_4996_read_model_capabilities.py` — 更新済（12 fields, was 11）、全 pass
- `pytest tests/interfaces/ tests/runtime/ tests/scripts/ -q -k "5100 or config_warning or 5093 or read_model or capabilities"` — 75 passed
- `pytest tests/interfaces/ -q -k "chrome or app or textual_chat"` — 358 passed
- `ruff check` / `verify_module_docstrings.py` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- Strip-falsify: removed the new reported-check branch in `config_warning_text` — exactly 1 new test goes RED (predicted), other 5 unaffected. Restored, 6/6 green. Separately verified `LOCAL_CHAT_READ_CAPABILITIES.hooks_config_warnings_reported is True` / `REMOTE...is False` directly.

自己mergeしません。tui-coder さんに head 更新を連絡します。


- [x] 🔴 **[lead-coder]** **除外の理由が siblings と同型ではありません — ③ではなく①（axis）が正しい可能性が高い。**
  - 書かれた理由: 「remote has **no client-local** per-session hooks.yaml to report」。
  - しかし値の出所は **session** です — `status.py` の `"hooks_config_warnings": getattr(s, "hooks_config_warnings", [])`。**client-local ではありません。**
  - **remote 接続でも server 側の session は hooks.yaml を持ちます。**壊れた hooks があれば warning は**存在します**。`read_model.py` が `[]` を置いているのは「**構造的に無い**」からではなく「**配線していない**」からです。
  - 対して cite された siblings（`unknown_config_key_count` #4194 / `unknown_config_keys` #4357）は**本当に client-local な reyn.yaml** の話で、remote には**構造的に存在しません**。同じ class ではありません。
  - ⚠️ **operator から見た帰結**: remote 越しに壊れた hooks を持つ agent を見ても、画面は「警告なし」と読めます。**「問題なし」と「報告できない」が区別できません** — これは `_CLEARED_NON_FABRICATING_KEYS` の直上の docstring が「no axis is needed to distinguish **unsupported** from **empty**」と言っている条件を、**満たしていない**ということです。
  - 🔵 処方（判断は担当に委ねます）: **①`hooks_config_warnings_reported` を `ChatReadModelCapabilities` に足す**（remote=False / local=True）。#5034 が `hooks`/`skills`/`mcp_servers` に対してやったのと同じ形です。**それでも③が正しいと判断するなら、「remote 側 session の hooks warning が構造的に取得不能である」根拠を本文に書いてください。**

