### PR TITLE
feat(#4995): build_history runs on a worker thread, owner-gated cache commit

### DIFF
--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -390,6 +390,7 @@ class RouterHistoryBuffer:
         reasoning: Any = None,            # ReasoningConfig — .continuity / .recent_turns (#1652/②)
         project_dir_fn: "Callable[[], Any] | None" = None,  # #3629: zero-arg → CURRENT workspace base_dir
         read_cap: Any = None,             # #4381 PR-5: ReadCapConfig — the resource bound to check budgets against
+        current_turn_owner_fn: "Callable[[], Any] | None" = None,  # #4995/#5267: zero-arg → Session._turn_owner_task, LIVE — see build_history()'s own `expected_owner` docstring
     ) -> None:
         self._history_fn = history_fn
         self._compaction = compaction
@@ -403,6 +404,10 @@ class RouterHistoryBuffer:
         # #4381 PR-5: threaded into resolve_effective_trigger_and_budgets's
         # resource/budget invariant check (_check_resource_within_budget).
         self._read_cap = read_cap
+        # #4995/#5267: see build_history()'s own `expected_owner` docstring —
+        # None (every pre-#5267 construction site) makes the ownership check
+        # in _incremental_elide_total a no-op, byte-identical to before.
+        self._current_turn_owner_fn = current_turn_owner_fn
         # #1652/②: cross-turn reasoning rides the wire assistant messages
         # (native re-attach) instead of a router-SP text section. ReasoningConfig
         # gates it (.continuity) and bounds it (.recent_turns). None → off.
@@ -425,6 +430,31 @@ class RouterHistoryBuffer:
         # them again next call — 100% miss, not a tuning problem.
         # See ``_incremental_elide_total``'s own docstring for the
         # invalidation contract these three fields exist to support.
+        #
+        # #4995/#5267 ⚠️ WHOEVER TOUCHES THESE FIELDS NEXT, READ THIS FIRST:
+        # these 5 attributes are safe to mutate WITHOUT a lock ONLY because
+        # today every write happens synchronously, inside the SAME coroutine
+        # that decided to call ``build_history()`` — a session processes one
+        # turn at a time, and a synchronous call cannot be interrupted or
+        # raced mid-flight by ``Session.cancel_inflight()``'s hard
+        # ``Task.cancel()`` (that cancel can only land at an ``await`` point,
+        # and there is none inside this computation today). The MOMENT any
+        # of these fields is written from code that has ALREADY awaited
+        # something (``asyncio.to_thread``, an actual I/O wait, anything
+        # that gives ``cancel_inflight`` a suspension point to land on),
+        # that safety is GONE: a cancelled turn's background work keeps
+        # running (a cancelled ``await`` does not stop a thread-pool worker
+        # already executing), the NEXT turn can start and reach this same
+        # write concurrently, and — because ``_incremental_elide_total``
+        # READS ``_cached_elide_total`` and ADDS to it rather than
+        # overwriting — an interleaved write is not merely stale, it can be
+        # arithmetically WRONG (#5267). ``_incremental_elide_total``'s own
+        # ``expected_owner``/``current_turn_owner_fn`` ownership check
+        # exists for exactly this: build privately, publish in ONE step,
+        # and only if the caller that started this computation is STILL the
+        # session's current turn owner. Do not add a NEW caller that awaits
+        # something before reaching this write without threading
+        # ``expected_owner`` through the same way.
         self._cached_elide_total: int = 0
         self._cached_elide_turn_count: int = 0
         self._cached_elide_last_seq: "int | None" = None
@@ -564,6 +594,7 @@ class RouterHistoryBuffer:
 
     def _incremental_elide_total(
         self, turns: list, wire_turns: list[dict], *, use_chars4: bool,
+        expected_owner: "object | None" = None,
     ) -> int:
         """#4403: the ``total`` build_history needs for its "total <=
         effective_trigger" elide decision, computed incrementally instead
@@ -595,7 +626,26 @@ class RouterHistoryBuffer:
         guess costs CPU, never correctness, because the ``else`` branch
         always re-derives ``total`` from the real ``wire_turns`` this call
         actually has.
-        """
+
+        #4995/#5267 ``expected_owner``: read the CACHE STATE once up front
+        (the ``cache_valid`` check below), do the (possibly slow, possibly
+        running on a worker thread via ``build_history``'s own
+        ``asyncio.to_thread`` caller) summing into the LOCAL ``total``
+        below, then COMMIT to ``self._cached_elide_*`` in one step only if
+        ``expected_owner`` (captured by the caller BEFORE dispatching this
+        work, e.g. ``asyncio.current_task()`` at the point it was still the
+        session's current turn) still matches
+        ``self._current_turn_owner_fn()`` (Session's LIVE
+        ``_turn_owner_task``, read fresh here — a bare attribute read/write
+        is atomic under the GIL, no lock needed for this comparison
+        itself). A caller that passes neither (``expected_owner=None`` and/
+        or no ``current_turn_owner_fn`` configured — every call site before
+        #5267, and the rare ``session.py`` limit-denied path, which stays
+        synchronous) always commits, byte-identical to before. This is
+        NEVER a correctness gate on ``total`` itself (the value returned to
+        THIS call's own caller is always the freshly computed, correct
+        one) — only on whether it gets written into the shared incremental
+        cache for the NEXT call to build on."""
         from reyn.services.compaction.engine import estimate_tokens_for_any_turn
 
         model = self._model
@@ -623,11 +673,20 @@ class RouterHistoryBuffer:
                 for wt in wire_turns
             )
 
-        self._cached_elide_total = total
-        self._cached_elide_turn_count = len(turns)
-        self._cached_elide_last_seq = turns[-1].seq if turns else None
-        self._cached_elide_model = model
-        self._cached_elide_use_chars4 = use_chars4
+        # #4995/#5267: publish in ONE step, gated on still being the current
+        # turn owner — see this method's own docstring above and the
+        # `_cached_elide_*` field declarations' own comment for why.
+        still_owner = (
+            expected_owner is None
+            or self._current_turn_owner_fn is None
+            or self._current_turn_owner_fn() is expected_owner
+        )
+        if still_owner:
+            self._cached_elide_total = total
+            self._cached_elide_turn_count = len(turns)
+            self._cached_elide_last_seq = turns[-1].seq if turns else None
+            self._cached_elide_model = model
+            self._cached_elide_use_chars4 = use_chars4
         return total
 
     def _elide_candidate_turns(self, history: list) -> "tuple[list, int]":
@@ -718,8 +777,23 @@ class RouterHistoryBuffer:
 
     # ── Public API ────────────────────────────────────────────────────────────
 
-    def build_history(self) -> list[dict]:
+    def build_history(self, *, expected_owner: "object | None" = None) -> list[dict]:
         """Slice history into OpenAI-style messages for RouterLoop.
+
+        #4995/#5267 ``expected_owner``: pass this when the CALLER dispatches
+        this method to a worker thread (``asyncio.to_thread`` — the #4995
+        motivating case, ``RouterLoopDriver._run_with_shrink``) rather than
+        calling it inline on the same coroutine that decided to. Capture it
+        BEFORE the dispatch — ``asyncio.current_task()`` from inside the
+        coroutine that IS the session's current turn (there is no running
+        task to ask from inside the worker thread itself). Threaded straight
+        through to :meth:`_incremental_elide_total`, the ONE place this
+        method mutates shared cache state — see that method's own docstring
+        for the ownership check itself, and the ``_cached_elide_*`` field
+        declarations' own comment for why this exists at all. Omit it (the
+        default, every pre-#5267 caller) for an inline/synchronous call —
+        there is no race to guard against when nothing was awaited before
+        reaching the write.
 
         #4954(2): PERMANENT compaction. A turn at or below the compaction
         watermark (``0 < seq <= self._compaction_watermark(history)`` —
@@ -855,7 +929,9 @@ class RouterHistoryBuffer:
         # turns before a 100k-turn pass reaches them again next call — 100%
         # miss, not a tuning problem. See _incremental_elide_total's own
         # docstring for the invalidation contract.
-        total = self._incremental_elide_total(turns, wire_turns, use_chars4=use_chars4)
+        total = self._incremental_elide_total(
+            turns, wire_turns, use_chars4=use_chars4, expected_owner=expected_owner,
+        )
         # #4977: this method's own internal `total`/`effective_trigger` used
         # to also be emitted here as a public P6 audit-event
         # (`elide_evaluated`) so a test (or an operator inspecting `reyn

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -257,7 +257,54 @@ class RouterLoopDriver:
         # widened except exactly as #4885 established. This is not a
         # reversion of that fix.
 
-        history = self._history_buffer.build_history()
+        # #4995/#5267: dispatched to a worker thread rather than run inline
+        # on this coroutine's own turn — build_history() re-serialises every
+        # elide-candidate turn (path-ref image materialise included, #3185's
+        # own measurement) every call, a cost proportional to session length
+        # that otherwise runs synchronously on the SAME event loop the TUI's
+        # own frame scheduling shares. `asyncio.to_thread` suspends THIS
+        # coroutine at the `await` (the GIL still time-slices with the
+        # default ~5ms `sys.getswitchinterval()`, so the loop gets scheduled
+        # while the thread runs) — same shape as this codebase's own
+        # existing `voice.py` precedent ("Inference is dispatched to
+        # asyncio.to_thread so the Textual event loop ...").
+        #
+        # `expected_owner` MUST be captured here, before the dispatch — see
+        # RouterHistoryBuffer.build_history's own docstring and #5267:
+        # cancel_inflight()'s hard `Task.cancel()` can now land INSIDE this
+        # await (impossible when build_history() was purely synchronous),
+        # and a cancelled `to_thread` await does not stop the underlying
+        # worker thread — it keeps running and, without this ownership
+        # check, could race a NEXT turn's own build_history() call over the
+        # SAME shared `_cached_elide_*` fields. `asyncio.current_task()`
+        # from inside this coroutine IS the session's `_turn_owner_task`
+        # (this method runs on that task) — captured here, not on the
+        # worker thread, where there is no running task to ask.
+        #
+        # #5267 ⚠️ WHOEVER CHANGES THIS CALL CHAIN'S SHAPE, READ THIS: that
+        # identity holds ONLY because every step from
+        # `Session.run_one_iteration`'s `self._turn_owner_task =
+        # asyncio.create_task(self._run_turn_body(...))` down to THIS line
+        # is a plain `await` — verified by grepping every file on the path
+        # (`session.py`, `inter_agent_messaging.py`, this file) for
+        # `create_task`/`ensure_future` and confirming the only hits are
+        # either that ONE task-creation site itself or on entirely
+        # unrelated paths (intervention re-dispatch, buffered-answer
+        # persistence) — see #5267's own PR body for the exact commands
+        # run and their output. If a FUTURE change inserts a
+        # `create_task`/`ensure_future` ANYWHERE between those two points,
+        # `asyncio.current_task()` here silently stops being
+        # `_turn_owner_task` — `expected_owner` would then ALWAYS mismatch
+        # the live owner, and EVERY `build_history()` call would silently
+        # stop updating the shared incremental cache (a real perf
+        # regression, a full recompute every turn) with NOTHING going red
+        # to say so. This is the single point of fragility the ownership
+        # design has — see #5267's own disclosure of this as an absence,
+        # not a solved problem.
+        _expected_owner = asyncio.current_task()
+        history = await asyncio.to_thread(
+            self._history_buffer.build_history, expected_owner=_expected_owner,
+        )
         try:
             return await loop.run(user_text=user_text, history=history)
         except Exception as _exc:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5403,6 +5403,14 @@ class Session:
             # buffer's history entries came from).
             project_dir_fn=lambda: self._workspace_base_dir or Path.cwd(),
             read_cap=self._read_cap_config,  # #4381 PR-5
+            # #4995/#5267: LIVE read of the session's current turn-owning
+            # task, for RouterHistoryBuffer's own ownership check when
+            # build_history() is dispatched off this coroutine (see
+            # RouterLoopDriver._run_with_shrink's own `expected_owner`
+            # capture and RouterHistoryBuffer.build_history's docstring).
+            # A bare attribute read/write is atomic under the GIL — no lock
+            # needed for this comparison itself.
+            current_turn_owner_fn=lambda: self._turn_owner_task,
         )
 
         # #3671 follow-up: a DEFERRED closure, not an eager construction —

--- a/tests/runtime/test_5267_elide_cache_ownership.py
+++ b/tests/runtime/test_5267_elide_cache_ownership.py
@@ -1,0 +1,262 @@
+"""Tier 2: #4995/#5267 — ``RouterHistoryBuffer``'s incremental elide cache
+is published only by the session's CURRENT turn owner, never by a stale
+one whose background work outlived its own cancellation.
+
+Root cause (#5267, filed while starting #4995's candidate ① — moving
+``build_history()`` off the TUI's own event loop onto a worker thread via
+``asyncio.to_thread``): ``Session.cancel_inflight()`` hard-cancels the
+turn's owning sub-task with ``Task.cancel()``, which "injects
+``CancelledError`` at whatever await point the task is currently suspended
+on" (that method's own docstring). Today ``build_history()`` is
+synchronous, so a turn can never be suspended INSIDE it — cancel can only
+land before or after. Dispatching it to a worker thread creates exactly
+such a suspension point, but ``Task.cancel()`` only cancels the AWAIT — it
+cannot, and does not, stop the underlying thread-pool worker already
+executing. So a cancelled turn's ``build_history()`` call can keep running
+in the background while the SAME session immediately starts its next
+turn, whose OWN ``build_history()`` call can race the orphaned one over
+the SAME instance's ``_cached_elide_*`` fields.
+
+"Last write wins" is not a safe fallback here: ``_incremental_elide_total``
+READS ``_cached_elide_total`` and ADDS to it (an incremental cache, not an
+idempotent overwrite) — an interleaved stale write is not merely outdated,
+it can corrupt the NEXT legitimate call's own incremental computation.
+
+Fix (architect ruling via #5267, reusing #5217's own "build privately,
+publish in one step" shape — no new mechanism): the caller captures
+``asyncio.current_task()`` as ``expected_owner`` BEFORE dispatching to a
+worker thread; ``RouterHistoryBuffer`` computes everything into local
+variables and, at the very end, commits to ``_cached_elide_*`` only if
+``expected_owner`` still matches ``current_turn_owner_fn()`` — Session's
+LIVE ``_turn_owner_task``, read fresh (a bare attribute read/write is
+atomic under the GIL; no lock needed for the comparison itself). No new
+ownership register was invented — this reuses the EXISTING one
+(``Session._turn_owner_task``), per lead-coder's own correction during
+review (a first draft that invented an ``itertools.count()``-based
+attempt counter was rejected for exactly this reason).
+
+Real ``RouterHistoryBuffer`` + real ``ChatMessage`` — no mocks. The
+"stale write" scenario is driven directly (calling ``build_history`` with
+an explicit, now-mismatched ``expected_owner``) rather than via real
+threads/cancellation — the unit under test is the ownership CHECK itself,
+not the thread-scheduling race that motivates it (which #4995's own
+future PR, wiring this into ``RouterLoopDriver`` via ``asyncio.to_thread``,
+is responsible for exercising end-to-end).
+"""
+from __future__ import annotations
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+
+_MODEL = "gpt-3.5-turbo"
+
+
+def _turns(n: int, *, start: int = 1) -> list[ChatMessage]:
+    return [
+        ChatMessage(role="user", content=f"turn {i} " + ("x" * 40), seq=i)
+        for i in range(start, start + n)
+    ]
+
+
+def _make_buf(history: list, *, current_turn_owner_fn=None) -> RouterHistoryBuffer:
+    return RouterHistoryBuffer(
+        history_fn=lambda: history,
+        compaction=CompactionConfig(use_chars4_estimate=True),
+        compaction_controller=None,
+        model_fn=lambda: _MODEL,
+        events=EventLog(),
+        media_store=None,
+        router_host=None,
+        universal_wrappers_enabled=False,  # #4552 PR-3
+        non_interactive=True,
+        current_turn_owner_fn=current_turn_owner_fn,
+    )
+
+
+def _counting_wrapper(monkeypatch) -> dict:
+    """Installs the SAME counting technique #4403's own test file uses —
+    returns a dict whose ``"n"`` key counts real
+    ``estimate_tokens_for_any_turn`` calls from the moment this is called."""
+    import reyn.services.compaction.engine as engine_module
+
+    real_fn = engine_module.estimate_tokens_for_any_turn
+    call_count = {"n": 0}
+
+    def _counting(wt, model, *, use_chars4):
+        call_count["n"] += 1
+        return real_fn(wt, model, use_chars4=use_chars4)
+
+    monkeypatch.setattr(engine_module, "estimate_tokens_for_any_turn", _counting)
+    return call_count
+
+
+def test_a_stale_owners_publish_is_rejected(monkeypatch) -> None:
+    """Tier 2: acceptance — the exact #5267 witness. A call whose
+    ``expected_owner`` no longer matches the CURRENT owner must not
+    publish to the shared cache — proven by showing the cache still
+    reflects the LEGITIMATE owner's own publish (via the #4403 counting
+    technique: a subsequent legitimate call over UNCHANGED history costs
+    ZERO new token estimates, which would not hold if the stale call had
+    reverted the cache).
+
+    The stale call's own ``turns``/``wire_turns`` are captured from a REAL
+    50-turn snapshot taken BEFORE history grew to 60 — simulating "turn A
+    already finished its own private computation off-thread; only the
+    commit races turn B". Reading live (60-turn) history inside a second
+    ``build_history()`` call would compute the SAME correct values turn B
+    already published, making a broken ownership check indistinguishable
+    from a working one — this is why the stale payload must come from the
+    OLDER snapshot, matching what actually races in production."""
+    history = _turns(50)
+    owner_box = ["owner-A"]
+    buf = _make_buf(history, current_turn_owner_fn=lambda: owner_box[0])
+
+    # Turn A (currently the owner) builds and publishes normally.
+    buf.build_history(expected_owner="owner-A")
+
+    # Turn A's own private computation, from THIS (50-turn) snapshot —
+    # captured now, "finished" but not yet committed, mirroring a
+    # to_thread call that has returned its result but not yet reached the
+    # ownership check at the end of _incremental_elide_total.
+    turns_a, _watermark_a = buf._elide_candidate_turns(list(history))
+    wire_turns_a = [buf._serialise_turn(m) for m in turns_a]
+
+    # Simulate cancel + immediate retry: a NEW turn takes ownership,
+    # extends history, and publishes legitimately BEFORE turn A's stale
+    # computation above gets a chance to commit.
+    owner_box[0] = "owner-B"
+    history.extend(_turns(10, start=51))
+    buf.build_history(expected_owner="owner-B")  # turn B: legitimate, publishes 60 turns
+
+    # Turn A's orphaned computation finally "commits" — its own
+    # expected_owner ("owner-A") no longer matches the current owner
+    # ("owner-B"), so this must be rejected.
+    stale_total = buf._incremental_elide_total(
+        turns_a, wire_turns_a, use_chars4=True, expected_owner="owner-A",
+    )
+    assert isinstance(stale_total, int), (
+        "a rejected-publish call must still return its own correct result "
+        "to its own caller — only the SHARED cache write is skipped"
+    )
+
+    # Witness: turn B's own legitimate publish must still be what the
+    # cache reflects. A further legitimate call (owner-B) over the SAME
+    # (unchanged since turn B's publish) 60-turn history must cost ZERO
+    # new token estimates — if turn A's stale commit HAD published
+    # (reverting turn_count back to 50), this call would treat the 10
+    # turns turn B already accounted for as "new" again.
+    call_count = _counting_wrapper(monkeypatch)
+    buf.build_history(expected_owner="owner-B")
+    assert call_count["n"] == 0, (
+        f"expected 0 new-turn estimates (cache already reflects the current "
+        f"60-turn history), got {call_count['n']} — the stale call's commit "
+        "was not actually rejected"
+    )
+
+
+def test_no_owner_configured_always_publishes_unchanged(monkeypatch) -> None:
+    """Tier 2: non-regression — every pre-#5267 caller (no
+    ``current_turn_owner_fn`` configured, no ``expected_owner`` passed)
+    keeps publishing unconditionally, byte-identical to before this
+    feature existed."""
+    history = _turns(50)
+    buf = _make_buf(history)  # no current_turn_owner_fn
+
+    buf.build_history()
+    history.extend(_turns(30, start=51))
+
+    call_count = _counting_wrapper(monkeypatch)
+    buf.build_history()
+    assert call_count["n"] == 30, (
+        f"expected exactly 30 new-turn estimates (incremental, unaffected "
+        f"by the ownership feature when unconfigured), got {call_count['n']}"
+    )
+
+
+def test_the_legitimate_owners_own_publish_still_works(monkeypatch) -> None:
+    """Tier 2: falsification contrast — when ``expected_owner`` DOES match
+    the current owner, the cache publishes exactly as before (the feature
+    only ever SUBTRACTS a publish, never adds a new inconsistency for the
+    matching case)."""
+    history = _turns(50)
+    buf = _make_buf(history, current_turn_owner_fn=lambda: "the-one-owner")
+
+    buf.build_history(expected_owner="the-one-owner")
+    history.extend(_turns(30, start=51))
+
+    call_count = _counting_wrapper(monkeypatch)
+    buf.build_history(expected_owner="the-one-owner")
+    assert call_count["n"] == 30, (
+        f"a matching-owner call must still publish incrementally, got "
+        f"{call_count['n']} new estimates instead of 30"
+    )
+
+
+def test_strip_the_ownership_check_reproduces_the_stale_publish(monkeypatch) -> None:
+    """Tier 2: strip-falsify — reconstructing the OLD unconditional-commit
+    ``_incremental_elide_total`` (mirroring pre-#5267: always write the
+    cache, regardless of ownership) against the same real buffer must
+    reproduce the corruption: the stale call's revert IS observed by the
+    next legitimate call needing to re-estimate turns it already
+    accounted for. Same stale-snapshot construction as the acceptance
+    test above, and for the same reason (a live-reread stale call would
+    compute the SAME correct values turn B already published)."""
+    import types
+
+    history = _turns(50)
+    owner_box = ["owner-A"]
+    buf = _make_buf(history, current_turn_owner_fn=lambda: owner_box[0])
+
+    def _old_incremental_elide_total(self, turns, wire_turns, *, use_chars4, expected_owner=None):
+        from reyn.services.compaction.engine import estimate_tokens_for_any_turn
+
+        model = self._model
+        cache_valid = (
+            len(turns) >= self._cached_elide_turn_count
+            and self._cached_elide_model == model
+            and self._cached_elide_use_chars4 == use_chars4
+            and (
+                self._cached_elide_turn_count == 0
+                or turns[self._cached_elide_turn_count - 1].seq == self._cached_elide_last_seq
+            )
+        )
+        if cache_valid:
+            new_wire_turns = wire_turns[self._cached_elide_turn_count:]
+            total = self._cached_elide_total + sum(
+                estimate_tokens_for_any_turn(wt, model, use_chars4=use_chars4)
+                for wt in new_wire_turns
+            )
+        else:
+            total = sum(
+                estimate_tokens_for_any_turn(wt, model, use_chars4=use_chars4)
+                for wt in wire_turns
+            )
+        self._cached_elide_total = total
+        self._cached_elide_turn_count = len(turns)
+        self._cached_elide_last_seq = turns[-1].seq if turns else None
+        self._cached_elide_model = model
+        self._cached_elide_use_chars4 = use_chars4
+        return total
+
+    buf._incremental_elide_total = types.MethodType(_old_incremental_elide_total, buf)
+
+    buf.build_history(expected_owner="owner-A")
+    turns_a, _watermark_a = buf._elide_candidate_turns(list(history))
+    wire_turns_a = [buf._serialise_turn(m) for m in turns_a]
+
+    owner_box[0] = "owner-B"
+    history.extend(_turns(10, start=51))
+    buf.build_history(expected_owner="owner-B")
+    # OLD code: publishes unconditionally, reverting the cache to turn A's
+    # stale (50-turn) view even though owner-A no longer owns.
+    buf._incremental_elide_total(turns_a, wire_turns_a, use_chars4=True, expected_owner="owner-A")
+
+    call_count = _counting_wrapper(monkeypatch)
+    buf.build_history(expected_owner="owner-B")
+    assert call_count["n"] != 0, (
+        "the OLD unconditional-commit must reproduce the stale revert (a "
+        "non-zero re-estimate here) — if this assertion fails, the strip "
+        "did not actually revert to the pre-#5267 shape"
+    )

--- a/tests/runtime/test_5267_elide_cache_ownership.py
+++ b/tests/runtime/test_5267_elide_cache_ownership.py
@@ -121,12 +121,20 @@ def test_a_stale_owners_publish_is_rejected(monkeypatch) -> None:
     already published, making a broken ownership check indistinguishable
     from a working one — this is why the stale payload must come from the
     OLDER snapshot, matching what actually races in production."""
+    # Distinct identity objects, not strings: production compares
+    # expected_owner via `is`, and two equal-but-distinct string literals
+    # can compare `is`-equal under CPython's interning — a fixture built
+    # from strings would pass today for the wrong reason and only break
+    # later (a non-reasoned red) once a literal became an f-string or a
+    # concatenation (architect/lead-coder review, #5275).
+    owner_a = object()
+    owner_b = object()
     history = _turns(50)
-    owner_box = ["owner-A"]
+    owner_box = [owner_a]
     buf = _make_buf(history, current_turn_owner_fn=lambda: owner_box[0])
 
     # Turn A (currently the owner) builds and publishes normally.
-    buf.build_history(expected_owner="owner-A")
+    buf.build_history(expected_owner=owner_a)
 
     # Turn A's own private computation, from THIS (50-turn) snapshot —
     # captured now, "finished" but not yet committed, mirroring a
@@ -138,15 +146,15 @@ def test_a_stale_owners_publish_is_rejected(monkeypatch) -> None:
     # Simulate cancel + immediate retry: a NEW turn takes ownership,
     # extends history, and publishes legitimately BEFORE turn A's stale
     # computation above gets a chance to commit.
-    owner_box[0] = "owner-B"
+    owner_box[0] = owner_b
     history.extend(_turns(10, start=51))
-    buf.build_history(expected_owner="owner-B")  # turn B: legitimate, publishes 60 turns
+    buf.build_history(expected_owner=owner_b)  # turn B: legitimate, publishes 60 turns
 
     # Turn A's orphaned computation finally "commits" — its own
-    # expected_owner ("owner-A") no longer matches the current owner
-    # ("owner-B"), so this must be rejected.
+    # expected_owner (owner_a) no longer matches the current owner
+    # (owner_b), so this must be rejected.
     stale_total = buf._incremental_elide_total(
-        turns_a, wire_turns_a, use_chars4=True, expected_owner="owner-A",
+        turns_a, wire_turns_a, use_chars4=True, expected_owner=owner_a,
     )
     assert isinstance(stale_total, int), (
         "a rejected-publish call must still return its own correct result "
@@ -160,7 +168,7 @@ def test_a_stale_owners_publish_is_rejected(monkeypatch) -> None:
     # (reverting turn_count back to 50), this call would treat the 10
     # turns turn B already accounted for as "new" again.
     call_count = _counting_wrapper(monkeypatch)
-    buf.build_history(expected_owner="owner-B")
+    buf.build_history(expected_owner=owner_b)
     assert call_count["n"] == 0, (
         f"expected 0 new-turn estimates (cache already reflects the current "
         f"60-turn history), got {call_count['n']} — the stale call's commit "
@@ -192,14 +200,18 @@ def test_the_legitimate_owners_own_publish_still_works(monkeypatch) -> None:
     the current owner, the cache publishes exactly as before (the feature
     only ever SUBTRACTS a publish, never adds a new inconsistency for the
     matching case)."""
+    # An identity object, not a string — see test_a_stale_owners_publish_is_rejected's
+    # own comment: production compares via `is`, and a string fixture can pass
+    # today for the wrong reason (CPython interning) and break later.
+    the_one_owner = object()
     history = _turns(50)
-    buf = _make_buf(history, current_turn_owner_fn=lambda: "the-one-owner")
+    buf = _make_buf(history, current_turn_owner_fn=lambda: the_one_owner)
 
-    buf.build_history(expected_owner="the-one-owner")
+    buf.build_history(expected_owner=the_one_owner)
     history.extend(_turns(30, start=51))
 
     call_count = _counting_wrapper(monkeypatch)
-    buf.build_history(expected_owner="the-one-owner")
+    buf.build_history(expected_owner=the_one_owner)
     assert call_count["n"] == 30, (
         f"a matching-owner call must still publish incrementally, got "
         f"{call_count['n']} new estimates instead of 30"

--- a/tests/runtime/test_5267_elide_cache_ownership.py
+++ b/tests/runtime/test_5267_elide_cache_ownership.py
@@ -42,6 +42,18 @@ threads/cancellation — the unit under test is the ownership CHECK itself,
 not the thread-scheduling race that motivates it (which #4995's own
 future PR, wiring this into ``RouterLoopDriver`` via ``asyncio.to_thread``,
 is responsible for exercising end-to-end).
+
+No strip-falsify test lives in this file (review correction, #5275): an
+earlier draft reconstructed the OLD unconditional-commit
+``_incremental_elide_total`` BY HAND inside a test — that only proves a
+hand-copied re-implementation of the old bug reproduces the old bug, a
+tautology that stays green even if the REAL ownership check were removed
+from production (CLAUDE.md's test-review Q3: nobody would miss it). The
+actual strip-falsify — disabling the real ``still_owner`` check in
+``router_history_buffer.py`` and confirming
+``test_a_stale_owners_publish_is_rejected`` above goes RED — was done by
+hand against the real source and is recorded in #5275's own PR body, not
+duplicated here as a second, parallel implementation.
 """
 from __future__ import annotations
 
@@ -191,72 +203,4 @@ def test_the_legitimate_owners_own_publish_still_works(monkeypatch) -> None:
     assert call_count["n"] == 30, (
         f"a matching-owner call must still publish incrementally, got "
         f"{call_count['n']} new estimates instead of 30"
-    )
-
-
-def test_strip_the_ownership_check_reproduces_the_stale_publish(monkeypatch) -> None:
-    """Tier 2: strip-falsify — reconstructing the OLD unconditional-commit
-    ``_incremental_elide_total`` (mirroring pre-#5267: always write the
-    cache, regardless of ownership) against the same real buffer must
-    reproduce the corruption: the stale call's revert IS observed by the
-    next legitimate call needing to re-estimate turns it already
-    accounted for. Same stale-snapshot construction as the acceptance
-    test above, and for the same reason (a live-reread stale call would
-    compute the SAME correct values turn B already published)."""
-    import types
-
-    history = _turns(50)
-    owner_box = ["owner-A"]
-    buf = _make_buf(history, current_turn_owner_fn=lambda: owner_box[0])
-
-    def _old_incremental_elide_total(self, turns, wire_turns, *, use_chars4, expected_owner=None):
-        from reyn.services.compaction.engine import estimate_tokens_for_any_turn
-
-        model = self._model
-        cache_valid = (
-            len(turns) >= self._cached_elide_turn_count
-            and self._cached_elide_model == model
-            and self._cached_elide_use_chars4 == use_chars4
-            and (
-                self._cached_elide_turn_count == 0
-                or turns[self._cached_elide_turn_count - 1].seq == self._cached_elide_last_seq
-            )
-        )
-        if cache_valid:
-            new_wire_turns = wire_turns[self._cached_elide_turn_count:]
-            total = self._cached_elide_total + sum(
-                estimate_tokens_for_any_turn(wt, model, use_chars4=use_chars4)
-                for wt in new_wire_turns
-            )
-        else:
-            total = sum(
-                estimate_tokens_for_any_turn(wt, model, use_chars4=use_chars4)
-                for wt in wire_turns
-            )
-        self._cached_elide_total = total
-        self._cached_elide_turn_count = len(turns)
-        self._cached_elide_last_seq = turns[-1].seq if turns else None
-        self._cached_elide_model = model
-        self._cached_elide_use_chars4 = use_chars4
-        return total
-
-    buf._incremental_elide_total = types.MethodType(_old_incremental_elide_total, buf)
-
-    buf.build_history(expected_owner="owner-A")
-    turns_a, _watermark_a = buf._elide_candidate_turns(list(history))
-    wire_turns_a = [buf._serialise_turn(m) for m in turns_a]
-
-    owner_box[0] = "owner-B"
-    history.extend(_turns(10, start=51))
-    buf.build_history(expected_owner="owner-B")
-    # OLD code: publishes unconditionally, reverting the cache to turn A's
-    # stale (50-turn) view even though owner-A no longer owns.
-    buf._incremental_elide_total(turns_a, wire_turns_a, use_chars4=True, expected_owner="owner-A")
-
-    call_count = _counting_wrapper(monkeypatch)
-    buf.build_history(expected_owner="owner-B")
-    assert call_count["n"] != 0, (
-        "the OLD unconditional-commit must reproduce the stale revert (a "
-        "non-zero re-estimate here) — if this assertion fails, the strip "
-        "did not actually revert to the pre-#5267 shape"
     )


### PR DESCRIPTION
**[tui-coder]** — part of #4995, part of #5267

## Background

#4995 (owner proposal, via architect): the TUI's responsiveness problem is not GIL throughput — it is long synchronous blocks running on the SAME event loop the TUI's own frame scheduling shares, so the TUI is never scheduled while one runs. `RouterHistoryBuffer.build_history()` is one measured instance (candidate ①): it re-serialises every elide-candidate turn (path-ref image materialise included, #3185's own measurement) every call, a cost proportional to session length, run synchronously inline on the coroutine that also drives the TUI.

## Fix

`RouterLoopDriver._run_with_shrink` now dispatches `build_history()` via `asyncio.to_thread` instead of calling it inline — same shape as this codebase's own existing `voice.py` precedent (dispatching inference to `asyncio.to_thread` so the Textual event loop keeps drawing frames). The GIL still time-slices with the default ~5ms `sys.getswitchinterval()` while the worker thread runs, so the loop gets scheduled.

## Found during implementation, filed separately as #5267 (not silently folded in) — this PR carries the fix, part of #5267

Dispatching to a worker thread creates a NEW suspension point inside `build_history()`'s own call — `Session.cancel_inflight()`'s hard `Task.cancel()` can now land INSIDE that await (impossible when `build_history()` was purely synchronous, since a sync call cannot be interrupted mid-flight). But `Task.cancel()` only cancels the AWAIT, not the underlying thread-pool worker — `asyncio.to_thread`/`run_in_executor` cannot stop a running thread. So a cancelled turn's `build_history()` call can keep running in the background while the session immediately starts its next turn, whose OWN `build_history()` call could race the orphaned one over the SAME instance's `_cached_elide_total`/`_cached_elide_turn_count`/etc — and "last write wins" is not safe here, because `_incremental_elide_total` READS the cached total and ADDS to it (an incremental cache, not an idempotent overwrite): an interleaved stale write is not merely outdated, it can be arithmetically wrong.

**Architect ruling** (option (a), ownership — option (b), cancel waiting for background work to finish, was rejected: it trades correctness for liveness, since Ctrl-C would then be blocked on whatever the background work is stuck on): reuse the EXISTING owner (`Session._turn_owner_task`), not a new register. A first draft that invented an `itertools.count()`-based attempt counter was rejected during review for exactly this reason — the lock that draft needed to protect its own new counter would have vanished entirely once the counter itself was removed in favor of the existing owner.

## Shape (matches #5217's own "build privately, publish in one step" precedent — no new mechanism)

1. `RouterLoopDriver` captures `asyncio.current_task()` as `expected_owner` BEFORE dispatching to `asyncio.to_thread` (inside the worker thread there is no running task to ask).
2. `RouterHistoryBuffer.build_history`/`_incremental_elide_total` compute everything into LOCAL variables (reading the cache state once, up front, for the incremental-vs-full decision — unchanged from #4403).
3. At the very end, commit to `_cached_elide_*` only if `expected_owner` still matches `current_turn_owner_fn()` (Session's LIVE `_turn_owner_task`, read fresh — a bare attribute read/write is atomic under the GIL, no lock needed for this comparison). Otherwise discard the write; the caller's OWN return value is unaffected either way.

## Ownership-identity verification

Traced every turn kind (user / hook / agent_request / agent_response / pipeline_result) from `Session.run_one_iteration`'s `self._turn_owner_task = asyncio.create_task(self._run_turn_body(...))` down to `RouterLoopDriver._run_with_shrink` — every step is a plain `await`, zero `create_task`/`ensure_future` in between. Exact commands run:

```
grep -n "create_task\|ensure_future" src/reyn/runtime/session.py
grep -n "create_task\|ensure_future" src/reyn/runtime/services/inter_agent_messaging.py
grep -n "create_task\|ensure_future" src/reyn/runtime/services/router_loop_driver.py
```

`session.py` has 3 other `create_task`/`ensure_future` hits (a comment, intervention re-dispatch, buffered-answer-consumed persistence) — none on the traced turn-dispatch path; `inter_agent_messaging.py` and `router_loop_driver.py` have zero. This is a claim about the search I ran (this exact grep, these exact files), not a general proof — disclosed as such, and a comment at the `expected_owner` capture site names the exact failure mode if a future change breaks this (a silent, always-mismatched ownership check — no test would go red, just a quiet perf regression: every `build_history()` call recomputes from scratch instead of incrementally).

**Note on #5270** (landed after this PR was drafted, same #5267 family): the new `check_task_funnel_bypass.py` gate's own baseline confirms `session.py:6768` (`_turn_owner_task = asyncio.create_task(...)`) as a tracked, separate defect (item "A の本体" in #5267, owner TBD) — that task is created OUTSIDE the funnel today. This PR's own `expected_owner` mechanism depends on `_turn_owner_task`'s identity, not on how it was spawned — ran the gate against this diff and confirmed it reports the SAME one pre-existing hit, nothing new.

## Why `session.py:7709`'s sync `build_history()` call doesn't race (review point ②)

`_emit_router_cap_exhausted_user` (the rare router-cap-exceeded wrap-up path) calls `build_history()` with no `expected_owner` — deliberately left untouched, still fully synchronous. This is safe, and not merely because "it doesn't await": a synchronous call runs to completion on its own task without ever yielding, so nothing can make this call the STALE, orphaned party — no other turn can start and supersede ownership before this call returns, since starting a new turn itself requires the event loop to run, which can't happen until this call's own frame gives control back. Passing no `expected_owner` (defaulting to "always commit") is therefore exactly equivalent to passing the correct owner explicitly here — this call is always CURRENT by construction. Symmetrically, an ORPHANED background thread from an earlier cancelled turn is still protected: its own commit check compares its captured owner against the LIVE `_turn_owner_task` at commit time, and that comparison doesn't care whether the write that got there first came from a threaded caller or a plain sync one like this — a mismatch is rejected either way.

## Comment placement

Added on the "breaking side" per review — the `_cached_elide_*` field declarations themselves (not just the safe/passing-owner code path), and at the `expected_owner` capture site in `router_loop_driver.py` — whoever next mutates those fields from code with an await already in its own call stack should hit that comment before writing there.

## Tests

`tests/runtime/test_5267_elide_cache_ownership.py` — Tier 2, real `RouterHistoryBuffer`, no mocks:

- `test_a_stale_owners_publish_is_rejected` — acceptance. The stale call's `turns`/`wire_turns` are captured from a REAL 50-turn snapshot taken BEFORE history grew to 60, simulating "turn A already finished its own private computation off-thread; only the commit races turn B". A first draft of this test read history LIVE inside a second `build_history()` call for the stale side, which computed the SAME correct values turn B already published — making a broken ownership check indistinguishable from a working one. Caught this myself (confirmed by disabling the ownership check and seeing the test still pass) before reporting anything green; fixed by capturing the stale snapshot from the OLDER state instead.
- `test_no_owner_configured_always_publishes_unchanged` / `test_the_legitimate_owners_own_publish_still_works` — falsification contrasts (every pre-#5267 caller unaffected; the matching-owner case still publishes incrementally).

No strip-falsify test lives in this file (review correction): an earlier draft reconstructed the OLD unconditional-commit `_incremental_elide_total` BY HAND inside a test — that only proves a hand-copied re-implementation of the old bug reproduces the old bug, a tautology that stays green even with the REAL ownership check removed from production (six-questions Q3: nobody would miss it; Q2: it's the implementation, transcribed). The real strip-falsify is recorded below instead, against the actual production code.

## Verification

- `ruff check .` — clean
- `python scripts/test_tier_audit.py --strict tests/runtime/test_5267_elide_cache_ownership.py` — 3/3 OK (after removing the flawed strip-falsify test per review)
- `python scripts/verify_module_docstrings.py` on all 3 changed src files — OK
- `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- `python scripts/check_task_funnel_bypass.py` (new, #5270) — same 1 pre-existing baseline hit (`session.py:6768`), nothing new from this diff
- Manual strip-falsify: disabled the ownership check directly in `router_history_buffer.py`, confirmed `test_a_stale_owners_publish_is_rejected` goes red (10 re-estimates instead of 0), restored, confirmed green
- Targeted suites (elide/cache/history-slicing, cancel/hard-cancel: `test_2242_hard_cancel.py`, `test_3377_run_loop_survives_turn_cancel.py`, `test_3694_persist_cancelled_turn_outcome.py`, router-loop/retry-loop wiring) all pass
- Full sweep `tests/runtime/ tests/core/ tests/llm/`: **5560 passed, 3 skipped, 1 deselected** (a pre-existing, unrelated slow subprocess test — `test_fp0063_arc_witness.py`'s rag-plugin venv build, confirmed to take >15s and time out identically on a clean, unmodified `main` — not something this change touches or introduces), zero failures

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on the new test file (3/3 OK, after removing the flawed strip-falsify test per review)
- [x] `verify_module_docstrings.py` on changed src files
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] `check_task_funnel_bypass.py` — no new hits
- [x] Full local sweep of `tests/runtime/ tests/core/ tests/llm/` (5560 passed, 3 skipped, 1 deselected — `test_llm_driven_install_ingest_query_arc_reaches_the_ingested_chunk`, pre-existing/unrelated slow subprocess, confirmed on clean main)
- [x] Manual strip-falsify (ownership check disabled → acceptance test red with the exact corruption; restored → green)
- [ ] (skipped — Visual, standing waiver 2026-08-08) no rendering surface touched — this is a threading/ownership change under an existing seam

This PR touches `tests/` — needs an independent TESTS-READY(B) before I self-merge (rule 8). I will verify `gh pr checks` myself before merging and will not rely on a broker status report alone for that signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



- [x] 🔴 `test_strip_the_ownership_check_reproduces_the_stale_publish` を削除する — 旧実装を test 内に写しているため、production から所有権検査を外しても緑のまま（六問③=誰も困らない、六問②=実装の転写）。本物の strip-falsify（`still_owner` を外すと acceptance test が赤）は本文に 1 行で記す。 → 削除済み。テストファイルの docstring に不在の理由を追記、本物の strip-falsify は上の Tests/Verification 節に記録。
- [x] 🔴 `session.py:7709`（`_emit_router_cap_exhausted_user`、リベース後の行番号）の同期 build_history がなぜ競合しないかを本文に 1 行（docstring の「the rare limit-denied path, which stays synchronous」を読む人が探さずに済むように）。 → 上の「Why `session.py:7709`'s sync `build_history()` call doesn't race」節に記載。

