### PR TITLE
feat(#5276): reactive status-panel fields (mcp_subscriptions event-driven, config-derived memoized)

### DIFF
--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import Callable
+from weakref import WeakKeyDictionary
 
 from reyn.interfaces.repl.renderer import (
     _CC_ACCENT,
@@ -222,6 +223,51 @@ def _extract_hooks(config) -> list[dict]:
         except Exception:  # noqa: BLE001
             label = f"hook {i}"
         result.append({"label": label})
+    return result
+
+
+#: #5276: ``cron_jobs``/``mcp_servers``/``hooks``/``skills`` (the 4
+#: extractors above) never change after construction for a given
+#: (session, config) pair — the ``config`` object a caller holds is a
+#: frozen reference assigned exactly ONCE, at construction, and never
+#: reassigned (grep-confirmed: ``TextualChatApp.__init__``'s
+#: ``self._config = config`` is the only assignment site in that class;
+#: ``Session`` never assigns ``self._config`` at all). The actual
+#: hot-reload machinery (``HotReloader``) re-reads ``.reyn/*.yaml`` and
+#: applies it through per-component seams that mutate SEPARATE live
+#: objects (the cron scheduler, the hook dispatcher's registry, the
+#: session's own ``_available_skills``, the MCP tool cache) — never this
+#: ``config`` reference. So caching these 4 fields here causes ZERO
+#: behavior change either way: before this cache existed, every one of
+#: the ~60 renders/sec this ran at recomputed the IDENTICAL result from
+#: the same unchanging input. #5278 (filed separately, NOT fixed here)
+#: is the real, disclosed gap this leaves untouched: the status panel
+#: never reflects a hot-reload for these 4 kinds, and never did.
+#: Keyed by session identity (``WeakKeyDictionary`` — entries vanish with
+#: the session, no manual teardown needed) plus ``id(config)`` so a
+#: caller that genuinely swaps in a DIFFERENT config object (none does
+#: today, per the grep above, but nothing here assumes it never will)
+#: still recomputes rather than silently reusing a stale-by-construction
+#: entry.
+_CONFIG_DERIVED_CACHE: "WeakKeyDictionary[object, dict]" = WeakKeyDictionary()
+
+
+def _config_derived_fields(session, config) -> dict:
+    """#5276: the memoized ``{cron_jobs, mcp_servers, hooks, skills}``
+    computed at most once per (session, config) pair — see
+    :data:`_CONFIG_DERIVED_CACHE`'s own comment for the full "why caching
+    here is safe and behavior-neutral" reasoning."""
+    cached = _CONFIG_DERIVED_CACHE.get(session)
+    if cached is not None and cached.get("_config_id") == id(config):
+        return cached
+    result = {
+        "_config_id": id(config),
+        "cron_jobs": _extract_cron_jobs(config) if config is not None else [],
+        "mcp_servers": _extract_mcp_servers(config) if config is not None else [],
+        "hooks": _extract_hooks(config) if config is not None else [],
+        "skills": _extract_skills(config) if config is not None else [],
+    }
+    _CONFIG_DERIVED_CACHE[session] = result
     return result
 
 
@@ -565,10 +611,15 @@ def _snapshot_for_session(registry, s, config=None):
         # state — the LOCAL implementation is always CAPABLE of
         # reporting cron config, whether or not one happens to be
         # loaded on THIS particular call.
-        "cron_jobs": _extract_cron_jobs(config) if config is not None else [],
-        "mcp_servers": _extract_mcp_servers(config) if config is not None else [],
-        "hooks": _extract_hooks(config) if config is not None else [],
-        "skills": _extract_skills(config) if config is not None else [],
+        #
+        # #5276: routed through _config_derived_fields — memoized per
+        # (session, config) pair, computed at most once (see that
+        # function's own comment for why this is behavior-neutral: #5278,
+        # filed separately, is the real staleness gap this leaves as-is).
+        "cron_jobs": _config_derived_fields(s, config)["cron_jobs"],
+        "mcp_servers": _config_derived_fields(s, config)["mcp_servers"],
+        "hooks": _config_derived_fields(s, config)["hooks"],
+        "skills": _config_derived_fields(s, config)["skills"],
         # #4194: the policy-tier unknown/renamed config-key count
         # (ReynConfig.unknown_config_key_count, set once at load_config()
         # time — see that field's own docstring in root.py). Read every

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -244,11 +244,25 @@ def _extract_hooks(config) -> list[dict]:
 #: is the real, disclosed gap this leaves untouched: the status panel
 #: never reflects a hot-reload for these 4 kinds, and never did.
 #: Keyed by session identity (``WeakKeyDictionary`` — entries vanish with
-#: the session, no manual teardown needed) plus ``id(config)`` so a
-#: caller that genuinely swaps in a DIFFERENT config object (none does
-#: today, per the grep above, but nothing here assumes it never will)
-#: still recomputes rather than silently reusing a stale-by-construction
-#: entry.
+#: the session, no manual teardown needed) plus a STRONG reference to the
+#: ``config`` object itself, compared via ``is`` — so a caller that
+#: genuinely swaps in a DIFFERENT config object (none does today, per the
+#: grep above, but nothing here assumes it never will) still recomputes
+#: rather than silently reusing a stale-by-construction entry.
+#:
+#: #5279 review (architect/lead-coder): an EARLIER version of this guard
+#: compared ``id(config)`` (a bare int) instead of holding the object
+#: itself. That is unsafe in general — ``id()`` is only unique while the
+#: object it names is alive; once garbage-collected, CPython can and does
+#: reuse the same int for an unrelated later object, which would make a
+#: stale cache entry compare EQUAL to a completely different config by
+#: coincidence. Doesn't happen today (a session holds its own config for
+#: its whole life — the same grep-confirmed invariant this whole cache
+#: relies on), but that's exactly the "future config swap" case this
+#: guard exists to protect, and holding only an int would silently stop
+#: protecting it. A strong reference costs nothing extra here: the
+#: session already keeps its config alive for its entire lifetime
+#: regardless of whether this cache holds a second reference to it.
 _CONFIG_DERIVED_CACHE: "WeakKeyDictionary[object, dict]" = WeakKeyDictionary()
 
 
@@ -256,12 +270,14 @@ def _config_derived_fields(session, config) -> dict:
     """#5276: the memoized ``{cron_jobs, mcp_servers, hooks, skills}``
     computed at most once per (session, config) pair — see
     :data:`_CONFIG_DERIVED_CACHE`'s own comment for the full "why caching
-    here is safe and behavior-neutral" reasoning."""
+    here is safe and behavior-neutral" reasoning, and for why the guard
+    holds a real reference to ``config`` (compared via ``is``) rather than
+    a bare ``id()`` int."""
     cached = _CONFIG_DERIVED_CACHE.get(session)
-    if cached is not None and cached.get("_config_id") == id(config):
+    if cached is not None and cached.get("_config_ref") is config:
         return cached
     result = {
-        "_config_id": id(config),
+        "_config_ref": config,
         "cron_jobs": _extract_cron_jobs(config) if config is not None else [],
         "mcp_servers": _extract_mcp_servers(config) if config is not None else [],
         "hooks": _extract_hooks(config) if config is not None else [],

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1384,18 +1384,20 @@ class Session:
             self._on_audit_event_for_state_change,
         )
 
-        # #5276: mcp_subscription_state()'s reactive cache — recomputed only
-        # when one of the events that can actually change the subscription
-        # summary fires (subscribe/unsubscribe, a server being installed/
-        # removed, or a (re)connect — mcp_initialized/mcp_resource_updated,
-        # per #5277's own investigation that these two ALREADY cover a bare
-        # reconnect's mode/honored-set shift, so no new kind was needed).
-        # ``None`` means "never computed yet" — the first real read (lazy,
-        # not at construction) fills it; every subsequent read is a bare
-        # attribute return, matching ``turn_usage_fn``/``ctx_compaction_
-        # status_fn``'s own "store, don't run on every render frame" shape,
-        # but PUSH- rather than PULL-invalidated (recompute happens off the
-        # render path entirely, in the subscriber callback).
+        # #5276: mcp_subscription_state()'s reactive cache — invalidated
+        # (marked dirty, NOT recomputed here — #5279 review, see
+        # mcp_subscription_state's own docstring for why eager-inside-the-
+        # subscriber was rejected) only when one of the events that can
+        # actually change the subscription summary fires (subscribe/
+        # unsubscribe, a server being installed/removed, or a (re)connect —
+        # mcp_initialized/mcp_resource_updated, per #5277's own
+        # investigation that these two ALREADY cover a bare reconnect's
+        # mode/honored-set shift, so no new kind was needed).
+        # ``None`` means "needs a real recompute on the next read" — both
+        # at construction and right after any of these events — every OTHER
+        # read is a bare attribute return, matching ``turn_usage_fn``/
+        # ``ctx_compaction_status_fn``'s own "store, don't run on every
+        # render frame" shape.
         self._cached_mcp_subscriptions: "list[dict] | None" = None
         self._audit_events.add_subscriber(
             self._invalidate_mcp_subscription_cache,
@@ -9269,11 +9271,34 @@ class Session:
         connection service — same condition ``mcp_held_servers`` documents).
 
         #5276: reactive cache — ``self._cached_mcp_subscriptions`` is filled
-        lazily on first call (or by :meth:`_invalidate_mcp_subscription_cache`
-        whenever a subscribe/unsubscribe/install/removed/(re)connect event
-        fires — see the subscriber registration in ``__init__``), so a
-        render-frame caller pays for the real recomputation only on the
-        rare frame where something actually changed, not every frame.
+        lazily HERE, on the next real read after construction or after a
+        subscribe/unsubscribe/install/removed/(re)connect event marks it
+        dirty (see :meth:`_invalidate_mcp_subscription_cache` and the
+        subscriber registration in ``__init__``), so a render-frame caller
+        pays for the real recomputation only on the rare frame where
+        something actually changed AND something is actually reading it —
+        never on a frame nobody reads this, and never inside the event
+        dispatch itself.
+
+        #5279 review (architect BLOCK on an earlier draft that recomputed
+        EAGERLY inside the subscriber callback instead of merely marking
+        dirty): that shape had two real problems, both closed by moving
+        the recompute here instead. (1) ``EventLog``'s dispatch loop
+        isolates each subscriber with its own try/except (#4963/#4961 A) —
+        a raise from ``subscription_summary()`` inside the subscriber
+        would be silently swallowed, leaving the STALE cached value in
+        place with nobody aware a refresh failed (before #5276, every
+        read hit the real call directly, so a raise was never silently
+        absorbed this way). (2) recomputing on every qualifying EVENT ties
+        the actual compute cost to whatever paces those events — e.g.
+        ``mcp_resource_updated``'s cadence is controlled by the remote MCP
+        server, not by this session — so a headless run that never reads
+        this value went from 0 real computations (pre-#5276) to one per
+        event (the eager draft), with no bounding subject. Marking dirty
+        here instead bounds the cost to actual READS, exactly like every
+        other cache in this file, and a raise here propagates to THIS
+        call's own caller exactly as it always did.
+
         Recomputation itself is still this SAME thin forwarder to
         ``MCPConnectionService.subscription_summary`` — see that method's
         own docstring for why the composition lives there and not here (the
@@ -9286,13 +9311,15 @@ class Session:
 
     def _invalidate_mcp_subscription_cache(self, _event: object) -> None:
         """#5276: the subscriber callback wired to the events that can
-        actually change :meth:`mcp_subscription_state`'s answer — recomputes
-        EAGERLY, off the render path entirely, so the next render-frame
-        read of :attr:`_cached_mcp_subscriptions` is a bare attribute
-        return. Takes the event only to match the ``Subscriber`` shape
+        actually change :meth:`mcp_subscription_state`'s answer — marks the
+        cache dirty (``None``) rather than recomputing here; the next real
+        call to :meth:`mcp_subscription_state` does the actual work,
+        lazily, on its own caller's stack (see that method's own #5279
+        review paragraph for why eager-inside-the-subscriber was rejected).
+        Takes the event only to match the ``Subscriber`` shape
         (``Callable[[Event], None]``) — the event itself carries no
-        information this recompute needs beyond "something happened"."""
-        self._cached_mcp_subscriptions = self._mcp_connection_service.subscription_summary()
+        information this invalidation needs beyond "something happened"."""
+        self._cached_mcp_subscriptions = None
 
     async def aclose_background_tasks(self) -> None:
         """#4759 teardown: drain every background task this session (or a

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1384,6 +1384,28 @@ class Session:
             self._on_audit_event_for_state_change,
         )
 
+        # #5276: mcp_subscription_state()'s reactive cache — recomputed only
+        # when one of the events that can actually change the subscription
+        # summary fires (subscribe/unsubscribe, a server being installed/
+        # removed, or a (re)connect — mcp_initialized/mcp_resource_updated,
+        # per #5277's own investigation that these two ALREADY cover a bare
+        # reconnect's mode/honored-set shift, so no new kind was needed).
+        # ``None`` means "never computed yet" — the first real read (lazy,
+        # not at construction) fills it; every subsequent read is a bare
+        # attribute return, matching ``turn_usage_fn``/``ctx_compaction_
+        # status_fn``'s own "store, don't run on every render frame" shape,
+        # but PUSH- rather than PULL-invalidated (recompute happens off the
+        # render path entirely, in the subscriber callback).
+        self._cached_mcp_subscriptions: "list[dict] | None" = None
+        self._audit_events.add_subscriber(
+            self._invalidate_mcp_subscription_cache,
+            kinds=[
+                "mcp_resource_subscribed", "mcp_resource_unsubscribed",
+                "mcp_server_installed", "mcp_server_removed",
+                "mcp_initialized", "mcp_resource_updated",
+            ],
+        )
+
         # Budget adapter, byte-identical extraction, simplest of the #3082 families (Family 4, see session-construction.md#family-4-cost-budget)
         self._budget = self._build_budget(
             budget_tracker, self._audit_events, self.agent_name, _router_cap,
@@ -9246,12 +9268,31 @@ class Session:
         Always ``[]`` for an ephemeral session (never populates the
         connection service — same condition ``mcp_held_servers`` documents).
 
-        Thin forwarder to ``MCPConnectionService.subscription_summary`` —
-        see that method's own docstring for why the composition lives there
-        and not here (the single-producer reasoning behind both this method
-        and ``RouterHostAdapter.mcp_list_subscriptions`` reading the same
+        #5276: reactive cache — ``self._cached_mcp_subscriptions`` is filled
+        lazily on first call (or by :meth:`_invalidate_mcp_subscription_cache`
+        whenever a subscribe/unsubscribe/install/removed/(re)connect event
+        fires — see the subscriber registration in ``__init__``), so a
+        render-frame caller pays for the real recomputation only on the
+        rare frame where something actually changed, not every frame.
+        Recomputation itself is still this SAME thin forwarder to
+        ``MCPConnectionService.subscription_summary`` — see that method's
+        own docstring for why the composition lives there and not here (the
+        single-producer reasoning behind both this method and
+        ``RouterHostAdapter.mcp_list_subscriptions`` reading the same
         source)."""
-        return self._mcp_connection_service.subscription_summary()
+        if self._cached_mcp_subscriptions is None:
+            self._cached_mcp_subscriptions = self._mcp_connection_service.subscription_summary()
+        return self._cached_mcp_subscriptions
+
+    def _invalidate_mcp_subscription_cache(self, _event: object) -> None:
+        """#5276: the subscriber callback wired to the events that can
+        actually change :meth:`mcp_subscription_state`'s answer — recomputes
+        EAGERLY, off the render path entirely, so the next render-frame
+        read of :attr:`_cached_mcp_subscriptions` is a bare attribute
+        return. Takes the event only to match the ``Subscriber`` shape
+        (``Callable[[Event], None]``) — the event itself carries no
+        information this recompute needs beyond "something happened"."""
+        self._cached_mcp_subscriptions = self._mcp_connection_service.subscription_summary()
 
     async def aclose_background_tasks(self) -> None:
         """#4759 teardown: drain every background task this session (or a

--- a/tests/interfaces/test_5276_config_derived_fields_memoized.py
+++ b/tests/interfaces/test_5276_config_derived_fields_memoized.py
@@ -1,0 +1,119 @@
+"""Tier 2: #5276 — cron_jobs/mcp_servers/hooks/skills are computed at most
+ONCE per (session, config) pair, not recomputed every render frame.
+
+Root cause: these 4 status-panel fields are pure functions of ``config``,
+and ``config`` is a frozen reference assigned exactly once at construction
+(``TextualChatApp.__init__``'s ``self._config = config`` is the only
+assignment site in that class; ``Session`` never assigns ``self._config``
+at all — grep-confirmed). So every pre-#5276 render frame recomputed the
+IDENTICAL result from the same unchanging input — pure waste, not a
+correctness issue. #5278 (filed separately, NOT fixed here) is the real,
+disclosed gap this leaves untouched: the actual hot-reload machinery
+mutates SEPARATE live objects (the cron scheduler, the hook dispatcher's
+registry, ``_available_skills``, the MCP tool cache), never ``config``
+itself — so these 4 fields never reflected a hot-reload before this PR
+either, and still don't after it. This file tests ONLY the "computed at
+most once" claim — it does not, and must not, assert anything about
+hot-reload reflection (that would be asserting #5278's own absence).
+
+Real ``AgentRegistry``/``Session`` — no mocks. Uses the #4403 counting
+technique (wrap the real extractor, count real calls) — the SAME technique
+``test_5267_elide_cache_ownership.py`` uses for its own cache-hit witness.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.interfaces.repl.status import _snapshot_for_session
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    return reg
+
+
+def _counting_wrapper(monkeypatch) -> dict:
+    """Mirrors #4403's own counting technique: wraps the real
+    ``_extract_cron_jobs`` and counts real calls from this point on."""
+    import reyn.interfaces.repl.status as status_module
+
+    real_fn = status_module._extract_cron_jobs
+    call_count = {"n": 0}
+
+    def _counting(config):
+        call_count["n"] += 1
+        return real_fn(config)
+
+    monkeypatch.setattr(status_module, "_extract_cron_jobs", _counting)
+    return call_count
+
+
+@pytest.mark.asyncio
+async def test_config_derived_fields_computed_once_across_repeated_snapshots(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: acceptance — 3 ``_snapshot_for_session`` calls with the SAME
+    session + config cost exactly 1 real ``_extract_cron_jobs`` call, not
+    3 (the pre-#5276 shape)."""
+    reg = _make_registry(tmp_path)
+    s = await reg.ensure_running("alpha")
+    config = SimpleNamespace(cron=SimpleNamespace(jobs=[
+        SimpleNamespace(name="job1", schedule="@daily", enabled=True),
+    ]))
+    call_count = _counting_wrapper(monkeypatch)
+
+    snap1 = _snapshot_for_session(reg, s, config)
+    snap2 = _snapshot_for_session(reg, s, config)
+    snap3 = _snapshot_for_session(reg, s, config)
+
+    assert call_count["n"] == 1, (
+        f"expected exactly 1 real _extract_cron_jobs call across 3 snapshots "
+        f"(memoized per session+config), got {call_count['n']}"
+    )
+    assert snap1["cron_jobs"] == snap2["cron_jobs"] == snap3["cron_jobs"] == [
+        {"name": "job1", "schedule": "@daily", "enabled": True},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_config_derived_fields_recompute_for_a_different_config_object(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: falsification contrast — a genuinely DIFFERENT config object
+    (even for the same session) is NOT silently served the first config's
+    stale cache entry; it recomputes."""
+    reg = _make_registry(tmp_path)
+    s = await reg.ensure_running("alpha")
+    config_a = SimpleNamespace(cron=SimpleNamespace(
+        jobs=[SimpleNamespace(name="a", schedule="@daily", enabled=True)],
+    ))
+    config_b = SimpleNamespace(cron=SimpleNamespace(
+        jobs=[SimpleNamespace(name="b", schedule="@daily", enabled=True)],
+    ))
+    call_count = _counting_wrapper(monkeypatch)
+
+    snap_a = _snapshot_for_session(reg, s, config_a)
+    snap_b = _snapshot_for_session(reg, s, config_b)
+
+    assert call_count["n"] == 2, (
+        f"a different config object must recompute rather than reuse the "
+        f"other config's cached entry, got {call_count['n']} real calls"
+    )
+    assert snap_a["cron_jobs"] == [{"name": "a", "schedule": "@daily", "enabled": True}]
+    assert snap_b["cron_jobs"] == [{"name": "b", "schedule": "@daily", "enabled": True}]

--- a/tests/runtime/test_5276_mcp_subscription_reactive_cache.py
+++ b/tests/runtime/test_5276_mcp_subscription_reactive_cache.py
@@ -1,0 +1,120 @@
+"""Tier 2: #5276 — ``Session.mcp_subscription_state()``'s reactive cache.
+
+Root cause: this method used to forward straight to
+``MCPConnectionService.subscription_summary()`` on EVERY call, including
+every render frame the status panel drew. That composition is real work
+(iterates every held server, per-URI honored-set lookups) for a value that
+only ever changes on a handful of specific events (subscribe/unsubscribe,
+a server install/remove, or a (re)connect). Fix: a subscriber registered
+once in ``Session.__init__`` recomputes EAGERLY (off the render path) only
+when one of those events fires; every other call is a bare cached-attribute
+return.
+
+Real ``Session`` + real ``MCPConnectionService`` (no held servers — this
+file tests the CACHING mechanism, not connection/subscription composition
+correctness, which #4686's own suite already covers against a real MCP
+subprocess). Uses the #4403 counting technique (wrap the real
+``subscription_summary``, count real calls) and
+``tests/_support/events.py``'s ``settle`` (#3868/#4966) to wait for the
+subscriber's queued dispatch before reading the post-event state.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+from tests._support.events import settle
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return make_session(
+        agent_name="alice",
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "alice" / "state" / "snapshot.json",
+    )
+
+
+def _counting_wrapper(monkeypatch, service) -> dict:
+    """Mirrors #4403's own counting technique, applied to this session's
+    OWN ``MCPConnectionService`` instance (bound method, not the class) —
+    counts real ``subscription_summary()`` calls from this point on."""
+    real_fn = service.subscription_summary
+    call_count = {"n": 0}
+
+    def _counting():
+        call_count["n"] += 1
+        return real_fn()
+
+    monkeypatch.setattr(service, "subscription_summary", _counting)
+    return call_count
+
+
+@pytest.mark.asyncio
+async def test_repeated_reads_cost_one_real_compute(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — 3 repeated ``mcp_subscription_state()`` reads
+    with NO intervening event cost exactly 1 real ``subscription_summary``
+    call (the first, lazy fill), not 3."""
+    s = _make_session(tmp_path)
+    call_count = _counting_wrapper(monkeypatch, s._mcp_connection_service)
+
+    r1 = s.mcp_subscription_state()
+    r2 = s.mcp_subscription_state()
+    r3 = s.mcp_subscription_state()
+
+    assert call_count["n"] == 1, (
+        f"expected exactly 1 real subscription_summary call across 3 reads "
+        f"with no intervening event, got {call_count['n']}"
+    )
+    assert r1 == r2 == r3 == []
+
+
+@pytest.mark.asyncio
+async def test_a_relevant_event_triggers_exactly_one_recompute(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — after the first (lazy) read, emitting ONE of
+    the events that can change the subscription summary triggers exactly
+    ONE recompute (in the subscriber callback, off the render path) —
+    demonstrated by a SUBSEQUENT read costing 0 additional real calls."""
+    s = _make_session(tmp_path)
+    call_count = _counting_wrapper(monkeypatch, s._mcp_connection_service)
+
+    s.mcp_subscription_state()  # lazy fill: 1 real call
+    assert call_count["n"] == 1
+
+    s._audit_events.emit("mcp_resource_subscribed", server="srv", uri="resource://x")
+    await settle(s._audit_events)
+
+    assert call_count["n"] == 2, (
+        f"expected the subscriber to have recomputed once by now (off the "
+        f"render path), got {call_count['n']} real calls total"
+    )
+
+    # A subsequent read is now a bare cache return — 0 additional calls.
+    s.mcp_subscription_state()
+    assert call_count["n"] == 2, (
+        f"a read AFTER the subscriber already recomputed must cost nothing "
+        f"more, got {call_count['n']} real calls total"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unrelated_event_does_not_trigger_a_recompute(tmp_path, monkeypatch) -> None:
+    """Tier 2: falsification contrast — an event OUTSIDE the subscribed
+    kind set must not recompute (proves the subscriber is kind-filtered,
+    not firing on every event)."""
+    s = _make_session(tmp_path)
+    call_count = _counting_wrapper(monkeypatch, s._mcp_connection_service)
+
+    s.mcp_subscription_state()  # lazy fill: 1 real call
+    assert call_count["n"] == 1
+
+    s._audit_events.emit("user_submitted", text="hello", chain_id="c1", msg_id="m1", seq=1)
+    await settle(s._audit_events)
+
+    assert call_count["n"] == 1, (
+        f"an unrelated event kind must not trigger a recompute, got "
+        f"{call_count['n']} real calls total"
+    )

--- a/tests/runtime/test_5276_mcp_subscription_reactive_cache.py
+++ b/tests/runtime/test_5276_mcp_subscription_reactive_cache.py
@@ -6,9 +6,21 @@ every render frame the status panel drew. That composition is real work
 (iterates every held server, per-URI honored-set lookups) for a value that
 only ever changes on a handful of specific events (subscribe/unsubscribe,
 a server install/remove, or a (re)connect). Fix: a subscriber registered
-once in ``Session.__init__`` recomputes EAGERLY (off the render path) only
-when one of those events fires; every other call is a bare cached-attribute
-return.
+once in ``Session.__init__`` marks the cache DIRTY (``None``) — never
+recomputes itself — when one of those events fires; the actual
+recomputation happens lazily, on the next real ``mcp_subscription_state()``
+call, on that caller's own stack.
+
+Corrected mid-review (architect BLOCK on an earlier draft that recomputed
+EAGERLY inside the subscriber callback, #5279): (1) ``EventLog``'s
+per-subscriber try/except (#4963/#4961 A) would silently swallow a raise
+from an eager recompute, leaving a stale value in place with nobody aware
+a refresh failed; (2) recomputing per EVENT ties the real cost to
+whatever paces those events (e.g. a remote MCP server's own reconnect
+cadence), not to whether anyone is actually reading the value — a
+headless run that never reads this went from 0 real computations to one
+per event. Marking dirty instead bounds the cost to actual reads, exactly
+like every other cache in this file.
 
 Real ``Session`` + real ``MCPConnectionService`` (no held servers — this
 file tests the CACHING mechanism, not connection/subscription composition
@@ -73,11 +85,16 @@ async def test_repeated_reads_cost_one_real_compute(tmp_path, monkeypatch) -> No
 
 
 @pytest.mark.asyncio
-async def test_a_relevant_event_triggers_exactly_one_recompute(tmp_path, monkeypatch) -> None:
+async def test_a_relevant_event_marks_dirty_but_does_not_itself_recompute(
+    tmp_path, monkeypatch,
+) -> None:
     """Tier 2: acceptance — after the first (lazy) read, emitting ONE of
-    the events that can change the subscription summary triggers exactly
-    ONE recompute (in the subscriber callback, off the render path) —
-    demonstrated by a SUBSEQUENT read costing 0 additional real calls."""
+    the events that can change the subscription summary marks the cache
+    dirty WITHOUT itself costing a real call (the subscriber only sets
+    ``None`` — #5279 review: recomputing inside the subscriber would
+    silently swallow a raise via EventLog's per-subscriber try/except, and
+    would tie the real cost to event cadence rather than actual reads).
+    The NEXT real read is what pays for exactly one more real call."""
     s = _make_session(tmp_path)
     call_count = _counting_wrapper(monkeypatch, s._mcp_connection_service)
 
@@ -87,16 +104,24 @@ async def test_a_relevant_event_triggers_exactly_one_recompute(tmp_path, monkeyp
     s._audit_events.emit("mcp_resource_subscribed", server="srv", uri="resource://x")
     await settle(s._audit_events)
 
-    assert call_count["n"] == 2, (
-        f"expected the subscriber to have recomputed once by now (off the "
-        f"render path), got {call_count['n']} real calls total"
+    assert call_count["n"] == 1, (
+        f"the event itself must NOT trigger a real call (only marks dirty), "
+        f"got {call_count['n']} real calls total"
     )
 
-    # A subsequent read is now a bare cache return — 0 additional calls.
+    # The next real read pays for exactly one more real call (the lazy fill).
     s.mcp_subscription_state()
     assert call_count["n"] == 2, (
-        f"a read AFTER the subscriber already recomputed must cost nothing "
-        f"more, got {call_count['n']} real calls total"
+        f"expected exactly 1 more real call on the first read after the "
+        f"dirty-marking event, got {call_count['n']} real calls total"
+    )
+
+    # A further read with no intervening event is once again a bare cache
+    # return — 0 additional calls.
+    s.mcp_subscription_state()
+    assert call_count["n"] == 2, (
+        f"a read with no intervening event must cost nothing more, got "
+        f"{call_count['n']} real calls total"
     )
 
 


### PR DESCRIPTION
**[tui-coder]** — part of #5276 (partial — see Scope below; does not close it), part of #4995/#5267's larger "get off the TUI's own event loop / per-frame cost" family. Builds on #5277 (`visibility_changed`/`hook_changed` audit-events, merged).

## Background

Owner's own py-spy profiling: `_pump_frames` → `_refresh_live_chrome` → `_snapshot` runs once per frame, and `_snapshot_for_session` (status.py) walks config + session state almost every time — `_session_visibility_items` flagged highest priority (owner: "高いとわかってるものは全て対策してほしい… visibility_itemsが優先度高い"). Design review found the design already knows "per-frame is expensive" for 2 fields (`turn_usage_fn`/`ctx_compaction_status_fn`, stored uncalled) but the other 7 candidate fields (`visibility_items`/`hook_items`/`mcp_subscriptions`/`cron_jobs`/`mcp_servers`/`hooks`/`skills`) get no such treatment.

Lead-coder ruling (2nd pass, after a first "lazy/pull" proposal was withdrawn as owner-rejected — "以前も言ったけど reactive にしてよ", 2度目): genuinely REACTIVE (recompute only when the underlying data changes; render reads a held value, never recomputes), driven by real audit-events (#5263's `EventLog.add_subscriber(fn, kinds=...)`) — not a new mechanism.

## Required check before touching anything (owner's own concern)

Grepped `visibility_items`/`hook_items`/`mcp_subscriptions`/`cron_jobs`/`mcp_servers`/`hooks`/`skills` against `chrome.py`'s `status_line_text`/`cost_figure`/`_ctx_pct` — **zero hits**. The always-visible status line depends on none of the 7 candidates; all 7 are drawer-pane-only (`_refresh_pane`). None needed to stay eager for that reason.

## This PR's scope: `mcp_subscriptions` (event-driven) + `cron_jobs`/`mcp_servers`/`hooks`/`skills` (memoized once)

`visibility_items`/`hook_items` are NOT in this PR — #5277 added their toggle-side audit-events (`visibility_changed`/`hook_changed`) as a prerequisite; wiring their own reactive cache is a separate follow-up (their triggers are more numerous — toggle + envelope/turn-context shifts — and #5277 was already its own review cycle).

### `mcp_subscriptions` — genuinely event-driven

`Session.__init__` registers one subscriber (kinds: `mcp_resource_subscribed`, `mcp_resource_unsubscribed`, `mcp_server_installed`, `mcp_server_removed`, `mcp_initialized`, `mcp_resource_updated`) that recomputes `MCPConnectionService.subscription_summary()` EAGERLY, off the render path, into `self._cached_mcp_subscriptions`. `mcp_subscription_state()` becomes a bare cached-attribute return except on the very first call (lazy fill) or immediately after one of those 6 kinds fires.

`mcp_initialized`/`mcp_resource_updated` cover a bare reconnect's mode/honored-set shift — this is #5277's own finding (investigated there before adding a 3rd new kind; none was needed), reused here as-is.

### `cron_jobs`/`mcp_servers`/`hooks`/`skills` — memoized once, genuine finding mid-implementation

These 4 extractors are pure functions of `config`. Grepped: `config` is a frozen reference assigned exactly ONCE at construction — `TextualChatApp.__init__`'s `self._config = config` is the only assignment site in that class; `Session` never assigns `self._config` at all. Meanwhile `HotReloader`'s actual reapply seams (`_reapply_cron`/`_reapply_mcp`/`_reapply_hooks`/`_reapply_skills`) mutate entirely SEPARATE live objects (the cron scheduler, the hook dispatcher's registry, `_available_skills`, the MCP tool cache) — never `config` itself.

Consequence: subscribing to `config_reloaded` for these 4 fields would be pointless (the event fires but the source data these extractors read never changes). The correct, minimal fix is memoization keyed on `(session, config)` identity via a `WeakKeyDictionary` in `status.py` — **zero behavior change either way**: every pre-#5276 render frame already recomputed the IDENTICAL result from the same unchanging input, so caching it once changes nothing observable.

**#5278 filed separately** for the real gap this surfaces: these 4 status-panel fields never reflected a hot-reload before this PR, and still don't after it (an operator who hot-reloads a new cron job/MCP server/hook/skill sees it take effect live but the panel keeps showing the old list). Not fixed here — lead-coder's explicit ruling: the fix is a separate design decision (which live object each extractor should actually read), not something to silently bundle into a performance PR. **This PR's own behavior claim: "1度だけ計算にしても挙動は変わらない（staleのまま）"** — reading the panel before and after this PR shows the identical (already-stale) values; only the recomputation COUNT changes.

## No "got faster" claim

Per instruction: only "called fewer times" is claimed, shown by the tests below (no hardware access to the owner's own machine).

## Tests

- `tests/runtime/test_5276_mcp_subscription_reactive_cache.py` — Tier 2, real `Session` + real `MCPConnectionService` (no held servers — this file tests the caching mechanism, not subscription-composition correctness, which #4686's own suite covers against a real MCP subprocess). #4403 counting technique on `subscription_summary`:
  - `test_repeated_reads_cost_one_real_compute` — 3 reads, no intervening event → 1 real call.
  - `test_a_relevant_event_triggers_exactly_one_recompute` — one subscribed-kind event → exactly 1 more real call (in the subscriber), and the NEXT read costs 0 additional.
  - `test_an_unrelated_event_does_not_trigger_a_recompute` — falsification contrast (kind-filtering actually works, not "fires on everything").
- `tests/interfaces/test_5276_config_derived_fields_memoized.py` — Tier 2, real `AgentRegistry`/`Session`. #4403 counting technique on `_extract_cron_jobs`:
  - `test_config_derived_fields_computed_once_across_repeated_snapshots` — 3 `_snapshot_for_session` calls, same config → 1 real call.
  - `test_config_derived_fields_recompute_for_a_different_config_object` — falsification contrast: a genuinely different config object is NOT served the first one's stale cache entry.

## Verification

- `ruff check .` — clean
- `python scripts/test_tier_audit.py --strict` on both new test files — 5/5 OK
- `python scripts/verify_module_docstrings.py` on both changed src files — OK
- `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- `python scripts/check_task_funnel_bypass.py` — same 1 pre-existing baseline hit (`session.py`'s `_turn_owner_task`), nothing new
- Full sweep `tests/interfaces/ tests/runtime/test_5267_elide_cache_ownership.py tests/runtime/test_5276_toggle_audit_events.py tests/runtime/test_5276_mcp_subscription_reactive_cache.py tests/mcp/test_4686_subscription_visibility.py`: **2097 passed, 9 skipped** (pre-existing optional-dependency skips — `terminaltexteffects`/voice extras — unrelated), zero failures

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on both new test files (5/5 OK)
- [x] `verify_module_docstrings.py` on changed src files
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] `check_task_funnel_bypass.py` — no new hits
- [x] Full targeted sweep (2097 passed, 9 pre-existing skips, 0 failures)
- [ ] (skipped — Visual, standing waiver 2026-08-08) no rendering surface touched — this is a caching/invalidation change under an existing seam

This PR touches `tests/` — needs an independent TESTS-READY(B) before I self-merge (rule 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



- [x] 🔴 `_config_id == id(config)` は `id()` の再利用で偽の一致になり得る（config が解放され同じ address に別 config が載る）。今日は session が config を生涯保持するので起きないが、この guard は「将来の差し替え」のために置かれたもので、まさにその世界では古い config が解放され得る — 守ろうとした場面でだけ壊れる。config への参照を持ち `is` で比較すること（強参照でよいなら単純。どちらにせよ理由を 1 行）。

  → **Fixed** (head `d36725b34`): `_CONFIG_DERIVED_CACHE`'s cache entry now stores `"_config_ref": config` (a strong reference to the actual object) and the guard compares via `cached.get("_config_ref") is config`, not `id(config)`. Reasoning (now in both `_CONFIG_DERIVED_CACHE`'s own comment and `_config_derived_fields`'s docstring): `id()` is only unique while its object is alive — after garbage collection CPython can and does reuse the same int for an unrelated later object, which would make a stale entry compare equal to a completely different config by coincidence. Doesn't happen today (the session holds its own config for its whole life, the same invariant this cache already relies on), but that's exactly the "future config swap" case the guard exists to protect — holding only an int would silently stop protecting it in that world. A strong reference costs nothing extra: the session already keeps `config` alive for its entire lifetime regardless. Both existing tests re-run green unchanged (they assert on behavior, not the guard's internals).




- [x] 🔴 **[architect]** `_invalidate_mcp_subscription_cache` recomputes eagerly inside a per-subscriber try/except (#4961 A): a raise leaves the STALE value cached and swallowed (pre-PR it surfaced at the read), and the recompute rate on `mcp_resource_updated` is paced by the remote MCP server, not by us (headless sessions pay it for zero readers). Either make it `self._cached_mcp_subscriptions = None` (one line — both go away), or keep eager and write the silence + name the bounding subject in the comment. See issuecomment on this PR.

  → **Fixed** (head `a94072381`, lead-coder's own choice: took the `= None` line, not the eager+comment alternative). `_invalidate_mcp_subscription_cache` now only marks the cache dirty; the real recompute happens lazily on the next `mcp_subscription_state()` call, on that caller's own stack — a raise there propagates exactly like before #5276, and the cost is bounded by actual reads, not event cadence. Test `test_a_relevant_event_triggers_exactly_one_recompute` renamed to `test_a_relevant_event_marks_dirty_but_does_not_itself_recompute` and rewritten to assert the corrected shape (event → 0 new real calls; the NEXT read → 1). Strip-falsified: reverting to eager recompute inside the subscriber reproduces the exact regression this test now catches.

  **Also fixed a genuine CI red this same defect caused** (`tests/runtime/test_5167_mcp_hook_auto_subscribe.py::test_declared_concrete_hook_is_subscribed_with_no_turn_and_no_tool_call`, failing on both 3.11/3.12): the eager subscriber's recompute ran before `_auto_subscribe_mcp_resource_hooks()`'s own subscribe had fully settled state; the lazy read now happens fresh at the real call site, after the subscribe completes. Verified: all 7 tests in that file pass individually with this fix.

  Comment on the earlier `id()`→identity-ref fix (architect, previous point) kept as-is per explicit instruction — not shortened.

## Answer to architect's non-blocking B question (does a held server ever vanish without any of the 6 kinds firing?)

**Yes — confirmed by reading, filed as #5280 (disclosed, not fixed here — same treatment as #5278, per architect's own suggestion).** `MCPConnectionService._reconnect` pops the dead client from `self._clients` FIRST, then attempts to reopen; if the reopen itself raises (the server is genuinely gone, not just a transient transport blip), the server is already removed from `held_servers()` (hence from `subscription_summary()`'s answer) and `mcp_initialized` — the only one of the 6 kinds that fires on a (re)connect — never fires, because the reconnect failed. Two call paths reach this (`_HeldConnection._heal`'s reactive path, and `_on_subscription_lost`'s proactive path, the latter fully silent — caught and logged as a warning). Unlike #5278, this staleness is genuinely NEW (introduced by this PR — pre-#5279 every render frame recomputed fresh, so a dropped server was reflected on the very next frame regardless).



