### PR TITLE
feat(#5276②): hook_items reactive cache, synchronous invalidation

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1408,6 +1408,26 @@ class Session:
             ],
         )
 
+        # #5276②: hook_state()'s reactive cache. Deliberately NOT invalidated
+        # via an EventLog subscriber (unlike mcp_subscription_state's cache
+        # above) — caught during implementation via a genuine, pre-existing
+        # test failure (test_hook_slash_disables_via_public_state):
+        # set_hook_enabled is a plain SYNCHRONOUS method, and a caller that
+        # toggles then reads hook_state() immediately, with no intervening
+        # await, has always gotten the fresh answer synchronously. But
+        # EventLog.emit() QUEUES subscriber dispatch onto a background
+        # consumer task whenever a loop is running (#4966) — so a
+        # subscriber-based invalidation would not have run YET by the time
+        # such a caller reads hook_state(), returning the STALE pre-toggle
+        # cache. mcp_subscription_state's own cache doesn't hit this because
+        # every real trigger there already crosses an async boundary (a
+        # network round-trip) before any caller could plausibly read the
+        # panel. Fix: invalidate this cache SYNCHRONOUSLY, directly at each
+        # mutation site (set_hook_enabled's applied path, _reapply_hooks,
+        # load_persisted_toggles) — see each site's own comment. No
+        # subscriber registration for this cache at all.
+        self._cached_hook_items: "list[dict] | None" = None
+
         # Budget adapter, byte-identical extraction, simplest of the #3082 families (Family 4, see session-construction.md#family-4-cost-budget)
         self._budget = self._build_budget(
             budget_tracker, self._audit_events, self.agent_name, _router_cap,
@@ -3032,6 +3052,15 @@ class Session:
         else:
             self._disabled_hooks.add(name)
         self._persist_hook_disabled()  # #2285 step2 — survive restart (best-effort)
+        # #5276②: invalidate hook_state()'s cache SYNCHRONOUSLY, right here
+        # — not via the audit-event below. A caller that toggles then reads
+        # hook_state() immediately (no await in between, e.g. the existing
+        # test_hook_slash_disables_via_public_state) must see the fresh
+        # answer; EventLog.emit()'s subscriber dispatch is QUEUED whenever a
+        # loop is running (#4966), so relying on an emitted event to
+        # invalidate this cache would still be showing the stale pre-toggle
+        # value by the time such a caller reads it.
+        self._cached_hook_items = None
         self._audit_events.emit(
             "hook_changed", name=name, enabled=enabled, applied=True, origin=origin,
         )
@@ -3106,6 +3135,11 @@ class Session:
                     self._disabled_hooks = {str(n) for n in disabled}
         except Exception as exc:  # noqa: BLE001
             logger.warning("#2285: load hook disabled-set failed: %r", exc)
+        # #5276②: this method resets/repopulates self._disabled_hooks above
+        # (unconditionally, at both call sites this docstring names) —
+        # invalidate hook_state()'s cache synchronously here too, same
+        # reasoning as set_hook_enabled's own comment.
+        self._cached_hook_items = None
         if loaded_visibility:
             self._capability_visibility.reapply_visibility_override()
         if loaded_skill_visibility:
@@ -3155,12 +3189,26 @@ class Session:
         shared predicate this display and :meth:`set_hook_enabled`'s refusal decision both
         call, rather than each writing its own copy of the same boolean expression (architect
         ruling, #5230: a census of every surface reporting this state cannot be closed with
-        confidence, so the fix collapses the predicate structurally instead)."""
-        out: "list[dict]" = []
-        for name, hook in self._hook_defs_by_name().items():
-            enabled = not self._hook_effectively_disabled(name, hook.origin)
-            out.append({"name": name, "scope": hook.origin, "enabled": enabled})
-        return out
+        confidence, so the fix collapses the predicate structurally instead).
+
+        #5276②: reactive cache — ``self._cached_hook_items`` is filled lazily
+        here, on the next real call after construction or after a mutation
+        site (``set_hook_enabled``'s applied path, ``_reapply_hooks``,
+        ``load_persisted_toggles``) directly clears it to ``None``.
+        Deliberately NOT invalidated via an ``EventLog`` subscriber (unlike
+        ``mcp_subscription_state``'s own cache) — see this field's own
+        comment in ``__init__`` for the genuine, pre-existing test failure
+        (a synchronous toggle-then-read caller) that direct, synchronous
+        invalidation was needed to fix, since subscriber dispatch is queued
+        (#4966) and would not have run yet by the time such a caller reads
+        this."""
+        if self._cached_hook_items is None:
+            out: "list[dict]" = []
+            for name, hook in self._hook_defs_by_name().items():
+                enabled = not self._hook_effectively_disabled(name, hook.origin)
+                out.append({"name": name, "scope": hook.origin, "enabled": enabled})
+            self._cached_hook_items = out
+        return self._cached_hook_items
 
     def _hook_defs_by_name(self) -> "dict[str, HookDef]":
         """The merged registry's ``HookDef``s keyed by name, most-specific origin
@@ -6078,8 +6126,16 @@ class Session:
         re-combine with the FIXED reyn.yaml startup layer, and swap the dispatcher's
         registry. The dispatcher reads its registry fresh per dispatch, so the swap
         propagates to every holder. The startup layer is never re-read (safety
-        boundary). Always rebuilds (handles add / change / remove of either layer)."""
+        boundary). Always rebuilds (handles add / change / remove of either layer).
+
+        #5276②: invalidates ``hook_state()``'s cache synchronously right
+        after swapping the registry — same "direct at the mutation site,
+        no subscriber" reasoning as :meth:`set_hook_enabled`'s own comment
+        (an awaited caller reading ``hook_state()`` right after this
+        reload completes must see the fresh declaration set, not a value
+        an event subscriber hasn't gotten around to invalidating yet)."""
         self._hook_dispatcher.replace_registry(self._build_hook_registry(in_set))
+        self._cached_hook_items = None
         return True
 
     def _hot_reload_project_root(self) -> "Path":

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1426,6 +1426,28 @@ class Session:
         # mutation site (set_hook_enabled's applied path, _reapply_hooks,
         # load_persisted_toggles) — see each site's own comment. No
         # subscriber registration for this cache at all.
+        #
+        # #5284 review (lead-coder BLOCK): the 3-site enumeration above is
+        # a claim about a search actually run, not an assumption — every
+        # write to the two things hook_state()'s answer is a pure function
+        # of (`self._disabled_hooks`, `self._hook_dispatcher`'s registry):
+        #   grep -n '_disabled_hooks\s*=\|_disabled_hooks\.add\|_disabled_hooks\.discard' session.py
+        #     → exactly 4 lines, all inside set_hook_enabled (2) and
+        #       load_persisted_toggles (2)
+        #   grep -rn '\.replace_registry\(' src/reyn/
+        #     → exactly 1 call site (session.py, inside _reapply_hooks);
+        #       HookDispatcher.replace_registry is the ONLY method that
+        #       reassigns HookDispatcher._registry after construction
+        #       (checked dispatcher.py directly — the constructor's own
+        #       assignment doesn't need an invalidation, since this cache
+        #       starts at None regardless)
+        # ⚠️ WHOEVER ADDS A NEW SITE THAT MUTATES EITHER OF THOSE TWO
+        # THINGS MUST ALSO CLEAR `self._cached_hook_items = None` THERE —
+        # nothing here will turn red on its own; a 4th such site added
+        # without this line means hook_state() silently starts returning a
+        # stale answer (the #5267 "breaking side" comment placement: on
+        # the field that breaks, not just the code path that uses it
+        # correctly today).
         self._cached_hook_items: "list[dict] | None" = None
 
         # Budget adapter, byte-identical extraction, simplest of the #3082 families (Family 4, see session-construction.md#family-4-cost-budget)

--- a/tests/runtime/test_5276_hook_items_reactive_cache.py
+++ b/tests/runtime/test_5276_hook_items_reactive_cache.py
@@ -182,3 +182,39 @@ async def test_a_hook_declaration_reload_invalidates_the_cache(tmp_path, monkeyp
 
     after = {h["name"] for h in s.hook_state()}
     assert "reloaded-hook" in after
+
+
+def test_load_persisted_toggles_invalidates_the_cache(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — the 3rd invalidation site (architect B on #5284:
+    only 2 of 3 sites had a witness). Priming ``hook_state()``'s cache,
+    THEN persisting a disabled-set directly to the per-session state dir's
+    ``hooks.yaml`` (bypassing ``set_hook_enabled`` entirely — the exact
+    restart-recovery shape ``load_persisted_toggles`` exists for), THEN
+    calling ``load_persisted_toggles()`` must make the NEXT ``hook_state()``
+    read reflect the persisted disable — proving this site's own
+    ``self._cached_hook_items = None`` line is load-bearing (removing it
+    reproduces this test going red with no other change)."""
+    import yaml
+
+    _write_agent_hook(tmp_path, "myhook")
+    s = _make_session(tmp_path)
+
+    # Prime the cache with the pre-restore (enabled) state.
+    before = {h["name"]: h["enabled"] for h in s.hook_state()}
+    assert before.get("myhook") is True
+
+    # Persist a disabled-set directly (mirrors a prior session's own
+    # _persist_hook_disabled write, restored on a fresh instance) —
+    # bypasses set_hook_enabled's own synchronous invalidation entirely.
+    state_dir = Path(s._snapshot_path).parent
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "hooks.yaml").write_text(
+        yaml.safe_dump({"disabled": ["myhook"]}), encoding="utf-8",
+    )
+
+    s.load_persisted_toggles()
+    after = {h["name"]: h["enabled"] for h in s.hook_state()}
+    assert after.get("myhook") is False, (
+        "hook_state() read after load_persisted_toggles() must reflect the "
+        "just-restored disabled-set, not the primed pre-restore cache"
+    )

--- a/tests/runtime/test_5276_hook_items_reactive_cache.py
+++ b/tests/runtime/test_5276_hook_items_reactive_cache.py
@@ -1,0 +1,184 @@
+"""Tier 2: #5276② — ``Session.hook_state()``'s reactive cache.
+
+Root cause: this method used to re-walk ``self._hook_defs_by_name()`` (a
+full merged-registry scan) on EVERY call, including every render frame the
+status panel drew, for an answer that only changes on a toggle
+(``set_hook_enabled``) or a hook-declaration hot-reload (``_reapply_hooks``).
+
+Genuine finding caught mid-implementation (a real, pre-existing test
+failure, ``test_hook_slash_disables_via_public_state``): an EventLog-
+subscriber-based invalidation (the shape ``mcp_subscription_state`` uses)
+is UNSAFE here, because ``set_hook_enabled`` is a plain SYNCHRONOUS method
+and an existing caller toggles then reads ``hook_state()`` immediately,
+with no intervening ``await`` — but ``EventLog.emit()`` QUEUES subscriber
+dispatch onto a background consumer task whenever a loop is running
+(#4966), so the invalidating subscriber would not have run yet by the time
+such a caller reads the (still-stale) cache. Fix: invalidate SYNCHRONOUSLY,
+directly at each mutation site (``set_hook_enabled``'s applied path,
+``_reapply_hooks``, ``load_persisted_toggles``) — no subscriber for this
+cache at all.
+
+Real ``Session``/``HookDispatcher`` — no mocks, mirrors
+``test_5222_hook_state_origin_aware.py``'s own real-seam pattern. Uses the
+#4403 counting technique (wrap ``_hook_defs_by_name``, count real calls).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
+from tests._support.agent_session import make_session
+
+_STARTUP_HOOK_NAME = "project-supervision-hook"
+_STARTUP_HOOKS = [
+    {
+        "on": "turn_end",
+        "name": _STARTUP_HOOK_NAME,
+        "template_push": {"message": "startup fired", "wake": True},
+    },
+]
+
+
+def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
+    return make_session(
+        agent_name="alice",
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "alice" / "state" / "snapshot.json",
+        reactivity=ReactivityConfig(hooks_config=hooks_config),
+    )
+
+
+def _write_agent_hook(tmp_path: Path, name: str) -> None:
+    """Mirrors ``test_hook_applicability_2285.py``'s own helper — a
+    per-agent-origin hook (freely disableable, unlike the startup/runtime
+    origins #5230 protects), written BEFORE the session that reads it is
+    constructed."""
+    p = tmp_path / ".reyn" / "agents" / "alice" / "hooks.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        yaml.safe_dump({"hooks": [
+            {"on": "turn_end", "name": name, "template_push": {"message": "ping", "wake": True}},
+        ]}),
+        encoding="utf-8",
+    )
+
+
+def _counting_wrapper(monkeypatch, session: Session) -> dict:
+    """Mirrors #4403's own counting technique — counts real
+    ``_hook_defs_by_name`` calls (the merged-registry walk ``hook_state``
+    would otherwise re-run every call) from this point on."""
+    real_fn = session._hook_defs_by_name
+    call_count = {"n": 0}
+
+    def _counting():
+        call_count["n"] += 1
+        return real_fn()
+
+    monkeypatch.setattr(session, "_hook_defs_by_name", _counting)
+    return call_count
+
+
+def test_repeated_reads_cost_one_real_walk(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — 3 repeated ``hook_state()`` reads with no
+    intervening toggle cost exactly 1 real registry walk, not 3."""
+    s = _make_session(tmp_path)
+    call_count = _counting_wrapper(monkeypatch, s)
+
+    r1 = s.hook_state()
+    r2 = s.hook_state()
+    r3 = s.hook_state()
+
+    assert call_count["n"] == 1, (
+        f"expected exactly 1 real registry walk across 3 reads with no "
+        f"intervening toggle, got {call_count['n']}"
+    )
+    assert r1 == r2 == r3
+
+
+@pytest.mark.asyncio
+async def test_a_synchronous_toggle_then_read_sees_the_fresh_value_immediately(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: acceptance — the exact #5276② witness. A caller that toggles
+    a hook then reads ``hook_state()`` IMMEDIATELY, with no ``await`` in
+    between, must see the fresh value (this is a SYNCHRONOUS method calling
+    another SYNCHRONOUS method — no async boundary crossed at all), proving
+    the cache is invalidated directly at the mutation site rather than via
+    a queued event subscriber (which would still show the stale value
+    here — this is precisely the regression the initial subscriber-based
+    draft introduced and this test would have caught)."""
+    _write_agent_hook(tmp_path, "myhook")  # per-agent origin — freely disableable
+    s = _make_session(tmp_path)
+
+    # Prime the cache with the pre-toggle (enabled) state.
+    before = {h["name"]: h["enabled"] for h in s.hook_state()}
+    assert before.get("myhook") is True
+
+    s.set_hook_enabled("myhook", False)
+    after_off = {h["name"]: h["enabled"] for h in s.hook_state()}
+    assert after_off.get("myhook") is False, (
+        "hook_state() read immediately after a synchronous toggle, with no "
+        "await in between, must reflect it — got a stale/cached value"
+    )
+
+    s.set_hook_enabled("myhook", True)
+    after_on = {h["name"]: h["enabled"] for h in s.hook_state()}
+    assert after_on.get("myhook") is True, (
+        "a second synchronous toggle-then-read must ALSO see the fresh "
+        "value, not a value cached from before EITHER toggle"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_refused_toggle_does_not_invalidate_unnecessarily(tmp_path, monkeypatch) -> None:
+    """Tier 2: falsification contrast — a REFUSED disable (#5230, a
+    protected startup/runtime-origin hook) changes no state
+    (``_disabled_hooks`` untouched), so it must NOT invalidate the cache —
+    a subsequent ``hook_state()`` read costs 0 additional registry walks.
+
+    ``set_hook_enabled`` itself calls the SAME ``_hook_defs_by_name`` this
+    test wraps (to resolve the hook's own origin, independent of
+    ``hook_state``'s cache) — so the expected count includes that 1 call
+    too. What this test actually isolates is the SECOND ``hook_state()``
+    call below costing 0 MORE: if the refusal had incorrectly invalidated
+    the cache, that call would add a 3rd, not stay at 2."""
+    s = _make_session(tmp_path, hooks_config=_STARTUP_HOOKS)
+    call_count = _counting_wrapper(monkeypatch, s)
+
+    s.hook_state()  # 1 real walk, fills the cache
+    assert call_count["n"] == 1
+
+    result = s.set_hook_enabled(_STARTUP_HOOK_NAME, False)  # +1 (its own resolve, not hook_state's cache)
+    assert result.applied is False
+    assert call_count["n"] == 2
+
+    s.hook_state()
+    assert call_count["n"] == 2, (
+        f"a refused (no-op) toggle must not invalidate hook_state()'s "
+        f"cache — expected 0 additional walks on this read, got "
+        f"{call_count['n'] - 2} more (total {call_count['n']})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_hook_declaration_reload_invalidates_the_cache(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — ``_reapply_hooks`` (the hot-reload seam that
+    swaps the LIVE dispatcher registry — #5278 does NOT apply here, unlike
+    cron_jobs/mcp_servers/skills) invalidates the cache, so a NEWLY declared
+    hook is visible on the very next read, with no intervening await needed
+    beyond awaiting ``_reapply_hooks`` itself."""
+    s = _make_session(tmp_path)
+    before = {h["name"] for h in s.hook_state()}
+    assert "reloaded-hook" not in before
+
+    await s._reapply_hooks({
+        "hooks": [{"on": "turn_end", "name": "reloaded-hook", "template_push": {"message": "x"}}],
+    })
+
+    after = {h["name"] for h in s.hook_state()}
+    assert "reloaded-hook" in after


### PR DESCRIPTION
**[tui-coder]** — part of #5276 (partial — `visibility_items` still open, currently under fresh investigation per owner's own real-machine measurement). Builds on #5277/#5279 (merged).

## Change

`Session.hook_state()` (the status panel's hook read model) now caches its answer in `self._cached_hook_items`, invalidated directly at each of the 3 sites that can change it:

- `set_hook_enabled`'s applied path (a toggle actually changed `self._disabled_hooks`)
- `_reapply_hooks` (the hot-reload seam that swaps the LIVE dispatcher registry — unlike `cron_jobs`/`mcp_servers`/`skills`, #5278 does NOT apply here, since `hook_state()` reads the live registry, never the frozen `config`)
- `load_persisted_toggles` (restores `_disabled_hooks` at session construction/spawn-fixup)

## Deliberately NOT event-subscriber-based (unlike `mcp_subscription_state`, #5279) — a real regression caught mid-implementation

My first draft mirrored #5279's shape exactly: an `EventLog.add_subscriber(kinds=["hook_changed", "config_reloaded"])` that marked the cache dirty. This broke a genuine, pre-existing test: `test_hook_slash_disables_via_public_state` (toggle off → assert `hook_state()` shows disabled, toggle on → assert it shows enabled, both reads immediately after the toggle, no `await` in between).

Root cause: `set_hook_enabled` is a plain SYNCHRONOUS method. `EventLog.emit()` QUEUES subscriber dispatch onto a background consumer task whenever an event loop is running (#4966) — so the invalidating subscriber had not run yet by the time this existing, synchronous-toggle-then-read caller read `hook_state()`, which returned the stale pre-toggle cache. This is exactly the KIND of hazard #5279's own architect review caught for `mcp_subscription_state` (eager-recompute-inside-subscriber), but manifesting on the OPPOSITE side here: `mcp_subscription_state`'s real triggers all cross an async boundary (a network round-trip) before any real caller could plausibly read the panel, so a queued invalidation is fine there; `hook_state`'s toggle path has NO such boundary — the mutation and a synchronous read can happen back-to-back with zero yields, and a subscriber-based fix cannot possibly close that gap (it would need the SAME queued dispatch to run before the read, i.e., it fundamentally cannot).

Fix: invalidate synchronously, at the mutation site, with no subscriber involved for this cache at all. Verified: reverting the fix (restoring the subscriber-based draft) reproduces BOTH `test_hook_slash_disables_via_public_state`'s original failure AND this PR's own new test — same regression, confirmed via strip-falsify.

## Tests

`tests/runtime/test_5276_hook_items_reactive_cache.py` — Tier 2, real `Session`/`HookDispatcher`, no mocks. #4403 counting technique (wrap `_hook_defs_by_name`, count real registry walks):

- `test_repeated_reads_cost_one_real_walk` — 3 reads, no intervening toggle → 1 real walk.
- `test_a_synchronous_toggle_then_read_sees_the_fresh_value_immediately` — the exact witness: a toggle then an immediate synchronous read (no `await`) sees the fresh value, both directions (off then on).
- `test_a_refused_toggle_does_not_invalidate_unnecessarily` — falsification contrast: a #5230-refused disable (protected origin) changes no state, so it must not invalidate the cache.
- `test_a_hook_declaration_reload_invalidates_the_cache` — `_reapply_hooks` invalidation, a newly-declared hook appears on the very next read.

## Verification

- `ruff check .` — clean
- `python scripts/test_tier_audit.py --strict` on the new test file — 4/4 OK
- `python scripts/verify_module_docstrings.py` on the changed src file — OK
- `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- `python scripts/check_task_funnel_bypass.py` — same 1 pre-existing baseline hit, nothing new
- Targeted sweep (hooks/#5276 family, 59 tests, listed in commit) — all pass
- Strip-falsify: reverting to the subscriber-based draft reproduces the exact regression this PR's own new test — and the ORIGINAL pre-existing test — catch

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on the new test file (4/4 OK)
- [x] `verify_module_docstrings.py` on the changed src file
- [x] `mypy_ratchet.py`
- [x] `check_task_funnel_bypass.py` — no new hits
- [x] Targeted sweep (59 tests) — all pass
- [x] Strip-falsify confirms the fix is load-bearing
- [ ] (skipped — Visual, standing waiver 2026-08-08) no rendering surface touched — this is a caching/invalidation change under an existing seam

This PR touches `tests/` — needs an independent TESTS-READY(B) before I self-merge (rule 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- [x] 🔴 3 つの mutation site（`set_hook_enabled` の applied 枝 / `_reapply_hooks` / `load_persisted_toggles`）が**全部だと、どうやって分かったか**を本文に 1 行（引いたコマンドと結果）。今のままだと「今日の列挙」に安全性が乗っていて、**4 つ目の mutation site が足された日に、何も赤くならないまま stale を返します**。あわせて `_cached_hook_items` の宣言のすぐ上に「**新しい mutation site を足す人は、ここも無効化すること**」を 1 行 — 壊す側に置いてください（#5267 で確立した形）。

  → **Fixed** (head `99a4ebf34`). Commands run, results:
  ```
  grep -n '_disabled_hooks\s*=\|_disabled_hooks\.add\|_disabled_hooks\.discard' src/reyn/runtime/session.py
    → exactly 4 lines, all inside set_hook_enabled (2) and load_persisted_toggles (2)

  grep -rn '\.replace_registry\(' --include="*.py" src/reyn/
    → exactly 1 call site (session.py, inside _reapply_hooks)
  ```
  Also checked `src/reyn/hooks/dispatcher.py` directly: `HookDispatcher.replace_registry` is the ONLY method (besides `__init__`'s own construction-time assignment, which needs no invalidation — this cache starts at `None` regardless) that reassigns `HookDispatcher._registry`. Since `hook_state()`'s answer is a pure function of exactly two things (`self._disabled_hooks` and the dispatcher's registry), and both are now grep-confirmed to have exactly the mutation sites this PR already invalidates at, the 3-site enumeration is exhaustive as of this diff.

  Added a breaking-side warning directly above `_cached_hook_items`'s own declaration (mirrors #5267's own comment-placement precedent) naming both grep commands and explicitly stating: whoever adds a 4th mutation site to either of those two things must also clear `self._cached_hook_items = None` there, or `hook_state()` silently starts returning stale data with nothing turning red.

  ⚪ subscriber を使わない判断自体は通します。理由が具体で、実際の test 失敗に基づき、mcp 側との差（あちらは必ず async 境界を跨ぐ）まで名指しできています。





- [x] 🔴 **[architect]** Site 3 of 3 has no witness: strip `self._cached_hook_items = None` from `load_persisted_toggles` and nothing turns red. This is distinct from the disclosed "a 4th site could exist" gap — site 3 is a line this PR just wrote. Either add the test (prime the cache → write a persisted disabled-set → call `load_persisted_toggles()` → assert the read reflects it; real seam, no fake, same shape as the other three) or, if the cache is provably always `None` at both of its call sites, say so in the comment. See issuecomment on this PR.

  → **Fixed** (head `cfd87fbe9`). Added `test_load_persisted_toggles_invalidates_the_cache`: primes the cache, persists a disabled-set directly to the state dir (bypassing `set_hook_enabled` entirely — the actual restart-recovery shape), calls `load_persisted_toggles()`, asserts the very next read reflects it. Strip-falsified: removing the invalidation line reproduces this exact test going red, no other change.

## Non-blocking follow-ups (architect)

- **Fingerprinted-cache alternative** (vs. enumerate-and-invalidate): considered, not adopted in this PR. `hook_state()`'s inputs (`self._disabled_hooks`, a mutable set; `self._hook_dispatcher.registry`, a swapped-not-mutated object) don't have a cheap, natural fingerprint the way #5279's `config` object identity did — `frozenset(self._disabled_hooks)` would need a fresh copy+hash on every read to detect a change, which reintroduces real per-call cost for a set that's typically tiny, so the saving over the current enumerate-and-invalidate shape is unclear. Not filing a separate issue for this — flagging here as considered-and-set-aside rather than silently dropped; happy to revisit if a 4th mutation site's discipline becomes a repeated pain point.
- **Merge-order note**: this branch was created after #5273/#5274 (`6f0d63932`) landed on `main` and includes that commit via the ordinary rebase — no separate action, noting per architect's request since the PR diff view can make an unrelated merged commit look like part of this PR's own change.


