### PR TITLE
feat(#5276): visibility_items — memoize the envelope census, keep overlay live

### DIFF
--- a/src/reyn/runtime/capability_visibility.py
+++ b/src/reyn/runtime/capability_visibility.py
@@ -233,8 +233,10 @@ class CapabilityVisibility:
         # #5276: the expensive envelope-only census's cache — see
         # _envelope_census's own docstring. None = never computed / needs
         # recompute; invalidated synchronously by invalidate_envelope_census
-        # (called by Session at its 3 grep-confirmed mutation sites — never
-        # via an EventLog subscriber, the #5279/#5284 lesson).
+        # — called from Session at 3 sites (grep-confirmed:
+        # `git grep invalidate_envelope_census -- src` → session.py's
+        # `_reapply_mcp`, `_reapply_skills`, `load_persisted_toggles`) —
+        # never via an EventLog subscriber, the #5279/#5284 lesson.
         self._cached_envelope_census: "dict | None" = None
 
     @property
@@ -667,11 +669,22 @@ class CapabilityVisibility:
         session's own construction/spawn/restore and never mutated by any
         live, in-session command — ``resolved_profile_for``'s answer for a
         GIVEN (agent, sid) does not change while that session keeps
-        running. What DOES change mid-session, and this cache correctly
-        tracks via :meth:`invalidate_envelope_census`'s 3 call sites,
-        is WHICH capabilities exist to classify at all: the MCP server
-        roster (``_reapply_mcp``) and the skill registry
-        (``_reapply_skills``) can both change via hot-reload.
+        running EXCEPT for one edge the ``sid=`` argument itself exposes —
+        a session's own sid CAN be re-keyed post-construction (spawn
+        fixup; see this class's own module docstring), so ``load_persisted_
+        toggles`` (called right after a re-key) is this cache's 3rd
+        invalidation site, alongside the two below. What DOES change
+        mid-session otherwise, and this cache correctly tracks via
+        :meth:`invalidate_envelope_census`'s 3 call sites, is WHICH
+        capabilities exist to classify at all: the MCP server roster
+        (``_reapply_mcp``) and the skill registry (``_reapply_skills``)
+        can both change via hot-reload.
+
+        #5288 (filed, not fixed here): whether some OTHER input the active
+        scheme's own ``build_presentation`` reads (e.g.
+        ``list_available_agents()``, via ``_VisibilityProbeOps``) can
+        change mid-session independent of these 3 sites is not
+        grep-verified.
 
         Returns a dict whose shape mirrors the ORIGINAL method's own 3
         per-kind treatments exactly (preserved verbatim, just relocated —

--- a/src/reyn/runtime/capability_visibility.py
+++ b/src/reyn/runtime/capability_visibility.py
@@ -230,6 +230,12 @@ class CapabilityVisibility:
         self._visibility_override: "dict[str, set[str]]" = {
             "tool": set(), "mcp": set(), "category": set(), "skill": set(),
         }
+        # #5276: the expensive envelope-only census's cache — see
+        # _envelope_census's own docstring. None = never computed / needs
+        # recompute; invalidated synchronously by invalidate_envelope_census
+        # (called by Session at its 3 grep-confirmed mutation sites — never
+        # via an EventLog subscriber, the #5279/#5284 lesson).
+        self._cached_envelope_census: "dict | None" = None
 
     @property
     def contextual_permission(self) -> "object | None":
@@ -631,6 +637,128 @@ class CapabilityVisibility:
             names = (names - wrapper_plumbing) | catalog_names
         return names
 
+    def invalidate_envelope_census(self) -> None:
+        """#5276: mark :attr:`_cached_envelope_census` dirty. Called
+        SYNCHRONOUSLY by ``Session`` at each of its 3 grep-confirmed
+        mutation sites (``_reapply_mcp``, ``_reapply_skills``,
+        ``load_persisted_toggles``) — NOT via an ``EventLog`` subscriber
+        (the #5279/#5284 lesson: subscriber dispatch is queued whenever a
+        loop is running, #4966, so it cannot reliably invalidate a cache
+        before a caller that mutates-then-reads-immediately observes it).
+        See :meth:`capability_visibility_state`'s own docstring for what
+        this census covers and why it is safe to memoize."""
+        self._cached_envelope_census = None
+
+    def _envelope_census(self) -> dict:
+        """#5276: the EXPENSIVE, envelope-only half of
+        ``capability_visibility_state`` — memoized in
+        :attr:`_cached_envelope_census`. Computes, for every reachable
+        tool/mcp/category/skill, whether the AGENT ENVELOPE (topology ∩
+        delegate ∩ per-session config — never the ``/visibility`` override,
+        never the per-turn ephemeral taint) authorizes it — via
+        ``_reachable_tool_names``'s real, bridged-sync scheme
+        ``build_presentation`` call (#3220) and a fresh
+        ``resolved_profile_for`` read, both genuinely non-trivial per-call
+        costs this method exists to stop paying every render frame.
+
+        Grep-confirmed (#5276 investigation) invariant this memoization
+        relies on: the ENVELOPE itself (topology bindings, the #2081
+        delegate floor, #2103-S1a per-session config) is set at THIS
+        session's own construction/spawn/restore and never mutated by any
+        live, in-session command — ``resolved_profile_for``'s answer for a
+        GIVEN (agent, sid) does not change while that session keeps
+        running. What DOES change mid-session, and this cache correctly
+        tracks via :meth:`invalidate_envelope_census`'s 3 call sites,
+        is WHICH capabilities exist to classify at all: the MCP server
+        roster (``_reapply_mcp``) and the skill registry
+        (``_reapply_skills``) can both change via hot-reload.
+
+        Returns a dict whose shape mirrors the ORIGINAL method's own 3
+        per-kind treatments exactly (preserved verbatim, just relocated —
+        see the loop below): ``eph_pending_authorized``/
+        ``eph_pending_unknown`` hold TOOL/MCP rows that still need the
+        cheap per-turn ephemeral check the caller applies (the only rows
+        that ever did, in the pre-#5276 code); ``final_authorized``/
+        ``final_unknown`` hold CATEGORY/SKILL rows that are already the
+        FINAL answer (categories and skills were never checked against
+        the ephemeral gate at all, before or after this change — a
+        category is either envelope-authorized or not, full stop; a
+        skill is always authorized, full stop). ``denied_by_envelope``
+        is final for every kind (the pre-#5276 code never re-checked an
+        envelope denial against the ephemeral gate either — an envelope
+        denial already IS the actionable answer, #3380's own docstring).
+        Getting this 3-way split wrong would silently apply the
+        turn-context check to a kind that must never carry it (or vice
+        versa) — caught and fixed during this PR's own implementation by
+        re-deriving each kind's original branch instead of assuming
+        symmetry."""
+        from typing import cast
+
+        from reyn.security.permissions.effective import (
+            CapabilityAxis,
+            ContextualLayer,
+            ContextualPermission,
+        )
+        from reyn.tools.universal_catalog import CATEGORIES
+
+        if self._cached_envelope_census is not None:
+            return self._cached_envelope_census
+
+        base_ctx: "ContextualPermission | None" = None
+        base_excl: "frozenset[str]" = frozenset()
+        envelope_unknown = not (
+            self._registry is not None and hasattr(self._registry, "resolved_profile_for")
+        )
+        if not envelope_unknown:
+            raw_ctx, base_excl = self._registry.resolved_profile_for(
+                self._agent_name, sid=self._session_id_provider(),
+            )
+            base_ctx = cast("ContextualPermission | None", raw_ctx)
+        else:
+            self._surface_unreadable_envelope_source_for_read()
+        ctx = ContextualLayer(base_ctx)  # the envelope gate (None → allows all)
+
+        eph_pending_authorized: "list[dict]" = []
+        eph_pending_unknown: "list[dict]" = []
+        denied: "list[dict]" = []
+        final_authorized: "list[dict]" = []
+        final_unknown: "list[dict]" = []
+
+        def _place(axis: "CapabilityAxis", row: dict) -> None:
+            if envelope_unknown:
+                eph_pending_unknown.append({**row, "_axis": axis})
+            elif not ctx.allows(axis, row["name"]):
+                denied.append(row)
+            else:
+                eph_pending_authorized.append({**row, "_axis": axis})
+
+        for name in sorted(self._reachable_tool_names(base_excl)):
+            _place(CapabilityAxis.TOOL, {"kind": "tool", "name": name})
+        for server in self._router_host.get_mcp_servers():
+            n = server.get("name")
+            if n:
+                _place(CapabilityAxis.MCP, {"kind": "mcp", "name": n})
+        for category in CATEGORIES:
+            if envelope_unknown:
+                final_unknown.append({"kind": "category", "name": category})
+            elif category not in base_excl:
+                final_authorized.append({"kind": "category", "name": category})
+        # #2548 PR-B: skills are togglable per-session; the registered base set is the
+        # envelope — never gated by resolved_profile_for, so #3615's envelope_unknown
+        # does not apply here (unaffected by whether the base could be read).
+        for entry in (self._available_skills_provider() or []):
+            final_authorized.append({"kind": "skill", "name": entry.name})
+
+        self._cached_envelope_census = {
+            "eph_pending_authorized": eph_pending_authorized,
+            "eph_pending_unknown": eph_pending_unknown,
+            "denied_by_envelope": denied,
+            "final_authorized": final_authorized,
+            "final_unknown": final_unknown,
+            "envelope_unknown": envelope_unknown,
+        }
+        return self._cached_envelope_census
+
     def capability_visibility_state(
         self, *, ephemeral_contextual: "object | None" = None,
     ) -> dict:
@@ -694,31 +822,26 @@ class CapabilityVisibility:
         ``self._registry``), so it stays fully determined even when the envelope is
         unknown — a row the ephemeral gate denies is reported there, not swept into
         ``unknown``, because that denial is a fact regardless of what the envelope
-        would have said."""
+        would have said.
+
+        #5276: the EXPENSIVE envelope-only classification (this method used
+        to redo it on every call, including every render frame) is memoized
+        in :meth:`_envelope_census` — see that method's own docstring for
+        the invariant this relies on and its 3 grep-confirmed invalidation
+        sites. What runs HERE, on every call, is only the CHEAP overlay:
+        splitting each already-envelope-classified row against the live
+        ``ephemeral_contextual`` (a plain ``ContextualLayer.allows`` check,
+        no catalog work) and reading ``self._visibility_override`` fresh
+        (a dict already held in memory) for ``hidden_by_session``. Neither
+        of those may be cached — #3380's whole point is that the ephemeral
+        taint self-clears the instant the tainted entry compacts out, and
+        the override changes on every ``/visibility`` toggle."""
         from typing import cast
 
-        from reyn.security.permissions.effective import (
-            CapabilityAxis,
-            ContextualLayer,
-            ContextualPermission,
-        )
-        from reyn.tools.universal_catalog import CATEGORIES
+        from reyn.security.permissions.effective import ContextualLayer, ContextualPermission
 
-        # resolved_profile_for's declared return is the wider `object | None`; cast to the
-        # concrete type ContextualLayer expects (registry.py:3509 documents ContextualPermission).
-        base_ctx: "ContextualPermission | None" = None
-        base_excl: "frozenset[str]" = frozenset()
-        envelope_unknown = not (
-            self._registry is not None and hasattr(self._registry, "resolved_profile_for")
-        )
-        if not envelope_unknown:
-            raw_ctx, base_excl = self._registry.resolved_profile_for(
-                self._agent_name, sid=self._session_id_provider(),
-            )
-            base_ctx = cast("ContextualPermission | None", raw_ctx)
-        else:
-            self._surface_unreadable_envelope_source_for_read()
-        ctx = ContextualLayer(base_ctx)  # the envelope gate (None → allows all)
+        census = self._envelope_census()
+        envelope_unknown = census["envelope_unknown"]
         # #3380: the ephemeral gate, asked ONLY for what the envelope already allows —
         # so a capability the envelope denies keeps its durable reason even while the
         # context happens to be tainted (both deny it; the un-liftable one is the
@@ -727,47 +850,38 @@ class CapabilityVisibility:
             cast("ContextualPermission | None", ephemeral_contextual)
         )
 
-        authorized: "list[dict]" = []
-        denied: "list[dict]" = []
+        # #5276: only TOOL/MCP rows (`eph_pending_*`) were ever checked
+        # against the ephemeral gate, before or after this change —
+        # CATEGORY/SKILL rows (`final_*`) pass straight through unchanged,
+        # exactly like the pre-#5276 code's own category/skill loops
+        # (neither ever called `eph.allows` at all).
+        authorized: "list[dict]" = [
+            {"kind": row["kind"], "name": row["name"]}
+            for row in census["final_authorized"]
+        ]
         denied_turn: "list[dict]" = []
-        unknown: "list[dict]" = []
+        unknown: "list[dict]" = [
+            {"kind": row["kind"], "name": row["name"]}
+            for row in census["final_unknown"]
+        ]
 
-        def _place(axis: "CapabilityAxis", row: dict) -> None:
-            if envelope_unknown:
-                # #3615: no base to test the ENVELOPE axis against — classifying into
-                # authorized/denied_by_envelope would be a guess dressed as an answer.
-                # The TURN-CONTEXT axis is independent of the envelope source (``eph``
-                # composes only ``ephemeral_contextual``, a caller-supplied argument
-                # that has nothing to do with ``self._registry``), so a turn-context
-                # denial is still a determined fact and must not be swallowed into
-                # "unknown" — only the row's envelope-standing is undetermined.
-                if not eph.allows(axis, row["name"]):
-                    denied_turn.append(row)
-                else:
-                    unknown.append(row)
-            elif not ctx.allows(axis, row["name"]):
-                denied.append(row)
-            elif not eph.allows(axis, row["name"]):
-                denied_turn.append(row)
+        for row in census["eph_pending_authorized"]:
+            if eph.allows(row["_axis"], row["name"]):
+                authorized.append({"kind": row["kind"], "name": row["name"]})
             else:
-                authorized.append(row)
-
-        for name in sorted(self._reachable_tool_names(base_excl)):
-            _place(CapabilityAxis.TOOL, {"kind": "tool", "name": name})
-        for server in self._router_host.get_mcp_servers():
-            n = server.get("name")
-            if n:
-                _place(CapabilityAxis.MCP, {"kind": "mcp", "name": n})
-        for category in CATEGORIES:
-            if envelope_unknown:
-                unknown.append({"kind": "category", "name": category})
-            elif category not in base_excl:
-                authorized.append({"kind": "category", "name": category})
-        # #2548 PR-B: skills are togglable per-session; the registered base set is the
-        # envelope — never gated by resolved_profile_for, so #3615's envelope_unknown
-        # does not apply here (unaffected by whether the base could be read).
-        for entry in (self._available_skills_provider() or []):
-            authorized.append({"kind": "skill", "name": entry.name})
+                denied_turn.append({"kind": row["kind"], "name": row["name"]})
+        for row in census["eph_pending_unknown"]:
+            # #3615: no base to test the ENVELOPE axis against — classifying into
+            # authorized/denied_by_envelope would be a guess dressed as an answer.
+            # The TURN-CONTEXT axis is independent of the envelope source (``eph``
+            # composes only ``ephemeral_contextual``, a caller-supplied argument
+            # that has nothing to do with ``self._registry``), so a turn-context
+            # denial is still a determined fact and must not be swallowed into
+            # "unknown" — only the row's envelope-standing is undetermined.
+            if eph.allows(row["_axis"], row["name"]):
+                unknown.append({"kind": row["kind"], "name": row["name"]})
+            else:
+                denied_turn.append({"kind": row["kind"], "name": row["name"]})
 
         hidden = [
             {"kind": kind, "name": name}
@@ -777,7 +891,10 @@ class CapabilityVisibility:
         return {
             "authorized": authorized,
             "hidden_by_session": hidden,
-            "denied_by_envelope": denied,
+            "denied_by_envelope": [
+                {"kind": row["kind"], "name": row["name"]}
+                for row in census["denied_by_envelope"]
+            ],
             "denied_by_turn_context": denied_turn,
             "unknown": unknown,
             "envelope_unknown": envelope_unknown,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6196,8 +6196,15 @@ class Session:
     async def _reapply_mcp(self, in_set: dict) -> bool:
         """Reapply MCP servers (#2073 S2) — re-probe via the existing turn-boundary
         refresh chain (which reads the re-read .reyn/mcp.yaml). Returns whether the
-        in-memory tool cache changed."""
+        in-memory tool cache changed.
+
+        #5276: invalidates ``capability_visibility_state()``'s memoized
+        envelope census (`get_mcp_servers()`'s answer, one of the census's
+        own inputs, can change here) — synchronously, right after the
+        refresh, same "no subscriber" reasoning as ``hook_state()``'s own
+        cache (#5279/#5284)."""
         result = await self.refresh_mcp_servers()
+        self._capability_visibility.invalidate_envelope_census()
         return bool(result.get("refreshed"))
 
     async def _reapply_skills(self, in_set: dict) -> bool:
@@ -6235,6 +6242,10 @@ class Session:
                 return False
         self._available_skills = new_skills or None
         self._capability_visibility.reapply_skill_visibility()
+        # #5276: invalidates the memoized envelope census (the skill roster
+        # just reassigned above is one of its own inputs) — synchronously,
+        # same reasoning as _reapply_mcp's own comment.
+        self._capability_visibility.invalidate_envelope_census()
         return True
 
     async def _reapply_pipelines(self, in_set: dict) -> bool:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3162,6 +3162,19 @@ class Session:
         # invalidate hook_state()'s cache synchronously here too, same
         # reasoning as set_hook_enabled's own comment.
         self._cached_hook_items = None
+        # #5276/#5285 review (architect): this method's own module
+        # docstring (capability_visibility.py, top) already documents WHY
+        # `session_id_provider` is a live getter, not a snapshot — a
+        # session's own sid CAN be re-keyed post-construction (spawn
+        # fixup), and `load_persisted_toggles` is called AFTER that
+        # re-key. `_envelope_census()` bakes `resolved_profile_for(...,
+        # sid=...)` into its cache, so a re-keyed sid can genuinely change
+        # what that call returns for the SAME session object — the one
+        # scenario this PR's own earlier "envelope never changes
+        # mid-session" claim did not hold for. Invalidate here too,
+        # synchronously (same "no subscriber" reasoning as every other
+        # site — #5279/#5284).
+        self._capability_visibility.invalidate_envelope_census()
         if loaded_visibility:
             self._capability_visibility.reapply_visibility_override()
         if loaded_skill_visibility:

--- a/tests/runtime/test_5276_visibility_census_reactive_cache.py
+++ b/tests/runtime/test_5276_visibility_census_reactive_cache.py
@@ -1,0 +1,185 @@
+"""Tier 2: #5276 (visibility_items) — the EXPENSIVE, envelope-only half of
+``capability_visibility_state()`` (the tool/mcp/category/skill census
+against the agent envelope) is memoized; only the CHEAP overlay
+(``/visibility`` override + per-turn ephemeral taint) recomputes every call.
+
+Root cause: ``capability_visibility_state()`` used to redo the ENTIRE
+classification on every call, including every render frame — dominated by
+``_reachable_tool_names``'s real, sync-bridged scheme ``build_presentation``
+call (#3220) and a fresh ``resolved_profile_for`` read, both genuinely
+non-trivial. Owner's own real-machine measurement, post-#5279 landing:
+"visibility item 多発してそう" (this field looked dominant). Investigated
+(not assumed): the ENVELOPE itself (topology/delegate/per-session config)
+is grep-confirmed to be set at session construction/spawn/restore and never
+mutated by any live in-session command, so memoizing the envelope-only
+census causes no staleness there. What DOES change mid-session — and this
+cache correctly tracks, invalidated synchronously (the #5279/#5284 lesson:
+no EventLog subscriber) at ``_reapply_mcp``/``_reapply_skills`` — is WHICH
+capabilities exist to classify (the MCP roster / skill registry).
+
+Real ``AgentRegistry``/``Session`` (real envelope via
+``spawn_session_recorded(narrowing=...)``) — no mocks, mirrors
+``test_visibility_toggle_2285.py``'s own pattern. Uses the #4403 counting
+technique on ``_reachable_tool_names`` (the expensive part) to witness
+recompute counts.
+
+Disclosed, not chased further (scope note): the envelope census's other
+inputs via the active scheme's own ``build_presentation`` (e.g.
+``list_available_agents()``, which could change on a sibling agent
+spawn) are not independently grep-verified as invariant here — only the
+two mutation sites Session itself owns (``_reapply_mcp``/
+``_reapply_skills``) are covered. A future finding that some OTHER input
+changes mid-session belongs in a follow-up issue, not silently assumed
+away by this test suite.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = make_session(agent_name=profile.name, state_log=state_log, registry=holder.get("reg"))
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+def _counting_wrapper(monkeypatch, cap_vis) -> dict:
+    """Mirrors #4403's own counting technique — counts real
+    ``_reachable_tool_names`` calls (the expensive scheme-census part of
+    the envelope classification) from this point on."""
+    real_fn = cap_vis._reachable_tool_names
+    call_count = {"n": 0}
+
+    def _counting(excluded_categories):
+        call_count["n"] += 1
+        return real_fn(excluded_categories)
+
+    monkeypatch.setattr(cap_vis, "_reachable_tool_names", _counting)
+    return call_count
+
+
+@pytest.mark.asyncio
+async def test_repeated_reads_cost_one_real_census(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — 3 repeated ``capability_visibility_state()``
+    reads with no intervening mutation cost exactly 1 real census
+    computation, not 3."""
+    reg = _make_registry(tmp_path)
+    s = reg.get_session("alice", await reg.spawn_session_recorded(
+        "alice", presentation_consumer=None, intervention_bridge=None,
+    ))
+    call_count = _counting_wrapper(monkeypatch, s._capability_visibility)
+
+    r1 = s.capability_visibility_state()
+    r2 = s.capability_visibility_state()
+    r3 = s.capability_visibility_state()
+
+    assert call_count["n"] == 1, (
+        f"expected exactly 1 real census computation across 3 reads with "
+        f"no intervening mutation, got {call_count['n']}"
+    )
+    assert r1 == r2 == r3
+
+
+@pytest.mark.asyncio
+async def test_a_visibility_toggle_does_not_trigger_a_recompute(tmp_path, monkeypatch) -> None:
+    """Tier 2: falsification contrast — a ``/visibility`` toggle
+    (``set_capability_visible``) only mutates the CHEAP override
+    (``hidden_by_session``), never the memoized envelope census, so it
+    must not trigger a real recompute."""
+    reg = _make_registry(tmp_path)
+    s = reg.get_session("alice", await reg.spawn_session_recorded(
+        "alice", presentation_consumer=None, intervention_bridge=None,
+    ))
+    call_count = _counting_wrapper(monkeypatch, s._capability_visibility)
+
+    before = s.capability_visibility_state()
+    assert call_count["n"] == 1
+    some_tool = before["authorized"][0]["name"] if before["authorized"] else None
+    assert some_tool is not None, "test needs at least one authorized tool to toggle"
+
+    s.set_capability_visible("tool", some_tool, False)
+    after = s.capability_visibility_state()
+
+    assert call_count["n"] == 1, (
+        f"a /visibility toggle must not trigger a real census recompute "
+        f"(it only affects the cheap override), got {call_count['n']} "
+        f"real calls total"
+    )
+    assert any(
+        row["kind"] == "tool" and row["name"] == some_tool
+        for row in after["hidden_by_session"]
+    ), "the toggle itself must still take effect in hidden_by_session"
+
+
+@pytest.mark.asyncio
+async def test_mcp_reload_invalidates_the_census(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — ``_reapply_mcp`` (the MCP-roster hot-reload
+    seam) invalidates the census, so a subsequent read costs exactly 1
+    more real computation."""
+    reg = _make_registry(tmp_path)
+    s = reg.get_session("alice", await reg.spawn_session_recorded(
+        "alice", presentation_consumer=None, intervention_bridge=None,
+    ))
+    call_count = _counting_wrapper(monkeypatch, s._capability_visibility)
+
+    s.capability_visibility_state()
+    assert call_count["n"] == 1
+
+    await s._reapply_mcp({})
+    s.capability_visibility_state()
+
+    assert call_count["n"] == 2, (
+        f"expected exactly 1 more real census computation after "
+        f"_reapply_mcp, got {call_count['n']} real calls total"
+    )
+
+
+@pytest.mark.asyncio
+async def test_categories_and_skills_are_never_ephemeral_checked(tmp_path, monkeypatch) -> None:
+    """Tier 2: regression guard — a real bug caught mid-implementation of
+    this PR: CATEGORY and SKILL rows must never be checked against the
+    per-turn ephemeral gate (only TOOL/MCP rows were, in the pre-#5276
+    code, and still are). Passing a maximally-restrictive
+    ``ephemeral_contextual`` (denies everything) must still authorize
+    every category/skill row exactly as with no ephemeral taint at all —
+    only tool/mcp rows may move to ``denied_by_turn_context``."""
+    from reyn.security.permissions.effective import ContextualPermission
+
+    reg = _make_registry(tmp_path)
+    s = reg.get_session("alice", await reg.spawn_session_recorded(
+        "alice", presentation_consumer=None, intervention_bridge=None,
+    ))
+    cap_vis = s._capability_visibility
+
+    untainted = cap_vis.capability_visibility_state(ephemeral_contextual=None)
+    deny_all = ContextualPermission(tool_allow=frozenset(), mcp_allow=frozenset())
+    tainted = cap_vis.capability_visibility_state(ephemeral_contextual=deny_all)
+
+    untainted_categories = {r["name"] for r in untainted["authorized"] if r["kind"] == "category"}
+    tainted_categories = {r["name"] for r in tainted["authorized"] if r["kind"] == "category"}
+    untainted_skills = {r["name"] for r in untainted["authorized"] if r["kind"] == "skill"}
+    tainted_skills = {r["name"] for r in tainted["authorized"] if r["kind"] == "skill"}
+
+    assert tainted_categories == untainted_categories, (
+        "category rows must never be affected by the ephemeral gate"
+    )
+    assert tainted_skills == untainted_skills, (
+        "skill rows must never be affected by the ephemeral gate"
+    )

--- a/tests/runtime/test_5276_visibility_census_reactive_cache.py
+++ b/tests/runtime/test_5276_visibility_census_reactive_cache.py
@@ -12,10 +12,16 @@ non-trivial. Owner's own real-machine measurement, post-#5279 landing:
 (not assumed): the ENVELOPE itself (topology/delegate/per-session config)
 is grep-confirmed to be set at session construction/spawn/restore and never
 mutated by any live in-session command, so memoizing the envelope-only
-census causes no staleness there. What DOES change mid-session — and this
-cache correctly tracks, invalidated synchronously (the #5279/#5284 lesson:
-no EventLog subscriber) at ``_reapply_mcp``/``_reapply_skills`` — is WHICH
-capabilities exist to classify (the MCP roster / skill registry).
+census causes no staleness there — EXCEPT one real edge the census's own
+``sid=self._session_id_provider()`` argument exposes: a session's own sid
+CAN be re-keyed post-construction (spawn fixup — see
+``capability_visibility.py``'s own module docstring), so a stale cache
+survives-then-lies for the SAME session object across a re-key. Caught
+during review (architect, #5285): invalidated at 3 sites, not 2 —
+``_reapply_mcp``/``_reapply_skills`` (the MCP roster / skill registry, WHICH
+capabilities exist to classify) AND ``load_persisted_toggles`` (called
+after a re-key completes, per that method's own docstring), all
+synchronously (the #5279/#5284 lesson: no ``EventLog`` subscriber).
 
 Real ``AgentRegistry``/``Session`` (real envelope via
 ``spawn_session_recorded(narrowing=...)``) — no mocks, mirrors
@@ -23,14 +29,12 @@ Real ``AgentRegistry``/``Session`` (real envelope via
 technique on ``_reachable_tool_names`` (the expensive part) to witness
 recompute counts.
 
-Disclosed, not chased further (scope note): the envelope census's other
-inputs via the active scheme's own ``build_presentation`` (e.g.
+Disclosed AND filed (architect, #5285 review — a docstring note alone
+was judged insufficient for a panel-visible field): whether some OTHER
+input to the active scheme's own ``build_presentation`` — e.g.
 ``list_available_agents()``, which could change on a sibling agent
-spawn) are not independently grep-verified as invariant here — only the
-two mutation sites Session itself owns (``_reapply_mcp``/
-``_reapply_skills``) are covered. A future finding that some OTHER input
-changes mid-session belongs in a follow-up issue, not silently assumed
-away by this test suite.
+spawn — changes mid-session independent of the 3 sites above is not
+grep-verified here. Filed as #5288, same treatment as #5280.
 """
 from __future__ import annotations
 
@@ -39,18 +43,27 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.state_log import StateLog
+from reyn.data.skills.registry import SkillEntry
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import CapabilityScope
 from tests._support.agent_session import make_session
 
 
-def _make_registry(tmp_path: Path) -> AgentRegistry:
+def _make_registry(tmp_path: Path, *, available_skills=None) -> AgentRegistry:
     state_log = StateLog(tmp_path / "wal.jsonl")
     holder: dict = {}
 
     def _factory(profile: AgentProfile) -> Session:
-        s = make_session(agent_name=profile.name, state_log=state_log, registry=holder.get("reg"))
+        capability_scope = (
+            CapabilityScope(available_skills=available_skills)
+            if available_skills is not None else None
+        )
+        s = make_session(
+            agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
+            capability_scope=capability_scope,
+        )
         s.register_intervention_listener("test")
         return s
 
@@ -159,7 +172,16 @@ async def test_categories_and_skills_are_never_ephemeral_checked(tmp_path, monke
     code, and still are). Passing a maximally-restrictive
     ``ephemeral_contextual`` (denies everything) must still authorize
     every category/skill row exactly as with no ephemeral taint at all —
-    only tool/mcp rows may move to ``denied_by_turn_context``."""
+    only tool/mcp rows may move to ``denied_by_turn_context``.
+
+    #5285 review (architect): the skill side must not compare empty-set
+    to empty-set (six-questions ④ — that stays green no matter how the
+    split is implemented). ``spawn_session_recorded`` already registers
+    this repo's own real declared skills (confirmed non-empty below), so
+    no fixture skill needs to be invented — asserted explicitly rather
+    than assumed, so a future change that made this fixture skill-less
+    would fail LOUDLY here instead of silently making the equality check
+    vacuous."""
     from reyn.security.permissions.effective import ContextualPermission
 
     reg = _make_registry(tmp_path)
@@ -177,9 +199,71 @@ async def test_categories_and_skills_are_never_ephemeral_checked(tmp_path, monke
     untainted_skills = {r["name"] for r in untainted["authorized"] if r["kind"] == "skill"}
     tainted_skills = {r["name"] for r in tainted["authorized"] if r["kind"] == "skill"}
 
+    assert untainted_skills, (
+        "test fixture registered no skills — an empty set here would make "
+        "the equality check below vacuous (six-questions ④)"
+    )
     assert tainted_categories == untainted_categories, (
         "category rows must never be affected by the ephemeral gate"
     )
     assert tainted_skills == untainted_skills, (
         "skill rows must never be affected by the ephemeral gate"
+    )
+
+
+@pytest.mark.asyncio
+async def test_skill_reload_invalidates_the_census(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — the 3rd site missing a witness (architect B on
+    #5285): ``_reapply_skills`` (the skill-registry hot-reload seam) must
+    invalidate the census, so a subsequent read costs exactly 1 more real
+    computation. Mirrors ``test_mcp_reload_invalidates_the_census``."""
+    reg = _make_registry(tmp_path)
+    s = reg.get_session("alice", await reg.spawn_session_recorded(
+        "alice", presentation_consumer=None, intervention_bridge=None,
+    ))
+    call_count = _counting_wrapper(monkeypatch, s._capability_visibility)
+
+    s.capability_visibility_state()
+    assert call_count["n"] == 1
+
+    # _reapply_skills re-reads the full config cascade for real (load_config)
+    # but only ``build_skill_registry``'s OUTPUT needs to differ from the
+    # empty starting set for the "did the roster change" branch to fall
+    # through to the reassignment + invalidation this test targets.
+    monkeypatch.setattr(
+        "reyn.data.skills.registry.build_skill_registry",
+        lambda skills_cfg: [SkillEntry(name="new-skill", description="d", path="skills/new/SKILL.md")],
+    )
+    await s._reapply_skills({})
+    s.capability_visibility_state()
+
+    assert call_count["n"] == 2, (
+        f"expected exactly 1 more real census computation after "
+        f"_reapply_skills, got {call_count['n']} real calls total"
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_persisted_toggles_invalidates_the_census(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — the 3rd invalidation site (architect B on
+    #5285, finding ①): ``load_persisted_toggles`` is called right after a
+    session re-key, and the census's own ``sid=self._session_id_provider()``
+    argument means a re-key CAN change what it should return for the SAME
+    session object. Calling ``load_persisted_toggles()`` must invalidate
+    the cache, so a subsequent read costs exactly 1 more real computation."""
+    reg = _make_registry(tmp_path)
+    s = reg.get_session("alice", await reg.spawn_session_recorded(
+        "alice", presentation_consumer=None, intervention_bridge=None,
+    ))
+    call_count = _counting_wrapper(monkeypatch, s._capability_visibility)
+
+    s.capability_visibility_state()
+    assert call_count["n"] == 1
+
+    s.load_persisted_toggles()
+    s.capability_visibility_state()
+
+    assert call_count["n"] == 2, (
+        f"expected exactly 1 more real census computation after "
+        f"load_persisted_toggles, got {call_count['n']} real calls total"
     )


### PR DESCRIPTION
**[tui-coder]** — part of #5276 (the `visibility_items` half). Builds on #5277/#5279 (merged) and #5284 (`hook_items`, awaiting B).

## Background

Owner's own real-machine measurement, taken AFTER #5279 landed: "マージして試したけど、やっぱり遅くて、visibility item 多発してそう" — `visibility_items` (previously deliberately left untouched, per an earlier design review) turned out to be the dominant cost. Lead-coder retracted "don't touch it" and pointed at a docstring-derived hypothesis: the catalog census (envelope-derived) is expensive and near-static, while the turn_context overlay is cheap and must stay live — with an explicit instruction to verify this independently rather than agree with the read.

## Independent verification (read the actual code, not the docstring alone)

`CapabilityVisibility._reachable_tool_names` bridges a REAL `ToolUseScheme.build_presentation` (async, #3220) through a dedicated-thread sync bridge (`_run_coro_sync`) on **every** `capability_visibility_state()` call — genuinely non-trivial (coroutine scheduling overhead, catalog-entry building, wrapper expansion), plus a fresh `resolved_profile_for` read alongside it. The turn_context/ephemeral check, by contrast, is a plain `ContextualLayer(ephemeral_contextual).allows(...)` call against an ALREADY-classified row — cheap, and #3380 requires it stay live (it self-clears the instant a tainted history entry compacts out; caching it would silently reintroduce exactly that staleness).

Confirmed lead-coder's read: the split is real and correctly assigns the cost.

## Grep-confirmed invariant this memoization relies on

The ENVELOPE itself (topology bindings, the #2081 delegate floor, #2103-S1a per-session config) is set at a session's own construction/spawn/restore and never mutated by any live, in-session command — checked the two real call sites of `resolved_profile_for` outside `capability_visibility.py` itself (`registry.py:3605`/`3779`, both inside spawn/recovery paths) and `/session new`'s own narrowing-inheritance code — no runtime command re-narrows an ALREADY-running session's own envelope. What DOES change mid-session is WHICH capabilities exist to classify at all: the MCP server roster (`_reapply_mcp`) and the skill registry (`_reapply_skills`), both hot-reload seams.

**Disclosed, not exhaustively chased**: whether some OTHER input to the active scheme's own `build_presentation` (e.g. `list_available_agents()`, on a sibling agent spawn) could change mid-session independent of the MCP/skill roster is not grep-verified here — only the two mutation sites `Session` itself owns are covered. Noted in the new test file's own docstring as a scope boundary, not silently assumed away.

## Change

- `CapabilityVisibility._envelope_census()` (new) — the expensive envelope-only classification (tool/mcp/category/skill vs. the agent envelope), memoized in `self._cached_envelope_census`.
- `CapabilityVisibility.invalidate_envelope_census()` (new, public) — marks the cache dirty. Called SYNCHRONOUSLY by `Session` at `_reapply_mcp`/`_reapply_skills` — NOT via an `EventLog` subscriber (the #5279/#5284 lesson: subscriber dispatch is queued whenever a loop is running, #4966, so it cannot reliably invalidate a cache before a mutate-then-read-immediately caller observes it).
- `capability_visibility_state()` rewritten to read the memoized census, then apply only the cheap overlay (per-turn ephemeral split + `self._visibility_override` for `hidden_by_session`) fresh every call.
- The `/visibility` toggle side (`visibility_changed`, #5277) needed NO further wiring here — the override was already a cheap, always-live dict read, never part of the expensive census.

## A real bug I caught and fixed during this PR's own implementation

My first draft applied the ephemeral overlay check to CATEGORY and SKILL rows too. The pre-#5276 code never did this — categories and skills were NEVER checked against the ephemeral gate at all (a category is authorized-by-envelope or not, full stop; a skill is always authorized, full stop; only TOOL/MCP rows ever went through the ephemeral check). This would have silently changed behavior (a maximally-restrictive ephemeral taint would have incorrectly hidden every category/skill too). Fixed by re-deriving each kind's original branch from the actual pre-existing code instead of assuming symmetry across kinds — `test_categories_and_skills_are_never_ephemeral_checked` is the dedicated regression guard, strip-falsified (mixing category/skill rows into the eph-check path crashes on a missing `_axis` key, confirming the split is load-bearing).

## Tests

`tests/runtime/test_5276_visibility_census_reactive_cache.py` — Tier 2, real `AgentRegistry`/`Session` with a real resolved envelope (`spawn_session_recorded`), no mocks. #4403 counting technique on `_reachable_tool_names`:

- `test_repeated_reads_cost_one_real_census` — 3 reads, no mutation → 1 real census computation.
- `test_a_visibility_toggle_does_not_trigger_a_recompute` — falsification contrast: a `/visibility` toggle only affects the cheap override, never triggers a real recompute.
- `test_mcp_reload_invalidates_the_census` — `_reapply_mcp` invalidates, next read costs exactly 1 more real call.
- `test_categories_and_skills_are_never_ephemeral_checked` — the regression guard described above.

## Verification

- `ruff check .` — clean
- `python scripts/test_tier_audit.py --strict` on the new test file — 4/4 OK
- `python scripts/verify_module_docstrings.py` on both changed src files — OK
- `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- `python scripts/check_task_funnel_bypass.py` — same 1 pre-existing baseline hit, nothing new
- Targeted sweep (visibility/hook/mcp family, 63 tests) — all pass
- Manual strip-falsify: (1) removing `_reapply_mcp`'s invalidation call reproduces `test_mcp_reload_invalidates_the_census` going red; (2) mixing category/skill rows into the eph-check path crashes `test_categories_and_skills_are_never_ephemeral_checked` with a `KeyError` on the missing `_axis` field — both confirmed, then reverted

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on the new test file (4/4 OK)
- [x] `verify_module_docstrings.py` on changed src files
- [x] `mypy_ratchet.py`
- [x] `check_task_funnel_bypass.py` — no new hits
- [x] Targeted sweep (63 tests, visibility/hook/mcp family) — all pass
- [x] Strip-falsify confirms both the invalidation and the category/skill-exclusion are load-bearing
- [ ] (skipped — Visual, standing waiver 2026-08-08) no rendering surface touched — this is a caching/invalidation change under an existing seam

This PR touches `tests/` — needs an independent TESTS-READY(B) before I self-merge (rule 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



- [x] 🔴 **[architect]** (1) `capability_visibility.py:640/671` claim **3** invalidation sites including `load_persisted_toggles`, but `git grep invalidate_envelope_census -- src` finds **2** calls (`session.py:6129`, `:6170`) — and this PR test docstring says "only the **two**". Wire the third or make the count 2 and say why (the census bakes `resolved_profile_for(..., sid=...)`, and `load_persisted_toggles` runs after the per-session dir is re-keyed). (2) `_reapply_skills` has no witness — strip `session.py:6170` and nothing turns red. (3) `test_categories_and_skills_are_never_ephemeral_checked`s skill half compares two EMPTY sets (no skill provider in this fixture) — add a non-empty guard or disclose that half is not covered. See issuecomment on this PR.

