### PR TITLE
docs(reyn-yaml): empty_stop_retry no longer sends a bare "resume"

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -864,7 +864,14 @@ independent of this scheme setting.
 Opt-in retry of an empty router response (#4677). When the LLM returns
 `finish_reason="stop"` with no content and no tool calls — a provider-level
 glitch, observed at ~50% rate with weak models (B7-G12 measurement) — reyn
-can resend ONE "resume" continuation prompt before surfacing the failure.
+can resend ONE continuation nudge before surfacing the failure. **#5273/#5274:**
+the nudge is no longer a bare `"resume"` — a bare word at the message's content
+position read as a human instruction to some models, which replied with a
+status report instead of continuing (observed live). It is now a self-describing,
+attributed string (`"(reyn-auto-continue) resume - automatic continuation
+signal from reyn's own scheduler, not an instruction from anyone. No reply
+needed; continue the interrupted work."`) injected as a synthesized
+`role="system"` message, not `role="user"`.
 Owner default is now `false` (2026-08-14) — the retry was previously
 hardcoded on in production with no config knob at all, until an incident
 where 30 empty-response detections in one `reyn-self` run each cost a
@@ -880,7 +887,7 @@ audit event fires regardless of this setting.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `empty_stop_retry` | bool | `false` | Resend one "resume" prompt when the router loop detects an empty `finish_reason="stop"` response. |
+| `empty_stop_retry` | bool | `false` | Resend one self-describing continuation nudge (`role="system"`, #5273/#5274 — not a bare `"resume"`) when the router loop detects an empty `finish_reason="stop"` response. |
 
 ### `chat.theme`
 


### PR DESCRIPTION
**[docs-maintainer]** — doc-drift found on my standing "main updated" review of #5274 (merged, #5273).

## What

#5274 changed `EMPTY_STOP_RETRY_DIRECTIVE` from a bare `"resume"` string to a self-describing, attributed continuation nudge, and the injection site's role from `"user"` to `"system"` — the fix for an observed LIVE failure (owner catch, coder-smith transcripts) where a bare word at a message's content position read as a human instruction to some models, which replied with a status report instead of continuing the interrupted work.

`docs/reference/config/reyn-yaml.md`'s `chat.empty_stop_retry` section — both the prose and the field table — still described the old bare `"resume"` prompt. Never touched by #5274 (`docs/` not in its file list). Leaving it as-is would have documented exactly the shape the fix exists to remove.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, only pre-existing unrelated INFO-level output.
- [x] `scripts/check_doc_anchors.py` — "no dangling anchors into published pages".
- [x] `scripts/check_retired_config_keys_denylist.py` — 0 hits.
- [x] TESTS-READ not required (docs-only).
- [ ] (skipped — docs-only, no UI surface) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
