### PR TITLE
fix(#5256): quota exhaustion is never shrinkable, never ends the session

### DIFF
--- a/src/reyn/runtime/error_format.py
+++ b/src/reyn/runtime/error_format.py
@@ -9,7 +9,9 @@ and gives the user no path forward.
 
 This module maps the common patterns to a short, actionable prefix:
 
-    [rate limit]      provider 429 — wait a moment and retry
+    [rate limit]      provider 429 (per-request) — wait a moment and retry
+    [usage limit]     provider 429 (usage-window/plan quota exhausted,
+                      #5256) — a wait, not a retry-worthy failure
     [provider error]  provider 5xx / connection failure — retry shortly
     [auth error]      bad / missing API key
     [timeout]         client- or server-side timeout
@@ -21,10 +23,64 @@ The classifier inspects ``type(exc).__name__`` and falls back to a
 import litellm or httpx — keeping this layer free of provider deps
 means new provider exceptions don't have to be re-imported here as
 long as their class names follow common conventions.
+
+#5256: a 429 is not one failure — a per-request rate limit (shrinking
+the input can genuinely help avoid it) and a usage-window/plan quota
+exhaustion (shrinking cannot: the window resets on a clock, not on
+input size) both surface as ``RateLimitError`` today. ``is_quota_
+exhausted_error``/``quota_reset_seconds`` below read the STRUCTURED
+provider body litellm exposes on ``exc.body`` (a dict) to tell the two
+apart and surface a wait time — never the provider's own free-text
+message (#5257: a provider/SDK changing its own wording is not reyn's
+bug to catch or reyn's string to own).
 """
 from __future__ import annotations
 
 from reyn.runtime.budget.budget import BudgetExceeded
+
+#: #5256: the ONE provider ``type`` value observed to mean "usage-window /
+#: plan quota exhausted, waiting is the only remedy" (reyn-self, litellm/
+#: Anthropic-proxy, 2026-08-24/25/27 — see issue #5256's own real
+#: transcripts). A provider that expresses the same failure class under a
+#: DIFFERENT ``type`` string is a disclosed gap, not a silently-assumed
+#: absence — this is a positive allowlist, not an attempt to enumerate
+#: every provider's vocabulary.
+_QUOTA_EXHAUSTED_BODY_TYPE = "usage_limit_reached"
+
+
+def is_quota_exhausted_error(exc: BaseException) -> bool:
+    """True when *exc* is a provider usage-window/plan quota exhaustion —
+    genuinely time-based and input-size-independent (#5256), never
+    something shrinking the request can fix. Distinguishes this from an
+    ordinary per-request rate limit, which a ``RateLimitError`` ALSO
+    reports and which shrinking the input CAN help avoid.
+
+    Checked via the structured field litellm exposes on ``exc.body``
+    (the provider's own parsed error dict), never ``str(exc)`` — matching
+    the provider's own free-text message is a responsibility that belongs
+    to the provider, not reyn (#5257's own precedent for this exact
+    class of mistake)."""
+    body = getattr(exc, "body", None)
+    return isinstance(body, dict) and body.get("type") == _QUOTA_EXHAUSTED_BODY_TYPE
+
+
+def quota_reset_seconds(exc: BaseException) -> "int | None":
+    """The provider's own ``resets_in_seconds`` field, if *exc* carries one
+    — how long until the exhausted quota window resets. ``None`` if absent
+    or not an int.
+
+    Deliberately does NOT read ``resets_at`` (an absolute epoch timestamp
+    the SAME provider also returns): a real occurrence (#5256 issue
+    thread) computed a wait time from ``resets_at`` that was wrong by
+    ~4 days against the account's actual recovery — the field does not
+    reliably predict recovery time, so no promise is derived from it here.
+    ``resets_in_seconds`` is used as reported (a duration, not a promise);
+    the caller frames it as "reported by the provider", not a guarantee."""
+    body = getattr(exc, "body", None)
+    if not isinstance(body, dict):
+        return None
+    val = body.get("resets_in_seconds")
+    return val if isinstance(val, int) else None
 
 
 def classify_router_error(exc: BaseException) -> str:
@@ -43,7 +99,7 @@ def classify_router_error(exc: BaseException) -> str:
     msg = str(exc) or name
     code = getattr(exc, "status_code", None)
 
-    bucket = _bucket_for(name, code)
+    bucket = _bucket_for(name, code, exc)
     if bucket is None:
         return f"router failed: {msg}"
     label, hint = bucket
@@ -55,7 +111,7 @@ def classify_router_error(exc: BaseException) -> str:
     return f"router failed: [{label}] {short} • {hint}"
 
 
-def _bucket_for(name: str, code: int | None) -> tuple[str, str] | None:
+def _bucket_for(name: str, code: "int | None", exc: BaseException) -> "tuple[str, str] | None":
     """Return a ``(label, hint)`` pair for the matched bucket, or None.
 
     Class-name matching is intentionally substring-based so subclasses
@@ -67,6 +123,22 @@ def _bucket_for(name: str, code: int | None) -> tuple[str, str] | None:
     """
     # Rate limit — 429
     if "RateLimit" in name or code == 429:
+        # #5256: a quota exhaustion (waiting is the only remedy) gets a
+        # distinct, decision-enabling hint from a plain per-request rate
+        # limit — "wait a moment" understates a multi-hour usage window.
+        if is_quota_exhausted_error(exc):
+            resets = quota_reset_seconds(exc)
+            if resets is not None:
+                return (
+                    "usage limit",
+                    f"provider reports it resets in {resets}s — no need to "
+                    "reply, it will recover on its own",
+                )
+            return (
+                "usage limit",
+                "provider usage limit reached — it will recover on its own, "
+                "no fixed wait reported",
+            )
         return "rate limit", "wait a moment then retry"
     # Auth — 401 / 403
     if "Authentication" in name or "PermissionDenied" in name or code in (401, 403):
@@ -98,4 +170,4 @@ def _bucket_for(name: str, code: int | None) -> tuple[str, str] | None:
     return None
 
 
-__all__ = ["classify_router_error"]
+__all__ = ["classify_router_error", "is_quota_exhausted_error", "quota_reset_seconds"]

--- a/src/reyn/runtime/error_format.py
+++ b/src/reyn/runtime/error_format.py
@@ -44,7 +44,11 @@ from reyn.runtime.budget.budget import BudgetExceeded
 #: transcripts). A provider that expresses the same failure class under a
 #: DIFFERENT ``type`` string is a disclosed gap, not a silently-assumed
 #: absence — this is a positive allowlist, not an attempt to enumerate
-#: every provider's vocabulary.
+#: every provider's vocabulary. lead-coder review (#5292): if the provider
+#: ever renames this field's VALUE, ``is_quota_exhausted_error`` silently
+#: stops matching — nothing here turns red to say so, and #5256's own
+#: failure mode (shrink-then-terminate on a quota exhaustion) can recur
+#: with no signal until it is observed live again.
 _QUOTA_EXHAUSTED_BODY_TYPE = "usage_limit_reached"
 
 

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -239,6 +239,15 @@ class RouterLoopDriver:
 
         No ``router_context_overflow_unrecovered`` event here — the caller
         is the one that emits it, on the overflow it treats as terminal.
+
+        #5256: a provider usage-window/plan quota exhaustion is checked
+        FIRST and re-raised UNWRAPPED without entering the shrink loop at
+        all — shrinking cannot fix a clock-based limit, and trying anyway
+        (compaction's own LLM call) spends more of the same exhausted
+        quota. This is NOT one of the two overflow outcomes above; the
+        caller's own except clause does not catch it, so it reaches
+        Session's generic exception handler, which keeps the session
+        alive (owner ruling).
         """
         from reyn.runtime.usage_shim import _RouterUsageShim
         from reyn.services.compaction.engine import (
@@ -308,6 +317,30 @@ class RouterLoopDriver:
         try:
             return await loop.run(user_text=user_text, history=history)
         except Exception as _exc:
+            # #5256: a provider usage-window/plan quota exhaustion is NEVER
+            # shrinkable — it is time-based, not input-size-based — and
+            # entering retry_loop below would spend more of the SAME
+            # exhausted quota on compaction's own LLM call (the real
+            # incident: 2 agents x 2 turns x 3 shrink attempts = 12 wasted
+            # calls, each itself hitting the same 429). Checked BEFORE
+            # is_context_overflow_error on purpose: a RateLimitError whose
+            # message happens to contain a context-overflow keyword (e.g.
+            # "usage LIMIT reached") would otherwise match that predicate's
+            # own keyword fallback and be misdiagnosed as "context too
+            # large" — the exact defect this issue reports. Re-raising here
+            # (never wrapped in ContextOverflowError/UnrecoveredError)
+            # means it propagates to run_turn's own except, which does NOT
+            # catch a bare RateLimitError, then to Session._handle_inbox_
+            # text's generic catch-all — which already does the right
+            # thing for an un-wrapped exception: surface it via the
+            # outbox (classify_router_error) and return normally, keeping
+            # the session alive (owner ruling, #5256: quota exhaustion
+            # must never end the session).
+            from reyn.runtime.error_format import (
+                is_quota_exhausted_error as _is_quota_exhausted_error,
+            )
+            if _is_quota_exhausted_error(_exc):
+                raise
             # #3783 stage 1: single shared predicate (was an inline copy).
             if not _is_context_overflow_error(_exc):
                 raise

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -322,20 +322,34 @@ class RouterLoopDriver:
             # entering retry_loop below would spend more of the SAME
             # exhausted quota on compaction's own LLM call (the real
             # incident: 2 agents x 2 turns x 3 shrink attempts = 12 wasted
-            # calls, each itself hitting the same 429). Checked BEFORE
-            # is_context_overflow_error on purpose: a RateLimitError whose
-            # message happens to contain a context-overflow keyword (e.g.
-            # "usage LIMIT reached") would otherwise match that predicate's
-            # own keyword fallback and be misdiagnosed as "context too
-            # large" — the exact defect this issue reports. Re-raising here
-            # (never wrapped in ContextOverflowError/UnrecoveredError)
-            # means it propagates to run_turn's own except, which does NOT
-            # catch a bare RateLimitError, then to Session._handle_inbox_
-            # text's generic catch-all — which already does the right
-            # thing for an un-wrapped exception: surface it via the
-            # outbox (classify_router_error) and return normally, keeping
-            # the session alive (owner ruling, #5256: quota exhaustion
-            # must never end the session).
+            # calls, each itself hitting the same 429). Without this gate,
+            # a RateLimitError whose message happens to contain a context-
+            # overflow keyword (e.g. "usage LIMIT reached") matches is_
+            # context_overflow_error's own keyword fallback and gets
+            # misdiagnosed as "context too large" — the exact defect this
+            # issue reports (see this file's own witness in test_5256_
+            # quota_not_context_overflow.py, which pins that a quota
+            # exception DOES classify as overflow today, proving this
+            # gate is load-bearing, not decorative).
+            #
+            # Checked BEFORE is_context_overflow_error, but not because
+            # ordering changes the OUTCOME (it doesn't — that predicate
+            # calling ensure_litellm_ready_or_defer() to check for
+            # litellm.ContextWindowExceededError first, then this check
+            # right after, would still end in the same re-raise). It's
+            # checked first so the quota path never pays for warming
+            # litellm at all — a plain attribute read on exc.body, no
+            # import, no warm-up cost, for a cause that was never going to
+            # be treated as an overflow either way.
+            #
+            # Re-raising here (never wrapped in ContextOverflowError/
+            # UnrecoveredError) means it propagates to run_turn's own
+            # except, which does NOT catch a bare RateLimitError, then to
+            # Session._handle_inbox_text's generic catch-all — which
+            # already does the right thing for an un-wrapped exception:
+            # surface it via the outbox (classify_router_error) and
+            # return normally, keeping the session alive (owner ruling,
+            # #5256: quota exhaustion must never end the session).
             from reyn.runtime.error_format import (
                 is_quota_exhausted_error as _is_quota_exhausted_error,
             )

--- a/tests/runtime/test_5256_quota_not_context_overflow.py
+++ b/tests/runtime/test_5256_quota_not_context_overflow.py
@@ -81,9 +81,17 @@ def test_quota_exhaustion_never_enters_shrink_and_never_ends_the_session(
         "reyn.runtime.router_loop.call_llm_tools", _fake_call_llm_tools,
     )
 
-    # Must not raise — the generic catch-all keeps the session alive.
-    asyncio.run(session._handle_inbox_text("hi", chain_id="chain-quota-1"))
-    asyncio.run(settle(session._audit_events))
+    async def _drive() -> None:
+        # Must not raise — the generic catch-all keeps the session alive.
+        await session._handle_inbox_text("hi", chain_id="chain-quota-1")
+        await settle(session._audit_events)
+
+    # architect review (#5292): a separate asyncio.run() per await runs each
+    # on its OWN event loop — today's dispatch consumers happen to drain
+    # before either loop closes, but that is not guaranteed, and a day it
+    # doesn't would surface as an unrelated flake (a join() that never
+    # returns), not a real assertion failure. One loop for both awaits.
+    asyncio.run(_drive())
 
     # ① never shrinkable: exactly ONE LLM call — a shrink retry would
     # have made a second one (and the real incident's own compaction
@@ -136,3 +144,14 @@ def test_a_genuine_context_overflow_still_shrinks_unaffected(monkeypatch) -> Non
     exc = _PlainOverflowError("maximum context length exceeded")
     assert is_quota_exhausted_error(exc) is False
     assert is_context_overflow_error(exc) is True
+
+    # architect/lead-coder review (#5292): without this line, nothing here
+    # asserts WHY the #5256 gate is load-bearing — this test only exercised
+    # a DIFFERENT string, so removing "limit" from _CONTEXT_OVERFLOW_KEYWORDS
+    # would make the gate a silent no-op and every test in this PR would
+    # stay green. Pin the actual would-be-misdiagnosis directly: the quota
+    # exception's own message ("The usage limit has been reached") DOES
+    # match is_context_overflow_error's keyword fallback today — that
+    # positive match is exactly what the new gate in _run_with_shrink
+    # exists to intercept before it ever reaches this predicate.
+    assert is_context_overflow_error(_QuotaExhaustedError()) is True

--- a/tests/runtime/test_5256_quota_not_context_overflow.py
+++ b/tests/runtime/test_5256_quota_not_context_overflow.py
@@ -1,0 +1,138 @@
+"""Tier 2: #5256 — a provider usage-window/plan quota exhaustion (429
+``usage_limit_reached``) must never be diagnosed as "context overflow" (never
+enters the shrink/compaction retry path) and must never end the session.
+
+Real reported incident (reyn-self, 2026-08-24..27): a 429 carrying
+``{"type": "usage_limit_reached", ...}`` was treated as a shrinkable
+context-overflow cause because its message text happened to contain the
+word "limit" (``is_context_overflow_error``'s own keyword fallback). Each
+shrink attempt itself made a compaction LLM call that ALSO hit the same
+exhausted quota, burning more of it; after
+``_MAX_CONSECUTIVE_SAME_CAUSE_RECOVERS`` (2) repeats, ``retry_loop`` raised
+``UnrecoveredError``, which the chat driver recorded as
+``router_context_overflow_unrecovered`` (a lie — nothing overflowed) and
+then let propagate, ending the session (owner ruling: "quota 枯渇で
+session を終わらせてはいけない").
+
+End-to-end through a real Session + RouterLoop (``call_llm_tools`` patched
+at ``reyn.runtime.router_loop.call_llm_tools`` with a real async callable
+that raises — never a mock, per testing.md) — exercises the REAL production
+except-clause chain (``RouterLoopDriver._run_with_shrink`` ->
+``run_turn`` -> ``Session._handle_inbox_text``'s generic catch-all), not a
+re-implementation of it.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
+
+
+class _QuotaExhaustedError(Exception):
+    """Real, scripted stand-in for litellm's ``RateLimitError`` shape for a
+    usage-window/plan quota exhaustion — the exact fields observed in the
+    real incident's own ``llm_request_error`` event (issue #5256): a
+    ``status_code`` and a structured ``.body`` dict litellm exposes from
+    the provider's own parsed error response."""
+
+    def __init__(self) -> None:
+        super().__init__("The usage limit has been reached")
+        self.status_code = 429
+        self.body = {
+            "type": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+            "plan_type": "plus",
+            "resets_at": 1788132890,
+            "resets_in_seconds": 12258,
+        }
+
+
+def _drain_outbox(session) -> list:
+    msgs = []
+    while not session.outbox.empty():
+        msgs.append(session.outbox.get_nowait())
+    return msgs
+
+
+def test_quota_exhaustion_never_enters_shrink_and_never_ends_the_session(
+    monkeypatch,
+) -> None:
+    """Tier 2: the acceptance witness for #5256's own two named defects.
+
+    ① misdiagnosis: no compaction/shrink attempt happens (the LLM call
+       fires exactly once — a shrink retry would make a second call).
+    ② termination: the exception never reaches ``run_turn``'s own
+       ``except (ContextOverflowError, UnrecoveredError)`` (no
+       ``router_context_overflow_unrecovered`` event — the lying record
+       the issue names) and never propagates out of ``_handle_inbox_
+       text`` at all (the session survives to handle a next turn)."""
+    session = make_session(agent_name="quota_test")
+    collected = collect_events(session._audit_events)
+
+    call_count = 0
+
+    async def _fake_call_llm_tools(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise _QuotaExhaustedError()
+
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools", _fake_call_llm_tools,
+    )
+
+    # Must not raise — the generic catch-all keeps the session alive.
+    asyncio.run(session._handle_inbox_text("hi", chain_id="chain-quota-1"))
+    asyncio.run(settle(session._audit_events))
+
+    # ① never shrinkable: exactly ONE LLM call — a shrink retry would
+    # have made a second one (and the real incident's own compaction
+    # call would have made a THIRD, itself failing the same way).
+    assert call_count == 1, (
+        f"expected exactly 1 LLM call (no shrink retry), got {call_count}"
+    )
+
+    # ② the lying record must never fire for this cause.
+    kinds = [e.type for e in collected]
+    assert "router_context_overflow_detected" not in kinds, (
+        "a quota exhaustion must never be classified as context overflow"
+    )
+    assert "router_context_overflow_unrecovered" not in kinds, (
+        "a quota exhaustion is not an overflow — this record would lie "
+        "to whoever reads it later (#5256)"
+    )
+
+    # The generic catch-all's own existing instrument DID fire — proof the
+    # exception genuinely reached that handler (not swallowed earlier by
+    # some other branch) and was reported, not silently dropped.
+    terminated = [e for e in collected if e.type == "router_loop_terminated_by_exception"]
+    assert terminated, "the exception must reach the generic catch-all's own P6 instrument"
+    assert terminated[0].data["error_type"] == "_QuotaExhaustedError"
+
+    # ③ operator-visible, decision-enabling message — not "wait a moment"
+    # (which understates a multi-hour usage window), and not silence.
+    msgs = _drain_outbox(session)
+    error_msgs = [m for m in msgs if m.kind == "error"]
+    assert error_msgs, "the operator must see something — not a silent end"
+    assert "[usage limit]" in error_msgs[0].text
+    # The provider's own resets_in_seconds value surfaces (#5256: resets_at
+    # is NOT used — see quota_reset_seconds's own docstring for why).
+    assert "12258" in error_msgs[0].text
+
+
+def test_a_genuine_context_overflow_still_shrinks_unaffected(monkeypatch) -> None:
+    """Tier 2: non-vacuity — the #5256 fix must not disturb the EXISTING,
+    correct behaviour for a real context-window overflow (a completely
+    different exception shape, no ``.body`` at all): it must still enter
+    the shrink path. Proves the new quota check is a narrow addition, not
+    a change to ``is_context_overflow_error``'s own established
+    classification."""
+    from reyn.runtime.error_format import is_quota_exhausted_error
+    from reyn.services.compaction.engine import is_context_overflow_error
+
+    class _PlainOverflowError(Exception):
+        pass
+
+    exc = _PlainOverflowError("maximum context length exceeded")
+    assert is_quota_exhausted_error(exc) is False
+    assert is_context_overflow_error(exc) is True

--- a/tests/runtime/test_router_error_classify.py
+++ b/tests/runtime/test_router_error_classify.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 import pytest
 
 from reyn.runtime.budget.budget import BudgetExceeded
-from reyn.runtime.error_format import classify_router_error
+from reyn.runtime.error_format import (
+    classify_router_error,
+    is_quota_exhausted_error,
+    quota_reset_seconds,
+)
 
 # ── synthetic exception shapes mimicking provider classes ────────────────────
 
@@ -134,3 +138,70 @@ def test_very_long_message_is_truncated() -> None:
     assert out.endswith("• wait a moment then retry"), out
     # Truncation marker must be present
     assert "…" in out
+
+
+# ── #5256: quota exhaustion is a distinct 429 shape, not a plain rate limit ──
+
+
+class _QuotaExhaustedRateLimitError(Exception):
+    """Real shape observed (#5256): a RateLimitError whose litellm ``.body``
+    carries the provider's own structured usage-window/plan quota fields."""
+
+    def __init__(self, *, resets_in_seconds: "int | None" = None) -> None:
+        super().__init__("The usage limit has been reached")
+        self.status_code = 429
+        body = {"type": "usage_limit_reached", "message": "The usage limit has been reached"}
+        if resets_in_seconds is not None:
+            body["resets_in_seconds"] = resets_in_seconds
+        self.body = body
+
+
+def test_is_quota_exhausted_error_reads_the_structured_body_type() -> None:
+    """Tier 1: the discriminator is the STRUCTURED ``body.type`` field, never
+    ``str(exc)`` (#5257's own precedent — a provider's free-text wording is
+    not reyn's contract to match)."""
+    assert is_quota_exhausted_error(_QuotaExhaustedRateLimitError()) is True
+    # A plain RateLimitError with no such body is NOT quota-exhaustion —
+    # non-vacuity: the predicate must not fire on every RateLimitError.
+    assert is_quota_exhausted_error(RateLimitError("429 too many requests")) is False
+    # A body dict present but with a DIFFERENT type must not match either.
+    other = RateLimitError("429")
+    other.body = {"type": "some_other_reason"}
+    assert is_quota_exhausted_error(other) is False
+
+
+def test_quota_reset_seconds_reads_resets_in_seconds_not_resets_at() -> None:
+    """Tier 1: #5256 — a real occurrence computed a wait time from
+    ``resets_at`` (an absolute epoch) that was wrong by ~4 days against the
+    account's actual recovery; ``resets_in_seconds`` (a duration, used
+    as-is, never derived) is the field this reads."""
+    exc = _QuotaExhaustedRateLimitError(resets_in_seconds=12258)
+    exc.body["resets_at"] = 1788132890  # present, must be ignored
+    assert quota_reset_seconds(exc) == 12258
+
+    absent = _QuotaExhaustedRateLimitError()
+    assert quota_reset_seconds(absent) is None
+
+
+def test_quota_exhaustion_gets_its_own_bucket_with_the_reset_duration() -> None:
+    """Tier 1: the [usage limit] bucket is distinct from [rate limit] and
+    surfaces the provider's own reported wait — never the provider's own
+    wording (#5257), and never a value derived from resets_at."""
+    out = classify_router_error(_QuotaExhaustedRateLimitError(resets_in_seconds=12258))
+    assert out.startswith("router failed: [usage limit]"), out
+    assert "12258" in out
+
+
+def test_quota_exhaustion_without_a_reset_duration_still_gets_the_bucket() -> None:
+    """Tier 1: non-vacuity for the missing-duration branch — the bucket
+    still fires and still says something decision-enabling, not a crash
+    on a missing field."""
+    out = classify_router_error(_QuotaExhaustedRateLimitError())
+    assert out.startswith("router failed: [usage limit]"), out
+
+
+def test_plain_rate_limit_is_unaffected_by_the_new_bucket() -> None:
+    """Tier 2: non-vacuity — an ordinary RateLimitError with no quota body
+    still lands in the pre-existing [rate limit] bucket, unchanged."""
+    out = classify_router_error(RateLimitError("429 too many requests"))
+    assert out.startswith("router failed: [rate limit]"), out


### PR DESCRIPTION
**[e2e-coder]** — Closes #5256. Design confirmed by lead-coder (owner-approved on the issue thread).

## What
A 429 carrying the provider's own structured `{"type":"usage_limit_reached","resets_in_seconds":N}` was diagnosed as a shrinkable context-overflow cause purely because its message text contained the word "limit" (`is_context_overflow_error`'s own keyword fallback). Each shrink attempt made a compaction LLM call that ALSO hit the same exhausted quota, burning more of it (real trace: 2 agents × 2 turns × 3 attempts = 12 wasted calls). After the retry cap, `retry_loop` raised `UnrecoveredError`, recorded as `router_context_overflow_unrecovered` (a lie — nothing overflowed) and let propagate, ending the session (owner: "quota 枯渇で session を終わらせてはいけない").

## Two fixes, one root cause
**① Misdiagnosis** — `src/reyn/runtime/error_format.py` gets `is_quota_exhausted_error()`/`quota_reset_seconds()`, reading the STRUCTURED provider body litellm exposes on `exc.body` (never `str(exc)` — #5257's own precedent). `RouterLoopDriver._run_with_shrink` checks this FIRST, before `is_context_overflow_error`, and re-raises immediately without entering `retry_loop` at all. `is_context_overflow_error` itself is left completely untouched (its own carefully-scoped #3783/#4381 history stays intact — this is a new gate in FRONT of it, not a redefinition).

**② Termination** — a solved consequence of ①, not a separate patch: the un-wrapped exception no longer matches `run_turn`'s `except (ContextOverflowError, UnrecoveredError)`, so it never emits the lying record and instead reaches `Session._handle_inbox_text`'s EXISTING generic catch-all, which already does the right thing for interactive chat — surface via the outbox and return normally, keeping the session alive. No new termination-handling code needed.

`classify_router_error` gets a new `[usage limit]` bucket, distinct from `[rate limit]`, surfacing `resets_in_seconds` when reported ("wait a moment then retry" understates a multi-hour usage window). Deliberately does **not** use `resets_at` (an absolute epoch) — a real occurrence computed a wait time from it that was wrong by ~4 days against the account's actual recovery.

## Tests
- Unit-level (`test_router_error_classify.py`): the two new predicates + the new bucket, including non-vacuity (a plain `RateLimitError` with no quota body still gets `[rate limit]`, unchanged).
- End-to-end (`test_5256_quota_not_context_overflow.py`): real `Session` + `RouterLoop`, `call_llm_tools` patched to raise the exact observed shape. Asserts exactly 1 LLM call (no shrink retry), no `router_context_overflow_(detected|unrecovered)` events, the session survives (does not raise), and the outbox carries `[usage limit]` + the reset duration. A companion test confirms `is_context_overflow_error`'s own existing classification for a genuine overflow is unaffected.
- Strip-falsified: reverting the `_run_with_shrink` short-circuit flips the end-to-end test RED (2 LLM calls, `UnrecoveredError` raised) — confirmed, then restored.

Local gates: ruff, `test_tier_audit.py --strict`, `mypy_ratchet.py`, `verify_module_docstrings.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green. Scoped pytest across all overflow/compaction-classification tests (`test_4381_stage1_overflow_classification.py`, `test_3783_stage3_invert_default_to_recover.py`, `test_router_loop_pure_helpers.py`, `test_retry_loop_chat_wiring_1125.py`, `test_router_loop_swallow_instrument_187.py`) — 70 passed.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on changed/new test files
- [x] `mypy_ratchet.py`
- [x] `verify_module_docstrings.py` on changed src files
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] Scoped pytest across the overflow/compaction-classification suite
- [x] Strip-falsify: end-to-end test confirmed RED under a real revert, then restored
- [x] (skipped — no visual surface changed)

Cannot self-merge (touches `tests/`) — needs a TESTS-READ note per rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)