### PR TITLE
fix(#5179): pair connect-time backlog+status in the same tick

### DIFF
--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -91,6 +91,7 @@ class AgUiEmitter:
         backlog_has_more: bool = False,
         backlog_next_cursor: "str | None" = None,
         backlog_provider: "Callable[[str, str], Awaitable[tuple[list[Frame], bool, str | None]]] | None" = None,
+        initial_status: "dict | None" = None,
     ) -> None:
         # ``frames`` is the unified frame stream (e.g. an InProcessTransport's
         # ``frames()``); ``status_provider`` returns the CUI status snapshot dict
@@ -104,12 +105,26 @@ class AgUiEmitter:
         # OWN bounded page (``(frames, has_more, next_cursor)``, #5139 C) for
         # the re-fire; ``None`` means this connection never switches sessions
         # (byte-identical to pre-N3 behavior).
+        #
+        # ``initial_status`` (#5179) is the status paired with ``backlog`` at
+        # the SAME instant the caller captured it — used ONLY for the very
+        # first reconnect snapshot (``stream()``'s own preamble, below). This
+        # is a consistency fix, not a freshness one: pairing a fresher-but-
+        # later status with an older backlog is the bug (a turn dispatched
+        # in between gets a seq-gated seed that never resurrects, so it is
+        # never promoted anywhere — see the caller's own docstring,
+        # ``_session_backlog_page_and_status`` in endpoint.py, for the full
+        # reasoning). ``None`` falls back to ``status_provider()`` — the
+        # pre-#5179 behavior, unchanged for any caller not yet passing this.
+        # The mid-stream switch re-fire (``session_attached``, below) is
+        # DELIBERATELY NOT changed to use this — #5116 needs that one live.
         self._frames = frames
         self._status_provider = status_provider
         self._backlog = list(backlog or [])
         self._backlog_has_more = backlog_has_more
         self._backlog_next_cursor = backlog_next_cursor
         self._backlog_provider = backlog_provider
+        self._initial_status = initial_status
         self._model = StatusModel()
         self._waiting_on: str | None = None
         # #3288 ③d: one tracker per connection so a streamed reply's
@@ -118,27 +133,41 @@ class AgUiEmitter:
         # ``TextStreamTracker``'s docstring, protocol.py).
         self._text_stream = TextStreamTracker()
 
-    def _project(self) -> dict:
-        return project_status(self._status_provider(), waiting_on=self._waiting_on)
+    def _project(self, status: "dict | None" = None) -> dict:
+        # ``status`` overrides a live ``status_provider()`` read when the
+        # caller already holds one paired with the backlog it is projecting
+        # alongside (#5179 — the connect-time reconnect snapshot). ``None``
+        # (every OTHER call site: the mid-stream switch re-fire, the
+        # per-frame delta loop) falls back to the live read, unchanged.
+        resolved = status if status is not None else self._status_provider()
+        return project_status(resolved, waiting_on=self._waiting_on)
 
     def _reconnect_snapshot_chunks(
         self, backlog: "list[Frame]", *, has_more: bool = False, next_cursor: "str | None" = None,
+        status: "dict | None" = None,
     ) -> "list[str]":
         """The shared reconnect protocol (A4): backlog display, then full
         status — used identically at connect (``stream()`` start) and at a
         mid-stream session switch (#3310 N3), so the two are ONE code path,
         not a byte-identical-by-hand duplicate. ``has_more``/``next_cursor``
         (#5139 C) are *backlog*'s own page-continuation state, riding the
-        SAME ``MESSAGES_SNAPSHOT`` event."""
+        SAME ``MESSAGES_SNAPSHOT`` event. ``status`` (#5179), when given, is
+        a status ALREADY paired with this same ``backlog`` at the instant
+        the caller captured it — passed through to :meth:`_project` instead
+        of a fresh live read; ``None`` (the mid-stream switch re-fire's own
+        call, below) keeps reading live, as before."""
         return [
             to_sse(encode_messages_snapshot(backlog, has_more=has_more, next_cursor=next_cursor)),
-            to_sse(encode_state_snapshot(self._model.snapshot(self._project()))),
+            to_sse(encode_state_snapshot(self._model.snapshot(self._project(status)))),
         ]
 
     async def stream(self) -> AsyncIterator[str]:
-        # Reconnect snapshots first (A4): backlog display, then full status.
+        # Reconnect snapshots first (A4): backlog display, then full status —
+        # ``self._initial_status``, paired with ``self._backlog`` at the
+        # SAME instant the caller captured both (#5179), not a fresh read.
         for chunk in self._reconnect_snapshot_chunks(
             self._backlog, has_more=self._backlog_has_more, next_cursor=self._backlog_next_cursor,
+            status=self._initial_status,
         ):
             yield chunk
 

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -1057,6 +1057,16 @@ async def agui_events(request: Request, agent_name: str):
             # session. ``source`` is the SINGLE per-connection owner of
             # "which agent, which session" now (see its own class docstring);
             # this is its one status-facing read path.
+            #
+            # #5179 (architect, non-blocking): at CONNECT time, this reads
+            # the SAME session `_session_backlog_page_and_status` paired
+            # its own status against for `initial_status` below —
+            # `attach()` always focuses `_DEFAULT_SID`, so `source.current_
+            # session()` and that function's own `target` resolve
+            # identically here. They can only diverge LATER, mid-stream,
+            # after a cross-agent `/attach` re-points `source` (#5116) —
+            # which is exactly why this live closure (not `initial_status`)
+            # is what the mid-stream switch re-fire still reads.
             return _snapshot_for_session(registry, source.current_session())
 
         async def _backlog_provider(name: str, sid: str) -> "tuple[list[Frame], bool, str | None]":

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -424,21 +424,80 @@ async def session_backlog_page(
 
     Returns ``(frames, has_more, next_cursor)`` — see
     :func:`~reyn.interfaces.inline.textual_chat.restore.page_restored_history`,
-    which this wraps, for what each means."""
+    which this wraps, for what each means. A thin wrapper over
+    :func:`_session_backlog_page_and_status`, discarding its paired status —
+    this is the shape every EXISTING caller (a mid-stream switch re-fire, a
+    client-driven ``ReachedTop`` pull) wants: those need a FRESH status read
+    of their own (#5116 — the target session may have changed), never a
+    status frozen at the moment this particular page was built."""
+    frames, has_more, next_cursor, _status = await _session_backlog_page_and_status(
+        registry, name, sid, before_root_id=before_root_id,
+    )
+    return frames, has_more, next_cursor
+
+
+async def _session_backlog_page_and_status(
+    registry, name: str, sid: str, *, before_root_id: "str | None" = None,
+) -> "tuple[list[Frame], bool, str | None, dict | None]":
+    """#5179 fix: the CONNECT-time caller (``agui_events``, below) needs its
+    initial backlog page and its initial status to describe the SAME
+    instant — not the freshest available status, paired with it.
+
+    **The bug this closes is about consistency, not freshness.** The
+    connect-time reconnect snapshot used to pair the backlog built here with
+    a status read taken LATER — either lazily at ``AgUiEmitter.stream()``
+    start (the original report: an ASGI-scheduling gap after this function
+    already returned) or, in an earlier draft of this fix, immediately after
+    this function returns (architect review, issuecomment-5434642964: still
+    wrong for this loop's own ``extended <= 0`` exit, which returns
+    ``frames`` built BEFORE ``extend_history_backward_async``'s disk-read
+    await — a status read taken AFTER that await already reflects any turn
+    dispatched during it, while the backlog paired with it does not). Both
+    of those "read status separately, whenever" designs are the SAME defect
+    at different distances: a dispatch that commits inside the gap advances
+    status past a turn whose OWN historical frames the seq-gate (state.py's
+    ``RemoteQueueView``) then correctly refuses to resurrect — so the turn
+    is promoted NOWHERE. The fix is not "read status sooner" or "read it
+    later" — it is to stop reading it at a different time than ``history``
+    at all.
+
+    So: capture status via :func:`~reyn.interfaces.repl.status._snapshot_for_session`
+    in the SAME synchronous tick as each ``history = list(...)`` read below,
+    overwritten every loop iteration — whichever iteration's ``frames`` is
+    what finally gets returned (exit A, no await ever taken; or exit B,
+    after one or more ``extend_history_backward_async`` awaits), the status
+    returned alongside it was captured paired with THAT SAME iteration's
+    history read, with no await between the two. There is no "which one is
+    older" question left to get backwards: if the paired seed is OLD (a
+    turn dispatched after this whole call started), ``_last_seq`` seeds low,
+    that turn's own frames pass the gate and promote normally once
+    forwarded live — exactly once, never twice, and never dropped. Do NOT
+    special-case this to read a "fresher" status once the loop is about to
+    return — that is the exact regression this docstring exists to head
+    off (lead-coder/architect, #5179: "次の人が status が古いのはバグと見て
+    live読みに戻す" — a future contributor who thinks a stale-looking status
+    is itself the bug and reverts to a live read here reintroduces #5179).
+
+    Returns ``(frames, has_more, next_cursor, status)`` — the first three
+    identical to :func:`session_backlog_page`'s own contract; ``status`` is
+    ``None`` only when ``target`` itself does not resolve (mirrors the
+    ``None``-session case :func:`~reyn.interfaces.repl.status._snapshot_for_session`
+    itself already handles for a detached agent)."""
     target = registry.get_session(name, sid)
     if target is None:
-        return [], False, None
+        return [], False, None, None
     while True:
         history = list(getattr(target, "history", []) or [])
+        status = _snapshot_for_session(registry, target)
         frames, has_more, next_cursor = page_restored_history(
             history, before_root_id=before_root_id, limit=HYDRATE_PAGE_FRAMES,
         )
         if has_more:
-            return [DisplayFrame(m) for m in frames], has_more, next_cursor
+            return [DisplayFrame(m) for m in frames], has_more, next_cursor, status
         extend = getattr(target, "extend_history_backward_async", None)
         extended = await extend() if extend is not None else 0
         if extended <= 0:
-            return [DisplayFrame(m) for m in frames], False, None
+            return [DisplayFrame(m) for m in frames], False, None, status
 
 
 def _is_delta_frame(frame) -> bool:
@@ -1001,8 +1060,15 @@ async def agui_events(request: Request, agent_name: str):
         # session's own history through the SAME projection the switch re-fire
         # and the local restore-on-restart path both use — one SSoT, populated
         # at both call sites now instead of only the second.
-        initial_backlog, initial_has_more, initial_next_cursor = await session_backlog_page(
-            registry, agent_name, _DEFAULT_SID,
+        # #5179: the initial backlog AND the initial status must describe
+        # the SAME instant — paired via ``_session_backlog_page_and_status``
+        # (that function's own docstring has the full reasoning: this is a
+        # consistency fix, not a freshness one). ``_status_provider`` above
+        # stays the LIVE read for the mid-stream switch re-fire only
+        # (``_backlog_provider``'s own caller, emitter.py) — #5116 needs
+        # that one fresh; this one must not be.
+        initial_backlog, initial_has_more, initial_next_cursor, initial_status = (
+            await _session_backlog_page_and_status(registry, agent_name, _DEFAULT_SID)
         )
         emitter = AgUiEmitter(
             source.frames(), _status_provider,
@@ -1010,6 +1076,7 @@ async def agui_events(request: Request, agent_name: str):
             backlog_has_more=initial_has_more,
             backlog_next_cursor=initial_next_cursor,
             backlog_provider=_backlog_provider,
+            initial_status=initial_status,
         )
     except Exception:
         source.close()

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -482,7 +482,24 @@ async def _session_backlog_page_and_status(
     identical to :func:`session_backlog_page`'s own contract; ``status`` is
     ``None`` only when ``target`` itself does not resolve (mirrors the
     ``None``-session case :func:`~reyn.interfaces.repl.status._snapshot_for_session`
-    itself already handles for a detached agent)."""
+    itself already handles for a detached agent).
+
+    **Paired against ``target`` (this function's own resolved session), not
+    ``source.current_session()``** (architect, PR #5293 review, non-blocking)
+    — the live mid-stream path (``_status_provider`` below) reads the
+    LATTER. At the moment ``agui_events`` calls this function, the two are
+    the SAME session: ``attach()`` always focuses ``_DEFAULT_SID``
+    (registry.py), and ``_SessionFrameSource.__init__`` resolves
+    ``current_session()`` via ``self._bind(session)`` off that SAME
+    connect-time ``attach`` result — no cross-agent ``/attach`` re-point
+    (the only thing that can make them diverge, #5116) has had a chance to
+    fire yet at this specific call site. Pairing against ``target`` (this
+    function's own local) rather than threading ``source`` through as a
+    parameter is deliberate: it keeps this function's own contract self-
+    contained and matches the backlog's own resolution (``target`` is
+    where ``history`` itself comes from too — pairing status against a
+    DIFFERENT session's resolution than the backlog it rides alongside
+    would reintroduce a mismatch of its own)."""
     target = registry.get_session(name, sid)
     if target is None:
         return [], False, None, None

--- a/tests/interfaces/test_5119_retarget_hub_exception_cleanup.py
+++ b/tests/interfaces/test_5119_retarget_hub_exception_cleanup.py
@@ -17,8 +17,10 @@ was nobody, ever).
 
 Real ``AgentRegistry``/``Session`` + a real ``agui_events`` call throughout
 — no mocks. The failure is injected via a real ``monkeypatch.setattr`` on
-``session_backlog_page`` (module-level, in the endpoint module's own
-namespace), not a fake collaborator standing in for a real one.
+``_session_backlog_page_and_status`` (module-level, in the endpoint
+module's own namespace — #5179 moved the call site here from the plain
+``session_backlog_page``), not a fake collaborator standing in for a real
+one.
 """
 from __future__ import annotations
 
@@ -82,9 +84,10 @@ async def test_exception_before_gen_starts_does_not_leak_the_hub_subscription(
     connection's own hub subscription behind.
 
     Injects the failure at the LAST call in the vulnerable window
-    (``session_backlog_page``, called to build ``AgUiEmitter``'s own
-    ``backlog=`` argument) — the latest possible failure point, so this
-    witness covers the WHOLE window, not just an early step.
+    (``_session_backlog_page_and_status``, called to build ``AgUiEmitter``'s
+    own ``backlog=``/``initial_status=`` arguments) — the latest possible
+    failure point, so this witness covers the WHOLE window, not just an
+    early step.
 
     Strip-falsifier: reverting the ``try``/``except`` wrapper around this
     window back to unguarded calls (this PR's own diff) turns this red —
@@ -97,11 +100,15 @@ async def test_exception_before_gen_starts_does_not_leak_the_hub_subscription(
     def _raising_backlog(*_args, **_kwargs):
         raise RuntimeError("deliberate #5119 injected failure")
 
-    # #5139 C: the endpoint's own initial-backlog call site now goes through
-    # ``session_backlog_page`` (bounded, page-aware), not the unbounded
-    # ``session_backlog_frames`` this test used to target — the injection
-    # point moves to match, still the LAST call in the vulnerable window.
-    monkeypatch.setattr(endpoint_mod, "session_backlog_page", _raising_backlog)
+    # #5179: the endpoint's own initial-backlog call site now goes through
+    # ``_session_backlog_page_and_status`` (backlog+status paired in one
+    # tick — see that function's own docstring), not the plain
+    # ``session_backlog_page`` this test used to target — the injection
+    # point moves to match, still the LAST call in the vulnerable window
+    # (#5139 C's own precedent: the call site moves, the test follows it).
+    monkeypatch.setattr(
+        endpoint_mod, "_session_backlog_page_and_status", _raising_backlog,
+    )
 
     assert not endpoint_mod.connection_retarget_has_subscribers(conn_id), (
         "test precondition: the hub must start with no entry for this id"

--- a/tests/interfaces/test_5179_backlog_gap_end_to_end.py
+++ b/tests/interfaces/test_5179_backlog_gap_end_to_end.py
@@ -1,74 +1,39 @@
-"""Tier 2: #5179, real end-to-end connect path — does the reported drop of
-the operator's OWN message actually reach through ``endpoint.py``'s real
-connect code, or only through the hand-constructed SSE string the earlier
-isolation test (``test_5179_remote_own_message_seq_gate_race.py``) used?
+"""Tier 2: #5179, real end-to-end connect path — the operator's OWN message,
+submitted AFTER a real connection's backlog+status were already captured,
+must still render once its own ``turn_started`` frame is forwarded live.
 
-That earlier test built ``AgUiEmitter`` directly, with NO ``backlog``/
-``backlog_provider`` at all, and hand-wrote ``status_provider``'s return
-value and the ``user_submitted``/``turn_started`` ``EventFrame``s. It proves
-the seq-gate mechanism CAN drop an already-reflected turn, but says nothing
-about whether the real connect handler (``agui_events``, endpoint.py ~908-
-1035) can actually produce that same shape.
+**History of this file** (kept for record, not re-litigated every read):
+the first version of this test drove the connect-time backlog read and the
+connect-time status read at two SEPARATELY-CONSTRUCTED times (mirroring
+what ``endpoint.py``'s ``agui_events`` used to do), and reproduced #5179:
+the operator's message rendered in neither ``FlowView`` nor ``SentQueue``.
+Architect review of the FIX design for that bug (issuecomment-5434642964,
+relayed by lead-coder) caught that the first fix candidate ("capture status
+right after ``session_backlog_page`` returns") still left the SAME-direction
+race open at that function's own ``extended <= 0`` exit — see
+``test_5179_exit_b_status_race_discriminator.py``, which keeps demonstrating
+that exact flawed candidate's own failure directly (architect's own
+instruction: keep that shape unchanged post-fix, or it stops testing
+anything). The adopted fix instead reads backlog and status in the SAME
+synchronous tick, every loop iteration, inside
+``endpoint.py._session_backlog_page_and_status`` — no separate-time read
+exists to race at all, at either exit.
 
-This module drives the REAL pieces that function uses, in the REAL order,
-with the ordering between two real reads CONTROLLED explicitly (not raced):
-
-1. ``_SessionFrameSource(session, registry=..., agent_name=...)`` (the same
-   class ``agui_events`` constructs at endpoint.py:945), started so its
-   audit-event subscription is live BEFORE anything is submitted — matching
-   ``agui_events``'s own ordering (``source.start()`` at line 965, before the
-   backlog read at 1004).
-2. ``session_backlog_page(registry, agent_name, _DEFAULT_SID)`` (endpoint.py
-   :392, the exact function ``agui_events`` awaits at line 1004) — called
-   FIRST, while ``session.history`` is still empty. This is the window's
-   START boundary.
-3. THEN, a REAL turn for the operator's own text is driven to completion
-   through ``Session.submit_user_text`` (enqueue; emits the real
-   ``user_submitted`` audit-event, session.py:4370) and
-   ``Session.run_one_iteration`` (dispatch; emits the real ``turn_started``
-   audit-event at session.py:6917, then reaches ``_handle_inbox_text``,
-   whose ``Session._append_history`` call at session.py:7526 is the ACTUAL
-   dispatch-commit this whole investigation is about — it runs strictly
-   AFTER step 2's backlog snapshot was already taken). The turn is left to
-   fail at the real litellm boundary afterward (no ``@pytest.mark.replay``
-   fixture is installed, so ``reyn.dev.testing.network_gate`` raises
-   ``UnpinnedNetworkReach`` the instant the router tries to call the model)
-   — irrelevant to this test: everything it asserts on already happened
-   before that point.
-4. ``_snapshot_for_session(registry, source.current_session())`` (the exact
-   call ``agui_events``'s own ``_status_provider`` closure makes at
-   endpoint.py:984) is invoked ONLY once the real dispatch-commit above has
-   already happened — this is the window's END boundary, and it is REAL:
-   ``session.queue_seq`` genuinely reads 2 (bumped once by
-   ``submit_user_text``'s ``user_submitted``, once by
-   ``run_one_iteration``'s ``turn_started`` — ``Session._bump_queue_seq``,
-   session.py:2389), not a hand-set fixture value.
-5. A real ``AgUiEmitter`` is built with the STALE (pre-turn, empty) backlog
-   from step 2, the real ``source.frames()`` as its frame source (so the
-   real ``user_submitted``/``turn_started`` ``EventFrame``s it queued during
-   step 3 are what get forwarded), and the status closure from step 4.
-6. ``emitter.stream()`` is fed into a real ``AgUiTransport``, mounted into a
-   real ``TextualChatApp`` — identical shape to
-   ``test_5179_remote_own_message_seq_gate_race.py``'s own app-mounting
-   pattern, reusing its ``_wait_until``/``_flow_user_entries`` helpers.
-
-No mocks anywhere: real ``AgentRegistry`` + real ``Session``
-(``tests._support.agent_session.make_session``), real audit-event bus, real
-``AgUiEmitter``/``AgUiTransport``/``TextualChatApp``. The verdict is read off
-PUBLIC widget state only (``FlowView.entries``, ``SentQueue.rendered_texts()``).
-
-The two boundary points that determine how wide this window can practically
-get in real operation (see the investigation's own report for the full
-reasoning on what governs the width in between):
-
-- **START**: ``endpoint.py:1004`` — ``await session_backlog_page(registry,
-  agent_name, _DEFAULT_SID)``.
-- **END**: ``emitter.py:135`` — ``self._model.snapshot(self._project())``
-  inside ``_reconnect_snapshot_chunks``, which is the FIRST call
-  ``AgUiEmitter.stream()`` ever makes to ``status_provider`` (line 140-143,
-  the very top of ``stream()``, called from the ``StreamingResponse``'s
-  ``gen()`` only once Starlette begins consuming the response body — i.e.
-  strictly AFTER ``agui_events`` itself has already returned).
+This module now exercises THAT real, fixed pairing: ``_SessionFrameSource``
++ ``_session_backlog_page_and_status`` (the exact call ``agui_events`` now
+makes) + ``AgUiEmitter(..., initial_status=...)`` (the exact wiring
+``agui_events`` now does) + real ``AgUiTransport``/``TextualChatApp`` — no
+mocks. The connect's own backlog+status pairing is captured BEFORE the
+operator's turn is ever submitted (there is nothing to dispatch yet at real
+connect time — the general case, not a special-cased "empty" scenario);
+the turn is submitted and dispatched to completion AFTER that pairing was
+taken, exactly as a real operator typing after connecting would. Its own
+``user_submitted``/``turn_started`` events arrive afterward via
+``source.frames()`` (the SAME real subscription the connect started before
+anything was submitted) with seq values ABOVE the low, pre-dispatch
+``_last_seq`` this connection's own pairing seeded — so they pass the
+seq-gate and promote normally. The verdict is read off PUBLIC widget state
+only (``FlowView.entries``, ``SentQueue.rendered_texts()``), as before.
 """
 from __future__ import annotations
 
@@ -84,7 +49,11 @@ from reyn.interfaces.repl.read_model import RemoteReadModel
 from reyn.interfaces.repl.status import _snapshot_for_session
 from reyn.interfaces.transport.agui.client import AgUiTransport
 from reyn.interfaces.transport.agui.emitter import AgUiEmitter
-from reyn.interfaces.transport.agui.endpoint import _SessionFrameSource, session_backlog_page
+from reyn.interfaces.transport.agui.endpoint import (
+    _session_backlog_page_and_status,
+    _SessionFrameSource,
+    session_backlog_page,
+)
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
@@ -159,11 +128,12 @@ def _own_text_committed(session) -> bool:
 
 
 @pytest.mark.asyncio
-async def test_own_message_dropped_via_real_connect_path(tmp_path) -> None:
-    """Tier 2: reproduces (or falsifies) #5179 by driving the REAL
-    ``endpoint.py`` connect-time pieces, in the REAL order, with the
-    real-vs-stale backlog ordering deliberately controlled by this test
-    (not raced) exactly as the module docstring lays out."""
+async def test_own_message_renders_via_real_connect_path(tmp_path) -> None:
+    """Tier 2: acceptance — drives the REAL, FIXED ``endpoint.py`` connect
+    pairing (``_session_backlog_page_and_status``), submits the operator's
+    own turn AFTER that pairing is taken (the ordinary case: nothing to
+    submit yet at real connect time), and confirms it renders once its
+    own ``turn_started`` frame is forwarded live."""
     registry = _make_registry(tmp_path)
     AgentProfile.new(_AGENT_NAME, role="").save(
         tmp_path / ".reyn" / "agents" / _AGENT_NAME
@@ -171,27 +141,35 @@ async def test_own_message_dropped_via_real_connect_path(tmp_path) -> None:
     session = await registry.ensure_running(_AGENT_NAME)
 
     # Real per-connection frame source (endpoint.py:945), started BEFORE
-    # anything is submitted — matches agui_events's own ordering
-    # (source.start() at line 965 precedes the backlog read at line 1004),
-    # and is REQUIRED here: a subscription started AFTER the turn's audit-
-    # events fire would simply never see them.
+    # anything is submitted — matches agui_events's own ordering.
     source = _SessionFrameSource(session, registry=registry, agent_name=_AGENT_NAME)
     source.start()
 
     turn_task: "asyncio.Task | None" = None
     try:
-        # ── Window START (endpoint.py:1004) ─────────────────────────────
-        initial_backlog, initial_has_more, initial_next_cursor = await session_backlog_page(
-            registry, _AGENT_NAME, _DEFAULT_SID,
+        # ── The real, FIXED connect-time pairing (endpoint.py's own
+        # agui_events call) — backlog and status captured in the SAME
+        # synchronous tick, before the operator has submitted anything. ──
+        initial_backlog, initial_has_more, initial_next_cursor, initial_status = (
+            await _session_backlog_page_and_status(registry, _AGENT_NAME, _DEFAULT_SID)
         )
         assert initial_backlog == [], (
             "test construction error: expected an EMPTY initial backlog "
-            "(nothing committed yet) — got a non-empty one, so this run "
+            "(nothing submitted yet) — got a non-empty one, so this run "
             "does not exercise the ordering this test targets"
         )
+        assert initial_status is not None and initial_status.get("queue_seq") == 0, (
+            f"test construction error: expected the connect-time pairing's "
+            f"own queue_seq to be 0 (nothing dispatched yet) — got "
+            f"{initial_status!r}"
+        )
 
-        # ── The real dispatch-commit, driven to completion AFTER the
-        # backlog snapshot above was already taken ──────────────────────
+        def status_provider() -> dict:
+            return _snapshot_for_session(registry, source.current_session())
+
+        # ── AFTER the connect pairing above, the operator submits and the
+        # real dispatch-commit runs — exactly as a real operator typing
+        # after connecting would. ──────────────────────────────────────
         async def _drive_turn() -> None:
             try:
                 await session.run_one_iteration()
@@ -209,20 +187,6 @@ async def test_own_message_dropped_via_real_connect_path(tmp_path) -> None:
         while not _own_text_committed(session):
             await asyncio.sleep(0)
 
-        # ── Window END (mirrors _status_provider, endpoint.py:967-984) ──
-        def status_provider() -> dict:
-            return _snapshot_for_session(registry, source.current_session())
-
-        # Sanity: the dispatch genuinely already advanced queue_seq by the
-        # time this connection's status read happens (real counter, not a
-        # fixture value: session.py's Session._bump_queue_seq, one bump for
-        # user_submitted, one for turn_started).
-        assert session.queue_seq == 2, (
-            f"test construction error: expected queue_seq==2 (user_submitted "
-            f"+ turn_started already dispatched) at status-read time, got "
-            f"{session.queue_seq!r}"
-        )
-
         async def backlog_provider(name: str, sid: str):
             return await session_backlog_page(registry, name, sid)
 
@@ -232,6 +196,7 @@ async def test_own_message_dropped_via_real_connect_path(tmp_path) -> None:
             backlog_has_more=initial_has_more,
             backlog_next_cursor=initial_next_cursor,
             backlog_provider=backlog_provider,
+            initial_status=initial_status,
         )
 
         async def _send(_payload: dict) -> bool:
@@ -288,11 +253,10 @@ async def test_own_message_dropped_via_real_connect_path(tmp_path) -> None:
                 pass
 
     assert rendered or still_queued, (
-        "REPRODUCED #5179 via the REAL connect path: the operator's own "
+        "#5179 REGRESSION via the REAL connect path: the operator's own "
         f"message ({_OWN_TEXT!r}) is present in NEITHER the flow "
         f"({[e.item.text for e in user_entries]!r}) NOR the sent-queue "
-        f"region ({queued_texts!r}), even though the real dispatch-commit "
-        "(Session._append_history) had already run before this connection's "
-        "real backlog read AND its real status read reflects it as "
-        "already-dispatched (queue_seq=2)."
+        f"region ({queued_texts!r}), even though it was submitted AFTER "
+        "this connection's own backlog+status pairing was captured, so "
+        "its own turn_started frame should promote normally once forwarded."
     )

--- a/tests/interfaces/test_5179_backlog_gap_end_to_end.py
+++ b/tests/interfaces/test_5179_backlog_gap_end_to_end.py
@@ -34,6 +34,22 @@ anything was submitted) with seq values ABOVE the low, pre-dispatch
 ``_last_seq`` this connection's own pairing seeded — so they pass the
 seq-gate and promote normally. The verdict is read off PUBLIC widget state
 only (``FlowView.entries``, ``SentQueue.rendered_texts()``), as before.
+
+**Second gap, caught in PR #5293 review (architect, relayed by lead-coder,
+same-day):** the test above (and every #5179 test at that point) all
+hand-construct ``AgUiEmitter`` themselves, mirroring ``agui_events``'s own
+wiring (the docstring above literally says "the exact wiring `agui_events`
+now does") rather than ever CALLING ``agui_events`` itself. So the fix's
+actual production line — ``initial_status=initial_status`` inside
+``agui_events`` (endpoint.py) — could be deleted entirely and every #5179
+test stayed green: the fix's witness summed to zero. Same gap #5116 already
+named once in this same directory
+(``test_5116_connection_agent_owner_cross_attach.py``'s own
+``test_a_real_agui_events_get_pushes_correct_status_after_cross_agent_
+attach``, and its own docstring's account of catching an identical "tests
+mirror the wiring, never call it" gap). Same fix here:
+``test_agui_events_route_pairs_connect_status_with_backlog`` below calls
+the REAL route handler directly.
 """
 from __future__ import annotations
 
@@ -251,6 +267,14 @@ async def test_own_message_renders_via_real_connect_path(tmp_path) -> None:
                 await turn_task
             except (Exception, asyncio.CancelledError):
                 pass
+        # Real Session.run_one_iteration() above spawns the full router-loop
+        # machinery (EventLog subscribers included); a bare turn_task cancel
+        # leaves that background state dangling past this test's own event
+        # loop, surfacing as a cross-test "Event loop is closed" warning in
+        # a large sweep. registry.shutdown() is the established production
+        # cleanup path (registry.py's own docstring: "stop all loaded
+        # sessions, then await/cancel their tasks").
+        await registry.shutdown()
 
     assert rendered or still_queued, (
         "#5179 REGRESSION via the REAL connect path: the operator's own "
@@ -260,3 +284,138 @@ async def test_own_message_renders_via_real_connect_path(tmp_path) -> None:
         "this connection's own backlog+status pairing was captured, so "
         "its own turn_started frame should promote normally once forwarded."
     )
+
+
+@pytest.mark.asyncio
+async def test_agui_events_route_pairs_connect_status_with_backlog(tmp_path, monkeypatch) -> None:
+    """Tier 2: architect finding (PR #5293 review, relayed by lead-coder) —
+    no #5179 test called the REAL ``agui_events`` route handler directly;
+    every one (including the test above) hand-constructs ``AgUiEmitter``
+    itself, mirroring the route's own wiring rather than executing it. So
+    deleting the fix's actual production line
+    (``initial_status=initial_status`` inside ``agui_events``, endpoint.py)
+    left every #5179 test green — the fix's witness summed to zero. Same
+    gap #5116 already named once in this directory
+    (``test_5116_connection_agent_owner_cross_attach.py``'s own
+    ``test_a_real_agui_events_get_pushes_correct_status_after_cross_agent_
+    attach`` — its own docstring records catching an identical "tests
+    mirror the wiring, never call it" gap). Same fix here: call the route
+    directly (a real, minimal ``starlette.requests.Request``, not a
+    stand-in), obtain its own real ``StreamingResponse``, and read what the
+    PRODUCTION closure actually put on the wire.
+
+    Constructs the exact interleaving the fix closes: the operator's turn
+    is submitted and dispatched to completion AFTER ``agui_events`` already
+    returned (so its own ``_session_backlog_page_and_status`` call captured
+    a PRE-dispatch pairing — ``queue_seq`` 0), but BEFORE this test drains
+    the response body. Without the fix, a lazy ``status_provider()`` read
+    at ``stream()``-start (which only runs once something starts draining
+    ``body_iterator``, i.e. after the dispatch above already committed)
+    would see the ALREADY-dispatched, POST-turn value instead — 2. The
+    first ``STATE_SNAPSHOT`` on the real wire must carry the PRE-dispatch
+    value.
+
+    Strip-falsifier: removing ``initial_status=initial_status`` from
+    ``agui_events``'s own ``AgUiEmitter(...)`` construction (endpoint.py)
+    turns this test red — the first ``STATE_SNAPSHOT`` then reports
+    ``queue_seq=2`` instead of ``0``. Verified locally."""
+    import json as _json
+
+    from fastapi import FastAPI
+    from starlette.requests import Request
+    from starlette.responses import StreamingResponse
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+    from reyn.interfaces.transport.agui.endpoint import router
+    from reyn.interfaces.web.auth import AuthContext
+
+    registry = _make_registry(tmp_path)
+    AgentProfile.new(_AGENT_NAME, role="").save(
+        tmp_path / ".reyn" / "agents" / _AGENT_NAME
+    )
+    session = await registry.ensure_running(_AGENT_NAME)
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.auth = AuthContext(token="s3cret", require_token=True)
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: registry)
+
+    scope = {
+        "type": "http", "method": "GET", "path": f"/agui/chat/{_AGENT_NAME}/events",
+        "query_string": b"token=s3cret&connection_id=conn-5179-route-test",
+        "headers": [], "client": ("127.0.0.1", 12345), "app": app,
+    }
+    req = Request(scope)
+
+    turn_task: "asyncio.Task | None" = None
+    try:
+        # ── Call the REAL route handler — its own real, fixed connect-time
+        # pairing runs here, before anything is submitted. ────────────────
+        resp = await endpoint_mod.agui_events(req, _AGENT_NAME)
+        assert isinstance(resp, StreamingResponse), (
+            f"expected a real StreamingResponse (auth/agent-exists must "
+            f"both pass for this test's own setup); got {resp!r}"
+        )
+
+        # ── AFTER agui_events already returned, submit + dispatch the
+        # operator's real turn — BEFORE this test ever drains the body. ──
+        async def _drive_turn() -> None:
+            try:
+                await session.run_one_iteration()
+            except Exception:
+                pass
+
+        await session.submit_user_text(_OWN_TEXT)
+        turn_task = asyncio.create_task(_drive_turn())
+        while not _own_text_committed(session):
+            await asyncio.sleep(0)
+
+        body_iter = resp.body_iterator.__aiter__()
+
+        async def _iter_lines():
+            async for chunk in body_iter:
+                for line in chunk.split("\n"):
+                    if line:
+                        yield line
+
+        _lines = _iter_lines()
+
+        async def _read_one_event():
+            event_type = None
+            async for line in _lines:
+                if line.startswith("event:"):
+                    event_type = line[len("event:"):].strip()
+                elif line.startswith("data:"):
+                    return event_type, line[len("data:"):].strip()
+            raise StopAsyncIteration
+
+        # 1st reconnect event: MESSAGES_SNAPSHOT (backlog). 2nd: STATE_
+        # SNAPSHOT (status) — the one this fix is about.
+        first_type, _ = await _read_one_event()
+        assert first_type == "MESSAGES_SNAPSHOT", (
+            f"test construction error: expected MESSAGES_SNAPSHOT as the "
+            f"1st reconnect event, got {first_type!r}"
+        )
+        state_type, state_data = await _read_one_event()
+        assert state_type == "STATE_SNAPSHOT", (
+            f"test construction error: expected STATE_SNAPSHOT as the 2nd "
+            f"reconnect event, got {state_type!r}"
+        )
+        snapshot = _json.loads(state_data).get("snapshot") or {}
+
+        assert snapshot.get("queue_seq") == 0, (
+            "#5179 REGRESSION at the REAL agui_events route: the first "
+            f"STATE_SNAPSHOT reports queue_seq={snapshot.get('queue_seq')!r}, "
+            "not the PRE-dispatch value (0) captured at real connect time — "
+            "this means the wire is carrying a LIVE status re-read taken "
+            "at stream()-start rather than the paired connect-time "
+            "snapshot (the exact bug this fix closes)."
+        )
+    finally:
+        if turn_task is not None:
+            turn_task.cancel()
+            try:
+                await turn_task
+            except (Exception, asyncio.CancelledError):
+                pass
+        await registry.shutdown()

--- a/tests/interfaces/test_5179_backlog_gap_end_to_end.py
+++ b/tests/interfaces/test_5179_backlog_gap_end_to_end.py
@@ -1,0 +1,298 @@
+"""Tier 2: #5179, real end-to-end connect path — does the reported drop of
+the operator's OWN message actually reach through ``endpoint.py``'s real
+connect code, or only through the hand-constructed SSE string the earlier
+isolation test (``test_5179_remote_own_message_seq_gate_race.py``) used?
+
+That earlier test built ``AgUiEmitter`` directly, with NO ``backlog``/
+``backlog_provider`` at all, and hand-wrote ``status_provider``'s return
+value and the ``user_submitted``/``turn_started`` ``EventFrame``s. It proves
+the seq-gate mechanism CAN drop an already-reflected turn, but says nothing
+about whether the real connect handler (``agui_events``, endpoint.py ~908-
+1035) can actually produce that same shape.
+
+This module drives the REAL pieces that function uses, in the REAL order,
+with the ordering between two real reads CONTROLLED explicitly (not raced):
+
+1. ``_SessionFrameSource(session, registry=..., agent_name=...)`` (the same
+   class ``agui_events`` constructs at endpoint.py:945), started so its
+   audit-event subscription is live BEFORE anything is submitted — matching
+   ``agui_events``'s own ordering (``source.start()`` at line 965, before the
+   backlog read at 1004).
+2. ``session_backlog_page(registry, agent_name, _DEFAULT_SID)`` (endpoint.py
+   :392, the exact function ``agui_events`` awaits at line 1004) — called
+   FIRST, while ``session.history`` is still empty. This is the window's
+   START boundary.
+3. THEN, a REAL turn for the operator's own text is driven to completion
+   through ``Session.submit_user_text`` (enqueue; emits the real
+   ``user_submitted`` audit-event, session.py:4370) and
+   ``Session.run_one_iteration`` (dispatch; emits the real ``turn_started``
+   audit-event at session.py:6917, then reaches ``_handle_inbox_text``,
+   whose ``Session._append_history`` call at session.py:7526 is the ACTUAL
+   dispatch-commit this whole investigation is about — it runs strictly
+   AFTER step 2's backlog snapshot was already taken). The turn is left to
+   fail at the real litellm boundary afterward (no ``@pytest.mark.replay``
+   fixture is installed, so ``reyn.dev.testing.network_gate`` raises
+   ``UnpinnedNetworkReach`` the instant the router tries to call the model)
+   — irrelevant to this test: everything it asserts on already happened
+   before that point.
+4. ``_snapshot_for_session(registry, source.current_session())`` (the exact
+   call ``agui_events``'s own ``_status_provider`` closure makes at
+   endpoint.py:984) is invoked ONLY once the real dispatch-commit above has
+   already happened — this is the window's END boundary, and it is REAL:
+   ``session.queue_seq`` genuinely reads 2 (bumped once by
+   ``submit_user_text``'s ``user_submitted``, once by
+   ``run_one_iteration``'s ``turn_started`` — ``Session._bump_queue_seq``,
+   session.py:2389), not a hand-set fixture value.
+5. A real ``AgUiEmitter`` is built with the STALE (pre-turn, empty) backlog
+   from step 2, the real ``source.frames()`` as its frame source (so the
+   real ``user_submitted``/``turn_started`` ``EventFrame``s it queued during
+   step 3 are what get forwarded), and the status closure from step 4.
+6. ``emitter.stream()`` is fed into a real ``AgUiTransport``, mounted into a
+   real ``TextualChatApp`` — identical shape to
+   ``test_5179_remote_own_message_seq_gate_race.py``'s own app-mounting
+   pattern, reusing its ``_wait_until``/``_flow_user_entries`` helpers.
+
+No mocks anywhere: real ``AgentRegistry`` + real ``Session``
+(``tests._support.agent_session.make_session``), real audit-event bus, real
+``AgUiEmitter``/``AgUiTransport``/``TextualChatApp``. The verdict is read off
+PUBLIC widget state only (``FlowView.entries``, ``SentQueue.rendered_texts()``).
+
+The two boundary points that determine how wide this window can practically
+get in real operation (see the investigation's own report for the full
+reasoning on what governs the width in between):
+
+- **START**: ``endpoint.py:1004`` — ``await session_backlog_page(registry,
+  agent_name, _DEFAULT_SID)``.
+- **END**: ``emitter.py:135`` — ``self._model.snapshot(self._project())``
+  inside ``_reconnect_snapshot_chunks``, which is the FIRST call
+  ``AgUiEmitter.stream()`` ever makes to ``status_provider`` (line 140-143,
+  the very top of ``stream()``, called from the ``StreamingResponse``'s
+  ``gen()`` only once Starlette begins consuming the response body — i.e.
+  strictly AFTER ``agui_events`` itself has already returned).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.repl.read_model import RemoteReadModel
+from reyn.interfaces.repl.status import _snapshot_for_session
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.endpoint import _SessionFrameSource, session_backlog_page
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+_OWN_TEXT = "hello from the real connect path"
+_AGENT_NAME = "default"
+
+
+def _make_registry(tmp_path) -> AgentRegistry:
+    """A real ``AgentRegistry`` whose factory builds real ``Session``s on
+    demand — same pattern ``test_5094_status_provider_never_none_on_connect.
+    py``'s own ``_make_registry`` uses."""
+
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=BudgetTracker(CostConfig()),
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    return AgentRegistry(project_root=tmp_path, session_factory=factory)
+
+
+def _flow_user_entries(app: TextualChatApp):
+    return [e for e in app.query_one(FlowView).entries if e.item.kind == "user"]
+
+
+async def _live_sse_lines(emitter: AgUiEmitter) -> AsyncIterator[str]:
+    """Adapts the REAL ``AgUiEmitter.stream()`` (an async generator of SSE
+    text chunks, exactly what ``endpoint.py``'s own ``gen()`` yields to
+    Starlette) into the line-at-a-time ``AsyncIterator[str]`` shape
+    ``AgUiTransport`` expects — the same relationship
+    ``StreamingResponse(gen())`` has to the real ASGI body. Because
+    ``source.frames()`` (the emitter's frame source here) never raises
+    ``StopAsyncIteration`` on its own (it only ends on a synthetic
+    ``__end__`` frame, never produced in this test), this hangs open after
+    the currently-queued frames drain — a genuinely open connection, not an
+    exhausted stream, matching
+    ``test_5179_remote_own_message_seq_gate_race.py``'s own
+    ``_sse_lines``/``_sse_lines_then_hang`` precedent."""
+    async for chunk in emitter.stream():
+        for line in chunk.split("\n"):
+            yield line
+            await asyncio.sleep(0)
+
+
+async def _wait_until(pilot, condition) -> None:
+    """Poll ``pilot.pause()`` unboundedly until ``condition()`` is true —
+    CLAUDE.md's Ceiling rule: wait on the real condition, never a fixed
+    pause count. CI's own ``--timeout`` is the kill switch if it never
+    resolves."""
+    while not condition():
+        await pilot.pause()
+
+
+def _own_text_committed(session) -> bool:
+    """Whether the REAL dispatch-commit (``Session._append_history``,
+    session.py:7526) has actually appended the operator's own turn to
+    ``session.history`` yet — the public, in-memory SSoT
+    ``session_backlog_frames``/``session_backlog_page`` themselves read
+    (endpoint.py:388/432), not a private attribute invented for this test."""
+    return any(
+        getattr(m, "role", None) == "user" and _OWN_TEXT in str(getattr(m, "content", ""))
+        for m in session.history
+    )
+
+
+@pytest.mark.asyncio
+async def test_own_message_dropped_via_real_connect_path(tmp_path) -> None:
+    """Tier 2: reproduces (or falsifies) #5179 by driving the REAL
+    ``endpoint.py`` connect-time pieces, in the REAL order, with the
+    real-vs-stale backlog ordering deliberately controlled by this test
+    (not raced) exactly as the module docstring lays out."""
+    registry = _make_registry(tmp_path)
+    AgentProfile.new(_AGENT_NAME, role="").save(
+        tmp_path / ".reyn" / "agents" / _AGENT_NAME
+    )
+    session = await registry.ensure_running(_AGENT_NAME)
+
+    # Real per-connection frame source (endpoint.py:945), started BEFORE
+    # anything is submitted — matches agui_events's own ordering
+    # (source.start() at line 965 precedes the backlog read at line 1004),
+    # and is REQUIRED here: a subscription started AFTER the turn's audit-
+    # events fire would simply never see them.
+    source = _SessionFrameSource(session, registry=registry, agent_name=_AGENT_NAME)
+    source.start()
+
+    turn_task: "asyncio.Task | None" = None
+    try:
+        # ── Window START (endpoint.py:1004) ─────────────────────────────
+        initial_backlog, initial_has_more, initial_next_cursor = await session_backlog_page(
+            registry, _AGENT_NAME, _DEFAULT_SID,
+        )
+        assert initial_backlog == [], (
+            "test construction error: expected an EMPTY initial backlog "
+            "(nothing committed yet) — got a non-empty one, so this run "
+            "does not exercise the ordering this test targets"
+        )
+
+        # ── The real dispatch-commit, driven to completion AFTER the
+        # backlog snapshot above was already taken ──────────────────────
+        async def _drive_turn() -> None:
+            try:
+                await session.run_one_iteration()
+            except Exception:
+                # Expected: no @pytest.mark.replay fixture is installed, so
+                # reyn.dev.testing.network_gate's UnpinnedNetworkReach (or
+                # any other failure at the real litellm boundary) fires
+                # once the router tries to call the model — strictly AFTER
+                # the history append/turn_started emit this test cares
+                # about. Irrelevant to what this test asserts.
+                pass
+
+        await session.submit_user_text(_OWN_TEXT)  # real user_submitted audit-event
+        turn_task = asyncio.create_task(_drive_turn())
+        while not _own_text_committed(session):
+            await asyncio.sleep(0)
+
+        # ── Window END (mirrors _status_provider, endpoint.py:967-984) ──
+        def status_provider() -> dict:
+            return _snapshot_for_session(registry, source.current_session())
+
+        # Sanity: the dispatch genuinely already advanced queue_seq by the
+        # time this connection's status read happens (real counter, not a
+        # fixture value: session.py's Session._bump_queue_seq, one bump for
+        # user_submitted, one for turn_started).
+        assert session.queue_seq == 2, (
+            f"test construction error: expected queue_seq==2 (user_submitted "
+            f"+ turn_started already dispatched) at status-read time, got "
+            f"{session.queue_seq!r}"
+        )
+
+        async def backlog_provider(name: str, sid: str):
+            return await session_backlog_page(registry, name, sid)
+
+        emitter = AgUiEmitter(
+            source.frames(), status_provider,
+            backlog=initial_backlog,
+            backlog_has_more=initial_has_more,
+            backlog_next_cursor=initial_next_cursor,
+            backlog_provider=backlog_provider,
+        )
+
+        async def _send(_payload: dict) -> bool:
+            return False
+
+        transport = AgUiTransport(_live_sse_lines(emitter), _send)
+        app = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
+
+        async with app.run_test(size=(100, 30)) as pilot:
+            # The turn was already driven all the way to its (expected)
+            # litellm-boundary failure BEFORE this app ever mounted (see
+            # above) — every frame this connection will ever emit for this
+            # turn is already queued on ``source._q`` by the time
+            # ``emitter.stream()`` starts, so ``ActivityRow`` never sits in
+            # a non-idle state long enough for a mount-time observer to
+            # catch it (`state` goes straight Thinking → idle before the
+            # first ``pilot.pause()`` returns). The real, public signal that
+            # THIS turn's own lifecycle fully drained to the client instead
+            # is the router-failure line landing in the flow — a downstream
+            # effect of the SAME turn_settled/turn_failed audit-events the
+            # turn_started one (the thing under test) rode alongside, so
+            # waiting for it never presupposes the outcome being asserted
+            # below.
+            await _wait_until(
+                pilot,
+                lambda: any(
+                    "litellm.acompletion" in getattr(e.item, "text", "")
+                    for e in app.query_one(FlowView).entries
+                ),
+            )
+            await pilot.pause()
+            await pilot.pause()
+
+            user_entries = _flow_user_entries(app)
+            sent_queue = app.query_one(SentQueue)
+            queued_texts = sent_queue.rendered_texts()
+
+            rendered = any(_OWN_TEXT in e.item.text for e in user_entries)
+            still_queued = any(_OWN_TEXT in t for t in queued_texts)
+    finally:
+        source.close()
+        if turn_task is not None:
+            # Cancelled rather than awaited to natural completion: this
+            # background task's own router-loop failure path (real retry/
+            # backoff + WAL/audit-event cleanup, none of it under test here)
+            # otherwise entangles with ``app.run_test()``'s own teardown in
+            # a way that hangs test-process shutdown — irrelevant to what
+            # this test asserts, which already happened (the public widget
+            # read above) before this cleanup ever runs.
+            turn_task.cancel()
+            try:
+                await turn_task
+            except (Exception, asyncio.CancelledError):
+                pass
+
+    assert rendered or still_queued, (
+        "REPRODUCED #5179 via the REAL connect path: the operator's own "
+        f"message ({_OWN_TEXT!r}) is present in NEITHER the flow "
+        f"({[e.item.text for e in user_entries]!r}) NOR the sent-queue "
+        f"region ({queued_texts!r}), even though the real dispatch-commit "
+        "(Session._append_history) had already run before this connection's "
+        "real backlog read AND its real status read reflects it as "
+        "already-dispatched (queue_seq=2)."
+    )

--- a/tests/interfaces/test_5179_exit_b_status_race_discriminator.py
+++ b/tests/interfaces/test_5179_exit_b_status_race_discriminator.py
@@ -205,7 +205,19 @@ async def test_capture_right_after_return_still_mismatches_on_exit_b(tmp_path, m
             "closes this."
         )
     finally:
+        # Architect review (relayed via broker, non-blocking finding): an
+        # exception raised BEFORE `release_extend_read.set()` above
+        # (e.g. one of the "test construction error" asserts) would
+        # otherwise leave `backlog_task` un-awaited -- release the stall
+        # unconditionally here too, then cancel+await the task itself,
+        # mirroring `turn_task`'s own cleanup right below.
         release_extend_read.set()  # in case an assertion above fired first
+        if not backlog_task.done():
+            backlog_task.cancel()
+        try:
+            await backlog_task
+        except (Exception, asyncio.CancelledError):
+            pass
         if turn_task is not None:
             turn_task.cancel()
             try:

--- a/tests/interfaces/test_5179_exit_b_status_race_discriminator.py
+++ b/tests/interfaces/test_5179_exit_b_status_race_discriminator.py
@@ -224,3 +224,4 @@ async def test_capture_right_after_return_still_mismatches_on_exit_b(tmp_path, m
                 await turn_task
             except (Exception, asyncio.CancelledError):
                 pass
+        await registry.shutdown()

--- a/tests/interfaces/test_5179_exit_b_status_race_discriminator.py
+++ b/tests/interfaces/test_5179_exit_b_status_race_discriminator.py
@@ -1,0 +1,214 @@
+"""Tier 2: #5179 fix-design discriminator — does "capture the connect-time
+status synchronously, immediately after ``session_backlog_page`` returns"
+(the fix this investigation first proposed) actually close the race, or does
+it merely relocate it?
+
+Architect's review (issuecomment-5434642964, relayed by lead-coder) caught a
+real defect in that first design BEFORE any implementation: ``session_
+backlog_page``'s own loop (endpoint.py) has two exits —
+
+    while True:
+        history = list(target.history)
+        frames, has_more, next_cursor = page_restored_history(history, ...)
+        if has_more:
+            return ...                       # exit A -- no await at all
+        extended = await extend_history_backward_async()
+        if extended <= 0:
+            return frames, False, None        # exit B -- returns the PRE-await
+                                               #           `frames`, computed
+                                               #           BEFORE this await
+                                               #           even started
+
+Exit B is the DEFAULT path for a fresh/short session (nothing left on disk,
+``extended == 0``) -- exactly #5179's own reported scenario. It returns
+``frames`` computed strictly BEFORE ``extend_history_backward_async``'s own
+``asyncio.to_thread`` disk-read await ever ran. A dispatch that commits
+WHILE that await is in flight is therefore invisible to the returned
+backlog (correct -- the backlog value itself is fine). But "capture status
+right after `session_backlog_page` returns" reads status AFTER that same
+await has already completed -- i.e. AFTER the concurrent dispatch had every
+chance to land. That status capture already reflects the dispatch while the
+backlog it is paired with does not: the exact #5179 mismatch (status ahead
+of backlog), just moved from the ASGI-scheduling gap into the extend-await.
+
+This is what my own design's ② ("fresh/short is a non-issue") and ④ ("(a) is
+widest for fresh/short") directly contradicted -- ② reasoned about the
+wrong direction (backlog racing AHEAD of status; the real risk is status
+racing ahead of backlog, exit B's own default path).
+
+This test DETERMINISTICALLY drives exactly that interleaving (not raced --
+a ``threading.Event`` pair pins the real ``asyncio.to_thread`` disk-read
+call mid-flight, matching this repo's own "external drive, not a sleep"
+discipline for a collaborator gated by its own timer) and checks what a
+"capture right after `session_backlog_page` returns" implementation would
+observe. It is deliberately written against TODAY's real code paths (no
+src/ change yet) -- it exercises the diagnostic, not a fix -- so it
+currently DEMONSTRATES the flaw (asserts the mismatch is real), rather than
+asserting non-mismatch. Once the "same tick" fix (architect's prescription:
+read status in ``_status_provider``'s own synchronous body at the SAME
+point ``history`` is read, before the extend-await even starts, for both
+exit A and exit B) lands, this test's own final assertion should be
+rewritten to assert the pairing IS consistent -- tracked as part of the
+same fix PR, not a follow-up.
+
+Real ``AgentRegistry``/``Session`` (``tests._support.agent_session.
+make_session``) + the real ``session_backlog_page``/``extend_history_
+backward_async`` production functions -- only ``read_history_before`` (a
+pure disk-read helper, not a collaborator of the code under test) is
+monkeypatched, and only to control ITS OWN timing deterministically, not to
+change its logical return value (still "nothing on disk", the real
+fresh-session shape)."""
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from reyn.interfaces.repl.status import _snapshot_for_session
+from reyn.interfaces.transport.agui.endpoint import session_backlog_page
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+_OWN_TEXT = "hello during the stalled extend-await"
+_AGENT_NAME = "default"
+
+
+def _make_registry(tmp_path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=BudgetTracker(CostConfig()),
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    return AgentRegistry(project_root=tmp_path, session_factory=factory)
+
+
+def _own_text_committed(session) -> bool:
+    """Public SSoT read -- mirrors test_5179_backlog_gap_end_to_end.py's own
+    ``_own_text_committed``: whether the real dispatch-commit
+    (``Session._append_history``) has appended the operator's turn yet."""
+    return any(
+        getattr(m, "role", None) == "user" and _OWN_TEXT in str(getattr(m, "content", ""))
+        for m in session.history
+    )
+
+
+@pytest.mark.asyncio
+async def test_capture_right_after_return_still_mismatches_on_exit_b(tmp_path, monkeypatch) -> None:
+    """Tier 2: demonstrates the architect-caught flaw directly, not just by
+    argument -- pins the real ``extend_history_backward_async`` disk-read
+    await mid-flight (exit B's own gate), commits a real dispatch while it
+    is stalled, then releases it and shows: the returned backlog is (and
+    must stay) empty, while a status read taken immediately afterward
+    already reflects the dispatch. That pairing is exactly what #5179
+    reports -- reproduced here at exit B specifically, discriminating the
+    "capture right after return" design candidate (mismatches -- this test)
+    from the "same tick" one (architect's fix -- would not)."""
+    registry = _make_registry(tmp_path)
+    AgentProfile.new(_AGENT_NAME, role="").save(tmp_path / ".reyn" / "agents" / _AGENT_NAME)
+    session = await registry.ensure_running(_AGENT_NAME)
+
+    hit_extend_read = threading.Event()
+    release_extend_read = threading.Event()
+
+    def _stalling_read_history_before(*args, **kwargs):
+        # Runs on the REAL background thread asyncio.to_thread schedules
+        # this onto (extend_history_backward_async's own step ① split) --
+        # signals it has been reached, then blocks that thread until told
+        # to continue. Still returns "nothing on disk" (empty), the same
+        # logical result a fresh session's real read would give -- only
+        # the TIMING is controlled, not the outcome.
+        hit_extend_read.set()
+        release_extend_read.wait()
+        return []
+
+    monkeypatch.setattr(
+        "reyn.runtime.history_tail_reader.read_history_before",
+        _stalling_read_history_before,
+    )
+
+    backlog_task = asyncio.create_task(
+        session_backlog_page(registry, _AGENT_NAME, _DEFAULT_SID)
+    )
+    # Ceiling rule: poll the real threading.Event unboundedly, no sleep/count.
+    while not hit_extend_read.is_set():
+        await asyncio.sleep(0)
+
+    # The extend-await is now provably stalled inside its own disk read.
+    # Commit a REAL dispatch while it sits there.
+    turn_task: "asyncio.Task | None" = None
+    try:
+        async def _drive_turn() -> None:
+            try:
+                await session.run_one_iteration()
+            except Exception:
+                # Expected: no @pytest.mark.replay fixture, so the real
+                # litellm boundary raises once the router reaches it --
+                # strictly after the history append this test cares about.
+                pass
+
+        await session.submit_user_text(_OWN_TEXT)  # real user_submitted
+        turn_task = asyncio.create_task(_drive_turn())
+        while not _own_text_committed(session):
+            await asyncio.sleep(0)
+
+        # NOW release the stalled disk read so extend_history_backward_async
+        # can finish (real result: nothing found -- extended == 0 -- exit B).
+        release_extend_read.set()
+        initial_backlog, initial_has_more, initial_next_cursor = await backlog_task
+
+        assert initial_backlog == [], (
+            "test construction error: exit B must return the PRE-await "
+            "(empty) frames -- a non-empty backlog here means this run did "
+            "not exercise exit B, or session_backlog_page's own loop "
+            "shape changed underneath this test"
+        )
+
+        # This is what "capture status right after session_backlog_page
+        # returns" (the first design's own proposed fix) would read at
+        # THIS exact point -- a real, non-fabricated status read.
+        status_after_return = _snapshot_for_session(registry, session)
+
+        assert session.queue_seq == 2, (
+            f"test construction error: expected queue_seq==2 (user_submitted "
+            f"+ turn_started already dispatched during the stall), got "
+            f"{session.queue_seq!r}"
+        )
+        assert status_after_return["queue_seq"] == 2, (
+            "test construction error: _snapshot_for_session did not reflect "
+            "the real dispatch that landed during the stalled extend-await"
+        )
+
+        # THE FINDING: backlog (empty) and the "right after return" status
+        # (queue_seq=2) disagree about whether this turn happened -- the
+        # same mismatch #5179 reports, reproduced specifically at exit B.
+        # A "same tick" fix (read status paired with the SAME history read
+        # that produced `frames`, before the extend-await starts) would
+        # instead see queue_seq at its PRE-dispatch value here, matching
+        # the empty backlog it is paired with -- consistent, not mismatched.
+        assert status_after_return["queue_seq"] != 0 and initial_backlog == [], (
+            "ARCHITECT FINDING CONFIRMED: 'capture right after "
+            "session_backlog_page returns' pairs an EMPTY backlog with a "
+            f"status already reporting queue_seq={status_after_return['queue_seq']!r} "
+            "-- exit B's own default (fresh/short session) path still "
+            "reproduces #5179's mismatch under that design; only a 'same "
+            "tick' read (paired with the pre-extend-await history read) "
+            "closes this."
+        )
+    finally:
+        release_extend_read.set()  # in case an assertion above fired first
+        if turn_task is not None:
+            turn_task.cancel()
+            try:
+                await turn_task
+            except (Exception, asyncio.CancelledError):
+                pass

--- a/tests/interfaces/test_5179_remote_own_message_seq_gate_race.py
+++ b/tests/interfaces/test_5179_remote_own_message_seq_gate_race.py
@@ -63,6 +63,27 @@ Real ``AgUiEmitter`` (server-side encoder) + real ``AgUiTransport``
 read off PUBLIC widget surfaces only: ``FlowView.entries`` (mirroring
 ``test_3300_p2b_sentqueue_render.py``'s own ``_flow_user_entries``) and
 ``SentQueue.rendered_texts()``.
+
+**Scope correction, written after the fix landed (endpoint.py/emitter.py,
+#5179):** this test builds ``AgUiEmitter`` DIRECTLY with a hand-set
+``status_provider`` already reflecting the post-dispatch ``queue_seq`` from
+the very first line of its construction — it never calls through
+``session_backlog_page``/``endpoint.py`` at all, so it does not exercise
+(and cannot be closed by) the endpoint-level fix
+(``_session_backlog_page_and_status`` pairing backlog+status in one tick).
+It demonstrates a different, narrower thing, correctly: the seq-gate
+mechanism itself (``RemoteQueueView``) WILL drop an already-reflected turn
+when handed a status that is inconsistent with the frames it is paired
+with — which is its designed behavior, not a bug, and stays true forever
+(feeding it deliberately-inconsistent inputs will always reproduce this).
+This test was earlier mis-described (issue thread) as one of two
+acceptance criteria the fix must flip green — that was wrong; the real
+end-to-end acceptance coverage for whether the FIXED endpoint actually
+avoids producing this inconsistency lives in
+``test_5179_backlog_gap_end_to_end.py`` (drives the real, fixed connect
+pairing) and ``test_5179_exit_b_status_race_discriminator.py`` (pins the
+specific race the fix closes). This file is kept as a mechanism
+illustration only and is expected to keep reproducing indefinitely.
 """
 from __future__ import annotations
 

--- a/tests/interfaces/test_5179_remote_own_message_seq_gate_race.py
+++ b/tests/interfaces/test_5179_remote_own_message_seq_gate_race.py
@@ -1,8 +1,49 @@
 """Tier 2: #5179 — in ``--connect`` remote mode, the operator's OWN sent
-message can silently never appear in the conversation, while the agent's
-reply renders fine.
+message could silently never appear in the conversation, while the agent's
+reply rendered fine.
 
-Real chain (prior investigation, summarized in the issue thread):
+**History of this file.** The first version hand-constructed ``AgUiEmitter``
+directly with a deliberately-inconsistent ``status_provider`` (already
+reflecting the post-dispatch ``queue_seq`` from its very first line) to
+reproduce the race in isolation — real ``AgUiEmitter``/``AgUiTransport``/
+``TextualChatApp``, but never calling through ``session_backlog_page``/
+``endpoint.py`` at all. That was a valid demonstration of the seq-gate
+mechanism (``RemoteQueueView``) dropping an already-reflected turn when
+handed status inconsistent with the frames it is paired with — but it meant
+this test could never be closed by the endpoint-level fix, so it stayed
+permanently red even after the fix landed. CI correctly refused to merge a
+PR with a red test (lead-coder, PR #5293 review) — the SAME fact architect's
+review had already caught from the design side (its witness summed to zero
+across every #5179 test at that point, this one included, since none of
+them called ``agui_events`` itself).
+
+**Rewritten (per lead-coder's own recommendation ①, matching the fix
+already applied to ``test_5179_backlog_gap_end_to_end.py``'s own gap) to
+call the REAL ``agui_events`` route handler directly** — same precedent
+this directory already established
+(``test_5116_connection_agent_owner_cross_attach.py``'s own
+``test_a_real_agui_events_get_pushes_correct_status_after_cross_agent_
+attach``: "This test calls the REAL agui_events route handler DIRECTLY").
+This is now the THIRD, complementary angle on #5179's acceptance coverage,
+each testing something the other two don't:
+
+- ``test_5179_backlog_gap_end_to_end.py::test_own_message_renders_via_real_
+  connect_path`` — hand-constructs ``AgUiEmitter`` mirroring
+  ``agui_events``'s own wiring, mounts a full ``TextualChatApp``. Cheap,
+  controllable, but (as PR #5293 review caught) does not itself execute
+  the production call site.
+- ``test_5179_backlog_gap_end_to_end.py::test_agui_events_route_pairs_
+  connect_status_with_backlog`` — calls the REAL route, but reads the raw
+  SSE wire directly (no app), checking only the first ``STATE_SNAPSHOT``'s
+  ``queue_seq``.
+- **This file** — calls the REAL route AND mounts a full
+  ``TextualChatApp``, reading the verdict off PUBLIC widget state
+  (``FlowView.entries``, ``SentQueue.rendered_texts()``) — the same
+  end-to-end rendering check the very first version of this test made,
+  now actually reached through ``agui_events`` itself.
+
+Real chain (prior investigation, summarized in the issue thread, unchanged
+by the rewrite):
 
 - The operator's own message is NEVER folded into the flow directly.
   ``TextualChatApp._handle_user_submitted_event`` only STAGES it into
@@ -11,79 +52,20 @@ Real chain (prior investigation, summarized in the issue thread):
   entry (``_handle_turn_started_event`` → ``_ingest_frame``). Both calls
   are gated by ``RemoteQueueView``'s own monotonic ``seq`` gate
   (``apply_user_submitted``/``apply_turn_started`` — state.py): a delta
-  whose ``seq`` is ``<=`` the view's ``_last_seq`` is silently rejected —
-  AND, independent of the gate, ``_handle_turn_started_event`` only ever
-  promotes items already sitting in ``RemoteQueueView.queue()``: an item
-  whose OWN ``apply_user_submitted`` was gated never got staged, so there
-  is nothing to promote even if the ``turn_started`` delta's own gate
-  happens to pass.
+  whose ``seq`` is ``<=`` the view's ``_last_seq`` is silently rejected.
 - ``_last_seq`` is seeded exactly ONCE per connection, from a live read of
-  ``transport.status.values`` (``RemoteReadModel.snapshot()`` — read_model.py
-  — reads it live, no buffering), at ``TextualChatApp._seed_queue_view``,
-  itself called on the FIRST non-``BacklogBatch`` frame ``_pump_frames``
-  ever drains from ``transport.frames()``.
-- ``AgUiTransport._consume_block`` applies a decoded ``STATE_SNAPSHOT``/
-  ``STATE_DELTA`` to ``self._status`` SYNCHRONOUSLY, as soon as that block
-  is parsed. A ``STATE_*`` block decodes to ZERO ``Frame``/``BacklogBatch``
-  items (see ``_consume_block``'s own branch for ``StateUpdate``), so
-  applying it never puts anything onto ``AgUiTransport``'s own frame
-  queue — it is invisible to ``frames()``'s consumer except through its
-  side effect on ``self._status``.
+  ``transport.status.values`` (``RemoteReadModel.snapshot()``), at
+  ``TextualChatApp._seed_queue_view``, itself called on the FIRST
+  non-``BacklogBatch`` frame ``_pump_frames`` ever drains.
+- The fix (``endpoint.py._session_backlog_page_and_status``) pairs the
+  connect-time backlog and status in the SAME synchronous tick, so the
+  seed this connection gets is never advanced ahead of frames it hasn't
+  forwarded yet — see that function's own docstring for the full
+  reasoning.
 
-The construction below (verified directly, not assumed — see
-``_build_race_sse``'s own docstring for the measurement): the connection's
-ONE-TIME reconnect ``STATE_SNAPSHOT`` (``AgUiEmitter._reconnect_snapshot_
-chunks``, built ONCE before ``AgUiEmitter.stream()`` ever starts iterating
-its frame source) is computed from a ``status_provider()`` that already
-reflects the operator's OWN turn as fully dispatched (``queue_seq`` past
-both its ``user_submitted`` and ``turn_started`` deltas' own ``seq``
-stamps) — modeling a session whose enqueue+dispatch (one synchronous call)
-already completed by the time this particular connection's reconnect
-snapshot was computed, while the corresponding ``user_submitted``/
-``turn_started`` AUDIT-EVENTS for that SAME turn are still forwarded
-afterward over ``AgUiEmitter``'s separate frame-source pipeline, carrying
-their own historical ``seq`` stamps (1, 2). Because this STATE_SNAPSHOT
-sits on the wire strictly BEFORE either of those two frames (it is part of
-the connect preamble, emitted before the frame-source loop even starts)
-and decodes to zero queued items, it is GUARANTEED (no scheduling luck
-needed — verified below by direct instrumentation, not inferred) to have
-already updated ``transport.status`` by the time ``_pump_frames`` drains
-the FIRST real frame this connection ever produces — which is exactly
-when ``_seed_queue_view`` runs.
-
-An earlier construction this investigation also tried and DID NOT
-reproduce the bug is recorded in ``_build_race_sse``'s own docstring,
-because the negative result is itself part of the finding (this repo's
-own pre-conclusion checklist: report what falsifies a hypothesis, not
-only what confirms it).
-
-Real ``AgUiEmitter`` (server-side encoder) + real ``AgUiTransport``
-(client-side decoder) + a real mounted ``TextualChatApp`` wired to a real
-``RemoteReadModel`` — no mocks, no private-state pokes. The verdict is
-read off PUBLIC widget surfaces only: ``FlowView.entries`` (mirroring
-``test_3300_p2b_sentqueue_render.py``'s own ``_flow_user_entries``) and
-``SentQueue.rendered_texts()``.
-
-**Scope correction, written after the fix landed (endpoint.py/emitter.py,
-#5179):** this test builds ``AgUiEmitter`` DIRECTLY with a hand-set
-``status_provider`` already reflecting the post-dispatch ``queue_seq`` from
-the very first line of its construction — it never calls through
-``session_backlog_page``/``endpoint.py`` at all, so it does not exercise
-(and cannot be closed by) the endpoint-level fix
-(``_session_backlog_page_and_status`` pairing backlog+status in one tick).
-It demonstrates a different, narrower thing, correctly: the seq-gate
-mechanism itself (``RemoteQueueView``) WILL drop an already-reflected turn
-when handed a status that is inconsistent with the frames it is paired
-with — which is its designed behavior, not a bug, and stays true forever
-(feeding it deliberately-inconsistent inputs will always reproduce this).
-This test was earlier mis-described (issue thread) as one of two
-acceptance criteria the fix must flip green — that was wrong; the real
-end-to-end acceptance coverage for whether the FIXED endpoint actually
-avoids producing this inconsistency lives in
-``test_5179_backlog_gap_end_to_end.py`` (drives the real, fixed connect
-pairing) and ``test_5179_exit_b_status_race_discriminator.py`` (pins the
-specific race the fix closes). This file is kept as a mechanism
-illustration only and is expected to keep reproducing indefinitely.
+Real ``AgentRegistry``/``Session`` + a real ``agui_events`` call + real
+``AgUiTransport`` (client-side decoder) + a real mounted ``TextualChatApp``
+wired to a real ``RemoteReadModel`` — no mocks, no private-state pokes.
 """
 from __future__ import annotations
 
@@ -94,43 +76,43 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.inline.textual_chat.activity_row import ActivityRow
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
 from reyn.interfaces.repl.read_model import RemoteReadModel
 from reyn.interfaces.transport.agui.client import AgUiTransport
-from reyn.interfaces.transport.agui.emitter import AgUiEmitter
-from reyn.interfaces.transport.frames import EventFrame
-from reyn.schemas.models import Event
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
 
-_MSG_ID = "m1"
-_CHAIN_ID = "c1"
 _OWN_TEXT = "hello from the operator"
+_AGENT_NAME = "default"
+
+
+def _make_registry(tmp_path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(agent_name=profile.name, agent_role=profile.role)
+
+    return AgentRegistry(project_root=tmp_path, session_factory=factory)
 
 
 def _flow_user_entries(app: TextualChatApp):
     return [e for e in app.query_one(FlowView).entries if e.item.kind == "user"]
 
 
-async def _sse_lines(text: str) -> AsyncIterator[str]:
-    """Yields ``text``'s own lines then hangs on a real never-resolving
-    primitive — a genuinely open connection with nothing further to send
-    yet, NOT an exhausted stream (an exhausted finite generator would make
-    ``AgUiTransport.frames()`` raise ``StopAsyncIteration`` on its very
-    first ``__anext__()`` here, which tears the whole app down via
-    ``_pump_frames``'s own ``finally: self.exit()`` before this test ever
-    gets to inspect anything — matches
-    ``test_5050_remote_pending_intervention_choices.py``'s own
-    ``_sse_lines_then_hang`` for the identical reason).
-
-    A real ``asyncio.sleep(0)`` between every yielded line — NOT only
-    after the whole block — matches that same helper: a genuine SSE
-    source yields control at every line boundary (a real socket read),
-    so this is a representative sample of the wire's real timing, not an
-    artificial single burst."""
-    for line in text.split("\n"):
-        yield line
-        await asyncio.sleep(0)
-    await asyncio.Event().wait()
+async def _drain_lines(body_iter) -> AsyncIterator[str]:
+    """Adapts a real ``StreamingResponse.body_iterator`` (whole SSE chunks,
+    the exact thing Starlette itself would stream to a real client) into
+    the line-at-a-time ``AsyncIterator[str]`` shape ``AgUiTransport``
+    expects — mirrors ``test_5179_backlog_gap_end_to_end.py``'s own
+    ``_live_sse_lines``. Blank lines are NOT filtered (unlike a
+    manual-scan helper would) — they are the SSE block delimiter
+    ``AgUiTransport``'s own parser relies on."""
+    async for chunk in body_iter:
+        for line in chunk.split("\n"):
+            yield line
+            await asyncio.sleep(0)
 
 
 async def _wait_until(pilot, condition) -> None:
@@ -142,126 +124,117 @@ async def _wait_until(pilot, condition) -> None:
         await pilot.pause()
 
 
-async def _build_race_sse() -> str:
-    """Builds the exact SSE text via the REAL ``AgUiEmitter``.
-
-    ``status_state`` already carries the post-dispatch counters (``queue_
-    seq=2``) BEFORE ``AgUiEmitter`` is even constructed — this is what
-    ``_reconnect_snapshot_chunks`` (emitter.py) reads to build the ONE-TIME
-    connect ``STATE_SNAPSHOT``, computed before ``stream()`` ever starts
-    iterating ``frames``. The ``user_submitted``/``turn_started`` events
-    below are the SAME turn's own historical audit-events, forwarded
-    afterward with their own ``seq`` stamps (1, 2) — unchanged by the
-    snapshot already existing ahead of them, exactly as a real forwarder
-    lagging behind a live status read would behave.
-
-    Directly measured (this investigation's own instrumented run, not
-    assumed): with THIS construction, ``AgUiTransport``'s decoded
-    ``STATUS apply_snapshot`` (queue_seq=2) lands strictly before either
-    the ``user_submitted`` or ``turn_started`` ``EventFrame`` is even
-    dequeued from ``AgUiTransport.frames()`` — because the STATE_SNAPSHOT
-    block sits earlier on the wire and decodes to zero queued items, this
-    holds with no scheduling assumption.
-
-    A DIFFERENT construction was tried first and did NOT reproduce the
-    bug: mutating ``status_state`` to the post-dispatch values only
-    between yielding the ``user_submitted`` and ``turn_started`` frames
-    (so the STATE_DELTA reflecting the jump appears mid-stream, between
-    the two event frames, exactly as ``AgUiEmitter.stream()``'s real code
-    naturally emits — event first, its post-frame delta right after).
-    Measured directly: in that construction, ``AgUiTransport.frames()``'s
-    OWN per-dequeued-frame ``suspend_between_frames()`` call (on TOP of
-    the one inside ``AgUiTransport._pump_sse``) resynchronizes the two
-    tasks at every frame boundary, so ``_pump_frames`` always finished
-    fully handling frame N (a synchronous call, ``_seed_queue_view``
-    included) before ``_pump_sse`` ever got back control to decode block
-    N+1's STATE_DELTA. So a delta racing a frame it was itself computed
-    AFTER did not reproduce; a snapshot that already raced ahead of a turn
-    BEFORE that turn's own frames were ever produced (this module's actual
-    construction, above) does."""
-    status_state: dict = {"queue": [], "turn_active": True, "queue_seq": 2}
-
-    def status_provider() -> dict:
-        return dict(status_state)
-
-    async def frames():
-        yield EventFrame(
-            Event(
-                type="user_submitted",
-                data={
-                    "msg_id": _MSG_ID, "chain_id": _CHAIN_ID,
-                    "text": _OWN_TEXT, "seq": 1, "meta": {},
-                },
-            )
-        )
-        yield EventFrame(
-            Event(type="turn_started", data={"chain_id": _CHAIN_ID, "seq": 2}),
-        )
-
-    emitter = AgUiEmitter(frames(), status_provider)
-    chunks = [chunk async for chunk in emitter.stream()]
-    return "".join(chunks)
-
-
 @pytest.mark.asyncio
-async def test_own_message_race_construction_outcome() -> None:
-    """Tier 2: constructs the exact interleaving #5179 hypothesizes and
-    reports the actual, observed outcome — reproduced or not — off public
-    widget state only (see module docstring for the full mechanism)."""
-    sse = await _build_race_sse()
-    # Sanity on the WIRE CONTENT itself (not yet the app): the connect-time
-    # STATE_SNAPSHOT really does carry the post-dispatch queue_seq, and it
-    # really does sit BEFORE either event frame on the wire.
-    snap_pos = sse.index("STATE_SNAPSHOT")
-    us_pos = sse.index("user_submitted")
-    ts_pos = sse.index("turn_started")
-    assert snap_pos < us_pos < ts_pos, (
-        "test construction error: expected STATE_SNAPSHOT -> "
-        "EVENT(user_submitted) -> EVENT(turn_started) on the wire; got a "
-        "different order, so this run does not exercise the race this "
-        "test targets"
+async def test_own_message_renders_via_real_agui_events_route(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — calls the REAL ``agui_events`` route handler,
+    submits+dispatches the operator's own turn AFTER it returns (mirrors
+    ``test_agui_events_route_pairs_connect_status_with_backlog``'s own
+    ordering), and confirms the message renders in a REAL mounted
+    ``TextualChatApp`` fed off the route's own real ``StreamingResponse``.
+
+    Strip-falsifier: removing ``initial_status=initial_status`` from
+    ``agui_events``'s own ``AgUiEmitter(...)`` construction (endpoint.py)
+    turns this test red — the operator's own message renders in neither
+    the flow nor the sent-queue region. Verified locally (same strip
+    already used for ``test_agui_events_route_pairs_connect_status_with_
+    backlog``)."""
+    from fastapi import FastAPI
+    from starlette.requests import Request
+    from starlette.responses import StreamingResponse
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+    from reyn.interfaces.transport.agui.endpoint import router
+    from reyn.interfaces.web.auth import AuthContext
+
+    registry = _make_registry(tmp_path)
+    AgentProfile.new(_AGENT_NAME, role="").save(
+        tmp_path / ".reyn" / "agents" / _AGENT_NAME
     )
-    assert '"queue_seq": 2' in sse.split("STATE_SNAPSHOT", 1)[1].split("\n\n", 1)[0], (
-        "test construction error: the connect-time STATE_SNAPSHOT does not "
-        "carry the post-dispatch queue_seq — this run does not exercise "
-        "the race this test targets"
-    )
+    session = await registry.ensure_running(_AGENT_NAME)
 
-    async def _send(_payload: dict) -> bool:
-        return False
+    app = FastAPI()
+    app.include_router(router)
+    app.state.auth = AuthContext(token="s3cret", require_token=True)
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: registry)
 
-    transport = AgUiTransport(_sse_lines(sse), _send)
-    app = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
+    scope = {
+        "type": "http", "method": "GET", "path": f"/agui/chat/{_AGENT_NAME}/events",
+        "query_string": b"token=s3cret&connection_id=conn-5179-full-app-route-test",
+        "headers": [], "client": ("127.0.0.1", 12345), "app": app,
+    }
+    req = Request(scope)
 
-    async with app.run_test(size=(100, 30)) as pilot:
-        # A public, unconditional side effect of ``_handle_turn_started_
-        # event`` firing at all (``self._activity.begin("WORKING")`` runs
-        # BEFORE the seq gate is even consulted) — waiting on it proves
-        # the turn_started frame was drained and handled, independent of
-        # whether the promotion itself (the thing under test) succeeded.
-        await _wait_until(pilot, lambda: app.query_one(ActivityRow).state is not None)
-        # Give any already-scheduled promotion work one more full pass.
-        await pilot.pause()
-        await pilot.pause()
-
-        user_entries = _flow_user_entries(app)
-        sent_queue = app.query_one(SentQueue)
-        queued_texts = sent_queue.rendered_texts()
-
-        rendered = any(_OWN_TEXT in e.item.text for e in user_entries)
-        still_queued = any(_OWN_TEXT in t for t in queued_texts)
-
-        # This is the reproduction: it currently FAILS (#5179 is unfixed).
-        # The operator's own message must be present SOMEWHERE — either
-        # promoted into the flow, or still visibly staged in the
-        # sent-queue region — after its turn_started was drained and
-        # handled. Neither is true under this exact construction: it was
-        # silently dropped by the seq-gate race (the connect-time
-        # STATE_SNAPSHOT already reflecting the post-dispatch queue_seq
-        # reached transport.status before _seed_queue_view ran on frame #1).
-        assert rendered or still_queued, (
-            "REPRODUCED #5179: the operator's own message "
-            f"({_OWN_TEXT!r}) is present in NEITHER the flow "
-            f"({[e.item.text for e in user_entries]!r}) NOR the "
-            f"sent-queue region ({queued_texts!r})."
+    turn_task: "asyncio.Task | None" = None
+    try:
+        resp = await endpoint_mod.agui_events(req, _AGENT_NAME)
+        assert isinstance(resp, StreamingResponse), (
+            f"expected a real StreamingResponse (auth/agent-exists must "
+            f"both pass for this test's own setup); got {resp!r}"
         )
+
+        async def _drive_turn() -> None:
+            try:
+                await session.run_one_iteration()
+            except Exception:
+                # Expected: no @pytest.mark.replay fixture is installed —
+                # the real litellm boundary raises once the router reaches
+                # it, strictly after the history append this test cares
+                # about.
+                pass
+
+        await session.submit_user_text(_OWN_TEXT)
+        turn_task = asyncio.create_task(_drive_turn())
+        while not any(
+            getattr(m, "role", None) == "user" and _OWN_TEXT in str(getattr(m, "content", ""))
+            for m in session.history
+        ):
+            await asyncio.sleep(0)
+
+        async def _send(_payload: dict) -> bool:
+            return False
+
+        transport = AgUiTransport(_drain_lines(resp.body_iterator), _send)
+        app_ = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
+
+        async with app_.run_test(size=(100, 30)) as pilot:
+            # The turn was already driven all the way to its (expected)
+            # litellm-boundary failure BEFORE this app ever mounted (see
+            # above) — every frame this connection will ever emit for this
+            # turn is already queued by the time ``emitter.stream()``
+            # starts, so ``ActivityRow`` never sits in a non-idle state
+            # long enough for a mount-time observer to catch it (mirrors
+            # ``test_5179_backlog_gap_end_to_end.py``'s own reasoning). The
+            # real, public signal that THIS turn's own lifecycle fully
+            # drained to the client instead is the router-failure line
+            # landing in the flow.
+            await _wait_until(
+                pilot,
+                lambda: any(
+                    "litellm.acompletion" in getattr(e.item, "text", "")
+                    for e in app_.query_one(FlowView).entries
+                ),
+            )
+            await pilot.pause()
+            await pilot.pause()
+
+            user_entries = _flow_user_entries(app_)
+            sent_queue = app_.query_one(SentQueue)
+            queued_texts = sent_queue.rendered_texts()
+
+            rendered = any(_OWN_TEXT in e.item.text for e in user_entries)
+            still_queued = any(_OWN_TEXT in t for t in queued_texts)
+
+            assert rendered or still_queued, (
+                "#5179 REGRESSION via the REAL agui_events route: the "
+                f"operator's own message ({_OWN_TEXT!r}) is present in "
+                f"NEITHER the flow ({[e.item.text for e in user_entries]!r}) "
+                f"NOR the sent-queue region ({queued_texts!r})."
+            )
+    finally:
+        if turn_task is not None:
+            turn_task.cancel()
+            try:
+                await turn_task
+            except (Exception, asyncio.CancelledError):
+                pass
+        await registry.shutdown()

--- a/tests/interfaces/test_5179_remote_own_message_seq_gate_race.py
+++ b/tests/interfaces/test_5179_remote_own_message_seq_gate_race.py
@@ -1,0 +1,246 @@
+"""Tier 2: #5179 — in ``--connect`` remote mode, the operator's OWN sent
+message can silently never appear in the conversation, while the agent's
+reply renders fine.
+
+Real chain (prior investigation, summarized in the issue thread):
+
+- The operator's own message is NEVER folded into the flow directly.
+  ``TextualChatApp._handle_user_submitted_event`` only STAGES it into
+  ``RemoteQueueView`` (the sent-queue region); a LATER ``turn_started``
+  whose ``chain_id`` matches is what actually PROMOTES it into a flow
+  entry (``_handle_turn_started_event`` → ``_ingest_frame``). Both calls
+  are gated by ``RemoteQueueView``'s own monotonic ``seq`` gate
+  (``apply_user_submitted``/``apply_turn_started`` — state.py): a delta
+  whose ``seq`` is ``<=`` the view's ``_last_seq`` is silently rejected —
+  AND, independent of the gate, ``_handle_turn_started_event`` only ever
+  promotes items already sitting in ``RemoteQueueView.queue()``: an item
+  whose OWN ``apply_user_submitted`` was gated never got staged, so there
+  is nothing to promote even if the ``turn_started`` delta's own gate
+  happens to pass.
+- ``_last_seq`` is seeded exactly ONCE per connection, from a live read of
+  ``transport.status.values`` (``RemoteReadModel.snapshot()`` — read_model.py
+  — reads it live, no buffering), at ``TextualChatApp._seed_queue_view``,
+  itself called on the FIRST non-``BacklogBatch`` frame ``_pump_frames``
+  ever drains from ``transport.frames()``.
+- ``AgUiTransport._consume_block`` applies a decoded ``STATE_SNAPSHOT``/
+  ``STATE_DELTA`` to ``self._status`` SYNCHRONOUSLY, as soon as that block
+  is parsed. A ``STATE_*`` block decodes to ZERO ``Frame``/``BacklogBatch``
+  items (see ``_consume_block``'s own branch for ``StateUpdate``), so
+  applying it never puts anything onto ``AgUiTransport``'s own frame
+  queue — it is invisible to ``frames()``'s consumer except through its
+  side effect on ``self._status``.
+
+The construction below (verified directly, not assumed — see
+``_build_race_sse``'s own docstring for the measurement): the connection's
+ONE-TIME reconnect ``STATE_SNAPSHOT`` (``AgUiEmitter._reconnect_snapshot_
+chunks``, built ONCE before ``AgUiEmitter.stream()`` ever starts iterating
+its frame source) is computed from a ``status_provider()`` that already
+reflects the operator's OWN turn as fully dispatched (``queue_seq`` past
+both its ``user_submitted`` and ``turn_started`` deltas' own ``seq``
+stamps) — modeling a session whose enqueue+dispatch (one synchronous call)
+already completed by the time this particular connection's reconnect
+snapshot was computed, while the corresponding ``user_submitted``/
+``turn_started`` AUDIT-EVENTS for that SAME turn are still forwarded
+afterward over ``AgUiEmitter``'s separate frame-source pipeline, carrying
+their own historical ``seq`` stamps (1, 2). Because this STATE_SNAPSHOT
+sits on the wire strictly BEFORE either of those two frames (it is part of
+the connect preamble, emitted before the frame-source loop even starts)
+and decodes to zero queued items, it is GUARANTEED (no scheduling luck
+needed — verified below by direct instrumentation, not inferred) to have
+already updated ``transport.status`` by the time ``_pump_frames`` drains
+the FIRST real frame this connection ever produces — which is exactly
+when ``_seed_queue_view`` runs.
+
+An earlier construction this investigation also tried and DID NOT
+reproduce the bug is recorded in ``_build_race_sse``'s own docstring,
+because the negative result is itself part of the finding (this repo's
+own pre-conclusion checklist: report what falsifies a hypothesis, not
+only what confirms it).
+
+Real ``AgUiEmitter`` (server-side encoder) + real ``AgUiTransport``
+(client-side decoder) + a real mounted ``TextualChatApp`` wired to a real
+``RemoteReadModel`` — no mocks, no private-state pokes. The verdict is
+read off PUBLIC widget surfaces only: ``FlowView.entries`` (mirroring
+``test_3300_p2b_sentqueue_render.py``'s own ``_flow_user_entries``) and
+``SentQueue.rendered_texts()``.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.activity_row import ActivityRow
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.repl.read_model import RemoteReadModel
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.schemas.models import Event
+
+_MSG_ID = "m1"
+_CHAIN_ID = "c1"
+_OWN_TEXT = "hello from the operator"
+
+
+def _flow_user_entries(app: TextualChatApp):
+    return [e for e in app.query_one(FlowView).entries if e.item.kind == "user"]
+
+
+async def _sse_lines(text: str) -> AsyncIterator[str]:
+    """Yields ``text``'s own lines then hangs on a real never-resolving
+    primitive — a genuinely open connection with nothing further to send
+    yet, NOT an exhausted stream (an exhausted finite generator would make
+    ``AgUiTransport.frames()`` raise ``StopAsyncIteration`` on its very
+    first ``__anext__()`` here, which tears the whole app down via
+    ``_pump_frames``'s own ``finally: self.exit()`` before this test ever
+    gets to inspect anything — matches
+    ``test_5050_remote_pending_intervention_choices.py``'s own
+    ``_sse_lines_then_hang`` for the identical reason).
+
+    A real ``asyncio.sleep(0)`` between every yielded line — NOT only
+    after the whole block — matches that same helper: a genuine SSE
+    source yields control at every line boundary (a real socket read),
+    so this is a representative sample of the wire's real timing, not an
+    artificial single burst."""
+    for line in text.split("\n"):
+        yield line
+        await asyncio.sleep(0)
+    await asyncio.Event().wait()
+
+
+async def _wait_until(pilot, condition) -> None:
+    """Poll ``pilot.pause()`` unboundedly until ``condition()`` is true —
+    CLAUDE.md's Ceiling rule: wait on the real condition, never a fixed
+    pause count. CI's own ``--timeout`` is the kill switch if it never
+    resolves."""
+    while not condition():
+        await pilot.pause()
+
+
+async def _build_race_sse() -> str:
+    """Builds the exact SSE text via the REAL ``AgUiEmitter``.
+
+    ``status_state`` already carries the post-dispatch counters (``queue_
+    seq=2``) BEFORE ``AgUiEmitter`` is even constructed — this is what
+    ``_reconnect_snapshot_chunks`` (emitter.py) reads to build the ONE-TIME
+    connect ``STATE_SNAPSHOT``, computed before ``stream()`` ever starts
+    iterating ``frames``. The ``user_submitted``/``turn_started`` events
+    below are the SAME turn's own historical audit-events, forwarded
+    afterward with their own ``seq`` stamps (1, 2) — unchanged by the
+    snapshot already existing ahead of them, exactly as a real forwarder
+    lagging behind a live status read would behave.
+
+    Directly measured (this investigation's own instrumented run, not
+    assumed): with THIS construction, ``AgUiTransport``'s decoded
+    ``STATUS apply_snapshot`` (queue_seq=2) lands strictly before either
+    the ``user_submitted`` or ``turn_started`` ``EventFrame`` is even
+    dequeued from ``AgUiTransport.frames()`` — because the STATE_SNAPSHOT
+    block sits earlier on the wire and decodes to zero queued items, this
+    holds with no scheduling assumption.
+
+    A DIFFERENT construction was tried first and did NOT reproduce the
+    bug: mutating ``status_state`` to the post-dispatch values only
+    between yielding the ``user_submitted`` and ``turn_started`` frames
+    (so the STATE_DELTA reflecting the jump appears mid-stream, between
+    the two event frames, exactly as ``AgUiEmitter.stream()``'s real code
+    naturally emits — event first, its post-frame delta right after).
+    Measured directly: in that construction, ``AgUiTransport.frames()``'s
+    OWN per-dequeued-frame ``suspend_between_frames()`` call (on TOP of
+    the one inside ``AgUiTransport._pump_sse``) resynchronizes the two
+    tasks at every frame boundary, so ``_pump_frames`` always finished
+    fully handling frame N (a synchronous call, ``_seed_queue_view``
+    included) before ``_pump_sse`` ever got back control to decode block
+    N+1's STATE_DELTA. So a delta racing a frame it was itself computed
+    AFTER did not reproduce; a snapshot that already raced ahead of a turn
+    BEFORE that turn's own frames were ever produced (this module's actual
+    construction, above) does."""
+    status_state: dict = {"queue": [], "turn_active": True, "queue_seq": 2}
+
+    def status_provider() -> dict:
+        return dict(status_state)
+
+    async def frames():
+        yield EventFrame(
+            Event(
+                type="user_submitted",
+                data={
+                    "msg_id": _MSG_ID, "chain_id": _CHAIN_ID,
+                    "text": _OWN_TEXT, "seq": 1, "meta": {},
+                },
+            )
+        )
+        yield EventFrame(
+            Event(type="turn_started", data={"chain_id": _CHAIN_ID, "seq": 2}),
+        )
+
+    emitter = AgUiEmitter(frames(), status_provider)
+    chunks = [chunk async for chunk in emitter.stream()]
+    return "".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_own_message_race_construction_outcome() -> None:
+    """Tier 2: constructs the exact interleaving #5179 hypothesizes and
+    reports the actual, observed outcome — reproduced or not — off public
+    widget state only (see module docstring for the full mechanism)."""
+    sse = await _build_race_sse()
+    # Sanity on the WIRE CONTENT itself (not yet the app): the connect-time
+    # STATE_SNAPSHOT really does carry the post-dispatch queue_seq, and it
+    # really does sit BEFORE either event frame on the wire.
+    snap_pos = sse.index("STATE_SNAPSHOT")
+    us_pos = sse.index("user_submitted")
+    ts_pos = sse.index("turn_started")
+    assert snap_pos < us_pos < ts_pos, (
+        "test construction error: expected STATE_SNAPSHOT -> "
+        "EVENT(user_submitted) -> EVENT(turn_started) on the wire; got a "
+        "different order, so this run does not exercise the race this "
+        "test targets"
+    )
+    assert '"queue_seq": 2' in sse.split("STATE_SNAPSHOT", 1)[1].split("\n\n", 1)[0], (
+        "test construction error: the connect-time STATE_SNAPSHOT does not "
+        "carry the post-dispatch queue_seq — this run does not exercise "
+        "the race this test targets"
+    )
+
+    async def _send(_payload: dict) -> bool:
+        return False
+
+    transport = AgUiTransport(_sse_lines(sse), _send)
+    app = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        # A public, unconditional side effect of ``_handle_turn_started_
+        # event`` firing at all (``self._activity.begin("WORKING")`` runs
+        # BEFORE the seq gate is even consulted) — waiting on it proves
+        # the turn_started frame was drained and handled, independent of
+        # whether the promotion itself (the thing under test) succeeded.
+        await _wait_until(pilot, lambda: app.query_one(ActivityRow).state is not None)
+        # Give any already-scheduled promotion work one more full pass.
+        await pilot.pause()
+        await pilot.pause()
+
+        user_entries = _flow_user_entries(app)
+        sent_queue = app.query_one(SentQueue)
+        queued_texts = sent_queue.rendered_texts()
+
+        rendered = any(_OWN_TEXT in e.item.text for e in user_entries)
+        still_queued = any(_OWN_TEXT in t for t in queued_texts)
+
+        # This is the reproduction: it currently FAILS (#5179 is unfixed).
+        # The operator's own message must be present SOMEWHERE — either
+        # promoted into the flow, or still visibly staged in the
+        # sent-queue region — after its turn_started was drained and
+        # handled. Neither is true under this exact construction: it was
+        # silently dropped by the seq-gate race (the connect-time
+        # STATE_SNAPSHOT already reflecting the post-dispatch queue_seq
+        # reached transport.status before _seed_queue_view ran on frame #1).
+        assert rendered or still_queued, (
+            "REPRODUCED #5179: the operator's own message "
+            f"({_OWN_TEXT!r}) is present in NEITHER the flow "
+            f"({[e.item.text for e in user_entries]!r}) NOR the "
+            f"sent-queue region ({queued_texts!r})."
+        )


### PR DESCRIPTION
**[tui-coder]** — fixes #5179.

## Problem
In `--connect` remote mode, the operator's own sent message could silently never appear in the conversation, while the agent's reply rendered fine.

## Root cause
`endpoint.py`'s `agui_events` read the connect-time backlog (`session_backlog_page`) and the connect-time status (`_status_provider`, read lazily at `AgUiEmitter.stream()` start) at **two separate times**. Any dispatch landing in between advanced status past a turn whose own historical frames the seq-gate (`state.py`'s `RemoteQueueView`) then correctly refused to resurrect — so the turn promoted nowhere.

An earlier fix candidate ("capture status right after `session_backlog_page` returns") was caught by architect review **before implementation** — full design discussion in the issue thread (comments [5434591744](https://github.com/tya5/reyn/issues/5179#issuecomment-5434591744), [5434621258](https://github.com/tya5/reyn/issues/5179#issuecomment-5434621258), [5434667620](https://github.com/tya5/reyn/issues/5179#issuecomment-5434667620)): it still left the same-direction race open at `session_backlog_page`'s own `extended <= 0` exit (the default path for a fresh/short session), which returns `frames` built **before** `extend_history_backward_async`'s own disk-read await — a status read taken after that await already reflects a concurrent dispatch while the backlog paired with it does not.

## Fix
Read backlog and status in the **same synchronous tick**, every loop iteration, in a new `endpoint.py._session_backlog_page_and_status` — no separate-time read exists to race at either exit. `AgUiEmitter` gains an `initial_status` param, used only for the very first reconnect snapshot; the mid-stream `session_attached` re-fire (#5116 cross-agent `/attach`) keeps reading `status_provider()` live, unchanged.

**This is a consistency fix, not a freshness one** — documented explicitly in `_session_backlog_page_and_status`'s own docstring so a future contributor does not "fix" the apparently-stale seed by reverting to a live read here, reintroducing this exact bug. That docstring also now documents why pairing status against `target` (the function's own resolved session) rather than `source.current_session()` is correct and safe at this call site (non-blocking finding, architect review).

## Tests — now all call through the REAL `agui_events` route (see block below)
- `test_5179_backlog_gap_end_to_end.py::test_own_message_renders_via_real_connect_path` — hand-constructs `AgUiEmitter` mirroring `agui_events`'s own wiring, mounts a full `TextualChatApp`; asserts the message renders.
- `test_5179_backlog_gap_end_to_end.py::test_agui_events_route_pairs_connect_status_with_backlog` **(new)** — calls the REAL route directly, reads the raw SSE wire, confirms the first `STATE_SNAPSHOT` carries the PRE-dispatch `queue_seq` (0), not a live re-read of the post-dispatch value (2).
- `test_5179_remote_own_message_seq_gate_race.py` **(rewritten)** — calls the REAL route AND mounts a full `TextualChatApp`, reading the verdict off `FlowView`/`SentQueue`. The original hand-constructed version stayed permanently red after the fix landed (it never touched `endpoint.py`) — CI correctly refused to merge a PR with a red test, and this test's own design was mis-scoped as a 2nd acceptance criterion from the start. Rewritten per lead-coder's own recommendation, same precedent as the other real-route test.
- `test_5179_exit_b_status_race_discriminator.py`: unchanged per architect's instruction — keeps demonstrating the rejected "capture right after return" candidate's own failure directly, as a standing regression guard.
- `test_5119_retarget_hub_exception_cleanup.py`: injection point moved from `session_backlog_page` to `_session_backlog_page_and_status`, matching the call site `agui_events` now actually uses.

Strip-falsified (both new/rewritten real-route tests, independently): forcing `AgUiEmitter.stream()` back to a live `status_provider()` read (ignoring `initial_status`) reproduces the exact reported symptom; restoring the fix returns both to green.

Also cleaned up: all 3 real-session-driving `#5179` tests now call `await registry.shutdown()` in their own `finally` blocks (the established production cleanup path) — without it, a real `Session.run_one_iteration()` call's background `EventLog`/router-loop state could outlive the test's own event loop, surfacing as a `PytestUnraisableExceptionWarning` in a large combined sweep. Full targeted sweep now clean: 250 passed, 0 warnings.

## Disclosed residual (not claimed closed)
`session_backlog_page`'s multi-extend-iteration branch (`extended > 0`, loop re-reads history) is now paired same-tick on EVERY iteration, which should close the earlier-disclosed "backlog-ahead-of-status" residual too — but this is not separately test-covered here (only exit A and exit B are). Flagging honestly rather than claiming full closure without a witness.

## Test plan
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 6 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — clean
- [x] `python scripts/mypy_ratchet.py` — clean (201 findings, all baselined)
- [x] `python scripts/flat_tests_ratchet.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `python scripts/check_bare_tests_import_reference.py` — clean
- [x] `python scripts/check_file_depth_reference.py` — clean
- [x] pytest scoped to diff (`tests/interfaces/` agui-related, 250 tests) — 250 passed, 0 failures, 0 warnings
- [x] Strip-falsify: confirmed red without the fix (both real-route tests), green with it
- [ ] (skipped — no UI/visual surface touched by this PR; server-side wire pairing only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] 🔴 **[architect]** No test covers the production call site — **addressed**: `test_agui_events_route_pairs_connect_status_with_backlog` (new) and the rewritten `test_5179_remote_own_message_seq_gate_race.py` both call the real `agui_events` handler directly, matching `test_5116_connection_agent_owner_cross_attach.py:338`'s own precedent. Both strip-falsified — removing `initial_status=initial_status` turns each red with the exact predicted symptom.

