### PR TITLE
refactor(#5291): remove build_tools's dead available_agents parameter

### DIFF
--- a/src/reyn/runtime/capability_visibility.py
+++ b/src/reyn/runtime/capability_visibility.py
@@ -96,8 +96,12 @@ class _VisibilityProbeOps:
 
         # This probe stands in for the router's own ``present``, which is always a
         # ``tool_calls`` presentation — the channel exists (#3421).
+        # #5291: no longer reads .reyn/agents/ here — build_tools's own
+        # available_agents param is dead (never read by its body, #3978 P6
+        # retired the only consumer); this call ran on EVERY render frame
+        # (this class's own docstring), making it the hottest of the
+        # confirmed-dead call sites.
         return Presentation(tools_channel=AdvertisedTools(entries=build_tools(
-            self._host.list_available_agents(),
             file_permissions=self._host.get_file_permissions(),
             mcp_servers=self._host.get_mcp_servers(),
             web_fetch_allowed=self._host.get_web_fetch_allowed(),
@@ -109,8 +113,8 @@ class _VisibilityProbeOps:
     def base_tools(self, available: dict, layer_ctx: dict) -> "list[dict]":
         from reyn.runtime.router_tools import build_tools
 
+        # #5291: see present()'s own comment above — same dead read, same fix.
         return build_tools(
-            self._host.list_available_agents(),
             file_permissions=self._host.get_file_permissions(),
             mcp_servers=self._host.get_mcp_servers(),
             web_fetch_allowed=self._host.get_web_fetch_allowed(),

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3242,8 +3242,10 @@ class RouterLoop:
 
         univ = layer_ctx["univ_enabled"]
         search_visible = layer_ctx["search_visible"]
+        # #5291: build_tools's available_agents param is removed — it was
+        # never read by that function's own body (only consumer retired,
+        # #3978 P6) — so this call no longer reads .reyn/agents/ from disk.
         tools = build_tools(
-            self.host.list_available_agents(),
             file_permissions=self.host.get_file_permissions(),
             mcp_servers=self.host.get_mcp_servers(),
             web_fetch_allowed=self.host.get_web_fetch_allowed(),
@@ -3262,8 +3264,8 @@ class RouterLoop:
         ``build_tools`` with the universal wrappers OFF. The common base a
         self-contained scheme starts from (enumerate-all adds ``catalog_entries``
         on top instead of the wrappers)."""
+        # #5291: see present()'s own comment above — same dead read, same fix.
         return build_tools(
-            self.host.list_available_agents(),
             file_permissions=self.host.get_file_permissions(),
             mcp_servers=self.host.get_mcp_servers(),
             web_fetch_allowed=self.host.get_web_fetch_allowed(),

--- a/src/reyn/runtime/router_tools.py
+++ b/src/reyn/runtime/router_tools.py
@@ -2,8 +2,18 @@
 
 Public API
 ----------
-build_tools(available_agents, *, file_permissions, mcp_servers)
+build_tools(*, file_permissions, mcp_servers)
     Returns 14–30 tools in fixed order for litellm.acompletion.
+
+    #5291: the leading positional ``available_agents`` parameter this
+    function used to require was removed (was never read by this
+    function's own body — its only consumer, ``delegate_to_agent``'s
+    per-call ``to`` enum injection, retired in #3978 P6; every call site
+    that supplied it was reading ``.reyn/agents/`` from disk for
+    nothing, some on every render frame). If a future capability needs
+    the caller's peer-agent list again, add a NEW, actually-read
+    parameter — reintroducing this exact name for a different purpose
+    would read as a silent revival of the dead one.
 
 Gemini-safe schema rules enforced throughout:
 - No oneOf / anyOf / additionalProperties / format keys
@@ -252,7 +262,6 @@ def build_mcp_search_tool(mcp_tool_specs: list[dict]) -> dict:
 
 
 def build_tools(
-    available_agents: list[dict],  # [{name, role}, ...]
     *,
     file_permissions: dict | None = None,  # {"read": [paths], "write": [paths]}
     mcp_servers: list[dict] | None = None,  # [{"name": ..., "description": ...}, ...]
@@ -286,11 +295,6 @@ def build_tools(
 
     Parameters
     ----------
-    available_agents:
-        Peer agent entries. Each dict must have at least ``name``. Kept for
-        backward compatibility with all callers — its only consumer,
-        ``delegate_to_agent``'s per-call ``to`` enum injection, retired in
-        #3978 P6.
     file_permissions:
         Optional dict with ``read`` and/or ``write`` lists of path strings.
         - None or both empty → File tools omitted entirely (C1–C4).

--- a/src/reyn/tools/llm_reachability.py
+++ b/src/reyn/tools/llm_reachability.py
@@ -31,10 +31,14 @@ can deliver it to the model:
       ``search_actions``) are only emitted under a *particular*
       configuration (MCP servers configured / context near budget /
       embedding enabled) — that is correct conditional gating, not an
-      unreachability defect, and executing ``build_tools([])`` with one
-      fixed arg tuple cannot tell the two apart (confirmed: doing so
+      unreachability defect, and executing ``build_tools()`` with one
+      fixed set of kwargs cannot tell the two apart (confirmed: doing so
       flags those as "unreachable" too, a false positive this census
-      avoids).
+      avoids). #5291: ``build_tools``'s own leading positional arg
+      (``available_agents``, dead — 0 real consumers) was removed; this
+      module's own census never depended on that argument's value, only
+      on what parameters MAKE a tool appear, so the removal changes
+      nothing here but the call shape in this prose.
   (b) **Dispatch via ``invoke_action``** — the name is a catalog action,
       i.e. a member of ``universal_dispatch.KNOWN_ACTION_NAMES`` (the
       ``_CATEGORY_ACTIONS`` membership table). #3429 abolished the
@@ -253,10 +257,10 @@ def compute_direct_advertisable_tool_names(*, source_text: str | None = None) ->
     """Derive route (a): every tool name ``build_tools()`` can place directly
     in the ``tools=`` payload under SOME valid combination of its parameters.
 
-    Structural (AST) census, not one execution with one args tuple — see the
-    module docstring for why a single ``build_tools([])`` call produces false
-    positives for correctly-conditional tools (MCP resource verbs, ``compact``,
-    ``spawn_session``, ``search_actions``).
+    Structural (AST) census, not one execution with one fixed set of kwargs —
+    see the module docstring for why a single ``build_tools()`` call produces
+    false positives for correctly-conditional tools (MCP resource verbs,
+    ``compact``, ``spawn_session``, ``search_actions``).
 
     ``source_text`` defaults to the real ``build_tools`` source (via
     ``inspect.getsource``); tests pass a modified string to strip-falsify

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -498,14 +498,17 @@ class ToolDefinition:
     # Per-call schema enrichment hook (= ADR-0026 M4 Phase 3).
     # When set, callers (= build_tools) invoke this hook AFTER
     # render_for_router to inject per-session dynamic data into the
-    # schema (canonical example: delegate_to_agent.to enum from
-    # available_agents).
+    # schema (live example, #5291: tools/mcp.py's _enrich_router_schema
+    # reads state.mcp_servers to enumerate call_mcp_tool's server names;
+    # the original canonical example, delegate_to_agent.to from
+    # available_agents, is gone — that consumer retired #3978 P6, and
+    # available_agents itself was removed, #5291, 0 remaining readers).
     #
     # Signature: (rendered_tool_dict, RouterCallerState) -> rendered_tool_dict
     #   - rendered_tool_dict: the dict produced by render_for_router
     #     (= function/parameters/etc shape)
-    #   - RouterCallerState: contains available_agents and other
-    #     per-session data the enricher may consult
+    #   - RouterCallerState: per-session data the enricher may consult
+    #     (e.g. mcp_servers)
     #   - returns: a NEW dict with dynamic enrichment applied (do NOT
     #     mutate the input; static schema is the canonical render)
     #
@@ -552,10 +555,10 @@ class ToolDefinition:
 
         M4 Phase 3: when ``schema_enricher`` is set on the ToolDefinition AND
         ``state`` is provided, the static render is post-processed by the
-        enricher to inject per-call dynamic data (e.g. delegate_to_agent.to
-        enum from RouterCallerState.available_agents). When either is None (= 24/26
-        capabilities, plus all callers that don't supply state), the static
-        render is returned as-is.
+        enricher to inject per-call dynamic data (e.g. ``call_mcp_tool``'s
+        server-name enum from ``RouterCallerState.mcp_servers``, #5291).
+        When either is None (= 24/26 capabilities, plus all callers that
+        don't supply state), the static render is returned as-is.
         """
         rendered = {
             "type": "function",

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -60,7 +60,12 @@ class RouterCallerState:
     """
     # Catalog discovery (= for catalog tools list_agents / describe_agent handlers)
     agent_registry: Any = None
-    available_agents: list[Mapping[str, Any]] | None = None
+    # #5291: available_agents removed — 0 real consumers (its only one,
+    # delegate_to_agent's per-call `to` enum injection, retired #3978 P6);
+    # every populate site was a real disk read (list_available_agents())
+    # for a value nothing downstream read. If a future capability needs
+    # this again, give it a real reader (mcp_servers-shaped, a live field
+    # some enricher actually reads) — not an eager list nobody consumes.
 
     # IS-1 (docs/proposals/reyn-pipeline-v0.9-design-resolutions.md R6): the
     # PipelineRegistry the run_pipeline tool looks up a registered Pipeline by
@@ -301,7 +306,9 @@ async def build_resource_caller_state(host: Any) -> "RouterCallerState":
         rag_sources = None
 
     return RouterCallerState(
-        available_agents=list(getattr(host, "list_available_agents", list)()),
+        # #5291: no longer reads .reyn/agents/ here — RouterCallerState.
+        # available_agents was removed (0 real consumers); this was a
+        # real disk read (list_available_agents()) on every call.
         op_context_factory=getattr(host, "make_router_op_context", None),
         host=host,
         available_rag_sources=rag_sources,

--- a/tests/core/test_2692_present_render_template_invocation_surface.py
+++ b/tests/core/test_2692_present_render_template_invocation_surface.py
@@ -94,7 +94,7 @@ def test_present_and_render_template_resolve_in_the_default_registry():
 def test_build_tools_contains_present_and_render_template():
     """Tier 2: the default chat catalog (build_tools output) now advertises present +
     render_template — directly reversing the observed 0/69 (unreachable from chat)."""
-    tools = build_tools([{"name": "a1", "description": "d"}])
+    tools = build_tools()
     names = {t["function"]["name"] for t in tools}
     assert "present" in names
     assert "render_template" in names

--- a/tests/core/test_web_search_unified.py
+++ b/tests/core/test_web_search_unified.py
@@ -139,9 +139,7 @@ def test_build_tools_includes_web_search_via_registry():
     output (byte-identity gate for LLMReplay fixtures)."""
     from reyn.runtime.router_tools import build_tools
 
-    tools = build_tools(
-        available_agents=[],
-    )
+    tools = build_tools()
 
     # Find web_search in the returned tools list
     ws_tools = [t for t in tools if t.get("function", {}).get("name") == "web_search"]
@@ -169,9 +167,7 @@ def test_build_tools_web_search_not_duplicated():
     being included simultaneously."""
     from reyn.runtime.router_tools import build_tools
 
-    tools = build_tools(
-        available_agents=[],
-    )
+    tools = build_tools()
     ws_tools = [t for t in tools if t.get("function", {}).get("name") == "web_search"]
     assert ws_tools, "web_search should appear in build_tools output"
 

--- a/tests/runtime/test_2120_session_spawn_advertised.py
+++ b/tests/runtime/test_2120_session_spawn_advertised.py
@@ -26,7 +26,7 @@ from reyn.runtime.router_tools import build_tools
 
 
 def _advertised(**kw) -> set:
-    return {t.get("function", {}).get("name") for t in build_tools([], **kw)}
+    return {t.get("function", {}).get("name") for t in build_tools(**kw)}
 
 
 def test_session_spawn_is_advertised_individual_mode() -> None:
@@ -50,7 +50,7 @@ def test_session_spawn_schema_is_advertised_complete() -> None:
     """Tier 2: the advertised spawn_session carries its spawn-time schema (the mode
     enum + request) — the LLM sees a usable tool, not a name-only stub."""
     tool = next(
-        t for t in build_tools([])
+        t for t in build_tools()
         if t.get("function", {}).get("name") == "spawn_session"
     )
     props = tool["function"]["parameters"]["properties"]

--- a/tests/runtime/test_2123_router_dispatch_sot_1953.py
+++ b/tests/runtime/test_2123_router_dispatch_sot_1953.py
@@ -117,7 +117,6 @@ _EXPECTED_DISPATCH: "frozenset[str]" = frozenset({
     "describe_session",
 })
 
-_AG = [{"name": "a1", "description": "d"}]
 _MCP = [{"name": "fs", "description": "Filesystem MCP server"}]
 
 
@@ -127,7 +126,6 @@ def _advertised_bare_router_tools() -> "set[str]":
     names: set[str] = set()
     for wrappers in (True, False):
         tools = build_tools(
-            _AG,
             file_permissions={"read": ["src"], "write": ["out"]},
             mcp_servers=_MCP, universal_wrappers_enabled=wrappers, compact_visible=True,
         )

--- a/tests/runtime/test_3220_capability_visibility_composed_payload.py
+++ b/tests/runtime/test_3220_capability_visibility_composed_payload.py
@@ -198,7 +198,6 @@ class _OracleOps:
         from reyn.tools.scheme import AdvertisedTools, Presentation
 
         return Presentation(tools_channel=AdvertisedTools(entries=build_tools(
-            self._host.list_available_agents(),
             file_permissions=self._host.get_file_permissions(),
             mcp_servers=self._host.get_mcp_servers(),
             web_fetch_allowed=self._host.get_web_fetch_allowed(),
@@ -210,7 +209,6 @@ class _OracleOps:
         from reyn.runtime.router_tools import build_tools
 
         return build_tools(
-            self._host.list_available_agents(),
             file_permissions=self._host.get_file_permissions(),
             mcp_servers=self._host.get_mcp_servers(),
             web_fetch_allowed=self._host.get_web_fetch_allowed(),

--- a/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
+++ b/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
@@ -53,7 +53,6 @@ from reyn.runtime.services.mcp_cache_file import cache_file_path, read_cache
 _SERVER = "reyn_markitdown"
 _TOOL = "convert_to_markdown"
 _TOOLS = [{"name": _TOOL, "description": "convert a uri to markdown"}]
-_AGENTS = [{"name": "researcher", "role": "Research agent", "cluster": "default"}]
 
 from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
 
@@ -171,7 +170,7 @@ def _mcp_tool_enum(adapter: RouterHostAdapter) -> "list[str] | None":
     (= the schema degrades to a free-form string and the model is told
     nothing about which tools exist).
     """
-    tools = build_tools(_AGENTS, mcp_servers=adapter.get_mcp_servers())
+    tools = build_tools(mcp_servers=adapter.get_mcp_servers())
     for entry in tools:
         if entry.get("type") == "function" and entry["function"]["name"] == "call_mcp_tool":
             props = entry["function"]["parameters"]["properties"]

--- a/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
+++ b/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
@@ -14,9 +14,10 @@ the mechanism ran. The mechanism-level facts (a `mcp_tool_probe_degraded`
 audit-event fires; the cache dict has/hasn't a key) are all downstream
 proxies; the thing the issue is about is whether the model is told about
 capabilities it actually has, and that is the ``mcp_tool_name`` enum inside
-``build_tools(...)`` output. `build_tools(agents, mcp_servers=host.get_mcp_servers())`
+``build_tools(...)`` output. `build_tools(mcp_servers=host.get_mcp_servers())`
 is the exact expression `RouterLoop` uses to assemble `tools=`, so these tests
-call it with the same input, not a paraphrase of it.
+call it with the same input, not a paraphrase of it. (#5291: available_agents
+removed from build_tools's own signature — 0 real consumers.)
 
 Three surfaces, one defect — a fix that misses any of them leaves it alive:
   1. the in-memory cache          → `test_payload_*`
@@ -164,9 +165,10 @@ def _mcp_tool_enum(adapter: RouterHostAdapter) -> "list[str] | None":
     """The `mcp_tool_name` enum as the LLM would receive it in `tools=`.
 
     Reproduces `RouterLoop`'s own assembly expression —
-    ``build_tools(..., mcp_servers=self.host.get_mcp_servers())`` — so what is
-    asserted is the payload content, not an intermediate the payload happens
-    to be derived from. Returns None when the field carries no enum at all
+    ``build_tools(mcp_servers=self.host.get_mcp_servers())`` (#5291:
+    available_agents removed from the signature) — so what is asserted is
+    the payload content, not an intermediate the payload happens to be
+    derived from. Returns None when the field carries no enum at all
     (= the schema degrades to a free-form string and the model is told
     nothing about which tools exist).
     """

--- a/tests/runtime/test_5291_available_agents_removed.py
+++ b/tests/runtime/test_5291_available_agents_removed.py
@@ -1,0 +1,110 @@
+"""Tier 2: #5291 — RouterCallerState.available_agents removed; the
+registry-dispatch path never reads .reyn/agents/ for it any more.
+
+Owner observation (py-spy, reyn-self): stat calls dominating the main loop,
+traced to list_available_agents() being called from build_tools()'s (now-
+removed) available_agents param and — the 9th, previously undocumented
+path found investigating this issue — RouterLoopDriver._invoke_via_registry,
+which rebuilt a full RouterCallerState (including the disk-reading
+available_agents field) on EVERY registry-dispatched tool_call, regardless
+of whether that tool had anything to do with agents.
+
+This is the witness architect/lead-coder specified for that 9th path:
+patch RouterHostAdapter.list_available_agents with a call-counter and
+drive a real registry-dispatched tool_call through a real Session. A bare
+"== 0" assertion is wrong here — the turn's ONE remaining legitimate
+reader (the system-prompt build, #187/#1563) still calls it once,
+unaffected by #5291 — so the witness instead asserts the count does NOT
+SCALE with the number of registry-dispatched tool_calls in the turn (1
+vs 3 tool_calls must produce the SAME total), isolating specifically the
+per-tool_call read this issue is about.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.services.router_host_adapter import RouterHostAdapter
+from tests._support.agent_session import make_session
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+def _tool_call_result(name: str, args: dict, *, call_id: str = "tc_0") -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=None,
+        tool_calls=[{
+            "id": call_id, "type": "function",
+            "function": {"name": name, "arguments": json.dumps(args)},
+        }],
+        finish_reason="tool_calls",
+        usage=_EMPTY_USAGE,
+    )
+
+
+def _text_result(text: str) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=text, tool_calls=[], finish_reason="stop", usage=_EMPTY_USAGE,
+    )
+
+
+def _run_turn_with_n_registry_dispatched_tool_calls(monkeypatch, n: int) -> int:
+    """Drive one turn whose model response calls ``list_memory`` (a
+    REGISTRY_DISPATCH_TOOLS member unrelated to agents) *n* times before
+    finishing, counting every ``RouterHostAdapter.list_available_agents()``
+    call across the WHOLE turn (this legitimately includes the ONE real,
+    live consumer left — the system-prompt's own ``available_agents``
+    rendering, #187/#1563 — unaffected by #5291). Returns that count."""
+    call_count = 0
+    real_list_available_agents = RouterHostAdapter.list_available_agents
+
+    def _counting_list_available_agents(self):
+        nonlocal call_count
+        call_count += 1
+        return real_list_available_agents(self)
+
+    monkeypatch.setattr(
+        RouterHostAdapter, "list_available_agents", _counting_list_available_agents,
+    )
+
+    session = make_session(agent_name="avail_agents_removed_test")
+
+    calls = (
+        [_tool_call_result("list_memory", {"path": ""}) for _ in range(n)]
+        + [_text_result("done")]
+    )
+    call_iter = iter(calls)
+
+    async def _fake_call_llm_tools(*args, **kwargs):
+        return next(call_iter)
+
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools", _fake_call_llm_tools,
+    )
+
+    asyncio.run(session._handle_inbox_text("what's in memory?", chain_id="chain-5291"))
+    return call_count
+
+
+def test_registry_dispatched_tool_call_never_reads_available_agents(monkeypatch) -> None:
+    """Tier 1: #5291 — a REGISTRY_DISPATCH_TOOLS tool call (list_memory,
+    which has nothing to do with agents) drives all the way through
+    RouterLoopDriver._invoke_via_registry -> build_resource_caller_state ->
+    (formerly) list_available_agents(). Witness: driving 1 vs 3 such
+    tool_calls in the same turn must produce the SAME total call count —
+    the turn's one remaining legitimate reader (the system-prompt build,
+    fired once regardless of how many tool_calls follow) is unaffected,
+    but the count must NOT scale with the number of tool_calls. A bare
+    "== 0" assertion would be wrong here (the SP build is a real, live
+    consumer, #5291 does not touch it) — this delta form isolates
+    specifically the registry-dispatch path this issue is about."""
+    count_with_1 = _run_turn_with_n_registry_dispatched_tool_calls(monkeypatch, 1)
+    count_with_3 = _run_turn_with_n_registry_dispatched_tool_calls(monkeypatch, 3)
+
+    assert count_with_1 == count_with_3, (
+        f"list_available_agents() call count scaled with the number of "
+        f"registry-dispatched tool_calls ({count_with_1} vs {count_with_3}) "
+        "— the #5291 per-tool_call read is not gone"
+    )

--- a/tests/runtime/test_5291_available_agents_removed.py
+++ b/tests/runtime/test_5291_available_agents_removed.py
@@ -89,7 +89,7 @@ def _run_turn_with_n_registry_dispatched_tool_calls(monkeypatch, n: int) -> int:
 
 
 def test_registry_dispatched_tool_call_never_reads_available_agents(monkeypatch) -> None:
-    """Tier 1: #5291 — a REGISTRY_DISPATCH_TOOLS tool call (list_memory,
+    """Tier 2: #5291 — a REGISTRY_DISPATCH_TOOLS tool call (list_memory,
     which has nothing to do with agents) drives all the way through
     RouterLoopDriver._invoke_via_registry -> build_resource_caller_state ->
     (formerly) list_available_agents(). Witness: driving 1 vs 3 such
@@ -103,6 +103,16 @@ def test_registry_dispatched_tool_call_never_reads_available_agents(monkeypatch)
     count_with_1 = _run_turn_with_n_registry_dispatched_tool_calls(monkeypatch, 1)
     count_with_3 = _run_turn_with_n_registry_dispatched_tool_calls(monkeypatch, 3)
 
+    # architect review (#5294): count_with_1 == count_with_3 alone is
+    # vacuously green if BOTH are 0 — e.g. if the system-prompt build's own
+    # call site moved to a different class this patch doesn't cover, the
+    # counter would silently stop firing at all and this test would keep
+    # passing while witnessing nothing. Assert the docstring's own stated
+    # premise (the one live reader still fires) directly.
+    assert count_with_1 >= 1, (
+        "the counter never fired at all — either RouterHostAdapter.list_"
+        "available_agents() moved, or this patch target is stale"
+    )
     assert count_with_1 == count_with_3, (
         f"list_available_agents() call count scaled with the number of "
         f"registry-dispatched tool_calls ({count_with_1} vs {count_with_3}) "

--- a/tests/runtime/test_action_retrieval_wiring.py
+++ b/tests/runtime/test_action_retrieval_wiring.py
@@ -113,7 +113,7 @@ def test_router_host_adapter_with_flag_on() -> None:
 
 def test_build_tools_off_when_flag_off() -> None:
     """Tier 2: with flag off, universal wrappers do NOT appear in tools=."""
-    tools = build_tools([], universal_wrappers_enabled=False)
+    tools = build_tools(universal_wrappers_enabled=False)
     names = [t["function"]["name"] for t in tools]
     for w in ("list_actions", "describe_action", "invoke_action"):
         assert w not in names
@@ -121,7 +121,7 @@ def test_build_tools_off_when_flag_off() -> None:
 
 def test_build_tools_on_when_flag_on() -> None:
     """Tier 2: with flag on, 3 universal wrappers appear at the end of tools=."""
-    tools = build_tools([], universal_wrappers_enabled=True)
+    tools = build_tools(universal_wrappers_enabled=True)
     names = [t["function"]["name"] for t in tools]
     assert names[-3:] == ["list_actions", "describe_action", "invoke_action"]
 

--- a/tests/runtime/test_hn_followup_descriptions.py
+++ b/tests/runtime/test_hn_followup_descriptions.py
@@ -31,7 +31,6 @@ def test_q6_read_file_description_has_root_convention_hint() -> None:
     project-root path directly.
     """
     tools = build_tools(
-        available_agents=[],
         file_permissions={"read": ["."]},
     )
     desc = _find_tool(tools, "read_file")["description"]

--- a/tests/runtime/test_mcp_search_tool_invariants.py
+++ b/tests/runtime/test_mcp_search_tool_invariants.py
@@ -23,7 +23,6 @@ from reyn.runtime.router_tools import build_mcp_search_tool, build_tools
 # ── Shared fixtures ───────────────────────────────────────────────────────────
 
 _SAMPLE_SKILLS = [{"name": "skill_a", "description": "A skill"}]
-_SAMPLE_AGENTS = [{"name": "agent_a", "role": "Agent A"}]
 
 _INLINE_MCP_TOOL_NAMES = {"list_mcp_servers", "list_mcp_tools", "call_mcp_tool"}
 
@@ -69,7 +68,6 @@ def test_below_threshold_uses_inline_mcp_tools():
     servers = _make_mcp_servers(below_count)
 
     tools = build_tools(
-        _SAMPLE_AGENTS,
         mcp_servers=servers,
         mcp_search_threshold=_explicit_threshold,
     )
@@ -107,7 +105,6 @@ def test_above_threshold_uses_search_tool():
     servers = _make_mcp_servers(at_count)
 
     tools = build_tools(
-        _SAMPLE_AGENTS,
         mcp_servers=servers,
         mcp_search_threshold=_explicit_threshold,
     )

--- a/tests/runtime/test_pipeline_driver_resource_caller_state_2567.py
+++ b/tests/runtime/test_pipeline_driver_resource_caller_state_2567.py
@@ -110,8 +110,14 @@ class _FakeHost:
 # below. Deliberately NOT including host-derived-but-async-manifest
 # ``available_rag_sources`` in this list; it's checked separately since both
 # sides read the SAME real ``get_source_manifest(Path.cwd())`` (no fake).
+#
+# #5291: ``available_agents`` removed from this list — the field itself was
+# removed from ``RouterCallerState`` (0 real consumers; every populate site
+# was a real .reyn/agents/ disk read for a value nothing downstream read).
+# The other 10 (a)-fields' own equality checks are unaffected — this list
+# just has one fewer entry to prove equal.
 _RESOURCE_FIELDS = (
-    "available_agents", "op_context_factory", "host", "action_embedding_index",
+    "op_context_factory", "host", "action_embedding_index",
     "embedding_provider", "embedding_model_class", "sandbox_backend",
     "mcp_servers", "available_skills", "agent_registry", "pipeline_registry",
 )

--- a/tests/runtime/test_present_blueprint_representable_3630.py
+++ b/tests/runtime/test_present_blueprint_representable_3630.py
@@ -46,7 +46,7 @@ _TWO_COMPONENT_BLUEPRINT = [
 
 def _present_parameters() -> dict:
     """The parameter schema as actually published to the model."""
-    for tool in build_tools([]):
+    for tool in build_tools():
         function = tool["function"]
         if function["name"] == "present":
             return function["parameters"]

--- a/tests/runtime/test_router_loop.py
+++ b/tests/runtime/test_router_loop.py
@@ -661,7 +661,7 @@ async def test_session_spawn_dispatches_to_host_not_unhandled():
     loop = RouterLoop(host=host, chain_id="chain-test")
 
     from reyn.runtime.router_tools import build_tools
-    tools = build_tools(host.list_available_agents())
+    tools = build_tools()
     loop._catalog = {t["function"]["name"]: t for t in tools}
     loop._tool_names = frozenset(loop._catalog.keys())
 
@@ -701,7 +701,7 @@ async def test_send_to_session_dispatches_to_host_not_unhandled():
     loop = RouterLoop(host=host, chain_id="chain-test")
 
     from reyn.runtime.router_tools import build_tools
-    tools = build_tools(host.list_available_agents())
+    tools = build_tools()
     loop._catalog = {t["function"]["name"]: t for t in tools}
     loop._tool_names = frozenset(loop._catalog.keys())
 

--- a/tests/runtime/test_router_tools.py
+++ b/tests/runtime/test_router_tools.py
@@ -8,10 +8,9 @@ from reyn.runtime.router_tools import build_tools
 
 # ── Fixtures / helpers ────────────────────────────────────────────────────────
 
-SAMPLE_AGENTS = [
-    {"name": "researcher", "role": "Research agent"},
-    {"name": "editor", "role": "Editorial agent"},
-]
+# #5291: SAMPLE_AGENTS was build_tools()'s own retired available_agents arg's
+# only consumer in this file — removed alongside every call site that passed
+# it (the parameter itself never read it; #3978 P6 retired its own consumer).
 
 FORBIDDEN_KEYS = {"oneOf", "anyOf", "additionalProperties", "format"}
 
@@ -129,7 +128,7 @@ def test_build_tools_returns_expected_baseline_tools():
     baseline is exactly EXPECTED_TOOL_NAMES. All file-class tools and MCP
     remain gated.
     """
-    tools = build_tools(SAMPLE_AGENTS)
+    tools = build_tools()
     assert _tool_names(tools) == EXPECTED_TOOL_NAMES, (
         f"Expected tools {EXPECTED_TOOL_NAMES}, got {_tool_names(tools)}"
     )
@@ -137,8 +136,8 @@ def test_build_tools_returns_expected_baseline_tools():
 
 def test_tool_order_is_deterministic():
     """Tier 2: build_tools() returns tools in a stable, deterministic order."""
-    tools_a = build_tools(SAMPLE_AGENTS)
-    tools_b = build_tools(SAMPLE_AGENTS)
+    tools_a = build_tools()
+    tools_b = build_tools()
     assert _tool_names(tools_a) == _tool_names(tools_b)
     assert _tool_names(tools_a) == EXPECTED_TOOL_NAMES
 
@@ -149,10 +148,10 @@ def test_compact_visible_gates_tool():
     search_actions §D14 visibility gate; keeps tools= stable on ample-window
     turns (and LLMReplay fixtures keyed on tools byte-stable).
     """
-    default = _tool_names(build_tools(SAMPLE_AGENTS))
+    default = _tool_names(build_tools())
     assert "compact" not in default, "compact must be hidden when the window is ample"
 
-    gated = _tool_names(build_tools(SAMPLE_AGENTS, compact_visible=True))
+    gated = _tool_names(build_tools(compact_visible=True))
     assert "compact" in gated, "compact must appear when the window is filling"
     # Enabling the gate only adds compact — no other tool churn.
     assert set(gated) - set(default) == {"compact"}
@@ -160,7 +159,7 @@ def test_compact_visible_gates_tool():
 
 def test_no_forbidden_schema_keywords():
     """Tier 2: No tool schema contains Gemini-forbidden keywords."""
-    tools = build_tools(SAMPLE_AGENTS)
+    tools = build_tools()
     for tool in tools:
         fn = tool["function"]
         for key, _val, _depth in _walk_dict(fn.get("parameters", {})):
@@ -176,7 +175,7 @@ def test_nested_objects_max_depth_1():
       - depth-0 'properties' key is the top-level parameter list → OK
       - depth-1 'properties' key would be a nested object's inner fields → NOT OK
     """
-    tools = build_tools(SAMPLE_AGENTS)
+    tools = build_tools()
     for tool in tools:
         fn = tool["function"]
         params = fn.get("parameters", {})
@@ -190,7 +189,7 @@ def test_nested_objects_max_depth_1():
 
 def test_required_fields_present_per_tool():
     """Tier 1: Every tool has type, function.name, function.description, and function.parameters."""
-    tools = build_tools(SAMPLE_AGENTS)
+    tools = build_tools()
     for tool in tools:
         assert tool.get("type") == "function", (
             f"Tool missing 'type: function': {tool}"
@@ -203,7 +202,7 @@ def test_required_fields_present_per_tool():
 
 def test_remember_type_enum():
     """Tier 1: remember_shared and remember_agent must both expose the canonical type enum."""
-    tools = build_tools(SAMPLE_AGENTS)
+    tools = build_tools()
     tool_map = {t["function"]["name"]: t for t in tools}
 
     expected_enum = ["user", "feedback", "project", "reference"]
@@ -222,7 +221,7 @@ def test_remember_type_enum():
 
 def test_layer_enum():
     """Tier 1: read_memory_body and forget_memory must both expose the canonical layer enum."""
-    tools = build_tools(SAMPLE_AGENTS)
+    tools = build_tools()
     tool_map = {t["function"]["name"]: t for t in tools}
 
     expected_enum = ["shared", "agent"]
@@ -255,7 +254,7 @@ def test_file_tools_omitted_when_no_permissions():
     tools cover the gap (= reading Reyn's own OSS repo, not user
     files).
     """
-    tools = build_tools(SAMPLE_AGENTS)
+    tools = build_tools()
     names = set(_tool_names(tools))
     assert names.isdisjoint(FILE_TOOL_NAMES), (
         f"Expected no file tools, but found: {names & FILE_TOOL_NAMES}"
@@ -267,8 +266,7 @@ def test_file_tools_omitted_when_no_permissions():
 
 def test_file_read_only_tools_present():
     """Tier 2: read scope only → list_directory and read_file present; write tools absent."""
-    tools = build_tools(SAMPLE_AGENTS,
-        file_permissions={"read": ["src"], "write": []},
+    tools = build_tools(file_permissions={"read": ["src"], "write": []},
     )
     names = set(_tool_names(tools))
     assert "list_directory" in names, "list_directory missing with read scope"
@@ -279,8 +277,7 @@ def test_file_read_only_tools_present():
 
 def test_file_full_tools_present():
     """Tier 2: Both read and write scope → all 4 file tools present."""
-    tools = build_tools(SAMPLE_AGENTS,
-        file_permissions={"read": ["src"], "write": ["out"]},
+    tools = build_tools(file_permissions={"read": ["src"], "write": ["out"]},
     )
     names = set(_tool_names(tools))
     missing = FILE_TOOL_NAMES - names
@@ -292,7 +289,7 @@ def test_file_full_tools_present():
 
 def test_mcp_tools_omitted_when_no_servers():
     """Tier 2: No mcp_servers kwarg → all MCP tools absent."""
-    tools = build_tools(SAMPLE_AGENTS)
+    tools = build_tools()
     names = set(_tool_names(tools))
     assert names.isdisjoint(MCP_TOOL_NAMES), (
         f"Expected no MCP tools, but found: {names & MCP_TOOL_NAMES}"
@@ -301,7 +298,7 @@ def test_mcp_tools_omitted_when_no_servers():
 
 def test_mcp_tools_present_when_servers_configured():
     """Tier 2: mcp_servers non-empty → all 3 MCP tools present."""
-    tools = build_tools(SAMPLE_AGENTS, mcp_servers=SAMPLE_MCP_SERVERS)
+    tools = build_tools(mcp_servers=SAMPLE_MCP_SERVERS)
     names = set(_tool_names(tools))
     missing = MCP_TOOL_NAMES - names
     assert not missing, f"Missing MCP tools when servers configured: {missing}"
@@ -352,8 +349,7 @@ def test_total_tool_count_with_full_permissions():
     an equality check alone would pass silently if ``EXPECTED_FULL_TOOL_
     NAMES`` were ever emptied out from under it, same as ``names == []``
     passing for a ``build_tools`` that returned nothing."""
-    tools = build_tools(SAMPLE_AGENTS,
-        file_permissions={"read": ["src"], "write": ["out"]},
+    tools = build_tools(file_permissions={"read": ["src"], "write": ["out"]},
         mcp_servers=SAMPLE_MCP_SERVERS,
         web_fetch_allowed=True,
     )
@@ -371,8 +367,7 @@ def test_total_tool_count_with_full_permissions():
 
 def test_no_forbidden_schema_keywords_full_permissions():
     """Tier 2: new file+MCP tools must also pass Gemini-safe schema check."""
-    tools = build_tools(SAMPLE_AGENTS,
-        file_permissions={"read": ["src"], "write": ["out"]},
+    tools = build_tools(file_permissions={"read": ["src"], "write": ["out"]},
         mcp_servers=SAMPLE_MCP_SERVERS,
     )
     for tool in tools:
@@ -385,8 +380,7 @@ def test_no_forbidden_schema_keywords_full_permissions():
 
 def test_nested_objects_max_depth_1_full_permissions():
     """Tier 2: new file+MCP tools must also satisfy max depth-1 object nesting."""
-    tools = build_tools(SAMPLE_AGENTS,
-        file_permissions={"read": ["src"], "write": ["out"]},
+    tools = build_tools(file_permissions={"read": ["src"], "write": ["out"]},
         mcp_servers=SAMPLE_MCP_SERVERS,
     )
     for tool in tools:

--- a/tests/runtime/test_router_tools_invariants.py
+++ b/tests/runtime/test_router_tools_invariants.py
@@ -21,11 +21,6 @@ from reyn.runtime.router_tools import (
     get_dispatch_kind,
 )
 
-# ── shared fixtures ───────────────────────────────────────────────────────────
-
-_SAMPLE_AGENTS = [{"name": "peer_agent", "role": "Peer"}]
-
-
 # ── 1. ToolSpec round-trip to OpenAI shape ────────────────────────────────────
 
 
@@ -104,7 +99,7 @@ def test_build_tools_dispatch_kinds_consistent() -> None:
     default to "sync". delegate_to_agent (the original sole async tool
     besides spawn_session) retired in proposal 0067 P6 (#3978).
     """
-    tools = build_tools(_SAMPLE_AGENTS)
+    tools = build_tools()
     tool_names = [t["function"]["name"] for t in tools]
 
     # All tools in the baseline set must be "sync" except the known async ones.
@@ -122,7 +117,6 @@ def test_build_tools_full_permissions_dispatch_kinds_consistent() -> None:
     (list_directory, read_file, write_file, delete_file, list_mcp_servers,
     list_mcp_tools, call_mcp_tool, web_fetch) must all be 'sync'."""
     tools = build_tools(
-        _SAMPLE_AGENTS,
         file_permissions={"read": ["src"], "write": ["out"]},
         mcp_servers=[{"name": "fs", "description": "FS"}],
         web_fetch_allowed=True,
@@ -171,7 +165,6 @@ def test_build_tools_advertises_all_mcp_verbs() -> None:
     could not discover or call them even though the handlers worked.
     """
     tools = build_tools(
-        _SAMPLE_AGENTS,
         mcp_servers=[{"name": "fs", "description": "FS"}],
     )
     tool_names = {t["function"]["name"] for t in tools}

--- a/tests/runtime/test_router_tools_universal_wrappers.py
+++ b/tests/runtime/test_router_tools_universal_wrappers.py
@@ -27,8 +27,6 @@ import pytest
 from reyn.runtime.router_loop import RouterLoop
 from reyn.runtime.router_tools import build_tools
 
-_SAMPLE_AGENTS = [{"name": "peer_agent", "role": "Peer"}]
-
 
 def _tool_names(tools: list[dict]) -> list[str]:
     return [t["function"]["name"] for t in tools]
@@ -39,7 +37,7 @@ def _tool_names(tools: list[dict]) -> list[str]:
 
 def test_default_flag_off_excludes_universal_wrappers() -> None:
     """Tier 2: with the default (False), no universal wrappers appear."""
-    tools = build_tools(_SAMPLE_AGENTS)
+    tools = build_tools()
     names = set(_tool_names(tools))
     for w in ("list_actions", "search_actions", "describe_action",
               "invoke_action"):
@@ -55,9 +53,9 @@ def test_default_flag_off_matches_explicit_false() -> None:
     Defensive check — confirms no unintentional default flip during
     refactor.  Both calls must return identical tool name sequences.
     """
-    a = _tool_names(build_tools(_SAMPLE_AGENTS))
+    a = _tool_names(build_tools())
     b = _tool_names(build_tools(
-        _SAMPLE_AGENTS, universal_wrappers_enabled=False,
+        universal_wrappers_enabled=False,
     ))
     assert a == b
 
@@ -75,7 +73,7 @@ def test_flag_on_appends_three_wrappers_in_order() -> None:
     ``test_flag_on_with_search_visible_appends_four_wrappers``).
     """
     names = _tool_names(build_tools(
-        _SAMPLE_AGENTS, universal_wrappers_enabled=True,
+        universal_wrappers_enabled=True,
     ))
     # All 3 wrappers present (search_actions gated separately)
     assert "list_actions" in names
@@ -97,7 +95,6 @@ def test_flag_on_with_search_visible_appends_four_wrappers() -> None:
     in the canonical order.
     """
     names = _tool_names(build_tools(
-        _SAMPLE_AGENTS,
         universal_wrappers_enabled=True,
         search_actions_visible=True,
     ))
@@ -122,12 +119,10 @@ def test_search_visible_alone_does_not_inject_wrappers() -> None:
     stays False keeps the legacy tools= shape unchanged.
     """
     a = _tool_names(build_tools(
-        _SAMPLE_AGENTS,
         universal_wrappers_enabled=False,
         search_actions_visible=True,
     ))
     b = _tool_names(build_tools(
-        _SAMPLE_AGENTS,
         universal_wrappers_enabled=False,
     ))
     assert a == b
@@ -143,7 +138,7 @@ def test_flag_on_wrappers_at_end_of_tools_list() -> None:
     in their previous positions.
     """
     names = _tool_names(build_tools(
-        _SAMPLE_AGENTS, universal_wrappers_enabled=True,
+        universal_wrappers_enabled=True,
     ))
     # The last 3 entries should be the wrappers in canonical order
     assert names[-3:] == ["list_actions", "describe_action", "invoke_action"]
@@ -166,7 +161,7 @@ def test_flag_on_strips_legacy_and_adds_wrappers() -> None:
     wrapper mode.
     """
     on_names = _tool_names(build_tools(
-        _SAMPLE_AGENTS, universal_wrappers_enabled=True,
+        universal_wrappers_enabled=True,
     ))
     # Wrappers present
     assert "list_actions" in on_names
@@ -190,7 +185,7 @@ def test_flag_on_wrapper_shapes_are_openai_function_tools() -> None:
       - nested ``function.parameters.type == "object"``
     """
     tools = build_tools(
-        _SAMPLE_AGENTS, universal_wrappers_enabled=True,
+        universal_wrappers_enabled=True,
     )
     wrappers = [
         t for t in tools
@@ -256,7 +251,7 @@ def test_flag_on_wrappers_present_even_with_empty_skills_agents() -> None:
     Wrappers are universal (§D21 category-external) so they don't
     depend on skill / agent / MCP / file presence.
     """
-    names = _tool_names(build_tools([], universal_wrappers_enabled=True,
+    names = _tool_names(build_tools(universal_wrappers_enabled=True,
     ))
     assert "list_actions" in names
     assert "describe_action" in names
@@ -278,7 +273,6 @@ def test_wrappers_on_strips_all_legacy_tools() -> None:
     addresses everything through the universal wrappers only.
     """
     names = _tool_names(build_tools(
-        _SAMPLE_AGENTS,
         universal_wrappers_enabled=True,
     ))
     # Wrappers present
@@ -320,7 +314,6 @@ def test_ask_user_absent_from_router_tools_when_wrappers_enabled() -> None:
     never stripped, just gated at the definition level.
     """
     names = set(_tool_names(build_tools(
-        _SAMPLE_AGENTS,
         universal_wrappers_enabled=True,
     )))
     # ask_user: gated to phase-only (gates.router='deny') so correctly absent

--- a/tests/security/test_3458_file_scope_one_source.py
+++ b/tests/security/test_3458_file_scope_one_source.py
@@ -190,7 +190,7 @@ def test_unconfigured_project_advertises_the_file_tools(tmp_path: Path) -> None:
     resolver = PermissionResolver({}, project_root=zone)
     names = {
         t["function"]["name"]
-        for t in build_tools([], file_permissions=resolver.advertised_file_permissions())
+        for t in build_tools(file_permissions=resolver.advertised_file_permissions())
     }
     assert {"read_file", "list_directory"} <= names
     assert _gate_readable(resolver, str(zone / "src" / "a.py")) is True
@@ -206,7 +206,7 @@ def test_deny_hides_the_file_tools(tmp_path: Path) -> None:
     assert resolver.advertised_file_permissions() is None
     names = {
         t["function"]["name"]
-        for t in build_tools([], file_permissions=resolver.advertised_file_permissions())
+        for t in build_tools(file_permissions=resolver.advertised_file_permissions())
     }
     assert not ({"read_file", "list_directory", "write_file", "delete_file"} & names)
     assert _gate_readable(resolver, str(zone / "src" / "a.py")) is False

--- a/tests/security/test_web_fetch_unified.py
+++ b/tests/security/test_web_fetch_unified.py
@@ -146,9 +146,7 @@ def test_build_tools_includes_web_fetch_via_registry():
     parameter is kept for backward compat but is a no-op."""
     from reyn.runtime.router_tools import build_tools
 
-    tools = build_tools(
-        available_agents=[],
-    )
+    tools = build_tools()
 
     # Find web_fetch in the returned tools list
     wf_tools = [t for t in tools if t.get("function", {}).get("name") == "web_fetch"]
@@ -174,9 +172,7 @@ def test_build_tools_web_fetch_not_duplicated():
     being included simultaneously. FP-0022: web_fetch is always in catalog."""
     from reyn.runtime.router_tools import build_tools
 
-    tools = build_tools(
-        available_agents=[],
-    )
+    tools = build_tools()
     wf_tools = [t for t in tools if t.get("function", {}).get("name") == "web_fetch"]
     assert wf_tools, "web_fetch should appear in build_tools output"
 

--- a/tests/tools/test_enumerate_all_scheme_1593.py
+++ b/tests/tools/test_enumerate_all_scheme_1593.py
@@ -201,7 +201,7 @@ async def test_enumerate_all_excludes_catalog_mcp_wrapper_3219() -> None:
     assert any(e["function"]["name"] == "mcp_call_tool" for e in real_catalog)
 
     real_base = build_tools(
-        [], mcp_servers=[{"name": "srv", "description": "d"}],
+        mcp_servers=[{"name": "srv", "description": "d"}],
     )
     # Sanity: native call_mcp_tool is present via base_tools (real build_tools).
     assert any(t["function"]["name"] == "call_mcp_tool" for t in real_base)

--- a/tests/tools/test_no_qualified_tool_names_3429.py
+++ b/tests/tools/test_no_qualified_tool_names_3429.py
@@ -151,7 +151,6 @@ def test_no_advertised_tool_name_is_qualified() -> None:
     advertised = [
         entry.get("function", {}).get("name") or entry.get("name", "")
         for entry in build_tools(
-            available_agents=[{"name": "peer", "role": "r"}],
             file_permissions={"read": ["."], "write": ["."]},
             mcp_servers=[{"name": "echo", "tools": [{"name": "ping"}]}],
             universal_wrappers_enabled=True,

--- a/tests/tools/test_router_call_mcp_tool_enum.py
+++ b/tests/tools/test_router_call_mcp_tool_enum.py
@@ -44,7 +44,6 @@ from reyn.tools.types import RouterCallerState, ToolContext
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
 
-_AGENTS = [{"name": "researcher", "role": "Research agent", "cluster": "default"}]
 _EMPTY_MEMORY: dict = {"status": "not_found", "content": ""}
 
 _MCP_SERVERS_NO_TOOLS = [
@@ -90,7 +89,7 @@ def test_call_mcp_tool_param_renamed_to_mcp_tool_name():
     FP-0032 vocabulary unification: the old 'tool' param collided with OpenAI's
     standard 'tool' semantics. 'mcp_tool_name' is unambiguous.
     """
-    tools = build_tools(_AGENTS, mcp_servers=_MCP_SERVERS_NO_TOOLS)
+    tools = build_tools(mcp_servers=_MCP_SERVERS_NO_TOOLS)
     fn = _get_tool(tools, "call_mcp_tool")
     assert fn is not None, "call_mcp_tool must be present when mcp_servers are configured"
     props = fn["parameters"]["properties"]
@@ -115,7 +114,7 @@ def test_call_mcp_tool_server_enum_injected():
 
     P4 alignment: LLM can only pick from OS-provided server names.
     """
-    tools = build_tools(_AGENTS, mcp_servers=_MCP_SERVERS_NO_TOOLS)
+    tools = build_tools(mcp_servers=_MCP_SERVERS_NO_TOOLS)
     fn = _get_tool(tools, "call_mcp_tool")
     assert fn is not None
     server_schema = fn["parameters"]["properties"]["server"]
@@ -138,7 +137,7 @@ def test_call_mcp_tool_mcp_tool_name_enum_injected_when_tools_available():
 
     Dotted form <server>.<tool> avoids name collision across servers.
     """
-    tools = build_tools(_AGENTS, mcp_servers=_MCP_SERVERS_WITH_TOOLS)
+    tools = build_tools(mcp_servers=_MCP_SERVERS_WITH_TOOLS)
     fn = _get_tool(tools, "call_mcp_tool")
     assert fn is not None
     tool_name_schema = fn["parameters"]["properties"]["mcp_tool_name"]
@@ -157,7 +156,7 @@ def test_call_mcp_tool_no_mcp_tool_name_enum_when_no_tools_listed():
 
     Graceful fallback: schema remains valid, no empty enum.
     """
-    tools = build_tools(_AGENTS, mcp_servers=_MCP_SERVERS_NO_TOOLS)
+    tools = build_tools(mcp_servers=_MCP_SERVERS_NO_TOOLS)
     fn = _get_tool(tools, "call_mcp_tool")
     assert fn is not None
     tool_name_schema = fn["parameters"]["properties"]["mcp_tool_name"]
@@ -179,7 +178,7 @@ def test_call_mcp_tool_not_present_when_no_mcp_servers():
     Same pattern as invoke_skill being absent when available_skills=[].
     An empty-server catalog should not present MCP tools at all.
     """
-    tools = build_tools(_AGENTS, mcp_servers=[])
+    tools = build_tools(mcp_servers=[])
     names = {t["function"]["name"] for t in tools if t.get("type") == "function"}
     assert "call_mcp_tool" not in names, (
         "call_mcp_tool must be absent when mcp_servers is empty"
@@ -357,7 +356,7 @@ def test_describe_mcp_tool_enum_mirrors_call_mcp_tool():
 
     Symmetry invariant: both tools constrain LLM to the same candidate set.
     """
-    tools = build_tools(_AGENTS, mcp_servers=_MCP_SERVERS_WITH_TOOLS)
+    tools = build_tools(mcp_servers=_MCP_SERVERS_WITH_TOOLS)
     call_fn = _get_tool(tools, "call_mcp_tool")
     describe_fn = _get_tool(tools, "describe_mcp_tool")
     assert call_fn is not None, "call_mcp_tool must be present"
@@ -554,7 +553,6 @@ def test_default_threshold_always_inline():
         for i in range(50)
     ]
     tools = build_tools(
-        _AGENTS,
         mcp_servers=many_servers,
         mcp_search_threshold=MCP_SEARCH_THRESHOLD,  # == 0
     )
@@ -583,7 +581,7 @@ def test_describe_mcp_tool_present_in_build_tools():
     Closes the symmetry gap: skill has describe_skill, agent has describe_agent,
     MCP now has describe_mcp_tool.
     """
-    tools = build_tools(_AGENTS, mcp_servers=_MCP_SERVERS_NO_TOOLS)
+    tools = build_tools(mcp_servers=_MCP_SERVERS_NO_TOOLS)
     names = {t["function"]["name"] for t in tools if t.get("type") == "function"}
     assert "describe_mcp_tool" in names, (
         "describe_mcp_tool (D4) must appear in build_tools output alongside D1–D3"
@@ -592,7 +590,7 @@ def test_describe_mcp_tool_present_in_build_tools():
 
 def test_describe_mcp_tool_absent_when_no_mcp_servers():
     """Tier 2: describe_mcp_tool is absent when mcp_servers=[] (same guard as D1–D3)."""
-    tools = build_tools(_AGENTS, mcp_servers=None)
+    tools = build_tools(mcp_servers=None)
     names = {t["function"]["name"] for t in tools if t.get("type") == "function"}
     assert "describe_mcp_tool" not in names, (
         "describe_mcp_tool must be absent when no mcp_servers configured"

--- a/tests/tools/test_tool_registry_invariants.py
+++ b/tests/tools/test_tool_registry_invariants.py
@@ -345,7 +345,6 @@ def test_router_caller_state_defaults_all_none():
     """Tier 2: RouterCallerState() with no arguments defaults all fields to None."""
     state = RouterCallerState()
     assert state.agent_registry is None
-    assert state.available_agents is None
     assert state.send_to_session_fn is None
     assert state.chain_id is None
     assert state.budget is None
@@ -408,7 +407,6 @@ def test_router_caller_state_partial_population():
     state = RouterCallerState(agent_registry=sentinel_registry)
 
     assert state.agent_registry is sentinel_registry
-    assert state.available_agents is None
     assert state.send_to_session_fn is None
     assert state.chain_id is None
     assert state.budget is None
@@ -428,7 +426,6 @@ def test_router_caller_state_full_population():
 
     state = RouterCallerState(
         agent_registry=sentinel_agent_reg,
-        available_agents=[{"name": "a1"}],
         send_to_session_fn=_send_to_session,
         chain_id="chain-xyz",
         budget=sentinel_budget,
@@ -438,7 +435,6 @@ def test_router_caller_state_full_population():
     )
 
     assert state.agent_registry is sentinel_agent_reg
-    assert state.available_agents == [{"name": "a1"}]
     assert state.send_to_session_fn is _send_to_session
     assert state.chain_id == "chain-xyz"
     assert state.budget is sentinel_budget
@@ -490,11 +486,17 @@ def test_tool_definition_schema_enricher_defaults_none():
 
 
 def test_tool_definition_schema_enricher_can_be_set():
-    """Tier 2: ToolDefinition.schema_enricher accepts a callable and can be invoked."""
+    """Tier 2: ToolDefinition.schema_enricher accepts a callable and can be invoked.
+
+    #5291: was keyed on ``available_agents`` (removed — 0 real consumers,
+    #5291's own field-removal commit); ``mcp_servers`` is the actual field
+    a live enricher reads (``tools/mcp.py``'s ``_enrich_router_schema``) —
+    switching the sample to it keeps this test exercising the SAME
+    mechanism a real capability uses, not a dead one."""
     def _enricher(rendered: dict, state: RouterCallerState) -> dict:
         enriched = dict(rendered)
         enriched["_enriched"] = True
-        enriched["_agents_count"] = len(state.available_agents or [])
+        enriched["_servers_count"] = len(state.mcp_servers or [])
         return enriched
 
     tool = ToolDefinition(
@@ -510,9 +512,9 @@ def test_tool_definition_schema_enricher_can_be_set():
     assert callable(tool.schema_enricher)
 
     sample_rendered = {"type": "function", "function": {"name": "enricher_tool"}}
-    state = RouterCallerState(available_agents=[{"name": "agent_a"}, {"name": "agent_b"}])
+    state = RouterCallerState(mcp_servers=[{"name": "server_a"}, {"name": "server_b"}])
     result = tool.schema_enricher(sample_rendered, state)
 
     assert result["_enriched"] is True
-    assert result["_agents_count"] == 2
+    assert result["_servers_count"] == 2
     assert result["type"] == "function"

--- a/tests/tools/test_tool_schema_3383_process_history_independence.py
+++ b/tests/tools/test_tool_schema_3383_process_history_independence.py
@@ -160,17 +160,16 @@ def test_render_for_router_survives_in_place_mutation_of_a_handed_out_payload() 
 
 def test_build_tools_survives_in_place_mutation_of_a_handed_out_payload() -> None:
     """Tier 1: mutating a build_tools() payload cannot alter the next build_tools()."""
-    agents = [{"name": "researcher", "role": "Research agent"}]
-    pristine = deepcopy(build_tools(agents))
+    pristine = deepcopy(build_tools())
 
-    payload = build_tools(agents)
+    payload = build_tools()
     touched = _mutate_in_place(payload)
     assert touched > len(pristine), (
         f"mutation did not reach nested sub-schemas (touched={touched})"
     )
     assert payload != pristine, "the mutation helper did not change the payload"
 
-    assert build_tools(agents) == pristine, (
+    assert build_tools() == pristine, (
         "build_tools() changed after an EARLIER payload was mutated in place — "
         "a ToolSpec / ToolDefinition schema escaped by reference (#3383)"
     )


### PR DESCRIPTION
> ⚠️ **Scope (lead-coder, 2026-08-27): this PR now contains BOTH slices, not just commit 1.**
> A behaviour-changing slice landed here too — `src/reyn/tools/types.py` (the `available_agents`
> field removed + its populate line dropped) and `tests/tools/test_tool_registry_invariants.py`
> (enricher sample switched to `mcp_servers`). Read them as two slices: the mechanical one
> (`build_tools`'s argument, across ~20 files) and the behavioural one (the two files above).
> Do not read this as a zero-behaviour-change PR. Reviewed and accepted as one PR by architect
> (git surgery would invite a new accident). Remaining: `types.py`'s 3 stale comments, the
> equality tuple in `test_pipeline_driver_resource_caller_state_2567.py`, and the witness.

**[e2e-coder]** — part of #5291 (Family: stat-flood on the main loop, owner py-spy). Final design confirmed on the issue thread (architect + lead-coder, both converged on ① — remove the parameter, not just stop passing it).

## Commit 1 (this push) — zero behavior change
`build_tools()`'s `available_agents` parameter was never read by its own body (architect's grep: 3 lines only — module docstring, signature, docstring; its only consumer, `delegate_to_agent`'s per-call `to` enum injection, retired in #3978 P6). Every one of its 4 production call sites was reading `.reyn/agents/` from disk (iterdir + 2-3 stat per agent) for nothing — 2 of the 4 (`capability_visibility.py`'s `_VisibilityProbeOps`) run on **every render frame** (that class's own docstring).

Removed the parameter entirely rather than making it optional/defaulted — an optional param still lets a future caller pass `list_available_agents()` again (owner standing rule: close the class, not the instance).

Zero behavior change: the return value is byte-identical for every existing call (the argument was never read), so all ~75 existing call sites (4 production, ~65 test, across 20 files) needed only the now-obsolete argument dropped, mechanically — verified via AST (not grep) that no call anywhere in `src/` or `tests/` still passes a first positional or `available_agents=` argument. Also removed 8 now-dead agent-fixture constants/locals whose only remaining reference was their own definition.

## Commit 2 — `types.py:304` lazy deferral (in progress)
Separate commit (real behavior change, needs its own witness), per architect's request not to mix a zero-behavior-change removal with a behavioral one in the same commit. I found a discrepancy while starting it — flagging on broker before implementing rather than guessing.

## Tests
Scoped pytest across all 20 touched files (197 tests) + ruff + the 5 local gates — all green.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on changed test files
- [x] `mypy_ratchet.py`
- [x] `verify_module_docstrings.py` on changed src files
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] Scoped pytest across all 20 touched files (197 passed)
- [x] AST-verified no remaining `build_tools()` call anywhere passes the removed argument
- [x] Commit 2 (field removal + witness) pushed — strip-falsified: reintroducing the populate-line flips the witness RED (5 vs 7), confirmed then restored
- [x] (skipped — no visual surface changed)

Cannot self-merge (touches `tests/`) — needs a TESTS-READ note per rule 8. Commit 2 to follow in this same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- [x] 🔴 **[architect]** Four prose references still show the removed signature — `src/reyn/tools/llm_reachability.py:34` and `:257` both say `build_tools([])`, which is a `TypeError` after this PR (and that module is specifically about AST-census vs execution, so a reader may try it), plus `tests/runtime/test_3520_unknown_probe_is_not_an_answer.py:17` and `:167` (`build_tools(agents, mcp_servers=...)`). CLAUDE.md: fix a doc describing a changed mechanism in the SAME PR. The `router_tools.py` module docstring was already updated the right way. See issuecomment on this PR.


---

## 🔴 Blocking (reviewer: architect / transcribed to the body by lead-coder per house rule 7)

- [x] 🔴 **消えた signature が散文に 4 か所残っている — CLAUDE.md「fix it in the SAME PR」**
  - `src/reyn/tools/llm_reachability.py:34` / `:257` — 逐語 `build_tools([])`。**この PR の後は TypeError**。しかもこの module は「AST census か実行か」を論じる場所で、**読者が実際に試す**。
  - `tests/runtime/test_3520_unknown_probe_is_not_an_answer.py:17` — 逐語 `build_tools(agents, mcp_servers=host.get_mcp_servers())`。同 file `:173` の実コードは既に `build_tools(mcp_servers=...)` に直っており、散文だけが古い。
  - 同 `:167` — 逐語 `build_tools(..., mcp_servers=self.host.get_mcp_servers())`。同じ class。
  - 参考: `router_tools.py` の module docstring は**既に正しく直っている** — 漏れたのはこの 4 か所。

<!-- lead-coder: 確認済 — 上記 4 か所は origin/feat/5291-drop-dead-available-agents-reads で実在。 -->



<!-- lead-coder 2026-08-27: 上記 4 か所は head 554168a69 で解消を確認（`build_tools([])` / `build_tools(agents,...)` とも 0 件、残る hit は省略記号と正しい kwarg 形のみ）。よって本チェックを閉じます。architect 側の同旨チェックは architect の判断で。 -->

## ⚠️ commit 分離が崩れた件（e2e-coder 自己申告 / lead-coder 裁定）

`554168a69`（散文修正コミット）に commit 2 の一部（`types.py` の field 削除＋populate 行削除、`test_tool_registry_invariants.py` の enricher 差し替え）が意図せず混入した。

**裁定: 履歴の作り直しはしない。** branch 作り直しは main 側の変更を巻き戻し得るうえ、通常の PR 差分がその向きを映さない。代わりに:

**裁定（lead-coder、architect 合意済）: このまま 1 本で進める。履歴の作り直しはしない。**
architect の目的は「どれが挙動を変えたか読める」ことの一点で、挙動を変える側は file が分かれている
（`src/reyn/tools/types.py` / `tests/tools/test_tool_registry_invariants.py`）ため 2 slice として読める。
branch 作り直しは main 側の変更を巻き戻し得るうえ、通常の PR 差分がその向きを映さない。
（当初 lead-coder が求めた「第 3 commit に分けて積む」は撤回。普通に積んでよい。）

残作業（e2e-coder、この PR 内で完了させる — 上の Test plan の未チェック項がこれに当たる）:
`types.py` に残る古いコメント 3 か所 ／ `test_pipeline_driver_resource_caller_state_2567.py` の
等価性 tuple ／ **witness**（`list_available_agents` に counter を掛け、registry dispatch の
tool_call を 1 回流して **0 回** — field の不在ではなく「**経路が消えた**」ことを見る）。




