### PR TITLE
fix(#5267): re-type session.py's funnel-bypass entry from defect to false_positive

### DIFF
--- a/scripts/check_task_funnel_bypass.py
+++ b/scripts/check_task_funnel_bypass.py
@@ -124,9 +124,12 @@ declared-baseline idiom this repo already uses for exactly this problem
 (``mypy_ratchet.py``'s ``(file, code)`` pairs, ``flat_tests_ratchet.py``'s
 filename set): every CURRENTLY accepted offender is a declared entry,
 keyed by file path, each carrying its own ``"type"`` (``"defect"`` — a
-real hazard tracked for its own fix PR, same as ``session.py`` today —
-or ``"false_positive"`` — the gate is wrong about this one) and a
-``"note"`` explaining which and why. The test
+real hazard tracked for its own fix PR — or ``"false_positive"`` — the
+gate is wrong about this one) and a ``"note"`` explaining which and why.
+``session.py`` was this file's first entry and was typed ``"defect"``;
+#5267 measured the hazard it named and could not reproduce it, so it is
+now the first ``"false_positive"`` — which is exactly the count the
+promotion condition below reads. The test
 (``tests/scripts/test_check_task_funnel_bypass_5267.py``) asserts the
 REAL tree's offenders match the declared set exactly; a new,
 undeclared offender fails that test (a real, already-blocking CI signal

--- a/scripts/task_funnel_bypass_baseline.json
+++ b/scripts/task_funnel_bypass_baseline.json
@@ -1,6 +1,6 @@
 {
   "src/reyn/runtime/session.py": {
-    "type": "defect",
-    "note": "#5267's own chain (Session.run_one_iteration's _turn_owner_task) — a real hazard, tracked for its own separate fix PR, not a gate false positive."
+    "type": "false_positive",
+    "note": "Session.run_one_iteration's _turn_owner_task (session.py:6937). The funnel is for tasks that outlive their creating call; this one is awaited at :6942 and discarded at :7013. Two grounds, both checked in #5267: (a) a driver cancelled by ANY route does cancel it -- Task.cancel() propagates through _fut_waiter, measured on a minimal repro and on a real Session, falsifying the orphaning hazard this entry was first typed 'defect' for; (b) quiescence is already covered without the funnel -- await_quiescent's own docstring calls its list 'the exhaustive set of append-capable spawned tasks in this surface' and names 'the current turn (_turn_idle)' first. Re-type to 'defect' only if a reproduction of an actually-orphaned turn task appears."
   }
 }


### PR DESCRIPTION
**[lead-coder]** — part of #5267.

## What
`scripts/task_funnel_bypass_baseline.json`'s only entry, `src/reyn/runtime/session.py`, is re-typed `"defect"` → `"false_positive"`.

## Why the original typing was wrong
I wrote that entry (#5270) with the note "a **real hazard**, tracked for its own separate fix PR, not a gate false positive". The hazard it named was: a driver cancelled by a route other than `cancel_inflight()` would leave `_turn_owner_task` orphaned.

**e2e-coder measured it and it does not reproduce.** `Task.cancel()` propagates to `self._fut_waiter`, so with the direct `await self._turn_owner_task` shape (session.py:6942) a cancelled driver *does* cancel the sub-task — confirmed on a minimal repro and on a real `Session`. architect, who supplied the mechanism, has retracted it.

The obvious replacement ground — "an untracked task is missed at shutdown" — does not hold either. `await_quiescent`'s own docstring names its coverage **verbatim** "the exhaustive set of append-capable spawned tasks in this surface" and lists **"the current turn (`_turn_idle`)"** first. The task is created at `:6937`, awaited at `:6942`, discarded at `:7013` — it never outlives the call that creates it, which is what the funnel is for.

## Disclosure: this changes the gate's own promotion accounting
The script's docstring is explicit — verbatim: "the commit(s) adding a `"false_positive"` entry **ARE** the false-positive count, in order, against the PRs that touched an in-scope file over that stretch." So **this is the gate's first false positive**, and the promotion condition ("20 consecutive PRs with 0 new false positives") must be read against it. I am not adjusting that condition here; I am making the count visible so whoever decides promotion sees it.

## Doc-drift fixed in the same commit (CLAUDE.md hard rule)
The same docstring used this very entry as its example of a `"defect"` — verbatim "a real hazard tracked for its own fix PR, **same as `session.py` today**". That sentence is now false and is corrected in the same commit.

## Not done here
#5267's own body (the `to_thread` × shared `_cached_elide_*` ownership work, direction (a) ratified 2026-08-27) is untouched and stays open. Only the funnel-routing sub-item is settled.

## Test plan
- [x] `ruff check .` — clean
- [x] `pytest tests/scripts/test_check_task_funnel_bypass_5267.py` — 10 passed
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_task_funnel_bypass_5267.py` — exit 0
- [x] `python scripts/verify_module_docstrings.py scripts/check_task_funnel_bypass.py` — clean
- [x] JSON parses; gate runs and still reports the same single declared offender
- [x] (skipped — no visual surface changed)

Touches `tests/`? No — only `scripts/`. No TESTS-READ needed, but a reviewer's read of the two grounds above is welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
