### PR TITLE
test(#5010): pin the doc-drift calibration fixture to 2 immutable refs

### DIFF
--- a/.github/workflows/check-doc-drift-fixture.yml
+++ b/.github/workflows/check-doc-drift-fixture.yml
@@ -1,0 +1,61 @@
+name: Doc-drift gate calibration fixture (#5010)
+
+# #5010: 4 regression tests in tests/scripts/test_check_doc_drift_5003.py
+# pin the doc-drift gate's calibration to 2 immutable, historical SHAs
+# (`e802ad73a` / `ba9690bb2^`) via `git show <sha>:<path>` — never the
+# live working tree, so the fixture measures the same thing regardless
+# of how far `main` has moved (see that test file's own #5010 section
+# for the full account).
+#
+# Isolated into its OWN workflow, path-scoped to the 2 files that could
+# possibly need it, rather than folded into `test.yml`'s `test:` job —
+# lead-coder review (#5298): that job's own checkout is depth-1
+# (shallow) by default, and adding `fetch-depth: 0` there would pay a
+# full-clone cost on EVERY PR just for 4 tests that only exercise 2
+# specific, rarely-touched files. This job pays that cost only when a
+# PR actually touches one of them.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+    paths:
+      - "scripts/check_doc_drift.py"
+      - "tests/scripts/test_check_doc_drift_5003.py"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/check_doc_drift.py"
+      - "tests/scripts/test_check_doc_drift_5003.py"
+
+permissions:
+  contents: read
+
+jobs:
+  doc-drift-fixture:
+    name: doc-drift gate calibration fixture (#5010)
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    timeout-minutes: 5
+
+    steps:
+      # fetch-depth: 0 (full history) — the fixture's own `_content_at`
+      # helper reads real file content at 2 pinned, historical SHAs via
+      # `git show <sha>:<path>`; a shallow (depth-1) checkout would 404
+      # on objects that old, raising CalledProcessError (the fixture's
+      # own `check=True` is deliberate — see its docstring — so this
+      # fails loudly rather than silently, but it still needs the real
+      # history present to succeed at all).
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install test dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run the #5010 calibration fixture tests
+        run: pytest tests/scripts/test_check_doc_drift_5003.py -k 5010 -v

--- a/tests/scripts/test_check_doc_drift_5003.py
+++ b/tests/scripts/test_check_doc_drift_5003.py
@@ -614,7 +614,7 @@ def _pinned_shas_resolve_locally() -> bool:
     ([[feedback_git_existence_check_cat_file_not_ls_tree]]-equivalent
     discipline: an object either resolves or it does not, no separate
     empty-output case to misread)."""
-    for ref in (_5010_SRC_SHA, _5010_DOCS_PRE_SHA.rstrip("^")):
+    for ref in (_5010_SRC_SHA, _5010_DOCS_PRE_SHA):
         result = subprocess.run(
             ["git", "cat-file", "-e", ref], cwd=REPO_ROOT, capture_output=True
         )

--- a/tests/scripts/test_check_doc_drift_5003.py
+++ b/tests/scripts/test_check_doc_drift_5003.py
@@ -561,3 +561,176 @@ def test_find_removed_identifiers_precise_falls_back_and_logs_when_file_deleted(
         captured = capsys.readouterr()
         assert "falling back to line heuristic" in captured.err
         assert "gone_file.py" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# #5010 calibration fixture — the real #5095/#5106 incident, pinned to 2
+# immutable refs (architect, issuecomment-5435721126). Closes the module
+# docstring's own disclosed gap: the earlier calibration attempt
+# (`--pr 5095` against the LIVE tree) went green for the wrong reason —
+# by the time anyone re-ran it, #5106 had already fixed the docs, so the
+# same command measured a DIFFERENT world than the one #5095 shipped
+# into (architect's own diagnosis, issuecomment-5380414073: "an
+# observation does not name its own referent"). Pinning both the src-side
+# removal commit and the docs-side pre-fix commit as fixed SHAs means
+# this fixture measures the SAME thing every time it runs, regardless of
+# how far `main` has moved since — the same discipline #5290 names for a
+# different check.
+#
+# Every read below is `git show <PINNED_SHA>:<path>` against this
+# repo's own immutable history — never the checked-out working tree at
+# HEAD, which is free to move. The two refs:
+#   - src side (identifier removed): e802ad73a — "fix(#5091): remove the
+#     'broker' concept from reyn's own runtime (#5095)".
+#   - docs side (pre-fix state):     ba9690bb2^ — the commit immediately
+#     BEFORE "docs: ... 3 places still cite the removed field (#5106)".
+# ---------------------------------------------------------------------------
+
+_5010_SRC_SHA = "e802ad73a"  # #5095 — removes AgentProfile.broker_identity
+_5010_DOCS_PRE_SHA = "ba9690bb2^"  # immediately before #5106's doc fix
+_5010_IDENTIFIER = "broker_identity"
+# The 2 src/ files whose only surviving mention is comment/docstring prose
+# (architect, issuecomment-5435721126 — verified independently below via
+# `git grep -n` against the pinned SHA, not taken on report).
+_5010_SRC_PROSE_ONLY_FILES = (
+    "src/reyn/runtime/profile.py",
+    "src/reyn/runtime/session.py",
+)
+# The 2 docs/ files (4 total line-level occurrences — 2 each) #5106 fixed;
+# untouched by #5095 itself.
+_5010_DOC_FILES = (
+    "docs/reference/config/reyn-yaml.md",
+    "docs/reference/config/reyn-yaml.ja.md",
+)
+
+
+def _content_at(sha: str, path: str) -> str:
+    """Real file content at a pinned, immutable ref in THIS repo's own
+    git history — never the live working tree. Fails loudly (via
+    ``check=True``) rather than silently substituting empty content if
+    either ref ever stopped resolving (e.g. a history rewrite) — a
+    fixture that can go quietly empty is worse than one that errors."""
+    result = subprocess.run(
+        ["git", "show", f"{sha}:{path}"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def _materialize_fixture_repo(tmp_path: Path) -> Path:
+    """An isolated, throwaway git repo (never the live reyn-dev tree)
+    seeded with the REAL byte-for-byte content of the 2 src/ files and 2
+    docs/ files at their pinned SHAs above. `identifier_survives_in_src`/
+    `find_doc_files_containing` both shell out to `git grep`, which
+    requires an actual git working directory to search — this gives them
+    one, without ever pointing either function at this repo's own,
+    movable HEAD."""
+    repo = _init_repo(tmp_path)
+    for rel in _5010_SRC_PROSE_ONLY_FILES:
+        dest = repo / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(_content_at(_5010_SRC_SHA, rel))
+    for rel in _5010_DOC_FILES:
+        dest = repo / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(_content_at(_5010_DOCS_PRE_SHA, rel))
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "fixture"], cwd=repo, check=True)
+    return repo
+
+
+def test_5010_fixture_content_matches_the_real_historical_commits_exactly():
+    """Tier 2: sanity check on the fixture itself, independent of
+    ``check_doc_drift.py`` entirely — a plain ``git grep -n`` against the
+    pinned SHAs in THIS repo's real history, confirming the exact 4
+    file:line occurrences architect reported (issuecomment-5435721126)
+    are still there, unchanged, before trusting anything built on top of
+    them. If this ever goes red, the fixture's own premise moved (e.g. a
+    history rewrite), not the discriminator under test."""
+    doc_hits = subprocess.run(
+        ["git", "grep", "-n", "-F", _5010_IDENTIFIER, _5010_DOCS_PRE_SHA, "--", "docs/"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    ).stdout
+    assert f"{_5010_DOCS_PRE_SHA}:docs/reference/config/reyn-yaml.ja.md:35:" in doc_hits
+    assert f"{_5010_DOCS_PRE_SHA}:docs/reference/config/reyn-yaml.ja.md:66:" in doc_hits
+    assert f"{_5010_DOCS_PRE_SHA}:docs/reference/config/reyn-yaml.md:37:" in doc_hits
+    assert f"{_5010_DOCS_PRE_SHA}:docs/reference/config/reyn-yaml.md:72:" in doc_hits
+
+    src_hits = subprocess.run(
+        ["git", "grep", "-n", "-F", _5010_IDENTIFIER, _5010_SRC_SHA, "--", "src/"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    ).stdout
+    assert f"{_5010_SRC_SHA}:src/reyn/runtime/profile.py:29:" in src_hits
+    assert f"{_5010_SRC_SHA}:src/reyn/runtime/session.py:5619:" in src_hits
+
+    # #5095 (e802ad73a) never touched either docs/ file — #5106 (a LATER,
+    # separate commit) is what eventually fixed them.
+    touched = subprocess.run(
+        ["git", "show", "--stat", "--format=", _5010_SRC_SHA],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    ).stdout
+    assert "reyn-yaml.md" not in touched
+    assert "reyn-yaml.ja.md" not in touched
+
+
+def test_5010_naive_grep_says_the_identifier_still_survives(tmp_path):
+    """Tier 2: acceptance ① of #5010's re-promotion fixture (architect,
+    issuecomment-5435721126) — the OLD discriminator class this fixture
+    exists to distinguish from. A bare, unredacted ``git grep -lF`` (no
+    call into any of ``check_doc_drift.py``'s own functions — this is an
+    independent external-tool baseline, not a transcription of
+    production logic) finds ``broker_identity`` still present in both
+    src/ files, because it cannot tell a live code occurrence from a
+    comment/docstring PROSE citation recording the removal. This is what
+    made the ORIGINAL (#5007/#5010-round-1) discriminator call the
+    identifier "still survives" and skip it — a false negative, not a
+    false positive: the doc-drift finding these 2 docs deserved never
+    fired."""
+    repo = _materialize_fixture_repo(tmp_path)
+    raw_grep = subprocess.run(
+        ["git", "grep", "-lF", "--", _5010_IDENTIFIER, "--", "src"],
+        cwd=repo, capture_output=True, text=True,
+    )
+    assert raw_grep.returncode == 0, "the naive grep must find it (that's the bug)"
+    hits = set(raw_grep.stdout.splitlines())
+    assert hits == set(_5010_SRC_PROSE_ONLY_FILES)
+
+
+def test_5010_real_discriminator_correctly_says_it_does_not_survive(tmp_path):
+    """Tier 2: acceptance ② — the REAL, current ``identifier_survives_in_src``
+    (the tokenizer/AST-backed redaction fix, #5010 round 2) on the exact
+    same fixture correctly says ``broker_identity`` does NOT survive as
+    living code — both of its only 2 remaining mentions are comment/
+    docstring prose (verified above, independent of this call). This is
+    the discriminator this fixture exists to pin: the naive and the real
+    check give OPPOSITE answers on the same real historical incident."""
+    repo = _materialize_fixture_repo(tmp_path)
+    assert m.identifier_survives_in_src(_5010_IDENTIFIER, repo) is False
+
+
+def test_5010_end_to_end_finds_the_real_4_line_drift_untouched_by_5095():
+    """Tier 2: acceptance ③ — wires ①+② together the way
+    ``resolve_gone_identifiers_precise``/``check_doc_drift_pure`` do, over
+    the SAME fixture, to reproduce the exact shape #5010's calibration
+    reported: the identifier is gone from src/ (as CODE), 2 non-history
+    docs/ files still name it, and neither was touched by the commit that
+    removed it — so the discriminator correctly flags both files. This
+    fixture never reads this repo's own live working tree — every value
+    below traces back to `git show <PINNED_SHA>:<path>` at the top of
+    this section."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = _materialize_fixture_repo(Path(tmp))
+        assert m.identifier_survives_in_src(_5010_IDENTIFIER, repo) is False
+        doc_files = m.find_doc_files_containing(_5010_IDENTIFIER, repo)
+        assert doc_files == set(_5010_DOC_FILES)
+
+        # #5095 (the commit that removed it) touched neither doc file —
+        # mirrors check_doc_drift_pure's own "touched_files" input.
+        touched_files: "set[str]" = set()
+        findings = m.check_doc_drift_pure(
+            gone_identifiers={_5010_IDENTIFIER},
+            doc_files_by_identifier={_5010_IDENTIFIER: doc_files},
+            touched_files=touched_files,
+        )
+        found_paths = {f.doc_path for f in findings}
+        assert found_paths == set(_5010_DOC_FILES)

--- a/tests/scripts/test_check_doc_drift_5003.py
+++ b/tests/scripts/test_check_doc_drift_5003.py
@@ -26,6 +26,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from tests._support.paths import REPO_ROOT
 
 
@@ -604,6 +606,41 @@ _5010_DOC_FILES = (
 )
 
 
+def _pinned_shas_resolve_locally() -> bool:
+    """True iff both #5010 pinned SHAs are present in this checkout's
+    object database. False in a shallow (fetch-depth: 1) checkout --
+    e.g. test.yml's own `test:` job, which has no reason to fetch commits
+    this old. `git cat-file -e` is the existence check
+    ([[feedback_git_existence_check_cat_file_not_ls_tree]]-equivalent
+    discipline: an object either resolves or it does not, no separate
+    empty-output case to misread)."""
+    for ref in (_5010_SRC_SHA, _5010_DOCS_PRE_SHA.rstrip("^")):
+        result = subprocess.run(
+            ["git", "cat-file", "-e", ref], cwd=REPO_ROOT, capture_output=True
+        )
+        if result.returncode != 0:
+            return False
+    return True
+
+
+# Disclosed, reasoned skip (never silent) -- lead-coder, #5298: test.yml's
+# main `test:` job collects the whole tree with no deselect/marker filter,
+# so these 4 tests would otherwise run there too and fail with
+# CalledProcessError on a shallow checkout. They run for real, unskipped,
+# in .github/workflows/check-doc-drift-fixture.yml's dedicated
+# fetch-depth: 0 job -- this guard only prevents a false failure on a
+# checkout that structurally cannot satisfy the fixture, it does not
+# reduce what actually gets exercised.
+_skip_unless_full_history = pytest.mark.skipif(
+    not _pinned_shas_resolve_locally(),
+    reason=(
+        "#5010 pinned SHAs not present -- this checkout is shallow "
+        "(fetch-depth: 1); these tests run instead in "
+        "check-doc-drift-fixture.yml's full-history job"
+    ),
+)
+
+
 def _content_at(sha: str, path: str) -> str:
     """Real file content at a pinned, immutable ref in THIS repo's own
     git history — never the live working tree. Fails loudly (via
@@ -639,6 +676,7 @@ def _materialize_fixture_repo(tmp_path: Path) -> Path:
     return repo
 
 
+@_skip_unless_full_history
 def test_5010_fixture_content_matches_the_real_historical_commits_exactly():
     """Tier 2: sanity check on the fixture itself, independent of
     ``check_doc_drift.py`` entirely — a plain ``git grep -n`` against the
@@ -673,6 +711,7 @@ def test_5010_fixture_content_matches_the_real_historical_commits_exactly():
     assert "reyn-yaml.ja.md" not in touched
 
 
+@_skip_unless_full_history
 def test_5010_naive_grep_says_the_identifier_still_survives(tmp_path):
     """Tier 2: acceptance ① of #5010's re-promotion fixture (architect,
     issuecomment-5435721126) — the OLD discriminator class this fixture
@@ -696,6 +735,7 @@ def test_5010_naive_grep_says_the_identifier_still_survives(tmp_path):
     assert hits == set(_5010_SRC_PROSE_ONLY_FILES)
 
 
+@_skip_unless_full_history
 def test_5010_real_discriminator_correctly_says_it_does_not_survive(tmp_path):
     """Tier 2: acceptance ② — the REAL, current ``identifier_survives_in_src``
     (the tokenizer/AST-backed redaction fix, #5010 round 2) on the exact
@@ -708,6 +748,7 @@ def test_5010_real_discriminator_correctly_says_it_does_not_survive(tmp_path):
     assert m.identifier_survives_in_src(_5010_IDENTIFIER, repo) is False
 
 
+@_skip_unless_full_history
 def test_5010_end_to_end_finds_the_real_4_line_drift_untouched_by_5095():
     """Tier 2: acceptance ③ — wires ①+② together the way
     ``resolve_gone_identifiers_precise``/``check_doc_drift_pure`` do, over


### PR DESCRIPTION
**[docs-maintainer]** — closes the last remaining item in #5010's calibration effort (architect, issuecomment-5435721126; N and the FP rate were already decided separately — N=9, FP 0/9, architect's own ruling). All facts below verified independently against this repo's real git history before writing anything, not taken on report.

## Scope — explicitly narrow, per dispatch

This PR does **not** flip `.github/workflows/check-doc-drift.yml` to blocking. That workflow's own comment already documents why re-promotion needs a NEW structural discriminator (telling "records a past rename" apart from "still describes current behavior" — the class a LATER PR like #4582/#5106 fixing an EARLIER PR's doc gap exposes) and stays warn-only until one exists. This PR only adds the missing regression-test fixture for the tokenizer-based extraction fix that was already kept (never reverted) — closing the one item architect's investigation left open.

## What

The earlier calibration attempt (`--pr 5095` against the live tree) went green for the wrong reason: by the time anyone re-ran it, #5106 had already fixed the docs it was supposed to catch, so the same command measured a different world than the one #5095 actually shipped into (architect's own diagnosis — "an observation does not name its own referent").

Pins both sides to fixed, immutable SHAs instead:
- src side (identifier removed): `e802ad73a` — #5095, `fix(#5091): remove the "broker" concept from reyn's own runtime`.
- docs side (pre-fix state): `ba9690bb2^` — immediately before #5106's doc fix.

Every read in the new tests is `git show <PINNED_SHA>:<path>` against this repo's own history — never the live working tree, so the fixture measures the same thing no matter how far `main` moves (the same discipline #5290 names for a different check).

## 4 new tests (`tests/scripts/test_check_doc_drift_5003.py`)

1. A sanity check independent of `check_doc_drift.py` entirely (plain `git grep -n` against the pinned SHAs) confirming the exact 4 `file:line` occurrences architect reported are still there, and that #5095 itself never touched either doc file.
2. The naive, unredacted `git grep -lF` baseline (an independent external-tool call, not a call into any `check_doc_drift.py` function) says the identifier still survives — the false-negative class the #5010-round-2 tokenizer/AST redaction fix closed.
3. The real, current `identifier_survives_in_src` on the same fixture correctly says it does NOT survive (its only 2 remaining mentions are comment/docstring prose).
4. End-to-end: wires the fixture through `check_doc_drift_pure` the way production does, reproducing the exact 2-doc-file finding #5095 should have triggered.

Strip-falsified: reverted `identifier_survives_in_src`'s redaction to a bare `git grep`, confirmed tests 3 and 4 go RED (test 2's naive baseline is unaffected, as expected — it never calls production code), restored, confirmed all 4 green again.

## CI-placement fix (lead-coder review)

lead-coder caught that the 4 new tests read arbitrary historical SHAs via
`git show`/`git grep`, but `test.yml`'s own `test:` (pytest) job checks out
with the default shallow `fetch-depth: 1` — those objects would 404 in real
CI even though they pass locally in a full-history worktree. Two options
were offered, unpreferred: (a) add `fetch-depth: 0` to the `test:` job, or
(b) split the 4 tests into their own job with full history.

**Chose (b)**, as a new dedicated workflow file
(`.github/workflows/check-doc-drift-fixture.yml`), not a new job inside
`test.yml`. Reasoning:

- (a) would pay a full-clone cost on **every PR's** pytest matrix run
  (currently 2 Python versions × however many other jobs share that
  checkout), for the sake of 4 tests that touch exactly 2 files. That cost
  never goes away once paid, regardless of whether those 2 files are ever
  touched again.
- The `audit:` job (already `fetch-depth: 0`) was considered as a home for
  these 4 tests and ruled out: it's deliberately stdlib-only / no pip
  install, by explicit design ("keeps the job fast and decoupled from src/
  install state") — folding pytest in defeats that.
- A brand-new workflow, path-scoped to
  `["scripts/check_doc_drift.py", "tests/scripts/test_check_doc_drift_5003.py"]`,
  mirrors `check-doc-drift.yml`'s own existing pattern exactly (same
  `fetch-depth: 0` rationale, same narrow trigger-path idea) and pays the
  full-clone cost only on the rare PR that actually touches one of those 2
  files — never on the common path.

**This alone was incomplete** (lead-coder caught it as a second blocking
point, quoted and resolved below): `test.yml`'s `test:` job
(`python -m pytest -q -n auto --timeout=120 -rs --durations=25`,
`test.yml:120`) collects the WHOLE tree with no deselect/`-k` filter, so
it still ran these same 4 tests on its own shallow checkout, independent
of the new dedicated job. Confirmed empirically — not just from reading
the workflow source — via a real `git clone --depth 1 --branch
<this-branch>` of the repo: before the fix, `pytest
tests/scripts/test_check_doc_drift_5003.py` against that clone gave `4
failed`, exact `CalledProcessError`/exit-128 on `git show`; after, `36
passed, 4 skipped`, skip reasons visible via `pytest -rs` (not silent).
The full-history worktree still runs all 40 unskipped, confirmed
separately.

**Chose (b-1)** (of the two options offered, unpreferred): guard each of
the 4 tests with a disclosed `pytest.mark.skipif`, keyed on whether `git
cat-file -e` resolves both pinned SHAs locally (true under full history,
false under a shallow checkout). Not (b-2), relocating the tests out of
collection reach entirely — the 4 tests belong logically next to the
rest of this file's `check_doc_drift.py` fixture tests; a location-based
exclusion would need either a `conftest.py` collection-ignore keyed on
the identical shallow/full-history distinction (same complexity, less
visible at the test's own call site) or physically splitting one
coherent fixture across two files for a CI-topology reason that has
nothing to do with the fixture's own logic.

## Test plan

- [x] `pytest tests/scripts/test_check_doc_drift_5003.py -q` — 40/40 pass (full-history worktree).
- [x] `ruff check` on both changed files — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_doc_drift_5003.py` — 40/40 OK, 0 Tier-4.
- [x] `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK.
- [x] Strip-falsify (identifier extraction): reverted the production redaction fix, confirmed the exact 2 new tests that assert correct behavior go RED, restored, confirmed green.
- [x] Strip-falsify (CI-placement fix): real `git clone --depth 1 --branch <this branch>`, `pytest` against it — RED (4 failed, `CalledProcessError` exit 128) before the skip-guard commit, GREEN (36 passed, 4 skipped, reasons visible via `-rs`) after. Full-history worktree reconfirmed still 40/40 unskipped.
- [ ] (skipped — no UI surface, gate/test-only change) Visual

**Non-blocking nit fixed** (lead-coder): `_pinned_shas_resolve_locally` stripped the `^` off `_5010_DOCS_PRE_SHA` before checking existence, but `_content_at`'s `git show` call uses the caret form unchanged — checking a different ref than the one actually used. Confirmed independently (`git cat-file -e ba9690bb2^` resolves, exit 0) and fixed to pass the constant through unchanged. Re-verified with a fresh shallow clone: still 36 passed/4 skipped.

This PR touches `tests/` — needs an independent TESTS-READ (B) before merge (rule 8), from someone other than me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

- [x] 🔴 **[lead-coder]** **(b) は「新しい job を足す」だけでは完成しません — 4 本は `test.yml` の pytest でも走ります。**
  - `test:` job のコマンドは `python -m pytest -q -n auto --timeout=120 -rs --durations=25`（`test.yml:120`）＝ **rootdir 全体**。deselect も `-k` も無し。
  - 私が head `237a28892` で確認: この 4 本に `pytest.mark.skipif` も他の marker も**付いていません**（`grep` で 0 件）。`pyproject.toml` の `norecursedirs` は `dogfood/fixtures` / `.reyn` / `.claude` / `reyn-worktrees` のみで、**`tests/scripts/` は除外されていません**。
  - ∴ **`test:` job は今も shallow のままこの 4 本を収集し、`CalledProcessError`（exit 128）で落ちます。** 新しい job が緑になっても、本体の pytest は赤のままです。（この PR の pytest はまだ pending なので、これは workflow とコードから導いた予測です — 前回の同じ予測は shallow clone の手元再現と CI の pytest 3.12 の両方で確定しました。）
  - 🔵 処方（私は指定しません、選択は本文に理由とともに）: **(b-1)** 4 本に「pinned SHA が解決できなければ skip」のガードを付ける（shallow で skip、専用 job では実行）。skip は**理由つきで開示**すること — 六問④は沈黙を咎めます。**(b-2)** 4 本を専用 job だけが拾う場所へ移し、本体の収集対象から外す。
  - ⚪ 新 workflow 自体の設計（path-scoped、`fetch-depth: 0`、理由をコメントに明記）は**良い形**です。欠けているのは「本体からどう外すか」の一手だけです。
  - **Resolved** — implemented (b-1) exactly as specified above ("CI-placement fix" section), with the disclosed-skip requirement met (`pytest -rs` shows the reason). Falsified with a real shallow clone, not just a source read. Details and test-plan entries above.
