### PR TITLE
fix(#5290): stop double-getsource-ing Session in the router-op-bus seam test

### DIFF
--- a/tests/runtime/test_3049_driver_router_op_intervention_reaches_originator.py
+++ b/tests/runtime/test_3049_driver_router_op_intervention_reaches_originator.py
@@ -200,15 +200,30 @@ async def test_detached_driver_mcp_permission_fail_closed_deny(tmp_path: Path) -
 # ── Structural: every router-op intervention bus is the single bridge-aware seam ──────────
 
 
-def _self_bound_bus_construction_methods() -> "list[str]":
+def _parsed_session_source() -> "tuple[str, ast.Module]":
+    """Parse ``Session``'s own source ONCE — ``inspect.getsource(Session)``
+    (a CLASS) resolves via CPython's ``_ClassFinder`` (matches on
+    ``__qualname__`` via a fresh ``ast.parse``, #5290), not the function/
+    method branch (``findsource``'s ``co_firstlineno``-plus-regex-scan,
+    invalidated only by ``linecache.checkcache`` re-reading whatever the
+    file currently contains at that cached line — fragile if the file is
+    edited between this call and a LATER ``getsource`` call in the same
+    process, #5290's own report). Both the offender scan and the vacuity
+    guard below read the SAME parse of the SAME source instead of each
+    doing its own ``getsource`` (which is exactly the shape #5290
+    describes: two ``getsource`` calls in one test, one of a class — safe
+    — one of a method — not)."""
+    src = textwrap.dedent(inspect.getsource(Session))
+    return src, ast.parse(src)
+
+
+def _self_bound_bus_construction_methods(tree: ast.Module) -> "list[str]":
     """Enumerate ``Session`` methods whose body constructs a SELF-BOUND
     ``ChatInterventionBus(self, ...)`` directly (positional first arg ``self``) — derived from
     the live class source, never hand-listed, so a NEWLY-added router-op seam that hardcodes its
     own self-bound bus is caught automatically. ``_make_router_intervention_bus`` (the ONE
     sanctioned construction point, which chooses self-bound only when no bridge is present) is
     excluded — it is the seam every other method must route through."""
-    src = textwrap.dedent(inspect.getsource(Session))
-    tree = ast.parse(src)
     offenders: list[str] = []
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -237,7 +252,8 @@ def test_router_op_intervention_bus_has_single_bridge_aware_seam() -> None:
     MCP-style op method that builds its own self-bound bus — reintroducing the #3049 orphan for a
     driver session — makes this list non-empty and fails here. RED before the fix: the 5 MCP op
     methods (``_mcp_call_tool`` + resource/prompt siblings) each hardcoded the self-bound bus."""
-    offenders = _self_bound_bus_construction_methods()
+    src, tree = _parsed_session_source()
+    offenders = _self_bound_bus_construction_methods(tree)
     assert offenders == [], (
         "these Session methods construct a self-bound ChatInterventionBus(self, ...) directly, "
         "bypassing the bridge-aware _make_router_intervention_bus seam — a driver session's "
@@ -247,7 +263,35 @@ def test_router_op_intervention_bus_has_single_bridge_aware_seam() -> None:
     # Vacuity guard: the helper itself MUST contain the sanctioned self-bound construction, else
     # the scan matches nothing for a trivial reason (renamed class / moved seam) and the guard is
     # inert. Assert the one legitimate site exists so "offenders == []" means "swept", not "empty scan".
-    helper_src = inspect.getsource(Session._make_router_intervention_bus)
+    #
+    # #5290: reads the method's own source segment out of the SAME tree the
+    # offender scan just walked (ast.get_source_segment, byte-exact against
+    # `src`) rather than a second, independent `inspect.getsource(<method>)`
+    # call — that second call resolves via CPython's line-number-plus-regex
+    # branch (`inspect.findsource`'s ``co_firstlineno``), re-read from
+    # whatever the file on disk currently contains (`linecache.checkcache`)
+    # at call time. If the file is edited between the two `getsource` calls
+    # in the same test run (a real, observed shape the night this was
+    # found: #5284/#5285 both landed lines in session.py mid-sweep), this
+    # method's SOURCE moves and the second call can read a DIFFERENT
+    # method's body entirely — a false vacuity-guard failure that looks
+    # like the seam disappeared, when nothing did. The class-source branch
+    # (``inspect.getsource(Session)`` above) is immune: it resolves by
+    # ``__qualname__`` via a fresh ``ast.parse``, not a cached line number.
+    helper_node = next(
+        (
+            node for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "_make_router_intervention_bus"
+        ),
+        None,
+    )
+    assert helper_node is not None, (
+        "_make_router_intervention_bus not found in Session's source — the seam "
+        "was renamed or moved; this guard needs updating, not a bare StopIteration."
+    )
+    helper_src = ast.get_source_segment(src, helper_node)
+    assert helper_src is not None
     assert "ChatInterventionBus(" in helper_src and "_intervention_bridge" in helper_src, (
         "the bridge-aware seam _make_router_intervention_bus no longer contains the guarded "
         "construction — the structural scan would be vacuously green (guard inert)."


### PR DESCRIPTION
**[e2e-coder]** — fix for #5290 (architect's own diagnosis and one-line prescription, `origin/main` issue body).

## What

`test_router_op_intervention_bus_has_single_bridge_aware_seam()` in
`tests/runtime/test_3049_driver_router_op_intervention_reaches_originator.py`
called `inspect.getsource()` twice against the live `Session` class in the
same test: once on the class (offender scan, class branch) and once on a
specific bound method, `_make_router_intervention_bus` (vacuity guard,
method branch).

Per architect's stdlib read (`inspect.findsource`, `co_firstlineno`,
`linecache.checkcache`): the class branch resolves via `__qualname__` + a
fresh `ast.parse` of the whole class body (`_ClassFinder`) — immune to
source-file edits made after import. The method branch resolves via the
function object's `__code__.co_firstlineno`, a line number baked in at
**import time**, plus `linecache.checkcache(file)` re-reading the file's
**current** content at call time. If lines are inserted/removed above the
target method between import and the `getsource()` call, the line-number
walk can land in a **different function's** body entirely — the guard then
silently checks the wrong function's source. Architect's mechanism match
for the one real red observed (#5284/#5285 landing lines in `session.py`
mid-sweep the same night) — not a confirmed reproduction, per the issue's
own disclosure.

## Fix

Parse `Session`'s source once (`_parsed_session_source()`), reuse that same
`ast.Module` for both the offender scan and the vacuity guard, extracting
`_make_router_intervention_bus`'s node via `ast.walk` +
`ast.get_source_segment` instead of a second `getsource()` call. Both checks
now depend only on the class-branch resolution path. Guard semantics
unchanged ("the sanctioned method still contains the guarded construction").

## Verification

Standalone script (not committed — a live concurrent-file-edit race is not
something to pin as a permanent regression test, per this repo's
no-duration/no-race-pinning test policy): inserted 5 lines above
`_make_router_intervention_bus` mid-run.
- OLD code under the race: `getsource` returns `_make_router_op_context`'s
  body instead → guard assertion would silently pass on the wrong function.
- NEW code under the identical race: `ast.get_source_segment` off the
  already-parsed tree still returns the correct body.

Scoped pytest: 4/4 passed. Local gates: ruff, `test_tier_audit --strict`,
`mypy_ratchet.py`, `flat_tests_ratchet.py`,
`check_tests_path_literal_reference.py`,
`check_bare_tests_import_reference.py`, `check_file_depth_reference.py` —
all green.

## Scope note (family)

Architect's issue explicitly did not count the wider family and asked
whoever picks this up to first classify `git grep -n "getsource(" -- tests`
hits by class-branch (safe) vs function/method-branch (fragile) before
deciding on a broader sweep. I ran that classification (AST-based, not a
manual read of all 35 hits) and count **11 function/method-branch call
sites** across 9 other test files, none reproduced as failing, all left
untouched — out of this PR's prescribed one-file scope. Posting the list to
the issue as a follow-up comment rather than expanding this PR.

part of #5290 — #5290 stays open as the class-level issue tracking the wider
family (11 fragile sites + ~20 unclassified, from the census above); this PR
covers only the one prescribed test.

## Test plan

- [x] Scoped pytest (4/4) — done
- [x] Local gates (7/7) — done
- [x] Standalone strip-falsify script (before/after) — done, not committed
- [x] (skipped — no UI/behavior change) Visual

Cannot self-merge: touches `tests/`, needs a TESTS-READ note per PR-workflow rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- [x] 🔴 **[architect]** the premature closing declaration for #5290 was changed to a non-closing one, fixed in both the PR body (above) and the commit message trailer (amended). #5290 left open.


