### PR TITLE
feat(#5296): gate byte recovery compaction by policy

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -2348,6 +2348,7 @@ chat:
     body_token_cap: 1500               # hard cap on summary body tokens (post-truncation)
     resummarize_passes: 1              # LLM re-compression passes before hard_truncate floor
     max_schema_reprompt_attempts: 1    # bounded re-prompt budget on invalid compaction JSON
+    recovery_policy: next_turn         # #5296: compaction only; spill follows the constraint
     max_shrink_iterations: 8           # retry_loop's overflow-recovery safety cap (escape valve, not a cure)
     # Section budget weights within body, normalised at runtime.
     section_weights:
@@ -2374,6 +2375,7 @@ chat:
 | `body_token_cap` | int | `1500` | Hard cap on summary body tokens after post-truncation. |
 | `resummarize_passes` | int | `1` | Max LLM re-compression passes when a produced `topic_arc` overshoots its body budget, before the deterministic `hard_truncate` floor. `0` = skip re-summary (straight to the floor). |
 | `max_schema_reprompt_attempts` | int | `1` | #4883: bounded re-prompt budget when the compaction LLM's JSON response has an empty/missing `topic_arc` (whose emptiness can't be told apart from a dead response). Exhausting the budget raises rather than silently accepting an empty summary. `0` = raise on the first invalid response, no re-prompt. `new_turn_seqs` plays no part in this: `covers_through_seq` is derived from `compact()`'s own input, never read from an LLM echo (#4951-A) — and #4951-B removed the `new_turn_seqs` key from the schema/prompt entirely, so there is nothing left to gate or not gate. |
+| `recovery_policy` | `never` \| `next_turn` | `next_turn` | #5296: controls only irreversible compaction after measured byte-limit exhaustion. `next_turn` preserves the current behavior: compaction is persisted for the following turn; `never` skips compaction and ends with the existing structured error. It does not control spill; spill is triggered by the constraint itself. |
 | `max_shrink_iterations` | int | `8` | #4957: `retry_loop`'s own safety cap on overflow-recovery iterations. **This is an escape valve, not a cure** — raising it only delays exhaustion if the underlying cause (a persistent HTTP 413, a 5xx, a rate limit) never resolves on its own; it does not fix that cause. Must be `>= 1` (`0` would never run the shrink loop at all, raising immediately on the first overflow). Distinct from `RouterLoop`'s own unrelated `max_iterations` (the tool-call loop bound) — do not confuse the two. |
 | `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out for large deployments). |
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -434,6 +434,9 @@
 #                                      # topic_arc (0 = raise immediately). #4951-B:
 #                                      # new_turn_seqs no longer gates this — the key
 #                                      # was removed from the schema/prompt entirely.
+#     recovery_policy: next_turn        # #5296: 413 recovery stop-line for
+#                                      # irreversible compaction only; spill is
+#                                      # triggered by the constraint itself.
 #     max_shrink_iterations: 8         # #4957: retry_loop's own safety cap — an
 #                                      # ESCAPE VALVE for a slow-to-converge overflow
 #                                      # recovery, not a cure. Raising it only delays

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -801,6 +801,10 @@ class CompactionConfig:
     # a silently-accepted empty summary) — operator-tunable via this field
     # if a specific deployment's models warrant a different budget.
     max_schema_reprompt_attempts: int = 1
+    # #5296: stop-line for same-turn recovery after a measured payload
+    # constraint. `never` permits only reversible reductions; `same_turn`
+    # (the default) also permits durable compaction in the current turn.
+    recovery_policy: Literal["never", "same_turn"] = "same_turn"
     # #4957 (owner: "max iterations は config ノブにしておいた方が良いね") —
     # retry_loop's own `max_iterations` safety cap, previously a signature
     # default only (8) with no operator-facing knob: router_loop_driver.py
@@ -818,6 +822,11 @@ class CompactionConfig:
     section_token_caps: CompactionSectionCaps = field(default_factory=CompactionSectionCaps)
 
     def __post_init__(self) -> None:
+        if self.recovery_policy not in {"never", "same_turn"}:
+            raise ValueError(
+                "chat.compaction.recovery_policy must be 'never' or 'same_turn'; "
+                f"got {self.recovery_policy!r}"
+            )
         if self.max_shrink_iterations < 1:
             raise ValueError(
                 "chat.compaction.max_shrink_iterations must be >= 1 (0 would "
@@ -1177,6 +1186,9 @@ def _build_chat_config(raw: object) -> ChatConfig:
             compaction_raw.get(
                 "max_schema_reprompt_attempts", defaults.max_schema_reprompt_attempts
             )
+        ),
+        recovery_policy=str(
+            compaction_raw.get("recovery_policy", defaults.recovery_policy)
         ),
         max_shrink_iterations=int(
             compaction_raw.get("max_shrink_iterations", defaults.max_shrink_iterations)

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -802,8 +802,11 @@ class CompactionConfig:
     # if a specific deployment's models warrant a different budget.
     max_schema_reprompt_attempts: int = 1
     # #5296: stop-line for same-turn recovery after a measured payload
-    # constraint. `never` permits only reversible reductions; `next_turn`
-    # (the default) preserves compaction for the following turn.
+    # constraint. This stop-line applies only to the irreversible
+    # compaction step; it never controls spill. Spill is triggered by the
+    # constraint itself, not by this policy. `never` permits only reversible
+    # reductions; `next_turn` (the default) preserves compaction for the
+    # following turn.
     recovery_policy: Literal["never", "next_turn"] = "next_turn"
     # #4957 (owner: "max iterations は config ノブにしておいた方が良いね") —
     # retry_loop's own `max_iterations` safety cap, previously a signature

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -802,9 +802,9 @@ class CompactionConfig:
     # if a specific deployment's models warrant a different budget.
     max_schema_reprompt_attempts: int = 1
     # #5296: stop-line for same-turn recovery after a measured payload
-    # constraint. `never` permits only reversible reductions; `same_turn`
-    # (the default) also permits durable compaction in the current turn.
-    recovery_policy: Literal["never", "same_turn"] = "same_turn"
+    # constraint. `never` permits only reversible reductions; `next_turn`
+    # (the default) preserves compaction for the following turn.
+    recovery_policy: Literal["never", "next_turn"] = "next_turn"
     # #4957 (owner: "max iterations は config ノブにしておいた方が良いね") —
     # retry_loop's own `max_iterations` safety cap, previously a signature
     # default only (8) with no operator-facing knob: router_loop_driver.py
@@ -822,9 +822,9 @@ class CompactionConfig:
     section_token_caps: CompactionSectionCaps = field(default_factory=CompactionSectionCaps)
 
     def __post_init__(self) -> None:
-        if self.recovery_policy not in {"never", "same_turn"}:
+        if self.recovery_policy not in {"never", "next_turn"}:
             raise ValueError(
-                "chat.compaction.recovery_policy must be 'never' or 'same_turn'; "
+                "chat.compaction.recovery_policy must be 'never' or 'next_turn'; "
                 f"got {self.recovery_policy!r}"
             )
         if self.max_shrink_iterations < 1:

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -463,7 +463,10 @@ class RouterLoopDriver:
                 # the pre-trigger's own estimate was wrong, which the
                 # existing adaptive learner (not a second compaction
                 # trigger here) is the correct fix for.
-                if _unrecovered.saw_byte_limit:
+                if (
+                    _unrecovered.saw_byte_limit
+                    and self._compaction.recovery_policy == "same_turn"
+                ):
                     await self._compaction_controller.force_compact_now()
                 raise
             return _shim.usage

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -465,7 +465,7 @@ class RouterLoopDriver:
                 # trigger here) is the correct fix for.
                 if (
                     _unrecovered.saw_byte_limit
-                    and self._compaction.recovery_policy == "same_turn"
+                    and self._compaction.recovery_policy == "next_turn"
                 ):
                     await self._compaction_controller.force_compact_now()
                 raise

--- a/tests/core/test_5296_recovery_policy_config.py
+++ b/tests/core/test_5296_recovery_policy_config.py
@@ -1,0 +1,24 @@
+"""Tier 1: #5296 recovery-policy configuration contract."""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config.chat import CompactionConfig, _build_chat_config
+
+
+def test_recovery_policy_defaults_to_same_turn() -> None:
+    """Tier 1: the default permits same-turn recovery."""
+    assert CompactionConfig().recovery_policy == "same_turn"
+
+
+def test_recovery_policy_parses_never_and_same_turn() -> None:
+    """Tier 1: both declared stop-lines parse from chat.compaction."""
+    for policy in ("never", "same_turn"):
+        cfg = _build_chat_config({"compaction": {"recovery_policy": policy}})
+        assert cfg.compaction.recovery_policy == policy
+
+
+def test_recovery_policy_rejects_unknown_values() -> None:
+    """Tier 1: an undeclared stop-line fails at construction."""
+    with pytest.raises(ValueError, match="recovery_policy"):
+        CompactionConfig(recovery_policy="aggressive")

--- a/tests/core/test_5296_recovery_policy_config.py
+++ b/tests/core/test_5296_recovery_policy_config.py
@@ -6,14 +6,14 @@ import pytest
 from reyn.config.chat import CompactionConfig, _build_chat_config
 
 
-def test_recovery_policy_defaults_to_same_turn() -> None:
-    """Tier 1: the default permits same-turn recovery."""
-    assert CompactionConfig().recovery_policy == "same_turn"
+def test_recovery_policy_defaults_to_next_turn() -> None:
+    """Tier 1: the default preserves compaction for the next turn."""
+    assert CompactionConfig().recovery_policy == "next_turn"
 
 
-def test_recovery_policy_parses_never_and_same_turn() -> None:
+def test_recovery_policy_parses_never_and_next_turn() -> None:
     """Tier 1: both declared stop-lines parse from chat.compaction."""
-    for policy in ("never", "same_turn"):
+    for policy in ("never", "next_turn"):
         cfg = _build_chat_config({"compaction": {"recovery_policy": policy}})
         assert cfg.compaction.recovery_policy == policy
 

--- a/tests/runtime/test_retry_loop_chat_wiring_1125.py
+++ b/tests/runtime/test_retry_loop_chat_wiring_1125.py
@@ -376,19 +376,23 @@ def test_max_shrink_iterations_config_value_bounds_the_real_driver_call(
 # ── #4954 (b): a byte-limit exhaustion triggers a real compaction ────────────
 
 
-def test_byte_limit_exhaustion_triggers_a_real_compaction(tmp_path, monkeypatch) -> None:
-    """Tier 1: architect-ruled (b) — when `_run_with_shrink` exhausts with
-    `UnrecoveredError(saw_byte_limit=True)`, the driver's except block
-    triggers `CompactionController.force_compact_now()` (the SAME
-    durable-watermark path the pre-frame guard already uses — not
-    retry_loop's own non-continuous `covers`). This turn still fails
-    (`UnrecoveredError` still propagates) — the trigger only helps the
-    NEXT turn.
+@pytest.mark.parametrize(
+    ("recovery_policy", "compaction_expected"),
+    [("same_turn", True), ("never", False)],
+)
+def test_byte_limit_recovery_policy_controls_compaction(
+    tmp_path, monkeypatch, recovery_policy: str, compaction_expected: bool,
+) -> None:
+    """Tier 1: #5296 — the recovery stop-line changes real behavior.
 
-    Real effect observed, not a mock call-count: `force_compact_now`
-    emits a real `compaction_check` audit-event on the controller's own
-    EventLog — subscribed to directly, the same public observable an
-    operator's own event tooling would see.
+    With ``same_turn`` (the default), a byte-limit exhaustion triggers the
+    existing durable compaction path. With ``never``, the same measured
+    exhaustion propagates without compaction. Both assertions observe the
+    controller's real ``compaction_check`` event, not a mock call count.
+
+    The existing #4954 behavior is preserved by the default policy; the
+    ``never`` arm is the explicit opt-out for deployments that must not make
+    an irreversible change during same-turn recovery.
     """
     from reyn.services.compaction.engine import UnrecoveredError
 
@@ -402,6 +406,7 @@ def test_byte_limit_exhaustion_triggers_a_real_compaction(tmp_path, monkeypatch)
         use_chars4_estimate=True,
         section_caps_spec_tokens=0,
         max_shrink_iterations=3,
+        recovery_policy=recovery_policy,
     )
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
     bt = BudgetTracker(CostConfig())
@@ -430,9 +435,9 @@ def test_byte_limit_exhaustion_triggers_a_real_compaction(tmp_path, monkeypatch)
 
     assert excinfo.value.saw_byte_limit is True
     checks = [e for e in events if e.type == "compaction_check"]
-    assert checks, (
-        "expected force_compact_now to emit compaction_check on a "
-        "byte-limit exhaustion — none observed"
+    assert bool(checks) is compaction_expected, (
+        f"recovery_policy={recovery_policy!r} expected compaction="
+        f"{compaction_expected}, observed: {[e.data for e in checks]!r}"
     )
 
 

--- a/tests/runtime/test_retry_loop_chat_wiring_1125.py
+++ b/tests/runtime/test_retry_loop_chat_wiring_1125.py
@@ -378,15 +378,15 @@ def test_max_shrink_iterations_config_value_bounds_the_real_driver_call(
 
 @pytest.mark.parametrize(
     ("recovery_policy", "compaction_expected"),
-    [("same_turn", True), ("never", False)],
+    [("next_turn", True), ("never", False)],
 )
 def test_byte_limit_recovery_policy_controls_compaction(
     tmp_path, monkeypatch, recovery_policy: str, compaction_expected: bool,
 ) -> None:
     """Tier 1: #5296 — the recovery stop-line changes real behavior.
 
-    With ``same_turn`` (the default), a byte-limit exhaustion triggers the
-    existing durable compaction path. With ``never``, the same measured
+    With ``next_turn`` (the default), a byte-limit exhaustion triggers the
+    existing durable compaction path for the following turn. With ``never``, the same measured
     exhaustion propagates without compaction. Both assertions observe the
     controller's real ``compaction_check`` event, not a mock call count.
 


### PR DESCRIPTION
**[coder-smith]** — PR-1: recovery policy を既存の byte-limit compaction 経路へ接続します。part of #5296

## 変更

- `chat.compaction.recovery_policy` を追加（`next_turn` 既定 / `never`）
- 既存の 413 exhaustion 経路で policy を読み、`next_turn` のみ durable compaction を起動
- `never` は compaction を起動せず、既存の `UnrecoveredError` で正確に終端
- config parsing / unknown value rejection を追加
- 実 EventLog の `compaction_check` 有無で両 policy の挙動を検証

## 射程

これは PR-1 です。`next_turn` は現行 #4962 の契約（413 の turn は失敗し、compaction の効果を次 turn に反映）を明示する名前で、既存挙動を変更しません。`recovery_policy` は不可逆な compaction にだけ適用し、spill には設定ノブを設けません。

既存の `MediaStore` / `save_tool_result` は保存・復元機構として再利用できますが、payload 合計の overflow を契機に起動する spill 発火点は別途必要です。payload 単位の byte 発火点、既存 spill 入口への接続、same-turn 再送 coordinator、`payload_reduced` event は PR-2 の対象として分離します。same-turn 再送はこの PR ではまだ実装しません。

## Verification

- `.venv/bin/python -m pytest tests/core/test_5296_recovery_policy_config.py tests/runtime/test_retry_loop_chat_wiring_1125.py -q` — 14 passed, 1 warning
- `.venv/bin/ruff check src/reyn/config/chat.py src/reyn/runtime/services/router_loop_driver.py tests/core/test_5296_recovery_policy_config.py tests/runtime/test_retry_loop_chat_wiring_1125.py` — pass
- `.venv/bin/python scripts/test_tier_audit.py --strict tests/core/test_5296_recovery_policy_config.py tests/runtime/test_retry_loop_chat_wiring_1125.py` — 13 inspected, errors 0
- `.venv/bin/python scripts/verify_module_docstrings.py src/reyn/config/chat.py src/reyn/runtime/services/router_loop_driver.py` — pass
- `.venv/bin/python scripts/mypy_ratchet.py` — pass
- `.venv/bin/python scripts/flat_tests_ratchet.py` — pass
- `.venv/bin/python scripts/check_tests_path_literal_reference.py` — pass


---

> ⚠️ **効果の限界（lead-coder が追記、2026-08-27）— このPRは 413 による会話停止を減らしません。**
> `never` を選べば履歴を失わずに終端できるようになるだけで、継続確率を上げるのは payload 単位の
> 発火点と spill（PR-2）以降です。architect の設計 review 逐語「**PR-1 だけでは会話停止は減りません**」。
> この行が無いと「413 が直った」と読まれるため、レビュー要件として本文に置いています
> （本文のみの変更・コード無変更につき、head `ab56d65cb` の TESTS-READ(B) は有効なままです）。
