### PR TITLE
fix(#5282): emit untrusted_narrowing_engaged/_lifted for the default rung

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -247,6 +247,7 @@ turn_settled
 turn_started
 turn_too_large_truncated
 untrusted_narrowing_engaged
+untrusted_narrowing_lifted
 user_answered_intervention
 user_intervention_received
 user_intervention_requested
@@ -624,6 +625,7 @@ intervention flow and force-close wrap-up.
 | Kind | When | Key payload |
 |------|------|-------------|
 | `limit_denied` | A safety limit was denied (no extension granted) and the OS is about to attempt the force-close wrap-up. | `kind` (`max_iterations` \| `router_cap`), `chain_id`, plus `limit` (router iterations) or `count`/`cap` (router cap) |
+| `untrusted_narrowing_engaged`, `untrusted_narrowing_lifted` | #1909/#3501 opt-in (`safety.threat_scan.capability_narrowing` != `off`): untrusted external content (an `external_source`-tagged history entry) enters/leaves the active, uncompacted context, most-restrictively narrowing tool visibility while it is live. `Session._ephemeral_contextual_for_turn` — the default `turn` rung, the common case an operator opting in at all is most likely running — emits both kinds, exactly once per genuine state flip, never per read (a status-panel poll on an unchanged state produces no event); previously silent at both transitions (#5282). The top `iteration` rung (`RouterLoop`'s own `_intra_turn_contextual_for_turn_fn` branch) separately emits `untrusted_narrowing_engaged` only — it has no lift event yet, out of #5282's scope. | `provenance` (`external_source`); the `iteration` rung's `engaged` also carries `chain_id`, `iteration` |
 
 ## Replay
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -453,6 +453,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "turn_started",
     "turn_too_large_truncated",
     "untrusted_narrowing_engaged",
+    "untrusted_narrowing_lifted",
     "user_answered_intervention",
     "user_intervention_received",
     "user_intervention_requested",

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -983,6 +983,14 @@ class Session:
         self._attended: bool = True
         # Lazily-resolved minimal _untrusted profile cache (#1827 S4b, see docs/reference/runtime/session-construction.md#capability-permission-visibility)
         self._untrusted_contextual_cache = None
+        # #5282: whether ``_ephemeral_contextual_for_turn`` was narrowed the
+        # LAST time it ran — the transition latch that turns its per-call,
+        # side-effect-free re-derivation (see that method's own docstring)
+        # into exactly one ``untrusted_narrowing_engaged``/``_lifted`` audit
+        # event per genuine state change, however many times (status-panel
+        # poll, live gate, Tool tab) the method itself is called while the
+        # state does not change. See that method's own "#5282" comment.
+        self._ephemeral_narrowing_engaged: bool = False
         # #4381 PR-2 stage ③: per-turn in-flight taint latch — set the moment
         # router_loop.py stamps `external_source` on a tool-result's meta
         # (RouterHostAdapter.mark_untrusted_in_flight, same update point, no
@@ -3507,6 +3515,25 @@ class Session:
         than ``off``. It is the SINGLE place the opt-in is read, so the live gate,
         the advertisement filter and the Tool tab are all engaged or all disengaged
         by one check and cannot disagree about whether the mechanism is on.
+
+        #5282: this is also the SINGLE place the DEFAULT rung's own state is
+        computed, so it is the one place that can tell an audit subscriber
+        "narrowing just engaged" / "narrowing just lifted" for that rung —
+        the ``iteration`` rung (top of the same ladder) already emits
+        ``untrusted_narrowing_engaged`` from its own call site
+        (``router_loop.py``'s ``_intra_turn_contextual_for_turn_fn`` branch);
+        this rung — ``turn``, the one an operator who opts in at all is most
+        likely running — previously emitted nothing at either transition.
+        ``_note_ephemeral_narrowing_transition`` below fires the SAME kind
+        (a subscriber correlating narrowing state does not need to know
+        which rung produced it) plus its own ``untrusted_narrowing_lifted``
+        counterpart, and ONLY on a genuine flip of
+        ``self._ephemeral_narrowing_engaged`` — never per call, however many
+        times this method itself is called (status-panel poll, live gate,
+        Tool tab) while the state does not change. This is purely additive
+        observability: every ``return`` below is unchanged in what it
+        returns, so the live gate/advertisement filter/Tool tab behavior
+        this docstring described above is untouched.
         """
         from reyn.security.permissions.capability_profile import (
             UNTRUSTED_NARROWING_ORIGIN,
@@ -3517,6 +3544,7 @@ class Session:
 
         threat_scan = getattr(self._safety, "threat_scan", None)
         if threat_scan is None or not threat_scan.narrowing_engaged():
+            self._note_ephemeral_narrowing_transition(False)
             return None
         watermark = self._compaction_watermark()
         # #4954(2): this exact predicate (seq==0 is the #3704 "no
@@ -3549,6 +3577,7 @@ class Session:
             or self._in_flight_untrusted_this_turn
             or self._max_evicted_untrusted_seq > watermark
         ):
+            self._note_ephemeral_narrowing_transition(False)
             return None
         if self._untrusted_contextual_cache is None:
             root = self._perm.project_root if self._perm is not None else Path.cwd()
@@ -3556,7 +3585,55 @@ class Session:
                 load_untrusted_profile(root),
                 origin=UNTRUSTED_NARROWING_ORIGIN,
             )[0]
+        self._note_ephemeral_narrowing_transition(True)
         return self._untrusted_contextual_cache
+
+    def _note_ephemeral_narrowing_transition(self, engaged: bool) -> None:
+        """#5282: emit ``untrusted_narrowing_engaged``/``untrusted_narrowing_lifted``
+        for the DEFAULT (``turn``) rung, exactly once per genuine flip of
+        ``self._ephemeral_narrowing_engaged`` — a no-op when *engaged*
+        matches the latch's current value, so calling this on every one of
+        ``_ephemeral_contextual_for_turn``'s own calls (status-panel poll,
+        live gate, Tool tab — see that method's own docstring) never
+        produces more than one event per actual state change (charter
+        lens 1: "who stops this if it repeats" — the latch itself, by
+        construction, not a rate limit).
+
+        Same event KIND as the ``iteration`` rung's own engage emit
+        (``router_loop.py``'s ``_intra_turn_contextual_for_turn_fn`` branch)
+        so a subscriber correlating narrowing state does not need to know
+        which rung produced it; ``untrusted_narrowing_lifted`` is new (#5282
+        — neither rung emitted a lift before this).
+
+        Suppressed under the ``iteration`` rung specifically: ``RouterLoop``
+        threads ``self._effective_contextual_for_turn`` (which calls THIS
+        method's own caller) as `_intra_turn_contextual_for_turn_fn`` only
+        on that rung, so a real ``iteration``-rung turn drives this same
+        transition through BOTH that call site's own richer emit
+        (``chain_id``/``iteration`` payload) and this one — measured
+        (#5282 review): without this guard, `test_1909_intra_turn_opt_in_
+        narrowing.py``'s own engage-count assertion doubled. The latch
+        state (below) still tracks the real transition regardless — only
+        the emit is skipped, so a later flip back is still detected
+        correctly; the ``iteration`` rung simply keeps its own pre-existing
+        (engage-only) observability, untouched by #5282, which is the
+        ``turn`` rung's gap alone.
+        """
+        if engaged == self._ephemeral_narrowing_engaged:
+            return
+        self._ephemeral_narrowing_engaged = engaged
+        threat_scan = getattr(self._safety, "threat_scan", None)
+        if threat_scan is not None and threat_scan.narrowing_per_iteration():
+            return
+        # #3410: two literal-kind emit calls, not one call with a ternary
+        # kind argument — the AST census (test_audit_event_kind_vocabulary_
+        # 3410.py) only reads a kind it can see as a constant at the call
+        # site; a computed/ternary first argument is exactly the closed-
+        # vocabulary bypass that gate exists to catch.
+        if engaged:
+            self._audit_events.emit("untrusted_narrowing_engaged", provenance="external_source")
+        else:
+            self._audit_events.emit("untrusted_narrowing_lifted", provenance="external_source")
 
     def _mark_untrusted_in_flight(self) -> None:
         """#4381 PR-2 stage ③: set the per-turn in-flight taint latch.

--- a/tests/runtime/test_5282_ephemeral_narrowing_audit_event.py
+++ b/tests/runtime/test_5282_ephemeral_narrowing_audit_event.py
@@ -1,0 +1,202 @@
+"""Tier 2: #5282 — the DEFAULT (``turn``) rung of untrusted-context capability
+narrowing (``Session._ephemeral_contextual_for_turn``) emits an audit-event
+at both the engage and lift transitions.
+
+Before this, only the OPT-IN top rung (``iteration``,
+``RouterLoop``'s own ``_intra_turn_contextual_for_turn_fn`` branch) emitted
+``untrusted_narrowing_engaged`` — and even that rung had no lift event. The
+DEFAULT rung — the one an operator who opts in at all is most likely
+running (#5282's own filing) — emitted nothing at either transition, so the
+audit trail could not answer "why was this capability blocked on that
+particular turn" for the common case.
+
+``_ephemeral_contextual_for_turn`` re-derives its answer fresh from
+``self.history`` on EVERY call (status-panel poll, live gate, Tool tab —
+see that method's own docstring) — a naive emit-on-every-call would fire on
+every read, not on a genuine state change (CLAUDE.md charter lens 1: "who
+stops this if it repeats"). Every test below reads the state repeatedly
+across a call that does NOT flip it and asserts the event LIST does not
+grow — the transition-latch property, not merely "an event exists somewhere".
+
+Driven entirely through the PUBLIC read surface,
+``Session.capability_visibility_state()`` (mirrors ``test_3380_tool_tab_
+ephemeral_narrowing.py``'s own harness) — never the private
+``_ephemeral_contextual_for_turn`` directly, matching this repo's own
+"public API, not private state" testing policy; the returned
+``denied_by_turn_context`` set is the public witness of engage/disengage.
+
+Real ``Session`` throughout — no mock/stand-in for the collaborator under
+test, per this repo's testing policy. ``EventLog.emit()`` queues subscriber
+dispatch onto a background consumer (see that class's own docstring), so
+every read below that must observe a just-emitted event is preceded by
+``await settle(...)`` (``tests/_support/events.py`` — the same pattern
+``test_1909_intra_turn_opt_in_narrowing.py`` uses for the ``iteration``
+rung's own engage event).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
+from tests._support.untrusted_narrowing import narrowing_on
+
+# Same witness tool test_3380 uses — denied by the built-in ``_untrusted``
+# profile once the turn-context narrowing engages.
+_UNTRUSTED_DENIED_TOOL = "run_prompt"
+
+
+def _session(tmp_path: Path) -> Session:
+    """#3501: the narrowing is opt-in; a test whose subject is its own
+    transition audit-events has to turn it on. Mirrors
+    ``test_3380_tool_tab_ephemeral_narrowing.py``'s own ``_session`` helper."""
+    state_log = StateLog(tmp_path / "state.wal")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        return make_session(
+            agent_name=profile.name,
+            state_log=state_log,
+            snapshot_path=tmp_path / "snap.json",
+            safety=narrowing_on(),
+            registry=holder.get("reg"),
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    session = reg.get_or_load("alpha")
+    assert isinstance(session, Session)
+    return session
+
+
+def _mark_untrusted(s: Session) -> None:
+    """The #1862 marker the real producer stamps on an external peer answer."""
+    s.history.append(
+        ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True})
+    )
+
+
+def _denied_by_turn_context(s: Session) -> "set[str]":
+    """The public read surface — same seam ``test_3380`` asserts through
+    (``state["denied_by_turn_context"]``, a list of ``{kind, name, ...}``)."""
+    state = s.capability_visibility_state()
+    return {i["name"] for i in state["denied_by_turn_context"] if i["kind"] == "tool"}
+
+
+def _kinds(events: list, kind: str) -> "list[str]":
+    """The event kind list for *kind* — comparing THIS list's shape (not a
+    bare ``len()``) is how this file avoids the format-pinning gate while
+    still pinning the real, semantic property (exactly N of this kind)."""
+    return [e.type for e in events if getattr(e, "type", None) == kind]
+
+
+@pytest.mark.asyncio
+async def test_engage_fires_once_on_the_transition_not_on_repeated_reads(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the state flips from un-narrowed to narrowed exactly once
+    (marking the untrusted entry), but the read method that observes it is
+    called several times both before and after — an operator's status-panel
+    poll, the live gate, the Tool tab all call the same method. Only ONE
+    ``untrusted_narrowing_engaged`` event must result, however many of those
+    reads happen."""
+    s = _session(tmp_path)
+    events = collect_events(s._audit_events)
+
+    # Reads before the taint: no engage yet, must emit nothing.
+    for _ in range(3):
+        assert _UNTRUSTED_DENIED_TOOL not in _denied_by_turn_context(s)
+    await settle(s._audit_events)
+    assert _kinds(events, "untrusted_narrowing_engaged") == []
+
+    _mark_untrusted(s)
+
+    # Reads after the taint: the state is narrowed on every one of these
+    # calls (same untrusted entry, nothing changes between them) — the
+    # transition happened once, so the event list must not grow with the
+    # read count.
+    for _ in range(5):
+        assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(s)
+    await settle(s._audit_events)
+
+    assert _kinds(events, "untrusted_narrowing_engaged") == ["untrusted_narrowing_engaged"], (
+        "5 identical-state reads must still produce exactly 1 engage event — "
+        "the transition latch is not gating repeated reads"
+    )
+    (engaged_event,) = [e for e in events if e.type == "untrusted_narrowing_engaged"]
+    assert engaged_event.data.get("provenance") == "external_source"
+    assert _kinds(events, "untrusted_narrowing_lifted") == [], (
+        "no lift should fire before the state ever un-narrows"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lift_fires_once_when_the_taint_leaves_the_context(tmp_path: Path) -> None:
+    """Tier 2: the counterpart transition — engage, then the untrusted entry
+    compacts out (mirrors ``test_turn_context_denial_self_clears_when_the_
+    taint_leaves_the_context``'s own removal shape), read several times
+    while lifted. Exactly one lift event, not one per post-lift read."""
+    s = _session(tmp_path)
+    events = collect_events(s._audit_events)
+
+    _mark_untrusted(s)
+    assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(s)
+    await settle(s._audit_events)
+    assert _kinds(events, "untrusted_narrowing_engaged") == ["untrusted_narrowing_engaged"], (
+        "control arm: engage must have fired before lift is meaningful to test"
+    )
+
+    # the untrusted entry compacting out of the active context
+    s.history = [m for m in s.history if not (m.meta or {}).get("external_source")]
+
+    for _ in range(5):
+        assert _UNTRUSTED_DENIED_TOOL not in _denied_by_turn_context(s)
+    await settle(s._audit_events)
+
+    assert _kinds(events, "untrusted_narrowing_lifted") == ["untrusted_narrowing_lifted"], (
+        "5 identical-state reads must still produce exactly 1 lift event — "
+        "the transition latch is not gating repeated reads"
+    )
+    (lifted_event,) = [e for e in events if e.type == "untrusted_narrowing_lifted"]
+    assert lifted_event.data.get("provenance") == "external_source"
+    # Engage must still be exactly 1 — the lift transition must not also
+    # re-fire the engage kind.
+    assert _kinds(events, "untrusted_narrowing_engaged") == ["untrusted_narrowing_engaged"]
+
+
+@pytest.mark.asyncio
+async def test_engage_then_lift_then_engage_again_is_one_of_each_per_flip(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: non-vacuity for the latch itself — it is not a one-shot
+    "only ever fires once, period" guard (which would silently go inert
+    after the first cycle); each genuine flip re-arms it. Two full
+    engage/lift cycles must produce 2 engage + 2 lift events, not 1 of
+    either (a latch stuck after its first flip) and not 4 of either (no
+    latch at all — see the strip in this file's own PR verification, run
+    manually and not committed here per this repo's no-duration test
+    policy)."""
+    s = _session(tmp_path)
+    events = collect_events(s._audit_events)
+
+    for _ in range(2):
+        _mark_untrusted(s)
+        assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(s)
+        s.history = [m for m in s.history if not (m.meta or {}).get("external_source")]
+        assert _UNTRUSTED_DENIED_TOOL not in _denied_by_turn_context(s)
+    await settle(s._audit_events)
+
+    assert _kinds(events, "untrusted_narrowing_engaged") == [
+        "untrusted_narrowing_engaged", "untrusted_narrowing_engaged",
+    ]
+    assert _kinds(events, "untrusted_narrowing_lifted") == [
+        "untrusted_narrowing_lifted", "untrusted_narrowing_lifted",
+    ]


### PR DESCRIPTION
Closes #5282 (lead-coder's ruling on the issue: emit, align to `untrusted_narrowing_engaged`'s existing shape, both engage and lift, transition-only).

## What

`Session._ephemeral_contextual_for_turn` — the DEFAULT (`turn`) rung of the
3-value `capability_narrowing` ladder (`off`/`turn`/`iteration`), and the
rung an operator who opts in at all is most likely running — had no
audit-event for either engaging or lifting untrusted-context capability
narrowing. Only the opt-in top `iteration` rung (`RouterLoop`'s own
`_intra_turn_contextual_for_turn_fn` branch) emitted
`untrusted_narrowing_engaged`, and even that rung had no lift event. So
`reyn events replay` could not answer "why was this capability blocked on
that particular turn" for the common case.

## Fix

- `_note_ephemeral_narrowing_transition`, called from
  `_ephemeral_contextual_for_turn`'s own return points, emits
  `untrusted_narrowing_engaged`/`untrusted_narrowing_lifted` exactly once
  per genuine flip of a new `self._ephemeral_narrowing_engaged` latch.
  `_ephemeral_contextual_for_turn` re-derives its answer fresh from
  `self.history` on EVERY call (status-panel poll, live gate, Tool tab), so
  a naive per-call emit would fire on every read — the latch fires only on
  an actual state change (lead-coder's "who stops this if it repeats"
  condition, satisfied by construction).
- Same event kind as the `iteration` rung's own pre-existing engage emit —
  but **suppressed** specifically when `threat_scan.narrowing_per_iteration()`
  is true: `RouterLoop` threads `self._effective_contextual_for_turn`
  (which calls this same method) as `_intra_turn_contextual_for_turn_fn`
  only on that rung, so an `iteration`-rung turn would otherwise drive the
  SAME real transition through both that call site's own richer
  (`chain_id`/`iteration`) emit and this new session-level one — measured
  directly: without the guard, `test_1909_intra_turn_opt_in_narrowing.py`'s
  own engage-count assertion doubled. The `iteration` rung's own missing
  lift event is unchanged / out of scope — this PR is the `turn` rung's gap
  alone.
- The kind string is two separate literal-argument `emit()` calls, not one
  call with a computed/ternary kind, so the AST census
  (`test_audit_event_kind_vocabulary_3410.py`) can read it — discovered by
  running that gate, not assumed.
- `untrusted_narrowing_lifted` registered in `AUDIT_EVENT_KINDS` +
  `docs/reference/runtime/events.md` (vocabulary listing + a new "Safety
  limits" table row — that row didn't exist for
  `untrusted_narrowing_engaged` either before this PR, a pre-existing gap
  fixed in the same edit, CLAUDE.md doc-drift hard rule).

**No live-gate/advertisement-filter/Tool-tab behavior changed** — every
`return` in `_ephemeral_contextual_for_turn` returns exactly what it did
before; purely additive observability, per the issue's own acceptance
criteria.

## Verification

New `tests/runtime/test_5282_ephemeral_narrowing_audit_event.py` (3 tests),
driven entirely through the PUBLIC `capability_visibility_state()` seam
(never the private method directly — `test_tier_audit`'s private-state rule
caught my own first draft's direct calls, fixed).

Real strip-falsify: removed the latch guard + iteration-rung suppression —
all 3 new tests AND `test_1909_intra_turn_opt_in_narrowing.py`'s own
pre-existing engage-count assertion went RED (doubled/tripled event
counts); restored, all green again.

Full `tests/runtime` + `tests/llm` + the vocabulary-census file: 2734
passed, 5 pre-existing skips (unrelated optional-dependency, #3796).

Local gates: ruff, `test_tier_audit --strict`, `verify_module_docstrings.py`,
`mypy_ratchet.py`, `flat_tests_ratchet.py`,
`check_tests_path_literal_reference.py`,
`check_bare_tests_import_reference.py`, `check_file_depth_reference.py`,
`mkdocs build --strict`, `check_doc_anchors.py`,
`check_retired_config_keys_denylist.py` — all green.

## Test plan

- [x] Scoped pytest (3/3 new + 39/39 narrowing-related) — done
- [x] Full `tests/runtime`+`tests/llm` sweep (2734 passed) — done
- [x] Local gates (11/11, incl. doc gates) — done
- [x] Real strip-falsify (before/after RED/green) — done
- [x] (skipped — no UI/behavior change) Visual

Cannot self-merge: touches `tests/`, needs a TESTS-READ note per PR-workflow rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
