### PR TITLE
fix(#5260): migrate 3 subscribers + the public seam to declared kinds

### DIFF
--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -649,7 +649,13 @@ class _A2AProgressBridge:
     def attach(self) -> None:
         events = getattr(self._session, "_audit_events", None)
         if events is not None:
-            events.add_subscriber(self.on_event)
+            # #5260: declare the fixed interest at registration instead of
+            # letting every OTHER event reach on_event just to be filtered
+            # at its own top (the ``event_type not in self.TRACKED_EVENTS``
+            # check there — kept as a defensive no-op, not removed, since a
+            # narrowed declaration must never be the ONLY thing enforcing
+            # the filter).
+            events.add_subscriber(self.on_event, kinds=self.TRACKED_EVENTS)
 
     def detach(self) -> None:
         if self._detached:

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -975,7 +975,13 @@ class _MCPProgressBridge:
     def attach(self) -> None:
         events = getattr(self._session, "_audit_events", None)
         if events is not None:
-            events.add_subscriber(self._on_event)
+            # #5260: declare the fixed interest at registration instead of
+            # letting every OTHER event reach _on_event just to be filtered
+            # at its own top (the ``event_type not in self.TRACKED_EVENTS``
+            # check there — kept as a defensive no-op, not removed, since a
+            # narrowed declaration must never be the ONLY thing enforcing
+            # the filter).
+            events.add_subscriber(self._on_event, kinds=self.TRACKED_EVENTS)
 
     def detach(self) -> None:
         if self._detached:

--- a/src/reyn/observability/otel_exporter.py
+++ b/src/reyn/observability/otel_exporter.py
@@ -152,6 +152,26 @@ _TOOL_EVENT_TYPES: frozenset[str] = frozenset({
     "web_search_failed",
 })
 
+# The fixed set of kinds ``_dispatch``'s own if/elif chain actually branches
+# on (#5260) — every other event type falls through to the trailing "SR5b:
+# silently ignored" comment there and does nothing. Declared as one constant
+# so the registration site (``session.py``'s ``_build_events_backend``) can
+# pass it as ``kinds=`` instead of every event reaching ``__call__`` only to
+# be dropped by the same elif chain. Reuses ``_TOOL_EVENT_TYPES``/
+# ``_LOG_EVENT_TYPES`` (the two branches that already read a shared
+# frozenset) rather than re-listing their members, but the 8 single-kind
+# branches above them (``session_started`` .. ``llm_response_received``)
+# have no such shared constant to read, so they are hand-typed here — a
+# kind added to ``_dispatch`` still needs a matching addition here, same as
+# any other declared-vocabulary pair in this repo (test_dispatch_kinds_
+# match_handled_event_types below is the gate that catches drift, not this
+# comment).
+HANDLED_EVENT_TYPES: frozenset[str] = frozenset({
+    "session_started", "session_completed", "turn_started",
+    "turn_completed", "turn_cancelled", "turn_settled",
+    "llm_called", "llm_response_received",
+}) | _TOOL_EVENT_TYPES | _LOG_EVENT_TYPES
+
 
 def _corr_keys(data: dict[str, Any]) -> list[str]:
     """Correlation keys for an event, most-specific first.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -10,6 +10,7 @@ import json
 import logging
 import re
 import tempfile
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
@@ -1592,15 +1593,25 @@ class Session:
     def _accumulate(self, result) -> None:
         self._budget.accumulate(result)
 
-    def subscribe_audit_events(self, cb: "Callable[..., None]") -> None:
+    def subscribe_audit_events(
+        self, cb: "Callable[..., None]", *, kinds: "Iterable[str] | None" = None,
+    ) -> None:
         """Register ``cb`` for this session's audit events (narrow public API).
 
         Encapsulates the internal EventLog so UI callers (e.g. the inline CUI
         working indicator) subscribe without reaching into ``_audit_events``.
         ``cb`` receives an ``Event`` (``.type`` / ``.data``) synchronously on the
         session loop. Pair with :meth:`unsubscribe_audit_events`.
+
+        #5260: ``kinds`` forwards to ``EventLog.add_subscriber``'s own
+        ``kinds`` param — added there by #5263, but this public seam never
+        threaded it through, so a caller reaching the EventLog only via
+        ``Session`` (rather than the internal ``_audit_events`` attribute
+        directly) had no way to declare a fixed interest, however narrow.
+        ``None`` (the default) keeps the pre-#5260 contract exactly: every
+        event, matching every existing caller of this method unchanged.
         """
-        self._audit_events.add_subscriber(cb)
+        self._audit_events.add_subscriber(cb, kinds=kinds)
 
     def unsubscribe_audit_events(self, cb: "Callable[..., None]") -> bool:
         """Remove a callback registered via :meth:`subscribe_audit_events`."""
@@ -4780,10 +4791,17 @@ class Session:
         )
         otel_exporter = None
         try:
-            from reyn.observability.otel_exporter import build_otel_exporter
+            from reyn.observability.otel_exporter import (
+                HANDLED_EVENT_TYPES,
+                build_otel_exporter,
+            )
             otel_exporter = build_otel_exporter(observability_config)
             if otel_exporter is not None:
-                audit_events.add_subscriber(otel_exporter)
+                # #5260: declare the fixed set of kinds _dispatch's own
+                # elif chain actually handles, instead of every event
+                # reaching __call__ only to fall through its trailing
+                # "SR5b: silently ignored" branch.
+                audit_events.add_subscriber(otel_exporter, kinds=HANDLED_EVENT_TYPES)
         except Exception:  # noqa: BLE001 — OTEL attach must never break session init
             otel_exporter = None
         return _AuditEventBundle(

--- a/tests/core/test_5260_session_subscribe_audit_events_kinds.py
+++ b/tests/core/test_5260_session_subscribe_audit_events_kinds.py
@@ -1,0 +1,63 @@
+"""Tier 2: #5260 — ``Session.subscribe_audit_events`` threads its new
+``kinds`` param through to the underlying ``EventLog.add_subscriber`` (added
+by #5263, already covered end-to-end at that layer by
+``test_5260_subscriber_declared_kinds.py``).
+
+Before this, the ONLY route to a fixed-interest declaration was reaching
+into ``session._audit_events`` directly — the narrow public seam this
+method exists to be an encapsulated alternative to (see this method's own
+docstring: "so UI callers subscribe without reaching into
+``_audit_events``") had no way to express one at all. A caller going
+through the public API was stuck with "every event", the same over-broad
+default #5260's own filing found at 3 internal registration sites.
+
+Real ``Session`` throughout (mirrors ``test_2761_pr2_hotreload_immediate_
+apply.py``'s own ``subscribe_audit_events`` witness style — effect through
+the public seam, not a private-attribute peek).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests._support.agent_session import make_session
+from tests._support.events import settle
+
+
+@pytest.mark.asyncio
+async def test_a_kinds_declaration_through_the_public_seam_is_honoured() -> None:
+    """Tier 2: a callback registered via ``session.subscribe_audit_events(cb,
+    kinds={...})`` is called for a declared kind and NOT for an undeclared
+    one — the same filter contract #5263 gives ``EventLog.add_subscriber``
+    directly, now reachable through the public seam too."""
+    session = make_session(agent_name="test_agent")
+    received: list[str] = []
+    session.subscribe_audit_events(
+        lambda e: received.append(e.type), kinds={"session_halted"},
+    )
+
+    session._audit_events.emit("session_halted", reason="test")
+    session._audit_events.emit("visibility_changed", kind="tool", name="x", on=True, applied=True)
+    await settle(session._audit_events)
+
+    assert received == ["session_halted"], (
+        f"a kinds= declaration through Session.subscribe_audit_events must "
+        f"admit only the declared kind; observed={received!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_omitting_kinds_still_admits_every_event() -> None:
+    """Tier 2: falsification pair — without this, a public seam that
+    silently narrowed by default (rather than requiring an explicit
+    ``kinds=``) would still pass the test above, and every EXISTING caller
+    of ``subscribe_audit_events`` (none of which pass ``kinds``) would
+    silently stop receiving most events."""
+    session = make_session(agent_name="test_agent")
+    received: list[str] = []
+    session.subscribe_audit_events(lambda e: received.append(e.type))
+
+    session._audit_events.emit("session_halted", reason="test")
+    session._audit_events.emit("visibility_changed", kind="tool", name="x", on=True, applied=True)
+    await settle(session._audit_events)
+
+    assert received == ["session_halted", "visibility_changed"]

--- a/tests/observability/test_otel_exporter.py
+++ b/tests/observability/test_otel_exporter.py
@@ -540,3 +540,76 @@ def test_orphan_span_flushed_and_closed_on_shutdown() -> None:
     # every finished span carries an end timestamp (closed, not leaked)
     for s in cap.spans():
         assert s.end_time is not None
+
+
+# ── 8. HANDLED_EVENT_TYPES structurally matches _dispatch (#5260) ───────────
+
+
+def test_handled_event_types_matches_the_dispatch_elif_chain() -> None:
+    """Tier 1: #5260 — ``HANDLED_EVENT_TYPES`` (the ``kinds=`` declaration the
+    registration site in ``session.py`` now passes) must be EXACTLY the set
+    of kinds ``_dispatch``'s own if/elif chain does something with, not a
+    hand-typed list that can silently drift from it. A kind added to
+    ``_dispatch`` without a matching addition to ``HANDLED_EVENT_TYPES``
+    would, once the registration declares kinds, never reach this exporter
+    at all — no exception, no log, just a telemetry gap nobody would notice
+    without this test.
+
+    Parses ``OtelExporter``'s source via the CLASS branch of
+    ``inspect.getsource`` (``__qualname__`` + a fresh ``ast.parse`` — immune
+    to the line-number-cache hazard the METHOD branch has, #5290) and walks
+    ``_dispatch``'s own ``ast.Compare`` nodes for the exact literal/name
+    comparisons it makes against ``etype`` — not a runtime read of
+    ``_dispatch``'s bytecode, and not a duplicate hand-typed list of its
+    own that could equally drift.
+    """
+    import ast
+    import inspect
+
+    from reyn.observability.otel_exporter import (
+        _LOG_EVENT_TYPES,
+        _TOOL_EVENT_TYPES,
+        HANDLED_EVENT_TYPES,
+        OtelExporter,
+    )
+
+    tree = ast.parse(inspect.getsource(OtelExporter))
+    dispatch_node = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_dispatch"
+    )
+
+    literal_kinds: set[str] = set()
+    name_refs: set[str] = set()
+    for cmp_node in ast.walk(dispatch_node):
+        if not isinstance(cmp_node, ast.Compare):
+            continue
+        # Only comparisons whose left side is the ``etype`` local this
+        # method's whole chain switches on — excludes unrelated comparisons
+        # elsewhere in the same function body (there are none today, but a
+        # future addition should not silently widen what this test reads).
+        if not (isinstance(cmp_node.left, ast.Name) and cmp_node.left.id == "etype"):
+            continue
+        for comparator in cmp_node.comparators:
+            if isinstance(comparator, ast.Constant) and isinstance(comparator.value, str):
+                literal_kinds.add(comparator.value)
+            elif isinstance(comparator, ast.Tuple):
+                for elt in comparator.elts:
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                        literal_kinds.add(elt.value)
+            elif isinstance(comparator, ast.Name):
+                name_refs.add(comparator.id)
+
+    assert literal_kinds, "no literal-kind comparisons found — the parse/walk is broken"
+    assert name_refs == {"_TOOL_EVENT_TYPES", "_LOG_EVENT_TYPES"}, (
+        f"expected _dispatch to compare etype against exactly these two named "
+        f"constants, got {name_refs} — HANDLED_EVENT_TYPES's own composition "
+        f"(literals | _TOOL_EVENT_TYPES | _LOG_EVENT_TYPES) needs updating to match"
+    )
+
+    reconstructed = literal_kinds | _TOOL_EVENT_TYPES | _LOG_EVENT_TYPES
+    assert reconstructed == HANDLED_EVENT_TYPES, (
+        f"HANDLED_EVENT_TYPES has drifted from _dispatch's own elif chain — "
+        f"in chain but not declared: {reconstructed - HANDLED_EVENT_TYPES}; "
+        f"declared but not in chain: {HANDLED_EVENT_TYPES - reconstructed}"
+    )


### PR DESCRIPTION
Closes #5260 — architect's own current-state comment on the issue (issuecomment-5433785873) enumerated exactly 4 remaining items; all 4 done in this PR.

## What

`EventLog.add_subscriber(fn, *, kinds=...)` was already added by #5263, but
3 registration sites still relied on their own entry-point filtering
instead of declaring a fixed interest, and the public
`Session.subscribe_audit_events` seam never threaded `kinds` through at
all — a caller reaching the EventLog only via `Session` had no way to
declare one, however narrow.

architect's own current-state comment named the exact remainder:
`a2a.py:652`, `mcp/server.py:978`, `otel_exporter`'s registration in
`session.py`, and the missing `kinds=` param on the public seam. The 3
sites architect classified as correctly NOT declaring
(`ChatLifecycleForwarder` ×2, `lifecycle_forwarder.py`'s driver
subscription — genuinely "want everything") are untouched, by design.

## Fix

- `a2a.py`'s `_A2AProgressBridge.attach` / `mcp/server.py`'s symmetric
  bridge: `add_subscriber(..., kinds=self.TRACKED_EVENTS)` — the SAME
  class attribute their own `on_event`/`_on_event` entry-point check
  already reads, so this is structurally in sync **by construction**, not
  a second hand-typed list that could drift. The entry-point check is
  kept as a defensive no-op, not removed — a narrowed declaration must
  never be the ONLY thing enforcing the filter.
- `otel_exporter.py`: new `HANDLED_EVENT_TYPES` constant (the union of
  every kind `_dispatch`'s own if/elif chain branches on), passed as
  `kinds=` at the `session.py` registration site. Unlike the two sites
  above, `_dispatch`'s 8 single-kind branches have no existing shared
  constant to point at, so `HANDLED_EVENT_TYPES` hand-types them (reusing
  `_TOOL_EVENT_TYPES`/`_LOG_EVENT_TYPES` for the other two branches) — a
  real drift risk a hand-typed list always carries. Closed with a new
  **structural** test, `test_handled_event_types_matches_the_dispatch_elif_chain`:
  parses `OtelExporter`'s source via the **class branch** of
  `inspect.getsource` (`__qualname__` + a fresh `ast.parse` — immune to
  the line-number-cache hazard the method branch has, #5290, landed the
  same night), walks `_dispatch`'s own `ast.Compare` nodes for its
  literal/name comparisons against `etype`, and asserts the reconstructed
  set equals `HANDLED_EVENT_TYPES`.
- `Session.subscribe_audit_events` gained a `kinds=` param
  (`Iterable[str] | None = None`, forwarded to `EventLog.add_subscriber`).
  `None` (the default) keeps every existing caller's behavior
  byte-identical.

## Verification

3 new/updated test files
(`test_5260_session_subscribe_audit_events_kinds.py`, `test_otel_exporter.py`'s
new test) plus the pre-existing #5263 EventLog-level coverage
(`test_5260_subscriber_declared_kinds.py`) — 26 passed.

Real strip-falsify, twice:
- `HANDLED_EVENT_TYPES`: removed one kind — the new structural test went
  RED naming exactly that kind; restored, green.
- Public seam: reverted `Session.subscribe_audit_events` to drop `kinds` —
  the new positive test went RED (observed both kinds instead of one);
  restored, green.

Full `tests/interfaces`+`tests/mcp`+`tests/observability`+`tests/core`:
**5154 passed**, 1 pre-existing failure
(`test_install_command_warns_on_tmp_args_on_darwin` — confirmed identical
on a clean `origin/main` checkout via `git stash`, a venv/PATH environment
quirk unrelated to this change), 10 skipped.

Local gates: ruff, `test_tier_audit --strict`, `verify_module_docstrings.py`,
`mypy_ratchet.py`, `flat_tests_ratchet.py`,
`check_tests_path_literal_reference.py`,
`check_bare_tests_import_reference.py`, `check_file_depth_reference.py` —
all green.

## Test plan

- [x] Scoped pytest (26/26 new/updated + pre-existing #5263 coverage) — done
- [x] Full 4-directory sweep (5154 passed, 1 pre-existing unrelated failure) — done
- [x] Local gates (8/8) — done
- [x] Real strip-falsify ×2 (before/after RED/green) — done
- [x] (skipped — no UI/behavior change) Visual

Cannot self-merge: touches `tests/`, needs a TESTS-READ note per PR-workflow rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
