### PR TITLE
fix(#5238): pin reyn.yaml into tmp_path for 6 write-gate tests whose anchor TMPDIR could flip

### DIFF
--- a/tests/security/test_2248_prc_write_gate_prefix.py
+++ b/tests/security/test_2248_prc_write_gate_prefix.py
@@ -8,6 +8,21 @@ index_drop). The no-legit-op-blocked matrix proven here: a dedicated-op write (e
 decl) PASSES; a raw file.write to a recovery-core prefix is DENIED; ``approvals.yaml``
 (top-level persist) stays protected; ``memory/`` + ``cache/`` + other ``.reyn/`` paths stay
 default-granted (the prefix-deny must not over-reach).
+
+#5238 (TMPDIR-dependent anchor audit, full count in the issue): of this file's 6
+tests, 2 pin their own ``reyn.yaml`` into ``tmp_path`` below (they call
+``reyn.api.safe.file``'s WALK-based ``_project_root_for_gate()``, which a
+``TMPDIR`` placing ``tmp_path`` inside an outer ``reyn.yaml`` tree would
+otherwise mis-anchor). The other 4 do not, and do not need to:
+``test_recovery_core_prefix_paths_excluded_from_default_zone`` /
+``test_non_recovery_core_reyn_paths_still_default_granted`` call
+``reyn.security.permissions.permissions``'s SAME-NAMED sibling functions, which
+take a plain ``Path.cwd()`` base with no walk at all — immune by construction.
+``test_safe_file_allows_non_recovery_core_reyn_write`` targets
+``.reyn/memory/``/``.reyn/cache/``, never in the protected/recovery-core lists
+under ANY root. ``test_safe_file_recovery_core_gate_anchors_on_project_root_
+not_launch_subdir`` already pins its own ``reyn.yaml`` (it is the pattern the
+2 fixed tests below now follow).
 """
 from __future__ import annotations
 
@@ -47,7 +62,19 @@ def test_non_recovery_core_reyn_paths_still_default_granted(tmp_path, monkeypatc
 def test_safe_file_denies_raw_write_under_recovery_core_prefix(tmp_path, monkeypatch):
     """Tier 2: safe.file._check_write DENIES a raw write to .reyn/config/ or .reyn/state/
     covered only by the broad .reyn/ parent-dir (no explicit listing) — forcing the
-    dedicated-op path. RED if the prefix-deny were removed (the .reyn/ zone would allow it)."""
+    dedicated-op path. RED if the prefix-deny were removed (the .reyn/ zone would allow it).
+
+    #5238: ``_check_write`` anchors via ``_project_root_for_gate()``, which walks UP
+    from cwd looking for ``reyn.yaml`` — pinning one directly in ``tmp_path`` (same
+    pattern as ``test_safe_file_recovery_core_gate_anchors_on_project_root_not_
+    launch_subdir`` below) makes the walk stop here regardless of whatever
+    ``reyn.yaml`` may or may not exist further up under ``TMPDIR``. Without this, a
+    ``TMPDIR`` that places ``tmp_path`` inside an ancestor's own ``reyn.yaml`` tree
+    (real incident, coder-smith, 2026-08-24) anchors the gate on that OUTER
+    project instead — this test's own ``.reyn/config``/``.reyn/state`` targets then
+    fall outside the (wrongly-anchored) recovery-core prefix, the raw write is
+    wrongly ALLOWED, and this test's own ``pytest.raises`` fails to see a raise."""
+    (tmp_path / "reyn.yaml").write_text("mcp:\n  servers: {}\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     from reyn.api.safe import file as safe_file
 
@@ -64,7 +91,19 @@ def test_safe_file_denies_raw_write_under_recovery_core_prefix(tmp_path, monkeyp
 def test_safe_file_accepts_config_write_with_explicit_decl(tmp_path, monkeypatch):
     """Tier 2: the dedicated-op path — .reyn/config/mcp.yaml WITH an explicit file.write
     decl PASSES (mcp_install/drop session-approve the exact path). RED if the prefix-deny
-    rejected even an explicitly-declared write = the no-legit-op-blocked invariant broken."""
+    rejected even an explicitly-declared write = the no-legit-op-blocked invariant broken.
+
+    #5238: pinned anchor (see the sibling deny-test's docstring) — this closes a
+    real vacuous-pass, not just a hypothetical one: WITHOUT the pin, a ``TMPDIR``
+    that anchors the gate on an outer project makes ``_is_under_recovery_core_
+    prefix`` return False before the explicit-decl branch this test claims to
+    exercise is ever reached — the assertion below ("must not raise") was true
+    either way, so the test passed while checking nothing. STRIP-FALSIFY
+    (performed, not left as a claim): with the anchor pinned, removing the
+    explicit ``.reyn/config/mcp.yaml`` decl from ``write_paths`` makes this
+    correctly go RED (``PermissionError``, the no-legit-op-blocked invariant this
+    test exists to prove) — confirmed manually, reverted before commit."""
+    (tmp_path / "reyn.yaml").write_text("mcp:\n  servers: {}\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     from reyn.api.safe import file as safe_file
 

--- a/tests/security/test_permission_collapse_phase2.py
+++ b/tests/security/test_permission_collapse_phase2.py
@@ -20,6 +20,15 @@ Verifies the OS-invariants introduced by Phase 2:
 Tier policy: these are OS-invariant tests pinning the contract between
 the permission resolver and `reyn.api.safe.file`. They use real
 PermissionResolver instances + the real safe.file module — no mocks.
+
+#5238 (TMPDIR-dependent anchor audit, full count in the issue): 3 of this
+file's tests pin their own `reyn.yaml` into `tmp_path` below, for the same
+reason `test_2248_prc_write_gate_prefix.py`'s module docstring gives —
+they call `reyn.api.safe.file`'s WALK-based `_project_root_for_gate()`,
+which a `TMPDIR` placing `tmp_path` inside an outer `reyn.yaml` tree would
+otherwise mis-anchor onto. `test_safe_file_check_write_still_allows_non_
+canonical_under_reyn` does not need one — its targets (`.reyn/cache/`,
+bare `.reyn/` files) are never canonical/recovery-core under any root.
 """
 from __future__ import annotations
 
@@ -164,7 +173,13 @@ def test_canonical_path_via_explicit_file_write_requires_startup_approval(tmp_pa
 
 
 def test_safe_file_check_write_rejects_canonical_via_parent_dir(tmp_path, monkeypatch):
-    """Tier 2: safe.file._check_write rejects a canonical path covered only by parent dir."""
+    """Tier 2: safe.file._check_write rejects a canonical path covered only by parent dir.
+
+    #5238: `reyn.yaml` pinned into `tmp_path` — see module docstring; without
+    it, a `TMPDIR` anchoring `_project_root_for_gate()` on an outer project
+    makes `_is_canonical_protected_write` return False and this test's own
+    `pytest.raises` fails to see a raise (real incident, coder-smith, 08-24)."""
+    (tmp_path / "reyn.yaml").write_text("mcp:\n  servers: {}\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     from reyn.api.safe import file as safe_file
 
@@ -178,7 +193,17 @@ def test_safe_file_check_write_rejects_canonical_via_parent_dir(tmp_path, monkey
 
 
 def test_safe_file_check_write_accepts_canonical_via_explicit_path(tmp_path, monkeypatch):
-    """Tier 2: safe.file._check_write accepts canonical path when listed explicitly."""
+    """Tier 2: safe.file._check_write accepts canonical path when listed explicitly.
+
+    #5238: pinned anchor (see the sibling reject-test's docstring) — this
+    closes a real vacuous-pass: WITHOUT the pin, an outer-anchored TMPDIR
+    makes the canonical-path check return False before the explicit-path
+    branch this test claims to exercise is ever reached, so "must not raise"
+    held either way. STRIP-FALSIFY (performed, not left as a claim): with the
+    anchor pinned, removing the explicit `sources.yaml` entry from
+    `write_paths` makes this correctly go RED (`PermissionError`) — confirmed
+    manually, reverted before commit."""
+    (tmp_path / "reyn.yaml").write_text("mcp:\n  servers: {}\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     from reyn.api.safe import file as safe_file
 
@@ -218,7 +243,12 @@ def test_safe_file_check_write_rejects_approvals_yaml(tmp_path, monkeypatch):
 
     Falsification contrast: a non-protected sibling under .reyn/ stays writable
     in-zone — the denial is specific to the protected-path list.
+
+    #5238: `reyn.yaml` pinned into `tmp_path` — see module docstring; without
+    it, an outer-anchored TMPDIR makes the canonical-path check return False
+    and the `pytest.raises` below fails to see a raise.
     """
+    (tmp_path / "reyn.yaml").write_text("mcp:\n  servers: {}\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     from reyn.api.safe import file as safe_file
 
@@ -350,7 +380,15 @@ async def test_mcp_cron_config_reprotected_by_recovery_core_prefix(tmp_path, mon
     No legit op blocked: the dedicated ops write via their own write_text + an EXPLICIT
     file.write decl, so they pass (proven in test_2248_prc_write_gate_prefix). approvals.yaml
     (top-level persist) stays protected via its explicit carve-out.
+
+    #5238: `reyn.yaml` pinned into `tmp_path` for the `safe_file._check_write`
+    calls below — see module docstring. The `resolver.require_file_write`/
+    `_in_default_write_zone` calls in this same test are unaffected either way
+    (the resolver takes an explicit `project_root=tmp_path` above; the bare
+    `_in_default_write_zone(rel)` call defaults to `Path.cwd()`, no walk) —
+    only the walk-based `safe.file` gate needed the pin.
     """
+    (tmp_path / "reyn.yaml").write_text("mcp:\n  servers: {}\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
     from reyn.api.safe import file as safe_file


### PR DESCRIPTION
**[docs-maintainer]** — fixes the 6 tests counted in #5238's own count-only comment (issuecomment-5437681167), per lead-coder's implementation ruling on that issue.

## What

`reyn.api.safe.file._check_write`/`_is_canonical_protected_write`/`_is_under_recovery_core_prefix` all anchor via `_project_root_for_gate()`, which walks UP from `os.getcwd()` looking for `reyn.yaml`. 6 tests across 2 files implicitly assumed `tmp_path` sits outside any `reyn.yaml` tree — a `TMPDIR` placing it INSIDE one (real incident, coder-smith, 2026-08-24: `repos/coder-smith/reyn.yaml` existed, `TMPDIR` unset, pytest's tmp landed under it) anchors the gate on that OUTER project instead.

## The 6 tests, 2 shapes

- **4 flip pass↔fail** — expect `PermissionError`, would silently stop raising under a false anchor (someone notices — CI goes red for the wrong reason, as it did for coder-smith):
  - `test_safe_file_denies_raw_write_under_recovery_core_prefix`
  - `test_safe_file_check_write_rejects_canonical_via_parent_dir`
  - `test_safe_file_check_write_rejects_approvals_yaml`
  - `test_mcp_cron_config_reprotected_by_recovery_core_prefix` (its `safe_file._check_write` asserts specifically — its `resolver.require_file_write`/`_in_default_write_zone` asserts in the same test were always immune, see below)
- **2 silently vacuous-pass** — expect no-raise, would KEEP passing under a false anchor, but for the wrong reason: the gate never engages at all, so the explicit-decl branch each claims to exercise never runs. Nobody notices (six-questions ④'s exact family):
  - `test_safe_file_accepts_config_write_with_explicit_decl`
  - `test_safe_file_check_write_accepts_canonical_via_explicit_path`

## Fix

Pin `(tmp_path / "reyn.yaml").write_text(...)` before exercising the gate in each of the 6. `_project_root_for_gate()`'s walk stops at the FIRST ancestor carrying `reyn.yaml` — pinning one directly in `tmp_path` makes that the answer unconditionally, regardless of whatever exists further up under `TMPDIR`.

**Not a new mechanism** — `test_safe_file_recovery_core_gate_anchors_on_project_root_not_launch_subdir` (in `test_2248_prc_write_gate_prefix.py`) already used this exact pattern in production test code before this PR. This generalizes an existing pattern to a 2nd/3rd/etc. site, per the judge-invariant this arc has used repeatedly today (0 = uncovered, 1 = wired, 2+ = a real duplication worth removing) — the fix removes the TEST-side implicit assumption, never touches `_project_root_for_gate()` itself (its walk-up behavior is correct and load-bearing elsewhere, #4204 bucket C).

## 5 tests examined and left unchanged — reasons recorded in each file's module docstring, not just here

1. `test_recovery_core_prefix_paths_excluded_from_default_zone`
2. `test_non_recovery_core_reyn_paths_still_default_granted`
   — both call `reyn.security.permissions.permissions`'s SAME-NAMED sibling functions, which take a `base` parameter defaulting to plain `Path.cwd()` — **no walk at all**, immune by construction.
3. `test_safe_file_allows_non_recovery_core_reyn_write`
4. `test_safe_file_check_write_still_allows_non_canonical_under_reyn`
   — target paths (`.reyn/memory/`, `.reyn/cache/`) are never in the protected/recovery-core lists under ANY root.
5. `test_safe_file_recovery_core_gate_anchors_on_project_root_not_launch_subdir`
   — already pins its own `reyn.yaml`; it's the pattern this PR generalizes, not a gap.

## Strip-falsified, both directions

- **Confirms the classification**: reverted all 7 `reyn.yaml` pins (the 6 new + the 1 pre-existing sibling) and re-ran the full 22-test pair under a simulated hostile `TMPDIR` (`--basetemp` pointed under a directory carrying its own `reyn.yaml`) — reproduced exactly the 4 predicted flip-failures (`DID NOT RAISE PermissionError`) plus the pre-existing sibling test (5 failed), while the 2 vacuous-pass tests stayed green either way — confirming they were never sensitive to the anchor in the first place (that's precisely why they're the vacuous-pass class, not the flip class).
- **Confirms the fix genuinely closes the vacuous-pass gap**: with pins restored, removed the explicit-decl entry from each of the 2 previously-vacuous tests' `write_paths` — both now correctly go RED (`PermissionError`), proving they exercise the explicit-decl branch they claim to, not passing regardless.

## Test plan

- [x] `pytest tests/security/test_2248_prc_write_gate_prefix.py tests/security/test_permission_collapse_phase2.py -q` — 22/22 pass.
- [x] `pytest tests/security/ -q` — 804 passed, 26 skipped (pre-existing, unrelated).
- [x] `ruff check` on both changed files — clean.
- [x] `python scripts/test_tier_audit.py --strict <both files>` — 22/22 OK, 0 Tier-4.
- [x] `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK.
- [x] Strip-falsify (anchor pins): reverted all 7, simulated hostile `TMPDIR` via `--basetemp` under an outer `reyn.yaml` — reproduced the exact 4 predicted flips + the 1 pre-existing sibling (5 failed), 2 vacuous-pass tests stayed green either way as expected. Restored, re-confirmed 22/22.
- [x] Strip-falsify (vacuous-pass closed for real): with pins in place, removed the explicit-decl entry from each of the 2 fixed vacuous tests — both correctly went RED. Restored, re-confirmed 22/22.
- [ ] (skipped — no UI surface, test-only change) Visual

This PR touches `tests/` — needs an independent TESTS-READ (B) before merge (rule 8), from someone other than me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
