### PR TITLE
test(#5237): witness that A2A/web sessions actually fire declared reyn.yaml hooks

### DIFF
--- a/tests/interfaces/test_5237_web_deps_hooks_witness.py
+++ b/tests/interfaces/test_5237_web_deps_hooks_witness.py
@@ -1,0 +1,94 @@
+"""Tier 2: #5237 — A2A/web (`deps.get_registry`) actually delivers a
+declared reyn.yaml `hooks:` entry to a real Session.
+
+#5228 restructured `hooks_config`/`composers_config`/`fs_watch_config`
+from flat kwargs into `SessionFactoryConfig.reactivity_config`
+(`build_scoped_chat_session` now reads `factory_config.reactivity_config`
+directly). #5228's own accept② ("hooks actually reach an A2A/web session")
+had 0 witnesses when #5234 merged it — #5234's own test covered a
+DIFFERENT invariant (`Session(reactivity=None)` raising `TypeError`), not
+this one. This is the missing witness.
+
+Drives the REAL production path — `deps.get_registry()` (the exact
+callable `Depends(get_registry)` resolves to in every A2A/web router) →
+`AgentRegistry.resolve_session` (the real routing-key get-or-spawn
+primitive, same one `a2a.py`'s handlers call) — never a hand-built
+Session or a test-owned session factory. `resolve_session` spawns via the
+registry's real `session_factory` closure (`deps.py`'s `_session_factory`,
+unchanged, un-mocked).
+
+Observation: `_hook_dispatcher` is reached only to CALL its own public
+``dispatch()`` — never read as state inside an assertion — mirroring
+``test_5222_hook_state_origin_aware.py``'s own established idiom
+("Corroborate against the REAL dispatch outcome"). The actual assertion
+is on ``session.inbox`` (a public ``asyncio.Queue``), which is what a
+``wake: true`` push production-fires into — proof the hook actually
+FIRES, not merely that a `HookDef` object sits in a list somewhere.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.hooks.schema_registry import build_hook_payload
+from reyn.interfaces.web import deps
+from reyn.interfaces.web.deps import CliScopedOverrides, cli_scoped_overrides
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+_HOOK_YAML = (
+    MINIMAL_REYN_YAML
+    + "hooks:\n"
+    "  - \"on\": session_start\n"
+    "    template_push:\n"
+    "      message: \"witness hook fired\"\n"
+    "      wake: true\n"
+)
+
+
+def _real_web_session(tmp_path, monkeypatch, *, sid: str):
+    """Spawn a Session through the REAL A2A/web construction path —
+    `deps.get_registry()` (what every router's `Depends(get_registry)`
+    resolves to) then `AgentRegistry.resolve_session` (the same
+    routing-key get-or-spawn primitive `a2a.py`'s handlers call)."""
+    monkeypatch.chdir(tmp_path)
+    with cli_scoped_overrides(CliScopedOverrides()):
+        registry = deps.get_registry()
+        return registry.resolve_session("default", "web", sid)
+
+
+@pytest.mark.asyncio
+async def test_declared_startup_hook_actually_fires_on_a_real_a2a_web_session(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #5228 accept② — a `hooks:` entry declared in reyn.yaml
+    actually FIRES on a Session spawned via `deps.get_registry()`. Not
+    "construction succeeded" (#5228 already had that — #5234's own test)
+    — the declared hook's push actually lands in the session's inbox."""
+    (tmp_path / "reyn.yaml").write_text(_HOOK_YAML, encoding="utf-8")
+
+    session = _real_web_session(tmp_path, monkeypatch, sid="witness-declared")
+
+    await session._hook_dispatcher.dispatch(
+        "session_start", build_hook_payload("session_start", agent_name=session.agent_name),
+    )
+    assert session.inbox.qsize() >= 1, (
+        "the reyn.yaml session_start hook did not fire on the real A2A/web "
+        "session — its inbox is empty"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_hooks_block_yields_no_dispatch_at_all(tmp_path, monkeypatch):
+    """Tier 2: differential half — an A2A/web session with NO declared
+    hooks dispatches to nothing (a genuinely empty inbox, not a
+    construction failure silently swallowed into a look-alike no-op).
+    Same construction path, same dispatch call, only the config differs —
+    proves the positive test above is reading real config-sensitivity,
+    not a fixture artifact that would fire either way."""
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+
+    session = _real_web_session(tmp_path, monkeypatch, sid="witness-empty")
+
+    await session._hook_dispatcher.dispatch(
+        "session_start", build_hook_payload("session_start", agent_name=session.agent_name),
+    )
+    assert session.inbox.qsize() == 0


### PR DESCRIPTION
**[docs-maintainer]** — part of #5237. #5228's accept② ("A2A/web sessions actually get reyn.yaml's declared hooks") had 0 witnesses when #5234 merged it — this is that witness.

## What

2 new tests, driving the REAL production path: `deps.get_registry()` (the exact callable `Depends(get_registry)` resolves to in every A2A/web router) → `AgentRegistry.resolve_session` (the same routing-key get-or-spawn primitive `a2a.py`'s handlers call) → the registry's real `session_factory` closure, unmocked.

- `test_declared_startup_hook_actually_fires_on_a_real_a2a_web_session` — a `session_start` hook declared in `reyn.yaml`, dispatched for real, lands in `session.inbox` (`wake: true`).
- `test_no_hooks_block_yields_no_dispatch_at_all` — same construction path, same dispatch call, no `hooks:` block → genuinely empty inbox. The differential half: proves the positive test is reading real config-sensitivity, not a fixture artifact that would fire either way.

`_hook_dispatcher` is reached only to CALL its own public `dispatch()` — never read as state inside an assertion, mirroring `test_5222_hook_state_origin_aware.py`'s own established idiom ("Corroborate against the REAL dispatch outcome, not just the display"). The assertion is on `session.inbox` (a public `asyncio.Queue`), proving the hook actually FIRES — not merely that a `HookDef` sits in a registry list somewhere.

## Investigation note — a retracted false alarm, recorded for the record

I initially believed and reported (to lead-coder, on the issue thread and via broker) a **live production defect**: `deps.py`'s `_session_factory` appearing to never thread `hooks_config` through to `Session`, based on running the real path and observing an empty hook registry.

**Retracted after re-measurement.** The empty result traced to my own test setup — an accidental `PYTHONPATH` pointing at an already-deleted worktree from a prior task, which silently fell through to a **stale home-checkout `main`** (pre-#5228 refactor code, where `hooks_config` genuinely was a dead-threaded flat kwarg). On a correctly-fresh `origin/main` worktree, the real mechanism is confirmed correct: `SessionFactoryConfig.from_config` already builds `ReactivityConfig(hooks_config=config.hooks, ...)`, and `build_scoped_chat_session` reads `factory_config.reactivity_config` directly (the separately-popped `**base` kwargs of the same names are dead code, kept only so a legacy caller's stale kwarg doesn't silently leak into `Session.__init__`). My first proposed "fix" (adding `hooks_config=` directly to `deps.py`'s `build_scoped_chat_session` call) would have been inert dead code — not pushed.

Full back-and-forth (my error, the correction, and lead-coder's own root-cause naming of the mistake class — "a deleted dir doesn't mean 'absent', it means 'fall through to the next PYTHONPATH candidate'") is on issue #5237's thread and this session's broker log, not repeated here.

## Strip-falsified

Temporarily changed `factory_config.py`'s `hooks_config=config.hooks` to `hooks_config=[]` — the positive test goes RED (empty inbox) with the exact predicted failure message ("the reyn.yaml session_start hook did not fire..."); the differential (no-hooks) test is unaffected, as expected. Reverted, confirmed both green again.

## Test plan

- [x] `pytest tests/interfaces/test_5237_web_deps_hooks_witness.py -v` — 2/2 pass.
- [x] `pytest tests/interfaces/ tests/runtime/ -q -k hook` — 196 passed.
- [x] `pytest tests/interfaces/ -q -k "5237 or hooks or a2a"` — 111 passed, 1 pre-existing skip.
- [x] `ruff check` on the new file — clean.
- [x] `python scripts/test_tier_audit.py --strict <file>` — 2/2 OK, 0 Tier-4.
- [x] `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK.
- [x] Strip-falsify: broke `factory_config.py`'s hooks wiring, confirmed the positive test goes RED with the exact predicted message, differential test unaffected. Restored, re-confirmed 2/2 green.
- [ ] (skipped — no UI surface, test-only change) Visual

This PR touches `tests/` — needs an independent TESTS-READ (B) before merge (rule 8), from someone other than me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
