### PR TITLE
fix(#5236): emit permission_approval_granted at the moment of grant

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -162,6 +162,7 @@ oauth_login_started
 peer_reply_failed_surfaced
 pending_intervention_claimed
 pending_intervention_discarded
+permission_approval_granted
 permission_approval_revoked
 permission_approvals_cleared
 permission_denied
@@ -408,6 +409,7 @@ Each Control IR op kind emits its own event:
 | `control_ir_skipped`, `control_ir_failed` | dispatch failures (`control_ir_skipped` reasons include `handler_not_implemented`) |
 | `permission_denied` | When an op is denied by the resolver |
 | `permission_approval_revoked`, `permission_approvals_cleared` | #5065 — a management operation on the SAVED-approvals ledger (`.reyn/approvals.jsonl`), e.g. the `/api/permissions` REST router. Distinct from `permission_granted`/`permission_denied` above (those are in-run decisions, hence `run_id`/`actor`/`phase`; these happen outside any run, so they carry neither): `permission_approval_revoked` — `key`, `surface`; `permission_approvals_cleared` — `count`, `surface`. |
+| `permission_approval_granted` | #5236 — the grant half of the pair above: an operator answering an interactive permission prompt with the persist-and-allow choice (`PermissionResolver._persist`, the SINGLE choke point every such choice funnels through — `_prompt`'s ALWAYS branch, `_prompt_file_access`'s JUST_PATH/RECURSIVE branches). Before this, only the undo (revoke/clear) was observable; the grant itself left no trail. `surface="permission_prompt"` (not `"web"`/`"cli"`, unlike the revoke pair above) — a grant can be answered from ANY surface presenting the prompt (TUI, an SSE-delivered web intervention, A2A, MCP elicitation), and `_persist` itself never learns which one; claiming a specific surface would be a fabricated field. | `key`, `surface` |
 
 ## MCP
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -97,6 +97,12 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # key it removed; a bulk clear has no single key to name).
     "permission_approval_revoked": frozenset({"key", "surface"}),
     "permission_approvals_cleared": frozenset({"count", "surface"}),
+    # #5236: the grant half of the pair above — a management operation on
+    # the SAVED-approvals store, same non-in-run reasoning (no run_id/
+    # actor/phase). Same field shape as permission_approval_revoked
+    # (key, surface) — the value the approval covers is deliberately never
+    # in the payload, matching that kind's own choice.
+    "permission_approval_granted": frozenset({"key", "surface"}),
     # #5067: same shape as the two above, on the OTHER band pairing
     # (cost-budget x audit-events, not permission x audit-events) — a
     # management operation on the live BudgetTracker's hard caps
@@ -368,6 +374,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "peer_reply_failed_surfaced",
     "pending_intervention_claimed",
     "pending_intervention_discarded",
+    "permission_approval_granted",
     "permission_approval_revoked",
     "permission_approvals_cleared",
     "permission_denied",

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -904,6 +904,40 @@ class PermissionResolver:
         # it — CLI, web router, or here) — no extra write needed for it.
         from reyn.security.permissions.approval_ledger import ApprovalLedger
         ApprovalLedger(self._approval_ledger_path).append_approval(key, approved)
+        # #5236: the grant half of the same band pairing #5065 only closed
+        # for revoke — "audit that records only the undo, never the
+        # decision itself, is not an audit" (lead-coder's own filing).
+        # ``_persist`` is THIS process's SINGLE choke point for a grant:
+        # every ``approved=True`` call funnels through here (``_prompt``'s
+        # ALWAYS choice, ``_prompt_file_access``'s JUST_PATH/RECURSIVE
+        # choices — the only 3 call sites in this module, confirmed by
+        # `git grep '_persist(' `) — there is no REST/CLI grant endpoint at
+        # all (only revoke/clear), unlike revoke's own web-only gap #②
+        # this issue explicitly left untouched.
+        #
+        # ``emit_direct_event`` (not ``Session.emit_audit_event``) matches
+        # the SAME choice ``permission_approval_revoked``/``_cleared``
+        # already made — ``PermissionResolver`` has no live-Session
+        # reference to call through even when one happens to exist
+        # elsewhere in-process; band: workspace-SSoT, not a Session
+        # convenience.
+        #
+        # ``surface="permission_prompt"``, not ``"web"``/``"cli"``: unlike
+        # revoke (REST-route-only today, so ``"web"`` is honest), a grant
+        # can be answered from ANY surface presenting the interactive
+        # ``UserIntervention`` this method's own callers await (TUI inline
+        # chat, an SSE-delivered web intervention, A2A, MCP elicitation) —
+        # ``_persist`` itself never learns which one. Claiming ``"web"``
+        # here would be a fabricated field the #5065 charter band explicitly
+        # warns against (reconstructible, not merely field-present).
+        if approved:
+            from reyn.core.events.events import emit_direct_event
+            emit_direct_event(
+                "permission_approval_granted",
+                surface="permission_prompt",
+                reyn_root=self._project_root / ".reyn",
+                key=key,
+            )
         # #398 v4 emitter wiring: notify subscribers (= Session
         # instances that registered themselves) so the LLM sees the
         # permission change as a ``state_change`` history entry next

--- a/tests/security/test_5236_permission_approval_granted_audit_event.py
+++ b/tests/security/test_5236_permission_approval_granted_audit_event.py
@@ -1,0 +1,139 @@
+"""Tier 2: #5236 — the moment an operator GRANTS a permanent approval (the
+ALWAYS choice on an interactive permission prompt) emits a P6 audit-event.
+Before this, only the undo half of the pair (``permission_approval_revoked``/
+``_cleared``, #5065) was observable — the audit trail could record that a
+decision was taken back, but never that it was made.
+
+Real ``PermissionResolver`` + a real interactive-choice ``InterventionBus``
+throughout (mirrors ``tests/security/test_permission_collapse_phase3.py``'s
+own ``_AlwaysBus`` harness for driving the ALWAYS choice) — no mock. Witness
+reads the actual ``.reyn/events/direct/permission_prompt/`` files this PR's
+``emit_direct_event`` call writes (mirrors
+``tests/web/test_5065_permissions_router_emits_audit_event.py``'s own
+``_read_direct_web_events`` shape, generalized to a different ``surface``).
+
+Strip-falsifier: comment out the ``emit_direct_event(...)`` call in
+``permissions.py``'s ``_persist`` — the approval still lands (``fold()``
+still shows it granted), but no new ``.reyn/events`` file/line appears,
+turning the witness red. Verified for real in this PR's own commit message.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.security.permissions.approval_ledger import ApprovalLedger
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
+
+
+class _ChoiceBus(InterventionBus):
+    """A real (non-mock) ``InterventionBus`` that always answers with one
+    fixed choice — the same shape ``test_permission_collapse_phase3.py``'s
+    own ``_AlwaysBus`` uses to drive the ALWAYS branch."""
+
+    def __init__(self, choice_id: str) -> None:
+        self.requests: "list[UserIntervention]" = []
+        self._choice_id = choice_id
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.requests.append(iv)
+        return InterventionAnswer(choice_id=self._choice_id)
+
+
+def _read_direct_permission_prompt_events(project_root: Path) -> "list[dict]":
+    """Read every event line under
+    ``.reyn/events/direct/permission_prompt/`` — this PR's new
+    ``surface="permission_prompt"`` directory."""
+    surface_dir = project_root / ".reyn" / "events" / "direct" / "permission_prompt"
+    if not surface_dir.is_dir():
+        return []
+    out: "list[dict]" = []
+    for f in sorted(surface_dir.glob("*/*.jsonl")):
+        for line in f.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def test_the_always_choice_emits_one_audit_event_naming_the_granted_key(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: driving a real permission prompt to its ALWAYS choice ->
+    exactly one new ``.reyn/events`` entry, naming the GRANTED key (not
+    just "one more event appeared" — matching the strengthened,
+    key-specific witness lead-coder required for the revoke side, #5065)."""
+    assert _read_direct_permission_prompt_events(tmp_path) == []
+
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl(http_get=[{"host": "example.com"}])
+    bus = _ChoiceBus("always")
+    asyncio.run(resolver.require_http_get(decl, "example.com", bus, "test_skill"))
+    assert bus.requests, "control arm: the prompt must have fired at all"
+
+    events = _read_direct_permission_prompt_events(tmp_path)
+    assert events, "expected an audit event for the grant, got none"
+    assert events[1:] == [], f"expected exactly one audit event, got {events}"
+    assert events[0]["type"] == "permission_approval_granted"
+    assert events[0]["data"]["key"] == "test_skill/http.get/example.com"
+    assert events[0]["data"]["surface"] == "permission_prompt"
+
+    # The write itself lands, unaffected by the audit addition.
+    saved, _bound = ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl").fold()
+    assert saved.get("test_skill/http.get/example.com") is True
+
+
+def test_a_repeat_call_after_always_is_silent_and_emits_nothing_new(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: non-vacuity for "exactly once" — a SECOND call for the same,
+    already-persisted key must not re-prompt (test_permission_collapse_
+    phase3.py's own "must not re-prompt" invariant) and therefore must not
+    emit a second grant event either; ``_persist`` is only reached via a
+    live prompt answer, never via the persisted-lookup fast path."""
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl(http_get=[{"host": "example.com"}])
+    bus = _ChoiceBus("always")
+    asyncio.run(resolver.require_http_get(decl, "example.com", bus, "test_skill"))
+    first_events = _read_direct_permission_prompt_events(tmp_path)
+    assert [e["type"] for e in first_events] == ["permission_approval_granted"]
+    requests_after_first_call = list(bus.requests)
+
+    asyncio.run(resolver.require_http_get(decl, "example.com", bus, "test_skill"))
+
+    assert bus.requests == requests_after_first_call, "the second call must not re-prompt"
+    assert _read_direct_permission_prompt_events(tmp_path) == first_events, (
+        "a call that never re-persists must not emit a second grant event"
+    )
+
+
+def test_the_never_choice_denial_emits_nothing(tmp_path: Path) -> None:
+    """Tier 2: falsification pair — the NEVER choice (deny + persist,
+    ``_persist(key, False)`` — this repo's real "unknown/no" fallback is
+    the same session-only-deny branch YES already covers structurally, so
+    NEVER is the meaningful non-grant persist to check) must emit no
+    ``permission_approval_granted``. Without this, a naive "emit whenever
+    _persist is CALLED, ignoring approved's value" implementation would
+    still pass the positive test above (it calls _persist with True there)
+    while ALSO wrongly emitting for every revoke — exactly the double-count
+    ``test_5065_permissions_router_emits_audit_event.py``'s own suite would
+    then start silently accumulating alongside this file's local gates."""
+    assert _read_direct_permission_prompt_events(tmp_path) == []
+
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    decl = PermissionDecl(http_get=[{"host": "example.com"}])
+    bus = _ChoiceBus("never")
+    with pytest.raises(PermissionError):
+        asyncio.run(resolver.require_http_get(decl, "example.com", bus, "test_skill"))
+
+    assert _read_direct_permission_prompt_events(tmp_path) == []
+    # The persisted-False row (a revoke-shaped record for a key that was
+    # never granted) is real too — confirms _persist(key, False) genuinely
+    # ran, so the absence of an event above is a real non-emission, not a
+    # vacuous "nothing happened at all".
+    saved, _bound = ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl").fold()
+    assert saved.get("test_skill/http.get/example.com") is False


### PR DESCRIPTION
Closes #5236 — lead-coder's own ①②③ acceptance criteria (emit at grant, revoked's payload shape, exactly-once witness).

## What

The undo half of the pair (`permission_approval_revoked`/`_cleared`,
#5065) was observable via `.reyn/events`; the grant itself was not.
lead-coder's own filing: "an audit that records only the undo, never the
decision itself, is not an audit" (band: permission × audit-events).

## Fix

Traced every path that can persist a grant: `PermissionResolver._persist`
is the **single choke point** every `approved=True` call funnels
through — `_prompt`'s ALWAYS choice, `_prompt_file_access`'s
JUST_PATH/RECURSIVE choices (the only 3 call sites in `permissions.py`,
confirmed via `git grep`). There is **no REST/CLI grant endpoint at all**
— only revoke/clear exist there — unlike revoke's own web-only-surface
gap (the issue's own "②" finding), which this PR does not touch
(lead-coder scoped that as informational, not a fix target here).

- Emits `permission_approval_granted` (`key`, `surface`) via
  `emit_direct_event` — the SAME no-live-Session seam
  `permission_approval_revoked`/`_cleared` already use, since
  `PermissionResolver` has no Session reference even when one happens to
  exist elsewhere in-process.
- `surface="permission_prompt"`, not `"web"`/`"cli"`: unlike revoke
  (REST-route-only today, so `"web"` is honest), a grant can be answered
  from ANY surface presenting the interactive `UserIntervention` this
  choke point awaits (TUI, an SSE-delivered web intervention, A2A, MCP
  elicitation) — `_persist` itself never learns which one, and claiming a
  specific surface would be exactly the fabricated-field shape the #5065
  charter band warns against.
- Registered in `AUDIT_EVENT_KINDS` + `EVENT_AUDIT_REQUIREMENTS` + a new
  row in `docs/reference/runtime/events.md` (same PR, CLAUDE.md doc-drift
  hard rule) — the vocabulary census
  (`test_audit_event_kind_vocabulary_3410.py`) caught a first-draft miss
  where the kind was declared in `EVENT_AUDIT_REQUIREMENTS` but not
  `AUDIT_EVENT_KINDS` itself; fixed before this commit.

## Verification

New `tests/security/test_5236_permission_approval_granted_audit_event.py`
(3 tests), real `PermissionResolver` + a real choice-driven
`InterventionBus` (mirrors `test_permission_collapse_phase3.py`'s own
`_AlwaysBus` harness):
- ALWAYS emits exactly one event naming the granted key.
- A second call for an already-persisted key re-prompts nothing and emits
  nothing new (non-vacuity for "exactly once").
- NEVER (persist + deny) emits nothing (falsification pair, proving the
  emit is gated on `approved=True`, not on `_persist` merely being
  called).

Real strip-falsify: commented out the `emit_direct_event` call — both
positive tests went RED (no event / wrong count); restored, green again.

`tests/security` + `tests/web` +
`tests/core/test_audit_event_kind_vocabulary_3410.py`: **903 passed**, 26
skipped (pre-existing optional-dependency/platform gates).

Local gates: ruff, `test_tier_audit --strict`, `verify_module_docstrings.py`,
`mypy_ratchet.py`, `flat_tests_ratchet.py`,
`check_tests_path_literal_reference.py`,
`check_bare_tests_import_reference.py`, `check_file_depth_reference.py`,
`mkdocs build --strict`, `check_doc_anchors.py`,
`check_retired_config_keys_denylist.py` — all green.

## Test plan

- [x] Scoped pytest (3/3 new) — done
- [x] Broader sweep (903 passed, tests/security+web+vocabulary-census) — done
- [x] Local gates (11/11, incl. doc gates) — done
- [x] Real strip-falsify (before/after RED/green) — done
- [x] (skipped — no UI/behavior change) Visual

Cannot self-merge: touches `tests/`, needs a TESTS-READ note per PR-workflow rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
