### PR TITLE
feat(#5296): same-turn spill/compaction recovery from a byte-limited 413

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -159,6 +159,7 @@ network_ssl_verify_disabled
 new_msg_exceeds_budget
 oauth_login_completed
 oauth_login_started
+payload_reduced
 peer_reply_failed_surfaced
 pending_intervention_claimed
 pending_intervention_discarded
@@ -617,6 +618,7 @@ mostly informational.
 | `compact_op_unavailable` | The `compact` Control IR op was dispatched in a context where no compaction engine is wired. | `run_id`, `phase` |
 | `summary_resummarize_failed` | Re-summarising an existing summary (nested compaction) raised. | `error` |
 | `budget_reset` | The chat budget gateway reset its per-window accounting. | `before` (prior accumulated value) |
+| `payload_reduced` | #5296 PR-2 — `RouterLoopDriver`'s same-turn recovery from a BYTE-limited (HTTP 413) `UnrecoveredError`: spill (tool-result turns offloaded to `MediaStore` via a session-lived, non-durable projection overlay — never mutates `history.jsonl` or a stored `ChatMessage`, never advances the compaction watermark) and, only if spill made no progress, durable compaction (`ContextBudgetAdvisor`'s existing `force_compact_now` path) reduced the wire payload below what it was before the attempt, and the turn is being re-sent with the SAME `chain_id` — `user_submitted`/`turn_started`/the WAL append are NOT re-fired (this retry loop lives entirely inside `run_turn`, below where those fire). A non-byte-limited overflow (retry_loop's own token axis, never saw a 413) never reaches this path — see `_run_with_shrink_and_byte_reduction`'s own docstring. | `chain_id`, `attempt` (1-based, within this turn) |
 | `budget_caps_updated` | #5067 — `PATCH /api/budget/caps` (`budget.py`'s REST router) changed one or more of the live `BudgetTracker`'s hard caps. In-process only (not persisted to `reyn.yaml`), reachable via `project_root` (no live Session, hence no `run_id`/`actor`/`phase` — same shape as #5065's `permission_approval_revoked`/`permission_approvals_cleared`, the OTHER band pairing: cost-budget x audit-events). Because this change is not persisted anywhere else, this event is the ONLY record either value ever existed. | `changes` (a `{field_name: {"from": old_hard_limit, "to": new_hard_limit}}` mapping of ONLY the fields the request actually set), `surface` |
 
 ## Safety limits

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -103,6 +103,12 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # (key, surface) — the value the approval covers is deliberately never
     # in the payload, matching that kind's own choice.
     "permission_approval_granted": frozenset({"key", "surface"}),
+    # #5296 PR-2: fires once per same-turn recovery attempt after a
+    # BYTE-limited (HTTP 413) unrecovered overflow — spill and/or durable
+    # compaction reduced the wire payload and the turn is being re-sent
+    # WITHOUT re-triggering user_submitted/turn_started (same chain_id).
+    # `attempt` is the 1-based retry count within this turn.
+    "payload_reduced": frozenset({"chain_id", "attempt"}),
     # #5067: same shape as the two above, on the OTHER band pairing
     # (cost-budget x audit-events, not permission x audit-events) — a
     # management operation on the live BudgetTracker's hard caps
@@ -371,6 +377,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "new_msg_exceeds_budget",
     "oauth_login_completed",
     "oauth_login_started",
+    "payload_reduced",
     "peer_reply_failed_surfaced",
     "pending_intervention_claimed",
     "pending_intervention_discarded",

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -460,6 +460,26 @@ class RouterHistoryBuffer:
         self._cached_elide_last_seq: "int | None" = None
         self._cached_elide_model: "str | None" = None
         self._cached_elide_use_chars4: "bool | None" = None
+        # #5296 PR-2: session-lived, non-durable reactive-spill overlay —
+        # maps a tool-result turn's content hash (``"sha256:<hex>"``, same
+        # form/derivation as MediaStore's own ``content_hash``, #5296's own
+        # architect ruling: "既存spillの _offload_content_hash と語彙を揃
+        # える") to the offloaded preview text that replaces it in every
+        # FUTURE ``_serialise_turn`` call for a turn whose content hashes to
+        # that key. Applied at the SAME projection stage as the watermark
+        # filter (architect ruling, issuecomment-5439234430) — never
+        # written to ``history.jsonl``, never mutates a ``ChatMessage`` in
+        # place (that would silently change what an already-attached
+        # operator sees, a UX change #5296 explicitly does not authorize),
+        # never advances the compaction watermark, and does not survive a
+        # restart (reversible/idempotent by construction: re-deriving it is
+        # just re-spilling the same oversized turn again, not a correctness
+        # loss). Keyed by CONTENT, not by index/seq: a compaction pass
+        # trimming ``head`` shifts every downstream index, so a positional
+        # key would silently point at the wrong turn after the very
+        # recovery step (#4954-style durable compaction) this overlay's own
+        # caller may trigger next.
+        self._spill_overlay: "dict[str, str]" = {}
 
     @property
     def _model(self) -> str:
@@ -536,6 +556,19 @@ class RouterHistoryBuffer:
         content = _refresh_skill_location_tokens(
             content, getattr(m, "meta", None), self._project_dir_fn,
         )
+        # #5296 PR-2: apply the reactive-spill overlay, same stage as the
+        # watermark filter above — a hit replaces this turn's content with
+        # its offloaded preview for every projection from here on (until a
+        # future overlay entry supersedes it or the process restarts). The
+        # `self._spill_overlay` guard keeps this a no-op fast path (no
+        # hashing at all) on every call before the first spill ever fires —
+        # the overwhelming common case.
+        if self._spill_overlay and isinstance(content, str):
+            import hashlib
+            content_hash = "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
+            replacement = self._spill_overlay.get(content_hash)
+            if replacement is not None:
+                content = replacement
         msg: dict = {"role": role, "content": content}
         if m.tool_calls is not None:
             msg["tool_calls"] = m.tool_calls
@@ -1074,6 +1107,58 @@ class RouterHistoryBuffer:
         # is in-place, so the shared dicts in head/raw_middle/tail are bounded).
         self._bound_wire_reasoning(head + raw_middle + tail)
         return head, raw_middle, tail, summary_dict, seq_by_id
+
+    def spill_turn_content(
+        self, content: str, *, chain_id: str = "", tool: str = "tool", seq: int = 1,
+    ) -> "str | None":
+        """#5296 PR-2: reactively spill one already-serialised tool-result
+        wire string — offload it via the SAME mechanism the existing
+        write-time cap already uses (``tool_result_cap.cap_tool_result_
+        content`` + ``MediaStore.save_tool_result``, architect ruling:
+        "既存機構を再利用"), record the resulting overlay entry so every
+        FUTURE ``_serialise_turn`` of a turn with this exact content
+        returns the offloaded preview instead, and return that preview
+        text (``None`` if no ``media_store`` is configured — the same
+        no-op degrade the write-time cap already has for that case; the
+        caller treats that as "no progress" and escalates).
+
+        ``cap_tokens=1`` forces the offload branch unconditionally — this
+        method is called only once a caller has ALREADY decided (by
+        ordering: oldest/largest first, #5296's own contract ②) that THIS
+        turn should be spilled; ``cap_tool_result_content`` itself has no
+        "force offload regardless of size" mode, only "offload if over
+        cap_tokens", so a threshold no real content can be under is how
+        this reuses that function without adding a second offload path.
+        No new threshold config here — #5296's own contract explicitly
+        rules that out ("閾値configを作らない").
+        """
+        if self._media_store is None:
+            return None
+        import hashlib
+
+        from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+
+        def _save(c: "str | dict", **kw: Any) -> dict:
+            return self._media_store.save_tool_result(
+                c, chain_id=chain_id, tool=tool, seq=seq, **kw
+            )
+
+        replacement = cap_tool_result_content(
+            content,
+            cap_tokens=1,
+            model=self._model,
+            save_fn=_save,
+            use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
+            events=self._events,
+        )
+        if replacement == content:
+            # cap_tool_result_content's own no-op paths (cap<=0, or the
+            # store write itself somehow returned the input unchanged) —
+            # nothing was actually offloaded, so no overlay entry to add.
+            return None
+        content_hash = "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
+        self._spill_overlay[content_hash] = replacement
+        return replacement
 
     def build_system_prompt(self) -> str:
         """Return the router system prompt for the current session state.

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -1131,6 +1131,14 @@ class RouterHistoryBuffer:
         this reuses that function without adding a second offload path.
         No new threshold config here — #5296's own contract explicitly
         rules that out ("閾値configを作らない").
+
+        Deliberately does NOT check ``offload.enabled`` (the write-time
+        cap's own debug lever, ``ContextBudgetAdvisor.cap_tool_result``'s
+        first check) — spill is a REACTIVE overflow-recovery operation,
+        not a proactive budget-shaping one (architect review); that flag
+        exists to let an operator disable the routine per-turn offload
+        decision, not to also silence the last lever between a 413 and a
+        failed turn.
         """
         if self._media_store is None:
             return None
@@ -1159,6 +1167,22 @@ class RouterHistoryBuffer:
         content_hash = "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
         self._spill_overlay[content_hash] = replacement
         return replacement
+
+    def discard_spill_overlay_for(self, content: str) -> None:
+        """#5296 PR-2 (lead-coder review): undo a :meth:`spill_turn_content`
+        call for *content* whose caller has determined it did NOT help
+        (the total payload did not shrink) — without this, a no-progress
+        spill attempt still LEAVES its overlay entry in place, so a turn
+        whose every candidate got spilled for zero net benefit would keep
+        ALL of them spilled anyway: exactly the "destroy more of the
+        operator's visible context than necessary" outcome
+        :meth:`spill_turn_content`'s own docstring already disclaims.
+        Recomputes the SAME hash :meth:`spill_turn_content` used (the
+        ORIGINAL content, not the replacement) — a no-op if no entry is
+        present (idempotent, safe to call speculatively)."""
+        import hashlib
+        content_hash = "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
+        self._spill_overlay.pop(content_hash, None)
 
     def build_system_prompt(self) -> str:
         """Return the router system prompt for the current session state.

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -47,6 +47,20 @@ def _narrowing_per_iteration(safety: "SafetyConfig") -> bool:
     return bool(safety.threat_scan.narrowing_per_iteration())
 
 
+# #5296 PR-2: the ONE place this turn's total send-BUDGET (across
+# _run_with_shrink calls) is declared — architect ruling
+# (issuecomment-5439181599): retry_loop's own ``max_shrink_iterations``
+# bounds a SINGLE _run_with_shrink call's own token-shrink escalation (a
+# different layer — the driver's except block is the trigger point,
+# retry_loop stays a pure transport operation); this constant bounds how
+# many TIMES ``run_turn`` may call ``_run_with_shrink`` again after a
+# byte-limited failure, each retry preceded by a real reduction attempt
+# (spill, then compaction if spill made no progress). The two compose,
+# they do not conflict: this turn's total LLM-call-attempt upper bound is
+# ``(1 + _MAX_BYTE_REDUCTION_ATTEMPTS) * compaction.max_shrink_iterations``.
+_MAX_BYTE_REDUCTION_ATTEMPTS: int = 2
+
+
 class RouterLoopDriver:
     """Orchestrates the per-turn router loop for one Session.
 
@@ -221,6 +235,179 @@ class RouterLoopDriver:
             self._budget.check_and_increment_router_cap(user_text)
 
     # ── Overflow-resilient router invocation ─────────────────────────────────
+
+    @staticmethod
+    def _spill_candidates(head: "list[dict]", tail: "list[dict]") -> "list[dict]":
+        """#5296 PR-2 ②: oldest-and-largest-first spill candidates.
+
+        ``head`` (older turns) is offered entirely before ``tail`` (more
+        recent turns — "this turn's own subject", contract's own "今回の
+        主題は最後"); within each group, the largest content goes first
+        (the fastest route to a byte-count decrease per spill). Only
+        ``role == "tool"`` turns with an inline string body are candidates
+        — an already-ref'd/non-string content has nothing left to spill.
+        ``new_msg`` (the turn's own newest user message) is never passed
+        in here at all — contract's own "user自身の最新messageは落とさな
+        い" is satisfied structurally, not by a filter that could miss it.
+        """
+        def _spillable(turns: "list[dict]") -> "list[dict]":
+            cands = [
+                t for t in turns
+                if t.get("role") == "tool" and isinstance(t.get("content"), str)
+            ]
+            return sorted(cands, key=lambda t: -len(t["content"]))
+        return _spillable(head) + _spillable(tail)
+
+    async def _attempt_reactive_spill(self, user_text: str, *, chain_id: str) -> bool:
+        """#5296 PR-2 ②③: one spill pass over the CURRENT head/tail.
+
+        Spills candidates (oldest/largest first) one at a time, re-measuring
+        total wire bytes after each, STOPPING as soon as the total has
+        decreased from before this pass started (contract ⑥'s "each
+        attempt strictly decreases bytes" — spilling more than needed
+        would destroy more of the operator's visible context than
+        necessary) or candidates are exhausted. The returned bool is this
+        method's OWN local verdict (useful standalone/for tests); the
+        caller (``_run_with_shrink_and_byte_reduction``) makes its own
+        escalate-to-compaction decision from a wrapper-wide
+        ``_wire_bytes_now()`` reading instead — see that method's own
+        docstring for why a narrower, call-scoped verdict is not always
+        the right signal.
+        """
+        from reyn.services.compaction.engine import estimate_wire_bytes
+
+        SP = self._history_buffer.build_system_prompt()
+        new_msg = {"role": "user", "content": user_text}
+        head, _raw_middle, tail, summary, _ = (
+            self._history_buffer.decompose_history_for_retry()
+        )
+        before = estimate_wire_bytes(SP=SP, head=head, summary=summary, tail=tail, new_msg=new_msg)
+
+        candidates = self._spill_candidates(head, tail)
+        for i, turn in enumerate(candidates):
+            replacement = self._history_buffer.spill_turn_content(
+                turn["content"], chain_id=chain_id, seq=i + 1,
+            )
+            if replacement is None:
+                continue
+            head2, _rm2, tail2, summary2, _sb2 = (
+                self._history_buffer.decompose_history_for_retry()
+            )
+            after = estimate_wire_bytes(
+                SP=SP, head=head2, summary=summary2, tail=tail2, new_msg=new_msg,
+            )
+            if after < before:
+                return True
+        # Every candidate spilled (or none were spillable at all) without
+        # ever getting strictly under `before` — no progress.
+        return False
+
+    async def _attempt_compaction_reduction(self) -> bool:
+        """#5296 PR-2 ④: durable compaction, ONLY reached when spill made no
+        progress AND the cause is CONFIRMED bytes (the caller only invokes
+        this after ``exc.saw_byte_limit`` — contract's own "設定は診断を
+        飛ばす権限ではない": an `unknown` cause never reaches here).
+
+        Reuses the SAME existing durable-watermark path
+        ``_run_with_shrink``'s own except block already calls for the
+        `next_turn` recovery policy (``force_compact_now`` —
+        `_durable_active_history_after`-backed, continuous from the last
+        real `covers_through_seq`) — not `retry_loop`'s own compaction
+        result, for the same reason that except block's own comment gives
+        (retry_loop's `covers` can skip `head` entirely).
+
+        Progress is measured via ``_wire_bytes_now()`` (``build_history()``
+        underneath), NOT ``decompose_history_for_retry()``: the latter's
+        own "everything fits under effective_trigger" fast path returns
+        EVERY role-matched turn regardless of the compaction watermark
+        whenever nothing needs eliding (measured directly building this
+        PR: a corpus small enough to stay under effective_trigger showed
+        the SAME head/tail before/after a real, watermark-advancing
+        compaction pass — the wire byte count genuinely does not move on
+        that path even though the NEXT real send, which goes through
+        ``build_history()``, would see far fewer turns). ``build_history()``
+        always applies the watermark filter (its own docstring/contract,
+        unconditionally) — the correct one to check "would the actual next
+        attempt see less."
+
+        This method's OWN return value is a local, standalone verdict
+        (this call's own before/after); the caller
+        (``_run_with_shrink_and_byte_reduction``) makes its actual
+        escalation decision from its own wrapper-wide baseline instead —
+        see that method's own docstring for why.
+        """
+        before_bytes = self._wire_bytes_now()
+        await self._compaction_controller.force_compact_now()
+        return self._wire_bytes_now() < before_bytes
+
+    def _wire_bytes_now(self) -> int:
+        """The wire-JSON byte size of what ``build_history()`` would send
+        RIGHT NOW — the single canonical "how big is the payload" reading
+        both the attempt-start baseline and every reduction-progress check
+        below share, so they can never disagree about what "smaller"
+        means."""
+        import json
+        return len(
+            json.dumps(self._history_buffer.build_history(), ensure_ascii=False)
+            .encode("utf-8")
+        )
+
+    async def _run_with_shrink_and_byte_reduction(
+        self, loop: Any, user_text: str, *, chain_id: str,
+    ) -> Any:
+        """#5296 PR-2 wrapper: same-turn recovery for a BYTE-limited (HTTP
+        413) unrecovered overflow, per the frozen implementation contract
+        (issue #5296, issuecomment-5437029911).
+
+        ``_run_with_shrink``'s own contract is UNCHANGED (architect
+        ruling) — this wrapper only decides whether to call it AGAIN after
+        it raises, never alters what it does internally. On each byte-
+        limited ``UnrecoveredError``: spill first (②), re-measure (③);
+        if spill made no progress, durable compaction ONLY because the
+        cause is confirmed bytes (④); if NEITHER made progress, re-raise
+        (⑤ — the caller's own except still names the cause via
+        ``repr(exc)``). A non-byte-limited ``UnrecoveredError`` (never saw
+        a 413 — retry_loop's own token axis already exhausted itself) and
+        ``ContextOverflowError`` (the window itself is too small) are
+        UNCHANGED — this wrapper only intervenes on the ONE cause spill/
+        compaction can actually address.
+
+        The "did this attempt make progress" verdict is taken from
+        ``_wire_bytes_now()`` at the START of the attempt vs AFTER spill/
+        compaction ran — not from either sub-method's own narrower
+        before/after check. ``_run_with_shrink``'s OWN PRE-EXISTING
+        #4954(b) next_turn side-effect can ALREADY compact as part of its
+        own except-handling before it re-raises here (measured directly
+        building this PR) — a check scoped to only THIS wrapper's own
+        calls would then see nothing left for `_attempt_compaction_
+        reduction` to do and wrongly report no progress, even though the
+        actual next-attempt payload IS already smaller.
+        """
+        from reyn.services.compaction.engine import UnrecoveredError as _UnrecoveredError
+
+        for attempt in range(_MAX_BYTE_REDUCTION_ATTEMPTS + 1):
+            attempt_start_bytes = self._wire_bytes_now()
+            try:
+                return await self._run_with_shrink(loop, user_text)
+            except _UnrecoveredError as exc:
+                if not exc.saw_byte_limit or attempt >= _MAX_BYTE_REDUCTION_ATTEMPTS:
+                    raise
+                await self._attempt_reactive_spill(user_text, chain_id=chain_id)
+                if self._wire_bytes_now() >= attempt_start_bytes:
+                    await self._attempt_compaction_reduction()
+                if self._wire_bytes_now() >= attempt_start_bytes:
+                    raise
+                # #5296 PR-2 ⑥: chain_id is the SAME value this call already
+                # closes over — no new chain_id, no re-emitted
+                # user_submitted/turn_started/WAL append (those all live
+                # ABOVE run_turn, in Session — unreached by looping back to
+                # the top of this for-loop and calling _run_with_shrink
+                # again from HERE).
+                self._events.emit(
+                    "payload_reduced", chain_id=chain_id, attempt=attempt + 1,
+                )
+                continue
+        raise AssertionError("unreachable: loop always returns or raises")
 
     async def _run_with_shrink(self, loop: Any, user_text: str) -> Any:
         """Run the router once with the reactive bounded-shrink ``retry_loop``.
@@ -581,7 +768,16 @@ class RouterLoopDriver:
         # #4381 family (tool-result spill) is what now keeps an
         # oversized single result from reaching this point at all.
         try:
-            router_usage = await self._run_with_shrink(loop, user_text)
+            # #5296 PR-2: was a bare `self._run_with_shrink(loop, user_text)`
+            # — this wrapper adds same-turn spill/compaction recovery for a
+            # byte-limited (HTTP 413) unrecovered overflow, then re-tries
+            # THIS call (bounded, `_MAX_BYTE_REDUCTION_ATTEMPTS`) instead of
+            # always failing the turn on the first 413 that survives
+            # `_run_with_shrink`'s own token-axis attempts. See that
+            # method's own docstring for the full contract.
+            router_usage = await self._run_with_shrink_and_byte_reduction(
+                loop, user_text, chain_id=chain_id,
+            )
         # #4885: widened from `_ContextOverflowError` alone — `_run_with_
         # shrink` no longer merges `_UnrecoveredError` (shrinking recovered
         # the SAME cause repeatedly without resolving it, e.g. an HTTP 413

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -298,47 +298,17 @@ class RouterLoopDriver:
             )
             if after < before:
                 return True
-        # Every candidate spilled (or none were spillable at all) without
-        # ever getting strictly under `before` — no progress.
+            # #5296 PR-2 (architect review): this spill did NOT help —
+            # undo it rather than leaving a useless overlay entry in
+            # place. Without this, a turn whose every candidate happens
+            # to spill for zero net benefit ends this loop with ALL of
+            # them spilled anyway — this method's own docstring already
+            # disclaims exactly that outcome ("destroy more of the
+            # operator's visible context than necessary").
+            self._history_buffer.discard_spill_overlay_for(turn["content"])
+        # Every candidate spilled-then-undone (or none were spillable at
+        # all) without ever getting strictly under `before` — no progress.
         return False
-
-    async def _attempt_compaction_reduction(self) -> bool:
-        """#5296 PR-2 ④: durable compaction, ONLY reached when spill made no
-        progress AND the cause is CONFIRMED bytes (the caller only invokes
-        this after ``exc.saw_byte_limit`` — contract's own "設定は診断を
-        飛ばす権限ではない": an `unknown` cause never reaches here).
-
-        Reuses the SAME existing durable-watermark path
-        ``_run_with_shrink``'s own except block already calls for the
-        `next_turn` recovery policy (``force_compact_now`` —
-        `_durable_active_history_after`-backed, continuous from the last
-        real `covers_through_seq`) — not `retry_loop`'s own compaction
-        result, for the same reason that except block's own comment gives
-        (retry_loop's `covers` can skip `head` entirely).
-
-        Progress is measured via ``_wire_bytes_now()`` (``build_history()``
-        underneath), NOT ``decompose_history_for_retry()``: the latter's
-        own "everything fits under effective_trigger" fast path returns
-        EVERY role-matched turn regardless of the compaction watermark
-        whenever nothing needs eliding (measured directly building this
-        PR: a corpus small enough to stay under effective_trigger showed
-        the SAME head/tail before/after a real, watermark-advancing
-        compaction pass — the wire byte count genuinely does not move on
-        that path even though the NEXT real send, which goes through
-        ``build_history()``, would see far fewer turns). ``build_history()``
-        always applies the watermark filter (its own docstring/contract,
-        unconditionally) — the correct one to check "would the actual next
-        attempt see less."
-
-        This method's OWN return value is a local, standalone verdict
-        (this call's own before/after); the caller
-        (``_run_with_shrink_and_byte_reduction``) makes its actual
-        escalation decision from its own wrapper-wide baseline instead —
-        see that method's own docstring for why.
-        """
-        before_bytes = self._wire_bytes_now()
-        await self._compaction_controller.force_compact_now()
-        return self._wire_bytes_now() < before_bytes
 
     def _wire_bytes_now(self) -> int:
         """The wire-JSON byte size of what ``build_history()`` would send
@@ -362,26 +332,34 @@ class RouterLoopDriver:
         ``_run_with_shrink``'s own contract is UNCHANGED (architect
         ruling) — this wrapper only decides whether to call it AGAIN after
         it raises, never alters what it does internally. On each byte-
-        limited ``UnrecoveredError``: spill first (②), re-measure (③);
-        if spill made no progress, durable compaction ONLY because the
-        cause is confirmed bytes (④); if NEITHER made progress, re-raise
-        (⑤ — the caller's own except still names the cause via
-        ``repr(exc)``). A non-byte-limited ``UnrecoveredError`` (never saw
-        a 413 — retry_loop's own token axis already exhausted itself) and
+        limited ``UnrecoveredError``: spill (②), re-measure (③); if the
+        payload shrank (from EITHER spill or ``_run_with_shrink``'s own
+        pre-existing side-effect below), re-send; if not, re-raise (⑤ —
+        the caller's own except still names the cause via ``repr(exc)``).
+        A non-byte-limited ``UnrecoveredError`` (never saw a 413 —
+        retry_loop's own token axis already exhausted itself) and
         ``ContextOverflowError`` (the window itself is too small) are
-        UNCHANGED — this wrapper only intervenes on the ONE cause spill/
-        compaction can actually address.
+        UNCHANGED — this wrapper only intervenes on the ONE cause spill
+        can actually address.
 
-        The "did this attempt make progress" verdict is taken from
-        ``_wire_bytes_now()`` at the START of the attempt vs AFTER spill/
-        compaction ran — not from either sub-method's own narrower
-        before/after check. ``_run_with_shrink``'s OWN PRE-EXISTING
-        #4954(b) next_turn side-effect can ALREADY compact as part of its
-        own except-handling before it re-raises here (measured directly
-        building this PR) — a check scoped to only THIS wrapper's own
-        calls would then see nothing left for `_attempt_compaction_
-        reduction` to do and wrongly report no progress, even though the
-        actual next-attempt payload IS already smaller.
+        #5296 PR-2 review (architect, 2nd finding): this wrapper does NOT
+        call ``force_compact_now`` itself — contract ④'s durable-
+        compaction step is already covered WITHOUT a second call site,
+        because ``_run_with_shrink``'s own except block ALREADY calls
+        ``force_compact_now`` as its pre-existing #4954(b) ``next_turn``
+        side-effect, before it ever re-raises back to this wrapper — a
+        SEPARATE call here would either be redundant (``next_turn``: the
+        watermark already advanced moments ago, nothing left to compact)
+        or, worse, would silently violate ``recovery_policy="never"``
+        (this NEW call site was never gated by that check #5303 added to
+        the ONE existing call site — an operator who opted out of
+        same-turn-visible compaction would have gotten it anyway). The
+        "did this attempt make progress" verdict is taken from
+        ``_wire_bytes_now()`` at the START of the attempt vs AFTER spill
+        ran — that single read already reflects ANY reduction that
+        happened in between, spill's own or the pre-existing side-effect's,
+        without this wrapper needing to trigger or gate compaction itself
+        at all.
         """
         from reyn.services.compaction.engine import UnrecoveredError as _UnrecoveredError
 
@@ -393,8 +371,6 @@ class RouterLoopDriver:
                 if not exc.saw_byte_limit or attempt >= _MAX_BYTE_REDUCTION_ATTEMPTS:
                     raise
                 await self._attempt_reactive_spill(user_text, chain_id=chain_id)
-                if self._wire_bytes_now() >= attempt_start_bytes:
-                    await self._attempt_compaction_reduction()
                 if self._wire_bytes_now() >= attempt_start_bytes:
                     raise
                 # #5296 PR-2 ⑥: chain_id is the SAME value this call already

--- a/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
+++ b/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
@@ -135,7 +135,7 @@ def _push(session, role: str, text: str, **kw) -> None:
 def _make_spill_session(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *,
     max_shrink_iterations: int = 1, t_max: "int | None" = None,
-    fake_compaction_engine: bool = False,
+    fake_compaction_engine: bool = False, recovery_policy: str = "next_turn",
 ):
     """A real Session with a real MediaStore (default ``make_session`` gives
     ``media_store=None`` — the spill mechanism needs a real one to have any
@@ -146,7 +146,18 @@ def _make_spill_session(
     ``fake_compaction_engine`` swaps in ``_NoNetworkCompactionEngine`` — ONLY
     the one scenario that needs a `compact()` call to actually SUCCEED
     (rather than merely be attempted and fail/be avoided) needs this; the
-    others never let ``compact()`` run for real at all."""
+    others never let ``compact()`` run for real at all.
+
+    ``recovery_policy`` — lead-coder review: default ``"next_turn"`` means
+    ``_run_with_shrink``'s own PRE-EXISTING #4954(b) side-effect ALSO
+    compacts on every byte-limited failure, confounding a test that wants
+    to isolate whether THIS PR's own ``_attempt_compaction_reduction`` is
+    what recovered a turn (measured directly: with the pre-existing
+    side-effect left on, disabling this PR's compaction call entirely
+    still passed the "compaction recovers it" scenario — the pre-existing
+    mechanism alone was doing the work, and the test never noticed).
+    ``"never"`` disables that side-effect, so any compaction observed can
+    only be THIS PR's own."""
     monkeypatch.chdir(tmp_path)
     if t_max is not None:
         import reyn.llm.model_budget as _mb
@@ -156,6 +167,7 @@ def _make_spill_session(
         use_chars4_estimate=True,
         section_caps_spec_tokens=0,
         max_shrink_iterations=max_shrink_iterations,
+        recovery_policy=recovery_policy,
     )
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
     bt = BudgetTracker(CostConfig())
@@ -240,16 +252,30 @@ def test_single_huge_tool_result_recovers_via_spill_not_compaction(
     assert not _has_content(last_call, huge)
 
 
-# ── ① small turns in bulk — spill finds nothing, compaction closes it ───────
+# ── ① small turns in bulk — spill finds nothing; recovery depends on the ───
+# ── PRE-EXISTING next_turn side-effect, which this wrapper must detect ─────
 
 
-def test_history_dominant_overflow_recovers_via_compaction_not_spill(
+def test_history_dominant_overflow_recovers_via_pre_existing_compaction(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Tier 2: contract acceptance ① — many small turns, no tool-result
     turn at all (nothing spillable — spill's own candidate scan
-    structurally finds zero candidates), so compaction must be what
-    actually recovers the turn.
+    structurally finds zero candidates).
+
+    #5296 PR-2 review (architect + lead-coder, 2nd finding): this
+    wrapper does NOT call ``force_compact_now`` itself (removed — see
+    ``_run_with_shrink_and_byte_reduction``'s own docstring for why a
+    second call site would either be redundant or, worse, silently
+    violate ``recovery_policy="never"``). Contract ④'s durable-
+    compaction step is instead covered by ``_run_with_shrink``'s own
+    PRE-EXISTING #4954(b) ``next_turn`` side-effect (the DEFAULT policy),
+    which already runs ``force_compact_now`` inside its own except block
+    before re-raising. This test's job is narrower than its name once
+    suggested: prove the wrapper correctly DETECTS that pre-existing
+    reduction (via ``_wire_bytes_now()``) and retries successfully — not
+    that the wrapper itself triggers compaction (it structurally cannot,
+    anymore).
 
     ``fake_compaction_engine`` (a network-free stand-in, same shape the
     PR-N6 test file's own ``_OverflowingEngine`` uses — a real
@@ -258,25 +284,19 @@ def test_history_dominant_overflow_recovers_via_compaction_not_spill(
     ``tail_budget=1500``, ``effective_trigger=7000``) — 50 turns of 80
     tokens each (4000 total, measured directly while building this test)
     exceeds ``head_budget + tail_budget`` (real compaction candidates
-    exist for ``force_compact_now``) while staying under
-    ``effective_trigger`` (``decompose_history_for_retry`` keeps
-    ``raw_middle`` EMPTY — retry_loop's own internal fold never
-    triggers, so this genuinely exercises THIS wrapper's own
-    ``_attempt_compaction_reduction`` fallback, not a pre-existing
-    mechanism)."""
+    exist) while staying under ``effective_trigger``
+    (``decompose_history_for_retry`` keeps ``raw_middle`` EMPTY —
+    retry_loop's own internal fold never triggers, isolating the
+    pre-existing except-block side-effect as the only compaction path
+    exercised)."""
     session = _make_spill_session(
-        tmp_path, monkeypatch, max_shrink_iterations=1, fake_compaction_engine=True,
+        tmp_path, monkeypatch, max_shrink_iterations=1,
+        fake_compaction_engine=True,  # recovery_policy="next_turn" (default)
     )
     for _i in range(50):
         _push(session, "user", "X" * 320)
 
     events: list = []
-    # The REAL, observable signal that compaction (not spill) is what
-    # unblocked this turn: a `compaction_completed` event — driven off
-    # whichever path actually retires content (retry_loop's own internal
-    # raw_middle fold, or this wrapper's own `force_compact_now` fallback
-    # both emit the SAME event; acceptance ① only cares that compaction —
-    # not spill — is what did it).
     compacted = {"done": False}
 
     def _on_event(e) -> None:
@@ -301,6 +321,55 @@ def test_history_dominant_overflow_recovers_via_compaction_not_spill(
         "nothing was spillable (no tool-result turns) — spill must not "
         f"have offloaded anything: {[e.data for e in spill_events]!r}"
     )
+
+
+def test_recovery_policy_never_leaves_the_watermark_alone_and_terminates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5296 PR-2 review (architect's own prescribed witness,
+    2nd finding) — with ``recovery_policy="never"``, an operator's
+    "don't summarize my history" choice must hold even through THIS
+    wrapper's own retry path: the SAME history-dominant, nothing-
+    spillable scenario as the sibling test above, but with compaction
+    disabled, must (①) leave the compaction watermark exactly where it
+    was (no ``compaction_completed`` at all — not the pre-existing
+    side-effect, and not a resurrected wrapper-owned call) and (②)
+    terminate cleanly (raise ``UnrecoveredError``, not hang or loop
+    forever) rather than silently compacting anyway."""
+    session = _make_spill_session(
+        tmp_path, monkeypatch, max_shrink_iterations=1,
+        fake_compaction_engine=True, recovery_policy="never",
+    )
+    for _i in range(50):
+        _push(session, "user", "X" * 320)
+
+    events: list = []
+    session._audit_events.add_subscriber(lambda e: events.append(e))
+
+    loop = _ContentDrivenLoop(lambda history, user_text: True)  # always 413
+
+    with pytest.raises(UnrecoveredError) as excinfo:
+        asyncio.run(
+            session._loop_driver._run_with_shrink_and_byte_reduction(
+                loop, "continue please", chain_id="c1",
+            )
+        )
+    assert excinfo.value.saw_byte_limit is True
+
+    # ① watermark untouched.
+    assert not [e for e in events if e.type == "compaction_completed"], (
+        "recovery_policy='never' must leave the watermark alone — no "
+        "compaction_completed event may fire, from either the pre-"
+        "existing next_turn side-effect (disabled by this policy) or a "
+        "wrapper-owned call (removed entirely)"
+    )
+    # ② clean, bounded termination — not a hang. The call count is
+    # structurally bounded by _MAX_BYTE_REDUCTION_ATTEMPTS regardless of
+    # how large the history is (a wall-clock timeout is never needed to
+    # prove this) — sliced past the composite bound, the tail must be
+    # empty.
+    from reyn.runtime.services.router_loop_driver import _MAX_BYTE_REDUCTION_ATTEMPTS
+    assert loop.calls[(1 + _MAX_BYTE_REDUCTION_ATTEMPTS) * 1:] == []
 
 
 # ── ③ oversized user message alone — both levers fail, clean termination ───
@@ -332,9 +401,10 @@ def test_oversized_new_message_alone_terminates_cleanly_not_a_hang(
 
     # Bounded: (1 + _MAX_BYTE_REDUCTION_ATTEMPTS) outer attempts, each an
     # independent retry_loop call bounded by max_shrink_iterations=1 (one
-    # main_call per outer attempt here — no raw_middle to fold first).
+    # main_call per outer attempt here — no raw_middle to fold first) —
+    # sliced past the composite bound, the tail must be empty.
     from reyn.runtime.services.router_loop_driver import _MAX_BYTE_REDUCTION_ATTEMPTS
-    assert len(loop.calls) <= (1 + _MAX_BYTE_REDUCTION_ATTEMPTS) * 1
+    assert loop.calls[(1 + _MAX_BYTE_REDUCTION_ATTEMPTS) * 1:] == []
 
 
 # ── spill persists across turns (session-lived overlay) ────────────────────
@@ -387,4 +457,49 @@ def test_spill_persists_into_the_next_turn_413_fires_once(
     assert loop2.calls[1:] == [], (
         f"turn 2 must succeed on its FIRST attempt (overlay already "
         f"applied) — observed {len(loop2.calls)} calls"
+    )
+
+
+# ── a no-progress spill must not leave a useless overlay entry behind ──────
+
+
+def test_a_spill_that_does_not_help_is_undone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5296 PR-2 review (architect, 1st finding) — spilling a
+    TINY tool result makes it BIGGER, not smaller (the offloaded preview
+    carries a fixed pointer-path overhead — measured directly building
+    this PR: an 11-char original became a 115-char replacement). Before
+    this fix, ``_attempt_reactive_spill`` left that overlay entry in
+    place regardless, contradicting its own docstring ("destroy more of
+    the operator's visible context than necessary"). Witnessed via the
+    PUBLIC ``build_history()`` seam (never the private ``_spill_overlay``
+    dict directly): the tiny turn's ORIGINAL content must still be what
+    gets sent, not the bloated replacement."""
+    session = _make_spill_session(tmp_path, monkeypatch)
+    _push(session, "user", "hi")
+    # NOT "hi" — a 2-char body estimates at <=1 token, so `cap_tokens=1`
+    # never offloads it at all (`spill_turn_content` returns `None`,
+    # never reaching the discard path this test means to exercise —
+    # confirmed directly: an earlier draft using "hi" here stayed GREEN
+    # even with `discard_spill_overlay_for` stripped out). "tiny result"
+    # (11 chars) DOES cross the 1-token cap and genuinely gets offloaded
+    # — into a 115-char preview, bigger than the original.
+    tiny = "tiny result"
+    _push(session, "tool", tiny, tool_call_id="tc1", name="tool")
+    _push(session, "assistant", "ok")
+
+    reduced = asyncio.run(
+        session._loop_driver._attempt_reactive_spill("continue", chain_id="c1")
+    )
+    assert reduced is False, (
+        "control arm: spilling a tiny result must NOT report progress — "
+        "it makes the payload bigger, not smaller"
+    )
+
+    history = session._loop_driver._history_buffer.build_history()
+    assert _has_content(history, tiny), (
+        "a no-progress spill must be undone — the tiny turn's ORIGINAL "
+        "content should still be what gets sent, not a bloated "
+        "offloaded-preview replacement left behind uselessly"
     )

--- a/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
+++ b/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
@@ -1,0 +1,390 @@
+"""Tier 2: #5296 PR-2 — same-turn recovery from a BYTE-limited (HTTP 413)
+unrecovered overflow.
+
+Before this, `RouterLoopDriver._run_with_shrink`'s own `UnrecoveredError`
+(with `.saw_byte_limit=True`) always ended the turn — #4954(b)'s own
+`recovery_policy="next_turn"` only advanced the watermark for a LATER turn
+via a real `force_compact_now()`, but THIS turn still failed. #5296 PR-2's
+`_run_with_shrink_and_byte_reduction` (the new wrapper `run_turn` now calls
+instead of the bare `_run_with_shrink`) intervenes on exactly that one
+failure shape: spill first (reusing the existing `MediaStore.save_tool_
+result` + `tool_result_cap.cap_tool_result_content` machinery via a new
+session-lived, non-durable `RouterHistoryBuffer` projection overlay — never
+`self.history`/`history.jsonl`, never the compaction watermark), then
+durable compaction only if spill made no progress, then re-tries
+`_run_with_shrink` — bounded by `_MAX_BYTE_REDUCTION_ATTEMPTS`.
+
+Real `Session` + real `RouterLoopDriver`/`RouterHistoryBuffer`/`MediaStore`
+throughout — the same harness `test_retry_loop_chat_wiring_1125.py`'s own
+`_run_with_shrink` tests use (`session._loop_driver._run_with_shrink(...)`
+driven directly, a scripted fake `loop.run`, since a real RouterLoop LLM
+call cannot run offline). The fake loop here is CONTENT-driven (raises 413
+based on what `history` it was actually handed, not a hardcoded call
+count) — genuinely exercises whether spill/compaction changed the payload,
+not an assumption about how many attempts it takes.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.config import CompactionConfig, MultimodalConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.chat_message import ChatMessage
+from reyn.services.compaction.engine import UnrecoveredError
+from tests._support.agent_session import make_session
+
+
+class _FakeStatusError(Exception):
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class _NoNetworkCompactionEngine:
+    """A real-shaped, network-free ``CompactionEngine`` stand-in — mirrors
+    ``test_pr_n6_compaction_overflow_retry.py``'s own ``_OverflowingEngine``
+    (the sibling PR-N6 test file's documented way to exercise ``retry_loop``
+    without a real LLM call). ``compact()`` always succeeds trivially,
+    matching whatever ``covers_through_seq`` the offered turns imply — a
+    real ``CompactionEngine.compact()`` would attempt an actual litellm
+    call, which this test's `_run_with_shrink_and_byte_reduction` harness
+    (driven through a real Session, unlike the sibling file's own
+    ``retry_loop``-direct calls) has no way to stub via a `main_call`
+    parameter alone; `force_compact_now`/retry_loop's own raw_middle fold
+    BOTH reach this same seam."""
+
+    def __init__(self) -> None:
+        from reyn.core.events.events import EventLog
+        from reyn.services.compaction.engine import ComputedBudgets
+        self.budgets = ComputedBudgets(
+            main_pool=10_000, head_budget=1_000, body_budget=500,
+            tail_budget=1_500, new_msg_budget=1_000,
+            B_M=8_000, main_M_room=7_000, effective_trigger=7_000,
+            section_caps={
+                "topic_arc": 50, "decisions": 200, "pending": 150,
+                "session_user_facts": 50, "artifacts_referenced": 175,
+            },
+        )
+        self._events = EventLog()
+        self._T_comp_SP = 100
+        self._model = "openai/test-standard-model"
+
+    async def compact(self, input_chunk):
+        from reyn.services.compaction.engine import ChatSummary
+
+        def _seq(t: object) -> int:
+            if isinstance(t, dict):
+                return t.get("seq", 0)
+            return getattr(t, "seq", 0)
+
+        return ChatSummary(
+            topic_arc="stub summary",
+            covers_through_seq=max((_seq(t) for t in input_chunk.new_turns), default=0),
+        )
+
+
+def _inject_fake_engine(session) -> None:
+    """Bypass ``CompactionController``'s lazy real-engine factory (private,
+    name-mangled cache field — the same seam that property's own docstring
+    names as "computed at most once") with a network-free stand-in, BEFORE
+    anything triggers the real factory."""
+    session._compaction_controller._CompactionController__engine_cache = (
+        _NoNetworkCompactionEngine()
+    )
+
+
+class _ContentDrivenLoop:
+    """A fake ``RouterLoop`` whose ``run()`` raises a 413-shaped error
+    exactly while ``should_fail(history)`` says so, driven by the REAL
+    ``history`` payload it is handed on each call — never a hardcoded
+    call-count script, so a test genuinely exercises whether a reduction
+    attempt changed the wire payload rather than assuming a fixed shape."""
+
+    def __init__(self, should_fail) -> None:
+        self._should_fail = should_fail
+        self.calls: "list[list[dict]]" = []
+
+    async def run(self, *, user_text: str, history: "list[dict]") -> "object | None":
+        self.calls.append(history)
+        if self._should_fail(history, user_text):
+            raise _FakeStatusError("request too large", status_code=413)
+        return None
+
+
+def _now() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _push(session, role: str, text: str, **kw) -> None:
+    # `_append_history` (not a bare `session.history.append`) — the real
+    # write path, WAL-durable. `force_compact_now`'s own candidate read is
+    # from the DURABLE store (`history.jsonl`), never `session.history`
+    # directly (#4472's own "residency has no influence" invariant) — a
+    # plain in-memory append would make every compaction test below
+    # observe zero durable turns regardless of how much was pushed
+    # (measured directly while building this test: `forced_sync_no_turns`
+    # for 2000 in-memory-only turns).
+    session._append_history(ChatMessage(role=role, content=text, ts=_now(), **kw))
+
+
+def _make_spill_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *,
+    max_shrink_iterations: int = 1, t_max: "int | None" = None,
+    fake_compaction_engine: bool = False,
+):
+    """A real Session with a real MediaStore (default ``make_session`` gives
+    ``media_store=None`` — the spill mechanism needs a real one to have any
+    effect at all). ``t_max`` (mirrors ``test_retry_loop_chat_wiring_1125.
+    py``'s own harness) forces a small ``effective_trigger`` so a real
+    history genuinely produces compaction candidates instead of fitting
+    comfortably under the real (fallback ~128k-token) model window.
+    ``fake_compaction_engine`` swaps in ``_NoNetworkCompactionEngine`` — ONLY
+    the one scenario that needs a `compact()` call to actually SUCCEED
+    (rather than merely be attempted and fail/be avoided) needs this; the
+    others never let ``compact()`` run for real at all."""
+    monkeypatch.chdir(tmp_path)
+    if t_max is not None:
+        import reyn.llm.model_budget as _mb
+        monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: t_max)
+    cfg = CompactionConfig(
+        body_token_cap=1500,
+        use_chars4_estimate=True,
+        section_caps_spec_tokens=0,
+        max_shrink_iterations=max_shrink_iterations,
+    )
+    state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    bt = BudgetTracker(CostConfig())
+    session = make_session(
+        agent_name="default",
+        agent_role="",
+        output_language="en",
+        budget_tracker=bt,
+        state_log=state_log,
+        compaction_config=cfg,
+        multimodal_config=MultimodalConfig(),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
+    if fake_compaction_engine:
+        _inject_fake_engine(session)
+    return session
+
+
+def _has_content(history: "list[dict]", needle: str) -> bool:
+    return any(needle in str(m.get("content", "")) for m in history)
+
+
+# ── ② one huge tool result — spill fixes it, watermark does not move ────────
+
+
+def test_single_huge_tool_result_recovers_via_spill_not_compaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: contract acceptance ② — a single oversized tool result is
+    the ONLY large thing in history. Spill alone must fix it (watermark
+    unchanged — no `compaction_check`/`compaction_completed` event)."""
+    session = _make_spill_session(tmp_path, monkeypatch)
+    _push(session, "user", "look something up")
+    huge = "Y" * 50_000
+    _push(session, "tool", huge, tool_call_id="tc1", name="tool")
+    _push(session, "assistant", "ok, done")
+
+    events: list = []
+    session._audit_events.add_subscriber(lambda e: events.append(e))
+
+    loop = _ContentDrivenLoop(
+        lambda history, user_text: _has_content(history, huge)
+    )
+
+    result = asyncio.run(
+        session._loop_driver._run_with_shrink_and_byte_reduction(
+            loop, "continue please", chain_id="c1",
+        )
+    )
+    assert result is None  # the fake loop's own successful return
+
+    # `_run_with_shrink`'s own PRE-EXISTING #4954(b) next_turn side-effect
+    # (untouched by this PR, architect ruling) opportunistically compacts
+    # on EVERY byte-limited UnrecoveredError regardless of what this
+    # wrapper does next — so a `compaction_check` event existing at all is
+    # expected. What matters for THIS test is that it found nothing to
+    # ACTUALLY compact — either no durable turns at all
+    # (`outcome="forced_sync_no_turns"`) or a real pass that selected zero
+    # middle candidates (`outcome="forced_sync"`, `candidate_count=0`) —
+    # never a real compacting pass — i.e. spill, not compaction, is what
+    # actually let the retry succeed.
+    checks = [e for e in events if e.type == "compaction_check"]
+    assert all(
+        e.data.get("outcome") == "forced_sync_no_turns"
+        or (e.data.get("outcome") == "forced_sync" and e.data.get("candidate_count") == 0)
+        for e in checks
+    ), (
+        f"a real compaction ran for a single-oversized-result overflow — "
+        f"spill alone should have sufficed: {[e.data for e in checks]!r}"
+    )
+    assert not [e for e in events if e.type == "compaction_completed"], (
+        "no compaction pass should have actually completed"
+    )
+    reduced = [e for e in events if e.type == "payload_reduced"]
+    assert reduced, "expected a payload_reduced event"
+    assert reduced[0].data.get("chain_id") == "c1"
+    assert reduced[0].data.get("attempt") == 1
+
+    # The huge string must no longer appear verbatim in what the loop was
+    # LAST handed — it was replaced by a bounded preview.
+    last_call = loop.calls[-1]
+    assert not _has_content(last_call, huge)
+
+
+# ── ① small turns in bulk — spill finds nothing, compaction closes it ───────
+
+
+def test_history_dominant_overflow_recovers_via_compaction_not_spill(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: contract acceptance ① — many small turns, no tool-result
+    turn at all (nothing spillable — spill's own candidate scan
+    structurally finds zero candidates), so compaction must be what
+    actually recovers the turn.
+
+    ``fake_compaction_engine`` (a network-free stand-in, same shape the
+    PR-N6 test file's own ``_OverflowingEngine`` uses — a real
+    ``CompactionEngine.compact()`` would attempt an actual litellm call)
+    declares FIXED, small budgets (``head_budget=1000``,
+    ``tail_budget=1500``, ``effective_trigger=7000``) — 50 turns of 80
+    tokens each (4000 total, measured directly while building this test)
+    exceeds ``head_budget + tail_budget`` (real compaction candidates
+    exist for ``force_compact_now``) while staying under
+    ``effective_trigger`` (``decompose_history_for_retry`` keeps
+    ``raw_middle`` EMPTY — retry_loop's own internal fold never
+    triggers, so this genuinely exercises THIS wrapper's own
+    ``_attempt_compaction_reduction`` fallback, not a pre-existing
+    mechanism)."""
+    session = _make_spill_session(
+        tmp_path, monkeypatch, max_shrink_iterations=1, fake_compaction_engine=True,
+    )
+    for _i in range(50):
+        _push(session, "user", "X" * 320)
+
+    events: list = []
+    # The REAL, observable signal that compaction (not spill) is what
+    # unblocked this turn: a `compaction_completed` event — driven off
+    # whichever path actually retires content (retry_loop's own internal
+    # raw_middle fold, or this wrapper's own `force_compact_now` fallback
+    # both emit the SAME event; acceptance ① only cares that compaction —
+    # not spill — is what did it).
+    compacted = {"done": False}
+
+    def _on_event(e) -> None:
+        events.append(e)
+        if e.type == "compaction_completed":
+            compacted["done"] = True
+
+    session._audit_events.add_subscriber(_on_event)
+
+    loop = _ContentDrivenLoop(lambda history, user_text: not compacted["done"])
+
+    result = asyncio.run(
+        session._loop_driver._run_with_shrink_and_byte_reduction(
+            loop, "continue please", chain_id="c1",
+        )
+    )
+    assert result is None
+
+    assert compacted["done"], "expected a real compaction_completed event"
+    spill_events = [e for e in events if e.type == "tool_result_offloaded"]
+    assert not spill_events, (
+        "nothing was spillable (no tool-result turns) — spill must not "
+        f"have offloaded anything: {[e.data for e in spill_events]!r}"
+    )
+
+
+# ── ③ oversized user message alone — both levers fail, clean termination ───
+
+
+def test_oversized_new_message_alone_terminates_cleanly_not_a_hang(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: contract acceptance ③ — the incoming user message ITSELF
+    (never spilled, never compacted — #5296's own contract, and this
+    module's #43-cited "NEVER dropped" invariant) is what is oversized.
+    Neither spill nor compaction can touch it, so the wrapper must
+    terminate — bounded by construction (`_MAX_BYTE_REDUCTION_ATTEMPTS`),
+    not by a wall-clock timeout this test would have to wait out."""
+    session = _make_spill_session(tmp_path, monkeypatch, max_shrink_iterations=1)
+    _push(session, "user", "hi")
+    _push(session, "tool", "small result", tool_call_id="tc1", name="tool")
+    _push(session, "assistant", "ok")
+
+    loop = _ContentDrivenLoop(lambda history, user_text: True)  # always 413
+
+    with pytest.raises(UnrecoveredError) as excinfo:
+        asyncio.run(
+            session._loop_driver._run_with_shrink_and_byte_reduction(
+                loop, "X" * 1_000_000, chain_id="c1",
+            )
+        )
+    assert excinfo.value.saw_byte_limit is True
+
+    # Bounded: (1 + _MAX_BYTE_REDUCTION_ATTEMPTS) outer attempts, each an
+    # independent retry_loop call bounded by max_shrink_iterations=1 (one
+    # main_call per outer attempt here — no raw_middle to fold first).
+    from reyn.runtime.services.router_loop_driver import _MAX_BYTE_REDUCTION_ATTEMPTS
+    assert len(loop.calls) <= (1 + _MAX_BYTE_REDUCTION_ATTEMPTS) * 1
+
+
+# ── spill persists across turns (session-lived overlay) ────────────────────
+
+
+def test_spill_persists_into_the_next_turn_413_fires_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: contract acceptance — 2 turns in a row that would BOTH
+    naturally 413 on the same oversized tool result: turn 1 recovers via
+    spill; turn 2, hitting the SAME still-inline-in-self.history turn,
+    must NOT need to recover again — the overlay persists (session-lived,
+    #5296's own architect ruling) so `_serialise_turn` already projects
+    the spilled form on turn 2's very first attempt. Witnessed via the
+    fake loop's own call count for turn 2 (== 1, no 413 at all) AND via
+    the real on-disk manifest (the spill is not merely an in-memory
+    claim)."""
+    session = _make_spill_session(tmp_path, monkeypatch)
+    _push(session, "user", "look something up")
+    huge = "Q" * 50_000
+    _push(session, "tool", huge, tool_call_id="tc1", name="tool")
+    _push(session, "assistant", "ok, done")
+
+    loop1 = _ContentDrivenLoop(lambda history, user_text: _has_content(history, huge))
+    asyncio.run(
+        session._loop_driver._run_with_shrink_and_byte_reduction(
+            loop1, "continue please", chain_id="c1",
+        )
+    )
+    assert any(_has_content(c, huge) for c in loop1.calls[:-1]), (
+        "control arm: turn 1 must have actually hit the 413 at least once "
+        "before recovering, else this test cannot witness a difference"
+    )
+
+    manifest_path = session._media_store._spill_manifest_path()
+    assert manifest_path.is_file() and manifest_path.stat().st_size > 0, (
+        "spill must be recorded in the real on-disk manifest, not just "
+        "the in-memory overlay"
+    )
+
+    # Turn 2: the SAME history (spill did not touch self.history) — the
+    # overlay from turn 1 must already apply.
+    loop2 = _ContentDrivenLoop(lambda history, user_text: _has_content(history, huge))
+    asyncio.run(
+        session._loop_driver._run_with_shrink_and_byte_reduction(
+            loop2, "one more thing", chain_id="c2",
+        )
+    )
+    assert loop2.calls, "control arm: turn 2 must have called loop.run at least once"
+    assert loop2.calls[1:] == [], (
+        f"turn 2 must succeed on its FIRST attempt (overlay already "
+        f"applied) — observed {len(loop2.calls)} calls"
+    )


### PR DESCRIPTION
Closes #5296 — PR-2 ("spill本体"), the second and final implementation PR against the frozen contract (PR-1/measurement already merged as #5303).

## What

The frozen PR-2 implementation contract (issue #5296, `issuecomment-5437029911`, ratified by owner + architect + lead-coder over an extended design negotiation) closed the gap: a byte-limited (HTTP 413) `UnrecoveredError` that survives `retry_loop`'s own token-axis attempts previously ended the turn unconditionally — #4954(b)'s own `recovery_policy="next_turn"` only advanced the watermark for a LATER turn (`force_compact_now`), but THIS turn still failed every time.

## Placement (architect ruling, `issuecomment-5439181599`)

The driver's except block, not inside `retry_loop` — `retry_loop` is a pure TRANSPORT operation (also a public re-exported API surface); spill/compaction need store/session state a transport-layer function should not have injected into it. `_run_with_shrink`'s own contract is **completely unchanged** — this PR only decides whether to call it AGAIN after it raises.

## Fix (current shape, post review-fix round — see below)

`RouterLoopDriver._run_with_shrink_and_byte_reduction` wraps `_run_with_shrink`:
- **① signal**: only a byte-limited (`saw_byte_limit=True`) `UnrecoveredError` — never a genuine token-only overflow (`ContextOverflowError`, or an `UnrecoveredError` that never saw a 413).
- **② spill first**: reuses the EXISTING mechanism — `RouterHistoryBuffer.spill_turn_content` calls `tool_result_cap.cap_tool_result_content` (`cap_tokens=1` forces the offload branch unconditionally — no new threshold config, contract's own "閾値configを作らない") + `MediaStore.save_tool_result`, the SAME machinery the pre-existing write-time cap already uses. Candidates (`_spill_candidates`) are `role=="tool"` turns in head-then-tail order (oldest first, "今回の主題は最後"), largest-first within each group; `new_msg` is never a candidate at all — structural. A candidate whose spill does NOT reduce total bytes is undone (`discard_spill_overlay_for`, review-fix — see below).
- **③ re-measure**: via a new `_wire_bytes_now()` helper (`build_history()`'s own wire-JSON byte size — see below for why NOT `decompose_history_for_retry()`).
- **④ NO new compaction call site** (review-fix — see below): `_attempt_compaction_reduction` was removed entirely. `_run_with_shrink`'s own except block already calls `force_compact_now` as its pre-existing #4954(b) `next_turn` side-effect before re-raising — this wrapper's re-measure step (③) already reflects any reduction that side-effect made, with no second call needed.
- **⑤ terminate with the cause named** if no progress (re-raised, `repr(exc)` still names it).
- **⑥ same-turn resend**: same `chain_id`, no re-emitted `user_submitted`/`turn_started`/WAL append (all three live ABOVE `run_turn` in Session — structurally unreached by looping inside this wrapper). A new `_MAX_BYTE_REDUCTION_ATTEMPTS` constant is the ONE place this turn's total send-budget across `_run_with_shrink` calls is declared — composes with (does not conflict with) `retry_loop`'s own `max_shrink_iterations`: different layers.

## Spill placement (architect ruling, `issuecomment-5439234430`, placement (iii))

Neither in-place `ChatMessage` mutation (would silently change what an already-attached operator's UI displays — a UX change requiring owner sign-off) nor a one-shot "this call only" override (next turn would revert, contradicting owner's "spill should also persist" ruling) — a **session-lived, non-durable projection overlay** on `RouterHistoryBuffer` (the #4958 layer that already separates "what is stored" from "what the LLM sees"). Keyed by content hash (same `"sha256:<hex>"` vocabulary as `MediaStore`'s own `content_hash`) — never by index/seq, which a later compaction pass would shift out from under it. Applied inside `_serialise_turn`, the single method both `build_history()` and `decompose_history_for_retry()` already share. Never touches `history.jsonl`, `self.history`, the compaction watermark, or the operator-visible display; lost on restart by design (reversible/idempotent).

## Genuine bugs found and fixed mid-build (before any review)

`_attempt_compaction_reduction`'s (now-removed) first draft measured progress via `decompose_history_for_retry()` — its own "everything fits under `effective_trigger`" fast path returns every role-matched turn **regardless of the compaction watermark** whenever nothing needs eliding. Measured directly: a real, watermark-advancing compaction pass left `decompose`'s own head/tail byte count completely unchanged, even though the actual next send (through `build_history()`) would see far fewer turns — the wrapper's retry decision was silently fooled by this until switched to `build_history()` (which always applies the watermark filter). The wrapper's own baseline is also taken at the START of each attempt, not narrowly around its own spill call — `_run_with_shrink`'s own PRE-EXISTING `next_turn` side-effect can already compact as part of its own except-handling before re-raising, and a narrower check would then wrongly report no progress.

## New audit event

`payload_reduced` (`chain_id`, `attempt`) — fires once per same-turn recovery attempt. Registered in `AUDIT_EVENT_KINDS` + `EVENT_AUDIT_REQUIREMENTS` + a new `docs/reference/runtime/events.md` row (same PR, CLAUDE.md doc-drift hard rule).

## Review-fix round (both reviewers, converged)

Both architect and lead-coder independently found the same two defects after the initial PR:

1. **Test-witness gap** (lead-coder found via strip, architect independently confirmed by reading — I independently re-verified via my own strip before acting): scenario①'s claimed "recovers via compaction" was FALSE — even with the wrapper's own compaction call disabled entirely, the test still passed, because `_run_with_shrink`'s pre-existing #4954(b) side-effect was doing all the recovery. The wrapper's own compaction contribution had zero witness.
2. **Ungated new call site** (architect found; lead-coder found the identical issue independently via `git diff` grep showing `recovery_policy` appears in a docstring only, zero code references): `_attempt_compaction_reduction`'s call was unconditional, silently bypassing `recovery_policy="never"` — the ONE prior call site (`_run_with_shrink`'s own except block) was gated by #5303; this NEW site was not, breaking #5303's own stated promise ("このノブは不可逆な compaction にだけ適用").

**Both reviewers converged on the identical fix**: remove `_attempt_compaction_reduction` entirely rather than gate it — under `next_turn` the pre-existing side-effect already does the work (a 2nd call is redundant); under `never` the wrapper must not call it at all. Applied. Scenario① renamed to `test_history_dominant_overflow_recovers_via_pre_existing_compaction`, docstring now accurately claims only that the wrapper *detects* the pre-existing side-effect's reduction — never that it triggers compaction itself. New `test_recovery_policy_never_leaves_the_watermark_alone_and_terminates` is the exact witness both reviewers prescribed (`recovery_policy="never"`, one turn: watermark unmoved, clean termination).

Separately, architect's smaller in-PR finding — `_attempt_reactive_spill` left a spilled-but-useless overlay entry in place when a candidate's spill did not cross the `before` threshold, contradicting the method's own docstring promise — fixed via a new `discard_spill_overlay_for()`, with its own new test (`test_a_spill_that_does_not_help_is_undone`) and strip-falsify.

## Verification

`tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py` — now 6 tests (4 original + 2 from the review-fix round), real `Session`/`RouterLoopDriver`/`RouterHistoryBuffer`/`MediaStore` throughout (mirrors `test_retry_loop_chat_wiring_1125.py`'s own `_run_with_shrink` harness — content-driven fake `RouterLoop.run`, not a hardcoded call-count script):
- Many small turns, nothing spillable → the pre-existing `next_turn` side-effect recovers it, wrapper detects and re-sends (network-free `CompactionEngine` stand-in, same shape `test_pr_n6_compaction_overflow_retry.py`'s own `_OverflowingEngine`).
- One oversized tool result → **spill alone** recovers it, watermark genuinely unmoved.
- `recovery_policy="never"` → watermark stays unmoved, clean bounded termination (the review-fix witness).
- The incoming user message itself oversized → neither lever can touch it → clean, **bounded termination** (asserted via `_MAX_BYTE_REDUCTION_ATTEMPTS`, never a wall-clock timeout).
- Spill **persists into a second turn** — turn 2's fake loop never 413s at all — plus the real on-disk manifest file, not just the in-memory claim.
- A no-progress spill is **undone**, not left stuck (the overlay-cleanup review-fix witness).

Fresh real strip-falsify of the review-fix round, each restored green after: (1) spill call disabled → the 2 spill-dependent tests go RED; (2) progress gate disabled → both termination-bound tests go RED; (3) `discard_spill_overlay_for` call disabled → the new overlay test goes RED.

`tests/runtime` + `tests/services`: **2134 passed**, no regression. Sibling retry_loop/compaction/quota/vocabulary-census sweep (`-k "retry_loop or compaction or quota or vocabulary or event_schema"`): **238 passed**.

Local gates: ruff, `test_tier_audit --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green (no `docs/` changes this round).

## Test plan

- [x] Scoped pytest (6/6) — done
- [x] Broader sweep (2134 passed, tests/runtime+services) — done
- [x] Sibling retry_loop/compaction/quota/vocabulary tests (238 passed, no regression) — done
- [x] Local gates (8/8 applicable this round) — done
- [x] Real strip-falsify of every changed mechanism (spill call, progress gate, overlay-discard) — done
- [x] (skipped — no UI/behavior change) Visual

Cannot self-merge: touches `tests/`, needs a TESTS-READ note per PR-workflow rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



- [x] 🔴 **[architect]** `_attempt_reactive_spill` keeps an overlay entry even when that spill did NOT reduce the total: it re-measures, and on `after >= before` simply moves to the next candidate, leaving the entry in place. If no candidate helps, every candidate ends up spilled for zero gain — the opposite of the method own docstring ("spilling more than needed would destroy more of the operator visible context than necessary"). Pop the entry on no-progress (or check `len(replacement) < len(content)` before recording). Acceptance: a no-progress pass leaves the overlay unchanged.

**Fixed** — new `RouterHistoryBuffer.discard_spill_overlay_for()`, called from `_attempt_reactive_spill`'s loop whenever `after >= before`. New witness test `test_a_spill_that_does_not_help_is_undone` (real strip: removing the discard call goes RED, confirmed via direct execution).


---

## 🔴 Blocking (lead-coder)

- [x] 🔴 **`test_history_dominant_overflow_recovers_via_compaction_not_spill` が compaction を witness していない — compaction を完全に殺しても緑のまま。**
  - **私の実測**: `RouterLoopDriver._attempt_compaction_reduction` の docstring 直後に `return` を挿入（＝compaction 経路を殺す）→ **4 passed**。当該テスト単体でも **1 passed**。
  - ⚪ **strip が当たったことは検証済**です（編集後のファイルを読み直し、`return  # strip: compaction disabled` が docstring 直後に在ることを確認）。当たらずに緑だったのではありません。
  - 🔴 名前は「**recovers via compaction**」ですが、**compaction 無しでも同じ結果**になります。∴ この test は「compaction で回復した」ことを見ておらず、**受入①の witness が 0** です。
  - 🔵 **対照は正しく効いています**: `_attempt_reactive_spill` を殺すと `test_single_huge_tool_result_recovers_via_spill_not_compaction` と `test_spill_persists_into_the_next_turn_413_fires_once` の **2 本だけが赤**（compaction 側 2 本は無傷）。**spill 側は witness されています。**
  - 🔵 想定される原因（**私の推測、未確認**）: history 支配の fixture で spill が空振りした後、**compaction を通らずに byte が減る経路がある**（`_run_with_shrink` 自身の既存 next_turn 副作用など — 本文で言及されている「`_run_with_shrink`'s own pre-existing next_turn side-effect can already compact before re-raising」がまさにそれかもしれません）。**そうであれば、その test は「wrapper が compaction を起動した」ではなく「既存経路で減った」を見ています。**
  - ✅ **求めるもの**: compaction を殺すと**赤になる** witness。「compaction が呼ばれた」ではなく「**compaction でなければ回復しなかった**」が見える形で。

  **私も実測で確認しました（独立の strip）**。ご指摘どおりです — `_attempt_compaction_reduction` を完全に削除し、wrapper を「spill → 再測定 → 減っていれば再送」のみに再設計しました（両レビュアーの一致した処方）。当該 test は `test_history_dominant_overflow_recovers_via_pre_existing_compaction` に改名し、docstring も「wrapper 自身が compaction を起動した」ではなく「既存副作用の減少を検知した」ことのみを主張するよう書き直しました。加えて `recovery_policy="never"` 用の新witness (`test_recovery_policy_never_leaves_the_watermark_alone_and_terminates`) を追加— ②の指摘の witness も兼ねます。

⚪ 他は良いです — spill 側の 2 本は strip で正しく赤／`payload_reduced` は `event_schema.py` に登録済＋`events.md` も同 PR。


- [x] 🔴 **[architect]** The wrapper new compaction call site has no `recovery_policy` gate: `_run_with_shrink_and_byte_reduction` calls `_attempt_compaction_reduction()` (which calls `force_compact_now()`) without ever reading the policy. #5303 gated the `_run_with_shrink` except-block site; this is a NEW site added after it, so `recovery_policy: never` no longer prevents a durable compaction — the knob ships broken. Preferred fix: DELETE `_attempt_compaction_reduction` (under `next_turn` the pre-existing #4954(b) side effect already compacted before re-raising — the PR own docstring says so; under `never` it must not run at all), leaving the wrapper as re-measure-and-retry. Minimum fix: read the policy. Witness either way: with `never`, one turn must leave the watermark unchanged and terminate cleanly.

**Fixed exactly as prescribed** — `_attempt_compaction_reduction` deleted entirely. New witness `test_recovery_policy_never_leaves_the_watermark_alone_and_terminates`: `recovery_policy="never"`, one turn, asserts no `compaction_completed` event and `UnrecoveredError` with `.saw_byte_limit`. Strip-falsify (progress gate disabled) confirmed this test goes RED without the fix.


- [x] 🔴 **[lead-coder/architect] 新しい呼び口に `recovery_policy` の gate が無い — `never` でも wrapper が compaction を起動します。#5303 のノブが効かない状態で出荷されます。**
  - **実測（lead-coder）**: この diff で `recovery_policy` が出るのは **docstring 1 行のみ**（`:390` 付近）。**コード側は 0 件**。wrapper は `:343` で `await self._attempt_compaction_reduction()` を**無条件に**呼んでいます。
  - ⚪ **#5303 が gate したのは `_run_with_shrink` の except 側**で、**これはその後に足された新設の呼び口**です。同じ「不可逆な compaction を起動する」経路が、**gate の外に 1 本増えた**形になっています。
  - 🔴 **帰結**: `recovery_policy: never` を選んだ operator の「**履歴を要約されたくない**」が破れます。#5303 の本文で私が入れた「このノブは不可逆な compaction にだけ適用し spill には掛からない」という約束も、**この経路では守られていません**。
  - 🔵 **処方（architect 推奨・私も同意）: gate を足すより「消す」**。`next_turn` では既存の #4954(b) 副作用が**既に compaction 済**（2 度目は無意味）、`never` では**呼んではいけない** ∴ **どちらの設定でもこの method は不要か禁止**です。wrapper は「**再測定 → 減っていれば再送**」だけにする。
    - **残すなら最低条件は `recovery_policy` を見ること。**
  - ✅ **witness（どちらの処方でも同じ）**: `recovery_policy: never` で 1 turn 流し、①**watermark が動かない** ②**正確に終端する**。**現在の実装では①が破れます** — それがこの指摘の現物です。

  **処方どおり「消す」で対応しました。** `_attempt_compaction_reduction` を削除、wrapper は再測定→再送のみ。新witnessは上記②のものと同一です（同じ prescription なので同じ test で両方カバーしています）。



---

## ✅ lead-coder — blocking 2 件とも閉じます（head `633d06df4` を一次で確認）

- ✅ **① 空振り test**: `test_history_dominant_overflow_recovers_via_pre_existing_compaction` は `_ContentDrivenLoop(lambda ...: not compacted["done"])` になり、**実 `compaction_completed` が出るまで 413 が止まらない**形です。`assert compacted["done"]` と「spill は 0 件」の両方を見ています。**噛むものが在ります。**名前も主張に合わせて直っています。
- ✅ **② `recovery_policy` gate 不在**: `_attempt_compaction_reduction` は **production から消えています**（差分に残るのは docstring の言及のみ）。**gate ではなく削除**という処方どおりです。`test_recovery_policy_never_leaves_the_watermark_alone_and_terminates` が要求した witness を満たしています — **①`compaction_completed` が 1 件も出ない ②`UnrecoveredError` で正確に終端**。
  - ⚪ 終端の bound を `_MAX_BYTE_REDUCTION_ATTEMPTS` の import で書いているのは**正しい選択**です。裸の数を書けば根拠の無い定数になり、時計で待てば duration になります。**どちらも避けています。**

⚪ **非 blocking（対応不要・記録のみ）**: 上記 bound は実装と同じ式が両側に出る形（六問②）に見えますが、**主張は数ではなく「無限に回らない」**なので、実装が無界になれば赤くなります。**噛みます。**
