### PR TITLE
**[coder-brown]** — stop MessageBus pumps after session completion

### DIFF
--- a/src/reyn/runtime/message_bus.py
+++ b/src/reyn/runtime/message_bus.py
@@ -161,6 +161,12 @@ class MessageBus:
 
             # Pump one iteration if inbox has work; otherwise yield briefly.
             if not agent.inbox.empty():
+                if getattr(agent, "session_completed", False):
+                    logger.warning(
+                        "MessageBus.request: session completed; leaving queued inbox work "
+                        "undispatched"
+                    )
+                    break
                 await agent.run_one_iteration()
             else:
                 await asyncio.sleep(_QUIESCENCE_POLL_INTERVAL)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1218,6 +1218,7 @@ class Session:
         # Kept directly (not only via journal), see docs/reference/runtime/session-construction.md#family-2-recovery-wal-journal
         self._state_log = state_log
         self._halted_reason: "str | None" = None  # #2259 PR-3: set on FAIL-STOP, see session-construction.md#family-2-recovery-wal-journal
+        self._session_completed = False
         # In-memory buffer of restored-then-resolved intervention answers (PR-intervention-link L6, see docs/reference/runtime/session-construction.md#safety-limits-interactive-mode)
         self._buffered_intervention_answers: dict[str, "InterventionAnswer"] = {}
         # In-memory staging for wake=false ride-along messages, durably
@@ -6567,6 +6568,11 @@ class Session:
         return True
 
     @property
+    def session_completed(self) -> bool:
+        """Whether the session lifecycle has emitted its completion event."""
+        return self._session_completed
+
+    @property
     def halted_reason(self) -> "str | None":
         """#2259 PR-3: the fail-stop reason (e.g. ``"durability_failure"``) once the session has
         halted; ``None`` while running. The operator-visible in-memory state paired with the
@@ -7437,6 +7443,7 @@ class Session:
                 # #1800 slice 5a: session lifecycle audit event (P6). Emitted alongside
                 # chat_stopped; marks the end of the session's resource scope.
                 self._audit_events.emit("session_completed", agent_name=self.agent_name)
+                self._session_completed = True
                 # #1800 slice 5b: session_end lifecycle hooks (F's natural resource
                 # scope). The run-loop has exited, so an E push here is not drained
                 # (harmless); session_end is the C/F point in practice.

--- a/tests/runtime/test_transport_ref.py
+++ b/tests/runtime/test_transport_ref.py
@@ -357,7 +357,9 @@ async def test_message_bus_stops_after_session_completed(tmp_path, monkeypatch, 
         processed.append(text)
 
     monkeypatch.setattr(Session, "_handle_inbox_text", handle)
-    session._session_completed = True
+    await session.inbox.put(("shutdown", {}))
+    await session.run()
+    assert session.session_completed is True
     await session.inbox.put(("user", {"text": "late"}))
     replies = await MessageBus().request(
         session, TurnOrigin.EXTERNAL_MESSAGE, {"text": "new"},

--- a/tests/runtime/test_transport_ref.py
+++ b/tests/runtime/test_transport_ref.py
@@ -27,6 +27,7 @@ from reyn.runtime.transport import (
     SystemRef,
     TuiRef,
 )
+from reyn.runtime.turn_origin import TurnOrigin
 from tests._support.agent_session import make_session
 
 # ---------------------------------------------------------------------------
@@ -344,6 +345,27 @@ def test_routing_layer_registered_types():
 # ---------------------------------------------------------------------------
 # Component D: MessageBus
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_message_bus_stops_after_session_completed(tmp_path, monkeypatch, caplog):
+    """Tier 2: completed sessions do not dispatch queued MessageBus work."""
+    session = _make_session(tmp_path)
+    processed = []
+
+    async def handle(text, *, chain_id):
+        processed.append(text)
+
+    monkeypatch.setattr(Session, "_handle_inbox_text", handle)
+    session._session_completed = True
+    await session.inbox.put(("user", {"text": "late"}))
+    replies = await MessageBus().request(
+        session, TurnOrigin.EXTERNAL_MESSAGE, {"text": "new"},
+        A2aRef(request_id="r"), timeout=0.01,
+    )
+    assert processed == []
+    assert replies == []
+    assert any("session completed" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_transport_ref.py
+++ b/tests/runtime/test_transport_ref.py
@@ -363,7 +363,7 @@ async def test_message_bus_stops_after_session_completed(tmp_path, monkeypatch, 
     await session.inbox.put(("user", {"text": "late"}))
     replies = await MessageBus().request(
         session, TurnOrigin.EXTERNAL_MESSAGE, {"text": "new"},
-        A2aRef(request_id="r"), timeout=0.01,
+        A2aRef(request_id="r"), timeout=float("inf"),
     )
     assert processed == []
     assert replies == []


### PR DESCRIPTION
**[coder-brown]** — Prevent direct `MessageBus.request` callers from dispatching queued work after a Session has emitted `session_completed`. Expose the lifecycle state through `Session.session_completed`, leave late inbox work queued, and emit a warning so the dropped dispatch is observable. Add a Tier 2 regression witness plus the existing pre/post comparison coverage.

part of #5214

Checks: `.venv/bin/ruff check src/reyn/runtime/message_bus.py src/reyn/runtime/session.py tests/runtime/test_transport_ref.py`; `.venv/bin/python -m pytest tests/runtime/test_transport_ref.py -q` (15 passed); Tier audit (15 inspected, 0 errors).

---

## 🔴 Blocking (lead-coder) — **ticked せずに残すこと。閉じるのは lead-coder です（家則 7）**

reyn-reviewer の TESTS-READ(B) finding を **lead-coder が一次で確認**しました（`gh pr diff 5313`）。両方とも正です。

- [x] 🔴 **producer→state の配線を誰も witness していない。** ✅ **b6b354913 で解消・lead-coder 確認済**（実 `session.run()` を通し、公開 `session.session_completed` を読んでいます）。**閉じます。**
  - ~~ 差分 `:76` が `session._session_completed = True` と **private state を直接書いています**。この PR が足した配線は `run()` の `emit("session_completed")` → `self._session_completed = True`（差分 `:45-46`）ですが、**test はそこを通りません**。46 行目を消しても **この test は緑のまま**です。
  - ⚪ CLAUDE.md: 「**テストは private state に依存してはならない** — 構文上の位置を名指すのは読みを 1 行上へ動かすだけ」。ここは名指しですらなく**書き込み**です。
  - ✅ **正常終了した実 `Session.run()` を通して状態を作る**か、少なくとも `session_completed` を emit する公開 seam を経由してください。`processed == []` と warning（consumer 側）は有効なので、**足りないのは producer 側 1 本**です。

  ~~

- [ ] 🔴 **`timeout=0.01`（差分 `:80`）は天井で、しかも緑を偽装できます。** 配線が**正しく**ても、負荷のかかった CI では 0.01 秒で timeout して `processed == []` になります — **壊れている場合と同じ観測**です。六問④「**噛むものが無いまま走って緑**」に当たります。
  - ⚪ CLAUDE.md:「**待ちは無制限に条件で待つ。CI の `--timeout=120` が kill switch**」。
  - ✅ 天井を書かず、`processed` が確定する**条件**で待ってください。timeout が本当に対象なら、それは**注入する入力**であって assert が依存する待ち時間ではありません。

⚪ **`part of #5214` / closing なし・ruling (c)「MessageBus 側で回さない」への適合は確認済**です。実装の形に異論はありません。**足りないのは witness だけ**です。



---

⚠️ **`timeout=0.01` は b6b354913 でも残っています（差分 `:82`）。②は開いたままです。**


## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [ ] 🔴 **`monkeypatch.setattr(Session, "_handle_inbox_text", handle)` が家則 2 つに同時に触れています** — 逐語 `Never fake a collaborator … no MagicMock/AsyncMock/patch` と `A test must not depend on private state`（`_handle_inbox_text` は private）。⚪ **本当の finding はその先**で、CLAUDE.md 逐語 `if neither exists, that absence is the finding` — **「queued な inbox work が dispatch されたか」を公開面から読む術が無い**ことを、この test が示しています（#5326 / #5336 と同じ形）。✅ **推奨は A**: 判別しているのは `caplog` の 1 本なので、**`processed` ごと落とせば patch も private 依存も丸ごと消え、差分は減ります**。公開の観測面を足す B は本 PR の射程を超えるので別 issue でも可。根拠: PR comment issuecomment-5443392466
