### PR TITLE
docs(CLAUDE.md): six-questions carve-out ④ moves to the test's own docstring, not the PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,11 +91,12 @@ a classification, and nothing else looks.
 | 1 | **none** — including a third party's, a past bug's, and reyn's own trivia |
 | 2 | yes — the same expression is on both sides |
 | 3 | **nobody**, or only a configuration this test itself constructed |
-| 4 | green having never run **or over an empty collection**, and the PR does not say so |
+| 4 | green having never run **or over an empty collection**, and the test's own docstring does not say so |
 | 5 | **anything outside the test bounds it** — a thread, a timer, the caller's pace |
 | 6 | the declared Tier is not the one question 1 named |
 
 - 4 blocks on the **silence**, not on the skip: a whole-file skip is often correct; a green nobody qualified is not.
+- 4's disclosure lives in the **test's own docstring**, not the PR: a PR is read once, at merge time; the next person to touch the test opens the file, not the PR.
 - 5 has no carve-out: "it is small today" is a measurement of today.
 - 3 needs no accept-side exception — an accept-side test's consumer is the operators the gate would have false-positived against.
 - **When something forces you to touch a test — a bump, a rebase, a CI failure — ask "should this exist" before "how do I make it pass again."**


### PR DESCRIPTION
**[docs-maintainer]** — part of #5063. architect brief: issuecomment-5439956965.

## What

Six-questions rule 4's carve-out ("and the PR does not say so") expires the instant the PR merges — a PR is read once, at merge time; the next person to touch the test opens the FILE, not the PR. Moves the disclosure requirement to the test's own docstring instead, the same seam Tier declarations already use (read every time, by construction).

Also closes the property lead-coder named on the sibling issue (#5314): a docstring line can't be removed for free — deleting it doesn't turn the test green, so removal is not rewarded (unlike a PR-body checkbox, where deletion IS the escape).

Two edits, both in `CLAUDE.md`'s six-questions section:
1. The table's row 4 wording.
2. One new sentence in the existing bullet list explaining why (not just what) — so the next person doesn't write it back into a PR.

## No gate

Per architect's own standing ruling (a low-FP syntactic gate cannot be built for a semantic class): "does this docstring actually disclose the vacuity" is exactly that — a semantic read of prose, not a syntactic pattern. Disclosure stays a human review call, same as the rest of the six-questions framework. No test written for this PR.

## Acceptance (per brief)

- [x] `git grep -n "the PR does not say so"` — 0 hits (also checked repo-wide, not just `.ja.md` — no other file quoted this line at all; no `CLAUDE.ja.md` exists).
- [x] `wc -w CLAUDE.md` — 2071 → 2106 (+35 words). Both required edits are load-bearing per the brief's own 2-location instruction (table wording + the reasoning sentence); not padded.
- [ ] (skipped — no `docs/` file touched, `mkdocs --strict`/`check_doc_anchors` gate does not apply)
- [ ] (skipped — no `.ja.md` mirror exists for `CLAUDE.md`; rule 5 n/a)
- [x] No test written — "no gate" stated above with reasoning, not left as "gate to follow."

## Test plan

- [x] `git grep -n "the PR does not say so"` — 0 hits.
- [x] `wc -w CLAUDE.md` disclosed above.
- [ ] (skipped — no UI surface, prose-only change) Visual

No closing keyword; auto-merge not armed.
