### PR TITLE
feat(#5209): cron action: hook — a token-0 periodic check

### DIFF
--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -37,7 +37,7 @@ valid in one is not necessarily valid in the other:
 | `turn_end` | `builtin:lifecycle:turn_end` | a turn's terminal `stop_reason` | ✅ | ✅ |
 | `mcp_resource_updated` | `builtin:external:mcp_resource_updated` | a subscribed MCP resource pushes an update | ✅ | ✅ |
 | `file_changed` | `builtin:external:file_changed` | a watched path changes ([`fs_watch`](../../reference/config/reyn-yaml.md#fs_watch-block) required) | ✅ | ✅ |
-| `cron_fired` | `builtin:external:cron_fired` | a message-based `cron:` job delivers | ✅ | ✅ |
+| `cron_fired` | `builtin:external:cron_fired` | a `cron:` job fires (either `action`, #5209) | ✅ | ✅ |
 | `webhook_received` | `builtin:external:webhook_received` | an inbound webhook resolves to this session | ✅ | ✅ |
 | `task_settled` | `builtin:task:task_settled` | an async task (see below for its producers) reaches a terminal disposition | ✅ | ✅ |
 | — (open) | `composed:<name>` | a Composer (see below) publishes its correlated output | ✅ | ✅ (chaining — another Composer's output) |
@@ -316,14 +316,19 @@ burst fires the hook once, not once per underlying filesystem event.
 
 ### `cron_fired`
 
-Fires when a message-based `cron:` job delivers to its own session.
+Fires on every `cron:` job's fire, on its own resolved `cron:<job_name>`
+session — for both `action: message` (the message also delivers to the
+inbox, separately) and `action: hook` (#5209 — this hook fire is the ONLY
+thing that happens; no message is ever delivered). See the `cron` block
+reference (`docs/reference/config/reyn-yaml.md#cron-block`) for `action`.
 
 Template vars:
 
 | Var | Meaning |
 |-----|---------|
 | `job_name` | The fired job's configured name. |
-| `to` | The target agent name. |
+| `to` | The target agent name (the job's host session). |
+| `action` | `"message"` or `"hook"` (#5209) — lets a hook branch on which kind of fire this was, e.g. `matcher: {action: "hook"}`. |
 
 ### `webhook_received`
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1687,9 +1687,13 @@ See also:
 
 ## `cron` block
 
-Schedule recurring message dispatches. The scheduler runs as part of
-`reyn web` (= started in the FastAPI lifespan) or as a foreground
-process via `reyn cron run`.
+Schedule recurring cron jobs. The scheduler runs as part of `reyn web`
+(= started in the FastAPI lifespan) or as a foreground process via
+`reyn cron run`. Each job declares an `action` (#5209): `message` (default)
+dispatches text to an agent's inbox — always starts an LLM turn; `hook`
+only fires the `cron_fired` external-event hook — a `hooks.yaml`
+`on: cron_fired` entry's own `push_when` then decides whether anything
+happens next, at zero LLM turns when it doesn't.
 
 ```yaml
 cron:
@@ -1705,17 +1709,36 @@ cron:
       message: "weekly ops report"
       schedule: "0 9 * * MON"   # Monday 09:00
       enabled: true
+
+    - name: poll_deploy_status   # action: hook — a "token 0" periodic check
+      to: ops_agent              # (#5209): no message is delivered here at all;
+      action: hook                # the fired cron_fired hook's own push_when
+      schedule: "*/5 * * * *"    # decides whether to wake ops_agent
 ```
 
 ### Fields
 
 - **`name`** (required) — job identifier, unique within the schedule
-- **`to`** (required) — target agent name; the message is dispatched to its
-  inbox with `sender="cron:<name>"` attribution
-- **`message`** (required) — free-form text delivered to the target agent
+- **`to`** (required, every `action`) — the agent this job runs on (its
+  `cron:<job_name>` Session is what `cron_fired` fires on); for
+  `action: message` it also doubles as the message RECIPIENT
+- **`action`** (optional, default `"message"`) — `"message"`: `to` doubles
+  as the recipient and `message` is required, dispatched to its inbox with
+  `sender="cron:<name>"` attribution, always starting an LLM turn.
+  `"hook"` (#5209): only fires the `cron_fired` external-event hook on the
+  host session — never starts a turn itself; `message` must NOT be set (a
+  hook job never delivers text). Whether a turn happens next is entirely up
+  to a `hooks.yaml` `on: cron_fired` entry's own `push_when` (typically an
+  `exec_capture` script) — an unsatisfied `push_when` costs zero LLM turns,
+  the reason this action exists (a periodic condition-check that only wakes
+  the agent when it finds something).
+- **`message`** (required for `action: message`; forbidden for
+  `action: hook`) — free-form text delivered to the target agent
 - **`schedule`** (required) — 5-field cron expression
   (minute / hour / day-of-month / month / day-of-week)
 - **`notify`** (optional) — opt-in unattended notification channel
+  (`action: message` only — a hook job's own push, if any, carries its
+  own `session`/routing via the hook definition)
 - **`input`** (optional, default `{}`) — extra input dict carried on the job
 - **`enabled`** (optional, default `true`) — `false` keeps the entry in
   configuration but skips scheduling

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -1305,24 +1305,43 @@ def _build_sandbox_config(raw: object) -> SandboxConfig:
 
 @dataclass
 class CronJobConfig:
-    """One ``cron.jobs[]`` entry (FP-0009 Component B + FP-0041 #489 PR-B).
+    """One ``cron.jobs[]`` entry (FP-0009 Component B + FP-0041 #489 PR-B;
+    ``action`` field #5209).
 
     Maps directly onto ``CronJob`` consumed by ``CronScheduler``; this
     config-side dataclass exists to keep the YAML parsing layer
     independent of the runtime layer.
 
-    Jobs are message-based (= FP-0041 #489 PR-B): ``to`` (target agent) +
-    ``message`` (free-form text). Cron dispatches the message to the target
-    agent's inbox with a ``sender="cron:<name>"`` envelope.
+    ``to`` (target agent) is required for EVERY job regardless of
+    ``action`` — it names the agent whose ``cron:<job_name>`` Session this
+    job runs on (the "host"), which ``resolve_cron_session`` /
+    ``dispatch_cron_fired`` need to resolve a Session to fire
+    ``cron_fired`` on at all; there is no session-less dispatch path.
+    ``action`` declares what a fire actually DOES on that host session:
 
-    (A bare name without ``to`` + ``message`` is not a valid job shape;
-    an entry missing those fields is rejected at load with a ValueError naming it.)
+      - ``"message"`` (default, unchanged): ``to`` doubles as the message
+        RECIPIENT too — ``message`` (free-form text) is required, dispatched
+        to the agent's inbox as a normal attributed turn (= always starts an
+        LLM turn).
+      - ``"hook"`` (#5209): only fires the ``cron_fired`` external-event hook
+        on the host session — never starts a turn itself. Whether anything
+        happens next is entirely up to a hooks.yaml ``on: cron_fired``
+        entry's own ``push_when`` (an ``exec_capture`` hook whose script
+        decides token-0 vs push, #5209's own reason to exist). ``message``
+        set on a ``"hook"`` job is a config error — a hook job never has
+        text to deliver, so a written ``message`` would silently be
+        ignored without this check (#5209, architect ruling: declare the
+        action positively, never let an absent field carry meaning).
+
+    Unknown ``action`` values are rejected at load, same as a missing
+    ``to``/``message`` shape.
     """
 
     name: str
     schedule: str   # 5-field cron expression
-    to: str | None = None        # target agent name
-    message: str | None = None   # free-form text dispatched to the agent's inbox
+    to: str | None = None        # target agent name — required for every action (see class docstring)
+    message: str | None = None   # free-form text dispatched to the agent's inbox — action="message" only
+    action: str = "message"      # #5209: "message" (default) | "hook"
     notify: str | None = None    # FP-0043 S4b-3b: opt-in notify channel (e.g. "telegram"); None = event-log only
     input: dict = field(default_factory=dict)
     enabled: bool = True
@@ -1344,7 +1363,7 @@ class CronConfig:
 def _build_cron_config(raw: object) -> CronConfig:
     """Parse the ``cron:`` section from reyn.yaml / ``.reyn/cron.yaml``.
 
-    Shape (FP-0009 + FP-0041 #489 PR-B)::
+    Shape (FP-0009 + FP-0041 #489 PR-B; ``action`` #5209)::
 
         cron:
           jobs:
@@ -1353,13 +1372,17 @@ def _build_cron_config(raw: object) -> CronConfig:
               message: "今日の主要ニュースをまとめて"
               schedule: "0 9 * * *"
               enabled: true
+            - name: check_deploy_status   # action: hook — no turn unless the
+              to: ops_agent               # hook's own push_when says so
+              action: hook
+              schedule: "*/5 * * * *"
 
     ``None`` / missing block / empty dict → ``CronConfig(jobs=[])``.
-    Validates ``name`` + ``schedule`` are non-empty strings + ``to`` +
-    ``message`` are set per entry, raising ``ValueError`` naming the
-    offending entry on failure. An entry without the ``to`` + ``message``
-    shape (entry missing ``to`` + ``message``) is rejected with that
-    ValueError. Unknown extra fields are ignored (= forward-compatible).
+    Validates ``name`` + ``schedule`` are non-empty strings + ``to`` is
+    always set + ``action``-appropriate shape per entry (#5209:
+    ``action: message`` needs ``message`` too; ``action: hook`` rejects a
+    ``message``), raising ``ValueError`` naming the offending entry on
+    failure. Unknown extra fields are ignored (= forward-compatible).
     """
     if raw is None:
         return CronConfig()
@@ -1386,19 +1409,38 @@ def _build_cron_config(raw: object) -> CronConfig:
                 f"cron.jobs[{i}] (name={name!r}): 'schedule' must be a non-empty string "
                 f"(got {schedule!r})"
             )
-        # FP-0041 #489 PR-B: a job must be message-based (to + message). An
-        # entry lacking that shape is rejected below.
-        to = entry.get("to")
-        message = entry.get("message")
-        has_message_shape = (
-            bool(to) and isinstance(to, str)
-            and bool(message) and isinstance(message, str)
-        )
-        if not has_message_shape:
+        # #5209: action declares what a fire does; to is required either
+        # way (the host session cron_fired resolves against).
+        action = entry.get("action", "message")
+        if action not in ("message", "hook"):
             raise ValueError(
-                f"cron.jobs[{i}] (name={name!r}): must set "
-                f"'to' + 'message'."
+                f"cron.jobs[{i}] (name={name!r}): 'action' must be "
+                f"'message' or 'hook' (got {action!r})"
             )
+        to = entry.get("to")
+        if not to or not isinstance(to, str):
+            raise ValueError(
+                f"cron.jobs[{i}] (name={name!r}): 'to' must be a non-empty "
+                f"string (the agent this job runs on — required for every "
+                f"action, got {to!r})"
+            )
+        message = entry.get("message")
+        if action == "message":
+            # FP-0041 #489 PR-B: a message job must set 'message' too.
+            if not message or not isinstance(message, str):
+                raise ValueError(
+                    f"cron.jobs[{i}] (name={name!r}): action='message' "
+                    f"requires a non-empty 'message' (got {message!r})"
+                )
+        else:  # action == "hook"
+            # #5209: a hook job never delivers text — a written 'message'
+            # would silently be ignored without this check.
+            if message is not None:
+                raise ValueError(
+                    f"cron.jobs[{i}] (name={name!r}): action='hook' must "
+                    f"not set 'message' (it is never delivered — got "
+                    f"{message!r})"
+                )
         raw_input = entry.get("input") or {}
         if not isinstance(raw_input, dict):
             raw_input = {}
@@ -1411,6 +1453,7 @@ def _build_cron_config(raw: object) -> CronConfig:
             schedule=schedule,
             to=to,
             message=message,
+            action=action,
             notify=notify,
             input=dict(raw_input),
             enabled=enabled,

--- a/src/reyn/hooks/ingress.py
+++ b/src/reyn/hooks/ingress.py
@@ -276,8 +276,10 @@ class CronIngressAdapter:
         registry.ensure_session_running(agent_name, self.session_id(job_name))
         return session
 
-    def to_event(self, job_name: str, to: str) -> HookEvent:
-        payload = build_hook_payload("cron_fired", job_name=job_name, to=to)
+    def to_event(self, job_name: str, to: str, *, action: str = "message") -> HookEvent:
+        """``action`` (#5209): ``"message"`` (default) or ``"hook"`` — lets
+        an ``on: cron_fired`` hook branch on which kind of fire this was."""
+        payload = build_hook_payload("cron_fired", job_name=job_name, to=to, action=action)
         return HookEvent(kind=canonical_kind("cron_fired"), payload=payload)
 
     def deliver(self, event: HookEvent, session: Any) -> None:

--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -262,7 +262,9 @@ class HookDef:
         ``reyn.hooks.matcher.matches`` for the match semantics and
         ``reyn.hooks.dispatcher.HookDispatcher.dispatch`` for where it's
         applied (before the hook's action runs). Absent/empty -> always fires
-        (unchanged for every hook that predates H2).
+        (unchanged for every hook that predates H2). ``cron_fired``'s
+        ``action`` field (#5209, ``"message"``/``"hook"``) is also exact-match
+        here, same as ``job_name`` — not a glob field either.
     subprocess:
         OPERATOR-declared per-hook sandbox knob (#2827): may this hook's exec
         argv spawn children? Only meaningful for ``exec`` / ``exec_capture``

--- a/src/reyn/hooks/schema_registry.py
+++ b/src/reyn/hooks/schema_registry.py
@@ -114,7 +114,10 @@ BUILTIN_HOOK_SCHEMAS: "dict[str, frozenset[str]]" = {
         {"point", "server", "uri", "agent_name", "resync"},
     ),
     "builtin:external:file_changed": frozenset({"point", "path", "event_type"}),
-    "builtin:external:cron_fired": frozenset({"point", "job_name", "to"}),
+    # #5209: "action" — "message" (default, also delivered a message to the
+    # inbox) or "hook" (fired cron_fired only, no message) — lets an
+    # on: cron_fired hook branch on which kind of fire this was.
+    "builtin:external:cron_fired": frozenset({"point", "job_name", "to", "action"}),
     "builtin:external:webhook_received": frozenset({"point", "transport", "sender"}),
     # proposal 0067 P3/P4e: TWO producers — the pipeline-async terminal-
     # delivery path (P3, owner ruling via lead-coder, 2026-08-10) and

--- a/src/reyn/interfaces/cli/commands/cron.py
+++ b/src/reyn/interfaces/cli/commands/cron.py
@@ -91,8 +91,10 @@ def _load_jobs() -> list:
 def _jobs_to_cron_jobs(job_configs) -> list:
     """Convert CronJobConfig entries to CronJob instances.
 
-    Jobs are message-based (= ``to`` + ``message``); the runner dispatches
-    the message to the target agent's inbox.
+    ``action="message"`` (default): ``to`` + ``message``, the runner
+    dispatches the message to the target agent's inbox. ``action="hook"``
+    (#5209): ``to`` only — the runner fires ``cron_fired`` on the host
+    session without pushing anything.
     """
     from reyn.runtime.cron import CronJob
     return [
@@ -101,6 +103,7 @@ def _jobs_to_cron_jobs(job_configs) -> list:
             schedule=jc.schedule,
             to=jc.to,
             message=jc.message,
+            action=jc.action,
             notify=jc.notify,
             input=dict(jc.input),
             enabled=jc.enabled,

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -33,20 +33,43 @@ logger = logging.getLogger(__name__)
 def _make_cron_runner():
     """Return an async callable that executes a CronJob headlessly.
 
-    FP-0009 Component B + FP-0041 #489 PR-B: dispatches based on job
-    shape via ``build_default_runner``. Task-based job execution uses the
-    message-based path; only message-based jobs run:
+    FP-0009 Component B + FP-0041 #489 PR-B; ``action`` #5209: dispatches
+    based on ``job.action`` via ``build_default_runner``.
 
-      - Message-based (FP-0041): pushes message into target agent's
+      - ``action="message"`` (FP-0041): pushes message into target agent's
         inbox via ``AgentRegistry.ensure_running``, with
         ``sender="cron:<name>"`` envelope so the agent reads it as a
         normal attributed turn from a scheduled trigger.
+      - ``action="hook"`` (#5209): only fires ``cron_fired`` on the job's
+        host session — no inbox push, no turn started here. See
+        ``_hook_only_dispatcher``.
     """
     from reyn.runtime.cron.runners import build_default_runner
 
+    async def _resolve_and_fire(to: str, native_id: str, *, action: str):
+        """Shared by both dispatchers below: resolve the job's host session
+        and fire ``cron_fired`` on it. Returns the resolved Session, or
+        ``None`` on a resolve failure (caller returns "error")."""
+        from reyn.interfaces.web.deps import _get_registry
+        from reyn.runtime.cron.routing import (
+            dispatch_cron_fired,
+            resolve_cron_session,
+        )
+        registry = _get_registry()
+        try:
+            session = resolve_cron_session(registry, to, native_id)
+        except (FileNotFoundError, KeyError):
+            return None
+        # #2608 H5: fire the cron_fired external-event hook on the job's own
+        # resolved session — non-blocking, so a slow hook action never stalls
+        # this fire's own inbox delivery (message jobs) / returns promptly
+        # (hook jobs). See dispatch_cron_fired's docstring.
+        dispatch_cron_fired(session, native_id, to, action=action)
+        return session
+
     async def _inbox_pusher(to: str, envelope: dict, native_id: str) -> str:
         """Deliver ``envelope`` to the job's own ``cron:<job_name>`` Session of
-        agent ``to`` via the registry.
+        agent ``to`` via the registry (``action="message"`` jobs only).
 
         FP-0043 S4b-3a: a message-based cron job is re-keyed from the agent's
         "main" session to a per-job ``cron:<native_id>`` Session (resolve_session
@@ -63,22 +86,10 @@ def _make_cron_runner():
         this unattended session instead of being read by the model. Cron is not a
         human at a client, so it stopped saying it was one.
         """
-        from reyn.interfaces.web.deps import _get_registry
-        from reyn.runtime.cron.routing import (
-            dispatch_cron_fired,
-            resolve_cron_session,
-        )
         from reyn.runtime.turn_origin import TurnOrigin
-        registry = _get_registry()
-        try:
-            session = resolve_cron_session(registry, to, native_id)
-        except (FileNotFoundError, KeyError):
+        session = await _resolve_and_fire(to, native_id, action="message")
+        if session is None:
             return "error"
-        # #2608 H5: fire the cron_fired external-event hook on the job's own
-        # resolved session — non-blocking, so a slow hook action never stalls
-        # this fire's own inbox delivery below. See dispatch_cron_fired's
-        # docstring.
-        dispatch_cron_fired(session, native_id, to)
         payload = dict(envelope)
         # FP-0043 S4b-3b: opt-in notify → tag the inbox with reply_to=ExternalRef so
         # the agent's final reply is relayed to the channel by the (already
@@ -90,6 +101,15 @@ def _make_cron_runner():
             payload["reply_to"] = ExternalRef(transport=notify, destination={})
         await session._put_inbox(TurnOrigin.CRON, payload)
         return "ok"
+
+    async def _hook_only_dispatcher(to: str, native_id: str) -> str:
+        """#5209: resolve the job's host session and fire ``cron_fired`` on
+        it — no inbox push, no turn started by the runner itself. Whether a
+        turn happens next is entirely up to a ``hooks.yaml``
+        ``on: cron_fired`` entry's own ``push_when`` (``action="hook"``
+        jobs only)."""
+        session = await _resolve_and_fire(to, native_id, action="hook")
+        return "ok" if session is not None else "error"
 
     async def _failure_notifier(job, reason: str) -> None:
         """FP-0043 S4b-3b errors=(b): relay a job-execution FAILURE (a job that
@@ -117,6 +137,7 @@ def _make_cron_runner():
 
     return build_default_runner(
         inbox_pusher=_inbox_pusher,
+        hook_only_dispatcher=_hook_only_dispatcher,
         failure_notifier=_failure_notifier,
     )
 

--- a/src/reyn/runtime/cron/routing.py
+++ b/src/reyn/runtime/cron/routing.py
@@ -57,23 +57,28 @@ def resolve_cron_session(registry, agent_name: str, job_name: str):
     return _ADAPTER.resolve_session(registry, agent_name, job_name)
 
 
-def dispatch_cron_fired(session, job_name: str, to: str) -> None:
+def dispatch_cron_fired(session, job_name: str, to: str, *, action: str = "message") -> None:
     """#2608 H5 / Hook-Event Phase 2 §6.4: fire the ``cron_fired`` external-event
     hook on ``session`` (the job's own resolved Session — pass the object
     :func:`resolve_cron_session` returned, so the hook fires on the SAME
     session the job's message was delivered to).
 
     Delegates to ``CronIngressAdapter``'s ``to_event`` (builds the typed
-    ``HookEvent`` via Phase 1's ``build_hook_payload``, unchanged field-set)
-    then ``deliver`` (``reyn.hooks.external_fire.fire_and_forget`` — a slow
-    hook action must never stall the cron job's own inbox delivery).
-    ``template_vars`` carry only operator-authored config metadata
-    (``job_name``, the target agent name) — a cron job never carries
-    end-user-supplied secrets the way an inbound webhook body can, so
-    nothing is withheld here (contrast
-    ``reyn.runtime.webhook_routing.dispatch_webhook_received``). ``job_name``
-    is the matchable field (exact match — not a glob field, see
+    ``HookEvent`` via Phase 1's ``build_hook_payload``) then ``deliver``
+    (``reyn.hooks.external_fire.fire_and_forget`` — a slow hook action must
+    never stall the cron job's own inbox delivery). ``template_vars`` carry
+    only operator-authored config metadata (``job_name``, the target agent
+    name, ``action``) — a cron job never carries end-user-supplied secrets
+    the way an inbound webhook body can, so nothing is withheld here
+    (contrast ``reyn.runtime.webhook_routing.dispatch_webhook_received``).
+    ``job_name`` is the matchable field (exact match — not a glob field, see
     ``reyn.hooks.matcher``), e.g. ``matcher: {job_name: "backup"}``.
+
+    ``action`` (#5209) — ``"message"`` (default) if the job also delivered a
+    message to the inbox, ``"hook"`` if this fire is hook-only (never pushed
+    anything itself) — lets a ``hooks.yaml`` ``on: cron_fired`` entry branch
+    on which kind of fire this was via ``matcher: {action: "hook"}`` or its
+    own template logic.
 
     #4605: also emits a ``cron_fired`` AUDIT event on ``session._audit_events``
     (P6, distinct from the hook fire above) — the ARRIVAL of the signal is
@@ -87,5 +92,5 @@ def dispatch_cron_fired(session, job_name: str, to: str) -> None:
         session._audit_events.emit("cron_fired", job_name=job_name, to=to)
     except Exception:  # noqa: BLE001 — audit emit is best-effort, never blocks the job
         _log.debug("dispatch_cron_fired: audit emit failed for job %r", job_name, exc_info=True)
-    event = _ADAPTER.to_event(job_name, to)
+    event = _ADAPTER.to_event(job_name, to, action=action)
     _ADAPTER.deliver(event, session)

--- a/src/reyn/runtime/cron/runners.py
+++ b/src/reyn/runtime/cron/runners.py
@@ -1,21 +1,35 @@
-"""Shared cron runner factory (FP-0009 + FP-0041 #489 PR-B).
+"""Shared cron runner factory (FP-0009 + FP-0041 #489 PR-B; ``action`` #5209).
 
 Builds the ``runner_fn`` passed to ``CronScheduler``. Each fired
-``CronJob`` is message-based (= FP-0041 PR-B, ``to + message``): the
-runner pushes an envelope into the target agent's inbox with
-``sender="cron:<name>"`` attribution, and the agent's router_loop
-consumes it as a normal attributed turn from a scheduled trigger.
+``CronJob`` declares its ``action`` (#5209):
 
-(A cron job must be message-based: ``to`` + ``message``. A config entry
-lacking that shape — e.g. a legacy bare ``agent`` name — is rejected at load.)
+  - ``"message"`` (default, FP-0041 PR-B, ``to + message``): the runner
+    pushes an envelope into the target agent's inbox with
+    ``sender="cron:<name>"`` attribution, and the agent's router_loop
+    consumes it as a normal attributed turn from a scheduled trigger —
+    always starts an LLM turn.
+  - ``"hook"`` (#5209): the runner only fires the ``cron_fired``
+    external-event hook on the job's host session — no inbox push, no
+    turn started by this runner itself. Whatever happens next is up to a
+    ``hooks.yaml`` ``on: cron_fired`` entry's own ``push_when`` (a
+    condition-gated ``exec_capture``), which can cost zero LLM turns when
+    unsatisfied — the reason #5209 exists ("token 0 の定期検査").
 
-The transport collaborator is injected (= keeps this factory transport-agnostic):
+(``to`` is required for every job regardless of ``action`` — it is the
+host agent whose session ``cron_fired`` fires on. A config entry missing
+the shape its ``action`` requires is rejected at load.)
 
-  - ``inbox_pusher(to, envelope) -> str``: deliver ``envelope`` to the
-    target agent's inbox. In web mode this routes via the
-    AgentRegistry. In CLI standalone mode no registry exists; pass
-    ``None`` and message-based jobs will warn + return "error" instead
-    of dispatching.
+The transport collaborators are injected (= keeps this factory transport-agnostic):
+
+  - ``inbox_pusher(to, envelope, native_id) -> str``: deliver ``envelope``
+    to the target agent's inbox (``action="message"`` jobs only). In web
+    mode this routes via the AgentRegistry. In CLI standalone mode no
+    registry exists; pass ``None`` and message-based jobs will warn +
+    return "error" instead of dispatching.
+  - ``hook_only_dispatcher(to, native_id) -> str`` (#5209): resolve the
+    host session and fire ``cron_fired`` on it, WITHOUT pushing anything
+    to the inbox (``action="hook"`` jobs only). ``None`` behaves the same
+    as a missing ``inbox_pusher`` — warn + "error".
 """
 from __future__ import annotations
 
@@ -32,6 +46,7 @@ logger = logging.getLogger(__name__)
 def build_default_runner(
     *,
     inbox_pusher: Callable[[str, dict, str], Awaitable[str]] | None = None,
+    hook_only_dispatcher: Callable[[str, str], Awaitable[str]] | None = None,
     failure_notifier: Callable[["CronJob", str], Awaitable[None]] | None = None,
 ) -> Callable[["CronJob"], Awaitable[str]]:
     """Construct a CronScheduler-compatible runner.
@@ -42,9 +57,14 @@ def build_default_runner(
         ``async (to: str, envelope: dict, native_id: str) -> str`` that
         delivers an envelope to the target agent's inbox. ``native_id`` is the
         job name (FP-0043 S4b-3a routing-key native-id) so the pusher routes to
-        the job's own ``cron:<job_name>`` Session. When None, message-based jobs
-        return "error" with a warning (= e.g. CLI standalone mode with no
-        AgentRegistry context).
+        the job's own ``cron:<job_name>`` Session. Used for ``action="message"``
+        jobs only. When None, message-based jobs return "error" with a
+        warning (= e.g. CLI standalone mode with no AgentRegistry context).
+    hook_only_dispatcher:
+        ``async (to: str, native_id: str) -> str`` (#5209) that resolves the
+        job's host session and fires ``cron_fired`` on it — no inbox push.
+        Used for ``action="hook"`` jobs only. When None, hook jobs return
+        "error" with a warning, same shape as a missing ``inbox_pusher``.
     failure_notifier:
         ``async (job: CronJob, reason: str) -> None`` invoked when a job with an
         opt-in ``notify`` channel FAILS to dispatch (FP-0043 S4b-3b, errors = (b)
@@ -70,9 +90,39 @@ def build_default_runner(
             )
 
     async def _runner(job: "CronJob") -> str:
+        if job.is_hook_based():
+            # #5209: fire cron_fired only — never push to the inbox, never
+            # start a turn itself. That's entirely a hooks.yaml on:cron_fired
+            # entry's own decision (push_when).
+            if not job.to:
+                logger.warning(
+                    "Cron job %r is action=hook but has no 'to' (host "
+                    "agent) — skipping. Config load should have rejected "
+                    "this; treating as malformed.",
+                    job.name,
+                )
+                return "error"
+            if hook_only_dispatcher is None:
+                logger.warning(
+                    "Cron job %r is action=hook (to=%r) but no "
+                    "hook_only_dispatcher is configured — hook-only "
+                    "dispatch is not supported in this process "
+                    "(= standalone `reyn cron run` lacks a session "
+                    "registry; use `reyn web` with cron section).",
+                    job.name, job.to,
+                )
+                return "error"
+            try:
+                result = await hook_only_dispatcher(job.to, job.name)
+            except Exception as exc:
+                await _notify_failure(job, f"{type(exc).__name__}: {exc}")
+                raise
+            if result == "error":
+                await _notify_failure(job, "dispatch failed (could not resolve cron session)")
+            return result
         if not job.is_message_based():
-            # All cron jobs are message-based; config rejects any legacy
-            # non-message entry at load. A non-message job here is malformed.
+            # A non-hook, non-message job here is malformed — config
+            # rejects any entry lacking its action's required shape at load.
             logger.warning(
                 "Cron job %r is not message-based (to=%r, message set=%s) — "
                 "skipping. Set both 'to' and 'message'.",

--- a/src/reyn/runtime/cron/scheduler.py
+++ b/src/reyn/runtime/cron/scheduler.py
@@ -15,15 +15,29 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class CronJob:
-    """One scheduled execution (FP-0009 Component B + FP-0041 #489 PR-B).
+    """One scheduled execution (FP-0009 Component B + FP-0041 #489 PR-B;
+    ``action`` #5209).
 
-    Jobs are message-based (= FP-0041 PR-B): set ``to`` (= target agent
-    name) and ``message`` (= free-form text). The scheduler dispatches the
-    message to the agent's inbox with ``sender="cron:<name>"`` so the LLM
-    reads it as a normal attributed turn from a scheduled trigger.
+    ``to`` (= target agent name) is required for EVERY job regardless of
+    ``action`` — it names the agent whose ``cron:<job_name>`` Session this
+    job runs on (the "host"): ``resolve_cron_session``/``dispatch_cron_fired``
+    have no session-less path to fire ``cron_fired`` on. ``action`` declares
+    what a fire actually does on that host session:
 
-    (A cron job must be message-based: ``to`` + ``message``. A config entry
-    lacking that shape — e.g. a legacy bare ``agent`` name — is rejected at load.)
+      - ``"message"`` (default, unchanged, FP-0041 PR-B): ``to`` doubles as
+        the message RECIPIENT too. ``message`` (= free-form text) is
+        required; the scheduler dispatches it to the agent's inbox with
+        ``sender="cron:<name>"`` so the LLM reads it as a normal attributed
+        turn — always starts an LLM turn.
+      - ``"hook"`` (#5209): only fires ``cron_fired`` on the host session —
+        never starts a turn itself. A ``hooks.yaml`` ``on: cron_fired`` entry
+        (typically ``exec_capture`` + ``push_when``) decides whether
+        anything happens next; an unfired/false ``push_when`` costs zero
+        LLM turns. ``message`` is never set on a ``"hook"`` job (rejected at
+        config load).
+
+    (A config entry missing the required shape for its ``action`` — e.g. no
+    ``to`` at all, or a ``message`` on a ``"hook"`` job — is rejected at load.)
 
     Mutable on the scheduler side: ``last_run_at`` / ``last_run_status``
     / ``last_run_error`` / ``next_run_at`` are updated after each fire.
@@ -31,9 +45,9 @@ class CronJob:
 
     name: str               # job identifier, unique within scheduler
     schedule: str           # cron expression, 5-field (e.g. "0 */6 * * *")
-    # ── message-based (FP-0041 PR-B) ─────────────────
-    to: str | None = None       # target agent name
-    message: str | None = None  # free-form text dispatched to agent.inbox
+    to: str | None = None       # target agent name — the host session, required for every action
+    message: str | None = None  # free-form text dispatched to agent.inbox — action="message" only
+    action: str = "message"     # #5209: "message" (default) | "hook"
     # FP-0043 S4b-3b: opt-in unattended notification channel (e.g. "telegram").
     # None = off (event-log only = current behaviour). When set, the fired cron
     # turn's final reply is routed to the channel via the external-transport outbox
@@ -54,12 +68,18 @@ class CronJob:
         """True if this job uses the message-based shape (= ``to + message``)."""
         return bool(self.to and self.message)
 
+    def is_hook_based(self) -> bool:
+        """#5209: True if this job only fires ``cron_fired`` — never starts
+        a turn itself (``action == "hook"``)."""
+        return self.action == "hook"
+
     def to_dict(self) -> dict:
         """JSON-safe shape for `reyn cron list` and `reyn cron status`."""
         return {
             "name": self.name,
             "to": self.to,
             "message": self.message,
+            "action": self.action,
             "notify": self.notify,
             "schedule": self.schedule,
             "input": self.input,

--- a/tests/config/test_fp0009_b_cron_config.py
+++ b/tests/config/test_fp0009_b_cron_config.py
@@ -125,10 +125,19 @@ def test_missing_name_raises_value_error() -> None:
         _build_cron_config(raw)
 
 
-def test_missing_to_message_raises_value_error() -> None:
-    """Tier 1: a job with neither a message shape nor a (legacy) skill raises ValueError."""
+def test_missing_to_raises_value_error() -> None:
+    """Tier 1: 'to' (the host agent, #5209) is required for every action."""
     raw = {"jobs": [{"name": "my_job", "schedule": "0 * * * *"}]}
-    with pytest.raises(ValueError, match="to.*message"):
+    with pytest.raises(ValueError, match="to"):
+        _build_cron_config(raw)
+
+
+def test_missing_message_raises_value_error() -> None:
+    """Tier 1: action='message' (default) with 'to' set but no 'message'
+    raises ValueError — #5209 split the old combined to+message check into
+    two independent field checks."""
+    raw = {"jobs": [{"name": "my_job", "to": "agent_a", "schedule": "0 * * * *"}]}
+    with pytest.raises(ValueError, match="message"):
         _build_cron_config(raw)
 
 
@@ -246,4 +255,76 @@ def test_legacy_skill_based_job_rejected() -> None:
         ]
     }
     with pytest.raises(ValueError, match="legacy_index"):
+        _build_cron_config(raw)
+
+
+# ── #5209: action — "message" (default) | "hook" ────────────────────────────
+
+
+def test_action_defaults_to_message_and_requires_message() -> None:
+    """Tier 1: action defaults to "message" (byte-identical to pre-#5209
+    behaviour) — a job missing 'message' still raises the same as before."""
+    ok = _build_cron_config({
+        "jobs": [
+            {"name": "morning_news", "to": "news_agent",
+             "message": "summarise today", "schedule": "0 9 * * *"},
+        ]
+    })
+    assert ok.jobs[0].action == "message"
+
+
+def test_action_hook_requires_to_but_not_message() -> None:
+    """Tier 1: #5209 core shape — action='hook' needs only 'to' (the host
+    agent); no 'message' is required (none is ever delivered)."""
+    cfg = _build_cron_config({
+        "jobs": [
+            {"name": "poll_deploy", "to": "ops_agent", "action": "hook",
+             "schedule": "*/5 * * * *"},
+        ]
+    })
+    (job,) = cfg.jobs
+    assert job.action == "hook"
+    assert job.to == "ops_agent"
+    assert job.message is None
+
+
+def test_action_hook_with_message_raises_value_error() -> None:
+    """Tier 1: #5209 acceptance ④ (architect's corrected brief,
+    issuecomment-5440197832) — action='hook' + 'message' is a config error:
+    a hook job never delivers text, so a written 'message' would silently be
+    ignored without this check."""
+    raw = {
+        "jobs": [
+            {"name": "poll_deploy", "to": "ops_agent", "action": "hook",
+             "message": "this is never sent", "schedule": "*/5 * * * *"},
+        ]
+    }
+    with pytest.raises(ValueError, match="message"):
+        _build_cron_config(raw)
+
+
+def test_action_hook_without_to_raises_value_error() -> None:
+    """Tier 1: #5209 acceptance ⑤ (architect's corrected brief) — action='hook'
+    still requires 'to' (the host agent whose session cron_fired fires on) —
+    resolve_cron_session/dispatch_cron_fired have no session-less dispatch
+    path, so a hook job without 'to' cannot run at all."""
+    raw = {
+        "jobs": [
+            {"name": "poll_deploy", "action": "hook", "schedule": "*/5 * * * *"},
+        ]
+    }
+    with pytest.raises(ValueError, match="to"):
+        _build_cron_config(raw)
+
+
+def test_action_unknown_value_raises_value_error() -> None:
+    """Tier 1: an unrecognised action value is rejected at load, not silently
+    treated as "message" (declare-don't-infer, architect ruling)."""
+    raw = {
+        "jobs": [
+            {"name": "poll_deploy", "to": "ops_agent", "action": "notify",
+             "schedule": "*/5 * * * *"},
+        ]
+    }
+    with pytest.raises(ValueError, match="action"):
         _build_cron_config(raw)

--- a/tests/runtime/test_5209_cron_action_hook.py
+++ b/tests/runtime/test_5209_cron_action_hook.py
@@ -107,10 +107,16 @@ async def test_action_hook_with_push_when_false_starts_zero_turns(tmp_path):
     """Tier 2: THE core #5209 proof. A real ``action="hook"`` CronJob fires
     through the REAL runner (``build_default_runner``'s hook_only_dispatcher
     branch); the configured ``on: cron_fired`` hook's own ``push_when``
-    template renders false — nothing lands in the session's inbox, so no
-    turn is ever triggered. Waits on the PUBLIC ``pending_dispatch_count``
-    snapshot (not a fixed sleep) to know the fire-and-forget hook dispatch
-    has actually settled before asserting the (negative) outcome."""
+    template renders false — nothing lands in the session's inbox. Waits on
+    the PUBLIC ``pending_dispatch_count`` snapshot (not a fixed sleep) to
+    know the fire-and-forget hook dispatch has actually settled before
+    asserting the (negative) outcome.
+
+    Witness scope (architect review, non-blocking): this asserts the inbox
+    stays empty, not "the LLM was called 0 times" directly — at THIS layer
+    (``_NoRunAgentRegistry``, no live ``Session.run()`` loop) a turn can only
+    ever start via an inbox arrival, so an empty inbox is a faithful proxy,
+    but it is a proxy, not a direct LLM-call count."""
     hooks_config = [
         {
             "on": "cron_fired",

--- a/tests/runtime/test_5209_cron_action_hook.py
+++ b/tests/runtime/test_5209_cron_action_hook.py
@@ -1,0 +1,256 @@
+"""Tier 2: #5209 — ``action: hook`` cron jobs (a "token 0" periodic check).
+
+Before this, every cron job was message-based: a fire ALWAYS pushed a
+message into the target agent's inbox, which ALWAYS starts an LLM turn —
+there was no way to build "run a script periodically, wake the agent only
+if it found something" without paying an LLM turn (and its accumulated
+history) on every tick regardless of outcome (owner constraint, 2026-08-23:
+"pull するたびに token 消費するのは問題").
+
+``action: hook`` (default remains ``"message"``, unchanged) closes that gap:
+the runner only fires the pre-existing ``cron_fired`` external-event hook on
+the job's host session — never pushes a message itself. A ``hooks.yaml``
+``on: cron_fired`` entry's own ``push_when`` (already-existing machinery,
+#2069/#1800) then decides whether anything happens next; an unsatisfied
+``push_when`` costs zero LLM turns.
+
+Real instances only, per the testing policy: no ``unittest.mock`` /
+``MagicMock`` / ``AsyncMock`` / ``patch``. Every test drives a real
+``CronJob`` through a real ``CronScheduler``-compatible runner (the REAL
+``build_default_runner``) against a real ``AgentRegistry`` + real
+``Session`` + real ``HookDispatcher``, observing effects on the session's
+own (public) inbox and the public ``pending_dispatch_count`` snapshot read
+(``reyn.hooks.external_fire`` — #2620's own witness for "has the
+fire-and-forget hook dispatch settled", used here instead of a fixed
+``sleep`` so a push_when=false negative is proven, not merely unraced by
+luck) rather than any private state.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.hooks.external_fire import pending_dispatch_count
+from reyn.runtime.cron import CronJob
+from reyn.runtime.cron.routing import dispatch_cron_fired, resolve_cron_session
+from reyn.runtime.cron.runners import build_default_runner
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
+from reyn.runtime.turn_origin import TurnOrigin
+from tests._support.agent_session import make_session
+
+
+class _NoRunAgentRegistry(AgentRegistry):
+    """Real AgentRegistry with ``ensure_session_running`` reduced to a peek
+    (mirrors ``test_2608_h5_cron_webhook_hooks.py``'s own harness) — only
+    booting ``Session.run()``'s background inbox-consumption loop is
+    disabled; every other method is the real, unmodified implementation."""
+
+    def ensure_session_running(self, name: str, sid: str):
+        return self._peek_session(name, sid)
+
+
+def _make_registry(tmp_path: Path, *, hooks_config=None) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = make_session(
+            agent_name=profile.name, state_log=state_log,
+            reactivity=ReactivityConfig(hooks_config=hooks_config),
+        )
+        s.register_intervention_listener("test")
+        return s
+
+    return _NoRunAgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+
+
+def _seed(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def _drain(session) -> list[tuple[str, dict]]:
+    items = []
+    while not session.inbox.empty():
+        items.append(session.inbox.get_nowait())
+    return items
+
+
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Unbounded per the owner's testing policy (docs/deep-dives/contributing/
+    testing.md, ## Time) — no test carries a time budget; CI's --timeout=120
+    is the blast-radius kill-switch, not a contract."""
+    while not predicate():
+        await asyncio.sleep(delay)
+
+
+async def _hook_only_dispatcher(reg, to: str, native_id: str) -> str:
+    """Mirrors production's ``reyn.interfaces.web.server``'s
+    ``_hook_only_dispatcher`` exactly: resolve the host session, fire
+    ``cron_fired`` on it — no inbox push."""
+    session = resolve_cron_session(reg, to, native_id)
+    dispatch_cron_fired(session, native_id, to, action="hook")
+    return "ok"
+
+
+# ---------------------------------------------------------------------------
+# ① the core existence-reason: push_when=false costs ZERO turns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_action_hook_with_push_when_false_starts_zero_turns(tmp_path):
+    """Tier 2: THE core #5209 proof. A real ``action="hook"`` CronJob fires
+    through the REAL runner (``build_default_runner``'s hook_only_dispatcher
+    branch); the configured ``on: cron_fired`` hook's own ``push_when``
+    template renders false — nothing lands in the session's inbox, so no
+    turn is ever triggered. Waits on the PUBLIC ``pending_dispatch_count``
+    snapshot (not a fixed sleep) to know the fire-and-forget hook dispatch
+    has actually settled before asserting the (negative) outcome."""
+    hooks_config = [
+        {
+            "on": "cron_fired",
+            "template_push": {"message": "should never be sent", "push_when": "false"},
+        },
+    ]
+    reg = _make_registry(tmp_path, hooks_config=hooks_config)
+    _seed(tmp_path, "ops_agent")
+
+    runner = build_default_runner(
+        hook_only_dispatcher=lambda to, native_id: _hook_only_dispatcher(reg, to, native_id),
+    )
+    job = CronJob(name="poll_deploy", schedule="*/5 * * * *", to="ops_agent", action="hook")
+
+    result = await runner(job)
+    assert result == "ok"
+
+    session = reg.get_session("ops_agent", "cron:poll_deploy")
+    await _wait_for(lambda: pending_dispatch_count(session) == 0)
+    assert _drain(session) == [], (
+        "push_when=false must cost ZERO turns — nothing may land in the "
+        "inbox, the #5209 existence reason"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ② push_when=true — the mechanism is alive, a turn IS triggered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_action_hook_with_push_when_true_starts_a_turn(tmp_path):
+    """Tier 2: the positive control for ① — the SAME action="hook" fire, the
+    SAME runner, only the hook's push_when differs (true). Something DOES
+    land in the inbox — proves ① is a real gate finding zero, not the
+    mechanism itself being dead."""
+    hooks_config = [
+        {
+            "on": "cron_fired",
+            "template_push": {"message": "deploy status changed", "push_when": "true", "wake": True},
+        },
+    ]
+    reg = _make_registry(tmp_path, hooks_config=hooks_config)
+    _seed(tmp_path, "ops_agent")
+
+    runner = build_default_runner(
+        hook_only_dispatcher=lambda to, native_id: _hook_only_dispatcher(reg, to, native_id),
+    )
+    job = CronJob(name="poll_deploy", schedule="*/5 * * * *", to="ops_agent", action="hook")
+
+    result = await runner(job)
+    assert result == "ok"
+
+    session = reg.get_session("ops_agent", "cron:poll_deploy")
+    await _wait_for(lambda: session.inbox.qsize() >= 1)
+    (only_item,) = _drain(session)
+    kind, payload = only_item
+    assert kind == TurnOrigin.HOOK  # the hook's own push, not a cron-direct message
+    assert payload["text"] == "deploy status changed"
+
+
+# ---------------------------------------------------------------------------
+# ③ regression — action="message" (default) is byte-identical to pre-#5209
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_action_message_default_regression_unchanged(tmp_path):
+    """Tier 2: a plain CronJob() (action defaults to "message") still pushes
+    the job's own message via inbox_pusher, unaffected by the new
+    hook_only_dispatcher branch — #5209 must not alter the pre-existing path."""
+    reg = _make_registry(tmp_path, hooks_config=None)
+    _seed(tmp_path, "news_agent")
+
+    async def _inbox_pusher(to: str, envelope: dict, native_id: str) -> str:
+        session = resolve_cron_session(reg, to, native_id)
+        dispatch_cron_fired(session, native_id, to)  # action defaults to "message"
+        await session._put_inbox(TurnOrigin.CRON, envelope)
+        return "ok"
+
+    runner = build_default_runner(inbox_pusher=_inbox_pusher)
+    job = CronJob(name="morning_news", schedule="0 9 * * *", to="news_agent", message="hi")
+
+    result = await runner(job)
+    assert result == "ok"
+
+    session = reg.get_session("news_agent", "cron:morning_news")
+    await _wait_for(lambda: session.inbox.qsize() >= 1)
+    (only_item,) = _drain(session)
+    kind, payload = only_item
+    assert kind == TurnOrigin.CRON
+    assert payload["text"] == "hi"
+
+
+# ---------------------------------------------------------------------------
+# no hook_only_dispatcher injected — action=hook jobs fail loud, not silent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_action_hook_without_dispatcher_configured_returns_error() -> None:
+    """Tier 2: mirrors the pre-existing "no inbox_pusher" contract for
+    message jobs (CLI standalone `reyn cron run`, no session registry) —
+    an action="hook" job with no hook_only_dispatcher returns "error", not
+    a silent no-op."""
+    runner = build_default_runner()  # neither collaborator injected
+    job = CronJob(name="poll_deploy", schedule="*/5 * * * *", to="ops_agent", action="hook")
+    result = await runner(job)
+    assert result == "error"
+
+
+# ---------------------------------------------------------------------------
+# the "action" field is threaded onto the real cron_fired hook payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cron_fired_payload_carries_action_hook(tmp_path):
+    """Tier 2: a hooks.yaml ``matcher: {action: "hook"}`` entry — new in
+    #5209's schema change — fires for an action="hook" job. Proves the
+    ``action`` field actually reaches the real dispatched HookEvent's
+    template_vars, not just the schema declaration."""
+    hooks_config = [
+        {
+            "on": "cron_fired",
+            "matcher": {"action": "hook"},
+            "template_push": {"message": "hook-only fire seen", "push_when": "true", "wake": True},
+        },
+    ]
+    reg = _make_registry(tmp_path, hooks_config=hooks_config)
+    _seed(tmp_path, "ops_agent")
+
+    runner = build_default_runner(
+        hook_only_dispatcher=lambda to, native_id: _hook_only_dispatcher(reg, to, native_id),
+    )
+    job = CronJob(name="poll_deploy", schedule="*/5 * * * *", to="ops_agent", action="hook")
+    await runner(job)
+
+    session = reg.get_session("ops_agent", "cron:poll_deploy")
+    await _wait_for(lambda: session.inbox.qsize() >= 1)
+    (only_item,) = _drain(session)
+    _kind, payload = only_item
+    assert payload["text"] == "hook-only fire seen"


### PR DESCRIPTION
Closes #5209

## What

Before this, every cron job was message-based: a fire ALWAYS pushed a message into the target agent's inbox, which ALWAYS starts an LLM turn. There was no way to build "run a script periodically, wake the agent only if it found something" without paying an LLM turn (plus its accumulated history) on every tick regardless of outcome — owner constraint, 2026-08-23 (issue body, verbatim): "ただし pull するたびに token 消費するのは問題".

`CronJobConfig`/`CronJob` gain `action` (default `"message"`, byte-identical to pre-#5209 behaviour): `"hook"` only fires the pre-existing `cron_fired` external-event hook on the job's host session — never pushes a message itself. A `hooks.yaml` `on: cron_fired` entry's own `push_when` (already-existing `exec_capture`/`template_push` machinery, #2069/#1800) then decides whether anything happens next; an unsatisfied `push_when` costs zero LLM turns.

## Design, and a genuine pre-implementation catch

Per architect's frozen brief (`issuecomment-5440084723`): `to` (the host agent whose `cron:<job_name>` Session `cron_fired` fires on) remains **required for EVERY job regardless of `action`** — `resolve_cron_session`/`dispatch_cron_fired` have no session-less dispatch path. Only `message` is action-specific: required for `"message"`, forbidden for `"hook"` (a hook job never has text to deliver).

**Before writing any code**, I asked architect a precise question citing the exact conflict: the brief's original wording ("`action: hook` — `to`/`message` は書いたらエラー") would have forbidden `to` too, but `resolve_cron_session(registry, agent_name, job_name)` / `dispatch_cron_fired(session, job_name, to)` both hard-require an agent identity — there is no code path that resolves a session without one. Architect confirmed this was their own error and corrected the brief (`issuecomment-5440197832`) before any implementation started: only `message` is forbidden; `to` stays required, now understood as carrying two roles (host / message-recipient) that action=hook only needs one of.

## Changes

- `config/infra.py`: `CronJobConfig.action`; split the old combined to+message validation into per-action checks (`to` always required; `message` required only for `"message"`, forbidden for `"hook"`); unknown `action` values rejected at load.
- `runtime/cron/scheduler.py`: `CronJob.action` + `is_hook_based()`.
- `runtime/cron/runners.py`: `build_default_runner` gains a `hook_only_dispatcher` collaborator; the runner branches on `job.is_hook_based()` before the pre-existing `is_message_based()` check.
- `runtime/cron/routing.py` + `hooks/ingress.py`: `dispatch_cron_fired`/`CronIngressAdapter.to_event` thread `action` through to the hook payload.
- `hooks/schema_registry.py`: `cron_fired` schema gains `"action"` (the only schema change needed — `"to"` itself needed no change, architect's brief originally thought it did and self-corrected that too).
- `interfaces/web/server.py`: `_make_cron_runner` gains `_hook_only_dispatcher` (resolve + fire `cron_fired`, no inbox push) alongside the existing `_inbox_pusher`, sharing a new `_resolve_and_fire` helper.
- `interfaces/cli/commands/cron.py`: threads `action` through `CronJobConfig` → `CronJob`.
- docs: `cron` block (`reyn-yaml.md`) + `cron_fired` hook (`hooks.md`) updated in the same PR (CLAUDE.md doc-drift hard rule — both previously described `cron_fired` as firing only for "a message-based cron job").

## Verification

26 new/updated tests, real `Session`/`AgentRegistry`/`HookDispatcher` throughout, no mocks:

**Config-layer (21, `tests/config/test_fp0009_b_cron_config.py`)** — including the exact 2 acceptance witnesses the brief named:
- `action="hook"` + `message` set → config error (④)
- `action="hook"` without `to` → config error (⑤, "host が要ることの witness")
- action defaults to `"message"`, unknown `action` rejected, `action="hook"` needs only `to`

**Runtime (5, new `tests/runtime/test_5209_cron_action_hook.py`)**:
- `push_when=false` → **zero turns** — THE core #5209 proof
- `push_when=true` → a turn IS triggered — positive control (proves ① is a real gate finding zero, not a dead mechanism)
- `action="message"` (default) — regression, byte-identical to pre-#5209
- no `hook_only_dispatcher` injected → fails loud ("error"), not silent
- the `action` field reaches the real dispatched `cron_fired` hook payload (a `matcher: {action: "hook"}` entry fires)

The zero-turns witness waits on the **public** `pending_dispatch_count` snapshot (`reyn.hooks.external_fire`, #2620's own "has the fire-and-forget hook dispatch settled" read) rather than a fixed `sleep` — the negative outcome (nothing in the inbox) is proven only after the async hook dispatch has genuinely finished, not merely unraced by luck.

**Real strip-falsify** (each restored green after):
1. Disabled the `is_hook_based()` branch in the runner → 3/5 new runtime tests went RED with the exact expected failure mode (jobs fell through to the message-based path and errored for lacking a message).
2. Disabled the `action="hook"` message-forbidden check → the config test went RED (`DID NOT RAISE`).
3. Disabled the `action="hook"` to-required check → both to-requirement config tests went RED.

**Full sweep**: `tests/config` + `tests/runtime` + `tests/interfaces` + `tests/hooks` (`-k "not slow"`): **4666 passed, 15 skipped** (pre-existing, unrelated — optional-dependency extras), no regression.

**Local gates**: ruff, `test_tier_audit --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `mkdocs build --strict`, `check_doc_anchors.py`, `check_retired_config_keys_denylist.py` — all green.

## Test plan

- [x] Scoped pytest (26/26 new/updated) — done
- [x] Broader sweep (4666 passed, tests/config+runtime+interfaces+hooks) — done
- [x] Real strip-falsify ×3 (before/after RED/green) — done
- [x] Local gates (11/11) — done
- [x] (skipped — no UI/behavior change) Visual

Cannot self-merge: touches `tests/`, needs a TESTS-READ note per PR-workflow rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
