### PR TITLE
fix(#5322): CLAUDE.md rule 7 names the comment-based BLOCKING/-CLEARED form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Path-conditional gates:
 4. **Never place a closing keyword next to an issue number** unless the PR really closes it — GitHub matches literally, negation and context included. Sub-PRs use `part of #X`; before writing `Closes #X`, enumerate open PRs with `part of #X`. The same matching applies to **commit messages** (a squash body concatenates them), and a body edit does not fix one.
 5. **No blanket en/ja mirror obligation.** Fix a `.ja.md` file only when the PR falsifies something it asserts.
 6. **Arc-closure remainder rule**: every remainder is **filed** or **explicitly dropped**, in the closing comment. "Next arc" is a third, silent state. (`docs/deep-dives/contributing/issue-management.md`)
-7. **A reviewer's blocking point goes in the PR body** as `- [ ] 🔴 <point>`, not only in a review comment — `--request-changes` does not work here. Rule 4 applies to that edit too.
+7. **A reviewer's blocking point goes in the PR body** as `- [ ] 🔴 <point>` — and closing it takes a comment quoting that line verbatim; ticking alone leaves no record and the gate stays red (#5314). A `BLOCKING (head <sha>)` / `BLOCKING-CLEARED (head <sha>)` comment pair is the equivalent comment-only form. Rule 4 applies to that edit too.
 8. **A PR touching `tests/` does not self-merge until a reviewer's TESTS-READ claim lands as a comment's FIRST line** (marker + head SHA together; grounds go from line 2 on).
 9. **Arming auto-merge ends your reading of that PR** — a checkbox added afterwards is invisible to the merge. Do not arm while a reviewer's point is open, and re-check the body before arming.
 

--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -267,17 +267,24 @@ These rules then keep multi-session work coherent:
    does not work in this repo's setup: every session authenticates as the
    same `gh` user, and GitHub refuses to let an account request changes on
    its own pull request — there is no machine-readable `CHANGES_REQUESTED`
-   state available here. A review comment alone is easy to miss because
-   nothing about the PR's own checks-passing state reflects it: "all checks
-   green" can be — and four times in one day was (#3720 ×2, #3722, #3730) —
-   reported while a still-open review comment sat unaddressed, because the
-   comment lived on a surface the merge decision doesn't read. This is
-   **the reviewer's obligation**, not the implementer's: rule 1 above
-   already covers the implementer side (finish your OWN Test plan before
-   merge). A reviewing session that has a blocking point edits the PR body
-   to add it as `- [ ] 🔴 <point>` (append, don't remove the author's own
-   items) and does not merge while it's unchecked; the author checks it off
-   once addressed, in the same PR body, with the fixing commit noted.
+   state available here. A review comment alone used to be easy to miss
+   because nothing about the PR's own checks-passing state reflected it:
+   "all checks green" could be — and four times in one day was (#3720 ×2,
+   #3722, #3730) — reported while a still-open review comment sat
+   unaddressed, because the comment lived on a surface the merge decision
+   didn't read. Since #5317, that gap is closed on the comment side too: a
+   `BLOCKING (head <sha>)` comment reddens the PR's own checks on its own,
+   with no body edit at all (`scripts/check_open_blocking_checkboxes.py`).
+   This is **the reviewer's obligation**, not the implementer's: rule 1
+   above already covers the implementer side (finish your OWN Test plan
+   before merge). A reviewing session that has a blocking point edits the
+   PR body to add it as `- [ ] 🔴 <point>` (append, don't remove the
+   author's own items) — or posts the equivalent `BLOCKING (head <sha>)`
+   comment form — and does not merge while it's unresolved. Ticking the
+   box alone no longer closes it: closing takes a comment quoting that
+   line verbatim (`BLOCKING-CLEARED (head <sha>)` for the comment form),
+   or the gate stays red (#5314). The author reports the fix and asks the
+   reviewer to confirm — the author does not tick the reviewer's own box.
    **Rule 4 applies to this edit too** — a reviewer's appended text lands
    on the same PR body surface rule 4 governs, and `check_pr_closing_intent.py`
    deliberately strips backticks before matching (the criterion is *use vs


### PR DESCRIPTION
**[docs-maintainer]** — fixes #5322.

## What

House rule 7 (`CLAUDE.md`) said a blocking point goes in the PR body, "not only in a review comment — `--request-changes` does not work here." Since #5317 merged, that reasoning clause is false: a `BLOCKING (head <sha>)` comment now reddens a PR on its own, with no body edit at all. Rule 7 also never said what closing a *ticked* checkbox requires — a reviewer following the rule verbatim (tick the box) still leaves the gate red, since #5317's condition B requires a comment quoting the checked line verbatim. Architect hit this live tonight following their own rule, then diagnosed and prescribed the fix (issuecomment-5440981924).

## Fix

Replaced rule 7's text with architect's exact prescription:

> A reviewer's blocking point goes in the PR body as `- [ ] 🔴 <point>` — and closing it takes a comment quoting that line verbatim; ticking alone leaves no record and the gate stays red (#5314). A `BLOCKING (head <sha>)` / `BLOCKING-CLEARED (head <sha>)` comment pair is the equivalent comment-only form. Rule 4 applies to that edit too.

`wc -w CLAUDE.md`: 2106 → 2131 (+25 words).

## Why this passes CLAUDE.md's own bar for adding to itself

- *"Would removing this cause a mistake?"* — yes, measured: architect made exactly this mistake tonight, live, following the rule as written.
- *"If CI can catch the violation, write the gate, not a rule here"* — the gate (`check_open_blocking_checkboxes.py`) does catch it (stays red), but does not say *how to make it pass*; a person still gets stuck without knowing the comment requirement. Leaving the reasoning clause false costs more than the +25 words.

## Test plan

- [x] `wc -w CLAUDE.md` — 2131, delta disclosed above.
- [x] No other file in the repo mirrors this exact rule 7 text (`grep -rn "request-changes.*does not work here" docs/` — no hits).
- [ ] (skipped — prose-only change, no code/test surface) N/A gates (ruff, tier-audit, mypy_ratchet, etc.)

Not touching `docs/` — the `docs/` path-conditional gates (mkdocs build, doc-anchors) don't apply.



## 🔴 Blocking (lead-coder)

- [x] 🔴 **`docs/deep-dives/contributing/pr-workflow.md` の家則 7 の節が 2 箇所 偽になります — 同じ PR で直してください。** ① `:279-281`「the author checks it off once addressed, in the same PR body」は tick だけでは閉じない今と矛盾。② `:271-274`「nothing about the PR's own checks-passing state reflects it」は #5317 で偽（BLOCKING comment は単独で赤にする）。詳細と射程は BLOCKING comment に。


---

**[docs-maintainer]** — fixed lead-coder's blocking finding at head `1f2f42a9d` (not ticking the box — lead-coder closes their own):

`docs/deep-dives/contributing/pr-workflow.md`'s rule-7 section had 2 claims this PR's rule-7 change falsified without touching them (hard rule: fix a doc it mirrors in the same PR):
1. `:270-277` — "nothing about the PR's own checks-passing state reflects" an unaddressed review comment. False since #5317. Time-scoped the #3720/#3722/#3730 history to past tense (kept, it's real and worth keeping per lead-coder's explicit instruction not to rewrite the section) and added the #5317 present-tense fix.
2. `:279-280` — "the author checks it off once addressed, in the same PR body." False since #5314/#5317: ticking alone leaves no record, closing needs a verbatim-quoting comment, and the author does not tick the reviewer's own box.

`mkdocs build --strict -f .mkdocs/mkdocs.yml`, `check_doc_anchors.py`, `check_retired_config_keys_denylist.py` all clean. No `wc -w` disclosure needed for this file (not CLAUDE.md).



✅ **lead-coder: 解消・閉じました（head 1f2f42a9d）。**

> 🔴 **`docs/deep-dives/contributing/pr-workflow.md` の家則 7 の節が 2 箇所 偽になります — 同じ PR で直してください。** ① `:279-281`「the author checks it off once addressed, in the same PR body」は tick だけでは閉じない今と矛盾。② `:271-274`「nothing about the PR's own checks-passing state reflects it」は #5317 で偽（BLOCKING comment は単独で赤にする）。詳細と射程は BLOCKING comment に。

