### PR TITLE
fix(#5138): open-blocking-checkbox gate re-runs on issue_comment, reports via commit status

### DIFF
--- a/.github/workflows/check-open-blocking-checkboxes.yml
+++ b/.github/workflows/check-open-blocking-checkboxes.yml
@@ -11,22 +11,60 @@ name: Open blocking-checkbox check
 # check-pr-closing-intent.yml is one: the body is edited *after* opening —
 # a reviewer adds the box, the author ticks it — and `edited` is not one of
 # the default pull_request event types.
+#
+# #5138 (this workflow's own instance, discovered via #5314/#5317): since
+# #5317, this gate also reads COMMENTS (a `BLOCKING (head <sha>)` /
+# `BLOCKING-CLEARED (head <sha>)` pair, and the verbatim-quoting comment a
+# checked `- [x] 🔴` line requires) — but `pull_request` does not fire on a
+# new comment. Measured on #5324 (2026-08-27): a reviewer posted the
+# resolving comment, the gate script itself reported `OK` when run by hand,
+# and the check stayed red until someone noticed and re-ran the workflow.
+# `check-tests-read-names-its-tree.yml` already solved the identical shape
+# for TESTS-READ notes (#5138, same issue number — this workflow shares its
+# root cause). This workflow now mirrors that one's shape exactly:
+# `issue_comment` triggers a re-check, and the verdict is reported via a
+# GitHub commit STATUS posted to the PR's own head sha (resolved via `gh pr
+# view`, which works the same regardless of which event triggered this
+# run) — never a check run's own pass/fail, because a check run triggered
+# by `issue_comment` attaches to the DEFAULT BRANCH's sha, not the PR's,
+# and would never appear on the PR's own rollup (measured 4/4 on the
+# sibling workflow's own #5127/#5128/#5132/#5136 before that fix landed).
+# `pending` is posted BEFORE the script runs and `success`/`failure` AFTER
+# — a job that dies mid-run leaves `pending` standing (blocks merge)
+# rather than going silent.
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  issue_comment:
+    types: [created, edited]
 
 permissions:
   contents: read
   pull-requests: read
+  statuses: write
+
+env:
+  # Single fixed context so both triggers report to the SAME status slot —
+  # a branch protection rule names this string once.
+  STATUS_CONTEXT: open-blocking-checkbox
 
 jobs:
   open-blocking-checkbox:
     name: no open blocking checkbox in the PR body
+    # `issue_comment` fires for plain issues too; only pull requests have a
+    # `pull_request` key on the issue payload.
+    if: github.event_name == 'pull_request' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
+      # No checkout of the PR itself — only the script, from the base
+      # branch (no `ref:`). The `issue_comment` event's default checkout
+      # target is the DEFAULT BRANCH, which is exactly what's wanted here;
+      # nothing here ever executes a contributor's tree.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -34,9 +72,59 @@ jobs:
           python-version: "3.11"
           cache: pip
 
-      # scripts/check_open_blocking_checkboxes.py is stdlib-only.
-      - name: Check the PR body for an open blocking checkbox
+      - name: Resolve this PR's number and head sha
+        id: pr
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          python scripts/check_open_blocking_checkboxes.py --pr "${{ github.event.pull_request.number }}"
+          # `pull_request` events carry the number on .pull_request; an
+          # `issue_comment` on a PR carries it on .issue. Either way the
+          # HEAD SHA has to come from `gh pr view` — it is not on the
+          # `issue_comment` payload at all, and posting a status needs it.
+          NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          SHA="$(gh pr view "$NUMBER" --json headRefOid -q .headRefOid)"
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Post pending status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.sha }}" \
+            -f state=pending \
+            -f context="$STATUS_CONTEXT" \
+            -f description="Checking the PR body and comments for an open blocking point..."
+
+      # scripts/check_open_blocking_checkboxes.py is stdlib-only.
+      # `continue-on-error: true` keeps a script failure from also turning
+      # this step, and with it the job, red: the commit status posted below
+      # is the only channel that carries this verdict.
+      - name: Check the PR body and comments for an open blocking point
+        id: check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_open_blocking_checkboxes.py --pr "${{ steps.pr.outputs.number }}"
+
+      # `if: always()` is the whole point: this step must run whether the
+      # check step above passed, failed, or (if the runner itself dies
+      # first) never ran at all — in that last case this step ALSO never
+      # runs, and the status posted above stays `pending` rather than
+      # silently vanishing.
+      - name: Post final status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ steps.check.outcome }}" = "success" ]; then
+            STATE=success
+            DESC="No open blocking point in the PR body or comments."
+          else
+            STATE=failure
+            DESC="Open blocking point found -- see the job log."
+          fi
+          gh api "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.sha }}" \
+            -f state="$STATE" \
+            -f context="$STATUS_CONTEXT" \
+            -f description="$DESC"


### PR DESCRIPTION
**[docs-maintainer]** — fixes #5138.

## What

`check-open-blocking-checkboxes.yml` (#5135, extended by #5314/#5317 to read comments) only triggered on `pull_request: [opened, edited, synchronize, reopened]`. Since #5317 the gate script also reads PR comments (a `BLOCKING (head <sha>)` / `BLOCKING-CLEARED (head <sha>)` pair, and the verbatim-quoting comment a checked `- [x] 🔴` line requires) — but `pull_request` never fires on a new comment. Measured live on #5324 (2026-08-27): a reviewer posted the resolving comment, the script itself reported `OK` when run by hand, and the check's own last `pull_request` run stayed red until someone noticed and manually re-ran the workflow.

`check-tests-read-names-its-tree.yml` already solved the identical shape (same root issue, #5138, filed for that gate first). This PR mirrors it exactly, per lead-coder's ruling — zero design round-trips, this is a copy of an already-landed pattern:

- Added `issue_comment: [created, edited]` trigger, with the `github.event.issue.pull_request` guard (`issue_comment` fires on plain issues too — sibling `:56`-ish).
- Added `statuses: write` permission.
- Reports via a GitHub commit **status** posted to the PR's own head sha (resolved via `gh pr view`, not the triggering event's own sha) — never a check run's pass/fail, because an `issue_comment` check run attaches to the *default branch's* sha and would never reach the PR's own rollup (sibling's own measured history, #5127/#5128/#5132/#5136).
- `pending` posted before the script runs, `success`/`failure` after — a job that dies mid-run leaves `pending` standing (still blocks a human reading it) rather than going silent.
- Kept the `pull_request` trigger as-is; kept the checkout without a `ref:` (only the script is needed, from the base branch — this was already the safe shape, unlike the sibling's own earlier `issue_comment`-checks-out-the-PR-tree mistake, which this workflow never had).

## Why switching check-run → commit-status doesn't regress enforcement

Checked directly: `gh api repos/tya5/reyn/branches/main/protection/required_status_checks -q .contexts` → `["pytest (Python 3.11)","pytest (Python 3.12)","ruff","test-tier audit","docs build (strict)"]`. Neither the old check-run name (`no open blocking checkbox in the PR body`) nor the sibling's own status context (`tests-read-names-its-tree`) is in that list — this gate was already advisory-only (a signal a human reads, same category as #5135's original body-only form), not a merge-blocking required check. Switching reporting channel removes no existing enforcement. (This is the exact class of infra change I flagged and declined to make unilaterally on #5317's PR — deciding here only because lead-coder ruled it directly and I verified the required-checks list myself before proceeding.)

## Acceptance (lead-coder's explicit condition) — structural constraint discovered

Attempted live verification on this PR itself before reporting anything: injected a temporary `- [x] 🔴` test line into this PR's body (turned the gate red via `pull_request: edited`, confirmed), then posted a verbatim-quoting comment with no push. Result: **no `issue_comment` run was ever created** — checked `gh api .../actions/workflows/check-open-blocking-checkboxes.yml/runs` directly; the workflow's entire run history shows zero `issue_comment` events, on this PR or any other.

Root cause (GitHub Actions, not this implementation): for events outside the `pull_request`/`pull_request_target` family, GitHub evaluates the workflow file as it exists **on the default branch**, never the PR branch's own version. A newly-added `issue_comment` trigger structurally cannot fire on the PR that introduces it — there is no way to pre-merge-verify this class of change on itself. (The sibling workflow could not have been live-verified pre-merge either, for the same reason — its own PR history doesn't show one.)

Removed the temporary test line from this PR's body. Verification now has to happen **after merge**, on a subsequent PR — I'll do that once this lands and report back before closing #5138.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] Pushed successfully over this session's HTTPS remote with `workflow` scope present (checked `gh auth status` before starting, per lead-coder's instruction — no push rejection).
- [x] Verified `required_status_checks` does not include either the old or new reporting channel's name (above).
- [x] Live pre-merge verification attempted and found structurally impossible (GitHub evaluates non-pull_request-family triggers from the default branch) — disclosed above; post-merge verification still owed before closing #5138.
- [ ] (skipped — CI-infra-only change, no code/test surface) N/A gates (ruff, tier-audit, mypy_ratchet, etc.)

Not touching `docs/` — the `docs/` path-conditional gates don't apply.



