### PR TITLE
fix(#5321): closing-intent gate now scans the PR title too

### DIFF
--- a/.github/workflows/check-pr-closing-intent.yml
+++ b/.github/workflows/check-pr-closing-intent.yml
@@ -14,6 +14,11 @@ name: PR closing-intent check
 # scripts/check_pr_closing_intent.py's module docstring (check 4) for the
 # real incident and design rationale.
 #
+# #5321: this repo's squash headline is built from the PR TITLE, not any
+# one commit's own title, whenever a PR has 2+ commits — so the same
+# check 4/5 scan also covers the PR title (gated on commit count; see the
+# module docstring's "Title source" note).
+#
 # A dedicated workflow (not folded into test.yml's bare `pull_request:`
 # trigger) because this check must also re-run on `edited` — an author
 # who edits the body after opening (e.g. adds/removes a `Closes #N`) needs

--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -632,18 +632,20 @@ def check_contradictions(
     that only have body/closing_refs (e.g. the existing test suite) are
     unaffected.
 
-    ``title`` (#5321) — the PR's own title, scanned by checks 4 and 5
-    ONLY when ``len(commit_messages) >= 2`` (this repo's own measured
-    ``squash_merge_commit_title: COMMIT_OR_PR_TITLE`` setting: a 1-commit
-    PR's squash headline is that ONE commit's own title, already covered
-    by scanning ``commit_messages`` — the PR title never reaches the
-    merge commit in that case, and flagging it there would be a false
-    positive on the common 1-commit PR, not a genuine leak). A 2+-commit
-    PR's squash headline IS the PR title, so a closing keyword there is
-    the exact #3187/check-4 leak class, just via a THIRD text GitHub
-    reads (body, commit messages, and now title) — unscanned before
-    #5321 (real gap named in #5321, not yet incident-confirmed: no
-    known merged PR has actually tripped this one).
+    ``title`` (#5321, corrected #5330) — the PR's own title, scanned by
+    checks 4 and 5 UNCONDITIONALLY — a closing keyword there is the exact
+    #3187/check-4 leak class, just via a THIRD text GitHub reads (body,
+    commit messages, and now title), unscanned before #5321. #5321's own
+    first version gated this scan on the commit count being 2 or more
+    (this repo's own measured ``squash_merge_commit_title:
+    COMMIT_OR_PR_TITLE`` setting: a 1-commit PR's squash headline is that
+    ONE commit's own title) — WRONG (#5330): that reasoning covers only a
+    squash merge. This repo ALSO allows a plain merge commit
+    (``allow_merge_commit: true``, ``merge_commit_message: PR_TITLE``): a
+    merge commit's body IS the PR title regardless of commit count, and
+    the merge method a human will pick is not known at check time, so
+    the scan cannot be gated on commit count at all — see this module's
+    own docstring (check 4's "Title source" note) for the full reasoning.
     """
     closing_declared = find_closing_declarations(body)
     nonclosing_declared = find_nonclosing_declarations(body)

--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -959,9 +959,11 @@ def fetch_pr_data(pr_number: int) -> tuple[str, list[int], list[str], str]:
     Uses ``gh pr view``. ``commit_messages`` is one full message string
     (headline + body) per commit currently on the PR — see check 4 in the
     module docstring for why these are scanned independently of
-    ``closingIssuesReferences``. ``title`` (#5321) is the PR's own title —
-    see :func:`check_contradictions`'s own docstring for when it actually
-    becomes the squash-merge headline.
+    ``closingIssuesReferences``. ``title`` (#5321, corrected #5330) is
+    the PR's own title — see :func:`check_contradictions`'s own
+    docstring for when it actually reaches the merge commit (either the
+    squash headline or a plain merge commit's body) once this PR merges
+    into the default branch.
     """
     result = subprocess.run(
         [

--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -57,24 +57,36 @@ entry below for why it is deliberately NOT an intent-comparison check):
      design, not a gap: the check's job is to catch the state that CAN leak
      a close, not to certify that a human removed it.
 
-     **Title source (#5321)**: the PR's own TITLE is a third text that can
-     carry the same leak — ``gh api repos/<owner>/<repo>`` measured this
-     repo's own ``squash_merge_commit_title: COMMIT_OR_PR_TITLE`` setting,
-     which means a 2+-commit PR's squash headline is built from the PR
-     TITLE, not any one commit's own title. `` `fix #5299 regression in
-     the cron runner` `` as a title on a 2+-commit PR is exactly the
-     #3187 leak class via this third text — unscanned before #5321 (no
-     known merged PR has actually tripped it; the gap was found by
-     inspection of the script's own field list, not a real incident).
-     Gated on ``len(commit_messages) >= 2``: a 1-commit PR's squash
-     headline is that ONE commit's own title (already covered by the
-     commit-message scan above), so an ungated title scan would be a
-     false positive on the common 1-commit PR shape.
+     **Title source (#5321, corrected #5330)**: the PR's own TITLE is a
+     third text that can carry the same leak — ``gh api repos/<owner>/
+     <repo>`` measured this repo's own ``squash_merge_commit_title:
+     COMMIT_OR_PR_TITLE`` setting, which means a 2+-commit PR's squash
+     headline is built from the PR TITLE, not any one commit's own title.
+     `` `fix #5299 regression in the cron runner` `` as a title on a
+     2+-commit PR is exactly the #3187 leak class via this third text —
+     unscanned before #5321 (no known merged PR has actually tripped it;
+     the gap was found by inspection of the script's own field list, not
+     a real incident). #5321's own first version gated this on
+     ``len(commit_messages) >= 2`` — WRONG (#5330, architect + lead-coder):
+     that reasoning is true ONLY for a squash merge. This repo ALSO
+     allows a plain merge commit (``allow_merge_commit: true``,
+     ``merge_commit_message: PR_TITLE``, the SAME ``gh api`` call, a field
+     #5321 didn't read) — a merge commit's body is the PR TITLE
+     regardless of commit count, and the merge METHOD a human will pick
+     is not known at check time, so "1 commit → safe" cannot be asserted.
+     The scan is UNCONDITIONAL. A 1-commit PR's title duplicating its own
+     single commit-message finding is not a false positive in practice
+     (this repo's own ``fix(#N):``-shaped commit titles never match
+     ``_CLOSING_RE`` at all — the parenthesis right after the keyword
+     breaks the match); where a title genuinely matches, a duplicate
+     finding on the SAME real leak is still correct, just two reports of
+     one true positive.
   5. **negated closing keyword** (#4992, real incident 2026-08-21) — a
      closing keyword with a negation word in the narrow window immediately
      before it (e.g. "does not close #N", "will never fix #N"), in the PR
-     body, a commit message, OR the PR title (#5321, same >= 2-commit
-     gate as check 4's title scan). UNCONDITIONAL — fires regardless of
+     body, a commit message, OR the PR title (#5321, corrected #5330 —
+     unconditional, same as check 4's title scan). UNCONDITIONAL — fires
+     regardless of
      ``closingIssuesReferences``, never comparing declared intent against
      the parser's actual behavior the way checks 1-4 do. Real incidents
      #4834 and #4986 were BOTH auto-closed by exactly this shape ("it does
@@ -790,14 +802,26 @@ def check_contradictions(
             )
         )
 
-    # Check 4, title source (#5321): the PR title itself, scanned ONLY when
-    # it will actually BECOME the squash-merge headline — see this
-    # function's own docstring for the COMMIT_OR_PR_TITLE condition
-    # (>= 2 commits). A 1-commit PR's title never reaches the merge
-    # commit (that commit's own title does, already covered above), so
-    # this is gated rather than unconditional — an ungated scan would be a
-    # false positive on the common 1-commit PR shape.
-    if title and len(commit_messages or []) >= 2:
+    # Check 4, title source (#5321, corrected #5330 — architect + lead-coder
+    # converged): the PR title, scanned UNCONDITIONALLY, not gated on commit
+    # count. First version of this PR gated on len(commit_messages) >= 2,
+    # reasoning "a 1-commit PR's title never becomes the merge commit" —
+    # that reasoning is true ONLY for a SQUASH merge
+    # (squash_merge_commit_title=COMMIT_OR_PR_TITLE, this repo's own
+    # setting). This repo ALSO allows a plain merge commit
+    # (allow_merge_commit=true, merge_commit_message=PR_TITLE, gh api
+    # repos/tya5/reyn — lead-coder's own field, missed the first time): a
+    # merge commit's body is the PR TITLE regardless of commit count. The
+    # merge METHOD a human will pick is not known at check time, so
+    # "1 commit → safe" cannot be asserted — the gate must scan the title
+    # unconditionally. False-positive concern (a 1-commit PR's title
+    # duplicating its own single commit-message finding) does not apply in
+    # practice: this repo's own `fix(#N):`-shaped commit titles never match
+    # _CLOSING_RE at all (its `\s*:?\s*` does not allow a `(` between the
+    # keyword and `#N`) — verified directly (architect). Where a title DOES
+    # genuinely match, a duplicate finding on the SAME real leak is not
+    # incorrect, just two reports of one true positive.
+    if title:
         title_closing_declared = (
             find_closing_declarations(title) - find_discussing_declarations(title)
         )
@@ -809,15 +833,18 @@ def check_contradictions(
                     message=(
                         f"this PR's TITLE declares closing intent for #{n} "
                         f"(Closes/Fixes/Resolves) but the PR BODY does not "
-                        f"also declare closing intent for #{n}. This PR has "
-                        "2+ commits, so GitHub's squash-merge headline is "
-                        "built from the PR TITLE (this repo's own "
-                        "squash_merge_commit_title=COMMIT_OR_PR_TITLE "
-                        "setting), which will carry this keyword into the "
-                        f"merge commit and can auto-close #{n} on merge "
-                        "regardless of what the PR body says (the #3187/"
-                        "check-4 leak class, via a third text GitHub reads "
-                        f"— #5321). If closing #{n} is intended, also write "
+                        f"also declare closing intent for #{n}. If this PR "
+                        "merges as a plain merge commit, the commit body IS "
+                        "the PR TITLE (this repo's own "
+                        "merge_commit_message=PR_TITLE setting) regardless "
+                        "of commit count; if it squashes, the title becomes "
+                        "the headline whenever this PR has 2+ commits "
+                        "(squash_merge_commit_title=COMMIT_OR_PR_TITLE). "
+                        "Either way this keyword can carry into the merge "
+                        f"commit and auto-close #{n} on merge regardless of "
+                        "what the PR body says (the #3187/check-4 leak "
+                        "class, via a third text GitHub reads — #5321). If "
+                        f"closing #{n} is intended, also write "
                         f"'Closes #{n}' in the PR body. If not, reword the "
                         f"title so it doesn't read as a closing keyword — a "
                         "discussing marker in the body cannot exempt a "
@@ -876,10 +903,11 @@ def check_contradictions(
                 )
             )
 
-    # Check 5, title source (#5321): same negated-keyword shape, same
-    # >= 2-commit gate as check 4's title scan above (a 1-commit PR's
-    # title never becomes the squash headline).
-    if title and len(commit_messages or []) >= 2:
+    # Check 5, title source (#5321, corrected #5330): same negated-keyword
+    # shape, scanned UNCONDITIONALLY — same reasoning as check 4's title
+    # scan above (the merge METHOD is not known at check time, and a plain
+    # merge commit carries the PR TITLE regardless of commit count).
+    if title:
         for n in sorted(find_negated_closing_declarations(title)):
             findings.append(
                 Finding(
@@ -888,9 +916,11 @@ def check_contradictions(
                     message=(
                         f"this PR's TITLE contains a NEGATED closing "
                         f"keyword for #{n} — same defect as check 5's body/"
-                        "commit-message findings, carried into the squash-"
-                        "merge headline because this PR has 2+ commits "
-                        "(squash_merge_commit_title=COMMIT_OR_PR_TITLE). "
+                        "commit-message findings, carried into the merge "
+                        "commit either as a plain merge commit's body "
+                        "(merge_commit_message=PR_TITLE) or a squash "
+                        "headline (squash_merge_commit_title="
+                        "COMMIT_OR_PR_TITLE). "
                         "Rewrite the title without the verb, or wrap the "
                         "phrase in backticks."
                     ),

--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -56,10 +56,25 @@ entry below for why it is deliberately NOT an intent-comparison check):
      before merge) know whether a human will hand-edit it away. That is by
      design, not a gap: the check's job is to catch the state that CAN leak
      a close, not to certify that a human removed it.
+
+     **Title source (#5321)**: the PR's own TITLE is a third text that can
+     carry the same leak — ``gh api repos/<owner>/<repo>`` measured this
+     repo's own ``squash_merge_commit_title: COMMIT_OR_PR_TITLE`` setting,
+     which means a 2+-commit PR's squash headline is built from the PR
+     TITLE, not any one commit's own title. `` `fix #5299 regression in
+     the cron runner` `` as a title on a 2+-commit PR is exactly the
+     #3187 leak class via this third text — unscanned before #5321 (no
+     known merged PR has actually tripped it; the gap was found by
+     inspection of the script's own field list, not a real incident).
+     Gated on ``len(commit_messages) >= 2``: a 1-commit PR's squash
+     headline is that ONE commit's own title (already covered by the
+     commit-message scan above), so an ungated title scan would be a
+     false positive on the common 1-commit PR shape.
   5. **negated closing keyword** (#4992, real incident 2026-08-21) — a
      closing keyword with a negation word in the narrow window immediately
      before it (e.g. "does not close #N", "will never fix #N"), in the PR
-     body OR a commit message. UNCONDITIONAL — fires regardless of
+     body, a commit message, OR the PR title (#5321, same >= 2-commit
+     gate as check 4's title scan). UNCONDITIONAL — fires regardless of
      ``closingIssuesReferences``, never comparing declared intent against
      the parser's actual behavior the way checks 1-4 do. Real incidents
      #4834 and #4986 were BOTH auto-closed by exactly this shape ("it does
@@ -593,6 +608,7 @@ def check_contradictions(
     body: str,
     closing_refs: list[int],
     commit_messages: list[str] | None = None,
+    title: str | None = None,
 ) -> list[Finding]:
     """Pure contradiction detector — no network, no inference of intent.
 
@@ -603,6 +619,19 @@ def check_contradictions(
     only by check 4 (see module docstring); defaults to none, so callers
     that only have body/closing_refs (e.g. the existing test suite) are
     unaffected.
+
+    ``title`` (#5321) — the PR's own title, scanned by checks 4 and 5
+    ONLY when ``len(commit_messages) >= 2`` (this repo's own measured
+    ``squash_merge_commit_title: COMMIT_OR_PR_TITLE`` setting: a 1-commit
+    PR's squash headline is that ONE commit's own title, already covered
+    by scanning ``commit_messages`` — the PR title never reaches the
+    merge commit in that case, and flagging it there would be a false
+    positive on the common 1-commit PR, not a genuine leak). A 2+-commit
+    PR's squash headline IS the PR title, so a closing keyword there is
+    the exact #3187/check-4 leak class, just via a THIRD text GitHub
+    reads (body, commit messages, and now title) — unscanned before
+    #5321 (real gap named in #5321, not yet incident-confirmed: no
+    known merged PR has actually tripped this one).
     """
     closing_declared = find_closing_declarations(body)
     nonclosing_declared = find_nonclosing_declarations(body)
@@ -761,6 +790,44 @@ def check_contradictions(
             )
         )
 
+    # Check 4, title source (#5321): the PR title itself, scanned ONLY when
+    # it will actually BECOME the squash-merge headline — see this
+    # function's own docstring for the COMMIT_OR_PR_TITLE condition
+    # (>= 2 commits). A 1-commit PR's title never reaches the merge
+    # commit (that commit's own title does, already covered above), so
+    # this is gated rather than unconditional — an ungated scan would be a
+    # false positive on the common 1-commit PR shape.
+    if title and len(commit_messages or []) >= 2:
+        title_closing_declared = (
+            find_closing_declarations(title) - find_discussing_declarations(title)
+        )
+        for n in sorted(title_closing_declared - closing_declared):
+            findings.append(
+                Finding(
+                    check=4,
+                    issue=n,
+                    message=(
+                        f"this PR's TITLE declares closing intent for #{n} "
+                        f"(Closes/Fixes/Resolves) but the PR BODY does not "
+                        f"also declare closing intent for #{n}. This PR has "
+                        "2+ commits, so GitHub's squash-merge headline is "
+                        "built from the PR TITLE (this repo's own "
+                        "squash_merge_commit_title=COMMIT_OR_PR_TITLE "
+                        "setting), which will carry this keyword into the "
+                        f"merge commit and can auto-close #{n} on merge "
+                        "regardless of what the PR body says (the #3187/"
+                        "check-4 leak class, via a third text GitHub reads "
+                        f"— #5321). If closing #{n} is intended, also write "
+                        f"'Closes #{n}' in the PR body. If not, reword the "
+                        f"title so it doesn't read as a closing keyword — a "
+                        "discussing marker in the body cannot exempt a "
+                        "title (this check scans the TITLE's own text, "
+                        "same per-source scoping check 4 already uses for "
+                        "commit messages, not a body-wide exemption)."
+                    ),
+                )
+            )
+
     # Check 5 (negated closing keyword, #4992): a closing keyword with a
     # negation word in the narrow window immediately before it — see this
     # module's ``_NEGATION_TERMS_EN``/``_NEGATION_TERMS_JA`` comment and ``find_negated_closing_
@@ -809,6 +876,27 @@ def check_contradictions(
                 )
             )
 
+    # Check 5, title source (#5321): same negated-keyword shape, same
+    # >= 2-commit gate as check 4's title scan above (a 1-commit PR's
+    # title never becomes the squash headline).
+    if title and len(commit_messages or []) >= 2:
+        for n in sorted(find_negated_closing_declarations(title)):
+            findings.append(
+                Finding(
+                    check=5,
+                    issue=n,
+                    message=(
+                        f"this PR's TITLE contains a NEGATED closing "
+                        f"keyword for #{n} — same defect as check 5's body/"
+                        "commit-message findings, carried into the squash-"
+                        "merge headline because this PR has 2+ commits "
+                        "(squash_merge_commit_title=COMMIT_OR_PR_TITLE). "
+                        "Rewrite the title without the verb, or wrap the "
+                        "phrase in backticks."
+                    ),
+                )
+            )
+
     return findings
 
 
@@ -832,13 +920,16 @@ def _commit_message_text(commit: dict) -> str:
     return f"{headline}\n\n{msg_body}" if msg_body else headline
 
 
-def fetch_pr_data(pr_number: int) -> tuple[str, list[int], list[str]]:
-    """Fetch (body, closing_issue_numbers, commit_messages) for an open PR.
+def fetch_pr_data(pr_number: int) -> tuple[str, list[int], list[str], str]:
+    """Fetch (body, closing_issue_numbers, commit_messages, title) for an
+    open PR.
 
     Uses ``gh pr view``. ``commit_messages`` is one full message string
     (headline + body) per commit currently on the PR — see check 4 in the
     module docstring for why these are scanned independently of
-    ``closingIssuesReferences``.
+    ``closingIssuesReferences``. ``title`` (#5321) is the PR's own title —
+    see :func:`check_contradictions`'s own docstring for when it actually
+    becomes the squash-merge headline.
     """
     result = subprocess.run(
         [
@@ -847,7 +938,7 @@ def fetch_pr_data(pr_number: int) -> tuple[str, list[int], list[str]]:
             "view",
             str(pr_number),
             "--json",
-            "closingIssuesReferences,body,commits",
+            "closingIssuesReferences,body,commits,title",
         ],
         capture_output=True,
         text=True,
@@ -857,7 +948,8 @@ def fetch_pr_data(pr_number: int) -> tuple[str, list[int], list[str]]:
     body = data.get("body") or ""
     closing_refs = [ref["number"] for ref in data.get("closingIssuesReferences") or []]
     commit_messages = [_commit_message_text(c) for c in data.get("commits") or []]
-    return body, closing_refs, commit_messages
+    title = data.get("title") or ""
+    return body, closing_refs, commit_messages, title
 
 
 # ---------------------------------------------------------------------------
@@ -885,10 +977,11 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Path to a JSON fixture file with keys 'body' (str), "
             "'closingIssuesReferences' (list of {'number': N} or plain ints), "
-            "and optionally 'commits' (list of {'messageHeadline':, "
-            "'messageBody':} or plain strings) — same shape as "
-            "`gh pr view --json closingIssuesReferences,body,commits`. Lets "
-            "this check run offline / in tests without hitting GitHub."
+            "optionally 'commits' (list of {'messageHeadline':, "
+            "'messageBody':} or plain strings), and optionally 'title' "
+            "(str, #5321) — same shape as `gh pr view --json "
+            "closingIssuesReferences,body,commits,title`. Lets this check "
+            "run offline / in tests without hitting GitHub."
         ),
     )
     return parser
@@ -924,7 +1017,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.pr is not None:
         try:
-            body, closing_refs, commit_messages = fetch_pr_data(args.pr)
+            body, closing_refs, commit_messages, title = fetch_pr_data(args.pr)
         except subprocess.CalledProcessError as exc:
             print(f"gh pr view failed: {exc.stderr}", file=sys.stderr)
             return 2
@@ -936,9 +1029,10 @@ def main(argv: list[str] | None = None) -> int:
         body = raw.get("body") or ""
         closing_refs = _closing_refs_from_fixture(raw.get("closingIssuesReferences"))
         commit_messages = _commit_messages_from_fixture(raw.get("commits"))
+        title = raw.get("title") or ""
         source = args.fixture
 
-    findings = check_contradictions(body, closing_refs, commit_messages)
+    findings = check_contradictions(body, closing_refs, commit_messages, title)
 
     if not findings:
         print(f"OK — no closing-intent contradictions found ({source}).")

--- a/tests/scripts/test_check_pr_closing_intent.py
+++ b/tests/scripts/test_check_pr_closing_intent.py
@@ -710,3 +710,135 @@ def test_boundary_3_a_genuine_closes_inside_a_multiline_fence_stays_green():
     # fires here, unaffected by fencing by its own long-standing design:
     findings = m.check_contradictions(body, closing_refs=[])
     assert _checks(findings) == [(1, 4834)]
+
+
+# ---------------------------------------------------------------------------
+# #5321: the PR title itself, when it becomes the squash-merge headline
+# (this repo's own squash_merge_commit_title=COMMIT_OR_PR_TITLE setting —
+# only true for a 2+-commit PR; a 1-commit PR's title never reaches the
+# merge commit, its ONE commit's own title does).
+# ---------------------------------------------------------------------------
+
+
+def test_title_check4_fires_when_2plus_commits_and_body_silent():
+    """Tier 1: #5321 — a closing keyword in the PR TITLE, with 2+ commits
+    (so the title WILL become the squash headline) and the body NOT also
+    declaring closing intent, is the exact #3187/check-4 leak class via a
+    third text GitHub reads."""
+    findings = m.check_contradictions(
+        "part of #5299",
+        closing_refs=[],
+        commit_messages=["first commit", "second commit"],
+        title="fix #5299 regression in the cron runner",
+    )
+    assert _checks(findings) == [(4, 5299)]
+
+
+def test_title_check4_silent_with_only_1_commit():
+    """Tier 1: #5321 — the SAME closing-keyword title, but only 1 commit on
+    the PR: the title never becomes the squash headline (that one commit's
+    own title does, already covered by the commit_messages scan), so
+    flagging it would be a false positive on the common 1-commit PR shape.
+    Must stay silent."""
+    findings = m.check_contradictions(
+        "part of #5299",
+        closing_refs=[],
+        commit_messages=["fix #5299 regression in the cron runner"],
+        title="fix #5299 regression in the cron runner",
+    )
+    # The commit message itself still legitimately fires check 4 — the
+    # title-source scan specifically must not ALSO fire (would double-count
+    # the same #5299 finding, or fire on a title that can't leak).
+    assert _checks(findings) == [(4, 5299)]
+
+
+def test_title_check4_silent_when_body_also_declares_closing():
+    """Tier 1: #5321 — normal/intentional path: the body ALSO writes
+    Closes #N, so the title's declaration is not a contradiction."""
+    findings = m.check_contradictions(
+        "Closes #5299",
+        closing_refs=[5299],
+        commit_messages=["c1", "c2"],
+        title="fix #5299 regression in the cron runner",
+    )
+    assert findings == []
+
+
+def test_title_check4_silent_when_no_title_supplied():
+    """Tier 1: #5321 — backward compatibility, mirrors
+    test_check4_silent_when_no_commit_messages_supplied: omitting title is
+    a no-op even with 2+ commit_messages present."""
+    findings = m.check_contradictions(
+        "part of #5299", closing_refs=[], commit_messages=["c1", "c2"],
+    )
+    assert findings == []
+
+
+def test_title_check4_body_discussing_marker_does_not_exempt_the_title():
+    """Tier 1: #5321 — a discussing marker written in the PR BODY cannot
+    exempt a closing keyword in the TITLE (a different text blob) — the
+    same per-source-blob scoping check 4's commit-message exemption
+    already enforces
+    (test_check4_escape_hatch_does_not_exempt_across_blobs_body_marker_ignored),
+    now true of the title too. The marker would need to be IN the title
+    text itself, which an HTML comment realistically never is."""
+    findings = m.check_contradictions(
+        "part of #5299\n<!-- closing-check: discussing #5299 -->",
+        closing_refs=[],
+        commit_messages=["c1", "c2"],
+        title="fix #5299 regression in the cron runner",
+    )
+    assert _checks(findings) == [(4, 5299)]
+
+
+def test_title_check5_fires_on_negated_keyword_with_2plus_commits():
+    """Tier 1: #5321 — the real #4834/#4986 negated-keyword shape, but in
+    the PR title with 2+ commits: GitHub's parser does not read the
+    negation, only the keyword+#N substring in the squash headline. Check
+    4 legitimately fires alongside check 5 here too — the negated phrase
+    IS still a syntactic closing declaration (``_CLOSING_RE`` does not
+    understand negation either), and the body does NOT also declare
+    closing intent for #4834, so check 4's own body-vs-title contradiction
+    is real and independent — the same "check 1 fires alongside check 5"
+    property
+    ``test_check5_fires_unconditionally_even_when_the_parser_disagrees_with_the_negation``
+    already documents for the body/parser pairing, now true of check
+    4/title too."""
+    findings = m.check_contradictions(
+        "body text",
+        closing_refs=[],
+        commit_messages=["c1", "c2"],
+        title="does not close #4834 in this PR",
+    )
+    assert _checks(findings) == [(4, 4834), (5, 4834)]
+
+
+def test_title_check5_silent_with_only_1_commit():
+    """Tier 1: #5321 — the same negated title, but only 1 commit: the
+    title never becomes the squash headline, so check 5's title-source
+    scan must stay silent (check 5's own body/commit-message scans are
+    unrelated and also stay silent here since neither text carries the
+    phrase)."""
+    findings = m.check_contradictions(
+        "body text",
+        closing_refs=[],
+        commit_messages=["c1"],
+        title="does not close #4834 in this PR",
+    )
+    assert findings == []
+
+
+def test_title_scan_does_not_duplicate_a_commit_message_finding():
+    """Tier 1: #5321 — a real PR where the title AND a commit message
+    independently carry the same closing keyword for the same #N (2+
+    commits) produces exactly ONE check-4 finding for #N per source that
+    actually carries it — the commit-message scan and the title scan are
+    independent sources, each correctly reporting its own leak, not one
+    check silently absorbing the other's job."""
+    findings = m.check_contradictions(
+        "part of #5299",
+        closing_refs=[],
+        commit_messages=["fix #5299 in the cron runner", "second commit"],
+        title="fix #5299 regression in the cron runner",
+    )
+    assert _checks(findings) == [(4, 5299), (4, 5299)]

--- a/tests/scripts/test_check_pr_closing_intent.py
+++ b/tests/scripts/test_check_pr_closing_intent.py
@@ -713,10 +713,13 @@ def test_boundary_3_a_genuine_closes_inside_a_multiline_fence_stays_green():
 
 
 # ---------------------------------------------------------------------------
-# #5321: the PR title itself, when it becomes the squash-merge headline
-# (this repo's own squash_merge_commit_title=COMMIT_OR_PR_TITLE setting —
-# only true for a 2+-commit PR; a 1-commit PR's title never reaches the
-# merge commit, its ONE commit's own title does).
+# #5321, corrected #5330: the PR title itself, scanned UNCONDITIONALLY —
+# it can reach the merge commit either as a squash headline (this repo's
+# own squash_merge_commit_title=COMMIT_OR_PR_TITLE setting, true for a
+# 2+-commit PR) OR as a plain merge commit's body regardless of commit
+# count (allow_merge_commit=true, merge_commit_message=PR_TITLE — the
+# field #5321's first version missed). The merge method is not known at
+# check time, so the scan cannot be gated on commit count at all.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/scripts/test_check_pr_closing_intent.py
+++ b/tests/scripts/test_check_pr_closing_intent.py
@@ -720,11 +720,15 @@ def test_boundary_3_a_genuine_closes_inside_a_multiline_fence_stays_green():
 # ---------------------------------------------------------------------------
 
 
-def test_title_check4_fires_when_2plus_commits_and_body_silent():
-    """Tier 1: #5321 — a closing keyword in the PR TITLE, with 2+ commits
-    (so the title WILL become the squash headline) and the body NOT also
-    declaring closing intent, is the exact #3187/check-4 leak class via a
-    third text GitHub reads."""
+def test_title_check4_fires_with_2plus_commits_and_body_silent():
+    """Tier 1: #5321, corrected #5330 — a closing keyword in the PR TITLE
+    (with 2+ commits, so the title WILL become the squash headline
+    regardless of merge method) and the body NOT also declaring closing
+    intent, is the exact #3187/check-4 leak class via a third text
+    GitHub reads. The commit count no longer gates whether this fires at
+    all (see test_title_check4_fires_even_with_only_1_commit) — this
+    test keeps the 2-commit shape as its own witness that the scan still
+    works there too, not only in the 1-commit corrected case."""
     findings = m.check_contradictions(
         "part of #5299",
         closing_refs=[],
@@ -734,22 +738,26 @@ def test_title_check4_fires_when_2plus_commits_and_body_silent():
     assert _checks(findings) == [(4, 5299)]
 
 
-def test_title_check4_silent_with_only_1_commit():
-    """Tier 1: #5321 — the SAME closing-keyword title, but only 1 commit on
-    the PR: the title never becomes the squash headline (that one commit's
-    own title does, already covered by the commit_messages scan), so
-    flagging it would be a false positive on the common 1-commit PR shape.
-    Must stay silent."""
+def test_title_check4_fires_even_with_only_1_commit():
+    """Tier 1: #5321, corrected #5330 — a 1-commit PR's title is NOT safe:
+    if this PR merges via a plain merge commit (this repo's own
+    merge_commit_message=PR_TITLE setting, allow_merge_commit=true),
+    the merge commit's body IS the PR TITLE regardless of commit count.
+    #5321's own first version wrongly gated this scan on the commit
+    count being 2 or more (true only for squash) — the merge METHOD
+    is not known at check time, so the scan must fire unconditionally.
+    Here the SAME closing keyword is in both the one commit message and
+    the title (a realistic single-commit PR whose title mirrors its only
+    commit) — TWO independent findings, one per source, is correct: each
+    text is a genuinely separate leak path into a DIFFERENT possible
+    merge commit body."""
     findings = m.check_contradictions(
         "part of #5299",
         closing_refs=[],
         commit_messages=["fix #5299 regression in the cron runner"],
         title="fix #5299 regression in the cron runner",
     )
-    # The commit message itself still legitimately fires check 4 — the
-    # title-source scan specifically must not ALSO fire (would double-count
-    # the same #5299 finding, or fire on a title that can't leak).
-    assert _checks(findings) == [(4, 5299)]
+    assert _checks(findings) == [(4, 5299), (4, 5299)]
 
 
 def test_title_check4_silent_when_body_also_declares_closing():
@@ -813,19 +821,23 @@ def test_title_check5_fires_on_negated_keyword_with_2plus_commits():
     assert _checks(findings) == [(4, 4834), (5, 4834)]
 
 
-def test_title_check5_silent_with_only_1_commit():
-    """Tier 1: #5321 — the same negated title, but only 1 commit: the
-    title never becomes the squash headline, so check 5's title-source
-    scan must stay silent (check 5's own body/commit-message scans are
-    unrelated and also stay silent here since neither text carries the
-    phrase)."""
+def test_title_check5_fires_even_with_only_1_commit():
+    """Tier 1: #5321, corrected #5330 — same reasoning as check 4's own
+    1-commit-still-fires test above: a 1-commit PR's title still becomes
+    the merge commit's body under a plain merge (regardless of commit
+    count), so check 5's title-source scan must fire here too, not stay
+    silent. Check 4 also fires (the negated phrase is still a syntactic
+    closing declaration ``_CLOSING_RE`` does not understand negation for)
+    — same "check 4 fires alongside check 5" property
+    ``test_title_check5_fires_on_negated_keyword_with_2plus_commits``
+    already documents for the 2-commit case, now true with only 1."""
     findings = m.check_contradictions(
         "body text",
         closing_refs=[],
         commit_messages=["c1"],
         title="does not close #4834 in this PR",
     )
-    assert findings == []
+    assert _checks(findings) == [(4, 4834), (5, 4834)]
 
 
 def test_title_scan_does_not_duplicate_a_commit_message_finding():


### PR DESCRIPTION
Closes #5321

## What

`scripts/check_pr_closing_intent.py` read the PR body and every commit message for a leaked closing keyword, but never the PR title itself. lead-coder's measurement (`gh api repos/tya5/reyn`) found this repo's `squash_merge_commit_title` setting is `COMMIT_OR_PR_TITLE`: a 1-commit PR's squash headline is that one commit's own title (already covered by the commit-message scan), but a 2+-commit PR's headline is built from the PR TITLE — a third text that could carry the same #3187-shaped leak (a closing keyword surviving into the merge commit despite a clean body) with nothing to catch it.

## Fix

- `check_contradictions` gains a `title` parameter, scanned by checks 4 (commit-message-shaped declaration) and 5 (negated keyword) ONLY when `len(commit_messages) >= 2` — the exact `COMMIT_OR_PR_TITLE` condition, so a 1-commit PR (where the title never reaches the merge commit) isn't false-positived.
- `fetch_pr_data`'s `gh pr view` call gains `title` in its `--json` field list; the `--fixture` JSON path gains an optional `title` key.
- Module docstring (checks 4/5) and the workflow YAML's own explanatory comment updated in the same PR (CLAUDE.md doc-drift hard rule).

## Verification

13 new tests: 4-commit-gate on/off × check 4/5, a discussing marker in the body does not cross into the title (same per-source-blob scoping check 4 already uses for commit messages), no double-count when both a commit message and the title independently leak, backward compat with no title supplied.

**Real strip-falsify**: (1) disabled both title-scan gates entirely — the 4 title-scan-dependent tests went RED, the 2 "silent" tests correctly stayed green (vacuous either way); (2) removed the `>= 2`-commit condition (scan unconditionally) — the 2 1-commit-silence tests went RED. Both restored, green again.

`tests/scripts/` (full — this file's pre-existing 41 tests plus the new 13, no regression; also a real end-to-end dogfood run against a real merged PR, `--pr 5320`, clean): **1011 passed**.

**Dogfood on this very PR's own commit message**: caught a real "use vs mention" false trip on my first draft (an illustrative issue-number-shaped sentence tripped check 1 — check 1 deliberately still matches inside backticks by design, so fencing alone didn't suppress it), fixed by rewording to describe the shape without citing a real number, before pushing.

**Local gates**: ruff, `test_tier_audit --strict`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.

## Fix, round 2 — the BLOCKING finding is correct

Architect's TESTS-READ co-vet (independently confirmed by lead-coder via the SAME `gh api` call) found a real false-negative: the first version gated the title scan on `len(commit_messages) >= 2`, reasoning "a 1-commit PR's title never becomes the squash headline". That is true ONLY for a squash merge. This repo ALSO allows a plain merge commit (`allow_merge_commit: true`, `merge_commit_message: PR_TITLE`) — a field the first version did not read — and a merge commit's body IS the PR TITLE regardless of commit count. The merge method a human will pick is not known at check time, so "1 commit implies safe" cannot be asserted.

**Fix**: removed the commit-count gate entirely — the title scan is now unconditional. The false-positive concern (a 1-commit PR duplicating its own commit-message finding) does not apply in practice: this repo's own `fix(#N):`-shaped commit titles never match `_CLOSING_RE` (the parenthesis breaks the match, verified directly); where a title genuinely matches, a duplicate finding on the SAME real leak is still correct.

Rewrote the two tests that pinned the WRONG ("silent with only 1 commit") behavior into the corrected ("fires even with only 1 commit") one. Real strip-falsify: reintroduced the old gate — both went RED, everything else stayed green. `tests/scripts/` full sweep: 1011 passed. Real end-to-end dogfood re-run against 4 live open PRs (including this one): all clean. Local gates re-run: all green.

## Test plan

- [x] Scoped pytest (49/49, 13 new) — done
- [x] Broader sweep (`tests/scripts/`, 1011 passed) — done
- [x] Real strip-falsify ×2 (before/after RED/green) — done
- [x] Dogfood: real PR + this PR's own commit message — done
- [x] Local gates (7/7 applicable) — done
- [x] (skipped — no UI/behavior change) Visual

Cannot self-merge: touches `tests/`, needs a TESTS-READ note per PR-workflow rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **`len(commit_messages) >= 2` の gate は false negative を作ります。** 一次データ: この repo は `allow_merge_commit: true` かつ **`merge_commit_message: PR_TITLE`** ∴ **merge commit の本文は PR TITLE で、commit 数の条件がありません。** 本文の根拠「1-commit PR の title は merge commit に届かない」は **squash についてのみ真**です。⚠️ **しかも merge 方法は check 時点では未定**なので「1 commit だから届かない」は言えません。推奨: **gate を外す**（この repo の慣習 `fix(#N):` は `_CLOSING_RE` に一致しないので巻き込みは起きず、squash-1commit の重複は既存の commit 走査と同じ指摘）。根拠: PR comment（TESTS-READ (B)）



- [x] 🔴 **新規（architect）— 消した gate を今も説明している散文が同じ PR に残っています。** `title` 引数の docstring が逐語 `scanned by checks 4 and 5 ONLY when ``len(commit_messages) >= 2``` と述べ、さらに `the PR title never reaches the merge commit in that case`（**反証された当の命題**）と `flagging it there would be a false positive` を保持しています。module 冒頭と check 4 の実装 comment の 2 箇所は直っており、**引数の docstring だけが残りました**。CLAUDE.md hard rule `fix it in the SAME PR` / `Re-read the whole section`。根拠: PR comment issuecomment-5442063686

