### PR TITLE
fix(#5329-A): quota exhaustion inside retry_loop's own compact() call terminates on first occurrence

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -63,6 +63,7 @@ from reyn.llm.litellm_bootstrap import (
     ensure_litellm_ready_or_defer,
 )
 from reyn.prompt import compaction as _prompt_compaction
+from reyn.runtime.error_format import is_quota_exhausted_error
 
 if TYPE_CHECKING:
     from reyn.config import CompactionConfig
@@ -2187,6 +2188,35 @@ async def retry_loop(
                         # summary.
                         continue
                 except Exception as exc:
+                    # #5329: a provider usage-window/plan quota exhaustion
+                    # (429 usage_limit_reached) is the ONE exception #3783
+                    # stage 3's own "no per-exception-type allowlist"
+                    # ruling below does not cover — it is genuinely never
+                    # shrinkable (the window resets on a clock, not on
+                    # input size, #5256's own finding for the SAME
+                    # predicate at the outer _run_with_shrink gate). Real
+                    # incident (owner, reyn-self): compact()'s own LLM call
+                    # hit the SAME exhausted quota that had already failed
+                    # main_call, got wrapped as CompactionOverflowError by
+                    # the general rule below, and burned 2 more calls into
+                    # the SAME dead window before the stage-2 cap finally
+                    # gave up — 3 wasted round-trips during an active
+                    # outage, not 1. Re-raised BARE (never wrapped), the
+                    # SAME shape #5256's outer gate already uses and
+                    # ``_handle_inbox_text``'s generic catch-all already
+                    # handles safely — this is reuse of an existing,
+                    # already-battle-tested seam, not a new one.
+                    #
+                    # Deliberately NARROWER than "remove RateLimitError
+                    # from the shrinkable family" (architect ruling,
+                    # #5329): an ordinary per-request 429 (no structured
+                    # ``usage_limit_reached`` body) is NOT touched here —
+                    # #3783 stage 3's own reasoning for including it stays
+                    # intact, this predicate only carves out the ONE
+                    # subtype that can never recover regardless of how
+                    # many times shrinking retries it.
+                    if is_quota_exhausted_error(exc):
+                        raise
                     # #3783 stage 3 (owner-ratified): EVERY compact()-call
                     # exception now recovers by default — shrinking the
                     # input is a general remedy (a truncated JSON response,

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -841,7 +841,27 @@ def is_context_overflow_error(exc: BaseException) -> bool:
     longer depends on the exception's message text containing "too large"
     at all, so a differently-worded 413 (a different provider/proxy, a
     non-English locale) is now caught too.
+
+    #5329 (architect review): a provider usage-window/plan quota
+    exhaustion (429 ``usage_limit_reached``) is NEVER a context overflow
+    — but its free-text message ("The usage limit has been reached")
+    matches this predicate's own ``"limit"`` keyword fallback, so it used
+    to classify as True here at EVERY call site that reaches this
+    function without its own quota guard first (#5256's outer
+    ``_run_with_shrink`` gate always checks quota before calling this —
+    unaffected either way — but ``_router_main_call``'s own except,
+    router_loop_driver.py, calls this DIRECTLY with no such guard: a
+    quota exhaustion striking THAT call site, after ``retry_loop``'s
+    compact() call already succeeded once, would re-enter the shrink
+    ladder there instead — the SAME wasteful class #5329's compact()-wrap
+    fix closes at a DIFFERENT call site). Checked here, at the single
+    shared predicate, rather than adding a guard at each of its call
+    sites individually — #5329's own reason to exist is exactly a
+    call-site-by-call-site guard missing one spot; a fix at the ONE
+    predicate every site funnels through cannot have a missed spot.
     """
+    if is_quota_exhausted_error(exc):
+        return False
     # #4381 stage 1: checked BEFORE the litellm import below (and so
     # regardless of whether that import succeeds) — a plain attribute
     # read needs no litellm dependency at all, and this signal must not

--- a/tests/runtime/test_5256_quota_not_context_overflow.py
+++ b/tests/runtime/test_5256_quota_not_context_overflow.py
@@ -145,13 +145,15 @@ def test_a_genuine_context_overflow_still_shrinks_unaffected(monkeypatch) -> Non
     assert is_quota_exhausted_error(exc) is False
     assert is_context_overflow_error(exc) is True
 
-    # architect/lead-coder review (#5292): without this line, nothing here
-    # asserts WHY the #5256 gate is load-bearing — this test only exercised
-    # a DIFFERENT string, so removing "limit" from _CONTEXT_OVERFLOW_KEYWORDS
-    # would make the gate a silent no-op and every test in this PR would
-    # stay green. Pin the actual would-be-misdiagnosis directly: the quota
+    # #5329 (architect review): this assertion used to pin the OPPOSITE
+    # value (True) — documenting a genuine misdiagnosis: the quota
     # exception's own message ("The usage limit has been reached") DOES
-    # match is_context_overflow_error's keyword fallback today — that
-    # positive match is exactly what the new gate in _run_with_shrink
-    # exists to intercept before it ever reaches this predicate.
-    assert is_context_overflow_error(_QuotaExhaustedError()) is True
+    # match is_context_overflow_error's own "limit" keyword fallback, so
+    # any call site reaching this predicate WITHOUT its own quota guard
+    # first (unlike #5256's outer _run_with_shrink gate, which always
+    # checks quota before calling this) would still misdiagnose a quota
+    # exhaustion as an overflow. #5329 closed that at the single shared
+    # predicate itself (is_quota_exhausted_error checked FIRST, inside
+    # is_context_overflow_error) rather than requiring every call site to
+    # remember its own guard — this now asserts the FIXED value.
+    assert is_context_overflow_error(_QuotaExhaustedError()) is False

--- a/tests/runtime/test_5256_quota_not_context_overflow.py
+++ b/tests/runtime/test_5256_quota_not_context_overflow.py
@@ -156,4 +156,21 @@ def test_a_genuine_context_overflow_still_shrinks_unaffected(monkeypatch) -> Non
     # predicate itself (is_quota_exhausted_error checked FIRST, inside
     # is_context_overflow_error) rather than requiring every call site to
     # remember its own guard — this now asserts the FIXED value.
+
+    # #5329 (architect review, 2nd finding — vacuity): the `is False`
+    # assertion below is green for TWO possible reasons — (a) the new
+    # quota check fired (intended) or (b) someone silently removed
+    # "limit" from _CONTEXT_OVERFLOW_KEYWORDS, making the keyword
+    # fallback a no-op regardless of quota — exactly the class of thing
+    # the ORIGINAL (pre-#5329) comment on this test named as its own
+    # reason to exist. This positive control uses the SAME "limit" text
+    # on a NON-quota exception (no .body) — it must still match True. With
+    # that pinned, the class of exceptions here differs ONLY in .body, so
+    # the `is False` below can only be attributed to the quota check.
+    class _PlainLimitMessageError(Exception):
+        pass
+
+    assert is_context_overflow_error(
+        _PlainLimitMessageError("The usage limit has been reached"),
+    ) is True
     assert is_context_overflow_error(_QuotaExhaustedError()) is False

--- a/tests/services/test_5329_compact_quota_not_wastefully_shrunk.py
+++ b/tests/services/test_5329_compact_quota_not_wastefully_shrunk.py
@@ -1,0 +1,234 @@
+"""Tier 2: #5329 — a quota exhaustion inside ``retry_loop``'s OWN
+``engine.compact()`` call must terminate on the FIRST occurrence, never
+enter the shrink ladder.
+
+#5256 already guarded the OUTER gate (``RouterLoopDriver._run_with_shrink``,
+router_loop_driver.py) so a quota-exhausted ``main_call`` never enters
+``retry_loop`` at all. But retry_loop's OWN internal ``compact()`` call (the
+compaction LLM call, triggered once a GENUINE context overflow is already
+being recovered) had no equivalent gate — #3783 stage 3's own "EVERY
+compact()-call exception recovers by default" rule wrapped a quota
+exception the SAME as a transient 5xx, entering the shrink-escalation
+ladder and burning ``_MAX_CONSECUTIVE_SAME_CAUSE_RECOVERS`` (2) more calls
+into the SAME exhausted quota window before finally giving up with
+``UnrecoveredError`` — 3 wasted round-trips during an active outage
+(owner's real-machine incident, reyn-self).
+
+Real ``retry_loop`` throughout, no mocks — only ``engine.compact()`` is a
+scripted real async callable (matching this module's own established
+harness, e.g. ``test_wire_byte_estimate_4944.py``'s ``_MinimalCompactionEngine``).
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.runtime.services.token_multiplier_learner import TokenMultiplierLearner
+from reyn.services.compaction.engine import (
+    CompactionOverflowError,
+    ComputedBudgets,
+    UnrecoveredError,
+    retry_loop,
+)
+
+
+class _QuotaExhaustedError(Exception):
+    """Real, scripted stand-in for litellm's ``RateLimitError`` shape for a
+    usage-window/plan quota exhaustion — the same structured ``.body``
+    shape #5256's own fixture uses (a real observed incident field set,
+    not invented for this test)."""
+
+    def __init__(self) -> None:
+        super().__init__("The usage limit has been reached")
+        self.status_code = 429
+        self.body = {
+            "type": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+            "resets_in_seconds": 12258,
+        }
+
+
+class _TransientRateLimitError(Exception):
+    """A REAL, ordinary per-request 429 — no structured ``usage_limit_
+    reached`` body. #3783 stage 3's own reasoning (shrinking can genuinely
+    help this class) must stay unaffected by #5329's narrower carve-out."""
+
+    def __init__(self) -> None:
+        super().__init__("Rate limit exceeded, please retry")
+        self.status_code = 429
+
+
+class _MinimalCompactionEngine:
+    """Smallest real collaborator retry_loop needs — mirrors
+    test_wire_byte_estimate_4944.py's own ``_MinimalCompactionEngine``."""
+
+    def __init__(self) -> None:
+        self.budgets = ComputedBudgets(
+            main_pool=10_000, head_budget=1_000, body_budget=500,
+            tail_budget=1_500, new_msg_budget=1_000,
+            B_M=8_000, main_M_room=7_000, effective_trigger=7_000,
+            section_caps={"topic_arc": 50, "decisions": 200, "pending": 150,
+                          "session_user_facts": 50, "artifacts_referenced": 175},
+        )
+        self._events = EventLog()
+        self._T_comp_SP = 100
+
+
+def _cfg() -> CompactionConfig:
+    return CompactionConfig(
+        component_weights={
+            "head": 10, "body": 5, "tail": 15, "new_msg": 10, "compaction_batch": 60,
+        },
+        section_weights={
+            "topic_arc": 5, "decisions": 40, "pending": 25,
+            "session_user_facts": 10, "artifacts_referenced": 35,
+        },
+        section_caps_spec_tokens=100,
+        use_chars4_estimate=True,
+    )
+
+
+def _learner() -> TokenMultiplierLearner:
+    return TokenMultiplierLearner(storage_path=Path(tempfile.mkdtemp()) / "m.json")
+
+
+def test_quota_exhausted_compact_terminates_on_first_occurrence_bare() -> None:
+    """Tier 2: THE core #5329 proof. ``engine.compact()`` always raises the
+    quota-exhausted shape — retry_loop must call ``compact()`` exactly
+    ONCE (not the shrink ladder's multiple attempts) and the exception
+    that propagates OUT of retry_loop must be the BARE quota exception
+    itself — never wrapped in ``CompactionOverflowError``/
+    ``UnrecoveredError`` (the SAME "re-raise bare, let the existing
+    generic catch-all handle it" shape #5256's outer gate already uses)."""
+    engine = _MinimalCompactionEngine()
+    compact_calls = 0
+
+    async def _compact(input_chunk):
+        nonlocal compact_calls
+        compact_calls += 1
+        raise _QuotaExhaustedError()
+
+    engine.compact = _compact
+
+    async def _never_called_main_call(**kwargs):
+        raise AssertionError("main_call must never run — compact() never succeeds")
+
+    async def _drive():
+        await retry_loop(
+            SP="sp", head=[], summary=None,
+            raw_middle=[{"role": "user", "content": "x", "seq": 1}],
+            tail=[], new_msg={"role": "user", "content": "q", "seq": 2},
+            cfg=_cfg(), model="test-model", engine=engine,  # type: ignore[arg-type]
+            learner=_learner(), main_call=_never_called_main_call,
+            max_iterations=8,
+        )
+
+    with pytest.raises(_QuotaExhaustedError):
+        asyncio.run(_drive())
+
+    assert compact_calls == 1, (
+        f"expected exactly 1 compact() call (no shrink retry into the SAME "
+        f"exhausted quota) — got {compact_calls}"
+    )
+
+
+def test_quota_exhausted_compact_is_never_wrapped_in_compaction_overflow_error() -> None:
+    """Tier 2: #5329 — the SAME scenario, but the assertion is on the
+    exception TYPE specifically, not just count: a caller catching
+    ``CompactionOverflowError``/``UnrecoveredError`` (retry_loop's own
+    normal failure vocabulary) must NOT catch this — it needs to reach
+    the SAME bare-exception path #5256's outer gate already proved safe."""
+    engine = _MinimalCompactionEngine()
+
+    async def _compact(input_chunk):
+        raise _QuotaExhaustedError()
+
+    engine.compact = _compact
+
+    async def _never_called_main_call(**kwargs):
+        raise AssertionError("main_call must never run")
+
+    async def _drive():
+        try:
+            await retry_loop(
+                SP="sp", head=[], summary=None,
+                raw_middle=[{"role": "user", "content": "x", "seq": 1}],
+                tail=[], new_msg={"role": "user", "content": "q", "seq": 2},
+                cfg=_cfg(), model="test-model", engine=engine,  # type: ignore[arg-type]
+                learner=_learner(), main_call=_never_called_main_call,
+                max_iterations=8,
+            )
+        except (CompactionOverflowError, UnrecoveredError):
+            raise AssertionError(
+                "a quota exhaustion must propagate BARE — retry_loop's "
+                "own wrapper types would be caught by callers as an "
+                "ordinary overflow, not a quota-specific terminal cause"
+            )
+
+    with pytest.raises(_QuotaExhaustedError):
+        asyncio.run(_drive())
+
+
+def test_transient_rate_limit_still_enters_the_shrink_ladder_unaffected() -> None:
+    """Tier 2: non-vacuity — #3783 stage 3's own owner-ratified reasoning
+    (an ordinary per-request 429 CAN genuinely recover via shrinking) must
+    stay completely unaffected by #5329's narrower carve-out. The SAME
+    raw_middle-only harness as the core #5329 proofs above, but
+    ``engine.compact()`` raises ``_TransientRateLimitError`` (no
+    usage_limit_reached body) instead of the quota shape — it must be
+    wrapped as CompactionOverflowError and recover multiple times via the
+    same-cause cap (#3783 stage 2) before ``UnrecoveredError`` finally
+    fires, never terminating on the first occurrence the way #5329's
+    quota carve-out does."""
+    engine = _MinimalCompactionEngine()
+    compact_calls = 0
+
+    async def _compact(input_chunk):
+        nonlocal compact_calls
+        compact_calls += 1
+        raise _TransientRateLimitError()
+
+    engine.compact = _compact
+
+    # A single-turn raw_middle hits retry_loop's OWN "cannot split any
+    # further" floor on the FIRST compact() failure regardless of cause
+    # (a different mechanism from the same-cause cap this test means to
+    # exercise) — 4 turns gives the same-cause cap (2, tripping on the
+    # 3rd consecutive recover) room to fire well before any halving could
+    # reach that floor.
+    async def _never_called_main_call(**kwargs):
+        raise AssertionError(
+            "main_call must never run — the same-cause cap trips "
+            "UnrecoveredError before raw_middle could ever empty"
+        )
+
+    async def _drive():
+        await retry_loop(
+            SP="sp", head=[], summary=None,
+            raw_middle=[
+                {"role": "user", "content": "x", "seq": i} for i in range(4)
+            ],
+            tail=[], new_msg={"role": "user", "content": "q", "seq": 99},
+            cfg=_cfg(), model="test-model", engine=engine,  # type: ignore[arg-type]
+            learner=_learner(), main_call=_never_called_main_call,
+            max_iterations=8,
+        )
+
+    with pytest.raises(UnrecoveredError) as excinfo:
+        asyncio.run(_drive())
+
+    assert "consecutive times" in str(excinfo.value)
+    # #3783 stage 2's own cap (_MAX_CONSECUTIVE_SAME_CAUSE_RECOVERS=2) means
+    # the SAME cause recovering 3 times (1 initial + 2 more) is what finally
+    # trips UnrecoveredError — more than 1 compact() attempt, proving this
+    # is still the shrink-ladder path, not #5329's single-occurrence
+    # carve-out (which would have stopped a quota exhaustion after exactly 1).
+    assert compact_calls > 1, (
+        f"a transient (non-quota) rate limit must still enter the shrink "
+        f"ladder — expected multiple compact() attempts, got {compact_calls}"
+    )

--- a/tests/services/test_5329_compact_quota_not_wastefully_shrunk.py
+++ b/tests/services/test_5329_compact_quota_not_wastefully_shrunk.py
@@ -100,11 +100,20 @@ def _learner() -> TokenMultiplierLearner:
 def test_quota_exhausted_compact_terminates_on_first_occurrence_bare() -> None:
     """Tier 2: THE core #5329 proof. ``engine.compact()`` always raises the
     quota-exhausted shape — retry_loop must call ``compact()`` exactly
-    ONCE (not the shrink ladder's multiple attempts) and the exception
+    ONCE (not the shrink ladder's multiple attempts), and the exception
     that propagates OUT of retry_loop must be the BARE quota exception
     itself — never wrapped in ``CompactionOverflowError``/
     ``UnrecoveredError`` (the SAME "re-raise bare, let the existing
-    generic catch-all handle it" shape #5256's outer gate already uses)."""
+    generic catch-all handle it" shape #5256's outer gate already uses;
+    a caller catching retry_loop's own normal failure vocabulary must NOT
+    catch this).
+
+    #5292-style six-questions note (architect review on this PR): a
+    prior version of this file had the count check and the TYPE check as
+    two separate tests — the second could only ever go red in exactly
+    the situation the first already does (nothing distinguishes them),
+    so they are one test now, both invariants proven from the SAME
+    single drive."""
     engine = _MinimalCompactionEngine()
     compact_calls = 0
 
@@ -117,41 +126,6 @@ def test_quota_exhausted_compact_terminates_on_first_occurrence_bare() -> None:
 
     async def _never_called_main_call(**kwargs):
         raise AssertionError("main_call must never run — compact() never succeeds")
-
-    async def _drive():
-        await retry_loop(
-            SP="sp", head=[], summary=None,
-            raw_middle=[{"role": "user", "content": "x", "seq": 1}],
-            tail=[], new_msg={"role": "user", "content": "q", "seq": 2},
-            cfg=_cfg(), model="test-model", engine=engine,  # type: ignore[arg-type]
-            learner=_learner(), main_call=_never_called_main_call,
-            max_iterations=8,
-        )
-
-    with pytest.raises(_QuotaExhaustedError):
-        asyncio.run(_drive())
-
-    assert compact_calls == 1, (
-        f"expected exactly 1 compact() call (no shrink retry into the SAME "
-        f"exhausted quota) — got {compact_calls}"
-    )
-
-
-def test_quota_exhausted_compact_is_never_wrapped_in_compaction_overflow_error() -> None:
-    """Tier 2: #5329 — the SAME scenario, but the assertion is on the
-    exception TYPE specifically, not just count: a caller catching
-    ``CompactionOverflowError``/``UnrecoveredError`` (retry_loop's own
-    normal failure vocabulary) must NOT catch this — it needs to reach
-    the SAME bare-exception path #5256's outer gate already proved safe."""
-    engine = _MinimalCompactionEngine()
-
-    async def _compact(input_chunk):
-        raise _QuotaExhaustedError()
-
-    engine.compact = _compact
-
-    async def _never_called_main_call(**kwargs):
-        raise AssertionError("main_call must never run")
 
     async def _drive():
         try:
@@ -172,6 +146,11 @@ def test_quota_exhausted_compact_is_never_wrapped_in_compaction_overflow_error()
 
     with pytest.raises(_QuotaExhaustedError):
         asyncio.run(_drive())
+
+    assert compact_calls == 1, (
+        f"expected exactly 1 compact() call (no shrink retry into the SAME "
+        f"exhausted quota) — got {compact_calls}"
+    )
 
 
 def test_transient_rate_limit_still_enters_the_shrink_ladder_unaffected() -> None:


### PR DESCRIPTION
part of #5329

## What (①, half of #5329's two named defects)

Real owner-machine incident (reyn-self): a provider usage-window/plan quota exhaustion (429 `usage_limit_reached`) hit `retry_loop`'s OWN internal `engine.compact()` call — the compaction LLM call, triggered once a genuine context overflow is already being recovered. #3783 stage 3's own "EVERY compact()-call exception recovers by default" rule (owner-ratified, deliberately no per-exception-type allowlist at that wrap site) wrapped the quota exception the same as a transient 5xx, entering the shrink-escalation ladder and burning `_MAX_CONSECUTIVE_SAME_CAUSE_RECOVERS` (2) more calls into the SAME exhausted quota window before finally giving up with `UnrecoveredError` — **3 wasted round-trips during an active quota outage**, not 1.

#5256 already guarded the OUTER gate (`RouterLoopDriver._run_with_shrink`) so a quota-exhausted `main_call` never enters `retry_loop` at all — but that gate has no equivalent at `retry_loop`'s own internal `compact()`-call site.

## Fix (architect ruling)

Deliberately **narrower** than "exclude `RateLimitError` from the shrinkable family" — that would reopen #3783's own owner-ratified decision, which explicitly names "a rate limit" as a general remedy shrinking helps (a transient per-request 429 genuinely CAN recover via a smaller retry). Only the specific quota-exhausted subtype (`is_quota_exhausted_error`, `exc.body["type"] == "usage_limit_reached"` — the SAME predicate #5256 already introduced and battle-tested at the outer gate, **reused here not reinvented**) terminates on the first occurrence, re-raised **bare** (never wrapped in `CompactionOverflowError`/`UnrecoveredError`) — the SAME shape #5256's outer gate already uses, which `Session._handle_inbox_text`'s generic catch-all already handles safely (confirmed via #5256's own existing test).

I asked architect a precise question before implementing (given a genuine architectural ambiguity about where the crash-boundary gap actually was), and their initial ① framing ("exclude the RateLimitError family") turned out to conflict with #3783's owner-ratified decision — architect self-corrected before I wrote code, to the narrower `usage_limit_reached`-only carve-out this PR implements.

## Fix, round 2 — closing the class (architect co-vet finding)

Architect's TESTS-READ co-vet found a real, adjacent gap: `RouterLoopDriver._router_main_call` (used INSIDE `retry_loop`'s own `main_call` param) has its own except that classifies raw exceptions via `is_context_overflow_error` directly, with no quota guard ahead of it. A live check (lead-coder, `PYTHONPATH=src`) confirmed a real quota exception's own message matches `is_context_overflow_error`'s "limit" keyword fallback -> True — so once `compact()` succeeds once, a SUBSEQUENT quota exhaustion at `main_call` would still misclassify as `_ContextOverflowError` and re-enter the shrink ladder there instead. Same wasteful class, different call site, not closed by the first commit.

Fix (architect + lead-coder converged): moved the guard to the single shared predicate itself — `is_context_overflow_error` now checks `is_quota_exhausted_error` FIRST and returns `False` for that subtype, rather than requiring every call site to remember its own guard. `#5256`'s own outer gate is unaffected (it already checked quota before ever calling this predicate).

**Consumer sweep** (full-repo grep, per the "消費者を全部見てから" caution): exactly 2 production call sites — `router_loop_driver.py:522` (already quota-guarded ahead) and `:550` (now correctly closed). Every pre-existing `is_context_overflow_error` test (`test_4381_stage1_overflow_classification.py`, `test_3783_stage3_invert_default_to_recover.py`, `test_router_loop_pure_helpers.py`) exercises exceptions with no `.body` attribute at all — the new early-return is a structural no-op there, confirmed by running all 33 tests: green, no regression.

`test_5256_quota_not_context_overflow.py`'s own `test_a_genuine_context_overflow_still_shrinks_unaffected`: the assertion that used to PIN the misdiagnosis (`is_context_overflow_error(_QuotaExhaustedError()) is True`) now asserts the fixed value (`False`) — docstring rewritten to explain why.

Also addressed architect's six-questions note: the two quota-terminates tests in `test_5329_compact_quota_not_wastefully_shrunk.py` (the 2nd could only ever go red in the exact situation the 1st already does) are now one test proving both invariants from the same drive.

`tests/services/` + `tests/runtime/` re-run (`-k "not slow"`): **2128 passed**, same 1 pre-existing unrelated failure. Local gates re-run: ruff, `test_tier_audit --strict`, `mypy_ratchet.py` — all green.

## Verification

3 new tests (`tests/services/test_5329_compact_quota_not_wastefully_shrunk.py`). Real `retry_loop` throughout, no mocks — only `engine.compact()` is a scripted real async callable (matching this module's own established `_MinimalCompactionEngine` harness, `test_wire_byte_estimate_4944.py`):
- `compact()` always quota-exhausted → exactly 1 `compact()` call, the bare exception propagates (never wrapped).
- Same scenario, asserted by exception TYPE specifically (not caught by `CompactionOverflowError`/`UnrecoveredError`).
- **Non-vacuity**: an ordinary `_TransientRateLimitError` (no `usage_limit_reached` body) still enters the shrink ladder and recovers multiple times via the same-cause cap before `UnrecoveredError` — #3783 stage 3's own reasoning stays completely unaffected.

**Real strip-falsify**: disabled the `is_quota_exhausted_error` check entirely (`if False: raise`) — both quota-dependent tests went RED (the third, transient-rate-limit regression test, correctly stayed green). Restored, green again.

`tests/services/` + `tests/runtime/` (`-k "not slow"`): **2129 passed**, **1 pre-existing unrelated failure disclosed** (`test_2961_token_counter_fallback_false_positive.py` — confirmed identical on a clean stash of this diff against `origin/main` during #5316's own PR this same session, an environment-dependent litellm network-probe flake). Sibling regression: `tests/runtime/test_5256_quota_not_context_overflow.py` + `tests/services/test_pr_n6_compaction_overflow_retry.py`: **43 passed**, no regression.

**Local gates**: ruff, `test_tier_audit --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.

## Remaining scope in #5329

#5329's other requirement (② — the router-loop-boundary crash itself, owner: "quota切れでtui落ちるの対策してよ") is a **separate, still-open** question: architect mechanically disproved lead-coder's first two proposed explanations for the crash chain (`session.py`'s own catch-all already returns normally for interactive sessions; a proposed return-value fix at `_handle_inbox_text` does not reach the loop that would need it). Blocked on the owner's own observation (did the TUI show an error line before the crash?) — not implemented here (this PR is `part of`, not a full close).

## Test plan

- [x] Scoped pytest (3/3 new) — done
- [x] Broader sweep (2129 passed, 1 pre-existing unrelated failure disclosed) — done
- [x] Sibling regression (43 passed) — done
- [x] Real strip-falsify (before/after RED/green) — done
- [x] Local gates (8/8 applicable) — done
- [x] (skipped — no UI/behavior change) Visual

Cannot self-merge: touches `tests/`, needs a TESTS-READ note per PR-workflow rule 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **同じクラスの姉妹 site が開いたままです。** `router_loop_driver.py` の `_router_main_call` の except（`_is_context_overflow_error(_call_exc)` で wrap する行）に quota guard が無く、**quota 例外はその predicate に True を返させます**（`origin/main` の `test_5256_quota_not_context_overflow.py` が逐語 `assert is_context_overflow_error(_QuotaExhaustedError()) is True` で pin 済）。∴ `compact()` が成功し `main_call` が枯渇 quota に当たる経路で**同じ無駄撃ちが続きます**。owner 恒常指示「穴でなくクラスを閉じる」。推奨は **`is_context_overflow_error` 自身に「quota なら False」**（1 箇所で 3 site が直る）。根拠: PR comment（TESTS-READ (B)）



- [x] 🔴 **新規（architect）— 反転した pin が「別の理由で」緑になります。** `assert is_context_overflow_error(_QuotaExhaustedError()) is False` は (a) quota check が効いた場合と (b) 誰かが `_CONTEXT_OVERFLOW_KEYWORDS` から `"limit"` を落とした場合の**両方で緑**です ∴ **新 guard を丸ごと消しても緑のまま**（六問④）。削除された comment が名指しで防いでいた当のものです。**quota でない例外に同じ文面を持たせて `True` を pin**すれば `is False` が quota check に帰属します。根拠: PR comment issuecomment-5441983179

