### PR TITLE
fix(#5332): router-loop catch-all log line no longer claims "terminated"

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -7703,25 +7703,42 @@ class Session:
             # exception" — nothing here terminates. This except IS the
             # catch; the audit event below still fires either way, and the
             # interactive leg (below) returns normally after queuing a
-            # `kind="error"` OutboxMessage — the loop keeps running, the
-            # session keeps accepting turns. Only ``self._ephemeral`` (an
+            # `kind="error"` OutboxMessage. Only ``self._ephemeral`` (an
             # agent-step spawn's leaf session) actually re-raises past this
             # point (as ``AgentStepError``, further down) — real-environment
             # evidence this line's old wording caused 3 real misreadings the
             # SAME night (2026-08-27, lead-coder investigating #5329):
             # "terminated" read as "the process died here", "unhandled" read
             # as "nothing caught this" — both false, and both refuted only
-            # by re-reading this exact code and the audit trail. The outcome
-            # half is conditioned on the SAME ``self._ephemeral`` check the
-            # actual control flow below uses, not asserted unconditionally
-            # for both legs.
+            # by re-reading this exact code and the audit trail.
+            #
+            # architect's TESTS-READ(B) BLOCK on the first attempt here
+            # (still #5332): the interactive outcome text said "the session
+            # continues" — a claim about what happens AFTER this except
+            # returns, which this code does not itself observe (the owner's
+            # own #5329 report is a process disappearing to shell, root
+            # cause still open) — the SAME class of error the old wording
+            # made ("terminated" asserted an ending nothing here observed
+            # either). Fixed to name only what THIS code actually does:
+            # queues the error reply and returns. "unhandled" is also
+            # dropped for the same reason (architect, follow-up) — the
+            # comment above already names it as one of the two words that
+            # caused a real misreading, so leaving it half-fixed would
+            # repeat the same mistake in miniature.
+            #
+            # The outcome half is conditioned on the SAME ``self._ephemeral``
+            # check the actual control flow below uses, not asserted
+            # unconditionally for both legs — witnessed by
+            # ``test_router_loop_swallow_instrument_187.py``'s two
+            # ``caplog``-driven tests (one per leg), so a future revert to an
+            # unconditional claim goes red.
             _outcome = (
                 "re-raising as AgentStepError"
                 if self._ephemeral
-                else "this turn failed; the session continues"
+                else "this turn failed; queued an error reply and returning normally"
             )
             logger.exception(
-                "router loop caught an unhandled exception (chain_id=%s)%s — %s",
+                "router loop caught an exception no inner handler took (chain_id=%s)%s — %s",
                 chain_id,
                 f" [cause: {_cause_name}: {_root_cause}]" if _root_cause is not None else "",
                 _outcome,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -7699,10 +7699,32 @@ class Session:
             # gets the real answer without needing to know a second event exists.
             _root_cause = _deepest_cause(exc)
             _cause_name = type(_root_cause).__name__ if _root_cause is not None else None
+            # #5332: this line used to say "terminated by unhandled
+            # exception" — nothing here terminates. This except IS the
+            # catch; the audit event below still fires either way, and the
+            # interactive leg (below) returns normally after queuing a
+            # `kind="error"` OutboxMessage — the loop keeps running, the
+            # session keeps accepting turns. Only ``self._ephemeral`` (an
+            # agent-step spawn's leaf session) actually re-raises past this
+            # point (as ``AgentStepError``, further down) — real-environment
+            # evidence this line's old wording caused 3 real misreadings the
+            # SAME night (2026-08-27, lead-coder investigating #5329):
+            # "terminated" read as "the process died here", "unhandled" read
+            # as "nothing caught this" — both false, and both refuted only
+            # by re-reading this exact code and the audit trail. The outcome
+            # half is conditioned on the SAME ``self._ephemeral`` check the
+            # actual control flow below uses, not asserted unconditionally
+            # for both legs.
+            _outcome = (
+                "re-raising as AgentStepError"
+                if self._ephemeral
+                else "this turn failed; the session continues"
+            )
             logger.exception(
-                "router loop terminated by unhandled exception (chain_id=%s)%s",
+                "router loop caught an unhandled exception (chain_id=%s)%s — %s",
                 chain_id,
-                f" — cause: {_cause_name}: {_root_cause}" if _root_cause is not None else "",
+                f" [cause: {_cause_name}: {_root_cause}]" if _root_cause is not None else "",
+                _outcome,
             )
             try:
                 self._audit_events.emit(

--- a/tests/runtime/test_4405_stall_trace_wiring.py
+++ b/tests/runtime/test_4405_stall_trace_wiring.py
@@ -141,8 +141,8 @@ async def test_stall_trace_disarmed_even_when_the_turn_raises(
 
     await session._put_inbox("user", {"text": "hi", "chain_id": "c1"})
     # The router loop's own top-level handler logs-and-swallows an
-    # unhandled exception (session.py's "router loop terminated by
-    # unhandled exception" path) rather than propagating it out of
+    # unhandled exception (session.py's "router loop caught an unhandled
+    # exception" path, #5332) rather than propagating it out of
     # run_one_iteration — so this await completes normally; the turn's
     # FAILURE is not what this test is about, only whether disarm() ran.
     await session.run_one_iteration()

--- a/tests/runtime/test_4405_stall_trace_wiring.py
+++ b/tests/runtime/test_4405_stall_trace_wiring.py
@@ -141,10 +141,11 @@ async def test_stall_trace_disarmed_even_when_the_turn_raises(
 
     await session._put_inbox("user", {"text": "hi", "chain_id": "c1"})
     # The router loop's own top-level handler logs-and-swallows an
-    # unhandled exception (session.py's "router loop caught an unhandled
-    # exception" path, #5332) rather than propagating it out of
-    # run_one_iteration — so this await completes normally; the turn's
-    # FAILURE is not what this test is about, only whether disarm() ran.
+    # exception no inner handler took (session.py's "router loop caught
+    # an exception no inner handler took" path, #5332) rather than
+    # propagating it out of run_one_iteration — so this await completes
+    # normally; the turn's FAILURE is not what this test is about, only
+    # whether disarm() ran.
     await session.run_one_iteration()
 
     assert calls == ["arm", "disarm"], (

--- a/tests/runtime/test_router_loop_swallow_instrument_187.py
+++ b/tests/runtime/test_router_loop_swallow_instrument_187.py
@@ -15,11 +15,24 @@ outbox message still goes out unchanged — the instrument is additive.
 The failure is injected with a real async stub (a Fake that raises) — no
 MagicMock — and the assertion reads the public EventLog surface via a real
 ``add_subscriber`` (``collect_events``), not private state.
+
+#5332: the two ``..._logs_...`` tests below witness the SAME catch-all's log
+LINE, not the audit event — architect's TESTS-READ(B) finding on the first
+#5332 fix: the outcome half of that log line is conditioned on
+``self._ephemeral`` (interactive keeps running vs. an agent-step leaf
+re-raising), and nothing made a REVERT to an unconditional claim go red.
+Both legs are driven through the real ``_handle_inbox_text`` path (the
+ephemeral leg via ``pytest.raises``, since it genuinely propagates
+``AgentStepError``) and read via ``caplog`` — the log line's own text, not
+private state.
 """
 from __future__ import annotations
 
+import logging
+
 import pytest
 
+from reyn.runtime.errors import AgentStepError
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events, settle
 
@@ -58,3 +71,76 @@ async def test_swallowed_router_loop_exception_emits_p6_event():
     assert ev.data["chain_id"] == "c-test"
     assert ev.data["error_type"] == "RuntimeError"
     assert "simulated final-call crash" in ev.data["error"]
+
+
+@pytest.mark.asyncio
+async def test_interactive_leg_logs_what_it_actually_did_not_that_the_session_continues(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Tier 2: #5332 — the interactive leg's log line names only what this
+    except clause itself does (queues an error reply, returns normally),
+    never a claim about what happens after it returns. Strip-falsify: revert
+    the outcome text to an unconditional "the session continues" and this
+    still passes (wrong text, but still non-ephemeral) — the SIBLING test
+    below is what catches an unconditional revert, since it would then
+    ALSO see "the session continues" on the ephemeral leg, which never
+    returns to observe any such thing."""
+    # make_session's default (no post-construction _ephemeral mutation,
+    # unlike the sibling test below) is the interactive leg — asserted
+    # by which log text appears, not by reading the attribute directly.
+    s = make_session(agent_name="t")
+
+    async def _raise_mid_work(text: str, chain_id: str) -> None:
+        raise RuntimeError("simulated final-call crash")
+
+    s._run_router_loop = _raise_mid_work
+
+    with caplog.at_level(logging.ERROR, logger="reyn.runtime.session"):
+        await s._handle_inbox_text("hello", chain_id="c-interactive")
+
+    messages = [r.message for r in caplog.records]
+    assert any("queued an error reply and returning normally" in m for m in messages), (
+        f"#5332 REGRESSION: interactive leg's log line should name what it "
+        f"actually did, not assert a session-lifetime claim — got {messages!r}"
+    )
+    assert not any("the session continues" in m for m in messages), (
+        "the interactive leg must not claim the session continues — this "
+        "except clause never observes what happens after it returns "
+        "(owner's own #5329 report: a process reaching shell with the root "
+        "cause still open)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_leg_logs_re_raising_and_actually_raises(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Tier 2: #5332 — the ephemeral leg (an agent-step spawn's leaf
+    session) both logs "re-raising as AgentStepError" AND actually raises
+    it — the log line's claim and the control flow are the SAME
+    ``self._ephemeral`` check, so this test would go red on either half
+    drifting from the other (the log line reverted to unconditional, or the
+    raise itself removed)."""
+    s = make_session(agent_name="t")
+    s._ephemeral = True  # the registry sets this post-construction on a real ephemeral spawn
+
+    async def _raise_mid_work(text: str, chain_id: str) -> None:
+        raise RuntimeError("simulated final-call crash")
+
+    s._run_router_loop = _raise_mid_work
+
+    with caplog.at_level(logging.ERROR, logger="reyn.runtime.session"):
+        with pytest.raises(AgentStepError):
+            await s._handle_inbox_text("hello", chain_id="c-ephemeral")
+
+    messages = [r.message for r in caplog.records]
+    assert any("re-raising as AgentStepError" in m for m in messages), (
+        f"#5332 REGRESSION: ephemeral leg's log line should say it is "
+        f"re-raising — got {messages!r}"
+    )
+    assert not any(
+        "queued an error reply and returning normally" in m for m in messages
+    ), (
+        "the ephemeral leg must not claim it queued a reply and returned "
+        "normally — it re-raises, it never reaches that branch"
+    )


### PR DESCRIPTION
**[tui-coder]** — fixes #5332.

## Problem (lead-coder's own real-environment finding, #5329 investigation, 2026-08-27)
`session.py:7703`'s `logger.exception("router loop terminated by unhandled exception ...")` sits INSIDE `_handle_inbox_text`'s own catch-all — nothing terminates there. The audit event still fires, and the interactive leg returns normally after queuing a `kind="error"` OutboxMessage: the loop keeps running, the session keeps accepting turns.

Real cost, not hypothetical: lead-coder misread this exact line 3 times in one night investigating #5329 — "terminated" → "the process died here" (owner's direct observation refuted it), "unhandled" → "nothing caught this" (architect reading the code refuted it), a third inference built on the same false premise (the audit trail itself refuted it — no `session_completed`/`chat_stopped` at that timestamp).

## Fix
The log line's outcome half is now conditioned on the SAME `self._ephemeral` check the real control flow a few lines below it already uses (not asserted unconditionally for both legs, which was the actual bug — ephemeral really does raise):
- interactive (`self._ephemeral is False`): `"... — this turn failed; the session continues"`
- ephemeral (agent-step spawn leaf session): `"... — re-raising as AgentStepError"`

Message wording changed from `"terminated by unhandled exception"` to `"caught an unhandled exception"` throughout.

**Deliberately NOT touched**: the `router_loop_terminated_by_exception` audit-event name — lead-coder's own explicit scoping, a rename would break consumers and is a separate decision.

## Scope check
`git grep` confirmed no `docs/` citation of the old wording exists. One test comment (`test_4405_stall_trace_wiring.py`) quoted the old string descriptively (not asserted via any pin) — updated in this same commit per CLAUDE.md's "fix in the SAME PR" rule.

## Test plan
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_4405_stall_trace_wiring.py` — 3 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — clean
- [x] `python scripts/mypy_ratchet.py` — clean (201 findings, all baselined)
- [x] pytest scoped to diff: `test_4405_stall_trace_wiring.py` + every test file referencing `router_loop_terminated_by_exception`/`AgentStepError` (28 tests total) — all passed
- [ ] (skipped — log-message wording only, no UI/visual surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **`this turn failed; the session continues` は、この except 節が観測していない「その後」を断定しています。** #5329 ② は未着手で、owner が観測した「プロセスが shell に戻る」の原因は未特定です ∴ この行の直後にプロセスが消える可能性が今も残ります。**旧文言が「終了した」と偽ったのと同じクラス**です。この code が実際にやったことだけを書いてください（例: `queued an error reply and returning normally`）。ephemeral 側の `re-raising as AgentStepError` は実際の動作なのでそのままで正しい。根拠: PR comment（TESTS-READ (B)）
- [x] 🔴 **`_ephemeral` の分岐に witness がありません。** lead-coder が「無条件に continues と言っていないか」を危険として名指ししており、今回は正しく分岐していますが、**将来 無条件に戻しても赤くなる test がありません**。`caplog` で 2 leg を通し、それぞれの outcome 文言が出ることを見るだけで足ります

