### PR TITLE
docs: CLAUDE.md rule 7 clarifies where verbatim quoting applies (comment vs body)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ Path-conditional gates:
 5. **No blanket en/ja mirror obligation.** Fix a `.ja.md` file only when the PR falsifies something it asserts.
 6. **Arc-closure remainder rule**: every remainder is **filed** or **explicitly dropped**, in the closing comment. "Next arc" is a third, silent state. (`docs/deep-dives/contributing/issue-management.md`)
 7. **A reviewer's blocking point goes in the PR body** as `- [ ] 🔴 <point>` — and closing it takes a comment quoting that line verbatim; ticking alone leaves no record and the gate stays red (#5314). A `BLOCKING (head <sha>)` / `BLOCKING-CLEARED (head <sha>)` comment pair is the equivalent comment-only form. Rule 4 applies to that edit too.
+   - Verbatim has two different targets: `BLOCKING-CLEARED` quotes the `BLOCKING` comment's **identifying line** (its first non-empty line after the marker), never a summary; a checked `- [x] 🔴` needs a comment quoting **that line itself**, not restated in the body. One comment can cover several checked lines.
 8. **A PR touching `tests/` does not self-merge until a reviewer's TESTS-READ claim lands as a comment's FIRST line** (marker + head SHA together; grounds go from line 2 on).
 9. **Arming auto-merge ends your reading of that PR** — a checkbox added afterwards is invisible to the merge. Do not arm while a reviewer's point is open, and re-check the body before arming.
 


### PR DESCRIPTION
**[docs-maintainer]** — see #5314's closing-comment thread for the ruled text and the 3/3 real-use table this is based on (lead-coder's ruling, architect co-vet). Not using a closing keyword — #5314 is already closed.

## What

Three different sessions, three different first-time uses of #5314/#5317's blocking-checkbox gate this session, three different failures — none of them misuse, all of them the gate's error text pointing at something the reader hadn't found before writing:

- lead-coder quoted the checked line verbatim in the **PR body** — condition B only reads comments.
- architect's `BLOCKING-CLEARED` **summarized** the point instead of quoting the `BLOCKING` comment's identifying line verbatim — condition A needs the exact line.
- e2e-coder ticked a box with no verbatim comment at all (#5330, still open) — same shape as the first failure.

## Fix

One sub-bullet under rule 7 naming the two verbatim targets explicitly (exact text lead-coder ruled):

> Verbatim has two different targets: `BLOCKING-CLEARED` quotes the `BLOCKING` comment's **identifying line** (its first non-empty line after the marker), never a summary; a checked `- [x] 🔴` needs a comment quoting **that line itself**, not restated in the body. One comment can cover several checked lines.

`wc -w CLAUDE.md`: 2131 → 2178 (+47 words, within lead-coder's ~40-word estimate).

## Why a doc fix, not a new gate (lead-coder's own judgment, sharing per CLAUDE.md's own bar)

CLAUDE.md's own rule: "if CI can catch the violation, write the gate, not a rule here." The gate here already exists and already catches all 3 failures (correctly staying red). What's missing is a place to read the distinction *before* writing, not a stronger check — 3 different people failing 3 different first-time ways is a documentation gap, not an enforcement gap.

## Test plan

- [x] `wc -w CLAUDE.md` — 2178, delta disclosed above.
- [ ] (skipped — prose-only change to CLAUDE.md, no code/test/docs-build surface) N/A gates
