### PR TITLE
fix(#5328): job-level check-run for both blocking gates cannot go red, ever

### DIFF
--- a/.github/workflows/check-open-blocking-checkboxes.yml
+++ b/.github/workflows/check-open-blocking-checkboxes.yml
@@ -96,12 +96,32 @@ jobs:
             -f description="Checking the PR body and comments for an open blocking point..."
 
       # scripts/check_open_blocking_checkboxes.py is stdlib-only.
-      # `continue-on-error: true` keeps a script failure from also turning
-      # this step, and with it the job, red: the commit status posted below
-      # is the only channel that carries this verdict.
+      #
+      # #5328: this step used to run with `continue-on-error: true`, on the
+      # reasoning "the commit status posted below is the only channel that
+      # carries this verdict" — but `continue-on-error: true` forces the
+      # STEP's (and so the JOB's, and so this job's own auto-generated
+      # check-run's) *conclusion* to `success` regardless of the script's
+      # real exit code. That is not "a second channel that goes stale
+      # between comments" (the residual, disclosed limitation below) — it
+      # is unconditional: measured empirically (#5337, a throwaway PR
+      # carrying a deliberately open `- [ ] 🔴`), this job's own check-run
+      # read `pass` at the SAME push-time evaluation the commit status
+      # below correctly read `fail` for. A job that can never go red is not
+      # a second source of truth a reader can ignore — GitHub's rollup
+      # shows it as a plain PASS, indistinguishable at a glance from a
+      # gate that actually ran the check.
+      #
+      # Removed. This job's own conclusion (and so its check-run) now
+      # tracks the SAME script result the commit status below is computed
+      # from, in the SAME run — the two can only disagree afterward, when
+      # a LATER `issue_comment`-triggered run updates the commit status
+      # without a matching `pull_request` event to refresh this job's own
+      # check-run (that half of the shape is inherent — an `issue_comment`
+      # event's own check-run attaches to the DEFAULT BRANCH's sha, never
+      # the PR's, see the module comment above), not unconditional.
       - name: Check the PR body and comments for an open blocking point
         id: check
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -111,7 +131,12 @@ jobs:
       # check step above passed, failed, or (if the runner itself dies
       # first) never ran at all — in that last case this step ALSO never
       # runs, and the status posted above stays `pending` rather than
-      # silently vanishing.
+      # silently vanishing. #5328: now that the check step has no
+      # `continue-on-error`, a real failure there would otherwise SKIP this
+      # step under the default `if:` (all previous steps succeeded) — this
+      # `always()` is what keeps the commit status accurate instead of
+      # stuck on `pending` every time there actually IS an open blocking
+      # point, which is exactly the case this status exists to report.
       - name: Post final status
         if: always()
         env:

--- a/.github/workflows/check-tests-read-names-its-tree.yml
+++ b/.github/workflows/check-tests-read-names-its-tree.yml
@@ -103,15 +103,29 @@ jobs:
 
       # scripts/check_tests_read_names_its_tree.py is stdlib-only
       # (argparse / json / re / subprocess). No pip install needed.
-      # `continue-on-error: true` keeps a script failure from also turning
-      # this step, and with it the job, red: the commit status posted below
-      # is the only channel that carries this verdict. `steps.check.outcome`
-      # (read below) still reports the script's real result -- `outcome` is
-      # the pre-continue-on-error result; `conclusion` is what
-      # continue-on-error would force to `success` and is not read here.
+      #
+      # #5328: this step used to run with `continue-on-error: true`,
+      # reasoning "the commit status posted below is the only channel that
+      # carries this verdict" -- but that setting forces the STEP's (and
+      # so the JOB's, and so this job's own auto-generated check-run's)
+      # *conclusion* to `success` regardless of the script's real exit
+      # code. Measured (the sibling `check-open-blocking-checkboxes.yml`'s
+      # own #5328 fix, #5337 empirical PR): a job with `continue-on-error:
+      # true` on its only real step reads PASS on its own check-run at the
+      # SAME push-time evaluation a correctly-computed commit status reads
+      # FAIL for -- not staleness (that residual gap is real and disclosed
+      # below), unconditional. This workflow shares the identical shape,
+      # so the identical fix applies: removed.
+      #
+      # This job's own conclusion (and so its check-run) now tracks the
+      # SAME script result the commit status below is computed from, in
+      # the SAME run -- the two can only disagree afterward, when a LATER
+      # `issue_comment`-triggered run updates the commit status without a
+      # matching `pull_request` event to refresh this job's own check-run
+      # (an `issue_comment` event's own check-run attaches to the DEFAULT
+      # BRANCH's sha, never the PR's -- see the module comment above).
       - name: Check the TESTS-READ note names this PR's tree
         id: check
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -123,16 +137,14 @@ jobs:
       # runs, and the status posted above stays `pending` rather than
       # silently vanishing. That is what answers "a job that dies mid-run
       # must not go silent"; it is a property of these three steps existing
-      # in this order, not something a unit test can exercise.
-      #
-      # The commit status posted here is the only verdict channel. The
-      # job's own conclusion is deliberately not a signal -- `check` runs
-      # with `continue-on-error: true`, so a script failure never reddens
-      # this job or its check run, only the status below. A runner that
-      # dies before this step runs leaves the `pending` status from above
-      # standing, which remains as the visible verdict -- not in
-      # `required_status_checks` today (#5138 ②), so it does not block
-      # merge; nothing here overwrites it with a red check run.
+      # in this order, not something a unit test can exercise. #5328: now
+      # that the check step has no `continue-on-error`, a real failure
+      # there would otherwise SKIP this step under the default `if:` (all
+      # previous steps succeeded) -- this `always()` is what keeps the
+      # commit status accurate instead of stuck on `pending` every time the
+      # note is genuinely missing or stale, which is exactly the case this
+      # status exists to report. Not in `required_status_checks` today
+      # (#5138 ②), so it does not block merge on its own.
       - name: Post final status
         if: always()
         env:


### PR DESCRIPTION
**[tui-coder]** — fixes #5328.

## Problem, and what lead-coder's report understated
`check-open-blocking-checkboxes.yml` / `check-tests-read-names-its-tree.yml` both ran their real check step with `continue-on-error: true`, on the reasoning "the commit status posted below is the only channel that carries this verdict." But `continue-on-error: true` forces the STEP's — and so the JOB's, and so the job's own auto-generated check-run's — *conclusion* to `success` regardless of the script's real exit code.

lead-coder's own report correctly diagnosed one real gap (an `issue_comment`-triggered check-run attaches to the DEFAULT BRANCH's sha, never the PR's, so a later comment can't refresh the job-level check-run — genuine staleness). But there's a STRONGER defect underneath: the job-level check-run cannot go red **at any time**, including immediately after a fresh push, not just "stuck stale from an earlier true state."

**Empirical proof** (throwaway PR #5337, opened off unfixed `main`, closed+deleted after use): a deliberately open `- [ ] 🔴 test blocking point` line in the PR body, checked at the SAME push-time evaluation —
- `open-blocking-checkbox` (commit status): `fail` — correct.
- `no open blocking checkbox in the PR body` (job-level check-run): `pass` — wrong, at the exact same moment.

## Fix
Removed `continue-on-error: true` from the real check step in both workflows. `if: always()` on "Post final status" was already present in both (still correct, and now load-bearing in a stronger sense — without `continue-on-error`, a real failure now genuinely stops the default-conditioned path, so `always()` is what keeps the commit status from deadlocking on `pending`). `steps.check.outcome` is unaffected either way.

This does NOT fully close the residual staleness gap lead-coder named (a job-level check-run genuinely can't be refreshed by a comment-only event, inherent to how GitHub attaches issue_comment check-runs) — it closes the STRONGER bug (always-green regardless of real state at push time), shrinking the disagreement window to exactly that already-disclosed, inherent gap.

## Scope
Per the issue's own instruction to check both workflows during implementation: `check-tests-read-names-its-tree.yml` had the identical pattern despite its own header comment claiming to have "already solved" this family's shape — fixed identically.

## Live verification (this PR)
I will temporarily add an open `- [ ] 🔴` line to THIS PR's own body after opening, to confirm the FIXED workflow (running from this branch, since `pull_request`-triggered workflows use the PR's own head) now shows the job-level check-run go red too — then remove it and confirm both green again. Will post the before/after in a comment.

## Test plan
- [x] YAML syntax validated (`yaml.safe_load`, both files)
- [x] `ruff check .` — clean
- [x] Existing scoped script test suites unaffected (33 tests, `test_check_open_blocking_checkboxes.py` + `test_check_tests_read_names_its_tree_5039.py`) — green (expected: this PR touches only workflow YAML orchestration, not either script's exit-code semantics)
- [x] Empirical strip-falsify on unfixed `main` via throwaway PR #5337 (opened, observed the defect, closed+deleted)
- [x] Live verification on THIS PR's own fixed workflow — before/after confirmed (issuecomment-5442232579, issuecomment-5442236909)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

