### PR TITLE
fix(#5290): stop double-getsource-ing Session in the budget-bus bridge test

### DIFF
--- a/tests/runtime/test_3053_budget_bus_bridge_aware.py
+++ b/tests/runtime/test_3053_budget_bus_bridge_aware.py
@@ -318,9 +318,31 @@ def test_budget_bus_has_no_frozen_self_bound_dispatch_capture() -> None:
     # session.py mid-sweep), `__init__`'s SOURCE moves and the second call can read a DIFFERENT
     # method's body entirely — a false vacuity-guard failure that looks like the wiring
     # disappeared, when nothing did.
+    #
+    # architect's TESTS-READ(B) BLOCK (#5341): an earlier version of this fix searched
+    # `ast.walk(tree)` for a node named `__init__` — `Session` has TWO nested classes
+    # (`_ChatBudgetBus`, `_ChatLimitBus`; neither currently defines its own `__init__`), and
+    # `ast.walk`'s own docstring is explicit — "in no specified order" — so that search
+    # depended on an unspecified CPython implementation detail (today's BFS order) AND would
+    # silently start reading a NESTED class's `__init__` body instead of `Session`'s own the
+    # moment either nested class gained one — reintroducing the exact "silently reads a
+    # different method's body" defect this fix exists to remove, just relocated. Fixed to walk
+    # only `Session`'s OWN ClassDef body (never descending into a nested class at all), which
+    # depends on neither `ast.walk`'s order nor a re-run census of what nested classes
+    # currently do or don't define.
+    #
+    # No separate test witnesses "one parse, not two, is used" — that is a structural property
+    # of THIS code (which resolution path it takes), not an observable behavior a test can
+    # assert on without transcribing the implementation (Tier 4). What DOES stay observable,
+    # and is guarded below, is that `__init__` is actually found and that its source still
+    # names the two markers the vacuity guard exists to check.
+    session_cls = next(
+        node for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Session"
+    )
     init_node = next(
         (
-            node for node in ast.walk(tree)
+            node for node in session_cls.body
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
             and node.name == "__init__"
         ),

--- a/tests/runtime/test_3053_budget_bus_bridge_aware.py
+++ b/tests/runtime/test_3053_budget_bus_bridge_aware.py
@@ -233,7 +233,21 @@ async def test_root_no_listener_budget_exceed_fail_closed_not_parked(tmp_path: P
 # ── self-bound `_dispatch_intervention` capture ──────────────────────────────────────────────
 
 
-def _frozen_dispatch_capture_bus_classes() -> "list[str]":
+def _parsed_session_source() -> "tuple[str, ast.Module]":
+    """Parse ``Session``'s own source ONCE — ``inspect.getsource(Session)`` (a CLASS) resolves
+    via CPython's ``_ClassFinder`` (matches on ``__qualname__`` via a fresh ``ast.parse``,
+    #5290), not the function/method branch (``findsource``'s ``co_firstlineno``-plus-regex-scan,
+    re-read from whatever ``linecache.checkcache`` finds on disk at call time — fragile if the
+    file is edited between this call and a LATER ``getsource`` call in the same process, #5290's
+    own report, mirroring #5299's identical fix on the sibling #3049 test). Both the offender
+    scan and the vacuity guard below read the SAME parse of the SAME source instead of each
+    doing its own ``getsource`` — the exact shape #5290 describes: two ``getsource`` calls in
+    one test, one of a class (safe) and one of a method (not)."""
+    src = textwrap.dedent(inspect.getsource(Session))
+    return src, ast.parse(src)
+
+
+def _frozen_dispatch_capture_bus_classes(tree: ast.Module) -> "list[str]":
     """Enumerate nested classes defined inside a ``Session`` method that invoke a LOCAL name
     assigned directly from ``self._dispatch_intervention`` (e.g. ``_x = self._dispatch_intervention``
     then ``_x(iv)`` inside the nested class) — the #3053 anti-pattern: a bespoke intervention-bus
@@ -241,8 +255,6 @@ def _frozen_dispatch_capture_bus_classes() -> "list[str]":
     ``_make_router_intervention_bus`` (bridge-aware). Derived from the live class source (never
     hand-listed), so a FUTURE limit/budget-style bus reintroducing the same self-bound freeze is
     caught automatically, independent of variable naming."""
-    src = textwrap.dedent(inspect.getsource(Session))
-    tree = ast.parse(src)
     offenders: list[str] = []
     for func in ast.walk(tree):
         if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -283,7 +295,8 @@ def test_budget_bus_has_no_frozen_self_bound_dispatch_capture() -> None:
     OWN listener-less registry instead of reaching the pipeline originator. RED before the fix:
     ``__init__`` captured ``_session_dispatch = self._dispatch_intervention`` and
     ``_ChatBudgetBus.request`` called it directly."""
-    offenders = _frozen_dispatch_capture_bus_classes()
+    src, tree = _parsed_session_source()
+    offenders = _frozen_dispatch_capture_bus_classes(tree)
     assert offenders == [], (
         "these Session-nested bus classes invoke a frozen self-bound `_dispatch_intervention` "
         "capture directly, bypassing the bridge-aware `_make_router_intervention_bus` seam — "
@@ -294,7 +307,31 @@ def test_budget_bus_has_no_frozen_self_bound_dispatch_capture() -> None:
     # Vacuity guard: `_ChatBudgetBus` must still resolve through `_make_router_intervention_bus`
     # on each call (not a frozen bus reference), else the scan above is vacuously green because
     # there is nothing left to freeze-and-call in the first place (guard inert).
-    init_src = inspect.getsource(Session.__init__)
+    #
+    # #5290: reads `__init__`'s own source segment out of the SAME tree the offender scan just
+    # walked (`ast.get_source_segment`, byte-exact against `src`) rather than a second,
+    # independent `inspect.getsource(Session.__init__)` call — that second call resolves via
+    # CPython's line-number-plus-regex branch (`inspect.findsource`'s `co_firstlineno`),
+    # re-read from whatever the file on disk currently contains (`linecache.checkcache`) at
+    # call time. If the file is edited between the two `getsource` calls in the same test run
+    # (a real, observed shape the night this was found: #5284/#5285 both landed lines in
+    # session.py mid-sweep), `__init__`'s SOURCE moves and the second call can read a DIFFERENT
+    # method's body entirely — a false vacuity-guard failure that looks like the wiring
+    # disappeared, when nothing did.
+    init_node = next(
+        (
+            node for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "__init__"
+        ),
+        None,
+    )
+    assert init_node is not None, (
+        "Session.__init__ not found in Session's own source — this guard needs updating, "
+        "not a bare StopIteration."
+    )
+    init_src = ast.get_source_segment(src, init_node)
+    assert init_src is not None
     assert "_ChatBudgetBus" in init_src and "_make_router_intervention_bus" in init_src, (
         "Session.__init__ no longer wires `_ChatBudgetBus` through `_make_router_intervention_bus` "
         "— the frozen-capture structural scan would be vacuously green (guard inert)."


### PR DESCRIPTION
**[tui-coder]** — part of #5290 (taking over from `default`, rate-limited — see #5290's own handoff comment).

## Problem
`test_budget_bus_has_no_frozen_self_bound_dispatch_capture()` (`tests/runtime/test_3053_budget_bus_bridge_aware.py`) called `inspect.getsource()` twice against the SAME live `Session` class: once on the class (offender scan, line 244) and once on `Session.__init__` (vacuity guard, line 297) — the identical pattern #5299 already fixed on the sibling `test_3049_driver_router_op_intervention_reaches_originator.py` (this is the second of the two confirmed instances lead-coder identified before handoff).

`inspect.getsource(<class>)` resolves via `__qualname__` + a fresh `ast.parse` of the whole class body (`inspect._ClassFinder`) — immune to source-file edits made after import. `inspect.getsource(<method>)` resolves via the function object's `__code__.co_firstlineno` (a line number baked in AT IMPORT TIME) plus `linecache.checkcache` re-reading the CURRENT file content at call time. If lines are inserted/removed above the target method between import and the `getsource()` call — a real, observed shape the night this was found (#5284/#5285 both landed lines in `session.py` mid-sweep) — the line-number lookup can walk into a DIFFERENT method's body entirely, and the guard silently checks the wrong source.

## Fix
Mirrors #5299's own established shape exactly: parse `Session`'s source once (`_parsed_session_source()`), reuse that same `ast.Module` for both the offender scan and the vacuity guard, extracting `__init__`'s node via `ast.walk` + `ast.get_source_segment` instead of a second `getsource()` call. Both checks now depend only on the class-branch resolution path.

## Verification
Standalone (uncommitted, matches #5299's own verification method) reproduction script: edited `session.py` to insert 5 lines above `Session.__init__` mid-run, then ran both the OLD pattern (two independent `getsource` calls) and the NEW pattern (single shared parse) against it —
- OLD: `False` — read the wrong method's body, missing both markers.
- NEW: `True` — correct, under the identical edit.

Also confirmed empirically (not assumed): `Session` has TWO nested classes (`_ChatBudgetBus` at `:1373`, `_ChatLimitBus` at `:8149`) and neither currently defines its own `__init__` — corrected from an earlier claim of "the one nested class," which was false (architect's TESTS-READ(B) finding).

## Test plan
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_3053_budget_bus_bridge_aware.py` — 4 tests, 0 errors
- [x] `python scripts/mypy_ratchet.py` — clean (201 findings, all baselined)
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all clean
- [x] Scoped pytest: 4/4 passed
- [x] Standalone repro script confirms the race (OLD breaks, NEW doesn't)
- [ ] (skipped — no UI/visual surface, a test-file-only structural fix)

part of #5290 — the wider census (25 files using `getsource(` in `tests/`, most excluded per lead-coder's own note as module-targeted) is in progress; #5290 stays open to track it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **本文の根拠が偽です。** 逐語 `_ChatBudgetBus`, the one nested class — **`Session` の nested class は 2 つ**です（`origin/main:src/reyn/runtime/session.py` の `:1373 class _ChatBudgetBus:` と `:8149 class _ChatLimitBus:`）。結論（今日 `__init__` は 1 つ）は変わりませんが、根拠が偽のまま残ると「nested class は 1 つだけ」を前提に次の人が推論します。根拠: PR comment（TESTS-READ (B)）
- [x] 🔴 **`ast.walk` の順序に依存しています。** `ast.walk.__doc__` 逐語 `in no specified order` ∴ 仕様上の保証はありません。加えて `Session` が `__init__` を持つ nested class を獲得した瞬間、guard は無言で別の body を読み得ます — **この PR が消したはずの症状と同じ**です。`Session` の `ClassDef` の**直下の body だけ**を見る形にすれば、順序にも将来の nested class にも依存せず、census を毎回やり直す義務ごと消えます（処方は comment に）
- [x] 🔴 **「なぜ witness が無いか」を docstring に 1 行。** witness が無いこと自体は**正しい**（「1 回しか parse しない」は構造の性質で、pin すれば Tier 4）。ただしその判断が記録されていないと、次の人が Tier 4 を書くか、無いことを欠陥と読みます


