### PR TITLE
fix(#5244): exec_capture over-cap message is bounded in place, not discarded whole

### DIFF
--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -22,14 +22,18 @@ Contract
 * **Timeout** (default 60 s, overridable per-hook via ``timeout_seconds``).
   Timeout / non-zero exit → log + return ``None``; the runner NEVER crashes the
   agent.
-* **Output size** (``exec_capture`` only, #5210): the returned/parsed stdout
-  is unbounded by default (``output_token_cap=None``, byte-identical to
-  every pre-#5210 caller) — the LOGGED copy has always been capped at 200
-  bytes (see ``:200`` below) but the RETURNED value, which ends up as an
-  inbox message and ultimately a prompt, was not. A caller that supplies
-  ``output_token_cap`` gets an explicit, recorded failure (never a silent
-  truncation — see ``run_shell_hook``'s own docstring) when the decoded
-  stdout exceeds it.
+* **Output size** (``exec_capture`` only, #5210, corrected #5244): the
+  returned/parsed stdout is unbounded by default (``output_token_cap=None``,
+  byte-identical to every pre-#5210 caller) — the LOGGED copy has always
+  been capped at 200 bytes (see ``:200`` below) but the RETURNED value,
+  which ends up as an inbox message and ultimately a prompt, was not. A
+  caller that supplies ``output_token_cap`` gets the parsed directive's
+  ``message`` field bounded IN PLACE (structure preserved, marked with a
+  visible elision note, still delivered) when it exceeds the cap — #5210's
+  own "never truncate" ruling governs the SERIALIZED byte stream (cutting
+  JSON mid-stream breaks the parse); it does not forbid bounding a
+  structured field's VALUE after a successful parse, which #5244 found
+  #5210's original form conflated (see ``run_shell_hook``'s own docstring).
 
 Sandbox (CRITICAL)
 ------------------
@@ -529,30 +533,51 @@ async def run_shell_hook(
         the TUI events tab. NOT called when consent is refused or the command is
         skipped (then nothing ran). Best-effort: a sink error never breaks the run.
     output_token_cap:
-        #5210 — ``(cap_tokens, model)`` for ``capture_stdout=True`` runs only;
-        ``None`` (default) applies NO cap, matching every pre-#5210 caller's
-        behavior unchanged. When set, the decoded stdout's estimated token
+        #5210, corrected #5244 — ``(cap_tokens, model)`` for
+        ``capture_stdout=True`` runs only; ``None`` (default) applies NO cap,
+        matching every pre-#5210 caller's behavior unchanged. When set, this
+        function parses the decoded stdout as the JSON push-directive itself
+        (a preview parse — the caller/dispatcher still does its own,
+        independent parse of whatever this returns) and, IF that parse
+        succeeds and yields a string ``message`` field whose estimated token
         count (:func:`~reyn.services.compaction.engine.estimate_tokens`,
-        against *model*) is checked BEFORE the caller ever sees or parses it —
-        exceeding *cap_tokens* is an EXPLICIT failure (logged, recorded via
-        *emit_event* with ``denial_class="exec_capture_output_cap_exceeded"``,
-        return ``None``), never a truncation: a truncated JSON push-directive
-        fails to parse and is indistinguishable from a clean no-push run at
-        the dispatcher (the exact "two silences" shape #5041 already closed
-        once for a different cause). *cap_tokens* is deliberately not invented
-        here — the caller derives it from a real, live context-budget source
-        (``HookDispatcher``'s own ``resolve_exec_capture_output_cap``,
-        wired from ``Session``'s ``TurnBudgetEngine.budget.output_reserve``)
-        and passes ``None`` when no such source is available, rather than
-        supplying an arbitrary fallback number.
+        against *model*) exceeds *cap_tokens*: bounds ONLY that field's text
+        (:func:`~reyn.services.compaction.engine.hard_truncate_summary`,
+        deterministic char-ratio truncation) with a visible elision marker
+        appended, re-serializes the SAME JSON object with the bounded
+        ``message``, and returns that — the directive's other fields, and
+        its structure, are untouched, and it still reaches the caller as a
+        normal push. Recorded via *emit_event* with
+        ``denial_class="exec_capture_message_bounded"``. #5210's original
+        form checked the RAW stdout byte/token count BEFORE any parse and
+        discarded the whole directive on overflow (a `#5244 finding
+        <https://github.com/tya5/reyn/issues/5244>`_: #5210's own "never
+        truncate" ruling is about not cutting the SERIALIZED byte stream —
+        a truncated JSON push-directive fails to parse and is
+        indistinguishable from a clean no-push run at the dispatcher, the
+        exact "two silences" shape #5041 already closed once for a
+        different cause — it says nothing about bounding a structured
+        field's VALUE after a successful parse, which is what this branch
+        now does). If the preview parse fails, or yields no usable
+        ``message`` string, this function does not attempt to bound
+        anything — the caller's own (separate) parse handles that shape the
+        same fail-safe way it always has. *cap_tokens* is deliberately not
+        invented here — the caller derives it from a real, live
+        context-budget source (``HookDispatcher``'s own
+        ``resolve_exec_capture_output_cap``, wired from ``Session``'s
+        ``TurnBudgetEngine.budget.output_reserve``) and passes ``None`` when
+        no such source is available, rather than supplying an arbitrary
+        fallback number.
 
     Returns
     -------
     str | None
-        The decoded stdout when ``capture_stdout=True`` and the run succeeded
-        AND (if *output_token_cap* is set) is within it; otherwise ``None``
-        (always ``None`` for ``capture_stdout=False``, and on any failure in
-        either mode, including exceeding *output_token_cap*).
+        The decoded stdout when ``capture_stdout=True`` and the run
+        succeeded — with its ``message`` field bounded in place if
+        *output_token_cap* was set and exceeded (see above); otherwise
+        ``None`` (always ``None`` for ``capture_stdout=False``, and on any
+        run failure — non-zero exit, timeout, consent refusal, exception —
+        in either mode).
 
     Notes
     -----
@@ -667,40 +692,73 @@ async def run_shell_hook(
         # run_and_classify (#3823 ①) — reused here, not re-derived.
         denial_class = launched.denial_class
 
-        # #5210: computed HERE — before the single unconditional emit_event
-        # call below — so an over-cap rejection rides that SAME event
-        # (architect's own prescription: reuse denial_class, no new event
-        # surface) rather than firing a second, separate one. Only relevant
-        # for a would-be-successful capture_stdout run; an already-failed
-        # run (non-zero exit) is unaffected — that path's own denial_class
-        # (e.g. DENIAL_FORK) takes priority below, unchanged.
-        cap_exceeded = False
+        # #5210, corrected #5244: computed HERE — before the single
+        # unconditional emit_event call below — so a bounded-message
+        # verdict rides that SAME event (architect's own prescription:
+        # reuse denial_class, no new event surface) rather than firing a
+        # second, separate one. Only relevant for a would-be-successful
+        # capture_stdout run; an already-failed run (non-zero exit) is
+        # unaffected — that path's own denial_class (e.g. DENIAL_FORK)
+        # takes priority below, unchanged.
+        #
+        # #5244 (architect ruling, correcting #5210): #5210's own "never
+        # truncate" reasoning is about the SERIALIZED byte stream — cutting
+        # JSON mid-stream produces a directive that fails to parse and is
+        # indistinguishable from a clean, deliberate no-push run (the exact
+        # "two silences" shape #5041 already closed once). That reasoning
+        # does NOT extend to bounding a single structured field's VALUE
+        # after a successful parse — the structure survives, the caller's
+        # own parse still succeeds, and the push still reaches its target.
+        # #5210's original form conflated the two (checked raw stdout
+        # BEFORE any parse, discarded the whole directive on overflow) —
+        # coder-brown's census (28 output-capping call sites repo-wide)
+        # found this was the only one of the 28 that discarded wholesale
+        # rather than marking and delivering a bounded result; #5244 brings
+        # it in line with the other 27.
+        bounded_stdout: str | None = None
         if (
             capture_stdout
             and result.returncode == 0
             and output_token_cap is not None
         ):
             cap_tokens, cap_model = output_token_cap
-            from reyn.services.compaction.engine import estimate_tokens  # noqa: PLC0415
+            from reyn.services.compaction.engine import (  # noqa: PLC0415
+                estimate_tokens,
+                hard_truncate_summary,
+            )
 
             decoded_stdout_for_cap = result.stdout.decode("utf-8", errors="replace")
-            actual_tokens = estimate_tokens(decoded_stdout_for_cap, cap_model)
-            if actual_tokens > cap_tokens:
-                cap_exceeded = True
-                denial_class = "exec_capture_output_cap_exceeded"
-                # #5210 (architect ruling, issue #5210): NEVER truncate — a
-                # cut JSON push-directive fails to parse at the dispatcher
-                # and is indistinguishable from a clean, deliberate no-push
-                # run (the exact "two silences" #5041 already closed once).
-                # Reject outright, loudly, and record it (below) — never
-                # silently degrade.
-                _log.warning(
-                    "shell-hook %r exec_capture output (%d estimated tokens) "
-                    "exceeds the context-budget-derived cap (%d tokens) — push "
-                    "skipped, NOT truncated (a truncated JSON directive would "
-                    "silently fail to parse instead).",
-                    command, actual_tokens, cap_tokens,
-                )
+            # A preview parse, purely to reach the `message` field for
+            # bounding — the caller/dispatcher still does its own,
+            # independent parse of whatever this function returns
+            # (`_parse_exec_push`, unchanged). If this preview parse fails,
+            # or the directive has no usable string `message`, nothing is
+            # bounded here — the caller's own fail-safe parse handles that
+            # shape the same way it always has.
+            try:
+                directive = json.loads(decoded_stdout_for_cap)
+            except (json.JSONDecodeError, ValueError):
+                directive = None
+            message = directive.get("message") if isinstance(directive, dict) else None
+            if isinstance(message, str):
+                message_tokens = estimate_tokens(message, cap_model)
+                if message_tokens > cap_tokens:
+                    denial_class = "exec_capture_message_bounded"
+                    elided = message_tokens - cap_tokens
+                    bounded_message = hard_truncate_summary(message, cap_tokens, cap_model)
+                    bounded_message += (
+                        f"\n\n… ({elided} estimated tokens elided by the "
+                        "context-budget-derived hook-output cap)"
+                    )
+                    directive["message"] = bounded_message
+                    bounded_stdout = json.dumps(directive)
+                    _log.warning(
+                        "shell-hook %r exec_capture message (%d estimated tokens) "
+                        "exceeds the context-budget-derived cap (%d tokens) — "
+                        "message bounded in place (%d tokens elided, structure "
+                        "and other fields preserved, push still delivered).",
+                        command, message_tokens, cap_tokens, elided,
+                    )
 
         if emit_event is not None:
             try:
@@ -758,13 +816,16 @@ async def run_shell_hook(
                 )
             return None  # fail-safe: a failed command yields no push-directive
 
-        # Success. capture_stdout (exec_capture) → return decoded stdout for the
-        # caller to parse; otherwise (exec) output is ignored. #5210: a
-        # cap_exceeded verdict (computed above, before the emit_event call,
-        # so the rejection rides that SAME event) still returns None here —
-        # never a truncated prefix of the real output.
-        if not capture_stdout or cap_exceeded:
+        # Success. capture_stdout (exec_capture) → return decoded stdout for
+        # the caller to parse; otherwise (exec) output is ignored. #5244: a
+        # bounded-message verdict (computed above, before the emit_event
+        # call, so it rides that SAME event) still returns the directive —
+        # with its `message` field bounded — never None; only a genuine run
+        # failure above returns None.
+        if not capture_stdout:
             return None
+        if bounded_stdout is not None:
+            return bounded_stdout
         return result.stdout.decode("utf-8", errors="replace")
 
     except Exception as exc:

--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -541,12 +541,22 @@ async def run_shell_hook(
         independent parse of whatever this returns) and, IF that parse
         succeeds and yields a string ``message`` field whose estimated token
         count (:func:`~reyn.services.compaction.engine.estimate_tokens`,
-        against *model*) exceeds *cap_tokens*: bounds ONLY that field's text
+        against *model*) exceeds *cap_tokens*: bounds that field's text
         (:func:`~reyn.services.compaction.engine.hard_truncate_summary`,
-        deterministic char-ratio truncation) with a visible elision marker
-        appended, re-serializes the SAME JSON object with the bounded
-        ``message``, and returns that — the directive's other fields, and
-        its structure, are untouched, and it still reaches the caller as a
+        deterministic char-ratio truncation) to leave room for a visible
+        elision marker WITHIN *cap_tokens* — the marker's own estimated
+        token cost is reserved from the body's budget first (architect's
+        TESTS-READ catch, #5343: appending the marker to a body already
+        truncated to the FULL cap would let the combined message exceed
+        *cap_tokens*, the exact thing this cap exists to prevent) — then
+        re-serializes the SAME JSON object with the bounded ``message``,
+        and returns that. A *cap_tokens* smaller than the marker's own
+        token floor (~20 tokens for its fixed English text) cannot be
+        honored exactly no matter how much the body is truncated — a
+        real, live context-budget-derived cap is never this small in
+        practice, so this is a theoretical floor, not a handled case with
+        its own fallback. The directive's other fields, and its
+        structure, are untouched, and it still reaches the caller as a
         normal push. Recorded via *emit_event* with
         ``denial_class="exec_capture_message_bounded"``. #5210's original
         form checked the RAW stdout byte/token count BEFORE any parse and
@@ -745,11 +755,22 @@ async def run_shell_hook(
                 if message_tokens > cap_tokens:
                     denial_class = "exec_capture_message_bounded"
                     elided = message_tokens - cap_tokens
-                    bounded_message = hard_truncate_summary(message, cap_tokens, cap_model)
-                    bounded_message += (
+                    # architect's TESTS-READ catch (#5343): the marker
+                    # itself costs tokens too. Appending it to a body
+                    # already truncated to the FULL cap would let the
+                    # combined message exceed cap_tokens — the exact
+                    # thing this cap exists to prevent. Reserve the
+                    # marker's own token cost from the body's budget FIRST
+                    # so the combined result stays within cap_tokens (the
+                    # marker is counted IN the cap, not appended on top of
+                    # it).
+                    marker = (
                         f"\n\n… ({elided} estimated tokens elided by the "
                         "context-budget-derived hook-output cap)"
                     )
+                    marker_tokens = estimate_tokens(marker, cap_model)
+                    body_budget = max(0, cap_tokens - marker_tokens)
+                    bounded_message = hard_truncate_summary(message, body_budget, cap_model) + marker
                     directive["message"] = bounded_message
                     bounded_stdout = json.dumps(directive)
                     _log.warning(

--- a/tests/hooks/test_5210_exec_capture_output_cap.py
+++ b/tests/hooks/test_5210_exec_capture_output_cap.py
@@ -1,19 +1,38 @@
-"""Tier 2: #5210 — exec_capture's returned stdout is bounded when a caller
-supplies a real, context-budget-derived cap; unbounded (byte-identical to
-pre-#5210) when it does not.
+"""Tier 2: #5210, corrected #5244 — exec_capture's returned stdout is bounded
+when a caller supplies a real, context-budget-derived cap; unbounded
+(byte-identical to pre-#5210) when it does not.
 
 Architect ruling (issue #5210): the LOGGED copy of a shell-hook's stdout has
 always been capped at 200 bytes (``shell_runner.py``'s own ``[:200]`` slices);
 the RETURNED copy — the ``exec_capture`` push directive, whose ``message``
-field lands in an inbox and ultimately a prompt — was not. Do NOT truncate:
-a truncated JSON push-directive fails to parse and is indistinguishable from
-a clean, deliberate no-push run at the dispatcher (the exact "two silences"
-shape #5041 already closed once). Exceeding the cap is an EXPLICIT failure
-(no push, recorded via the existing ``hook_shell_executed`` event's
-``denial_class`` field), never a silent truncation. The cap itself is never
-invented — it is derived from a real, live context-budget source
+field lands in an inbox and ultimately a prompt — was not.
+
+Architect's #5244 correction (own #5210 ruling, self-corrected): "never
+truncate" was about the SERIALIZED byte stream — cutting the JSON string
+mid-stream produces a directive that fails to parse and is indistinguishable
+from a clean, deliberate no-push run at the dispatcher (the exact "two
+silences" shape #5041 already closed once). That reasoning does not forbid
+bounding a single structured field's VALUE after a successful parse: the
+STRUCTURE survives, the caller's own parse still succeeds, and the push
+still reaches its target — only the ``message`` text itself is shortened,
+with a visible elision marker appended. #5210's original form checked the
+raw stdout BEFORE any parse and discarded the whole directive wholesale on
+overflow; coder-brown's census (28 output-capping call sites repo-wide)
+found this was the only one of the 28 that discarded rather than marking
+and delivering a bounded result — #5244 brings it in line with the other 27.
+Recorded via the existing ``hook_shell_executed`` event's ``denial_class``
+field (now ``"exec_capture_message_bounded"``, not
+``"exec_capture_output_cap_exceeded"`` — the outcome changed from "no push"
+to "bounded push", so the class name changed with it). The cap itself is
+never invented — it is derived from a real, live context-budget source
 (``RouterHostAdapter.wrap_up_output_reserve``, the SAME token budget the
 force-close wrap-up call is already hard-capped to).
+
+A directive that isn't valid JSON, or has no usable string ``message``
+field, is left untouched by this bounding step even when it's huge —
+bounding only ever operates on a successfully-parsed directive's
+``message`` field; a malformed directive is the dispatcher's own (separate,
+unchanged) fail-safe parse's problem, not this layer's.
 
 Level 1 (``run_shell_hook`` itself): REAL subprocesses (``python -c``
 one-liners), mirroring ``test_1800_hook_shell_runner.py``'s own established
@@ -44,14 +63,8 @@ def _noop_backend() -> NoopBackend:
     return NoopBackend()
 
 
-def _policy(timeout: int = 10, temp_dir: str = "") -> SandboxPolicy:
-    return SandboxPolicy(
-        network=False,
-        deny_subprocess=True,
-        timeout_seconds=timeout,
-        temp_dir=temp_dir,
-        temp_source="session",
-    )
+def _policy(timeout: int = 10) -> SandboxPolicy:
+    return SandboxPolicy(network=False, deny_subprocess=True, timeout_seconds=timeout)
 
 
 # ── Level 1 — run_shell_hook itself, real subprocesses ────────────────────
@@ -75,7 +88,7 @@ async def test_output_within_cap_is_returned_unchanged(
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(temp_dir=str(tmp_path)),
+        sandbox_policy=_policy(),
         allowlist_path=tmp_path / "allowlist.json",
         capture_stdout=True,
         output_token_cap=(1000, "openai/gpt-4o-mini"),
@@ -86,23 +99,25 @@ async def test_output_within_cap_is_returned_unchanged(
 
 
 @pytest.mark.asyncio
-async def test_output_exceeding_the_cap_is_rejected_not_truncated(
+async def test_message_exceeding_the_cap_is_bounded_not_discarded(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog,
 ) -> None:
-    """Tier 2: acceptance — the #5210 witness itself. A real subprocess whose
-    stdout genuinely exceeds a small token cap must return ``None`` (an
-    EXPLICIT rejection), not a truncated prefix of its own output — a
-    truncated JSON string would fail ``json.loads`` at the dispatcher and be
-    indistinguishable from a clean no-push run, exactly the silent-failure
-    shape this issue exists to prevent."""
+    """Tier 2: acceptance — the #5244 witness itself. A real subprocess
+    whose JSON directive's ``message`` field genuinely exceeds a small
+    token cap gets that field bounded IN PLACE (structure preserved, a
+    visible elision marker appended, still delivered as a normal push) —
+    never a whole-directive discard (#5210's original, now-corrected form)."""
     import logging
 
     from reyn.hooks.shell_runner import run_shell_hook
+    from reyn.services.compaction.engine import estimate_tokens
 
     monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
-    # A long, repetitive string — genuinely large, real subprocess output,
-    # not a synthetic in-process value.
-    script = "import sys; sys.stdout.write('x' * 20000)"
+    # A long, repetitive message inside an otherwise-valid directive — real
+    # subprocess output, not a synthetic in-process value.
+    long_message = "word " * 5000
+    directive = {"push_when": True, "wake": True, "message": long_message}
+    script = f"import json,sys; sys.stdout.write(json.dumps({directive!r}))"
 
     events: "list[dict]" = []
 
@@ -115,31 +130,70 @@ async def test_output_exceeding_the_cap_is_rejected_not_truncated(
             event_context={"event": "turn_end"},
             timeout_seconds=10,
             sandbox_backend=_noop_backend(),
-            sandbox_policy=_policy(temp_dir=str(tmp_path)),
+            sandbox_policy=_policy(),
             allowlist_path=tmp_path / "allowlist.json",
             capture_stdout=True,
             emit_event=_emit_event,
             output_token_cap=(5, "openai/gpt-4o-mini"),
         )
 
-    assert result is None, (
-        "output genuinely exceeding the cap must be rejected outright, "
-        "never truncated into a shorter (and likely unparseable) string"
+    assert result is not None, (
+        "a bounded message must still be DELIVERED as a push, never turned "
+        "into None the way a whole-directive discard would"
     )
+    parsed = json.loads(result)
+    assert parsed["push_when"] is True
+    assert parsed["wake"] is True
+    assert "elided" in parsed["message"]
+    assert estimate_tokens(parsed["message"], "openai/gpt-4o-mini") < estimate_tokens(
+        long_message, "openai/gpt-4o-mini"
+    ), "the bounded message must be genuinely shorter than the original"
     assert any(
         "exceeds the context-budget-derived cap" in r.message for r in caplog.records
-    ), "the rejection must be logged, not silent"
-    (event,) = events  # raises if not exactly 1: the rejection must ride the
+    ), "the bounding must be logged, not silent"
+    (event,) = events  # raises if not exactly 1: the verdict must ride the
     # SAME single hook_shell_executed event the run already emits, not fire
     # a second, separate one.
     assert event["event_type"] == "hook_shell_executed"
     assert event["mode"] == "exec_capture"
     assert event["returncode"] == 0
-    assert event["denial_class"] == "exec_capture_output_cap_exceeded", (
-        "the rejection must be recorded on the existing hook_shell_executed "
+    assert event["denial_class"] == "exec_capture_message_bounded", (
+        "the verdict must be recorded on the existing hook_shell_executed "
         "event's denial_class field (architect's own prescription: reuse "
-        "denial_class, no new surface needed) so a future reader (#5041's "
-        f"own design) can see it — got {event!r}"
+        f"denial_class, no new surface needed) — got {event!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_malformed_or_message_less_directive_is_left_untouched_even_if_huge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: falsification contrast — bounding only ever operates on a
+    successfully-parsed directive's ``message`` field. A huge, genuinely
+    invalid-JSON payload with a cap set is returned UNCHANGED (not bounded,
+    not rejected) — the dispatcher's own, separate, unchanged fail-safe
+    parse handles that shape the same way it always has; this layer must
+    not invent a second opinion about malformed input."""
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+    payload = "x" * 20000  # not valid JSON at all
+
+    result = await run_shell_hook(
+        [_PY, "-c", f"import sys; sys.stdout.write({payload!r})"],
+        event_context={"event": "turn_end"},
+        timeout_seconds=10,
+        sandbox_backend=_noop_backend(),
+        sandbox_policy=_policy(),
+        allowlist_path=tmp_path / "allowlist.json",
+        capture_stdout=True,
+        output_token_cap=(5, "openai/gpt-4o-mini"),
+    )
+
+    assert result == payload, (
+        "a directive this layer cannot parse (or that has no usable "
+        "message field) must pass through unchanged — bounding is not "
+        "attempted, and the dispatcher's own fail-safe parse is untouched"
     )
 
 
@@ -163,7 +217,7 @@ async def test_no_cap_supplied_is_unbounded_matching_pre_5210(
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(temp_dir=str(tmp_path)),
+        sandbox_policy=_policy(),
         allowlist_path=tmp_path / "allowlist.json",
         capture_stdout=True,
         # output_token_cap omitted -- the default
@@ -177,28 +231,26 @@ async def test_no_cap_supplied_is_unbounded_matching_pre_5210(
 
 
 @pytest.mark.asyncio
-async def test_strip_the_cap_check_reproduces_the_original_defect(
+async def test_cap_supplied_changes_the_outcome_for_the_same_oversized_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tier 2: strip-falsify — mirrors the real check by hand: with a cap
-    supplied but a genuinely-oversized output, if the cap enforcement were
-    removed the function would return the full string instead of None. This
-    test pins that a cap being SUPPLIED changes the outcome versus not being
-    supplied (contrasted against the previous test), which is what proves
-    the check in shell_runner.py's own return-point logic is load-bearing,
+    """Tier 2: contrast — the SAME oversized message is returned whole with
+    no cap supplied, and bounded when a cap is supplied — proving the
+    bounding logic in ``shell_runner.py``'s own return-point is load-bearing,
     not decorative."""
     from reyn.hooks.shell_runner import run_shell_hook
 
     monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
-    payload = "x" * 20000
-    script = f"import sys; sys.stdout.write({payload!r})"
+    long_message = "word " * 5000
+    directive = {"push_when": True, "wake": True, "message": long_message}
+    script = f"import json,sys; sys.stdout.write(json.dumps({directive!r}))"
 
     no_cap_result = await run_shell_hook(
         [_PY, "-c", script],
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(temp_dir=str(tmp_path)),
+        sandbox_policy=_policy(),
         allowlist_path=tmp_path / "allowlist.json",
         capture_stdout=True,
     )
@@ -207,17 +259,17 @@ async def test_strip_the_cap_check_reproduces_the_original_defect(
         event_context={"event": "turn_end"},
         timeout_seconds=10,
         sandbox_backend=_noop_backend(),
-        sandbox_policy=_policy(temp_dir=str(tmp_path)),
+        sandbox_policy=_policy(),
         allowlist_path=tmp_path / "allowlist.json",
         capture_stdout=True,
         output_token_cap=(5, "openai/gpt-4o-mini"),
     )
 
-    assert no_cap_result == payload
-    assert with_cap_result is None, (
-        "the SAME oversized output must be treated differently depending "
-        "on whether a cap was supplied — proving the cap check actually "
-        "gates the return value"
+    assert json.loads(no_cap_result)["message"] == long_message
+    assert json.loads(with_cap_result)["message"] != long_message, (
+        "the SAME oversized message must be treated differently depending "
+        "on whether a cap was supplied — proving the bounding logic "
+        "actually gates the returned message text"
     )
 
 

--- a/tests/hooks/test_5210_exec_capture_output_cap.py
+++ b/tests/hooks/test_5210_exec_capture_output_cap.py
@@ -134,7 +134,14 @@ async def test_message_exceeding_the_cap_is_bounded_not_discarded(
             allowlist_path=tmp_path / "allowlist.json",
             capture_stdout=True,
             emit_event=_emit_event,
-            output_token_cap=(5, "openai/gpt-4o-mini"),
+            # 50, not a single-digit value: large enough that the elision
+            # marker itself (a fixed ~20-token string) fits comfortably
+            # inside the budget alongside a real truncated body — a cap
+            # smaller than the marker's own footprint cannot be honored by
+            # any amount of body truncation (there is a real floor), which
+            # is a separate, degenerate-input concern this test doesn't
+            # need to explore.
+            output_token_cap=(50, "openai/gpt-4o-mini"),
         )
 
     assert result is not None, (
@@ -145,9 +152,18 @@ async def test_message_exceeding_the_cap_is_bounded_not_discarded(
     assert parsed["push_when"] is True
     assert parsed["wake"] is True
     assert "elided" in parsed["message"]
-    assert estimate_tokens(parsed["message"], "openai/gpt-4o-mini") < estimate_tokens(
+    bounded_tokens = estimate_tokens(parsed["message"], "openai/gpt-4o-mini")
+    assert bounded_tokens < estimate_tokens(
         long_message, "openai/gpt-4o-mini"
     ), "the bounded message must be genuinely shorter than the original"
+    assert bounded_tokens <= 50, (
+        "architect's TESTS-READ catch (#5343): the elision MARKER itself "
+        "costs tokens too — appending it to a body already truncated to "
+        "the FULL cap would let the combined message exceed cap_tokens, "
+        "the exact thing this cap exists to prevent. The marker's own "
+        "cost must come OUT of the cap budget, not be added on top of it "
+        f"— got {bounded_tokens} tokens against a cap of 50"
+    )
     assert any(
         "exceeds the context-budget-derived cap" in r.message for r in caplog.records
     ), "the bounding must be logged, not silent"


### PR DESCRIPTION
**[docs-maintainer]** — part of #5244, implementing architect's ruling (issuecomment-5442775246) on the message-bound (②) fix only, dispatched by lead-coder. #5244 stays open — its other 3 findings remain.

## What

architect's #5210 ruling ("NEVER truncate — a cut JSON push-directive fails to parse at the dispatcher and is indistinguishable from a clean, deliberate no-push run") governed the **serialized byte stream**. #5210's own implementation checked raw stdout *before* any parse and discarded the whole push directive on overflow — architect's own self-correction on #5244 separates what "never truncate" actually protects (parse-ability of the byte stream) from a different operation (bounding one structured field's *value* after a successful parse, which doesn't touch parse-ability at all).

coder-brown's census (28 output-capping call sites repo-wide) found this was the only one of the 28 that discarded wholesale rather than marking-and-delivering a bounded result.

## Fix

- **Layer A (memory protection, unchanged)**: the OS-level subprocess byte cap (`_subprocess_io.communicate_capped`) stays a hard drain-and-discard — parse is never attempted on that path.
- **Layer B (context budget, this fix)**: `run_shell_hook` now does a preview JSON parse of the decoded stdout specifically to reach the `message` field. If parsing fails, or there's no usable string `message`, nothing is bounded — the dispatcher's own separate, unchanged fail-safe parse (`_parse_exec_push`) handles that shape exactly as before. If `message` exceeds the token cap, only that field's text is bounded (`hard_truncate_summary` — reused, not reinvented) with a visible elision marker appended, the same JSON object is re-serialized with the bounded message, and the push still reaches its target — structure and every other field untouched.
- `denial_class` changed from `exec_capture_output_cap_exceeded` (implied "no push") to `exec_capture_message_bounded` (means "bounded push"), recorded on the same `hook_shell_executed` event — no new event surface, per architect's own prescription.

## Test plan

- [x] Rewrote the 2 old #5210 tests that pinned the discard-everything behavior into 2 tests asserting bound-in-place; added a 3rd covering the malformed/no-message fail-safe path (`tests/hooks/test_5210_exec_capture_output_cap.py`, 9/9 passing).
- [x] **Real strip-falsify**: reverted the return-point to the old discard logic — exactly the 2 rewritten tests went RED, the other 7 stayed green. Restored, 9/9 green.
- [x] Broader regression: `tests/hooks/` (362 tests) all pass.
- [x] Consumer sweep: `grep -rn exec_capture_output_cap_exceeded src/ tests/ docs/` — only the new test file's own explanatory docstring (describing the old value that changed), no live consumer of the old string.
- [x] Local gates: ruff, `test_tier_audit --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all clean.
- [x] (skipped — no UI/behavior change) Visual

## Out of scope (per architect's own ruling, quoted)

architect explicitly left the default cap *value* undecided (owner's "まだマシ" was recorded as non-endorsement, not part of this ruling) and explicitly excluded #5244's other 3 findings (network-denial silence, per-agent-layer declaration silently not honored, YAML `on:` boolean trap) from this fix — those remain #5244's own open scope, not closed here.

Touches `tests/` — needs an independent TESTS-READ (B) before merge (rule 8). Co-vet: architect (per lead-coder's dispatch).



## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **「上限を守った」ことを誰も assert していません。** acceptance test は `estimate_tokens(parsed["message"], …) < estimate_tokens(<元の message>)` ＝ **「元より小さい」だけ**で、**`cap_tokens` 以下であることは主張していません**。本 PR では `hard_truncate_summary(...)` の結果に marker を **append** しているので**結果は cap をわずかに超え得ます** ∴ `hard_truncate_summary` が将来ずれても marker が長くなっても、この test は緑のままです。処方: `assert estimate_tokens(parsed["message"], MODEL) <= cap_tokens` を足す。**これが通らないなら test の問題ではなく「marker を cap に含めるか」を決めていないということ**なので、決めたうえで assert してください（含めないなら `<= cap_tokens + _MARKER_TOKENS` と、その定数を名前で）。根拠: PR comment issuecomment-5442994685


---

**[docs-maintainer]** — fixed architect's TESTS-READ finding at head 9033dfdb4 (not ticking their box — architect closes their own): the elision marker's own token cost is now reserved from the body's truncation budget first, so the combined bounded message stays within cap_tokens (was appending the marker on top of the full cap, letting the total exceed it). Strengthened the acceptance test to assert `estimate_tokens(bounded_message) <= cap_tokens` directly. Strip-falsified: reverting to the old append-on-top behavior turns exactly that assertion red (70 tokens against a cap of 50). Restored, 9/9 green. Also caught and fixed a real closing-intent hazard in my own earlier body edit (a negated closing keyword next to #5244) before it could land.

