### PR TITLE
fix(#5041): the live per-frame path now carries the origin agent's name

### DIFF
--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -186,18 +186,42 @@ def forwarded_frame_kinds() -> frozenset[str]:
 
 @dataclass(frozen=True)
 class DisplayFrame:
-    """A display-path frame: one verbatim outbox message → ``renderer.message``."""
+    """A display-path frame: one verbatim outbox message → ``renderer.message``.
+
+    #5041 ①: ``agent`` is the ORIGIN agent's name — architect's own reading
+    (issuecomment-5442805752) found this frame carried no attribution at
+    all, structurally, so a consumer draining a stream that N agents'
+    frames converge onto (e.g. the registry's process-wide ``repl_outbox``,
+    #5041's own motivating case) could not tell them apart, even in
+    principle. Not a new concept: :class:`BacklogBatch` below already
+    carries ``agent`` on the snapshot/reconnect path (#5139) — this is that
+    same axis threaded onto the live per-frame path too. Optional / defaults
+    to ``None`` so every existing construction site (there are many, across
+    the AG-UI wire encode/decode paths and test doubles) is unaffected;
+    :class:`~reyn.interfaces.transport.in_process.InProcessTransport` is the
+    one production path that populates it today (from the registry's
+    already-tracked attached-agent name), closing ①'s finding for the
+    ``repl_outbox`` convergence point specifically. Scope note (disclosed,
+    not silently dropped): the SAME structural gap exists for an
+    ``EventFrame`` sourced from a session's own audit-event subscription
+    outside that convergence point — left for a follow-up, per the owner
+    dispatch's own explicit "①だけ、広げない" scoping."""
 
     message: "OutboxMessage"
     tag: FrameTag = FrameTag.DISPLAY
+    agent: "str | None" = None
 
 
 @dataclass(frozen=True)
 class EventFrame:
-    """An event-path frame: one renderer-relevant audit-event → ``on_audit_event``."""
+    """An event-path frame: one renderer-relevant audit-event → ``on_audit_event``.
+
+    #5041 ①: see :class:`DisplayFrame`'s own docstring — same missing-
+    attribution finding, same fix shape, same optional/defaulted field."""
 
     event: "Event"
     tag: FrameTag = FrameTag.EVENT
+    agent: "str | None" = None
 
 
 # A client consumes a stream of these; ``frame.tag`` selects the renderer entry.

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import replace
 from typing import TYPE_CHECKING, AsyncIterator
 
 from reyn.interfaces.transport.client_transport import ClientTransport
@@ -102,9 +103,20 @@ class InProcessTransport(ClientTransport):
         # renderer-relevant subset onto the unified stream. Non-renderer events
         # are dropped here — the transport carries the renderer's vocabulary,
         # not every audit-event.
+        #
+        # #5041 ①: this callback is only ever subscribed to the CURRENTLY
+        # attached session (rewired on every /attach — see
+        # ``AgentRegistry._wire_focus_listeners``), so ``attached_name`` read
+        # fresh at call time is always the true origin, no local tracking
+        # needed (unlike ``_pump_outbox`` below, where multiple sessions'
+        # items can coexist in the SAME queue during a switch race).
+        # ``getattr(..., None)`` — a test double standing in for the registry
+        # need not implement this property; ``agent`` degrades to its own
+        # default (``None``), same as before this field existed.
         etype = getattr(event, "type", None)
         if etype in self._forward_events:
-            self._frames.put_nowait(EventFrame(event))
+            agent = getattr(self._registry, "attached_name", None)
+            self._frames.put_nowait(EventFrame(event, agent=agent))
 
     async def _pump_outbox(self) -> None:
         # Re-tag the display outbox onto the unified stream, preserving order.
@@ -117,13 +129,31 @@ class InProcessTransport(ClientTransport):
         # (the very stream a switch swaps). Pass an already-tagged frame
         # through UNCHANGED; only a bare ``OutboxMessage`` gets re-tagged as a
         # ``DisplayFrame`` here.
+        #
+        # #5041 ①: ``current_agent`` tracks WHOSE frames are flowing through
+        # this queue right now, updated only by the ``session_attached``
+        # barrier itself — never by re-querying live registry state at drain
+        # time, which could race a switch that happens between an item's PUT
+        # (gated on ``is_attached`` at that moment, in the registry's own
+        # ``_forwarder``) and this GET. The barrier's own documented FIFO
+        # property (registry.py's ``_announce_session_attached``: "before
+        # this frame = old session's frames, after = new session's frames")
+        # is exactly what makes queue-position-based tracking correct where
+        # real-time state would not be. Seeded from ``attached_name`` so the
+        # FIRST batch of frames (before any switch/barrier has been seen)
+        # is still attributed, not left at the field's own ``None`` default.
         outbox = self._registry.repl_outbox
+        current_agent = getattr(self._registry, "attached_name", None)
         while True:
             item = await outbox.get()
             if isinstance(item, EventFrame):
+                if item.event.type == "session_attached":
+                    current_agent = item.event.data.get("agent", current_agent)
+                if item.agent is None:
+                    item = replace(item, agent=current_agent)
                 self._frames.put_nowait(item)
                 continue
-            self._frames.put_nowait(DisplayFrame(item))
+            self._frames.put_nowait(DisplayFrame(item, agent=current_agent))
             if item.kind == "__end__":
                 return
 

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -98,24 +98,32 @@ class InProcessTransport(ClientTransport):
 
     # -- frame production ---------------------------------------------------
 
-    def _forward_audit_event(self, event: "Event") -> None:
+    def _forward_audit_event(self, event: "Event", *, agent: "str | None" = None) -> None:
         # Synchronous subscriber (same mechanism as before): enqueue ONLY the
         # renderer-relevant subset onto the unified stream. Non-renderer events
         # are dropped here — the transport carries the renderer's vocabulary,
         # not every audit-event.
         #
-        # #5041 ①: this callback is only ever subscribed to the CURRENTLY
-        # attached session (rewired on every /attach — see
-        # ``AgentRegistry._wire_focus_listeners``), so ``attached_name`` read
-        # fresh at call time is always the true origin, no local tracking
-        # needed (unlike ``_pump_outbox`` below, where multiple sessions'
-        # items can coexist in the SAME queue during a switch race).
-        # ``getattr(..., None)`` — a test double standing in for the registry
-        # need not implement this property; ``agent`` degrades to its own
-        # default (``None``), same as before this field existed.
+        # #5041 ① (architect's own BLOCK finding, #5344's TESTS-READ(B)):
+        # an earlier version of this read ``self._registry.attached_name``
+        # HERE, at call time — reasoning "this callback is only ever
+        # subscribed to the CURRENTLY attached session, so live state is
+        # always the true origin". That reasoning assumed dispatch is
+        # synchronous with emit; ``EventLog`` actually dispatches via its
+        # own background consumer (#4961 C), so a callback CAN run after a
+        # LATER switch has already happened — reading live state at that
+        # point would confidently attach the WRONG agent's name, worse
+        # than the pre-①  "no attribution at all" (a reader trusts a
+        # wrong answer; it never questioned a missing one). Fixed at the
+        # SOURCE instead: ``AgentRegistry._wire_focus_listeners`` now
+        # BINDS the agent name into the subscribed closure at subscribe
+        # time (before this method is ever called), so ``agent`` here is
+        # always the name of the session this callback was ACTUALLY wired
+        # to — correct regardless of when the callback happens to run.
+        # The default (``None``) only matters for a direct call bypassing
+        # that binding (e.g. a test double), never for a real registry.
         etype = getattr(event, "type", None)
         if etype in self._forward_events:
-            agent = getattr(self._registry, "attached_name", None)
             self._frames.put_nowait(EventFrame(event, agent=agent))
 
     async def _pump_outbox(self) -> None:

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -398,6 +398,13 @@ class AgentRegistry:
         # on every attach so a `/attach <other>` doesn't strand them on the old
         # session. Generic session-level listeners (not domain-specific).
         self._focus_chat_listener: "Callable[..., None] | None" = None
+        # #5041 ①: the ACTUAL closure subscribed to a session's audit_events
+        # — never the raw ``_focus_chat_listener`` itself once a listener is
+        # set (see ``_wire_focus_listeners``'s own docstring for why this
+        # exists: the raw listener is called with a name BOUND AT SUBSCRIBE
+        # TIME, and unsubscribe must target the exact wrapped object, not a
+        # freshly-built one, or the unsubscribe silently no-ops).
+        self._wired_chat_listener: "Callable[[object], None] | None" = None
         self._focus_intervention_channel: str | None = None
         # WAL truncation throttle (WAL-floor design). monotonic ts of last
         # successful truncation attempt; ``None`` means no throttle is active.
@@ -3864,10 +3871,38 @@ class AgentRegistry:
         self._focus_intervention_channel = None
 
     def _wire_focus_listeners(self, session: "object | None") -> None:
+        """#5041 ① (architect's own BLOCK finding, #5344's TESTS-READ(B)):
+        the closure actually subscribed to ``session.audit_events`` BINDS
+        the target agent's name NOW, at subscribe time — never left for
+        the listener to read a live ``self.attached_name`` later, when it
+        is actually CALLED. ``EventLog`` dispatches to subscribers via its
+        own background consumer (#4961 C), not synchronously with
+        ``emit()`` — so a listener that reads global "who's attached"
+        state at call time is answering an EXECUTION-ORDER question
+        ("has a switch landed before this callback happened to run?") it
+        has no business depending on. Binding here instead means a
+        callback that runs late still carries the name of the session it
+        was ACTUALLY subscribed to, regardless of any later switch —
+        structurally, not by timing luck.
+
+        ``self.attached_name`` is safe to read HERE specifically because
+        this call always happens in the SAME synchronous block as the
+        connection flip that made ``session`` the target (``attach()`` /
+        ``attach_session()`` / ``bind_focus_listeners``'s own initial
+        wire) — the same no-``await``-in-between barrier property
+        ``_announce_session_attached`` already relies on elsewhere in
+        this file."""
         if session is None:
             return
         if self._focus_chat_listener is not None:
-            session.subscribe_audit_events(self._focus_chat_listener)
+            listener = self._focus_chat_listener
+            agent = self.attached_name
+
+            def _bound_listener(event: "object", _listener=listener, _agent=agent) -> None:
+                _listener(event, agent=_agent)
+
+            self._wired_chat_listener = _bound_listener
+            session.subscribe_audit_events(_bound_listener)
         if self._focus_intervention_channel is not None:
             try:
                 session.register_intervention_listener(self._focus_intervention_channel)
@@ -3877,8 +3912,14 @@ class AgentRegistry:
     def _unwire_focus_listeners(self, session: "object | None") -> None:
         if session is None:
             return
-        if self._focus_chat_listener is not None:
-            session.unsubscribe_audit_events(self._focus_chat_listener)
+        if self._wired_chat_listener is not None:
+            # Unsubscribe the EXACT closure `_wire_focus_listeners` built
+            # (never a freshly-constructed one, or the identity check
+            # inside `unsubscribe_audit_events` silently no-ops and the
+            # old session keeps calling a listener meant for a switch
+            # that already happened).
+            session.unsubscribe_audit_events(self._wired_chat_listener)
+            self._wired_chat_listener = None
         if self._focus_intervention_channel is not None:
             try:
                 session.unregister_intervention_listener(self._focus_intervention_channel)

--- a/tests/interfaces/test_5041_1_frame_agent_attribution.py
+++ b/tests/interfaces/test_5041_1_frame_agent_attribution.py
@@ -13,21 +13,40 @@ ever let two agents be "attached" concurrently, a consumer draining the
 converged stream would have no way to tell their frames apart — not
 unlikely, structurally impossible.
 
-Fix (``src/reyn/interfaces/transport/frames.py`` + ``in_process.py``):
-``DisplayFrame``/``EventFrame`` gain an optional ``agent: str | None = None``
-field (mirrors ``BacklogBatch.agent``, defaults to ``None`` so every OTHER
-existing construction site across the AG-UI wire paths and test doubles is
-unaffected). ``InProcessTransport`` populates it two ways: the audit-event
-path reads ``registry.attached_name`` fresh at each call (always correct —
-that callback is only ever wired to the CURRENTLY attached session); the
-``repl_outbox``-draining path tracks a running ``current_agent``, updated
-ONLY by the ``session_attached`` barrier frame itself (never by re-querying
-live registry state at drain time, which could race a switch that happens
-between an item's PUT — gated on ``is_attached`` at THAT moment, in the
-registry's own ``_forwarder`` — and this GET). The barrier's own documented
-FIFO property (registry.py's ``_announce_session_attached``: "before this
-frame = old session's frames, after = new session's frames") is exactly
-what makes queue-position-based tracking correct.
+Fix (``src/reyn/interfaces/transport/frames.py`` + ``in_process.py`` +
+``registry.py``): ``DisplayFrame``/``EventFrame`` gain an optional
+``agent: str | None = None`` field (mirrors ``BacklogBatch.agent``,
+defaults to ``None`` so every OTHER existing construction site across the
+AG-UI wire paths and test doubles is unaffected). ``InProcessTransport``
+populates it two ways, NEITHER of which reads live "who's attached now"
+state at the moment a frame is produced (architect's own TESTS-READ(B)
+BLOCK finding, issuecomment-5443216808, on an EARLIER version of this fix
+that read ``registry.attached_name`` in the audit-event path at call
+time — an execution-order assumption a background-dispatched callback can
+break, attaching a CONFIDENTLY WRONG name instead of the pre-fix "no
+attribution at all", worse as an attribution failure mode):
+
+- the ``repl_outbox``-draining path tracks a running ``current_agent``,
+  updated ONLY by the ``session_attached`` barrier frame itself flowing
+  through the SAME queue (never by re-querying live registry state at
+  drain time, which could race a switch that happens between an item's
+  PUT — gated on ``is_attached`` at THAT moment, in the registry's own
+  ``_forwarder`` — and this GET). The barrier's own documented FIFO
+  property (registry.py's ``_announce_session_attached``: "before this
+  frame = old session's frames, after = new session's frames") is what
+  makes queue-position-based tracking correct.
+- the audit-event path has no such queue to track position in, so
+  ``AgentRegistry._wire_focus_listeners`` instead BINDS the agent name
+  into the subscribed closure at SUBSCRIBE time (wrapping the raw
+  listener before ``session.subscribe_audit_events`` ever sees it) —
+  ``EventLog`` dispatches via its own background consumer (#4961 C), not
+  synchronously with ``emit()``, so a late-running callback still
+  carries the name of whichever session it was ACTUALLY subscribed to.
+  This closes the race STRUCTURALLY (no live state is ever read at call
+  time to race against), not merely narrows its window — per architect's
+  own note, there is deliberately no test attempting to force that
+  specific timing here: once binding removes the only state a race could
+  act on, there is nothing left for such a test to observe failing.
 
 Real ``AgentRegistry`` + 2 real sessions (``make_session``) + a real
 ``InProcessTransport`` — no mocks. Drives ``session._put_outbox`` directly

--- a/tests/interfaces/test_5041_1_frame_agent_attribution.py
+++ b/tests/interfaces/test_5041_1_frame_agent_attribution.py
@@ -1,0 +1,175 @@
+"""Tier 2: #5041 ① — the live per-frame path (``DisplayFrame``/``EventFrame``)
+now carries the origin agent's name.
+
+Architect's own reading (issuecomment-5442805752, resolved by reading, not
+observation — the 55-comment thread's "does repl_outbox mix N agents'
+output" question was never one that needed a 2-agent-concurrent repro to
+answer): ``registry.repl_outbox`` is a SINGLE process-wide queue every
+attached agent's own forwarder writes onto, and neither ``OutboxMessage``
+nor the frame types wrapping it carried any "whose" axis at all —
+``BacklogBatch`` already does (``agent: str``, #5139, the reconnect/switch
+snapshot path); only the LIVE per-frame path didn't. If a future redesign
+ever let two agents be "attached" concurrently, a consumer draining the
+converged stream would have no way to tell their frames apart — not
+unlikely, structurally impossible.
+
+Fix (``src/reyn/interfaces/transport/frames.py`` + ``in_process.py``):
+``DisplayFrame``/``EventFrame`` gain an optional ``agent: str | None = None``
+field (mirrors ``BacklogBatch.agent``, defaults to ``None`` so every OTHER
+existing construction site across the AG-UI wire paths and test doubles is
+unaffected). ``InProcessTransport`` populates it two ways: the audit-event
+path reads ``registry.attached_name`` fresh at each call (always correct —
+that callback is only ever wired to the CURRENTLY attached session); the
+``repl_outbox``-draining path tracks a running ``current_agent``, updated
+ONLY by the ``session_attached`` barrier frame itself (never by re-querying
+live registry state at drain time, which could race a switch that happens
+between an item's PUT — gated on ``is_attached`` at THAT moment, in the
+registry's own ``_forwarder`` — and this GET). The barrier's own documented
+FIFO property (registry.py's ``_announce_session_attached``: "before this
+frame = old session's frames, after = new session's frames") is exactly
+what makes queue-position-based tracking correct.
+
+Real ``AgentRegistry`` + 2 real sessions (``make_session``) + a real
+``InProcessTransport`` — no mocks. Drives ``session._put_outbox`` directly
+(the seam under test; the session's own full router-loop run is not what's
+being verified here) and ``registry.attach()`` for the switch. No polling,
+no self-authored timeout: ``transport.frames().__anext__()`` suspends on a
+real ``asyncio.Queue.get()`` the background forwarder/pump tasks feed, so
+a bare, unbounded ``await`` on it IS the wait — CI's own ``--timeout`` is
+the kill switch (CLAUDE.md's Ceiling rule), not a number chosen here.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path) -> AgentRegistry:
+    def factory(profile: AgentProfile):
+        return make_session(agent_name=profile.name, agent_role=profile.role)
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    reg.create("beta")
+    return reg
+
+
+def _cancel_all(reg: AgentRegistry) -> None:
+    for task in reg.running_tasks():
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_live_display_frame_carries_the_attached_agents_name(tmp_path) -> None:
+    """Tier 2: a message from the attached agent's own outbox is forwarded
+    onto ``repl_outbox`` by the REAL registry forwarder, and the
+    ``DisplayFrame`` ``InProcessTransport`` produces from it carries that
+    agent's name — closing the "cannot tell whose frame this is, even in
+    principle" finding for the single-attached case visible today, and
+    threading the type-level axis through for a future N-attached one."""
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        alpha = reg.attached_session()
+        assert alpha is not None
+        transport = InProcessTransport(reg, intervention_channel="test-5041")
+        transport.start()
+        try:
+            await alpha._put_outbox(OutboxMessage(kind="agent", text="hello from alpha"))
+            # attach() itself already queued a session_attached EventFrame
+            # (the #3310 N1 barrier) before this test's own message — skip
+            # past it, same shape as the switch test below.
+            frame = None
+            while frame is None:
+                candidate = await transport.frames().__anext__()
+                if isinstance(candidate, DisplayFrame):
+                    frame = candidate
+            assert frame.message.text == "hello from alpha"
+            assert frame.agent == "alpha", (
+                f"#5041 REGRESSION: a live DisplayFrame should carry the "
+                f"attached agent's name — got {frame.agent!r}"
+            )
+        finally:
+            transport.close()
+    finally:
+        _cancel_all(reg)
+
+
+@pytest.mark.asyncio
+async def test_attribution_follows_a_real_switch_via_the_barrier(tmp_path) -> None:
+    """Tier 2: after a real ``/attach``-style switch (alpha -> beta), a
+    message from beta's own outbox is attributed to "beta", not stuck on
+    the PREVIOUS agent's name — proving the barrier-based tracking (not a
+    stale seed) is what drives attribution across a switch, the exact
+    shape the queue-position (not real-time-state) design exists for."""
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        transport = InProcessTransport(reg, intervention_channel="test-5041")
+        transport.start()
+        try:
+            await reg.attach("beta")
+            beta = reg.attached_session()
+            assert beta is not None
+            await beta._put_outbox(OutboxMessage(kind="agent", text="hello from beta"))
+
+            seen_agents: "list[str | None]" = []
+            display_frame = None
+            while display_frame is None:
+                frame = await transport.frames().__anext__()
+                if isinstance(frame, EventFrame):
+                    seen_agents.append(frame.agent)
+                    continue
+                display_frame = frame
+
+            assert display_frame.message.text == "hello from beta"
+            assert display_frame.agent == "beta", (
+                f"#5041 REGRESSION: after a switch, the live DisplayFrame should "
+                f"follow the barrier to the NEW agent's name — got "
+                f"{display_frame.agent!r}"
+            )
+        finally:
+            transport.close()
+    finally:
+        _cancel_all(reg)
+
+
+@pytest.mark.asyncio
+async def test_audit_event_frame_carries_the_currently_attached_agents_name(
+    tmp_path,
+) -> None:
+    """Tier 2: the OTHER live frame source — a session's own audit-event
+    subscription — also carries attribution now, read fresh from
+    ``registry.attached_name`` at each event (correct because that
+    subscriber is only ever wired to the CURRENTLY attached session,
+    re-wired on every switch — no queue-convergence race to guard against
+    on this path, unlike ``repl_outbox``)."""
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        alpha = reg.attached_session()
+        assert alpha is not None
+        transport = InProcessTransport(reg, intervention_channel="test-5041")
+        transport.start()
+        try:
+            alpha._audit_events.emit("turn_started", chain_id="c-5041")
+            frame = None
+            while frame is None:
+                candidate = await transport.frames().__anext__()
+                if isinstance(candidate, EventFrame) and candidate.event.type == "turn_started":
+                    frame = candidate
+            assert frame.agent == "alpha", (
+                f"#5041 REGRESSION: a live EventFrame from the audit-event path "
+                f"should carry the currently-attached agent's name — got "
+                f"{frame.agent!r}"
+            )
+        finally:
+            transport.close()
+    finally:
+        _cancel_all(reg)


### PR DESCRIPTION
**[tui-coder]** — part of #5041 (①, per lead-coder's handoff and architect's ruling, issuecomment-5442805752).

## Problem
Architect's own reading (resolved by reading, not observation — the 55-comment thread's "does `repl_outbox` mix N agents' output" question never needed a 2-agent-concurrent repro to answer): `registry.repl_outbox` is a SINGLE process-wide queue every attached agent's own forwarder writes onto, and neither `OutboxMessage` nor the frame types wrapping it (`DisplayFrame`/`EventFrame`) carried any "whose" axis at all. `BacklogBatch` already does (`agent: str`, #5139, the reconnect/switch snapshot path) — only the live per-frame path didn't.

## Fix
`DisplayFrame`/`EventFrame` (`src/reyn/interfaces/transport/frames.py`) gain an optional `agent: str | None = None` field, mirroring `BacklogBatch.agent`, defaulting to `None` so every OTHER existing construction site (many, across the AG-UI wire encode/decode paths and test doubles) is unaffected.

`InProcessTransport` populates it two ways:
- the audit-event path (`_forward_audit_event`) reads `registry.attached_name` fresh at each call — correct because that callback is only ever wired to the CURRENTLY attached session, re-wired on every `/attach`.
- the `repl_outbox`-draining path (`_pump_outbox`) tracks a running `current_agent`, updated ONLY by the `session_attached` barrier frame itself — never by re-querying live registry state at drain time, which could race a switch happening between an item's PUT (gated on `is_attached` at THAT moment, in the registry's own `_forwarder`) and this GET. The barrier's own documented FIFO property (registry.py's `_announce_session_attached`: "before this frame = old session's frames, after = new session's frames") is what makes queue-position-based tracking correct where real-time state would not be.

`registry.py` is deliberately NOT touched — `repl_outbox` keeps its existing `OutboxMessage | EventFrame` item contract, so the ~9 test files that directly `put_nowait` raw items onto a fake registry's `repl_outbox` (matching this exact family's own established double-based test convention) are unaffected. `attached_name` (a registry property that already existed, FP-0043 S3) is accessed via `getattr(..., None)` so a test double that doesn't implement it degrades to the field's own `None` default rather than raising.

## Scope (disclosed, not silently dropped)
A session's own audit-event-sourced `EventFrame` gets attribution now too, but this is DELIBERATELY the `repl_outbox` convergence point only — ②-⑥ and the supervision-design thread that #5041's own 55 comments partly evolved into are explicitly out of scope per the dispatch's own "①だけ、広げない" instruction. #5041 itself reverts to tracking the original 6-item friction log per architect's ruling — this PR does not close it.

## Tests
`tests/interfaces/test_5041_1_frame_agent_attribution.py` (3 new) — real `AgentRegistry` + 2 real sessions (`make_session`) + a real `InProcessTransport`, no mocks:
1. a live `DisplayFrame` carries the attached agent's name.
2. after a real switch (alpha → beta), attribution follows the barrier to the NEW agent, not stuck on the old one.
3. the audit-event path's `EventFrame` also carries the currently-attached agent's name.

No self-authored wait ceiling anywhere (CLAUDE.md's Ceiling rule): `transport.frames().__anext__()` suspends on a real `asyncio.Queue.get()` the background forwarder/pump tasks feed, so a bare unbounded `await` on it IS the wait — CI's own `--timeout` is the kill switch.

**Strip-falsify**: reverted `frames.py`/`in_process.py` (via a scoped `git stash`), confirmed all 3 new tests go RED with the exact predicted symptom (`AttributeError: 'EventFrame' object has no attribute 'agent'`), restored and reconfirmed green — byte-identical restore verified via diff against a saved copy before popping the stash.

## Test plan
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_5041_1_frame_agent_attribution.py` — 3 tests, 0 errors
- [x] `python scripts/mypy_ratchet.py` — clean (201 findings, all baselined)
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all clean
- [x] Broader regression sweep: 222 tests across the full in_process/transport/frame/outbox/3310/agui surface (219 pre-existing + 3 new) — all green, confirmed identical before/after this change (a pre-existing 2-warning "Event loop is closed" teardown noise appears in both runs, unrelated)
- [x] Strip-falsify: confirmed red without the fix, green with it
- [ ] (skipped — no UI/visual surface, a type-level attribution field + transport wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **audit-event 側だけ「呼び出し時刻に global を読んでも正しい」という実行順序の仮定が残っています。** `agent = getattr(self._registry, "attached_name", None)` — **同じ PR の `_pump_outbox` はその仮定を明示的に拒み、`session_attached` を queue 内で流して `current_agent` を更新しています**。難しい方が解かれ、簡単に見える方に仮定が残った形です。⚠️ **①以前は「誰の行か分からない」でしたが、①以後は「確信をもって間違った名前が付く」が有り得ます** — 帰属機構としては後者の方が悪い（読み手は疑いません）。処方: **購読時に agent 名を束縛する**（listener を session に配線する時点で closure に入れ、呼び出し時に global を読まない）∴ 遅れて走った callback も自分が購読していた session の名前を付け、**順序に依存しなくなります**。⚪ 束縛にすれば、現在 witness の無い「audit 側の切替」は**構造上 起きなくなります**（押さえる対象が消えます）。根拠: PR comment issuecomment-5443216808

