### PR TITLE
fix: close the marker read-before-write-completes race in #5226's test

### DIFF
--- a/tests/runtime/test_5226_process_registry.py
+++ b/tests/runtime/test_5226_process_registry.py
@@ -250,19 +250,47 @@ def test_the_real_cli_entry_point_actually_calls_register_process(
     )
     try:
         marker_dir = home / ".reyn" / "processes"
-        _wait_until(lambda: marker_dir.is_dir() and any(marker_dir.glob("*.json")))
+        # #5342 CI observation (lead-coder): this test failed on json.loads
+        # under an unrelated PR's CI run — real, not a flake. Root cause:
+        # register_process() writes via Path.write_text(), which is NOT
+        # atomic — the file is created (and so becomes glob-visible) the
+        # moment it's opened, before its content is written and flushed.
+        # The OLD wait predicate here only checked for the file's EXISTENCE
+        # (``any(marker_dir.glob("*.json"))``), so under real disk-I/O
+        # contention (12000+ tests across xdist workers measured the night
+        # this was found) a reader could win the race between "file exists"
+        # and "file's bytes are fully written" — reading a truncated/empty
+        # file straight into json.loads.
+        #
+        # Fixed two ways at once: (a) the wait predicate now requires the
+        # file to be SUCCESSFULLY PARSEABLE, not merely present — closing
+        # the exact race; (b) the marker is addressed by this test's own
+        # already-known ``proc.pid`` directly, not "whichever file glob
+        # returns first" — closing a SEPARATE concern lead-coder raised
+        # (``markers[0]`` had no guarantee of being THIS test's own marker
+        # rather than some other file, however unlikely under `tmp_path`
+        # isolation in practice).
+        marker_path = marker_dir / f"{proc.pid}.json"
+
+        def _marker_is_readable() -> bool:
+            if not marker_path.is_file():
+                return False
+            try:
+                json.loads(marker_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                return False
+            return True
+
+        _wait_until(_marker_is_readable)
 
         markers = list(marker_dir.glob("*.json"))
-        # Non-empty AND nothing past the first — a behavioral "exactly one
-        # marker for the one process this test launched" claim, phrased to
-        # avoid test_tier_audit.py's Tier 4 format-pinning flag on an
-        # explicit length-equality check.
-        assert markers and markers[1:] == [], (
-            f"#5226 REGRESSION: the real CLI entry point (main()) did not "
-            f"register itself via register_process — got {markers!r} under "
+        assert markers == [marker_path], (
+            f"#5226 REGRESSION: the real CLI entry point (main()) should "
+            f"register itself via register_process under exactly this "
+            f"process's own pid ({proc.pid}) — got {markers!r} under "
             f"{marker_dir}"
         )
-        data = json.loads(markers[0].read_text(encoding="utf-8"))
+        data = json.loads(marker_path.read_text(encoding="utf-8"))
         assert data["pid"] == proc.pid, (
             "the marker's own pid should be the real child process's pid"
         )


### PR DESCRIPTION
**[tui-coder]** — lead-coder reported this via broker (no tracking issue filed for the specific finding — observed on PR #5342's CI run, an unrelated LLMReplay diff with nothing to do with this test).

## Problem
`test_the_real_cli_entry_point_actually_calls_register_process` (#5226/#5326) failed in CI: `json.loads` raised reading the marker file the test's own subprocess had just written.

Root cause: `register_process()` (`src/reyn/runtime/process_registry.py`) writes the marker via `Path.write_text()`, which is NOT atomic — the file is created (and so becomes glob-visible to a concurrent reader) the moment it's opened, before its content is written and flushed. This test's own wait predicate only checked the file's EXISTENCE (`any(marker_dir.glob("*.json"))`), not its readability, so under real disk-I/O contention (the CI run that caught this ran 12000+ tests across xdist workers) a reader could win the race between "file exists" and "file's bytes are fully written" — reading a truncated/empty file straight into `json.loads` immediately after the wait returned.

Production code (`live_processes()`) already tolerates this — it wraps its own read+parse in `try/except (OSError, json.JSONDecodeError): continue`, silently skipping a transiently-partial marker (a real D-2 best-effort posture, not a bug). This was a **test-only** gap, not a production one.

## Fix
Two things at once:
1. The wait predicate now requires the marker to be **successfully parseable**, not merely present — closing the exact race. Verified directly (a standalone script, not checked in, simulating an empty file → a partial write → a complete one) that the new predicate returns `False`/`False`/`True` for those three states respectively.
2. The marker is now addressed by this test's own already-known `proc.pid` directly (`marker_dir / f"{proc.pid}.json"`), not "whichever file `glob()[0]` happens to return" — closing a separate concern lead-coder raised: `markers[0]` had no guarantee of being THIS test's own marker rather than some other file (unlikely under `tmp_path` isolation in practice, but not guaranteed by the code as written).

## Test plan
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5226_process_registry.py` — 4 tests, 0 errors
- [x] `python scripts/mypy_ratchet.py` — clean (201 findings, all baselined)
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] Scoped pytest: 4/4 passed
- [x] Predicate verified directly against the 3 race states (empty/partial/complete)
- [ ] (skipped — no UI/visual surface, a test-file-only race fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)