### PR TITLE
fix(#5346): register_process() writes atomically (tmp + rename)

### DIFF
--- a/src/reyn/runtime/process_registry.py
+++ b/src/reyn/runtime/process_registry.py
@@ -92,6 +92,18 @@ def _marker_path(pid: int) -> Path:
     return PROCESSES_DIR / f"{pid}.json"
 
 
+def _tmp_marker_path(pid: int) -> Path:
+    """#5346: the staging path :func:`register_process` writes to BEFORE
+    the atomic rename onto :func:`_marker_path`'s own name — never a real
+    marker itself. ``*.json`` globs (both here and in
+    :func:`live_processes`) never match this suffix, so a reader can never
+    mistake a still-being-written marker for a real one; only
+    :func:`live_processes`'s own reap pass (below) ever looks at this
+    suffix at all, and only to remove one whose owning PID is confirmed
+    dead."""
+    return PROCESSES_DIR / f"{pid}.json.tmp"
+
+
 def register_process(subcommand: "str | None") -> None:
     """Write this process's own marker and register its own cleanup.
 
@@ -105,7 +117,16 @@ def register_process(subcommand: "str | None") -> None:
     missing home directory, a full disk) must never block reyn from
     starting — this is a diagnostic aid, not a precondition (mirrors
     ``proctitle.py``'s own "a diagnostic aid that can stop a program
-    from starting is worse than the diagnosis it offers")."""
+    from starting is worse than the diagnosis it offers").
+
+    #5346: writes to a ``.tmp`` staging path first, then
+    :meth:`~pathlib.Path.replace` (``os.replace``, atomic on the same
+    filesystem on POSIX) onto the real marker name — a reader
+    (:func:`live_processes`) can therefore only ever see this pid's
+    marker as either "fully written" or "not there yet", never
+    partial. Found via a real CI failure (#5345/#5226, lead-coder's own
+    observation): a reader that raced a plain ``write_text`` straight to
+    the final path could read a truncated file mid-write."""
     pid = os.getpid()
     marker = {
         "pid": pid,
@@ -116,7 +137,9 @@ def register_process(subcommand: "str | None") -> None:
     }
     try:
         PROCESSES_DIR.mkdir(parents=True, exist_ok=True)
-        _marker_path(pid).write_text(json.dumps(marker), encoding="utf-8")
+        tmp_path = _tmp_marker_path(pid)
+        tmp_path.write_text(json.dumps(marker), encoding="utf-8")
+        tmp_path.replace(_marker_path(pid))
     except OSError:
         logger.warning(
             "process_registry: failed to write launch marker for pid %d "
@@ -181,9 +204,30 @@ def live_processes() -> "list[dict]":
     abandoned session) — it only ever removes metadata about a process
     that :func:`~reyn.data.index.build_lock.pid_alive` has already
     confirmed does not exist, so the next read does not have to
-    re-confirm the same negative."""
+    re-confirm the same negative.
+
+    #5346: also reaps an orphaned ``.tmp`` staging file (:func:`register_process`'s
+    write target BEFORE its atomic rename onto the real marker name) —
+    the one shape that can leave one behind is the process dying between
+    the ``.tmp`` write and the rename, a narrow window but not a zero
+    one. A ``.tmp`` file is never trusted as a live marker regardless (the
+    ``*.json`` glob below never matches it, and its own content is never
+    read here — only its PID-shaped filename, since a still-mid-write
+    file's content is exactly what must not be trusted); this is charter
+    Q1's bounding subject for THAT one channel of "who stops it if it
+    repeats" — a live, still-registering process's own ``.tmp`` is never
+    touched (only a CONFIRMED-DEAD one's is), so this can never race the
+    write it might belong to."""
     if not PROCESSES_DIR.is_dir():
         return []
+    for tmp_path in sorted(PROCESSES_DIR.glob("*.json.tmp")):
+        pid_str = tmp_path.name.removesuffix(".json.tmp")
+        if not pid_str.isdigit() or pid_alive(int(pid_str)):
+            continue
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
     result: "list[dict]" = []
     for path in sorted(PROCESSES_DIR.glob("*.json")):
         try:

--- a/tests/runtime/test_5226_process_registry.py
+++ b/tests/runtime/test_5226_process_registry.py
@@ -302,3 +302,141 @@ def test_the_real_cli_entry_point_actually_calls_register_process(
         assert proc.stdin is not None  # sanity: PIPE was requested above
         proc.stdin.close()  # release the real blocked read — a graceful exit
         proc.wait()
+
+
+# ── #5346: register_process() writes via a .tmp staging file + atomic rename ─
+
+
+def test_a_tmp_only_marker_is_invisible_to_live_processes_and_never_misglobbed(
+    _isolated_processes_dir: Path,
+) -> None:
+    """Tier 2: #5346 — architect's own prescribed witness. A ``.tmp``
+    staging file (the intermediate state ``register_process`` passes
+    through between writing content and the atomic rename onto the real
+    marker name) must be invisible to ``live_processes()`` two ways at
+    once: the pid it names must not appear in the returned list, AND the
+    file itself must never be mistaken for a real ``*.json`` marker (the
+    exact failure #5345 fixed on the READER side of this same file —
+    #5346 closes the WRITER side)."""
+    pid = os.getpid() + 1  # a pid guaranteed not to be this test process's own
+    _isolated_processes_dir.mkdir(parents=True, exist_ok=True)
+    tmp_marker = _isolated_processes_dir / f"{pid}.json.tmp"
+    tmp_marker.write_text(json.dumps({"pid": pid, "subcommand": "mid-write"}), encoding="utf-8")
+
+    result = process_registry.live_processes()
+
+    assert all(entry["pid"] != pid for entry in result), (
+        f"#5346 REGRESSION: a bare .tmp staging file's pid should never "
+        f"appear as a live process — got {result!r}"
+    )
+    real_markers = list(_isolated_processes_dir.glob("*.json"))
+    assert real_markers == [], (
+        f"#5346 REGRESSION: a .tmp file should never be matched by the "
+        f"*.json glob — got {real_markers!r}"
+    )
+
+
+def test_dead_pid_tmp_marker_is_reaped_on_the_next_read(
+    _isolated_processes_dir: Path,
+) -> None:
+    """Tier 2: #5346 — a ``.tmp`` orphaned by a process that died BETWEEN
+    writing it and the atomic rename (a narrow window, but a real one —
+    architect's own charter Q1 bounding: something must eventually stop
+    this from accumulating) is reaped the next time anything reads the
+    registry, once its pid is confirmed dead — mirrors the EXISTING
+    dead-``.json``-marker reap exactly, same criterion
+    (``pid_alive``), same file."""
+    proc = _spawn_registering_subprocess()
+    try:
+        _wait_until(lambda: len(process_registry.live_processes()) == 1)
+        real_marker = _isolated_processes_dir / f"{proc.pid}.json"
+        assert real_marker.exists()  # sanity: the real write+rename completed
+
+        proc.kill()
+        proc.wait()
+        _wait_until(lambda: not process_registry.pid_alive(proc.pid))
+
+        # Simulate the orphan-.tmp shape directly (deterministic — not
+        # trying to force the real, narrow write/death race): a .tmp
+        # file for this now-confirmed-dead pid, exactly what would be
+        # left if the kill had landed between the tmp write and the
+        # rename instead of after it.
+        orphan_tmp = _isolated_processes_dir / f"{proc.pid}.json.tmp"
+        orphan_tmp.write_text(
+            json.dumps({"pid": proc.pid, "subcommand": "orphaned"}), encoding="utf-8",
+        )
+
+        process_registry.live_processes()
+
+        assert not orphan_tmp.exists(), (
+            "#5346 REGRESSION: a .tmp orphan for a confirmed-dead pid should "
+            "be reaped on the next read, the same as a dead .json marker is"
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+
+def test_live_pid_tmp_marker_is_never_reaped(
+    _isolated_processes_dir: Path,
+) -> None:
+    """Tier 2: #5346 — the reap must never touch a ``.tmp`` belonging to a
+    process that is still ALIVE (mid-write, or simply slow) — reaping a
+    live process's in-flight staging file would be indistinguishable from
+    corrupting its next write. Uses this TEST's own real, indisputably-
+    alive pid (never a synthetic one) as the ``.tmp`` owner."""
+    _isolated_processes_dir.mkdir(parents=True, exist_ok=True)
+    own_tmp = _isolated_processes_dir / f"{os.getpid()}.json.tmp"
+    own_tmp.write_text(json.dumps({"pid": os.getpid(), "subcommand": "still-writing"}), encoding="utf-8")
+    try:
+        process_registry.live_processes()
+        assert own_tmp.exists(), (
+            "#5346 REGRESSION: live_processes() must never reap a .tmp file "
+            "belonging to a confirmed-ALIVE pid"
+        )
+    finally:
+        own_tmp.unlink(missing_ok=True)
+
+
+def test_register_process_writes_via_tmp_then_atomic_rename_never_direct(
+    _isolated_processes_dir: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5346 — strip-falsify target for the fix itself, not just
+    its surrounding reap logic. Forces the atomic-rename step
+    (``Path.replace``) to fail AFTER the content write succeeds, then
+    checks what's on disk: a COMPLETE, valid ``.tmp`` file, and NO
+    ``.json`` file at all. Under the OLD code (a direct ``write_text`` to
+    the final path, no ``.tmp``/rename at all), patching ``Path.replace``
+    has no effect on that code path — the final ``.json`` would exist
+    directly and no ``.tmp`` would exist, failing BOTH assertions here.
+    No duration anywhere: the failure is forced structurally (a raised
+    exception), never a real race waited out."""
+    real_replace = Path.replace
+
+    def _failing_replace(self: Path, target) -> None:
+        raise OSError("#5346 test: simulated rename failure, proves write-then-rename order")
+
+    monkeypatch.setattr(Path, "replace", _failing_replace)
+    pid = os.getpid()
+    process_registry.register_process("rename-fails")
+    monkeypatch.setattr(Path, "replace", real_replace)  # restore before any cleanup .replace() call
+
+    tmp_marker = _isolated_processes_dir / f"{pid}.json.tmp"
+    final_marker = _isolated_processes_dir / f"{pid}.json"
+    try:
+        assert tmp_marker.is_file(), (
+            "#5346 REGRESSION: the content write should still have happened "
+            "before the (forced-failing) rename was attempted"
+        )
+        assert json.loads(tmp_marker.read_text(encoding="utf-8"))["pid"] == pid
+        assert not final_marker.exists(), (
+            "#5346 REGRESSION: the final marker must never exist unless the "
+            "atomic rename actually succeeded"
+        )
+    finally:
+        tmp_marker.unlink(missing_ok=True)
+        # register_process()'s own except-OSError branch returns BEFORE
+        # arming atexit when the write+rename fails (confirmed by reading
+        # the source, not asserted here as private state) — no
+        # unregister_process() call needed to avoid a stray atexit handler.


### PR DESCRIPTION
**[tui-coder]** — fixes #5346.

## Problem
architect's own finding, a side-product of #5345's TESTS-READ(B) (issuecomment-5443151598): `register_process()`'s marker write was non-atomic (`Path.write_text()` straight to the final path) — the file becomes glob-visible the instant it's opened, before its content is written. #5345 fixed the READER side (that module's own test). This fixes the WRITER side: production `live_processes()` already tolerates a transiently-partial marker (`except (OSError, json.JSONDecodeError): continue`), but "tolerates" here means SKIPS it — so `reyn doctor` transiently undercounts by exactly one live process during the write window. #5226's own entire job is "how many, right now" — a narrow window, but the situation this feature exists FOR (many processes starting concurrently) is exactly when that window gets exercised most.

## Fix
Write to a `.tmp` staging path first, then `Path.replace()` (POSIX `os.replace`, atomic on the same filesystem) onto the real marker name — a reader can only ever see a pid's marker as "fully written" or "not there yet", never partial.

**Bounding subject** for the one new accumulation this introduces (charter Q1, architect's own note): a process killed BETWEEN the tmp write and the rename (narrow, but real) leaves an orphaned `.tmp`. `live_processes()` now also reaps a `.tmp` whose owning pid is confirmed dead (same `pid_alive()` criterion, same reap pass, same file — extending the existing dead-marker reap rather than inventing a second mechanism), never touching one belonging to a still-alive pid.

## Tests (4 new)
1. architect's own prescribed witness: a bare `.tmp` file is invisible to `live_processes()` two ways at once — the pid doesn't appear, AND the file is never mis-globbed as a real `*.json` marker (the mirror image of #5345's own fix, on the writer side).
2. a `.tmp` orphaned by a confirmed-dead pid is reaped on the next read.
3. a `.tmp` belonging to a confirmed-ALIVE pid is never reaped (safety: never touch an in-flight write).
4. strip-falsify target: forces `Path.replace()` to raise AFTER the content write succeeds (no duration — a raised exception, not a waited-out race), confirming the on-disk state is a complete `.tmp` and NO `.json` — proving write-then-rename ORDER, not just success.

## Strip-falsify
Reverted `process_registry.py` (scoped `git stash`), confirmed 2 of the 4 new tests go RED under the old code with the predicted symptoms (the reap test — no reap logic existed at all; the write-order test — no `.tmp`/rename exists under the old direct-write code). The other 2 pass under old code too (legitimate regression guards for a property — `live_processes()`'s glob specificity — that happened to already hold before this fix; not discriminating, still worth pinning going forward). Restored, reconfirmed all 8 (now 10 with #5345's own tests) green — byte-identical restore verified via diff against a saved copy.

## Test plan
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5226_process_registry.py` — 8 tests, 0 errors
- [x] `python scripts/mypy_ratchet.py` — clean (201 findings, all baselined)
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] Scoped pytest: 10/10 passed (post-rebase onto #5345)
- [x] Strip-falsify: confirmed red without the fix, green with it
- [ ] (skipped — no UI/visual surface, a production write-path + test fix)

part of #5226 (`process_registry.py`, my own area) — filed as its own PR since #5345 (the reader-side sibling fix) is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)