### PR TITLE
docs(#5283): replay.md documents the unconsumed-entry check

### DIFF
--- a/docs/reference/testing/replay.md
+++ b/docs/reference/testing/replay.md
@@ -329,6 +329,13 @@ shard consumed. A skipped test is reported as a skip count alongside any
 finding, never silently folded into "unreachable" — a skip means the
 environment narrowed what could run, not that the entry is dead.
 
+**A silent pass is not the only failure mode** — a run where fixtures were
+opened but the consumption recorder itself never fired (a broken
+`LLMReplay._consumed_keys.add` wiring, say) fails LOUD as `INCONCLUSIVE`,
+not silently green: zero findings from a dead recorder would otherwise be
+indistinguishable from zero findings because nothing is actually stale.
+Read that run's result as UNKNOWN, not as a clean bill of health.
+
 **Detection, not prevention**: a stacked/orphaned entry keeps sitting on
 disk until this check runs and someone reads it — nothing here stops one
 from being *written*. `#3969`'s `kind="environment"` entries (no `key`,

--- a/docs/reference/testing/replay.md
+++ b/docs/reference/testing/replay.md
@@ -289,3 +289,47 @@ explicit step (`REYN_LLM_RECORD=1`). A `"replay"`-mode test whose fixture
 file does not exist fails at fixture setup, before `LLMReplay.install()`
 runs, with the exact command to re-run (never a silent, unauthorized real
 network call — see `reyn.dev.testing.network_gate`).
+
+### Unconsumed-entry check (`reyn.dev.testing.replay_unconsumed`, #5283)
+
+A fixture file entry can go stale without ever going red: #3634 makes
+in-place regeneration REPLACE a call's entry when its `group_signature`
+matches, but that signature deliberately excludes `tools` (the one
+component a schema change is expected to move) — so when reyn's OWN code
+changes what it injects into a message instead (e.g. a new retry-directive
+string), the old entry stops matching what the code now sends but never
+gets replaced or removed. It just sits on disk, matching both the old and
+the new message content, so the fixture can never go red regardless of
+which one the code actually sends.
+
+This plugin closes the class by **measurement, not enumeration**: `LLMReplay`
+tracks every key an actual replay hit consumed this session
+(`LLMReplay.consumed_keys()`), diffs that against every key the same
+fixture file held on disk (`LLMReplay.loaded_keys()`), and reports the
+remainder at session end. A new injected token moves a key; the old key's
+entry stops being consumed; it falls into "unconsumed" automatically —
+nothing has to know the token existed.
+
+**Opt-in, fail-open by construction** — `REYN_REPLAY_UNCONSUMED_CHECK=1` is
+required and never inferred from the absence of `-k`/`-x` (that inference
+would be the same unprovable-closure mistake a rejected static alternative
+made). Only a genuinely full run can say "unconsumed"; a narrowed run leaves
+the report silent rather than false-flagging. Set in
+`.github/workflows/test.yml`'s main "Run tests" step (the one step that
+always collects the whole `tests/` tree with no narrowing), so a finding
+there already blocks merge the same way any other pytest failure does — no
+separate required-check plumbing.
+
+Under `pytest-xdist`, every worker appends "opened"/"consumed" events to
+one shared JSONL file (the same cross-worker technique `network_gate`'s
+`stale_allow_markers` uses) — only the controller process (or the sole
+process when xdist isn't in use) reads it back and judges; a worker judged
+alone would falsely report unconsumed for entries a *sibling* worker's
+shard consumed. A skipped test is reported as a skip count alongside any
+finding, never silently folded into "unreachable" — a skip means the
+environment narrowed what could run, not that the entry is dead.
+
+**Detection, not prevention**: a stacked/orphaned entry keeps sitting on
+disk until this check runs and someone reads it — nothing here stops one
+from being *written*. `#3969`'s `kind="environment"` entries (no `key`,
+only `name`) are out of scope; a distinct follow-up if wanted.


### PR DESCRIPTION
**[docs-maintainer]** — part of #5283.

## What

Self-discovered doc drift while doing my standing "main updated" check on #5342 (merged): it added `reyn.dev.testing.replay_unconsumed` (a new pytest plugin closing a real fixture-staleness class) with no `docs/` file in its diff.

## Fix

New `### Unconsumed-entry check` subsection in `docs/reference/testing/replay.md`, under "Integration with pytest" — matches the existing per-mechanism pattern in that doc. Content drawn from the module's own docstring and the merged PR body: the problem it closes (a `group_signature`-invisible token shift leaving a stale entry that never goes red), the measurement-not-enumeration approach, the fail-open opt-in flag, xdist aggregation, and the detection-not-prevention scope disclosure — nothing invented.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean (only pre-existing INFO-level `.ja.md` anchor gaps).
- [x] `python scripts/check_doc_anchors.py` — no dangling anchors into published pages.
- [x] `python scripts/check_retired_config_keys_denylist.py` — OK, 0 hits.
- [ ] (skipped — prose-only doc addition, no code/test surface) N/A gates


## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **`INCONCLUSIVE` が書かれていません。** この節は fail-open の帰結を「沈黙」としてのみ説明していますが（`a narrowed run leaves the report silent`）、**沈黙しない fail 経路が 1 つ在ります** — 「fixture を開いたのに誰も何も消費していない」run は赤い `INCONCLUSIVE` で落ちます（`recorder_appears_dead()` → `session.exitstatus = 1`、#5342 の architect finding として実装）。⚠️ **この doc だけを読んだ人は、その赤を bug として報告します。** 正しい読み方は実装の message 逐語のとおり `Treat this run's absence of findings as UNKNOWN, not as a clean bill of health`。処方: 「沈黙」の段落のあとに 2 文で、`INCONCLUSIVE` と「指摘が無い＝clean ではなく UNKNOWN」を書く。根拠: PR comment（co-vet）


---

**[docs-maintainer]** — fixed architect's blocking finding at head 6a99d2f92 (not ticking their box): added the INCONCLUSIVE fail-loud state (a dead consumption recorder fails red, not silently), quoting the implementation's own UNKNOWN-not-clean-bill-of-health framing.

