### PR TITLE
docs(#5333): pid_alive's two definitions cross-reference each other

### DIFF
--- a/src/reyn/api/safe/process.py
+++ b/src/reyn/api/safe/process.py
@@ -55,6 +55,14 @@ def pid_alive(pid: int) -> bool:
     :class:`PermissionError` — that means the PID exists but is owned
     by a different user, which still counts as "alive" for stale-lock
     purposes.
+
+    Core's own twin is :func:`reyn.data.index.build_lock.pid_alive`
+    (semantically identical today) — deliberately NOT unified (#5333,
+    architect's ruling): this module is the curated, sandbox-scoped
+    surface exposed to safe-mode python, and every direction of sharing
+    (core importing this, this importing core, or a third shared module)
+    either crosses that boundary or just relocates the question without
+    closing it.
     """
     if pid <= 0:
         return False

--- a/src/reyn/data/index/build_lock.py
+++ b/src/reyn/data/index/build_lock.py
@@ -34,6 +34,14 @@ def pid_alive(pid: int) -> bool:
     On POSIX, ``os.kill(pid, 0)`` raises ProcessLookupError when the PID
     is gone and PermissionError when it exists but is not ours; both
     mean "still alive enough to defer to". Windows is best-effort.
+
+    The sandbox-mode twin is :func:`reyn.api.safe.process.pid_alive`
+    (semantically identical today) — deliberately NOT unified (#5333,
+    architect's ruling): that module is the curated, sandbox-scoped
+    surface exposed to safe-mode python, and every direction of sharing
+    (that module importing core, core importing that module, or a third
+    shared module) either crosses the boundary that surface exists to
+    keep, or just relocates the question without closing it.
     """
     if pid <= 0:
         return False


### PR DESCRIPTION
**[docs-maintainer]** — closes #5333, per architect's own "explicit drop + 1-line cross-reference" ruling (the issue's own closing condition).

## What

architect's ruling, quoted verbatim from the issue (not my own summary — lead-coder's explicit instruction after their own summary caused 2 errors tonight): a census found exactly 2 duplicate `pid_alive` definitions (`api/safe/process.py:46`, `data/index/build_lock.py:31`), inline duplication 0. Not a "族" (a general class fixable by unifying): all 3 possible sharing directions either cross `api/safe/`'s own sandbox-scoped-surface boundary or just relocate the boundary question without closing it. `process_registry.py`'s own docstring already disclosed this exact tradeoff when #5326 landed — #5333 is that same finding being independently rediscovered because it wasn't visible at the definitions themselves.

## Fix (exactly what the ruling prescribes — 2 lines, at the right place)

One cross-reference line added to each `pid_alive` docstring, naming the twin and the boundary reason — turning an invisible duplicate into a disclosed one. Not unifying anything.

## Divergence disclosure (architect's own, carried forward)

The two docstrings already describe slightly different edge-case handling (`OSError` breadth vs. Windows best-effort). No caller reads both — advisory lock / index build lock / process registry are separate domains — so a future divergence would not create a cross-domain inconsistency. Recorded, not fixed.

## Test plan

- [x] `ruff check` on both changed files — clean.
- [x] `verify_module_docstrings.py` on both changed files — OK.
- [x] Scoped pytest (`-k "pid_alive or build_lock or safe_process"`) — 7/7 pass.
- [ ] (skipped — docstring-only change, no behavior change) N/A gates
