### PR TITLE
fix(#5329): _pump_frames' own frame stream no longer exits silently on failure

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6671,6 +6671,48 @@ class TextualChatApp(App):
                         logger.exception("textual chat: compact layout failed")
                 except Exception:
                     logger.exception("textual chat: live chrome refresh failed")
+        except Exception:
+            # #5329 ②: every OTHER failure mode in this method (18 sites
+            # above) is guarded — a single frame's ingest, chrome refresh,
+            # or layout decision failing logs and the pump keeps running.
+            # The one thing that was NOT guarded was the loop's own supply
+            # — ``self._transport.frames()`` itself. An exception raised
+            # there (post-#5126, ``frames()`` now correctly RAISES a real
+            # transport failure instead of silently ending the stream —
+            # this except is the next layer up that #5126 alone did not
+            # reach) fell straight through this method with no handler,
+            # into the SAME ``finally: self.exit()`` a clean end-of-stream
+            # also takes — making a genuine crash and a normal shutdown
+            # produce the identical, silent "app closed, shell prompt
+            # back" symptom (owner's own real-machine observation this
+            # session: "the process completely terminates and returns to
+            # shell").
+            #
+            # This does not decide whether exiting was the RIGHT response
+            # to this failure (lead-coder's own scoping: "終了の可否を先
+            # に決めようとしないでください" — a real transport closure is
+            # itself sometimes a legitimate reason to exit) — only that
+            # the two paths must be DISTINGUISHABLE afterward. logger.
+            # exception here is the SAME durable channel — reyn.log — the
+            # 18 sibling guards above already use and this session already
+            # established has real readers (an operator tailing it
+            # directly, ``scripts/dogfood_trace.py --mode llm-payloads``,
+            # #4364's own доctor-style diagnostics precedent) — a log line
+            # nobody reads would be absence under another name, which is
+            # exactly what this fixes, not what it would become. The
+            # DISPLAY question (whether/how an operator sees this WHILE
+            # the TUI is still open, before it exits) is deliberately left
+            # open — that is an owner visual-judgment call this fix does
+            # not attempt to make; what it guarantees is that the reason
+            # survives the exit and is discoverable AFTER the process has
+            # already returned to shell, which is the shape the owner's
+            # own observation actually needs answered first.
+            logger.exception(
+                "textual chat: _pump_frames' frame stream (self._transport"
+                ".frames()) raised — the app is exiting BECAUSE of this "
+                "exception, not because the stream ended normally"
+            )
+            raise
         finally:
             self.exit()
 

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6672,41 +6672,17 @@ class TextualChatApp(App):
                 except Exception:
                     logger.exception("textual chat: live chrome refresh failed")
         except Exception:
-            # #5329 ②: every OTHER failure mode in this method (18 sites
-            # above) is guarded — a single frame's ingest, chrome refresh,
-            # or layout decision failing logs and the pump keeps running.
-            # The one thing that was NOT guarded was the loop's own supply
-            # — ``self._transport.frames()`` itself. An exception raised
-            # there (post-#5126, ``frames()`` now correctly RAISES a real
-            # transport failure instead of silently ending the stream —
-            # this except is the next layer up that #5126 alone did not
-            # reach) fell straight through this method with no handler,
-            # into the SAME ``finally: self.exit()`` a clean end-of-stream
-            # also takes — making a genuine crash and a normal shutdown
-            # produce the identical, silent "app closed, shell prompt
-            # back" symptom (owner's own real-machine observation this
-            # session: "the process completely terminates and returns to
-            # shell").
-            #
-            # This does not decide whether exiting was the RIGHT response
-            # to this failure (lead-coder's own scoping: "終了の可否を先
-            # に決めようとしないでください" — a real transport closure is
-            # itself sometimes a legitimate reason to exit) — only that
-            # the two paths must be DISTINGUISHABLE afterward. logger.
-            # exception here is the SAME durable channel — reyn.log — the
-            # 18 sibling guards above already use and this session already
-            # established has real readers (an operator tailing it
-            # directly, ``scripts/dogfood_trace.py --mode llm-payloads``,
-            # #4364's own доctor-style diagnostics precedent) — a log line
-            # nobody reads would be absence under another name, which is
-            # exactly what this fixes, not what it would become. The
-            # DISPLAY question (whether/how an operator sees this WHILE
-            # the TUI is still open, before it exits) is deliberately left
-            # open — that is an owner visual-judgment call this fix does
-            # not attempt to make; what it guarantees is that the reason
-            # survives the exit and is discoverable AFTER the process has
-            # already returned to shell, which is the shape the owner's
-            # own observation actually needs answered first.
+            # #5329 ②: the loop's own supply, ``self._transport.frames()``,
+            # was the one failure point in this method with no handler —
+            # every other site above logs and keeps the pump running.
+            # Remove this except and a genuine stream failure again falls
+            # silently into the same ``finally: self.exit()`` a clean
+            # end-of-stream takes, so a crash and a normal shutdown are
+            # indistinguishable afterward. ``reyn.log`` has a real reader
+            # even with the TUI closed: ``chrome.py``'s diagnostics line
+            # names this same log path to the operator inline. Whether/how
+            # to surface this WHILE the TUI is still open is left open —
+            # an owner visual-judgment call, not this fix's job.
             logger.exception(
                 "textual chat: _pump_frames' frame stream (self._transport"
                 ".frames()) raised — the app is exiting BECAUSE of this "

--- a/tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py
+++ b/tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py
@@ -1,0 +1,225 @@
+"""Tier 2: #5329 ② — ``TextualChatApp._pump_frames`` no longer conflates a
+genuine exception from its frame stream with a clean end-of-stream.
+
+lead-coder's own real-machine measurement (issuecomment-5443600309,
+``origin/main`` at ``34d66ee94``, AST): the 18 OTHER failure points inside
+``_pump_frames`` are all guarded (a frame's own ingest, chrome refresh, layout
+decision — each wrapped in its own ``except Exception: logger.exception(...)``
+so a single bad frame never kills the pump). The ONE thing left unguarded was
+the loop's own supply, ``self._transport.frames()`` itself: zero ``except``
+handlers, and a ``finally: self.exit()`` that ran identically whether the
+stream ended cleanly or blew up. Owner's own real-machine observation this
+session — "the process completely terminates and returns to shell" — matches
+this shape exactly, though matching a shape is not a root-cause claim (lead-
+coder's own explicit caveat, having been wrong 3 times tonight about what
+actually caused #5329's crash): the fix here does not depend on knowing why
+``frames()`` raised, only that when it does, that fact must survive past the
+same silent ``self.exit()`` a clean shutdown also takes.
+
+This is the direct continuation of #5126 (``AgUiTransport._pump_sse``,
+``tests/interfaces/test_5126_pump_sse_exception_not_swallowed.py``), which
+fixed the PRODUCER side of this exact class of bug (``frames()`` used to
+disguise a real failure as a clean end; #5126 made it RAISE the real
+exception instead). #5329 ② is the next layer up: now that ``frames()``
+correctly raises, THIS consumer had no handler for it at all. Mirrors that
+PR's own two-test shape (a real failure case + a clean-end regression guard)
+and its own witness idiom: inject the failure by raising out of a real,
+minimal ``ClientTransportStub`` subclass, driven through a REAL
+``TextualChatApp`` via ``app.run_test()`` (Textual's own real test harness,
+the same one every other Phase-1/2/3 TUI test in this suite uses,
+e.g. ``test_textual_chat_phase1_3273.py``'s ``ScriptedTransport``) — no
+mocks, no duration: ``pilot.pause()`` yields control back to the event loop
+exactly enough times for the worker to run, never a sleep.
+"""
+from __future__ import annotations
+
+import logging
+from typing import AsyncIterator
+
+import pytest
+from textual.worker import WorkerFailed
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+_LOGGER_NAME = "reyn.interfaces.inline.textual_chat.app"
+
+
+class _InjectedPumpFailure(RuntimeError):
+    """Stands in for a real transport-level failure (#5329's own motivating
+    case is a 429 quota exhaustion, but what actually raises is irrelevant
+    to the property under test — lead-coder's own explicit scoping: "quota
+    を再現できなくても構いません。任意の例外で witness が書ければ十分")."""
+
+
+class _RaisingTransport(ClientTransportStub):
+    """A real, minimal :class:`ClientTransport` (``ClientTransportStub``
+    supplies every OTHER abstract method's default) whose ``frames()``
+    yields one genuine frame — proving pre-failure frames still got
+    delivered, the same sanity ``test_5126``'s own witness checks — then
+    raises. Mirrors that PR's ``_sse_lines_then_fail`` exactly, one layer
+    up the stack."""
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        yield DisplayFrame(OutboxMessage(kind="agent", text="before the failure"))
+        raise _InjectedPumpFailure("simulated transport failure")
+
+    async def submit_user_text(self, text: str) -> "str | None":  # pragma: no cover - trivial
+        return None
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover - trivial
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover - trivial
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover - trivial
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class _CleanEndTransport(ClientTransportStub):
+    """The regression-guard sibling: a stream that ends NORMALLY (no
+    exception, just ``__end__``) — the fix must not turn this into a
+    logged failure. Only a genuine exception should produce the new log
+    line."""
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        yield DisplayFrame(OutboxMessage(kind="agent", text="a normal reply"))
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    async def submit_user_text(self, text: str) -> "str | None":  # pragma: no cover - trivial
+        return None
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover - trivial
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover - trivial
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover - trivial
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+@pytest.mark.asyncio
+async def test_a_pump_exception_is_logged_distinguishably_before_exit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: #5329 ②'s own witness — a genuine exception from
+    ``self._transport.frames()`` must leave a distinguishable, durable
+    record (this session's own precedent for "durable" — ``reyn.log``, the
+    same channel the 18 sibling guards in this method already use and
+    already have real readers: an operator tailing it directly,
+    ``scripts/dogfood_trace.py --mode llm-payloads``) BEFORE the app exits
+    — not merely SOME record eventually, at the exact point that
+    distinguishes this from a clean shutdown.
+
+    Strip-falsifier: reverting the new ``except Exception: logger.exception(
+    ...); raise`` block around the ``async for`` (back to the bare
+    ``try/finally`` with zero handlers) turns this red — no matching log
+    record exists, because nothing in ``_pump_frames`` ever saw the
+    exception to log it. No duration anywhere: ``pilot.pause()`` yields to
+    the event loop exactly enough times for the worker to process the one
+    real frame and then hit the injected raise; CI's own ``--timeout`` is
+    the only ceiling.
+
+    ``run_test``'s own pilot re-raises the worker's failure as
+    ``WorkerFailed`` on context exit — this is Textual's OWN pre-existing
+    behaviour (``Worker._run``'s ``exit_on_error`` path calls
+    ``app._handle_exception``, docstring: "Always results in the app
+    exiting"), unconditional on whether ``_pump_frames`` itself has a
+    handler. It fired identically before this fix (the bare, handler-less
+    ``try/finally`` never stopped the exception reaching the worker
+    machinery) — the fix adds the log line, not this propagation, so
+    asserting it here is not asserting the fix itself, only setting up a
+    place to observe it from."""
+    transport = _RaisingTransport()
+    app = TextualChatApp(transport=transport)
+    with caplog.at_level(logging.ERROR, logger=_LOGGER_NAME):
+        with pytest.raises(WorkerFailed):
+            async with app.run_test(size=(80, 24)) as pilot:
+                await pilot.pause()
+                await pilot.pause()
+
+    messages = [r.message for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any(
+        "_pump_frames' frame stream" in m and "raised" in m for m in messages
+    ), (
+        f"#5329 REGRESSION: a genuine _pump_frames exception should be "
+        f"logged, distinguishably from a clean end-of-stream — got "
+        f"{messages!r}"
+    )
+    assert any("BECAUSE of this exception" in m for m in messages), (
+        "the log line should say the exit is BECAUSE of the exception, "
+        "not merely that something happened — this is the distinguishing "
+        "half, not just a bare traceback"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_clean_end_of_stream_logs_nothing_new(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: regression guard, mirrors #5126's own
+    ``test_a_clean_end_of_stream_still_returns_normally`` — an ORDINARY
+    end-of-stream (no exception, just ``__end__``) must NOT trigger the
+    new log line. Only a genuine exception should surface as one; a clean
+    end is still silent, exactly as it was before this fix (the fix adds
+    a signal on the exception path, not noise on the normal one)."""
+    transport = _CleanEndTransport()
+    app = TextualChatApp(transport=transport)
+    with caplog.at_level(logging.ERROR, logger=_LOGGER_NAME):
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+
+    messages = [r.message for r in caplog.records if r.name == _LOGGER_NAME]
+    assert not any("_pump_frames' frame stream" in m for m in messages), (
+        f"#5329 REGRESSION: a CLEAN end-of-stream must not produce the "
+        f"exception-only log line — got {messages!r}"
+    )

--- a/tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py
+++ b/tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py
@@ -152,12 +152,11 @@ async def test_a_pump_exception_is_logged_distinguishably_before_exit(
 ) -> None:
     """Tier 2: #5329 ②'s own witness — a genuine exception from
     ``self._transport.frames()`` must leave a distinguishable, durable
-    record (this session's own precedent for "durable" — ``reyn.log``, the
-    same channel the 18 sibling guards in this method already use and
-    already have real readers: an operator tailing it directly,
-    ``scripts/dogfood_trace.py --mode llm-payloads``) BEFORE the app exits
-    — not merely SOME record eventually, at the exact point that
-    distinguishes this from a clean shutdown.
+    record (``reyn.log``, the same channel the 18 sibling guards in this
+    method already use, and the same path ``chrome.py``'s own diagnostics
+    line names to the operator inline) BEFORE the app exits — not merely
+    SOME record eventually, at the exact point that distinguishes this
+    from a clean shutdown.
 
     Strip-falsifier: reverting the new ``except Exception: logger.exception(
     ...); raise`` block around the ``async for`` (back to the bare
@@ -186,7 +185,8 @@ async def test_a_pump_exception_is_logged_distinguishably_before_exit(
                 await pilot.pause()
                 await pilot.pause()
 
-    messages = [r.message for r in caplog.records if r.name == _LOGGER_NAME]
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    messages = [r.message for r in records]
     assert any(
         "_pump_frames' frame stream" in m and "raised" in m for m in messages
     ), (
@@ -194,10 +194,15 @@ async def test_a_pump_exception_is_logged_distinguishably_before_exit(
         f"logged, distinguishably from a clean end-of-stream — got "
         f"{messages!r}"
     )
-    assert any("BECAUSE of this exception" in m for m in messages), (
-        "the log line should say the exit is BECAUSE of the exception, "
-        "not merely that something happened — this is the distinguishing "
-        "half, not just a bare traceback"
+    # The distinguishing property is structural, not wording: this record
+    # carries the real exception (``exc_info``, set by ``logger.exception``),
+    # which is what makes it recoverable evidence rather than a bare "some
+    # error happened" line — the same property a clean end-of-stream (next
+    # test) never produces at all.
+    assert any(r.exc_info is not None for r in records), (
+        "the log record should carry the real exception (exc_info), not "
+        "just a message — that's what makes this durably distinguishable "
+        "from a clean shutdown, not merely the wording"
     )
 
 

--- a/tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py
+++ b/tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py
@@ -215,14 +215,29 @@ async def test_a_clean_end_of_stream_logs_nothing_new(
     end-of-stream (no exception, just ``__end__``) must NOT trigger the
     new log line. Only a genuine exception should surface as one; a clean
     end is still silent, exactly as it was before this fix (the fix adds
-    a signal on the exception path, not noise on the normal one)."""
+    a signal on the exception path, not noise on the normal one).
+
+    The deny-side assert alone (architect's finding, TESTS-READ (B)) is
+    satisfied by an empty ``messages`` list for reasons that have nothing
+    to do with the fix — the app failing to start, the logger name
+    drifting, ``caplog`` catching nothing. The affirmative assert below
+    closes that gap: it requires the SAME pump that would carry the new
+    log line to have actually run and delivered its frame."""
+    from textual_flowview import FlowView
+
     transport = _CleanEndTransport()
     app = TextualChatApp(transport=transport)
     with caplog.at_level(logging.ERROR, logger=_LOGGER_NAME):
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()
             await pilot.pause()
+            delivered = [e.item.text for e in app.query_one(FlowView).entries]
 
+    assert "a normal reply" in delivered, (
+        f"the pump must have actually run and rendered the clean-end "
+        f"frame — got {delivered!r}; without this, the assert below "
+        f"would pass just as well on a pump that never ran at all"
+    )
     messages = [r.message for r in caplog.records if r.name == _LOGGER_NAME]
     assert not any("_pump_frames' frame stream" in m for m in messages), (
         f"#5329 REGRESSION: a CLEAN end-of-stream must not produce the "


### PR DESCRIPTION
**[tui-coder]** — Part of #5329 (② — the frame-stream side; ① was landed separately as #5331, per lead-coder's dispatch on issuecomment-5443600309).

## What

`TextualChatApp._pump_frames` (`src/reyn/interfaces/inline/textual_chat/app.py`) has an `async for frame in self._transport.frames(): ...` loop wrapped in a bare `try/finally`, with `finally: self.exit()`. Of the 18 failure points inside this method, this was the one left unguarded — every other site (a frame's ingest, a chrome refresh, a layout decision) wraps itself in `except Exception: logger.exception(...)` so a single bad frame never kills the pump; the loop's own supply had zero handlers. An exception raised there fell straight through into the same silent `finally: self.exit()` a clean end-of-stream also takes — making a genuine crash and a normal shutdown produce the identical, silent "process terminates, back to shell" symptom. This matches (not proves — lead-coder's own caveat, having been wrong 3 times tonight about #5329's actual cause) owner's own real-machine observation this session.

Direct continuation of #5126 (`AgUiTransport._pump_sse`): that PR fixed the PRODUCER side of the identical bug shape (`frames()` used to disguise a real failure as a clean end; fixed to properly raise). #5329 ② is the next layer up — now that `frames()` correctly raises, this consumer had no handler for it.

## Fix

`except Exception: logger.exception(...); raise` around the `async for`, positioned between the 18 existing inner-loop guards and the outer `finally: self.exit()`. Scope, explicitly:

- Does **not** decide whether exiting is the right response to this failure (a real transport closure can itself be a legitimate reason to exit — that's a separate, deferred question).
- Does **not** decide how/whether an operator sees this **while the TUI is still open** — that's owner's own visual-judgment call.
- **Does** guarantee the reason survives past the exit: `logger.exception` on `reyn.log`, the same durable channel the 18 sibling guards already use (real readers: an operator tailing it directly, `scripts/dogfood_trace.py --mode llm-payloads`).

## Tests

`tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py` — mirrors #5126's own two-test shape:
- a real `ClientTransportStub` subclass whose `frames()` yields one genuine frame then raises (proving pre-failure frames still deliver), driven through a real `TextualChatApp` via `app.run_test()` — no mocks.
- a clean-end-of-stream regression guard: normal `__end__` shutdown produces no new log line.

No duration anywhere — `pilot.pause()` yields to the event loop; CI's own `--timeout` is the only ceiling.

Note: `run_test`'s pilot re-raises the worker failure as `WorkerFailed` on context exit — this is Textual's own pre-existing behaviour (`Worker._run`'s `exit_on_error` path unconditionally calls `app._handle_exception`, docstring: "Always results in the app exiting"), independent of whether `_pump_frames` itself has a handler. It fired identically before this fix. The test wraps the context manager in `pytest.raises(WorkerFailed)` to observe the log line from the right vantage point, not to assert the fix itself.

## Strip-falsify

Scoped `git stash` of `app.py` only (`git stash push -u -m <tag> -- src/.../app.py`), confirmed `test_a_pump_exception_is_logged_distinguishably_before_exit` goes red (no matching log record — nothing in `_pump_frames` saw the exception to log it), restored via `git stash apply <sha>`, verified byte-identical via `diff`, dropped the stash entry, re-confirmed both tests green.

## Gates

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py` (2/2 OK)
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py`
- [x] `python scripts/mypy_ratchet.py` (201 findings, all baselined)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] Regression sweep: all `test_textual_chat_phase{1..5}*` TUI tests (114 tests) green

## Test plan

- [x] New tests pass locally, scoped to the diff
- [x] Strip-falsify confirms the test is a real witness (red without the fix, green with it)
- [x] Regression sweep on related TUI pump/phase tests
- [x] (skipped — Visual gate does not block main merge; standing waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

- [x] 🔴 ① コメントの「real readers」の主張が **偽**。`scripts/dogfood_trace.py --mode llm-payloads` が読むのは `.reyn/llm_trace.jsonl`（同スクリプト冒頭の usage、逐語 `--trace .reyn/llm_trace.jsonl`）であって `.reyn/logs/reyn.log` ではない。`#4364` は **open**（`owner 実機待ち`）＝未出荷。3 つ挙げたうち成立するのは「operator が直接 tail する」1 つだけ。**しかも本当の読み手を挙げていない** — `src/reyn/interfaces/inline/textual_chat/chrome.py:1856` が `diagnostics: {count} — {path or '.reyn/logs/reyn.log'}` を TUI の chrome に出している（＝ TUI 上に読み口が実在する）。私が問うた「誰が読むのか」への答えとして、**引いた 3 つのうち 2 つが支えていない**。
- [x] 🔴 ② コメントに **変更履歴** と **PR 手続きの引用** が入っている。「post-#5126, `frames()` now correctly RAISES … this except is the next layer up that #5126 alone did not reach」は履歴。lead-coder の日本語指示（`終了の可否を先に決めようとしないでください`）の逐語引用は **この PR についての記述**であって、コードについての記述ではない。5 行の修正に 35 行のコメントが付いているが、**問題は長さではなく内容**（`docs/deep-dives/contributing/comments.md` は長さでなく内容で分類する）。残すべきは「この except を外すと、正常終了と例外離脱が区別できなくなる」の 1 点。
- [x] 🔴 ③ 追加コメント内に **文字化け**: `#4364's own доctor-style` の `до` が **キリル文字**（U+0434 U+043E）。`doctor` で grep しても当たらない。
- [x] 🔴 ④ test の 2 本目の assert が **ログの文面を pin** している：`assert any("BECAUSE of this exception" in m …)`。実装側の文字列定数と test 側が **同じ表現**で、片方を編集する人は両方を編集する（六問②の block 条件）。1 本目の assert が既に「例外経路が区別できる」を witness しているので、2 本目は編集上の言い回しを固定しているだけ。**性質で見るなら文面でなく構造** — 例外経路のレコードだけが `exc_info` を持つ、等。



## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **2 本目（`..._clean_end_of_stream_logs_nothing_new`）に「在ること」の assert がありません。** `assert not any("_pump_frames' frame stream" in m for m in messages)` は **deny 側だけ**で、**`messages` が空なら緑**です — app が起動に失敗しても、logger 名がずれても、`caplog` が何も拾わなくても通ります。「正常終了で新しい行が出ない」と「そもそも何も起きなかった」が区別できません。処方: **同じ test に「在ること」の兄弟を 1 行**（1 本目が持っている「失敗前の 1 frame が確かに配達された」を clean run 側でも使う）。∴「frame は届いた ＋ 新しい行は出ていない」になり、空の世界では 1 本目の assert が落ちます。根拠: PR comment（TESTS-READ (B)）

