### PR TITLE
fix(#5358): a reap must not destroy the only evidence a process ran

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -190,6 +190,7 @@ presentation_install_blocked
 presentation_installed
 presentation_load_failed
 presented
+process_marker_reaped
 project_context_changed
 repo_ingest_files_skipped
 resource_cap_exceeds_budget_trigger

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -632,6 +632,17 @@ intervention flow and force-close wrap-up.
 | `limit_denied` | A safety limit was denied (no extension granted) and the OS is about to attempt the force-close wrap-up. | `kind` (`max_iterations` \| `router_cap`), `chain_id`, plus `limit` (router iterations) or `count`/`cap` (router cap) |
 | `untrusted_narrowing_engaged`, `untrusted_narrowing_lifted` | #1909/#3501 opt-in (`safety.threat_scan.capability_narrowing` != `off`): untrusted external content (an `external_source`-tagged history entry) enters/leaves the active, uncompacted context, most-restrictively narrowing tool visibility while it is live. `Session._ephemeral_contextual_for_turn` — the default `turn` rung, the common case an operator opting in at all is most likely running — emits both kinds, exactly once per genuine state flip, never per read (a status-panel poll on an unchanged state produces no event); previously silent at both transitions (#5282). The top `iteration` rung (`RouterLoop`'s own `_intra_turn_contextual_for_turn_fn` branch) separately emits `untrusted_narrowing_engaged` only — it has no lift event yet, out of #5282's scope. | `provenance` (`external_source`); the `iteration` rung's `engaged` also carries `chain_id`, `iteration` |
 
+## Process registry
+
+`.reyn/processes/<pid>.json` (#5226) is a machine-wide, per-PID liveness
+marker — not per-project like every other event source in this doc. A
+reader (`reyn doctor`, `reyn.runtime.process_registry.live_processes`)
+reaps any marker whose PID is confirmed dead as a side effect of reading.
+
+| Kind | Trigger | Key payload |
+|------|---------|-------------|
+| `process_marker_reaped` | #5358: a confirmed-dead PID's marker is about to be reaped (unlinked) — the marker was the ONLY record that PID ever ran, since the process itself never got to say it was stopping (a graceful exit's own `atexit` handler would have already removed it). Emitted from the reading CALLER's process, but under the DEAD process's OWN project (`reyn_root` resolved by walking up from the marker's own `cwd` field, never the caller's cwd — a `reyn doctor` run from project A must not misattribute a reap for a process that ran in project B). Best-effort: an emit failure (no `.reyn/` reachable from the marker's cwd, or any other error) logs a warning and never blocks the reap itself. Detection, not diagnosis — carries no information about WHY the process stopped (crash / SIGKILL / power loss / OOM are indistinguishable from here). | `marker` (the dead process's own full recorded content: `pid`/`ppid`/`cwd`/`subcommand`/`started_at`), `observed_at` (an UPPER BOUND on the stop time — the real stop happened sometime between the marker's `started_at` and this timestamp, never asserted as the exact moment) |
+
 ## Replay
 
 ```bash

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -419,6 +419,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "presentation_installed",
     "presentation_load_failed",
     "presented",
+    "process_marker_reaped",
     "project_context_changed",
     "repo_ingest_files_skipped",
     "resource_cap_exceeds_budget_trigger",

--- a/src/reyn/runtime/process_registry.py
+++ b/src/reyn/runtime/process_registry.py
@@ -224,6 +224,12 @@ def live_processes() -> "list[dict]":
         pid_str = tmp_path.name.removesuffix(".json.tmp")
         if not pid_str.isdigit() or pid_alive(int(pid_str)):
             continue
+        # #5358 (architect, non-blocking note on #5359): deliberately no
+        # process_marker_reaped event here — an orphaned .tmp means the
+        # process died BEFORE ever completing registration (no real marker
+        # was ever recorded), never that a registered process stopped. Its
+        # own content is untrusted/unread by design (see this function's
+        # own docstring above), so there is nothing to report losing.
         try:
             tmp_path.unlink()
         except OSError:
@@ -252,9 +258,47 @@ def live_processes() -> "list[dict]":
             # reap in the first place. What it closes is narrower and
             # structural: a stop that used to be perfectly silent (this
             # same reap, with no record before it) now has exactly one.
-            from reyn.core.events.events import emit_cli_event
+            #
+            # lead-coder's TESTS-READ(B) BLOCK (#5359): the reaping PROCESS'S
+            # own cwd (what emit_cli_event walks up from) has NOTHING to do
+            # with the DEAD process's own project — PROCESSES_DIR is one
+            # machine-wide directory, so `reyn doctor` run from project A can
+            # reap a marker for a process that ran in project B, and (worse)
+            # a caller running from a cwd inside NO project's `.reyn/` at all
+            # made emit_cli_event's own best-effort "warn and return" fire
+            # silently, reintroducing the exact silence this issue exists to
+            # close. Fixed by resolving reyn_root from the DEAD marker's own
+            # ``cwd`` field (the project the process actually ran in), never
+            # the caller's — same `_find_reyn_dir` helper `emit_cli_event`
+            # uses internally, called directly here via `emit_direct_event`.
+            #
+            # The whole block is best-effort, matching the unlink beneath it
+            # and every other diagnostic-aid in this module (register_process
+            # / _cleanup): an audit-emit failure (no `.reyn/` reachable from
+            # the marker's own cwd, or any other error) must never block the
+            # actual reap — leaving a marker permanently un-reaped because
+            # its OWN diagnostic record failed to write would be a worse
+            # regression than the record simply not existing this once.
+            try:
+                from reyn.core.events.events import _find_reyn_dir, emit_direct_event
 
-            emit_cli_event("process_marker_reaped", marker=data, observed_at=time.time())
+                marker_cwd = data.get("cwd")
+                reyn_dir = _find_reyn_dir(Path(marker_cwd)) if marker_cwd else None
+                if reyn_dir is not None:
+                    emit_direct_event(
+                        "process_marker_reaped",
+                        surface="cli",
+                        reyn_root=reyn_dir,
+                        track_audit_seq=False,
+                        marker=data,
+                        observed_at=time.time(),
+                    )
+            except Exception:
+                logger.warning(
+                    "process_registry: failed to emit process_marker_reaped "
+                    "for pid %d (diagnostic-only, does not block the reap)",
+                    pid, exc_info=True,
+                )
             try:
                 path.unlink()
             except OSError:

--- a/src/reyn/runtime/process_registry.py
+++ b/src/reyn/runtime/process_registry.py
@@ -236,6 +236,25 @@ def live_processes() -> "list[dict]":
             continue
         pid = data.get("pid")
         if not isinstance(pid, int) or not pid_alive(pid):
+            # #5358: the marker itself is the only record that this PID
+            # ever ran — the process that owned it never got to say it was
+            # stopping (a graceful exit's own atexit handler would have
+            # unlinked this file already; reaching this branch at all means
+            # it did not). One event BEFORE the unlink below, carrying the
+            # marker's own content plus this observation's own wall-clock
+            # time (an UPPER BOUND on when the process actually stopped,
+            # never the stop time itself — nothing here knows when between
+            # the marker's last write and this read the process actually
+            # died). This is not a crash-diagnosis mechanism: it does not
+            # know WHY the process stopped (crash / SIGKILL / power loss /
+            # OOM are indistinguishable from here), and a process that died
+            # before ever reaching register_process() leaves no marker to
+            # reap in the first place. What it closes is narrower and
+            # structural: a stop that used to be perfectly silent (this
+            # same reap, with no record before it) now has exactly one.
+            from reyn.core.events.events import emit_cli_event
+
+            emit_cli_event("process_marker_reaped", marker=data, observed_at=time.time())
             try:
                 path.unlink()
             except OSError:

--- a/tests/runtime/test_5226_process_registry.py
+++ b/tests/runtime/test_5226_process_registry.py
@@ -196,6 +196,106 @@ def test_marker_content_never_carries_argv_or_a_path_beyond_cwd(
         process_registry.unregister_process(os.getpid())
 
 
+# ── #5358: reap destroys the only evidence a process ever ran — a P6
+# event before the unlink is what makes the stop no longer silent ──────────
+
+
+def _read_events_of_kind(events_dir: Path, kind: str) -> list[dict]:
+    """Read every JSONL event of *kind* from anywhere under *events_dir*
+    (same helper shape ``test_asyncio_diagnostics.py`` uses for the SAME
+    ``emit_cli_event`` seam)."""
+    found: list[dict] = []
+    if not events_dir.exists():
+        return found
+    for path in events_dir.rglob("*.jsonl"):
+        for line in path.read_text().splitlines():
+            if not line.strip():
+                continue
+            rec = json.loads(line)
+            if rec.get("type") == kind:
+                found.append(rec)
+    return found
+
+
+def test_reaping_a_dead_marker_emits_one_event_carrying_the_markers_own_content(
+    _isolated_processes_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5358 — the reap in ``live_processes()`` used to unlink a
+    confirmed-dead marker with zero logger/audit-event calls (docs-maintainer's
+    real-machine measurement, #4850's own investigation): the ONLY record
+    that PID ever ran was the marker file itself, and the reap destroyed it
+    with nothing written first. One ``process_marker_reaped`` P6 event must
+    now land, BEFORE the unlink, carrying the marker's own content (not a
+    summary/subset of it — a reader needs to reconstruct what was lost) plus
+    an ``observed_at`` timestamp (an upper bound on when the process actually
+    stopped, never asserted as an exact stop time — this is a
+    detection mechanism, not a diagnosis one)."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    proc = _spawn_registering_subprocess()
+    try:
+        _wait_until(lambda: len(process_registry.live_processes()) == 1)
+        marker_path = _isolated_processes_dir / f"{proc.pid}.json"
+        original_marker = json.loads(marker_path.read_text(encoding="utf-8"))
+
+        proc.kill()
+        proc.wait()
+        _wait_until(lambda: not process_registry.pid_alive(proc.pid))
+
+        before_reap = time.time()
+        result = process_registry.live_processes()
+        after_reap = time.time()
+
+        assert result == []  # sanity: the dead marker was reaped, as before
+        assert not marker_path.exists()  # sanity: same reap behavior, unchanged
+
+        events = _read_events_of_kind(reyn_dir / "events", "process_marker_reaped")
+        [event] = events  # exactly one — unpack raises otherwise
+        data = event["data"]
+        assert data["marker"] == original_marker, (
+            "#5358 REGRESSION: the event must carry the marker's own full "
+            f"content, not a summary — got {data['marker']!r}, expected "
+            f"{original_marker!r}"
+        )
+        assert before_reap <= data["observed_at"] <= after_reap, (
+            "observed_at must be a real timestamp taken at reap time, not a "
+            "constant or the marker's own started_at"
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+
+def test_a_live_marker_is_never_reaped_and_emits_no_event(
+    _isolated_processes_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5358 deny side, in the SAME shape as the positive witness
+    above (CLAUDE.md's own six-questions ④ — a deny-only assertion is green
+    even if the whole mechanism silently never ran; pairing it with the
+    positive witness above closes that gap the same way #5331's own
+    reviewer named it). A confirmed-ALIVE process's marker must be neither
+    reaped NOR reported — reaping only fires for a confirmed-dead PID."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    process_registry.register_process("self")
+    try:
+        result = process_registry.live_processes()
+        assert os.getpid() in {e["pid"] for e in result}  # sanity: still reported live
+
+        events = _read_events_of_kind(reyn_dir / "events", "process_marker_reaped")
+        assert events == [], (
+            "#5358 REGRESSION: a live process's marker must never be "
+            f"reported as reaped — got {events!r}"
+        )
+    finally:
+        process_registry.unregister_process(os.getpid())
+
+
 def test_the_real_cli_entry_point_actually_calls_register_process(
     tmp_path: Path,
 ) -> None:

--- a/tests/runtime/test_5226_process_registry.py
+++ b/tests/runtime/test_5226_process_registry.py
@@ -71,14 +71,20 @@ def _isolated_processes_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     return processes_dir
 
 
-def _spawn_registering_subprocess() -> subprocess.Popen:
+def _spawn_registering_subprocess(cwd: "Path | None" = None) -> subprocess.Popen:
     """A REAL, separate OS subprocess that imports this exact module,
     calls ``register_process`` for ITS OWN real PID (genuinely different
     from this test process's own PID), then blocks on a real stdin read
     (never a sleep) until the test releases it by closing stdin. The
     PROCESSES_DIR override is threaded through an env var, since a
     subprocess has no access to this test's own monkeypatched module
-    attribute."""
+    attribute.
+
+    ``cwd`` (#5358): the child's own working directory, hence its
+    marker's own ``cwd`` field — deliberately independent of THIS test
+    process's cwd, so a test can prove a #5358-shaped fix resolves the
+    marker's own project, not whatever directory the reaping caller
+    happens to be running from."""
     script = (
         "import sys\n"
         "from reyn.runtime import process_registry\n"
@@ -89,7 +95,7 @@ def _spawn_registering_subprocess() -> subprocess.Popen:
     return subprocess.Popen(
         [sys.executable, "-c", script, str(process_registry.PROCESSES_DIR)],
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        text=True,
+        text=True, cwd=str(cwd) if cwd is not None else None,
     )
 
 
@@ -217,7 +223,7 @@ def _read_events_of_kind(events_dir: Path, kind: str) -> list[dict]:
     return found
 
 
-def test_reaping_a_dead_marker_emits_one_event_carrying_the_markers_own_content(
+def test_reaping_a_dead_marker_emits_one_event_under_the_markers_own_project(
     _isolated_processes_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Tier 2: #5358 — the reap in ``live_processes()`` used to unlink a
@@ -229,16 +235,34 @@ def test_reaping_a_dead_marker_emits_one_event_carrying_the_markers_own_content(
     summary/subset of it — a reader needs to reconstruct what was lost) plus
     an ``observed_at`` timestamp (an upper bound on when the process actually
     stopped, never asserted as an exact stop time — this is a
-    detection mechanism, not a diagnosis one)."""
-    reyn_dir = tmp_path / ".reyn"
-    reyn_dir.mkdir()
-    monkeypatch.chdir(tmp_path)
+    detection mechanism, not a diagnosis one).
 
-    proc = _spawn_registering_subprocess()
+    lead-coder's TESTS-READ(B) BLOCK (#5359): ``PROCESSES_DIR`` is one
+    machine-wide directory but ``.reyn/events`` is per-project — the
+    REAPING caller's own cwd has nothing to do with the DEAD process's
+    project. This test deliberately runs the dying subprocess from its OWN
+    project directory (``dead_process_project``) while THIS test process
+    (the reaping caller, standing in for ``reyn doctor``) sits in a
+    SEPARATE directory that has no ``.reyn/`` at all — the shape that used
+    to make ``emit_cli_event``'s own cwd-based discovery warn-and-skip
+    silently, reintroducing the exact silence #5358 exists to close. The
+    event must land under the marker's OWN project, never the caller's
+    (which has nowhere for it to land at all)."""
+    dead_process_project = tmp_path / "dead_process_project"
+    dead_process_project.mkdir()
+    (dead_process_project / ".reyn").mkdir()
+    caller_cwd = tmp_path / "caller_with_no_reyn_dir"
+    caller_cwd.mkdir()
+    monkeypatch.chdir(caller_cwd)
+
+    proc = _spawn_registering_subprocess(cwd=dead_process_project)
     try:
         _wait_until(lambda: len(process_registry.live_processes()) == 1)
         marker_path = _isolated_processes_dir / f"{proc.pid}.json"
         original_marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        assert original_marker["cwd"] == str(dead_process_project.resolve()), (
+            "sanity: the marker's own cwd is the subprocess's real cwd"
+        )
 
         proc.kill()
         proc.wait()
@@ -251,7 +275,14 @@ def test_reaping_a_dead_marker_emits_one_event_carrying_the_markers_own_content(
         assert result == []  # sanity: the dead marker was reaped, as before
         assert not marker_path.exists()  # sanity: same reap behavior, unchanged
 
-        events = _read_events_of_kind(reyn_dir / "events", "process_marker_reaped")
+        # Nothing landed under the CALLER's own (nonexistent) .reyn/ — there
+        # isn't one to land under; this only fails if some OTHER code path
+        # accidentally created one.
+        assert not (caller_cwd / ".reyn").exists()
+
+        events = _read_events_of_kind(
+            dead_process_project / ".reyn" / "events", "process_marker_reaped",
+        )
         [event] = events  # exactly one — unpack raises otherwise
         data = event["data"]
         assert data["marker"] == original_marker, (
@@ -294,6 +325,62 @@ def test_a_live_marker_is_never_reaped_and_emits_no_event(
         )
     finally:
         process_registry.unregister_process(os.getpid())
+
+
+def test_reap_still_happens_when_the_audit_emit_itself_fails(
+    _isolated_processes_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5358, lead-coder's TESTS-READ(B) BLOCK ③ — the pre-existing
+    ``except OSError: pass`` around the unlink only ever protected the
+    enumeration loop from a filesystem error on the unlink itself; the NEW
+    audit-emit call sits ahead of it with no guard of its own. Forces
+    ``emit_direct_event`` to raise (a real exception, not a mock — the
+    genuinely-importable production function, monkeypatched to fail on
+    THIS one call) and confirms ``live_processes()`` still completes,
+    still returns the empty-of-dead-markers result, and still reaps the
+    marker file — an audit-emit failure must degrade to a log line, never
+    break the read path this module's whole reason to exist is to keep
+    working.
+
+    The spawned process needs a REAL ``.reyn/``-reachable cwd (this repo's
+    own autouse ``_isolated_cwd`` fixture already chdirs THIS test process
+    itself to a bare tmp dir with none — otherwise ``reyn_dir is None``
+    would skip the emit call entirely, and this test would pass without
+    ever exercising the code path it means to falsify, invisibly."""
+    dead_process_project = tmp_path / "dead_process_project"
+    dead_process_project.mkdir()
+    (dead_process_project / ".reyn").mkdir()
+
+    from reyn.core.events import events as events_mod
+
+    def _raising_emit(*args, **kwargs):
+        raise RuntimeError("#5358 test: simulated emit_direct_event failure")
+
+    monkeypatch.setattr(events_mod, "emit_direct_event", _raising_emit)
+
+    proc = _spawn_registering_subprocess(cwd=dead_process_project)
+    try:
+        _wait_until(lambda: len(process_registry.live_processes()) == 1)
+        marker_path = _isolated_processes_dir / f"{proc.pid}.json"
+
+        proc.kill()
+        proc.wait()
+        _wait_until(lambda: not process_registry.pid_alive(proc.pid))
+
+        result = process_registry.live_processes()  # must not raise
+
+        assert result == [], (
+            "#5358 REGRESSION: a failing audit-emit must not prevent the "
+            f"dead marker from being correctly excluded — got {result!r}"
+        )
+        assert not marker_path.exists(), (
+            "#5358 REGRESSION: a failing audit-emit must not prevent the "
+            "reap itself — the marker should still be gone"
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
 
 
 def test_the_real_cli_entry_point_actually_calls_register_process(


### PR DESCRIPTION
**[e2e-coder]** — Closes #5358.

## What this closes

`live_processes()` reaped a confirmed-dead PID's marker (`path.unlink()`) with zero logger/audit-event calls — the marker was the ONLY record that PID ever existed, and the reap destroyed it before anything could read it. #4850's own investigation (a real owner-reported "reyn-self crashed") hit this directly: nothing anywhere records that a process itself stopped, so a real crash and an idle overnight gap are indistinguishable in the logs.

## Design (architect's own answer, #5358 issuecomment-5444098247)

No new mechanism needed — `register_process()`'s marker IS the mechanism. The stopping side never gets to write "I stopped" (that's the whole problem); what a graceful exit's own `atexit` handler unlinking the marker on success, versus a marker surviving to be reaped later, already encodes is "did NOT exit gracefully" — the absence itself is the record. Emitting one `process_marker_reaped` event immediately BEFORE the unlink, carrying the marker's own full content plus an `observed_at` timestamp, is what stops the reap from erasing that record before anyone reads it.

## Explicit limits (architect's disclosure, carried verbatim per lead-coder's instruction)

This is a mechanism that makes a stop no longer SILENT, not one that DIAGNOSES a crash:
- Does not know WHY a process stopped (crash / SIGKILL / power loss / OOM are indistinguishable).
- The stop time is a bounded interval (`observed_at` is an upper bound), never a point — no heartbeat added to narrow it.
- A process that dies before ever reaching `register_process()` leaves no marker to reap in the first place.
- PID reuse windows are a known, unaddressed limitation.

## Mechanism

Reuses the existing `emit_cli_event`/`emit_direct_event` seam `asyncio_unhandled_exception` already established for exactly this "CLI process, no live Session" shape — already registered in `KIND_EMIT_SEAMS`, no new seam declaration needed. New kind `process_marker_reaped` added to the closed `AUDIT_EVENT_KINDS` vocabulary + `docs/reference/runtime/events.md`'s enumeration (CI-gated pair, #3410).

## Tests

Same real-subprocess-and-real-SIGKILL discipline this file's own #5226/#5346 tests already use — no mocks, no synthetic markers for a PID that isn't actually running:
- Positive witness: the event fires with the marker's own full content, `observed_at` bounded between real before/after timestamps taken around the reap call.
- Deny witness (paired, per lead-coder's instruction — a deny-only assertion is green even if the whole mechanism never ran): a confirmed-ALIVE marker is neither reaped nor reported.

## Real execution this session

- Strip-falsify: removed the `emit_cli_event` call, confirmed the positive witness goes red (deny witness stays green, unaffected), restored, re-confirmed both green.
- Full regression sweep (`tests/runtime/` + `tests/interfaces/test_5226_doctor_process_registry.py` + `tests/core/`) — 4860 passed, 9 skipped (missing optional extras, unrelated), 0 failures.

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5226_process_registry.py` — 10/10 OK
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `pytest tests/core/test_audit_event_kind_vocabulary_3410.py` — 10/10 (doc/code pair, #3410)
- [x] Strip-falsify: `emit_cli_event` call removed → positive witness red, deny witness unaffected; restored → both green
- [x] Full regression sweep — 4860 passed, 9 skipped, 0 failures
- [ ] (skipped — Visual) no UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

- [x] 🔴 ① **marker と event の「根」が違う**。`PROCESSES_DIR = Path.home() / ".reyn" / "processes"`（`process_registry.py:88`）＝ **機械全体で 1 つ**。一方 `emit_cli_event` は **`Path.cwd()` から遡って `.reyn/` を探す**（`events.py:983`）＝ **project ごと**。∴ project A で走ったプロセスの marker の reap が、**呼び手の cwd 次第で project B の audit へ**入り得る（誤帰属）。さらに **どの project にも居ない cwd から呼ばれると `logger.warning` を出して `return`**（`events.py:984-991`）＝ **event は書かれない**。これは #5358 が閉じようとした **沈黙そのもの**が残る経路。
- [x] 🔴 ② **witness が ①を見られない**。test は `reyn_dir = tmp_path / ".reyn"; reyn_dir.mkdir()` ＋ `monkeypatch.chdir(tmp_path)` で、**この test 自身が「cwd の下に `.reyn/` が在る」構成を作ってから**測っている。六問③（*Who would miss this test if it were gone?* — 「**only a configuration this test itself constructed**」は block 条件）。①の 2 経路（別 project へ入る／どこにも書かれない）は、この構成では**原理的に出ない**。
- [x] 🔴 ③ **read 経路に無防備な書き込みを足した**。`live_processes()` は読み取り専用の列挙で、既存の unlink は `except OSError: pass` で**列挙が失敗しないように**守られている。新しい `emit_cli_event(...)` は **その手前に無防備で置かれた**ので、audit 書き込みが失敗すると **`live_processes()` 自体が例外で落ちる**（`reyn doctor` 等、全呼び手が巻き添え）。しかも unlink に到達しないので marker は残り、**次回も同じ場所で落ちる**。band Q1「繰り返したら誰が止めるか」＝ 今は誰も。

