### PR TITLE
fix(#5356): reject write_paths declared at an agent-writable hooks layer

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -92,6 +92,7 @@ hook_changed
 hook_event_emitted
 hook_push_fired
 hook_shell_executed
+hooks_layer_rejected
 inbox_cancel
 index_dropped
 index_update_cost_warning

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -321,6 +321,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "hook_event_emitted",
     "hook_push_fired",
     "hook_shell_executed",
+    "hooks_layer_rejected",
     "inbox_cancel",
     "index_dropped",
     "index_update_cost_warning",

--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -78,6 +78,24 @@ _WRONG_SCOPE_HINTS: dict[str, str] = {
     ),
 }
 
+#: #5356: the two ``HookDef.origin`` values whose config FILE an agent can
+#: already write directly via the ordinary file-write op (the SAME two
+#: layers ``session.py``'s own ``_build_hook_registry`` comment and
+#: ``hook_origin_is_at_least_as_specific_as``'s docstring name as
+#: "agent-writable": ``.reyn/agents/<name>/hooks.yaml`` and the per-session
+#: state dir's ``hooks.yaml``). A ``write_paths:`` declared at either is a
+#: confused-deputy self-grant, not a silent drop: verified directly
+#: (docs-maintainer, real ``SeatbeltBackend``, #5351/#5356) that the
+#: declaration is fully HONORED — an agent could already write its own
+#: hooks.yaml, and this key would then grant that same agent's hook
+#: sandbox write access to an arbitrary declared path, including another
+#: agent's working tree. Rejecting the key at these two origins closes the
+#: class (both layers share the same write-access-to-the-declaration
+#: reasoning); the operator's ``startup``/``runtime`` layers are untouched
+#: (those are NOT agent-writable, so the same grant carries no self-
+#: escalation risk there).
+_AGENT_WRITABLE_ORIGINS: frozenset[str] = frozenset({"per-agent", "per-session"})
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -461,6 +479,26 @@ def _parse_entry(
     # write_paths — a list of path strings. An explicit `[]` is a real (empty)
     # grant, so presence, not truthiness, decides "the operator wrote this";
     # stored as a tuple because HookDef is frozen.
+    #
+    # #5356 (architect ruling, docs-maintainer measurement): eager-rejected
+    # at an agent-writable origin, BEFORE the type/shape checks below — an
+    # agent can already write its own per-agent/per-session hooks.yaml via
+    # the ordinary file-write op, and this key is fully honored by the real
+    # sandbox (verified directly, no silent drop), so declaring it there is
+    # a confused-deputy self-grant: the same actor writes the rule and is
+    # bound by it. This is NOT the #4501 unknown-key shape (the key name is
+    # correct and known) — it is a known key rejected at a specific origin,
+    # so it is checked here rather than folded into `_KNOWN_HOOK_ENTRY_KEYS`.
+    if "write_paths" in raw and origin in _AGENT_WRITABLE_ORIGINS:
+        raise HookConfigError(
+            f"hooks[{entry_index}].write_paths is not permitted at the "
+            f"{origin!r} layer — an agent can write its own "
+            f"{origin} hooks.yaml, so a write_paths grant declared there "
+            f"is a self-grant, not an operator's expressed will (#5356). "
+            f"Declare write_paths at the startup (reyn.yaml) or runtime "
+            f"(.reyn/config/hooks.yaml) layer instead — neither is "
+            f"agent-writable."
+        )
     write_paths_raw: "tuple[str, ...] | None" = None
     if "write_paths" in raw:
         _exec_only("write_paths")

--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -36,6 +36,7 @@ from reyn.hooks.composer import COMPOSED_KIND_PREFIX
 from reyn.hooks.event_pattern import from_legacy_matcher
 from reyn.hooks.event_pattern import validate_against_schema as validate_event_pattern
 from reyn.hooks.registry import HookRegistry
+from reyn.hooks.sandbox_scope import HOOK_SANDBOX_SCOPE
 from reyn.hooks.schema import (
     ALLOWED_HOOK_POINTS,
     HookConfigError,
@@ -100,6 +101,23 @@ _WRONG_SCOPE_HINTS: dict[str, str] = {
 #: agent-writable, so the same grant carries no self-escalation risk
 #: there).
 _AGENT_WRITABLE_ORIGINS: frozenset[str] = frozenset({"per-agent", "per-session"})
+
+#: #5356 (architect, 2nd-round point): the per-hook sandbox key names this
+#: module rejects at an agent-writable origin, derived from
+#: :data:`~reyn.hooks.sandbox_scope.HOOK_SANDBOX_SCOPE`'s RIGHT column (the
+#: per-hook keys) rather than hand-listed — this PR's own reasoning ("closing
+#: one hole is not closing the class") applies one level up to itself: a
+#: hand-written 3-tuple is complete only until a 4th axis is added to that
+#: registry, and would then silently fall outside this rejection with no
+#: signal. `HOOK_SANDBOX_SCOPE` is the authoritative registry of exactly
+#: this vocabulary (its own module docstring: "the per-site, operator-owned
+#: sandbox surface") and deliberately excludes the deny-side fields
+#: (`read_deny_paths`/`write_deny_paths`/`env_deny_names`/`timeout_seconds`)
+#: that are not part of it — so deriving from it cannot accidentally widen
+#: this rejection to a narrowing-only field.
+_AGENT_WRITABLE_SANDBOX_KEYS: tuple[str, ...] = tuple(
+    hook_key for _config_field, hook_key in HOOK_SANDBOX_SCOPE
+)
 
 
 # ---------------------------------------------------------------------------
@@ -480,23 +498,27 @@ def _parse_entry(
 
     # #5356 (architect ruling, docs-maintainer measurement; scope corrected
     # by lead-coder after the first version of this fix rejected only
-    # `write_paths`): eager-rejected at an agent-writable origin, BEFORE the
-    # type/shape checks below — an agent can already write its own
-    # per-agent/per-session hooks.yaml via the ordinary file-write op, and
-    # ALL THREE per-hook sandbox keys this site's own comment above calls
-    # "the three axes an operator owns per-site" (`subprocess` #2827,
-    # `network`/`write_paths` #3005) are threaded to the real sandbox
-    # identically, with no origin-based branching anywhere — verified
-    # directly against `dispatcher.py`, where `allow_subprocess=hook.
-    # subprocess, network=hook.network` sit right next to `write_paths=
-    # hook.write_paths` in the same call. The self-grant reasoning (the
-    # actor who writes the rule and the actor bound by it are identical) is
-    # key-name-independent, so rejecting only `write_paths` would close one
-    # hole, not the class (CLAUDE.md). This is NOT the #4501 unknown-key
-    # shape (each key name is correct and known) — each is a known key
-    # rejected at a specific origin, so it is checked here rather than
-    # folded into `_KNOWN_HOOK_ENTRY_KEYS`.
-    for _agent_writable_key in ("subprocess", "network", "write_paths"):
+    # `write_paths`; the key SET corrected again by architect's 2nd-round
+    # point to derive from the registry, see `_AGENT_WRITABLE_SANDBOX_KEYS`):
+    # eager-rejected at an agent-writable origin, BEFORE the type/shape
+    # checks below — an agent can already write its own per-agent/
+    # per-session hooks.yaml via the ordinary file-write op, and every
+    # per-hook sandbox key `HOOK_SANDBOX_SCOPE` names (today: `subprocess`
+    # #2827, `network`/`write_paths` #3005 — this site's own comment above
+    # calls them "the three axes an operator owns per-site") is threaded to
+    # the real sandbox identically, with no origin-based branching anywhere
+    # — verified directly against `dispatcher.py`, where `allow_subprocess=
+    # hook.subprocess, network=hook.network` sit right next to
+    # `write_paths=hook.write_paths` in the same call. The self-grant
+    # reasoning (the actor who writes the rule and the actor bound by it are
+    # identical) is key-name-independent, so rejecting a hand-listed subset
+    # would close only today's holes, not the class (CLAUDE.md) — the same
+    # reasoning this PR applies to a single key applies one level up to the
+    # key SET itself. This is NOT the #4501 unknown-key shape (each key name
+    # is correct and known) — each is a known key rejected at a specific
+    # origin, so it is checked here rather than folded into
+    # `_KNOWN_HOOK_ENTRY_KEYS`.
+    for _agent_writable_key in _AGENT_WRITABLE_SANDBOX_KEYS:
         if _agent_writable_key in raw and origin in _AGENT_WRITABLE_ORIGINS:
             raise HookConfigError(
                 f"hooks[{entry_index}].{_agent_writable_key} is not "

--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -83,17 +83,22 @@ _WRONG_SCOPE_HINTS: dict[str, str] = {
 #: layers ``session.py``'s own ``_build_hook_registry`` comment and
 #: ``hook_origin_is_at_least_as_specific_as``'s docstring name as
 #: "agent-writable": ``.reyn/agents/<name>/hooks.yaml`` and the per-session
-#: state dir's ``hooks.yaml``). A ``write_paths:`` declared at either is a
-#: confused-deputy self-grant, not a silent drop: verified directly
-#: (docs-maintainer, real ``SeatbeltBackend``, #5351/#5356) that the
-#: declaration is fully HONORED — an agent could already write its own
-#: hooks.yaml, and this key would then grant that same agent's hook
-#: sandbox write access to an arbitrary declared path, including another
-#: agent's working tree. Rejecting the key at these two origins closes the
-#: class (both layers share the same write-access-to-the-declaration
-#: reasoning); the operator's ``startup``/``runtime`` layers are untouched
-#: (those are NOT agent-writable, so the same grant carries no self-
-#: escalation risk there).
+#: state dir's ``hooks.yaml``). A ``write_paths:``/``subprocess:``/
+#: ``network:`` declared at either is a confused-deputy self-grant, not a
+#: silent drop: verified directly (docs-maintainer, real
+#: ``SeatbeltBackend``, #5351/#5356) that ``write_paths`` is fully HONORED
+#: — an agent could already write its own hooks.yaml, and this key would
+#: then grant that same agent's hook sandbox write access to an arbitrary
+#: declared path, including another agent's working tree — and confirmed
+#: (against ``dispatcher.py``) that ``subprocess``/``network`` are threaded
+#: to the real sandbox the exact same unconditional way, so the same
+#: self-grant applies to all three (lead-coder, #5356). Rejecting all
+#: three at these two origins closes the class (both layers share the
+#: same write-access-to-the-declaration reasoning, and the reasoning does
+#: not depend on which of the three keys is used); the operator's
+#: ``startup``/``runtime`` layers are untouched (those are NOT
+#: agent-writable, so the same grant carries no self-escalation risk
+#: there).
 _AGENT_WRITABLE_ORIGINS: frozenset[str] = frozenset({"per-agent", "per-session"})
 
 
@@ -473,32 +478,43 @@ def _parse_entry(
             )
         return value
 
+    # #5356 (architect ruling, docs-maintainer measurement; scope corrected
+    # by lead-coder after the first version of this fix rejected only
+    # `write_paths`): eager-rejected at an agent-writable origin, BEFORE the
+    # type/shape checks below — an agent can already write its own
+    # per-agent/per-session hooks.yaml via the ordinary file-write op, and
+    # ALL THREE per-hook sandbox keys this site's own comment above calls
+    # "the three axes an operator owns per-site" (`subprocess` #2827,
+    # `network`/`write_paths` #3005) are threaded to the real sandbox
+    # identically, with no origin-based branching anywhere — verified
+    # directly against `dispatcher.py`, where `allow_subprocess=hook.
+    # subprocess, network=hook.network` sit right next to `write_paths=
+    # hook.write_paths` in the same call. The self-grant reasoning (the
+    # actor who writes the rule and the actor bound by it are identical) is
+    # key-name-independent, so rejecting only `write_paths` would close one
+    # hole, not the class (CLAUDE.md). This is NOT the #4501 unknown-key
+    # shape (each key name is correct and known) — each is a known key
+    # rejected at a specific origin, so it is checked here rather than
+    # folded into `_KNOWN_HOOK_ENTRY_KEYS`.
+    for _agent_writable_key in ("subprocess", "network", "write_paths"):
+        if _agent_writable_key in raw and origin in _AGENT_WRITABLE_ORIGINS:
+            raise HookConfigError(
+                f"hooks[{entry_index}].{_agent_writable_key} is not "
+                f"permitted at the {origin!r} layer — an agent can write "
+                f"its own {origin} hooks.yaml, so a "
+                f"{_agent_writable_key} grant declared there is a "
+                f"self-grant, not an operator's expressed will (#5356). "
+                f"Declare {_agent_writable_key} at the startup "
+                f"(reyn.yaml) or runtime (.reyn/config/hooks.yaml) layer "
+                f"instead — neither is agent-writable."
+            )
+
     subprocess_raw = _sandbox_bool("subprocess")
     network_raw = _sandbox_bool("network")
 
     # write_paths — a list of path strings. An explicit `[]` is a real (empty)
     # grant, so presence, not truthiness, decides "the operator wrote this";
     # stored as a tuple because HookDef is frozen.
-    #
-    # #5356 (architect ruling, docs-maintainer measurement): eager-rejected
-    # at an agent-writable origin, BEFORE the type/shape checks below — an
-    # agent can already write its own per-agent/per-session hooks.yaml via
-    # the ordinary file-write op, and this key is fully honored by the real
-    # sandbox (verified directly, no silent drop), so declaring it there is
-    # a confused-deputy self-grant: the same actor writes the rule and is
-    # bound by it. This is NOT the #4501 unknown-key shape (the key name is
-    # correct and known) — it is a known key rejected at a specific origin,
-    # so it is checked here rather than folded into `_KNOWN_HOOK_ENTRY_KEYS`.
-    if "write_paths" in raw and origin in _AGENT_WRITABLE_ORIGINS:
-        raise HookConfigError(
-            f"hooks[{entry_index}].write_paths is not permitted at the "
-            f"{origin!r} layer — an agent can write its own "
-            f"{origin} hooks.yaml, so a write_paths grant declared there "
-            f"is a self-grant, not an operator's expressed will (#5356). "
-            f"Declare write_paths at the startup (reyn.yaml) or runtime "
-            f"(.reyn/config/hooks.yaml) layer instead — neither is "
-            f"agent-writable."
-        )
     write_paths_raw: "tuple[str, ...] | None" = None
     if "write_paths" in raw:
         _exec_only("write_paths")

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6121,6 +6121,19 @@ class Session:
                     "config hot-reload: malformed %s hooks layer — skipped, keeping "
                     "the valid hook layers: %s", label, exc,
                 )
+                # #5356: a log line alone is invisible with the shipped
+                # config — the whole point of this except block is that an
+                # UNTRUSTED layer can be silently wrong (a typo, or a
+                # rejected self-grant), and the second band gate ("is this
+                # visible with the shipped config?") is not satisfied by a
+                # log line nobody is guaranteed to be watching. Fires only
+                # when a layer was ACTUALLY dropped (this except block, not
+                # every reload) — matching #4501's own rejection, which
+                # shared this exact site but had no audit-event of its own
+                # until now (verified directly: #4501 predates this emit).
+                self._audit_events.emit(
+                    "hooks_layer_rejected", layer=label, reason=str(exc),
+                )
         from reyn.hooks.registry import HookRegistry
 
         return HookRegistry(defs)

--- a/tests/hooks/test_5356_write_paths_rejected_at_agent_writable_origin.py
+++ b/tests/hooks/test_5356_write_paths_rejected_at_agent_writable_origin.py
@@ -1,6 +1,6 @@
-"""Tier 2: #5356 — a hook's write_paths declaration is eager-rejected at an
-agent-writable origin (per-agent, per-session), and unaffected at either
-non-agent-writable origin (startup, runtime).
+"""Tier 2: #5356 — a hook's write_paths/subprocess/network declaration is
+eager-rejected at an agent-writable origin (per-agent, per-session), and
+unaffected at either non-agent-writable origin (startup, runtime).
 
 Real incident this closes (architect + docs-maintainer measurement,
 #5244/#5351/#5356): an agent can already write its own per-agent/per-
@@ -14,8 +14,15 @@ add-on that #5326's own hooks_add op already writes to the same path, and
 an "intersect with the agent-level allow_write_paths" design that assumed
 a parent grant exists for hook shells at all — it does not: dropping
 write_paths yields the hard floor, verified with a real PermissionError).
-This test file exercises the FINAL, simplest correct form: reject the
-declaration outright at the two agent-writable origins.
+
+Scope correction (lead-coder, same issue thread): the self-grant reasoning
+is key-name-independent — `subprocess`/`network` are threaded to the real
+sandbox exactly the same unconditional way as `write_paths` (verified
+directly against dispatcher.py: `allow_subprocess=hook.subprocess,
+network=hook.network` sit right next to `write_paths=hook.write_paths` in
+the same call, no origin branching anywhere). This file exercises the
+FINAL, simplest correct form: reject all three declarations outright at
+the two agent-writable origins.
 """
 from __future__ import annotations
 
@@ -29,36 +36,62 @@ _ENTRY_WITH_WRITE_PATHS = {
     "write_paths": ["/tmp/somewhere"],
 }
 
+_AGENT_WRITABLE_KEY_ENTRIES = {
+    "write_paths": {
+        "on": "turn_end",
+        "exec": ["/usr/bin/true"],
+        "write_paths": ["/tmp/somewhere"],
+    },
+    "subprocess": {
+        "on": "turn_end",
+        "exec": ["/usr/bin/true"],
+        "subprocess": True,
+    },
+    "network": {
+        "on": "turn_end",
+        "exec": ["/usr/bin/true"],
+        "network": True,
+    },
+}
+
 
 @pytest.mark.parametrize("origin", ["per-agent", "per-session"])
-def test_write_paths_rejected_at_agent_writable_origins_accepted_elsewhere(
-    origin: str,
+@pytest.mark.parametrize("key", ["write_paths", "subprocess", "network"])
+def test_agent_writable_key_rejected_at_agent_writable_origins_accepted_elsewhere(
+    key: str, origin: str,
 ) -> None:
     """Tier 2: acceptance + falsification contrast in one test (the SAME
     entry, only the origin differs) — without the contrast, a rejection
     triggered by an unrelated bug (a broken parser, an empty known-key set)
-    would read as this test passing for the wrong reason."""
+    would read as this test passing for the wrong reason. Parametrized
+    across all three axes lead-coder named — closing the class, not one
+    hole."""
+    entry = _AGENT_WRITABLE_KEY_ENTRIES[key]
     # Deny side — an agent-writable origin rejects it outright.
-    with pytest.raises(HookConfigError, match="write_paths.*not permitted"):
-        load_hooks([_ENTRY_WITH_WRITE_PATHS], origin=origin)
+    with pytest.raises(HookConfigError, match=f"{key}.*not permitted"):
+        load_hooks([entry], origin=origin)
 
     # Positive side — the SAME entry, at a non-agent-writable origin,
     # loads clean and the declaration survives onto the HookDef.
     for safe_origin in ("startup", "runtime"):
-        registry = load_hooks([_ENTRY_WITH_WRITE_PATHS], origin=safe_origin)
+        registry = load_hooks([entry], origin=safe_origin)
         (hook,) = registry.all_defs()
-        assert hook.write_paths == ("/tmp/somewhere",)
+        expected = tuple(entry[key]) if key == "write_paths" else entry[key]
+        assert getattr(hook, key) == expected
 
 
-def test_entry_with_no_write_paths_is_unaffected_at_any_origin() -> None:
-    """Tier 2: non-regression — a hook that never declares write_paths at
-    all loads fine at every origin, including per-agent/per-session. The
-    rejection is scoped to the KEY's presence, not the origin generally."""
+def test_entry_with_no_agent_writable_keys_is_unaffected_at_any_origin() -> None:
+    """Tier 2: non-regression — a hook that never declares write_paths/
+    subprocess/network at all loads fine at every origin, including
+    per-agent/per-session. The rejection is scoped to the KEYS' presence,
+    not the origin generally."""
     entry = {"on": "turn_end", "exec": ["/usr/bin/true"]}
     for origin in ("startup", "runtime", "per-agent", "per-session", "unknown"):
         registry = load_hooks([entry], origin=origin)
         (hook,) = registry.all_defs()
         assert hook.write_paths is None
+        assert hook.subprocess is None
+        assert hook.network is None
 
 
 def test_error_names_the_offending_origin() -> None:

--- a/tests/hooks/test_5356_write_paths_rejected_at_agent_writable_origin.py
+++ b/tests/hooks/test_5356_write_paths_rejected_at_agent_writable_origin.py
@@ -1,0 +1,69 @@
+"""Tier 2: #5356 — a hook's write_paths declaration is eager-rejected at an
+agent-writable origin (per-agent, per-session), and unaffected at either
+non-agent-writable origin (startup, runtime).
+
+Real incident this closes (architect + docs-maintainer measurement,
+#5244/#5351/#5356): an agent can already write its own per-agent/per-
+session hooks.yaml via the ordinary file-write op (session.py's own
+"agent-writable" framing), and a hook's write_paths declaration is fully
+honored by the real sandbox (verified directly against SeatbeltBackend,
+no mocks) — so declaring write_paths there is a confused-deputy self-
+grant, not a silent drop. Two prior design attempts for this issue were
+each falsified by direct measurement before landing (a "protected-set"
+add-on that #5326's own hooks_add op already writes to the same path, and
+an "intersect with the agent-level allow_write_paths" design that assumed
+a parent grant exists for hook shells at all — it does not: dropping
+write_paths yields the hard floor, verified with a real PermissionError).
+This test file exercises the FINAL, simplest correct form: reject the
+declaration outright at the two agent-writable origins.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.hooks.loader import HookConfigError, load_hooks
+
+_ENTRY_WITH_WRITE_PATHS = {
+    "on": "turn_end",
+    "exec": ["/usr/bin/true"],
+    "write_paths": ["/tmp/somewhere"],
+}
+
+
+@pytest.mark.parametrize("origin", ["per-agent", "per-session"])
+def test_write_paths_rejected_at_agent_writable_origins_accepted_elsewhere(
+    origin: str,
+) -> None:
+    """Tier 2: acceptance + falsification contrast in one test (the SAME
+    entry, only the origin differs) — without the contrast, a rejection
+    triggered by an unrelated bug (a broken parser, an empty known-key set)
+    would read as this test passing for the wrong reason."""
+    # Deny side — an agent-writable origin rejects it outright.
+    with pytest.raises(HookConfigError, match="write_paths.*not permitted"):
+        load_hooks([_ENTRY_WITH_WRITE_PATHS], origin=origin)
+
+    # Positive side — the SAME entry, at a non-agent-writable origin,
+    # loads clean and the declaration survives onto the HookDef.
+    for safe_origin in ("startup", "runtime"):
+        registry = load_hooks([_ENTRY_WITH_WRITE_PATHS], origin=safe_origin)
+        (hook,) = registry.all_defs()
+        assert hook.write_paths == ("/tmp/somewhere",)
+
+
+def test_entry_with_no_write_paths_is_unaffected_at_any_origin() -> None:
+    """Tier 2: non-regression — a hook that never declares write_paths at
+    all loads fine at every origin, including per-agent/per-session. The
+    rejection is scoped to the KEY's presence, not the origin generally."""
+    entry = {"on": "turn_end", "exec": ["/usr/bin/true"]}
+    for origin in ("startup", "runtime", "per-agent", "per-session", "unknown"):
+        registry = load_hooks([entry], origin=origin)
+        (hook,) = registry.all_defs()
+        assert hook.write_paths is None
+
+
+def test_error_names_the_offending_origin() -> None:
+    """Tier 2: the error message names which origin rejected it — a
+    reader landing on this error from a real config-load failure needs to
+    know WHERE to move the declaration, not just that it failed."""
+    with pytest.raises(HookConfigError, match="'per-agent'"):
+        load_hooks([_ENTRY_WITH_WRITE_PATHS], origin="per-agent")

--- a/tests/runtime/test_5091_broker_participation_via_per_session_hooks.py
+++ b/tests/runtime/test_5091_broker_participation_via_per_session_hooks.py
@@ -34,13 +34,23 @@ from tests._support.agent_session import make_session
 
 
 def _make_session(
-    tmp_path: Path, agent_name: str, *, workspace_base_dir: "Path | None" = None,
+    tmp_path: Path,
+    agent_name: str,
+    *,
+    workspace_base_dir: "Path | None" = None,
+    hooks_config: "list | None" = None,
 ) -> Session:
+    """``hooks_config`` (#5356/#5360, added for the ``session_start``
+    exec-hook test below): threads through ``ReactivityConfig.hooks_config``
+    to ``Session._startup_hooks_raw`` (origin ``"startup"``) — the same
+    layer a real ``reyn.yaml`` occupies, and NOT agent-writable, unlike the
+    per-agent/per-session layers ``_write_broker_inbox_hook`` below writes
+    to."""
     return make_session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / f"{agent_name}.wal"),
         snapshot_path=tmp_path / agent_name / "snap.json",
-        reactivity=ReactivityConfig(),
+        reactivity=ReactivityConfig(hooks_config=hooks_config),
         workspace_base_dir=workspace_base_dir,
         sandbox_backend=NoopBackend(),
     )
@@ -252,25 +262,34 @@ async def test_session_start_exec_hook_resolves_the_register_script_in_its_own_b
         encoding="utf-8",
     )
 
-    # Written to the per-session state dir BEFORE construction: the
-    # dispatcher's own registry is built ONCE, in `Session.__init__` —
-    # `_build_hook_registry()` itself re-reads the per-session layer fresh
-    # on every call (the OTHER tests in this module call it directly,
-    # after construction, for exactly that reason), but the dispatcher's
-    # already-built registry does not re-read until told to. Writing
-    # first, matching how an operator's hand-authored file is already on
-    # disk before `reyn chat`/`--connect` ever constructs the session.
-    (tmp_path / "coder-smith").mkdir(parents=True, exist_ok=True)
-    (tmp_path / "coder-smith" / "hooks.yaml").write_text(
-        "hooks:\n"
-        "  - on: session_start\n"
-        "    network: true\n"
-        "    exec:\n"
-        f"      - {sys.executable}\n"
-        "      - register_with_broker.py\n",
-        encoding="utf-8",
+    # #5356/#5360: `network: true` at an agent-writable origin (per-agent,
+    # per-session — an agent can already write either via the ordinary
+    # file-write op / `hooks_add`) is now an eager-rejected confused-deputy
+    # self-grant, dropping the whole layer. This test used to write this
+    # exact declaration into the per-session layer; it is REWRITTEN here
+    # to the startup layer instead — matching the REAL deployed shape
+    # (lead-coder's own measurement, 2026-08-24: every live `network: true`
+    # hook declaration already lives in `reyn.yaml`'s startup layer, none
+    # in per-agent/per-session, which are both empty), not a design
+    # regression. `_make_session`'s `hooks_config` threads to
+    # `Session._startup_hooks_raw` (origin "startup", not agent-writable,
+    # so #5356's rejection does not apply here). The property this test
+    # verifies — a `session_start` exec hook's relative argv resolves
+    # against THIS agent's own `base_dir` via `HookDispatcher`'s
+    # `hook_cwd` — depends on `workspace_base_dir`/dispatch, not on which
+    # config layer supplied the hook, so it is unaffected by this move.
+    session = _make_session(
+        tmp_path,
+        "coder-smith",
+        workspace_base_dir=base_dir,
+        hooks_config=[
+            {
+                "on": "session_start",
+                "network": True,
+                "exec": [sys.executable, "register_with_broker.py"],
+            },
+        ],
     )
-    session = _make_session(tmp_path, "coder-smith", workspace_base_dir=base_dir)
 
     await session._hook_dispatcher.dispatch("session_start", {})
 

--- a/tests/runtime/test_5356_hooks_layer_rejection_audit_event.py
+++ b/tests/runtime/test_5356_hooks_layer_rejection_audit_event.py
@@ -1,0 +1,87 @@
+"""Tier 2: #5356 — a rejected per-agent/per-session hooks.yaml layer (a
+write_paths self-grant, or any other HookConfigError) emits exactly one
+hooks_layer_rejected audit-event, and a valid layer emits none.
+
+A log line alone is invisible with the shipped config (band gate 2). This
+site (Session._build_hook_registry's per-layer try/except) is shared with
+#4501's own unknown-key rejection, which had no audit-event of its own
+before this — verified directly the site had none (only logger.warning).
+
+No mocks: a real Session, a real per-agent hooks.yaml on disk, observed
+via _audit_events.add_subscriber (the same pattern test_5296 established)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+_AGENT = "wp-agent"
+
+
+def _write_per_agent_hooks(tmp_path: Path, body: str) -> Path:
+    agent_dir = tmp_path / ".reyn" / "agents" / _AGENT
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    path = agent_dir / "hooks.yaml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return make_session(
+        agent_name=_AGENT,
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+
+
+def test_write_paths_self_grant_drops_the_layer_and_emits_one_event(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: acceptance — a per-agent hooks.yaml declaring write_paths
+    (the #5356 self-grant shape) is rejected wholesale (the hook does not
+    reach the registry at all) and exactly one hooks_layer_rejected event
+    fires, naming the per-agent layer."""
+    monkeypatch.chdir(tmp_path)
+    _write_per_agent_hooks(
+        tmp_path,
+        "hooks:\n  - on: turn_end\n    exec: [/usr/bin/true]\n"
+        "    write_paths: ['/tmp/somewhere']\n",
+    )
+    session = _make_session(tmp_path)
+
+    events: list = []
+    session._audit_events.add_subscriber(lambda e: events.append(e))
+    registry = session._build_hook_registry({})
+
+    assert registry.hooks_for("turn_end") == [], (
+        "the rejected per-agent layer must not contribute ANY hook to the "
+        "registry — the layer is dropped wholesale, not the single field"
+    )
+    (event,) = [e for e in events if e.type == "hooks_layer_rejected"]  # raises if not exactly 1
+    assert event.data["layer"] == "per-agent"
+    assert "write_paths" in event.data["reason"]
+
+
+def test_a_valid_per_agent_layer_emits_no_rejection_event(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: falsification contrast — a per-agent hooks.yaml with no
+    write_paths (and otherwise well-formed) loads clean and emits ZERO
+    hooks_layer_rejected events. Without this, "an event fired" could mean
+    nothing more than "the boot code ran," not "a real rejection happened.\""""
+    monkeypatch.chdir(tmp_path)
+    _write_per_agent_hooks(
+        tmp_path,
+        "hooks:\n  - on: turn_end\n    template_push:\n      message: ok\n      wake: true\n",
+    )
+    session = _make_session(tmp_path)
+
+    events: list = []
+    session._audit_events.add_subscriber(lambda e: events.append(e))
+    registry = session._build_hook_registry({})
+
+    assert len(registry.hooks_for("turn_end")) == 1, "the valid hook must load"
+    rejected = [e for e in events if e.type == "hooks_layer_rejected"]
+    assert rejected == []


### PR DESCRIPTION
**[docs-maintainer]** — closes #5356, per architect's final ruling (option A, "drop entirely" — the intersection design's own premise was falsified by my measurement).

## What

A confused-deputy self-grant: an agent can already write its own `.reyn/agents/<name>/hooks.yaml` (per-agent) or per-session state dir `hooks.yaml` via the ordinary file-write op, and a hook's `write_paths` declaration there is fully honored by the real sandbox (verified directly, real `SeatbeltBackend`, no mocks). Constructed and verified the actual cross-agent write directly: agent A's own hook, declaring `write_paths` into agent B's tree, succeeded.

Two design attempts before this were each falsified by direct measurement, not reasoning — recorded on the issue thread:
- A "protected-set" add-on — the same write path `hooks_add` already legitimately uses.
- An "intersect with the agent-level `allow_write_paths`" design — assumed a parent grant exists for hook shells. It doesn't: dropping `write_paths` yields the hard floor (a real `PermissionError`), so there's nothing to intersect with.

Also verified no live configuration breaks: architect read the actual `reyn-self` host directly — every per-agent/runtime hooks.yaml there is empty; every real `write_paths` declaration lives at the `startup` layer, untouched by this change.

## Fix

- `hooks/loader.py`: `_parse_entry` eager-rejects `write_paths:` at origin `per-agent`/`per-session` (new `_AGENT_WRITABLE_ORIGINS`), naming the offending origin in the error. A known key rejected at a specific origin — a different shape from #4501's unknown-key-name rejection, so a separate check.
- `runtime/session.py`: `_build_hook_registry`'s existing per-layer try/except (already drops a malformed untrusted layer wholesale) now also emits a `hooks_layer_rejected` audit-event.

**Real finding along the way**: #4501's own rejection shares this exact except-block and had no audit-event of its own until now — verified directly (only a `logger.warning` existed). Closing the silence for #5356 closes the identical gap for #4501 too, since both share the one site.

## Test plan

- [x] `tests/hooks/test_5356_write_paths_rejected_at_agent_writable_origin.py` — positive+deny in the same test (per architect's spec — deny alone would pass vacuously if the known-key set were empty), plus a non-regression and an error-message test.
- [x] `tests/runtime/test_5356_hooks_layer_rejection_audit_event.py` — a real `Session`, real per-agent hooks.yaml on disk: rejected layer contributes zero hooks (dropped wholesale) and emits exactly one event; a valid layer emits zero.
- [x] **Real strip-falsify (both witnesses, independently)**: disabling the origin check → exactly the 4 rejection-dependent tests go RED, 2 contrast tests stay green. Removing the audit-event emit → exactly the event-count test goes RED, rejection + the other test stay green. Both restored, 6/6 green.
- [x] Broader regression: `tests/hooks/` + `tests/runtime/` (2374 tests) all pass.
- [x] Local gates: ruff, `test_tier_audit --strict` (caught and fixed a real `len(x)==N` format-pin — switched to the canonical unpack idiom), `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all clean.
- [ ] (skipped — no UI/behavior change) Visual

## Remainder (house rule 6)

architect is fixing the reyn-self live config's own now-falsified comment directly (they have access, it's outside version control) — not a remainder on this PR.

Touches `tests/` — needs an independent TESTS-READ (B) before merge (rule 8). Co-vet: architect.


---

- [x] 🔴 **三軸のうち 1 つしか閉じていない。** この site 自身のコメント（`loader.py:444`、逐語）が `subprocess (#2827) / network + write_paths (#3005)` を **"The three axes an operator owns per-site"** と呼んでいる。#5356 の論理（*agent は自分の per-agent/per-session hooks.yaml を書ける ∴ そこで宣言された特権は self-grant*）は **キー名に依存しない** — `network: true` / `subprocess: true` を per-agent 層で宣言するのも、規則を書く主体と縛られる主体が同一という同じ形。**穴でなくクラスを閉じる**（CLAUDE.md）に照らすと `write_paths` だけの拒否は 1 穴。**要求は「3 つとも塞げ」ではない**: ① 3 つとも拒否する、または ② `network`/`subprocess` が per-agent 由来では **honor されない**ことを `write_paths` と同じ強さで測って（実 sandbox、mock 無し）**本文に開示**する、のどちらか。② なら 1 つだけ塞ぐのが正しく、その根拠が残る。⚠️ 私はどちらが真かを **測っていない** — 断定していません。


## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **【architect 取り下げ・偽でした】この拒否は本番では 1 度も発火しません。** `load_hooks` の production 呼び口（`config.py:428/436/455`、`doctor.py:362/586/605`）は **1 つも `origin=` を渡しておらず**、既定は `"unknown"` ∴ `origin in _AGENT_WRITABLE_ORIGINS` は**常に False**。本 PR も production 側に `origin=` を足していません（追加された `origin=` 4 件は comment と test のみ）。`origin="per-agent"` を渡している行は **この PR の test 内の 1 行だけ**です。⚠️ `#5213` の `hook_origin_is_at_least_as_specific_as` が使う origin は **`disabled:` toggle 経路（`HookToggleResult`）の別の出所**で、`load_hooks` の `HookDef.origin` ではありません。⚪ **六問③の block 条件 `only a configuration this test itself constructed` に正面から当たります。** 処方: ①production の呼び口で `origin` を渡す（trusted 側も `"startup"`/`"runtime"` と明示、`"unknown"` のままだと未配線と区別が付かない）②**実の読み込み経路で拒否されることを見る配線 witness**（`load_hooks` を直接呼ぶ test は配線を見ていません、#5326 と同じ形）③`"per-session"` を配線すると **`hooks_add` で `write_paths` を付ける呼び出しが失敗する**ので本文に明記。根拠: PR comment（TESTS-READ (B)）

- [x] 🔴 **この拒否は production では 1 度も発火しない**（@architect、TESTS-READ (B) の実測）。`load_hooks` の production 呼び口 6 箇所（`config.py:428/436/455`、`doctor.py:362/586/605`）は **1 つも `origin=` を渡しておらず**、既定は `"unknown"` ∴ `origin in _AGENT_WRITABLE_ORIGINS` は **常に False**。本 PR も production に `origin=` を足していない（追加は comment と test のみ）。`origin="per-agent"` を渡す行は **この PR の test 内の 1 行だけ**。⚠️ **「2374 tests pass」が緑であること自体がこの点の証拠**（実の読み込み経路が変わっていれば何かが動く）。処方 3 点: ① production で `origin` を渡す（trusted 側も明示 — `"unknown"` のままだと *未配線* と区別が付かない）② **実の読み込み経路で拒否を見る配線 witness**（`load_hooks` 直呼びは配線を見ていない＝#5326 と同じ形）③ `"per-session"` を配線すると **`hooks_add` で `write_paths` を付ける呼び出しが失敗する**ので、その挙動変更を本文に明記。





## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **3 軸が registry からでなく手書きです。** `for _agent_writable_key in ("subprocess", "network", "write_paths")` は**今日は完全**ですが（`sandbox_scope.py:77` の `HOOK_SANDBOX_SCOPE` の右列がちょうどこの 3 つ）、**4 軸目が registry に足された日に黙って外れます**。家則「cover/gate all X は registry 列挙で証明（curated subset 不可）」、かつ **この PR 自身が「1 つでは class を閉じない」と論じている**ので、同じ論法を 1 段上げると手書きの 3 つも class を閉じていません。処方（2 行）: `HOOK_SANDBOX_SCOPE` の右列から導く。⚪ 安全性も確認済 — この mapping は**付与の面**で deny 系（`read_deny_paths`/`write_deny_paths`/`env_deny_names`/`timeout_seconds`）は意図的に外されているため、導出しても安全な narrowing を巻き込みません。根拠: PR comment issuecomment-5445194354

