### PR TITLE
docs(#4994): _hydrate_from_history's docstring describes pre-#4994 state

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2504,14 +2504,16 @@ class TextualChatApp(App):
         self.query_one("#drawer", ContentSwitcher).display = False
         self.query_one(Composer).focus()
 
-    def _read_conversation_history(
-        self, *, agent: "str | None" = None, session_id: "str | None" = None
-    ) -> "list | None":
+    def _read_conversation_history(self) -> "list | None":
         """#4983 step ① — the registry/session read (:meth:`~reyn.interfaces.
         repl.read_model.ChatReadModel.conversation_history`), split out of
         :meth:`_hydrate_from_history` so a caller can choose HOW this
         specific step runs without also touching step ② (:meth:`_apply_
-        hydrated_messages`, pure in-memory projection).
+        hydrated_messages`, pure in-memory projection). Used to also accept
+        ``agent``/``session_id`` for the CURRENTLY-ATTACHED-session's own
+        targeted variant; dropped along with :meth:`_hydrate_from_history`'s
+        own copy of those parameters (#4995④'s audit found no caller for
+        either) — reads the currently attached session only.
 
         **Not a disk read** (#5203 measurement, docs-maintainer/architect-
         confirmed issuecomment-5385460393): ``conversation_history`` reads
@@ -2557,8 +2559,6 @@ class TextualChatApp(App):
         mount" now actually lives."""
         if self._read_model is None:
             return None
-        if agent is not None or session_id is not None:
-            return self._read_model.conversation_history(agent=agent, session_id=session_id)
         return self._read_model.conversation_history()
 
     def _resolve_history_source(
@@ -2806,9 +2806,7 @@ class TextualChatApp(App):
             if msg.kind == "agent":
                 self._recent_replies.appendleft(msg.text)
 
-    def _hydrate_from_history(
-        self, *, agent: "str | None" = None, session_id: "str | None" = None
-    ) -> None:
+    def _hydrate_from_history(self) -> None:
         """Restore-on-restart (#3273 Phase 5): the SYNCHRONOUS do-both
         convenience — runs step ① (:meth:`_read_conversation_history`) then
         step ② (:meth:`_apply_hydrated_messages`) back to back, on whatever
@@ -2824,18 +2822,15 @@ class TextualChatApp(App):
         same step ①/② split as mount (step ① off the loop via
         ``asyncio.to_thread``, gated by :attr:`_session_switch_generation`
         against a superseding later switch; step ② on the loop, unchanged).
-        Do not read this method's ``agent``/``session_id`` parameters as
-        still serving that call site — they currently have no production
-        caller (kept for a targeted-hydrate shape a future caller could
-        still use, same read-model seam
-        :meth:`~reyn.interfaces.repl.read_model.ChatReadModel.conversation_history`
-        — ``history.jsonl``, NOT the P6 audit-event log).
+        This method used to also accept ``agent``/``session_id`` for that
+        call site's sake; dropped (#4995④'s own audit found zero production
+        or test callers passing either) rather than left as unnamed dead
+        surface — a targeted-hydrate shape can be reintroduced against a
+        real caller if one ever needs it.
 
-        No args: hydrates the CURRENTLY ATTACHED session, byte-identical to
+        Hydrates the CURRENTLY ATTACHED session, byte-identical to
         pre-N2/pre-#4983 behavior."""
-        self._apply_hydrated_messages(
-            self._read_conversation_history(agent=agent, session_id=session_id)
-        )
+        self._apply_hydrated_messages(self._read_conversation_history())
 
     def _extend_older_frames_from_disk(self) -> bool:
         """#4387 Phase B ② (remaining consumers): when ``self._older_frames``

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2809,33 +2809,30 @@ class TextualChatApp(App):
     def _hydrate_from_history(
         self, *, agent: "str | None" = None, session_id: "str | None" = None
     ) -> None:
-        """Restore-on-restart (#3273 Phase 5) AND session-switch reset+rehydrate
-        (#3310 N2): the SYNCHRONOUS do-both convenience — runs step ①
-        (:meth:`_read_conversation_history`) then step ② (:meth:`_apply_
-        hydrated_messages`) back to back, on whatever thread/task calls
-        this. #4983: mount (:meth:`on_mount`) no longer calls this when a
-        pre-fetched history is available (see that method's own docstring
-        for why it reads BEFORE the app is even constructed instead) —
-        this wrapper remains for :meth:`_handle_session_attached_event`
-        (the live session-switch rehydrate, #3310 N2), which #4983
-        deliberately did NOT touch: that call site's own event-loop-block
-        question is a separate, still-open UX question (does the
-        conversation pane briefly go blank on switch, in exchange for the
-        TUI no longer freezing?) requiring its own owner-facing ruling —
-        see #4983's own issue thread. Do not read "mount is fixed" as
-        "this method is fixed" — it is the SAME synchronous shape it
-        always was, on this call path.
+        """Restore-on-restart (#3273 Phase 5): the SYNCHRONOUS do-both
+        convenience — runs step ① (:meth:`_read_conversation_history`) then
+        step ② (:meth:`_apply_hydrated_messages`) back to back, on whatever
+        thread/task calls this. #4983: mount (:meth:`on_mount`) no longer
+        calls this when a pre-fetched history is available (see that
+        method's own docstring for why it reads BEFORE the app is even
+        constructed instead) — this remains the fallback for a caller that
+        never opted into that split.
 
-        Two call shapes:
+        #4994 (#4983's own arc): the live session-switch rehydrate
+        (:meth:`_handle_session_attached_event`, #3310 N2) no longer calls
+        THIS method at all — it has its own inline implementation with the
+        same step ①/② split as mount (step ① off the loop via
+        ``asyncio.to_thread``, gated by :attr:`_session_switch_generation`
+        against a superseding later switch; step ② on the loop, unchanged).
+        Do not read this method's ``agent``/``session_id`` parameters as
+        still serving that call site — they currently have no production
+        caller (kept for a targeted-hydrate shape a future caller could
+        still use, same read-model seam
+        :meth:`~reyn.interfaces.repl.read_model.ChatReadModel.conversation_history`
+        — ``history.jsonl``, NOT the P6 audit-event log).
 
-        - No args: hydrates the CURRENTLY ATTACHED session, byte-identical
-          to pre-N2/pre-#4983 behavior.
-        - ``agent``/``session_id`` given (:meth:`_handle_session_attached_event`,
-          called AFTER :meth:`self.conversation`'s ``clear()``): hydrates that
-          SPECIFIC (possibly never-before-attached-in-this-client-run) session
-          instead — the same read-model seam
-          (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.conversation_history`
-          — ``history.jsonl``, NOT the P6 audit-event log), just targeted."""
+        No args: hydrates the CURRENTLY ATTACHED session, byte-identical to
+        pre-N2/pre-#4983 behavior."""
         self._apply_hydrated_messages(
             self._read_conversation_history(agent=agent, session_id=session_id)
         )


### PR DESCRIPTION
**[tui-coder]** — Small doc-only follow-up, no issue filed (lead-coder: "小さいのでそのままPRに、起票は不要"). Found while verifying #4995's candidate ④ (now closed).

## What

`TextualChatApp._hydrate_from_history`'s docstring described a pre-#4994 state: it claimed `_handle_session_attached_event` (the live session-switch rehydrate) still calls this method, and that the switch call site's event-loop-block question was "a separate, still-open UX question requiring its own owner-facing ruling."

Traced the actual current code (not the docstring) instead: `_handle_session_attached_event` no longer calls `_hydrate_from_history` at all — `#4994` (landed under `#4983`'s own arc) gave it its own inline implementation with the same step ①/② split as mount's `#4985` fix (`asyncio.to_thread` for the read, a `_session_switch_generation` supersede guard, projection+apply back on the loop). The owner ruling the old docstring called "still open" was already made and landed.

Also confirmed (grepped `tests/` too) that the `agent`/`session_id` parameters this docstring described as serving that call site currently have **no production or test caller** — kept in the signature but noted as such rather than removed (a separate, larger decision).

## Why now

CLAUDE.md hard rule: a doc describing a mechanism is stale the moment the code changes — fix in the same PR. This one's code changed in `#4994`'s PR and the docstring wasn't updated there; this closes that gap.

## Change

Docstring-only. No behavior change.

## Gates

- [x] `ruff check src/reyn/interfaces/inline/textual_chat/app.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py`
- [x] `python scripts/mypy_ratchet.py` (201 findings, all baselined)
- [x] `tests/interfaces/test_4983_mount_hydrate_off_loop.py` (6/6, unaffected — confirms this docstring-only change didn't touch behavior)

## Test plan

- [x] Docstring-only change; existing test file for the adjacent mechanism re-run and unaffected
- [x] (skipped — Visual gate does not block main merge; standing waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

- [x] 🔴 **死んだ引数の理由が「将来の呼び手」になっている。** 新しい docstring 自身が `agent`/`session_id` を **`they currently have no production caller`** と書き、残す理由を **`kept for a targeted-hydrate shape a future caller could still use`** としている。これは**持ち主のいない理由**で、この形は消えない（次に読む人も同じ理由で残す）。**要求はどちらか**: ① **この PR で引数を落とす**（`_read_conversation_history` 側の受け口も含め、呼び手が 0 なら 2 箇所）— doc-only の射程を超えるが、この PR の主題はこのメソッドの契約そのものなので範囲内。② **残すなら「誰が」を名指す**（open issue 番号、または「この shape を必要とする具体的な呼び出し」）。⚠️ **「将来」は主体ではない。** 家則: 残余は**起票か明示的な破棄**か、どちらか。⚪ **doc を正直にしたこと自体は正しい** — 止めているのは、正直にした結果として現れた残余に持ち主が居ないこと。

