### PR TITLE
fix(#4986): CI teardown-hang stall dump

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,9 +125,38 @@ jobs:
         # excluded-injected-tokens fix option). -n auto is xdist; the gate
         # aggregates cross-worker via a shared events file (same mechanism
         # network_gate already uses here) before judging.
+        # REYN_STALL_TRACE_CI=600 (#4986): a session-spanning stack dump if
+        # the pytest process itself does not finish within 600s — 120s of
+        # margin below this step's own `timeout 12m` (720s) kill, comfortably
+        # above this suite's own normal completion (~7-8 min measured). Exists
+        # because neither `--timeout=120` (pytest-timeout) nor pytest's own
+        # builtin faulthandler_timeout can ever see a hang in SESSION
+        # teardown — both wrap only `pytest_runtest_protocol` per item and
+        # cancel their own watchdog the instant the last item's protocol
+        # returns (`_pytest/faulthandler.py`'s own source, confirmed, not
+        # guessed). See `reyn/dev/testing/stall_dump.py`'s own docstring.
         run: |
           set -o pipefail
-          REYN_REPLAY_UNCONSUMED_CHECK=1 timeout 12m python -m pytest -q -n auto --timeout=120 -rs --durations=25 | tee /tmp/pytest-output.log
+          REYN_REPLAY_UNCONSUMED_CHECK=1 REYN_STALL_TRACE_CI=600 timeout 12m python -m pytest -q -n auto --timeout=120 -rs --durations=25 | tee /tmp/pytest-output.log
+
+      # #4986: surface the stall dump above if (and only if) it fired. The
+      # log file is opened (empty) the moment the watchdog is armed —
+      # faulthandler needs an already-open file object — so a healthy run
+      # leaves an EMPTY file behind, not a missing one; `-s` (non-empty)
+      # is the actual "did it fire" test, not `-f`. `if: always()` + a
+      # non-firing no-op costs nothing on every healthy run. Without this
+      # step the dump would sit on the ephemeral runner's disk, unread by
+      # anyone — the whole point of #4986's fix is a diagnostic that
+      # SURVIVES to be read, not merely one that gets written.
+      - name: Stall-trace dump (#4986 — only non-empty if the session hung)
+        if: always()
+        run: |
+          if [ -s .reyn-ci-stall-trace.log ]; then
+            echo "::warning::#4986 stall-trace fired — pytest's own teardown did not finish within REYN_STALL_TRACE_CI seconds"
+            cat .reyn-ci-stall-trace.log
+          else
+            echo "no stall-trace dump (pytest session finished normally)"
+          fi
 
       # #4331: what a green run above does NOT say — the skip census (count
       # + reason breakdown) and the collection-error count, on the SAME

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ spike_results/
 /.mcp.json
 scratch/
 .reyn-memory-ceiling.log
+.reyn-ci-stall-trace.log

--- a/src/reyn/dev/testing/stall_dump.py
+++ b/src/reyn/dev/testing/stall_dump.py
@@ -11,23 +11,46 @@ WHY THIS EXISTS
     instant the LAST test's protocol returns — neither can ever see a hang
     that happens strictly AFTER that point. This arms a SEPARATE,
     session-spanning watchdog (reusing ``reyn.runtime.stall_trace``'s
-    ``arm``/``disarm``, #4405 — the same ``faulthandler.dump_traceback_later``
-    primitive, not a new mechanism) that only gets cancelled at
-    ``pytest_sessionfinish`` — so if teardown itself hangs, the timer is
-    NEVER cancelled and fires.
+    ``arm``, #4405 — the same ``faulthandler.dump_traceback_later``
+    primitive, not a new mechanism).
+
+WHY THIS NEVER DISARMS (architect finding, PR #5362 review,
+issuecomment-5445125316)
+    The first version of this module cancelled the timer at
+    ``pytest_sessionfinish`` — but ``pytest_sessionfinish`` returning is
+    NOT the end of the process: interpreter shutdown, ``atexit`` handlers,
+    and non-daemon thread joins all still remain, and THAT is a class of
+    hang this repo has actually hit for real (PR #5049's
+    ``ThreadedTransportProxy``: an assert failure → an ``Event`` never set
+    → a non-daemon thread left running → ``atexit``'s own thread-join
+    hangs). Disarming at ``pytest_sessionfinish`` would have structurally
+    excluded the exact failure class #4986 exists to catch. Fixed by never
+    disarming at all: ``arm()`` is called with ``exit=False``, so a timer
+    that outlives the test session merely dumps (repeatedly, every
+    ``REYN_STALL_TRACE_CI`` seconds) and does nothing else — a HEALTHY
+    process has already exited (ending the background thread with it)
+    long before the threshold arrives, so this costs nothing on a green
+    run; a process still alive at the threshold is, by construction,
+    already taking longer than this suite's own normal completion time by
+    a wide margin — exactly the condition worth dumping for, whether the
+    hang is inside pytest's own session or in the interpreter's shutdown
+    sequence afterward.
 
 WHY GATED, NOT ALWAYS ON
     Opt-in via ``REYN_STALL_TRACE_CI`` (seconds) — unset means this file does
     nothing, zero behavior change for local/dev runs. On a healthy CI run,
-    ``pytest_sessionfinish`` cancels the timer well before it would fire
-    (normal completion is ~7-8 minutes; :data:`LOG_PATH`'s own workflow value
-    leaves comfortable margin both ways), so a green run gains nothing from
-    this beyond one empty, unwritten file (faulthandler needs an
-    already-open file object at ARM time, so opening happens whether or not
-    the timer ever fires — the CI step that surfaces this file tests for
-    NON-EMPTY content, not mere existence, for exactly this reason) — no
-    added cost worth naming, no added output. Dump CONTENT only appears
-    when something has already gone wrong (CLAUDE.md band: cost/budget).
+    the WHOLE PROCESS exits (ending the background timer with it) well
+    before the threshold would ever be reached (normal completion is ~7-8
+    minutes; :data:`LOG_PATH`'s own workflow value leaves comfortable
+    margin), so a green run gains nothing from this beyond one empty,
+    unwritten file (faulthandler needs an already-open file object at ARM
+    time, so opening happens regardless of whether the timer ever fires —
+    the CI step that surfaces this file tests for NON-EMPTY content, not
+    mere existence, for exactly this reason) — no added cost worth naming,
+    no added output. Dump CONTENT only appears when something has already
+    gone wrong (CLAUDE.md band: cost/budget) — see "WHY THIS NEVER
+    DISARMS" above for why process-exit, not a cancel call, is what ends
+    this on the healthy path.
 
 WHY A DISK FILE, NOT sys.stderr
     ``faulthandler.dump_traceback_later``'s destination is fixed at ARM
@@ -107,13 +130,3 @@ def pytest_configure(config: "pytest.Config") -> None:
 
     _dump_file = open(LOG_PATH, "a", buffering=1)  # noqa: SIM115 — see module docstring
     arm(seconds, file=_dump_file)
-
-
-def pytest_sessionfinish(session: "pytest.Session", exitstatus: int) -> None:
-    if _is_xdist_worker(session.config):
-        return
-    if _seconds_from_env() is None:
-        return
-    from reyn.runtime.stall_trace import disarm
-
-    disarm()

--- a/src/reyn/dev/testing/stall_dump.py
+++ b/src/reyn/dev/testing/stall_dump.py
@@ -1,0 +1,119 @@
+"""CI teardown-hang diagnostic (#4986): dump every thread's stack if the
+pytest session itself does not finish within ``REYN_STALL_TRACE_CI`` seconds.
+
+WHY THIS EXISTS
+    #4986: CI's own pytest run has hung 3 times in session TEARDOWN (asyncio's
+    ``_cancel_all_tasks`` stuck in ``gather()``), each time with ZERO
+    diagnostic surviving — confirmed structurally, not by guesswork: both
+    pytest-timeout's ``--timeout`` and pytest's own builtin
+    ``faulthandler_timeout`` wrap ONLY ``pytest_runtest_protocol`` per item
+    (``_pytest/faulthandler.py``'s own source), cancelling the watchdog the
+    instant the LAST test's protocol returns — neither can ever see a hang
+    that happens strictly AFTER that point. This arms a SEPARATE,
+    session-spanning watchdog (reusing ``reyn.runtime.stall_trace``'s
+    ``arm``/``disarm``, #4405 — the same ``faulthandler.dump_traceback_later``
+    primitive, not a new mechanism) that only gets cancelled at
+    ``pytest_sessionfinish`` — so if teardown itself hangs, the timer is
+    NEVER cancelled and fires.
+
+WHY GATED, NOT ALWAYS ON
+    Opt-in via ``REYN_STALL_TRACE_CI`` (seconds) — unset means this file does
+    nothing, zero behavior change for local/dev runs. On a healthy CI run,
+    ``pytest_sessionfinish`` cancels the timer well before it would fire
+    (normal completion is ~7-8 minutes; :data:`LOG_PATH`'s own workflow value
+    leaves comfortable margin both ways), so a green run gains nothing from
+    this beyond one empty, unwritten file (faulthandler needs an
+    already-open file object at ARM time, so opening happens whether or not
+    the timer ever fires — the CI step that surfaces this file tests for
+    NON-EMPTY content, not mere existence, for exactly this reason) — no
+    added cost worth naming, no added output. Dump CONTENT only appears
+    when something has already gone wrong (CLAUDE.md band: cost/budget).
+
+WHY A DISK FILE, NOT sys.stderr
+    ``faulthandler.dump_traceback_later``'s destination is fixed at ARM
+    time — there is no chance to redirect it once teardown is already
+    hanging. pytest's own capture manager can own ``sys.stderr`` for parts
+    of a session (the same hazard ``memory_ceiling.py`` already solved for
+    its own kill message — see that module's ``LOG_PATH`` comment). A
+    plain, already-open disk file sidesteps that entirely: writing to a
+    real fd outside pytest's capture is unaffected by whatever pytest does
+    to the process's own stdout/stderr streams.
+
+WHY NOT ARMED IN EVERY xdist WORKER
+    The observed hang is in the CONTROLLER's own event loop
+    (``_cancel_all_tasks`` → ``run_until_complete``, per the #4986 stack
+    dumps already on file) — ``config.workerinput`` is xdist's own
+    controller/worker discriminator (present only inside a worker
+    subprocess). Arming per-worker would multiply the timer for no
+    additional signal and, on the rare occasion it DOES fire, multiply the
+    dump output N-workers-over for nothing.
+
+THE NUMBER
+    Must be comfortably under ``.github/workflows/test.yml``'s own outer
+    ``timeout 12m`` (720s) — a dump that fires AFTER that kill never gets
+    written, and comfortably ABOVE this suite's own normal completion time
+    (~7-8 min measured on recent green runs) so a slow-but-healthy run
+    never fires it. Set via ``REYN_STALL_TRACE_CI`` at the workflow level
+    (not hardcoded here) so the margin can be re-tuned from one place if
+    ``test.yml``'s own outer timeout ever changes.
+"""
+from __future__ import annotations
+
+import os
+from typing import IO, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+_ENV_VAR = "REYN_STALL_TRACE_CI"
+
+#: Under the repo root (matches ``memory_ceiling.py``'s own ``LOG_PATH``
+#: convention), not a scratch dir that a CI runner discards before anyone
+#: could read it, and not ``.reyn/`` (a real project's own dir, which a
+#: bare `pytest` invocation from a fresh checkout may not even have yet).
+LOG_PATH = os.path.join(os.getcwd(), ".reyn-ci-stall-trace.log")
+
+#: Kept open for the whole session (faulthandler needs an already-open
+#: file object at ARM time, and may write to it from a background thread
+#: at any later moment) — closed implicitly at process exit; there is no
+#: earlier safe point to close it without risking the very hang this
+#: module exists to catch.
+_dump_file: "IO[str] | None" = None
+
+
+def _seconds_from_env() -> "float | None":
+    raw = os.environ.get(_ENV_VAR)
+    if not raw:
+        return None
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return None
+    return seconds if seconds > 0 else None
+
+
+def _is_xdist_worker(config: "pytest.Config") -> bool:
+    return hasattr(config, "workerinput")
+
+
+def pytest_configure(config: "pytest.Config") -> None:
+    if _is_xdist_worker(config):
+        return
+    seconds = _seconds_from_env()
+    if seconds is None:
+        return
+    global _dump_file
+    from reyn.runtime.stall_trace import arm
+
+    _dump_file = open(LOG_PATH, "a", buffering=1)  # noqa: SIM115 — see module docstring
+    arm(seconds, file=_dump_file)
+
+
+def pytest_sessionfinish(session: "pytest.Session", exitstatus: int) -> None:
+    if _is_xdist_worker(session.config):
+        return
+    if _seconds_from_env() is None:
+        return
+    from reyn.runtime.stall_trace import disarm
+
+    disarm()

--- a/src/reyn/runtime/stall_trace.py
+++ b/src/reyn/runtime/stall_trace.py
@@ -56,6 +56,10 @@ import faulthandler
 import logging
 import os
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import IO
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +99,7 @@ def _log_stream():
     return sys.stderr
 
 
-def arm(seconds: float) -> None:
+def arm(seconds: float, *, file: "IO[str] | int | None" = None) -> None:
     """Start the background-thread stall timer. Call at turn entry, paired
     with :func:`disarm` in a ``finally`` so a turn that raises still
     disarms it — never call twice without a ``disarm`` in between
@@ -104,8 +108,20 @@ def arm(seconds: float) -> None:
     new *seconds*/file, which is not this module's problem to solve since
     only one turn ever runs at a time on a given event loop by
     construction).
+
+    ``file`` (#4986): overrides the destination — default ``None`` keeps
+    every existing caller's behavior (:func:`_log_stream`'s own
+    resolution) byte-identical. A caller arming this OUTSIDE reyn's own
+    runtime, where ``sys.stderr``/a reyn log handler may not be the real
+    destination it looks like (pytest's capture manager can own
+    ``sys.stderr`` for parts of a session — the same hazard
+    ``memory_ceiling.py`` already documents for its own kill message),
+    should pass its own already-open file object instead — see
+    ``reyn.dev.testing.stall_dump`` for that caller.
     """
-    faulthandler.dump_traceback_later(seconds, repeat=True, file=_log_stream(), exit=False)
+    faulthandler.dump_traceback_later(
+        seconds, repeat=True, file=file if file is not None else _log_stream(), exit=False
+    )
 
 
 def disarm() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -636,21 +636,16 @@ def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> 
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    from reyn.dev.testing import (
-        extra_skip_report,
-        network_gate,
-        replay_unconsumed,
-        stall_dump,
-    )
+    from reyn.dev.testing import extra_skip_report, network_gate, replay_unconsumed
 
     network_gate.pytest_sessionfinish(session, exitstatus)
     extra_skip_report.pytest_sessionfinish(session, exitstatus)
     replay_unconsumed.pytest_sessionfinish(session, exitstatus)
-    # #4986: cancel LAST — a session-teardown hang (the exact case this
-    # watchdog exists to catch) must not have its timer cancelled by an
-    # earlier sessionfinish hook's own side effect finishing first; this
-    # call itself is cheap and unconditional either way.
-    stall_dump.pytest_sessionfinish(session, exitstatus)
+    # #4986 (reyn.dev.testing.stall_dump): deliberately has no
+    # pytest_sessionfinish hook — see that module's own "WHY THIS NEVER
+    # DISARMS" docstring section (architect finding, PR #5362 review): a
+    # cancel here would exclude exactly the interpreter-shutdown/atexit
+    # hang class #4986 exists to catch.
 
 
 # ── Autouse fixture ────────────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -614,6 +614,13 @@ def pytest_configure(config: pytest.Config) -> None:
 
     memory_ceiling.pytest_configure(config)
 
+    # #4986: CI teardown-hang stall dump — opt-in (REYN_STALL_TRACE_CI unset
+    # means this is a no-op), see that module's own docstring for why a
+    # session-spanning watchdog is needed at all.
+    from reyn.dev.testing import stall_dump
+
+    stall_dump.pytest_configure(config)
+
 
 def pytest_runtest_setup(item: pytest.Item) -> None:
     from reyn.dev.testing import memory_ceiling, network_gate
@@ -629,11 +636,21 @@ def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> 
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    from reyn.dev.testing import extra_skip_report, network_gate, replay_unconsumed
+    from reyn.dev.testing import (
+        extra_skip_report,
+        network_gate,
+        replay_unconsumed,
+        stall_dump,
+    )
 
     network_gate.pytest_sessionfinish(session, exitstatus)
     extra_skip_report.pytest_sessionfinish(session, exitstatus)
     replay_unconsumed.pytest_sessionfinish(session, exitstatus)
+    # #4986: cancel LAST — a session-teardown hang (the exact case this
+    # watchdog exists to catch) must not have its timer cancelled by an
+    # earlier sessionfinish hook's own side effect finishing first; this
+    # call itself is cheap and unconditional either way.
+    stall_dump.pytest_sessionfinish(session, exitstatus)
 
 
 # ── Autouse fixture ────────────────────────────────────────────────────────────

--- a/tests/dev/test_stall_dump_4986.py
+++ b/tests/dev/test_stall_dump_4986.py
@@ -1,0 +1,167 @@
+"""Tier 1: Contract — reyn.dev.testing.stall_dump, the #4986 CI
+teardown-hang diagnostic.
+
+Same style as tests/dev/test_extra_skip_report_4104.py: a REAL, isolated
+inner pytest session (via pytester's own subprocess seam) is the only way
+to exercise a genuine pytest_configure/pytest_sessionfinish pair without
+faking pytest's own session lifecycle. Run as real SUBPROCESSES (not
+pytester's in-process runpytest()) so the plugin's own faulthandler
+arm/disarm calls never interact with THIS outer test session's own
+faulthandler state.
+
+No duration anywhere the assertion depends on: the inner session's own
+hang is a REAL, deterministic block (``sys.stdin.readline()`` on a pipe
+this test controls, released by closing it — the same idiom this
+repo's own real-subprocess tests already use), and the outer wait for the
+dump file to appear is an unbounded poll (``while not condition: sleep(0)``)
+— the ceiling is whatever timeout wraps THIS test itself, never a
+self-authored one. ``REYN_STALL_TRACE_CI``'s own seconds value is the
+injected clock CLAUDE.md's duration rule asks for when a duration
+genuinely is the subject, not a guessed wait.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+_INNER_CONFTEST = 'pytest_plugins = ["reyn.dev.testing.stall_dump"]\n'
+
+_INNER_TEST_HANGS_AT_TEARDOWN = """
+import sys
+from pathlib import Path
+import pytest
+
+@pytest.fixture(scope="session", autouse=True)
+def _hang_forever_at_teardown():
+    yield
+    # Blocks until the outer test closes this process's stdin — a real,
+    # deterministic wait, released deterministically, never a sleep.
+    sys.stdin.readline()
+
+def test_body():
+    # A durable, unbuffered marker the OUTER test polls for — proof the
+    # test body itself already ran and only the deliberate teardown hang
+    # remains (pytest's own final summary line never prints while that
+    # hang holds the session open, so stdout/stderr can't serve this role).
+    Path("test_started.marker").write_text("started")
+    assert True
+"""
+
+_INNER_TEST_NORMAL = "def test_body():\n    assert True\n"
+
+
+def test_a_session_teardown_hang_produces_a_stall_dump(
+    pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 1: the mechanism this issue exists for actually fires. A session
+    whose own teardown blocks forever (the #4986 shape: something after the
+    last test's own result is already decided never lets the process exit)
+    produces a non-empty stall-trace dump file — not merely "no crash", the
+    file must contain a real thread stack.
+
+    Strip-falsifier: unset REYN_STALL_TRACE_CI (or revert
+    reyn/dev/testing/stall_dump.py's pytest_configure to a no-op) and this
+    goes red — the log file never appears, because nothing armed the
+    watchdog."""
+    pytester.makeconftest(_INNER_CONFTEST)
+    pytester.makepyfile(test_inner=_INNER_TEST_HANGS_AT_TEARDOWN)
+    monkeypatch.setenv("REYN_STALL_TRACE_CI", "1")
+
+    log_path = Path(pytester.path) / ".reyn-ci-stall-trace.log"
+    assert not log_path.exists(), "test setup invariant: no stale dump file"
+
+    # `-s`: pytest's own capture manager replaces sys.stdin with an object
+    # that RAISES on read rather than blocking (`DontReadFromInput`) —
+    # without this flag the fixture's `readline()` never actually blocks,
+    # it errors out immediately and the session finishes right away.
+    proc = pytester.popen(
+        [sys.executable, "-m", "pytest", "-q", "-s", "test_inner.py"],
+        stdin=subprocess.PIPE,
+    )
+    try:
+        while not (log_path.exists() and log_path.stat().st_size > 0):
+            time.sleep(0)
+        content = log_path.read_text()
+    finally:
+        assert proc.stdin is not None
+        proc.stdin.close()  # releases _hang_forever_at_teardown's readline()
+        proc.wait()
+
+    assert "Thread" in content, (
+        f"the dump file should contain a real faulthandler thread-stack "
+        f"dump, got {content!r}"
+    )
+
+
+def test_a_normal_session_produces_no_stall_dump(
+    pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 1: regression guard — a session that finishes normally, well
+    inside the configured threshold, must not produce dump CONTENT. Mirrors
+    #4986's own "no cost on a green run" requirement: the watchdog is
+    cancelled at pytest_sessionfinish before it would ever fire.
+
+    (The log file itself is opened, empty, the moment the watchdog is
+    armed — faulthandler needs an already-open file object, so "opened"
+    and "written to" are different claims; the one that matters for cost
+    is the latter.)"""
+    pytester.makeconftest(_INNER_CONFTEST)
+    pytester.makepyfile(test_inner=_INNER_TEST_NORMAL)
+    monkeypatch.setenv("REYN_STALL_TRACE_CI", "600")
+
+    result = pytester.runpytest_subprocess("test_inner.py")
+    result.assert_outcomes(passed=1)
+
+    log_path = Path(pytester.path) / ".reyn-ci-stall-trace.log"
+    assert not (log_path.exists() and log_path.stat().st_size > 0), (
+        "#4986 REGRESSION: a normal, fast session must not leave a "
+        "stall-trace DUMP (non-empty content) behind"
+    )
+
+
+def test_the_watchdog_stays_off_when_unset(
+    pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 1: REYN_STALL_TRACE_CI unset is a genuine no-op, even for a
+    session whose own teardown hangs — #4986's own "opt-in, zero behavior
+    change" requirement. Without this, ANY teardown hang anywhere (not just
+    CI's own opted-in run) would start leaving dump files in every
+    developer's own working tree.
+
+    No duration: waits on the inner test's own marker file (a real event —
+    proof the test body ran and only the deliberate teardown hang remains)
+    rather than sleeping some guessed "long enough" span before checking
+    absence."""
+    pytester.makeconftest(_INNER_CONFTEST)
+    pytester.makepyfile(test_inner=_INNER_TEST_HANGS_AT_TEARDOWN)
+    monkeypatch.delenv("REYN_STALL_TRACE_CI", raising=False)
+
+    log_path = Path(pytester.path) / ".reyn-ci-stall-trace.log"
+    marker_path = Path(pytester.path) / "test_started.marker"
+    # `-s`: see test_a_session_teardown_hang_produces_a_stall_dump's own
+    # comment — without it the fixture's `readline()` raises instead of
+    # blocking, and this would stop being a genuine hang.
+    proc = pytester.popen(
+        [sys.executable, "-m", "pytest", "-q", "-s", "test_inner.py"],
+        stdin=subprocess.PIPE,
+    )
+    try:
+        while not marker_path.exists():
+            time.sleep(0)
+        # Now deterministically inside the deliberate teardown hang (the
+        # test body already ran and returned) — no dump was ever armed
+        # (env unset), so the file cannot exist and cannot come into
+        # existence for as long as the hang holds.
+        assert not log_path.exists(), (
+            "#4986 REGRESSION: REYN_STALL_TRACE_CI unset must stay a true no-op"
+        )
+    finally:
+        assert proc.stdin is not None
+        proc.stdin.close()
+        proc.wait()

--- a/tests/dev/test_stall_dump_4986.py
+++ b/tests/dev/test_stall_dump_4986.py
@@ -3,11 +3,15 @@ teardown-hang diagnostic.
 
 Same style as tests/dev/test_extra_skip_report_4104.py: a REAL, isolated
 inner pytest session (via pytester's own subprocess seam) is the only way
-to exercise a genuine pytest_configure/pytest_sessionfinish pair without
-faking pytest's own session lifecycle. Run as real SUBPROCESSES (not
-pytester's in-process runpytest()) so the plugin's own faulthandler
-arm/disarm calls never interact with THIS outer test session's own
-faulthandler state.
+to exercise a genuine pytest_configure without faking pytest's own session
+lifecycle. Run as real SUBPROCESSES (not pytester's in-process runpytest())
+so the plugin's own faulthandler ``arm()`` call never interacts with THIS
+outer test session's own faulthandler state.
+
+stall_dump deliberately has no pytest_sessionfinish hook (architect
+finding, PR #5362 review) — the watchdog is never cancelled; a healthy
+process's own exit ends it. See that module's own "WHY THIS NEVER DISARMS"
+docstring section.
 
 No duration anywhere the assertion depends on: the inner session's own
 hang is a REAL, deterministic block (``sys.stdin.readline()`` on a pipe
@@ -54,6 +58,54 @@ def test_body():
 """
 
 _INNER_TEST_NORMAL = "def test_body():\n    assert True\n"
+
+_INNER_TEST_HANGS_AT_ATEXIT = """
+import atexit
+import sys
+
+def _hang_forever():
+    sys.stdin.readline()
+
+atexit.register(_hang_forever)
+
+def test_body():
+    assert True
+"""
+
+
+def test_an_atexit_hang_after_sessionfinish_also_produces_a_stall_dump(
+    pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 1: the specific class architect's PR #5362 review named — a
+    hang in interpreter shutdown/``atexit``, strictly AFTER
+    ``pytest_sessionfinish`` has already returned (this repo's own real
+    precedent: PR #5049's ``ThreadedTransportProxy``, a non-daemon thread
+    left running past session end, joined at ``atexit``) — is still
+    caught. This is the exact case a `pytest_sessionfinish`-cancelled
+    timer would have missed; stall_dump deliberately has no such hook
+    (see its own module docstring's "WHY THIS NEVER DISARMS")."""
+    pytester.makeconftest(_INNER_CONFTEST)
+    pytester.makepyfile(test_inner=_INNER_TEST_HANGS_AT_ATEXIT)
+    monkeypatch.setenv("REYN_STALL_TRACE_CI", "1")
+
+    log_path = Path(pytester.path) / ".reyn-ci-stall-trace.log"
+    proc = pytester.popen(
+        [sys.executable, "-m", "pytest", "-q", "-s", "test_inner.py"],
+        stdin=subprocess.PIPE,
+    )
+    try:
+        while not (log_path.exists() and log_path.stat().st_size > 0):
+            time.sleep(0)
+        content = log_path.read_text()
+    finally:
+        assert proc.stdin is not None
+        proc.stdin.close()  # releases _hang_forever's readline()
+        proc.wait()
+
+    assert "Thread" in content, (
+        f"the dump file should contain a real faulthandler thread-stack "
+        f"dump even for an atexit-time hang, got {content!r}"
+    )
 
 
 def test_a_session_teardown_hang_produces_a_stall_dump(
@@ -104,8 +156,10 @@ def test_a_normal_session_produces_no_stall_dump(
 ) -> None:
     """Tier 1: regression guard — a session that finishes normally, well
     inside the configured threshold, must not produce dump CONTENT. Mirrors
-    #4986's own "no cost on a green run" requirement: the watchdog is
-    cancelled at pytest_sessionfinish before it would ever fire.
+    #4986's own "no cost on a green run" requirement: stall_dump never
+    disarms (see its own module docstring) — what ends the timer on a
+    healthy run is the PROCESS ITSELF exiting long before the threshold
+    arrives, not a cancel call.
 
     (The log file itself is opened, empty, the moment the watchdog is
     armed — faulthandler needs an already-open file object, so "opened"


### PR DESCRIPTION
**[tui-coder]** — Part of #4986 (② of the disposition, per lead-coder's ruling on issuecomment-5444794108: "①の発見が判断を変えました... ②は既存機構の再利用（stall_trace.py / #4405）で、新機構ではありません").

## Why

`awaiting-recurrence` no longer meant what it said: #4986 recurred a 3rd time tonight (#5355's own CI run, head `23b3af298`), and — per this PR's own diagnosis, confirmed from `_pytest/faulthandler.py`'s real source, not guesswork — a 4th, 5th, Nth occurrence would leave exactly the same zero evidence, because both `pytest-timeout` (`--timeout`) and pytest's own builtin `faulthandler_timeout` wrap only `pytest_runtest_protocol` per test item and cancel their watchdog the instant the last item's protocol returns. A hang in session TEARDOWN (the observed `_cancel_all_tasks`/`gather()` shape) is structurally invisible to both — waiting for another recurrence is not slow, it's useless (pre-conclusion checklist ④: the observation infrastructure doesn't capture what the claim needs).

## What

A session-spanning stack dump that reuses `reyn.runtime.stall_trace`'s existing `arm()`/`disarm()` (#4405 — `faulthandler.dump_traceback_later`, already in this codebase, not a new mechanism): armed at `pytest_configure`, only cancelled at `pytest_sessionfinish` — so a session-teardown hang leaves the timer armed and it fires, where the two per-item watchdogs above never could.

- `arm()` gains an optional `file=` override (default unchanged — every existing production caller is byte-identical). CI needs this because pytest's own capture manager can own `sys.stderr` for parts of a session (the same hazard `memory_ceiling.py` already documents for its own kill message) — a plain, already-open disk file sidesteps that.
- New `src/reyn/dev/testing/stall_dump.py`, wired into `tests/conftest.py`'s existing `pytest_configure`/`pytest_sessionfinish` (same idiom as `network_gate`/`memory_ceiling`/`replay_unconsumed` already there).
- Opt-in via `REYN_STALL_TRACE_CI` — unset is a true no-op (zero behavior change for local/dev runs). Not armed per xdist worker — the observed hang is in the **controller's** own event loop (per the #4986 stack dumps already on file), so worker-level arming would just multiply dump output for no signal.
- `test.yml`: `REYN_STALL_TRACE_CI=600` (120s margin below the step's own `timeout 12m` kill, ~150-200s margin above ~7-8min normal completion) + a new `if: always()` step that surfaces the dump's content — without it the file would sit unread on the ephemeral runner's disk, which is the exact "no evidence survives" problem this PR exists to fix.

## Scope — what this does NOT do

- Does not fix the underlying hang. Only makes the next recurrence leave evidence.
- Does not decide "how many occurrences warrant action" — lead-coder's own explicit call, not mine.
- Does not change `_pytest/faulthandler.py` or pytest-timeout's own behavior — those stay exactly as they are, this adds an independent, session-spanning watchdog alongside them.

## Tests

`tests/dev/test_stall_dump_4986.py` — same `pytester`-subprocess style as `test_extra_skip_report_4104.py` (a real isolated inner pytest session is the only way to exercise a genuine `pytest_configure`/`pytest_sessionfinish` pair without faking pytest's own lifecycle):

- A session whose own teardown genuinely hangs (a session-scoped fixture blocking on real `sys.stdin.readline()`, released deterministically by closing the pipe) produces a non-empty dump containing a real thread stack.
- A normal, fast session leaves the file **empty** (opened at arm time regardless of whether it ever fires — faulthandler needs an already-open file object — so the CI step and this test both check *non-empty*, not mere existence).
- `REYN_STALL_TRACE_CI` unset stays a true no-op even during a genuine hang (waits on the inner test's own marker file, a real event, never a guessed sleep).

No duration anywhere an assertion depends on: the threshold itself is the injected clock CLAUDE.md's duration rule asks for when a duration genuinely is the subject; both outer waits poll a real event (dump content / marker file), never `time.sleep(N)`.

## Strip-falsify

Removed the `arm()` call in `stall_dump.pytest_configure` — the hang-produces-a-dump test went red (caught by the outer suite's own 60s `--timeout`, as intended — no self-authored ceiling). Restored byte-identical, confirmed via `diff`, re-ran green.

## Gates

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/dev/test_stall_dump_4986.py` (3/3 OK)
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/stall_trace.py src/reyn/dev/testing/stall_dump.py`
- [x] `python scripts/mypy_ratchet.py` (201 findings, all baselined)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python -m yaml` parse of `.github/workflows/test.yml` (syntax valid)
- [x] Regression sweep: full `tests/dev/` (294 tests) + existing `stall_trace`/mount-hydrate suites, all green — `arm()`'s new `file` kwarg is additive/optional only

## Test plan

- [x] New tests pass locally, scoped to the diff
- [x] Strip-falsify confirms the test is a real witness (red without the fix, green with it)
- [x] Regression sweep on stall_trace's existing callers + tests/dev/
- [x] (skipped — Visual gate does not block main merge; standing waiver, owner 2026-08-08)

⚠️ **Co-vet requested: @architect** (per lead-coder's own note — this touches CI machinery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **watchdog の窓が 1 段 早く閉じ、この repo が実際に見た hang の class が外に落ちます。** `pytest_sessionfinish` で `disarm()` していますが、**その後に interpreter shutdown・`atexit`・非 daemon thread の join が残ります**。そこは実際に hang した場所です（**PR #5049 `ThreadedTransportProxy` で私が出した形**: assert 落ち → `Event` 未 set → 非 daemon thread 残留 → `atexit` の join で hang）。∴「session teardown の hang を捕まえる」という題に対し、**最も捕まえたい 1 つが構造的に外れます**（実測: 現 head に `atexit` は 0 件）。処方: ①`disarm` を `atexit` へ（LIFO ゆえ不完全、採るなら docstring に限界を明記）／②**そもそも disarm しない**（`exit=False` なので残った timer は dump するだけ。通常 420-480s ＋ shutdown が 120-180s を食う run は既に病的で、むしろ dump してほしい側）— **私は②を推します**。根拠: PR comment issuecomment-5445125316

