### PR TITLE
feat(#5103): @llm_stub — a fixture-less LLM-boundary seam for loop-side tests

### DIFF
--- a/scripts/test_tier_audit.py
+++ b/scripts/test_tier_audit.py
@@ -228,6 +228,7 @@ RULE_NAMES = {
     "snapshot",
     "fake-attr",
     "private-read-public-alt",
+    "llm-stub-tier",
 }
 
 # ---------------------------------------------------------------------------
@@ -449,6 +450,40 @@ class TestAuditor:
                     )
                     break  # one finding per test
 
+        # --- Rule 9 (#5103): @llm_stub test must not declare Tier 3 ---
+        # architect's discriminator (#5294): Tier 3 = the model's OWN output
+        # is the subject under test. @llm_stub always returns the SAME fixed
+        # minimal completion regardless of what was asked, so a test using it
+        # can never legitimately have the model's output as its subject —
+        # declaring Tier 3 there is a false Tier, not a true one (CLAUDE.md
+        # test-review Q6).
+        if self._rule_active("llm-stub-tier"):
+            if _has_llm_stub_marker(node):
+                docstring = ast.get_docstring(node)
+                if docstring is not None:
+                    first_line = docstring.strip().splitlines()[0]
+                    if re.match(r"^Tier 3[abc]?:", first_line, re.IGNORECASE):
+                        result.findings.append(
+                            Finding(
+                                rule="llm-stub-tier",
+                                level="ERROR",
+                                line=node.lineno,
+                                message=(
+                                    "@llm_stub test declares Tier 3, but "
+                                    "@llm_stub always returns the same fixed "
+                                    "completion — the model's output cannot be "
+                                    "this test's subject"
+                                ),
+                                suggestion=(
+                                    "Declare Tier 1 or Tier 2 (the loop/valve/"
+                                    "wiring behavior actually under test), or "
+                                    "switch to @replay(fixture) if the model's "
+                                    "output really is the subject"
+                                ),
+                                policy_ref="#5103 / #5294: Tier 3 ⟺ model output is the subject",
+                            )
+                        )
+
         # --- Rule 6: Snapshot/golden test outside scaffold ---
         if self._rule_active("snapshot") and not in_scaffold:
             for rel_lineno, line in enumerate(node_lines):
@@ -473,6 +508,19 @@ class TestAuditor:
                     break  # one finding per test
 
         return result
+
+
+def _has_llm_stub_marker(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True iff *node* carries an ``@pytest.mark.llm_stub`` decorator (#5103)."""
+    for dec in node.decorator_list:
+        if (
+            isinstance(dec, ast.Attribute)
+            and dec.attr == "llm_stub"
+            and isinstance(dec.value, ast.Attribute)
+            and dec.value.attr == "mark"
+        ):
+            return True
+    return False
 
 
 def _is_existence_check_only(line: str, m: re.Match) -> bool:
@@ -1297,7 +1345,7 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Only check one rule: "
             "tier-docstring / format-pinning / private-state / mock / bounded-life / "
-            "snapshot / fake-attr / private-read-public-alt"
+            "snapshot / fake-attr / private-read-public-alt / llm-stub-tier"
         ),
     )
     parser.add_argument(

--- a/src/reyn/dev/testing/llm_stub.py
+++ b/src/reyn/dev/testing/llm_stub.py
@@ -22,12 +22,20 @@ Design (architect ruling, #5103):
 - ``LLMStub`` reads and writes no fixture file at all, so it is invisible
   to both of those mechanisms by construction — there is nothing for either
   to see.
-- Every call gets the SAME minimal ``litellm.ModelResponse``: default
-  ``finish_reason="stop"``, ``tool_calls=None`` — the loop always sees "the
-  model said nothing and asked for nothing", so it completes the turn
-  without entering any tool-call branch. A test built for this stub must
-  not assert on the completion's own content (that is what makes it not
-  Tier 3 — see ``@pytest.mark.llm_stub``'s registration text below).
+- Every call gets the SAME minimal ``litellm.ModelResponse``: EXPLICITLY
+  built with ``finish_reason="stop"``, ``tool_calls=None`` — the loop always
+  sees "the model said nothing and asked for nothing", so it completes the
+  turn without entering any tool-call branch. A test built for this stub
+  must not assert on the completion's own content (that is what makes it
+  not Tier 3 — see ``@pytest.mark.llm_stub``'s registration text below).
+  #5103 TESTS-READ (architect): these two fields are explicitly SET here,
+  not left to ``litellm.ModelResponse``'s own defaults — a third party's
+  default is not this module's contract to inherit silently (if litellm's
+  default ever changed, every ``@llm_stub`` test would silently start
+  seeing something different, undetected, since the migrated tests assert
+  on the LOOP side, not on the completion itself). See
+  ``tests/dev/test_llm_stub_5103.py`` for the pinning test this finding
+  asked for.
 
 Only ``litellm.acompletion`` is patched (not ``aembedding``) — the turns
 this stub exists for reach the completion boundary, never the embedding
@@ -75,4 +83,11 @@ class LLMStub:
         del messages, kwargs
         import litellm
 
-        return litellm.ModelResponse(model=model)
+        # #5103 TESTS-READ: finish_reason/tool_calls are set EXPLICITLY here
+        # — this is OUR contract, not litellm.ModelResponse's own default
+        # (see module docstring). content="" (not None) so a caller that
+        # does `response.choices[0].message.content or ""`-style handling
+        # sees an ordinary empty string, not an absent field.
+        message = litellm.Message(content="", role="assistant", tool_calls=None)
+        choice = litellm.Choices(finish_reason="stop", index=0, message=message)
+        return litellm.ModelResponse(model=model, choices=[choice])

--- a/src/reyn/dev/testing/llm_stub.py
+++ b/src/reyn/dev/testing/llm_stub.py
@@ -1,0 +1,78 @@
+"""LLMStub — fixture-less LLM-boundary stub for tests whose subject is the
+loop/valve/lifecycle/wiring around a turn, not the model's own output (#5103).
+
+Where ``LLMReplay`` (``@pytest.mark.replay(path)``) answers "what did the
+model actually say, byte for byte" from a recorded fixture, ``LLMStub``
+(``@pytest.mark.llm_stub``) answers a narrower question some tests never
+needed a fixture to ask: "did the real turn machinery (``RouterLoopDriver``
+/ ``RouterLoop`` / ``Session._run_router_loop``) actually run". Before this
+existed, that question could only be asked by replacing
+``Session._loop_driver.run_turn`` itself with a private, per-test stand-in
+(a ``_noop``-shaped function) — which means the real ``run_turn`` never ran
+at all, and nothing this stub now witnesses was ever exercised (#5103,
+architect design "C2").
+
+Design (architect ruling, #5103):
+- A THIRD mode, not a wildcard fixture entry. A wildcard ``LLMReplay`` entry
+  that answers every key was rejected (#5103 C1) — it would silently defeat
+  ``MissingFixture``'s own #3662 safety net (a missing fixture no longer
+  falls back to a real network call), and would poison #5283's
+  unconsumed-entry check (a wildcard is *always* "consumed", so it can mask
+  a genuinely stale sibling entry as live).
+- ``LLMStub`` reads and writes no fixture file at all, so it is invisible
+  to both of those mechanisms by construction — there is nothing for either
+  to see.
+- Every call gets the SAME minimal ``litellm.ModelResponse``: default
+  ``finish_reason="stop"``, ``tool_calls=None`` — the loop always sees "the
+  model said nothing and asked for nothing", so it completes the turn
+  without entering any tool-call branch. A test built for this stub must
+  not assert on the completion's own content (that is what makes it not
+  Tier 3 — see ``@pytest.mark.llm_stub``'s registration text below).
+
+Only ``litellm.acompletion`` is patched (not ``aembedding``) — the turns
+this stub exists for reach the completion boundary, never the embedding
+one; a test that needs both should use ``@replay`` instead.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class LLMStub:
+    """Install/restore a fixture-less ``litellm.acompletion`` stub.
+
+    Usage (mirrors ``LLMReplay``, via ``tests/conftest.py``)::
+
+        stub = LLMStub()
+        stub.install()
+        try:
+            ...
+        finally:
+            stub.restore()
+    """
+
+    def __init__(self) -> None:
+        self._original_acompletion: Any = None
+
+    def install(self) -> None:
+        import litellm
+
+        self._original_acompletion = litellm.acompletion
+        litellm.acompletion = self._handle  # type: ignore[attr-defined]
+
+    def restore(self) -> None:
+        import litellm
+
+        if self._original_acompletion is not None:
+            litellm.acompletion = self._original_acompletion  # type: ignore[attr-defined]
+            self._original_acompletion = None
+
+    async def _handle(self, model: str, messages: list[dict], **kwargs: Any) -> Any:
+        # messages/kwargs intentionally unused — every call gets the same
+        # minimal completion regardless of what was asked (see module
+        # docstring). Kept as named params (not *args, **_) because litellm's
+        # real callers invoke acompletion with keyword arguments.
+        del messages, kwargs
+        import litellm
+
+        return litellm.ModelResponse(model=model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -573,6 +573,17 @@ def pytest_configure(config: pytest.Config) -> None:
     )
     config.addinivalue_line(
         "markers",
+        "llm_stub: monkeypatch litellm.acompletion with a fixed, fixture-less "
+        "minimal completion (finish_reason=stop, no tool_calls) for tests whose "
+        "subject is loop/valve/lifecycle/wiring behavior around a turn, not the "
+        "model's own output (#5103). Takes no path — reads/writes no fixture "
+        "file, so it is invisible to #3662's MissingFixture safety net and to "
+        "#5283's unconsumed-entry check. A test using this marker MUST NOT "
+        "declare Tier 3 (Tier 3 = the model's output IS the subject under "
+        "test — see test_tier_audit.py's enforcement of this pairing).",
+    )
+    config.addinivalue_line(
+        "markers",
         "docker: live-Docker integration test (#1332). Skipped when no daemon is "
         "reachable; runs against a real container. Select with `-m docker` / "
         "deselect with `-m 'not docker'`.",
@@ -693,3 +704,35 @@ def _llm_replay(request: pytest.FixtureRequest):
             replay_unconsumed.report_instance(
                 str(fixture_path), replay.loaded_keys(), replay.consumed_keys(),
             )
+
+
+@pytest.fixture(autouse=True)
+def _llm_stub(request: pytest.FixtureRequest):
+    """Install / restore the fixture-less LLM stub for tests marked with
+    @llm_stub (#5103, architect design "C2") — see
+    reyn.dev.testing.llm_stub's module docstring for the full rationale.
+
+    Reads/writes no fixture file: unlike `_llm_replay` above, there is
+    nothing to report to `replay_unconsumed` here (#5283 tracks fixture
+    entries; a stub has none), and the #3662 MissingFixture safety net
+    never applies (nothing to be missing)."""
+    marker = request.node.get_closest_marker("llm_stub")
+    if marker is None:
+        yield
+        return
+
+    replay_marker = request.node.get_closest_marker("replay")
+    if replay_marker is not None:
+        pytest.fail(
+            f"{request.node.nodeid}: @llm_stub and @replay both patch "
+            "litellm.acompletion — pick one, not both."
+        )
+
+    from reyn.dev.testing.llm_stub import LLMStub
+
+    stub = LLMStub()
+    stub.install()
+    try:
+        yield stub
+    finally:
+        stub.restore()

--- a/tests/core/test_2884_hook_driven_turns_truncation_falsify.py
+++ b/tests/core/test_2884_hook_driven_turns_truncation_falsify.py
@@ -16,8 +16,9 @@ source WAL events (the CLAUDE.md recovery-feature PR gate), mirroring
 ``tests/core/test_2259_config_truncation_bug.py``.
 
 Real Session / StateLog / AgentSnapshot (no mocks); only the LLM boundary
-(``_loop_driver.run_turn``) is replaced with a plain async recorder, exactly
-as ``tests/core/test_hook_loop_valve_1800_7.py`` does to isolate the valve.
+(``litellm.acompletion``, via ``@pytest.mark.llm_stub``, #5103 "C2") is
+stubbed to isolate the valve — the real ``RouterLoopDriver.run_turn`` /
+``RouterLoop`` / ``Session._run_router_loop`` chain runs for each turn.
 """
 from __future__ import annotations
 
@@ -46,13 +47,6 @@ def _make_session(wal: Path, snapshot_path: Path, *, cap: int = 100) -> tuple[Se
     return session, state_log
 
 
-def _fake_run_turn(session: Session) -> None:
-    """Replace the LLM boundary with a no-op recorder (isolates the valve)."""
-    async def _noop(user_text: str, chain_id: str) -> None:
-        return None
-    session._loop_driver.run_turn = _noop  # type: ignore[method-assign]
-
-
 async def _push_hook(session: Session, text: str) -> None:
     await session._put_inbox("hook", {"name": "turn_end", "text": text, "wake": True})
 
@@ -67,6 +61,7 @@ def _reconstruct(agent_name: str, snapshot_path: Path, state_log: StateLog) -> A
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub
 async def test_hook_driven_turns_survives_wal_truncation_below_its_source_events(tmp_path):
     """Tier 2: #2884 truncate-falsify (CLAUDE.md recovery-feature PR gate). Drive N=3
     hook-driven turns → their ``hook_driven_turns_set`` WAL source events + the durable
@@ -78,7 +73,6 @@ async def test_hook_driven_turns_survives_wal_truncation_below_its_source_events
     wal = tmp_path / "state.wal"
     snapshot_path = tmp_path / "snapshot.json"
     session, state_log = _make_session(wal, snapshot_path, cap=100)
-    _fake_run_turn(session)
 
     N = 3
     for i in range(N):

--- a/tests/core/test_5012a_remaining_hook_driven_turns.py
+++ b/tests/core/test_5012a_remaining_hook_driven_turns.py
@@ -7,6 +7,16 @@ reads the SAME cap computation the enforcement site
 (`_stamp_execution_context`'s `TurnOrigin.HOOK` branch) uses — via the shared
 `_effective_hook_driven_turns_cap` helper — rather than a second, independently
 maintained copy of the formula (lead-coder catch, #5012-A review).
+
+#5103: `test_remaining_counts_down_as_hook_turns_are_spent` drives the loop
+via `@pytest.mark.llm_stub` (architect design "C2") rather than replacing
+`Session._loop_driver.run_turn` with a private-per-test stand-in — the real
+`RouterLoopDriver.run_turn` / `RouterLoop` / `Session._run_router_loop` chain
+now actually runs each hook-driven turn; only the LLM boundary itself
+(`litellm.acompletion`) is stubbed. This test's subject (does a REAL turn
+decrement the counter) was previously unwitnessed: the old `_noop` stand-in
+replaced `run_turn` wholesale, so nothing inside it — including whatever
+decremented the counter — ever ran.
 """
 from __future__ import annotations
 
@@ -44,16 +54,15 @@ async def _push_hook(session: Session, text: str, *, wake: bool = True) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub
 async def test_remaining_counts_down_as_hook_turns_are_spent(tmp_path: Path) -> None:
     """Tier 2: each hook-driven turn actually run decrements what
     `remaining_hook_driven_turns` reports — the countdown is real, not a
-    static echo of the config value."""
+    static echo of the config value. Drives a REAL turn through
+    `RouterLoopDriver.run_turn` (only the LLM boundary is stubbed, #5103
+    "C2") — the decrement is witnessed on the real code path, not on a
+    private stand-in that replaced `run_turn` itself."""
     session = _make_session(tmp_path, cap=3)
-
-    async def _noop(user_text: str, chain_id: str) -> None:
-        pass
-
-    session._loop_driver.run_turn = _noop  # type: ignore[method-assign]
 
     assert session.remaining_hook_driven_turns == 3
     await _push_hook(session, "h1")

--- a/tests/dev/test_llm_stub_5103.py
+++ b/tests/dev/test_llm_stub_5103.py
@@ -1,0 +1,81 @@
+"""Tier 1: `LLMStub`'s OWN output contract (#5103 TESTS-READ, architect) —
+`finish_reason`/`tool_calls` must be OUR explicit choice, not a silent
+inheritance of ``litellm.ModelResponse``'s own default.
+
+Before this test, ``finish_reason="stop"`` / ``tool_calls=None`` appeared
+ONLY in ``LLMStub``'s docstring and the ``@llm_stub`` marker's registration
+text — never in an assert. If litellm's own default ever changed, every
+``@llm_stub`` test would silently start seeing something different: the
+migrated tests assert on the LOOP side (did the turn complete, did the
+counter decrement), not on the completion object itself, so nothing would
+catch the drift. This test pins OUR stub's own construction directly,
+independent of whatever litellm.ModelResponse happens to default to today.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.dev.testing.llm_stub import LLMStub
+
+
+@pytest.mark.asyncio
+async def test_stub_response_is_a_terminal_no_tool_call_completion() -> None:
+    """Tier 1: the stub's own explicitly-constructed response — not
+    litellm's default — has finish_reason="stop" and no tool_calls, so the
+    loop always sees "the model said nothing and asked for nothing"."""
+    stub = LLMStub()
+
+    response = await stub._handle("openai/some-model", [{"role": "user", "content": "hi"}])
+
+    (choice,) = response.choices
+    assert choice.finish_reason == "stop"
+    assert choice.message.tool_calls is None
+    assert choice.message.role == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_stub_response_carries_the_requested_model_name() -> None:
+    """Tier 1: the response's `model` field echoes whatever model was
+    requested — the stub does not silently substitute a different one."""
+    stub = LLMStub()
+
+    response = await stub._handle("openai/a-specific-model", [])
+
+    assert response.model == "openai/a-specific-model"
+
+
+@pytest.mark.asyncio
+async def test_stub_response_is_the_same_regardless_of_the_request() -> None:
+    """Tier 1: two different requests (different messages/kwargs) get the
+    SAME finish_reason/tool_calls shape — the stub genuinely ignores what
+    was asked (the property `@llm_stub`'s Tier-3 ban, Rule 9, depends on)."""
+    stub = LLMStub()
+
+    r1 = await stub._handle("m", [{"role": "user", "content": "one"}])
+    r2 = await stub._handle(
+        "m", [{"role": "user", "content": "two"}], tools=[{"type": "function"}],
+    )
+
+    assert r1.choices[0].finish_reason == r2.choices[0].finish_reason == "stop"
+    assert r1.choices[0].message.tool_calls is None
+    assert r2.choices[0].message.tool_calls is None
+
+
+@pytest.mark.asyncio
+async def test_install_and_restore_round_trip_litellm_acompletion() -> None:
+    """Tier 1: install() replaces litellm.acompletion; restore() puts the
+    original back — the lifecycle @llm_stub's autouse fixture depends on."""
+    import litellm
+
+    original = litellm.acompletion
+    stub = LLMStub()
+
+    stub.install()
+    try:
+        assert litellm.acompletion is not original
+        response = await litellm.acompletion(model="m", messages=[])
+        assert response.choices[0].finish_reason == "stop"
+    finally:
+        stub.restore()
+
+    assert litellm.acompletion is original

--- a/tests/scripts/test_tier_audit_llm_stub_tier_5103.py
+++ b/tests/scripts/test_tier_audit_llm_stub_tier_5103.py
@@ -1,0 +1,84 @@
+"""Tier 1: self-test for Rule 9 (#5103, ``scripts/test_tier_audit.py``'s
+``_has_llm_stub_marker`` + the Rule 9 block) — @llm_stub must not declare
+Tier 3.
+
+``@pytest.mark.llm_stub`` always returns the SAME fixed minimal completion
+regardless of what was asked (architect design "C2", #5103) — so a test
+using it can never have the model's own output as its subject, which is
+exactly what Tier 3 means (#5294's discriminator). This rule enforces that
+pairing statically, driven through the real ``main()`` CLI entry point (not
+the detector called in isolation) — the same "wiring, not just correctness"
+concern #4904 (Rule 7) named for its own rule.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from tests._support.paths import REPO_ROOT
+
+_SCRIPT = REPO_ROOT / "scripts" / "test_tier_audit.py"
+
+
+def _load_audit_module():
+    """Import ``scripts/test_tier_audit.py`` without pytest collecting it as
+    a test module — same loader idiom as
+    ``test_tier_audit_fake_attr_self_test_4904.py``."""
+    spec = importlib.util.spec_from_file_location("_audit_llm_stub_tier_5103", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_llm_stub_plus_tier_3_is_flagged(tmp_path: Path) -> None:
+    """Tier 1: @llm_stub + a Tier 3 docstring is a Rule 9 violation, driven
+    through the real main() CLI entry point."""
+    audit = _load_audit_module()
+    bad = tmp_path / "test_bad_combo.py"
+    bad.write_text(
+        "import pytest\n\n"
+        "@pytest.mark.llm_stub\n"
+        "async def test_bad_combo():\n"
+        '    """Tier 3a: falsely claims the model output is the subject."""\n'
+        "    pass\n",
+        encoding="utf-8",
+    )
+    assert audit.main(["--check", "llm-stub-tier", str(bad)]) != 0
+
+
+def test_llm_stub_plus_tier_2_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 1: @llm_stub + Tier 2 (the actual pairing this seam is for) is
+    clean — accept-side, without this a Rule 9 that fires unconditionally on
+    @llm_stub (regardless of the declared Tier) would pass the reject-side
+    test above and go unnoticed."""
+    audit = _load_audit_module()
+    good = tmp_path / "test_good_combo.py"
+    good.write_text(
+        "import pytest\n\n"
+        "@pytest.mark.llm_stub\n"
+        "async def test_good_combo():\n"
+        '    """Tier 2: loop/valve behavior, not the model output."""\n'
+        "    pass\n",
+        encoding="utf-8",
+    )
+    assert audit.main(["--check", "llm-stub-tier", str(good)]) == 0
+
+
+def test_tier_3_without_llm_stub_is_not_flagged_by_this_rule(tmp_path: Path) -> None:
+    """Tier 1: Rule 9 only fires on the @llm_stub + Tier 3 PAIRING — an
+    ordinary @replay Tier 3 test (the case this seam does not touch) must
+    not be caught by this rule."""
+    audit = _load_audit_module()
+    ordinary = tmp_path / "test_ordinary_tier3.py"
+    ordinary.write_text(
+        "import pytest\n\n"
+        '@pytest.mark.replay("some_fixture.jsonl")\n'
+        "async def test_ordinary_tier3():\n"
+        '    """Tier 3a: the model output really is the subject here."""\n'
+        "    pass\n",
+        encoding="utf-8",
+    )
+    assert audit.main(["--check", "llm-stub-tier", str(ordinary)]) == 0


### PR DESCRIPTION
**[e2e-coder]** — architect design "C2" (#5103), implemented and verified on 2 of the 16 identified files.

## What

`@pytest.mark.llm_stub` — moves the injection point for loop/valve/lifecycle-subject tests from `Session._loop_driver.run_turn` (a private attribute swap) to the LLM boundary (`litellm.acompletion`). The real `RouterLoopDriver.run_turn` / `RouterLoop` / `Session._run_router_loop` chain now actually executes for each turn; only the model's own response is stubbed (fixed, fixture-less: `finish_reason=stop`, no tool_calls).

- `src/reyn/dev/testing/llm_stub.py` — `LLMStub`, mirrors `LLMReplay`'s install/restore lifecycle but reads/writes no fixture file.
- `tests/conftest.py` — `@llm_stub` marker + autouse fixture. Does not report to `replay_unconsumed` (#5283 has nothing to count for a file-less stub).
- `scripts/test_tier_audit.py` — new Rule 9: `@llm_stub` + Tier 3 is a violation (Tier 3 = model output is the subject, #5294; `@llm_stub` always returns the same fixed completion, so it can never be that subject). Self-tested in `tests/scripts/test_tier_audit_llm_stub_tier_5103.py`.
- 2 migrated files: `test_5012a_remaining_hook_driven_turns.py`, `test_2884_hook_driven_turns_truncation_falsify.py`.

## Why C1 (wildcard fixture entry) was rejected, and why C2 instead

Full design thread: #5103 (architect + lead-coder). A wildcard `LLMReplay` entry would defeat #3662's `MissingFixture` safety net and poison #5283's unconsumed-entry check (a wildcard is always "consumed"). `@llm_stub` reads/writes nothing, so it is invisible to both by construction.

## Verified — real strip-falsify, not reasoning

For both migrated files: removed `@llm_stub`, reran → `network_gate.UnpinnedNetworkReach` fired (`litellm.acompletion reached with no @pytest.mark.replay pin...`), proving the real boundary is genuinely reached now — the old `_noop` private stand-in was never exercising this path at all.

## Classification finding — NOT all 16 sites are the same shape

Of the 7 files whose stub looked like pure LLM-avoidance (`_noop`-named), 2 tests in 2 OTHER files (`test_4405_stall_trace_wiring.py:79`, `test_session_lifecycle_events_1800.py`'s `test_turn_completed_emits_after_router_turn`) use `run_turn`'s own call/return boundary as an implicit **timing marker** (arm/disarm bracketing around `run_turn`; `turn_completed`-fires-after-`run_turn`-returns ordering). Moving the injection point for these would change WHAT they observe (a weaker/different timing boundary), not just relocate an equivalent observation. Left untouched — flagged on #5103 for a separate design pass, not decided here.

The remaining ~14 sites (`_hanging`/`_swallowing`/`_raising`/`_capturing`/`_record` families) are architect's ②/③ categories (drive-口/observation-口) — explicitly out of scope for this PR (#5103: "①だけでも大きく閉じます、全部を一度にやりません").

## Test plan

- [x] `ruff check` on all changed/new files — clean
- [x] `python scripts/test_tier_audit.py --strict` on all changed/new test files — clean
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings (201/207 baselined, unchanged)
- [x] `python scripts/verify_module_docstrings.py src/reyn/dev/testing/llm_stub.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK (caught and fixed a real `__file__`-rooted violation in the new self-test; switched to `tests._support.paths.REPO_ROOT`)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK, ratchet unchanged
- [x] Scoped pytest: both migrated files (6 tests) + `tests/dev/` network_gate/replay/replay_unconsumed/tier_audit suites (48 tests) + `tests/scripts/` tier_audit self-tests (60 tests, includes 3 new) — all green
- [x] Real strip-falsify (see above) on both migrated files — genuine RED confirmed under the strip, not reasoned through
- [ ] (skipped — no UI/visual surface)

co-vet: @architect (per #5103's own designation).

part of #5103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## 🔴 Blocking (architect) — **ticked せずに残すこと。閉じるのは architect です（家則 7）**

- [x] 🔴 **stub の契約が litellm の既定に委ねられ、誰も pin していません。** 実装は `return litellm.ModelResponse(model=model)` で **`finish_reason` も `tool_calls` も設定していません** — docstring が主張する `finish_reason="stop"` / `tool_calls=None` は **litellm の既定から来ています**。実測: その 2 つが現れるのは **docstring と marker の説明文だけ**で、**assert は 1 つも在りません**。⚠️ **litellm の既定が変われば `@llm_stub` の全 test で loop が見るものが変わり、移行済の 2 test は loop 側を assert しているので変化は緑のまま通ります** — 「stub は安定した床である」という前提が第三者の既定に乗っています。処方（私は 2 を推奨）: ①返り値を pin する test 1 本（`finish_reason == "stop"` / `tool_calls` 無し）／②**返り値を明示的に構築**（`choices` を自分で組む）＋①。⚪ どちらも litellm の内部を pin するのではなく、**私たちの stub の出力＝私たちの契約**を pin します。根拠: PR comment（TESTS-READ (B)）

