### PR TITLE
fix(#5364): spill ladder includes mid, staged head→mid→tail, mid never undone

### DIFF
--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -237,18 +237,40 @@ class RouterLoopDriver:
     # ── Overflow-resilient router invocation ─────────────────────────────────
 
     @staticmethod
-    def _spill_candidates(head: "list[dict]", tail: "list[dict]") -> "list[dict]":
-        """#5296 PR-2 ②: oldest-and-largest-first spill candidates.
+    def _spill_candidates(
+        head: "list[dict]", raw_middle: "list[dict]", tail: "list[dict]",
+    ) -> "list[dict]":
+        """#5364 (owner ruling, verbatim "mid も対象にしてね。
+        head->mid->tail->open"): spill candidates in STAGED order —
+        ``head`` entirely before ``raw_middle`` entirely before ``tail``
+        (open-turn is handled by the caller, outside this function) —
+        largest-first WITHIN each stage.
 
-        ``head`` (older turns) is offered entirely before ``tail`` (more
-        recent turns — "this turn's own subject", contract's own "今回の
-        主題は最後"); within each group, the largest content goes first
-        (the fastest route to a byte-count decrease per spill). Only
-        ``role == "tool"`` turns with an inline string body are candidates
-        — an already-ref'd/non-string content has nothing left to spill.
-        ``new_msg`` (the turn's own newest user message) is never passed
-        in here at all — contract's own "user自身の最新messageは落とさな
-        い" is satisfied structurally, not by a filter that could miss it.
+        ``raw_middle`` (mid) is included even though spilling it moves
+        ZERO wire bytes (it is already elided out of ``build_history``'s
+        payload — ``estimate_wire_bytes`` never reads it, only ``summary``
+        does): #5364 §1.3 names two byte-independent reasons to spill it
+        anyway — (1) ``spilled`` is PERSISTENT (D), so a mid turn that
+        later slides into head/tail (as the window advances) is already
+        done; (2) when overflow later folds ``raw_middle`` into a summary,
+        the fold reads the (now-smaller) ref instead of the full body,
+        shrinking compaction's own input. The caller must not treat "this
+        candidate moved no bytes" as failure for a mid-stage candidate —
+        see ``_attempt_reactive_spill``.
+
+        Only ``role == "tool"`` turns with an inline string body are
+        candidates — an already-ref'd/non-string content has nothing left
+        to spill. ``new_msg`` (the turn's own newest user message) is never
+        passed in here at all — contract's own "user自身の最新messageは
+        落とさない" is satisfied structurally, not by a filter that could
+        miss it.
+
+        "Spilled candidates first" was considered and rejected (owner):
+        once spilled, a candidate's only remaining state is ``lost`` either
+        way, so an already-spilled entry does not need protecting from
+        being resorted alongside an unspilled one — E and C (the size-cap
+        GC) serve different purposes (E = minimize round-trips and
+        collateral spilling this turn; C = evict low-value data over time).
         """
         def _spillable(turns: "list[dict]") -> "list[dict]":
             cands = [
@@ -256,39 +278,65 @@ class RouterLoopDriver:
                 if t.get("role") == "tool" and isinstance(t.get("content"), str)
             ]
             return sorted(cands, key=lambda t: -len(t["content"]))
-        return _spillable(head) + _spillable(tail)
+        return _spillable(head) + _spillable(raw_middle) + _spillable(tail)
 
     async def _attempt_reactive_spill(self, user_text: str, *, chain_id: str) -> bool:
-        """#5296 PR-2 ②③: one spill pass over the CURRENT head/tail.
+        """#5296 PR-2 ②③ / #5364 (mid included): one spill pass over the
+        CURRENT head/mid/tail, staged (see ``_spill_candidates``).
 
-        Spills candidates (oldest/largest first) one at a time, re-measuring
-        total wire bytes after each, STOPPING as soon as the total has
-        decreased from before this pass started (contract ⑥'s "each
-        attempt strictly decreases bytes" — spilling more than needed
-        would destroy more of the operator's visible context than
-        necessary) or candidates are exhausted. The returned bool is this
-        method's OWN local verdict (useful standalone/for tests); the
-        caller (``_run_with_shrink_and_byte_reduction``) makes its own
+        Spills candidates one at a time, re-measuring total wire bytes
+        after each, STOPPING as soon as the total has decreased from
+        before this pass started (contract ⑥'s "each attempt strictly
+        decreases bytes" — spilling more than needed would destroy more
+        of the operator's visible context than necessary) or candidates
+        are exhausted. The returned bool is this method's OWN local
+        verdict (useful standalone/for tests); the caller
+        (``_run_with_shrink_and_byte_reduction``) makes its own
         escalate-to-compaction decision from a wrapper-wide
         ``_wire_bytes_now()`` reading instead — see that method's own
         docstring for why a narrower, call-scoped verdict is not always
         the right signal.
+
+        #5364: a ``raw_middle`` candidate can NEVER move wire bytes (it is
+        already elided out of ``estimate_wire_bytes``'s inputs by
+        construction) — undoing it under the "did not help" rule below
+        would discard EVERY mid spill unconditionally, contradicting
+        #5364 §1.3's own point in including mid at all (persisted
+        ``spilled`` state + a smaller future compaction fold). A
+        mid-sourced spill is therefore never undone for "no byte
+        decrease" and never itself ends the pass with a `True` verdict —
+        it is byte-neutral by design, so the loop moves on to the next
+        candidate (mid, then tail) rather than treating it as either
+        progress or failure.
+
+        #5364 ①/②'s open question (does the OUTER retry loop's
+        ``_MAX_BYTE_REDUCTION_ATTEMPTS`` cap still bound the number of
+        REAL acompletion attempts, or does the candidate ladder now run
+        to exhaustion across real per-candidate retries) is NOT resolved
+        here — this method still reports its OWN local byte-decrease
+        verdict per call, unchanged in that respect; see the tracking
+        discussion on #5364 before changing the caller's retry count.
         """
         from reyn.services.compaction.engine import estimate_wire_bytes
 
         SP = self._history_buffer.build_system_prompt()
         new_msg = {"role": "user", "content": user_text}
-        head, _raw_middle, tail, summary, _ = (
+        head, raw_middle, tail, summary, _ = (
             self._history_buffer.decompose_history_for_retry()
         )
         before = estimate_wire_bytes(SP=SP, head=head, summary=summary, tail=tail, new_msg=new_msg)
 
-        candidates = self._spill_candidates(head, tail)
+        mid_ids = {id(t) for t in raw_middle}
+        candidates = self._spill_candidates(head, raw_middle, tail)
         for i, turn in enumerate(candidates):
             replacement = self._history_buffer.spill_turn_content(
                 turn["content"], chain_id=chain_id, seq=i + 1,
             )
             if replacement is None:
+                continue
+            if id(turn) in mid_ids:
+                # Byte-neutral by construction (see docstring) — keep the
+                # spill, do not report progress from it alone, move on.
                 continue
             head2, _rm2, tail2, summary2, _sb2 = (
                 self._history_buffer.decompose_history_for_retry()

--- a/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
+++ b/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
@@ -503,3 +503,106 @@ def test_a_spill_that_does_not_help_is_undone(
         "content should still be what gets sent, not a bloated "
         "offloaded-preview replacement left behind uselessly"
     )
+
+
+# ── #5364: candidate order is STAGED (head → mid → tail), size-desc/stage ──
+
+
+def test_spill_candidates_are_staged_head_then_mid_then_tail_size_desc_each(
+) -> None:
+    """Tier 2: #5364 §1.3 (owner verbatim "mid も対象にしてね。head->mid->
+    tail->open") — ``_spill_candidates`` offers ``head``'s tool turns
+    ENTIRELY (largest first) before any ``raw_middle`` turn, and every
+    ``raw_middle`` turn before any ``tail`` turn (largest first within
+    each group). Hand-built head/mid/tail — this is a pure static method,
+    so this test pins its own output directly rather than reconstructing a
+    real overflowing history just to get a particular split shape."""
+    head = [
+        {"role": "tool", "content": "h" * 5},
+        {"role": "tool", "content": "h" * 50},  # largest in head
+        {"role": "user", "content": "not a tool turn"},
+    ]
+    mid = [
+        {"role": "tool", "content": "m" * 10},
+        {"role": "tool", "content": "m" * 1_000_000},  # huge, but mid — still 2nd stage
+    ]
+    tail = [
+        {"role": "tool", "content": "t" * 3},
+    ]
+
+    from reyn.runtime.services.router_loop_driver import RouterLoopDriver
+
+    candidates = RouterLoopDriver._spill_candidates(head, mid, tail)
+
+    assert [c["content"] for c in candidates] == [
+        "h" * 50, "h" * 5,          # head, largest first
+        "m" * 1_000_000, "m" * 10,  # mid, largest first — despite dwarfing everything
+        "t" * 3,                    # tail last, even though it's the newest turn
+    ], (
+        "mid's 1,000,000-char candidate must NOT jump ahead of head, and "
+        "tail's candidate must come last regardless of size — order is "
+        "staged by group, not globally size-sorted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_mid_spill_is_kept_even_though_it_moves_zero_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5364 §1.3 — a ``raw_middle`` candidate can never move wire
+    bytes (elided out of ``estimate_wire_bytes`` by construction), so the
+    pre-existing "no byte decrease → undo" rule must NOT apply to it —
+    applying it unconditionally would discard every mid spill, contradicting
+    #5364's own reason for including mid at all (persisted ``spilled``
+    state + a smaller future compaction fold). Witnessed via the PUBLIC
+    ``is_tool_result_spill`` seam on the path recorded by
+    ``spill_turn_content`` — never a private overlay dict directly."""
+    session = _make_spill_session(tmp_path, monkeypatch, t_max=4_000)
+    # Enough turns that SOME land in raw_middle once elided (t_max forces a
+    # real split — see decompose_history_for_retry's own docstring on when
+    # raw_middle is non-empty).
+    for i in range(40):
+        _push(session, "user", f"q{i}")
+        _push(session, "tool", f"result body {i} " * 100, tool_call_id=f"tc{i}", name="tool")
+        _push(session, "assistant", f"a{i}")
+
+    head, raw_middle, tail, _summary, _seq_by_id = (
+        session._loop_driver._history_buffer.decompose_history_for_retry()
+    )
+    mid_tools = [t for t in raw_middle if t.get("role") == "tool"]
+    assert mid_tools, (
+        "test setup sanity: raw_middle must contain at least one tool "
+        "turn, or this test cannot exercise the mid-is-never-undone path "
+        "— adjust t_max/turn count"
+    )
+
+    reduced = await session._loop_driver._attempt_reactive_spill(
+        "continue", chain_id="c1",
+    )
+    assert reduced is False, (
+        "control arm: with no genuinely spillable head/tail progress in "
+        "this setup, the byte-decrease verdict stays False — this test's "
+        "subject is whether the MID spill survived regardless, next"
+    )
+
+    original_mid_content = mid_tools[0]["content"]
+    target_id = mid_tools[0].get("tool_call_id")
+    head2, raw_middle2, tail2, _summary2, _seq2 = (
+        session._loop_driver._history_buffer.decompose_history_for_retry()
+    )
+    reserialised = [
+        t for t in head2 + raw_middle2 + tail2
+        if t.get("tool_call_id") == target_id
+    ]
+    assert reserialised, "test setup sanity: the same mid turn must still decompose somewhere"
+    assert reserialised[0]["content"] != original_mid_content, (
+        "the mid spill must survive into a LATER decompose_history_for_retry() "
+        "call — its content should now be the offloaded preview, not the "
+        "original body. If this is still the original content, the "
+        "overlay was discarded (the bug #5364 names: mid spills undone "
+        "because they never satisfy 'after < before')."
+    )
+    assert "read_file(path=" in reserialised[0]["content"], (
+        "the surviving content should be the offload preview naming the "
+        f"read-back path — got: {reserialised[0]['content']!r}"
+    )

--- a/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
+++ b/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
@@ -508,40 +508,76 @@ def test_a_spill_that_does_not_help_is_undone(
 # ── #5364: candidate order is STAGED (head → mid → tail), size-desc/stage ──
 
 
-def test_spill_candidates_are_staged_head_then_mid_then_tail_size_desc_each(
+@pytest.mark.asyncio
+async def test_spill_candidates_are_staged_head_then_mid_then_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Tier 2: #5364 §1.3 (owner verbatim "mid も対象にしてね。head->mid->
-    tail->open") — ``_spill_candidates`` offers ``head``'s tool turns
-    ENTIRELY (largest first) before any ``raw_middle`` turn, and every
-    ``raw_middle`` turn before any ``tail`` turn (largest first within
-    each group). Hand-built head/mid/tail — this is a pure static method,
-    so this test pins its own output directly rather than reconstructing a
-    real overflowing history just to get a particular split shape."""
-    head = [
-        {"role": "tool", "content": "h" * 5},
-        {"role": "tool", "content": "h" * 50},  # largest in head
-        {"role": "user", "content": "not a tool turn"},
-    ]
-    mid = [
-        {"role": "tool", "content": "m" * 10},
-        {"role": "tool", "content": "m" * 1_000_000},  # huge, but mid — still 2nd stage
-    ]
-    tail = [
-        {"role": "tool", "content": "t" * 3},
-    ]
+    tail->open") — the FIRST candidate spilled is a ``head`` turn, never a
+    ``raw_middle`` turn, even when the mid candidate's content dwarfs
+    every head candidate. A global size-sort (the bug this staged design
+    replaces) would offer the largest content first regardless of group —
+    here that would be the mid candidate — so which one is spilled FIRST
+    directly distinguishes staged order from global size order.
 
-    from reyn.runtime.services.router_loop_driver import RouterLoopDriver
+    Witnessed via the PUBLIC ``tool_result_offloaded`` audit-event
+    (``tool_result_cap.py``'s own emit, threaded through
+    ``spill_turn_content``) — its ``total_chars`` names the size of the
+    candidate that was JUST spilled, a public order-witness for
+    ``RouterLoopDriver._spill_candidates`` without calling that private
+    static method directly (CLAUDE.md testing policy: "if neither [a
+    public surface nor a snapshot-style read] exists, that absence is the
+    finding" — here a public read DOES exist once driven through a real
+    spill pass, so this is that seam, not a documented absence).
+    ``session._audit_events.drain()`` is required before reading the
+    subscriber's list — events queue, they are not delivered
+    synchronously inside ``emit()`` (measured directly: the subscriber
+    list was empty without it, on every run)."""
+    session = _make_spill_session(tmp_path, monkeypatch, t_max=2_500)
+    events: list = []
+    session._audit_events.add_subscriber(lambda e: events.append(e))
 
-    candidates = RouterLoopDriver._spill_candidates(head, mid, tail)
+    # Head: one small tool turn. Mid: one turn whose content is FAR
+    # larger than the head candidate — if global size-sort fired instead
+    # of staged order, THIS would be spilled first. Padding filler turns
+    # (not tool-role, never candidates) so t_max forces a genuine
+    # head/mid split with each tool turn landing in its own group.
+    small_head_content = "tiny result h1 " + "a" * 10
+    huge_mid_content = "M" * 5_000
+    _push(session, "tool", small_head_content, tool_call_id="tc-h1", name="tool")
+    for i in range(20):
+        _push(session, "user", f"filler question number {i + 100} " * 8)
+        _push(session, "assistant", f"filler answer number {i + 100} " * 8)
+    _push(session, "tool", huge_mid_content, tool_call_id="tc-m1", name="tool")
+    for i in range(3):
+        _push(session, "user", f"filler question number {i + 300} " * 8)
+        _push(session, "assistant", f"filler answer number {i + 300} " * 8)
 
-    assert [c["content"] for c in candidates] == [
-        "h" * 50, "h" * 5,          # head, largest first
-        "m" * 1_000_000, "m" * 10,  # mid, largest first — despite dwarfing everything
-        "t" * 3,                    # tail last, even though it's the newest turn
-    ], (
-        "mid's 1,000,000-char candidate must NOT jump ahead of head, and "
-        "tail's candidate must come last regardless of size — order is "
-        "staged by group, not globally size-sorted"
+    head, raw_middle, _tail, _summary, _seq_by_id = (
+        session._loop_driver._history_buffer.decompose_history_for_retry()
+    )
+    head_ids = {t.get("tool_call_id") for t in head if t.get("role") == "tool"}
+    mid_ids = {t.get("tool_call_id") for t in raw_middle if t.get("role") == "tool"}
+    assert head_ids == {"tc-h1"}, (
+        f"test setup sanity: the head candidate must land in head, got {head_ids!r} "
+        f"— adjust t_max/turn counts"
+    )
+    assert mid_ids == {"tc-m1"}, (
+        f"test setup sanity: the mid candidate must land in raw_middle, got {mid_ids!r}"
+    )
+
+    await session._loop_driver._attempt_reactive_spill("continue", chain_id="c1")
+    await session._audit_events.drain()
+
+    offloaded = [e for e in events if e.type == "tool_result_offloaded"]
+    assert offloaded, "test setup sanity: at least one candidate must have been spilled"
+    first_spilled_size = offloaded[0].data["total_chars"]
+    assert first_spilled_size == len(small_head_content), (
+        f"the FIRST candidate spilled must be the head turn "
+        f"({len(small_head_content)} chars), not the far-larger mid turn "
+        f"({len(huge_mid_content)} chars) — got first_spilled_size="
+        f"{first_spilled_size}. A global size-sort would spill the mid "
+        f"candidate first."
     )
 
 
@@ -554,9 +590,11 @@ async def test_a_mid_spill_is_kept_even_though_it_moves_zero_bytes(
     pre-existing "no byte decrease → undo" rule must NOT apply to it —
     applying it unconditionally would discard every mid spill, contradicting
     #5364's own reason for including mid at all (persisted ``spilled``
-    state + a smaller future compaction fold). Witnessed via the PUBLIC
-    ``is_tool_result_spill`` seam on the path recorded by
-    ``spill_turn_content`` — never a private overlay dict directly."""
+    state + a smaller future compaction fold). Witnessed via
+    ``decompose_history_for_retry()``'s own returned content (never the
+    private ``_spill_overlay`` dict directly) — surviving content must
+    equal the offload preview, matched by its ``read_file(path=...)``
+    marker."""
     session = _make_spill_session(tmp_path, monkeypatch, t_max=4_000)
     # Enough turns that SOME land in raw_middle once elided (t_max forces a
     # real split — see decompose_history_for_retry's own docstring on when


### PR DESCRIPTION
**[e2e-coder]** — part of #5364 §1.3 (梯子). Scoped sub-PR — see #5364 §4 ("大きいなら分割可").

## What

- `_spill_candidates(head, raw_middle, tail)`: mid is now a candidate stage (owner verbatim: "mid も対象にしてね。head->mid->tail->open"). Staged: head entirely → mid entirely → tail entirely, largest-first WITHIN each stage. Previously `raw_middle` was discarded outright (`head, _raw_middle, tail, ... = ...`).
- `_attempt_reactive_spill`: a mid-sourced spill is never undone by the "no byte decrease → undo" rule — mid is elided out of `estimate_wire_bytes`'s inputs by construction, so it can NEVER move wire bytes; applying that rule to it would discard every mid spill unconditionally, contradicting #5364's own reason for spilling mid (persisted `spilled` state (D) + a smaller future compaction fold).

## What this does NOT include (open question)

`_MAX_BYTE_REDUCTION_ATTEMPTS` (outer retry cap, currently 2) is UNCHANGED here. #5364 §1.3's stop condition ("収まるまで" / until it fits) and "1つずつspill→acompletion" phrasing suggest the outer real-acompletion-retry loop and the inner per-candidate spill loop may need to merge — i.e. each spilled candidate gets its OWN real acompletion retry, with the natural bound becoming "candidates exhausted" rather than a fixed constant of 2. This has real per-turn LLM-call-count/cost implications (CLAUDE.md's cost/budget band), so I asked rather than decided it unilaterally: https://github.com/tya5/reyn/issues/5364#issuecomment-5446888093 (unanswered as of this PR). Tracked on #5364, not resolved by this PR.

## Verified

Real strip-falsify on the new mid-survival test: removed the mid-not-undone special case, reran → genuinely RED (the mid turn's content reverted to its original body instead of the offloaded preview). Confirmed by running it, not reasoned through.

## Test plan

- [x] `ruff check` on changed files — clean
- [x] `python scripts/test_tier_audit.py --strict` on the changed test file — clean
- [x] `python scripts/mypy_ratchet.py` — OK, 201/207 baselined, unchanged
- [x] Full `test_5296_pr2_byte_reduction_same_turn_retry.py` (8 tests, incl. 2 new) — green
- [x] 101 tests across every file referencing `router_loop_driver`/spill machinery (`tests/core`, `tests/llm`, `tests/runtime`, `tests/services`) — green, no regressions
- [x] Real strip-falsify on the new mid-survival test (see above)
- [ ] (skipped — no UI/visual surface)

co-vet: @architect (per #5364 §4).

part of #5364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Blocking points

- [x] 🔴 **test docstring が、使っていない witness を名乗っています。** `test_a_mid_spill_is_kept_even_though_it_moves_zero_bytes` の docstring は逐語「Witnessed via the **PUBLIC `is_tool_result_spill` seam**」と書いていますが、**`is_tool_result_spill` はこの diff に 1 回しか現れず、その 1 回がこの docstring です** — 呼んでいません。実際の witness は `decompose_history_for_retry()` の戻り content ＋ `assert "read_file(path=" in ...`。**(a) 実際に `is_tool_result_spill` で witness する／(b) docstring を実際に使っている seam の名前に直す** のどちらかを。根拠: PR comment（BLOCKING (head 5b18936461704b756b1a42cb25af1333a05783f7)）
- [x] 🔴 **private な static method を直接叩いています。** `RouterLoopDriver._spill_candidates(head, mid, tail)`。家則逐語「**A test must not depend on private state** … Use the public surface or a `snapshot()`-style read; **if neither exists, that absence is the finding.**」— 「候補の順序」を外から見る口が無いこと自体が finding です。**口を作るか、無いことを PR 本文に書いてください。** 案（形は決めません）: #5364 の P（spill 1 本ごとに audit-event）はどのみち要り、入れれば順序がそのまま出るのでこの test の口にもなります。根拠: 同上

