### PR TITLE
feat(#5364): §1.2 — the history-content resolver, wired end-to-end

### DIFF
--- a/src/reyn/core/offload/history_content_resolve.py
+++ b/src/reyn/core/offload/history_content_resolve.py
@@ -1,0 +1,74 @@
+"""The ONE tool-result history-content resolver — #5364 §1.2.
+
+``resolve()`` decides what a persisted history entry's tool-result content
+actually is, from exactly two orthogonal signals (owner ruling, #5364,
+verbatim: "spill/lost 判定は直行性を持たせるべき")::
+
+               │ file present   │ file lost
+    ───────────┼─────────────────┼──────────
+    not spilled│ inline (content)│ lost
+    spilled    │ ref (path)      │ lost
+
+``spilled`` is never re-derived from content shape (e.g. sniffing for a
+``read_file(path=...)`` marker in the text) — it is read from the entry's
+own persisted field, set once at write time and never re-guessed, so a
+restart never flips the answer (#5364 §1.2 "D"). Whether the backing file
+still exists is likewise never assumed from ``spilled`` alone — a spilled
+entry's file can be GC'd or fail to have ever been written at all, and an
+UNSPILLED entry's file existing or not is irrelevant (its content is
+already self-sufficient) — see :func:`resolve`'s own branch table.
+
+This module is the ONE place this 3-way branch is written (#5364 §1.2
+"history 構築（純関数・1 箇所）") — a second, independently-maintained copy
+of this table anywhere else in the history-build path is exactly the
+class of defect CLAUDE.md's testing policy singles out ("the same
+expression on both sides").
+"""
+from __future__ import annotations
+
+from typing import Callable, Literal, NamedTuple
+
+Resolution = Literal["inline", "ref", "lost"]
+
+
+class HistoryContentEntry(NamedTuple):
+    """The two persisted signals :func:`resolve` reads — never re-derived
+    from anything else (see module docstring). ``content`` is the
+    UNSPILLED inline body (meaningless when ``spilled`` is True — the
+    caller need not have kept it around, and the resolver never reads it
+    in that branch). ``ref`` is the backing file's path — set for every
+    entry regardless of ``spilled`` (#5364 §1.1 "A": every tool result is
+    always file-backed), used only to check existence and to report back
+    when the resolution is ``"ref"`` or ``"lost"``."""
+    spilled: bool
+    content: str
+    ref: str
+
+
+class Resolved(NamedTuple):
+    """``kind`` names which branch fired; ``value`` is the content to show
+    (the inline text) for ``"inline"``, or the backing path for ``"ref"``/
+    ``"lost"`` (a ``"lost"`` value still names the path that is missing —
+    #5364 §1.5's ``gc``/``never_persisted`` reasons are reported
+    separately by the caller, this function only says THAT it is lost,
+    not WHY — see that section's own two-reason split)."""
+    kind: Resolution
+    value: str
+
+
+def resolve(
+    entry: HistoryContentEntry, file_exists: "Callable[[str], bool]",
+) -> Resolved:
+    """Resolve one history entry's tool-result content (#5364 §1.2).
+
+    ``file_exists`` is injected (never a bare ``Path(ref).exists()``
+    call inline here) so this stays a pure function — the caller decides
+    what "exists" means (a real filesystem check in production, a
+    canned answer in a test) without this module importing ``pathlib``
+    or touching disk itself.
+    """
+    if not file_exists(entry.ref):
+        return Resolved("lost", entry.ref)
+    if entry.spilled:
+        return Resolved("ref", entry.ref)
+    return Resolved("inline", entry.content)

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -33,6 +33,36 @@ TOOL_STATUS_ERROR = "error"
 TOOL_ERROR_KIND_META_KEY = "error_kind"
 TOOL_ERROR_MESSAGE_META_KEY = "error_message"
 
+# #5364 §1.2: the tool-result history-content resolver's own persisted
+# signals — typed via named meta keys, NOT a new top-level ChatMessage
+# field (lead-coder ruling: a new field creates a "missing" state for
+# every ALREADY-persisted record, the same defect class ``seq: int = 0``'s
+# own "0 = no coordinate assigned (pre-fix history only)" already carries;
+# `meta` + a named key is this repo's typed convention for exactly this
+# shape — see `TOOL_STATUS_META_KEY` above, "restore.py reads this typed
+# field directly, matching reyn's typed-over-form-sniffed convention").
+#
+# ABSENCE of ``SPILLED_META_KEY`` (pre-#5364 history) means "never
+# spilled" (today's only possible history — nothing offloaded a tool
+# result into this store before #5364 existed), never "unknown".
+SPILLED_META_KEY = "spilled"
+# The backing file's project-relative path — set for every SPILLED entry.
+# #5364 §1.1 "A": every tool result is written to a file, but only a
+# SPILLED entry's own persisted content is the ref rather than the
+# original inline body, so only a spilled entry needs this to resolve.
+CONTENT_REF_META_KEY = "content_ref"
+# Set once `resolve()` (reyn.core.offload.history_content_resolve) has
+# actually observed the backing file missing — never guessed ahead of
+# that check. ABSENCE means "not (yet) known to be lost", never "present".
+LOST_META_KEY = "lost"
+LOST_REASON_META_KEY = "lost_reason"
+# #5364 §1.5: the two possible reasons, as constants (lead-coder review:
+# a bare "gc"/"never_persisted" string written at more than one call site
+# lets one side's typo pass silently — the same discipline
+# ``TOOL_STATUS_ERROR`` above already applies to its own value domain).
+LOST_REASON_GC = "gc"
+LOST_REASON_NEVER_PERSISTED = "never_persisted"
+
 # #3299 P4: the intervention PROMPT + resolved ANSWER, stamped on the
 # ``role="user"`` history entry ``InterventionHandler.deliver_answer_to``
 # already appends (mirroring ``intervention_id`` / ``intervention_kind``

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3466,7 +3466,9 @@ class RouterLoop:
         )
         from reyn.core.offload.seam import build_offload_body, render_tool_result
         from reyn.runtime.chat_message import (
+            CONTENT_REF_META_KEY,
             SKILL_SOURCE_PATH_META_KEY,
+            SPILLED_META_KEY,
             TOKEN_MAP_META_KEY,
             TOOL_ERROR_KIND_META_KEY,
             TOOL_ERROR_MESSAGE_META_KEY,
@@ -3502,6 +3504,17 @@ class RouterLoop:
             _media_store = getattr(host, "media_store", None)
             _save_fn = _media_store.save_tool_result if _media_store is not None else None
             _cap = getattr(host, "cap_tool_result", None)
+            # #5364 §1.2: the ONE typed channel this turn's cap call reports
+            # "this was offloaded, and to where" through — never re-derived
+            # later by parsing content_str's own read_file(path=...) marker
+            # (this repo's typed-over-form-sniffed convention, same as the
+            # #73 _tool_error_* locals above). Stays None when _cap never
+            # offloads (content stayed under the cap) or was never wired.
+            _offloaded_ref: "str | None" = None
+
+            def _on_offload(ref: str) -> None:
+                nonlocal _offloaded_ref
+                _offloaded_ref = ref
 
             # Error path (plain string, never JSON): a dispatch-envelope error carries
             # ``error.kind``/``.message`` (``permission_denied`` vs ``not_found`` imply different
@@ -3555,7 +3568,10 @@ class RouterLoop:
                 if (canonical.get("meta") or {}).get("isError"):
                     text_full = canonical.get("text", "") or ""
                     scan_target = f"Error: {text_full}"
-                    text = _cap(text_full) if _cap is not None else text_full
+                    text = (
+                        _cap(text_full, on_offload=_on_offload)
+                        if _cap is not None else text_full
+                    )
                     content_str = f"Error: {text}"
                     _tool_error_message = text_full
                 else:
@@ -3629,7 +3645,9 @@ class RouterLoop:
                         # text offload store as its mime_type — NEVER into frontmatter (built
                         # above, already sealed) — so a later present(data_ref=<this ref>) can
                         # recover it from the stored ref's file extension.
-                        text = _cap(text, content_type=content_type)
+                        text = _cap(
+                            text, content_type=content_type, on_offload=_on_offload,
+                        )
                     content_str = render_tool_result(frontmatter, text)
                     # #3629: `load_skill_to_canonical` is the one mapper that sets
                     # `history_text` — the SAME frontmatter, un-capped (a skill body is
@@ -3707,6 +3725,12 @@ class RouterLoop:
                 _tool_meta[TOKEN_MAP_META_KEY] = _history_meta_extra["token_map"]
             if "skill_source_path" in _history_meta_extra:
                 _tool_meta[SKILL_SOURCE_PATH_META_KEY] = _history_meta_extra["skill_source_path"]
+            # #5364 §1.2 "D": persisted so a restart never re-guesses whether
+            # this entry was spilled — the resolver reads this typed field,
+            # never the content string's own shape.
+            if _offloaded_ref is not None:
+                _tool_meta[SPILLED_META_KEY] = True
+                _tool_meta[CONTENT_REF_META_KEY] = _offloaded_ref
             if _append_entry is not None:
                 _append_entry(
                     role="tool",

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -221,7 +221,13 @@ class ContextBudgetAdvisor:
             alpha=cfg.cap_alpha,
         )
 
-    def cap_tool_result(self, content_str: str, *, content_type: "str | None" = None) -> str:
+    def cap_tool_result(
+        self,
+        content_str: str,
+        *,
+        content_type: "str | None" = None,
+        on_offload: "Callable[[str], None] | None" = None,
+    ) -> str:
         """Cap an oversized chat tool result (#1128 size axis).
 
         No-op when no media_store is configured, or when ``offload.enabled: false``
@@ -233,6 +239,10 @@ class ContextBudgetAdvisor:
         type, e.g. ``"text/html"``); forwarded to the store's ``mime_type`` so the offloaded ref's
         on-disk extension carries it (never into any LLM-visible field — this only ever reaches the
         store, never the frontmatter this method's caller builds separately).
+
+        ``on_offload`` (#5364 §1.2) — forwarded to
+        ``tool_result_cap.cap_tool_result_content``'s own param of the same
+        name; optional and additive, every existing caller unaffected.
         """
         if not self._offload_config.enabled:
             return content_str
@@ -251,6 +261,7 @@ class ContextBudgetAdvisor:
             use_chars4=use_chars4,
             events=self._events,
             content_type=content_type,
+            on_offload=on_offload,
             max_inline_bytes=cfg.max_inline_bytes,
             preview_head_chars=cfg.preview_head_chars,
             preview_tail_chars=cfg.preview_tail_chars,

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -11,6 +11,7 @@ Also owns the module-level helpers:
 
   - _materialise_path_ref_content
   - _read_pathref_image
+  - _resolve_spilled_content    — #5364 §1.2: lost-file detection for spilled entries
 
 history_fn dependency: a zero-arg callable that returns the raw history list
 (all ChatMessages including summaries) — passed in production as
@@ -163,6 +164,58 @@ def _refresh_skill_location_tokens(
         content, skill_source_path=skill_source_path, project_dir=project_dir,
         alias_claude=True,
     )
+
+
+def _resolve_spilled_content(
+    content: "str | list[dict]", meta: Any, project_dir_fn: "Callable[[], Any] | None",
+) -> "str | list[dict]":
+    """#5364 §1.2: replace a spilled entry's stale ref-preview with an
+    explicit "lost" notice once its backing file is actually gone —
+    every serialise, via the ONE resolver
+    (:func:`reyn.core.offload.history_content_resolve.resolve`).
+
+    No-op (content returned unchanged) unless ``content`` is a ``str``
+    AND ``meta`` carries ``SPILLED_META_KEY`` — an unspilled entry's own
+    content is already self-sufficient (§1.2's own truth table: the
+    ``spilled=False`` row never depends on file existence), so this never
+    touches it. ``project_dir_fn is None`` (legacy/test double with no
+    workspace access) degrades to "never check" — same fail-closed idiom
+    :func:`_refresh_skill_location_tokens` uses for the identical shape.
+
+    Without this, a spilled entry whose backing file was GC'd or never
+    persisted keeps showing the model a ``read_file(path=...)`` preview
+    naming a file that no longer exists — a silent dangling reference the
+    model can only discover by actually trying the read and getting an
+    error, rather than being told up front."""
+    if not isinstance(content, str) or not isinstance(meta, dict) or project_dir_fn is None:
+        return content
+    from reyn.runtime.chat_message import CONTENT_REF_META_KEY, SPILLED_META_KEY
+    if not meta.get(SPILLED_META_KEY):
+        return content
+    ref = meta.get(CONTENT_REF_META_KEY)
+    if not ref:
+        return content
+    project_dir = project_dir_fn()
+    if project_dir is None:
+        return content
+
+    from pathlib import Path as _Path
+
+    from reyn.core.offload.history_content_resolve import HistoryContentEntry, resolve
+
+    def _file_exists(rel_path: str) -> bool:
+        return (_Path(project_dir) / rel_path).is_file()
+
+    resolved = resolve(
+        HistoryContentEntry(spilled=True, content=content, ref=ref),
+        file_exists=_file_exists,
+    )
+    if resolved.kind == "lost":
+        return (
+            f"[content lost: the offloaded body at {ref!r} no longer exists "
+            "on disk — it may have been deleted or garbage-collected]"
+        )
+    return content
 
 
 # #4381 PR-1: warn-once cache for the resource/budget invariant below, keyed
@@ -554,6 +607,13 @@ class RouterHistoryBuffer:
         # persisted `load_skill` entry left literal, against the CURRENT
         # filesystem (see _refresh_skill_location_tokens's docstring).
         content = _refresh_skill_location_tokens(
+            content, getattr(m, "meta", None), self._project_dir_fn,
+        )
+        # #5364 §1.2: fresh, every serialise — a spilled entry's backing
+        # file may have been GC'd or never persisted since the last time
+        # this turn was serialised (see _resolve_spilled_content's own
+        # docstring for why this is not a one-time check at write time).
+        content = _resolve_spilled_content(
             content, getattr(m, "meta", None), self._project_dir_fn,
         )
         # #5296 PR-2: apply the reactive-spill overlay, same stage as the

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -744,7 +744,13 @@ class RouterHostAdapter:
 
     # --- RouterLoopHost identity attributes ---
 
-    def cap_tool_result(self, content_str: str, *, content_type: "str | None" = None) -> str:
+    def cap_tool_result(
+        self,
+        content_str: str,
+        *,
+        content_type: "str | None" = None,
+        on_offload: "Callable[[str], None] | None" = None,
+    ) -> str:
         """#1128 size axis: cap an oversized tool-result string at the
         router_loop chokepoint. Delegates to the session-supplied callable
         (which offloads the full body via the #385 store + returns a bounded
@@ -752,10 +758,15 @@ class RouterHostAdapter:
 
         #2425 案B: caps the canonical ``text`` body (already the clean payload) — a single string,
         no clean-payload kwargs. ``content_type`` (#2663) is the canonical's renderer-only sidecar,
-        forwarded to the session capper unchanged (identity path ignores it — nothing to store)."""
+        forwarded to the session capper unchanged (identity path ignores it — nothing to store).
+
+        ``on_offload`` (#5364 §1.2) — forwarded unchanged; optional and
+        additive, every existing caller unaffected."""
         if self._cap_tool_result is None:
             return content_str
-        return self._cap_tool_result(content_str, content_type=content_type)
+        return self._cap_tool_result(
+            content_str, content_type=content_type, on_offload=on_offload,
+        )
 
     def media_followup_budget(self, tool_content: str) -> int | None:
         """#272 media axis: tokens left for a tool turn's media follow-up after

--- a/src/reyn/runtime/services/tool_result_cap.py
+++ b/src/reyn/runtime/services/tool_result_cap.py
@@ -80,6 +80,7 @@ def cap_tool_result_content(
     max_inline_bytes: int = MAX_TOOL_RESULT_INLINE_BYTES,
     preview_head_chars: int = _PREVIEW_HEAD_CHARS,
     preview_tail_chars: int = _PREVIEW_TAIL_CHARS,
+    on_offload: "Callable[[str], None] | None" = None,
 ) -> str:
     """Return *content_str* unchanged if within the cap, else its offloaded plain-text preview.
 
@@ -106,6 +107,16 @@ def cap_tool_result_content(
                       ref's on-disk extension carries it (``None`` → the store's own
                       ``"text/plain"`` default, unchanged behaviour). Never read into ``content_str``
                       or any LLM-visible output of this function.
+        on_offload:   (#5364 §1.2) Called with the offloaded ref path exactly
+                      once, only when offload actually happens — the ONE
+                      typed channel a caller uses to learn "this was
+                      spilled, and to where" without re-deriving it by
+                      parsing the returned preview text for its
+                      ``read_file(path=...)`` marker (this repo's own
+                      "typed, never form-sniffed" convention —
+                      ``chat_message.py``'s ``TOOL_STATUS_META_KEY``
+                      docstring). Optional and additive: every existing
+                      caller that doesn't pass it is unaffected.
 
     Returns:
         The original string when ``estimate_tokens(content_str) <= cap_tokens``;
@@ -161,6 +172,8 @@ def cap_tool_result_content(
             ref=ref,
             content_hash=content_hash,
         )
+    if on_offload is not None:
+        on_offload(ref)
     return preview
 
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -9671,14 +9671,25 @@ class Session:
 
     # --- RouterLoop orchestration ---
 
-    def _cap_tool_result(self, content_str: str, *, content_type: "str | None" = None) -> str:
+    def _cap_tool_result(
+        self,
+        content_str: str,
+        *,
+        content_type: "str | None" = None,
+        on_offload: "Callable[[str], None] | None" = None,
+    ) -> str:
         """Forwarding → ContextBudgetAdvisor.cap_tool_result (PR-1).
 
         #2425 案B: the router chokepoint caps the canonical ``text`` body (already the clean payload),
         so the capper takes a single string — no clean-payload kwargs. ``content_type`` (#2663) is the
         canonical's renderer-only sidecar, forwarded so an offloaded ref's on-disk extension carries it
-        for present's stage-3 default viewer — never read into any LLM-visible field here."""
-        return self._budget_advisor.cap_tool_result(content_str, content_type=content_type)
+        for present's stage-3 default viewer — never read into any LLM-visible field here.
+
+        ``on_offload`` (#5364 §1.2) — forwarded unchanged; optional and
+        additive, every existing caller unaffected."""
+        return self._budget_advisor.cap_tool_result(
+            content_str, content_type=content_type, on_offload=on_offload,
+        )
 
     def _media_followup_budget(self, tool_content: str) -> "int | None":
         """Forwarding → ContextBudgetAdvisor.media_followup_budget (PR-1)."""

--- a/tests/core/test_5364_history_content_resolve.py
+++ b/tests/core/test_5364_history_content_resolve.py
@@ -1,4 +1,4 @@
-"""Tier 1: #5364 §1.2 — the tool-result history-content resolver's own
+"""Tier 2: #5364 §1.2 — the tool-result history-content resolver's own
 truth table (a pure function; all four branches directly, plus the
 orthogonality owner named explicitly)."""
 from __future__ import annotations
@@ -7,7 +7,7 @@ from reyn.core.offload.history_content_resolve import HistoryContentEntry, resol
 
 
 def test_not_spilled_and_file_present_resolves_inline() -> None:
-    """Tier 1: the common case — a small tool result, never offloaded,
+    """Tier 2: the common case — a small tool result, never offloaded,
     its backing file (§1.1 "A": always written) still exists."""
     entry = HistoryContentEntry(spilled=False, content="the original body", ref="some/path.txt")
 
@@ -18,7 +18,7 @@ def test_not_spilled_and_file_present_resolves_inline() -> None:
 
 
 def test_spilled_and_file_present_resolves_ref() -> None:
-    """Tier 1: an offloaded tool result whose backing file is still
+    """Tier 2: an offloaded tool result whose backing file is still
     there — resolves to the path, not the (possibly discarded) inline
     content."""
     entry = HistoryContentEntry(spilled=True, content="stale/unused", ref="spill/path.txt")
@@ -30,7 +30,7 @@ def test_spilled_and_file_present_resolves_ref() -> None:
 
 
 def test_not_spilled_but_file_missing_resolves_lost() -> None:
-    """Tier 1: orthogonality (owner ruling, #5364: "spill/lost 判定は直
+    """Tier 2: orthogonality (owner ruling, #5364: "spill/lost 判定は直
     行性を持たせるべき") — an UNSPILLED entry's backing file can still be
     gone (GC'd, or never persisted at all — #5364 §1.5's two reasons),
     and that alone is enough to resolve ``lost``, independent of
@@ -44,7 +44,7 @@ def test_not_spilled_but_file_missing_resolves_lost() -> None:
 
 
 def test_spilled_and_file_missing_resolves_lost() -> None:
-    """Tier 1: the fourth cell of the 2x2 table — spilled AND gone."""
+    """Tier 2: the fourth cell of the 2x2 table — spilled AND gone."""
     entry = HistoryContentEntry(spilled=True, content="irrelevant", ref="also/gone.txt")
 
     result = resolve(entry, file_exists=lambda ref: False)
@@ -54,7 +54,7 @@ def test_spilled_and_file_missing_resolves_lost() -> None:
 
 
 def test_file_exists_is_called_with_this_entrys_own_ref() -> None:
-    """Tier 1: the resolver checks THIS entry's ref, not some other path
+    """Tier 2: the resolver checks THIS entry's ref, not some other path
     — a resolver that hardcoded or mismatched paths would still pass the
     four branch tests above (they all resolve the SAME entry's own ref)
     but fail this one, which uses distinguishable refs per call."""

--- a/tests/core/test_5364_history_content_resolve.py
+++ b/tests/core/test_5364_history_content_resolve.py
@@ -1,0 +1,70 @@
+"""Tier 1: #5364 §1.2 — the tool-result history-content resolver's own
+truth table (a pure function; all four branches directly, plus the
+orthogonality owner named explicitly)."""
+from __future__ import annotations
+
+from reyn.core.offload.history_content_resolve import HistoryContentEntry, resolve
+
+
+def test_not_spilled_and_file_present_resolves_inline() -> None:
+    """Tier 1: the common case — a small tool result, never offloaded,
+    its backing file (§1.1 "A": always written) still exists."""
+    entry = HistoryContentEntry(spilled=False, content="the original body", ref="some/path.txt")
+
+    result = resolve(entry, file_exists=lambda ref: True)
+
+    assert result.kind == "inline"
+    assert result.value == "the original body"
+
+
+def test_spilled_and_file_present_resolves_ref() -> None:
+    """Tier 1: an offloaded tool result whose backing file is still
+    there — resolves to the path, not the (possibly discarded) inline
+    content."""
+    entry = HistoryContentEntry(spilled=True, content="stale/unused", ref="spill/path.txt")
+
+    result = resolve(entry, file_exists=lambda ref: True)
+
+    assert result.kind == "ref"
+    assert result.value == "spill/path.txt"
+
+
+def test_not_spilled_but_file_missing_resolves_lost() -> None:
+    """Tier 1: orthogonality (owner ruling, #5364: "spill/lost 判定は直
+    行性を持たせるべき") — an UNSPILLED entry's backing file can still be
+    gone (GC'd, or never persisted at all — #5364 §1.5's two reasons),
+    and that alone is enough to resolve ``lost``, independent of
+    ``spilled``."""
+    entry = HistoryContentEntry(spilled=False, content="never mattered", ref="gone/path.txt")
+
+    result = resolve(entry, file_exists=lambda ref: False)
+
+    assert result.kind == "lost"
+    assert result.value == "gone/path.txt"
+
+
+def test_spilled_and_file_missing_resolves_lost() -> None:
+    """Tier 1: the fourth cell of the 2x2 table — spilled AND gone."""
+    entry = HistoryContentEntry(spilled=True, content="irrelevant", ref="also/gone.txt")
+
+    result = resolve(entry, file_exists=lambda ref: False)
+
+    assert result.kind == "lost"
+    assert result.value == "also/gone.txt"
+
+
+def test_file_exists_is_called_with_this_entrys_own_ref() -> None:
+    """Tier 1: the resolver checks THIS entry's ref, not some other path
+    — a resolver that hardcoded or mismatched paths would still pass the
+    four branch tests above (they all resolve the SAME entry's own ref)
+    but fail this one, which uses distinguishable refs per call."""
+    seen: list[str] = []
+
+    def _file_exists(ref: str) -> bool:
+        seen.append(ref)
+        return True
+
+    resolve(HistoryContentEntry(spilled=False, content="x", ref="entry-a.txt"), _file_exists)
+    resolve(HistoryContentEntry(spilled=True, content="y", ref="entry-b.txt"), _file_exists)
+
+    assert seen == ["entry-a.txt", "entry-b.txt"]

--- a/tests/runtime/test_2425_step1c_chat_chokepoint.py
+++ b/tests/runtime/test_2425_step1c_chat_chokepoint.py
@@ -35,12 +35,18 @@ class _CapHost:
     def __init__(self, store: "MediaStore | None") -> None:
         self.media_store = store
 
-    def cap_tool_result(self, content_str: str, *, content_type: "str | None" = None) -> str:
+    def cap_tool_result(
+        self,
+        content_str: str,
+        *,
+        content_type: "str | None" = None,
+        on_offload=None,
+    ) -> str:
         if self.media_store is None:
             return content_str
         return cap_tool_result_content(
             content_str, cap_tokens=100, model=_MODEL, save_fn=self.media_store.save_tool_result,
-            use_chars4=True, content_type=content_type,
+            use_chars4=True, content_type=content_type, on_offload=on_offload,
         )
 
     def media_followup_budget(self, _content_str: str) -> int:

--- a/tests/runtime/test_5364_lost_content_resolution.py
+++ b/tests/runtime/test_5364_lost_content_resolution.py
@@ -1,0 +1,88 @@
+"""Tier 2: #5364 §1.2 — a spilled entry whose backing file is gone shows an
+explicit "lost" notice at wire-serialisation time, driven through the real
+RouterHistoryBuffer (not the resolver called in isolation — see
+tests/core/test_5364_history_content_resolve.py for that). Without this,
+a spilled entry's stale read_file(path=...) preview keeps pointing at a
+file that no longer exists, silently, until the model tries the read and
+gets an error with no context.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.config.chat import LoopConfig, OnLimitConfig, SafetyConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import CONTENT_REF_META_KEY, SPILLED_META_KEY, ChatMessage
+from tests._support.agent_session import make_session
+
+
+def _now() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def test_a_spilled_entry_with_a_missing_backing_file_shows_a_lost_notice(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: build_history() on a spilled entry whose ref file was
+    deleted out-of-band (simulating GC, or any other removal) returns an
+    explicit lost notice, not the stale ref-preview naming a dead path."""
+    session = make_session(
+        agent_name="lost-content-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        safety=SafetyConfig(loop=LoopConfig(), on_limit=OnLimitConfig(mode="unattended")),
+    )
+    ref_path = tmp_path / "gone.txt"
+    # Deliberately never written — this entry is "spilled" per its own
+    # meta, but its ref names a file that was never persisted / has since
+    # vanished (§1.5's two `lost` reasons share this one observable shape).
+    session._append_history(
+        ChatMessage(
+            role="tool",
+            content='...[truncated: 500 chars total — full body: read_file(path="gone.txt")]...',
+            ts=_now(),
+            tool_call_id="tc1",
+            name="tool",
+            meta={SPILLED_META_KEY: True, CONTENT_REF_META_KEY: "gone.txt"},
+        ),
+    )
+    assert not ref_path.exists(), "test setup sanity: the ref file must genuinely be absent"
+
+    history = session._loop_driver._history_buffer.build_history()
+
+    (tool_msg,) = [m for m in history if m.get("role") == "tool"]
+    assert "read_file(path=" not in tool_msg["content"], (
+        "a lost entry must not keep showing a dead read_file path"
+    )
+    assert "lost" in tool_msg["content"].lower()
+    assert "gone.txt" in tool_msg["content"], "the lost notice should still name the missing ref"
+
+
+def test_a_spilled_entry_with_its_file_present_is_unaffected(tmp_path: Path) -> None:
+    """Tier 2: accept-side — a spilled entry whose backing file DOES
+    exist keeps showing its normal ref-preview content unchanged."""
+    session = make_session(
+        agent_name="present-content-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        safety=SafetyConfig(loop=LoopConfig(), on_limit=OnLimitConfig(mode="unattended")),
+    )
+    ref_path = tmp_path / "present.txt"
+    ref_path.write_text("the real body", encoding="utf-8")
+    preview = '...[truncated: 500 chars total — full body: read_file(path="present.txt")]...'
+    session._append_history(
+        ChatMessage(
+            role="tool",
+            content=preview,
+            ts=_now(),
+            tool_call_id="tc1",
+            name="tool",
+            meta={SPILLED_META_KEY: True, CONTENT_REF_META_KEY: "present.txt"},
+        ),
+    )
+
+    history = session._loop_driver._history_buffer.build_history()
+
+    (tool_msg,) = [m for m in history if m.get("role") == "tool"]
+    assert tool_msg["content"] == preview, "a present file's ref-preview must pass through unchanged"

--- a/tests/runtime/test_5364_spilled_meta_wiring.py
+++ b/tests/runtime/test_5364_spilled_meta_wiring.py
@@ -9,11 +9,16 @@ no real signal to read (#5364, lead-coder: "resolver は呼び口と同じ PR �
 """
 from __future__ import annotations
 
+import pytest
+
+from reyn.config import CompactionConfig, MultimodalConfig
+from reyn.config.chat import OffloadConfig
 from reyn.data.workspace.media_store import MediaStore
 from reyn.runtime.chat_message import CONTENT_REF_META_KEY, SPILLED_META_KEY
 from reyn.runtime.router_loop import RouterLoop
 from reyn.runtime.services.tool_result_cap import cap_tool_result_content
 from reyn.tools.scheme import ExecutionResult
+from tests._support.agent_session import make_session
 
 _MODEL = "gpt-4o"
 _BIG = "\n".join(f"line {i}: " + "z" * 60 for i in range(400))  # well over the offload trigger
@@ -98,6 +103,53 @@ def test_unoffloaded_tool_result_is_never_stamped_spilled(tmp_path) -> None:
     meta = tool_entry["meta"]
     assert SPILLED_META_KEY not in meta
     assert CONTENT_REF_META_KEY not in meta
+
+
+def test_the_real_production_chain_stamps_spilled_meta_end_to_end(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: architect/lead-coder BLOCKING (#5372, head 8803bc020) — the 3
+    tests above all drive ``_RecordingHost``, a fake that REPLACES the real
+    ``RouterHostAdapter -> Session._cap_tool_result ->
+    ContextBudgetAdvisor.cap_tool_result`` forwarding chain (#5364 §1.2's
+    actual production path for ``on_offload``). Deleting any of those 3
+    forwarding sites' own ``on_offload=on_offload`` left every test above
+    green — the fake never exercised them.
+
+    This test drives the REAL chain instead: a real ``Session`` (via
+    ``make_session`` — no mocks, per ``tests/_support/router_host_adapter.py``'s
+    own "real collaborators" contract) built with ``offload.enabled: true``,
+    handing ``RouterLoop`` its real ``session.router_host`` (the actual
+    ``RouterHostAdapter`` production wires — same object ``_build_router_waist``
+    constructs, same as every real chat turn), and reading the persisted
+    ``ChatMessage`` back off ``session.history`` (not the wire-rendered
+    ``build_history()``, which the resolver already transforms — this test
+    wants the raw stamped meta the resolver's OWN write-side counterpart)."""
+    monkeypatch.chdir(tmp_path)
+    session = make_session(
+        agent_name="real-chain-agent",
+        multimodal_config=MultimodalConfig(),
+        offload_config=OffloadConfig(enabled=True),
+        compaction_config=CompactionConfig(use_chars4_estimate=True),
+    )
+
+    loop = RouterLoop(host=session.router_host, chain_id="c1", router_model=_MODEL)
+    result = ExecutionResult(
+        tool_results=[_mcp_env(content=_BIG)],
+        tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "mcp"}}],
+        assistant_content="",
+    )
+    loop.feedback(result)
+
+    (tool_msg,) = [m for m in session.history if m.role == "tool"]
+    assert tool_msg.meta.get(SPILLED_META_KEY) is True, (
+        f"real production chain never stamped SPILLED_META_KEY, meta={tool_msg.meta!r}"
+    )
+    ref = tool_msg.meta.get(CONTENT_REF_META_KEY)
+    assert ref, f"expected a content ref in meta, got: {tool_msg.meta!r}"
+    full = tmp_path / ref
+    assert full.is_file(), f"the ref must name a file that actually exists: {full}"
+    assert full.read_text(encoding="utf-8") == _BIG
 
 
 def test_no_media_store_never_stamps_spilled(tmp_path) -> None:

--- a/tests/runtime/test_5364_spilled_meta_wiring.py
+++ b/tests/runtime/test_5364_spilled_meta_wiring.py
@@ -1,0 +1,116 @@
+"""Tier 3a: #5364 §1.2 — the write-time cap chokepoint (RouterLoop.feedback,
+mirroring test_2425_step1c_chat_chokepoint.py's own real harness) stamps
+``SPILLED_META_KEY``/``CONTENT_REF_META_KEY`` on the persisted history entry
+exactly when an offload actually happened — never guessed from the
+rendered content string's own shape (this repo's typed-over-form-sniffed
+convention). This is the resolver's own write-side counterpart: without
+this wiring, ``reyn.core.offload.history_content_resolve.resolve()`` has
+no real signal to read (#5364, lead-coder: "resolver は呼び口と同じ PR で").
+"""
+from __future__ import annotations
+
+from reyn.data.workspace.media_store import MediaStore
+from reyn.runtime.chat_message import CONTENT_REF_META_KEY, SPILLED_META_KEY
+from reyn.runtime.router_loop import RouterLoop
+from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.tools.scheme import ExecutionResult
+
+_MODEL = "gpt-4o"
+_BIG = "\n".join(f"line {i}: " + "z" * 60 for i in range(400))  # well over the offload trigger
+_SMALL = "tiny result, stays inline"
+
+
+class _RecordingHost:
+    """Mirrors test_2425_step1c_chat_chokepoint.py's own ``_CapHost`` +
+    captures every ``append_history_entry`` call so this test can assert
+    on the persisted ``meta`` dict — the ONE thing ``RouterLoop.feedback``
+    actually hands a real Session in production."""
+
+    offload_enabled = True
+
+    def __init__(self, store: "MediaStore | None") -> None:
+        self.media_store = store
+        self.appended: list[dict] = []
+
+    def cap_tool_result(
+        self, content_str: str, *, content_type: "str | None" = None, on_offload=None,
+    ) -> str:
+        if self.media_store is None:
+            return content_str
+        return cap_tool_result_content(
+            content_str, cap_tokens=100, model=_MODEL,
+            save_fn=self.media_store.save_tool_result,
+            use_chars4=True, content_type=content_type, on_offload=on_offload,
+        )
+
+    def media_followup_budget(self, _content_str: str) -> int:
+        return 500
+
+    def append_history_entry(self, **kwargs) -> None:
+        self.appended.append(kwargs)
+
+
+def _mcp_env(**data_extra) -> dict:
+    data = {"kind": "mcp", "status": "ok", "server": "s", "tool": "t", "content": "", "media_blocks": []}
+    data.update(data_extra)
+    return {"status": "ok", "data": data, "_canonical_source": "mcp"}
+
+
+def _feedback(env: dict, host: "_RecordingHost"):
+    loop = RouterLoop(host=host, chain_id="c1", router_model=_MODEL)
+    result = ExecutionResult(
+        tool_results=[env],
+        tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "mcp"}}],
+        assistant_content="",
+    )
+    return loop.feedback(result)
+
+
+def test_offloaded_tool_result_is_stamped_spilled_with_a_content_ref(tmp_path) -> None:
+    """Tier 3a: content over the cap → the persisted entry's meta carries
+    SPILLED_META_KEY=True and CONTENT_REF_META_KEY naming a file that
+    actually exists and holds the ORIGINAL (pre-offload) content."""
+    store = MediaStore(project_root=tmp_path, session_id="test-session")
+    host = _RecordingHost(store)
+
+    _feedback(_mcp_env(content=_BIG), host)
+
+    (tool_entry,) = [e for e in host.appended if e["role"] == "tool"]
+    meta = tool_entry["meta"]
+    assert meta.get(SPILLED_META_KEY) is True
+    ref = meta.get(CONTENT_REF_META_KEY)
+    assert ref, f"expected a content ref in meta, got: {meta!r}"
+    full = tmp_path / ref
+    assert full.is_file(), f"the ref must name a file that actually exists: {full}"
+    assert full.read_text(encoding="utf-8") == _BIG
+
+
+def test_unoffloaded_tool_result_is_never_stamped_spilled(tmp_path) -> None:
+    """Tier 3a: content under the cap → no offload happens → meta carries
+    neither key at all (never False/None as a placeholder — see
+    SPILLED_META_KEY's own docstring: absence means "never spilled")."""
+    store = MediaStore(project_root=tmp_path, session_id="test-session")
+    host = _RecordingHost(store)
+
+    _feedback(_mcp_env(content=_SMALL), host)
+
+    (tool_entry,) = [e for e in host.appended if e["role"] == "tool"]
+    meta = tool_entry["meta"]
+    assert SPILLED_META_KEY not in meta
+    assert CONTENT_REF_META_KEY not in meta
+
+
+def test_no_media_store_never_stamps_spilled(tmp_path) -> None:
+    """Tier 3a: accept-side — a host with no media_store configured (cap
+    is identity, per _RecordingHost.cap_tool_result's own no-op branch)
+    never stamps SPILLED_META_KEY even for content that WOULD have been
+    offloaded had a store existed — proves the stamp is tied to an actual
+    offload, not just "content is large"."""
+    host = _RecordingHost(store=None)
+
+    _feedback(_mcp_env(content=_BIG), host)
+
+    (tool_entry,) = [e for e in host.appended if e["role"] == "tool"]
+    meta = tool_entry["meta"]
+    assert SPILLED_META_KEY not in meta
+    assert CONTENT_REF_META_KEY not in meta

--- a/tests/runtime/test_5364_spilled_meta_wiring.py
+++ b/tests/runtime/test_5364_spilled_meta_wiring.py
@@ -1,4 +1,4 @@
-"""Tier 3a: #5364 §1.2 — the write-time cap chokepoint (RouterLoop.feedback,
+"""Tier 2: #5364 §1.2 — the write-time cap chokepoint (RouterLoop.feedback,
 mirroring test_2425_step1c_chat_chokepoint.py's own real harness) stamps
 ``SPILLED_META_KEY``/``CONTENT_REF_META_KEY`` on the persisted history entry
 exactly when an offload actually happened — never guessed from the
@@ -67,7 +67,7 @@ def _feedback(env: dict, host: "_RecordingHost"):
 
 
 def test_offloaded_tool_result_is_stamped_spilled_with_a_content_ref(tmp_path) -> None:
-    """Tier 3a: content over the cap → the persisted entry's meta carries
+    """Tier 2: content over the cap → the persisted entry's meta carries
     SPILLED_META_KEY=True and CONTENT_REF_META_KEY naming a file that
     actually exists and holds the ORIGINAL (pre-offload) content."""
     store = MediaStore(project_root=tmp_path, session_id="test-session")
@@ -86,7 +86,7 @@ def test_offloaded_tool_result_is_stamped_spilled_with_a_content_ref(tmp_path) -
 
 
 def test_unoffloaded_tool_result_is_never_stamped_spilled(tmp_path) -> None:
-    """Tier 3a: content under the cap → no offload happens → meta carries
+    """Tier 2: content under the cap → no offload happens → meta carries
     neither key at all (never False/None as a placeholder — see
     SPILLED_META_KEY's own docstring: absence means "never spilled")."""
     store = MediaStore(project_root=tmp_path, session_id="test-session")
@@ -101,7 +101,7 @@ def test_unoffloaded_tool_result_is_never_stamped_spilled(tmp_path) -> None:
 
 
 def test_no_media_store_never_stamps_spilled(tmp_path) -> None:
-    """Tier 3a: accept-side — a host with no media_store configured (cap
+    """Tier 2: accept-side — a host with no media_store configured (cap
     is identity, per _RecordingHost.cap_tool_result's own no-op branch)
     never stamps SPILLED_META_KEY even for content that WOULD have been
     offloaded had a store existed — proves the stamp is tied to an actual

--- a/tests/runtime/test_5364_spilled_meta_wiring.py
+++ b/tests/runtime/test_5364_spilled_meta_wiring.py
@@ -29,7 +29,15 @@ class _RecordingHost:
     """Mirrors test_2425_step1c_chat_chokepoint.py's own ``_CapHost`` +
     captures every ``append_history_entry`` call so this test can assert
     on the persisted ``meta`` dict — the ONE thing ``RouterLoop.feedback``
-    actually hands a real Session in production."""
+    actually hands a real Session in production.
+
+    architect (#5372): a fast unit-level stand-in, not a substitute for the
+    real production chain — since
+    ``test_the_real_production_chain_stamps_spilled_meta_end_to_end`` below
+    closes the one risk a fake host posed here (wiring silently dropped
+    between ``RouterHostAdapter``/``Session``/``ContextBudgetAdvisor``),
+    this class stays legitimate for the fast per-branch coverage the 3
+    tests above want."""
 
     offload_enabled = True
 


### PR DESCRIPTION
**[e2e-coder]** — part of #5364 §1.2. **Stacked on #5369** (base branch — #5369 is BLOCKING-CLEARED + TESTS-READ passed, awaiting merge; this PR's diff will shrink to just its own commit once #5369 lands and this rebases onto main).

## What

lead-coder's ruling on the persistence question (#5364 issuecomment): **meta dict + named key constants, NOT a new ChatMessage field** — a new field creates a "missing" state for every already-persisted record (same defect class as `ChatMessage.seq`'s own "0 = no coordinate assigned (pre-fix history only)").

- `chat_message.py`: `SPILLED_META_KEY` / `CONTENT_REF_META_KEY` / `LOST_META_KEY` / `LOST_REASON_META_KEY` + `LOST_REASON_GC`/`LOST_REASON_NEVER_PERSISTED` value-domain constants — matching the existing `TOOL_STATUS_META_KEY` precedent in the same file.
- `reyn/core/offload/history_content_resolve.py`: the ONE pure resolver (`resolve(entry, file_exists) -> inline/ref/lost`) per §1.2's truth table (spilled × file-present, orthogonal — owner ruling).
- `tool_result_cap.cap_tool_result_content` gains an **additive** `on_offload` callback (called with the ref path exactly once, only when an offload actually happens) — the one typed channel a caller learns "this was spilled, and to where" without re-deriving it by parsing the returned preview text (this repo's typed-over-form-sniffed convention). Purely additive: every existing caller unaffected. Threaded through `ContextBudgetAdvisor.cap_tool_result` / `Session._cap_tool_result` / `RouterHostAdapter.cap_tool_result`.
- `router_loop.py`'s real write chokepoint (`RouterLoop.feedback`, both the error and success text-cap call sites) captures the ref and stamps `SPILLED_META_KEY`/`CONTENT_REF_META_KEY` on the persisted entry's meta — the resolver's write-side signal.
- `router_history_buffer.py`: `_resolve_spilled_content`, a new `_serialise_turn` step — every wire serialisation, a spilled entry whose backing file has since gone missing (GC'd, or never persisted) now shows an explicit "content lost" notice instead of a stale `read_file(path=...)` preview silently naming a dead path. **This is the resolver's real caller** — lead-coder: "resolver は呼び口と同じ PR で" ("宣言だけして誰も呼ばない" avoided).

## Not included (tracked on #5364)

§1.4 `durability_worker` wiring (write is still synchronous) · §1.5's `lost` REASON tracking (`gc`/`never_persisted` — this PR detects `lost`, a follow-up records WHY) · §1.6 GC.

## Verified

Real strip-falsify: removed the `on_offload` wiring at `router_loop.py`'s success-path call site, reran `test_5364_spilled_meta_wiring.py` — genuinely RED — reverted. 58 tests across every file touching `cap_tool_result`/`cap_tool_result_content` (full blast-radius sweep) green; one pre-existing fake Host (`test_2425_step1c_chat_chokepoint.py`'s `_CapHost`) needed its signature updated to accept the new additive kwarg, same as every real Host implementation.

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 17/17 (+ new files) clean
- [x] `python scripts/mypy_ratchet.py` — OK, 201/207 baselined, unchanged
- [x] Full blast-radius sweep (58 tests across every `cap_tool_result`/`cap_tool_result_content` caller) — green
- [x] Real strip-falsify (see above)
- [ ] (skipped — no UI/visual surface)

co-vet: @architect (per #5364 §4).

part of #5364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Blocking points

- [x] 🔴 **`test_5364_spilled_meta_wiring.py` の 3 本は Tier 3a ではなく Tier 2 です。** この file は `LLMReplay` を使わず、model の出力を主題にもしていません（`_MODEL` は cap の見積りに渡るだけで、`use_chars4=True`）。testing.md 逐語 `a Tier 3 test specifically uses ``LLMReplay`` (recorded ...)`。さらに `test_tier_audit.py` の Rule 9 が `policy_ref="#5103 / #5294: Tier 3 ⟺ model output is the subject"` として**私自身の判別子**を引いており、その判別子で **model の出力は主題ではありません**。六問⑥（宣言 Tier が真か）に掛かります。**3 本の 1 行目を `Tier 2:` に。** 根拠: PR comment（architect BLOCKING / TESTS-READ）

- [x] 🔴 **resolver の test 5 本の `Tier 1:` 宣言が成りません。** `testing.md:116-121` 逐語「Pins: **external boundaries** … - **Public Python API surface re-exported from each cluster's `__init__.py`**」。`reyn/core/offload/history_content_resolve.py` の `resolve()` は**本 PR で新設された内部の純関数**で、**`src/reyn/core/offload/__init__.py` から再 export されていません**（本 PR は `__init__.py` を 1 つも触っていません）。reyn.yaml schema / events JSONL / DSL contract のいずれでもない ∴ **Tier 1 の 4 つのどれにも当たりません**。**`Tier 2:` へ**（根拠: `:139`「Tier 2b — Subsystem invariants: derived contracts of major subsystems」＝ offload 部分系の派生契約）。⚠️ `2b` の細別は書かないでください（#5373 と同じ理由）。⚠️ **これは私が #5373 で使った判別子と同じもので、2 つの裁定が矛盾してはいけません。** 根拠: PR comment（BLOCKING）

- [x] 🔴 **`on_offload` の production 経路に witness がありません。** 本 PR は `on_offload` を **4 hop** 通します — ①`RouterLoop.feedback` → ②`RouterHostAdapter.cap_tool_result` → ③`Session._cap_tool_result` → ④`ContextBudgetAdvisor.cap_tool_result` → `cap_tool_result_content`。**新しい test が通るのは ① と最終段だけ**で、**② ③ ④ は `_RecordingHost` に置き換えられています**。∴ **`router_host_adapter.py` の `on_offload=on_offload` を消しても新 test は全部緑**です — 本番では meta が二度と刻まれず、lost notice も resolver も**永久に発火しないのに、何も赤くなりません**。**②③④ の各 hop に、その行を消すと RED になる test を。** 根拠: PR comment（architect BLOCKING / TESTS-READ）

