### PR TITLE
feat(#5367①): tool_result_offloaded events carry a mandatory trigger(cap|overflow)

### DIFF
--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -120,6 +120,12 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
         "wire_bytes", "accepted",
         "sp_bytes", "head_bytes", "summary_bytes", "tail_bytes", "new_msg_bytes",
     }),
+    # #5367①: two distinct mechanisms (tool_result_cap.TRIGGER_CAP — write-time
+    # size gate; TRIGGER_OVERFLOW — reactive same-turn spill, #5296 PR-2) emit
+    # this SAME kind through one shared emit site. `trigger` is mandatory so a
+    # reader distinguishing the two never has to infer which one fired from
+    # context (chain_id presence, call ordering, ...).
+    "tool_result_offloaded": frozenset({"trigger"}),
     # #5067: same shape as the two above, on the OTHER band pairing
     # (cost-budget x audit-events, not permission x audit-events) — a
     # management operation on the live BudgetTracker's hard caps

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -254,7 +254,7 @@ class ContextBudgetAdvisor:
         store = self._media_store
         if store is None:
             return content_str
-        from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+        from reyn.runtime.services.tool_result_cap import TRIGGER_CAP, cap_tool_result_content
 
         use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
         cfg = self._offload_config
@@ -262,6 +262,7 @@ class ContextBudgetAdvisor:
             content_str,
             cap_tokens=self.per_turn_cap_tokens(),
             model=self._model,
+            trigger=TRIGGER_CAP,
             save_fn=store.save_tool_result,
             use_chars4=use_chars4,
             events=self._events,

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -1209,7 +1209,10 @@ class RouterHistoryBuffer:
             return None
         import hashlib
 
-        from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+        from reyn.runtime.services.tool_result_cap import (
+            TRIGGER_OVERFLOW,
+            cap_tool_result_content,
+        )
 
         def _save(c: "str | dict", **kw: Any) -> dict:
             return self._media_store.save_tool_result(
@@ -1220,6 +1223,7 @@ class RouterHistoryBuffer:
             content,
             cap_tokens=1,
             model=self._model,
+            trigger=TRIGGER_OVERFLOW,
             save_fn=_save,
             use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
             events=self._events,

--- a/src/reyn/runtime/services/tool_result_cap.py
+++ b/src/reyn/runtime/services/tool_result_cap.py
@@ -50,6 +50,16 @@ _PREVIEW_TAIL_CHARS: int = 2_000
 ALPHA: float = 0.5
 FIXED_CEIL_TOKENS: int = 4096
 
+# #5367①: the two callers of this module drive genuinely different mechanisms —
+# TRIGGER_CAP is the write-time size gate (the config-default-off offload path,
+# ``ContextBudgetAdvisor.cap_tool_result``); TRIGGER_OVERFLOW is the reactive
+# same-turn spill a compaction/token-budget overflow provokes
+# (``RouterHistoryBuffer.spill_turn_content``, #5296 PR-2). Named constants
+# (not ad hoc strings at each call site) so a future third caller cannot invent
+# its own spelling of either value.
+TRIGGER_CAP: str = "cap"
+TRIGGER_OVERFLOW: str = "overflow"
+
 
 def compute_cap_tokens(
     effective_trigger: int,
@@ -74,6 +84,7 @@ def cap_tool_result_content(
     cap_tokens: int,
     model: str,
     save_fn: Callable[..., dict],
+    trigger: str,
     use_chars4: bool = False,
     events: Any = None,
     content_type: "str | None" = None,
@@ -98,6 +109,10 @@ def cap_tool_result_content(
                       least ``"path"`` (project-relative, read back via
                       ``read_file``) and ``"content_hash"``. In production this is
                       ``MediaStore.save_tool_result`` (the #385 store) — lossless.
+        trigger:      (#5367①) Which mechanism drove this call — :data:`TRIGGER_CAP`
+                      (write-time size gate) or :data:`TRIGGER_OVERFLOW` (reactive
+                      same-turn spill). No default: a caller that forgets it gets a
+                      ``TypeError``, not a silently-unlabelled audit event.
         use_chars4:   Match the engine's token estimator (``cfg.use_chars4_estimate``)
                       so the size measurement is unit-consistent with the
                       ``effective_trigger`` budget the cap is derived from.
@@ -197,6 +212,7 @@ def cap_tool_result_content(
             cap_tokens=cap_tokens,
             ref=ref,
             content_hash=content_hash,
+            trigger=trigger,
         )
     if on_offload is not None:
         on_offload(ref)

--- a/tests/core/test_2663_present_content_type_sidecar.py
+++ b/tests/core/test_2663_present_content_type_sidecar.py
@@ -28,7 +28,7 @@ from reyn.core.op_runtime.present import handle
 from reyn.core.present.source import resolve_present_source
 from reyn.data.workspace.media_store import MediaStore, mime_type_for_ext
 from reyn.data.workspace.workspace import Workspace
-from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.runtime.services.tool_result_cap import TRIGGER_CAP, cap_tool_result_content
 from reyn.schemas.models import PresentIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
@@ -149,14 +149,14 @@ def test_cap_tool_result_content_type_drives_stored_ref_extension(tmp_path: Path
 
     out_md = cap_tool_result_content(
         big, cap_tokens=64, model=_MODEL, save_fn=store.save_tool_result,
-        use_chars4=True, content_type="text/markdown",
+        trigger=TRIGGER_CAP, use_chars4=True, content_type="text/markdown",
     )
     ref_md = _ref_from(out_md)
     assert ref_md.endswith(".md"), f"declared text/markdown must drive a .md ref, got {ref_md}"
 
     out_plain = cap_tool_result_content(
         big, cap_tokens=64, model=_MODEL, save_fn=store.save_tool_result,
-        use_chars4=True, content_type=None,
+        trigger=TRIGGER_CAP, use_chars4=True, content_type=None,
     )
     ref_plain = _ref_from(out_plain)
     assert ref_plain.endswith(".txt"), "no declared content_type -> unchanged .txt default"

--- a/tests/core/test_offload_config_gate_pr3.py
+++ b/tests/core/test_offload_config_gate_pr3.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from reyn.config import CompactionConfig, OffloadConfig, _build_offload_config
+from reyn.core.events.events import EventLog
 from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
 from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
 from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
@@ -32,13 +33,15 @@ def _write_yaml(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-def _advisor(*, offload_config: OffloadConfig, media_store=None) -> ContextBudgetAdvisor:
+def _advisor(
+    *, offload_config: OffloadConfig, media_store=None, events=None,
+) -> ContextBudgetAdvisor:
     return ContextBudgetAdvisor(
         compaction=CompactionConfig(),
         compaction_controller=None,  # → effective_trigger straight from the model window
         media_store=media_store,
         model_fn=lambda: "openai/gpt-4o",
-        events=None,
+        events=events,
         history_fn=lambda: [],
         offload_config=offload_config,
     )
@@ -97,6 +100,30 @@ def test_offload_enabled_opted_in_caps_oversized_text(tmp_path):
     capped = advisor.cap_tool_result(oversized)
     assert capped != oversized
     assert len(capped) < len(oversized)
+
+
+def test_cap_tool_result_offload_event_names_trigger_cap(tmp_path):
+    """Tier 2: #5367①/BLOCKING witness — the REAL production wiring
+    (``ContextBudgetAdvisor.cap_tool_result``, no fake collaborator) names
+    its ``tool_result_offloaded`` event's ``trigger`` as ``"cap"``.
+
+    Strip-falsify: swapping ``TRIGGER_CAP``/``TRIGGER_OVERFLOW`` in
+    ``context_budget_advisor.py`` turns this RED (the event would carry
+    ``"overflow"`` instead) — this is exactly the witness the earlier
+    version of #5375 lacked (a test that calls
+    ``cap_tool_result_content`` directly and supplies its own ``trigger``
+    can't catch a wiring swap in the real caller)."""
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path, session_id="test-session")
+    events = EventLog()
+    seen: list = []
+    events.add_subscriber(lambda e: seen.append(e))
+    advisor = _advisor(offload_config=OffloadConfig(enabled=True), media_store=store, events=events)
+
+    advisor.cap_tool_result("x" * 200_000)
+
+    offloaded = [e for e in seen if e.type == "tool_result_offloaded"]
+    assert offloaded, "test setup sanity: the oversized content must have been offloaded"
+    assert offloaded[0].data["trigger"] == "cap"
 
 
 # ── Tier 2: gate 2 — structured inline gate (build_offload_body) ───────────

--- a/tests/core/test_offload_unify_3580.py
+++ b/tests/core/test_offload_unify_3580.py
@@ -32,6 +32,7 @@ from reyn.core.offload.seam import build_offload_body
 from reyn.core.op_runtime.web import handle_web_fetch
 from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
 from reyn.runtime.services.tool_result_cap import (
+    TRIGGER_CAP,
     cap_tool_result_content,
     compute_cap_tokens,
 )
@@ -187,10 +188,10 @@ def test_the_inline_preview_size_follows_its_config() -> None:
         return {"path": ".reyn/tool-results/x.txt"}
 
     shipped = cap_tool_result_content(
-        body, cap_tokens=100, model="openai/gpt-4o", save_fn=_save
+        body, cap_tokens=100, model="openai/gpt-4o", save_fn=_save, trigger=TRIGGER_CAP,
     )
     tuned = cap_tool_result_content(
-        body, cap_tokens=100, model="openai/gpt-4o", save_fn=_save,
+        body, cap_tokens=100, model="openai/gpt-4o", save_fn=_save, trigger=TRIGGER_CAP,
         preview_head_chars=100, preview_tail_chars=50,
     )
 

--- a/tests/runtime/test_2425_step1c_chat_chokepoint.py
+++ b/tests/runtime/test_2425_step1c_chat_chokepoint.py
@@ -16,7 +16,7 @@ import yaml
 
 from reyn.data.workspace.media_store import MediaStore
 from reyn.runtime.router_loop import RouterLoop
-from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.runtime.services.tool_result_cap import TRIGGER_CAP, cap_tool_result_content
 from reyn.tools.scheme import ExecutionResult
 
 _MODEL = "gpt-4o"
@@ -47,7 +47,7 @@ class _CapHost:
             return content_str
         return cap_tool_result_content(
             content_str, cap_tokens=100, model=_MODEL, save_fn=self.media_store.save_tool_result,
-            use_chars4=True, content_type=content_type, on_offload=on_offload,
+            trigger=TRIGGER_CAP, use_chars4=True, content_type=content_type, on_offload=on_offload,
             on_write_unavailable=on_write_unavailable,
         )
 

--- a/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
+++ b/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
@@ -743,6 +743,35 @@ def test_run_with_shrink_wires_spill_fn_into_retry_loop(
 
 
 @pytest.mark.asyncio
+async def test_spill_turn_content_offload_event_names_trigger_overflow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5367①/BLOCKING witness — the REAL production wiring
+    (``RouterHistoryBuffer.spill_turn_content``, driven through
+    ``RouterLoopDriver._attempt_reactive_spill``, no fake collaborator)
+    names its ``tool_result_offloaded`` event's ``trigger`` as ``"overflow"``.
+
+    Strip-falsify: swapping ``TRIGGER_CAP``/``TRIGGER_OVERFLOW`` in
+    ``router_history_buffer.py`` turns this RED (the event would carry
+    ``"cap"`` instead)."""
+    session = _make_spill_session(tmp_path, monkeypatch, t_max=2_500)
+    events: list = []
+    session._audit_events.add_subscriber(lambda e: events.append(e))
+
+    _push(session, "tool", "huge tool result " + "z" * 5_000, tool_call_id="tc-1", name="tool")
+    for i in range(20):
+        _push(session, "user", f"filler question number {i} " * 8)
+        _push(session, "assistant", f"filler answer number {i} " * 8)
+
+    await session._loop_driver._attempt_reactive_spill("continue", chain_id="c1")
+    await session._audit_events.drain()
+
+    offloaded = [e for e in events if e.type == "tool_result_offloaded"]
+    assert offloaded, "test setup sanity: at least one candidate must have been spilled"
+    assert offloaded[0].data["trigger"] == "overflow"
+
+
+@pytest.mark.asyncio
 async def test_a_mid_spill_is_kept_even_though_it_moves_zero_bytes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runtime/test_5364_media_store_flush_barrier.py
+++ b/tests/runtime/test_5364_media_store_flush_barrier.py
@@ -28,7 +28,7 @@ from reyn.data.workspace.media_store import MediaStore
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.router_loop import RouterLoop
-from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.runtime.services.tool_result_cap import TRIGGER_CAP, cap_tool_result_content
 from reyn.tools.scheme import ExecutionResult
 from tests._support.router_loop import FakeRouterHost
 
@@ -80,7 +80,7 @@ class _MediaStoreHost(FakeRouterHost):
     ) -> str:
         return cap_tool_result_content(
             content_str, cap_tokens=100, model=_MODEL,
-            save_fn=self.media_store.save_tool_result,
+            save_fn=self.media_store.save_tool_result, trigger=TRIGGER_CAP,
             use_chars4=True, content_type=content_type, on_offload=on_offload,
             on_write_unavailable=on_write_unavailable,
         )

--- a/tests/runtime/test_5364_spilled_meta_wiring.py
+++ b/tests/runtime/test_5364_spilled_meta_wiring.py
@@ -16,7 +16,7 @@ from reyn.config.chat import OffloadConfig
 from reyn.data.workspace.media_store import MediaStore
 from reyn.runtime.chat_message import CONTENT_REF_META_KEY, SPILLED_META_KEY
 from reyn.runtime.router_loop import RouterLoop
-from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.runtime.services.tool_result_cap import TRIGGER_CAP, cap_tool_result_content
 from reyn.tools.scheme import ExecutionResult
 from tests._support.agent_session import make_session
 
@@ -53,7 +53,7 @@ class _RecordingHost:
             return content_str
         return cap_tool_result_content(
             content_str, cap_tokens=100, model=_MODEL,
-            save_fn=self.media_store.save_tool_result,
+            save_fn=self.media_store.save_tool_result, trigger=TRIGGER_CAP,
             use_chars4=True, content_type=content_type, on_offload=on_offload,
             on_write_unavailable=on_write_unavailable,
         )

--- a/tests/runtime/test_5364_write_unavailable_keeps_content_inline.py
+++ b/tests/runtime/test_5364_write_unavailable_keeps_content_inline.py
@@ -38,7 +38,7 @@ from reyn.runtime.chat_message import (
     SPILLED_META_KEY,
 )
 from reyn.runtime.router_loop import RouterLoop
-from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.runtime.services.tool_result_cap import TRIGGER_CAP, cap_tool_result_content
 from reyn.tools.scheme import ExecutionResult
 from tests._support.agent_session import make_session
 
@@ -104,7 +104,7 @@ def test_cap_tool_result_content_keeps_content_inline_on_write_unavailable() -> 
 
     result = cap_tool_result_content(
         big, cap_tokens=10, model=_MODEL, save_fn=_always_unavailable,
-        use_chars4=True, events=events,
+        trigger=TRIGGER_CAP, use_chars4=True, events=events,
         on_write_unavailable=lambda: calls.append(None),
     )
 

--- a/tests/services/test_tool_result_cap_1128.py
+++ b/tests/services/test_tool_result_cap_1128.py
@@ -119,7 +119,7 @@ def test_trigger_is_required_no_default(tmp_path: Path) -> None:
     unlabelled audit event. A caller that forgets it fails loudly at the call
     site, before any offload/emit happens."""
     store = MediaStore(project_root=tmp_path, session_id="test-session")
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="trigger"):
         cap_tool_result_content(  # type: ignore[call-arg]
             "X" * 100_000, cap_tokens=64, model=_MODEL,
             save_fn=store.save_tool_result, use_chars4=True,

--- a/tests/services/test_tool_result_cap_1128.py
+++ b/tests/services/test_tool_result_cap_1128.py
@@ -26,9 +26,12 @@ from pathlib import Path
 
 import pytest
 
+from reyn.core.events.events import EventLog
 from reyn.data.workspace.media_store import MediaStore
 from reyn.runtime.services.tool_result_cap import (
     MAX_TOOL_RESULT_INLINE_BYTES,
+    TRIGGER_CAP,
+    TRIGGER_OVERFLOW,
     cap_tool_result_content,
     compute_cap_tokens,
 )
@@ -50,7 +53,7 @@ def test_under_cap_content_is_identity(tmp_path: Path) -> None:
     content = "small tool result"
     out = cap_tool_result_content(
         content, cap_tokens=2048, model=_MODEL,
-        save_fn=store.save_tool_result, use_chars4=True,
+        save_fn=store.save_tool_result, trigger=TRIGGER_CAP, use_chars4=True,
     )
     assert out == content
     # Nothing stored when under cap.
@@ -70,7 +73,7 @@ def test_over_cap_preview_is_within_cap_tokens(tmp_path: Path, cap_tokens: int) 
     content = "X" * 400_000  # ~100k tokens (chars//4) — far over any cap
     out = cap_tool_result_content(
         content, cap_tokens=cap_tokens, model=_MODEL,
-        save_fn=store.save_tool_result, use_chars4=True,
+        save_fn=store.save_tool_result, trigger=TRIGGER_CAP, use_chars4=True,
     )
     assert out != content, "oversized content must be offloaded, not returned raw"
     assert estimate_tokens(out, _MODEL, use_chars4=True) <= cap_tokens, (
@@ -91,7 +94,7 @@ def test_offloaded_body_reads_back_lossless(tmp_path: Path) -> None:
     content = "LINE\n" * 50_000  # large, distinctive
     out = cap_tool_result_content(
         content, cap_tokens=512, model=_MODEL,
-        save_fn=store.save_tool_result, use_chars4=True,
+        save_fn=store.save_tool_result, trigger=TRIGGER_CAP, use_chars4=True,
     )
     ref = _ref_from_preview(out)
 
@@ -106,9 +109,41 @@ def test_cap_disabled_when_zero(tmp_path: Path) -> None:
     content = "Y" * 100_000
     out = cap_tool_result_content(
         content, cap_tokens=0, model=_MODEL,
-        save_fn=store.save_tool_result, use_chars4=True,
+        save_fn=store.save_tool_result, trigger=TRIGGER_CAP, use_chars4=True,
     )
     assert out == content
+
+
+def test_trigger_is_required_no_default(tmp_path: Path) -> None:
+    """Tier 2: #5367① — omitting ``trigger`` is a ``TypeError``, not a silently
+    unlabelled audit event. A caller that forgets it fails loudly at the call
+    site, before any offload/emit happens."""
+    store = MediaStore(project_root=tmp_path, session_id="test-session")
+    with pytest.raises(TypeError):
+        cap_tool_result_content(  # type: ignore[call-arg]
+            "X" * 100_000, cap_tokens=64, model=_MODEL,
+            save_fn=store.save_tool_result, use_chars4=True,
+        )
+
+
+@pytest.mark.parametrize("trigger", [TRIGGER_CAP, TRIGGER_OVERFLOW])
+def test_offload_event_carries_the_trigger_it_was_given(tmp_path: Path, trigger: str) -> None:
+    """Tier 2: #5367① — the ``tool_result_offloaded`` audit event's ``trigger``
+    field is exactly the value the caller passed (real EventLog, no mock)."""
+    store = MediaStore(project_root=tmp_path, session_id="test-session")
+    events = EventLog()
+    seen: list = []
+    events.add_subscriber(lambda e: seen.append(e))
+
+    cap_tool_result_content(
+        "X" * 100_000, cap_tokens=64, model=_MODEL,
+        save_fn=store.save_tool_result, trigger=trigger, use_chars4=True,
+        events=events,
+    )
+
+    offloaded = [e for e in seen if e.type == "tool_result_offloaded"]
+    assert offloaded, "the oversized content must have been offloaded (test setup sanity)"
+    assert offloaded[0].data["trigger"] == trigger
 
 
 # ── load-bearing integration: capped turn folds via retry_loop, uncapped dead-ends ──
@@ -230,7 +265,7 @@ def test_capped_tool_turn_folds_via_retry_loop_without_overflow(tmp_path: Path) 
     capped = cap_tool_result_content(
         "Z" * 80_000,  # ~20k tokens — far over B_M=8000, the dead-end shape
         cap_tokens=cap_tokens, model=_MODEL,
-        save_fn=store.save_tool_result, use_chars4=True,
+        save_fn=store.save_tool_result, trigger=TRIGGER_CAP, use_chars4=True,
     )
     assert estimate_tokens(capped, _MODEL, use_chars4=True) < _budgets().B_M, (
         "precondition: the capped turn must fit the compaction budget"


### PR DESCRIPTION
**[tui-coder]** — part of #5367 (①)

## What

`tool_result_offloaded` is emitted from one shared site (`tool_result_cap.py`) by two distinct mechanisms — the write-time size gate (`ContextBudgetAdvisor.cap_tool_result`) and the reactive same-turn spill (`RouterHistoryBuffer.spill_turn_content`, #5296 PR-2). #5367's enumeration (issuecomment-5447482355) found no field distinguishing which one fired, and no reader that disambiguates them today.

- `cap_tool_result_content` gains a required keyword-only `trigger` param — **no default**, so an omitted `trigger` is a `TypeError` at the call site, not a silently-unlabelled audit event.
- `TRIGGER_CAP` / `TRIGGER_OVERFLOW` — named constants, not ad hoc strings at each call site.
- `event_schema.EVENT_AUDIT_REQUIREMENTS["tool_result_offloaded"] = frozenset({"trigger"})` — aligns the schema registry (previously `tool_result_offloaded` had no requirements entry at all).
- Both production call sites updated (`context_budget_advisor.py` → `TRIGGER_CAP`, `router_history_buffer.py` → `TRIGGER_OVERFLOW`); all 9 test call sites updated to pass a constant.

## Scope

Only the `trigger` addition and its wiring — no change to offload/spill behavior, cap computation, or preview construction.

## Test plan

- [x] `ruff check` on all 8 changed files — clean
- [x] `python scripts/test_tier_audit.py --strict` on the 3 changed test files — 27/27 OK
- [x] `python scripts/mypy_ratchet.py` — OK, baselined
- [x] `python scripts/flat_tests_ratchet.py` — OK, baselined
- [x] `python scripts/check_tests_path_literal_reference.py` — OK, baselined
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/verify_module_docstrings.py` on the 4 changed src files — OK
- [x] New witness tests: `test_trigger_is_required_no_default` (TypeError on omission), `test_offload_event_carries_the_trigger_it_was_given` (real EventLog, parametrized cap/overflow), `test_cap_tool_result_offload_event_names_trigger_cap` + `test_spill_turn_content_offload_event_names_trigger_overflow` (real-collaborator wiring witnesses, added to clear BLOCKING below)
- [x] `pytest tests/runtime tests/services tests/core -k "tool_result or budget_advisor or history_buffer or 5296 or offload or event_schema or audit_event"` — 177 passed
- [ ] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Blocking points

- [x] 🔴 **production の 2 箇所に witness が在りません — 2 つの定数を入れ替えても全部緑です。** test は全て `cap_tool_result_content(...)` を直接呼び `trigger=` を自分で渡すので、**`context_budget_advisor.py` の `TRIGGER_CAP` と `router_history_buffer.py` の `TRIGGER_OVERFLOW` を入れ替えても RED になりません**。そのとき**先回り cap が「overflow」と名乗り、事後 spill が「cap」と名乗る** ＝ **consumer は確信を持って誤り、`trigger` が無い今より悪くなります**。**受入: 実物の呼び手 2 つを通す test を各 1 本**（①`ContextBudgetAdvisor.cap_tool_result` → `trigger == "cap"` ②`RouterHistoryBuffer.spill_turn_content` → `trigger == "overflow"`）。⚠️ **fake で置き換えないこと**（家則「cheaply constructible なら fake するな」／先例 `tests/_support/router_host_adapter.py` 逐語「real collaborators (no mocks)」）。🔴 **strip-falsify は「2 つの定数を入れ替えて RED か」— これが判別子です。** ⚪ **この要求を最初の発注文に書かなかったのは私の落ち度です。** 根拠: PR comment（BLOCKING）

