### PR TITLE
fix(#5367②): correct 3 false runtime-ordering assertions in code

### DIFF
--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -870,9 +870,14 @@ class RouterHistoryBuffer:
           duplication) — plus the summary bridge, if any.
         - Else: elide the middle of the (already watermark-filtered) turns
           — head (trim_head) + tail (trim_tail) — plus the summary bridge,
-          if any. The pre-frame guard ``maybe_force_compact`` has already
-          compacted the middle before this runs, so the elide point is
-          structurally aligned.
+          if any. #5367②: the pre-frame guard ``maybe_force_compact``
+          (``router_loop_driver.py``) runs exactly ONCE, at the head of the
+          turn, before this method's FIRST call in that turn — so alignment
+          holds THEN, but this method has no way to know it is being called
+          again. A turn whose history is built more than once (a
+          shrink-ladder retry, a re-send) re-enters this elide logic with
+          no fresh ``maybe_force_compact`` run in between — nothing in this
+          file, or the call site, re-triggers it.
 
         Overlap guard: if trim_head and trim_tail collectively cover all
         turns (the chat is small relative to budgets but total > trigger —

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -2418,12 +2418,21 @@ async def retry_loop(
                 # False the only value this raise can ever carry, not an
                 # unreachable branch where the default happens not to
                 # matter.
+                # #5367②: the OLD text past this point claimed "shrinking is
+                # not resolving this cause" without qualification — false in
+                # the same way #5367①'s neighboring fix was: "shrinking" here
+                # names only the turn-count-reduction ladder this loop
+                # attempted (head/tail trim, halving raw_middle); it does not
+                # cover spilling a turn's CONTENT (replacing an oversized
+                # tool-result body with a ref), which this cap never tries
+                # before giving up (#5367③).
                 raise UnrecoveredError(
                     f"retry_loop: cause {_cause!r} recovered "
                     f"{_consecutive_same_cause} consecutive times (limit "
-                    f"{_MAX_CONSECUTIVE_SAME_CAUSE_RECOVERS}) — shrinking is "
-                    "not resolving this cause; stopping rather than "
-                    "exhausting max_iterations."
+                    f"{_MAX_CONSECUTIVE_SAME_CAUSE_RECOVERS}) — the "
+                    "turn-count shrink ladder attempted is not resolving "
+                    "this cause (content-level spill was not tried here); "
+                    "stopping rather than exhausting max_iterations."
                 ) from _overflow_exc
 
         # Shrink escalation: reduce context size monotonically.

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -2478,12 +2478,23 @@ async def retry_loop(
                 # cause on its own, with an accurate message, independent
                 # of this floor (predates this arc).
                 if _last_recover_is_byte_limit:
+                    # #5367②: the OLD text past this point claimed
+                    # "shrinking it further is not possible" — false. Only
+                    # the TURN-COUNT floor is reached here (mid is already
+                    # one turn; halving cannot produce a smaller nonzero
+                    # slice, #4947 ③). Nothing checked here about whether
+                    # mid's CONTENT could still shrink — a turn whose body
+                    # is a spillable tool result (owner: "spill は turn の
+                    # 中身を小さくします — 分割ではなく縮小") could still be
+                    # reduced without splitting it into more turns; this
+                    # retry_loop does not attempt that today (tracked as
+                    # #5367③).
                     raise UnrecoveredError(
                         "retry_loop: HTTP 413 (a request-BODY-BYTE limit) "
                         "recurred compacting a single raw_middle turn "
-                        "alone — mid cannot be split any further; this is "
-                        "not a token-shrink problem, shrinking it further "
-                        "is not possible." + _learned_byte_limit_clause(
+                        "alone — mid cannot be split any further (this is "
+                        "the turn-count floor, not a claim that mid's "
+                        "content is already minimal)." + _learned_byte_limit_clause(
                             last_accepted_wire_bytes=_last_accepted_wire_bytes,
                             last_rejected_wire_bytes=_last_rejected_wire_bytes,
                         ),


### PR DESCRIPTION
**[tui-coder]** — part of #5367 (②)

## What

#5367's sweep (issuecomment-5447177228) found 195 comment/docstring/exception-message assertions of runtime ordering/impossibility without judging their truth. lead-coder judged 3 of them false — this PR corrects those 3, keeping the load-bearing comment in place and writing what's actually true instead (per house policy: don't delete, say what's true).

1. **`router_history_buffer.py:873-875`** — "the pre-frame guard `maybe_force_compact` has already compacted the middle before this runs" holds for `build_history`'s FIRST call in a turn, but `maybe_force_compact` runs exactly once per turn (`router_loop_driver.py:785`) while `build_history` can run again within the same turn (a shrink-ladder retry) with no fresh compaction pass in between.

2. **`engine.py`, `UnrecoveredError` (byte-limit mid-split floor)** — "shrinking it further is not possible" conflated the TURN-COUNT floor (mid is already one turn — true) with a claim that mid's CONTENT is already minimal (not established). A spillable tool-result body inside that turn could still shrink without splitting it into more turns; `retry_loop` doesn't attempt that today (tracked separately as #5367③).

3. **`engine.py`, `UnrecoveredError` (same-cause-recovery cap)** — "shrinking is not resolving this cause" made the same conflation as ②: only the turn-count-reduction ladder was tried, not content-level spill.

## Scope

Prose-only — no behavior change. Each fix preserves the substring existing tests assert on (`"mid cannot be split any further"`, `"consecutive times"`) and only corrects the false trailing clause.

## Test plan

- [x] `ruff check` on both changed files — clean
- [x] `python scripts/mypy_ratchet.py` — OK, baselined
- [x] `python scripts/verify_module_docstrings.py` on both changed files — OK
- [x] `pytest tests/services tests/runtime tests/llm -k "compaction or retry_loop or history_buffer or engine or 5296 or 4947 or unrecovered"` — 179 passed (includes the exact tests asserting on the preserved substrings, `test_pr_n6_compaction_overflow_retry.py` and `test_5329_compact_quota_not_wastefully_shrunk.py`)
- [ ] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
