### PR TITLE
feat(#5364): §1.4 — save_tool_result's disk write moves off the event loop

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -70,13 +70,18 @@ Out of scope (= future work):
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from reyn.services.offload.store import offload_value, read_offloaded
+
+if TYPE_CHECKING:
+    from reyn.core.events.durability_worker import DurabilityWorker
 
 #: #4381: one JSON object per line (``{"path": "<absolute path>"}``), one
 #: line per :meth:`MediaStore.save_tool_result` write — the persisted
@@ -374,9 +379,24 @@ class MediaStore:
         agent_name: str | None = None,
         base_url: str | None = None,
         session_id: str,
+        worker: "DurabilityWorker | None" = None,
     ) -> None:
         self._config = config or MediaStoreConfig()
         self._project_root = project_root.resolve()
+        # #5364 §1.4 (owner: "UIを止めさせたくない" — a synchronous tool-result
+        # write can stall the event loop, same class of problem #1765 fixed
+        # for the WAL; see :meth:`save_tool_result`'s own docstring). Same
+        # lazy-default shape as EventStore's own worker (event_store.py) —
+        # this store's writes have no ordering dependency on the WAL's, so a
+        # DEDICATED worker (not the session's shared one) keeps the two
+        # substrates decoupled, matching EventStore's own precedent rather
+        # than StateLog's cross-substrate ``submit_durable`` sharing (that
+        # sharing exists because a snapshot's ``applied_seq`` must never
+        # precede the WAL entry it names — no such dependency here).
+        if worker is None:
+            from reyn.core.events.durability_worker import DurabilityWorker
+            worker = DurabilityWorker()
+        self._worker = worker
         self._media_dir = (
             self._project_root / self._config.media_dir
         ).resolve()
@@ -401,11 +421,13 @@ class MediaStore:
         ).resolve()
         # #5364 (lead-coder review, PR #5369): NO default here — a
         # forgotten session_id must never silently resolve to some OTHER
-        # real session's directory. `None` is a legitimate value for a
-        # read-only construction (4 of production's 5 construction sites
-        # never write a tool result at all, per that same review); it is
-        # only an error at the one point that actually needs it — see
-        # :meth:`_history_content_dir`.
+        # real session's directory. Required kwarg (option (a) of the
+        # two the review offered): a construction site with nothing real
+        # to pass (4 of production's 5 sites never write a tool result at
+        # all) supplies a self-documenting placeholder (e.g.
+        # ``"<read-only>"``) rather than omitting it — omitting it is a
+        # TypeError at construction, not a silent write into another
+        # session's directory.
         self._session_id = session_id
         self._agent_name = agent_name or None
         # #385 β sub-task 3b: when set, save_* augments path-refs with a
@@ -669,6 +691,11 @@ class MediaStore:
             preview_strategy=None,
             filename=filename,
             payload_field=payload_field,
+            # #5364 §1.4: the actual disk write moves off the event loop
+            # (fire-and-forget, serial FIFO) — see :meth:`flush`'s own
+            # docstring for the barrier this relies on to make the write
+            # observable before anything could try to read it back.
+            submit_nowait=self._submit_write_or_inline,
         )
 
         # Convert absolute path_ref to project-relative path for the block.
@@ -678,21 +705,41 @@ class MediaStore:
         # THIS process or a LATER one (a reference to it can sit in
         # ``history.jsonl`` past a restart) — can detect it's re-reading a
         # spill artifact (see :meth:`is_tool_result_spill`'s own
-        # docstring for why). The in-memory set update and the manifest
-        # append are independent, best-effort: a manifest-write failure
-        # (e.g. a read-only ``tool_results_dir``) must never fail the
-        # spill write itself, which is the load-bearing operation here —
-        # it only means a FUTURE process's guard won't recognize this one
-        # path, not that this write failed.
+        # docstring for why). The in-memory set update is immediate
+        # (in-memory, no I/O, no ordering hazard — protects a re-read
+        # within THIS same turn even before the content write is durable).
+        # The manifest append is independent, best-effort: a manifest-
+        # write failure (e.g. a read-only ``tool_results_dir``) must never
+        # fail the spill write itself, which is the load-bearing operation
+        # here — it only means a FUTURE process's guard won't recognize
+        # this one path, not that this write failed.
+        #
+        # #5364 §1.4: submitted via the SAME deferral path as the content
+        # write above, ALWAYS after it (same worker, FIFO-serial — see
+        # ``DurabilityWorker``'s own "enqueue order = durability order"
+        # guarantee) — never inline-synchronous here. `_load_spill_
+        # manifest`'s self-prune (see its own docstring) drops any entry
+        # whose target file doesn't exist ON DISK YET; writing this line
+        # before the content write actually landed would let a FRESH
+        # MediaStore instance's self-prune permanently discard a
+        # perfectly-good, merely-still-queued entry — ordering, not just
+        # eventual completion, is what this file's manifest contract needs.
         resolved_path = abs_path.resolve()
         self._tool_result_spill_paths.add(resolved_path)
-        try:
-            manifest_path = self._spill_manifest_path()
-            manifest_path.parent.mkdir(parents=True, exist_ok=True)
-            with manifest_path.open("a", encoding="utf-8") as f:
-                f.write(json.dumps({"path": str(resolved_path)}) + "\n")
-        except OSError:
-            pass
+
+        async def _write_manifest_line(_resolved_path: Path = resolved_path) -> None:
+            try:
+                manifest_path = self._spill_manifest_path()
+                manifest_path.parent.mkdir(parents=True, exist_ok=True)
+                line = json.dumps({"path": str(_resolved_path)}) + "\n"
+
+                def _append() -> None:
+                    with manifest_path.open("a", encoding="utf-8") as f:
+                        f.write(line)
+                await asyncio.to_thread(_append)
+            except OSError:
+                pass
+        self._submit_write_or_inline(_write_manifest_line)
         block: dict = {
             "type": "tool_result_ref",
             "path": rel_path,
@@ -701,6 +748,54 @@ class MediaStore:
         }
         self._attach_cross_host_fields(block, filename=filename, chain_id=chain_id)
         return block
+
+    def _submit_write_or_inline(self, do_write) -> None:
+        """#5364 §1.4: ``DurabilityWorker.submit_nowait`` requires a RUNNING
+        event loop (it binds its queue to one) — but ``save_tool_result``
+        has always been callable from a plain synchronous context (a CLI
+        script, ``reyn doctor``, a sync test with no ``asyncio.run``
+        wrapper), and every real chat turn's own call is already inside one
+        (``RouterLoop.feedback`` runs on ``_run_execute_round``'s live
+        loop). Rather than making every sync caller responsible for
+        spinning one up, this checks: a loop is running → defer via the
+        worker (the off-loop win this section exists for); no loop running →
+        run ``do_write`` inline via ``asyncio.run`` (byte-identical to the
+        pre-#5364-§1.4 synchronous write — a script/test never sees this
+        move as a behaviour change, only chat turns do)."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(do_write())
+        else:
+            self._worker.submit_nowait(do_write)
+
+    async def flush(self) -> None:
+        """#5364 §1.4: wait until every enqueued :meth:`save_tool_result`
+        write has actually landed on disk — WITHOUT closing the worker.
+
+        This is the ONE barrier the fire-and-forget write above relies on:
+        the router loop calls this once per turn, right before the NEXT LLM
+        call (never per-write — see ``router_loop.py``'s own call site) —
+        so by the time a ``read_file(path=<ref>)`` tool call could possibly
+        reach the model (it can only follow a completion the model has
+        already seen the ref in), the write behind that ref is guaranteed
+        durable. Mirrors ``DurabilityWorker.flush``'s own contract exactly
+        (this store just owns a dedicated worker instance — see
+        :meth:`__init__`)."""
+        await self._worker.flush()
+
+    async def aclose(self) -> None:
+        """#5364 §1.4 (same class of gap #2783 named for ``EventStore``,
+        #4961 C for ``_audit_events`` — a 3rd instance): drain this store's
+        worker before the process exits. Without this, a normal session
+        shutdown can drop a still-queued ``save_tool_result`` write —
+        ``asyncio.run`` cancels outstanding tasks at loop teardown and this
+        write is fire-and-forget by construction. Called from the
+        registry's session-teardown seams alongside
+        ``aclose_event_store``/``aclose_audit_events`` — same pattern, same
+        call sites (``Session.aclose_media_store``). Idempotent
+        (``DurabilityWorker.aclose`` is idempotent)."""
+        await self._worker.aclose()
 
     def read_tool_result(self, path_str: str) -> tuple[str, bool]:
         """Read tool result text by project-relative path.

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1443,6 +1443,11 @@ class AgentRegistry:
             aclose_audit_events = getattr(session, "aclose_audit_events", None)
             if callable(aclose_audit_events):
                 await aclose_audit_events()
+            # #5364 §1.4: same teardown-completeness gap — a 5th instance
+            # (see Session.aclose_media_store's own docstring).
+            aclose_media_store = getattr(session, "aclose_media_store", None)
+            if callable(aclose_media_store):
+                await aclose_media_store()
         cascade_changes, vanished_sids = self.remove(name, purge=purge)
         if self._state_log is not None:
             await self._state_log.append(
@@ -2681,6 +2686,11 @@ class AgentRegistry:
             aclose_audit_events = getattr(session, "aclose_audit_events", None)
             if callable(aclose_audit_events):
                 await aclose_audit_events()
+            # #5364 §1.4: same teardown-completeness gap — a 5th instance
+            # (see Session.aclose_media_store's own docstring).
+            aclose_media_store = getattr(session, "aclose_media_store", None)
+            if callable(aclose_media_store):
+                await aclose_media_store()
             # #4215 ②: cancel this session's own hook-bus->parent bridge
             # task, if it is one (bridged children only —
             # session_api._spawn_pipeline_driver_session's attached path;

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1941,6 +1941,17 @@ class RouterLoop:
                     )
                     result = memo
             if result is None:
+                # #5364 §1.4: barrier for MediaStore's fire-and-forget
+                # tool-result writes (save_tool_result → submit_nowait) —
+                # ONCE per iteration, right here, immediately before the
+                # LLM actually sees this turn's history (both branches
+                # below reach the model). Not per-write: a per-write flush
+                # would reintroduce the very stall #5364 §1.4 moved the
+                # write off the loop to avoid. getattr-guarded — a host
+                # with no media_store (or an older host stub) is a no-op.
+                _media_store = getattr(host, "media_store", None)
+                if _media_store is not None:
+                    await _media_store.flush()
                 if _force_close_now:
                     # #1092 PR-C: replace the normal act-turn call with the wrap-up
                     # (force-close) call — swaps the SP for the wrap-up SP +

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -9644,6 +9644,19 @@ class Session:
         """
         await self._event_store.aclose()
 
+    async def aclose_media_store(self) -> None:
+        """#5364 §1.4 teardown: drain this session's MediaStore worker before
+        the process exits — the same class of gap #2783 named for
+        ``EventStore`` above, a 5th instance. Without this, a normal
+        session shutdown can drop a still-queued ``save_tool_result``
+        write (fire-and-forget by construction, #5364 §1.4). Idempotent
+        (``MediaStore.aclose`` → ``DurabilityWorker.aclose``, idempotent).
+        A no-op when this session has no media_store (``multimodal_config``
+        was never set).
+        """
+        if self._media_store is not None:
+            await self._media_store.aclose()
+
     async def aclose_audit_events(self) -> None:
         """#4961 C teardown: close this session's ``_audit_events`` EventLog
         before the process exits — the same class of gap #2783 named for

--- a/src/reyn/services/offload/store.py
+++ b/src/reyn/services/offload/store.py
@@ -35,6 +35,7 @@ bound.  Responsibility for bounding the inline preview lies with the CALLER:
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import uuid
@@ -71,6 +72,7 @@ def offload_value(
     preview_strategy: Callable[[Any, str], Any] | None = None,
     filename: str | None = None,
     payload_field: str | None = None,
+    submit_nowait: "Callable[[Callable[[], Any]], None] | None" = None,
 ) -> OffloadResult:
     """Write *value* to *store_dir* and return preview + path_ref + content_hash.
 
@@ -107,6 +109,19 @@ def offload_value(
                           Absent / field missing → the whole-value serialisation.
                           The preview (and thus the inline envelope) is always built
                           over the WHOLE *value*, unchanged.
+        submit_nowait:    #5364 §1.4 (owner: "UIを止めさせたくない" — a synchronous
+                          write on the event loop, e.g. onto slow/network storage,
+                          stalls the whole loop, same class of problem #1765 fixed
+                          for the WAL). When provided (a ``DurabilityWorker.
+                          submit_nowait``-shaped callable), the actual disk write
+                          is handed to it FIRE-AND-FORGET instead of running
+                          inline — everything else (hash, preview, the returned
+                          path_ref) is still computed synchronously, since
+                          ``serialized`` is already fully in memory before the
+                          write is enqueued; only the write's OWN latency moves
+                          off the loop. ``None`` (default) keeps the prior
+                          synchronous behaviour byte-identical — every caller but
+                          MediaStore's own chat axis.
 
     Returns:
         :class:`OffloadResult` with preview (or ``None``), path_ref, content_hash.
@@ -123,7 +138,12 @@ def offload_value(
         serialized = payload if isinstance(payload, str) else json.dumps(payload, ensure_ascii=False)
     else:
         serialized = json.dumps(value, ensure_ascii=False) if not isinstance(value, str) else value
-    dest.write_text(serialized, encoding="utf-8")
+    if submit_nowait is not None:
+        async def _write_job(_dest: Path = dest, _serialized: str = serialized) -> None:
+            await asyncio.to_thread(_dest.write_text, _serialized, encoding="utf-8")
+        submit_nowait(_write_job)
+    else:
+        dest.write_text(serialized, encoding="utf-8")
 
     path_ref = str(dest)
     content_hash = "sha256:" + hashlib.sha256(serialized.encode()).hexdigest()

--- a/tests/core/test_4381_read_char_offset_and_spill_guard.py
+++ b/tests/core/test_4381_read_char_offset_and_spill_guard.py
@@ -166,6 +166,12 @@ async def test_bare_reread_of_a_spilled_file_errors_with_the_remedy(tmp_path: Pa
     huge = "line content here, " * 5000  # large enough to force truncation on re-read
     block = store.save_tool_result(huge, tool="some_tool")
     spill_path = block["path"]  # project-relative, as a subsequent read_file would receive it
+    # #5364 §1.4: the actual disk write is now off-loop (fire-and-forget) —
+    # a real chat turn only ever re-reads a ref in a LATER LLM round (the
+    # model must see the ref before it can name it, and every round
+    # boundary passes through router_loop.py's own flush barrier first),
+    # so this durability wait is what a real read always gets for free.
+    await store.flush()
 
     result = await handle(
         FileIROp(kind="file", op="read", path=spill_path),
@@ -196,6 +202,13 @@ async def test_spill_guard_survives_a_fresh_media_store_instance(tmp_path: Path)
     huge = "line content here, " * 5000
     block = writer.save_tool_result(huge, tool="some_tool")
     spill_path = block["path"]
+    # #5364 §1.4: writer's own manifest-append is off-loop too (chained
+    # after the content write, same worker, FIFO — see save_tool_result's
+    # own comment) — a real restart only ever observes a manifest entry
+    # AFTER real wall-clock time has passed (process exit/relaunch), which
+    # this flush stands in for; a fresh instance racing the SAME process's
+    # still-in-flight write is not a scenario a real restart can produce.
+    await writer.flush()
 
     reader = MediaStore(project_root=tmp_path, session_id="test-session")  # a FRESH instance — simulates a new process
     assert reader.is_tool_result_spill(spill_path), (

--- a/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
+++ b/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
@@ -429,11 +429,24 @@ def test_spill_persists_into_the_next_turn_413_fires_once(
     _push(session, "assistant", "ok, done")
 
     loop1 = _ContentDrivenLoop(lambda history, user_text: _has_content(history, huge))
-    asyncio.run(
-        session._loop_driver._run_with_shrink_and_byte_reduction(
+
+    async def _turn1() -> None:
+        await session._loop_driver._run_with_shrink_and_byte_reduction(
             loop1, "continue please", chain_id="c1",
         )
-    )
+        # #5364 §1.4: the manifest append is now off-loop (fire-and-forget,
+        # chained after the content write on save_tool_result's own
+        # worker — see media_store.py's own comment on that ordering). A
+        # REAL turn's own retry always re-enters RouterLoop.run_loop
+        # before its next LLM call, which flushes this durable —
+        # _ContentDrivenLoop (this test's own docstring: "A fake
+        # RouterLoop") never does, so this test needs the same explicit
+        # flush a real turn gets for free. MUST run in the SAME
+        # asyncio.run (DurabilityWorker.flush() no-ops on a different
+        # loop than the one its queue is bound to — see its own guard).
+        await session._media_store.flush()
+
+    asyncio.run(_turn1())
     assert any(_has_content(c, huge) for c in loop1.calls[:-1]), (
         "control arm: turn 1 must have actually hit the 413 at least once "
         "before recovering, else this test cannot witness a difference"

--- a/tests/runtime/test_5364_media_store_flush_barrier.py
+++ b/tests/runtime/test_5364_media_store_flush_barrier.py
@@ -1,0 +1,160 @@
+"""Tier 2: #5364 §1.4 — ``MediaStore.save_tool_result``'s actual disk write
+moves OFF the event loop (owner: "UIを止めさせたくない" — a synchronous write
+onto slow/network storage stalls the whole loop, the same class of problem
+#1765 fixed for the WAL). ``DurabilityWorker.submit_nowait`` enqueues it
+fire-and-forget; the ONE barrier that makes the write observable again is
+``router_loop.py``'s own ``run_loop`` — once per iteration, right before the
+LLM sees this turn's history, never per-write (a per-write flush would
+reintroduce the very stall this section moved the write off the loop to
+avoid).
+
+Two tests, two collaborators:
+
+- :func:`test_save_tool_result_write_is_deferred_until_flush` drives
+  ``MediaStore`` + a real ``DurabilityWorker`` directly (no RouterLoop
+  involved) — proves the deferral + the barrier's OWN contract.
+- :func:`test_router_loop_flushes_pending_writes_before_the_llm_call` drives
+  the ACTUAL ``router_loop.py`` call site — proves the barrier fires at the
+  right point in the real control flow, not just that ``MediaStore.flush``
+  works in isolation.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.data.workspace.media_store import MediaStore
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.router_loop import RouterLoop
+from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.tools.scheme import ExecutionResult
+from tests._support.router_loop import FakeRouterHost
+
+_MODEL = "gpt-4o"
+_BIG = "\n".join(f"line {i}: " + "z" * 60 for i in range(400))  # well over the offload trigger
+
+
+@pytest.mark.asyncio
+async def test_save_tool_result_write_is_deferred_until_flush(tmp_path: Path) -> None:
+    """Tier 2: inside a running loop, ``save_tool_result``'s block/hash/path
+    are all synchronous (the caller gets a usable ref immediately), but the
+    actual bytes on disk are NOT there yet until :meth:`MediaStore.flush`
+    is awaited — the write ran off-loop, fire-and-forget."""
+    store = MediaStore(project_root=tmp_path, session_id="flush-test")
+
+    block = store.save_tool_result(_BIG)
+    written = tmp_path / block["path"]
+
+    # No await has happened yet since save_tool_result returned (still the
+    # same synchronous call stack) — the drainer task cannot have run.
+    assert not written.exists(), (
+        "the write must not be on disk yet — save_tool_result only "
+        "ENQUEUES it (submit_nowait), it must not have run synchronously"
+    )
+
+    await store.flush()
+
+    assert written.is_file(), "flush() must make the enqueued write durable"
+    assert written.read_text(encoding="utf-8") == _BIG
+
+
+class _MediaStoreHost(FakeRouterHost):
+    """FakeRouterHost + a REAL MediaStore wired through ``cap_tool_result``
+    (mirrors ``_RecordingHost``/``_CapHost``'s established shape in the
+    sibling test files) — this test's target is ``router_loop.py``'s OWN
+    flush call site, not the on_offload forwarding chain (#5372 already
+    covers that with the real production adapter chain), so a FakeRouterHost
+    is the right-weight collaborator here: cheap, deterministic, and CLAUDE.md
+    only forbids faking what's cheaply constructible — MediaStore itself
+    stays real."""
+
+    def __init__(self, store: MediaStore) -> None:
+        super().__init__()
+        self.media_store = store
+
+    def cap_tool_result(
+        self, content_str: str, *, content_type: "str | None" = None, on_offload=None,
+    ) -> str:
+        return cap_tool_result_content(
+            content_str, cap_tokens=100, model=_MODEL,
+            save_fn=self.media_store.save_tool_result,
+            use_chars4=True, content_type=content_type, on_offload=on_offload,
+        )
+
+    def media_followup_budget(self, _content_str: str) -> int:
+        return 500
+
+
+class _ExistenceCheckingLLM:
+    """Real callable (not a mock) replacing ``call_llm_tools`` — records
+    whether ``target`` existed on disk at the moment it was invoked, then
+    ends the turn with a plain text reply (no tool_calls, so the loop stops
+    after this one call)."""
+
+    def __init__(self, target: Path) -> None:
+        self._target = target
+        self.existed_when_called: "bool | None" = None
+        self.call_count = 0
+
+    async def __call__(self, **kwargs) -> LLMToolCallResult:
+        self.call_count += 1
+        self.existed_when_called = self._target.is_file()
+        return LLMToolCallResult(
+            content="done", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
+
+
+async def _seed_pending_spill(host: _MediaStoreHost) -> Path:
+    """Enqueue one spilled write via the SAME chokepoint a real chat turn
+    uses (``RouterLoop.feedback``), synchronously — no ``await`` happens
+    between this call and the caller's next statement, so the write is
+    still PENDING (the drainer task has had no chance to run) by the time
+    ``run_loop`` is entered."""
+    loop = RouterLoop(host=host, chain_id="c-seed", router_model=_MODEL)
+    data = {"kind": "mcp", "status": "ok", "server": "s", "tool": "t", "content": _BIG, "media_blocks": []}
+    env = {"status": "ok", "data": data, "_canonical_source": "mcp"}
+    result = ExecutionResult(
+        tool_results=[env],
+        tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "mcp"}}],
+        assistant_content="",
+    )
+    loop.feedback(result)
+    (entry,) = [e for e in host.history if e.get("role") == "tool"]
+    ref = entry["meta"]["content_ref"]
+    return host.media_store._project_root / ref
+
+
+@pytest.mark.asyncio
+async def test_router_loop_flushes_pending_writes_before_the_llm_call(tmp_path: Path) -> None:
+    """Tier 2: #5364 §1.4 — ``run_loop``'s own flush call site (right before
+    the LLM sees this turn), driven for real: a write enqueued BEFORE
+    ``run_loop`` starts is durable by the time the (real, injected)
+    ``_llm_caller`` is invoked for this turn's very first iteration.
+
+    No await happens anywhere in ``run_loop`` before its flush call site
+    for a bare ``FakeRouterHost`` (no ``should_force_close`` /
+    ``peek_mid_turn_injection`` implemented — both getattr-guarded, both
+    short-circuit before their own ``await``) — confirmed by reading
+    ``router_loop.py`` lines 1753-1953 directly. So this is a genuine
+    ordering witness, not a scheduler-timing coincidence: nothing else in
+    this call graph could have run the drainer first."""
+    store = MediaStore(project_root=tmp_path, session_id="flush-test")
+    host = _MediaStoreHost(store)
+    written = await _seed_pending_spill(host)
+    assert not written.exists(), (
+        "test setup sanity: the seeded write must still be pending "
+        "(no await occurred between feedback() and here)"
+    )
+
+    llm = _ExistenceCheckingLLM(written)
+    loop = RouterLoop(host=host, chain_id="c-turn", llm_caller=llm, max_iterations=3)
+    await loop.run_loop(messages=[{"role": "user", "content": "go"}], tools=[], _univ_enabled=False)
+
+    assert llm.call_count == 1, "test setup sanity: the LLM must have been called exactly once"
+    assert llm.existed_when_called is True, (
+        "the pending write was NOT durable yet when the LLM was called — "
+        "run_loop's flush barrier did not run before this turn's LLM call"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5364 §1.4. **Stacked on #5372** (base branch — #5372 is BLOCKING-CLEARED-in-progress; this PR's diff will shrink to just its own commit once #5372 lands and this rebases onto main).

## What

Owner: "UIを止めさせたくない" — a synchronous tool-result write onto slow/network storage stalls the whole loop, the same class of problem #1765 fixed for the WAL.

- `services/offload/store.py`: `offload_value()` gains an optional `submit_nowait` param — when given, the actual `dest.write_text()` is handed to it fire-and-forget instead of running inline. Hash/preview/path_ref stay synchronous (`serialized` is already in memory). `None` (default) keeps every other caller byte-identical.
- `data/workspace/media_store.py`: `MediaStore` gains its OWN `DurabilityWorker` (lazy default, same shape as `EventStore`'s — no ordering dependency on the WAL's). `save_tool_result`'s content write AND its manifest-append are both deferred through the SAME worker, content write submitted first — FIFO-serial guarantees the manifest line is never visible before the file it names actually exists (a fresh `MediaStore`'s self-prune would otherwise permanently discard a merely-still-queued entry — caught by the existing #4381 test suite, see below). `_submit_write_or_inline` falls back to a synchronous `asyncio.run()` when no loop is running (CLI scripts, sync tests) — behaviour-identical to pre-§1.4 for every non-chat-turn caller. New `flush()`/`aclose()`.
- `runtime/router_loop.py`: `run_loop`'s own per-iteration LLM-call site awaits `host.media_store.flush()` ONCE, right before the LLM sees this turn's history — never per-write (would reintroduce the stall this section moved off the loop). A `read_file(path=<ref>)` can only follow a completion that already showed the model that ref, so this barrier is sufficient.
- `runtime/session.py` + `runtime/registry.py`: `aclose_media_store()` (mirrors `aclose_event_store`/`aclose_audit_events`, the SAME #2783-class teardown-completeness gap, a 5th instance) — wired into the same 2 registry call sites `audit_events` already uses.
- `tests/core/test_4381_read_char_offset_and_spill_guard.py`: 2 existing tests updated with an explicit `await store.flush()` — the new async-write reality these tests' own scenario now needs made explicit (a real chat turn always gets this for free via `router_loop`'s barrier; a bare same-process write-then-read has no such implicit boundary).

## Real regression caught + fixed mid-PR

The first cut (submit_nowait wired only into the content write, manifest appended synchronously right after) broke 2 of #4381's own tests: a manifest line became visible BEFORE its content file existed, so a fresh `MediaStore`'s self-prune permanently deleted a perfectly-good, merely-still-queued entry. Fixed by chaining the manifest-append as its own deferred job on the SAME worker, submitted after the content-write job — FIFO-serial guarantees ordering.

## Verified

- New `tests/runtime/test_5364_media_store_flush_barrier.py` (2 tests): (1) a running-loop write is NOT on disk until `flush()` is awaited — real `MediaStore` + real `DurabilityWorker`, no fakes; (2) `run_loop`'s own flush call site fires before the (real, injected) LLM caller sees a pending write — driven through the ACTUAL `router_loop.py` code path; confirmed no other `await` exists before that call site for a bare host (read `router_loop.py:1753-1953` directly), so this is a genuine ordering witness, not a scheduler-timing coincidence.
- Real strip-falsify: both the `router_loop.py` flush call site and `media_store.py`'s `submit_nowait` wiring confirmed genuinely RED when removed, each reverted before the next.
- Full blast-radius: 232 tests across every file referencing `offload_value`/`MediaStore`/`save_tool_result`/`aclose_event_store`/`aclose_audit_events` — all green.

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — clean (2 new tests, 2 updated)
- [x] `python scripts/mypy_ratchet.py` — OK, 201/207 baselined, unchanged
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] `python scripts/flat_tests_ratchet.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_tests_path_literal_reference.py` — all clean (tests/ touched)
- [x] Full blast-radius: 232 tests — all green
- [x] Real strip-falsify (see above)
- [ ] (skipped — no UI/visual surface)

## Not included

§1.5 failure path (lost reason: gc / never_persisted) · §1.6 GC (2GB cap) · `router_loop_driver.py:371` retry-loop restructuring — tracked on #5364, next in order.

co-vet: @architect (per #5364 §4).

part of #5364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>