### PR TITLE
feat(#5367③): try a content-level spill before the shrink-ladder floors raise

### DIFF
--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -414,7 +414,7 @@ class RouterLoopDriver:
         for attempt in range(_MAX_BYTE_REDUCTION_ATTEMPTS + 1):
             attempt_start_bytes = self._wire_bytes_now()
             try:
-                return await self._run_with_shrink(loop, user_text)
+                return await self._run_with_shrink(loop, user_text, chain_id=chain_id)
             except _UnrecoveredError as exc:
                 if not exc.saw_byte_limit or attempt >= _MAX_BYTE_REDUCTION_ATTEMPTS:
                     raise
@@ -433,7 +433,7 @@ class RouterLoopDriver:
                 continue
         raise AssertionError("unreachable: loop always returns or raises")
 
-    async def _run_with_shrink(self, loop: Any, user_text: str) -> Any:
+    async def _run_with_shrink(self, loop: Any, user_text: str, *, chain_id: str = "") -> Any:
         """Run the router once with the reactive bounded-shrink ``retry_loop``.
 
         Returns the router usage, or raises ``_ContextOverflowError``
@@ -459,6 +459,15 @@ class RouterLoopDriver:
         caller's own except clause does not catch it, so it reaches
         Session's generic exception handler, which keeps the session
         alive (owner ruling).
+
+        ``chain_id`` (#5367③, default ``""`` when not from the one real
+        caller below): threaded through to ``retry_loop``'s injected
+        ``spill_fn`` so a same-turn content-level spill (at either
+        terminal floor retry_loop can hit) writes through the SAME
+        ``MediaStore.save_tool_result`` metadata shape
+        ``RouterHistoryBuffer.spill_turn_content``'s other caller
+        (``_attempt_reactive_spill``) already uses — no new store-path
+        convention.
         """
         from reyn.runtime.usage_shim import _RouterUsageShim
         from reyn.services.compaction.engine import (
@@ -579,6 +588,23 @@ class RouterLoopDriver:
             )
             _new_msg = {"role": "user", "content": user_text}
 
+            def _spill_fn(turn: dict) -> "dict | None":
+                # #5367③: injected into retry_loop, not imported by it —
+                # matches ``context_budget_advisor.py``'s own ``save_fn``
+                # injection style for ``cap_tool_result_content``. Only a
+                # tool-result turn with plain-str content is spillable
+                # (mirrors ``_spill_candidates``'s own filter); everything
+                # else reports "nothing to try" rather than raising.
+                if turn.get("role") != "tool" or not isinstance(turn.get("content"), str):
+                    return None
+                replacement = self._history_buffer.spill_turn_content(
+                    turn["content"], chain_id=chain_id,
+                    tool=turn.get("name") or "tool", seq=turn.get("seq", 1),
+                )
+                if replacement is None or replacement == turn["content"]:
+                    return None
+                return {**turn, "content": replacement}
+
             async def _router_main_call(*, SP, head, summary, tail, new_msg):
                 _msgs = list(head)
                 if summary:
@@ -628,6 +654,7 @@ class RouterLoopDriver:
                     engine=engine,
                     learner=self._token_learner,
                     main_call=_router_main_call,
+                    spill_fn=_spill_fn,
                     max_iterations=self._compaction.max_shrink_iterations,
                     # #4957: operator-tunable escape valve (chat.compaction.
                     # max_shrink_iterations) — was previously always the

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1962,6 +1962,7 @@ async def retry_loop(
     learner: "TokenMultiplierLearner",
     main_call: Callable[..., Awaitable[Any]],
     max_iterations: int = 8,
+    spill_fn: "Callable[[dict], dict | None] | None" = None,
 ) -> Any:
     """Bounded shrink loop for context overflow recovery (PR-N6).
 
@@ -1986,10 +1987,23 @@ async def retry_loop(
       ``component_weights["head|tail"] / total_weight * main_pool``).
     - Terminal condition: when ``head``/``tail`` are at or below their
       minimum token budgets AND ``raw_middle`` cannot be split any
-      smaller (down to a single turn, #4947 ③'s floor), ``UnrecoveredError``
-      is raised — this is a **structured-failure guarantee, not a success
-      guarantee**: it promises retry_loop always STOPS instead of looping
-      forever or silently dropping content, not that it always converges.
+      smaller (down to a single turn, #4947 ③'s floor) AND spilling that
+      turn's content either was not available/possible or did not resolve
+      the overflow (#5367③, below), ``UnrecoveredError`` is raised — this
+      is a **structured-failure guarantee, not a success guarantee**: it
+      promises retry_loop always STOPS instead of looping forever or
+      silently dropping content, not that it always converges.
+    - #5367③: ``spill_fn`` (optional, injected by the caller — this module
+      never imports the caller, matching ``tool_result_cap.cap_tool_
+      result_content``'s own ``save_fn``-injection style) is tried EXACTLY
+      ONCE per distinct ``raw_middle[0]`` object, at BOTH terminal floors
+      below (the byte-limit mid-split floor and the non-byte same-cause
+      cap), regardless of which mode caused the overflow — a floor is a
+      floor either way, and the fix (replacing an oversized tool-result
+      body with a ref) is not byte/token-specific. A local per-call
+      ``id()`` set bounds this to at most one extra ``continue`` per
+      unique turn object, so it strictly tightens (never loosens) the
+      existing ``max_iterations``-bounded termination proof above.
     - ``max_iterations=8`` is a safety cap independent of the above — even
       a well-founded decreasing measure can still take more steps than an
       operator wants to wait for real LLM calls, so this cap can fire
@@ -2128,6 +2142,27 @@ async def retry_loop(
     # not on every floor check.
     _sp_tokens_floor = estimate_tokens(SP, model, use_chars4=use_chars4)
     _new_msg_tokens_floor = estimate_tokens_for_turn(new_msg, model, use_chars4=use_chars4)
+    # #5367③: which raw_middle[0] objects a spill has already been tried
+    # on this call — bounds the retry to at most one extra iteration per
+    # unique turn (never the same object twice), so this can only tighten
+    # the existing max_iterations-bounded termination proof, never loosen it.
+    _spill_attempted_ids: "set[int]" = set()
+
+    def _try_spill_first_mid_turn() -> bool:
+        """#5367③: if a turn is available and spillable, spill it in place
+        and report whether the caller should retry this iteration instead
+        of raising. Never attempts the SAME object twice."""
+        if spill_fn is None or not raw_middle:
+            return False
+        turn = raw_middle[0]
+        if id(turn) in _spill_attempted_ids:
+            return False
+        _spill_attempted_ids.add(id(turn))
+        spilled = spill_fn(turn)
+        if spilled is None:
+            return False
+        raw_middle[0] = spilled
+        return True
 
     for _iteration in range(max_iterations):
         # #4944①: tracks whether THIS iteration reached main_call — a
@@ -2418,21 +2453,20 @@ async def retry_loop(
                 # False the only value this raise can ever carry, not an
                 # unreachable branch where the default happens not to
                 # matter.
-                # #5367②: the OLD text past this point claimed "shrinking is
-                # not resolving this cause" without qualification — false in
-                # the same way #5367①'s neighboring fix was: "shrinking" here
-                # names only the turn-count-reduction ladder this loop
-                # attempted (head/tail trim, halving raw_middle); it does not
-                # cover spilling a turn's CONTENT (replacing an oversized
-                # tool-result body with a ref), which this cap never tries
-                # before giving up (#5367③).
+                # #5367③: before giving up, try spilling raw_middle[0]'s
+                # content (mode-independent — a floor is a floor whether
+                # the recurring cause is byte- or token-shaped) and retry
+                # this iteration if it made progress.
+                if _try_spill_first_mid_turn():
+                    continue
                 raise UnrecoveredError(
                     f"retry_loop: cause {_cause!r} recovered "
                     f"{_consecutive_same_cause} consecutive times (limit "
                     f"{_MAX_CONSECUTIVE_SAME_CAUSE_RECOVERS}) — the "
-                    "turn-count shrink ladder attempted is not resolving "
-                    "this cause (content-level spill was not tried here); "
-                    "stopping rather than exhausting max_iterations."
+                    "turn-count shrink ladder attempted, plus any "
+                    "content-level spill of raw_middle[0] this call had "
+                    "available, did not resolve this cause; stopping "
+                    "rather than exhausting max_iterations."
                 ) from _overflow_exc
 
         # Shrink escalation: reduce context size monotonically.
@@ -2491,19 +2525,21 @@ async def retry_loop(
                     # "shrinking it further is not possible" — false. Only
                     # the TURN-COUNT floor is reached here (mid is already
                     # one turn; halving cannot produce a smaller nonzero
-                    # slice, #4947 ③). Nothing checked here about whether
-                    # mid's CONTENT could still shrink — a turn whose body
-                    # is a spillable tool result (owner: "spill は turn の
-                    # 中身を小さくします — 分割ではなく縮小") could still be
-                    # reduced without splitting it into more turns; this
-                    # retry_loop does not attempt that today (tracked as
-                    # #5367③).
+                    # slice, #4947 ③). #5367③: mid's CONTENT could still
+                    # shrink — a turn whose body is a spillable tool result
+                    # (owner: "spill は turn の中身を小さくします — 分割で
+                    # はなく縮小") can be reduced without splitting it into
+                    # more turns, so that is tried here (below) before
+                    # this raise, not skipped.
+                    if _try_spill_first_mid_turn():
+                        continue
                     raise UnrecoveredError(
                         "retry_loop: HTTP 413 (a request-BODY-BYTE limit) "
                         "recurred compacting a single raw_middle turn "
-                        "alone — mid cannot be split any further (this is "
-                        "the turn-count floor, not a claim that mid's "
-                        "content is already minimal)." + _learned_byte_limit_clause(
+                        "alone — mid cannot be split any further (the "
+                        "turn-count floor), and a content-level spill of "
+                        "it, where available, did not resolve this "
+                        "either." + _learned_byte_limit_clause(
                             last_accepted_wire_bytes=_last_accepted_wire_bytes,
                             last_rejected_wire_bytes=_last_rejected_wire_bytes,
                         ),

--- a/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
+++ b/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
@@ -581,6 +581,154 @@ async def test_spill_candidates_are_staged_head_then_mid_then_tail(
     )
 
 
+class _SpillableByteLimitMidEngine:
+    """Real-shaped ``CompactionEngine`` stand-in whose ``compact()`` 413s
+    while the offered slice's FIRST turn still carries the ORIGINAL
+    marker content, succeeds once it is the SPILLED content — the driver-
+    path witness that ``RouterLoopDriver``'s own ``spill_fn`` wiring (not
+    merely ``retry_loop``'s internal logic, already covered directly in
+    ``test_pr_n6_compaction_overflow_retry.py``) is what makes this
+    resolve. ``raw_middle[0]`` is always the offered slice's first turn
+    regardless of how far ``_compact_attempt_len`` has halved (the slice
+    is always ``raw_middle[:_attempt_len]``, taken from index 0), so
+    checking only ``new_turns[0]`` is sufficient here."""
+
+    def __init__(self) -> None:
+        from reyn.core.events.events import EventLog
+        from reyn.services.compaction.engine import ComputedBudgets
+        self.budgets = ComputedBudgets(
+            main_pool=10_000, head_budget=20, body_budget=500,
+            tail_budget=20, new_msg_budget=1_000,
+            B_M=8_000, main_M_room=7_000, effective_trigger=3_000,
+            section_caps={
+                "topic_arc": 50, "decisions": 200, "pending": 150,
+                "session_user_facts": 50, "artifacts_referenced": 175,
+            },
+        )
+        self._events = EventLog()
+        self._T_comp_SP = 100
+        self._model = "openai/test-standard-model"
+        self.compact_calls = 0
+
+    async def compact(self, input_chunk):
+        self.compact_calls += 1
+        turn = input_chunk.new_turns[0]
+        content = turn.get("content") if isinstance(turn, dict) else None
+        if content == "OVERSIZED_MARKER_5367_3":
+            raise _FakeStatusError("compact 413", status_code=413)
+        from reyn.services.compaction.engine import ChatSummary
+
+        def _seq(t: object) -> int:
+            return t.get("seq", 0) if isinstance(t, dict) else getattr(t, "seq", 0)
+
+        return ChatSummary(
+            topic_arc="ok", covers_through_seq=max((_seq(t) for t in input_chunk.new_turns), default=0),
+        )
+
+
+def test_run_with_shrink_wires_spill_fn_into_retry_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5367③ BLOCKING① witness — a REAL driver path
+    (``RouterLoopDriver._run_with_shrink``, real ``Session``/
+    ``RouterHistoryBuffer``/``MediaStore``) resolves a byte-limit
+    mid-split-floor overflow via the ``spill_fn`` THIS PR wires in,
+    not merely ``retry_loop``'s own internal logic (already covered
+    directly in ``test_pr_n6_compaction_overflow_retry.py``).
+
+    Strip-falsify: removing ``spill_fn=_spill_fn,`` from
+    ``router_loop_driver.py``'s ``_retry_loop(...)`` call makes this test
+    raise ``UnrecoveredError`` instead of returning — ``retry_loop``
+    receives ``spill_fn=None`` and its own ``if spill_fn is None or not
+    raw_middle: return False`` guard makes the new mechanism a silent
+    no-op, exactly BLOCKING①'s point (a test that calls ``retry_loop``
+    directly and supplies its own ``spill_fn=`` cannot catch this — only
+    a test that goes through the real caller can).
+
+    The injected ``_SpillableByteLimitMidEngine`` carries its OWN tiny
+    budgets (``effective_trigger=3_000``, ``head_budget``/``tail_budget``
+    ``=20``) — ``resolve_effective_trigger_and_budgets`` reads these off
+    the compaction controller's cached engine, not from ``t_max``, once an
+    engine is injected (measured directly while building this test:
+    ``t_max`` alone left everything in ``head`` regardless of its value).
+    One small head turn + the marker (tool) + 7 filler (user, assistant)
+    pairs reliably lands the marker turn alone as ``raw_middle[0]`` — sized
+    in spirit only (the marker's actual content is tiny; only WIRING is
+    this test's subject, not byte-size behavior, which the engine-level
+    tests in ``test_pr_n6_compaction_overflow_retry.py`` already cover).
+    ``max_shrink_iterations=25`` is generous: the halving ladder needs a
+    few attempts to reach the mid=1 floor, then (after the spill succeeds)
+    retry_loop folds the remaining filler turns one at a time before ever
+    reaching ``main_call`` — a real, if wasteful, consequence of #4947 ③'s
+    "don't reset the discovered slice size to full" choice, not a bug this
+    test is pinning."""
+    session = _make_spill_session(
+        tmp_path, monkeypatch, t_max=2_500, max_shrink_iterations=25,
+        recovery_policy="never",
+    )
+    session._compaction_controller._CompactionController__engine_cache = (
+        _SpillableByteLimitMidEngine()
+    )
+    _push(session, "user", "small head content " * 5)
+    _push(session, "tool", "OVERSIZED_MARKER_5367_3", tool_call_id="tc-marker", name="big_tool")
+    for i in range(7):
+        _push(session, "user", f"filler question number {i} " * 40)
+        _push(session, "assistant", f"filler answer number {i} " * 40)
+
+    head, raw_middle, _tail, _summary, _seq_by_id = (
+        session._loop_driver._history_buffer.decompose_history_for_retry()
+    )
+    mid_ids = {t.get("tool_call_id") for t in raw_middle if t.get("role") == "tool"}
+    assert mid_ids == {"tc-marker"}, (
+        f"test setup sanity: the marker turn must land alone in "
+        f"raw_middle's tool turns, got {mid_ids!r} — adjust t_max/turn "
+        f"placement (this mirrors test_retry_loop_chat_wiring_1125.py's "
+        f"own independently-measured t_max=2800/8-turn split)"
+    )
+    assert raw_middle[0].get("tool_call_id") == "tc-marker", (
+        "test setup sanity: the marker turn must be raw_middle[0] — the "
+        "halving ladder always offers raw_middle[:_attempt_len] from "
+        "index 0"
+    )
+
+    # The FIRST call (via build_history()) must fail unconditionally to
+    # enter retry_loop at all — build_history's own elide logic already
+    # hides raw_middle's content from the wire before any real overflow
+    # occurs (this scenario's content is elidable-away by construction),
+    # so a marker-presence check alone would never see the first call
+    # fail. Every call AFTER the first goes through retry_loop's own
+    # internal main_call (head+summary+tail only, never raw_middle), so
+    # once compact() succeeds on the spilled content, that call's payload
+    # genuinely no longer carries the marker either way — checking call
+    # ORDER (first vs. later), not payload shape, is what this predicate
+    # actually needs.
+    _seen_first_call = {"done": False}
+
+    def _fail_only_the_very_first_call(history: list, user_text: str) -> bool:
+        if _seen_first_call["done"]:
+            return False
+        _seen_first_call["done"] = True
+        return True
+
+    loop = _ContentDrivenLoop(_fail_only_the_very_first_call)
+
+    # No exception raised (the assertion is the ABSENCE of one — retry_loop
+    # only returns via the fake loop's OWN return value, None on success,
+    # matching the sibling test's convention).
+    asyncio.run(
+        session._loop_driver._run_with_shrink(
+            loop, "continue please", chain_id="c1",
+        )
+    )
+    engine = session._compaction_controller._CompactionController__engine_cache
+    assert engine.compact_calls >= 2, (
+        f"expected at least 2 compact() calls (failing attempts on the "
+        f"original marker content, then a succeeding one on the spilled "
+        f"content) — got {engine.compact_calls}, meaning the spilled "
+        f"content never reached engine.compact() at all"
+    )
+
+
 @pytest.mark.asyncio
 async def test_a_mid_spill_is_kept_even_though_it_moves_zero_bytes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,

--- a/tests/services/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/services/test_pr_n6_compaction_overflow_retry.py
@@ -1413,6 +1413,117 @@ def test_4947_stage1_mid_split_terminates_instead_of_reproducing_old_state() -> 
     )
 
 
+def test_5367_3_spill_before_raise_resolves_byte_limit_mid_split_floor() -> None:
+    """Tier 2: #5367③ — at the byte-limit mid=1-turn floor, a spillable
+    ``raw_middle[0]`` (role ``tool``, str content) is offered to the
+    injected ``spill_fn`` BEFORE raising; if the spill produces smaller
+    content that compact() then accepts, retry_loop returns normally
+    instead of raising ``UnrecoveredError``.
+
+    Falsification (performed during review): removing the
+    ``_try_spill_first_mid_turn()`` call before the raise (reverting to
+    #5367②'s text-only fix) makes this test raise ``UnrecoveredError``
+    instead of returning — compact() never sees the spilled content
+    because the loop never retries.
+    """
+    cfg = _make_cfg()
+
+    class _SpillableByteLimitEngine(_OverflowingEngine):
+        """compact() 413s while the offered turn still carries the
+        ORIGINAL oversized marker; succeeds once it is the SPILLED one —
+        the compact()-side witness that spill_fn's replacement actually
+        reached engine.compact(), not just retry_loop's own state."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.compact_calls = 0
+
+        async def compact(self, input_chunk):
+            self.compact_calls += 1
+            turn = input_chunk.new_turns[0]
+            if turn.get("content") == "OVERSIZED_TOOL_RESULT":
+                raise _FakeStatusError("compact 413", status_code=413)
+            from reyn.services.compaction.engine import ChatSummary
+            return ChatSummary(topic_arc="ok", covers_through_seq=turn.get("seq", 0))
+
+    engine = _SpillableByteLimitEngine()
+    learner = TokenMultiplierLearner(storage_path=Path(tempfile.mkdtemp()) / "m.json")
+
+    raw_middle = [{
+        "role": "tool", "content": "OVERSIZED_TOOL_RESULT", "seq": 1,
+        "tool_call_id": "tc-1", "name": "big_tool",
+    }]
+    new_msg = {"role": "user", "content": "q", "seq": 999}
+    spill_calls: list = []
+
+    def _spill_fn(turn: dict) -> "dict | None":
+        spill_calls.append(turn)
+        if turn.get("role") != "tool" or turn.get("content") != "OVERSIZED_TOOL_RESULT":
+            return None
+        return {**turn, "content": "REF: spilled to .reyn/memory/history-content/..."}
+
+    async def _main_call(**kwargs):
+        from types import SimpleNamespace
+        return SimpleNamespace(usage=SimpleNamespace(prompt_tokens=10), choices=[])
+
+    result = asyncio.run(retry_loop(
+        SP="sp", head=[], summary=None, raw_middle=raw_middle,
+        tail=[], new_msg=new_msg, cfg=cfg, model="test-model",
+        engine=engine,  # type: ignore[arg-type]
+        learner=learner,
+        main_call=_main_call,
+        spill_fn=_spill_fn,
+        max_iterations=8,
+    ))
+
+    assert result is not None, "retry_loop must return normally, not raise"
+    # Exactly one spill_fn call for this single turn — unpacking to one
+    # element raises ValueError if the loop retried spill_fn a second time
+    # (which would mean the SAME object was offered for spilling twice).
+    (only_spill_call,) = spill_calls
+    assert only_spill_call["content"] == "OVERSIZED_TOOL_RESULT", (
+        "spill_fn must be offered the ORIGINAL content, not an already-"
+        "spilled one"
+    )
+    assert engine.compact_calls == 2, (
+        f"expected exactly 2 compact() calls (1 failing on the original "
+        f"content, 1 succeeding on the spilled content) — got "
+        f"{engine.compact_calls}"
+    )
+
+
+def test_5367_3_spill_unavailable_still_raises_with_accurate_message() -> None:
+    """Tier 2: #5367③ — with no ``spill_fn`` injected (the default,
+    matching every OTHER test in this file), the byte-limit mid-split
+    floor behaves exactly as #5367②'s text-only fix left it: raises
+    ``UnrecoveredError`` naming the turn-count floor, honestly silent
+    about spill (never claiming it was tried when it was not offered)."""
+    cfg = _make_cfg()
+    engine = _Always413CompactEngine(head_budget=10, tail_budget=10)
+    learner = TokenMultiplierLearner(storage_path=Path(tempfile.mkdtemp()) / "m.json")
+
+    raw_middle = [{"role": "tool", "content": "OVERSIZED_TOOL_RESULT", "seq": 1}]
+    new_msg = {"role": "user", "content": "q", "seq": 999}
+
+    async def _always_413(**kwargs):
+        raise ContextOverflowError("main_call 413") from _FakeStatusError(
+            "Request Entity Too Large", status_code=413,
+        )
+
+    with pytest.raises(UnrecoveredError) as excinfo:
+        asyncio.run(retry_loop(
+            SP="sp", head=[], summary=None, raw_middle=raw_middle,
+            tail=[], new_msg=new_msg, cfg=cfg, model="test-model",
+            engine=engine,  # type: ignore[arg-type]
+            learner=learner,
+            main_call=_always_413,
+            max_iterations=8,
+        ))
+
+    assert "mid cannot be split any further" in str(excinfo.value)
+    assert excinfo.value.saw_byte_limit is True
+
+
 def test_4947_stage1_success_resets_same_cause_streak() -> None:
     """Tier 2: #4947 ③ (architect-ruled, CI red on #4950) — a compact()
     SUCCESS resets the same-cause cap's consecutive-recover counter, so


### PR DESCRIPTION
**[tui-coder]** — part of #5367 (③, final in this arc)

## What

`retry_loop`'s two terminal floors (the byte-limit mid-split floor and the non-byte same-cause-recovery cap) previously raised `UnrecoveredError` as soon as `raw_middle` could not be split into more turns — never trying whether the SAME turn's content could shrink instead (a spillable tool-result body replaced with a ref). #5367②'s text fix already disclosed this exact gap; this PR closes it.

- `retry_loop` gains an optional `spill_fn` param — **no default**, omitting it preserves today's behavior exactly (verified by `test_5367_3_spill_unavailable_still_raises_with_accurate_message`).
- Injected by the caller, **never imported by `engine.py`** — matches `tool_result_cap.cap_tool_result_content`'s own `save_fn`-injection style (`context_budget_advisor.py` precedent).
- Tried at **both** terminal floors, **mode-independent** (byte or token cause — a floor is a floor either way), at most once per distinct `raw_middle[0]` object (a local `id()` set) — this can only tighten the existing `max_iterations`-bounded termination proof, never loosen it.
- `router_loop_driver.py` wires a real `spill_fn` closure (role==tool, str content only) bound to `RouterHistoryBuffer.spill_turn_content`, threading `chain_id` through `_run_with_shrink` (previously chain_id-less, since its one caller now needs it).
- **`engine.py`'s two comments from #5367② are corrected in this SAME PR** ("content-level spill was not tried here" / "does not attempt that today") — architect's finding (#5376 thread) that ③ landing makes ②'s disclaimer false the instant it merges (CLAUDE.md hard rule: fix the doc in the SAME PR). Both preserve the substrings existing tests assert on (`"mid cannot be split any further"`, `"consecutive times"`).

## `:371` — untouched

Per lead-coder's explicit instruction, this PR does not touch `router_loop_driver.py:371` (e2e-coder's #5372 territory).

## Scope note

The same-cause-cap (non-byte) floor shares the identical `_try_spill_first_mid_turn()` helper already strip-falsified below, but has **no dedicated spill-succeeds test of its own** — reaching that floor with a spillable `raw_middle[0]` turn needs the tail→raw_middle Phase-1 refill mechanics the existing same-cause-cap test depends on, and building that fixture plus a spill scenario didn't fit this PR's effort budget. **Filed as a child issue**: https://github.com/tya5/reyn/issues/5380.

## Test plan

- [x] `ruff check` on all 3 changed files — clean
- [x] `python scripts/test_tier_audit.py --strict tests/services/test_pr_n6_compaction_overflow_retry.py` — 43/43 OK
- [x] `python scripts/mypy_ratchet.py` — OK, baselined
- [x] `python scripts/verify_module_docstrings.py` on both changed src files — OK
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] New tests: `test_5367_3_spill_before_raise_resolves_byte_limit_mid_split_floor` (spill offered, compact() succeeds on the spilled content, retry_loop returns normally instead of raising), `test_5367_3_spill_unavailable_still_raises_with_accurate_message` (no `spill_fn` → identical behavior to #5367②)
- [x] Strip-falsify: removed the byte-limit-floor spill-attempt call, confirmed `test_5367_3_spill_before_raise_resolves_byte_limit_mid_split_floor` goes RED, restored (verified via `git diff` after restore showed a clean tree against the prior commit)
- [x] New test (BLOCKING① fix): `test_run_with_shrink_wires_spill_fn_into_retry_loop` — a real `Session`/`RouterHistoryBuffer`/`MediaStore` driven through `RouterLoopDriver._run_with_shrink`, a content-aware fake compaction engine (413s on the original marker, succeeds on the spilled content), proving the DRIVER's own `spill_fn` wiring resolves the overflow
- [x] Strip-falsify (BLOCKING① fix): removed `spill_fn=_spill_fn,` from the real `_retry_loop(...)` call in `router_loop_driver.py`, confirmed `test_run_with_shrink_wires_spill_fn_into_retry_loop` goes RED, restored
- [x] `pytest tests/services tests/runtime tests/llm -k "compaction or retry_loop or history_buffer or engine or 5296 or 4947 or unrecovered or router_loop_driver or 5367 or shrink"` — 189 passed
- [ ] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Blocking points

- [x] 🔴 **driver 側の注入に witness が在りません。** 新 test は `retry_loop` を直接呼び `spill_fn=_spill_fn` を自分で渡すので、**`router_loop_driver.py` の `spill_fn=_spill_fn,` を消しても新 test は全部緑**です（`retry_loop` は `spill_fn=None` を受け取り `if spill_fn is None or not raw_middle:` で素通り ＝ **③ の機能が丸ごと消える**）。⚠️ **#5375 / #5372 と同じ族で、同じ arc の 3 件目です。** **受入: 実物の driver 経路を通す test 1 本 —「`spill_fn=_spill_fn,` の行を消したら RED」。** fake 置換不可（家則「cheaply constructible なら fake するな」／先例 `tests/_support/router_host_adapter.py`「real collaborators (no mocks)」）。根拠: PR comment（BLOCKING）
- [x] 🔴 **開示された未検証の枝（同一 cause-cap 側の専用 spill 成功 test）を、★filed か explicitly dropped に。** 本文に書いたのは**正しい振る舞い**ですが、**PR 本文はその時点の記録で merge 後は誰も読みません**（恒久項「本文で塞いだ vacuity は時間とともに開く」／家則 6「every remainder is filed or explicitly dropped」）。**(a) 同 PR で test を足す ／ (b) #5367 の子として issue を立てる ／ (c) 明示的に落とす（なぜ要らないかを本文に 1 行）** のいずれかを。根拠: 同上

