### PR TITLE
feat(#5364): §1.5 — a permanently-failed write keeps content inline

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -244,6 +244,7 @@ tool_cycle_kept_whole_over_budget
 tool_executed
 tool_failed
 tool_result_offloaded
+tool_result_write_unavailable
 tool_returned
 turn_cancelled
 turn_completed

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -473,6 +473,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "tool_executed",
     "tool_failed",
     "tool_result_offloaded",
+    "tool_result_write_unavailable",
     "tool_returned",
     "turn_cancelled",
     "turn_completed",

--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -329,6 +329,26 @@ def parse_resource_uri(uri: str) -> tuple[str, str] | None:
     return agent, artifact
 
 
+class MediaStoreWriteUnavailable(Exception):
+    """#5364 §1.5: raised by :meth:`MediaStore.save_tool_result` instead of
+    returning a ref block, when this store's writes are known NOT to land —
+    either this exact call's own write failed synchronously (the
+    no-running-loop / sync-fallback path — an operator script, a CLI
+    command, a sync test), or an EARLIER write already exhausted
+    :class:`~reyn.core.events.durability_worker.DurabilityWorker`'s §4
+    retry bound and latched ``durability_failed`` (a chat-turn call,
+    off-loop — that failure was necessarily discovered async, after this
+    call's own synchronous return already happened once before, so this
+    exception only ever protects the NEXT attempt).
+
+    The caller (``tool_result_cap.cap_tool_result_content``) catches this
+    and keeps the content INLINE instead — #5364 §1.5's own requirement:
+    "a permanently-failed write's turn keeps content inline, never emits a
+    ref naming a file that doesn't exist." Never raised for a transient
+    (retryable) failure — those stay entirely inside the worker's own
+    bounded-backoff retry, invisible here."""
+
+
 class MediaStore:
     """Path-ref'd file storage for multimodal media + tool result text.
 
@@ -679,24 +699,51 @@ class MediaStore:
         externally by the caller (e.g. ``web.py`` ``_generate_web_fetch_preview``).
         See the ★ three-party bound contract in
         ``services/offload/store.py`` module docstring.
+
+        #5364 §1.5 (owner: "a permanently-failed write's turn keeps
+        content inline, never emits a ref naming a file that doesn't
+        exist"): raises :class:`MediaStoreWriteUnavailable` instead of
+        returning a block when this store's writes are known not to
+        land — see that exception's own docstring for the two ways this
+        can be discovered. ``cap_tool_result_content`` (this method's
+        one real caller) catches it and keeps the content inline.
         """
+        if self.durability_failed:
+            raise MediaStoreWriteUnavailable(
+                "MediaStore's durable-write worker has a PERSISTENT "
+                "failure latched (DurabilityWorker.durability_failed) — "
+                "refusing to mint a ref for a file that will not exist"
+            )
         chain_short = _safe_token(chain_id)[:6] if chain_id else ""
         tool_token = _safe_token(tool) or "tool"
         ext = _ext_for_mime(mime_type)
         filename = f"{_timestamp()}-{chain_short}-{tool_token}-{seq}{ext}"
 
-        result = offload_value(
-            content,
-            store_dir=self._history_content_dir(),
-            preview_strategy=None,
-            filename=filename,
-            payload_field=payload_field,
-            # #5364 §1.4: the actual disk write moves off the event loop
-            # (fire-and-forget, serial FIFO) — see :meth:`flush`'s own
-            # docstring for the barrier this relies on to make the write
-            # observable before anything could try to read it back.
-            submit_nowait=self._submit_write_or_inline,
-        )
+        try:
+            result = offload_value(
+                content,
+                store_dir=self._history_content_dir(),
+                preview_strategy=None,
+                filename=filename,
+                payload_field=payload_field,
+                # #5364 §1.4: the actual disk write moves off the event loop
+                # (fire-and-forget, serial FIFO) — see :meth:`flush`'s own
+                # docstring for the barrier this relies on to make the write
+                # observable before anything could try to read it back.
+                submit_nowait=self._submit_write_or_inline,
+            )
+        except OSError as exc:
+            # #5364 §1.5: only reachable via the SYNC-FALLBACK branch of
+            # _submit_write_or_inline (no running loop — the write ran
+            # inline, synchronously, so ITS OWN failure is known here and
+            # now, unlike the async/worker path's failures, which are
+            # necessarily discovered later — see MediaStoreWriteUnavailable's
+            # own docstring). No retry here: the async path already owns
+            # retry (DurabilityWorker §4); this path only ever runs when no
+            # loop is present to defer to it in the first place.
+            raise MediaStoreWriteUnavailable(
+                f"the synchronous (no-running-loop) write failed: {exc}"
+            ) from exc
 
         # Convert absolute path_ref to project-relative path for the block.
         abs_path = Path(result.path_ref)
@@ -748,6 +795,17 @@ class MediaStore:
         }
         self._attach_cross_host_fields(block, filename=filename, chain_id=chain_id)
         return block
+
+    @property
+    def durability_failed(self) -> bool:
+        """#5364 §1.5: True once a fire-and-forget ``save_tool_result``
+        write failed PERSISTENTLY (§4-exhausted retries) — the SAME
+        latched health-signal ``DurabilityWorker.durability_failed``
+        exposes, delegated here so :meth:`save_tool_result` itself can
+        refuse a NEW write once this is known, rather than minting a ref
+        for a file the worker has already given up trying to write.
+        Never auto-clears (mirrors the worker's own contract)."""
+        return self._worker.durability_failed
 
     def _submit_write_or_inline(self, do_write) -> None:
         """#5364 §1.4: ``DurabilityWorker.submit_nowait`` requires a RUNNING

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -47,9 +47,13 @@ TOOL_ERROR_MESSAGE_META_KEY = "error_message"
 # result into this store before #5364 existed), never "unknown".
 SPILLED_META_KEY = "spilled"
 # The backing file's project-relative path — set for every SPILLED entry.
-# #5364 §1.1 "A": every tool result is written to a file, but only a
-# SPILLED entry's own persisted content is the ref rather than the
+# #5364 §1.1 "A": an offload attempt is ALWAYS file-backed when it lands —
+# a SPILLED entry's own persisted content is the ref rather than the
 # original inline body, so only a spilled entry needs this to resolve.
+# #5364 §1.5: "A" is not "always" without exception — a write that is
+# known, in advance, not to land (MediaStoreWriteUnavailable) never
+# reaches this store at all; that turn's content stays inline and this
+# key is never set (see LOST_REASON_NEVER_PERSISTED below).
 CONTENT_REF_META_KEY = "content_ref"
 # Set once `resolve()` (reyn.core.offload.history_content_resolve) has
 # actually observed the backing file missing — never guessed ahead of

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3478,6 +3478,8 @@ class RouterLoop:
         from reyn.core.offload.seam import build_offload_body, render_tool_result
         from reyn.runtime.chat_message import (
             CONTENT_REF_META_KEY,
+            LOST_REASON_META_KEY,
+            LOST_REASON_NEVER_PERSISTED,
             SKILL_SOURCE_PATH_META_KEY,
             SPILLED_META_KEY,
             TOKEN_MAP_META_KEY,
@@ -3526,6 +3528,18 @@ class RouterLoop:
             def _on_offload(ref: str) -> None:
                 nonlocal _offloaded_ref
                 _offloaded_ref = ref
+
+            # #5364 §1.5: the sibling typed channel — "an offload was
+            # attempted and refused because this store's writes are known
+            # not to land" (MediaStoreWriteUnavailable, caught inside
+            # cap_tool_result_content). Mutually exclusive with
+            # _on_offload firing for the SAME call (one cap_tool_result
+            # call either offloads, refuses, or neither — never both).
+            _write_unavailable = False
+
+            def _on_write_unavailable() -> None:
+                nonlocal _write_unavailable
+                _write_unavailable = True
 
             # Error path (plain string, never JSON): a dispatch-envelope error carries
             # ``error.kind``/``.message`` (``permission_denied`` vs ``not_found`` imply different
@@ -3580,7 +3594,10 @@ class RouterLoop:
                     text_full = canonical.get("text", "") or ""
                     scan_target = f"Error: {text_full}"
                     text = (
-                        _cap(text_full, on_offload=_on_offload)
+                        _cap(
+                            text_full, on_offload=_on_offload,
+                            on_write_unavailable=_on_write_unavailable,
+                        )
                         if _cap is not None else text_full
                     )
                     content_str = f"Error: {text}"
@@ -3658,6 +3675,7 @@ class RouterLoop:
                         # recover it from the stored ref's file extension.
                         text = _cap(
                             text, content_type=content_type, on_offload=_on_offload,
+                            on_write_unavailable=_on_write_unavailable,
                         )
                     content_str = render_tool_result(frontmatter, text)
                     # #3629: `load_skill_to_canonical` is the one mapper that sets
@@ -3742,6 +3760,14 @@ class RouterLoop:
             if _offloaded_ref is not None:
                 _tool_meta[SPILLED_META_KEY] = True
                 _tool_meta[CONTENT_REF_META_KEY] = _offloaded_ref
+            # #5364 §1.5: an offload was ATTEMPTED and refused — content
+            # stayed inline (never a ref to a file that doesn't exist), but
+            # the entry still records WHY (operator-actionable: check
+            # disk/permissions, distinct from LOST_REASON_GC's "check the
+            # cap size" — #1.6, not yet wired). SPILLED_META_KEY stays
+            # absent — no ref was ever minted for this entry.
+            if _write_unavailable:
+                _tool_meta[LOST_REASON_META_KEY] = LOST_REASON_NEVER_PERSISTED
             if _append_entry is not None:
                 _append_entry(
                     role="tool",

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -227,6 +227,7 @@ class ContextBudgetAdvisor:
         *,
         content_type: "str | None" = None,
         on_offload: "Callable[[str], None] | None" = None,
+        on_write_unavailable: "Callable[[], None] | None" = None,
     ) -> str:
         """Cap an oversized chat tool result (#1128 size axis).
 
@@ -241,6 +242,10 @@ class ContextBudgetAdvisor:
         store, never the frontmatter this method's caller builds separately).
 
         ``on_offload`` (#5364 §1.2) — forwarded to
+        ``tool_result_cap.cap_tool_result_content``'s own param of the same
+        name; optional and additive, every existing caller unaffected.
+
+        ``on_write_unavailable`` (#5364 §1.5) — forwarded to
         ``tool_result_cap.cap_tool_result_content``'s own param of the same
         name; optional and additive, every existing caller unaffected.
         """
@@ -262,6 +267,7 @@ class ContextBudgetAdvisor:
             events=self._events,
             content_type=content_type,
             on_offload=on_offload,
+            on_write_unavailable=on_write_unavailable,
             max_inline_bytes=cfg.max_inline_bytes,
             preview_head_chars=cfg.preview_head_chars,
             preview_tail_chars=cfg.preview_tail_chars,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -750,6 +750,7 @@ class RouterHostAdapter:
         *,
         content_type: "str | None" = None,
         on_offload: "Callable[[str], None] | None" = None,
+        on_write_unavailable: "Callable[[], None] | None" = None,
     ) -> str:
         """#1128 size axis: cap an oversized tool-result string at the
         router_loop chokepoint. Delegates to the session-supplied callable
@@ -760,12 +761,14 @@ class RouterHostAdapter:
         no clean-payload kwargs. ``content_type`` (#2663) is the canonical's renderer-only sidecar,
         forwarded to the session capper unchanged (identity path ignores it — nothing to store).
 
-        ``on_offload`` (#5364 §1.2) — forwarded unchanged; optional and
-        additive, every existing caller unaffected."""
+        ``on_offload`` (#5364 §1.2) / ``on_write_unavailable`` (#5364 §1.5)
+        — forwarded unchanged; optional and additive, every existing
+        caller unaffected."""
         if self._cap_tool_result is None:
             return content_str
         return self._cap_tool_result(
             content_str, content_type=content_type, on_offload=on_offload,
+            on_write_unavailable=on_write_unavailable,
         )
 
     def media_followup_budget(self, tool_content: str) -> int | None:

--- a/src/reyn/runtime/services/tool_result_cap.py
+++ b/src/reyn/runtime/services/tool_result_cap.py
@@ -81,6 +81,7 @@ def cap_tool_result_content(
     preview_head_chars: int = _PREVIEW_HEAD_CHARS,
     preview_tail_chars: int = _PREVIEW_TAIL_CHARS,
     on_offload: "Callable[[str], None] | None" = None,
+    on_write_unavailable: "Callable[[], None] | None" = None,
 ) -> str:
     """Return *content_str* unchanged if within the cap, else its offloaded plain-text preview.
 
@@ -117,22 +118,47 @@ def cap_tool_result_content(
                       ``chat_message.py``'s ``TOOL_STATUS_META_KEY``
                       docstring). Optional and additive: every existing
                       caller that doesn't pass it is unaffected.
+        on_write_unavailable: (#5364 §1.5) Called with no arguments when
+                      ``save_fn`` raises ``MediaStoreWriteUnavailable`` —
+                      the ONE typed channel a caller uses to learn "an
+                      offload was attempted and refused because the
+                      store's writes are known not to land," so the
+                      entry can be marked accordingly instead of the
+                      caller having to guess from the (unchanged, still
+                      inline) return value alone. Optional and additive.
 
     Returns:
         The original string when ``estimate_tokens(content_str) <= cap_tokens``;
         otherwise a bounded plain-text preview (head + a truncation marker naming
         the ``read_file`` path + tail) with ``estimate_tokens(preview) <= cap_tokens``.
         The full body is always stored first — no information is lost.
+
+        #5364 §1.5: also the original string, unchanged, if ``save_fn`` raises
+        ``MediaStoreWriteUnavailable`` — "a permanently-failed write's turn
+        keeps content inline, never emits a ref naming a file that doesn't
+        exist" (owner). ``on_write_unavailable`` (if given) fires first.
     """
     if cap_tokens <= 0:
         return content_str
     if estimate_tokens(content_str, model, use_chars4=use_chars4) <= cap_tokens:
         return content_str
 
-    if content_type:
-        block = save_fn(content_str, mime_type=content_type)
-    else:
-        block = save_fn(content_str)
+    from reyn.data.workspace.media_store import MediaStoreWriteUnavailable
+    try:
+        if content_type:
+            block = save_fn(content_str, mime_type=content_type)
+        else:
+            block = save_fn(content_str)
+    except MediaStoreWriteUnavailable:
+        if on_write_unavailable is not None:
+            on_write_unavailable()
+        if events is not None:
+            events.emit(
+                "tool_result_write_unavailable",
+                total_chars=len(content_str),
+                cap_tokens=cap_tokens,
+            )
+        return content_str
     preview_source = content_str
     ref = block.get("path", "")
     content_hash = block.get("content_hash", "")

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -9690,6 +9690,7 @@ class Session:
         *,
         content_type: "str | None" = None,
         on_offload: "Callable[[str], None] | None" = None,
+        on_write_unavailable: "Callable[[], None] | None" = None,
     ) -> str:
         """Forwarding → ContextBudgetAdvisor.cap_tool_result (PR-1).
 
@@ -9698,10 +9699,12 @@ class Session:
         canonical's renderer-only sidecar, forwarded so an offloaded ref's on-disk extension carries it
         for present's stage-3 default viewer — never read into any LLM-visible field here.
 
-        ``on_offload`` (#5364 §1.2) — forwarded unchanged; optional and
-        additive, every existing caller unaffected."""
+        ``on_offload`` (#5364 §1.2) / ``on_write_unavailable`` (#5364 §1.5)
+        — forwarded unchanged; optional and additive, every existing
+        caller unaffected."""
         return self._budget_advisor.cap_tool_result(
             content_str, content_type=content_type, on_offload=on_offload,
+            on_write_unavailable=on_write_unavailable,
         )
 
     def _media_followup_budget(self, tool_content: str) -> "int | None":

--- a/tests/runtime/test_2425_step1c_chat_chokepoint.py
+++ b/tests/runtime/test_2425_step1c_chat_chokepoint.py
@@ -41,12 +41,14 @@ class _CapHost:
         *,
         content_type: "str | None" = None,
         on_offload=None,
+        on_write_unavailable=None,
     ) -> str:
         if self.media_store is None:
             return content_str
         return cap_tool_result_content(
             content_str, cap_tokens=100, model=_MODEL, save_fn=self.media_store.save_tool_result,
             use_chars4=True, content_type=content_type, on_offload=on_offload,
+            on_write_unavailable=on_write_unavailable,
         )
 
     def media_followup_budget(self, _content_str: str) -> int:

--- a/tests/runtime/test_5364_media_store_flush_barrier.py
+++ b/tests/runtime/test_5364_media_store_flush_barrier.py
@@ -136,13 +136,21 @@ async def test_router_loop_flushes_pending_writes_before_the_llm_call(tmp_path: 
     ``run_loop`` starts is durable by the time the (real, injected)
     ``_llm_caller`` is invoked for this turn's very first iteration.
 
-    No await happens anywhere in ``run_loop`` before its flush call site
-    for a bare ``FakeRouterHost`` (no ``should_force_close`` /
+    No await happens anywhere in ``run_loop`` between the top of its
+    per-iteration loop and its flush call site for a bare
+    ``FakeRouterHost`` (no ``should_force_close`` /
     ``peek_mid_turn_injection`` implemented — both getattr-guarded, both
-    short-circuit before their own ``await``) — confirmed by reading
-    ``router_loop.py`` lines 1753-1953 directly. So this is a genuine
-    ordering witness, not a scheduler-timing coincidence: nothing else in
-    this call graph could have run the drainer first."""
+    short-circuit BEFORE their own ``await``, never reaching it). This is
+    an invariant about the CODE PATH (guard-then-await, in that order,
+    both gated on a host attribute this fixture never implements), not a
+    line-number range — confirmed by reading ``router_loop.py``'s
+    ``run_loop`` directly at the head of each iteration, before the
+    flush call. If a future edit adds a new unconditional ``await``
+    ahead of the flush, this test would go green on scheduler luck
+    rather than the barrier — re-verify this comment's claim (not just
+    that the test still passes) whenever that region changes. So this is
+    a genuine ordering witness, not a scheduler-timing coincidence:
+    nothing else in this call graph could have run the drainer first."""
     store = MediaStore(project_root=tmp_path, session_id="flush-test")
     host = _MediaStoreHost(store)
     written = await _seed_pending_spill(host)

--- a/tests/runtime/test_5364_media_store_flush_barrier.py
+++ b/tests/runtime/test_5364_media_store_flush_barrier.py
@@ -76,11 +76,13 @@ class _MediaStoreHost(FakeRouterHost):
 
     def cap_tool_result(
         self, content_str: str, *, content_type: "str | None" = None, on_offload=None,
+        on_write_unavailable=None,
     ) -> str:
         return cap_tool_result_content(
             content_str, cap_tokens=100, model=_MODEL,
             save_fn=self.media_store.save_tool_result,
             use_chars4=True, content_type=content_type, on_offload=on_offload,
+            on_write_unavailable=on_write_unavailable,
         )
 
     def media_followup_budget(self, _content_str: str) -> int:

--- a/tests/runtime/test_5364_spilled_meta_wiring.py
+++ b/tests/runtime/test_5364_spilled_meta_wiring.py
@@ -47,6 +47,7 @@ class _RecordingHost:
 
     def cap_tool_result(
         self, content_str: str, *, content_type: "str | None" = None, on_offload=None,
+        on_write_unavailable=None,
     ) -> str:
         if self.media_store is None:
             return content_str
@@ -54,6 +55,7 @@ class _RecordingHost:
             content_str, cap_tokens=100, model=_MODEL,
             save_fn=self.media_store.save_tool_result,
             use_chars4=True, content_type=content_type, on_offload=on_offload,
+            on_write_unavailable=on_write_unavailable,
         )
 
     def media_followup_budget(self, _content_str: str) -> int:

--- a/tests/runtime/test_5364_write_unavailable_keeps_content_inline.py
+++ b/tests/runtime/test_5364_write_unavailable_keeps_content_inline.py
@@ -1,0 +1,182 @@
+"""Tier 2: #5364 §1.5 — the failure path (A's exception). Owner: "a
+permanently-failed write's turn keeps content inline, never emits a ref
+naming a file that doesn't exist." ``MediaStoreWriteUnavailable`` is the
+typed signal: ``save_tool_result`` raises it once
+``DurabilityWorker.durability_failed`` is known True (an EARLIER write
+already exhausted §4 retries) rather than minting a ref for a write that
+will never land. ``cap_tool_result_content`` catches it and keeps
+``content_str`` unchanged; ``RouterLoop.feedback`` stamps
+``LOST_REASON_META_KEY=LOST_REASON_NEVER_PERSISTED`` on the entry so an
+operator sees WHY, without any ref ever having been claimed.
+
+Three tests, three collaborators, narrowest-to-widest:
+
+- :func:`test_save_tool_result_refuses_once_durability_has_permanently_failed`
+  — real ``MediaStore`` + real ``DurabilityWorker`` (fast retry bounds,
+  no mocks) — a genuinely exhausted write latches ``durability_failed``,
+  the NEXT ``save_tool_result`` call raises immediately (no attempt).
+- :func:`test_cap_tool_result_content_keeps_content_inline_on_write_unavailable`
+  — a real (raising) callable stands in for ``save_fn`` — proves the
+  catch + inline fallback + ``on_write_unavailable`` firing.
+- :func:`test_the_real_production_chain_marks_the_entry_never_persisted`
+  — a real ``Session`` driven end-to-end through ``session.router_host``
+  (mirrors #5372's own real-chain test) — proves the wiring survives all
+  4 hops, not just a fast unit-level stand-in.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config import CompactionConfig, MultimodalConfig
+from reyn.config.chat import OffloadConfig
+from reyn.core.events.durability_worker import DurabilityWorker
+from reyn.data.workspace.media_store import MediaStore, MediaStoreWriteUnavailable
+from reyn.runtime.chat_message import (
+    CONTENT_REF_META_KEY,
+    LOST_REASON_META_KEY,
+    LOST_REASON_NEVER_PERSISTED,
+    SPILLED_META_KEY,
+)
+from reyn.runtime.router_loop import RouterLoop
+from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.tools.scheme import ExecutionResult
+from tests._support.agent_session import make_session
+
+_MODEL = "gpt-4o"
+_BIG = "\n".join(f"line {i}: " + "z" * 60 for i in range(400))  # well over the offload trigger
+
+
+def _fast_worker(max_attempts: int = 2) -> DurabilityWorker:
+    return DurabilityWorker(
+        max_write_attempts=max_attempts, retry_base_s=0.001, retry_max_s=0.005,
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_tool_result_refuses_once_durability_has_permanently_failed(
+    tmp_path,
+) -> None:
+    """Tier 2: an EARLIER write's persistent failure (real worker, real
+    exhausted retries, no filesystem trickery needed) latches
+    ``durability_failed`` — the NEXT ``save_tool_result`` call raises
+    ``MediaStoreWriteUnavailable`` immediately, never attempting a write
+    that is now known to be pointless. The store's own store_dir stays a
+    perfectly ordinary writable directory throughout — proves the refusal
+    is driven by the latched flag, not by anything actually broken on
+    disk."""
+    worker = _fast_worker()
+    store = MediaStore(project_root=tmp_path, session_id="broken", worker=worker)
+    assert store.durability_failed is False, "test setup sanity: starts healthy"
+
+    async def _always_fail() -> None:
+        raise OSError("disk full")
+
+    worker.submit_nowait(_always_fail)
+    await worker.flush()
+    assert store.durability_failed is True, (
+        "test setup sanity: the seeded failure must have latched durability_failed"
+    )
+
+    with pytest.raises(MediaStoreWriteUnavailable):
+        store.save_tool_result("this must never actually be attempted")
+
+
+def test_cap_tool_result_content_keeps_content_inline_on_write_unavailable() -> None:
+    """Tier 2: ``cap_tool_result_content`` catches ``MediaStoreWriteUnavailable``
+    from ``save_fn`` and returns ``content_str`` UNCHANGED (never a
+    preview naming a ref that will never exist) — the same shape as the
+    "content stayed under the cap" no-op path. ``on_write_unavailable``
+    fires exactly once; a real events sink also gets the audit event."""
+    calls: list[None] = []
+
+    def _always_unavailable(*_a, **_kw):
+        raise MediaStoreWriteUnavailable("store is broken")
+
+    class _RecordingEvents:
+        def __init__(self) -> None:
+            self.emitted: list[dict] = []
+
+        def emit(self, type: str, **data) -> None:
+            self.emitted.append({"type": type, **data})
+
+    events = _RecordingEvents()
+    big = "X" * 100_000
+
+    result = cap_tool_result_content(
+        big, cap_tokens=10, model=_MODEL, save_fn=_always_unavailable,
+        use_chars4=True, events=events,
+        on_write_unavailable=lambda: calls.append(None),
+    )
+
+    assert result == big, "content must stay inline, unchanged — no ref was ever minted"
+    assert calls == [None], "on_write_unavailable must fire exactly once"
+    kinds = [e["type"] for e in events.emitted]
+    assert "tool_result_write_unavailable" in kinds, (
+        f"expected a tool_result_write_unavailable audit event, got: {kinds!r}"
+    )
+    assert "tool_result_offloaded" not in kinds, (
+        "no offload happened — the offload event must not fire"
+    )
+
+
+def test_the_real_production_chain_marks_the_entry_never_persisted(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: architect/lead-coder's own #5372 precedent — a real
+    ``Session``, real ``RouterHostAdapter`` (``session.router_host``),
+    real ``ContextBudgetAdvisor``, driven end-to-end. The store's worker
+    is swapped for a fast one and seeded with one genuinely-exhausted
+    failure (same technique as the first test above) BEFORE the turn
+    runs, so the write-time cap's own attempt hits the pre-check and
+    raises — proving the full 4-hop ``on_write_unavailable`` wiring, not
+    just a fast unit-level stand-in."""
+    monkeypatch.chdir(tmp_path)
+    session = make_session(
+        agent_name="broken-store-agent",
+        multimodal_config=MultimodalConfig(),
+        offload_config=OffloadConfig(enabled=True),
+        compaction_config=CompactionConfig(use_chars4_estimate=True),
+    )
+    worker = _fast_worker()
+    session.router_host.media_store._worker = worker
+
+    async def _always_fail() -> None:
+        raise OSError("disk full")
+
+    async def _seed_failure() -> None:
+        worker.submit_nowait(_always_fail)
+        await worker.flush()
+
+    import asyncio
+    asyncio.run(_seed_failure())
+    assert session.router_host.media_store.durability_failed is True, (
+        "test setup sanity: the seeded failure must have latched durability_failed"
+    )
+
+    loop = RouterLoop(host=session.router_host, chain_id="c1", router_model=_MODEL)
+    result = ExecutionResult(
+        tool_results=[{
+            "status": "ok",
+            "data": {
+                "kind": "mcp", "status": "ok", "server": "s", "tool": "t",
+                "content": _BIG, "media_blocks": [],
+            },
+            "_canonical_source": "mcp",
+        }],
+        tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "mcp"}}],
+        assistant_content="",
+    )
+    loop.feedback(result)
+
+    (tool_msg,) = [m for m in session.history if m.role == "tool"]
+    assert SPILLED_META_KEY not in tool_msg.meta, (
+        "no ref was ever minted — SPILLED_META_KEY must stay absent"
+    )
+    assert CONTENT_REF_META_KEY not in tool_msg.meta
+    assert tool_msg.meta.get(LOST_REASON_META_KEY) == LOST_REASON_NEVER_PERSISTED, (
+        f"expected LOST_REASON_NEVER_PERSISTED, got meta={tool_msg.meta!r}"
+    )
+    assert _BIG in tool_msg.content, (
+        "the ORIGINAL content must still be present in the rendered turn "
+        "(inline, never truncated to a dead ref)"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5364 §1.5. **Stacked on #5377** (base branch — #5377 is out for review; this PR's diff will shrink once #5377 lands and this rebases onto main).

## What

Owner (§1.5's canonical spec): "a permanently-failed write's turn keeps content inline, never emits a ref naming a file that doesn't exist." `lost`'s reason has 2 values (`gc` / `never_persisted`) — same observation (file missing), different operator remedy (check the cap size vs check disk/permissions). **This PR covers `never_persisted`; `gc` needs §1.6's GC (not yet built) to actually tombstone what it removes.**

- `media_store.py`: new `MediaStoreWriteUnavailable` exception + a `durability_failed` property delegating to `DurabilityWorker`'s own latched health-signal. `save_tool_result` raises it instead of returning a block in two cases: (a) `durability_failed` is ALREADY known True (checked first — refuses immediately, no attempt) — the only case preventable in advance, since an async write's own failure is discovered later, off-loop; (b) the sync-fallback branch's OWN write fails synchronously (no running loop) — knowable immediately, unlike the async path's.
- `tool_result_cap.py`: `cap_tool_result_content` catches `MediaStoreWriteUnavailable` around `save_fn(...)`, returns `content_str` UNCHANGED (same shape as "stayed under the cap"), fires a new optional `on_write_unavailable` callback, emits a `tool_result_write_unavailable` audit event.
- `on_write_unavailable` threaded through the same 4 hops `on_offload` already uses (`context_budget_advisor.py` → `session.py` → `router_host_adapter.py` → `router_loop.py`'s `feedback()`) — same additive, optional shape.
- `router_loop.py`: on fire, stamps `LOST_REASON_META_KEY = LOST_REASON_NEVER_PERSISTED` on the entry (`SPILLED_META_KEY` stays absent — no ref was ever minted).
- `chat_message.py`: softened `CONTENT_REF_META_KEY`'s own comment, which read as "every tool result is always file-backed" — no longer true once a write can be refused in advance (per §1.5's own explicit requirement: don't leave this readable as "A is always ref").

## Verified

- New `tests/runtime/test_5364_write_unavailable_keeps_content_inline.py` (3 tests, narrowest to widest): (1) real `MediaStore` + real `DurabilityWorker` (fast retry bounds, genuinely exhausted, no filesystem trickery) — the NEXT `save_tool_result` call raises immediately; (2) `cap_tool_result_content`'s own catch + inline fallback + callback, using a real raising callable; (3) full 4-hop real-chain witness (mirrors #5372's own precedent) — real `Session`, real `session.router_host`, a swapped-in fast worker seeded with one genuine failure, driven through `RouterLoop.feedback` end-to-end.
- Real strip-falsify, one mechanism at a time: the `durability_failed` pre-check, `cap_tool_result_content`'s catch, and the meta-stamp — all 3 confirmed genuinely RED.
- Full blast-radius: 263 tests across every file referencing `save_tool_result`/`cap_tool_result`/`_attempt_reactive_spill`/`spill_turn_content`/`history_content_dir`/`read_tool_result`/`is_tool_result_spill`/`_spill_manifest_path`/`offload_value`/`MediaStore` — all green.

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — clean (found + fixed a real private-state violation of my own before finalizing)
- [x] `python scripts/mypy_ratchet.py` — OK, 201/207 baselined, unchanged
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] `python scripts/flat_tests_ratchet.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_tests_path_literal_reference.py` — all clean (tests/ touched)
- [x] Full blast-radius: 263 tests — all green
- [x] Real strip-falsify (see above)
- [ ] (skipped — no UI/visual surface)

## Not included

The `gc` lost-reason (needs §1.6's GC to tombstone what it removes) · §1.6 GC (2GB cap) · `router_loop_driver.py:371` retry-loop restructuring — tracked on #5364, next in order.

co-vet: @architect (per #5364 §4).

part of #5364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>