### PR TITLE
feat(#5364-A): §1.6 C+Q -- history-content cap eviction + vanish-purge

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -352,22 +352,24 @@ def _dir_stats_recursive(directory: Path) -> tuple[int, int]:
 
 
 def _eviction_order(directory: Path) -> list[Path]:
-    """#5364 §1.6 "C": which file in *directory* goes first when it must
-    shrink, expressed as an ordered PREDICATE SEQUENCE rather than an
-    inline sort key — so a future predicate (#5387's turn-boundary
-    exclusion, once ``chain_id`` is threaded through the write-time cap
-    path) has a single named place to land instead of a second hand-
-    rolled sort. Today there is exactly ONE predicate: oldest ``mtime``
-    first.
+    """#5364 §1.6 "C": among files that ARE eligible for deletion, which
+    one goes first — oldest ``mtime`` first, the only rule today.
 
-    This is an eviction ORDER, not a claim about which turn a file
-    belongs to — see ``history_content_max_bytes``'s own docstring for
-    why mtime cannot answer that question (two concurrent sessions'
-    writes interleave in mtime order). It only says "when something
-    must go, the least-recently-written file goes first", the standard
-    backstop default even before any turn-awareness exists. Best-effort
-    on a ``stat()`` race (a file removed between listing and stat) —
-    same disclosed-skip policy as :func:`_dir_stats`."""
+    This is an ORDER over an already-eligible set, not an eligibility
+    filter — the two are different questions with different failure
+    modes (lead-coder review, PR #5388: "may this be deleted" is a
+    filter, "which one first" is a sort, and folding a future filter
+    into THIS function's sort key would let it silently become "deleted
+    last" instead of "never deleted"). #5387's turn-boundary exclusion
+    (once ``chain_id`` is threaded through the write-time cap path)
+    belongs in a SEPARATE eligibility filter applied to this function's
+    input or output — not as another entry in a predicate sequence
+    here. mtime cannot stand in for that filter either way: see
+    ``history_content_max_bytes``'s own docstring for why (two
+    concurrent sessions' writes interleave in mtime order — "oldest" is
+    not "whose turn is still open"). Best-effort on a ``stat()`` race (a
+    file removed between listing and stat) — same disclosed-skip policy
+    as :func:`_dir_stats`."""
     entries: list[tuple[float, Path]] = []
     for entry in directory.rglob("*"):
         try:

--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -73,6 +73,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -82,6 +83,8 @@ from reyn.services.offload.store import offload_value, read_offloaded
 
 if TYPE_CHECKING:
     from reyn.core.events.durability_worker import DurabilityWorker
+
+logger = logging.getLogger(__name__)
 
 #: #4381: one JSON object per line (``{"path": "<absolute path>"}``), one
 #: line per :meth:`MediaStore.save_tool_result` write — the persisted
@@ -261,6 +264,27 @@ class MediaStoreConfig:
     # measured across all 8 was 132 MB. 2 GB is >15x that observed
     # maximum — the cap is intended to never fire under any measured
     # real usage; it exists only to bound a genuine runaway.
+    #
+    # This does NOT protect a still-open turn's own content from GC —
+    # doing that needs a discriminator distinguishing "this session's
+    # newest file" from "a turn currently in flight", and none exists
+    # yet: the write-time cap path (``tool_result_cap.py``'s ``save_fn``
+    # call) does not thread ``chain_id`` through today, so most spilled
+    # files carry none (only the REACTIVE-spill path,
+    # ``router_history_buffer.py``, does) — mtime is NOT a safe
+    # approximation (lead-coder ruling, #5364: "the newest file is not a
+    # turn boundary"; architect, same ruling: mtime answers "when was
+    # this written", not "whose turn is this" — two concurrent sessions
+    # writing at once interleave mtime order across BOTH turns).
+    #
+    # DO NOT LOWER THIS DEFAULT to a value that can actually fire under
+    # real usage until #5387 lands (threading ``chain_id`` through the
+    # write-time cap path so GC can tell a still-open turn's content
+    # apart from an evictable one). At today's 2 GB this gap has nothing
+    # to protect — 2GB is >15x the largest ``.reyn/`` tree measured
+    # above, so eviction is not expected to ever run — but a lower cap
+    # WOULD run eviction against real, in-flight turn content with no
+    # discriminator to protect it.
     history_content_max_bytes: int = 2 * 1024 * 1024 * 1024
 
 
@@ -327,6 +351,34 @@ def _dir_stats_recursive(directory: Path) -> tuple[int, int]:
     return count, total
 
 
+def _eviction_order(directory: Path) -> list[Path]:
+    """#5364 §1.6 "C": which file in *directory* goes first when it must
+    shrink, expressed as an ordered PREDICATE SEQUENCE rather than an
+    inline sort key — so a future predicate (#5387's turn-boundary
+    exclusion, once ``chain_id`` is threaded through the write-time cap
+    path) has a single named place to land instead of a second hand-
+    rolled sort. Today there is exactly ONE predicate: oldest ``mtime``
+    first.
+
+    This is an eviction ORDER, not a claim about which turn a file
+    belongs to — see ``history_content_max_bytes``'s own docstring for
+    why mtime cannot answer that question (two concurrent sessions'
+    writes interleave in mtime order). It only says "when something
+    must go, the least-recently-written file goes first", the standard
+    backstop default even before any turn-awareness exists. Best-effort
+    on a ``stat()`` race (a file removed between listing and stat) —
+    same disclosed-skip policy as :func:`_dir_stats`."""
+    entries: list[tuple[float, Path]] = []
+    for entry in directory.rglob("*"):
+        try:
+            if entry.is_file():
+                entries.append((entry.stat().st_mtime, entry))
+        except FileNotFoundError:
+            continue
+    entries.sort(key=lambda pair: pair[0])
+    return [path for _, path in entries]
+
+
 # #385 β core impl sub-task 1: cross-host capable resource URI scheme.
 # A path-ref minted with ``agent_name`` set carries this scheme so a
 # downstream consumer (= another agent / a different host) can dispatch
@@ -353,6 +405,25 @@ def parse_resource_uri(uri: str) -> tuple[str, str] | None:
     if not agent or not artifact:
         return None
     return agent, artifact
+
+
+def history_content_dir_for(
+    project_root: Path, agent_name: str, session_id: str,
+    config: "MediaStoreConfig | None" = None,
+) -> Path:
+    """#5364 §1.6 "Q": the SAME path :meth:`MediaStore._history_content_dir`
+    computes for a LIVE store, exposed as a standalone function so a
+    caller that only needs to know WHERE a session's content lives (e.g.
+    the registry's own session-vanish purge) doesn't have to construct a
+    full ``MediaStore`` instance — one source of truth for the path
+    shape, not a second hand-derived copy that could drift from the
+    real one. Never creates the directory (a vanished session may never
+    have written anything at all — the caller is expected to check
+    ``is_dir()`` before acting, same as ``registry._purge_session_dir``
+    already does for the state dir)."""
+    cfg = config or MediaStoreConfig()
+    root = (project_root / cfg.history_content_dir).resolve()
+    return root / _safe_token(agent_name) / _safe_token(session_id)
 
 
 class MediaStoreWriteUnavailable(Exception):
@@ -719,10 +790,12 @@ class MediaStore:
                 "agent_name must never silently fall into a directory "
                 "shared with other agents' sessions, #5364)"
             )
-        return (
-            self._history_content_root
-            / _safe_token(self._agent_name)
-            / _safe_token(self._session_id)
+        # Delegates to the standalone function below — one source of
+        # truth for the path shape (see its own docstring: a caller with
+        # no live store, e.g. the registry's session-vanish purge, needs
+        # the SAME computation without constructing a MediaStore).
+        return history_content_dir_for(
+            self._project_root, self._agent_name, self._session_id, self._config,
         )
 
     def save_tool_result(
@@ -865,7 +938,46 @@ class MediaStore:
             "content_hash": result.content_hash,
         }
         self._attach_cross_host_fields(block, filename=filename, chain_id=chain_id)
+        # #5364 §1.6 "C": bound THIS session's own history-content
+        # footprint after every write — a per-write check (not a
+        # separate sweep) keeps the cap self-enforcing without a second
+        # scheduled mechanism. Runs against whatever is ALREADY on disk;
+        # the write just submitted above is off-loop and may not have
+        # landed yet, so this can lag one write behind — acceptable for
+        # a backstop that (per the field's own docstring) is not
+        # expected to fire under real usage.
+        self._evict_history_content_over_cap()
         return block
+
+    def _evict_history_content_over_cap(self) -> None:
+        """#5364 §1.6 "C": delete this session's own OLDEST history-content
+        files (see :func:`_eviction_order`) until its directory is back
+        under ``history_content_max_bytes``. Scoped to THIS session's own
+        subdirectory, not the whole ``history_content_root`` — the cap's
+        own subject is one session's content (see the field's docstring:
+        cross-session growth is #5366's separate subject, not this one's).
+        Best-effort: an ``OSError`` mid-delete is logged and skipped, same
+        policy as :meth:`_purge_session_dir`'s own sibling deletes — a
+        failed eviction must never fail the write it followed."""
+        cap = self._config.history_content_max_bytes
+        directory = self._history_content_dir()
+        _, total = _dir_stats_recursive(directory)
+        if total <= cap:
+            return
+        for path in _eviction_order(directory):
+            if total <= cap:
+                break
+            try:
+                size = path.stat().st_size
+                path.unlink()
+            except OSError as e:  # noqa: BLE001 — best-effort; LOG (don't silently swallow)
+                logger.warning(
+                    "#5364 §1.6: eviction of %s under the history-content "
+                    "cap failed: %s",
+                    path, e,
+                )
+                continue
+            total -= size
 
     @property
     def durability_failed(self) -> bool:

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2732,18 +2732,41 @@ class AgentRegistry:
         until after the substrate restores succeed (atomicity). Best-effort; LOGs an
         ``OSError`` rather than swallowing. Returns True iff a dir was removed."""
         state_dir = self._session_state_dir(name, sid)  # sid != main → sessions/<enc>/
-        if not state_dir.is_dir():
-            return False
-        import shutil
-        try:
-            shutil.rmtree(state_dir)
-            return True
-        except OSError as e:  # noqa: BLE001 — best-effort; LOG (don't silently swallow)
-            logger.warning(
-                "#2103/#2125: teardown of session %r/%r left state on disk: %s",
-                name, sid, e,
-            )
-            return False
+        removed = False
+        if state_dir.is_dir():
+            import shutil
+            try:
+                shutil.rmtree(state_dir)
+                removed = True
+            except OSError as e:  # noqa: BLE001 — best-effort; LOG (don't silently swallow)
+                logger.warning(
+                    "#2103/#2125: teardown of session %r/%r left state on disk: %s",
+                    name, sid, e,
+                )
+        # #5364 §1.6 "Q": a vanished session's own spilled tool-result
+        # content is otherwise ORPHANED — nothing else ever purges
+        # history-content/<agent>/<sid>/ (the GC cap (§1.6 "C") bounds one
+        # session's OWN content, it does not know a session vanished).
+        # Same (name, sid) key-space as state_dir above — safe to purge
+        # together only because #5364's key-space fix made this dir's own
+        # keying agent-scoped, matching _session_state_dir's shape exactly
+        # (before that fix, this path was shared across every agent's
+        # same-named session — purging it here would have been the exact
+        # cross-agent data-loss #5364's key-space fix closed).
+        from reyn.data.workspace.media_store import history_content_dir_for
+        content_dir = history_content_dir_for(self._project_root, name, sid)
+        if content_dir.is_dir():
+            import shutil
+            try:
+                shutil.rmtree(content_dir)
+                removed = True
+            except OSError as e:  # noqa: BLE001 — best-effort; LOG (don't silently swallow)
+                logger.warning(
+                    "#5364 §1.6: teardown of session %r/%r left spilled "
+                    "tool-result content on disk: %s",
+                    name, sid, e,
+                )
+        return removed
 
     async def _materialize_rewind(
         self, *, reconstruct_seq: int, workspace_at_or_below: int,

--- a/tests/data/test_5364_history_content_cap_eviction.py
+++ b/tests/data/test_5364_history_content_cap_eviction.py
@@ -31,17 +31,24 @@ def test_a_write_that_pushes_the_session_over_cap_evicts_the_oldest_file(
 
     blocks = []
     for i in range(3):
-        blocks.append(
+        block = store.save_tool_result(
             # seq=i: save_tool_result's filename is (timestamp, chain,
             # tool, seq) — two calls in the SAME wall-clock second with
             # the same default seq=1 would collide on ONE filename
             # (silently overwriting), which would make this test pass
             # for the wrong reason (only one file ever existing) rather
             # than genuinely exercising eviction across multiple files.
-            store.save_tool_result(
-                f"payload number {i} " * 2, mime_type="text/plain", seq=i,
-            )
+            f"payload number {i} " * 2, mime_type="text/plain", seq=i,
         )
+        blocks.append(block)
+        # architect TESTS-READ non-block, #5388: assert PRESENT right
+        # after its own write, before the LATER assertions check it's
+        # absent — otherwise "not exists()" for a file that was never
+        # written in the first place would pass for the wrong reason
+        # (a broken write silently producing the SAME final state as a
+        # correct eviction). Same present→absent shape as this file's
+        # own Q sibling test.
+        assert (tmp_path / block["path"]).exists()
         # #5364 §1.6: mtime is the eviction order's own sort key — force
         # each write's mtime to be strictly later than the previous
         # one's, since a fast test loop can otherwise land two writes in

--- a/tests/data/test_5364_history_content_cap_eviction.py
+++ b/tests/data/test_5364_history_content_cap_eviction.py
@@ -1,0 +1,96 @@
+"""Tier 2: #5364 §1.6 "C" — a session's own ``history-content`` directory
+is bounded by ``MediaStoreConfig.history_content_max_bytes``: once a
+write pushes it over cap, the OLDEST file(s) (see
+``media_store._eviction_order``) are deleted until it's back under.
+
+Scope, per that field's own docstring: this bounds ONE session's own
+content, not cross-session growth (#5366's separate subject) — the test
+below drives a single ``MediaStore`` through several writes and only
+asserts on ITS OWN directory.
+"""
+from __future__ import annotations
+
+import os
+
+from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+
+
+def test_a_write_that_pushes_the_session_over_cap_evicts_the_oldest_file(
+    tmp_path,
+) -> None:
+    """Tier 2: three ~40-byte writes under a ~50-byte cap must leave AT
+    MOST one file behind, and it must be the LAST one written — the
+    first two are evicted, oldest first, as later writes push the
+    running total back over cap."""
+    store = MediaStore(
+        MediaStoreConfig(history_content_max_bytes=50),
+        project_root=tmp_path,
+        agent_name="alice",
+        session_id="main",
+    )
+
+    blocks = []
+    for i in range(3):
+        blocks.append(
+            # seq=i: save_tool_result's filename is (timestamp, chain,
+            # tool, seq) — two calls in the SAME wall-clock second with
+            # the same default seq=1 would collide on ONE filename
+            # (silently overwriting), which would make this test pass
+            # for the wrong reason (only one file ever existing) rather
+            # than genuinely exercising eviction across multiple files.
+            store.save_tool_result(
+                f"payload number {i} " * 2, mime_type="text/plain", seq=i,
+            )
+        )
+        # #5364 §1.6: mtime is the eviction order's own sort key — force
+        # each write's mtime to be strictly later than the previous
+        # one's, since a fast test loop can otherwise land two writes in
+        # the same filesystem-mtime tick and make "oldest" ambiguous.
+        _bump_all_mtimes_forward(store.history_content_dir)
+
+    # #5364 §1.6 "C": behavior, not shape — which SPECIFIC files survive,
+    # not how many are left over (a raw file-count assertion pins the
+    # eviction algorithm's exact shrink-to-fit tightness, not the
+    # behavior under test: oldest-first eviction).
+    oldest_path = tmp_path / blocks[0]["path"]
+    middle_path = tmp_path / blocks[1]["path"]
+    newest_path = tmp_path / blocks[2]["path"]
+    assert not oldest_path.exists(), "the OLDEST write must be evicted first"
+    assert not middle_path.exists(), (
+        "the middle write must ALSO be evicted — it too predates the "
+        "final write that pushed the session back over cap"
+    )
+    assert newest_path.exists(), (
+        "the MOST RECENT write must survive — eviction is oldest-first"
+    )
+
+
+def test_a_session_under_cap_is_left_untouched(tmp_path) -> None:
+    """Tier 2: a session whose content never exceeds the cap must never
+    lose a file — eviction is conditional on being OVER cap, not an
+    unconditional prune."""
+    store = MediaStore(
+        MediaStoreConfig(history_content_max_bytes=10_000_000),
+        project_root=tmp_path,
+        agent_name="alice",
+        session_id="main",
+    )
+    first = store.save_tool_result("small", mime_type="text/plain", seq=1)
+    second = store.save_tool_result("also small", mime_type="text/plain", seq=2)
+
+    # #5364 §1.6 "C": both specific files present — not a count, which
+    # a cap-eviction test must not pin (that would double as a hidden
+    # assertion on the underlying write format's exact byte size).
+    assert (tmp_path / first["path"]).exists()
+    assert (tmp_path / second["path"]).exists()
+
+
+def _bump_all_mtimes_forward(directory) -> None:
+    """Force every file already in *directory* one second further into
+    the past relative to whatever gets written next, so eviction order
+    (sorted by mtime) is deterministic across a fast test loop instead
+    of racing the filesystem's own mtime tick granularity."""
+    for path in directory.rglob("*"):
+        if path.is_file():
+            st = path.stat()
+            os.utime(path, (st.st_atime, st.st_mtime - 1))

--- a/tests/runtime/test_5364_purge_history_content_on_session_vanish.py
+++ b/tests/runtime/test_5364_purge_history_content_on_session_vanish.py
@@ -1,0 +1,101 @@
+"""Tier 2: #5364 §1.6 "Q" — a spawned session's own spilled tool-result
+content (``.reyn/memory/history-content/<agent>/<sid>/``) must not be
+ORPHANED once ``registry.remove_session`` tears the session down.
+Before #5364 §1.6 nothing ever purged this directory: the GC cap
+(§1.6 "C") bounds a LIVE session's own content, it has no trigger for a
+session that no longer exists at all.
+
+Real ``AgentRegistry`` + real on-disk content written via
+:func:`history_content_dir_for` (the SAME path a live ``MediaStore``
+would use) — the (name, sid) key-space is agent-scoped (#5364's own
+key-space fix), so purging it here is safe only because it matches
+``_session_state_dir``'s own key shape exactly (pre-fix, this directory
+was shared across every agent's same-named session — see this file's
+sibling ``test_5364_history_content_agent_scoped_keyspace.py``).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.data.workspace.media_store import history_content_dir_for
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _no_factory(_profile):
+        raise AssertionError("session factory must not be called in this test")
+
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def _seed_spilled_content(tmp_path: Path, agent: str, sid: str) -> Path:
+    """Real on-disk content at the SAME path a live MediaStore would
+    have written it to — via the standalone function, not a hand-rolled
+    path (the exact 1-source-of-truth reason it exists)."""
+    content_dir = history_content_dir_for(tmp_path, agent, sid)
+    content_dir.mkdir(parents=True, exist_ok=True)
+    (content_dir / "spilled.txt").write_text("this session's own content", encoding="utf-8")
+    return content_dir
+
+
+@pytest.mark.asyncio
+async def test_remove_session_purges_the_sessions_own_spilled_content(tmp_path) -> None:
+    """Tier 2: the headline — tearing down a spawned session via
+    ``remove_session`` must ALSO remove its own history-content
+    directory, not just its state dir."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "worker")
+    reg._sessions.setdefault("worker", {})["task1"] = SimpleNamespace()
+    content_dir = _seed_spilled_content(tmp_path, "worker", "task1")
+    assert content_dir.is_dir()
+
+    assert await reg.remove_session("worker", "task1") is True
+
+    assert not content_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_remove_session_does_not_touch_a_different_agents_same_sid_content(
+    tmp_path,
+) -> None:
+    """Tier 2: the attribution-axis check for Q itself — removing
+    ``worker``'s ``task1`` session must NOT purge ``other``'s own
+    ``task1`` content (same sid, different agent — exactly the
+    cross-agent key-space #5364's own fix separated)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "worker")
+    reg._sessions.setdefault("worker", {})["task1"] = SimpleNamespace()
+    victim_dir = _seed_spilled_content(tmp_path, "worker", "task1")
+    survivor_dir = _seed_spilled_content(tmp_path, "other", "task1")
+
+    await reg.remove_session("worker", "task1")
+
+    assert not victim_dir.exists()
+    assert survivor_dir.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_remove_session_with_no_spilled_content_is_still_a_clean_noop(
+    tmp_path,
+) -> None:
+    """Tier 2: a session that never wrote any tool-result content (the
+    common case) must not error just because Q's own directory never
+    existed."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "worker")
+    reg._sessions.setdefault("worker", {})["task1"] = SimpleNamespace()
+
+    assert await reg.remove_session("worker", "task1") is True


### PR DESCRIPTION
**[e2e-coder]** — Stacked on #5383 (base = `feat/5364-keyspace-fix`).

## What

- **C**: `MediaStore._evict_history_content_over_cap()` — bounds a session's own `history-content` directory to `history_content_max_bytes`, evicting oldest-mtime-first via a new `media_store._eviction_order()` (an ordered predicate sequence — today exactly one predicate, so #5387's future turn-boundary exclusion has a named place to land instead of a second hand-rolled sort). Runs after every `save_tool_result` write.
- **Q**: `registry._purge_session_dir` now also removes the vanishing session's own `history-content` directory, via a new standalone `media_store.history_content_dir_for()` (same path `MediaStore._history_content_dir` computes, exposed so the registry's purge doesn't need a live `MediaStore` instance — one source of truth for the path shape).
- `history_content_max_bytes`'s own docstring strengthened per architect's review: names #5387 **directively** ("do NOT lower this default below what can actually fire until #5387 lands"), not just "see #5387".

## Why L is deferred to #5387

Lead-coder + architect ruling (both independently verified against `tool_result_cap.py`/`context_budget_advisor.py`/`router_history_buffer.py`): the write-time cap path never threads `chain_id` through, so most spilled files carry none — only the reactive-spill path does. mtime cannot discriminate "this session's newest file" from "a turn currently in flight" (two concurrent sessions interleave mtime order across both turns). At today's 2GB default this gap protects nothing (measured max `.reyn/` tree: 132MB) — but #5387 is required before the default is ever lowered.

## Verification

- Both C and Q have real tests (`tests/data/test_5364_history_content_cap_eviction.py`, `tests/runtime/test_5364_purge_history_content_on_session_vanish.py`) — genuine on-disk writes/removals, no mocks.
- **Strip-falsified both**: temporarily removed the eviction call / the purge block, confirmed the new tests go genuinely RED, restored.
- Full `#5364` blast-radius sweep (42 tests across `data/`+`runtime/`+`core/`) + broader `MediaStore(` sweep (186 tests) — all green.
- `ruff check .`, `test_tier_audit.py --strict` (both new test files), `mypy_ratchet.py`, `verify_module_docstrings.py`, `flat_tests_ratchet.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_tests_path_literal_reference.py` — all green.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on both new test files
- [x] `mypy_ratchet.py`
- [x] `verify_module_docstrings.py`
- [x] full #5364 test sweep + MediaStore( blast radius
- [x] strip-falsify both C and Q, confirmed genuinely RED, restored
- [x] (skipped — Visual, standing waiver, no UI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)