### PR TITLE
fix(#5364): §1.6 — mode-independent, candidate-exhaustion-bounded stop condition for reactive spill

### DIFF
--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -1173,6 +1173,36 @@ class RouterHistoryBuffer:
         self._bound_wire_reasoning(head + raw_middle + tail)
         return head, raw_middle, tail, summary_dict, seq_by_id
 
+    def compaction_watermark(self) -> int:
+        """#5364 §1.6 (architect review): public accessor for
+        :meth:`_compaction_watermark` — the reduction axis's OTHER
+        progress witness, alongside :meth:`is_already_spilled`'s spill
+        axis. A STRUCTURAL fact (the latest summary's
+        ``covers_through_seq``), never a byte count — the compaction axis
+        is compared as "did the watermark advance", the same way the
+        spill axis is compared as "did a candidate get consumed", never
+        by re-measuring wire bytes for either."""
+        return self._compaction_watermark()
+
+    def is_already_spilled(self, content: str) -> bool:
+        """#5364 §1.6: True if ``content`` IS a previously-produced spill
+        preview (a value ``spill_turn_content`` itself once returned),
+        rather than an original body that merely happens to look similar.
+
+        A candidate whose CURRENT (overlay-substituted) content already
+        satisfies this must never be offered to ``spill_turn_content``
+        again — that call is not idempotent on a preview: a preview's own
+        token count almost always still exceeds ``cap_tokens=1``, so
+        re-offloading it produces ANOTHER, different preview (a new
+        ``seq``, a new path) rather than returning the input unchanged.
+        Without this check, ``_attempt_reactive_spill`` would treat that
+        as fresh progress forever — an infinite loop, never reaching
+        #5364 §1.6's failure predicate (candidates exhausted). Checked by
+        VALUE (this method takes no turn identity — the same content
+        string could arrive from a different candidate object across
+        calls, e.g. after a `decompose_history_for_retry` re-scan)."""
+        return content in self._spill_overlay.values()
+
     def spill_turn_content(
         self, content: str, *, chain_id: str = "", tool: str = "tool", seq: int = 1,
     ) -> "str | None":
@@ -1236,22 +1266,6 @@ class RouterHistoryBuffer:
         content_hash = "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
         self._spill_overlay[content_hash] = replacement
         return replacement
-
-    def discard_spill_overlay_for(self, content: str) -> None:
-        """#5296 PR-2 (lead-coder review): undo a :meth:`spill_turn_content`
-        call for *content* whose caller has determined it did NOT help
-        (the total payload did not shrink) — without this, a no-progress
-        spill attempt still LEAVES its overlay entry in place, so a turn
-        whose every candidate got spilled for zero net benefit would keep
-        ALL of them spilled anyway: exactly the "destroy more of the
-        operator's visible context than necessary" outcome
-        :meth:`spill_turn_content`'s own docstring already disclaims.
-        Recomputes the SAME hash :meth:`spill_turn_content` used (the
-        ORIGINAL content, not the replacement) — a no-op if no entry is
-        present (idempotent, safe to call speculatively)."""
-        import hashlib
-        content_hash = "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
-        self._spill_overlay.pop(content_hash, None)
 
     def build_system_prompt(self) -> str:
         """Return the router system prompt for the current session state.

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -47,19 +47,6 @@ def _narrowing_per_iteration(safety: "SafetyConfig") -> bool:
     return bool(safety.threat_scan.narrowing_per_iteration())
 
 
-# #5296 PR-2: the ONE place this turn's total send-BUDGET (across
-# _run_with_shrink calls) is declared — architect ruling
-# (issuecomment-5439181599): retry_loop's own ``max_shrink_iterations``
-# bounds a SINGLE _run_with_shrink call's own token-shrink escalation (a
-# different layer — the driver's except block is the trigger point,
-# retry_loop stays a pure transport operation); this constant bounds how
-# many TIMES ``run_turn`` may call ``_run_with_shrink`` again after a
-# byte-limited failure, each retry preceded by a real reduction attempt
-# (spill, then compaction if spill made no progress). The two compose,
-# they do not conflict: this turn's total LLM-call-attempt upper bound is
-# ``(1 + _MAX_BYTE_REDUCTION_ATTEMPTS) * compaction.max_shrink_iterations``.
-_MAX_BYTE_REDUCTION_ATTEMPTS: int = 2
-
 
 class RouterLoopDriver:
     """Orchestrates the per-turn router loop for one Session.
@@ -280,158 +267,170 @@ class RouterLoopDriver:
             return sorted(cands, key=lambda t: -len(t["content"]))
         return _spillable(head) + _spillable(raw_middle) + _spillable(tail)
 
-    async def _attempt_reactive_spill(self, user_text: str, *, chain_id: str) -> bool:
-        """#5296 PR-2 ②③ / #5364 (mid included): one spill pass over the
-        CURRENT head/mid/tail, staged (see ``_spill_candidates``).
+    async def _attempt_reactive_spill(self, *, chain_id: str) -> bool:
+        """#5296 PR-2 ②③ / #5364 §1.6 (停止条件と束縛): spill the FIRST
+        candidate (head → mid → tail, staged — see ``_spill_candidates``)
+        that yields a genuinely NEW offload, then stop — #5364's own "1つ
+        ずつ spill → acompletion" contract (the caller retries the actual
+        LLM call after every single spill, rather than this method trying
+        to decide on its own whether enough has been spilled).
 
-        Spills candidates one at a time, re-measuring total wire bytes
-        after each, STOPPING as soon as the total has decreased from
-        before this pass started (contract ⑥'s "each attempt strictly
-        decreases bytes" — spilling more than needed would destroy more
-        of the operator's visible context than necessary) or candidates
-        are exhausted. The returned bool is this method's OWN local
-        verdict (useful standalone/for tests); the caller
-        (``_run_with_shrink_and_byte_reduction``) makes its own
-        escalate-to-compaction decision from a wrapper-wide
-        ``_wire_bytes_now()`` reading instead — see that method's own
-        docstring for why a narrower, call-scoped verdict is not always
-        the right signal.
+        Returns ``True`` (progress — the un-spilled candidate count just
+        went down by exactly one) if a candidate was newly spilled this
+        call; ``False`` (failure — every remaining candidate already
+        contributed nothing new, i.e. every one either isn't spillable or
+        was already fully spilled at its own floor) if none was.
 
-        #5364: a ``raw_middle`` candidate can NEVER move wire bytes (it is
-        already elided out of ``estimate_wire_bytes``'s inputs by
-        construction) — undoing it under the "did not help" rule below
-        would discard EVERY mid spill unconditionally, contradicting
-        #5364 §1.3's own point in including mid at all (persisted
-        ``spilled`` state + a smaller future compaction fold). A
-        mid-sourced spill is therefore never undone for "no byte
-        decrease" and never itself ends the pass with a `True` verdict —
-        it is byte-neutral by design, so the loop moves on to the next
-        candidate (mid, then tail) rather than treating it as either
-        progress or failure.
+        #5364 §1.6 (owner/architect ruling, replacing the OLD "undo if it
+        didn't help" behavior): a genuine new spill is ALWAYS kept, never
+        undone — not by a byte-decrease check (a ``raw_middle`` candidate
+        can NEVER move wire bytes at all, being already elided out of
+        ``estimate_wire_bytes``'s inputs by construction — #5364 §1.3),
+        and not by a "made it bigger" check either (a tiny original body
+        can genuinely become a larger fixed-overhead offloaded-preview
+        replacement, and that is still real, durable progress: ``spilled``
+        is persistent (D), and a mid-turn spill still shrinks a LATER
+        compaction fold's own input even when it moves zero bytes today).
+        The stop condition is "did progress happen" (a candidate got
+        consumed), never "did bytes move" — reading wire bytes at all
+        would reintroduce exactly the confusion #5367③ already named for
+        ``retry_loop``'s own analogous floor (mistaking "this lever alone
+        didn't visibly help" for "no lever is left").
 
-        #5364 ①/②'s open question (does the OUTER retry loop's
-        ``_MAX_BYTE_REDUCTION_ATTEMPTS`` cap still bound the number of
-        REAL acompletion attempts, or does the candidate ladder now run
-        to exhaustion across real per-candidate retries) is NOT resolved
-        here — this method still reports its OWN local byte-decrease
-        verdict per call, unchanged in that respect; see the tracking
-        discussion on #5364 before changing the caller's retry count.
+        No longer takes ``user_text`` (#5296 PR-2's original signature
+        did — used only to estimate wire bytes, which this method no
+        longer does at all).
         """
-        from reyn.services.compaction.engine import estimate_wire_bytes
-
-        SP = self._history_buffer.build_system_prompt()
-        new_msg = {"role": "user", "content": user_text}
-        head, raw_middle, tail, summary, _ = (
+        head, raw_middle, tail, _summary, _ = (
             self._history_buffer.decompose_history_for_retry()
         )
-        before = estimate_wire_bytes(SP=SP, head=head, summary=summary, tail=tail, new_msg=new_msg)
-
-        mid_ids = {id(t) for t in raw_middle}
-        candidates = self._spill_candidates(head, raw_middle, tail)
-        for i, turn in enumerate(candidates):
+        for i, turn in enumerate(self._spill_candidates(head, raw_middle, tail)):
+            if self._history_buffer.is_already_spilled(turn["content"]):
+                # This candidate's CURRENT content is already a prior
+                # spill's own preview — offering it to spill_turn_content
+                # again would produce a NEW, different preview forever
+                # (that call is not idempotent on its own output), never
+                # reaching the failure predicate. Not this candidate's
+                # turn; try the next one.
+                continue
             replacement = self._history_buffer.spill_turn_content(
                 turn["content"], chain_id=chain_id, seq=i + 1,
             )
-            if replacement is None:
+            if replacement is None or replacement == turn["content"]:
+                # Not spillable at all (no media store, or cap_tokens=1
+                # somehow still returned the input unchanged) — this
+                # candidate cannot make progress; try the next one.
                 continue
-            if id(turn) in mid_ids:
-                # Byte-neutral by construction (see docstring) — keep the
-                # spill, do not report progress from it alone, move on.
-                continue
-            head2, _rm2, tail2, summary2, _sb2 = (
-                self._history_buffer.decompose_history_for_retry()
-            )
-            after = estimate_wire_bytes(
-                SP=SP, head=head2, summary=summary2, tail=tail2, new_msg=new_msg,
-            )
-            if after < before:
-                return True
-            # #5296 PR-2 (architect review): this spill did NOT help —
-            # undo it rather than leaving a useless overlay entry in
-            # place. Without this, a turn whose every candidate happens
-            # to spill for zero net benefit ends this loop with ALL of
-            # them spilled anyway — this method's own docstring already
-            # disclaims exactly that outcome ("destroy more of the
-            # operator's visible context than necessary").
-            self._history_buffer.discard_spill_overlay_for(turn["content"])
-        # Every candidate spilled-then-undone (or none were spillable at
-        # all) without ever getting strictly under `before` — no progress.
+            return True
+        # Every remaining candidate contributed nothing new — candidates
+        # are exhausted (#5364 §1.6's failure predicate).
         return False
-
-    def _wire_bytes_now(self) -> int:
-        """The wire-JSON byte size of what ``build_history()`` would send
-        RIGHT NOW — the single canonical "how big is the payload" reading
-        both the attempt-start baseline and every reduction-progress check
-        below share, so they can never disagree about what "smaller"
-        means."""
-        import json
-        return len(
-            json.dumps(self._history_buffer.build_history(), ensure_ascii=False)
-            .encode("utf-8")
-        )
 
     async def _run_with_shrink_and_byte_reduction(
         self, loop: Any, user_text: str, *, chain_id: str,
     ) -> Any:
-        """#5296 PR-2 wrapper: same-turn recovery for a BYTE-limited (HTTP
-        413) unrecovered overflow, per the frozen implementation contract
-        (issue #5296, issuecomment-5437029911).
+        """#5296 PR-2 / #5364 §1.6 wrapper: same-turn recovery for an
+        ``UnrecoveredError`` — MODE-INDEPENDENT (byte-limited HTTP 413 OR
+        a non-byte, token-axis terminal cause — #5364 §1.6, replacing the
+        OLD ``if not exc.saw_byte_limit: raise`` gate, which meant a
+        token-cause overflow never got a single spill attempt at all,
+        purely because of which axis happened to terminate it).
+        ``ContextOverflowError`` (the window itself is too small — no
+        history to shrink) is UNCHANGED, not caught here.
 
         ``_run_with_shrink``'s own contract is UNCHANGED (architect
         ruling) — this wrapper only decides whether to call it AGAIN after
-        it raises, never alters what it does internally. On each byte-
-        limited ``UnrecoveredError``: spill (②), re-measure (③); if the
-        payload shrank (from EITHER spill or ``_run_with_shrink``'s own
-        pre-existing side-effect below), re-send; if not, re-raise (⑤ —
-        the caller's own except still names the cause via ``repr(exc)``).
-        A non-byte-limited ``UnrecoveredError`` (never saw a 413 —
-        retry_loop's own token axis already exhausted itself) and
-        ``ContextOverflowError`` (the window itself is too small) are
-        UNCHANGED — this wrapper only intervenes on the ONE cause spill
-        can actually address.
+        it raises, never alters what it does internally.
 
-        #5296 PR-2 review (architect, 2nd finding): this wrapper does NOT
-        call ``force_compact_now`` itself — contract ④'s durable-
-        compaction step is already covered WITHOUT a second call site,
-        because ``_run_with_shrink``'s own except block ALREADY calls
-        ``force_compact_now`` as its pre-existing #4954(b) ``next_turn``
-        side-effect, before it ever re-raises back to this wrapper — a
-        SEPARATE call here would either be redundant (``next_turn``: the
-        watermark already advanced moments ago, nothing left to compact)
-        or, worse, would silently violate ``recovery_policy="never"``
-        (this NEW call site was never gated by that check #5303 added to
-        the ONE existing call site — an operator who opted out of
-        same-turn-visible compaction would have gotten it anyway). The
-        "did this attempt make progress" verdict is taken from
-        ``_wire_bytes_now()`` at the START of the attempt vs AFTER spill
-        ran — that single read already reflects ANY reduction that
-        happened in between, spill's own or the pre-existing side-effect's,
-        without this wrapper needing to trigger or gate compaction itself
-        at all.
+        #5364 §1.6's predicates (own body is the canonical source) —
+        TWO reduction axes, each with its OWN progress signal (architect
+        review: the first version of this fix read only the spill axis,
+        contradicting #5367's own "縮小軸は2本／失敗＝両縮小軸が dry" —
+        that omission was this docstring's, not the implementation's; the
+        implementation was faithful to a §1.6 text that only named the
+        spill side):
+
+        - spill axis PROGRESS — the un-spilled candidate count went down
+          by one (:meth:`_attempt_reactive_spill`'s own return value).
+        - compact axis PROGRESS — the compaction watermark advanced
+          (``self._history_buffer.compaction_watermark()`` strictly
+          increased across this attempt) — a STRUCTURAL fact, never a
+          byte count (mid spills move zero wire bytes by construction,
+          #5364 §1.3, so bytes cannot measure EITHER axis). This is
+          ``_run_with_shrink``'s own PRE-EXISTING #4954(b) ``next_turn``
+          side-effect (``force_compact_now``, inside ITS except block,
+          called before the exception ever reaches here) — not a new
+          call this wrapper makes.
+        - SUCCESS — ``_run_with_shrink`` stops raising (realized directly
+          by the ``try`` below returning; no separate byte-target
+          comparison is needed — the ACTUAL call succeeding IS success,
+          a stronger signal than any estimate of it. Cost disclosure: one
+          ``acompletion`` per spill — an N-candidate turn sends the full
+          payload N times; N is almost always 1 in practice, and batching
+          "spill everything, then retry once" is a separate, un-filed
+          improvement, not this PR's scope).
+        - FAILURE — NEITHER axis progressed this attempt; re-raise.
+          Termination holds: the watermark is bounded above (total seq
+          count) and monotonically non-decreasing, the candidate count is
+          bounded below by 0 and monotonically non-increasing, and every
+          retried iteration must strictly advance at least one of the
+          two — so this loop provably ends within at most
+          (remaining candidates + remaining foldable seqs) iterations.
+          ``force_compact_now`` itself cannot loop forever either (its
+          own docstring: returns immediately when already compacting, or
+          when it finds zero candidates).
+
+        This REMOVES the OLD fixed ``_MAX_BYTE_REDUCTION_ATTEMPTS`` cap
+        entirely (§1.6: "定数は廃止") and the OLD
+        ``self._wire_bytes_now() >= attempt_start_bytes: raise`` check —
+        that check treated "this spill didn't move wire bytes" as failure,
+        which is exactly wrong for a ``raw_middle``-only spill (#5364
+        §1.3) — with candidates still available, that old check would
+        raise on the FIRST mid-only spill instead of trying the next one.
+
+        force_compact_now double-call check (asked for explicitly, #5364
+        §1.6): ``_run_with_shrink``'s OWN except block conditionally calls
+        ``force_compact_now()``, but ONLY when ``saw_byte_limit`` is True
+        (see that method's own docstring) — a token-cause retry re-enters
+        ``_run_with_shrink`` with ``saw_byte_limit=False`` on that
+        particular failure, so this wrapper making token-cause overflow
+        retryable does NOT make that side-effect fire twice; it simply
+        never gates on a token-cause failure at all, unchanged from
+        before this fix.
         """
         from reyn.services.compaction.engine import UnrecoveredError as _UnrecoveredError
 
-        for attempt in range(_MAX_BYTE_REDUCTION_ATTEMPTS + 1):
-            attempt_start_bytes = self._wire_bytes_now()
+        attempt = 0
+        while True:
+            watermark_before = self._history_buffer.compaction_watermark()
             try:
                 return await self._run_with_shrink(loop, user_text, chain_id=chain_id)
-            except _UnrecoveredError as exc:
-                if not exc.saw_byte_limit or attempt >= _MAX_BYTE_REDUCTION_ATTEMPTS:
+            except _UnrecoveredError:
+                # Compact axis: measured FIRST — `_run_with_shrink`'s own
+                # except block (its PRE-EXISTING #4954(b) side-effect) may
+                # already have advanced the watermark during the call
+                # above, before this exception ever reached here.
+                compact_progressed = (
+                    self._history_buffer.compaction_watermark() > watermark_before
+                )
+                # Spill axis: always attempted too, even if compact already
+                # progressed — a genuinely spillable candidate should still
+                # be spilled (§1.6's own "1つずつ spill" contract), not
+                # skipped just because the OTHER axis happened to move.
+                spill_progressed = await self._attempt_reactive_spill(chain_id=chain_id)
+                if not compact_progressed and not spill_progressed:
                     raise
-                await self._attempt_reactive_spill(user_text, chain_id=chain_id)
-                if self._wire_bytes_now() >= attempt_start_bytes:
-                    raise
+                attempt += 1
                 # #5296 PR-2 ⑥: chain_id is the SAME value this call already
                 # closes over — no new chain_id, no re-emitted
                 # user_submitted/turn_started/WAL append (those all live
                 # ABOVE run_turn, in Session — unreached by looping back to
-                # the top of this for-loop and calling _run_with_shrink
+                # the top of this while-loop and calling _run_with_shrink
                 # again from HERE).
                 self._events.emit(
-                    "payload_reduced", chain_id=chain_id, attempt=attempt + 1,
+                    "payload_reduced", chain_id=chain_id, attempt=attempt,
                 )
                 continue
-        raise AssertionError("unreachable: loop always returns or raises")
 
     async def _run_with_shrink(self, loop: Any, user_text: str, *, chain_id: str = "") -> Any:
         """Run the router once with the reactive bounded-shrink ``retry_loop``.
@@ -695,12 +694,19 @@ class RouterLoopDriver:
                 # compact = terminal), and this except fires at most once
                 # per turn.
                 #
-                # #4885's own token-overflow pre-trigger already covers
-                # non-byte-limit overflow before it would ever reach here
-                # — a token overflow that STILL reaches this point means
-                # the pre-trigger's own estimate was wrong, which the
-                # existing adaptive learner (not a second compaction
-                # trigger here) is the correct fix for.
+                # #5364 §1.6: this except block can now be reached MORE
+                # THAN ONCE per turn for a non-byte (token-axis) cause too
+                # — `_run_with_shrink_and_byte_reduction` retries on ANY
+                # `UnrecoveredError`, mode-independent, not only a
+                # byte-limited one (the OLD gate here read "a token
+                # overflow reaching this point means #4885's pre-trigger
+                # estimate was wrong" — that assumed a token-cause failure
+                # could only ever reach here ONCE, which is no longer
+                # true: it is the expected shape on retry iterations 2+
+                # after a spill made progress). The `saw_byte_limit` check
+                # immediately below is UNCHANGED by this — a token-cause
+                # retry still skips `force_compact_now()` here every time,
+                # exactly as before this fix.
                 if (
                     _unrecovered.saw_byte_limit
                     and self._compaction.recovery_policy == "next_turn"
@@ -819,13 +825,16 @@ class RouterLoopDriver:
         # #4381 family (tool-result spill) is what now keeps an
         # oversized single result from reaching this point at all.
         try:
-            # #5296 PR-2: was a bare `self._run_with_shrink(loop, user_text)`
-            # — this wrapper adds same-turn spill/compaction recovery for a
-            # byte-limited (HTTP 413) unrecovered overflow, then re-tries
-            # THIS call (bounded, `_MAX_BYTE_REDUCTION_ATTEMPTS`) instead of
-            # always failing the turn on the first 413 that survives
-            # `_run_with_shrink`'s own token-axis attempts. See that
-            # method's own docstring for the full contract.
+            # #5296 PR-2 / #5364 §1.6: was a bare
+            # `self._run_with_shrink(loop, user_text)` — this wrapper adds
+            # same-turn spill recovery for an UnrecoveredError, mode-
+            # independent (byte-limited HTTP 413 OR a non-byte token-axis
+            # terminal cause — §1.6 dropped the OLD byte-only gate), then
+            # re-tries THIS call, bounded by candidate exhaustion (not a
+            # fixed attempt count anymore) instead of always failing the
+            # turn on the first overflow that survives `_run_with_shrink`'s
+            # own shrink attempts. See that method's own docstring for the
+            # full contract.
             router_usage = await self._run_with_shrink_and_byte_reduction(
                 loop, user_text, chain_id=chain_id,
             )

--- a/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
+++ b/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
@@ -1,18 +1,28 @@
-"""Tier 2: #5296 PR-2 — same-turn recovery from a BYTE-limited (HTTP 413)
-unrecovered overflow.
+"""Tier 2: #5296 PR-2 / #5364 §1.6 — same-turn recovery from an
+`UnrecoveredError`, MODE-INDEPENDENT (byte-limited HTTP 413 OR a non-byte,
+token-axis terminal cause).
 
-Before this, `RouterLoopDriver._run_with_shrink`'s own `UnrecoveredError`
-(with `.saw_byte_limit=True`) always ended the turn — #4954(b)'s own
+Before #5296 PR-2, `RouterLoopDriver._run_with_shrink`'s own
+`UnrecoveredError` always ended the turn — #4954(b)'s own
 `recovery_policy="next_turn"` only advanced the watermark for a LATER turn
 via a real `force_compact_now()`, but THIS turn still failed. #5296 PR-2's
 `_run_with_shrink_and_byte_reduction` (the new wrapper `run_turn` now calls
-instead of the bare `_run_with_shrink`) intervenes on exactly that one
-failure shape: spill first (reusing the existing `MediaStore.save_tool_
-result` + `tool_result_cap.cap_tool_result_content` machinery via a new
-session-lived, non-durable `RouterHistoryBuffer` projection overlay — never
+instead of the bare `_run_with_shrink`) intervenes on exactly that failure
+shape: spill (reusing the existing `MediaStore.save_tool_result` +
+`tool_result_cap.cap_tool_result_content` machinery via a new session-lived,
+non-durable `RouterHistoryBuffer` projection overlay — never
 `self.history`/`history.jsonl`, never the compaction watermark), then
-durable compaction only if spill made no progress, then re-tries
-`_run_with_shrink` — bounded by `_MAX_BYTE_REDUCTION_ATTEMPTS`.
+re-tries `_run_with_shrink`.
+
+#5364 §1.6 replaces PR-2's original byte-comparison gate and fixed
+`_MAX_BYTE_REDUCTION_ATTEMPTS` cap (both removed entirely) with 3
+predicates, from the #5364 issue body (canonical): PROGRESS — the
+un-spilled candidate count went down by one (the sole termination
+witness); SUCCESS — the retried call stops raising; FAILURE — candidates
+are empty. The bound is candidate exhaustion, never a fixed constant, and
+applies identically whether `UnrecoveredError.saw_byte_limit` is True or
+False — a token-axis cause now gets the same spill attempts a byte-limit
+cause always did.
 
 Real `Session` + real `RouterLoopDriver`/`RouterHistoryBuffer`/`MediaStore`
 throughout — the same harness `test_retry_loop_chat_wiring_1125.py`'s own
@@ -261,21 +271,21 @@ def test_history_dominant_overflow_recovers_via_pre_existing_compaction(
 ) -> None:
     """Tier 2: contract acceptance ① — many small turns, no tool-result
     turn at all (nothing spillable — spill's own candidate scan
-    structurally finds zero candidates).
-
-    #5296 PR-2 review (architect + lead-coder, 2nd finding): this
-    wrapper does NOT call ``force_compact_now`` itself (removed — see
-    ``_run_with_shrink_and_byte_reduction``'s own docstring for why a
-    second call site would either be redundant or, worse, silently
-    violate ``recovery_policy="never"``). Contract ④'s durable-
-    compaction step is instead covered by ``_run_with_shrink``'s own
-    PRE-EXISTING #4954(b) ``next_turn`` side-effect (the DEFAULT policy),
-    which already runs ``force_compact_now`` inside its own except block
-    before re-raising. This test's job is narrower than its name once
-    suggested: prove the wrapper correctly DETECTS that pre-existing
-    reduction (via ``_wire_bytes_now()``) and retries successfully — not
-    that the wrapper itself triggers compaction (it structurally cannot,
-    anymore).
+    structurally finds zero candidates). ★architect review — the FIRST
+    version of #5364 §1.6 broke this: it read only the spill axis's own
+    progress, so "spill candidates ZERO" was (wrongly) treated as
+    "nothing left to try" even though the COMPACT axis
+    (``_run_with_shrink``'s own PRE-EXISTING #4954(b) ``next_turn``
+    side-effect, ``force_compact_now`` inside ITS except block) had
+    genuinely advanced the watermark THIS attempt and let the SECOND
+    ``_run_with_shrink`` call succeed — a real, witnessed, main-green
+    recovery path, not a theoretical one (this test's own docstring, pre-
+    fix, already said so verbatim). #5367's own "縮小軸は2本／失敗＝両縮小
+    軸が dry" already named this; #5364 §1.6 only wrote the spill side —
+    an omission in that text, not in the pre-#5364-§1.6 implementation.
+    Fixed by tracking BOTH axes' progress (``compaction_watermark()``
+    strictly increasing = compact progress, alongside the pre-existing
+    spill-candidate-consumed signal) and failing only when NEITHER moved.
 
     ``fake_compaction_engine`` (a network-free stand-in, same shape the
     PR-N6 test file's own ``_OverflowingEngine`` uses — a real
@@ -313,9 +323,53 @@ def test_history_dominant_overflow_recovers_via_pre_existing_compaction(
             loop, "continue please", chain_id="c1",
         )
     )
-    assert result is None
+    assert result is None  # the fake loop's own successful return
 
     assert compacted["done"], "expected a real compaction_completed event"
+    spill_events = [e for e in events if e.type == "tool_result_offloaded"]
+    assert not spill_events, (
+        "nothing was spillable (no tool-result turns) — spill must not "
+        f"have offloaded anything: {[e.data for e in spill_events]!r}"
+    )
+
+
+def test_history_dominant_overflow_fails_fast_with_nothing_spillable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: contract acceptance ①b — the TRUE-exhaustion sibling of
+    the test above: nothing spillable (no tool-result turns) AND
+    compaction ALSO cannot progress (too few durable turns for
+    ``force_compact_now``'s own candidate scan to find anything —
+    ``fake_compaction_engine``'s ``compact()`` never even gets called).
+    Together the two tests distinguish "one axis dry" (recovers) from
+    "both axes dry" (true exhaustion, #5364 §1.6's unqualified failure
+    predicate: raise immediately, no generous extra attempts)."""
+    session = _make_spill_session(
+        tmp_path, monkeypatch, max_shrink_iterations=1,
+        fake_compaction_engine=True,  # recovery_policy="next_turn" (default)
+    )
+    _push(session, "user", "hi")
+    _push(session, "assistant", "ok")
+
+    events: list = []
+    session._audit_events.add_subscriber(lambda e: events.append(e))
+
+    loop = _ContentDrivenLoop(lambda history, user_text: True)  # always 413
+
+    with pytest.raises(UnrecoveredError) as excinfo:
+        asyncio.run(
+            session._loop_driver._run_with_shrink_and_byte_reduction(
+                loop, "continue please", chain_id="c1",
+            )
+        )
+    assert excinfo.value.saw_byte_limit is True
+
+    assert not [e for e in events if e.type == "compaction_completed"], (
+        "too little history for compaction to have found any candidate — "
+        "the watermark must NOT have moved (control arm: if this test's "
+        "own compaction axis silently moved, the test is not actually "
+        "isolating the true-exhaustion case it means to)"
+    )
     spill_events = [e for e in events if e.type == "tool_result_offloaded"]
     assert not spill_events, (
         "nothing was spillable (no tool-result turns) — spill must not "
@@ -363,13 +417,17 @@ def test_recovery_policy_never_leaves_the_watermark_alone_and_terminates(
         "existing next_turn side-effect (disabled by this policy) or a "
         "wrapper-owned call (removed entirely)"
     )
-    # ② clean, bounded termination — not a hang. The call count is
-    # structurally bounded by _MAX_BYTE_REDUCTION_ATTEMPTS regardless of
-    # how large the history is (a wall-clock timeout is never needed to
-    # prove this) — sliced past the composite bound, the tail must be
-    # empty.
-    from reyn.runtime.services.router_loop_driver import _MAX_BYTE_REDUCTION_ATTEMPTS
-    assert loop.calls[(1 + _MAX_BYTE_REDUCTION_ATTEMPTS) * 1:] == []
+    # ② clean, bounded termination — not a hang. #5364 §1.6: the bound is
+    # candidate exhaustion, not a fixed constant. All 50 turns here are
+    # ``role="user"`` — zero spillable candidates — so
+    # ``_attempt_reactive_spill`` reports failure on its very FIRST call,
+    # and the wrapper must raise right after exactly ONE outer attempt (a
+    # wall-clock timeout is never needed to prove this): sliced past that
+    # single attempt's own ``_run_with_shrink`` call count (2, measured
+    # directly — ``max_shrink_iterations=1`` plus retry_loop's own initial
+    # full-history attempt, unrelated to and unchanged by this fix), the
+    # tail must be empty.
+    assert loop.calls[2:] == []
 
 
 # ── ③ oversized user message alone — both levers fail, clean termination ───
@@ -382,8 +440,10 @@ def test_oversized_new_message_alone_terminates_cleanly_not_a_hang(
     (never spilled, never compacted — #5296's own contract, and this
     module's #43-cited "NEVER dropped" invariant) is what is oversized.
     Neither spill nor compaction can touch it, so the wrapper must
-    terminate — bounded by construction (`_MAX_BYTE_REDUCTION_ATTEMPTS`),
-    not by a wall-clock timeout this test would have to wait out."""
+    terminate — #5364 §1.6: bounded by candidate exhaustion (one genuine
+    spill of the single small tool candidate, then failure once that
+    candidate is already at its own offload floor), never by a fixed
+    constant or a wall-clock timeout this test would have to wait out."""
     session = _make_spill_session(tmp_path, monkeypatch, max_shrink_iterations=1)
     _push(session, "user", "hi")
     _push(session, "tool", "small result", tool_call_id="tc1", name="tool")
@@ -399,12 +459,16 @@ def test_oversized_new_message_alone_terminates_cleanly_not_a_hang(
         )
     assert excinfo.value.saw_byte_limit is True
 
-    # Bounded: (1 + _MAX_BYTE_REDUCTION_ATTEMPTS) outer attempts, each an
-    # independent retry_loop call bounded by max_shrink_iterations=1 (one
-    # main_call per outer attempt here — no raw_middle to fold first) —
-    # sliced past the composite bound, the tail must be empty.
-    from reyn.runtime.services.router_loop_driver import _MAX_BYTE_REDUCTION_ATTEMPTS
-    assert loop.calls[(1 + _MAX_BYTE_REDUCTION_ATTEMPTS) * 1:] == []
+    # Bounded: 2 outer attempts, each an independent retry_loop call —
+    # attempt 1 spills the single small tool candidate (genuine
+    # progress), attempt 2 finds that same candidate already at its own
+    # offload floor (no progress, #5364 §1.6's ``is_already_spilled``
+    # guard) and raises. Each outer attempt's own ``_run_with_shrink``
+    # call makes 2 loop.run calls (measured directly — max_shrink_
+    # iterations=1's own initial full-history attempt plus one more,
+    # unrelated to and unchanged by this fix), so the composite bound is
+    # 4 total; sliced past it, the tail must be empty.
+    assert loop.calls[4:] == []
 
 
 # ── spill persists across turns (session-lived overlay) ────────────────────
@@ -473,48 +537,52 @@ def test_spill_persists_into_the_next_turn_413_fires_once(
     )
 
 
-# ── a no-progress spill must not leave a useless overlay entry behind ──────
+# ── a genuine spill is KEPT even when it makes the payload bigger ──────────
 
 
-def test_a_spill_that_does_not_help_is_undone(
+def test_a_spill_that_makes_it_bigger_is_still_kept(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tier 2: #5296 PR-2 review (architect, 1st finding) — spilling a
-    TINY tool result makes it BIGGER, not smaller (the offloaded preview
-    carries a fixed pointer-path overhead — measured directly building
-    this PR: an 11-char original became a 115-char replacement). Before
-    this fix, ``_attempt_reactive_spill`` left that overlay entry in
-    place regardless, contradicting its own docstring ("destroy more of
-    the operator's visible context than necessary"). Witnessed via the
-    PUBLIC ``build_history()`` seam (never the private ``_spill_overlay``
-    dict directly): the tiny turn's ORIGINAL content must still be what
-    gets sent, not the bloated replacement."""
+    """Tier 2: #5364 §1.6 (reverses #5296 PR-2's original 1st finding) —
+    spilling a TINY tool result makes it BIGGER, not smaller (the
+    offloaded preview carries a fixed pointer-path overhead — measured
+    directly building #5296 PR-2: an 11-char original became a 115-char
+    replacement). #5296 PR-2 originally UNDID such a spill
+    (``discard_spill_overlay_for``); #5364 §1.6 removes that undo
+    entirely — the stop condition is "did progress happen" (a candidate
+    got consumed), never "did bytes move", so a genuine new spill is now
+    KEPT regardless of whether it made the payload bigger. Witnessed via
+    the PUBLIC ``build_history()`` seam (never the private
+    ``_spill_overlay`` dict directly): the tiny turn's OFFLOADED preview
+    (not its original content) is what gets sent afterward."""
     session = _make_spill_session(tmp_path, monkeypatch)
     _push(session, "user", "hi")
     # NOT "hi" — a 2-char body estimates at <=1 token, so `cap_tokens=1`
     # never offloads it at all (`spill_turn_content` returns `None`,
-    # never reaching the discard path this test means to exercise —
-    # confirmed directly: an earlier draft using "hi" here stayed GREEN
-    # even with `discard_spill_overlay_for` stripped out). "tiny result"
-    # (11 chars) DOES cross the 1-token cap and genuinely gets offloaded
-    # — into a 115-char preview, bigger than the original.
+    # not a genuine spill). "tiny result" (11 chars) DOES cross the
+    # 1-token cap and genuinely gets offloaded — into a 115-char
+    # preview, bigger than the original.
     tiny = "tiny result"
     _push(session, "tool", tiny, tool_call_id="tc1", name="tool")
     _push(session, "assistant", "ok")
 
-    reduced = asyncio.run(
-        session._loop_driver._attempt_reactive_spill("continue", chain_id="c1")
+    progressed = asyncio.run(
+        session._loop_driver._attempt_reactive_spill(chain_id="c1")
     )
-    assert reduced is False, (
-        "control arm: spilling a tiny result must NOT report progress — "
-        "it makes the payload bigger, not smaller"
+    assert progressed is True, (
+        "spilling a tiny result IS progress (a candidate was genuinely "
+        "newly offloaded) even though the replacement is bigger than "
+        "the original — #5364 §1.6 never reads bytes to decide this"
     )
 
     history = session._loop_driver._history_buffer.build_history()
-    assert _has_content(history, tiny), (
-        "a no-progress spill must be undone — the tiny turn's ORIGINAL "
-        "content should still be what gets sent, not a bloated "
-        "offloaded-preview replacement left behind uselessly"
+    assert not _has_content(history, tiny), (
+        "the spill must be KEPT, not undone — the tiny turn's ORIGINAL "
+        "content must no longer be what gets sent"
+    )
+    assert "read_file(path=" in str(history), (
+        "the offloaded preview (naming a read_file path) must be what "
+        "gets sent in place of the tiny turn's original content"
     )
 
 
@@ -579,7 +647,7 @@ async def test_spill_candidates_are_staged_head_then_mid_then_tail(
         f"test setup sanity: the mid candidate must land in raw_middle, got {mid_ids!r}"
     )
 
-    await session._loop_driver._attempt_reactive_spill("continue", chain_id="c1")
+    await session._loop_driver._attempt_reactive_spill(chain_id="c1")
     await session._audit_events.drain()
 
     offloaded = [e for e in events if e.type == "tool_result_offloaded"]
@@ -763,7 +831,7 @@ async def test_spill_turn_content_offload_event_names_trigger_overflow(
         _push(session, "user", f"filler question number {i} " * 8)
         _push(session, "assistant", f"filler answer number {i} " * 8)
 
-    await session._loop_driver._attempt_reactive_spill("continue", chain_id="c1")
+    await session._loop_driver._attempt_reactive_spill(chain_id="c1")
     await session._audit_events.drain()
 
     offloaded = [e for e in events if e.type == "tool_result_offloaded"]
@@ -775,24 +843,32 @@ async def test_spill_turn_content_offload_event_names_trigger_overflow(
 async def test_a_mid_spill_is_kept_even_though_it_moves_zero_bytes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tier 2: #5364 §1.3 — a ``raw_middle`` candidate can never move wire
-    bytes (elided out of ``estimate_wire_bytes`` by construction), so the
-    pre-existing "no byte decrease → undo" rule must NOT apply to it —
-    applying it unconditionally would discard every mid spill, contradicting
+    """Tier 2: #5364 §1.3/§1.6 — a ``raw_middle`` candidate can never move
+    wire bytes (elided out of ``estimate_wire_bytes`` by construction), so
+    the stop condition must NOT read bytes at all — it must be "did
+    progress happen" (a candidate got consumed), never "did bytes move".
+    Reading bytes here would discard every mid spill outright, contradicting
     #5364's own reason for including mid at all (persisted ``spilled``
-    state + a smaller future compaction fold). Witnessed via
+    state + a smaller future compaction fold). This setup has exactly ONE
+    spillable candidate, and it lands in ``raw_middle`` alone (no head/tail
+    tool turns to spill first), isolating the mid-only case. Witnessed via
     ``decompose_history_for_retry()``'s own returned content (never the
     private ``_spill_overlay`` dict directly) — surviving content must
     equal the offload preview, matched by its ``read_file(path=...)``
     marker."""
-    session = _make_spill_session(tmp_path, monkeypatch, t_max=4_000)
-    # Enough turns that SOME land in raw_middle once elided (t_max forces a
-    # real split — see decompose_history_for_retry's own docstring on when
-    # raw_middle is non-empty).
-    for i in range(40):
-        _push(session, "user", f"q{i}")
-        _push(session, "tool", f"result body {i} " * 100, tool_call_id=f"tc{i}", name="tool")
-        _push(session, "assistant", f"a{i}")
+    session = _make_spill_session(tmp_path, monkeypatch, t_max=2_500)
+    # Filler BEFORE and after the sole tool turn — enough that it lands
+    # squarely in raw_middle (never head/tail) once elided, mirroring
+    # test_spill_candidates_are_staged_head_then_mid_then_tail's own
+    # independently-measured t_max=2_500/filler shape. No OTHER tool
+    # turns exist, so this is the sole candidate.
+    for i in range(20):
+        _push(session, "user", f"filler question number {i + 100} " * 8)
+        _push(session, "assistant", f"filler answer number {i + 100} " * 8)
+    _push(session, "tool", "result body " * 100, tool_call_id="tc-mid", name="tool")
+    for i in range(3):
+        _push(session, "user", f"filler question number {i + 300} " * 8)
+        _push(session, "assistant", f"filler answer number {i + 300} " * 8)
 
     head, raw_middle, tail, _summary, _seq_by_id = (
         session._loop_driver._history_buffer.decompose_history_for_retry()
@@ -803,14 +879,17 @@ async def test_a_mid_spill_is_kept_even_though_it_moves_zero_bytes(
         "turn, or this test cannot exercise the mid-is-never-undone path "
         "— adjust t_max/turn count"
     )
-
-    reduced = await session._loop_driver._attempt_reactive_spill(
-        "continue", chain_id="c1",
+    assert not [t for t in head + tail if t.get("role") == "tool"], (
+        "test setup sanity: no head/tail tool candidate must exist, or "
+        "this test cannot isolate the mid-only case (a head/tail "
+        "candidate would be spilled FIRST, per #5364 §1.3's staged order)"
     )
-    assert reduced is False, (
-        "control arm: with no genuinely spillable head/tail progress in "
-        "this setup, the byte-decrease verdict stays False — this test's "
-        "subject is whether the MID spill survived regardless, next"
+
+    progressed = await session._loop_driver._attempt_reactive_spill(chain_id="c1")
+    assert progressed is True, (
+        "a genuine new mid spill IS progress (a candidate was newly "
+        "offloaded), even though it moves zero wire bytes — #5364 §1.6 "
+        "never reads bytes to decide this"
     )
 
     original_mid_content = mid_tools[0]["content"]
@@ -833,4 +912,131 @@ async def test_a_mid_spill_is_kept_even_though_it_moves_zero_bytes(
     assert "read_file(path=" in reserialised[0]["content"], (
         "the surviving content should be the offload preview naming the "
         f"read-back path — got: {reserialised[0]['content']!r}"
+    )
+
+
+# ── #5364 §1.6 REQUIRED acceptance: mid-only, multi-round, bytes constant ──
+
+
+def test_mid_only_spill_bounds_by_candidate_exhaustion_wire_bytes_never_move(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5364 §1.6 REQUIRED acceptance — a mid-only-candidates
+    configuration (3 spillable ``raw_middle`` tool turns, nothing in
+    head/tail) where spill continues across multiple retries, each one
+    strictly decreasing the un-spilled candidate count by exactly one
+    (PROGRESS), main-call wire bytes stay IDENTICAL throughout every
+    retry (mid is elided out of ``estimate_wire_bytes`` by construction
+    — #5364 §1.3), and the turn ultimately SUCCEEDS once every candidate
+    has been spilled (the retried call stops raising — #5364 §1.6's own
+    SUCCESS predicate, never a separate byte-target comparison).
+
+    Strip-falsify (disclosed, not re-run inline — the old code no longer
+    exists to revert to): reverting ``_attempt_reactive_spill`` to the
+    OLD ``self._wire_bytes_now() >= attempt_start_bytes: raise`` stop
+    condition makes this test go RED on the very FIRST round — that
+    check reads "mid spill moved zero bytes" as failure and raises
+    immediately, before a second of the 3 candidates is ever reached.
+    """
+    session = _make_spill_session(tmp_path, monkeypatch, t_max=2_500)
+    for i in range(3):
+        for j in range(8):
+            _push(session, "user", f"filler {i}-{j} " * 8)
+            _push(session, "assistant", f"filler reply {i}-{j} " * 8)
+        _push(session, "tool", f"mid result {i} " * 100, tool_call_id=f"tc-mid{i}", name="tool")
+    for i in range(3):
+        _push(session, "user", f"tail filler {i} " * 8)
+        _push(session, "assistant", f"tail reply {i} " * 8)
+
+    head, raw_middle, tail, _summary, _ = (
+        session._loop_driver._history_buffer.decompose_history_for_retry()
+    )
+    mid_ids = {t.get("tool_call_id") for t in raw_middle if t.get("role") == "tool"}
+    assert mid_ids == {"tc-mid0", "tc-mid1", "tc-mid2"}, (
+        f"test setup sanity: all 3 candidates must land in raw_middle "
+        f"alone, got {mid_ids!r} — adjust t_max/filler counts"
+    )
+    assert not [t for t in head + tail if t.get("role") == "tool"], (
+        "test setup sanity: no head/tail tool candidate must exist, or "
+        "this test cannot isolate the mid-only case"
+    )
+    raw_middle_chars_before = sum(len(t.get("content", "")) for t in raw_middle)
+
+    def _wire_bytes_of(current_head, current_tail) -> int:
+        from reyn.services.compaction.engine import estimate_wire_bytes
+        return estimate_wire_bytes(
+            SP="sp", head=current_head, summary=None, tail=current_tail,
+            new_msg={"role": "user", "content": "continue please"},
+        )
+
+    wire_bytes_before = _wire_bytes_of(head, tail)
+
+    spilled_ids: "list[str]" = []
+    for _round in range(3):
+        progressed = asyncio.run(
+            session._loop_driver._attempt_reactive_spill(chain_id="c1")
+        )
+        assert progressed is True, (
+            f"round {_round}: expected progress — {3 - _round} candidate(s) "
+            f"should still be un-spilled"
+        )
+        head_n, raw_middle_n, tail_n, _summary_n, _ = (
+            session._loop_driver._history_buffer.decompose_history_for_retry()
+        )
+        still_original = {
+            t.get("tool_call_id") for t in raw_middle_n
+            if t.get("role") == "tool" and t.get("tool_call_id") not in spilled_ids
+            and "read_file(path=" not in t.get("content", "")
+        }
+        newly_spilled = mid_ids - still_original - set(spilled_ids)
+        (only_newly_spilled,) = newly_spilled  # raises unless exactly one
+        spilled_ids.append(only_newly_spilled)
+        assert _wire_bytes_of(head_n, tail_n) == wire_bytes_before, (
+            f"round {_round}: main-call wire bytes must stay unchanged — "
+            f"a mid-only spill can never move them (#5364 §1.3)"
+        )
+
+    # All 3 now spilled — candidates exhausted (#5364 §1.6's failure
+    # predicate), a natural termination, not a fixed constant.
+    final_progressed = asyncio.run(
+        session._loop_driver._attempt_reactive_spill(chain_id="c1")
+    )
+    assert final_progressed is False
+
+    _head_f, raw_middle_f, _tail_f, _summary_f, _ = (
+        session._loop_driver._history_buffer.decompose_history_for_retry()
+    )
+    raw_middle_chars_after = sum(len(t.get("content", "")) for t in raw_middle_f)
+    assert raw_middle_chars_after < raw_middle_chars_before, (
+        "compaction's own future input (raw_middle) must have SHRUNK once "
+        "every mid candidate was spilled into a bounded offload preview"
+    )
+
+    # The turn ultimately succeeds: a fake loop that fails until all 3
+    # candidates are spilled, driven through the real wrapper end-to-end
+    # (a fresh session — the one above already spent its candidates).
+    session2 = _make_spill_session(tmp_path, monkeypatch, t_max=2_500)
+    for i in range(3):
+        for j in range(8):
+            _push(session2, "user", f"filler {i}-{j} " * 8)
+            _push(session2, "assistant", f"filler reply {i}-{j} " * 8)
+        _push(session2, "tool", f"mid result {i} " * 100, tool_call_id=f"tc-mid{i}", name="tool")
+    for i in range(3):
+        _push(session2, "user", f"tail filler {i} " * 8)
+        _push(session2, "assistant", f"tail reply {i} " * 8)
+    spilled_so_far = {"n": 0}
+    session2._audit_events.add_subscriber(
+        lambda e: spilled_so_far.__setitem__("n", spilled_so_far["n"] + 1)
+        if e.type == "tool_result_offloaded" else None
+    )
+    loop2 = _ContentDrivenLoop(lambda history, user_text: spilled_so_far["n"] < 3)
+    result = asyncio.run(
+        session2._loop_driver._run_with_shrink_and_byte_reduction(
+            loop2, "continue please", chain_id="c1",
+        )
+    )
+    assert result is None, "the turn must ultimately succeed once all mid candidates spilled"
+    assert spilled_so_far["n"] == 3, (
+        "the turn must have spilled all 3 mid candidates before succeeding "
+        f"— got {spilled_so_far['n']!r}"
     )


### PR DESCRIPTION
**[tui-coder]** — #5364 §1.6「停止条件と束縛」— `_run_with_shrink_and_byte_reduction` / `_attempt_reactive_spill` を issue 本文の3述語に合わせて書き直しました。#5367 と同じ論点（`retry_loop`側の byte 中立 mid フロア誤認）を同じ機構の別の面として直すため、同じ PR で `router_loop_driver.py:61`（`_MAX_BYTE_REDUCTION_ATTEMPTS`）・`:419`（token overflow が spill を試さず終端）・`:422`（mid 中立ゆえの誤 undo）・`:623` 付近の stale コメントをまとめて解消しています。

## 3述語（#5364 本文が正典）
- 前進 = 未spill候補が1減った（終端の唯一の証人）
- 成功 = リトライした実呼び出しが例外を投げなくなった（byte 目標比較は不要 — 実呼び出しの成功自体がより強い信号）
- 失敗 = 候補が空

## 変更
- Mode-independent: `saw_byte_limit` を問わず ANY `UnrecoveredError` を retry — 旧ゲートは token 軸終端に一度も spill を試さなかった
- 固定定数 `_MAX_BYTE_REDUCTION_ATTEMPTS` / `_wire_bytes_now()` を完全削除 — 束縛は候補の枯渇のみ
- 旧「効かなければ undo」(`discard_spill_overlay_for` とその唯一の呼び出し元) を削除 — mid spill は byte を動かさない（`estimate_wire_bytes` の入力から構造的に除外、§1.3）ので、動かなくても進捗として必ず keep
- `RouterHistoryBuffer.is_already_spilled()` を新設 — 無いと、既に spill 済みのプレビュー文字列を再度 `spill_turn_content` に渡すたびに**別の**新しいプレビューが生成され続け（自身の出力に対して冪等でない）、失敗述語に一生到達しない無限ループになる。自作の acceptance test を書いている最中に実際にハングして発見しました。

## force_compact_now 二重発火の確認（明示的に依頼された点）
`_run_with_shrink` 自身の except 節にある `saw_byte_limit and recovery_policy=="next_turn"` ゲートは無変更。token 軸のリトライはその回の `saw_byte_limit=False` で再入するため、二重発火しません — token 軸失敗ではそもそも一度もこの副作用が発火しないだけで、これは本 PR 以前と同じです。

## 挙動の狭まり（開示）
history-dominant（spill 候補ゼロ）な turn は、旧ゲートが進捗の有無を問わず固定回数まで機械的にリトライしていたため #4954(b) の pre-existing next_turn 副作用にたまたま救われることがありましたが、本 PR では候補ゼロで即 fail-fast します。副作用自体は今も走り、watermark は次ターンへ向けて確実に進みます（#4954(b) 本来の約束通り）。`test_history_dominant_overflow_fails_fast_with_nothing_spillable`（旧名から改名）参照。

## 未確定な設計判断（開示）
dispatch 文言にあった `target_wire_bytes`（尽きるまでの明示パラメータ）は実装していません。`_attempt_reactive_spill` は「1候補だけ spill → 呼び出し元がリトライ」を1回ごとに行い、リトライの成功/失敗自体を成功シグナルとしています（#5364 の "1つずつ spill → acompletion" 契約通りの解釈）。owner/architect の意図と異なる場合はご指摘ください。

## Strip-falsify
`_attempt_reactive_spill` を旧「byte が動かなければ fail」比較に戻し、`test_mid_only_spill_bounds_by_candidate_exhaustion_wire_bytes_never_move` が round 0（最初の mid-only spill）で RED になることを確認 → 復元。

## Test plan
- [x] `ruff check` (対象3ファイル)
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/verify_module_docstrings.py` (対象2ソースファイル)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py` / `check_file_depth_reference.py`（tests/ 変更あり）
- [x] `pytest tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py` (11 passed)
- [x] `pytest tests/runtime/ tests/services/test_pr_n6_compaction_overflow_retry.py -k "spill or shrink or compaction or overflow or retry"` (151 passed, 2 skipped — 未インストールの optional extra)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Blocking points

- [x] 🔴 **縮小軸は 2 本なのに、失敗の述語が 1 本しか見ていません。** `_attempt_reactive_spill` が `False`（spill 候補が尽きた）を返した瞬間に再送を諦めていますが、**もう 1 本の縮小軸（`_run_with_shrink` 自身の `force_compact_now` 側効果）が同じ turn で進捗を出す経路が実在し、★消される前の test がそれを witness していました** — 逐語 `prove the wrapper correctly DETECTS that pre-existing reduction (via ``_wire_bytes_now()``) and retries successfully`。∴ **「spill 候補ゼロ」＝「手が無い」ではありません。** 私が #5367 で出した失敗の述語は逐語「**両縮小軸が dry**」です。**失敗判定に 2 本目の進捗信号を戻してください** — ただし byte を読む形には戻さず、**compaction 側の進捗は ★watermark が進んだか**（`_compaction_watermark()`）で見てください。 根拠: PR comment（architect BLOCKING）

