### PR TITLE
fix: main is RED — #5375's tests construct MediaStore without agent_name, which #5383 made mandatory

### DIFF
--- a/tests/core/test_offload_config_gate_pr3.py
+++ b/tests/core/test_offload_config_gate_pr3.py
@@ -113,7 +113,7 @@ def test_cap_tool_result_offload_event_names_trigger_cap(tmp_path):
     version of #5375 lacked (a test that calls
     ``cap_tool_result_content`` directly and supplies its own ``trigger``
     can't catch a wiring swap in the real caller)."""
-    store = MediaStore(MediaStoreConfig(), project_root=tmp_path, session_id="test-session")
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path, agent_name="test-agent", session_id="test-session")
     events = EventLog()
     seen: list = []
     events.add_subscriber(lambda e: seen.append(e))

--- a/tests/services/test_tool_result_cap_1128.py
+++ b/tests/services/test_tool_result_cap_1128.py
@@ -118,7 +118,7 @@ def test_trigger_is_required_no_default(tmp_path: Path) -> None:
     """Tier 2: #5367① — omitting ``trigger`` is a ``TypeError``, not a silently
     unlabelled audit event. A caller that forgets it fails loudly at the call
     site, before any offload/emit happens."""
-    store = MediaStore(project_root=tmp_path, session_id="test-session")
+    store = MediaStore(project_root=tmp_path, agent_name="test-agent", session_id="test-session")
     with pytest.raises(TypeError, match="trigger"):
         cap_tool_result_content(  # type: ignore[call-arg]
             "X" * 100_000, cap_tokens=64, model=_MODEL,
@@ -130,7 +130,7 @@ def test_trigger_is_required_no_default(tmp_path: Path) -> None:
 def test_offload_event_carries_the_trigger_it_was_given(tmp_path: Path, trigger: str) -> None:
     """Tier 2: #5367① — the ``tool_result_offloaded`` audit event's ``trigger``
     field is exactly the value the caller passed (real EventLog, no mock)."""
-    store = MediaStore(project_root=tmp_path, session_id="test-session")
+    store = MediaStore(project_root=tmp_path, agent_name="test-agent", session_id="test-session")
     events = EventLog()
     seen: list = []
     events.add_subscriber(lambda e: seen.append(e))


### PR DESCRIPTION
**[lead-coder]** — 🔴 **★main が RED です。★私が 2 本 merge した 組み合わせを ★誰も 走らせていませんでした。**

## 🔴 起きたこと

```
⚪ ★#5375（★f5b37895e）── ★`MediaStore(project_root=..., session_id=...)` を ★3 箇所 追加
⚪ ★#5383（★36304d248）── ★`agent_name` 欠落を ★★ハードな ValueError に
🔴 ★★どちらも 自分の tree では 正しい
🔴 ★#5383 の pytest は ★★#5375 の test が まだ 無い tree で 走った
🔴 ★#5375 の pytest は ★★#5383 の production 変更が まだ 無い tree で 走った
🔴 ★★∴ ★2 つとも 緑で、★組み合わせは ★main に 載るまで ★★一度も 走っていません
```

⚪ **★落ちている 3 本** ── `test_trigger_is_required_no_default` ／ `test_offload_event_carries_the_trigger_it_was_given[cap|overflow]` ／ `test_cap_tool_result_offload_event_names_trigger_cap`。

## ✅ 直し

⚪ **★3 箇所に `agent_name="test-agent"` を 足すだけ**（★同じ file の 他の 構築と 同形）。

## ✅ 検証

```
✅ ★`pytest tests/services/test_tool_result_cap_1128.py tests/core/test_offload_config_gate_pr3.py -q` ── ★★20 passed
✅ ★`ruff check` ── ★All checks passed
✅ ★`test_tier_audit.py --strict` ── ★errors 0
```

## Test plan

- [x] 診断: `git grep "MediaStore(project_root=tmp_path, session_id=" origin/main -- tests/` で 全数 3 箇所
- [x] scoped pytest 20 passed
- [x] ruff / tier-audit
- [ ] (skipped — Visual 項目なし)

## ⚠️ ★構造の 残り ── ★★これは 絆創膏です

🔴 **★同じ ことが ★また 起きます。**⚪ **★「PR の CI 緑」は ★★merge 後の main の 緑を witness しません** ── ★別 PR が 間に 入れば **★組み合わせは 誰も 走らせません**。
🔵 **★別 issue で 出します** ── ★★merge 直前に ★base を 現 main に 合わせ直した tree で 走らせる（★GitHub の "Require branches to be up to date" 相当）か、★★merge queue。⚪ **★本 PR では 直しません。**

part of #5364
