### PR TITLE
test(#5386): _SameCauseOnCompactSpillableEngine asserts compact_calls

### DIFF
--- a/tests/services/test_5380_same_cause_cap_spill_witness.py
+++ b/tests/services/test_5380_same_cause_cap_spill_witness.py
@@ -176,6 +176,20 @@ def test_5380_spill_resolves_the_same_cause_cap_non_byte_floor() -> None:
     ))
 
     assert result is not None, "retry_loop must return normally, not raise"
+    # #5386: this class's own docstring names itself "the compact()-side
+    # witness that spill_fn's replacement actually reached
+    # engine.compact(), not just retry_loop's own state" — but nothing
+    # below actually asserted on compact_calls, so that claim went
+    # unwitnessed. `>=` (not `==`) — the exact count is the retry
+    # ladder's own implementation detail, not this test's subject (the
+    # engine-direct-call sibling test, ..._mid_split_floor, asserts
+    # `== 2` because IT calls the engine directly and the count IS its
+    # subject there).
+    assert engine.compact_calls >= 1, (
+        "this class's own docstring claims to be the compact()-side "
+        "witness that spill_fn's replacement reached engine.compact() "
+        "— nothing verified that until now"
+    )
     # Exactly one spill_fn call for the spillable turn — unpacking to one
     # element raises ValueError if retry_loop offered it a second time
     # (meaning the SAME object was offered for spilling twice).

--- a/tests/services/test_5380_same_cause_cap_spill_witness.py
+++ b/tests/services/test_5380_same_cause_cap_spill_witness.py
@@ -81,12 +81,24 @@ class _SameCauseOnCompactSpillableEngine(_OverflowingEngine):
     def __init__(self) -> None:
         super().__init__(fail_compact=False)
         self.compact_calls = 0
+        # #5395 BLOCKING (lead-coder): `compact_calls` alone increments
+        # on ENTRY, including the FIRST call — which always raises,
+        # since the marker is still present before spill_fn ever runs.
+        # A ``>= 1`` assert on that counter is satisfied on EVERY green
+        # run regardless of whether the replacement ever reached
+        # compact() at all, so it never actually witnessed this class's
+        # own claimed property. This counter increments ONLY in the
+        # marker-absent branch — the one call shape that can only be
+        # reached once spill_fn's replacement has actually landed in
+        # the turns compact() was given.
+        self.compact_calls_with_marker_gone = 0
 
     async def compact(self, input_chunk):
         self.compact_calls += 1
         turns = input_chunk.new_turns
         if any(t.get("content") == _SPILLABLE_MARKER for t in turns if isinstance(t, dict)):
             raise ContextOverflowError("compact also overflows, same cause")
+        self.compact_calls_with_marker_gone += 1
         from reyn.services.compaction.engine import ChatSummary
         return ChatSummary(
             topic_arc="ok",
@@ -176,19 +188,29 @@ def test_5380_spill_resolves_the_same_cause_cap_non_byte_floor() -> None:
     ))
 
     assert result is not None, "retry_loop must return normally, not raise"
-    # #5386: this class's own docstring names itself "the compact()-side
-    # witness that spill_fn's replacement actually reached
-    # engine.compact(), not just retry_loop's own state" — but nothing
-    # below actually asserted on compact_calls, so that claim went
-    # unwitnessed. `>=` (not `==`) — the exact count is the retry
-    # ladder's own implementation detail, not this test's subject (the
-    # engine-direct-call sibling test, ..._mid_split_floor, asserts
-    # `== 2` because IT calls the engine directly and the count IS its
-    # subject there).
-    assert engine.compact_calls >= 1, (
+    # #5386 / #5395 BLOCKING (lead-coder review): this class's own
+    # docstring names itself "the compact()-side witness that spill_fn's
+    # replacement actually reached engine.compact(), not just
+    # retry_loop's own state" — but a plain `compact_calls >= 1` does
+    # NOT witness that claim: `compact_calls` increments on ENTRY, and
+    # the FIRST compact() call always happens (and always raises)
+    # BEFORE spill_fn ever runs, since the marker is still present at
+    # that point. `>= 1` is therefore satisfied on every green run
+    # regardless of whether the replacement ever reached compact() at
+    # all. `compact_calls_with_marker_gone` increments ONLY in the
+    # marker-absent branch — the one call shape reachable only once
+    # spill_fn's replacement has genuinely landed in the turns
+    # compact() was given — so THIS is the counter that actually
+    # witnesses the claim. `>=` (not `==`) — the exact count is the
+    # retry ladder's own implementation detail, not this test's subject
+    # (the engine-direct-call sibling test, ..._mid_split_floor,
+    # asserts `== 2` because IT calls the engine directly and the count
+    # IS its subject there).
+    assert engine.compact_calls_with_marker_gone >= 1, (
         "this class's own docstring claims to be the compact()-side "
         "witness that spill_fn's replacement reached engine.compact() "
-        "— nothing verified that until now"
+        "— nothing verified that the replacement (not just any call) "
+        "reached it, until now"
     )
     # Exactly one spill_fn call for the spillable turn — unpacking to one
     # element raises ValueError if retry_loop offered it a second time


### PR DESCRIPTION
**[e2e-coder]** — closes #5386.

## What

`_SameCauseOnCompactSpillableEngine`'s own docstring names itself "the compact()-side witness that spill_fn's replacement actually reached `engine.compact()`, not just retry_loop's own state" — but nothing in the test actually asserted on `compact_calls`, so a green run never verified that claim. Adds `assert engine.compact_calls >= 1` right after the existing `assert result is not None`.

`>=` not `==` — the exact retry-ladder count is an implementation detail, not this test's subject (unlike the sibling `..._mid_split_floor` test, which calls the engine directly and asserts `== 2` because the count IS its subject there).

## Why

Architect (house rule 6 remainder from #5385's TESTS-READ, issuecomment-5448100645): the green-path this test's own docstring disclaims (spill replaces the marker → `tail` loses it → `_main_call` succeeds looking only at `tail` → `retry_loop` returns → `assert result is not None` passes) never required `engine.compact()` to have been called at all — the one property the class claims to witness was unwitnessed.

## Verification

- Ran the assert for real (not just added and trusted): 1 passed, `compact_calls >= 1` genuinely satisfied.
- `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` — all green.

## Test plan

- [x] `ruff check`
- [x] `test_tier_audit.py --strict`
- [x] `mypy_ratchet.py`
- [x] `verify_module_docstrings.py`
- [x] `pytest tests/services/test_5380_same_cause_cap_spill_witness.py` (1 passed)
- [x] (skipped — Visual, standing waiver, no UI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] 🔴 **`compact_calls >= 1` は、引用している docstring の主張（replacement が engine.compact() に届いた）を witness していません。** `compact_calls` は compact() の入口で増え、最初の呼び出しは spill より前に raise します ∴ replacement が永久に届かなくてもこの assert は緑です。**受入: 「marker が消えた側の compact()」を名指して数える**（else 側で数える／成功時の turns に marker が無いことを assert）。根拠: PR comment（BLOCKING、issuecomment-5448756xxx）
