### PR TITLE
fix(#5394): stall_dump tests wait on the dump's actual completion, not "non-empty"

### DIFF
--- a/tests/dev/test_stall_dump_4986.py
+++ b/tests/dev/test_stall_dump_4986.py
@@ -115,9 +115,24 @@ def test_an_atexit_hang_after_sessionfinish_also_produces_a_stall_dump(
         proc.stdin.close()  # releases _hang_forever's readline()
         proc.wait()
 
-    assert "Thread" in content, (
-        f"the dump file should contain a real faulthandler thread-stack "
-        f"dump even for an atexit-time hang, got {content!r}"
+    # lead-coder TESTS-READ (non-blocking, #5394): the wait condition
+    # above (`"File \"" in content`) ALREADY implies `"Thread" in
+    # content` — faulthandler writes header -> "Thread ..." -> "File
+    # ...", in that order, so once a frame line has landed the thread
+    # line is guaranteed present too. Asserting that again would never
+    # fail (a silent tautology after this fix — a genuine future partial-
+    # dump bug would now hang to CI's own 120s timeout instead of this
+    # test's own readable message). Assert the ORDER instead — a
+    # property the wait condition does NOT imply (content merely
+    # containing all three substrings says nothing about their
+    # sequence).
+    header_at = content.find("Timeout")
+    thread_at = content.find("Thread")
+    frame_at = content.find("File \"")
+    assert -1 < header_at < thread_at < frame_at, (
+        f"the dump should write its header, then the thread line, then "
+        f"stack frames, in that order — got header@{header_at}, "
+        f"thread@{thread_at}, frame@{frame_at} in {content!r}"
     )
 
 
@@ -173,9 +188,17 @@ def test_a_session_teardown_hang_produces_a_stall_dump(
         proc.stdin.close()  # releases _hang_forever_at_teardown's readline()
         proc.wait()
 
-    assert "Thread" in content, (
-        f"the dump file should contain a real faulthandler thread-stack "
-        f"dump, got {content!r}"
+    # lead-coder TESTS-READ (non-blocking, #5394): see the sibling test's
+    # own comment on why `"Thread" in content` is a tautology here (the
+    # wait condition already implies it) and why the order check below
+    # is the property actually worth asserting.
+    header_at = content.find("Timeout")
+    thread_at = content.find("Thread")
+    frame_at = content.find("File \"")
+    assert -1 < header_at < thread_at < frame_at, (
+        f"the dump should write its header, then the thread line, then "
+        f"stack frames, in that order — got header@{header_at}, "
+        f"thread@{thread_at}, frame@{frame_at} in {content!r}"
     )
 
 

--- a/tests/dev/test_stall_dump_4986.py
+++ b/tests/dev/test_stall_dump_4986.py
@@ -94,9 +94,22 @@ def test_an_atexit_hang_after_sessionfinish_also_produces_a_stall_dump(
         stdin=subprocess.PIPE,
     )
     try:
-        while not (log_path.exists() and log_path.stat().st_size > 0):
-            time.sleep(0)
-        content = log_path.read_text()
+        # #5394: faulthandler writes its dump in stages — the
+        # "Timeout (...)!" header, then a "Thread ... (most recent call
+        # first):" line, then the actual stack frames ("File \"...\",
+        # line N in func"). Waiting on mere non-emptiness (or even on
+        # "Thread" alone, measured directly while building this fix —
+        # that string is written BEFORE the frames) reads the file mid-
+        # write, racing the LAST part (machine-speed dependent — the same
+        # tree can go green or red). Wait on the actual completion this
+        # test needs instead: content containing a real stack frame IS
+        # "the dump finished writing", not a duration to guess at.
+        content = ""
+        while "File \"" not in content:
+            if log_path.exists():
+                content = log_path.read_text()
+            if "File \"" not in content:
+                time.sleep(0)
     finally:
         assert proc.stdin is not None
         proc.stdin.close()  # releases _hang_forever's readline()
@@ -137,9 +150,24 @@ def test_a_session_teardown_hang_produces_a_stall_dump(
         stdin=subprocess.PIPE,
     )
     try:
-        while not (log_path.exists() and log_path.stat().st_size > 0):
-            time.sleep(0)
-        content = log_path.read_text()
+        # #5394: faulthandler writes its dump in stages — the
+        # "Timeout (...)!" header, then a "Thread ... (most recent call
+        # first):" line, then the actual stack frames ("File \"...\",
+        # line N in func"). Waiting on mere non-emptiness (or even on
+        # "Thread" alone, measured directly while building this fix —
+        # that string is written BEFORE the frames) reads the file mid-
+        # write, racing the LAST part (machine-speed dependent — the same
+        # tree can go green or red; a header-only read was measured
+        # directly in a real CI red, #5394). Wait on the actual
+        # completion this test needs instead: content containing a real
+        # stack frame IS "the dump finished writing", not a duration to
+        # guess at.
+        content = ""
+        while "File \"" not in content:
+            if log_path.exists():
+                content = log_path.read_text()
+            if "File \"" not in content:
+                time.sleep(0)
     finally:
         assert proc.stdin is not None
         proc.stdin.close()  # releases _hang_forever_at_teardown's readline()


### PR DESCRIPTION
**[tui-coder]** — #5394: `test_stall_dump_4986.py`の2箇所を「非空」待ちから「実際に書き終わった」待ちに直しました。

## 機構
faulthandlerのdumpは段階的に書かれる: `Timeout (...)!`ヘッダ → `Thread ...`行 → 実スタックフレーム(`File "..."`)。「非空」（実は`"Thread"`が含まれるだけでも同様）で読むと、最後の書き込みとレースします — 機械速度依存で同じtreeが緑にも赤にもなります（#5392のCI run, Python 3.11で実際に再現、`Timeout (0:00:01)!\n`のみのcontentをそのまま捕捉）。

## 直し
待ち条件を「実スタックフレーム(`File "`)が含まれる」に変更 — これは「dumpが書き終わった」という観測可能な終端そのものです。sleepを足す/増やす形は取っていません（house rule違反）。各testの最終assertは待ち条件と別の性質（`"Thread"`が含まれる=本物のスレッドスタックである）を見るようにしました。

同ファイル内の他2箇所（`st_size`/`exists`チェック）は同期的なsubprocess完了後の単発読みで、書き込み中とレースする形ではないため対象外です。

## 検証
- ローカルで13回連続緑（うち5回は中間実装「"Thread"待ち」— これ自体`Thread`行はあるがframeが無い、という関連するが別のレースを100%再現し、段階書き込みの機構を直接確認できました）、その後最終修正で8回連続緑
- 本来のレース自体はこのマシンではローカル再現せず（機械速度依存、lead-coder既知）— 機構の根拠は(a) #5394 issue本文自身が捕捉した実CI red の逐語内容、(b) 本セッション自身が中間実装で偶発的に再現した隣接レース、の2点

## Test plan
- [x] `ruff check tests/dev/test_stall_dump_4986.py`
- [x] `python scripts/test_tier_audit.py --strict tests/dev/test_stall_dump_4986.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py` / `check_file_depth_reference.py`（tests/変更あり）
- [x] `pytest tests/dev/test_stall_dump_4986.py` × 8連続 (32/32 passed)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
