### PR TITLE
feat(#5387): open-turn GC exclusion ("L") — thread chain_id through the write-time cap path

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -1027,7 +1027,20 @@ class MediaStore:
         session's own open turn is out of C's reach entirely — C only
         ever enumerates THIS session's own directory — and stays
         unprotected only until a CROSS-session GC (#5366) is built; #5366
-        is where that would first need to be handled, not here."""
+        is where that would first need to be handled, not here.
+
+        Disclosed (architect review, non-blocking): if EVERY remaining
+        candidate is protected (all share the triggering chain), this
+        returns having deleted nothing, and the directory stays OVER
+        cap — deliberately: protecting an open turn's content is worth
+        more than strictly enforcing the byte cap on any given pass.
+        Not silent — the caller (:meth:`save_tool_result`) already logs
+        nothing extra here because this is the expected, harmless
+        common case (see ``history_content_max_bytes``'s own docstring:
+        2 GB default, eviction is not expected to fire under real usage
+        at all); a future lower cap that fires routinely against a
+        single long-running chain would see this over-cap state
+        persist across many writes, not a one-pass fluke."""
         cap = self._config.history_content_max_bytes
         directory = self._history_content_dir()
         _, total = _dir_stats_recursive(directory)

--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -265,27 +265,43 @@ class MediaStoreConfig:
     # maximum — the cap is intended to never fire under any measured
     # real usage; it exists only to bound a genuine runaway.
     #
-    # This does NOT protect a still-open turn's own content from GC —
-    # doing that needs a discriminator distinguishing "this session's
-    # newest file" from "a turn currently in flight", and none exists
-    # yet: the write-time cap path (``tool_result_cap.py``'s ``save_fn``
-    # call) does not thread ``chain_id`` through today, so most spilled
-    # files carry none (only the REACTIVE-spill path,
-    # ``router_history_buffer.py``, does) — mtime is NOT a safe
-    # approximation (lead-coder ruling, #5364: "the newest file is not a
-    # turn boundary"; architect, same ruling: mtime answers "when was
-    # this written", not "whose turn is this" — two concurrent sessions
-    # writing at once interleave mtime order across BOTH turns).
+    # #5387 landed the discriminator this used to lack: ``chain_id`` now
+    # threads through the write-time cap path too (previously only the
+    # REACTIVE-spill path, ``router_history_buffer.py``, carried one), so
+    # ``MediaStore.is_open_turn_file`` can tell "this session's newest
+    # file" apart from "a turn currently in flight" WITHOUT approximating
+    # via mtime (mtime is NOT safe for this — lead-coder ruling, #5364:
+    # "the newest file is not a turn boundary"; architect, same ruling:
+    # mtime answers "when was this written", not "whose turn is this" —
+    # two concurrent sessions writing at once interleave mtime order
+    # across BOTH turns). See ``protect_open_turn_from_gc`` below for the
+    # resulting default and its scope.
     #
-    # DO NOT LOWER THIS DEFAULT to a value that can actually fire under
-    # real usage until #5387 lands (threading ``chain_id`` through the
-    # write-time cap path so GC can tell a still-open turn's content
-    # apart from an evictable one). At today's 2 GB this gap has nothing
-    # to protect — 2GB is >15x the largest ``.reyn/`` tree measured
-    # above, so eviction is not expected to ever run — but a lower cap
-    # WOULD run eviction against real, in-flight turn content with no
-    # discriminator to protect it.
+    # A lower cap can now safely fire without destroying real, in-flight
+    # turn content — see ``protect_open_turn_from_gc``'s own docstring
+    # for the one thing it still does NOT cover (another session's own
+    # open turn — #5366's subject, not this field's).
     history_content_max_bytes: int = 2 * 1024 * 1024 * 1024
+    # #5387 "L" (owner: "open-turn は GC 対象から外せるようにしたいね。規定は
+    # そうして、opt-in で対象にもするようにしたい" — verbatim): when True
+    # (the default), ``_evict_history_content_over_cap`` never deletes a
+    # file whose recorded ``chain_id`` matches the chain that triggered
+    # THIS eviction pass (``MediaStore.is_open_turn_file`` — GC is
+    # writer-triggered, so that chain IS "the turn currently in flight").
+    # Set False to opt IN to eviction being allowed to reach open-turn
+    # content too (the owner's own "opt-in で対象に" — e.g. an operator who
+    # has independently decided in-flight content is not worth protecting
+    # at their site).
+    #
+    # Scope (architect design B, #5387 — stated explicitly so this is not
+    # mistaken for "we decided not to bother"): this protects ONLY the
+    # write that triggered THIS session's own GC pass. Another session's
+    # own open turn is out of reach entirely — the eviction scan only
+    # ever enumerates THIS session's own directory (see
+    # ``_evict_history_content_over_cap``'s own docstring) — and stays
+    # unprotected until a CROSS-session GC (#5366) is built; #5366 is
+    # where that would first need to be handled, not here.
+    protect_open_turn_from_gc: bool = True
 
 
 @dataclass(frozen=True)
@@ -361,10 +377,10 @@ def _eviction_order(directory: Path) -> list[Path]:
     filter, "which one first" is a sort, and folding a future filter
     into THIS function's sort key would let it silently become "deleted
     last" instead of "never deleted"). #5387's turn-boundary exclusion
-    (once ``chain_id`` is threaded through the write-time cap path)
-    belongs in a SEPARATE eligibility filter applied to this function's
-    input or output — not as another entry in a predicate sequence
-    here. mtime cannot stand in for that filter either way: see
+    lands as exactly that SEPARATE filter, applied to this function's
+    OUTPUT by :meth:`MediaStore._evict_history_content_over_cap` (never
+    folded into this function's own sort) — not this function's job.
+    mtime cannot stand in for that filter either way: see
     ``history_content_max_bytes``'s own docstring for why (two
     concurrent sessions' writes interleave in mtime order — "oldest" is
     not "whose turn is still open"). Best-effort on a ``stat()`` race (a
@@ -592,6 +608,15 @@ class MediaStore:
         # survives for the project's lifetime, same as :mod:`data.workspace.
         # artifact_ref`'s sibling table.
         self._tool_result_spill_paths: "set[Path]" = self._load_spill_manifest()
+        # #5387: the write-time cap path's ONE consumer of ``chain_id`` —
+        # NOT persisted (lead-coder ruling: GC is writer-triggered, so the
+        # chain that fired THIS eviction pass IS "the turn currently in
+        # flight"; a file from a PAST process's chain is, by definition,
+        # never the current one — nothing here needs to survive a
+        # restart). Populated only when a real (non-empty) ``chain_id``
+        # reaches :meth:`save_tool_result`; never read for a path whose
+        # entry is absent — see :meth:`is_open_turn_file`.
+        self._chain_by_path: "dict[Path, str]" = {}
 
     def _spill_manifest_path(self) -> Path:
         # #4584: PERSIST tier — `.reyn/memory/`, not `.reyn/cache/` (see
@@ -919,6 +944,14 @@ class MediaStore:
         # eventual completion, is what this file's manifest contract needs.
         resolved_path = abs_path.resolve()
         self._tool_result_spill_paths.add(resolved_path)
+        # #5387: record this write's chain_id (in-memory, per-process —
+        # see the field's own docstring) so a LATER eviction pass this
+        # same process runs can tell "this file belongs to the turn that
+        # just triggered GC" apart from everything else. A caller that
+        # passes no chain_id (still the default at some call sites) never
+        # gets an entry — such a file is never treated as open-turn.
+        if chain_id:
+            self._chain_by_path[resolved_path] = chain_id
 
         async def _write_manifest_line(_resolved_path: Path = resolved_path) -> None:
             try:
@@ -948,27 +981,66 @@ class MediaStore:
         # landed yet, so this can lag one write behind — acceptable for
         # a backstop that (per the field's own docstring) is not
         # expected to fire under real usage.
-        self._evict_history_content_over_cap()
+        self._evict_history_content_over_cap(current_chain_id=chain_id)
         return block
 
-    def _evict_history_content_over_cap(self) -> None:
-        """#5364 §1.6 "C": delete this session's own OLDEST history-content
-        files (see :func:`_eviction_order`) until its directory is back
-        under ``history_content_max_bytes``. Scoped to THIS session's own
-        subdirectory, not the whole ``history_content_root`` — the cap's
-        own subject is one session's content (see the field's docstring:
-        cross-session growth is #5366's separate subject, not this one's).
-        Best-effort: an ``OSError`` mid-delete is logged and skipped, same
-        policy as :meth:`_purge_session_dir`'s own sibling deletes — a
-        failed eviction must never fail the write it followed."""
+    def is_open_turn_file(self, path: Path, *, current_chain_id: str) -> bool:
+        """#5387: True if ``path`` was written by the SAME chain that is
+        triggering GC right now — "the turn currently in flight" (GC is
+        writer-triggered: see :meth:`_evict_history_content_over_cap`'s
+        own docstring for why the triggering write's own ``chain_id`` IS
+        "now"). ``not_open_turn(path) = recorded_chain(path) !=
+        current_chain`` (architect/owner design, #5387) — this is that
+        predicate's negation.
+
+        Deliberately requires BOTH a real ``current_chain_id`` (empty ==
+        "no chain known for this GC pass" == protects nothing) AND a
+        recorded entry for ``path`` (absent == "this file predates
+        #5387's wiring, or its own write never got a chain_id" == never
+        open-turn) — a file can only be excluded from GC by matching an
+        ACTUAL chain, never by an absence on either side coincidentally
+        comparing equal (``"" == ""`` would otherwise protect every
+        chainless file against every chainless GC trigger)."""
+        if not current_chain_id:
+            return False
+        return self._chain_by_path.get(path) == current_chain_id
+
+    def _evict_history_content_over_cap(self, *, current_chain_id: str = "") -> None:
+        """#5364 §1.6 "C" / #5387 "L": delete this session's own OLDEST
+        history-content files (see :func:`_eviction_order`) until its
+        directory is back under ``history_content_max_bytes`` — SKIPPING
+        any file :meth:`is_open_turn_file` says belongs to the turn that
+        triggered THIS pass (default: protected; see
+        ``MediaStoreConfig.protect_open_turn_from_gc`` for the opt-in to
+        disable this and evict open-turn content too). Scoped to THIS
+        session's own subdirectory, not the whole ``history_content_root``
+        — the cap's own subject is one session's content (see the field's
+        docstring: cross-session growth is #5366's separate subject, not
+        this one's). Best-effort: an ``OSError`` mid-delete is logged and
+        skipped, same policy as :meth:`_purge_session_dir`'s own sibling
+        deletes — a failed eviction must never fail the write it
+        followed.
+
+        #5387 scope (architect design B, stated explicitly — NOT a
+        decision to leave a gap, a reach limit): this only protects the
+        write that triggered THIS session's own GC pass. Another
+        session's own open turn is out of C's reach entirely — C only
+        ever enumerates THIS session's own directory — and stays
+        unprotected only until a CROSS-session GC (#5366) is built; #5366
+        is where that would first need to be handled, not here."""
         cap = self._config.history_content_max_bytes
         directory = self._history_content_dir()
         _, total = _dir_stats_recursive(directory)
         if total <= cap:
             return
+        protect_open_turn = self._config.protect_open_turn_from_gc
         for path in _eviction_order(directory):
             if total <= cap:
                 break
+            if protect_open_turn and self.is_open_turn_file(
+                path, current_chain_id=current_chain_id,
+            ):
+                continue
             try:
                 size = path.stat().st_size
                 path.unlink()

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3597,6 +3597,7 @@ class RouterLoop:
                         _cap(
                             text_full, on_offload=_on_offload,
                             on_write_unavailable=_on_write_unavailable,
+                            chain_id=self.chain_id,
                         )
                         if _cap is not None else text_full
                     )
@@ -3676,6 +3677,7 @@ class RouterLoop:
                         text = _cap(
                             text, content_type=content_type, on_offload=_on_offload,
                             on_write_unavailable=_on_write_unavailable,
+                            chain_id=self.chain_id,
                         )
                     content_str = render_tool_result(frontmatter, text)
                     # #3629: `load_skill_to_canonical` is the one mapper that sets

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -228,6 +228,7 @@ class ContextBudgetAdvisor:
         content_type: "str | None" = None,
         on_offload: "Callable[[str], None] | None" = None,
         on_write_unavailable: "Callable[[], None] | None" = None,
+        chain_id: str = "",
     ) -> str:
         """Cap an oversized chat tool result (#1128 size axis).
 
@@ -248,6 +249,14 @@ class ContextBudgetAdvisor:
         ``on_write_unavailable`` (#5364 §1.5) — forwarded to
         ``tool_result_cap.cap_tool_result_content``'s own param of the same
         name; optional and additive, every existing caller unaffected.
+
+        ``chain_id`` (#5387) — forwarded unchanged to
+        ``tool_result_cap.cap_tool_result_content``'s own param of the same
+        name (which forwards it to ``store.save_tool_result``, the ONE
+        thing GC needs to tell a still-open turn's content apart from an
+        evictable one — see that store's own docstring). Default ``""``:
+        byte-identical to every caller from before this parameter
+        existed.
         """
         if not self._offload_config.enabled:
             return content_str
@@ -272,6 +281,7 @@ class ContextBudgetAdvisor:
             max_inline_bytes=cfg.max_inline_bytes,
             preview_head_chars=cfg.preview_head_chars,
             preview_tail_chars=cfg.preview_tail_chars,
+            chain_id=chain_id,
         )
 
     def media_followup_budget(self, tool_content: str) -> "int | None":

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -1245,8 +1245,13 @@ class RouterHistoryBuffer:
         )
 
         def _save(c: "str | dict", **kw: Any) -> dict:
+            # #5387: ``chain_id`` arrives via ``**kw`` now — forwarded by
+            # ``cap_tool_result_content`` from the ``chain_id=chain_id``
+            # passed below (this method's OWN param, not a separate
+            # value) — NOT hardcoded here too, which would collide
+            # ("got multiple values for keyword argument 'chain_id'").
             return self._media_store.save_tool_result(
-                c, chain_id=chain_id, tool=tool, seq=seq, **kw
+                c, tool=tool, seq=seq, **kw
             )
 
         replacement = cap_tool_result_content(
@@ -1257,6 +1262,7 @@ class RouterHistoryBuffer:
             save_fn=_save,
             use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
             events=self._events,
+            chain_id=chain_id,
         )
         if replacement == content:
             # cap_tool_result_content's own no-op paths (cap<=0, or the

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -751,6 +751,7 @@ class RouterHostAdapter:
         content_type: "str | None" = None,
         on_offload: "Callable[[str], None] | None" = None,
         on_write_unavailable: "Callable[[], None] | None" = None,
+        chain_id: str = "",
     ) -> str:
         """#1128 size axis: cap an oversized tool-result string at the
         router_loop chokepoint. Delegates to the session-supplied callable
@@ -762,13 +763,15 @@ class RouterHostAdapter:
         forwarded to the session capper unchanged (identity path ignores it — nothing to store).
 
         ``on_offload`` (#5364 §1.2) / ``on_write_unavailable`` (#5364 §1.5)
-        — forwarded unchanged; optional and additive, every existing
-        caller unaffected."""
+        / ``chain_id`` (#5387, the write-time cap path's own chain — see
+        ``RouterLoop.feedback``'s call sites, which have it as
+        ``self.chain_id``) — forwarded unchanged; optional and additive,
+        every existing caller unaffected."""
         if self._cap_tool_result is None:
             return content_str
         return self._cap_tool_result(
             content_str, content_type=content_type, on_offload=on_offload,
-            on_write_unavailable=on_write_unavailable,
+            on_write_unavailable=on_write_unavailable, chain_id=chain_id,
         )
 
     def media_followup_budget(self, tool_content: str) -> int | None:

--- a/src/reyn/runtime/services/tool_result_cap.py
+++ b/src/reyn/runtime/services/tool_result_cap.py
@@ -93,6 +93,7 @@ def cap_tool_result_content(
     preview_tail_chars: int = _PREVIEW_TAIL_CHARS,
     on_offload: "Callable[[str], None] | None" = None,
     on_write_unavailable: "Callable[[], None] | None" = None,
+    chain_id: str = "",
 ) -> str:
     """Return *content_str* unchanged if within the cap, else its offloaded plain-text preview.
 
@@ -141,6 +142,16 @@ def cap_tool_result_content(
                       entry can be marked accordingly instead of the
                       caller having to guess from the (unchanged, still
                       inline) return value alone. Optional and additive.
+        chain_id:     (#5387) Forwarded to ``save_fn`` when offload
+                      actually happens, so ``MediaStore.save_tool_result``
+                      can record which turn wrote this file — the ONE
+                      discriminator GC needs to tell "this session's
+                      newest file" apart from "a turn currently in
+                      flight" (see that method's own docstring). Default
+                      ``""`` (= no chain known) matches every OTHER
+                      caller's existing behavior byte-for-byte — a file
+                      written with no chain_id is simply never treated
+                      as open-turn, same as before this parameter existed.
 
     Returns:
         The original string when ``estimate_tokens(content_str) <= cap_tokens``;
@@ -161,9 +172,9 @@ def cap_tool_result_content(
     from reyn.data.workspace.media_store import MediaStoreWriteUnavailable
     try:
         if content_type:
-            block = save_fn(content_str, mime_type=content_type)
+            block = save_fn(content_str, mime_type=content_type, chain_id=chain_id)
         else:
-            block = save_fn(content_str)
+            block = save_fn(content_str, chain_id=chain_id)
     except MediaStoreWriteUnavailable:
         if on_write_unavailable is not None:
             on_write_unavailable()

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -9691,6 +9691,7 @@ class Session:
         content_type: "str | None" = None,
         on_offload: "Callable[[str], None] | None" = None,
         on_write_unavailable: "Callable[[], None] | None" = None,
+        chain_id: str = "",
     ) -> str:
         """Forwarding → ContextBudgetAdvisor.cap_tool_result (PR-1).
 
@@ -9700,11 +9701,11 @@ class Session:
         for present's stage-3 default viewer — never read into any LLM-visible field here.
 
         ``on_offload`` (#5364 §1.2) / ``on_write_unavailable`` (#5364 §1.5)
-        — forwarded unchanged; optional and additive, every existing
-        caller unaffected."""
+        / ``chain_id`` (#5387) — forwarded unchanged; optional and
+        additive, every existing caller unaffected."""
         return self._budget_advisor.cap_tool_result(
             content_str, content_type=content_type, on_offload=on_offload,
-            on_write_unavailable=on_write_unavailable,
+            on_write_unavailable=on_write_unavailable, chain_id=chain_id,
         )
 
     def _media_followup_budget(self, tool_content: str) -> "int | None":

--- a/tests/runtime/test_2425_step1c_chat_chokepoint.py
+++ b/tests/runtime/test_2425_step1c_chat_chokepoint.py
@@ -42,13 +42,14 @@ class _CapHost:
         content_type: "str | None" = None,
         on_offload=None,
         on_write_unavailable=None,
+        chain_id: str = "",
     ) -> str:
         if self.media_store is None:
             return content_str
         return cap_tool_result_content(
             content_str, cap_tokens=100, model=_MODEL, save_fn=self.media_store.save_tool_result,
             trigger=TRIGGER_CAP, use_chars4=True, content_type=content_type, on_offload=on_offload,
-            on_write_unavailable=on_write_unavailable,
+            on_write_unavailable=on_write_unavailable, chain_id=chain_id,
         )
 
     def media_followup_budget(self, _content_str: str) -> int:

--- a/tests/runtime/test_5364_media_store_flush_barrier.py
+++ b/tests/runtime/test_5364_media_store_flush_barrier.py
@@ -124,13 +124,13 @@ class _MediaStoreHost(FakeRouterHost):
 
     def cap_tool_result(
         self, content_str: str, *, content_type: "str | None" = None, on_offload=None,
-        on_write_unavailable=None,
+        on_write_unavailable=None, chain_id: str = "",
     ) -> str:
         return cap_tool_result_content(
             content_str, cap_tokens=100, model=_MODEL,
             save_fn=self.media_store.save_tool_result, trigger=TRIGGER_CAP,
             use_chars4=True, content_type=content_type, on_offload=on_offload,
-            on_write_unavailable=on_write_unavailable,
+            on_write_unavailable=on_write_unavailable, chain_id=chain_id,
         )
 
     def media_followup_budget(self, _content_str: str) -> int:

--- a/tests/runtime/test_5364_spilled_meta_wiring.py
+++ b/tests/runtime/test_5364_spilled_meta_wiring.py
@@ -47,7 +47,7 @@ class _RecordingHost:
 
     def cap_tool_result(
         self, content_str: str, *, content_type: "str | None" = None, on_offload=None,
-        on_write_unavailable=None,
+        on_write_unavailable=None, chain_id: str = "",
     ) -> str:
         if self.media_store is None:
             return content_str
@@ -55,7 +55,7 @@ class _RecordingHost:
             content_str, cap_tokens=100, model=_MODEL,
             save_fn=self.media_store.save_tool_result, trigger=TRIGGER_CAP,
             use_chars4=True, content_type=content_type, on_offload=on_offload,
-            on_write_unavailable=on_write_unavailable,
+            on_write_unavailable=on_write_unavailable, chain_id=chain_id,
         )
 
     def media_followup_budget(self, _content_str: str) -> int:

--- a/tests/runtime/test_5387_open_turn_gc_exclusion.py
+++ b/tests/runtime/test_5387_open_turn_gc_exclusion.py
@@ -142,6 +142,54 @@ def test_a_file_from_a_different_chain_is_not_protected_by_the_current_one(
     )
 
 
+def test_the_older_of_two_same_chain_files_survives_only_because_of_the_exclusion(
+    tmp_path,
+) -> None:
+    """Tier 2: #5387 architect review — the sibling tests above (turn-
+    boundary, opt-in) are each ALSO fully explained by oldest-first
+    ordering alone, with zero exclusion in effect: the triggering
+    chain's own write is always the NEWEST file, so "the newest survives"
+    never distinguishes "protected" from "just not old enough to be
+    picked yet". This is the one construction where ordering alone
+    predicts the OPPOSITE outcome from exclusion, so exclusion is the
+    ONLY explanation left: two files from the SAME chain ("c1"), the
+    flag at its default (True) — an oldest-first-only implementation
+    would evict the older one (it is not the newest); the exclusion
+    must keep BOTH, since both share the chain that is triggering THIS
+    pass.
+
+    Strip-falsify: removing the ``protect_open_turn`` skip from
+    ``_evict_history_content_over_cap`` makes ONLY this test go RED (the
+    3 sibling tests all stay green — proof they were never
+    distinguishing this case)."""
+    store = MediaStore(
+        MediaStoreConfig(history_content_max_bytes=50),
+        project_root=tmp_path,
+        agent_name="alice",
+        session_id="main",
+    )
+
+    older_block = store.save_tool_result(
+        "payload number one " * 2, mime_type="text/plain", chain_id="c1", seq=1,
+    )
+    _bump_all_mtimes_forward(store.history_content_dir)
+    # The triggering write itself — same chain as the older file above,
+    # so BOTH must be recognized as "this pass's own open turn".
+    newer_block = store.save_tool_result(
+        "payload number two " * 2, mime_type="text/plain", chain_id="c1", seq=2,
+    )
+
+    older_path = tmp_path / older_block["path"]
+    newer_path = tmp_path / newer_block["path"]
+    assert older_path.exists(), (
+        "the OLDER file must survive — an oldest-first-only "
+        "implementation (no exclusion) would evict it, since it is "
+        "not the newest file; the exclusion is what keeps it, because "
+        "it shares the SAME chain as the write triggering this pass"
+    )
+    assert newer_path.exists()
+
+
 def test_protect_open_turn_from_gc_false_opts_the_current_chain_back_into_eviction(
     tmp_path,
 ) -> None:

--- a/tests/runtime/test_5387_open_turn_gc_exclusion.py
+++ b/tests/runtime/test_5387_open_turn_gc_exclusion.py
@@ -1,0 +1,174 @@
+"""Tier 2: #5387 "L" — a session's own history-content GC (#5364 §1.6 "C")
+must not delete a file that belongs to the turn CURRENTLY triggering it —
+"open-turn is GC-excluded by default, opt-in to include it" (owner
+verbatim). Architect design B: ``not_open_turn(path) = recorded_chain(path)
+!= current_chain`` — the triggering write's own ``chain_id`` IS "now" (GC
+is writer-triggered), never approximated via mtime (two concurrent
+sessions' writes interleave in mtime order — "oldest" is not "whose turn
+is still open", see ``MediaStoreConfig.history_content_max_bytes``'s own
+docstring).
+
+Scope (architect design B, stated explicitly so this is not mistaken for
+"we decided not to bother" — owner's own instruction, PR body carries the
+same 3 lines): L protects ONLY the write that triggered THIS session's own
+GC pass. Another session's own open turn is out of reach entirely — C only
+ever enumerates THIS session's own directory. That stays unprotected until
+a CROSS-session GC (#5366) is built; #5366 is where that would first need
+to be handled, not here.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from reyn.config import CompactionConfig, MultimodalConfig
+from reyn.config.chat import OffloadConfig
+from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+from reyn.runtime.router_loop import RouterLoop
+from reyn.tools.scheme import ExecutionResult
+from tests._support.agent_session import make_session
+
+_MODEL = "gpt-4o"
+_BIG = "\n".join(f"line {i}: " + "z" * 60 for i in range(400))  # well over the offload trigger
+
+
+def _mcp_env(**data_extra) -> dict:
+    data = {"kind": "mcp", "status": "ok", "server": "s", "tool": "t", "content": "", "media_blocks": []}
+    data.update(data_extra)
+    return {"status": "ok", "data": data, "_canonical_source": "mcp"}
+
+
+def _bump_all_mtimes_forward(directory) -> None:
+    """Mirrors test_5364_history_content_cap_eviction.py's own helper —
+    force every file already in *directory* one second further into the
+    past so eviction order (sorted by mtime) is deterministic across a
+    fast test loop."""
+    for path in directory.rglob("*"):
+        if path.is_file():
+            st = path.stat()
+            os.utime(path, (st.st_atime, st.st_mtime - 1))
+
+
+def test_the_write_time_cap_path_reaches_save_tool_result_with_a_real_chain_id(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5387 wiring witness — drives the REAL production chain
+    (``RouterLoop.feedback`` -> ``RouterHostAdapter.cap_tool_result`` ->
+    ``Session._cap_tool_result`` -> ``ContextBudgetAdvisor.cap_tool_result``
+    -> ``tool_result_cap.cap_tool_result_content`` -> real
+    ``MediaStore.save_tool_result``, mirroring
+    test_5364_spilled_meta_wiring.py's own
+    ``test_the_real_production_chain_stamps_spilled_meta_end_to_end`` real-
+    chain harness, no mocks/fakes at any of those 5 hops) with a real,
+    non-empty ``chain_id`` and asserts the write LANDED with that chain_id
+    recorded — via the PUBLIC ``MediaStore.is_open_turn_file`` seam, never
+    the private ``_chain_by_path`` dict directly.
+
+    Strip-falsify: removing ``chain_id=chain_id``/``chain_id=self.chain_id``
+    from ANY of this chain's forwarding call sites (tool_result_cap.py's
+    own ``save_fn`` call, context_budget_advisor.py's ``cap_tool_result``,
+    session.py's ``_cap_tool_result``, router_host_adapter.py's
+    ``cap_tool_result``, or router_loop.py's own two ``_cap(...)`` calls)
+    makes this go RED — the store never learns the chain, so
+    ``is_open_turn_file`` reports False for a real chain_id that was
+    genuinely used to write it."""
+    monkeypatch.chdir(tmp_path)
+    session = make_session(
+        agent_name="real-chain-agent",
+        multimodal_config=MultimodalConfig(),
+        offload_config=OffloadConfig(enabled=True),
+        compaction_config=CompactionConfig(use_chars4_estimate=True),
+    )
+
+    loop = RouterLoop(host=session.router_host, chain_id="the-real-chain", router_model=_MODEL)
+    result = ExecutionResult(
+        tool_results=[_mcp_env(content=_BIG)],
+        tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "mcp"}}],
+        assistant_content="",
+    )
+    loop.feedback(result)
+
+    (tool_msg,) = [m for m in session.history if m.role == "tool"]
+    ref = (tool_msg.meta or {}).get("content_ref")
+    assert ref, f"test setup sanity: expected an offloaded content ref, meta={tool_msg.meta!r}"
+    full_path = (tmp_path / ref).resolve()
+    store = session._media_store
+    assert store is not None, "test setup sanity: session must have a real MediaStore"
+    assert store.is_open_turn_file(full_path, current_chain_id="the-real-chain"), (
+        "the write-time cap path's write must have reached save_tool_result "
+        "with the real chain_id — is_open_turn_file reports False, meaning "
+        "the chain never landed"
+    )
+
+
+def test_a_file_from_a_different_chain_is_not_protected_by_the_current_one(
+    tmp_path,
+) -> None:
+    """Tier 2: #5387 "turn boundary" witness — protection is ZERO outside
+    the triggering turn, rejecting an "always protects everything"
+    implementation that would pass the wiring test above for the wrong
+    reason. Two files, two DIFFERENT chains; eviction triggered by chain
+    "c1" must protect ONLY the "c1" file and evict the "c2" one (out of
+    "c1"'s own turn) exactly as it would any ordinary evictable file."""
+    store = MediaStore(
+        MediaStoreConfig(history_content_max_bytes=50),
+        project_root=tmp_path,
+        agent_name="alice",
+        session_id="main",
+    )
+
+    old_block = store.save_tool_result(
+        "payload from chain two " * 2, mime_type="text/plain", chain_id="c2", seq=1,
+    )
+    _bump_all_mtimes_forward(store.history_content_dir)
+    # The triggering write itself: chain_id="c1" — its own presence pushes
+    # the directory over the tiny cap, so THIS call's own
+    # _evict_history_content_over_cap(current_chain_id="c1") is exactly
+    # the pass under test.
+    new_block = store.save_tool_result(
+        "payload from chain one " * 2, mime_type="text/plain", chain_id="c1", seq=2,
+    )
+
+    old_path = tmp_path / old_block["path"]
+    new_path = tmp_path / new_block["path"]
+    assert not old_path.exists(), (
+        "a file from a DIFFERENT chain than the one triggering GC must be "
+        "evicted like any ordinary file — protection does not extend past "
+        "the triggering turn"
+    )
+    assert new_path.exists(), (
+        "the file belonging to THIS pass's own triggering chain must survive"
+    )
+
+
+def test_protect_open_turn_from_gc_false_opts_the_current_chain_back_into_eviction(
+    tmp_path,
+) -> None:
+    """Tier 2: #5387 opt-in witness (owner verbatim: "既定はそうして、opt-in
+    で対象にもするようにしたい") — with the flag explicitly disabled, even the
+    triggering chain's own file is evictable, oldest-first, same as before
+    #5387 existed."""
+    store = MediaStore(
+        MediaStoreConfig(history_content_max_bytes=50, protect_open_turn_from_gc=False),
+        project_root=tmp_path,
+        agent_name="alice",
+        session_id="main",
+    )
+
+    first_block = store.save_tool_result(
+        "payload number one " * 2, mime_type="text/plain", chain_id="c1", seq=1,
+    )
+    _bump_all_mtimes_forward(store.history_content_dir)
+    second_block = store.save_tool_result(
+        "payload number two " * 2, mime_type="text/plain", chain_id="c1", seq=2,
+    )
+
+    first_path = tmp_path / first_block["path"]
+    second_path = tmp_path / second_block["path"]
+    assert not first_path.exists(), (
+        "opt-in (protect_open_turn_from_gc=False) must let the SAME chain's "
+        "own earlier file be evicted too, oldest-first, exactly as if it "
+        "carried no chain_id at all"
+    )
+    assert second_path.exists()


### PR DESCRIPTION
**[tui-coder]** — #5387「open-turn を GC 対象外に」— write-time cap 経路（先回り経路）に chain_id を通しました。

## 実装（architect design B / owner 逐語仕様に忠実）

- ①配線: `RouterLoop.feedback`の実call site 2箇所 → `RouterHostAdapter.cap_tool_result` → `Session._cap_tool_result` → `ContextBudgetAdvisor.cap_tool_result` → `tool_result_cap.cap_tool_result_content` → `MediaStore.save_tool_result`（既にchain_id受け口あり）。#5372(on_offload)/#5375(trigger)と同じ4-hopパターン。
- ②述語: `MediaStore.is_open_turn_file(path, current_chain_id)` = `recorded_chain(path) == current_chain`。GCは書き手発火なので、発火したwriteのchain_idが「今のturn」。記録はプロセス内のみ（`self._chain_by_path`）— 前プロセスのfileは定義上「今」ではないので永続化不要。
- 既定＝除外（`MediaStoreConfig.protect_open_turn_from_gc = True`）／opt-inで対象に（owner逐語通り）。

## 射程の明示（沈黙させない — architectの逐語通りそのまま記載）

- Lが守るのは**その write 自身の chain だけ**。
- 他 session の開いた turn は **C の射程外**（C は自 session の dir しか列挙しない）。
- 横断する GC（#5366）を作るときに**初めて必要になる**。

「守らないと決めた」でなく「**到達できない**」です。

## 受入（lead-coder指定通り）

- `test_the_write_time_cap_path_reaches_save_tool_result_with_a_real_chain_id` — 「先回りcap経路のwriteが空でないchain_idでsave_tool_resultに届く」を、real driver path（RouterLoop.feedback → 実Session(make_session) → 実RouterHostAdapter → 実MediaStore、fake無し5hop）で witness。test_5364_spilled_meta_wiring.py の"real production chain"harnessを踏襲。
- `test_a_file_from_a_different_chain_is_not_protected_by_the_current_one` — 「turn の外で保護がゼロであるwitness」。常に何かを守ってしまう実装を弾くため、別chainのfileがGCで通常通り消えることを確認。
- `test_protect_open_turn_from_gc_false_opts_the_current_chain_back_into_eviction` — opt-in witness。

## 発見・修正した実問題

strip-falsify掃引中に発見: `RouterHistoryBuffer.spill_turn_content`の既存reactive-spill経路は自分のchain_idを`_save`クロージャに直接ハードコードしていたため、`cap_tool_result_content`側の新規chain_id転送と衝突（`got multiple values for keyword argument 'chain_id'`）。`_save`が`**kw`経由でchain_idを受けるよう修正、単一の真実の源に統一。

## Stale doc（同PR内で修正 — CLAUDE.md hard rule）

`MediaStoreConfig.history_content_max_bytes`のdocstringが「#5387が着地するまでこのdefaultを下げるな」と書いていたので、着地した機構と`protect_open_turn_from_gc`への参照に更新。`_eviction_order`のdocstringも「将来別filterに入る」→「実際にこのmethodとして着地した」に更新。

## Strip-falsify

1. `router_loop.py`の実call site1箇所から`chain_id=self.chain_id`を削除 → wiring test が RED → 復元
2. `is_open_turn_file`を「どのchainでも保護する」バグに書き換え → turn-boundary test が RED → 復元

## Test plan
- [x] `ruff check`（対象7ソースファイル + 4テストファイル）
- [x] `python scripts/test_tier_audit.py --strict`（新規3件含む17件）
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/verify_module_docstrings.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] `pytest`scoped sweep（media_store/history_content/offload/spill関連, 230 passed）
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Blocking points

- [x] 🔴 **除外そのものに witness がありません — ★3 本とも「古い順に消す」だけで説明が付きます。** test② は **c2(古) 消滅・c1(新) 生存**、test③ は **flag off で c1(古) 消滅・c1(新) 生存** ＝ **どちらも ★保護がゼロでも同じ結果**です（eviction は oldest-first、そして**引き金の chain の file は定義上いちばん新しい**）。test① は `is_open_turn_file()` を直接呼ぶ**述語の検査**で、**eviction 経路を通りません** ∴ ★**`_evict_history_content_over_cap` から除外を丸ごと外しても 3 本とも緑**です。**足りないのは 1 本**: ★**同じ chain の ★古い file が、flag ON で ★生き残ること**（順序だけなら消える構成）。 根拠: PR comment（architect BLOCKING）

