### PR TITLE
fix(#5032): check 5's negation window respects clause boundaries

### DIFF
--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -394,6 +394,38 @@ _NEGATION_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# #5032 (2nd instance, PR #5398, 2026-08-28): a word-count-only window has
+# no notion of a CLAUSE — "content_write already reads during the pending
+# window, not after\nflush) -- this PR closes #5384 in full" put "not" (a
+# negation genuinely about the PRECEDING clause, "not after flush") inside
+# the 6-word window before "closes", across a `)` and a `--`, even though
+# the "closes" clause itself never negates anything. #5032's own 1st
+# instance (PR #5031, tracked separately, not this fix's acceptance
+# subject) was the same root cause. Cutting the window at the nearest
+# clause boundary (scanning backward from the keyword) fixes the CLASS,
+# not just this one sentence — architect's own instruction: do not widen
+# the vocabulary or shrink the word count, the defect is the missing
+# boundary, not the window's width (if anything this makes the window
+# NARROWER on average, never wider). A boundary token itself is EXCLUDED
+# from the window — it belongs to the clause it ends, not the one after.
+_CLAUSE_BOUNDARY_RE = re.compile(r"[,;)\.]$|^--$")
+
+
+def _clause_window(preceding_words: "list[str]") -> "list[str]":
+    """Cut *preceding_words* (already at most :data:`_NEGATION_WINDOW_WORDS`
+    long) at the nearest clause boundary, scanning backward from the
+    keyword — a negation word on the OTHER side of a boundary belongs to a
+    different clause and must never be checked. Returns every word from
+    the keyword back to (but not including) the first boundary token
+    encountered; the full list if none is found within the window."""
+    result: "list[str]" = []
+    for word in reversed(preceding_words):
+        if _CLAUSE_BOUNDARY_RE.search(word):
+            break
+        result.append(word)
+    result.reverse()
+    return result
+
 
 def _window_has_negation(window: str) -> bool:
     """True if *window* (the last few words before a closing keyword,
@@ -603,6 +635,7 @@ def find_negated_closing_declarations(body: str) -> set[int]:
     out: set[int] = set()
     for m in _CLOSING_RE.finditer(text):
         preceding_words = text[:m.start()].split()[-_NEGATION_WINDOW_WORDS:]
+        preceding_words = _clause_window(preceding_words)
         window = " ".join(preceding_words).lower()
         if _window_has_negation(window):
             out.add(int(m.group(1)))

--- a/tests/scripts/test_check_pr_closing_intent.py
+++ b/tests/scripts/test_check_pr_closing_intent.py
@@ -639,6 +639,52 @@ def test_check5_does_not_fire_on_an_unrelated_negation_far_from_the_keyword():
 
 
 # ---------------------------------------------------------------------------
+# #5032 (2nd instance, real PR #5398, 2026-08-28) — a NEGATION-in-a-
+# DIFFERENT-CLAUSE false positive: the word-count-only window has no
+# notion of a clause boundary, so a negation genuinely about the
+# PRECEDING clause can land in the few words before an unrelated closing
+# keyword in the FOLLOWING clause. Fixed by cutting the window at the
+# nearest clause boundary (`,` `;` `)` `.` `--`), scanning backward from
+# the keyword — architect's own instruction: do not widen the vocabulary
+# or word count, the defect is the missing boundary.
+# ---------------------------------------------------------------------------
+
+
+def test_check5_does_not_fire_on_the_real_5398_incident_sentence():
+    """Tier 1: accept side — the exact sentence that false-positived on PR
+    #5398's own commit message: "not" sits in the 6-word window before
+    "closes", but belongs to the PRECEDING clause ("not after flush)"),
+    separated from "this PR closes #5384" by a `)` and a `--`. The
+    author's intent was genuinely to close — GitHub's real parser agreed
+    (this PR's own closing_refs resolved #5384) — so check 5 must stay
+    silent."""
+    findings = m.check_contradictions(
+        "content_write already reads during the pending window, not after\n"
+        "flush) -- this PR closes #5384 in full.",
+        closing_refs=[5384],
+    )
+    assert findings == []
+
+
+def test_check5_still_fires_on_the_same_words_without_a_clause_boundary():
+    """Tier 1: the witness that a CLAUSE BOUNDARY is what changed the
+    verdict above, not merely "this one sentence happens to be green" —
+    CLAUDE.md's own test-review Q4 concern (a green that would stay green
+    even having never run, or here: even having nothing real to bite on).
+    The exact same words, same order, same distance from the keyword —
+    with the boundary punctuation (`)`, `--`) removed so "not" and
+    "closes" sit in ONE unbroken clause — must still fire; if this ever
+    goes green too, the fix stopped detecting real negations, it did not
+    get smarter about boundaries."""
+    findings = m.check_contradictions(
+        "content_write already reads during the pending window not after "
+        "flush this PR closes #5384 in full.",
+        closing_refs=[5384],
+    )
+    assert _checks(findings) == [(5, 5384)]
+
+
+# ---------------------------------------------------------------------------
 # Boundary-fixing witnesses (#4986, architect ruling on the #4992 review
 # thread) — three cases pinning EXACTLY where the CommonMark-compliant
 # `_INLINE_CODE_RE` fix (multi-line spans now recognized as fenced) starts


### PR DESCRIPTION
**[tui-coder]** — #5032「check 5の否定窓が節境界を無視する」を直しました（#5387の後、割当通り）。

## 機構
`check_pr_closing_intent.py`の check 5 は closing keyword 直前の固定語数窓(6語)を否定語でスキャンしますが、**節境界の概念がありません**。実PR #5398のcommit本文: 「content_write already reads during the pending window, not after\nflush) -- this PR closes #5384 in full.」— `not`は`closes`の6語前にありますが、`)`と`--`を跨いだ**別の節**（"not after flush"）に属しています。著者の意図は本当に閉じることで、GitHub parserもそう解釈しました（closing_refsは#5384を含む）。

#5032本文の1例目（PR #5031、別issueで追跡）も同じ根本原因でした。architect裁定通り「1件では何も言えない」ため保留していましたが、今回の2例目でしきい値を満たしました。

## 直し
語数窓を**最も近い節境界**（`,` `;` `)` `.` `--`）で打ち切り。キーワードから逆向きにスキャンし、境界トークン自体は窓から除外（それが終わらせる側の節に属するため）。

**変更していないもの**（architect明示指示通り）: 否定語の語彙、窓の語数。欠陥は「境界の不在」であって「窓の広さ」ではありません。むしろ平均的に窓は狭くなります。

## Test
- `test_check5_does_not_fire_on_the_real_5398_incident_sentence` — 実際にFPを起こした文がsilentになることを確認
- `test_check5_still_fires_on_the_same_words_without_a_clause_boundary` — **同じ語・同じ距離**で境界punctuationのみ除去した場合は今も赤になることを確認（「たまたまこの1文が緑」を witness と呼ばないための、CLAUDE.md test-review Q4対応）
- 既存の#4834/#4986真陽性fixtureは無変化で緑のまま（否定語彙・窓幅への回帰なし）

## Strip-falsify
節境界カットを丸ごと無効化 → 新規FP修正テストのみ RED、既存50本（両真陽性witness含む）は緑のまま → 復元

## Test plan
- [x] `ruff check`
- [x] `python scripts/test_tier_audit.py --strict`（51件全て）
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/verify_module_docstrings.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] `pytest tests/scripts/test_check_pr_closing_intent.py`（51 passed）
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
