### PR TITLE
fix(#5352 lens5): disclose Agent.sandbox_config is process-wide, not per-agent narrowed

### DIFF
--- a/src/reyn/runtime/agent.py
+++ b/src/reyn/runtime/agent.py
@@ -62,9 +62,33 @@ class Agent:
     workspace_base_dir: "Path | None" = None
     workspace_state_dir: "Path | None" = None
 
-    # Exec + FS seams (agent-level-uniform backends, #1200). ``sandbox_config`` is
-    # the exec-tool gating config; ``sandbox_backend`` is the SandboxBackend
-    # INSTANCE; ``environment_backend`` is the EnvironmentBackend INSTANCE.
+    # Exec + FS seams (agent-level-uniform backends, #1200 — "agent-level"
+    # there names the SCOPE the backend stays uniform ACROSS (one agent's
+    # own chat/planner/phase run-modes), not "narrowed differently per
+    # agent"). ``sandbox_config`` is the exec-tool gating config;
+    # ``sandbox_backend`` is the SandboxBackend INSTANCE;
+    # ``environment_backend`` is the EnvironmentBackend INSTANCE.
+    #
+    # #5352 (lens 5, security — reading (A) ruled by architect,
+    # issuecomment-5450347844): DESPITE living on a per-agent ``Agent``
+    # instance, ``sandbox_config`` today is the SAME object for every
+    # agent in a process — SessionFactoryConfig.from_config threads the
+    # ONE process-wide ``ReynConfig.sandbox`` (loaded once from
+    # reyn.yaml/reyn.local.yaml) to every agent's factory construction,
+    # unmodified; no code path narrows it per agent name. A field named
+    # on a per-agent dataclass reads as a per-agent narrowing point —
+    # there is no way to notice from here alone that it is not one.
+    # Consequence: reyn.yaml's absolute-path fields (``allow_write_paths``
+    # etc.) grant write access to every agent in the process equally,
+    # including one whose own worktree differs from the path an operator
+    # wrote for a DIFFERENT agent — harmless while every agent in a
+    # deployment is equally trusted, live the moment they are not.
+    # Deliberately NOT fixed by adding per-agent narrowing here — that is
+    # a NEW capability #1200 never decided to build, and a security
+    # capability's own promise ("this can be narrowed per agent") needs
+    # its own owner-level decision on who sets it (operator vs. a
+    # spawning model) before it exists at all — tracked as a SEPARATE
+    # question in #5352, not resolved by this disclosure.
     sandbox_config: Any = None
     sandbox_backend: Any = None
     environment_backend: Any = None

--- a/src/reyn/runtime/agent.py
+++ b/src/reyn/runtime/agent.py
@@ -75,8 +75,11 @@ class Agent:
     # agent in a process — SessionFactoryConfig.from_config threads the
     # ONE process-wide ``ReynConfig.sandbox`` (loaded once from
     # reyn.yaml/reyn.local.yaml) to every agent's factory construction,
-    # unmodified; no code path narrows it per agent name. A field named
-    # on a per-agent dataclass reads as a per-agent narrowing point —
+    # unmodified; no code path narrows it per agent name (repo-wide
+    # census, 2026-08-28 — until #5352 answers whether per-agent
+    # narrowing is built; that PR's own landing is what would make this
+    # claim false, not a byte-count or a date). A field named on a
+    # per-agent dataclass reads as a per-agent narrowing point —
     # there is no way to notice from here alone that it is not one.
     # Consequence: reyn.yaml's absolute-path fields (``allow_write_paths``
     # etc.) grant write access to every agent in the process equally,

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -134,6 +134,10 @@ class SessionFactoryConfig:
         # same validated snapshot.
         presentation_registry = build_presentation_registry(config.presentations)
         return cls(
+            # #5352: this ONE SandboxConfig instance is threaded, unmodified,
+            # to every agent's Agent.sandbox_config this factory constructs
+            # for THIS process — see that field's own docstring (agent.py)
+            # for the consequence (process-wide, not per-agent narrowed).
             sandbox_config=config.sandbox,
             multimodal_config=config.multimodal,
             # #4274: the previously-dead web_fetch.* config, now threaded live.


### PR DESCRIPTION
**[e2e-coder]** — #5352, closing the ① scope architect ruled (issuecomment-5450347844). Does NOT implement per-agent narrowing — explicitly out of scope, see below.

## What

`Agent.sandbox_config` lives on a per-agent dataclass but is today the SAME `SandboxConfig` instance for every agent in a process — `SessionFactoryConfig.from_config` threads the one process-wide `ReynConfig.sandbox` (loaded once from `reyn.yaml`/`reyn.local.yaml`) to every agent's factory construction, unmodified. No code path narrows it per agent name.

A field named on a per-agent dataclass reads as a per-agent narrowing point — there was no way to notice from the field alone that it is not one. This PR adds disclosure comments at both ends of the chain (`Agent.sandbox_config`'s own field comment, and `SessionFactoryConfig.from_config`'s `sandbox_config=config.sandbox` line) naming the actual scope and its consequence: `reyn.yaml`'s absolute-path fields (`allow_write_paths` etc.) grant write access to every agent in a process equally, including one whose own worktree differs from a path an operator wrote for a DIFFERENT agent.

## Why (A), not (B)

#1200's own "Completion goal" text: 「agent の EnvironmentBackend/sandbox_backend instance を agent-level-uniform に **chat-Workspace + PlanRuntime + OSRuntime** へ thread（`sandbox_config` が既に uniform に流れるのと同様）」 — the target of "thread…to" is three run-modes of ONE agent, so "agent-level-uniform" names the scope a backend stays uniform ACROSS (one agent's own modes), never "narrowed differently per agent". Today's process-wide sharing sits outside what #1200 actually described.

## What this PR deliberately does NOT do

Architect's explicit ruling: do not build per-agent narrowing here.
1. That would be a NEW capability #1200 never decided to build, added under a "defect repair" face.
2. A security capability's own promise ("this can be narrowed per agent") needs its own owner-level decision on WHO sets it (operator vs. a spawning model) before it exists at all — the same shape #5366 already hit once tonight ("a model deciding its own policy").

That broader question — should reyn support per-agent sandbox narrowing, and if so who decides it — is tracked in #5352 for lead-coder to raise with the owner; not this PR's scope.

## Verification

- `ruff check`, plain import, `verify_module_docstrings.py`, `mypy_ratchet.py` — all green.
- `pytest tests/runtime/test_transport_ref.py` (14 passed) — pure comment change, no behavior touched, confirming nothing broke.

## Test plan

- [x] `ruff check`
- [x] `mypy_ratchet.py`
- [x] `verify_module_docstrings.py`
- [x] `pytest tests/runtime/test_transport_ref.py` (14 passed, unaffected)
- [x] (skipped — Visual, standing waiver, no UI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] 🔴 **追加された comment は Class C（2 箇所の関係の主張）で witness も timestamp も持っていません。** #5389（本日 merge の `comments.md`）の条文「A Class C comment must carry a witness or a timestamp」に当たります。**受入: (a) witness を名指す／(b) 過去形 `as of #5352, ... was ...`／(c) `until #NNNN`（owner 判断待ちなのでこれが実態に合う）のどれか。** 根拠: PR comment（BLOCKING）
