### PR TITLE
fix(#5208): give every hook's exec/exec_capture child a structurally write-reachable REYN_AGENT_STATE_DIR

### DIFF
--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -114,7 +114,7 @@ class HookProcessContext:
     a REAL environment variable a spawned CHILD process reads because it
     has no way to run reyn's own in-process expander itself).
 
-    Exactly THREE named fields, never a free-form ``dict[str, str]`` —
+    Exactly FOUR named fields, never a free-form ``dict[str, str]`` —
     architect's own ruling (#5084, owner's standing directive "don't break
     the Sandbox abstraction"): a general ``run(env=Mapping[str, str])``
     would let a caller inject ARBITRARY env into a sandboxed subprocess
@@ -122,36 +122,52 @@ class HookProcessContext:
     actually runs, not just what it can read) — silently routing around
     the sandbox boundary's whole point. This type is a closed envelope
     (Tier-1 lens 2: typed, never free-formed): a caller cannot add a
-    fourth variable, and the three names below are the ONLY ones any
+    fifth variable, and the four names below are the ONLY ones any
     backend's :meth:`~reyn.security.sandbox.backend.SandboxBackend.run`
     implementation is asked to set.
 
-    ``project_dir``/``agent_base_dir`` are PATHS, resolved on the reyn
-    host — meaningless (or actively wrong) inside a container backend
-    whose repo lives at a different in-container path (the SAME asymmetry
-    ``SandboxBackend.run``'s own ``cwd`` docstring already draws for a
-    workspace-coupled backend); ``agent_name`` is a bare identity string,
-    equally true on either side of a container boundary, so it is passed
-    through unconditionally. A backend that cannot translate the two path
-    values omits them rather than passing a host-side path that would
-    silently resolve to nothing (or someone else's directory) inside the
-    container — never a silent full drop of all three."""
+    ``project_dir``/``agent_base_dir``/``agent_state_dir`` are PATHS,
+    resolved on the reyn host — meaningless (or actively wrong) inside a
+    container backend whose repo lives at a different in-container path
+    (the SAME asymmetry ``SandboxBackend.run``'s own ``cwd`` docstring
+    already draws for a workspace-coupled backend); ``agent_name`` is a
+    bare identity string, equally true on either side of a container
+    boundary, so it is passed through unconditionally. A backend that
+    cannot translate the three path values omits them rather than passing
+    a host-side path that would silently resolve to nothing (or someone
+    else's directory) inside the container — never a silent full drop of
+    all four.
+
+    #5208: ``agent_state_dir`` (``REYN_AGENT_STATE_DIR`` — the agent's own
+    ``.reyn/agents/<agent>/state/``) is a structurally reachable write
+    target for EVERY agent regardless of ``base_dir`` — ``.reyn`` sits
+    inside ``_DEFAULT_WRITE_ZONES`` (``reyn.security.permissions.permissions``),
+    so a hook that wants to persist something durable no longer has to
+    fight ``base_dir`` narrowing to find a place it is structurally
+    guaranteed to be allowed to write. reyn itself is responsible for this
+    directory existing by the time a hook's child process reads this
+    variable (it is already materialized before this point — the same
+    session-construction-time writes that create ``config.yaml``/
+    ``hooks.yaml``/``snapshot.json`` alongside it); a hook's own child
+    process is never asked to ``mkdir`` it."""
 
     project_dir: Path
     agent_base_dir: Path
     agent_name: str
+    agent_state_dir: Path
 
     def as_env(self) -> "dict[str, str]":
         """The literal ``os.environ`` additions a host-process backend
         applies verbatim. A container backend calls this too but MAY strip
-        the two path keys first (see the class docstring) before merging
+        the path keys first (see the class docstring) before merging
         the rest into the container's own env — never call ``os.environ``
-        directly from a backend; go through this method so the three
+        directly from a backend; go through this method so the four
         names stay defined in exactly one place."""
         return {
             "REYN_PROJECT_DIR": str(self.project_dir),
             "REYN_AGENT_BASE_DIR": str(self.agent_base_dir),
             "REYN_AGENT_NAME": self.agent_name,
+            "REYN_AGENT_STATE_DIR": str(self.agent_state_dir),
         }
 
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2431,6 +2431,22 @@ class Session:
             else Path.cwd() / ".reyn"
         )
 
+    def _ensure_agent_state_dir(self) -> "Path":
+        """#5208: this agent's own `.reyn/agents/<name>/state/` — the SAME
+        directory `self._snapshot_path`'s parent already names — created
+        here (idempotent `mkdir(parents=True, exist_ok=True)`, cheap on the
+        already-common case) if it does not already exist yet. reyn's own
+        responsibility, never a hook's `exec`/`exec_capture` child process's
+        (that child is only ever handed the resolved path via
+        `REYN_AGENT_STATE_DIR`, never asked to create it). Called lazily
+        from the `hook_process_context` callable right before a hook
+        dispatch reads it, so it is guaranteed to exist by then regardless
+        of whether anything else in this session's lifecycle happened to
+        create it first."""
+        state_dir = Path(self._snapshot_path).parent.resolve()
+        state_dir.mkdir(parents=True, exist_ok=True)
+        return state_dir
+
     @property
     def _environment_backend(self) -> Any:
         return self._agent.environment_backend
@@ -5040,6 +5056,18 @@ class Session:
                     self._workspace_base_dir or self._reyn_state_root.parent
                 ).resolve(),
                 agent_name=self.agent_name,
+                # #5208: a structurally write-reachable target for EVERY
+                # agent regardless of base_dir narrowing (`.reyn` is inside
+                # `_DEFAULT_WRITE_ZONES` — `permissions.py`). Same anchor
+                # `Path(self._snapshot_path).parent` already resolves to
+                # (line 3274 above) — not re-derived here so a future
+                # snapshot-path change can't silently diverge the two.
+                # reyn creates the directory here (never the hook's own
+                # child process's job — a hook is never asked to `mkdir`
+                # its own env var target): lazily, on this lambda's own
+                # call, so it exists by the time ANY hook that reads
+                # REYN_AGENT_STATE_DIR actually runs.
+                agent_state_dir=self._ensure_agent_state_dir(),
             ),
             # #5210: same deferred-lambda-over-live-state idiom as hook_cwd/
             # hook_process_context above — the model (and therefore the

--- a/tests/hooks/test_5084_hook_process_context.py
+++ b/tests/hooks/test_5084_hook_process_context.py
@@ -1,11 +1,18 @@
 """Tier 1/2: #5084 ④ — a hook's ``exec``/``exec_capture`` child process
-receives the CLOSED, 3-field ``REYN_*`` envelope (``HookProcessContext``,
+receives the CLOSED, 4-field ``REYN_*`` envelope (``HookProcessContext``,
 mechanism "B" — see :mod:`reyn.runtime.workspace_paths`'s own module
 docstring for the A/B split) via its own environment, and a relative argv
 resolves inside the DISPATCHING AGENT'S OWN tree via ``cwd`` — both sourced
 LIVE from ``HookDispatcher``'s injected callables (``hook_cwd``/
 ``hook_process_context``), never frozen at construction (#5081's
 ``_workspace_base_dir`` can change across the dispatcher's lifetime).
+
+#5208 added the 4th field, ``agent_state_dir``/``REYN_AGENT_STATE_DIR``: a
+write target every agent can structurally reach regardless of ``base_dir``
+narrowing (``.reyn`` sits inside ``_DEFAULT_WRITE_ZONES`` —
+``reyn.security.permissions.permissions``). This module's own witnesses
+below cover it: ①/② updated for 4 fields, plus a new strip-witness and a
+base_dir-narrowed acceptance test (§ "four" section at the bottom).
 
 Before this: ``hooks/dispatcher.py``'s two ``_run_shell`` call sites passed
 NO ``cwd`` at all — every hook exec silently inherited reyn's own launch
@@ -31,23 +38,26 @@ from tests._support.sandbox_backend import FULLY_ENFORCING_AXES
 # ── ② closed by construction (Tier 1) ────────────────────────────────────────
 
 
-def test_hook_process_context_is_closed_to_exactly_three_named_fields():
+def test_hook_process_context_is_closed_to_exactly_four_named_fields():
     """Tier 1: ``HookProcessContext`` is a CLOSED envelope — a caller cannot
-    add a fourth variable, and ``as_env()`` emits exactly these 3 keys, never
+    add a fifth variable, and ``as_env()`` emits exactly these 4 keys, never
     more. This is what makes the type a typed contract (Tier-1 lens 2)
     instead of a free-form ``dict[str, str]``: the field/key SET is fixed by
     the class definition itself, not by whatever a caller happens to pass."""
     field_names = {f.name for f in fields(HookProcessContext)}
-    assert field_names == {"project_dir", "agent_base_dir", "agent_name"}, (
-        f"a 4th field would silently widen the envelope; got {field_names!r}"
+    assert field_names == {
+        "project_dir", "agent_base_dir", "agent_name", "agent_state_dir",
+    }, (
+        f"a 5th field would silently widen the envelope; got {field_names!r}"
     )
 
     ctx = HookProcessContext(
         project_dir=Path("/proj"), agent_base_dir=Path("/proj/agents/coder1"),
-        agent_name="coder1",
+        agent_name="coder1", agent_state_dir=Path("/proj/.reyn/agents/coder1/state"),
     )
     assert set(ctx.as_env().keys()) == {
         "REYN_PROJECT_DIR", "REYN_AGENT_BASE_DIR", "REYN_AGENT_NAME",
+        "REYN_AGENT_STATE_DIR",
     }
 
 
@@ -90,6 +100,7 @@ async def _dispatch_with_agent(agent_name: str, backend: "_RecordingBackend") ->
             project_dir=Path("/workspace"),
             agent_base_dir=Path(f"/workspace/agents/{agent_name}"),
             agent_name=agent_name,
+            agent_state_dir=Path(f"/workspace/.reyn/agents/{agent_name}/state"),
         ),
     )
     await dispatcher.dispatch("turn_end", {})
@@ -178,4 +189,75 @@ async def test_relative_exec_argv_runs_inside_the_dispatching_agents_own_tree(tm
     assert not (other_dir / "marker.txt").exists(), (
         "a sibling agent's tree must be untouched — this is a PER-AGENT cwd, "
         "not a process-wide default"
+    )
+
+
+# ── ④ #5208: agent_state_dir reaches every agent regardless of base_dir ─────
+
+
+@pytest.mark.asyncio
+async def test_agent_state_dir_stays_under_the_project_reyn_dir_when_base_dir_is_narrowed(
+    tmp_path,
+):
+    """Tier 2: strip-witness + acceptance for #5208.
+
+    Six-questions ④: this MUST be taken with ``base_dir`` moved AWAY from
+    the ``.reyn``-owning project root — a DEFAULT agent (base_dir ==
+    project root) would pass trivially even if ``agent_state_dir`` were
+    accidentally derived FROM ``base_dir`` instead of from the project's
+    own ``.reyn/agents/<name>/state``, since the two paths would coincide.
+    This test narrows ``workspace_base_dir`` to a SIBLING directory outside
+    ``.reyn`` and asserts ``REYN_AGENT_STATE_DIR`` still resolves under the
+    project's ``.reyn/agents/<name>/state`` — never under the narrowed
+    ``base_dir`` — which is the whole point (a structurally write-reachable
+    target for EVERY agent, `.reyn` is inside `_DEFAULT_WRITE_ZONES`,
+    independent of how narrow `base_dir` gets).
+
+    Strip-witness: removing ``REYN_AGENT_STATE_DIR`` from ``as_env()`` (or
+    the ``agent_state_dir=`` kwarg at the real ``session.py`` construction
+    site) makes ``ctx.as_env()["REYN_AGENT_STATE_DIR"]`` raise ``KeyError``
+    here — verified locally by temporarily reverting the ``as_env()`` dict
+    literal to its pre-#5208 3-key form.
+    """
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    narrow_base = tmp_path / "elsewhere" / "narrow-base"
+    narrow_base.mkdir(parents=True)
+
+    from tests._support.agent_session import make_session
+
+    session = make_session(
+        agent_name="coder1",
+        workspace_state_dir=project_root / ".reyn",
+        workspace_base_dir=narrow_base,
+    )
+
+    expected_state_dir = (project_root / ".reyn" / "agents" / "coder1" / "state").resolve()
+    assert not expected_state_dir.exists(), (
+        "test setup sanity: nothing in this session's construction should "
+        "have created the state dir yet — the point below is that reyn "
+        "creates it, not that it happened to already be there"
+    )
+
+    # This is the live callable a real hook dispatch calls right before
+    # exec/exec_capture — it must create the directory itself (reyn's own
+    # responsibility, never a hook's child process's `mkdir`) so it exists
+    # by the time ANY hook that reads REYN_AGENT_STATE_DIR actually runs.
+    ctx = session._hook_dispatcher._hook_process_context()
+    assert expected_state_dir.exists(), (
+        "REYN_AGENT_STATE_DIR's target must exist once hook_process_context() "
+        "has been called — reyn creates it, a hook is never asked to `mkdir` "
+        "its own env var target"
+    )
+    assert ctx is not None
+    resolved = Path(ctx.as_env()["REYN_AGENT_STATE_DIR"])
+    assert resolved == expected_state_dir, (
+        f"expected REYN_AGENT_STATE_DIR to stay under the project's own "
+        f".reyn/agents/coder1/state ({expected_state_dir}) regardless of "
+        f"the narrowed base_dir ({narrow_base}); got {resolved}"
+    )
+    assert narrow_base not in resolved.parents and resolved != narrow_base, (
+        "agent_state_dir must never collapse into the narrowed base_dir — "
+        "that would make it just as narrow as base_dir, defeating #5208's "
+        "own point"
     )


### PR DESCRIPTION
**[tui-coder]** — closes #5208.

## What
Adds a 4th field to `HookProcessContext`'s closed `REYN_*` envelope (`shell_runner.py`): `REYN_AGENT_STATE_DIR = <project>/.reyn/agents/<agent>/state/`. `.reyn` sits inside `_DEFAULT_WRITE_ZONES` (`permissions.py`), so this is structurally write-reachable for **every** agent regardless of how narrow `base_dir` gets — a hook that wants to persist something durable no longer has to fight `base_dir` narrowing to find a place it's structurally guaranteed to be allowed to write.

## Design
Architect ruling (relayed by lead-coder): a 4th field, not a new mechanism — the closed-envelope contract (a caller cannot silently widen it to a free-form dict; a 5th field is still not possible without touching this one class) is preserved exactly as `#5084`'s original ruling intended.

## The 3 witnesses lead-coder flagged as must-not-drop
1. **Strip witness**: removing `REYN_AGENT_STATE_DIR` from `as_env()` reds `test_hook_process_context_is_closed_to_exactly_four_named_fields` and `test_agent_state_dir_stays_under_the_project_reyn_dir_when_base_dir_is_narrowed` — verified via a real commit → edit → revert strip-falsify pass (not just asserted).
2. **Acceptance taken with `base_dir` MOVED** away from the project root — per the pre-conclusion checklist's six-questions ④: a *default* agent (`base_dir == project root`) would pass this test trivially even if `agent_state_dir` were wrongly derived FROM `base_dir` instead of the project's own `.reyn`, since the two paths would coincide. The test docstring says this explicitly.
3. **`REYN_AGENT_STATE_DIR`'s target exists at hook-execution time**, created by reyn (`Session._ensure_agent_state_dir`, called lazily from the live `hook_process_context` callable right before a dispatch reads it) — a hook's own child process is never asked to `mkdir` it.

## Scope
Core only. reyn-self's own `_SUFFIX` removal (raised in the issue thread) is explicitly out of scope — a separate, later fix.

## Verification
Gate scripts green (ruff, mypy ratchet, test-tier-audit --strict, module docstrings, flat-tests ratchet, tests-path-literal, bare-tests-import, file-depth, collect-events-settle). `tests/hooks/` (all files, 378 passed) plus the two `#5140` token-expansion files that reference the same env-var family — all green, no regressions. Strip-falsify done via a real revert-and-restore, not asserted.

## Test plan
- [x] (skipped — no user-facing surface change; verified via the automated test suite above)
