### PR TITLE
fix(#5329 A/B): pump_frames stays open on session-end; shutdown sentinel gets a session_halted record

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6452,7 +6452,12 @@ class TextualChatApp(App):
         Display frames fold into the model (skipping command-UI sentinels) via
         :meth:`_ingest_frame` — appending a new entry, or COALESCING a correlated
         tool result into its RUNNING started entry (② settle-in-place). ``__end__``
-        stops the app (the session closed). Event frames are the working-indicator
+        ends THIS worker's own loop (the session closed) — #5329 A: it no longer
+        stops the app. Only an explicit operator ``/quit`` does that (see
+        ``on_composer_submitted``, which calls ``self.exit()`` directly and does
+        not depend on this method). See this method's own ``try/except/else``
+        below for the full 4-way table of how the loop can end and what each
+        one now does. Event frames are the working-indicator
         path — consumed but not drawn, EXCEPT for the turn-end subset
         (:data:`_TURN_END_EVENT_TYPES`), which triggers
         :meth:`_sweep_orphaned_running_tools` (#72: force-settle any tool still
@@ -6509,6 +6514,8 @@ class TextualChatApp(App):
         cache-shaped (a cached FlowView would be stale-by-construction: the
         forwarder drops a detached session's frames entirely).
         """
+        import asyncio  # noqa: PLC0415 — same lazy-import convention as _watch_loop_responsiveness above
+
         try:
             async for frame in self._transport.frames():
                 # #5139 (architect FINAL ruling, issuecomment-5383272756):
@@ -6670,26 +6677,49 @@ class TextualChatApp(App):
                         logger.exception("textual chat: compact layout failed")
                 except Exception:
                     logger.exception("textual chat: live chrome refresh failed")
-        except Exception:
-            # #5329 ②: the loop's own supply, ``self._transport.frames()``,
-            # was the one failure point in this method with no handler —
-            # every other site above logs and keeps the pump running.
-            # Remove this except and a genuine stream failure again falls
-            # silently into the same ``finally: self.exit()`` a clean
-            # end-of-stream takes, so a crash and a normal shutdown are
-            # indistinguishable afterward. ``reyn.log`` has a real reader
-            # even with the TUI closed: ``chrome.py``'s diagnostics line
-            # names this same log path to the operator inline. Whether/how
-            # to surface this WHILE the TUI is still open is left open —
-            # an owner visual-judgment call, not this fix's job.
-            logger.exception(
-                "textual chat: _pump_frames' frame stream (self._transport"
-                ".frames()) raised — the app is exiting BECAUSE of this "
-                "exception, not because the stream ended normally"
+        except asyncio.CancelledError:
+            # #5329 A: this worker's own task was cancelled (app teardown
+            # already in progress via some OTHER path, or a #5050-style
+            # worker restart) — NOT itself a reason to call self.exit().
+            # Before this fix, every one of the 4 ways this loop could end
+            # funneled into ONE unconditional `finally: self.exit()`,
+            # conflating "the operator asked to quit" with "the supply
+            # simply ended/failed/was cancelled" (architect's #5329 §1
+            # census). Only an explicit operator /quit exits now — see
+            # ``on_composer_submitted``, which calls ``self.exit()`` itself
+            # and does not depend on this method at all.
+            logger.info(
+                "textual chat: _pump_frames cancelled (reason=cancelled) — "
+                "the app stays open; only an explicit /quit exits."
             )
             raise
-        finally:
-            self.exit()
+        except Exception:
+            # #5329 ②(landed, #5355): the loop's own supply,
+            # ``self._transport.frames()``, was the one failure point in
+            # this method with no handler — every other site above logs
+            # and keeps the pump running. #5329 A (this change): a supply
+            # failure no longer exits the app either (reason=supply_failed)
+            # — see the class docstring above for the full 4-way table.
+            logger.exception(
+                "textual chat: _pump_frames' frame stream (self._transport"
+                ".frames()) raised (reason=supply_failed) — the app stays "
+                "open; only an explicit /quit exits."
+            )
+            raise
+        else:
+            # #5329 A: the supply ended normally — either the `__end__`
+            # sentinel broke the loop (Session.run() itself completed) or
+            # ``frames()`` was exhausted with no more items. Either shape is
+            # reason=session_ended. Previously this silently fell into
+            # ``finally: self.exit()`` — the exact "quota exhaustion makes
+            # the TUI vanish with nothing shown" owner report this issue is
+            # about: the session ending is not the same event as the
+            # operator wanting to leave.
+            logger.info(
+                "textual chat: _pump_frames' frame stream ended normally "
+                "(reason=session_ended) — the app stays open; only an "
+                "explicit /quit exits."
+            )
 
     def _refresh_live_chrome(self) -> None:
         """Re-render everything that must track live session state as frames land:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -7092,6 +7092,20 @@ class Session:
         ride_alongs, trigger = await self._inbox_arbiter.drain_to_wake()
         if trigger is None:
             # shutdown sentinel
+            # #5329 B: this branch's two siblings (durability_failure above,
+            # `cancelled` in run()'s own except) both emit a `session_halted`
+            # audit-event before returning False — this one silently
+            # returned. Not a new mechanism: the #2280 surface already
+            # exists (TUI status line + plain-CUI toolbar both render it);
+            # this was a gap in applying it, discovered while chasing
+            # owner's "quota exhaustion makes the TUI vanish with nothing
+            # shown" report (#5329) — the run() caller has no way to tell
+            # "shutdown sentinel" apart from "durability_failure"/"cancelled"
+            # without this. Same `_halted_reason is None` guard as its
+            # siblings: at most one halt notice per session.
+            if self._halted_reason is None:
+                self._halted_reason = "shutdown_requested"
+                self._audit_events.emit("session_halted", reason=self._halted_reason)
             return False
         kind, payload = trigger
         # proposal 0060 Phase 1 (A7): stamp per-turn provenance — see docs/reference/runtime/session-construction.md#safety-limits-interactive-mode (`_current_turn_origin`).

--- a/tests/core/test_5329_shutdown_sentinel_halted_reason.py
+++ b/tests/core/test_5329_shutdown_sentinel_halted_reason.py
@@ -1,0 +1,172 @@
+"""Tier 2: #5329 B — the shutdown-sentinel branch of ``run_one_iteration``
+now emits ``session_halted(reason="shutdown_requested")``, matching its two
+siblings (``durability_failure``, ``cancelled``) instead of returning
+``False`` silently.
+
+Not a new mechanism: the #2280 ``session_halted`` audit-event surface
+already exists and is already rendered by both the TUI status line and the
+plain-CUI toolbar (see #3377's own test file,
+``test_3377_run_loop_survives_turn_cancel.py``, for the ``cancelled``
+sibling's own witness of the same surface, and #2280's own
+``test_2280_durability_halt_observability.py`` for the ``durability_failure``
+sibling's). This closes a gap in applying it — one of the three branches
+that can make ``run_one_iteration`` return ``False`` was the only one of the
+three left silent. Found while chasing owner's "quota exhaustion makes the
+TUI vanish with nothing shown" report (#5329): ``Session.shutdown()``'s own
+sentinel path produced no record a caller (or a human reading
+``.reyn/events``) could use to tell "the session was asked to stop" apart
+from "durability failed" or "was cancelled".
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.durability_worker import DurabilityWorker
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
+
+AGENT = "shutdown-sentinel-agent"
+
+
+def _make_session(tmp_path: Path, *, worker: "DurabilityWorker | None" = None) -> "tuple[Session, StateLog]":
+    state_log = StateLog(tmp_path / "state.wal", worker=worker) if worker else StateLog(tmp_path / "state.wal")
+    session = make_session(
+        agent_name=AGENT,
+        state_log=state_log,
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+    return session, state_log
+
+
+async def _inject_persistent_durability_failure(log: StateLog) -> None:
+    """Genuinely trigger the real §4-exhausted fire-and-forget durable-write
+    failure that latches ``StateLog.durability_failed`` — the same real
+    trigger ``test_2280_durability_halt_observability.py`` uses, never a
+    private-attribute poke (``durability_failed`` is a read-only property
+    over ``DurabilityWorker``'s own internal latch)."""
+    async def _boom() -> None:
+        raise OSError("simulated disk death")
+
+    log.submit_durable_nowait(_boom)
+    await log.flush()
+    assert log.durability_failed, "setup: the injected failure must latch durability_failed"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_emits_session_halted_shutdown_requested(tmp_path):
+    """Tier 2: #5329 B's own witness — calling ``Session.shutdown()`` (the
+    sole producer of the shutdown sentinel, ``session.py``'s own
+    ``await self.inbox.put(("shutdown", {}))``) must leave a
+    ``session_halted(reason="shutdown_requested")`` record, not a silent
+    ``False``.
+
+    Strip-falsifier: removing the new ``if self._halted_reason is None: ...
+    emit(...)`` block from the ``trigger is None`` branch turns this red —
+    ``run_one_iteration`` still returns ``False`` (the loop still stops
+    correctly) but no event is emitted, so ``halted`` below comes back
+    empty. Verified by hand this session."""
+    session, state_log = _make_session(tmp_path)
+    collected = collect_events(session._audit_events)
+    run_task = asyncio.create_task(session.run())
+    try:
+        # Let the loop actually reach its idle inbox wait before shutting
+        # down — shutting down before the loop has started would not
+        # exercise the real drain_to_wake() -> trigger is None path.
+        await asyncio.sleep(0)
+        assert session.halted_reason is None
+
+        await session.shutdown()
+        await asyncio.wait_for(run_task, timeout=5)
+        await settle(session._audit_events)
+
+        assert session.halted_reason == "shutdown_requested", (
+            f"expected the shutdown sentinel to set halted_reason, got "
+            f"{session.halted_reason!r}"
+        )
+        halted = [e for e in collected if e.type == "session_halted"]
+        (halt_event,) = halted  # the #2280 at-most-once guard: exactly one
+        assert halt_event.data.get("reason") == "shutdown_requested"
+    finally:
+        await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_durability_failure_sibling_still_emits_exactly_one(tmp_path):
+    """Tier 2: #5329 B non-regression — the ``durability_failure`` sibling
+    (the branch immediately above the one this PR touches) must still emit
+    its own ``session_halted`` exactly once. This is witness #6 from
+    architect's #5329 design: what's fragile about this change is not the
+    NEW emit firing, but the EXISTING siblings staying at "one each"."""
+    worker = DurabilityWorker(max_write_attempts=1)  # fail-fast, no slow backoff
+    session, state_log = _make_session(tmp_path, worker=worker)
+    collected = collect_events(session._audit_events)
+
+    await _inject_persistent_durability_failure(state_log)
+
+    result = await session.run_one_iteration()
+    await settle(session._audit_events)
+
+    assert result is False
+    assert session.halted_reason == "durability_failure"
+    halted = [e for e in collected if e.type == "session_halted"]
+    (halt_event,) = halted  # the #2280 at-most-once guard: exactly one
+    assert halt_event.data.get("reason") == "durability_failure"
+
+    # Calling it again must NOT emit a second one — the at-most-once guard
+    # this branch shares with the shutdown-sentinel branch this PR adds.
+    await session.run_one_iteration()
+    await settle(session._audit_events)
+    halted_again = [e for e in collected if e.type == "session_halted"]
+    (still_one,) = halted_again  # unpack fails if a second one landed
+    assert still_one is halt_event
+
+    await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_sentinel_branch_respects_an_already_set_reason(tmp_path):
+    """Tier 2: #5329 B non-regression — witness #6's other half. If a
+    sibling (``durability_failure`` / ``cancelled``) already set
+    ``halted_reason`` before the shutdown-sentinel branch this PR touches
+    runs, that branch must NOT overwrite it or emit a second
+    ``session_halted``. Real #3377 sibling shape: ``run()``'s own
+    ``except asyncio.CancelledError`` sets ``halted_reason`` BEFORE the
+    loop condition is even re-checked, so a shutdown sentinel already
+    queued at that point must find the guard already closed.
+
+    This exercises the ACTUAL branch (via a real ``run_one_iteration()``
+    call reaching ``trigger is None``), not a hand-simulated substitute —
+    the sentinel is genuinely queued first via ``Session.shutdown()``, so
+    ``drain_to_wake()`` returns it immediately without blocking."""
+    session, state_log = _make_session(tmp_path)
+    collected = collect_events(session._audit_events)
+
+    # Simulate the sibling having already fired (as run()'s CancelledError
+    # handler does, immediately, before its while-loop's next condition
+    # check) THEN queue the shutdown sentinel — the shape a real cancel
+    # racing a real shutdown produces.
+    session._halted_reason = "cancelled"
+    session._audit_events.emit("session_halted", reason="cancelled")
+    await settle(session._audit_events)
+    await session.shutdown()
+
+    result = await session.run_one_iteration()
+    await settle(session._audit_events)
+
+    assert result is False
+    assert session.halted_reason == "cancelled", (
+        "the shutdown-sentinel branch must not overwrite an already-set "
+        f"halted_reason; got {session.halted_reason!r}"
+    )
+    halted = [e for e in collected if e.type == "session_halted"]
+    # the shutdown-sentinel branch must not have emitted a SECOND one
+    # despite halted_reason already being set — unpack fails otherwise
+    (halt_event,) = halted
+    assert halt_event.data.get("reason") == "cancelled"
+
+    await state_log.aclose()

--- a/tests/interfaces/test_5050_remote_pending_intervention_choices.py
+++ b/tests/interfaces/test_5050_remote_pending_intervention_choices.py
@@ -92,14 +92,16 @@ async def _sse_lines_then_hang(text: str):
     ``AgUiTransport.frames()`` raise ``StopAsyncIteration`` on its very
     first ``__anext__()`` when there is nothing to yield — which makes
     ``_pump_frames``'s ``async for`` loop complete with ZERO iterations
-    and fall straight into its own ``finally: self.exit()`` (a genuine
-    "the connection is over, quit the app" — correct for an actually-
-    closed stream, wrong for THIS scenario). A real long-lived connection
-    never exhausts this way; it just has nothing more to send yet. A
-    finite generator here would tear the WHOLE APP down via that
-    ``finally`` before witness ②'s own hydrated-intervention-head worker
-    ever gets a chance to run — not a mount race, a test artifact that
-    doesn't match the real bug shape.
+    and end its OWN worker (#5329 A: this no longer exits the app —
+    before that fix it fell straight into an unconditional ``finally:
+    self.exit()``, a genuine "the connection is over, quit the app" that
+    was correct for an actually-closed stream but wrong for THIS
+    scenario). A real long-lived connection never exhausts this way; it
+    just has nothing more to send yet. A finite generator here would
+    still end the pump's own loop with zero iterations, before witness
+    ②'s own hydrated-intervention-head worker ever gets a chance to run
+    — not a mount race, a test artifact that doesn't match the real bug
+    shape.
 
     A real ``asyncio.sleep(0)`` BETWEEN every yielded line (not merely
     after the whole block) — without it, ``_pump_frames``'s own worker

--- a/tests/interfaces/test_5329_pump_frames_supply_end_stays_open.py
+++ b/tests/interfaces/test_5329_pump_frames_supply_end_stays_open.py
@@ -1,0 +1,161 @@
+"""Tier 2: #5329 A — ``_pump_frames``'s supply ending (``__end__``, a
+genuine exception, or a task cancel) no longer tears the whole app down via
+an unconditional ``finally: self.exit()``. Only an explicit operator
+``/quit`` exits now.
+
+Owner's own real-machine report this session: quota exhaustion (a 429) made
+the TUI vanish — "process completely terminates and returns to shell" —
+with no error shown. architect's #5329 design (issuecomment-5451903...,
+"無音終了の機構を行で特定しました"): 4 ways ``_transport.frames()`` can stop
+supplying frames ALL funneled into the same unconditional ``finally:
+self.exit()``, conflating "the session ended" (``__end__``, from
+``Session.run()`` completing for ANY reason, including a quota-exhaustion
+fail-stop) with "the operator asked to leave" (``/quit``). Before this fix,
+those were indistinguishable and BOTH exited the process.
+
+architect's witness table (issue #5329, design comment):
+    #1  transport emits __end__         -> app stays alive, reason readable
+    #2  strip A's branching             -> #1 goes red
+    #3  /quit                           -> still exits (positive control)
+This file covers #1 and #3 (both permanent regression guards). #2 was
+verified by hand this session (reverting ``_pump_frames``'s
+``try/except/else`` back to a bare ``try/finally: self.exit()`` turns the
+first test below red — the app exits on ``__end__`` again) and is not
+re-encoded as a permanent test (a strip-falsifier is a verification step
+performed during review, not a standing assertion against a mechanism this
+file's own test already pins from the other direction).
+
+Same real-harness idiom as ``test_5329_2_pump_frames_exception_not_silent.py``
+(this issue's own sibling file) and ``test_5126_pump_sse_exception_not_
+swallowed.py``: a real, minimal ``ClientTransportStub`` subclass, driven
+through a REAL ``TextualChatApp`` via ``app.run_test()`` — no mocks, no
+duration.
+"""
+from __future__ import annotations
+
+import logging
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+_LOGGER_NAME = "reyn.interfaces.inline.textual_chat.app"
+
+
+class _CleanEndTransport(ClientTransportStub):
+    """A stream that ends NORMALLY via the ``__end__`` sentinel — the
+    real shape ``Session.run()`` completing (for ANY reason: idle
+    shutdown, a quota-exhaustion fail-stop, whatever) produces on the
+    wire. Mirrors ``test_5329_2``'s own ``_CleanEndTransport`` (same
+    file couldn't import it directly — module-private by convention in
+    that file, and this file's own docstring differs)."""
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        yield DisplayFrame(OutboxMessage(kind="agent", text="a normal reply"))
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    async def submit_user_text(self, text: str) -> "str | None":  # pragma: no cover - trivial
+        return None
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover - trivial
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover - trivial
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover - trivial
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+@pytest.mark.asyncio
+async def test_supply_ending_normally_does_not_exit_the_app(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: #5329 A witness #1 — a stream that ends via ``__end__`` must
+    leave the app RUNNING, with a readable reason in the log.
+
+    Strip-falsifier (verified by hand, not re-encoded here — see module
+    docstring): reverting ``_pump_frames``'s ``try/except/else`` to a bare
+    ``try/finally: self.exit()`` makes ``app.is_running`` False here.
+    """
+    transport = _CleanEndTransport()
+    app = TextualChatApp(transport=transport)
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.pause()
+
+            assert app.is_running, (
+                "#5329 REGRESSION: the app exited when the frame supply "
+                "simply ended (__end__) — only an explicit /quit should "
+                "exit."
+            )
+
+    messages = [r.message for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any(
+        "reason=session_ended" in m for m in messages
+    ), (
+        f"the normal-end path must leave a readable reason in the log — "
+        f"got {messages!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_quit_still_exits_the_app() -> None:
+    """Tier 2: #5329 A witness #3 (positive control) — an explicit
+    operator ``/quit`` must still exit the app. Without this, #5329 A's
+    "only /quit exits" change could silently regress into "nothing ever
+    exits" and nothing here would catch it — this is the case that PROVES
+    exit still works at all.
+
+    Drives the real composer submit path (``on_composer_submitted``),
+    not a direct ``app.exit()`` call — that handler is what #5329 A's
+    docstring names as the ONLY remaining exit path, so this test must
+    exercise THAT path specifically. Same real-Composer idiom as
+    ``test_textual_chat_phase1_3273.py``'s own
+    ``test_composer_submit_routes_to_transport``: type through the pilot,
+    press Enter, no direct widget-value assignment."""
+    from reyn.interfaces.inline.textual_chat import Composer
+
+    transport = _CleanEndTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        assert app.is_running, "setup: the app must be alive before /quit"
+
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        await pilot.press("/", "q", "u", "i", "t")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert not app.is_running, (
+            "#5329 REGRESSION: an explicit /quit no longer exits the app"
+        )


### PR DESCRIPTION
**[e2e-coder]** — part of #5329.

## What

architect's design (issue #5329, accepted by lead-coder). Owner's own real-machine report this session: quota exhaustion (429) made the TUI vanish — process terminates, returns to shell, nothing shown.

## A — `_pump_frames` no longer conflates 4 distinct endings into one exit

Before: every way the frame supply could stop (`__end__`, a genuine exception, a task cancel, an explicit `/quit`) funneled into the same unconditional `finally: self.exit()`. Now only an explicit operator `/quit` exits — that path (`on_composer_submitted`) already calls `self.exit()` itself, independent of this method, so its behavior is unchanged. The other three (`session_ended`, `supply_failed`, `cancelled`) log a readable reason and leave the app running — owner's updated accept criterion is "process does not terminate".

## B — the shutdown-sentinel branch was the one silent way to halt

`run_one_iteration`'s three `False`-returning branches (`durability_failure` / `cancelled` / `trigger is None` shutdown sentinel) — the first two already emit `session_halted` before returning; the third silently returned `False`. Not a new mechanism — a gap in applying the existing #2280 surface (the same TUI status line / plain-CUI toolbar already render it).

## Witnesses (architect's #5329 design, all verified this session)

| # | Witness | Status |
|---|---|---|
| 1 | transport emits `__end__` → app stays alive, reason readable in log | test (`test_5329_pump_frames_supply_end_stays_open.py`) |
| 2 | strip A's branching (revert to bare `finally: self.exit()`) → #1 goes red | verified by hand, not re-encoded as a standing test |
| 3 | `/quit` → still exits (positive control) | test (same file) |
| 4 | `Session.shutdown()` → `session_halted(reason="shutdown_requested")`, exactly 1 | test (`test_5329_shutdown_sentinel_halted_reason.py`) |
| 5 | strip B's emit → #4 goes red | verified by hand |
| 6 | `durability_failed` / `cancelled` siblings still emit exactly 1 each (not broken by B) | test (same file) |

⚠️ Especially **#3** and **#6** per lead-coder's own emphasis: the fragile side of this change is not the new "stays open" behavior, but "still exits on `/quit`" and "siblings unaffected" — both are positive/non-regression controls, not the headline feature.

## Doc-drift swept

- `_pump_frames`'s own module docstring (the `__end__ stops the app` claim) updated to the new 4-way behavior.
- `tests/interfaces/test_5050_remote_pending_intervention_choices.py`'s own rationale comment (referenced the old unconditional exit) corrected in the same PR — not the test's own assertions, which were unaffected.

## Deferred (per architect's own explicit scoping, not this PR's job)

- How the "session ended" / "supply failed" states are surfaced VISUALLY in the TUI (composer disabled? re-attach prompt?) — owner's own visual judgment call, named explicitly by both architect and lead-coder as out of scope here.
- Whether/which real code path actually carries a 429 into `Session.run()`'s own halt — this PR's accept criterion (owner's updated one: "process does not terminate") holds regardless of that path, per architect's own "does not bet on which route carries it" design rationale.

## Verification

- `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.
- `tests/interfaces/` full sweep: 2109 passed, 4 skipped (pre-existing, unrelated).
- `tests/core/test_3377_run_loop_survives_turn_cancel.py` + `tests/interfaces/test_2280_durability_halt_observability.py` (the two sibling mechanisms B's change sits next to): 15 passed.
- Both strip-falsifiers (#2, #5) executed by hand this session: genuinely RED under strip, GREEN on restore.

## Test plan

- [x] (skipped — TUI-internal behavior change with no new user-facing surface beyond "the app doesn't quit on its own now"; the in-TUI visual question is explicitly deferred to owner per the design above)
