### PR TITLE
fix(#5052): approval scope dimension -- agent-scoped by default, workspace explicit

### DIFF
--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -501,6 +501,7 @@ async def handle(
                 ctx.intervention_bus,
                 ctx.actor,
                 sandbox_policy=_sandbox,
+                agent_name=ctx.agent_name or ctx.actor,
             )
 
     # ── 4. Credentials: resolve isSecret env vars from env_overrides or

--- a/src/reyn/core/op_runtime/pipeline_install.py
+++ b/src/reyn/core/op_runtime/pipeline_install.py
@@ -169,6 +169,7 @@ async def handle(
                 ctx.intervention_bus,
                 ctx.actor,
                 sandbox_policy=_sandbox,
+                agent_name=ctx.agent_name or ctx.actor,
             )
 
         # 0b. Determine install destination — a stable name under .reyn/pipelines/.

--- a/src/reyn/core/op_runtime/plugin_install.py
+++ b/src/reyn/core/op_runtime/plugin_install.py
@@ -1035,6 +1035,7 @@ async def handle(op: PluginInstallIROp, ctx: OpContext) -> dict:
             await ctx.permission_resolver.require_http_get(
                 ctx.permission_decl, host, ctx.intervention_bus, ctx.actor,
                 sandbox_policy=sandbox,
+                agent_name=ctx.agent_name or ctx.actor,
             )
         staging = root / ".staging" / f"git-{uuid4().hex}"
         clone_err = await _shallow_clone(op.source.url, staging, ctx)

--- a/src/reyn/core/op_runtime/skill_install.py
+++ b/src/reyn/core/op_runtime/skill_install.py
@@ -332,6 +332,7 @@ async def handle(
                 ctx.intervention_bus,
                 ctx.actor,
                 sandbox_policy=_sandbox,
+                agent_name=ctx.agent_name or ctx.actor,
             )
 
         # 0b. Determine install destination — a stable name under .reyn/skills/.

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -286,9 +286,16 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext) -> dict:
         # wildcard fires the per-host prompt). #1199 S3.1c-2: a sandbox with
         # network:false vetoes the fetch. Re-run on EVERY hop (not just initial).
         if ctx.permission_resolver is not None:
+            # #5052: `ctx.agent_name or ctx.actor` is the SAME fallback
+            # `present.py` already uses to obtain a real running-agent
+            # identity — `ctx.actor` alone is a per-call role label (the
+            # session bridge passes a fixed constant), not the agent
+            # dimension a saved approval's scope needs to be checked/
+            # recorded against.
             await ctx.permission_resolver.require_http_get(
                 ctx.permission_decl, host, ctx.intervention_bus, ctx.actor,
                 sandbox_policy=_sandbox_policy_from_ctx(ctx),
+                agent_name=ctx.agent_name or ctx.actor,
             )
         # L2 — SSRF IP-deny (always; independent of the permission system).
         try:

--- a/src/reyn/interfaces/cli/commands/permissions.py
+++ b/src/reyn/interfaces/cli/commands/permissions.py
@@ -61,18 +61,23 @@ def _legacy_snapshot_path() -> Path:
     return project_root / ".reyn" / "approvals.yaml"
 
 
-def _load() -> dict[str, bool]:
+def _load() -> "tuple[dict[str, bool], dict[str, str]]":
     """Fold the ledger (migrating a legacy snapshot first, if present) —
     the SAME read every other approvals surface (`PermissionResolver`,
-    the web router) now does."""
+    the web router) now does.
+
+    #5052: also returns each key's ``scope`` — see
+    :func:`~reyn.interfaces.web.routers.permissions._load`'s own docstring
+    for why a legacy (pre-#5052, scope-less) entry is surfaced as
+    ``"legacy-workspace"`` rather than silently promoted to ``"workspace"``."""
     from reyn.security.permissions.approval_ledger import (
         ApprovalLedger,
         migrate_legacy_snapshot,
     )
     ledger = ApprovalLedger(_ledger_path())
     migrate_legacy_snapshot(ledger, _legacy_snapshot_path())
-    approvals, _bound = ledger.fold()
-    return approvals
+    approvals, _bound, scopes = ledger.fold()
+    return approvals, scopes
 
 
 def _parse_key(key: str) -> tuple[str, str, str] | None:
@@ -99,12 +104,22 @@ def _parse_key(key: str) -> tuple[str, str, str] | None:
 
 def _cmd_list(args: argparse.Namespace) -> None:
     path = _ledger_path()
-    data = _load()
+    data, scopes = _load()
     if not data:
         print(f"No saved approvals at {path}.")
         return
     print(f"# {path}")
     print()
+    legacy_count = sum(
+        1 for k, v in data.items() if v and scopes.get(k) == "legacy-workspace"
+    )
+    if legacy_count:
+        print(
+            f"  ⚠ {legacy_count} entr{'y' if legacy_count == 1 else 'ies'} predate "
+            f"the #5052 agent-scope field and still apply to EVERY agent in this "
+            f"workspace. Re-approve to narrow to one agent."
+        )
+        print()
     file_keys: list[tuple[str, str, str, bool]] = []  # actor, kind, path, approved
     other_keys: list[tuple[str, bool]] = []
     for key, approved in data.items():
@@ -141,7 +156,7 @@ def _cmd_list(args: argparse.Namespace) -> None:
 
 
 def _cmd_revoke(args: argparse.Namespace) -> None:
-    data = _load()
+    data, _scopes = _load()
     if args.key not in data:
         print(f"No saved approval with key {args.key!r}.", file=sys.stderr)
         # Friendly suggestion: any partial matches?
@@ -157,7 +172,7 @@ def _cmd_revoke(args: argparse.Namespace) -> None:
 
 
 def _cmd_clear(args: argparse.Namespace) -> None:
-    data = _load()
+    data, _scopes = _load()
     currently_approved = {k for k, v in data.items() if v}
     if not currently_approved:
         print("No saved approvals to clear.")

--- a/src/reyn/interfaces/web/routers/permissions.py
+++ b/src/reyn/interfaces/web/routers/permissions.py
@@ -56,16 +56,24 @@ def _legacy_snapshot_path(project_root: Path) -> Path:
     return project_root / ".reyn" / "approvals.yaml"
 
 
-def _load(project_root: Path) -> dict[str, bool]:
-    """Fold the ledger (migrating a legacy snapshot first, if present)."""
+def _load(project_root: Path) -> "tuple[dict[str, bool], dict[str, str]]":
+    """Fold the ledger (migrating a legacy snapshot first, if present).
+
+    #5052: returns ``(approvals, scopes)`` — ``scopes`` is
+    :data:`~reyn.security.permissions.approval_ledger.SCOPE_LEGACY_WORKSPACE`
+    for a pre-#5052 record (no ``scope`` field ever written), so
+    :func:`list_permissions` can surface that count rather than
+    silently folding it into ``SCOPE_WORKSPACE`` (architect ruling: "黙って
+    昇格させない" — a legacy-workspace entry that is still in effect must
+    say so, not disappear into an indistinguishable 'workspace' label)."""
     from reyn.security.permissions.approval_ledger import (
         ApprovalLedger,
         migrate_legacy_snapshot,
     )
     ledger = ApprovalLedger(_ledger_path(project_root))
     migrate_legacy_snapshot(ledger, _legacy_snapshot_path(project_root))
-    approvals, _bound = ledger.fold()
-    return approvals
+    approvals, _bound, scopes = ledger.fold()
+    return approvals, scopes
 
 
 # ── response models ───────────────────────────────────────────────────────────
@@ -74,6 +82,9 @@ def _load(project_root: Path) -> dict[str, bool]:
 class ApprovalEntry(BaseModel):
     key: str
     approved: bool
+    #: #5052: "workspace" / "agent:<name>" / "legacy-workspace" (a pre-#5052
+    #: entry — still honored workspace-wide, never silently relabeled).
+    scope: str
 
 
 # ── routes ───────────────────────────────────────────────────────────────────
@@ -83,9 +94,17 @@ class ApprovalEntry(BaseModel):
 async def list_permissions(
     project_root: Path = Depends(get_project_root),
 ) -> list[ApprovalEntry]:
-    """Return all saved approval entries, folded from the ledger."""
-    data = _load(project_root)
-    return [ApprovalEntry(key=k, approved=v) for k, v in sorted(data.items())]
+    """Return all saved approval entries, folded from the ledger.
+
+    #5052: each entry names its own ``scope`` — an operator (or a caller
+    counting ``scope == "legacy-workspace"``) can see which grants predate
+    the agent dimension and still apply to every agent, rather than that
+    fact being invisible."""
+    data, scopes = _load(project_root)
+    return [
+        ApprovalEntry(key=k, approved=v, scope=scopes.get(k, "legacy-workspace"))
+        for k, v in sorted(data.items())
+    ]
 
 
 @router.delete("/permissions/{key:path}", status_code=status.HTTP_204_NO_CONTENT)
@@ -104,7 +123,7 @@ async def revoke_permission(
     failure (see ``emit_direct_event``'s docstring) — the append always
     lands, but on an emit failure the audit trail does not record it.
     """
-    data = _load(project_root)
+    data, _scopes = _load(project_root)
     if key not in data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -137,7 +156,7 @@ async def clear_permissions(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Pass {\"confirm\": true} in the request body to clear all approvals.",
         )
-    data = _load(project_root)
+    data, _scopes = _load(project_root)
     currently_approved = [k for k, v in data.items() if v]
     from reyn.security.permissions.approval_ledger import ApprovalLedger
     ledger = ApprovalLedger(_ledger_path(project_root))

--- a/src/reyn/security/permissions/approval_ledger.py
+++ b/src/reyn/security/permissions/approval_ledger.py
@@ -74,6 +74,40 @@ shape this codebase closed 3 times over the same night this issue was
 ruled on. :meth:`fold` must never read ``ts`` for anything but a caller's
 own display formatting.
 
+**Scope (#5052)**: every approval decision now carries a ``scope`` value
+naming WHO it applies to — ``SCOPE_WORKSPACE`` ("every agent in this
+workspace") or an ``agent:<name>`` string built by :func:`scope_for_agent`
+("this one agent only"). This is a VALUE on the record, never a position in
+``key`` (architect ruling, issuecomment-5384686461, "C" — the repo's own
+standing "typed discriminated union over form-sniffed string" preference):
+putting the agent into the key string, or splitting into per-agent files,
+was explicitly rejected — the former can't tell "no agent dimension" apart
+from "matches everything", and the latter breaks the #5065 single-audit-
+surface goal. A THIRD value, ``session:<sid>``, was also explicitly
+rejected (architect + lead-coder, broker 2026-08-24): ``sid`` is generated
+by ``uuid4().hex[:8]`` (32 bits) and the registry keeps zero record of a
+retired session id (measured: ``registry.py``'s ``_has_session`` only
+checks CURRENTLY-LIVE sessions), so a session id CAN be reused — a
+session-scoped approval would silently reattach to an unrelated later
+session using the same id, which is worse than not having the scope at
+all.
+
+Append-only means a pre-#5052 record — written before this field existed —
+can NEVER be rewritten to carry one (rewriting a past ledger line is
+ledger falsification, the constitution's "does the repair destroy the
+evidence" question, answered "yes"). :meth:`fold` therefore treats a
+record with no ``scope`` key as ``SCOPE_LEGACY_WORKSPACE`` — deliberately
+a DIFFERENT sentinel from ``SCOPE_WORKSPACE``, never collapsed into it
+(the #4996-family discipline: "unspecified" and "specified-and-wide" are
+not the same value) — but one that matches the CURRENT-agent check the
+same way ``SCOPE_WORKSPACE`` does, because a pre-#5052 grant genuinely
+WAS a workspace-wide decision the moment it was made (there was no agent
+dimension for the operator to have narrowed). A fresh write never
+produces ``SCOPE_LEGACY_WORKSPACE`` — it is a read-time-only classification
+of absence, synthesized by :meth:`fold`, never persisted as a literal
+string. The moment a legacy key is re-approved, the newest record (which
+DOES carry an explicit scope) wins the fold, same as any other key.
+
 **Caveat, stated rather than solved** (acceptance ④): the append's
 atomicity depends on each record line being small — a local filesystem's
 ``write()`` for a buffer at or under ``PIPE_BUF``/the OS's own atomic-write
@@ -111,6 +145,52 @@ from typing import Any
 #: write-gate that protects it) moves together by construction.
 RELATIVE_PATH = ".reyn/approvals.jsonl"
 
+#: #5052: an approval that applies to every agent in the workspace. Only
+#: ever written when an operator EXPLICITLY chose the wide grant — never
+#: the silent default (see :func:`scope_for_agent`'s own docstring for the
+#: default reasoning).
+SCOPE_WORKSPACE = "workspace"
+
+#: #5052: read-time-only classification for a record that predates the
+#: ``scope`` field entirely (folded from a record with no ``"scope"`` key —
+#: see the module docstring's "Scope" section). Deliberately a DIFFERENT
+#: string from ``SCOPE_WORKSPACE`` — "this record never said" and "this
+#: record said workspace" must never collapse into the same value, even
+#: though both currently match every agent at lookup time. NEVER passed to
+#: :meth:`ApprovalLedger.append_approval` — a fresh write always carries an
+#: explicit scope, so this string can never appear as a literal on disk,
+#: only as :meth:`ApprovalLedger.fold`'s own in-memory classification.
+SCOPE_LEGACY_WORKSPACE = "legacy-workspace"
+
+
+def scope_for_agent(agent_name: str) -> str:
+    """#5052: the ``agent:<name>`` scope value naming ONE agent.
+
+    Default-scope reasoning (lead-coder ruling, issuecomment-5386
+    -family — reproduced here verbatim since acceptance ① requires the
+    default's justification live as a code comment at its definition
+    site, not only in the issue thread):
+
+    1. This is a "which direction is safer" question, not one where the
+       owner holds information the implementer lacks — the answer
+       follows from the risk shape alone, so it does not need to be
+       deferred.
+    2. The risk is ASYMMETRIC. Defaulting NARROW (``agent:<name>``) and
+       being wrong just means an operator is asked again for a second
+       agent — one extra prompt. Defaulting WIDE (``workspace``) and
+       being wrong means one agent's approval silently governs EVERY
+       agent in the workspace — the exact #5052 root cause, hitting the
+       permission band directly.
+    3. It is reversible in only ONE direction: an operator can WIDEN a
+       narrow grant later (re-approve with the workspace choice, or a
+       config override). There is no way to retroactively NARROW a
+       workspace grant that has already silently covered agents the
+       operator never saw prompted for.
+
+    ∴ the default for a genuine per-running-agent decision is this
+    function's own output, not :data:`SCOPE_WORKSPACE`."""
+    return f"agent:{agent_name}"
+
 
 class ApprovalLedger:
     """Append-only JSONL ledger for one project's permission-approval
@@ -130,16 +210,33 @@ class ApprovalLedger:
     def path(self) -> Path:
         return self._path
 
-    def append_approval(self, key: str, approved: bool) -> None:
+    def append_approval(
+        self, key: str, approved: bool, scope: "str | None" = None,
+    ) -> None:
         """Append one approval-decision record (a grant or a revoke).
         ``ts`` is DISPLAY-ONLY (see the module docstring's "Ordering
-        authority" section) — :meth:`fold` never reads it."""
-        self._write_record({
+        authority" section) — :meth:`fold` never reads it.
+
+        #5052: ``scope`` is :data:`SCOPE_WORKSPACE` or a
+        :func:`scope_for_agent` string — every REAL caller in this
+        codebase passes one explicitly (never relies on the ``None``
+        default here); ``None`` exists only so a record shaped like a
+        pre-#5052 legacy write can be constructed on purpose (tests
+        exercising the legacy-migration read path). A record written
+        with ``scope=None`` omits the ``"scope"`` key entirely rather
+        than writing a literal ``null`` — ``fold()`` distinguishes
+        "key absent" from "key present with a falsy value" the same
+        way, but omitting it keeps a legacy-shaped test record
+        byte-for-byte indistinguishable from a genuine pre-#5052 line."""
+        record: "dict[str, Any]" = {
             "ts": self._now_iso(),
             "kind": "approval",
             "key": key,
             "approved": approved,
-        })
+        }
+        if scope is not None:
+            record["scope"] = scope
+        self._write_record(record)
 
     def append_identity_bind(
         self, key: str, ino: int, birthtime: "float | None",
@@ -235,17 +332,27 @@ class ApprovalLedger:
 
     def fold(
         self,
-    ) -> "tuple[dict[str, bool], dict[str, tuple[int, float | None]]]":
-        """Replay every record in file order into the two maps
-        ``PermissionResolver`` needs: ``(approvals, bound_identities)``.
+    ) -> "tuple[dict[str, bool], dict[str, tuple[int, float | None]], dict[str, str]]":
+        """Replay every record in file order into the three maps
+        ``PermissionResolver`` needs: ``(approvals, bound_identities, scopes)``.
 
-        Last ``"approval"`` record per key wins for the boolean; last
+        Last ``"approval"`` record per key wins for the boolean AND for the
+        scope (they come from the SAME record — a re-approval always
+        replaces both together, never one without the other); last
         ``"identity_bind"`` record per key wins for the identity — EXCEPT
         an ``"approval"`` record with ``approved=False`` also clears that
         key's bound identity (see the module docstring's "Fold semantics"
-        section for why this mirrors #5157, not a new rule)."""
+        section for why this mirrors #5157, not a new rule).
+
+        #5052: ``scopes[key]`` is the record's own ``"scope"`` value when
+        present, else :data:`SCOPE_LEGACY_WORKSPACE` — see the module
+        docstring's "Scope" section for why a missing field is a
+        DIFFERENT value from an explicit ``SCOPE_WORKSPACE``, never
+        collapsed into it, even though both currently match every agent
+        at lookup time."""
         approvals: "dict[str, bool]" = {}
         bound: "dict[str, tuple[int, float | None]]" = {}
+        scopes: "dict[str, str]" = {}
         for rec in self.iter_records():
             key = rec.get("key")
             if not isinstance(key, str):
@@ -256,6 +363,8 @@ class ApprovalLedger:
                 if not isinstance(approved, bool):
                     continue
                 approvals[key] = approved
+                scope = rec.get("scope")
+                scopes[key] = scope if isinstance(scope, str) and scope else SCOPE_LEGACY_WORKSPACE
                 if not approved:
                     bound.pop(key, None)
             elif kind == "identity_bind":
@@ -264,7 +373,7 @@ class ApprovalLedger:
                     continue
                 bt = rec.get("birthtime")
                 bound[key] = (ino, float(bt) if isinstance(bt, (int, float)) else None)
-        return approvals, bound
+        return approvals, bound, scopes
 
 
 def _repair_missing_trailing_newline(path: Path) -> None:

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -514,6 +514,13 @@ class PermissionResolver:
         # property returns the SAME dict object each time, so in-place
         # `self._saved[key] = approved` still mutates the real stored dict.
         self.__saved: "dict[str, bool] | None" = None
+        # #5052: same lazy-load-once shape as `__saved`, folded from the
+        # SAME ledger pass — see `_ensure_folded`. `agent:<name>` /
+        # `workspace` / `legacy-workspace` (a pre-#5052 record with no
+        # `scope` field at all — see `approval_ledger.py`'s own module
+        # docstring's "Scope" section for why that is a DIFFERENT value
+        # from `workspace`, never collapsed into it).
+        self.__saved_scopes: "dict[str, str] | None" = None
         # #5042: PATH-flavor approvals only ("what dir/file was this grant
         # actually FOR, the moment it was last found valid") — a SIBLING
         # structure under its own top-level ``_bound_identities`` key in
@@ -620,6 +627,16 @@ class PermissionResolver:
         stored boolean (or None when not yet recorded)."""
         return self._saved.get(key)
 
+    def saved_scope_get(self, key: str) -> "str | None":
+        """#5052: read accessor for *key*'s persisted scope — ``None``
+        when *key* has no saved approval at all (never approved, or
+        session-only). A saved key with no explicit scope reads as
+        :data:`~reyn.security.permissions.approval_ledger.SCOPE_LEGACY_WORKSPACE`
+        (see :meth:`ApprovalLedger.fold`'s own docstring), never as
+        ``None`` — "recorded, no scope" and "never recorded" are kept
+        distinct so a caller cannot mistake one for the other."""
+        return self._saved_scopes.get(key)
+
     def bound_identity_get(self, key: str) -> "tuple[int, float | None] | None":
         """#5042: read accessor for the PATH-flavor identity binding,
         mirroring :meth:`saved_get`'s own convention — ``None`` when *key*
@@ -699,6 +716,15 @@ class PermissionResolver:
         assert self.__saved is not None  # _ensure_folded always sets both
         return self.__saved
 
+    @property
+    def _saved_scopes(self) -> "dict[str, str]":
+        """#5052: same lazy-load-once shape as :attr:`_saved` — folded
+        from the SAME ledger pass (see :meth:`_ensure_folded`)."""
+        if self.__saved_scopes is None:
+            self._ensure_folded()
+        assert self.__saved_scopes is not None  # _ensure_folded always sets all three
+        return self.__saved_scopes
+
     # ── #5042/#5153: bound identity for PATH-flavor approvals only ──────────
 
     @property
@@ -712,17 +738,22 @@ class PermissionResolver:
         return self.__bound_identities
 
     def _ensure_folded(self) -> None:
-        """#5153: the single fold site both :attr:`_saved` and
-        :attr:`_bound_identities` lazy-load through — one ledger read
-        producing BOTH maps together (they were always derived from the
-        same records; loading them separately would just be the same
-        file parsed twice). Migrates a legacy ``approvals.yaml`` snapshot
-        into the ledger first if the ledger doesn't exist yet (see
+        """#5153/#5052: the single fold site :attr:`_saved`,
+        :attr:`_bound_identities`, AND :attr:`_saved_scopes` lazy-load
+        through — one ledger read producing all THREE maps together
+        (they were always derived from the same records; loading them
+        separately would just be the same file parsed thrice). Migrates
+        a legacy ``approvals.yaml`` snapshot into the ledger first if the
+        ledger doesn't exist yet (see
         :func:`~reyn.security.permissions.approval_ledger.migrate_legacy_snapshot`)
         — a no-op on every call after the first, for this resolver or any
         other process (idempotent by construction: the ledger existing at
         all is what makes it skip)."""
-        if self.__saved is not None and self.__bound_identities is not None:
+        if (
+            self.__saved is not None
+            and self.__bound_identities is not None
+            and self.__saved_scopes is not None
+        ):
             return
         from reyn.security.permissions.approval_ledger import (
             ApprovalLedger,
@@ -730,7 +761,7 @@ class PermissionResolver:
         )
         ledger = ApprovalLedger(self._approval_ledger_path)
         migrate_legacy_snapshot(ledger, self._approvals_path)
-        self.__saved, self.__bound_identities = ledger.fold()
+        self.__saved, self.__bound_identities, self.__saved_scopes = ledger.fold()
 
     def _path_identity(self, path: Path) -> "tuple[int, float | None] | None":
         """#5042/#5084: raw ``(st_ino, st_birthtime)`` of *path* (file OR
@@ -863,13 +894,37 @@ class PermissionResolver:
             key, identity[0], identity[1],
         )
 
-    def _persist(self, key: str, approved: bool) -> None:
+    def _persist(
+        self, key: str, approved: bool, *, agent_name: str = "",
+    ) -> None:
         # #2248: approvals.yaml is PERSIST, not recovery-core — so NO config generation
         # recorded here (unlike mcp/cron/hooks/index). Approvals are a USER-authored security decision
         # (granted via a permission prompt; revoked via the web/CLI surfaces) — never
         # agent-authored — so a rewind must NOT revert them; they survive rewind like
         # `memory/`. Owner-confirmed reclassification (config → persist).
+        #
+        # #5052: the scope this decision is recorded under. `agent_name`
+        # is threaded from the caller's own running-agent identity (e.g.
+        # `require_http_get`'s own `agent_name` param, itself sourced the
+        # SAME way `present.py` already does: `ctx.agent_name or
+        # ctx.actor`) — when the caller HAS one, the default narrows to
+        # that one agent (see `approval_ledger.scope_for_agent`'s own
+        # docstring for the full 3-point reasoning: the risk is
+        # asymmetric — narrow-and-wrong just re-prompts a second agent;
+        # wide-and-wrong silently governs every agent — and only the
+        # narrow default is reversible via a later explicit widening).
+        # `agent_name == ""` means this decision was never per-running-
+        # agent to begin with (a subsystem/config write — `hooks`/`cron`/
+        # `mcp` actors are not agent identities), so `SCOPE_WORKSPACE` is
+        # the CORRECT, non-narrowing scope for those, not a silent
+        # regression of the new default.
+        scope = (
+            approval_ledger.scope_for_agent(agent_name)
+            if agent_name
+            else approval_ledger.SCOPE_WORKSPACE
+        )
         self._saved[key] = approved
+        self._saved_scopes[key] = scope
         self._session[key] = approved
         if not approved:
             # #5157 (architect ruling, issuecomment-5383671820, and a
@@ -903,7 +958,9 @@ class PermissionResolver:
         # that key's fold-time binding, from WHICHEVER writer produced
         # it — CLI, web router, or here) — no extra write needed for it.
         from reyn.security.permissions.approval_ledger import ApprovalLedger
-        ApprovalLedger(self._approval_ledger_path).append_approval(key, approved)
+        ApprovalLedger(self._approval_ledger_path).append_approval(
+            key, approved, scope,
+        )
         # #5236: the grant half of the same band pairing #5065 only closed
         # for revoke — "audit that records only the undo, never the
         # decision itself, is not an audit" (lead-coder's own filing).
@@ -1019,6 +1076,23 @@ class PermissionResolver:
                 return True
         return False
 
+    # ── #5052: scope (who a saved approval applies to) ───────────────────────
+
+    def _scope_covers_agent(self, key: str, agent_name: str) -> bool:
+        """True iff `key`'s SAVED (persisted) approval's scope covers
+        `agent_name` — caller must already know `key` is approved
+        (`self._saved.get(key)` truthy); this only decides WHO it
+        applies to. `SCOPE_WORKSPACE` (an explicit wide grant) and
+        `SCOPE_LEGACY_WORKSPACE` (a pre-#5052 record with no scope field
+        at all — see `approval_ledger.py`'s own "Scope" section for why
+        these are kept as DIFFERENT values despite matching identically
+        here) both cover every agent; an `agent:<name>` scope covers only
+        that one name."""
+        scope = self._saved_scopes.get(key, approval_ledger.SCOPE_LEGACY_WORKSPACE)
+        if scope in (approval_ledger.SCOPE_WORKSPACE, approval_ledger.SCOPE_LEGACY_WORKSPACE):
+            return True
+        return scope == approval_ledger.scope_for_agent(agent_name)
+
     # ── Core approval (non-file ops) ──────────────────────────────────────────
 
     async def _approve(
@@ -1028,6 +1102,7 @@ class PermissionResolver:
         bus: RequestBus,
         *,
         user_prompt: str | None = None,
+        agent_name: str = "",
     ) -> bool:
         if self._is_config_approved(key):
             return True
@@ -1042,11 +1117,26 @@ class PermissionResolver:
             return self._session[key]
         if key in self._saved:
             v = self._saved[key]
-            self._session[key] = v
-            return v
+            if not v:
+                # An explicit revoke applies to every agent regardless of
+                # scope — a scope only narrows WHO a GRANT covers, it
+                # never narrows a denial.
+                self._session[key] = False
+                return False
+            if self._scope_covers_agent(key, agent_name):
+                self._session[key] = True
+                return True
+            # #5052: a grant EXISTS for `key` but its scope is
+            # `agent:<other-name>` — it was never meant for THIS agent.
+            # Fall through to the interactive prompt instead of returning
+            # the other agent's decision (the exact leak #5052 reports:
+            # "an http.get approval granted while running as one agent
+            # silently applies to EVERY agent").
         if not self._interactive:
             return False
-        return await self._prompt(key, description, bus, user_prompt=user_prompt)
+        return await self._prompt(
+            key, description, bus, user_prompt=user_prompt, agent_name=agent_name,
+        )
 
     async def _prompt(
         self,
@@ -1055,6 +1145,7 @@ class PermissionResolver:
         bus: RequestBus,
         *,
         user_prompt: str | None = None,
+        agent_name: str = "",
     ) -> bool:
         # Issue #224: when the caller passes a user-facing question
         # (e.g. "Allow fetching this URL?"), use it as the prompt header
@@ -1074,10 +1165,10 @@ class PermissionResolver:
             self._session[key] = True
             return True
         if choice == ALWAYS:
-            self._persist(key, True)
+            self._persist(key, True, agent_name=agent_name)
             return True
         if choice == NEVER:
-            self._persist(key, False)
+            self._persist(key, False, agent_name=agent_name)
             return False
         # NO or unknown → deny (session-only)
         self._session[key] = False
@@ -1270,19 +1361,38 @@ class PermissionResolver:
         return self._is_offload_read_granted(path)
 
     def _is_host_approved_for(
-        self, host: str, actor: str, kind: str = "http.get",
+        self, host: str, actor: str, kind: str = "http.get", *, agent_name: str = "",
     ) -> bool:
-        """Return True if ``host`` is covered by a saved/session approval.
+        """Return True if ``host`` is covered by a saved/session approval
+        that also applies to ``agent_name``.
 
         Hosts are exact-string-matched against the persisted approval
-        key (= ``<actor>/http.get/<host>``). Mirrors
+        key (= ``<actor>/http.get/<host>``) — ``key`` carries NO agent
+        dimension by design (#5052 architect ruling "C": scope is a VALUE
+        the entry carries, not a position in the key). A saved approval's
+        own ``scope`` decides WHO it covers (see
+        :meth:`_scope_covers_agent`) — this is the #5052 fix: before this,
+        this method returned True for ANY agent the moment ``key`` was
+        approved for ONE, which is the exact leak the issue reports
+        ("an http.get approval granted while running as one agent
+        silently applies to EVERY agent"). Mirrors
         :meth:`_is_path_approved_for` but skips the filesystem
         resolution because hosts are network identifiers, not paths.
-        """
+
+        Session-only (non-persisted) approvals have no scope dimension —
+        they are checked first and short-circuit True, same as before
+        this fix (the #5052 design ruling scopes PERSISTED ledger
+        entries; a same-process session grant was never the reported
+        cross-agent leak, which is specifically about a decision
+        surviving to a LATER run as a different agent)."""
         if not actor or not host:
             return False
         key = f"{actor}/{kind}/{host}"
-        return bool(self._saved.get(key) or self._session.get(key))
+        if self._session.get(key):
+            return True
+        if not self._saved.get(key):
+            return False
+        return self._scope_covers_agent(key, agent_name)
 
     def session_approve_path(
         self, path: str, actor: str, kind: str, recursive: bool = False,
@@ -1540,8 +1650,17 @@ class PermissionResolver:
         actor: str = "",
         *,
         sandbox_policy: "SandboxPolicy | None" = None,
+        agent_name: str = "",
     ) -> None:
         """Gate HTTP access to ``host`` (#571 Phase 7 unification).
+
+        #5052: ``agent_name`` is the identity a saved grant's ``scope``
+        is checked/recorded against — pass ``ctx.agent_name or
+        ctx.actor`` (the SAME fallback convention ``present.py`` already
+        uses), never ``actor`` itself: ``actor`` is a per-call ROLE label
+        (e.g. the ``session.py`` bridge always passes the fixed
+        ``"chat_router"``), not a running agent's identity, so it cannot
+        stand in for the agent dimension this scope check needs.
 
         Mirrors the ``file.write`` model — declaration is intent, the
         prompt fires at the timing where the host actually becomes
@@ -1618,7 +1737,9 @@ class PermissionResolver:
 
         # Persisted per-host approval (from a prior interactive
         # runtime prompt, specific or wildcard).
-        if actor and self._is_host_approved_for(host, actor, "http.get"):
+        if actor and self._is_host_approved_for(
+            host, actor, "http.get", agent_name=agent_name,
+        ):
             return
         # Legacy session/saved ``web.fetch`` approval still authorises
         # every host while the deprecation window is open.
@@ -1664,6 +1785,7 @@ class PermissionResolver:
             approved = await self._approve(
                 approval_key, label, bus,
                 user_prompt=f"Allow fetching from {host!r}?",
+                agent_name=agent_name,
             )
             if not approved:
                 raise PermissionError(

--- a/tests/interfaces/test_5050_remote_pending_intervention_choices.py
+++ b/tests/interfaces/test_5050_remote_pending_intervention_choices.py
@@ -276,7 +276,7 @@ async def test_remote_always_choice_persists_to_the_approval_ledger(tmp_path, mo
     await require_task
 
     from reyn.security.permissions.approval_ledger import ApprovalLedger
-    saved, _bound = ApprovalLedger(ledger_path).fold()
+    saved, _bound, _scopes = ApprovalLedger(ledger_path).fold()
     assert saved.get("chat_router/http.get/news.ycombinator.com") is True, saved
 
 

--- a/tests/interfaces/test_5153_permissions_cli_ledger.py
+++ b/tests/interfaces/test_5153_permissions_cli_ledger.py
@@ -58,7 +58,7 @@ def test_revoke_appends_a_false_record_the_row_survives(tmp_path: Path, monkeypa
 
     out = capsys.readouterr().out
     assert f"Revoked {key!r}" in out
-    saved, _bound = _ledger(tmp_path).fold()
+    saved, _bound, _scopes = _ledger(tmp_path).fold()
     assert key in saved, "the approval row must survive a revoke, not disappear"
     assert saved[key] is False
 
@@ -90,7 +90,7 @@ def test_clear_revokes_every_currently_approved_key(tmp_path: Path, monkeypatch,
 
     out = capsys.readouterr().out
     assert "Cleared 2 approval(s)" in out
-    saved, _bound = ledger.fold()
+    saved, _bound, _scopes = ledger.fold()
     assert saved == {"actor/file.write/a/": False, "actor/file.write/b/": False}
 
 

--- a/tests/security/test_5042_approval_identity_binding.py
+++ b/tests/security/test_5042_approval_identity_binding.py
@@ -401,6 +401,6 @@ async def test_binding_writes_durably_no_tmp_file_ever_used(tmp_path) -> None:
         "create one at all"
     )
     from reyn.security.permissions.approval_ledger import ApprovalLedger
-    saved, bound = ApprovalLedger(ledger_path).fold()
+    saved, bound, _scopes = ApprovalLedger(ledger_path).fold()
     assert saved[key] is True
     assert bound[key][0] is not None

--- a/tests/security/test_5052_approval_scope_dimension.py
+++ b/tests/security/test_5052_approval_scope_dimension.py
@@ -1,0 +1,230 @@
+"""Tier 2: #5052 — a saved ``http.get`` approval carries a ``scope`` (who it
+applies to), closing the reported leak: ``_is_host_approved_for``'s key
+(``"{actor}/{kind}/{host}"``) has NO agent dimension at all, so an approval
+granted while running as one agent silently applied to EVERY agent in the
+workspace.
+
+Design ruling (architect "C", adopted by lead-coder, issue #5052 thread):
+scope is a VALUE the approval entry carries, never a position in the key —
+``agent:<name>`` (default) or ``workspace`` (explicit, wide). A third value,
+``session:<sid>``, was explicitly rejected (a session id CAN be reused —
+``registry.py``'s ``_has_session`` only tracks currently-live sessions, and
+nothing records a retired one — so a session-scoped grant would silently
+reattach to an unrelated later session).
+
+Migration choice for a PRE-#5052 record (no ``scope`` field at all — the
+ledger is append-only, so such a record can never be rewritten to carry
+one): it is read as ``SCOPE_LEGACY_WORKSPACE`` — STILL HONORED workspace-
+wide (that was genuinely its meaning the moment it was granted; there was
+no agent dimension for the operator to have narrowed), NOT silently
+promoted to the same value as an explicit ``SCOPE_WORKSPACE`` choice, and
+NOT silently unreadable either. The moment the same key is re-approved,
+the newest record (which DOES carry an explicit scope) wins the fold.
+
+Real ``PermissionResolver`` + a real ``ApprovalLedger`` on a real on-disk
+``.reyn/`` tree throughout — no mocks. A fresh ``PermissionResolver``
+instance per "agent" call forces each read to actually fold the ledger
+from disk, the same way two independent agent processes sharing one
+project would each see it.
+
+Strip-falsifier for ``test_default_agent_scoped_approval_does_not_leak_to_
+a_second_agent``: remove the ``self._scope_covers_agent(key, agent_name)``
+check from ``PermissionResolver._is_host_approved_for`` (revert to
+``return bool(self._saved.get(key) or self._session.get(key))``) — the
+test goes RED (agent B's prompt fires ``bus_b.requests == []`` and no
+``PermissionError`` is raised, i.e. agent B's request is silently
+approved by agent A's grant). Verified for real in this PR's own commit
+history: committed with the check in place (green), the check removed
+(red), then reverted (green again) — not merely asserted here.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.security.permissions.approval_ledger import (
+    SCOPE_LEGACY_WORKSPACE,
+    SCOPE_WORKSPACE,
+    ApprovalLedger,
+    scope_for_agent,
+)
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
+
+_HOST = "example.com"
+_ACTOR = "chat_router"
+_KEY = f"{_ACTOR}/http.get/{_HOST}"
+
+
+class _ChoiceBus(InterventionBus):
+    """A real (non-mock) ``InterventionBus`` that always answers with one
+    fixed choice — same shape as ``test_5236_permission_approval_granted_
+    audit_event.py``'s own ``_ChoiceBus``."""
+
+    def __init__(self, choice_id: str) -> None:
+        self.requests: "list[UserIntervention]" = []
+        self._choice_id = choice_id
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.requests.append(iv)
+        return InterventionAnswer(choice_id=self._choice_id)
+
+
+def _ledger(project_root: Path) -> ApprovalLedger:
+    return ApprovalLedger(project_root / ".reyn" / "approvals.jsonl")
+
+
+def _decl() -> PermissionDecl:
+    return PermissionDecl(http_get=[{"host": "*"}])
+
+
+# ── (a) default agent-scoped approval does not leak to a second agent ───────
+
+
+def test_default_agent_scoped_approval_does_not_leak_to_a_second_agent(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: Agent A grants ALWAYS (default scope = ``agent:agent-a``) -> agent B,
+    a DIFFERENT agent sharing the SAME project/ledger, is asked again
+    rather than silently inheriting A's grant.
+
+    Six-questions #4 caveat, stated explicitly: a config with only ONE
+    default agent name (e.g. calling ``require_http_get`` twice with the
+    SAME ``agent_name``) would pass this assertion trivially even under
+    the OLD buggy no-agent-dimension key, because the second call would
+    simply find the cached grant and return -- that is not what this test
+    does. Distinguishing "scoped correctly" from "just cached" requires
+    TWO DISTINCT agent names, which is what makes this a real 2-agent
+    witness rather than a single-agent one that happens to look like it.
+    """
+    bus_a = _ChoiceBus("always")
+    resolver_a = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    asyncio.run(
+        resolver_a.require_http_get(
+            _decl(), _HOST, bus_a, _ACTOR, agent_name="agent-a",
+        )
+    )
+    assert bus_a.requests, "control arm: agent A's prompt must have fired at all"
+
+    # A FRESH resolver instance for agent B -- forces a real fold of the
+    # SAME on-disk ledger agent A just wrote to (mirrors two independent
+    # agent processes sharing one project).
+    bus_b = _ChoiceBus("no")
+    resolver_b = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    with pytest.raises(PermissionError):
+        asyncio.run(
+            resolver_b.require_http_get(
+                _decl(), _HOST, bus_b, _ACTOR, agent_name="agent-b",
+            )
+        )
+    assert bus_b.requests, (
+        "agent B must have been prompted independently -- if this list is "
+        "empty, agent A's grant was silently honored for agent B (the "
+        "#5052 leak)."
+    )
+
+    # Ledger-level corroboration: the scope actually recorded is agent-a's,
+    # not workspace-wide.
+    assert resolver_a.saved_scope_get(_KEY) == scope_for_agent("agent-a")
+
+
+# ── (b) an explicit workspace-scoped approval DOES apply to both agents ────
+
+
+def test_explicit_workspace_scope_applies_to_both_agents(tmp_path: Path) -> None:
+    """Tier 2: a grant explicitly recorded with ``scope=SCOPE_WORKSPACE`` (the
+    operator's deliberate wide choice, never the silent default) is
+    honored for EVERY agent -- the flip side of (a): scope narrows by
+    DEFAULT, not unconditionally."""
+    _ledger(tmp_path).append_approval(_KEY, True, SCOPE_WORKSPACE)
+
+    for agent_name in ("agent-a", "agent-b"):
+        bus = _ChoiceBus("no")  # must NEVER be consulted -- already approved
+        resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+        asyncio.run(
+            resolver.require_http_get(_decl(), _HOST, bus, _ACTOR, agent_name=agent_name)
+        )
+        assert bus.requests == [], (
+            f"agent {agent_name!r} should not have been prompted -- a "
+            f"workspace-scoped grant covers every agent"
+        )
+
+
+# ── (c) a legacy (pre-#5052, scope-less) entry: the documented migration ───
+
+
+def test_legacy_scopeless_entry_is_still_honored_workspace_wide(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a record with NO ``scope`` field at all (the shape every approval
+    written before this fix has, and the shape the append-only ledger can
+    NEVER rewrite to add one) is treated as ``SCOPE_LEGACY_WORKSPACE`` --
+    still granted, for every agent, exactly as it was the moment it was
+    approved. This is the chosen migration behavior (documented in
+    ``approval_ledger.py``'s own module docstring): NOT silently promoted
+    to the SAME value as an explicit ``workspace`` choice (a #4996-family
+    "unspecified" vs "specified-and-wide" distinction), and NOT silently
+    treated as unreadable/gone -- both forbidden shapes lead-coder named."""
+    _ledger(tmp_path).append_approval(_KEY, True, scope=None)  # pre-#5052 shape
+
+    for agent_name in ("agent-a", "agent-b"):
+        bus = _ChoiceBus("no")  # must NEVER be consulted -- already approved
+        resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+        asyncio.run(
+            resolver.require_http_get(_decl(), _HOST, bus, _ACTOR, agent_name=agent_name)
+        )
+        assert bus.requests == [], (
+            f"agent {agent_name!r} should not have been prompted -- a "
+            f"legacy scope-less grant still covers every agent"
+        )
+        assert resolver.saved_scope_get(_KEY) == SCOPE_LEGACY_WORKSPACE, (
+            "a scope-less record must classify as the LEGACY sentinel, "
+            "never silently collapsed into SCOPE_WORKSPACE"
+        )
+
+
+def test_legacy_scopeless_entry_is_visible_not_silent_on_the_listing_surface(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: architect's explicit 'not silently' requirement: a legacy entry
+    still in effect must be OBSERVABLE, not merely functional. The web
+    router's own ``_load`` (the real production read path behind
+    ``GET /api/permissions``) reports this key's scope as the legacy
+    sentinel -- a caller (or an operator-facing listing) can count it,
+    rather than it disappearing into an indistinguishable "workspace"
+    label."""
+    _ledger(tmp_path).append_approval(_KEY, True, scope=None)
+
+    from reyn.interfaces.web.routers.permissions import _load
+
+    approvals, scopes = _load(tmp_path)
+    assert approvals[_KEY] is True
+    assert scopes[_KEY] == SCOPE_LEGACY_WORKSPACE
+    legacy_count = sum(
+        1 for k, v in approvals.items() if v and scopes.get(k) == SCOPE_LEGACY_WORKSPACE
+    )
+    assert legacy_count == 1, "the legacy grant must be countable, not silent"
+
+
+# ── (d) strip-falsifier control: the fold-level scope classification itself ─
+
+
+def test_fold_classifies_absent_scope_as_a_different_value_than_workspace(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: direct ``ApprovalLedger.fold()`` witness (no ``PermissionResolver``
+    involved) for the #4996-family distinction this design depends on:
+    an EXPLICIT ``workspace`` record and a scope-LESS record must fold to
+    two DIFFERENT scope strings, even though both currently match every
+    agent at lookup time. Collapsing them into the same string would be
+    exactly the "unspecified promoted to specified-and-wide" shape the
+    architect ruling forbids."""
+    ledger = _ledger(tmp_path)
+    ledger.append_approval("a/http.get/x.example.com", True, SCOPE_WORKSPACE)
+    ledger.append_approval("b/http.get/y.example.com", True, scope=None)
+    _approvals, _bound, scopes = ledger.fold()
+    assert scopes["a/http.get/x.example.com"] == SCOPE_WORKSPACE
+    assert scopes["b/http.get/y.example.com"] == SCOPE_LEGACY_WORKSPACE
+    assert scopes["a/http.get/x.example.com"] != scopes["b/http.get/y.example.com"]

--- a/tests/security/test_5153_approval_ledger.py
+++ b/tests/security/test_5153_approval_ledger.py
@@ -196,7 +196,7 @@ def test_two_real_processes_approving_different_keys_both_survive(tmp_path: Path
         f"should be an 'approval' from _worker_append_many, nothing else"
     )
 
-    approvals, _bound = ledger.fold()
+    approvals, _bound, _scopes = ledger.fold()
     # n is even, so the LAST record each process wrote (index n-1, odd) is
     # approved=False for both keys.
     assert approvals["actor/file.write/dir_a/"] is False
@@ -235,7 +235,7 @@ def test_two_real_processes_racing_the_same_key_resolve_by_log_order(
     assert written_total == 2, "both processes' appends must survive -- neither lost"
     last_record_approved = lines[-1]["approved"]
 
-    approvals, _bound = ledger.fold()
+    approvals, _bound, _scopes = ledger.fold()
     assert approvals[key] == last_record_approved, (
         "fold() must agree with whatever the ledger's OWN last line says "
         "for this key -- last wins by FILE ORDER, not by which process "
@@ -334,8 +334,7 @@ def test_migration_witness_fold_matches_the_legacy_reader(tmp_path: Path) -> Non
 
     ledger = ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl")
     migrate_legacy_snapshot(ledger, legacy_path)
-    saved, bound = ledger.fold()
-
+    saved, bound, _scopes = ledger.fold()
     assert saved == expected_saved
     assert bound == expected_bound
 
@@ -398,7 +397,7 @@ def test_two_processes_racing_the_first_migration_still_fold_correctly(
     assert p1.exitcode == 0
     assert p2.exitcode == 0
 
-    saved, _bound = ApprovalLedger(ledger_path).fold()
+    saved, _bound, _scopes = ApprovalLedger(ledger_path).fold()
     assert saved == {
         "actor/file.write/legacy_dir/": True,
         "actor/file.write/legacy_revoked/": False,
@@ -448,7 +447,7 @@ def test_a_slow_migration_racing_a_real_revoke_never_resurrects_the_stale_value(
     assert p_migrate.exitcode == 0
     assert p_revoke.exitcode == 0
 
-    saved, _bound = ApprovalLedger(ledger_path).fold()
+    saved, _bound, _scopes = ApprovalLedger(ledger_path).fold()
     assert saved[target_key] is False, (
         "a real, concurrent revoke must never be resurrected by a slow "
         "migration's stale legacy value landing after it in file order"
@@ -490,7 +489,7 @@ def test_migration_publish_never_clobbers_a_decision_that_wins_first(
     monkeypatch.setattr(os, "link", _real_decision_wins_the_narrowest_window)
     migrate_legacy_snapshot(ledger, legacy_path)
 
-    saved, _bound = ledger.fold()
+    saved, _bound, _scopes = ledger.fold()
     assert saved[target_key] is False, (
         "migration must never clobber a real decision, even one that "
         "wins the ledger path's existence in the narrowest possible "

--- a/tests/security/test_5157_identity_fd_release.py
+++ b/tests/security/test_5157_identity_fd_release.py
@@ -125,7 +125,7 @@ async def test_revoking_an_approval_also_clears_its_stale_identity_record(
     from reyn.security.permissions.approval_ledger import ApprovalLedger
 
     ledger_path = tmp_path / ".reyn" / "approvals.jsonl"
-    _saved, bound = ApprovalLedger(ledger_path).fold()
+    _saved, bound, _scopes = ApprovalLedger(ledger_path).fold()
     assert key not in bound, (
         "revoke must also clear the PERSISTED bound-identity record -- "
         "otherwise it survives a process restart and a later re-approval "

--- a/tests/security/test_5236_permission_approval_granted_audit_event.py
+++ b/tests/security/test_5236_permission_approval_granted_audit_event.py
@@ -83,7 +83,7 @@ def test_the_always_choice_emits_one_audit_event_naming_the_granted_key(
     assert events[0]["data"]["surface"] == "permission_prompt"
 
     # The write itself lands, unaffected by the audit addition.
-    saved, _bound = ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl").fold()
+    saved, _bound, _scopes = ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl").fold()
     assert saved.get("test_skill/http.get/example.com") is True
 
 
@@ -135,5 +135,5 @@ def test_the_never_choice_denial_emits_nothing(tmp_path: Path) -> None:
     # never granted) is real too — confirms _persist(key, False) genuinely
     # ran, so the absence of an event above is a real non-emission, not a
     # vacuous "nothing happened at all".
-    saved, _bound = ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl").fold()
+    saved, _bound, _scopes = ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl").fold()
     assert saved.get("test_skill/http.get/example.com") is False

--- a/tests/web/test_5065_permissions_router_emits_audit_event.py
+++ b/tests/web/test_5065_permissions_router_emits_audit_event.py
@@ -136,7 +136,7 @@ def test_revoke_permission_emits_one_audit_event_naming_the_key(tmp_project: Pat
     # the ledger no longer shows this key as approved (the row itself
     # SURVIVES, as an explicit revoke record -- audit-events acceptance).
     from reyn.security.permissions.approval_ledger import ApprovalLedger
-    saved, _bound = ApprovalLedger(
+    saved, _bound, _scopes = ApprovalLedger(
         tmp_project / ".reyn" / "approvals.jsonl"
     ).fold()
     assert saved.get("chat_router/http.get/example.com") is False
@@ -170,7 +170,7 @@ def test_clear_permissions_emits_one_audit_event_with_the_cleared_count(
     assert events[0]["data"]["surface"] == "web"
 
     from reyn.security.permissions.approval_ledger import ApprovalLedger
-    saved, _bound = ApprovalLedger(
+    saved, _bound, _scopes = ApprovalLedger(
         tmp_project / ".reyn" / "approvals.jsonl"
     ).fold()
     assert saved == {


### PR DESCRIPTION
**[tui-coder]** — closes #5052.

## What
`_is_host_approved_for`'s approval key (`{actor}/{kind}/{host}`) had no agent dimension — an approval granted while running as one agent silently applied to EVERY agent in the workspace. This adds a `scope` field carried by each approval entry, never a key position or per-agent file split (architect's design C, adopted; per-agent files were rejected — they'd break #5065's single-audit-surface goal, can't express an intentional workspace-wide grant without N files, and duplicate the existing `approvals.yaml`-stays-host-side decision N times).

## Design
Two scope values only: `agent:<name>` / `workspace`. No `session:` scope (a `sid` is reusable — would be a false narrowing). Default: **`agent:<name>`** — lead-coder's decision, not deferred to the owner, on asymmetric-risk grounds (narrow-default-wrong = more prompts; wide-default-wrong = one agent's approval silently applying to every agent, hitting the permission band directly; and it's reversible only narrow→wide, not the reverse). Reasoning lives as a code comment at `scope_for_agent`'s own definition site (`approval_ledger.py`).

## Migration (the part most likely to need review scrutiny)
The ledger (#5153) is append-only — existing scope-less entries can never be rewritten. They fold to a distinct `SCOPE_LEGACY_WORKSPACE` sentinel: kept **different** from `SCOPE_WORKSPACE` (never silently promoted — the #4996-family discipline: unspecified ≠ specified-and-wide) but still matches every agent at lookup time, i.e. the grant stays honored workspace-wide exactly as it was when originally granted. Visible, not silent: the web router's listing surface and the CLI both surface each entry's scope / a legacy-count banner. A fresh re-approval of the same key overwrites the legacy entry with an explicit scope.

## Acceptance conditions (lead-coder's list, all 4 met)
1. Default's reasoning is a code comment at its definition site.
2. Migration choice stated here, in the module docstring, and in the commit message.
3. 2-agent witness (`test_default_agent_scoped_approval_does_not_leak_to_a_second_agent` / `test_explicit_workspace_scope_applies_to_both_agents`) — docstring notes a single-default-agent test would pass trivially even with the OLD buggy key (six-questions #4).
4. Strip-falsify: scope check manually removed from `_is_host_approved_for`, confirmed exactly the leak-witness test goes red (`DID NOT RAISE PermissionError`), then reverted and re-confirmed green.

## Verification
Gate scripts green (ruff, mypy ratchet, test-tier-audit --strict, module docstrings, flat-tests ratchet, tests-path-literal, bare-tests-import, file-depth, collect-events-settle). `tests/security/` + the 2 touched `tests/interfaces/` files: 821 passed, 26 skipped, post-rebase onto current main (clean, no conflicts).

## Test plan
- [x] (skipped — no user-facing surface change beyond the CLI/web listing surfaces already covered by the automated test suite above)
