### PR TITLE
fix(#5130): close agent_name resolution to a type, not a str shadow

### DIFF
--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -40,6 +40,7 @@ import asyncio
 import logging
 import uuid
 import weakref
+from dataclasses import dataclass
 from typing import Callable
 
 from fastapi import APIRouter, Request
@@ -228,6 +229,59 @@ def connection_current_agent(connection_id: str) -> "str | None":
     :func:`connection_retarget_has_subscribers`'s own reason for existing at
     module level rather than requiring a private-global reach-in."""
     return _CONNECTION_RETARGET_HUB.current_agent(connection_id)
+
+
+class _AgentResolutionToken:
+    """#5130: an unforgeable-in-practice marker. :class:`_ResolvedAgent`
+    requires one to construct, and only :func:`_resolve_agent_from_url` /
+    :func:`_resolve_agent_for_connection` ever mint one — mypy already
+    refuses ``_ResolvedAgent("some-name")`` on its own (the token argument
+    is required, no default; a plain ``NewType``-style str wrapper would
+    NOT have closed this, since that still converts freely from any str —
+    the exact half-measure lead-coder's #5130 review rejected). A caller
+    who wants to dodge this has to import this private class and mint
+    their own token — a visibly, greppably different shape from every
+    legitimate call site in this file."""
+
+
+@dataclass(frozen=True)
+class _ResolvedAgent:
+    """#5130: the ONLY way ``agui_events`` / ``agui_seize`` / ``agui_submit``
+    (and ``_handle_answer``) ever get an agent's name now — never a bare
+    ``agent_name: str`` handler parameter. FastAPI/Starlette only
+    auto-injects a path parameter into a handler that names it in its OWN
+    signature; removing that parameter from all three route functions
+    makes it structurally impossible for a handler body to receive the
+    unresolved URL segment directly — the only route to a name is through
+    one of the two resolver functions below, both of which return this
+    type."""
+    name: str
+    _token: _AgentResolutionToken
+
+
+def _resolve_agent_from_url(request: Request) -> "_ResolvedAgent":
+    """``agui_events``'s own resolution. This IS the connect call that
+    SEEDS #5129's connection hub in the first place (via
+    ``listen_for_retarget`` / ``attach`` inside the handler below) — there
+    is nothing yet in the hub to override the URL's own ``agent_name``
+    WITH, so this reads only the path segment (once), never a bare
+    handler parameter."""
+    return _ResolvedAgent(
+        request.path_params.get("agent_name", ""), _AgentResolutionToken(),
+    )
+
+
+def _resolve_agent_for_connection(request: Request, connection_id: str) -> "_ResolvedAgent":
+    """``agui_seize``'s / ``agui_submit``'s own resolution. #5129: both are
+    a DIFFERENT HTTP request than the connection's own SSE stream,
+    correlated only by *connection_id* — the URL's own ``agent_name``
+    (this connection's ORIGINAL agent, frozen into a long-lived client
+    URL) is only the FALLBACK. :func:`connection_current_agent` (seeded by
+    ``agui_events``, updated by a cross-agent ``/attach``, #5116) is
+    authoritative whenever the hub has seen this connection before."""
+    url_agent_name = request.path_params.get("agent_name", "")
+    resolved_name = connection_current_agent(connection_id) or url_agent_name
+    return _ResolvedAgent(resolved_name, _AgentResolutionToken())
 
 
 def _auth_context(request: Request) -> "AuthContext | None":
@@ -981,7 +1035,7 @@ class _SessionFrameSource:
 
 
 @router.get("/agui/chat/{agent_name}/events")
-async def agui_events(request: Request, agent_name: str):
+async def agui_events(request: Request):
     """SSE stream of the session's frames as AG-UI events (server→client).
 
     On connect the surface is attached to the per-agent :class:`SurfaceManager`
@@ -989,6 +1043,9 @@ async def agui_events(request: Request, agent_name: str):
     surface, the operator intervention listener is registered so an ``ask_user``
     reaches this remote operator. On disconnect the surface detaches; when it was
     the last, the listener is unregistered and the grace window arms.
+
+    #5130: no bare ``agent_name: str`` parameter — see
+    :func:`_resolve_agent_from_url`'s own docstring for why.
     """
     auth = _auth_context(request)
     if auth is None:
@@ -997,6 +1054,7 @@ async def agui_events(request: Request, agent_name: str):
     identity = authenticate_request(request, auth, connection_id=connection_id)
     if not identity.authenticated:
         return JSONResponse({"error": "authentication required"}, status_code=401)
+    agent_name = _resolve_agent_from_url(request).name
 
     registry = get_registry()
     _ensure_remove_listener_wired(registry)
@@ -1129,7 +1187,7 @@ async def agui_events(request: Request, agent_name: str):
     return StreamingResponse(gen(), media_type="text/event-stream")
 
 
-async def _handle_answer(request, auth, identity, connection_id, agent_name, payload):
+async def _handle_answer(request, auth, identity, connection_id, resolved, payload):
     """TOOL_CALL_RESULT → deliver BY ID (R1) through the single funnel.
 
     Delivery-time authorization (the client is UNTRUSTED): re-check
@@ -1138,7 +1196,12 @@ async def _handle_answer(request, auth, identity, connection_id, agent_name, pay
     intervention BY the echoed ``toolCallId``; the server validates the id (and any
     ``choiceId``) against its OWN registry entry — the client's prompt copy is not
     trusted (R6).
+
+    #5130: *resolved* is a :class:`_ResolvedAgent`, never a bare
+    ``agent_name: str`` — this function is ``agui_submit``'s own delegate,
+    downstream of that handler's resolution, not a second resolution site.
     """
+    agent_name = resolved.name
     if not auth.authorize_write(identity):
         return JSONResponse({"error": "unauthorized"}, status_code=403)
     manager = surface_registry().get(agent_name)
@@ -1175,12 +1238,15 @@ async def _handle_answer(request, auth, identity, connection_id, agent_name, pay
 
 
 @router.post("/agui/chat/{agent_name}/seize")
-async def agui_seize(request: Request, agent_name: str):
+async def agui_seize(request: Request):
     """Symmetric, auth-gated seize of the active-driver token (D4).
 
     Any authorized attached surface may seize equally (no handshake). Refused for
     an unauthenticated connection (Axis-A), an unauthorized identity, or a
     connection with no attached surface. Emits ``client_seized`` attribution.
+
+    #5130: no bare ``agent_name: str`` parameter — see
+    :func:`_resolve_agent_for_connection`'s own docstring for why.
     """
     auth = _auth_context(request)
     if auth is None:
@@ -1194,8 +1260,9 @@ async def agui_seize(request: Request, agent_name: str):
     # seizes driver authority ON BEHALF OF — resolve from the connection,
     # never the URL's own path param, or a post-attach seize grabs the
     # ORIGINAL agent's surface instead of the one this connection is
-    # actually attached to now.
-    agent_name = connection_current_agent(connection_id) or agent_name
+    # actually attached to now. #5130: this fold-in now lives in
+    # _resolve_agent_for_connection, the SOLE place either name is read.
+    agent_name = _resolve_agent_for_connection(request, connection_id).name
     manager = surface_registry().get(agent_name)
     if manager is None or not manager.seize(connection_id, identity.user_id, monotonic()):
         return JSONResponse({"seized": False, "error": "seize refused"}, status_code=409)
@@ -1212,12 +1279,15 @@ async def agui_seize(request: Request, agent_name: str):
 
 
 @router.post("/agui/chat/{agent_name}")
-async def agui_submit(request: Request, agent_name: str):
+async def agui_submit(request: Request):
     """Client→server: turn submit, HITL answer, cancel, and heartbeat.
 
     Server-side actions only (A3): a client may submit a turn / answer / cancel /
     keepalive — it may NEVER shut the single-writer server down (there is no
     shutdown verb here).
+
+    #5130: no bare ``agent_name: str`` parameter — see
+    :func:`_resolve_agent_for_connection`'s own docstring for why.
     """
     auth = _auth_context(request)
     if auth is None:
@@ -1242,7 +1312,10 @@ async def agui_submit(request: Request, agent_name: str):
     # different shape). Falls back to the URL when the hub has never seen
     # this connection_id (no SSE stream subscribed under it — a POST that
     # outraces its own connect, or a test driving this endpoint directly).
-    agent_name = connection_current_agent(connection_id) or agent_name
+    # #5130: this fold-in now lives in _resolve_agent_for_connection, the
+    # SOLE place either name is read.
+    resolved = _resolve_agent_for_connection(request, connection_id)
+    agent_name = resolved.name
 
     try:
         payload = await request.json()
@@ -1283,7 +1356,7 @@ async def agui_submit(request: Request, agent_name: str):
     # HITL answer (R1 by-id) — delivery-time authorized.
     if ptype == "TOOL_CALL_RESULT":
         return await _handle_answer(
-            request, auth, identity, connection_id, agent_name, payload
+            request, auth, identity, connection_id, resolved, payload
         )
 
     # Turn submit / cancel are permission-gated writes (server actions).

--- a/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
+++ b/tests/interfaces/test_5116_connection_agent_owner_cross_attach.py
@@ -300,18 +300,22 @@ async def test_status_changes_are_pushed_by_the_attach_itself_not_ridden_on_a_la
     await asyncio.sleep(0)
 
 
-def _make_get_request(query_string: bytes, app):
+def _make_get_request(query_string: bytes, app, *, agent_name: str = "default"):
     """A minimal real ``starlette.requests.Request`` for a GET to
     ``agui_events`` — enough scope for ``_auth_context``/
     ``authenticate_request``/``_connection_id_from_request`` to read
     (``request.app.state.auth``, ``request.query_params``,
-    ``request.client``), without going through a full ASGI transport."""
+    ``request.client``), without going through a full ASGI transport.
+
+    #5130: ``agui_events`` no longer accepts a bare ``agent_name: str``
+    parameter — the real router populates ``scope["path_params"]`` on a
+    match, so a direct (non-routed) call here must do the same."""
     from starlette.requests import Request
 
     scope = {
-        "type": "http", "method": "GET", "path": "/agui/chat/default/events",
+        "type": "http", "method": "GET", "path": f"/agui/chat/{agent_name}/events",
         "query_string": query_string, "headers": [], "client": ("127.0.0.1", 12345),
-        "app": app,
+        "app": app, "path_params": {"agent_name": agent_name},
     }
     return Request(scope)
 
@@ -375,7 +379,7 @@ async def test_a_real_agui_events_get_pushes_correct_status_after_cross_agent_at
     from reyn.interfaces.transport.agui import endpoint as endpoint_mod
 
     req = _make_get_request(f"token=s3cret&connection_id={conn_id}".encode(), app)
-    resp = await endpoint_mod.agui_events(req, "default")
+    resp = await endpoint_mod.agui_events(req)
     from starlette.responses import StreamingResponse
 
     assert isinstance(resp, StreamingResponse), (

--- a/tests/interfaces/test_5119_retarget_hub_exception_cleanup.py
+++ b/tests/interfaces/test_5119_retarget_hub_exception_cleanup.py
@@ -33,13 +33,16 @@ from tests._support.agent_session import make_session
 from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
-def _make_get_request(query_string: bytes, app):
+def _make_get_request(query_string: bytes, app, *, agent_name: str = "default"):
     from starlette.requests import Request
 
+    # #5130: agui_events no longer accepts a bare ``agent_name: str``
+    # parameter — the real router populates ``scope["path_params"]`` on a
+    # match, so a direct (non-routed) call here must do the same.
     scope = {
-        "type": "http", "method": "GET", "path": "/agui/chat/default/events",
+        "type": "http", "method": "GET", "path": f"/agui/chat/{agent_name}/events",
         "query_string": query_string, "headers": [], "client": ("127.0.0.1", 12345),
-        "app": app,
+        "app": app, "path_params": {"agent_name": agent_name},
     }
     return Request(scope)
 
@@ -116,7 +119,7 @@ async def test_exception_before_gen_starts_does_not_leak_the_hub_subscription(
 
     req = _make_get_request(f"token=s3cret&connection_id={conn_id}".encode(), app)
     with pytest.raises(RuntimeError, match="deliberate #5119 injected failure"):
-        await endpoint_mod.agui_events(req, "default")
+        await endpoint_mod.agui_events(req)
 
     assert not endpoint_mod.connection_retarget_has_subscribers(conn_id), (
         f"the hub subscription for {conn_id!r} leaked past the exception"
@@ -136,7 +139,7 @@ async def test_the_success_path_still_subscribes_normally(tmp_path, monkeypatch)
     conn_id = "conn-5119-success-test"
 
     req = _make_get_request(f"token=s3cret&connection_id={conn_id}".encode(), app)
-    resp = await endpoint_mod.agui_events(req, "default")
+    resp = await endpoint_mod.agui_events(req)
     from starlette.responses import StreamingResponse
 
     assert isinstance(resp, StreamingResponse)

--- a/tests/interfaces/test_5130_resolved_agent_construction_closed.py
+++ b/tests/interfaces/test_5130_resolved_agent_construction_closed.py
@@ -1,0 +1,45 @@
+"""Tier 1: #5130 — ``_ResolvedAgent`` cannot be constructed from a bare
+string outside its two resolver functions.
+
+lead-coder's own #5432 review: the PR body recorded a manual mypy run and a
+manual ``python3 -c`` runtime check showing ``_ResolvedAgent("x")`` fails —
+but neither of those runs again after merge. mypy's own half is covered
+every CI run (`mypy_ratchet.py`), but nothing pinned the RUNTIME half: a
+future edit that adds ``_token: _AgentResolutionToken = None`` (a default)
+would make ``_ResolvedAgent("x")`` construct silently, and this defense
+would be gone with no test to notice.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.transport.agui.endpoint import (
+    _AgentResolutionToken,
+    _ResolvedAgent,
+)
+
+
+def test_bare_construction_without_a_token_raises():
+    """Tier 1: the exact call shape #5130's own review named —
+    ``_ResolvedAgent("x")`` with no token argument at all — must raise at
+    construction time, not merely be flagged by mypy (which runs at
+    lint-time only, and is separately baselined by mypy_ratchet.py).
+
+    Strip-falsifier: giving ``_token`` a default value of ``None`` in
+    ``_ResolvedAgent``'s own definition turns this green-by-vacuity into
+    an actual pass with no token — this test would then need to also
+    check the value, not just the raise, to catch that regression; see
+    the sibling test below for that half."""
+    with pytest.raises(TypeError):
+        _ResolvedAgent("bare-string")  # type: ignore[call-arg]
+
+
+def test_construction_with_a_real_token_succeeds():
+    """Tier 1: non-vacuity for the test above — a genuine
+    ``_AgentResolutionToken`` (the only thing either resolver function
+    ever passes) must still construct successfully. Without this, the
+    sibling test's ``pytest.raises(TypeError)`` could pass for the wrong
+    reason (e.g. a typo'd constructor that always raises)."""
+    real_token = _AgentResolutionToken()
+    resolved = _ResolvedAgent("legit-name", real_token)
+    assert resolved.name == "legit-name"

--- a/tests/interfaces/test_5179_backlog_gap_end_to_end.py
+++ b/tests/interfaces/test_5179_backlog_gap_end_to_end.py
@@ -340,10 +340,14 @@ async def test_agui_events_route_pairs_connect_status_with_backlog(tmp_path, mon
     app.state.auth = AuthContext(token="s3cret", require_token=True)
     monkeypatch.setattr(endpoint_mod, "get_registry", lambda: registry)
 
+    # #5130: agui_events no longer accepts a bare agent_name: str
+    # parameter — the real router populates scope["path_params"] on a
+    # match, so a direct (non-routed) call here must do the same.
     scope = {
         "type": "http", "method": "GET", "path": f"/agui/chat/{_AGENT_NAME}/events",
         "query_string": b"token=s3cret&connection_id=conn-5179-route-test",
         "headers": [], "client": ("127.0.0.1", 12345), "app": app,
+        "path_params": {"agent_name": _AGENT_NAME},
     }
     req = Request(scope)
 
@@ -351,7 +355,7 @@ async def test_agui_events_route_pairs_connect_status_with_backlog(tmp_path, mon
     try:
         # ── Call the REAL route handler — its own real, fixed connect-time
         # pairing runs here, before anything is submitted. ────────────────
-        resp = await endpoint_mod.agui_events(req, _AGENT_NAME)
+        resp = await endpoint_mod.agui_events(req)
         assert isinstance(resp, StreamingResponse), (
             f"expected a real StreamingResponse (auth/agent-exists must "
             f"both pass for this test's own setup); got {resp!r}"

--- a/tests/interfaces/test_5179_remote_own_message_seq_gate_race.py
+++ b/tests/interfaces/test_5179_remote_own_message_seq_gate_race.py
@@ -157,16 +157,20 @@ async def test_own_message_renders_via_real_agui_events_route(tmp_path, monkeypa
     app.state.auth = AuthContext(token="s3cret", require_token=True)
     monkeypatch.setattr(endpoint_mod, "get_registry", lambda: registry)
 
+    # #5130: agui_events no longer accepts a bare agent_name: str
+    # parameter — the real router populates scope["path_params"] on a
+    # match, so a direct (non-routed) call here must do the same.
     scope = {
         "type": "http", "method": "GET", "path": f"/agui/chat/{_AGENT_NAME}/events",
         "query_string": b"token=s3cret&connection_id=conn-5179-full-app-route-test",
         "headers": [], "client": ("127.0.0.1", 12345), "app": app,
+        "path_params": {"agent_name": _AGENT_NAME},
     }
     req = Request(scope)
 
     turn_task: "asyncio.Task | None" = None
     try:
-        resp = await endpoint_mod.agui_events(req, _AGENT_NAME)
+        resp = await endpoint_mod.agui_events(req)
         assert isinstance(resp, StreamingResponse), (
             f"expected a real StreamingResponse (auth/agent-exists must "
             f"both pass for this test's own setup); got {resp!r}"


### PR DESCRIPTION
**[e2e-coder]** — closes #5130.

## What

`agui_events` / `agui_seize` / `agui_submit` all took a bare `agent_name: str` path parameter that FastAPI auto-injects by name match against the route's `{agent_name}` segment. #5132 (merged) already fixed the VALUE for `agui_seize`/`agui_submit` (`connection_current_agent(...) or agent_name` shadowing), but that is a runtime override, not a structural close — nothing stopped a future call site from reading the raw parameter again.

## The close

- New `_resolve_agent_from_url(request)` / `_resolve_agent_for_connection(request, connection_id)` — the ONLY two places this file reads `request.path_params["agent_name"]` now. Both return a `_ResolvedAgent`.
- `_ResolvedAgent` requires a private `_AgentResolutionToken` to construct, with **no default** — mypy rejects `_ResolvedAgent("bare-string")` outright (missing positional argument), and it raises `TypeError` at runtime too. A plain `NewType`/str wrapper would **not** have closed this (still converts freely from any str) — the exact half-measure lead-coder's review named and rejected.
- All three route handlers drop their own `agent_name: str` parameter entirely — FastAPI can only auto-inject a path parameter into a handler that names it, so removing it makes it syntactically impossible for a handler body to receive the unresolved value directly.
- `_handle_answer` (`agui_submit`'s own `TOOL_CALL_RESULT` delegate) now takes a `_ResolvedAgent` too, not a bare `agent_name` — same reason.

## Verified structurally closed (not just described)

```
$ python -m mypy probe.py   # `_ResolvedAgent("x")`
error: Missing positional argument "_token" in call to "_ResolvedAgent"  [call-arg]

$ python3 -c '... _ResolvedAgent("x") ...'
TypeError: _ResolvedAgent.__init__() missing 1 required positional argument: '_token'
```

## Behavior preserved

- `agui_events`: no resolution-semantics change (still reads only the URL segment — it's the connect call that SEEDS the connection hub, so there is nothing yet in the hub to override the URL with).
- `agui_seize` / `agui_submit`: `connection_current_agent()` override folds into `_resolve_agent_for_connection`, same fallback-to-URL behavior #5129/#5132 already established.

## Test callers updated (signature change, not behavior)

4 test files called these handlers directly (bypassing real routing) with `agent_name` as a second positional arg — updated to populate `scope["path_params"]` the way the real router does, matching how a genuine ASGI match would look. No test assertions changed.

## Verification

- `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.
- `tests/interfaces/` full sweep: 2107 passed, 4 skipped (pre-existing, unrelated).
- Targeted scope (all `agent_name`-resolution-adjacent tests): 69 passed.

## Test plan

- [x] (skipped — no user-facing surface change; a pure internal type-closure refactor with byte-identical resolution behavior, verified via the automated suite + the direct mypy/runtime probes above)
