### PR TITLE
test(#5103): migrate 2 more class-① private run_turn stand-ins to @llm_stub

### DIFF
--- a/tests/core/test_3475_probe_degradation_visibility_and_timeout_config.py
+++ b/tests/core/test_3475_probe_degradation_visibility_and_timeout_config.py
@@ -123,15 +123,15 @@ def _make_probe_session(tmp_path: Path, *, mcp_probe_seconds: float, probe_cb):
 
 
 async def _drive_first_turn(session) -> None:
-    """Route one turn through the real turn-kind seam (`_run_router_loop`) without
-    invoking an actual LLM call — mirrors test_3475_mcp_probe_priming_all_turn_kinds.py's
-    `_install_snapshot_capturing_run_turn`, since this file's subject is the priming
-    chain's ARGUMENTS (per_server_timeout) and its side effects (audit-events), not
-    RouterLoop's own internals."""
-    async def _noop_run_turn(user_text: str, chain_id: str) -> None:
-        return None
+    """Route one turn through the real turn-kind seam (`_run_router_loop`).
 
-    session._loop_driver.run_turn = _noop_run_turn
+    #5103: the caller declares `@pytest.mark.llm_stub` — the REAL
+    `RouterLoopDriver.run_turn` / `RouterLoop` chain runs; only the LLM
+    boundary itself (`litellm.acompletion`) is stubbed (architect design
+    "C2", #5363's own precedent). Before this, `session._loop_driver.
+    run_turn` was replaced wholesale with a private `_noop`, so this
+    file's subject (does the priming chain's ARGUMENTS/audit-events
+    actually reach a real turn) was never witnessed on a real code path."""
     await session.submit_agent_request(
         from_agent="peer", request="hello", depth=1, chain_id="chain-3475",
     )
@@ -139,6 +139,7 @@ async def _drive_first_turn(session) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub
 async def test_session_threads_configured_probe_timeout_into_the_real_probe(tmp_path: Path):
     """Tier 2: (LOAD-BEARING) `safety.timeout.mcp_probe_seconds` set to a NON-default
     value (0) must reach `ensure_mcp_tools_cached`'s `per_server_timeout` — reyn's own
@@ -180,6 +181,7 @@ async def test_session_threads_configured_probe_timeout_into_the_real_probe(tmp_
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub
 async def test_probe_timeout_emits_visible_degradation_event(tmp_path: Path):
     """Tier 2: (LOAD-BEARING) a probe that times out under the configured budget emits
     `mcp_tool_probe_degraded` on the session's real EventLog, naming the server and
@@ -221,6 +223,7 @@ async def test_probe_timeout_emits_visible_degradation_event(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub
 async def test_probe_exception_emits_visible_degradation_event(tmp_path: Path):
     """Tier 2: a probe that raises (broken server, not merely slow) also emits
     `mcp_tool_probe_degraded`, with `reason="exception"` and a `detail` naming the

--- a/tests/core/test_session_lifecycle_events_1800.py
+++ b/tests/core/test_session_lifecycle_events_1800.py
@@ -18,10 +18,15 @@ Four tests verifying the new P6 events fire at the right points:
 Policy compliance (docs/deep-dives/contributing/testing.md):
 - No MagicMock / AsyncMock / patch for Session collaborators.
 - Real Session, real EventLog, real StateLog.
-- Only the LLM-calling boundary (_loop_driver.run_turn, which invokes
-  RouterLoop → call_llm_tools) is replaced with a plain async callable,
-  consistent with the "LLM is the only collaborator that may be faked"
-  rule (Tier 2c).
+- Test 3 (turn_started) drives the REAL `RouterLoopDriver.run_turn` /
+  RouterLoop chain via `@pytest.mark.llm_stub` (#5103, architect design
+  "C2") — only `litellm.acompletion` itself is stubbed. Test 4
+  (turn_completed) still replaces `_loop_driver.run_turn` directly with a
+  plain async callable: its own subject is the turn_completed emit's
+  ORDERING relative to `run_turn`'s own return, so replacing `run_turn`
+  itself is what the test needs, not what it is working around (#5103
+  triage: this is the "timing observation" class, not the "LLM
+  avoidance" class the llm_stub migration targets).
 - Events observed via add_subscriber (public EventLog API), not via
   private state assertions.
 """
@@ -170,25 +175,24 @@ async def test_session_started_and_completed_emit(tmp_path: Path, monkeypatch) -
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub
 async def test_turn_started_emits_with_kind(tmp_path: Path, monkeypatch) -> None:
     """Tier 2: turn_started is emitted once per turn in run_one_iteration(),
     carrying the inbox trigger's kind, before the turn's handler runs.
 
-    Approach: inject a 'user' inbox message, monkeypatch _loop_driver.run_turn
-    to a fast async noop (LLM-boundary fake — the only collaborator the policy
-    allows faking in Tier 2c), then call run_one_iteration() once.
+    Approach: inject a 'user' inbox message, then call run_one_iteration()
+    once. #5103: drives the REAL `run_one_iteration` -> `_handle_user_
+    message` -> `_run_router_loop` -> `RouterLoopDriver.run_turn` chain
+    (architect design "C2", #5363's own precedent) — only the LLM boundary
+    itself (`litellm.acompletion`) is stubbed via `@pytest.mark.llm_stub`,
+    not `run_turn` wholesale. What this test asserts (turn_started fires
+    with the right kind) was previously witnessed against a private
+    `_noop` stand-in that replaced `run_turn` entirely; now it is
+    witnessed on the real code path.
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
     collected = _collect_events(session)
-
-    # Replace the LLM-calling boundary (run_turn) with a plain async noop.
-    # This is the only fake; the real run_one_iteration → _handle_user_message
-    # → _run_router_loop chain runs.
-    async def _noop_run_turn(user_text: str, chain_id: str) -> None:
-        pass
-
-    session._loop_driver.run_turn = _noop_run_turn  # type: ignore[method-assign]
 
     _chain_id = "test-chain-001"
     await session._put_inbox("user", {"text": "hello", "chain_id": _chain_id})


### PR DESCRIPTION
**[e2e-coder]** — part of #5103.

## What

Continues #5363's precedent (architect design "C2"): tests whose subject is the loop/valve/lifecycle around a turn, not the model's own output, now drive the REAL `RouterLoopDriver.run_turn` / `RouterLoop` chain via `@pytest.mark.llm_stub` — only `litellm.acompletion` is stubbed. Before this, `session._loop_driver.run_turn` was replaced wholesale with a private per-test `_noop`, so nothing inside it — including whatever these tests actually assert on — ever ran on a real code path.

## Files

- `tests/core/test_3475_probe_degradation_visibility_and_timeout_config.py` — 3 tests sharing one `_drive_first_turn()` helper: removed its `_noop_run_turn`/assignment, added `@pytest.mark.llm_stub` to all 3 callers.
- `tests/core/test_session_lifecycle_events_1800.py` — `test_turn_started_emits_with_kind` only (1 of 4 tests in the file). `test_turn_completed_emits_after_router_turn` stays **unmigrated** — architect's own 4th classification, "timing/ordering": its subject is `turn_completed`'s emit ORDERING relative to `run_turn`'s own return, so replacing `run_turn` directly is what the test needs, not what it's working around. Module docstring updated to describe both tests' own approach instead of one blanket claim.

## Classification (lead-coder, issue #5103's own "15 件の分類（全件）" table)

Both files are class **①** (LLM-avoidance) — 2 files here, 2 already landed in #5363. The remainder (13 files) is classes ②/③/④ (cancel behavior / content-observation / timing), each needing its own separate design per architect's ruling against a generic `run_turn`-replacement seam (a wildcard/generic seam would not close the class — it would make the wrong form cheaper, per architect's #5103 comment).

## Verification

- `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.
- Both files' own test suites: 10 passed.
- `git diff -- tests/ | grep -E "^[+-]\s+assert"` — empty (no assertion changed; only the drive mechanism did).

## Test plan

- [x] (skipped — no user-facing surface; pure test-infrastructure migration, verified via the automated suite above)
