### PR TITLE
fix(#5357): pin MCPClient's open/close to one owner task, close its GC-leak gap

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -110,6 +110,7 @@ llm_request_error
 llm_response_received
 mcp_called
 mcp_cancelled
+mcp_client_close_leaked
 mcp_completed
 mcp_elicitation_answered
 mcp_elicitation_auto_declined
@@ -428,6 +429,7 @@ op dispatch:
 | `mcp_initialized` | Emitted on every (re)connect, once the server's handshake completes (`initialize` or, since #3698 PR-2's `Client(mode="auto")`, `discover`). | `server`, `negotiated_version`, `capabilities`, `subscription_adapter` (the selected `SubscriptionAdapter` class name — `LegacySubscriptionAdapter` or `ListenSubscriptionAdapter`, see [Concepts: MCP](../../concepts/tools-integrations/mcp.md) — the audit-visible witness of which delivery mechanism this connection actually uses) |
 | `mcp_resource_updated` | A subscribed resource's server-pushed `resources/updated` notification, or a synthetic resync fired per re-subscribed URI after a transport-death reconnect. Also wired into the hook dispatcher as an external-event hook-point — see [Concepts: hooks](../../concepts/runtime/hooks.md#mcp_resource_updated). | `server`, `uri`, `resync` (`true` for a reconnect resync, `false` for a real push) |
 | `mcp_reconnect_failed` | #5280: a reconnect attempt (`MCPConnectionService._reconnect`, either `_HeldConnection._heal`'s reactive path or `_reconnect_from_lost_subscription`'s proactive one) itself failed to reopen — the server subprocess is genuinely gone, not just a transient transport death. Fired instead of `mcp_initialized` (which only fires on success) specifically so `Session.mcp_subscription_state()`'s reactive cache (#5276/#5279) has a signal to invalidate on, since the server has already dropped out of `held_servers()` by this point. | `server` |
+| `mcp_client_close_leaked` | #5357: an `MCPClient`'s transport was torn down because its dedicated owner task was cancelled (nothing referenced the client any more) WITHOUT `close()`/`__aexit__` ever being called — the "reference just gets dropped" shape that used to crash the event loop with `RuntimeError: Attempted to exit cancel scope in a different task than it was entered in` (the loop's own async-generator finalizer closing the transport in NO task at all). `initialize()`/`close()` now pin the open and the eventual close to one dedicated task regardless of caller, so this no longer crashes — but it is still a genuine leak (nobody asked for the teardown), so it is reported. Never fires on a normal `close()` call (the noise guard). | `server`, `transport` |
 | `mcp_elicitation_requested` | A server issues an `elicitation/create` structured-input request. | `server`, `field_keys` (the requested schema's property **names** only — never values) |
 | `mcp_elicitation_answered` | The request resolves to `accept` or `decline` (human choice, or a `decline` from `auto_decline` config). | `server`, `field_keys`, `action` (`"accept"` \| `"decline"`) |
 | `mcp_elicitation_timed_out` | No answer arrived before `elicitation_timeout_seconds`. | `server`, `field_keys` |

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -376,6 +376,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "llm_response_received",
     "mcp_called",
     "mcp_cancelled",
+    "mcp_client_close_leaked",
     "mcp_completed",
     "mcp_elicitation_answered",
     "mcp_elicitation_auto_declined",

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -984,6 +984,33 @@ class MCPClient:
         # actually opens a connection (every transport now).
         self._exit_stack: "Any | None" = None
         self._initialized = False
+        # #5357: this client's open (initialize) and close run inside ONE
+        # dedicated "owner" asyncio.Task for the client's whole open lifetime —
+        # whoever ENTERS an anyio-backed context manager must be the SAME task
+        # that EXITS it (anyio's cancel-scope machinery checks task identity,
+        # not just "some task"). Pre-#5357, `initialize()` ran in whatever task
+        # called it and `close()` ran in whatever (possibly different) task
+        # called IT — and a caller that simply dropped its last reference
+        # without ever calling close() left the event loop's own async-
+        # generator finalizer to close the transport CM in NO task at all,
+        # which is exactly what production's chronic "Attempted to exit cancel
+        # scope in a different task than it was entered in" traceback was
+        # (`context_message` always "closing of asynchronous generator
+        # streamable_http_client", `task_repr` always empty — see #5357).
+        # `_owner_task` runs `_own_lifecycle` below: open, then wait for a
+        # close request, then close — ALL in this one task, no matter which
+        # (possibly different) tasks call `initialize()`/`close()` themselves.
+        self._owner_task: "asyncio.Task[None] | None" = None
+        self._close_requested: "asyncio.Event | None" = None
+        self._open_ready: "asyncio.Future[None] | None" = None
+        # #5357 stage 3: set True iff `_owner_task` was torn down (its own
+        # await on `_close_requested` was cancelled because nothing else
+        # referenced this client any more) WITHOUT `close()` ever being
+        # called — the exact "reference just gets dropped" leak this issue
+        # closes. Reported as a `mcp_client_close_leaked` audit-event from
+        # `_do_close()` (never fired on a normal `close()` call — see that
+        # method).
+        self._leaked_close = False
         # Captures subprocess stderr for stdio transport so initialize
         # failures (e.g. self-made MCP server exits immediately, writes
         # a traceback to stderr before the MCP handshake completes) can
@@ -1134,13 +1161,62 @@ class MCPClient:
         stays a declared dependency until this PR also removes it from
         ``pyproject.toml`` — a separate, later step in the same PR, not a
         follow-up).
+
+        #5357: the actual handshake now runs inside a dedicated ``_owner_task``
+        (spawned here, awaited to readiness) rather than directly in whichever
+        task calls this method — see :meth:`_own_lifecycle` and the matching
+        ``__init__`` comment for why. This method (and therefore ``__aenter__``,
+        and every lazy-init call site below that calls ``self.initialize()``)
+        stays a normal ``await`` from the CALLER's point of view; only
+        ``close()`` needs to know the teardown runs in that same owner task.
         """
         if self._initialized:
             return
-        if self._type == "stdio":
-            await self._initialize_stdio()
-        else:
-            await self._initialize_http_or_sse()
+        if self._owner_task is not None:
+            # A concurrent/prior initialize() already spawned the owner task
+            # (e.g. it failed and is still finishing, or another caller is
+            # already awaiting it) — join THAT SAME attempt rather than
+            # racing a second one.
+            assert self._open_ready is not None
+            await self._open_ready
+            return
+        self._close_requested = asyncio.Event()
+        self._open_ready = asyncio.get_running_loop().create_future()
+        self._owner_task = asyncio.create_task(self._own_lifecycle())
+        await self._open_ready
+
+    async def _own_lifecycle(self) -> None:
+        """#5357: the ONE task that both opens (below) and, eventually,
+        closes (:meth:`_do_close`) this client's transport — see the
+        ``__init__``/``initialize`` comments for the mechanism this closes.
+
+        Waits on ``_close_requested`` after a successful open. If that wait
+        is CANCELLED because nothing else references this client any more
+        (the caller dropped every reference without ever calling ``close()``)
+        rather than because ``close()`` set the event, ``_do_close()`` still
+        runs — in THIS SAME task, so anyio's cancel-scope task-identity check
+        never trips — but the teardown was never requested, so it is a
+        genuine leak: ``_leaked_close`` is set, and :meth:`_do_close` turns
+        that into a ``mcp_client_close_leaked`` audit-event (witness #2/#3 in
+        #5357: fires on this path, never on a normal ``close()``)."""
+        assert self._open_ready is not None
+        try:
+            if self._type == "stdio":
+                await self._initialize_stdio()
+            else:
+                await self._initialize_http_or_sse()
+        except BaseException as exc:
+            if not self._open_ready.done():
+                self._open_ready.set_exception(exc)
+            return
+        if not self._open_ready.done():
+            self._open_ready.set_result(None)
+        assert self._close_requested is not None
+        try:
+            await self._close_requested.wait()
+        except asyncio.CancelledError:
+            self._leaked_close = True
+        await self._do_close()
 
     async def _initialize_stdio(self) -> None:
         """#3698 stage 1 / PR-1: stdio via the official ``mcp`` SDK's
@@ -1497,14 +1573,23 @@ class MCPClient:
         self._server_capabilities = session.server_capabilities
 
     async def __aenter__(self) -> "MCPClient":
-        """#a359: structured lifecycle. ``initialize()`` here + ``close()`` in ``__aexit__`` run in
-        the SAME task/scope — so the transport + session (whose SDK stdio_client / ClientSession hold
-        internal anyio task-group scopes that MUST be exited in the task that entered them) open and
-        close within one ``async with`` block. Callers use ``async with MCPClient(cfg) as c:`` instead
-        of a lazy ``initialize()`` + a deferred ``self._stack`` closed by a later ``close()`` in a
-        possibly-different task — that deferral was the root cause of the cross-task 'cancel scope
-        crossed task boundary' error (Windows: BrokenResource / BaseExceptionGroup during subprocess
-        teardown)."""
+        """#a359: structured lifecycle. A caller using ``async with MCPClient(cfg) as c:`` gets
+        ``initialize()`` here and ``close()`` in ``__aexit__`` naturally in the same call scope.
+
+        #5357 update: that discipline is no longer what actually PROTECTS the transport + session's
+        internal anyio task-group scopes (which MUST be exited in the task that entered them) — a
+        caller that holds a ``client`` past this ``async with`` block, or calls ``initialize()``/
+        ``close()`` directly instead (every lazy-init call site below does), used to open in whichever
+        task called ``initialize()`` and close in whichever (possibly different) task later called
+        ``close()``/``__aexit__``, or — worse — never called either and just dropped the reference,
+        letting the event loop's own async-generator finalizer close it in NO task at all. That was the
+        root cause of the chronic 'cancel scope crossed task boundary' RuntimeError (`context_message`
+        always "closing of asynchronous generator streamable_http_client", `task_repr` always empty —
+        see #5357, not #a359's originally-diagnosed Windows BrokenResource/BaseExceptionGroup shape).
+        ``initialize()`` now pins the open AND the eventual close to one dedicated ``_owner_task`` (see
+        that method + ``_own_lifecycle``) regardless of which task calls either — this docstring's
+        ``async with`` recommendation is still the clearest usage, but is no longer load-bearing for
+        task-identity correctness."""
         await self.initialize()
         return self
 
@@ -1857,6 +1942,27 @@ class MCPClient:
     async def close(self) -> None:
         """Tear down the transport and session. Safe to call repeatedly.
 
+        #5357: the actual teardown (:meth:`_do_close`) always runs inside this
+        client's ``_owner_task`` — the SAME task that ran ``initialize()`` — no
+        matter which task calls THIS method. If that owner task never got as
+        far as opening anything (``initialize()`` was never called, or it
+        raised before spawning the owner task), there is nothing to close
+        beyond the stderr-capture/child-reap bookkeeping every close performs."""
+        owner_task = self._owner_task
+        if owner_task is None:
+            self.close_stderr_capture()
+            self._reap_child_process()  # nothing opened, or already closed once — still idempotent
+            return
+        if self._close_requested is not None and not self._close_requested.is_set():
+            self._close_requested.set()
+        await owner_task  # `_do_close()` runs — and completes — in THAT task, not this one
+
+    async def _do_close(self) -> None:
+        """The real teardown — called exactly once, from :meth:`_own_lifecycle`,
+        always in this client's ``_owner_task``. Never call this directly;
+        call :meth:`close` (or ``__aexit__``), which routes here through that
+        task regardless of which task calls IT.
+
         #2714: the graceful ``client.close()`` (fastmcp → mcp ``stdio_client``'s
         SIGTERM→SIGKILL / Windows Job-Object tree-terminate) is the PRIMARY reaper.
         But that teardown runs inside anyio cancel scopes that, on Windows, can raise
@@ -1931,6 +2037,21 @@ class MCPClient:
             # child alive.
             self._reap_child_process()
             self.close_stderr_capture()
+        # #5357 stage 3: fires ONLY when `_own_lifecycle` reached this close because
+        # its wait on `_close_requested` was cancelled (nothing referenced this client
+        # any more and `close()` was never called) — never on a normal `close()` call
+        # (witness #3: the noise guard). Best-effort — a sink-less caller (the
+        # ephemeral MCPClientPool path, or a direct construction with no emit_event)
+        # sees no behaviour change, same as every other `_emit_event` use in this file.
+        if self._leaked_close and self._emit_event is not None:
+            try:
+                self._emit_event(
+                    "mcp_client_close_leaked",
+                    server=self._server_name or "<unknown>",
+                    transport=self._type,
+                )
+            except Exception:  # noqa: BLE001 — reporting a leak must never itself raise
+                logger.warning("MCPClient: mcp_client_close_leaked emit failed", exc_info=True)
 
     def _reap_child_process(self) -> None:
         """#2714 belt-and-suspenders: synchronously terminate the captured stdio child

--- a/tests/mcp/test_5357_mcp_client_task_ownership.py
+++ b/tests/mcp/test_5357_mcp_client_task_ownership.py
@@ -1,0 +1,140 @@
+"""Tests for #5357 — MCPClient's open/close task-identity discipline.
+
+Chronic real-world ``RuntimeError: Attempted to exit cancel scope in a
+different task than it was entered in`` (60/72 occurrences over 15 days in
+reyn-self's own logs — always the same traceback shape: an anyio task-group
+``__aexit__``, inside Python's async-generator GC finalizer closing
+``streamable_http_client``, ``task_repr`` always EMPTY). Architect's root
+cause: nobody explicitly closed the streamable-http client's context manager;
+when the reference dropped, the EVENT LOOP's own async-generator finalizer
+closed it in NO task at all (not literally "a different task"), and anyio
+correctly complained.
+
+Real instances only, per the testing policy: no ``mock.patch`` / ``MagicMock``
+on the transport, session, or asyncio task machinery — the whole defect is
+about REAL task identity, so these tests build a real local HTTP MCP server
+(reusing ``test_mcp_client.py``'s own ``_HttpEchoServer`` — a real uvicorn
+server, not a fake) and drive real ``asyncio`` tasks against it.
+
+A note on HOW witness #1's "drop the reference" is driven: the abandoned
+client and its owner task hold a genuine reference CYCLE (the owner task's
+own coroutine closure holds the client), so an organic ``del client;
+gc.collect()`` depends on CPython's cyclic-collector *timing* to actually
+reclaim it — measured directly against this exact fix: sometimes one
+``gc.collect()`` call was enough, sometimes it took much longer under a full
+pytest process, with no bound. That is exactly the "a duration/timing detail
+stands in for an observation nobody exposed" hazard the testing policy
+warns about (never pin third-party GC timing). So these tests instead drive
+the abandonment DETERMINISTICALLY — cancelling the client's own owner task
+directly (``MCPClient`` exposes no public "abandon me" hook; per the testing
+policy's own carve-out, that absence is itself the finding, not a reason to
+wait on GC) — which exercises the identical code path
+(``_own_lifecycle``'s ``except asyncio.CancelledError`` branch) that organic
+GC-driven abandonment would hit, without depending on when or whether the
+cyclic collector gets to it.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.mcp.client import MCPClient
+from tests.mcp.test_mcp_client import _HttpEchoServer
+
+
+def test_abandoned_owner_task_closes_in_same_task_and_reports_leak() -> None:
+    """Tier 1: #5357 witnesses 1+2 — a streamable-http ``MCPClient`` whose owner
+    task is torn down WITHOUT ``close()``/``__aexit__`` ever being called (the
+    "reference just gets dropped" shape architect specified — see the module
+    docstring for why this drives it via a direct cancel rather than organic GC)
+    used to crash with ``RuntimeError: Attempted to exit cancel scope in a
+    different task than it was entered in`` pre-#5357 (reproduced directly
+    against this real transport before this fix landed — see the PR
+    description). ``initialize()`` now pins the open and the eventual close to
+    ONE dedicated owner task for the client's whole lifetime, so tearing that
+    task down without a close request still closes in the SAME task — no
+    exception reaches the loop's exception handler — and the abandoned close
+    (nobody ever asked for it) is reported as exactly one
+    ``mcp_client_close_leaked`` audit-event (the leak is real: the connection
+    HAD to be torn down without a close request; only the crash is gone)."""
+    errors: list[dict] = []
+    leaked_events: list[dict] = []
+
+    async def _run_it() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_exception_handler(lambda loop, context: errors.append(context))
+
+        def _emit(kind: str, **fields: object) -> None:
+            if kind == "mcp_client_close_leaked":
+                leaked_events.append(fields)
+
+        async with _HttpEchoServer() as server:
+            cfg = {"type": "streamable-http", "url": server.url}
+            client = MCPClient(cfg, emit_event=_emit, server_name="leak-probe")
+            await client.__aenter__()
+            owner_task = client._owner_task
+            assert owner_task is not None
+            # Deterministically drive the exact "abandoned, close never
+            # requested" condition this fix closes — see the module docstring
+            # for why this replaces waiting on organic cyclic GC.
+            owner_task.cancel()
+            await owner_task
+
+    asyncio.run(_run_it())
+
+    assert errors == [], (
+        f"the abandoned owner task crossed a task boundary: {errors}"
+    )
+    # Exactly one leak event, carrying this client's own identity — not merely
+    # "at least one" (a leak detector that double-reports is itself a bug) and
+    # not merely a count (the payload identifies the abandoned connection).
+    assert leaked_events == [{"server": "leak-probe", "transport": "streamable-http"}]
+
+
+def test_normal_close_never_reports_a_leak() -> None:
+    """Tier 1: #5357 witness 3 — the noise guard. A client that goes through the
+    normal ``async with MCPClient(...) as client:`` open/close path — the SAME
+    owner-task machinery witness 1's test exercises — never fires
+    ``mcp_client_close_leaked``. A leak detector that fires on every ordinary close
+    would be useless."""
+    leaked_events: list[dict] = []
+
+    def _emit(kind: str, **fields: object) -> None:
+        if kind == "mcp_client_close_leaked":
+            leaked_events.append(fields)
+
+    async def _run_it() -> None:
+        async with _HttpEchoServer() as server:
+            cfg = {"type": "streamable-http", "url": server.url}
+            async with MCPClient(cfg, emit_event=_emit, server_name="normal-probe") as client:
+                result = await client.call_tool("echo", {"text": "hi"})
+                assert result["isError"] is False
+
+    asyncio.run(_run_it())
+
+    assert leaked_events == []
+
+
+def test_close_from_a_different_task_than_initialize_still_succeeds() -> None:
+    """Tier 1: #5357 general-form check — ``initialize()`` in one asyncio Task and
+    ``close()`` from a DIFFERENT one (the exact shape ``connection_service.py``'s
+    ``_ensure_open``/``_reconnect`` split across separate calls) must not raise: the
+    actual anyio-sensitive teardown now always runs in the client's own owner task,
+    never in whichever task happens to call ``close()``."""
+
+    async def _run_it() -> None:
+        async with _HttpEchoServer() as server:
+            cfg = {"type": "streamable-http", "url": server.url}
+            client = MCPClient(cfg, server_name="cross-task-probe")
+
+            async def _open() -> None:
+                await client.__aenter__()
+
+            async def _close() -> None:
+                await client.__aexit__(None, None, None)
+
+            await asyncio.create_task(_open())
+            assert client.is_initialized() is True
+            await asyncio.create_task(_close())
+            assert client.is_initialized() is False
+
+    asyncio.run(_run_it())

--- a/tests/mcp/test_5357_mcp_client_task_ownership.py
+++ b/tests/mcp/test_5357_mcp_client_task_ownership.py
@@ -42,7 +42,7 @@ from tests.mcp.test_mcp_client import _HttpEchoServer
 
 
 def test_abandoned_owner_task_closes_in_same_task_and_reports_leak() -> None:
-    """Tier 1: #5357 witnesses 1+2 — a streamable-http ``MCPClient`` whose owner
+    """Tier 2: #5357 witnesses 1+2 — a streamable-http ``MCPClient`` whose owner
     task is torn down WITHOUT ``close()``/``__aexit__`` ever being called (the
     "reference just gets dropped" shape architect specified — see the module
     docstring for why this drives it via a direct cancel rather than organic GC)
@@ -91,7 +91,7 @@ def test_abandoned_owner_task_closes_in_same_task_and_reports_leak() -> None:
 
 
 def test_normal_close_never_reports_a_leak() -> None:
-    """Tier 1: #5357 witness 3 — the noise guard. A client that goes through the
+    """Tier 2: #5357 witness 3 — the noise guard. A client that goes through the
     normal ``async with MCPClient(...) as client:`` open/close path — the SAME
     owner-task machinery witness 1's test exercises — never fires
     ``mcp_client_close_leaked``. A leak detector that fires on every ordinary close
@@ -115,7 +115,7 @@ def test_normal_close_never_reports_a_leak() -> None:
 
 
 def test_close_from_a_different_task_than_initialize_still_succeeds() -> None:
-    """Tier 1: #5357 general-form check — ``initialize()`` in one asyncio Task and
+    """Tier 2: #5357 general-form check — ``initialize()`` in one asyncio Task and
     ``close()`` from a DIFFERENT one (the exact shape ``connection_service.py``'s
     ``_ensure_open``/``_reconnect`` split across separate calls) must not raise: the
     actual anyio-sensitive teardown now always runs in the client's own owner task,


### PR DESCRIPTION
**[tui-coder]** — closes #5357.

## What
reyn-self's own logs show `RuntimeError: Attempted to exit cancel scope in a different task than it was entered in` — 60/72 `asyncio_unhandled_exception` events over 15 days, always the same shape (anyio task-group `__aexit__`, inside Python's async-generator GC finalizer closing `mcp`'s `streamable_http_client`). Architect's root-cause finding (issue thread): nobody explicitly closes `MCPClient`'s held-open context manager; when the reference drops, the event loop's own finalizer closes it in **no particular task** (not "a different task" — "no task at all"), and anyio correctly complains. `client.py` calls `__aenter__()` (`initialize()`) and `__aexit__()` (`close()`) from separate code paths with no guarantee they run in the same asyncio task — only an `asyncio.Lock` serializes access, which does not pin task identity.

## Stage 1 — reproduced first (per lead-coder's explicit ordering)
Built a real streamable-http `MCPClient` against a real local HTTP MCP echo server, called `__aenter__()`, dropped every reference without `close()` — reproduced the exact production shape: the RuntimeError surfaced during the event loop's own teardown of an unnamed `async_generator_athrow` task, never the entering task. Confirms architect's "no task at all" reading.

## Stage 2 — fix (not a lock)
`initialize()` now spawns one dedicated `_owner_task` that performs the handshake, waits on a `_close_requested` `asyncio.Event`, then performs the real teardown (`_do_close()`, the renamed body of the old `close()`) — all inside that ONE task, regardless of which task calls `initialize()`/`close()`/`__aenter__`/`__aexit__`. No lock (a lock doesn't pin task identity — lead-coder's explicit ruling). Every existing caller (`pool.py`, `connection_service.py`, every lazy-init site) needed no changes — they all route through `initialize()`/`close()`.

## Stage 3 — leak detection (only after 1+2 landed)
If the owner task's wait is cancelled because the last reference dropped (never via an explicit close request), a new audit-event `mcp_client_close_leaked` (`server`, `transport`) fires — 3-registry contract (`AUDIT_EVENT_KINDS`, `EVENT_AUDIT_REQUIREMENTS`, `docs/reference/runtime/events.md`). Never fires on a normal close (verified — the noise guard).

## The 4 witnesses (all covered)
1. Abandoned client, no `close()` — reproduces today (stage 1, run first).
2. Same scenario, after the fix — no exception, one leak event.
3. Normal `close()` path — zero leak events.
4. Strip: reverting the same-task-pinning fix reds witness-1/2's test (verified manually — 1 failed, 2 passed — then restored).

## Test note
Witnesses 1/2 drive the abandonment by cancelling the owner task directly rather than waiting on organic cyclic-GC (`del`+`gc.collect()`), measured to be non-deterministic under a full pytest process (this repo's own testing policy: never pin third-party GC/finalizer timing).

## Scope
Fixes reyn's own task-ownership discipline around the CM — does not touch anyio/mcp's own behavior (explicitly out of scope per the issue).

## Verification
Gate scripts green (ruff, mypy ratchet, test-tier-audit --strict, module docstrings, flat-tests ratchet, tests-path-literal, bare-tests-import, file-depth, mkdocs --strict, doc-anchors, retired-config-keys-denylist). `tests/mcp/` (184 passed, 1 pre-existing unrelated skip) + `test_audit_event_kind_vocabulary_3410.py` (10 passed) — all green post-rebase onto current main (clean, no conflicts).

## Test plan
- [x] (skipped — no user-facing surface change; verified via the automated test suite above)

- [x] 🔴 **[architect]** `test_5357_mcp_client_task_ownership.py` の 3 本は **すべて `Tier 1` を宣言**していますが、六問①（この assert が落ちたら誰のバグか）の答えは **3 本とも reyn 自身の MCPClient** ∴ **Tier 2** です。

