### PR TITLE
feat(#5366 3/N): project-wide storage cap drives real eviction, refuses when exhausted

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -82,6 +82,7 @@ from typing import TYPE_CHECKING
 from reyn.services.offload.store import offload_value, read_offloaded
 
 if TYPE_CHECKING:
+    from reyn.config.infra import StorageConfig
     from reyn.core.events.durability_worker import DurabilityWorker
 
 logger = logging.getLogger(__name__)
@@ -591,8 +592,19 @@ class MediaStore:
         base_url: str | None = None,
         session_id: str,
         worker: "DurabilityWorker | None" = None,
+        storage: "StorageConfig | None" = None,
     ) -> None:
         self._config = config or MediaStoreConfig()
+        # #5366 §3: the PROJECT-wide cap/pin (StorageConfig.max_bytes/pin,
+        # reyn.yaml's `storage:` block) — a different subject than
+        # self._config.history_content_max_bytes (this store's own
+        # per-session fail-safe backstop; see that field's own docstring
+        # for why the two are deliberately never the same number). `None`
+        # (the default, matching StorageConfig's own default) means
+        # cross-session GC never fires — see
+        # :meth:`_evict_cross_session_over_cap`.
+        from reyn.config.infra import StorageConfig
+        self._storage = storage or StorageConfig()
         self._project_root = project_root.resolve()
         # #5364 §1.4 (owner: "UIを止めさせたくない" — a synchronous tool-result
         # write can stall the event loop, same class of problem #1765 fixed
@@ -958,6 +970,21 @@ class MediaStore:
                 "failure latched (DurabilityWorker.durability_failed) — "
                 "refusing to mint a ref for a file that will not exist"
             )
+        # #5366 §3: a PRE-check, same shape as durability_failed above —
+        # try to make room in the PROJECT-wide (cross-session) tree
+        # first; if evicting every available candidate still leaves the
+        # project ALREADY over StorageConfig.max_bytes (checked against
+        # what is on disk BEFORE this write — this does not project the
+        # size of the content this call is about to add), refuse this
+        # NEW write. A write that itself FIRST pushes the project over
+        # cap is therefore still allowed through (the project was under
+        # cap the instant this check ran) — the NEXT write's own
+        # pre-check is what observes and cleans up the resulting
+        # overage; see :meth:`_evict_cross_session_over_cap`'s own
+        # docstring. No-op (returns immediately) when
+        # StorageConfig.max_bytes is unset — see that field's own
+        # docstring: None means off, not "check anyway".
+        self._evict_cross_session_over_cap()
         chain_short = _safe_token(chain_id)[:6] if chain_id else ""
         tool_token = _safe_token(tool) or "tool"
         ext = _ext_for_mime(mime_type)
@@ -1141,6 +1168,122 @@ class MediaStore:
                 )
                 continue
             total -= size
+
+    def _evict_cross_session_over_cap(self) -> None:
+        """#5366 §3 (architect design, final ruling — issuecomment-
+        5451564768 / lead-coder confirmation issuecomment-5451700-ish):
+        bound the PROJECT-wide (cross-session) history-content footprint
+        against ``StorageConfig.max_bytes`` — a DIFFERENT number than
+        :attr:`MediaStoreConfig.history_content_max_bytes` (this store's
+        own per-session backstop, see that field's docstring for why the
+        two are deliberately never the same). No-op when ``max_bytes``
+        is unset (``None`` — the field's own default means "off", not
+        "check anyway").
+
+        Candidates come from :func:`cross_session_eviction_candidates`
+        against the project-wide root (:func:`history_content_root_for`)
+        minus pinned agents — deliberately no liveness filter (see that
+        function's own docstring for why: #5388's per-session cap
+        already evicts a LIVE session's own old files, so a liveness
+        filter here would protect cross-session GC MORE than per-session
+        GC protects itself, for the same resource).
+
+        Runs BEFORE the write this call is guarding (a pre-check, same
+        shape as the ``durability_failed`` check right above its own
+        call site) — not a post-write backstop like
+        :meth:`_evict_history_content_over_cap`. Checked against what is
+        ALREADY on disk before this write lands, never projecting this
+        write's own upcoming size — a write that itself first pushes the
+        project over cap is therefore still let through (the project
+        was under cap the instant this check ran); the NEXT write's own
+        pre-check is what observes and cleans up the resulting overage.
+        If evicting every available (non-pinned) candidate still leaves
+        the project ALREADY over cap, raises
+        :class:`MediaStoreWriteUnavailable` (#5364 §1.5's own contract:
+        refuse rather than mint a ref for content that cannot actually
+        fit) — architect's #5366 §3 spec: "候補が尽きて
+        なお超過なら MediaStoreWriteUnavailable". The caller
+        (``cap_tool_result_content``, this exception's one real
+        consumer) already keeps the content inline instead of failing
+        the turn; no new handling is needed at that seam.
+
+        Best-effort deletes (an ``OSError`` mid-delete is logged and
+        skipped), same policy as the per-session sibling above — a
+        failed eviction must never itself crash the write it precedes."""
+        max_bytes = self._storage.max_bytes
+        if max_bytes is None:
+            return
+        root = history_content_root_for(self._project_root, self._config)
+        _, total = _dir_stats_recursive(root)
+        if total <= max_bytes:
+            return
+        candidates = cross_session_eviction_candidates(
+            root, pin=self._storage.pin,
+        )
+        for path in candidates:
+            if total <= max_bytes:
+                return
+            try:
+                size = path.stat().st_size
+                path.unlink()
+            except OSError as e:  # noqa: BLE001 — best-effort; LOG (don't silently swallow)
+                logger.warning(
+                    "#5366 §3: cross-session eviction of %s under the "
+                    "project storage cap failed: %s", path, e,
+                )
+                continue
+            total -= size
+        if total > max_bytes:
+            raise MediaStoreWriteUnavailable(
+                f"project-wide storage.max_bytes ({max_bytes}) is "
+                f"exceeded ({total} bytes) even after evicting every "
+                "non-pinned candidate — refusing to mint a ref for a "
+                "file that would push the project further over"
+            )
+
+    def cross_session_eviction_preview(self) -> "list[Path]":
+        """#5366 §3 item ④ ("消える前」表示 — 2 と同じ関数を削除せずに走ら
+        せる"): the SAME candidate function
+        (:func:`cross_session_eviction_candidates`) and the SAME
+        stop-when-under-cap loop :meth:`_evict_cross_session_over_cap`
+        runs, but never calls ``path.unlink()`` — an operator-facing
+        "what would go" list, computed without side effects, in the
+        SAME order eviction would actually delete them. Returns ``[]``
+        when ``StorageConfig.max_bytes`` is unset or the project is
+        already under it (nothing WOULD be evicted, not "the answer is
+        unavailable" — the two are the same falsy return deliberately,
+        mirroring :func:`cross_session_eviction_candidates`'s own "no
+        pin → return everything ``_eviction_order`` finds" shape: an
+        empty result here always means "nothing to evict", never
+        "couldn't compute")."""
+        max_bytes = self._storage.max_bytes
+        if max_bytes is None:
+            return []
+        root = history_content_root_for(self._project_root, self._config)
+        _, total = _dir_stats_recursive(root)
+        if total <= max_bytes:
+            return []
+        candidates = cross_session_eviction_candidates(
+            root, pin=self._storage.pin,
+        )
+        preview: list[Path] = []
+        for path in candidates:
+            if total <= max_bytes:
+                break
+            try:
+                size = path.stat().st_size
+            except OSError:
+                # #5366 §3 item ④: a candidate that vanished between the
+                # listing above and this stat (a concurrent process's
+                # own real eviction, or #5388's per-session pass) is
+                # simply skipped here — it can no longer be "about to
+                # go" since it is already gone, and a preview must never
+                # itself delete or otherwise mutate state to work around
+                # this race.
+                continue
+            preview.append(path)
+            total -= size
+        return preview
 
     @property
     def durability_failed(self) -> bool:

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -55,6 +55,11 @@ class SessionFactoryConfig:
     # shape/role as read_cap_config (#4431's role split): bytes,
     # model-independent, config-driven.
     history_resident_config: Any
+    # #5366 §3: reyn.yaml storage.* (max_bytes / pin) — the PROJECT-wide
+    # (cross-session) history-content cap. Same shape/role as
+    # history_resident_config just above: a plain value, config-driven,
+    # not a per-turn supplier.
+    storage_config: Any
     embedding_config: Any
     router_config: Any
     retry_config: Any
@@ -149,6 +154,8 @@ class SessionFactoryConfig:
             auth_config=config.auth,
             # #4387 Phase B ③: the resource-bound history-resident cap config.
             history_resident_config=config.history_resident,
+            # #5366 §3: the project-wide (cross-session) storage cap/pin.
+            storage_config=config.storage,
             embedding_config=config.embedding,
             router_config=config.llm.router,
             retry_config=config.llm.retry,

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -162,6 +162,7 @@ def build_scoped_chat_session(
         read_cap_config=factory_config.read_cap_config,  # #4381 PR-5
         auth_config=factory_config.auth_config,  # #5012-A
         history_resident_config=factory_config.history_resident_config,  # #4387 Phase B ③
+        storage_config=factory_config.storage_config,  # #5366 §3
         embedding_config=factory_config.embedding_config,
         router_config=factory_config.router_config,
         retry_config=factory_config.retry_config,  # #1835

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -47,6 +47,7 @@ from reyn.config import (  # noqa: F401
     RenderTemplateConfig,
     RouterConfig,
     SafetyConfig,
+    StorageConfig,
     WebFetchConfig,
 )
 from reyn.core.events.agent_snapshot import AgentSnapshot
@@ -882,6 +883,11 @@ class Session:
         # #4387 Phase B ③: the resource-bound cap on self.history's resident
         # footprint (bytes). None → HistoryResidentConfig's own default (256 MiB).
         history_resident_config: "HistoryResidentConfig | None" = None,
+        # #5366 §3: reyn.yaml storage.* (max_bytes / pin) — the PROJECT-wide
+        # (cross-session) history-content cap, threaded to this Session's
+        # own MediaStore. None → StorageConfig's own default (max_bytes
+        # unset = cross-session GC never fires).
+        storage_config: "StorageConfig | None" = None,
         state_log: StateLog | None = None,
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
@@ -1044,6 +1050,10 @@ class Session:
         # #4387 Phase B ③: bounds self.history's resident footprint —
         # consulted by _append_history's eviction hook (below).
         self._history_resident_config = history_resident_config or HistoryResidentConfig()
+        # #5366 §3: stored so MediaStore construction below can thread it —
+        # no other reader today (mirrors read_cap_config/auth_config's own
+        # plain-value-not-supplier shape).
+        self._storage_config = storage_config or StorageConfig()
         # #4468 security block (lead-coder review): the highest seq of any
         # EVICTED entry that carried the untrusted-content marker
         # (security.permissions.capability_profile.UNTRUSTED_META_KEY) —
@@ -1073,6 +1083,8 @@ class Session:
                 # local `session_id` param (not `self._session_id`, which
                 # this constructor hasn't assigned yet at this point).
                 session_id=session_id,
+                # #5366 §3: the project-wide (cross-session) storage cap/pin.
+                storage=self._storage_config,
             )
         else:
             self._media_store = None

--- a/tests/data/test_5366_cross_session_eviction_driver.py
+++ b/tests/data/test_5366_cross_session_eviction_driver.py
@@ -1,0 +1,205 @@
+"""Tier 2: #5366 §3 — the project-wide GC's own DRIVER
+(``MediaStore._evict_cross_session_over_cap`` / ``cross_session_eviction_
+preview``), driven through a real ``save_tool_result`` write, not called
+directly.
+
+Real on-disk writes via real ``MediaStore`` instances (multiple agents),
+same idiom as ``test_5366_cross_session_eviction_candidates.py`` (this
+file's own sibling, which pins the candidate-LISTING half; this one pins
+the eviction/refuse/preview half that consumes it).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from reyn.config.infra import StorageConfig
+from reyn.data.workspace.media_store import (
+    MediaStore,
+    MediaStoreConfig,
+    MediaStoreWriteUnavailable,
+    history_content_root_for,
+)
+
+
+def _bump_mtime_forward(directory) -> None:
+    """Same determinism helper the candidate-listing sibling test uses —
+    forces every existing file further into the past so write-order
+    ties never race real filesystem mtime-tick granularity."""
+    for path in directory.rglob("*"):
+        if path.is_file():
+            st = path.stat()
+            os.utime(path, (st.st_atime, st.st_mtime - 1))
+
+
+def _dir_total_bytes(directory) -> int:
+    return sum(p.stat().st_size for p in directory.rglob("*") if p.is_file())
+
+
+def test_max_bytes_none_never_evicts(tmp_path):
+    """Tier 2: non-vacuity control — StorageConfig's own default
+    (max_bytes=None) means cross-session GC never even LOOKS, regardless
+    of how much is on disk. Without this control, a bug that always
+    skips eviction would pass every other test in this file for the
+    wrong reason (nothing to evict) rather than the right one (told not
+    to)."""
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=StorageConfig(max_bytes=None),
+    )
+    alice.save_tool_result("x" * 500, mime_type="text/plain", seq=1)
+    _bump_mtime_forward(history_content_root_for(tmp_path))
+
+    bob = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=StorageConfig(max_bytes=None),
+    )
+    # Would exceed any small cap, but max_bytes is None -> no check at all.
+    bob.save_tool_result("y" * 500, mime_type="text/plain", seq=1)
+
+    root = history_content_root_for(tmp_path)
+    remaining = [p for p in root.rglob("*") if p.is_file()]
+    # unpack-enforcement idiom: raises ValueError if not exactly 2 —
+    # never a bare len() == N check.
+    _alice_file, _bob_file = remaining
+
+
+def test_a_later_write_evicts_an_older_other_agents_file_once_over_cap(tmp_path):
+    """Tier 2: #5366 §3's own witness. This is a PRE-write check (same
+    shape as the ``durability_failed`` gate right above its own call
+    site) — it evicts to make room for whatever is ALREADY on disk
+    before this write lands, it does not project this write's own
+    upcoming size. So the write that FIRST pushes the project over cap
+    is allowed through (the project was under cap at the moment its own
+    pre-check ran); the NEXT write's pre-check is what observes the
+    now-over-cap state and evicts agent A's OLDER file first
+    (cross_session_eviction_candidates' own oldest-first order), even
+    though the evicting write never touched A's directory."""
+    storage = StorageConfig(max_bytes=600)
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=storage,
+    )
+    alice_block = alice.save_tool_result("a" * 500, mime_type="text/plain", seq=1)
+    _bump_mtime_forward(history_content_root_for(tmp_path))
+
+    bob = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=storage,
+    )
+    # Pre-check sees 500 <= 600 (alice's file alone) -> allowed through.
+    # After this write lands the project is ~1000 bytes, over cap, but
+    # nothing re-checks until the NEXT write's own pre-check.
+    bob.save_tool_result("b" * 500, mime_type="text/plain", seq=1)
+    assert (tmp_path / alice_block["path"]).resolve().exists(), (
+        "setup: alice's file must still be there right after bob's "
+        "FIRST write — that write's own pre-check ran before it landed"
+    )
+    _bump_mtime_forward(history_content_root_for(tmp_path))
+
+    # This second write's pre-check now sees the project over cap and
+    # evicts the oldest non-pinned candidate (alice's file) first.
+    bob.save_tool_result("c" * 10, mime_type="text/plain", seq=2)
+
+    root = history_content_root_for(tmp_path)
+    alice_path = (tmp_path / alice_block["path"]).resolve()
+    assert not alice_path.exists(), (
+        "alice's older file must have been evicted by the next write's "
+        "own pre-check once the project was observably over cap"
+    )
+    assert _dir_total_bytes(root) <= storage.max_bytes
+
+
+def test_pinned_agent_survives_cross_session_eviction(tmp_path):
+    """Tier 2: acceptance — a pinned agent's file is never evicted by the
+    driver, even when it is the oldest and the project is over cap."""
+    storage = StorageConfig(max_bytes=600, pin=["alice"])
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=storage,
+    )
+    alice_block = alice.save_tool_result("a" * 500, mime_type="text/plain", seq=1)
+    _bump_mtime_forward(history_content_root_for(tmp_path))
+
+    bob = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=storage,
+    )
+    bob.save_tool_result("b" * 500, mime_type="text/plain", seq=1)
+
+    alice_path = (tmp_path / alice_block["path"]).resolve()
+    assert alice_path.exists(), (
+        "a pinned agent's file must survive cross-session eviction even "
+        "while the project stays over cap"
+    )
+
+
+def test_raises_write_unavailable_when_candidates_exhausted_still_over_cap(tmp_path):
+    """Tier 2: #5366 §3's own core acceptance — "候補が尽きてなお超過なら
+    MediaStoreWriteUnavailable". Every existing file is pinned (no real
+    candidate to evict), so the NEW write's own pre-check must refuse
+    rather than mint a ref that pushes the project further over."""
+    storage = StorageConfig(max_bytes=100, pin=["alice"])
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=storage,
+    )
+    alice.save_tool_result("a" * 500, mime_type="text/plain", seq=1)
+    _bump_mtime_forward(history_content_root_for(tmp_path))
+
+    bob = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=storage,
+    )
+    with pytest.raises(MediaStoreWriteUnavailable):
+        bob.save_tool_result("b" * 500, mime_type="text/plain", seq=1)
+
+
+def test_preview_lists_what_would_go_without_deleting_it(tmp_path):
+    """Tier 2: #5366 §3 item ④ — cross_session_eviction_preview() reports
+    the same file eviction WOULD remove, but the file is still on disk
+    afterward (a pure read, no side effect)."""
+    storage = StorageConfig(max_bytes=600)
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=storage,
+    )
+    alice_block = alice.save_tool_result("a" * 500, mime_type="text/plain", seq=1)
+    _bump_mtime_forward(history_content_root_for(tmp_path))
+
+    bob = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=storage,
+    )
+    # bob's own write would itself trigger real eviction via save_tool_result
+    # (already covered above); here bob asks for a PREVIEW of ITS OWN
+    # store's view of the project without writing anything new at all —
+    # the project is not yet over cap from bob's perspective (only
+    # alice's 500 bytes exist so far, under the 600 cap), so nothing is
+    # previewed. Bump alice's directory over cap by itself first.
+    alice.save_tool_result("a" * 500, mime_type="text/plain", seq=2)
+
+    preview = bob.cross_session_eviction_preview()
+
+    alice_path = (tmp_path / alice_block["path"]).resolve()
+    assert alice_path in preview, (
+        f"the oldest file must appear in the preview once the project is "
+        f"over cap; got {preview!r}"
+    )
+    assert alice_path.exists(), (
+        "a preview must never actually delete anything"
+    )
+
+
+def test_preview_is_empty_when_under_cap(tmp_path):
+    """Tier 2: (accept-side) control — nothing is previewed when the
+    project is already under max_bytes, not a stale/leftover list."""
+    storage = StorageConfig(max_bytes=10_000)
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=storage,
+    )
+    alice.save_tool_result("small", mime_type="text/plain", seq=1)
+
+    assert alice.cross_session_eviction_preview() == []


### PR DESCRIPTION
**[e2e-coder]** — part of #5366 (3/N).

## What

architect's #5366 design table, items 3+4 (1/N config landed as #5415, 2/N candidate filter landed as #5417):

3. overflow drive — candidates exhausted, still over cap → raise `MediaStoreWriteUnavailable`
4. pre-disappearance preview — run the same candidate function without deleting

## The driver (`MediaStore._evict_cross_session_over_cap`)

A PRE-write check, same shape as the existing `durability_failed` gate right above its own call site in `save_tool_result` — not a post-write backstop like the sibling per-session `_evict_history_content_over_cap`. Checked against what is ALREADY on disk before this write lands, never projecting this write's own upcoming size: a write that itself first pushes the project over cap is still let through (the project was under cap the instant this check ran); the NEXT write's own pre-check observes and cleans up the resulting overage. No-op when `StorageConfig.max_bytes` is unset (the field's own default — cross-session GC never fires).

If evicting every available (non-pinned) candidate still leaves the project over cap, raises `MediaStoreWriteUnavailable` — the EXISTING exception and its one real catch site (`tool_result_cap.py` → `cap_tool_result_content`) already keep the content inline instead of failing the turn; no new handling needed there.

## Threading (`SessionFactoryConfig` → `Session` → `MediaStore`)

`storage_config` added to the ONE mapping point (`factory_config.py`'s `SessionFactoryConfig` + `from_config`), reaching all five factory sites uniformly (the class's own stated purpose — a per-site hand-thread gap silently missed `sandbox_config` once before, per its own module docstring). `Session` gets a new `storage_config` param (mirrors `history_resident_config`'s own plain-value shape), stored and threaded into `MediaStore(storage=...)`.

## Preview (`MediaStore.cross_session_eviction_preview`)

The SAME candidate function and the SAME stop-when-under-cap loop the driver runs, but never calls `path.unlink()` — an operator-facing "what would go" list computed without side effects, in the exact order eviction would actually delete them.

## ⚠️ Disclosed, not decided — the "lost_reason" vocabulary

Architect's spec line also said "理由は `lost` の reason に 1 つ追加" (add one to the lost-reason vocabulary). **Not done in this PR**: the existing `LOST_REASON_GC` constant (`chat_message.py`) is itself already disclosed elsewhere in the codebase as "not yet wired" for the ANALOGOUS per-session case (`router_loop.py`'s own comment, §1.6) — wiring a genuinely distinct reason through to the persisted meta field requires widening `tool_result_cap.py`'s `on_write_unavailable` callback signature (currently `Callable[[], None]`, no argument channel), which is a real API-surface change beyond this PR's own "small" sizing. Flagging for lead-coder/architect rather than guessing the wiring or silently skipping the disclosure — this may be its own follow-up piece.

## Verification

- `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.
- New test file (`tests/data/test_5366_cross_session_eviction_driver.py`): 6 passed. Strip-falsified: removing the driver's own call site in `save_tool_result` turns 2 tests genuinely red (confirmed), restored to green.
- `tests/data/` full sweep: 220 passed.
- Factory-wiring scope (`test_2093_factory_config_bundle.py` / `test_scoped_session_factory_invariant_1402.py` / `test_web_fetch_config_session_wiring_4274.py`): 10 passed — no signature-change breakage at the other 4 factory sites.

## Test plan

- [x] (skipped — no user-facing surface beyond opt-in config; verified via the automated suite + strip-falsify above)
