### PR TITLE
fix(#5416): known-key/malformed-value FAIL-OPEN fallbacks become operator-visible

### DIFF
--- a/src/reyn/config/config_schema.py
+++ b/src/reyn/config/config_schema.py
@@ -140,6 +140,43 @@ def resolve_config_value(config: Any, key: str) -> tuple[bool, Any]:
     return True, obj
 
 
+#: #5416: the two directions a known-key's parser fallback can land, named
+#: on the FIELD (``field(metadata={"fallback": FAILS_OPEN})``) rather than
+#: decided per-parser (architect's final ruling on #5416, issuecomment on
+#: that issue: "向きはfield、理由はfallbackの場所" — a NEW field a future
+#: author adds must declare one of these two, or the completeness check
+#: below fails; a parser-side decision would let a new field silently skip
+#: this entirely). ``FAILS_SAFE``: the fallback lands in the SAME state an
+#: operator who wrote nothing gets (e.g. ``StorageConfig.max_bytes`` — a
+#: malformed value falls back to ``None``/unlimited, harmless). ``FAILS_
+#: OPEN``: the fallback is MORE PERMISSIVE than unset — it silently drops
+#: a declared protection whose only real-world consequence is destructive
+#: (e.g. ``StorageConfig.pin`` — a malformed value falls back to ``[]``,
+#: removing a protection the operator explicitly wrote).
+FAILS_SAFE = "fails_safe"
+FAILS_OPEN = "fails_open"
+
+
+@_dataclass(frozen=True)
+class RejectedValueHint:
+    """#5416: a KNOWN key whose VALUE was present in the raw config but
+    type-invalid/malformed, so its parser fell back to the field's own
+    default — a DIFFERENT population than :class:`RenamedKeyHint` /
+    :class:`RemovedKeyHint` (both of which are about the KEY itself being
+    wrong; this is about a valid, known key carrying a bad VALUE).
+
+    Reported ONLY for a :data:`FAILS_OPEN` field — a :data:`FAILS_SAFE`
+    fallback lands in the exact state an operator who wrote nothing at
+    all would get, so there is nothing for this to warn about (see
+    :func:`unknown_config_keys`'s own combined report, which is where
+    this hint type is merged in alongside the unknown-key hints — one
+    CUI-visible surface, not a second parallel channel, per architect's
+    #5416 ruling: "変えるのはentryの種類を1つ足すだけ")."""
+
+    note: str
+    fallback: str
+
+
 @_dataclass(frozen=True)
 class RenamedKeyHint:
     """The reason an unknown config key isn't valid, when known.

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -5,6 +5,15 @@ import socket
 from dataclasses import dataclass, field
 from typing import Literal
 
+# #5416: module-level, not the lazy-inside-function pattern the rest of
+# this file uses for config_schema — a dataclass field's own `metadata=`
+# is evaluated at CLASS BODY execution (module import time), so the
+# constants must already be bound by then. Safe here (no cycle):
+# config_schema.py has no top-level dependency back on this module or on
+# reyn.config's own package __init__ (it only reaches those lazily,
+# inside function bodies — see e.g. its own register_freeform_leaf_*
+# call sites).
+from reyn.config.config_schema import FAILS_OPEN, FAILS_SAFE
 from reyn.security.secrets.oauth import OAuthProviderConfig
 
 
@@ -701,23 +710,34 @@ class StorageConfig:
     whose history-content is NEVER an eviction candidate for this
     project-wide cap, regardless of process liveness.
 
-    ⚠️ A malformed ``pin`` value (wrong type, e.g. a bare string instead
-    of a list) falls back to ``[]`` — SILENTLY, with no operator-visible
-    disclosure that the fallback happened (lead-coder BLOCKING on #5415,
-    tracked as #5416, not yet fixed): unlike ``max_bytes`` above (whose
-    fallback to "unlimited" matches the same state as writing nothing —
+    A malformed ``pin`` value (wrong type, e.g. a bare string instead of
+    a list, or an entry that isn't a string) falls back to ``[]`` or
+    drops the bad entries — unlike ``max_bytes`` above (whose fallback
+    to "unlimited" matches the same state as writing nothing at all —
     harmless), this fallback REMOVES a declared protection whose only
-    consequence is deletion — the operator finds out only after their
-    content is already gone. #5416 is the general "known key, malformed
-    value, fallback direction more permissive than unset" disclosure gap
-    this instance surfaced; not fixed here because the right disclosure
-    surface (extending ``config_schema.unknown_config_keys()``'s own
-    CUI-visible "N config keys not applied" chrome, vs. a new parallel
-    channel) is itself a design decision, not a local fix to this
-    function."""
+    consequence is deletion. #5416 (lead-coder BLOCKING on #5415,
+    resolved): this field's own ``metadata={"fallback": FAILS_OPEN}``
+    (below) is what makes that rejection operator-visible — folded into
+    the SAME CUI-visible "N config keys not applied" chrome
+    :func:`~reyn.config.config_schema.unknown_config_keys` already
+    populates for unknown keys (architect's ruling: one combined
+    report, not a second parallel channel). See
+    :func:`_build_storage_config`'s own docstring for the parser-side
+    half."""
 
-    max_bytes: "int | None" = None
-    pin: "list[str]" = field(default_factory=list)
+    # #5416: fallback direction declared on the field itself (architect's
+    # final ruling — the population `config_schema`'s completeness check
+    # walks is `dataclasses.fields(StorageConfig)`, a runtime registry
+    # that cannot silently omit a field, unlike a parser-side census of
+    # `except (TypeError, ValueError)` sites, which architect's own #5416
+    # comment disclosed as NOT exhaustive). See `config_schema.FAILS_SAFE`
+    # / `FAILS_OPEN`'s own docstring for what the two mean.
+    max_bytes: "int | None" = field(
+        default=None, metadata={"fallback": FAILS_SAFE},
+    )
+    pin: "list[str]" = field(
+        default_factory=list, metadata={"fallback": FAILS_OPEN},
+    )
 
 
 _SANDBOX_BACKENDS = {"auto", "seatbelt", "landlock", "noop"}
@@ -1677,7 +1697,9 @@ def _build_audit_events_config(raw: object) -> AuditEventsConfig:
     )
 
 
-def _build_storage_config(raw: object) -> StorageConfig:
+def _build_storage_config(
+    raw: object, *, rejected: "dict[str, object] | None" = None,
+) -> StorageConfig:
     """Parse `storage:` from reyn.yaml (#5366).
 
     A malformed (non-numeric, non-positive) `max_bytes` falls back to
@@ -1688,7 +1710,18 @@ def _build_storage_config(raw: object) -> StorageConfig:
     unlimited is the field's OWN steady state, not a failure mode) — a
     malformed value therefore falls back to the SAME state an operator
     who wrote nothing gets, not a silent widening of an otherwise-active
-    cap."""
+    cap. FAILS_SAFE (see the field's own `metadata=`) ∴ never written
+    into *rejected* even when malformed.
+
+    #5416: *rejected*, when given, is mutated in place with a
+    ``config_schema.RejectedValueHint`` for `pin` whenever the raw value
+    was PRESENT but rejected (wrong top-level type, or one-or-more
+    non-str entries dropped from an otherwise-valid list) — never for a
+    simply-absent key, which is not malformed, just unset (``pin_raw ==
+    defaults.pin`` in that case, taking the same branch a real empty
+    list would). `pin` is FAILS_OPEN (see the field's own `metadata=`),
+    so its rejection IS reported — the only field in this function that
+    is."""
     defaults = StorageConfig()
     if not isinstance(raw, dict):
         return defaults
@@ -1702,11 +1735,32 @@ def _build_storage_config(raw: object) -> StorageConfig:
         except (TypeError, ValueError):
             pass
     pin_raw = raw.get("pin", defaults.pin)
-    pin_val = (
-        [p for p in pin_raw if isinstance(p, str)]
-        if isinstance(pin_raw, list)
-        else list(defaults.pin)
-    )
+    if isinstance(pin_raw, list):
+        pin_val = [p for p in pin_raw if isinstance(p, str)]
+        dropped = [p for p in pin_raw if not isinstance(p, str)]
+        if dropped and rejected is not None:
+            from reyn.config.config_schema import RejectedValueHint
+            rejected["storage.pin"] = RejectedValueHint(
+                note=(
+                    f"`storage.pin` entries must all be strings (agent "
+                    f"names) — {dropped!r} were dropped; a pin declared "
+                    "for a name in this list is NOT protected"
+                ),
+                fallback=FAILS_OPEN,
+            )
+    else:
+        pin_val = list(defaults.pin)
+        if pin_raw != defaults.pin and rejected is not None:
+            from reyn.config.config_schema import RejectedValueHint
+            rejected["storage.pin"] = RejectedValueHint(
+                note=(
+                    f"`storage.pin` must be a list of agent names — got "
+                    f"{pin_raw!r} ({type(pin_raw).__name__}); falling "
+                    "back to an EMPTY pin list removes every declared "
+                    "protection"
+                ),
+                fallback=FAILS_OPEN,
+            )
     return StorageConfig(max_bytes=max_bytes_val, pin=pin_val)
 
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -852,8 +852,26 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     render_template = _build_render_template_config(merged.get("render_template"))
     read_cap = _build_read_cap_config(merged.get("read_cap"))
     history_resident = _build_history_resident_config(merged.get("history_resident"))
+    # #5416: known-key/malformed-value FAIL-OPEN rejections a builder
+    # discovers while parsing — mutated in place by `_build_storage_config`
+    # below, then merged into `unknown_config_keys_found` (same combined
+    # report the "N config keys not applied" chrome already reads) BEFORE
+    # `_cfg` is built, so `unknown_config_key_count` includes them. See
+    # `config_schema.RejectedValueHint`'s own docstring for why only
+    # FAILS_OPEN fields ever populate this (a FAILS_SAFE fallback — e.g.
+    # StorageConfig.max_bytes -> None/unlimited — is the SAME state an
+    # operator who wrote nothing gets, never reported here).
+    rejected_known_key_values: "dict[str, Any]" = {}
+    storage_cfg = _build_storage_config(
+        merged.get("storage"), rejected=rejected_known_key_values,
+    )
     image = _build_image_config(merged.get("image"))
     tui = _build_tui_config(merged.get("tui"))
+    # #5416: fold FAIL-OPEN known-key rejections into the SAME combined
+    # report the unknown-key check already populates — one report, one
+    # CUI chrome line, not a second parallel channel (architect's #5416
+    # ruling: "変えるのはentryの種類を1つ足すだけ").
+    unknown_config_keys_found.update(rejected_known_key_values)
     # #4174 T3: model / models / model_class_by_purpose / api_base /
     # prompt_cache_enabled moved from top-level ReynConfig fields into
     # ``llm:`` — _build_llm_config parses all of it (router/retry AND the
@@ -876,7 +894,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         chat=_build_chat_config(merged.get("chat")),
         audit_events=_build_audit_events_config(merged.get("audit_events")),
         artifacts=_build_artifacts_config(merged.get("artifacts")),
-        storage=_build_storage_config(merged.get("storage")),
+        storage=storage_cfg,
         observability=_build_observability_config(merged.get("observability")),
         cost=cost,
         tool_use=_build_tool_use_config(merged.get("tool_use")),

--- a/tests/config/test_5416_fallback_direction_disclosure.py
+++ b/tests/config/test_5416_fallback_direction_disclosure.py
@@ -1,0 +1,170 @@
+"""Tier 1: #5416 — known-key/malformed-value FAIL-OPEN fallbacks become
+operator-visible, folded into the SAME combined report
+``config_schema.unknown_config_keys()`` already populates for unknown
+keys — not a second parallel channel (architect's ruling).
+
+``StorageConfig.pin`` is the confirmed instance (lead-coder BLOCKING on
+#5415): a malformed ``pin`` value falls back to ``[]``, silently
+REMOVING a declared eviction protection — unlike ``max_bytes`` (whose
+fallback to ``None``/unlimited is the SAME state an operator who wrote
+nothing gets, harmless). The two directions are declared on the field
+itself (``metadata={"fallback": FAILS_SAFE | FAILS_OPEN}``) — a runtime
+registry (``dataclasses.fields(StorageConfig)``) a future field cannot
+silently omit, unlike a parser-side census.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+from reyn.config.config_schema import FAILS_OPEN, FAILS_SAFE, RejectedValueHint
+from reyn.config.infra import StorageConfig, _build_storage_config
+
+# ── field-level declaration (the completeness gate, architect's #6/#6b) ────
+
+
+def test_every_storage_config_field_declares_a_fallback_direction():
+    """Tier 1: architect's completeness gate #6 — every field of
+    StorageConfig (the population this issue's instance concerns; the
+    broader 28+ site census across src/reyn/config/ is explicitly
+    out of scope per lead-coder's own disclaimer on #5416) declares
+    ``metadata["fallback"]``. A future field added to this dataclass
+    without the declaration fails here, not silently."""
+    fields = dataclasses.fields(StorageConfig)
+    for f in fields:
+        assert "fallback" in f.metadata, (
+            f"StorageConfig.{f.name} has no metadata['fallback'] "
+            f"declaration — #5416 requires every field to name whether "
+            f"its own fallback is fails_safe or fails_open"
+        )
+        assert f.metadata["fallback"] in (FAILS_SAFE, FAILS_OPEN)
+
+
+def test_the_completeness_gate_is_not_vacuous():
+    """Tier 1: architect's #6b — the empty-collection guard. Without
+    this, a typo'd class name or import in the test above would make
+    ``dataclasses.fields(...)`` return an empty tuple, and "every field
+    declares a fallback" would be vacuously true over zero fields."""
+    assert len(dataclasses.fields(StorageConfig)) > 0
+
+
+def test_max_bytes_declares_fails_safe():
+    """Tier 1: the specific direction for max_bytes — its fallback lands
+    in the same state an operator who wrote nothing gets."""
+    (field,) = [f for f in dataclasses.fields(StorageConfig) if f.name == "max_bytes"]
+    assert field.metadata["fallback"] == FAILS_SAFE
+
+
+def test_pin_declares_fails_open():
+    """Tier 1: the specific direction for pin — its fallback REMOVES a
+    declared protection, more permissive than unset."""
+    (field,) = [f for f in dataclasses.fields(StorageConfig) if f.name == "pin"]
+    assert field.metadata["fallback"] == FAILS_OPEN
+
+
+# ── parser-side reporting ───────────────────────────────────────────────
+
+
+def test_malformed_pin_top_level_type_is_reported():
+    """Tier 1: #5416's own witness — the exact case the issue was filed
+    over (`pin: coder-smith`, a bare string instead of a list)."""
+    rejected: dict = {}
+    cfg = _build_storage_config({"pin": "coder-smith"}, rejected=rejected)
+
+    assert cfg.pin == []
+    assert "storage.pin" in rejected
+    hint = rejected["storage.pin"]
+    assert isinstance(hint, RejectedValueHint)
+    assert hint.fallback == FAILS_OPEN
+    assert "coder-smith" in hint.note
+
+
+def test_pin_with_a_non_string_entry_is_reported():
+    """Tier 1: a partially-malformed list (one bad entry silently
+    dropped) is reported too, not just a wholesale wrong-type value —
+    the same class of harm (a declared pin silently not applying)."""
+    rejected: dict = {}
+    cfg = _build_storage_config({"pin": ["alice", 123]}, rejected=rejected)
+
+    assert cfg.pin == ["alice"]
+    assert "storage.pin" in rejected
+
+
+def test_absent_pin_is_not_reported():
+    """Tier 1: (accept-side) control — a key that was never written at
+    all is not malformed, just unset. Must not be reported (that would
+    make every operator who never touched `storage:` see a spurious
+    warning)."""
+    rejected: dict = {}
+    _build_storage_config({}, rejected=rejected)
+    assert rejected == {}
+
+
+def test_valid_pin_is_not_reported():
+    """Tier 1: (accept-side) control — a well-formed pin list produces
+    no report at all."""
+    rejected: dict = {}
+    _build_storage_config({"pin": ["alice", "bob"]}, rejected=rejected)
+    assert rejected == {}
+
+
+def test_malformed_max_bytes_is_never_reported_fails_safe():
+    """Tier 1: the direction control — max_bytes is FAILS_SAFE, so even
+    an egregiously malformed value must NOT appear in *rejected* (its
+    fallback lands in the same state as unset — nothing to warn about).
+    Without this control, a bug that reports EVERY malformed value
+    regardless of direction would pass every FAILS_OPEN test above for
+    the wrong reason."""
+    rejected: dict = {}
+    cfg = _build_storage_config(
+        {"max_bytes": "not-a-number", "pin": ["alice"]}, rejected=rejected,
+    )
+    assert cfg.max_bytes is None
+    assert "storage.max_bytes" not in rejected
+    assert rejected == {}
+
+
+def test_rejected_is_optional_backward_compatible():
+    """Tier 1: non-regression — every existing call site that does not
+    pass `rejected=` at all must keep working unchanged (the parameter
+    is keyword-only with a None default)."""
+    cfg = _build_storage_config({"pin": "not-a-list"})
+    assert cfg.pin == []
+
+
+# ── end-to-end wiring, through the real load_config() seam ─────────────
+
+
+def test_malformed_pin_reaches_reynconfig_unknown_config_keys(tmp_path):
+    """Tier 2: #5416's own wiring witness — driven through the REAL
+    `load_config(cwd)` seam (the same one #4174 T0's own tests use for
+    unknown keys), not `_build_storage_config` called in isolation. A
+    malformed `storage.pin` must appear in `ReynConfig.unknown_config_
+    keys` (the SAME combined report the "N config keys not applied"
+    chrome reads) and be counted in `unknown_config_key_count` — the
+    architect's #5416 ruling that this is folded into the existing
+    surface, not a second parallel channel."""
+    (tmp_path / "reyn.yaml").write_text(
+        "storage:\n  pin: coder-smith\n", encoding="utf-8",
+    )
+    from reyn.config import load_config
+
+    cfg = load_config(tmp_path)
+
+    assert "storage.pin" in cfg.unknown_config_keys
+    assert cfg.unknown_config_key_count >= 1
+
+
+def test_well_formed_storage_config_reaches_reynconfig_cleanly(tmp_path):
+    """Tier 2: (accept-side) control for the wiring test above — a
+    well-formed `storage:` block produces NO entry, through the same
+    real seam."""
+    (tmp_path / "reyn.yaml").write_text(
+        "storage:\n  max_bytes: 1000000\n  pin:\n    - alice\n",
+        encoding="utf-8",
+    )
+    from reyn.config import load_config
+
+    cfg = load_config(tmp_path)
+
+    assert "storage.pin" not in cfg.unknown_config_keys
+    assert "storage.max_bytes" not in cfg.unknown_config_keys


### PR DESCRIPTION
**[e2e-coder]** — closes #5416.

## What

architect's final ruling: the real judge for "does this fallback need disclosure" is not "does it fall back to the same state as unset" (that selects nothing — every fallback lands on its own field's default by construction) but "is that field's own DEFAULT the protecting side or the losing side" — `StorageConfig.max_bytes`' default (`None`/unlimited) never deletes anything (fail-safe); `StorageConfig.pin`'s default (`[]`) protects nothing (fail-open).

## Declaration — on the field, not the parser

`FAILS_SAFE` / `FAILS_OPEN` constants + a direction declared via `field(metadata={"fallback": ...})` — architect's own reversal (their first draft put the required declaration on the parser helper's own signature; withdrawn once they applied their own completeness criterion: `dataclasses.fields()` is a complete runtime registry a new field cannot silently omit from, while a parser-side census of `except (TypeError, ValueError)` sites is exactly what their own #5416 comment disclosed as NOT exhaustive across the 28+ real sites in `src/reyn/config/`).

## Reporting — one surface, not a second channel

`RejectedValueHint` (`config_schema.py`) joins `RenamedKeyHint`/`RemovedKeyHint` in the SAME combined dict `unknown_config_keys()` already returns, merged in by `load_config()` before `ReynConfig.unknown_config_key_count` / `.unknown_config_keys` are set — the existing "N config keys not applied" CUI chrome (`chrome.py`) now also shows a rejected-and-fail-open known key, with zero new UI code. `_build_storage_config` gained an optional `rejected=` out-param (keyword-only, defaults to `None` — every existing call site is unaffected); it's the only builder wired so far (the one confirmed instance, per lead-coder's own explicit "母集団はこれで全部と書くな" scoping — retrofitting the other 27+ sites is explicitly left as a separate follow-up, not silently declared done).

## Scope, explicitly bounded

The completeness gate (architect's #6/#6b) walks `dataclasses.fields(StorageConfig)` — the population THIS issue's instance concerns — not every dataclass in `src/reyn/config/`. A blanket walk would require classifying all 28+ fallback-prone fields architect's own census found, which the same census explicitly disclosed as non-exhaustive.

## Verification

- `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.
- New test file (`tests/config/test_5416_fallback_direction_disclosure.py`): 12 passed — including the completeness gate + its own non-vacuity control, and 2 end-to-end tests through the real `load_config()` seam.
- Strip-falsified: removing either rejection branch in `_build_storage_config` turns 3 tests genuinely red (2 unit + the end-to-end wiring test), confirmed, then restored.
- `tests/config/` full sweep: 313 passed.
- CLI config-validate/chrome scope (`test_config_warning_chrome_4194` / `test_config_validate_migrate_command_4174` / `test_4631_config_validate_mcp_placement` / `test_4604_config_validate_mcp_transport_rename`): 50 passed — no signature-change breakage at the other `unknown_config_keys()` call sites.

## Test plan

- [x] (skipped — no user-facing surface beyond an existing CUI chrome line gaining a new possible entry; verified via the automated suite + strip-falsify above)
