### PR TITLE
fix(#5427): clamp SqliteIndexBackend cosine scores to their documented range

### DIFF
--- a/src/reyn/data/index/backends/sqlite.py
+++ b/src/reyn/data/index/backends/sqlite.py
@@ -394,6 +394,21 @@ class SqliteIndexBackend:
             row_norms = np.where(row_norms == 0.0, 1e-10, row_norms)
             scores = (vectors @ q_vec) / (row_norms * q_norm)
 
+        # #5427: cosine similarity's own MATHEMATICAL range is [-1.0, 1.0]
+        # — the contract ActionEmbeddingIndex.query's own docstring
+        # states (action_index.py) for this method's `score` — but
+        # `scores` is a float32 division — a near-parallel pair
+        # (self-match or a very close neighbor) can round to a value 1
+        # ulp past 1.0 (1.0000001192092896, float32's own eps ≈ 1.19e-7
+        # above 1.0), violating that documented range. Clamped HERE
+        # (implementation side, not left for every caller to tolerate)
+        # so the returned `score` genuinely stays inside the range the
+        # public contract promises — a caller (or a test) reading `-1.0
+        # <= score <= 1.0` is checking a contract this line now keeps
+        # true, not the underlying float32 arithmetic's own looser
+        # behavior.
+        scores = np.clip(scores, -1.0, 1.0)
+
         # Descending sort, take top_k. Sort ``-scores`` ascending with
         # ``kind="stable"`` (FP-0057 Phase 0 non-regression gate) rather
         # than ``np.argsort(scores)[::-1]``: reversing an ascending-stable

--- a/tests/data/test_5427_cosine_score_float32_clamp.py
+++ b/tests/data/test_5427_cosine_score_float32_clamp.py
@@ -1,0 +1,92 @@
+"""Tier 2: #5427 — SqliteIndexBackend.query's own float32 cosine
+computation can round a near-parallel pair's score 1 ulp past the
+mathematical [-1.0, 1.0] range; the real production consumer's own
+contract (ActionEmbeddingIndex.query's docstring) promises that range,
+so this clamps in the implementation rather than leaving every caller
+(and every test asserting the documented range) to tolerate float32's
+looser one.
+
+Real overshoot, not a synthetic value: a real, deterministic float32
+vector pair (seeded ``numpy.random.randn(8)``, self-matched) reproduces
+the EXACT score CI observed (``1.0000001192092896``) — verified by hand
+this session before writing this test.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from reyn.data.index.backend import ChunkRecord
+from reyn.data.index.backends.sqlite import SqliteIndexBackend
+
+
+def _overshooting_vector() -> "list[float]":
+    """A real float32 vector whose self-cosine (dot(v, v) / (|v| * |v|))
+    rounds to 1.0000001192092896 — the exact value CI observed
+    (#5427's own issue, #5424's CI run). Deterministic (fixed seed),
+    hand-verified this session: `np.random.seed(0)` then
+    `np.random.randn(8)` 10 times, the 10th draw (index 9) is this
+    overshooting pair."""
+    rng = np.random.default_rng()
+    rng = np.random.RandomState(0)  # noqa: NPY002 — matches the exact repro seed
+    v = None
+    for _ in range(10):
+        v = rng.randn(8).astype(np.float32)
+    assert v is not None
+    return [float(x) for x in v]
+
+
+def test_the_repro_vector_genuinely_overshoots_in_raw_numpy():
+    """Tier 1: non-vacuity — confirms the fixture vector actually
+    produces a score > 1.0 in RAW float32 numpy arithmetic (the same
+    computation the backend performs), before checking the backend
+    clamps it. Without this, a fixture that never actually overshoots
+    would make the backend test below pass for the wrong reason."""
+    v = np.asarray(_overshooting_vector(), dtype=np.float32)
+    raw_score = float((v @ v) / (float(np.linalg.norm(v)) ** 2))
+    assert raw_score > 1.0, (
+        f"fixture vector must genuinely overshoot in raw float32 "
+        f"arithmetic to be a real positive control; got {raw_score!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_self_match_score_is_clamped_to_one(tmp_path: Path) -> None:
+    """Tier 2: #5427's own witness — a real self-match through the
+    REAL backend (write then query with the identical vector) must
+    return a score that is never > 1.0, even though the raw float32
+    arithmetic (confirmed by the sibling test above) would produce
+    1.0000001192092896 for this exact vector.
+
+    Strip-falsifier: removing the ``np.clip(scores, -1.0, 1.0)`` line
+    in sqlite.py's query() turns this red — the real score returned is
+    1.0000001192092896, greater than 1.0. Verified by hand this
+    session."""
+    vector = _overshooting_vector()
+    backend = SqliteIndexBackend(workspace_root=tmp_path)
+    chunk = ChunkRecord(
+        text="self-match probe",
+        vector=vector,
+        metadata={
+            "source_path": "file.txt",
+            "source_type": "generic",
+            "content_hash": "h-5427",
+            "embedding_model": "test-model",
+            "chunk_index": 0,
+            "size_tokens": 1,
+            "parent_context": None,
+        },
+        score=None,
+    )
+    await backend.write("src-5427", [chunk], mode="append")
+
+    hits = await backend.query("src-5427", vector, top_k=1, filters={})
+    (top,) = hits
+    assert top["score"] is not None
+    assert top["score"] <= 1.0, (
+        f"#5427 REGRESSION: a self-match's cosine score exceeded the "
+        f"documented [-1.0, 1.0] range — got {top['score']!r}"
+    )
+    assert top["score"] >= -1.0


### PR DESCRIPTION
**[e2e-coder]** — closes #5427.

## What
CI observed `test_action_embedding_index.py:242` fail once (`1.0000001192092896 <= 1.0`) — float32's own eps (~1.19e-7) above 1.0, one ulp past the mathematical cosine range.

## Which fix I chose — CLAMP (implementation side)
`ActionEmbeddingIndex.query`'s own docstring already promises `score` in `[-1.0, 1.0]` as a public contract — an implementation that occasionally breaks its own documented range is the real defect, not the test that checks the range. A test-side tolerance would only mask this one assertion; every other caller reading `score` would still occasionally see `1.0000001...`.

## Repro (real, not synthetic)
A deterministic float32 vector (fixed seed, self-matched) reproduces the **exact** CI value `1.0000001192092896` via raw numpy arithmetic — verified by hand this session, before and after the fix.

## Verification
- `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.
- New test file (`tests/data/test_5427_cosine_score_float32_clamp.py`): 2 passed.
- Strip-falsified: removing the `np.clip()` line reproduces the exact CI failure (`1.0000001192092896 <= 1.0`), confirmed, then restored.
- `tests/data/` full sweep: 222 passed.

## Test plan
- [x] (skipped — no user-facing surface; internal numerical bound fix, verified via the automated suite + real-value strip-falsify above)