### PR TITLE
fix(#5431): delete PermissionResolver's 3 dead public read accessors

### DIFF
--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -622,27 +622,44 @@ class PermissionResolver:
         ``_project_root``."""
         return self._project_root
 
-    def saved_get(self, key: str) -> bool | None:
-        """Read accessor for the persisted approvals map. Returns the
-        stored boolean (or None when not yet recorded)."""
-        return self._saved.get(key)
-
-    def saved_scope_get(self, key: str) -> "str | None":
-        """#5052: read accessor for *key*'s persisted scope — ``None``
-        when *key* has no saved approval at all (never approved, or
-        session-only). A saved key with no explicit scope reads as
-        :data:`~reyn.security.permissions.approval_ledger.SCOPE_LEGACY_WORKSPACE`
-        (see :meth:`ApprovalLedger.fold`'s own docstring), never as
-        ``None`` — "recorded, no scope" and "never recorded" are kept
-        distinct so a caller cannot mistake one for the other."""
-        return self._saved_scopes.get(key)
-
-    def bound_identity_get(self, key: str) -> "tuple[int, float | None] | None":
-        """#5042: read accessor for the PATH-flavor identity binding,
-        mirroring :meth:`saved_get`'s own convention — ``None`` when *key*
-        has never been bound (never used, a legacy pre-#5042 entry, or a
-        non-path-flavor key, which is never bound at all)."""
-        return self._bound_identities.get(key)
+    # #5431: ``saved_get`` / ``saved_scope_get`` / ``bound_identity_get`` —
+    # three read accessors that used to live here — were removed. Each had
+    # ZERO production consumers (confirmed via `git grep '\.<name>(' --
+    # src/`, both at issue-filing time and again in this PR): every caller
+    # was a test file, the #4866 "publish _x as x to satisfy a test" shape
+    # at class scale. Per-accessor disposition (architect's decision
+    # framework: does an operator actually want to read THIS through the
+    # live resolver?):
+    #   - ``saved_scope_get`` — an operator already sees this exact data
+    #     via `reyn permissions list` / `GET /api/permissions`, both of
+    #     which fold a FRESH `ApprovalLedger` read (`_load()` in
+    #     `interfaces/cli/commands/permissions.py` and
+    #     `interfaces/web/routers/permissions.py`) — a strictly BETTER
+    #     read than this accessor's cached `self.__saved_scopes` (fresh
+    #     vs. loaded-once-then-cached). Redundant; deleted.
+    #   - ``saved_get`` — same shape. `self.__saved` is populated once
+    #     (`_ensure_folded`) and mutated only by `_persist`, which writes
+    #     the SAME value to disk in the SAME call — so it never diverges
+    #     from a fresh ledger fold for any state a caller could observe
+    #     from outside this process (`session_approve_path`'s session-only
+    #     grants live in the SEPARATE `self._session` dict, never
+    #     `self.__saved`, so this accessor could never surface those
+    #     either way). No operator use case a fresh ledger read doesn't
+    #     already cover. Deleted.
+    #   - ``bound_identity_get`` — no operator-facing surface exists for
+    #     bound-identity state at all today (both `_load()` sites discard
+    #     `ApprovalLedger.fold()`'s second return value as `_bound`) and
+    #     no #5042 thread ever proposed adding one. `ApprovalLedger.fold()`
+    #     itself (already a public, already-used-elsewhere class — see
+    #     `test_binding_writes_durably_no_tmp_file_ever_used`, which read
+    #     `fold()[1]` directly rather than through this accessor even
+    #     before this PR) is the genuine production surface a caller
+    #     reaches for this data. Deleted.
+    # None was renamed to a private wrapper: the class already has a
+    # private `_saved` / `_saved_scopes` / `_bound_identities` property
+    # each of these accessors did nothing but forward to — adding a
+    # `_saved_get`-shaped method used by nothing would just be a second,
+    # redundant private spelling of the same read.
 
     def unconfirmable_identity_check_count(self) -> int:
         """#5152 (architect ruling, issuecomment-5383604927): how many

--- a/tests/interfaces/test_5153_permissions_cli_ledger.py
+++ b/tests/interfaces/test_5153_permissions_cli_ledger.py
@@ -137,16 +137,21 @@ def test_cli_revoke_clears_the_bound_identity_a_live_resolver_would_have_held(
     asyncio.run(
         resolver.require_file_write(PermissionDecl(), str(target / "f.txt"), "actor"),
     )
-    assert resolver.bound_identity_get(key) is not None
+    # #5431: read via a fresh `ApprovalLedger.fold()` (this file's own
+    # `_ledger()` helper) — the removed `bound_identity_get` accessor's
+    # only callers were tests.
+    _saved, bound, _scopes = _ledger(tmp_path).fold()
+    assert key in bound
 
     # The CLI revokes it -- a SEPARATE process/door, no shared in-memory
     # state with `resolver` above.
     _cmd_revoke(Namespace(key=key))
 
-    # A FRESH resolver (the process-boundary analogue) must see NO bound
-    # identity for this key.
-    fresh = PermissionResolver({}, project_root=tmp_path)
-    assert fresh.bound_identity_get(key) is None, (
+    # No live PermissionResolver needed to observe this -- the CLI revoke
+    # writes straight to the SAME on-disk ledger, so a fresh fold (the
+    # process-boundary analogue) must show NO bound identity for this key.
+    _saved, bound, _scopes = _ledger(tmp_path).fold()
+    assert key not in bound, (
         "a CLI revoke must clear the bound identity too, not just the "
         "approval row -- otherwise a later re-approval of the same key "
         "could inherit a stale identity from before the revoke"

--- a/tests/runtime/test_permission_state_change_emitter.py
+++ b/tests/runtime/test_permission_state_change_emitter.py
@@ -147,8 +147,14 @@ def test_persist_callback_exception_does_not_crash_persist(tmp_path):
 
     # Good callback still fired despite bad_cb raising.
     assert good_calls == ["safe.key"]
-    # And approvals.yaml side still completed.
-    assert resolver.saved_get("safe.key") is True
+    # And the ledger side still completed. #5431: read via a fresh
+    # `ApprovalLedger.fold()` (the same production surface `reyn
+    # permissions list` / `GET /api/permissions` use) rather than the
+    # removed `saved_get` accessor, whose only callers were tests.
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
+
+    saved, _bound, _scopes = ApprovalLedger(resolver.approval_ledger_path).fold()
+    assert saved["safe.key"] is True
 
 
 # ── Session wiring ────────────────────────────────────────────────

--- a/tests/security/test_5042_approval_identity_binding.py
+++ b/tests/security/test_5042_approval_identity_binding.py
@@ -52,11 +52,31 @@ import shutil
 import pytest
 
 from reyn.security.permissions import PermissionDecl
+from reyn.security.permissions.approval_ledger import ApprovalLedger
 from reyn.security.permissions.permissions import PermissionResolver
 
 
 def _make_resolver(tmp_path) -> PermissionResolver:
     return PermissionResolver({}, project_root=tmp_path)
+
+
+def _fold(resolver: PermissionResolver):
+    """#5431: read (approvals, bound_identities, scopes) via a fresh
+    `ApprovalLedger.fold()` — the same production surface `reyn permissions
+    list` / `GET /api/permissions` use (migrating a legacy `approvals.yaml`
+    snapshot first, exactly like those two `_load()` functions, so a
+    legacy-only fixture is still visible), and the surface
+    `test_binding_writes_durably_no_tmp_file_ever_used` (below, unchanged
+    by this PR) already used directly for the SAME data — rather than the
+    removed `saved_get`/`bound_identity_get` accessors."""
+    from reyn.security.permissions.approval_ledger import migrate_legacy_snapshot
+
+    ledger = ApprovalLedger(resolver.approval_ledger_path)
+    # `resolver.project_root` is the public read; the legacy-snapshot
+    # relative path is the same fixed constant `interfaces/{cli,web}/
+    # .../permissions.py`'s own `_legacy_snapshot_path()` helpers use.
+    migrate_legacy_snapshot(ledger, resolver.project_root / ".reyn" / "approvals.yaml")
+    return ledger.fold()
 
 
 def test_purge_then_recreate_the_same_named_target_asks_again(tmp_path) -> None:
@@ -108,7 +128,8 @@ def test_the_approval_row_itself_survives_the_stale_mismatch(tmp_path) -> None:
     # A FRESH resolver (forces a real re-read from disk) still sees the
     # approval row as true.
     fresh = _make_resolver(tmp_path)
-    assert fresh.saved_get(key) is True, (
+    saved, _bound, _scopes = _fold(fresh)
+    assert saved[key] is True, (
         "the approval row disappeared from approvals.yaml -- #5042's own "
         "audit-events half (the row must never vanish) is not satisfied"
     )
@@ -126,19 +147,23 @@ def test_host_and_plugin_approvals_are_never_bound_to_an_identity(tmp_path) -> N
     target.mkdir()
     resolver = _make_resolver(tmp_path)
     resolver._saved["actor/file.write/some_dir/"] = True
-    resolver._saved["actor/http.get/example.com"] = True
-    resolver._saved["mcp.broker"] = True
+    # #5431: these two are persisted for real (`_persist`, the production
+    # write path) rather than poked directly into `resolver._saved`, so
+    # the ledger-fold read below actually finds them.
+    resolver._persist("actor/http.get/example.com", True)
+    resolver._persist("mcp.broker", True)
 
     write_path = str(target / "f.txt")
     asyncio.run(resolver.require_file_write(PermissionDecl(), write_path, "actor"))
 
-    assert resolver.saved_get("actor/http.get/example.com") is True
-    assert resolver.saved_get("mcp.broker") is True
-    assert resolver.bound_identity_get("actor/http.get/example.com") is None, (
+    saved, bound, _scopes = _fold(resolver)
+    assert saved["actor/http.get/example.com"] is True
+    assert saved["mcp.broker"] is True
+    assert "actor/http.get/example.com" not in bound, (
         "a HOST-flavor approval must never get a bound identity -- "
         "'target disappeared' has no meaning for a host"
     )
-    assert resolver.bound_identity_get("mcp.broker") is None, (
+    assert "mcp.broker" not in bound, (
         "a PLUGIN-flavor approval must never get a bound identity"
     )
 
@@ -152,8 +177,9 @@ async def test_an_approval_for_a_not_yet_existing_target_passes_on_first_use(
     prompt the first time the path shows up). Checking it before the
     target exists must still pass (nothing to bind yet); once the target
     is created, the NEXT check both passes AND performs the actual
-    binding (verified via the public `bound_identity_get` accessor, not a
-    private-state peek)."""
+    binding (verified via a fresh `ApprovalLedger.fold()`, the genuine
+    production surface for this data — #5431 removed the
+    `bound_identity_get` accessor, whose only callers were tests)."""
     target = tmp_path / "not_yet"
     resolver = _make_resolver(tmp_path)
     key = "actor/file.write/not_yet/"
@@ -165,16 +191,19 @@ async def test_an_approval_for_a_not_yet_existing_target_passes_on_first_use(
     # or returns None) -- it performs no filesystem I/O of its own, so
     # calling it against a not-yet-existing target is safe and exercises
     # the SAME public seam every real caller uses, not a private method.
-    assert resolver.bound_identity_get(key) is None
+    _saved, bound, _scopes = _fold(resolver)
+    assert key not in bound
     await resolver.require_file_write(PermissionDecl(), write_path, "actor")
-    assert resolver.bound_identity_get(key) is None, (
+    _saved, bound, _scopes = _fold(resolver)
+    assert key not in bound, (
         "a not-yet-existing target must not be bound to anything -- "
         "there is nothing real to bind to yet"
     )
 
     target.mkdir()
     await resolver.require_file_write(PermissionDecl(), write_path, "actor")
-    assert resolver.bound_identity_get(key) is not None, (
+    _saved, bound, _scopes = _fold(resolver)
+    assert key in bound, (
         "the first check AFTER the target started existing must have "
         "bound its identity"
     )
@@ -198,14 +227,16 @@ def test_a_legacy_bare_true_entry_is_treated_as_unbound_and_bound_on_first_use(
     (approvals_dir / "approvals.yaml").write_text(f"{key}: true\n", encoding="utf-8")
 
     resolver = _make_resolver(tmp_path)
-    assert resolver.saved_get(key) is True
-    assert resolver.bound_identity_get(key) is None, (
+    saved, bound, _scopes = _fold(resolver)
+    assert saved[key] is True
+    assert key not in bound, (
         "a legacy entry must read as unbound before its first use"
     )
 
     write_path = str(target / "f.txt")
     asyncio.run(resolver.require_file_write(PermissionDecl(), write_path, "actor"))
-    assert resolver.bound_identity_get(key) is not None, (
+    _saved, bound, _scopes = _fold(resolver)
+    assert key in bound, (
         "the legacy entry's first use must have bound it"
     )
 

--- a/tests/security/test_5052_approval_scope_dimension.py
+++ b/tests/security/test_5052_approval_scope_dimension.py
@@ -126,8 +126,13 @@ def test_default_agent_scoped_approval_does_not_leak_to_a_second_agent(
     )
 
     # Ledger-level corroboration: the scope actually recorded is agent-a's,
-    # not workspace-wide.
-    assert resolver_a.saved_scope_get(_KEY) == scope_for_agent("agent-a")
+    # not workspace-wide. #5431: read via a fresh `ApprovalLedger.fold()`
+    # (the same production surface `reyn permissions list` / `GET
+    # /api/permissions` use) rather than the removed `saved_scope_get`
+    # accessor — a strictly fresher read than that cached accessor ever
+    # was, not a weaker one.
+    _saved, _bound, scopes = _ledger(tmp_path).fold()
+    assert scopes[_KEY] == scope_for_agent("agent-a")
 
 
 # ── (b) an explicit workspace-scoped approval DOES apply to both agents ────
@@ -179,7 +184,9 @@ def test_legacy_scopeless_entry_is_still_honored_workspace_wide(
             f"agent {agent_name!r} should not have been prompted -- a "
             f"legacy scope-less grant still covers every agent"
         )
-        assert resolver.saved_scope_get(_KEY) == SCOPE_LEGACY_WORKSPACE, (
+        # #5431: fresh ledger fold, same reasoning as above.
+        _saved, _bound, scopes = _ledger(tmp_path).fold()
+        assert scopes[_KEY] == SCOPE_LEGACY_WORKSPACE, (
             "a scope-less record must classify as the LEGACY sentinel, "
             "never silently collapsed into SCOPE_WORKSPACE"
         )

--- a/tests/security/test_5157_identity_fd_release.py
+++ b/tests/security/test_5157_identity_fd_release.py
@@ -27,11 +27,20 @@ from __future__ import annotations
 import pytest
 
 from reyn.security.permissions import PermissionDecl
+from reyn.security.permissions.approval_ledger import ApprovalLedger
 from reyn.security.permissions.permissions import PermissionResolver
 
 
 def _make_resolver(tmp_path) -> PermissionResolver:
     return PermissionResolver({}, project_root=tmp_path)
+
+
+def _bound(resolver: PermissionResolver) -> dict:
+    """#5431: the bound-identities map via a fresh `ApprovalLedger.fold()`
+    — the removed `bound_identity_get` accessor's only callers were tests;
+    this file already read `fold()` directly further down for the SAME
+    data, this just applies it consistently."""
+    return ApprovalLedger(resolver.approval_ledger_path).fold()[1]
 
 
 @pytest.mark.asyncio
@@ -114,10 +123,10 @@ async def test_revoking_an_approval_also_clears_its_stale_identity_record(
     await resolver.require_file_write(
         PermissionDecl(), str(target / "f.txt"), "actor",
     )
-    assert resolver.bound_identity_get(key) is not None
+    assert key in _bound(resolver)
 
     resolver._persist(key, False)
-    assert resolver.bound_identity_get(key) is None, (
+    assert key not in _bound(resolver), (
         "revoke must clear the in-memory bound-identity record, not just "
         "the fd"
     )

--- a/tests/security/test_permission_resolver_lazy_saved_3671_p4d1.py
+++ b/tests/security/test_permission_resolver_lazy_saved_3671_p4d1.py
@@ -7,9 +7,19 @@ disk I/O + YAML parse, cost scaling with the number of persisted approval
 entries — even for a turn that never checks or persists any permission
 (the common case for most turns). The `_saved` property (single owner: the
 ONE place `self.__saved` is read or written) now loads on first access,
-whichever of `saved_get()` / `_persist()` / the internal read sites reaches
-it first — there is no second call site that could forget to trigger it,
-unlike an optional constructor kwarg (rejected pattern, #3681).
+whichever of `require_file_write()` / `_persist()` / the internal read
+sites reaches it first — there is no second call site that could forget to
+trigger it, unlike an optional constructor kwarg (rejected pattern,
+#3681).
+
+#5431: this file used to trigger/verify the read side through the
+`saved_get()` accessor, whose only callers (across the whole codebase)
+were tests — removed. The read-trigger tests below now go through
+`require_file_write()` (a genuine public gate every real caller uses,
+which reads `self._saved` internally via `_is_path_approved_for`) instead;
+value-correctness is verified via a fresh `ApprovalLedger.fold()` (the
+same production surface `reyn permissions list` / `GET /api/permissions`
+use).
 
 #5153: the load site is now `_ensure_folded` (folds the append-only
 `approvals.jsonl` ledger, migrating a legacy `approvals.yaml` snapshot
@@ -37,7 +47,8 @@ import asyncio
 
 import pytest
 
-from reyn.security.permissions.permissions import PermissionResolver
+from reyn.security.permissions.approval_ledger import ApprovalLedger
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
 
 def _seed_approvals(tmp_path, **entries) -> None:
@@ -45,6 +56,38 @@ def _seed_approvals(tmp_path, **entries) -> None:
     approvals_dir.mkdir(parents=True, exist_ok=True)
     lines = "\n".join(f"{k}: {str(v).lower()}" for k, v in entries.items())
     (approvals_dir / "approvals.yaml").write_text(lines + "\n", encoding="utf-8")
+
+
+async def _trigger_saved_read(resolver: PermissionResolver, tmp_path) -> None:
+    """A genuine public read-trigger for `self._saved`: `require_file_write`
+    on a path OUTSIDE the default write zone reads `self._saved` inside
+    `_is_path_approved_for` regardless of whether the path ends up
+    approved. #5431: replaces the removed `saved_get()` accessor as this
+    file's read-side trigger -- the outcome (approved / PermissionError)
+    is irrelevant here, only that the read fired."""
+    target = tmp_path / "outside_zone"
+    target.mkdir(exist_ok=True)
+    try:
+        await resolver.require_file_write(
+            PermissionDecl(), str(target / "f.txt"), "actor",
+        )
+    except PermissionError:
+        pass
+
+
+def _saved_map(resolver: PermissionResolver) -> dict:
+    """#5431: the persisted-approvals map via a fresh `ApprovalLedger.fold()`
+    -- the same production surface `reyn permissions list` / `GET
+    /api/permissions` use (migrating a legacy `approvals.yaml` snapshot
+    first, exactly like those two `_load()` functions, so a legacy-only
+    fixture is visible even if no resolver has migrated it yet) -- rather
+    than the removed `saved_get()` accessor, whose only callers were
+    tests."""
+    from reyn.security.permissions.approval_ledger import migrate_legacy_snapshot
+
+    ledger = ApprovalLedger(resolver.approval_ledger_path)
+    migrate_legacy_snapshot(ledger, resolver.project_root / ".reyn" / "approvals.yaml")
+    return ledger.fold()[0]
 
 
 def test_construction_does_not_read_approvals_yaml(tmp_path, monkeypatch):
@@ -69,9 +112,11 @@ def test_construction_does_not_read_approvals_yaml(tmp_path, monkeypatch):
     )
 
 
-def test_first_saved_get_triggers_exactly_one_load(tmp_path, monkeypatch):
-    """Tier 2: the FIRST read through any accessor triggers the load, and
-    only once — a second call must not re-read the file."""
+def test_first_read_triggers_exactly_one_load(tmp_path, monkeypatch):
+    """Tier 2: the FIRST read through any public gate triggers the load,
+    and only once — a second call must not re-read the file. #5431: the
+    trigger is `require_file_write` (a real caller's own seam) rather than
+    the removed `saved_get()` accessor."""
     _seed_approvals(tmp_path, **{"safe.key": True})
     calls = {"n": 0}
     orig = PermissionResolver._ensure_folded
@@ -85,18 +130,18 @@ def test_first_saved_get_triggers_exactly_one_load(tmp_path, monkeypatch):
     resolver = PermissionResolver({}, project_root=tmp_path)
     assert calls["n"] == 0
 
-    assert resolver.saved_get("safe.key") is True
+    asyncio.run(_trigger_saved_read(resolver, tmp_path))
     assert calls["n"] == 1
 
-    assert resolver.saved_get("safe.key") is True
+    asyncio.run(_trigger_saved_read(resolver, tmp_path))
     assert calls["n"] == 1, "a second read must reuse the cached dict, not re-load"
 
 
 def test_persist_also_triggers_lazy_load_exactly_once(tmp_path, monkeypatch):
     """Tier 2: `_persist()` (the WRITE path, `self._saved[key] = approved`)
-    is a DIFFERENT internal call site than `saved_get()` — confirms the
-    property is the single owner for BOTH read and write sites, not just
-    the one exercised above."""
+    is a DIFFERENT internal call site than the read path exercised above —
+    confirms the property is the single owner for BOTH read and write
+    sites, not just the one exercised above."""
     _seed_approvals(tmp_path, **{"other.key": False})
     calls = {"n": 0}
     orig = PermissionResolver._ensure_folded
@@ -114,21 +159,26 @@ def test_persist_also_triggers_lazy_load_exactly_once(tmp_path, monkeypatch):
     assert calls["n"] == 1
     # the persisted entry AND the pre-existing on-disk entry are both
     # visible — proves the load actually merged in, not just started
-    # from an empty dict.
-    assert resolver.saved_get("new.key") is True
-    assert resolver.saved_get("other.key") is False
-    assert calls["n"] == 1, "saved_get after _persist must not re-load"
+    # from an empty dict. #5431: read via a fresh `ApprovalLedger.fold()`
+    # (this file's own `_saved_map` helper) rather than the removed
+    # `saved_get()` accessor -- an INDEPENDENT ledger read, so this does
+    # not itself touch `resolver`'s own `_ensure_folded` spy.
+    saved = _saved_map(resolver)
+    assert saved["new.key"] is True
+    assert saved["other.key"] is False
+    assert calls["n"] == 1, "reading the ledger after _persist must not re-load the resolver"
 
 
-def test_saved_get_value_correctness_unchanged(tmp_path):
+def test_saved_value_correctness_unchanged(tmp_path):
     """Tier 2: no behavior change — real end-to-end value round-trip through
     the lazy path, no spies, matching what a caller actually observes."""
     _seed_approvals(tmp_path, **{"granted.key": True, "denied.key": False})
     resolver = PermissionResolver({}, project_root=tmp_path)
 
-    assert resolver.saved_get("granted.key") is True
-    assert resolver.saved_get("denied.key") is False
-    assert resolver.saved_get("never.mentioned.key") is None
+    saved = _saved_map(resolver)
+    assert saved["granted.key"] is True
+    assert saved["denied.key"] is False
+    assert "never.mentioned.key" not in saved
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_5065_permissions_router_emits_audit_event.py
+++ b/tests/web/test_5065_permissions_router_emits_audit_event.py
@@ -197,6 +197,7 @@ def test_web_revoke_clears_the_bound_identity_a_live_resolver_would_have_held(
     the SAME project after the HTTP revoke."""
     import asyncio
 
+    from reyn.security.permissions.approval_ledger import ApprovalLedger
     from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
     key = "chat_router/file.write/some_dir/"
@@ -213,15 +214,24 @@ def test_web_revoke_clears_the_bound_identity_a_live_resolver_would_have_held(
             PermissionDecl(), str(target / "f.txt"), "chat_router",
         ),
     )
-    assert resolver.bound_identity_get(key) is not None
+    # #5431: read via a fresh `ApprovalLedger.fold()` (the same production
+    # surface `GET /api/permissions` itself uses) rather than the removed
+    # `bound_identity_get` accessor, whose only callers were tests.
+    ledger_path = tmp_project / ".reyn" / "approvals.jsonl"
+    _saved, bound, _scopes = ApprovalLedger(ledger_path).fold()
+    assert key in bound
 
     response = _client().delete(
         "/api/permissions/chat_router%2Ffile.write%2Fsome_dir%2F",
     )
     assert response.status_code == 204, response.text
 
-    fresh = PermissionResolver({}, project_root=tmp_project)
-    assert fresh.bound_identity_get(key) is None, (
+    # No live PermissionResolver needed to observe this -- the DELETE
+    # route writes straight to the SAME on-disk ledger, so a fresh fold
+    # (the process-boundary analogue) must show NO bound identity for
+    # this key.
+    _saved, bound, _scopes = ApprovalLedger(ledger_path).fold()
+    assert key not in bound, (
         "a web-surface revoke must clear the bound identity too, not "
         "just the approval row"
     )


### PR DESCRIPTION
**[tui-coder]** — closes #5431.

## What
`PermissionResolver` published 3 read accessors (`saved_get`, `saved_scope_get`, `bound_identity_get`) with ZERO production consumers anywhere in `src/` (confirmed via `git grep`) — the #4866 shape at class scale, in the security layer.

## Per-accessor decision (architect's framework: does an operator actually want to read this?)

1. **`saved_scope_get`** — DELETED, per the issue's explicit instruction. The CLI/web `_load()` functions already read the same scope data via a fresh `ApprovalLedger.fold()` — that's what `reyn permissions list` / `GET /api/permissions` actually show an operator.
2. **`saved_get`** — DELETED, after checking the divergence question the issue raised: `self.__saved` is populated once and mutated only by `_persist`, which writes the SAME value to disk in the SAME call — it can never hold state a fresh ledger fold wouldn't also show. Session-only grants (`session_approve_path`) live in a completely separate `self._session` dict, never touched by this accessor either way. If anything the cached accessor is weaker than a fresh disk read (can go stale against a concurrent external writer). No operator-relevant use case survives.
3. **`bound_identity_get`** — DELETED. No operator-facing surface exists for bound-identity state anywhere today — both `_load()` sites discard `ApprovalLedger.fold()`'s bound-identities return value as `_bound`. No #5042-thread proposal to surface it either. `ApprovalLedger.fold()` itself is the genuine production surface.

None were renamed to a private wrapper — the class already has private `_saved`/`_saved_scopes`/`_bound_identities` properties each accessor just forwarded to; a redundant private method used by nothing would just be more dead code.

## Test rewrites
7 test files' call sites redirected to a fresh `ApprovalLedger(resolver.approval_ledger_path).fold()` read — the SAME production surface the CLI/web `_load()` paths use, never the private `_saved`/`_bound_identities` properties directly. One test (`test_5042`'s host/plugin witness) was upgraded from a private `_saved[key]=` poke to a real `resolver._persist(key, True)` call so the fold-based read actually finds it on disk. The lazy-load-trigger test now uses `require_file_write` (a genuine public gate) instead of `saved_get()`.

## Strip-falsify (all 3, not just `saved_scope_get`)
Temporarily commented out each of the 3 lines in `ApprovalLedger.fold()` that populate `approvals`/`scopes`/`bound` in turn — every rewritten test went red each time it depended on that field, then reverted. `approval_ledger.py` itself has zero net diff.

## Scope
Only `PermissionResolver`'s these 3 accessors — not bundled with #5428 (a different, oppositely-shaped issue: "no public surface exists at all" vs this one's "a public surface exists but nobody in production uses it").

## Verification
Gate scripts green (ruff, mypy ratchet, test-tier-audit --strict on all 7 changed test files — 41 tests, 0 Tier-4 violations, module docstrings, flat-tests ratchet, tests-path-literal, bare-tests-import, file-depth, collect-events-settle). `tests/security/` + the 3 touched cross-directory files: 830 passed, 26 skipped (pre-existing), post-rebase onto current main (clean, no conflicts). `git grep '\.saved_get(' -- src/ tests/` / `.saved_scope_get(` / `.bound_identity_get(` → 0 hits for all 3 old public names.

## Test plan
- [x] (skipped — no user-facing surface change; verified via the automated test suite above)
