### PR TITLE
fix(#4986 B): name what TrackedTaskSet.aclose() is waiting on, before it waits

### DIFF
--- a/scripts/detect_4986_teardown_hang.py
+++ b/scripts/detect_4986_teardown_hang.py
@@ -88,7 +88,13 @@ def format_notification(run_id: str) -> str:
         "evidence: `gh api /repos/tya5/reyn/actions/runs/"
         f"{run_id}/attempts/1/logs` (or `gh run view {run_id} "
         "--log-failed`) — a re-run may not reproduce the hang, and the "
-        "log is the only record of this occurrence."
+        "log is the only record of this occurrence. #4986 variant B: "
+        "check attempt 1's log for "
+        "'TrackedTaskSet.aclose(caller=...): waiting on N tracked "
+        "task(s): ...' — if present, it names exactly which task(s) "
+        "were still pending when the hang started (the one thing the "
+        "faulthandler-based pytest-timeout dump above cannot say, since "
+        "an asyncio Task is not an OS thread)."
     )
 
 

--- a/src/reyn/runtime/tracked_tasks.py
+++ b/src/reyn/runtime/tracked_tasks.py
@@ -309,6 +309,11 @@ class TrackedTaskSet:
             # round, so a normal (non-hanging) drain logs this at most once
             # and then never again once `pending` empties above — the noise
             # guard witness #4986's own acceptance table requires.
+            # `warning` is a requirement, not a default: lowering it to
+            # info/debug drops this out of pytest's own failure report,
+            # silently deleting the one trace a real hang leaves — do not
+            # lower it even though a normal shutdown also logs it once
+            # (a resident cancel_join task is routinely still pending).
             logger.warning(
                 "TrackedTaskSet.aclose(caller=%r): waiting on %d tracked "
                 "task(s): %s",

--- a/src/reyn/runtime/tracked_tasks.py
+++ b/src/reyn/runtime/tracked_tasks.py
@@ -294,6 +294,31 @@ class TrackedTaskSet:
             ]
             if not pending:
                 return
+            # #4986 variant B: name what's about to be waited on, BEFORE the
+            # wait below — the one thing a hang leaves no other trace of.
+            # `pytest-timeout`'s dump is faulthandler-based (OS-thread
+            # tracebacks); an asyncio Task is a coroutine on the ONE event-
+            # loop thread, not a thread of its own, so that dump can only
+            # ever say "the loop is polling" — never which task, which is
+            # why this line exists (see this method's own module for the
+            # #4986 design ruling; verified directly before this fix landed:
+            # faulthandler.dump_traceback() over a real hung task names only
+            # the loop's own frame, never the task). Logged once per
+            # fixpoint round, right here (not once per aclose() call): a
+            # task that finishes mid-round drops off this list on the NEXT
+            # round, so a normal (non-hanging) drain logs this at most once
+            # and then never again once `pending` empties above — the noise
+            # guard witness #4986's own acceptance table requires.
+            logger.warning(
+                "TrackedTaskSet.aclose(caller=%r): waiting on %d tracked "
+                "task(s): %s",
+                caller, len(pending),
+                ", ".join(
+                    f"{t.get_name()!r} disposition={self._tasks[t][0]!r} "
+                    f"appends_wal={self._tasks[t][1]!r}"
+                    for t in pending
+                ),
+            )
             for task in pending:
                 disp, _wal = self._tasks[task]
                 if disp == "cancel_join":

--- a/tests/runtime/test_4759_tracked_task_set.py
+++ b/tests/runtime/test_4759_tracked_task_set.py
@@ -232,7 +232,12 @@ async def test_aclose_names_a_still_pending_task_before_waiting_on_it(caplog):
         tracker.spawn(slow_task(), disposition="await", name="slow-task")
         await asyncio.sleep(0)  # let the spawned task actually start
         aclose_task = asyncio.create_task(tracker.aclose(caller="test-caller"))
-        await asyncio.sleep(0.05)  # give aclose() a chance to log before we release
+        # Wait on the CONDITION (the log line landed), not a duration —
+        # testing policy Floor: "no sleep(N) the assertion depends on ...
+        # not to let a task settle" (#4844). Unbounded: CI's own
+        # --timeout=120 is the kill switch if this never becomes true.
+        while not any("waiting on" in r.message for r in caplog.records):
+            await asyncio.sleep(0)
         release.set()
         await aclose_task
 

--- a/tests/runtime/test_4759_tracked_task_set.py
+++ b/tests/runtime/test_4759_tracked_task_set.py
@@ -202,3 +202,76 @@ async def test_non_reentrant_aclose_does_not_log_the_reentrancy_warning(caplog):
         await tracker.aclose()  # called from the TEST's own task, not a tracked one
 
     assert not any("reentrantly" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_aclose_names_a_still_pending_task_before_waiting_on_it(caplog):
+    """Tier 1: #4986 variant B, witness 1 -- an ``await``-disposition task
+    that has not finished yet is NAMED (its own name, disposition,
+    appends_wal) in a log line ``aclose()`` emits BEFORE it enters the wait
+    that round -- the one thing a real hang leaves no other trace of
+    (``pytest-timeout``'s dump is faulthandler-based: an OS-thread
+    traceback, never an individual asyncio Task's name -- verified
+    directly before this fix, see this fix's own commit message).
+
+    Also THIS fix's own witness #2 (strip): temporarily removing the
+    ``logger.warning(...)`` call ``aclose()``'s fixpoint loop adds makes
+    THIS test go RED (no 'waiting on' line in ``caplog.records`` at all)
+    -- confirmed via a real commit -> edit -> revert pass before this fix
+    landed, not merely asserted; see this fix's own commit message for
+    the exact strip performed."""
+    import logging
+
+    tracker = TrackedTaskSet()
+    release = asyncio.Event()
+
+    async def slow_task() -> None:
+        await release.wait()
+
+    with caplog.at_level(logging.WARNING, logger="reyn.runtime.tracked_tasks"):
+        tracker.spawn(slow_task(), disposition="await", name="slow-task")
+        await asyncio.sleep(0)  # let the spawned task actually start
+        aclose_task = asyncio.create_task(tracker.aclose(caller="test-caller"))
+        await asyncio.sleep(0.05)  # give aclose() a chance to log before we release
+        release.set()
+        await aclose_task
+
+    assert any(
+        "slow-task" in record.message and "waiting on" in record.message
+        for record in caplog.records
+    ), f"expected the pending task's own name in a 'waiting on' log line, got: {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_aclose_logs_nothing_once_every_task_has_finished(caplog):
+    """Tier 1: #4986 variant B, witness 3 -- the noise guard. A normal
+    drain where every tracked task finishes promptly logs the "waiting on"
+    line AT MOST ONCE (the round that observed it still pending) and never
+    again once the fixpoint loop's next round finds nothing pending --
+    without this, an "always log, whether or not anything is actually
+    pending" implementation would ALSO pass witness 1 trivially (six
+    questions #4: a positive-only witness is vacuous without this
+    negative control)."""
+    import logging
+
+    tracker = TrackedTaskSet()
+    started = asyncio.Event()
+
+    async def quick_task() -> None:
+        started.set()
+        await asyncio.sleep(0)
+
+    with caplog.at_level(logging.WARNING, logger="reyn.runtime.tracked_tasks"):
+        tracker.spawn(quick_task(), disposition="cancel_join", name="quick-task")
+        await started.wait()
+        await tracker.aclose(caller="test-caller")
+        # A second aclose() call on the now-empty tracker must log nothing
+        # new -- the fixpoint loop's very first check (`if not pending:
+        # return`) fires before the new log line is ever reached.
+        caplog.clear()
+        await tracker.aclose(caller="test-caller")
+
+    assert not any("waiting on" in record.message for record in caplog.records), (
+        f"an aclose() call with nothing pending must never log the "
+        f"'waiting on' line -- got: {[r.message for r in caplog.records]}"
+    )

--- a/tests/scripts/test_detect_4986_teardown_hang.py
+++ b/tests/scripts/test_detect_4986_teardown_hang.py
@@ -99,3 +99,18 @@ def test_notification_names_the_issue_and_the_evidence_preservation_step():
     assert "32459227086" in text
     assert "attempts/1/logs" in text
     assert "before re-running" in text.lower()
+
+
+def test_notification_points_at_the_variant_b_pending_task_line():
+    """Tier 1: #4986 variant B — the notification must tell whoever picks
+    up a real detection to check attempt 1's log for the "waiting on N
+    tracked task(s)" line ``TrackedTaskSet.aclose()`` now emits (this
+    fix's own module) — the one thing the faulthandler-based
+    pytest-timeout dump cannot name (an asyncio Task, not an OS thread).
+    Architect ruling: "CI の実物で出ること" is deliberately NOT the
+    acceptance bar for the fix itself; THIS notification hook is instead
+    what makes the next real occurrence self-identify whether the line
+    was present."""
+    text = format_notification("32459227086")
+    assert "waiting on" in text
+    assert "tracked task" in text


### PR DESCRIPTION
**[tui-coder]** — part of #4986 (variant B).

## What
Chronic CI teardown hangs left no evidence of which asyncio task was still pending when the hang started. `pytest-timeout`'s dump is faulthandler-based (OS-thread tracebacks); an asyncio Task is a coroutine on the ONE event-loop thread, not a thread of its own, so that dump can only ever say "the loop is polling" — never which task. **Verified directly before this fix** (not just read on architect's say-so, per lead-coder's explicit instruction): `faulthandler.dump_traceback()` over a real hung asyncio task names only the loop's own frame, never the task.

## Design (architect's — not a new mechanism)
The 3 pieces already exist: `TrackedTaskSet.pending()`, the per-task `(disposition, appends_wal)` tuple, and the existing `caller=` diagnostic line's logger. This adds exactly one thing: log "what's about to be waited on" once per fixpoint round, right before the wait, using the same logger. No new clock, no per-item timeout — explicitly rejected per the testing policy ("no `@pytest.mark.timeout`") **and** `tracked_tasks.py`'s own `aclose()` docstring ("NOT independently time-bounded — the budget is the caller's own").

## Placement (decided by running once, per lead-coder's instruction)
Inside the fixpoint loop, right after computing the pending-task list and before the cancel/gather — a task that finishes mid-round drops off the list on the NEXT round, so the noise guard (witness 3) falls out of this placement for free, no extra bookkeeping needed.

## Witnesses (architect's table, all 3)
1. An `await`-disposition task not yet done is named in the log line before `aclose()` waits on it.
2. Strip: removing the log line reds witness 1 — verified via a real commit → edit → revert pass before this fix landed, not just asserted.
3. Noise guard: a normal drain where everything finishes promptly logs the line at most once, never again once nothing is pending.

## Acceptance bar (architect's explicit exclusion)
"CI producing a real recurrence" is deliberately NOT the acceptance bar — architect: a witness written from an unreproducible danger becomes a green nobody probes. Instead: `detect_4986_teardown_hang.py`'s own notification text now points whoever reads a real detection at attempt 1's log for this exact line — the next real occurrence self-identifies whether it was present, without needing a synthetic CI reproduction first.

## A / B / C
A is visualized (#5362). B is this PR. C stays "awaiting recurrence" as-is — once B's line exists, C's own recurrence will carry it too.

## Verification
Gate scripts green (ruff, mypy ratchet, test-tier-audit --strict on both changed test files — 16 tests, 0 Tier-4 violations, module docstrings, flat-tests ratchet, tests-path-literal, bare-tests-import, file-depth, collect-events-settle). `tests/runtime/test_4759_tracked_task_set.py` (8) + `tests/scripts/test_detect_4986_teardown_hang.py` (8) — all green, post-rebase onto current main (clean, no conflicts).

## Test plan
- [x] (skipped — no user-facing surface change; verified via the automated test suite above)
