### PR TITLE
fix(#5428): public hook-env read + reyn doctor consumer, sharing the base_dir override primitive

### DIFF
--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -356,6 +356,80 @@ def run(args: argparse.Namespace) -> None:
     print("process currently alive on this machine, across every workspace:")
     _print_process_registry()
 
+    # ── #5428: hook env — what REYN_* an exec/exec_capture hook would see ──
+    print()
+    print("Hook env (REYN_* an exec/exec_capture child would receive right")
+    print("now, per configured agent — D-1: reads the SAME agent-profile")
+    print("override resolve_base_dir_candidate uses, not a restated declaration):")
+    _print_hook_env_snapshot(resolved_root)
+
+
+def _print_hook_env_snapshot(resolved_root: Path) -> None:
+    """#5428: the operator-facing consumer this issue required in the SAME
+    PR as the public read — architect's own reversal (issuecomment on
+    #5428): a public ``Session.hook_env_snapshot()`` with only a test
+    consumer is the #4866 shape #5442 already spent a PR closing; ``reyn
+    doctor`` is the declared receiving surface (module docstring: "reach
+    into sandbox / MCP / hook internals").
+
+    No live ``Session`` is constructed (doctor constructs none anywhere —
+    #5428's own investigation confirmed this: ``Session(`` has zero call
+    sites in this module). This resolves the SAME 4 values
+    :meth:`~reyn.runtime.session.Session.hook_env_snapshot` returns for a
+    LIVE session, via the SAME shared primitive
+    (:func:`~reyn.runtime.workspace_paths.resolve_base_dir_candidate`) —
+    with no session-layer override (doctor has no session), only the
+    agent-profile layer, mirroring what a session with no per-session
+    ``config.yaml`` override would resolve to anyway. Reads
+    ``.reyn/agents/<name>/profile.yaml`` directly for each configured
+    agent — the SAME enumeration ``_merged_hook_registry`` above already
+    uses for its own per-agent hook layer."""
+    from reyn.runtime.services.recovery import default_snapshot_path
+    from reyn.runtime.workspace_paths import resolve_base_dir_candidate
+
+    agents_dir = resolved_root / ".reyn" / "agents"
+    if not agents_dir.is_dir():
+        print("  no agents configured yet (.reyn/agents/ does not exist)")
+        return
+    found_any = False
+    for agent_dir in sorted(agents_dir.iterdir()):
+        if not agent_dir.is_dir():
+            continue
+        found_any = True
+        agent_name = agent_dir.name
+        profile_path = agent_dir / "profile.yaml"
+        base_dir_raw: "str | None" = None
+        if profile_path.is_file():
+            import yaml
+            try:
+                raw = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001 — hand/LLM-written yaml, surface not crash
+                raw = None
+            if isinstance(raw, dict):
+                value = raw.get("base_dir")
+                base_dir_raw = str(value) if value else None
+        agent_base_dir = resolve_base_dir_candidate(
+            base_dir_raw, workspace_root=resolved_root,
+        )
+        if agent_base_dir is None:
+            # No valid agent-profile override -> the Agent object's own
+            # default, which for an unnarrowed agent is "no restriction"
+            # -> the project root itself (the SAME fallback
+            # Session._build_hook_process_context's own
+            # `self._workspace_base_dir or self._reyn_state_root.parent`
+            # resolves to when neither layer has a value).
+            agent_base_dir = resolved_root
+        agent_state_dir = default_snapshot_path(
+            agent_name, root=resolved_root / ".reyn",
+        ).parent
+        print(f"  {agent_name}:")
+        print(f"    REYN_PROJECT_DIR={resolved_root}")
+        print(f"    REYN_AGENT_BASE_DIR={agent_base_dir}")
+        print(f"    REYN_AGENT_NAME={agent_name}")
+        print(f"    REYN_AGENT_STATE_DIR={agent_state_dir}")
+    if not found_any:
+        print("  no agents configured yet (.reyn/agents/ is empty)")
+
 
 def _configured_exec_hooks(config: object) -> "list[HookDef]":
     """Every configured ``exec``/``exec_capture`` ``HookDef`` — the caller

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2053,24 +2053,58 @@ class Session:
         value = raw.get("base_dir")
         if not value:
             return None
-        from reyn.plugins.tokens import expand_with_map
+
+        # #5428: the token-expand + boundary-check step is now the SHARED
+        # pure function `reyn.runtime.workspace_paths.resolve_base_dir_
+        # candidate` — `reyn doctor` (#5428's own real consumer) needs the
+        # identical validation with no session layer, and duplicating it
+        # would be the exact #5057 "same guard, second copy" class this
+        # repo already closed three instances of one night. The boundary
+        # check used to run at THIS method's own two call sites (the
+        # `_workspace_base_dir` property, below) instead of here; folding
+        # it in here does not weaken it — every caller still gets
+        # reject-and-None on an out-of-workspace value, only the log
+        # message's own wording moved (see the property's own comment at
+        # its two call sites for what it preserves).
+        from reyn.runtime.workspace_paths import resolve_base_dir_candidate
 
         workspace_root = self._reyn_state_root.parent.resolve()
-        # Order load-bearing (architect, issuecomment-5378958683): expand
-        # the token FIRST, so `${REYN_PROJECT_DIR}/...` is judged by what
-        # it expands to, never as a literal string or as "relative".
-        expanded = expand_with_map(str(value), {"REYN_PROJECT_DIR": str(workspace_root)})
-        candidate = Path(expanded)
-        if not candidate.is_absolute():
-            logger.warning(
-                "#5084: skipping base_dir override %r in %s -- a hand-written "
-                "value must be either an absolute path or "
-                "'${REYN_PROJECT_DIR}/...' (a bare relative path is rejected, "
-                "never silently reinterpreted as workspace-relative or as "
-                "relative to the reyn process's own working directory)",
-                str(value), path,
+        candidate = resolve_base_dir_candidate(str(value), workspace_root=workspace_root)
+        if candidate is None:
+            # #5428: the two rejection REASONS (not absolute / outside
+            # workspace) are distinguished here for the log message only —
+            # lead-coder's own TESTS-READ finding on #5086 (pinned by
+            # test_4200_session_base_dir_resolution.py's own caplog
+            # assertion on "must be either an absolute path or") requires
+            # the two stay distinguishable, so this re-runs the (cheap,
+            # NOT the hardened boundary/ordering logic) token-expansion
+            # step purely to pick which of the two pre-existing warning
+            # texts applies — the shared pure function above already made
+            # the real accept/reject decision; this never re-decides it.
+            from reyn.plugins.tokens import expand_with_map
+
+            expanded = expand_with_map(
+                str(value), {"REYN_PROJECT_DIR": str(workspace_root)},
             )
-            return None
+            if not Path(expanded).is_absolute():
+                logger.warning(
+                    "#5084: skipping base_dir override %r in %s -- a "
+                    "hand-written value must be either an absolute path "
+                    "or '${REYN_PROJECT_DIR}/...' (a bare relative path "
+                    "is rejected, never silently reinterpreted as "
+                    "workspace-relative or as relative to the reyn "
+                    "process's own working directory)",
+                    str(value), path,
+                )
+            else:
+                logger.warning(
+                    "#5081: base_dir override %r in %s resolves outside "
+                    "the project workspace %r -- ignoring (falls through "
+                    "to the next layer; restrict-only means this can "
+                    "only WIDEN toward that layer, never past the "
+                    "effective floor)",
+                    str(value), path, str(workspace_root),
+                )
         return candidate
 
     def _read_preferences_override(self, path: "Path") -> "dict[str, object]":
@@ -2172,39 +2206,28 @@ class Session:
         naive "reuse it" instruction would have produced a SECOND,
         independently-written copy of the same check instead — the exact
         "same guard, different code" family #5057 closed three instances
-        of a few hours earlier. Extracted once, both call sites here."""
-        from reyn.runtime.workspace_paths import within_workspace
+        of a few hours earlier. Extracted once, both call sites here.
 
-        workspace_root = self._reyn_state_root.parent.resolve()
-
+        #5428: the ⊆ workspace check itself now lives INSIDE
+        :meth:`_read_base_dir_override` (via the shared
+        ``workspace_paths.resolve_base_dir_candidate``) — a value this
+        method receives non-``None`` is therefore ALREADY known to be
+        within *workspace_root*; this property no longer re-checks it (a
+        second check here would be dead code, always true, and #5081's
+        own "falls through to the next layer" behavior is unchanged:
+        ``_read_base_dir_override`` returns ``None`` for an out-of-
+        workspace value exactly as before, just with the warning now
+        logged from inside that method instead of from here)."""
         session_override = self._read_base_dir_override(
             Path(self._snapshot_path).parent / "config.yaml"
         )
         if session_override is not None:
-            if within_workspace(session_override, workspace_root):
-                return session_override
-            logger.warning(
-                "#5081: session %s's config.yaml base_dir %r resolves "
-                "outside the project workspace %r -- ignoring (falls "
-                "through to the next layer; restrict-only means this can "
-                "only WIDEN toward that layer, never past the effective "
-                "floor)",
-                self.agent_name, str(session_override), str(workspace_root),
-            )
+            return session_override
         agent_override = self._read_base_dir_override(
             self._reyn_state_root / "agents" / self.agent_name / "profile.yaml"
         )
         if agent_override is not None:
-            if within_workspace(agent_override, workspace_root):
-                return agent_override
-            logger.warning(
-                "#5081: agent %s's profile.yaml base_dir %r resolves "
-                "outside the project workspace %r -- ignoring (falls "
-                "through to the next layer; restrict-only means this can "
-                "only WIDEN toward that layer, never past the effective "
-                "floor)",
-                self.agent_name, str(agent_override), str(workspace_root),
-            )
+            return agent_override
         return self._agent.workspace_base_dir
 
     @property
@@ -2468,15 +2491,15 @@ class Session:
         inline lambda) — a named, independently-callable builder rather
         than an anonymous closure buried in a large constructor call.
 
-        #5428: this extraction is deliberately NOT paired with a public
-        method in the same PR (architect BLOCKING on an earlier version
-        of this change, issuecomment on PR #5443): a public
-        ``hook_env_snapshot()`` with no production consumer would be the
-        exact #4866 shape #5442 spent that same PR closing 3 instances
-        of. #5428's own public read-surface, WITH its real consumer
-        (``reyn doctor`` — its own docstring already claims "reach into
-        sandbox / MCP / hook internals" / "a hook's argv actually
-        launched would be doctor's"), lands together in a follow-up.
+        #5428: this now has a real public read-surface,
+        :meth:`hook_env_snapshot`, WITH its real consumer (``reyn
+        doctor`` — its own docstring already claims "reach into sandbox
+        / MCP / hook internals" / "a hook's argv actually launched would
+        be doctor's") — landed in the SAME PR as that public method
+        (architect's own comment-policy §8 requirement: an earlier
+        revision of this paragraph said the public method was
+        deliberately deferred; that statement is now false, so this
+        paragraph is rewritten rather than left stale).
 
         Reads live state on every call (``_workspace_base_dir`` can change
         across this session's lifetime, #5081) — never frozen at
@@ -2493,6 +2516,28 @@ class Session:
             agent_name=self.agent_name,
             agent_state_dir=self._ensure_agent_state_dir(),
         )
+
+    def hook_env_snapshot(self) -> "dict[str, str]":
+        """#5428: the PUBLIC read of "what env would this agent's hook
+        get right now" — the gap architect's issue named: no public
+        surface answered this, so #5426's own test reached through two
+        private hops (``session._hook_dispatcher._hook_process_context()``),
+        and an operator had no way to look at all.
+
+        Returns the resolved ``REYN_*`` envelope as a plain
+        ``dict[str, str]`` (:meth:`HookProcessContext.as_env`'s own
+        shape) — never the callable itself, and never a free-form dict a
+        caller could widen; the four keys are exactly the closed set
+        :class:`~reyn.hooks.shell_runner.HookProcessContext` defines (see
+        that class's own docstring for why it is closed, not a general
+        ``Mapping[str, str]``).
+
+        Live on every call (:meth:`_build_hook_process_context`'s own
+        docstring: ``_workspace_base_dir`` can change across this
+        session's lifetime, #5081) — never a value frozen at
+        construction time. Real consumer: ``reyn doctor`` (see
+        ``interfaces/cli/commands/doctor.py``)."""
+        return self._build_hook_process_context().as_env()
 
     @property
     def _environment_backend(self) -> Any:

--- a/src/reyn/runtime/workspace_paths.py
+++ b/src/reyn/runtime/workspace_paths.py
@@ -76,4 +76,50 @@ def within_workspace(candidate: Path, workspace_root: Path) -> bool:
     return resolved == root or root in resolved.parents
 
 
-__all__ = ["within_workspace"]
+def resolve_base_dir_candidate(
+    raw_value: "str | None", *, workspace_root: Path,
+) -> "Path | None":
+    """#5428: the pure "one candidate → token-expand → boundary-check"
+    step, extracted out of
+    :meth:`reyn.runtime.session.Session._read_base_dir_override` so a
+    caller with NO session layer (``reyn doctor``, #5428's own real
+    consumer) can validate an agent-profile ``base_dir:`` candidate
+    without duplicating this logic — the exact #5057 "same guard, second
+    copy" class this module's own docstring already names.
+
+    Deliberately does NOT decide layer order (session-config vs
+    agent-profile vs Agent default) — lead-coder's own #5428 scoping: a
+    caller with no session layer would otherwise force a
+    session-layer-shaped branch into this function, growing its
+    signature for every new caller ("does the argument count grow when
+    the caller count grows?" — #5428's own discriminant). Callers own
+    their own layer order; this function only ever validates ONE
+    already-selected raw string.
+
+    Returns ``None`` for: absent/empty *raw_value*, a bare relative path
+    with no ``${REYN_PROJECT_DIR}`` token (rejected outright — never
+    silently reinterpreted as workspace-relative or as relative to the
+    calling process's own cwd, see this module's own docstring), or a
+    value that expands outside *workspace_root* (:func:`within_workspace`).
+    Never raises on a malformed value — the caller decides whether/how to
+    log a rejection; this function's own contract is validate-or-None,
+    not validate-or-raise (a malformed hand-written override must not
+    crash construction, #5081)."""
+    if not raw_value:
+        return None
+    from reyn.plugins.tokens import expand_with_map
+
+    root = workspace_root.resolve()
+    # Order load-bearing (architect, issuecomment-5378958683): expand the
+    # token FIRST, so `${REYN_PROJECT_DIR}/...` is judged by what it
+    # expands to, never as a literal string or as "relative".
+    expanded = expand_with_map(str(raw_value), {"REYN_PROJECT_DIR": str(root)})
+    candidate = Path(expanded)
+    if not candidate.is_absolute():
+        return None
+    if not within_workspace(candidate, root):
+        return None
+    return candidate
+
+
+__all__ = ["resolve_base_dir_candidate", "within_workspace"]

--- a/tests/hooks/test_5428_public_hook_env_snapshot.py
+++ b/tests/hooks/test_5428_public_hook_env_snapshot.py
@@ -1,0 +1,82 @@
+"""Tier 2: #5428 — a real PUBLIC read of "what env would this agent's
+hook get right now" (``Session.hook_env_snapshot()``), with a real
+production consumer (``reyn doctor``) landed in the SAME PR — architect's
+own reversal (issuecomment on #5428): a public method with only a test
+consumer is the exact #4866 shape #5442 already spent a PR closing 3
+instances of.
+
+Before this: the only reader was #5426's own test, reaching through TWO
+private hops (``session._hook_dispatcher._hook_process_context()``); an
+operator had no way to look at all.
+
+Witnesses (architect's own #5428 table):
+    1. All 4 REYN_* keys readable from the public surface.
+    2. Moving base_dir (session-layer config.yaml override) changes the
+       value on the NEXT read — live, not frozen at construction.
+    3. Strip: freezing the read at construction time reds witness 2.
+
+Real Session/HookDispatcher throughout — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests._support.agent_session import make_session
+
+# ── witness 1: all 4 keys readable from the public surface ────────────────
+
+
+def test_hook_env_snapshot_exposes_all_four_reyn_keys(tmp_path: Path) -> None:
+    """Tier 2: witness ① — Session.hook_env_snapshot() (the public
+    surface #5428 required) returns exactly the 4 REYN_* keys
+    HookProcessContext.as_env() defines, sourced from a REAL session."""
+    session = make_session(
+        agent_name="alpha",
+        workspace_state_dir=tmp_path / ".reyn",
+        snapshot_path=tmp_path / ".reyn" / "agents" / "alpha" / "state" / "snapshot.json",
+    )
+    env = session.hook_env_snapshot()
+    assert set(env.keys()) == {
+        "REYN_PROJECT_DIR", "REYN_AGENT_BASE_DIR", "REYN_AGENT_NAME",
+        "REYN_AGENT_STATE_DIR",
+    }
+    assert env["REYN_AGENT_NAME"] == "alpha"
+
+
+# ── witness 2/3: live, not frozen — with its own strip ─────────────────────
+
+
+def test_moving_base_dir_changes_the_value_on_the_next_read(tmp_path: Path) -> None:
+    """Tier 2: witness ② — writing a NEW base_dir override into this
+    session's own <session_state_dir>/config.yaml AFTER construction
+    changes what the NEXT hook_env_snapshot() call reports — a live
+    read, never a value frozen at Session construction time.
+
+    Strip-falsifier (recorded here, executed by hand this session):
+    caching ``self._build_hook_process_context()``'s own return value
+    at construction (e.g. `self._hook_ctx = self._build_hook_process_
+    context()` in __init__, `hook_env_snapshot` returning `self._hook_
+    ctx.as_env()`) turns this red — the second read would keep
+    reporting the ORIGINAL base_dir, never observing the override
+    written after construction. Verified locally."""
+    snapshot_path = tmp_path / ".reyn" / "agents" / "alpha" / "state" / "snapshot.json"
+    session = make_session(
+        agent_name="alpha",
+        workspace_state_dir=tmp_path / ".reyn",
+        snapshot_path=snapshot_path,
+    )
+    before = session.hook_env_snapshot()["REYN_AGENT_BASE_DIR"]
+
+    override_dir = tmp_path / "narrowed"
+    override_dir.mkdir()
+    session_config = snapshot_path.parent / "config.yaml"
+    session_config.write_text(f"base_dir: {override_dir}\n", encoding="utf-8")
+
+    after = session.hook_env_snapshot()["REYN_AGENT_BASE_DIR"]
+
+    assert after != before, (
+        "a base_dir override written after construction must change the "
+        "NEXT hook_env_snapshot() read — a frozen value would keep "
+        f"reporting {before!r}"
+    )
+    assert after == str(override_dir.resolve())

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -556,7 +556,26 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: persisted (spawn-time priority resolution happens in the spawn seam,
 #: which runs after ``Session.__init__``), so it cannot be threaded
 #: through construction without restructuring the spawn seam itself.
-_PUBLIC_MEMBER_CEILING = 119
+#: Raised 119 -> 120 for #5428: ``hook_env_snapshot`` — a NEW method.
+#: ① What was added: a live read of the 4 REYN_* values a hook's
+#: exec/exec_capture child process would receive right now (delegates
+#: to the existing ``_build_hook_process_context()``, returned as a
+#: plain ``dict[str, str]`` — ``HookProcessContext.as_env()``'s own
+#: shape, never the callable itself).
+#: ② Why not private: TWO real readers outside Session (architect's own
+#: #5428 finding — the issue existed BECAUSE neither had a way to look):
+#: an operator via ``reyn doctor``'s own ``_print_hook_env_snapshot``
+#: (``interfaces/cli/commands/doctor.py``), and any test that used to
+#: reach through two private hops (``session._hook_dispatcher.
+#: _hook_process_context()``, #5426's own shape) now reads this
+#: instead — not a slash handler reaching into session internals
+#: (#3595 S4's own failure mode); doctor has no Session at all to
+#: reach into.
+#: ③ Why not a constructor argument: the value is live-computed on
+#: every call (``_workspace_base_dir`` can change across this
+#: session's own lifetime, #5081) — there is no single value to supply
+#: at construction time that would stay correct.
+_PUBLIC_MEMBER_CEILING = 120
 
 
 def test_session_public_surface_does_not_grow() -> None:


### PR DESCRIPTION
**[e2e-coder]** — closes #5428.

## What

architect's final ruling: a public method with only a test consumer is the exact #4866 shape #5442 already spent a PR closing 3 instances of — the public read-surface and its real production consumer land together, in this one PR.

## Public surface

`Session.hook_env_snapshot()` — returns the resolved `REYN_*` envelope as a plain `dict[str, str]` (`HookProcessContext.as_env()`'s own shape), never the callable itself. Live on every call (delegates to the existing `_build_hook_process_context()`), matching witness ②'s own requirement.

## Consumer: `reyn doctor`

New section prints, per configured agent (`.reyn/agents/*`), the same 4 `REYN_*` values a real dispatch would set — verified **by hand** this session to be numerically **identical** to a real `Session`'s own `hook_env_snapshot()` for the same agent/config (not merely similarly-shaped).

## The extraction (lead-coder-scoped, issue comment)

`doctor` constructs no live `Session` anywhere (0 `Session(` call sites — confirmed) and `Session.__init__` requires `agent`/`generation_store`/`journal`/`state_log` as real scaffolding — neither "lightweight Session construction" nor "reimplement the whole override chain" was actually cheap. Extracted **only** the pure "one candidate → token-expand → boundary-check" step (`workspace_paths.resolve_base_dir_candidate`) — deliberately **not** the layer-ordering (session-config → agent-profile → Agent default), per lead-coder's own scoping discriminant ("does the argument count grow when the caller count grows?" — ordering would have forced a "no session layer" branch into the function for doctor's own sake). Each caller (`Session`, `doctor`) still owns its own layer order; only the validation of ONE already-selected raw string is shared.

## What the #5081/#5084 blocks protected, and how this extraction keeps it true

Both blocks required: (1) token expansion **before** the absolute-path check (order load-bearing — preserved, same order inside the extracted function); (2) a bare relative value **rejected outright**, never silently workspace-relative or cwd-relative (preserved — the extracted function still rejects non-absolute); (3) restrict-only workspace boundary (preserved — `within_workspace` still gates the return). The two **distinct** log messages (#5084's "must be either an absolute path or..." vs #5081's "...resolves outside the project workspace") are preserved verbatim at the `Session` call site (a cheap, non-hardened re-check of "is it absolute" purely to pick which pre-existing wording applies — the shared function already made the real accept/reject decision) — this is pinned by `test_4200_session_base_dir_resolution.py`'s own **existing** caplog assertion, confirmed still green, not just re-read.

## Comment policy §8

`_build_hook_process_context`'s docstring paragraph ("this extraction is deliberately NOT paired with a public method...") is now false the moment this PR lands — rewritten to describe the current state (landed together, in this PR), not left stale.

## Verification

- `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green.
- New test file (`tests/hooks/test_5428_public_hook_env_snapshot.py`): 2 passed (witnesses ①②). Strip-falsified: freezing the read at construction turns witness ② genuinely red, confirmed, then restored.
- `tests/hooks/` full sweep: 382 passed.
- Existing #5081/#5084/#4200/#4206/#5080 base_dir-override scope: 88 passed — zero behavior change, confirmed not just re-read.
- Doctor's own existing test files (6 files): 47 passed.

## Test plan

- [x] (skipped — CLI text-output addition + a new public read method, no interactive surface; verified via the automated suite + a real manual `reyn doctor` run compared byte-for-byte against a real `Session.hook_env_snapshot()` above)
