### PR TITLE
fix(#4855): reset LoopTripwire's one-shot notice on recovery, not once per App session

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -174,7 +174,9 @@ class LoopTripwire:
 
     @property
     def fired(self) -> bool:
-        """Whether the threshold has been crossed at least once."""
+        """Whether the CURRENT stall episode's onset has already been
+        reported (#4855: reset at each recovery, not "ever, this
+        session" — see :meth:`observe`'s recovery branch for why)."""
         return self._fired
 
     def consume_recovered(self) -> bool:
@@ -255,6 +257,19 @@ class LoopTripwire:
                 if self._current_stall_reported:
                     self._just_recovered = True
                     self._current_stall_reported = False
+                # #4855 (owner decision B): reset the one-shot notice gate
+                # HERE, at recovery — not "once per App session" but "once
+                # per un-recovered episode." Without this, an early stall
+                # (e.g. app-mount startup jitter) permanently consumed the
+                # session's only notice, and every LATER, possibly far more
+                # serious freeze went unreported for the rest of the
+                # session — the exact hole #4855 measured. The original
+                # reason for "once, not per-tick" (a notice repeated per
+                # tick buries the reply it's about) is unaffected: this
+                # still reports at most once PER STALL, only the boundary
+                # between stalls moved from "session start" to "the
+                # previous stall's own recovery."
+                self._fired = False
                 write_record(
                     "tripwire_recovered", lateness_ms=round(lateness_ms, 1), **extra,
                 )

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -257,7 +257,7 @@ class LoopTripwire:
                 if self._current_stall_reported:
                     self._just_recovered = True
                     self._current_stall_reported = False
-                # #4855 (owner decision B): reset the one-shot notice gate
+                # lead-coder ruling, #4855: reset the one-shot notice gate
                 # HERE, at recovery — not "once per App session" but "once
                 # per un-recovered episode." Without this, an early stall
                 # (e.g. app-mount startup jitter) permanently consumed the

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -339,49 +339,60 @@ def test_recovery_is_recorded_only_once_per_episode(monkeypatch, tmp_path: Path)
     )
 
 
-def test_consume_recovered_stays_false_when_the_stalls_own_onset_was_never_reported() -> None:
-    """Tier 2: #4855's root cause, reproduced directly against the unit
-    under test (no dump file, no real/virtual clock — ``_fired`` is a
-    permanent one-shot latch and needs no time to consume: a SECOND stall
-    episode alone is enough).
+def test_a_second_stall_after_recovery_is_reported_again() -> None:
+    """Tier 2: #4855 (owner decision B) — the once-only notice gate is now
+    "once per un-recovered episode," not "once per App session." Before
+    this fix, ``self._fired`` was a PERMANENT one-shot latch: a first
+    stall (even an unrelated app-mount startup hiccup) consumed the
+    session's only notice, and every LATER, possibly far more serious
+    freeze went unreported for the rest of the session — #4855's own
+    measured defect. ``observe()``'s recovery branch now resets
+    ``_fired`` at the exact point a stall recovers, so a genuinely NEW
+    episode after that point gets its own onset reported, exactly like
+    the first ever did.
 
-    Mechanism (confirmed by reading ``observe()``'s two branches):
-    ``self._fired`` silently swallows the ONSET return value for every
-    episode after the first (``if self._fired: return None`` — no notice
-    reaches the caller), but the pre-fix recovery branch set
-    ``self._just_recovered = True`` UNCONDITIONALLY on every recovery,
-    regardless of whether the episode it was "recovering from" ever had
-    its onset reported. In production this surfaces as
-    ``stall_recovered_log_line``'s literal text — "the interface recovered
-    from the stall reported above" — with no stall ever reported above,
-    exactly the CI-observed ``assert None is not None`` signature
-    (#4855's own PR-thread investigation: waiting for "recovered" then
-    asserting "unresponsive" never finds it, because episode 2's onset
-    line was never written).
-
-    A real host can reach episode 2's onset going unreported without any
-    injected delay at all: an unrelated stall during app-mount startup
-    jitter consumes ``_fired`` before the test's own intentional stall
-    ever runs — #4855's own root-cause comment traces exactly this path.
-    This test skips the mount-jitter framing and drives ``LoopTripwire``
-    directly through two consecutive episodes, which is sufficient to
-    exercise the same ``_fired``-already-True branch."""
+    This is the witness lead-coder asked for directly: "#4827①'s test
+    assumed 'my own stall produces a notice' — confirm that assumption
+    is TRUE AGAIN once B lands," not just that #4855's old symptom is
+    gone."""
     tripwire = LoopTripwire(threshold_ms=250.0)
 
-    tripwire.observe(1800.0)  # episode 1: stall — onset REPORTED (fired False -> True)
+    first_onset = tripwire.observe(1800.0)  # episode 1: stall
     tripwire.observe(50.0)  # episode 1: recovers
     assert tripwire.consume_recovered() is True, (
         "episode 1's own onset was reported, so its recovery must be too"
     )
 
-    tripwire.observe(1700.0)  # episode 2: stall — onset SWALLOWED (fired already True)
+    second_onset = tripwire.observe(1700.0)  # episode 2: a FRESH stall, post-recovery
     tripwire.observe(40.0)  # episode 2: recovers
-    assert tripwire.consume_recovered() is False, (
-        "episode 2's own onset was never reported (fired already True, "
-        "observe() returned None) — reporting its recovery would read as "
-        "\"recovered from the stall reported above\" with nothing ever "
-        "reported above, the exact #4855 defect"
+
+    assert first_onset is not None
+    assert second_onset is not None, (
+        "episode 2 comes AFTER episode 1's own recovery -- its onset must "
+        "be reported, the same as episode 1's was (owner decision B: "
+        "'once per session' was the defect this issue closes)"
     )
+    assert tripwire.consume_recovered() is True, (
+        "episode 2's own onset was reported, so its recovery must be too"
+    )
+
+
+def test_a_second_tick_within_the_same_still_ongoing_episode_is_not_reported_again() -> None:
+    """Tier 2: the ORIGINAL reason for "once, not per-tick" still holds
+    after #4855's fix — a stall that has not yet recovered must not
+    repeat its notice on every tick (a notice repeated per tick buries
+    the reply it's about). Only RECOVERY resets the gate; a later tick
+    that is STILL above threshold, with no recovery in between, must stay
+    quiet, same as before this fix."""
+    tripwire = LoopTripwire(threshold_ms=250.0)
+
+    onset = tripwire.observe(1800.0)  # crosses — reports once
+    still_stalled = tripwire.observe(1900.0)  # same episode, no recovery yet
+    still_stalled_again = tripwire.observe(2000.0)  # same episode, still no recovery
+
+    assert onset is not None
+    assert still_stalled is None, "the same still-ongoing episode must not re-report"
+    assert still_stalled_again is None, "the same still-ongoing episode must not re-report"
 
 
 def test_consume_recovered_needs_no_dump_env_at_all(monkeypatch) -> None:

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -340,7 +340,7 @@ def test_recovery_is_recorded_only_once_per_episode(monkeypatch, tmp_path: Path)
 
 
 def test_a_second_stall_after_recovery_is_reported_again() -> None:
-    """Tier 2: #4855 (owner decision B) — the once-only notice gate is now
+    """Tier 2: lead-coder ruling, #4855 — the once-only notice gate is now
     "once per un-recovered episode," not "once per App session." Before
     this fix, ``self._fired`` was a PERMANENT one-shot latch: a first
     stall (even an unrelated app-mount startup hiccup) consumed the
@@ -369,7 +369,7 @@ def test_a_second_stall_after_recovery_is_reported_again() -> None:
     assert first_onset is not None
     assert second_onset is not None, (
         "episode 2 comes AFTER episode 1's own recovery -- its onset must "
-        "be reported, the same as episode 1's was (owner decision B: "
+        "be reported, the same as episode 1's was (lead-coder ruling, #4855: "
         "'once per session' was the defect this issue closes)"
     )
     assert tripwire.consume_recovered() is True, (


### PR DESCRIPTION
**[tui-coder]** — closes #4855.

## What
`LoopTripwire._fired` was a permanent one-shot latch with no reset path anywhere (`git grep _fired -- src` → 0 hits outside `loop_probe.py`) — the human-facing stall notice fired "once per App session," not "once per stall." An early stall (even an unrelated app-mount startup jitter hiccup) permanently consumed the session's only notice, and every LATER, possibly far more serious freeze went unreported for the rest of the session — the exact hole this issue measured.

## Decision (owner's, already made — lead-coder relayed, `blocked:external` already cleared)
**B**: reset the notice's unit from "once per session" to "once per un-recovered episode" — `consume_recovered()` already existed (`loop_probe.py:180`, called from `app.py:2324`), so recovery detection was already implemented; this changes only the unit the one-shot gate resets on.

## Fix
`observe()`'s recovery branch now resets `self._fired = False` at the exact point a stall recovers. The original reason for "once, not per-tick" (a notice repeated per tick buries the reply it's about) is unaffected — still at most once PER STALL, only the boundary moved from "session start" to "the previous stall's own recovery."

## Test fallout (flagged in the issue itself)
The `#4827①` test's premise ("my own stall produces a notice") goes vacuous once B lands, exactly as the issue predicted: `test_consume_recovered_stays_false_when_the_stalls_own_onset_was_never_reported` tested the PRE-FIX defect directly (episode 2's onset permanently swallowed by episode 1's latch) — with the fix, episode 2's onset IS now reported, so the old assertion is simply false post-fix. Replaced with two tests:
- `test_a_second_stall_after_recovery_is_reported_again` — the actual #4855 acceptance bar: a fresh stall AFTER a prior one's recovery gets its own onset reported.
- `test_a_second_tick_within_the_same_still_ongoing_episode_is_not_reported_again` — the original once-per-tick suppression still holds within a single still-ongoing episode (recovery is the only thing that resets the gate).

## Strip-falsify
Temporarily removed the `self._fired = False` reset — confirmed `test_a_second_stall_after_recovery_is_reported_again` goes red (`assert None is not None` — episode 2's onset silently swallowed, the exact CI-observed #4855 signature), then restored.

## Verification
Gate scripts green (ruff, mypy ratchet, test-tier-audit --strict, module docstrings, flat-tests ratchet, tests-path-literal, bare-tests-import, file-depth, collect-events-settle). `tests/interfaces/test_loop_probe_3539.py` (27 passed, including the real `TextualChatApp` integration tests) + a broader `loop_probe`/`tripwire`/`stall` sweep (53 passed) — all green, post-rebase onto current main (clean, no conflicts).

## Test plan
- [x] (skipped — no user-facing surface beyond the notice's own timing, already covered by the real-app integration tests above)
