### PR TITLE
fix(#5382): LLMReplay replays exception fixtures (closed cause vocabulary)

### DIFF
--- a/src/reyn/dev/testing/replay.py
+++ b/src/reyn/dev/testing/replay.py
@@ -101,7 +101,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -131,6 +131,56 @@ class PreconditionMismatch(MissingFixture):
     and, because the message names the difference, makes their logs strictly
     more informative than before.
     """
+
+
+class UnknownReplayCause(Exception):
+    """Raised in replay mode when a ``kind="exception"`` fixture entry names
+    a ``cause`` outside :data:`_REPLAY_EXCEPTION_CAUSES` — #5382 witness 6:
+    an unrecognised cause must fail EXPLICITLY, never silently fall back to
+    replaying a (nonexistent) success response, the same "diagnose, don't
+    guess" posture :class:`MissingFixture` already has for a key miss."""
+
+
+def _make_rate_limit_error(message: str) -> Exception:
+    import litellm
+
+    return litellm.RateLimitError(message=message, llm_provider="replay", model="replay")
+
+
+def _make_context_overflow_error(message: str) -> Exception:
+    import litellm
+
+    return litellm.ContextWindowExceededError(
+        message=message, model="replay", llm_provider="replay",
+    )
+
+
+def _make_byte_limit_error(message: str) -> Exception:
+    import litellm
+
+    exc = litellm.BadRequestError(message=message, model="replay", llm_provider="replay")
+    # #4381 stage 1 / engine.py's own `saw_byte_limit` classifier reads
+    # `getattr(exc, "status_code", None) == 413` directly off the exception
+    # — litellm.BadRequestError defaults status_code to 400, so this is set
+    # explicitly to reproduce the real HTTP 413 (request-BODY-byte limit)
+    # shape that classifier is looking for.
+    exc.status_code = 413  # type: ignore[assignment]  # litellm types this Literal[400]
+    return exc
+
+
+#: #5382: the CLOSED vocabulary of replayable exception causes (architect
+#: ruling — a fixture's ``cause`` is a declared enum member, never a class
+#: name imported from a string: "data" must never be a channel that points
+#: at arbitrary code, and this is the one place "what can LLMReplay
+#: reproduce" has a single, readable answer). Each factory builds a REAL
+#: litellm exception instance shaped the way reyn's own classifiers
+#: (``services/compaction/engine.py``) already read it — not a synthetic
+#: stand-in class.
+_REPLAY_EXCEPTION_CAUSES: "dict[str, Callable[[str], Exception]]" = {
+    "rate_limit": _make_rate_limit_error,
+    "context_overflow": _make_context_overflow_error,
+    "byte_limit": _make_byte_limit_error,
+}
 
 
 class LLMReplay:
@@ -188,6 +238,16 @@ class LLMReplay:
         self._records: dict[str, dict] = {}
         # key → serialised EmbeddingResponse dict (kind="embedding")
         self._embed_records: dict[str, dict] = {}
+        # #5382: key → {"cause": <closed vocabulary member>, "message": str
+        # | None} (kind="exception") — a fixture that replays a raised
+        # exception instead of a response. Read-only dict, never consumed
+        # (same "same key = same answer every time" semantics _records
+        # already has — architect ruling: no repeat-count axis; a fixture
+        # replayed by the SAME key answers the SAME way every time, and a
+        # "same cause N times" scenario is written as N distinct keys, one
+        # per distinct request, matching the real #5296/#5364 shape where
+        # each retry's request actually differs (history shrinks)).
+        self._exception_records: dict[str, dict] = {}
         # #5283: keys actually served by a REPLAY hit this instance's
         # lifetime (added by ``_replay``/``_replay_embedding``, never by
         # ``_record``/``_record_embedding`` — record mode has its own
@@ -316,6 +376,10 @@ class LLMReplay:
                     self._embed_records[entry["key"]] = entry["response"]
                 elif kind == "environment":
                     self._environment[str(entry["name"])] = entry["value"]
+                elif kind == "exception":
+                    self._exception_records[entry["key"]] = {
+                        "cause": entry["cause"], "message": entry.get("message"),
+                    }
                 else:
                     self._records[entry["key"]] = entry["response"]
                     recorded = entry.get("preconditions")
@@ -726,7 +790,34 @@ class LLMReplay:
         replayed under different tooling would answer as if the model had
         been offered capabilities it was not. A hit with a matching
         environment is served.
+
+        #5382: a ``kind="exception"`` fixture entry is checked FIRST — it
+        lives in a separate dict (``_exception_records``) from the normal
+        completion fixtures, and raises a REAL litellm exception (from the
+        closed :data:`_REPLAY_EXCEPTION_CAUSES` vocabulary) instead of
+        returning a response. Same key = same answer every call, no
+        repeat-count tracked or consumed — architect ruling: a "same cause
+        N times" scenario is written as N distinct keys (one per distinct
+        request — the real #5296/#5364 shape, where each retry's request
+        actually differs as history shrinks), never as one key answering
+        differently on its Nth read; mixing "which call number this is"
+        into the answer would make the fixture depend on call ORDER/COUNT
+        instead of purely on request CONTENT, the property that keeps a
+        fixture stable across unrelated prompt edits.
         """
+        if key in self._exception_records:
+            entry = self._exception_records[key]
+            cause = entry["cause"]
+            factory = _REPLAY_EXCEPTION_CAUSES.get(cause)
+            if factory is None:
+                raise UnknownReplayCause(
+                    f"Fixture entry for key={key!r} names cause={cause!r}, "
+                    f"which is not in the closed replay vocabulary "
+                    f"{sorted(_REPLAY_EXCEPTION_CAUSES)!r}. Fixture: "
+                    f"{self.fixture_path}."
+                )
+            self._consumed_keys.add(key)
+            raise factory(entry.get("message") or f"replayed {cause} (fixture)")
         if key not in self._records:
             preview = self._prompt_preview(messages)
             attribution = explain_miss(

--- a/tests/dev/test_5382_llm_replay_exception_causes.py
+++ b/tests/dev/test_5382_llm_replay_exception_causes.py
@@ -125,22 +125,6 @@ async def test_three_distinct_keys_express_the_same_cause_without_a_count_field(
         )
 
 
-def test_strip_the_exception_kind_branch_makes_witness_1_fall_through_to_a_miss() -> None:
-    """Tier 1: witness 4 -- the strip witness. This test does not modify
-    production code (see this repo's testing policy); it documents the
-    manual strip-falsify already performed: temporarily removing the
-    ``if key in self._exception_records:`` branch from ``_replay()``
-    makes witness 1 (``test_a_rate_limit_fixture_raises_the_real_litellm_
-    exception``) go RED -- the key falls through to the ``key not in
-    self._records`` check and raises ``MissingFixture`` instead of
-    ``RateLimitError`` (confirmed via a real commit -> edit -> revert
-    pass, not merely asserted here)."""
-    assert True  # documentation-only; see docstring — the strip itself
-    # cannot be encoded as a live test without duplicating production
-    # logic into the test (there is no public seam to disable the branch
-    # from outside _replay() without reaching into private state).
-
-
 @pytest.mark.asyncio
 async def test_a_fixture_with_no_kind_still_replays_a_normal_response(tmp_path: Path) -> None:
     """Tier 1: witness 5 -- the backward-compatibility guard. An existing

--- a/tests/dev/test_5382_llm_replay_exception_causes.py
+++ b/tests/dev/test_5382_llm_replay_exception_causes.py
@@ -1,0 +1,183 @@
+"""Tier 1: #5382 — ``LLMReplay`` gains a ``kind="exception"`` fixture entry,
+so a compaction/retry test can express "this call fails with cause X"
+without differing engine (or LLMReplay) instance from #5382's issue thread.
+
+Architect ruling (issuecomment on #5382 -- read that thread for the full
+reasoning): a fixture's ``cause`` is a CLOSED vocabulary
+(``rate_limit`` / ``context_overflow`` / ``byte_limit``), never a class
+name imported from a string ("data" must never point at arbitrary code).
+No repeat-count axis: the key is already the request's own content hash,
+so "same cause N times" is written as N distinct keys (the real
+#5296/#5364 shape -- each retry's request actually differs as history
+shrinks), never one key answering differently on its Nth read (which
+would make a fixture depend on call ORDER, breaking the "stable across
+unrelated prompt edits" property the content-only key gives it today).
+
+Recording (``_record()``, real-LLM capture of an exception) is explicitly
+OUT OF SCOPE for this change (architect: "設計していません...この PR で
+作らないでください") -- only replay of a hand-authored fixture.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only --
+no ``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. Drives the
+REAL ``litellm.acompletion`` boundary ``LLMReplay`` patches (mirrors
+``tests/dev/test_3473_replay_environment_precondition.py``'s own
+``_replay_call`` idiom), not the handler directly.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import litellm
+import pytest
+
+from reyn.dev.testing.replay import LLMReplay, UnknownReplayCause
+
+_MODEL = "gpt-4o-mini"
+
+
+def _write_fixture(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(e, ensure_ascii=False) + "\n" for e in entries), encoding="utf-8",
+    )
+
+
+async def _replay_call(replay: LLMReplay, messages: list[dict]) -> Any:
+    """Drive one completion through the REAL boundary ``LLMReplay`` patches."""
+    replay.install()
+    try:
+        return await litellm.acompletion(model=_MODEL, messages=messages)
+    finally:
+        replay.restore()
+
+
+def _exception_entry(messages: list[dict], *, cause: str, message: "str | None" = None) -> dict:
+    entry: dict = {
+        "key": LLMReplay.key(_MODEL, messages), "kind": "exception", "cause": cause,
+    }
+    if message is not None:
+        entry["message"] = message
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_a_rate_limit_fixture_raises_the_real_litellm_exception(tmp_path: Path) -> None:
+    """Tier 1: witness 1 -- a ``cause: rate_limit`` fixture makes that
+    key's request raise a real ``litellm.RateLimitError``, not a
+    synthetic stand-in."""
+    messages = [{"role": "user", "content": "one"}]
+    fixture = tmp_path / "f.jsonl"
+    _write_fixture(fixture, [_exception_entry(messages, cause="rate_limit")])
+    replay = LLMReplay(fixture, mode="replay")
+
+    with pytest.raises(litellm.RateLimitError):
+        await _replay_call(replay, messages)
+
+
+@pytest.mark.asyncio
+async def test_the_same_key_raises_the_same_exception_every_call(tmp_path: Path) -> None:
+    """Tier 1: witness 2 -- calling the SAME key twice raises the same
+    exception BOTH times, with no repeat-count tracked or consumed --
+    proof the "no count axis" design actually holds (a count-based
+    implementation would raise once then fall through to a miss/response
+    on the second call)."""
+    messages = [{"role": "user", "content": "same request twice"}]
+    fixture = tmp_path / "f.jsonl"
+    _write_fixture(fixture, [_exception_entry(messages, cause="context_overflow")])
+    replay = LLMReplay(fixture, mode="replay")
+
+    with pytest.raises(litellm.ContextWindowExceededError):
+        await _replay_call(replay, messages)
+    with pytest.raises(litellm.ContextWindowExceededError):
+        await _replay_call(replay, messages)
+
+
+@pytest.mark.asyncio
+async def test_three_distinct_keys_express_the_same_cause_without_a_count_field(
+    tmp_path: Path,
+) -> None:
+    """Tier 1: witness 3 -- THE central witness (architect: this is the
+    one that proves "count is unnecessary" actually holds). The real
+    #5296/#5364 shape (a retry loop whose history shrinks each attempt,
+    so each retry's REQUEST differs) is expressed as 3 distinct keys, all
+    with cause="byte_limit", with no count/index field anywhere in the
+    fixture format -- and all 3 requests raise it."""
+    messages_by_attempt = [
+        [{"role": "user", "content": f"attempt {i}, history len {30 - i}"}]
+        for i in range(3)
+    ]
+    fixture = tmp_path / "f.jsonl"
+    _write_fixture(
+        fixture,
+        [_exception_entry(m, cause="byte_limit") for m in messages_by_attempt],
+    )
+    replay = LLMReplay(fixture, mode="replay")
+
+    for messages in messages_by_attempt:
+        with pytest.raises(litellm.BadRequestError) as excinfo:
+            await _replay_call(replay, messages)
+        assert getattr(excinfo.value, "status_code", None) == 413, (
+            "byte_limit must reproduce the real HTTP 413 shape "
+            "engine.py's own saw_byte_limit classifier reads "
+            "(getattr(exc, 'status_code', None) == 413)"
+        )
+
+
+def test_strip_the_exception_kind_branch_makes_witness_1_fall_through_to_a_miss() -> None:
+    """Tier 1: witness 4 -- the strip witness. This test does not modify
+    production code (see this repo's testing policy); it documents the
+    manual strip-falsify already performed: temporarily removing the
+    ``if key in self._exception_records:`` branch from ``_replay()``
+    makes witness 1 (``test_a_rate_limit_fixture_raises_the_real_litellm_
+    exception``) go RED -- the key falls through to the ``key not in
+    self._records`` check and raises ``MissingFixture`` instead of
+    ``RateLimitError`` (confirmed via a real commit -> edit -> revert
+    pass, not merely asserted here)."""
+    assert True  # documentation-only; see docstring — the strip itself
+    # cannot be encoded as a live test without duplicating production
+    # logic into the test (there is no public seam to disable the branch
+    # from outside _replay() without reaching into private state).
+
+
+@pytest.mark.asyncio
+async def test_a_fixture_with_no_kind_still_replays_a_normal_response(tmp_path: Path) -> None:
+    """Tier 1: witness 5 -- the backward-compatibility guard. An existing
+    fixture entry with NO ``kind`` field (pre-#3451 shape, defaults to
+    "completion" — see ``_load()``'s own docstring) must keep replaying a
+    normal response, unaffected by the new exception-kind branch."""
+    messages = [{"role": "user", "content": "ordinary request"}]
+    fixture = tmp_path / "f.jsonl"
+    entry = {
+        "key": LLMReplay.key(_MODEL, messages),
+        "model": _MODEL,
+        "prompt_preview": "ordinary request",
+        "response": {
+            "id": "rec-1", "created": 0, "model": _MODEL, "object": "chat.completion",
+            "choices": [{
+                "index": 0, "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "ok"},
+            }],
+        },
+    }
+    _write_fixture(fixture, [entry])
+    replay = LLMReplay(fixture, mode="replay")
+
+    result = await _replay_call(replay, messages)
+    assert result.choices[0].message.content == "ok"
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_cause_fails_explicitly_not_a_silent_fallback(tmp_path: Path) -> None:
+    """Tier 1: witness 6 -- an unrecognised ``cause`` value must fail
+    EXPLICITLY (``UnknownReplayCause``), never silently fall back to
+    replaying a (nonexistent) success response -- the same "diagnose,
+    don't guess" posture ``MissingFixture`` already has for a key miss."""
+    messages = [{"role": "user", "content": "unknown cause"}]
+    fixture = tmp_path / "f.jsonl"
+    _write_fixture(fixture, [_exception_entry(messages, cause="some_future_cause")])
+    replay = LLMReplay(fixture, mode="replay")
+
+    with pytest.raises(UnknownReplayCause):
+        await _replay_call(replay, messages)


### PR DESCRIPTION
**[tui-coder]** — part of #5382 (engine/LLM half only; the `MediaStore` worker-forwarding half is a separate remainder, not started in this PR — see below).

## What

`LLMReplay` gains a `kind="exception"` fixture entry, so a compaction/retry
test can express "this call fails with cause X" against the real
`litellm.acompletion` boundary, instead of a test reaching
`CompactionController`'s name-mangled private engine or hand-rolling a fake
collaborator.

## Design (architect ruling, quoted from #5382)

- `cause` is a **closed vocabulary** (`rate_limit` / `context_overflow` /
  `byte_limit`) — never a class name imported from a string. "data must never
  be a channel that points at arbitrary code," and this keeps "what can
  LLMReplay reproduce" readable in one place. Matches this repo's typed
  discriminated union preference over a form-sniffed string.
- Each cause factory builds a **real** `litellm` exception instance, shaped
  the way `services/compaction/engine.py`'s own classifiers already read it
  (`byte_limit` sets `status_code=413` to match `saw_byte_limit`'s
  `getattr(exc, "status_code", None) == 413`).
- **No repeat-count axis.** `LLMReplay`'s key is the request's own content
  hash (`sha256(json.dumps(messages, sort_keys=True))`), read via a plain
  dict lookup, never consumed. The real #5296/#5364 shape (a retry loop whose
  history shrinks each attempt, so each retry's *request* actually differs)
  is written as N distinct keys — never one key answering differently on its
  Nth read. Adding a count would make a fixture hit depend on call
  order/time instead of purely on request content, which is the property
  that keeps a fixture stable across unrelated prompt edits today.
- `message` may be set but is never matched on (provider wording changes
  upstream, out of reyn's control).
- Recording (`_record()`, capturing a real exception from a live call) is
  explicitly **out of scope** — architect: not designed, do not add here.

## Tests — 5 witnesses (architect's list)

`tests/dev/test_5382_llm_replay_exception_causes.py`:

1. A `cause: rate_limit` fixture raises that real exception for its key.
2. The same key raises the same exception on every call (no count consumed).
3. **The central witness** — 3 distinct keys, same `cause`, no count field
   anywhere in the fixture format, proving "no repeat-count axis" actually
   holds for the real shrinking-history retry shape.
5. Backward-compat: an existing `kind`-less fixture still replays a normal
   response.
6. An unrecognized `cause` raises `UnknownReplayCause` explicitly — never a
   silent fallback to a phantom success response.

(Numbering kept as architect assigned it in #5382, including the gap at 4 —
see Test plan below for what happened to witness 4.)

## Verification

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/dev/test_5382_llm_replay_exception_causes.py` — 5/5 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py src/reyn/dev/testing/replay.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_collect_events_settle.py` — OK
- [x] `pytest tests/dev/` — 292 passed (full regression, not just the diff)
- [x] `pytest tests/llm/ tests/runtime/test_reasoning_continuity_1652.py tests/security/test_4421_litellm_import_seam.py` — 752 passed (broader `LLMReplay`-consumer sweep)

## Test plan

- [x] Automated (see above)
- [x] (skipped — Visual, standing waiver 2026-08-08)
- [x] **Strip-falsify** (moved here from a since-deleted witness-4 test function
  per lead-coder BLOCKING, head `d3d74154b` — a permanently-green
  `assert True` asserted nothing about the system and is Tier 4; the
  strip-falsify *pass itself* stood, only its record's placement was wrong):
  - **Disabled**: `_replay()`'s `if key in self._exception_records:` branch,
    temporarily replaced with `if False and key in self._exception_records:`.
  - **Went red**: witnesses 1, 2, 3 (all `RateLimitError`/`ContextWindowExceededError`/
    `BadRequestError`-raising tests), and witness 6 (the unknown-`cause` test).
  - **Failed with**: `reyn.dev.testing.replay.MissingFixture` in every case —
    the key fell through to the pre-existing `key not in self._records` check
    instead of raising the fixture-declared exception (witness 6 hit the same
    `MissingFixture` path rather than its own `UnknownReplayCause`, since that
    branch was disabled too — also the expected shape).
  - Restored; all 5 witnesses green again; `git diff` showed no residual change.

## Remainder

The `MediaStore` worker-forwarding half of #5382 (`Session` passing a
`worker` param into `MediaStore(...)`) is **not started** in this PR —
tracked as an open remainder on #5382, to be picked up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
