### PR TITLE
fix(#5382): Session forwards a caller-supplied MediaStore worker

### DIFF
--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -900,6 +900,15 @@ trust decision on a specific skill, discovered later if at all.
   sets `multimodal.base_url` in `reyn.yaml`), so path-refs also carry a `url` field
   pointing at the resources router — cross-host consumers can then HTTP GET the body; when
   unset, only same-host `path` is available.
+- `media_store_worker` (#5382 example②) — an optional `DurabilityWorker` forwarded
+  straight into `MediaStore(worker=...)`. `None` (the default) leaves `MediaStore`'s own
+  lazy-default in place — a dedicated, unshared worker per Session, unchanged from before
+  this param existed. A caller passes one explicitly to give multiple sessions in one
+  process a single shared write-serialization point. `MediaStore(worker=...)` already
+  existed (#5364 §1.4); Session simply wasn't threading a caller-supplied one through — this
+  is the one construction input added, not a general override seam (an `overrides=...`
+  catch-all was considered and rejected on #5382: no boundary, and it would undo #3133's
+  45→36 param-surface cut with one opaque param).
 - `_pending_user_images` (#366) — queue of image blocks the user attached via `/image PATH`
   or `--image PATH`, drained on the next user-message turn (attached to that
   `ChatMessage`'s `media` field). litellm-style content parts:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from reyn.config.chat import CompactionConfig, ReasoningConfig
+    from reyn.core.events.durability_worker import DurabilityWorker
     from reyn.core.op_runtime.context import OpContext
     from reyn.hooks.bus import HookBus
     from reyn.hooks.composed_consumer import ComposedEventConsumer
@@ -893,6 +894,18 @@ class Session:
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
+        # #5382 example②: the ONE construction input MediaStore's own
+        # `worker=` already accepts (see MediaStore.__init__'s own #5364
+        # §1.4 comment) — Session just wasn't passing it through. Real
+        # production reason (architect, #5382): a single process running
+        # multiple sessions wants ONE shared write-serialization point,
+        # not one DurabilityWorker per session. None -> MediaStore's own
+        # lazy-default (a dedicated worker, unshared) — unchanged
+        # behaviour for every caller that doesn't pass this. Deliberately
+        # NOT a general override/`overrides=` seam (architect rejected
+        # that shape explicitly — no boundary, and it would undo #3133's
+        # 45->36 param-surface cut with one opaque catch-all).
+        media_store_worker: "DurabilityWorker | None" = None,
         # #4274: reyn.yaml web_fetch.* → the chat-router OpContext's web_fetch_config
         # (verify_ssl / allow_private_ips / max_download_bytes). Plain value, same
         # shape as multimodal_config — not a per-turn supplier.
@@ -1086,6 +1099,11 @@ class Session:
                 session_id=session_id,
                 # #5366 §3: the project-wide (cross-session) storage cap/pin.
                 storage=self._storage_config,
+                # #5382 example②: forward a caller-shared worker through;
+                # None -> MediaStore's own lazy-default dedicated worker
+                # (unchanged behaviour — see the media_store_worker param's
+                # own comment above).
+                worker=media_store_worker,
             )
         else:
             self._media_store = None

--- a/tests/runtime/test_5364_write_unavailable_keeps_content_inline.py
+++ b/tests/runtime/test_5364_write_unavailable_keeps_content_inline.py
@@ -121,20 +121,24 @@ def test_the_real_production_chain_marks_the_entry_never_persisted(
     """Tier 2: architect/lead-coder's own #5372 precedent — a real
     ``Session``, real ``RouterHostAdapter`` (``session.router_host``),
     real ``ContextBudgetAdvisor``, driven end-to-end. The store's worker
-    is swapped for a fast one and seeded with one genuinely-exhausted
-    failure (same technique as the first test above) BEFORE the turn
-    runs, so the write-time cap's own attempt hits the pre-check and
-    raises — proving the full 4-hop ``on_write_unavailable`` wiring, not
-    just a fast unit-level stand-in."""
+    is a fast one, passed in through ``make_session(media_store_worker=...)``
+    — Session's own public construction seam (#5382 example②), not a
+    private write to ``media_store._worker`` — and seeded with one
+    genuinely-exhausted failure (same technique as the first test above)
+    BEFORE the turn runs, so the write-time cap's own attempt hits the
+    pre-check and raises — proving the full 4-hop ``on_write_unavailable``
+    wiring, not just a fast unit-level stand-in."""
     monkeypatch.chdir(tmp_path)
+    worker = _fast_worker()
     session = make_session(
         agent_name="broken-store-agent",
         multimodal_config=MultimodalConfig(),
         offload_config=OffloadConfig(enabled=True),
         compaction_config=CompactionConfig(use_chars4_estimate=True),
+        # #5382 example②: the public construction seam — Session forwards
+        # this straight into MediaStore(worker=...), no private write.
+        media_store_worker=worker,
     )
-    worker = _fast_worker()
-    session.router_host.media_store._worker = worker
 
     async def _always_fail() -> None:
         raise OSError("disk full")


### PR DESCRIPTION
**[tui-coder]** — part of #5382, example② (MediaStore worker-forwarding half). NOT a close: example①'s own acceptance criterion (`__engine_cache` 0 hits) is still open — see the Note at the bottom.

## What

`Session` gains one construction input, `media_store_worker` (default `None`),
forwarded straight into `MediaStore(worker=...)`. `MediaStore` already
accepted `worker=` (#5364 §1.4); `Session` just wasn't threading a
caller-supplied one through — the offending test
(`session.router_host.media_store._worker = worker`) was reaching past a
construction seam that already existed one layer down.

## Design (architect ruling, quoted from #5382)

> `MediaStore(worker=…)` は既に在ります — Session がそれを渡す経路だけが無い。
> ∴ Session が worker を受け取って渡す。1 つだけです。

- Real production reason: a single process running multiple sessions wants
  **one shared write-serialization point**, not one `DurabilityWorker` per
  session.
- Deliberately **not** a general override seam — an `overrides=...`
  catch-all was explicitly considered and rejected on #5382: "no boundary,"
  and it would undo #3133's 45→36 param-surface cut with one opaque param.
  This is exactly the one construction input `MediaStore` already accepted.
- `#4866` guard: no `@property` republishing a private field — the fix adds
  a construction-time parameter, not a read-back seam.

## Test fix

`tests/runtime/test_5364_write_unavailable_keeps_content_inline.py::test_the_real_production_chain_marks_the_entry_never_persisted`
now passes its fast worker in through `make_session(media_store_worker=...)`
instead of writing `session.router_host.media_store._worker = worker`.

`git grep 'media_store\._worker' -- tests/ src/` now returns 0 code hits
(one remaining match is prose in this test's own docstring, describing the
migration for the next reader).

## Verification

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5364_write_unavailable_keeps_content_inline.py` — 3/3 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_collect_events_settle.py` — OK
- [x] `pytest tests/runtime/` — 2049 passed, 7 skipped (pre-existing missing-extras, unrelated)
- [x] **Strip-falsify**: temporarily replaced `worker=media_store_worker` with `worker=None` in `Session.__init__`'s `MediaStore(...)` call — `test_the_real_production_chain_marks_the_entry_never_persisted` correctly went red (`AssertionError: test setup sanity: the seeded failure must have latched durability_failed` — the fast worker was never actually installed, so the seeded OSError landed on a different, unfast worker instance). Restored; all 3 tests green again; no residual diff.

## Test plan

- [x] Automated (see above)
- [x] (skipped — Visual, standing waiver 2026-08-08)

## Doc update (same PR, per CLAUDE.md hard rule)

`docs/reference/runtime/session-construction.md`'s "Multimodal / media"
section gains a `media_store_worker` entry alongside the existing
`_media_store` one.

## Note — a separate finding, not fixed here

`git grep '__engine_cache' -- tests/` still shows 3 hits in
`tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py` (example①'s
own acceptance criterion #1). #5452 built the `LLMReplay` exception-cause
mechanism but did not migrate this existing test to use it — that test
injects a full fake `CompactionEngine`, a larger migration than the
LLMReplay/MediaStore work done so far. Flagging for lead-coder/architect to
scope as a follow-up rather than silently expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
