### PR TITLE
fix(#5350): broker_session_for -- derive, never store, agent to broker-session correspondence

### DIFF
--- a/src/reyn/runtime/services/broker_session.py
+++ b/src/reyn/runtime/services/broker_session.py
@@ -37,6 +37,15 @@ Two structural rules the design explicitly calls out (architect, #5350 §3):
    ("this session's agent?", which could have more than one right answer).
    This module does not build or expose an index; it re-derives on every
    call, matching "computed, never persisted" (see the ruling above).
+
+In-repo call sites are 0 by DESIGN, not by omission (architect, #5457
+review): ``reyn doctor`` cannot call this — its own charter (D-2, "doctor
+never connects") forbids reaching out to broker to fetch a live session
+listing. The real consumer is #5410's ``broker_drain.py`` hook, which lives
+in an operator's own config repo (``reyn-self``), outside this repo
+entirely. A future "0-consumer public surface" census (the #4866/#5442/
+#5447 family) should read this paragraph before flagging this function —
+the absence is structural, not a leftover.
 """
 from __future__ import annotations
 

--- a/src/reyn/runtime/services/broker_session.py
+++ b/src/reyn/runtime/services/broker_session.py
@@ -1,0 +1,76 @@
+"""``broker_session_for`` — #5350: derive, never store, the broker
+``session_id`` that corresponds to a reyn agent.
+
+Architect ruling (#5350, quoted): "対応を「持つ主体」は居ません。対応は保
+存するものではなく導出するものです。broker の変更は要りません" ("there is
+no subject that HOLDS the correspondence — it is derived, not saved; broker
+needs zero changes").
+
+Both sides already carry the same fact — a **path**:
+
+- reyn: an agent's own ``base_dir`` (``AgentProfile.base_dir`` /
+  ``registry.ensure_running(name)``'s working directory).
+- broker: a registered session's ``working_dir`` (``server.py`` stores it at
+  registration and returns it from ``list_sessions``/``inbox_stats``).
+
+So the correspondence is the JOIN of those two paths — no new ledger, no new
+field, no declared identifier. A prior attempt at a declared identifier
+(``AgentProfile.broker_identity``, #5084/#5085) was later removed from
+reyn's own runtime entirely (#5091/#5095, subject line verbatim: "remove the
+'broker' concept from reyn's own runtime") — architect's #5350 ruling is
+this repo's SECOND time reaching the same conclusion, not a new opinion.
+``broker`` is an operator-chosen MCP-server name under
+``external_transports:`` (see ``reyn.config.infra``), never a concept
+reyn's own core types carry — this module keeps it that way: it takes
+whatever session listing its caller already fetched (however they fetched
+it — an MCP ``list_sessions`` call, a test fixture) and returns a plain
+``str | None``, no broker-shaped type anywhere in this module's own surface.
+
+Two structural rules the design explicitly calls out (architect, #5350 §3):
+
+1. **Normalize both sides** (``Path(...).resolve()``) before comparing —
+   skipping this lets a symlink or a trailing slash silently produce a
+   false "no match" even though the same directory is meant on both sides.
+2. **Never assume 1:1.** Multiple reyn agents can legitimately share one
+   ``base_dir`` (sub-agents in the same project) — the correspondence is
+   asked one direction only ("this agent's session?"), never the reverse
+   ("this session's agent?", which could have more than one right answer).
+   This module does not build or expose an index; it re-derives on every
+   call, matching "computed, never persisted" (see the ruling above).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+def broker_session_for(
+    agent_base_dir: "str | Path", sessions: "Sequence[Mapping[str, Any]]",
+) -> "str | None":
+    """Return the ``session_id`` of the broker session whose ``working_dir``
+    resolves to the same path as ``agent_base_dir``, or ``None`` when no
+    registered session matches.
+
+    ``sessions`` is whatever the caller already fetched — the shape
+    broker's own ``list_sessions``/``inbox_stats`` MCP tools return: an
+    iterable of mappings each carrying at least ``session_id`` and
+    ``working_dir`` (see ``server.py``'s own ``sessions[session_id] =
+    SessionEntry(session_id=..., working_dir=...)``). This function makes
+    no MCP call itself and holds no broker-shaped type — the caller (a
+    hook, a future op) is the one that knows how to reach broker; this is
+    the pure JOIN step once that data is in hand.
+
+    ``None`` is a NORMAL answer, not a failure: "this agent has no live
+    broker session right now" is a true, current fact, not an error to
+    raise or paper over. A session entry missing ``working_dir`` (should
+    not happen against a real broker, but this function does not trust its
+    caller's data blindly) is skipped rather than raising.
+    """
+    target = Path(agent_base_dir).resolve()
+    for session in sessions:
+        working_dir = session.get("working_dir")
+        if working_dir is None:
+            continue
+        if Path(working_dir).resolve() == target:
+            return session.get("session_id")
+    return None

--- a/tests/runtime/test_5350_broker_session_for.py
+++ b/tests/runtime/test_5350_broker_session_for.py
@@ -1,4 +1,4 @@
-"""Tier 1: #5350 — ``broker_session_for`` derives (never stores) the broker
+"""Tier 2: #5350 — ``broker_session_for`` derives (never stores) the broker
 ``session_id`` corresponding to a reyn agent, by joining the one fact both
 sides already carry: a path (agent ``base_dir`` == session ``working_dir``).
 
@@ -25,7 +25,7 @@ def _session(session_id: str, working_dir: str) -> dict:
 
 
 def test_a_matching_working_dir_returns_that_sessions_id(tmp_path) -> None:
-    """Tier 1: witness 1 — agent base_dir == a session's working_dir ->
+    """Tier 2: witness 1 — agent base_dir == a session's working_dir ->
     that session_id is returned."""
     agent_dir = tmp_path / "agents" / "tui-coder"
     agent_dir.mkdir(parents=True)
@@ -38,7 +38,7 @@ def test_a_matching_working_dir_returns_that_sessions_id(tmp_path) -> None:
 
 
 def test_no_matching_session_returns_none_not_an_exception(tmp_path) -> None:
-    """Tier 1: witness 2 — the CENTRAL no-match case. "No live broker
+    """Tier 2: witness 2 — the CENTRAL no-match case. "No live broker
     session for this agent right now" is a normal, current answer — None,
     never an exception, never an empty string standing in for absence."""
     agent_dir = tmp_path / "agents" / "lonely-agent"
@@ -54,7 +54,7 @@ def test_no_matching_session_returns_none_not_an_exception(tmp_path) -> None:
 def test_two_agents_sharing_one_working_dir_both_resolve_to_the_same_session(
     tmp_path,
 ) -> None:
-    """Tier 1: witness 3 — THE central witness (architect: this is the one
+    """Tier 2: witness 3 — THE central witness (architect: this is the one
     that proves the "never assume 1:1" design actually holds). Two
     DIFFERENT reyn agents (sub-agents in the same project) share one
     base_dir; both queries must return the SAME session_id — proof this
@@ -74,7 +74,7 @@ def test_two_agents_sharing_one_working_dir_both_resolve_to_the_same_session(
 
 
 def test_a_symlinked_path_on_either_side_still_matches(tmp_path) -> None:
-    """Tier 1: witness 4 — normalization proof. The agent side is reached
+    """Tier 2: witness 4 — normalization proof. The agent side is reached
     through a symlink; the session's working_dir is the real path. Without
     ``.resolve()`` on both sides these compare unequal even though they
     name the same directory — a silent, wrong "no session" answer."""
@@ -88,7 +88,7 @@ def test_a_symlinked_path_on_either_side_still_matches(tmp_path) -> None:
 
 
 def test_a_session_with_no_working_dir_key_is_skipped_not_fatal(tmp_path) -> None:
-    """Tier 1: a malformed/partial session entry (missing working_dir) must
+    """Tier 2: a malformed/partial session entry (missing working_dir) must
     not raise — this function does not trust its caller's data blindly,
     it skips the entry and keeps looking."""
     agent_dir = tmp_path / "agents" / "tui-coder"

--- a/tests/runtime/test_5350_broker_session_for.py
+++ b/tests/runtime/test_5350_broker_session_for.py
@@ -1,0 +1,98 @@
+"""Tier 1: #5350 — ``broker_session_for`` derives (never stores) the broker
+``session_id`` corresponding to a reyn agent, by joining the one fact both
+sides already carry: a path (agent ``base_dir`` == session ``working_dir``).
+
+Architect's 5 witnesses (quoted, #5350):
+
+  | # | 構成 | 期待 |
+  |---|---|---|
+  | 1 | agent の base_dir ＝ ある session の working_dir | その session_id が返る |
+  | 2 | 一致する session が無い | None（例外でも空文字でもない） |
+  | 3 | 同じ working_dir に 2 agent | 両方とも同じ session_id を得る（多対一） |
+  | 4 | 片側だけ symlink 経由のパス | 一致する（正規化の証拠） |
+  | 5 | strip: 正規化を外す | 4 が赤 |
+
+"2 と 3 が本質" (architect): returning None as a normal answer, and never
+assuming 1:1.
+"""
+from __future__ import annotations
+
+from reyn.runtime.services.broker_session import broker_session_for
+
+
+def _session(session_id: str, working_dir: str) -> dict:
+    return {"session_id": session_id, "working_dir": working_dir, "role": None, "status": "idle"}
+
+
+def test_a_matching_working_dir_returns_that_sessions_id(tmp_path) -> None:
+    """Tier 1: witness 1 — agent base_dir == a session's working_dir ->
+    that session_id is returned."""
+    agent_dir = tmp_path / "agents" / "tui-coder"
+    agent_dir.mkdir(parents=True)
+    sessions = [
+        _session("tui-coder", str(agent_dir)),
+        _session("other-agent", str(tmp_path / "agents" / "other")),
+    ]
+
+    assert broker_session_for(agent_dir, sessions) == "tui-coder"
+
+
+def test_no_matching_session_returns_none_not_an_exception(tmp_path) -> None:
+    """Tier 1: witness 2 — the CENTRAL no-match case. "No live broker
+    session for this agent right now" is a normal, current answer — None,
+    never an exception, never an empty string standing in for absence."""
+    agent_dir = tmp_path / "agents" / "lonely-agent"
+    agent_dir.mkdir(parents=True)
+    sessions = [_session("someone-else", str(tmp_path / "agents" / "someone-else"))]
+
+    result = broker_session_for(agent_dir, sessions)
+
+    assert result is None
+    assert result != "", "absence must be None, never an empty-string stand-in"
+
+
+def test_two_agents_sharing_one_working_dir_both_resolve_to_the_same_session(
+    tmp_path,
+) -> None:
+    """Tier 1: witness 3 — THE central witness (architect: this is the one
+    that proves the "never assume 1:1" design actually holds). Two
+    DIFFERENT reyn agents (sub-agents in the same project) share one
+    base_dir; both queries must return the SAME session_id — proof this
+    module asks "this agent's session?" (many-to-one, always answerable)
+    and never builds a 1:1 index that would only have room for one."""
+    shared_dir = tmp_path / "agents" / "shared-project"
+    shared_dir.mkdir(parents=True)
+    sessions = [_session("the-one-session", str(shared_dir))]
+
+    # Two distinct callers (different agent identities), same base_dir.
+    result_a = broker_session_for(shared_dir, sessions)
+    result_b = broker_session_for(str(shared_dir), sessions)  # str form too
+
+    assert result_a == "the-one-session"
+    assert result_b == "the-one-session"
+    assert result_a == result_b
+
+
+def test_a_symlinked_path_on_either_side_still_matches(tmp_path) -> None:
+    """Tier 1: witness 4 — normalization proof. The agent side is reached
+    through a symlink; the session's working_dir is the real path. Without
+    ``.resolve()`` on both sides these compare unequal even though they
+    name the same directory — a silent, wrong "no session" answer."""
+    real_dir = tmp_path / "real-project"
+    real_dir.mkdir()
+    symlinked_dir = tmp_path / "link-to-project"
+    symlinked_dir.symlink_to(real_dir)
+    sessions = [_session("real-session", str(real_dir))]
+
+    assert broker_session_for(symlinked_dir, sessions) == "real-session"
+
+
+def test_a_session_with_no_working_dir_key_is_skipped_not_fatal(tmp_path) -> None:
+    """Tier 1: a malformed/partial session entry (missing working_dir) must
+    not raise — this function does not trust its caller's data blindly,
+    it skips the entry and keeps looking."""
+    agent_dir = tmp_path / "agents" / "tui-coder"
+    agent_dir.mkdir(parents=True)
+    sessions = [{"session_id": "no-working-dir"}, _session("tui-coder", str(agent_dir))]
+
+    assert broker_session_for(agent_dir, sessions) == "tui-coder"


### PR DESCRIPTION
**[tui-coder]** — part of #5350 (NOT a close — see the Remainder section at the bottom: this PR ships the derivation function with 0 production consumers).

## What

`broker_session_for(agent_base_dir, sessions) -> str | None` — a pure
function that derives which broker `session_id` corresponds to a reyn
agent, by joining the one fact both sides already carry: a path.

## Design (architect ruling, quoted from #5350)

> 対応を「持つ主体」は居ません。対応は保存するものではなく導出するもの
> です。broker の変更は要りません。

- reyn: an agent's own `base_dir`. broker: a registered session's
  `working_dir` (`server.py:52` at registration, `:568`/`:800` in
  `list_sessions`'s own listing). The correspondence is the **JOIN** of
  those two paths — no new ledger, no new field, no declared identifier.
- **This is this repo's SECOND time reaching this conclusion, not a new
  opinion**: `AgentProfile.broker_identity` (#5084/#5085) was a declared
  identifier, later removed from reyn's own runtime entirely
  (#5091/#5095 — subject line verbatim: *"remove the 'broker' concept
  from reyn's own runtime"*). Architect confirmed on-issue that the
  declaration approach's actual cost wasn't hypothetical either: the
  dead `broker_identity:` lines are STILL live in `reyn-self`'s own
  profile.yaml files today, silently ignored by `AgentProfile.load()`
  (which only reads known keys) — exactly the failure mode "derive,
  don't declare" avoids by construction.
- Two structural rules (architect, #5350 §3): normalize both paths
  (`.resolve()`) before comparing, and never assume 1:1 — multiple reyn
  agents can share one `base_dir` (sub-agents in the same project); the
  question is always "this agent's session?", answered independently
  per call, never a built index.
- No broker-shaped type anywhere in this module's own surface — it takes
  whatever session listing its caller already fetched (an MCP
  `list_sessions` call, a hook, a future op); this function is the pure
  JOIN step, nothing more. `broker` stays what it already is in reyn's
  vocabulary: an operator-chosen `external_transports:` entry, never a
  concept reyn's own types carry.

## Tests — 5 witnesses (architect's table)

`tests/runtime/test_5350_broker_session_for.py`:

1. `agent_base_dir == some session's working_dir` → that `session_id`.
2. **No match** → `None` (never an exception, never `""`) — one of the
   two witnesses architect called central.
3. **Two agents sharing one `working_dir`** → both resolve to the same
   `session_id` — the many-to-one proof, the other central witness.
4. A symlinked path on either side still matches (normalization proof).
5. A malformed session entry (no `working_dir` key) is skipped, not
   fatal.

## Verification

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5350_broker_session_for.py` — 5/5 OK, 0 Tier-4 (declared Tier 2, corrected from an initial Tier 1 misdeclaration — see lead-coder BLOCKING fix below)
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/services/broker_session.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_collect_events_settle.py` — OK
- [x] `pytest tests/runtime/` — 2054 passed, 7 skipped (pre-existing missing-extras, unrelated)
- [x] **Strip-falsify**: temporarily removed the `.resolve()` normalization on both sides of the comparison — witness 4 (symlink) correctly went red (`AssertionError: assert None == 'real-session'`, the unresolved symlink path compared unequal to the real path). Restored; all 5 green again; no residual diff.

## Test plan

- [x] Automated (see above)
- [x] (skipped — Visual, standing waiver 2026-08-08)

## What this unblocks

Per architect: once this lands, #5410's hook can stop hardcoding a
`"reyn-self"` session_id literal in its `broker_drain.py` argv — the
provisional "current mapping is an operator config line" ruling architect
made there ends here. Not wired up in this PR (this PR is the derivation
function only, per architect's scope: "reyn 側に関数 1 つ").

## Remainder — why this is "part of", not "closes"

lead-coder BLOCKING (head `9124ee905`): `broker_session_for` has **0
production call sites** (`git grep` finds only its own definition) — the
same shape as tonight's #5447 removal of `Session.hook_env_snapshot()`
("a public surface with 0 consumers"). The natural consumer is #5410's
`broker_drain.py` hook, which lives in `reyn-self` (an operator config
repo), not in this repo — wiring it here would pull an out-of-repo,
un-reviewed-by-this-PR script's needs into scope, and a CLI-surface
consumer inside `reyn` core is its own design decision (auth, output
shape, error handling) that shouldn't be rushed to close this issue.

**#5350 stays open** until a real consumer lands (either #5410's hook
directly reaching this function, or a `reyn` CLI/op surface exposing
it) — filed as an explicit remainder, not silently dropped (issue
management: every remainder is filed or explicitly dropped, never left
as a third silent "next arc" state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

