### PR TITLE
fix(#5382): correct LLMReplay closed cause vocabulary to real measurement

### DIFF
--- a/src/reyn/dev/testing/replay.py
+++ b/src/reyn/dev/testing/replay.py
@@ -147,25 +147,10 @@ def _make_rate_limit_error(message: str) -> Exception:
     return litellm.RateLimitError(message=message, llm_provider="replay", model="replay")
 
 
-def _make_context_overflow_error(message: str) -> Exception:
+def _make_internal_server_error(message: str) -> Exception:
     import litellm
 
-    return litellm.ContextWindowExceededError(
-        message=message, model="replay", llm_provider="replay",
-    )
-
-
-def _make_byte_limit_error(message: str) -> Exception:
-    import litellm
-
-    exc = litellm.BadRequestError(message=message, model="replay", llm_provider="replay")
-    # #4381 stage 1 / engine.py's own `saw_byte_limit` classifier reads
-    # `getattr(exc, "status_code", None) == 413` directly off the exception
-    # — litellm.BadRequestError defaults status_code to 400, so this is set
-    # explicitly to reproduce the real HTTP 413 (request-BODY-byte limit)
-    # shape that classifier is looking for.
-    exc.status_code = 413  # type: ignore[assignment]  # litellm types this Literal[400]
-    return exc
+    return litellm.InternalServerError(message=message, llm_provider="replay", model="replay")
 
 
 #: #5382: the CLOSED vocabulary of replayable exception causes (architect
@@ -176,10 +161,21 @@ def _make_byte_limit_error(message: str) -> Exception:
 #: litellm exception instance shaped the way reyn's own classifiers
 #: (``services/compaction/engine.py``) already read it — not a synthetic
 #: stand-in class.
+#:
+#: #5454 correction (architect, quoting a real measurement — reyn-self's
+#: own ``.reyn/events/``, ``router_loop_terminated_by_exception``, 83
+#: occurrences): the two members here are the ONLY causes actually
+#: observed in production (79 ``rate_limit`` / 4 ``internal_server_error``).
+#: The original PR (#5452) also shipped ``context_overflow``/``byte_limit``
+#: as illustrative examples — architect's own #5382 design comment named
+#: them — but neither has ever actually been observed; a closed vocabulary
+#: exists so "what LLMReplay can reproduce" has one honest, readable
+#: answer, and an unused member makes that answer lie. Removed, not kept
+#: unused: add a cause back here only backed by its own real measurement,
+#: the same bar this correction itself was held to.
 _REPLAY_EXCEPTION_CAUSES: "dict[str, Callable[[str], Exception]]" = {
     "rate_limit": _make_rate_limit_error,
-    "context_overflow": _make_context_overflow_error,
-    "byte_limit": _make_byte_limit_error,
+    "internal_server_error": _make_internal_server_error,
 }
 
 

--- a/src/reyn/dev/testing/replay.py
+++ b/src/reyn/dev/testing/replay.py
@@ -153,6 +153,27 @@ def _make_internal_server_error(message: str) -> Exception:
     return litellm.InternalServerError(message=message, llm_provider="replay", model="replay")
 
 
+def _make_context_overflow_error(message: str) -> Exception:
+    import litellm
+
+    return litellm.ContextWindowExceededError(
+        message=message, model="replay", llm_provider="replay",
+    )
+
+
+def _make_byte_limit_error(message: str) -> Exception:
+    import litellm
+
+    exc = litellm.BadRequestError(message=message, model="replay", llm_provider="replay")
+    # #4381 stage 1 / engine.py's own `saw_byte_limit` classifier reads
+    # `getattr(exc, "status_code", None) == 413` directly off the exception
+    # — litellm.BadRequestError defaults status_code to 400, so this is set
+    # explicitly to reproduce the real HTTP 413 (request-BODY-byte limit)
+    # shape that classifier is looking for.
+    exc.status_code = 413  # type: ignore[assignment]  # litellm types this Literal[400]
+    return exc
+
+
 #: #5382: the CLOSED vocabulary of replayable exception causes (architect
 #: ruling — a fixture's ``cause`` is a declared enum member, never a class
 #: name imported from a string: "data" must never be a channel that points
@@ -162,20 +183,37 @@ def _make_internal_server_error(message: str) -> Exception:
 #: (``services/compaction/engine.py``) already read it — not a synthetic
 #: stand-in class.
 #:
-#: #5454 correction (architect, quoting a real measurement — reyn-self's
-#: own ``.reyn/events/``, ``router_loop_terminated_by_exception``, 83
-#: occurrences): the two members here are the ONLY causes actually
-#: observed in production (79 ``rate_limit`` / 4 ``internal_server_error``).
-#: The original PR (#5452) also shipped ``context_overflow``/``byte_limit``
-#: as illustrative examples — architect's own #5382 design comment named
-#: them — but neither has ever actually been observed; a closed vocabulary
-#: exists so "what LLMReplay can reproduce" has one honest, readable
-#: answer, and an unused member makes that answer lie. Removed, not kept
-#: unused: add a cause back here only backed by its own real measurement,
-#: the same bar this correction itself was held to.
+#: #5454/#5458 correction history: architect's #5454 review proposed
+#: trimming this to only ``rate_limit``/``internal_server_error``, reading
+#: reyn-self's ``router_loop_terminated_by_exception`` event population (83
+#: occurrences: 79/4) as "what's actually observed". lead-coder's #5458
+#: review caught the flaw BEFORE merge: that event fires only for an
+#: exception NO inner handler recovered from (session.py's own "router loop
+#: caught an exception no inner handler took" path) — a STRUCTURALLY biased
+#: population that can never contain a cause reyn successfully recovers
+#: from. ``byte_limit`` (HTTP 413) is exactly such a cause: engine.py:869
+#: classifies it, and a whole recovery machinery (``force_compact_now`` /
+#: ``_run_with_shrink_and_byte_reduction`` / ``_attempt_reactive_spill`` /
+#: the #4944② learned ceiling) runs BEFORE the loop would ever reach the
+#: terminal-exception handler — recovering successfully means that handler
+#: never fires, so this cause is invisible to that measurement by
+#: construction, not because it doesn't happen. ``context_overflow`` WAS
+#: independently observed in a real environment regardless (#4381: "実環境
+#: で router failed: Router context overflow after bounded shrink"),
+#: directly contradicting "never actually observed". The correct
+#: membership test (lead-coder) is "does one of reyn's own production code
+#: paths classify/read this cause" (``is_context_overflow_error``,
+#: ``saw_byte_limit`` — both real, both read by real call sites), not "does
+#: it appear in one specific terminal-failure event's population". All four
+#: members below pass that test. #5382's own originating test
+#: (``test_5296_pr2_byte_reduction_same_turn_retry.py``) is itself a
+#: byte-reduction retry test — removing ``byte_limit`` would have left the
+#: very test that motivated this issue unable to use this mechanism.
 _REPLAY_EXCEPTION_CAUSES: "dict[str, Callable[[str], Exception]]" = {
     "rate_limit": _make_rate_limit_error,
     "internal_server_error": _make_internal_server_error,
+    "context_overflow": _make_context_overflow_error,
+    "byte_limit": _make_byte_limit_error,
 }
 
 

--- a/tests/dev/test_5382_llm_replay_exception_causes.py
+++ b/tests/dev/test_5382_llm_replay_exception_causes.py
@@ -5,16 +5,24 @@ without differing engine (or LLMReplay) instance from #5382's issue thread.
 Architect ruling (issuecomment on #5382 -- read that thread for the full
 reasoning): a fixture's ``cause`` is a CLOSED vocabulary, never a class
 name imported from a string ("data" must never point at arbitrary code).
-Vocabulary members (#5454 correction, same architect, quoting a real
-measurement: reyn-self's own event log, 83
-``router_loop_terminated_by_exception`` occurrences, 79
-``RateLimitError`` / 4 ``InternalServerError``) are ``rate_limit`` /
-``internal_server_error`` -- the two causes ever actually observed in
-production. #5452's original PR also shipped ``context_overflow`` /
-``byte_limit`` as illustrative examples from architect's own #5382
-design comment; #5454 struck them for the same reason a closed
-vocabulary exists at all -- an unused member makes "what LLMReplay can
-reproduce" a lie.
+
+Vocabulary membership -- correction history (#5454/#5458, read
+``replay.py``'s own ``_REPLAY_EXCEPTION_CAUSES`` comment for the full
+account): architect's #5454 review proposed narrowing the vocabulary to
+only ``rate_limit``/``internal_server_error``, reading reyn-self's
+``router_loop_terminated_by_exception`` event population as "what's
+observed in production". lead-coder's #5458 review caught the flaw before
+merge: that event only fires for an exception NO inner handler recovered
+from -- a population that structurally excludes any cause reyn
+successfully recovers from, which is exactly what ``byte_limit`` (HTTP
+413, engine.py's own retry/shrink/spill machinery) is. ``context_overflow``
+was independently, actually observed in a real environment regardless
+(#4381). The vocabulary therefore has FOUR members: ``rate_limit`` /
+``internal_server_error`` / ``context_overflow`` / ``byte_limit`` -- the
+correct membership test (lead-coder) is "does one of reyn's own
+production code paths classify/read this cause", not "does it appear in
+one specific terminal-failure event's population".
+
 No repeat-count axis: the key is already the request's own content hash,
 so "same cause N times" is written as N distinct keys (the real
 #5296/#5364 shape -- each retry's request actually differs as history
@@ -94,12 +102,12 @@ async def test_the_same_key_raises_the_same_exception_every_call(tmp_path: Path)
     on the second call)."""
     messages = [{"role": "user", "content": "same request twice"}]
     fixture = tmp_path / "f.jsonl"
-    _write_fixture(fixture, [_exception_entry(messages, cause="internal_server_error")])
+    _write_fixture(fixture, [_exception_entry(messages, cause="context_overflow")])
     replay = LLMReplay(fixture, mode="replay")
 
-    with pytest.raises(litellm.InternalServerError):
+    with pytest.raises(litellm.ContextWindowExceededError):
         await _replay_call(replay, messages)
-    with pytest.raises(litellm.InternalServerError):
+    with pytest.raises(litellm.ContextWindowExceededError):
         await _replay_call(replay, messages)
 
 
@@ -111,10 +119,11 @@ async def test_three_distinct_keys_express_the_same_cause_without_a_count_field(
     one that proves "count is unnecessary" actually holds). The real
     #5296/#5364 shape (a retry loop whose history shrinks each attempt,
     so each retry's REQUEST differs) is expressed as 3 distinct keys, all
-    with cause="rate_limit" (#5454: reyn-self's own production events
-    show exactly this pattern -- 79 RateLimitError occurrences, the
-    dominant real retry-loop cause), with no count/index field anywhere
-    in the fixture format -- and all 3 requests raise it."""
+    with cause="byte_limit" (the actual shape of #5382's own originating
+    test, test_5296_pr2_byte_reduction_same_turn_retry.py -- a
+    byte-reduction retry test), with no count/index field anywhere in the
+    fixture format -- and all 3 requests raise it, reproducing the real
+    HTTP 413 shape engine.py's own saw_byte_limit classifier reads."""
     messages_by_attempt = [
         [{"role": "user", "content": f"attempt {i}, history len {30 - i}"}]
         for i in range(3)
@@ -122,13 +131,34 @@ async def test_three_distinct_keys_express_the_same_cause_without_a_count_field(
     fixture = tmp_path / "f.jsonl"
     _write_fixture(
         fixture,
-        [_exception_entry(m, cause="rate_limit") for m in messages_by_attempt],
+        [_exception_entry(m, cause="byte_limit") for m in messages_by_attempt],
     )
     replay = LLMReplay(fixture, mode="replay")
 
     for messages in messages_by_attempt:
-        with pytest.raises(litellm.RateLimitError):
+        with pytest.raises(litellm.BadRequestError) as excinfo:
             await _replay_call(replay, messages)
+        assert getattr(excinfo.value, "status_code", None) == 413, (
+            "byte_limit must reproduce the real HTTP 413 shape "
+            "engine.py's own saw_byte_limit classifier reads "
+            "(getattr(exc, 'status_code', None) == 413)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_internal_server_error_fixture_raises_the_real_litellm_exception(
+    tmp_path: Path,
+) -> None:
+    """Tier 1: #5454's own addition -- a ``cause: internal_server_error``
+    fixture (4 real occurrences in reyn-self's own production event log)
+    makes that key's request raise a real ``litellm.InternalServerError``."""
+    messages = [{"role": "user", "content": "internal server error probe"}]
+    fixture = tmp_path / "f.jsonl"
+    _write_fixture(fixture, [_exception_entry(messages, cause="internal_server_error")])
+    replay = LLMReplay(fixture, mode="replay")
+
+    with pytest.raises(litellm.InternalServerError):
+        await _replay_call(replay, messages)
 
 
 @pytest.mark.asyncio
@@ -171,20 +201,3 @@ async def test_an_unknown_cause_fails_explicitly_not_a_silent_fallback(tmp_path:
 
     with pytest.raises(UnknownReplayCause):
         await _replay_call(replay, messages)
-
-
-@pytest.mark.asyncio
-async def test_a_never_observed_cause_now_fails_explicitly(tmp_path: Path) -> None:
-    """Tier 1: #5454 correction witness -- ``context_overflow`` and
-    ``byte_limit`` (#5452's original illustrative-example members, never
-    actually observed in production) are no longer in the vocabulary and
-    must raise ``UnknownReplayCause`` like any other unrecognised cause,
-    not silently succeed as they did before this correction."""
-    for removed_cause in ("context_overflow", "byte_limit"):
-        messages = [{"role": "user", "content": f"probes removed cause {removed_cause}"}]
-        fixture = tmp_path / f"f-{removed_cause}.jsonl"
-        _write_fixture(fixture, [_exception_entry(messages, cause=removed_cause)])
-        replay = LLMReplay(fixture, mode="replay")
-
-        with pytest.raises(UnknownReplayCause):
-            await _replay_call(replay, messages)

--- a/tests/dev/test_5382_llm_replay_exception_causes.py
+++ b/tests/dev/test_5382_llm_replay_exception_causes.py
@@ -3,9 +3,18 @@ so a compaction/retry test can express "this call fails with cause X"
 without differing engine (or LLMReplay) instance from #5382's issue thread.
 
 Architect ruling (issuecomment on #5382 -- read that thread for the full
-reasoning): a fixture's ``cause`` is a CLOSED vocabulary
-(``rate_limit`` / ``context_overflow`` / ``byte_limit``), never a class
+reasoning): a fixture's ``cause`` is a CLOSED vocabulary, never a class
 name imported from a string ("data" must never point at arbitrary code).
+Vocabulary members (#5454 correction, same architect, quoting a real
+measurement: reyn-self's own event log, 83
+``router_loop_terminated_by_exception`` occurrences, 79
+``RateLimitError`` / 4 ``InternalServerError``) are ``rate_limit`` /
+``internal_server_error`` -- the two causes ever actually observed in
+production. #5452's original PR also shipped ``context_overflow`` /
+``byte_limit`` as illustrative examples from architect's own #5382
+design comment; #5454 struck them for the same reason a closed
+vocabulary exists at all -- an unused member makes "what LLMReplay can
+reproduce" a lie.
 No repeat-count axis: the key is already the request's own content hash,
 so "same cause N times" is written as N distinct keys (the real
 #5296/#5364 shape -- each retry's request actually differs as history
@@ -85,12 +94,12 @@ async def test_the_same_key_raises_the_same_exception_every_call(tmp_path: Path)
     on the second call)."""
     messages = [{"role": "user", "content": "same request twice"}]
     fixture = tmp_path / "f.jsonl"
-    _write_fixture(fixture, [_exception_entry(messages, cause="context_overflow")])
+    _write_fixture(fixture, [_exception_entry(messages, cause="internal_server_error")])
     replay = LLMReplay(fixture, mode="replay")
 
-    with pytest.raises(litellm.ContextWindowExceededError):
+    with pytest.raises(litellm.InternalServerError):
         await _replay_call(replay, messages)
-    with pytest.raises(litellm.ContextWindowExceededError):
+    with pytest.raises(litellm.InternalServerError):
         await _replay_call(replay, messages)
 
 
@@ -102,8 +111,10 @@ async def test_three_distinct_keys_express_the_same_cause_without_a_count_field(
     one that proves "count is unnecessary" actually holds). The real
     #5296/#5364 shape (a retry loop whose history shrinks each attempt,
     so each retry's REQUEST differs) is expressed as 3 distinct keys, all
-    with cause="byte_limit", with no count/index field anywhere in the
-    fixture format -- and all 3 requests raise it."""
+    with cause="rate_limit" (#5454: reyn-self's own production events
+    show exactly this pattern -- 79 RateLimitError occurrences, the
+    dominant real retry-loop cause), with no count/index field anywhere
+    in the fixture format -- and all 3 requests raise it."""
     messages_by_attempt = [
         [{"role": "user", "content": f"attempt {i}, history len {30 - i}"}]
         for i in range(3)
@@ -111,18 +122,13 @@ async def test_three_distinct_keys_express_the_same_cause_without_a_count_field(
     fixture = tmp_path / "f.jsonl"
     _write_fixture(
         fixture,
-        [_exception_entry(m, cause="byte_limit") for m in messages_by_attempt],
+        [_exception_entry(m, cause="rate_limit") for m in messages_by_attempt],
     )
     replay = LLMReplay(fixture, mode="replay")
 
     for messages in messages_by_attempt:
-        with pytest.raises(litellm.BadRequestError) as excinfo:
+        with pytest.raises(litellm.RateLimitError):
             await _replay_call(replay, messages)
-        assert getattr(excinfo.value, "status_code", None) == 413, (
-            "byte_limit must reproduce the real HTTP 413 shape "
-            "engine.py's own saw_byte_limit classifier reads "
-            "(getattr(exc, 'status_code', None) == 413)"
-        )
 
 
 @pytest.mark.asyncio

--- a/tests/dev/test_5382_llm_replay_exception_causes.py
+++ b/tests/dev/test_5382_llm_replay_exception_causes.py
@@ -171,3 +171,20 @@ async def test_an_unknown_cause_fails_explicitly_not_a_silent_fallback(tmp_path:
 
     with pytest.raises(UnknownReplayCause):
         await _replay_call(replay, messages)
+
+
+@pytest.mark.asyncio
+async def test_a_never_observed_cause_now_fails_explicitly(tmp_path: Path) -> None:
+    """Tier 1: #5454 correction witness -- ``context_overflow`` and
+    ``byte_limit`` (#5452's original illustrative-example members, never
+    actually observed in production) are no longer in the vocabulary and
+    must raise ``UnknownReplayCause`` like any other unrecognised cause,
+    not silently succeed as they did before this correction."""
+    for removed_cause in ("context_overflow", "byte_limit"):
+        messages = [{"role": "user", "content": f"probes removed cause {removed_cause}"}]
+        fixture = tmp_path / f"f-{removed_cause}.jsonl"
+        _write_fixture(fixture, [_exception_entry(messages, cause=removed_cause)])
+        replay = LLMReplay(fixture, mode="replay")
+
+        with pytest.raises(UnknownReplayCause):
+            await _replay_call(replay, messages)

--- a/tests/runtime/test_4405_stall_trace_wiring.py
+++ b/tests/runtime/test_4405_stall_trace_wiring.py
@@ -20,12 +20,18 @@ The THIRD test (disarm-on-exception) keeps the private ``run_turn``
 replacement — it forces a genuine exception mid-turn, which
 ``LLMStub`` cannot do (it always returns a fixed non-erroring
 completion) and the new audit-events cannot inject either (they only
-OBSERVE, they do not CONTROL). This is #5103's own boundary: the new
-seam closes ③ (content) and ④ (ordering) observation, never ②
-(controlling what a turn does) — a controllable-failure stub is that
-class's own open design question (#5450), not this PR's scope. Reported
-to lead-coder/architect as the "does chain_id/turn_started work here"
-check #5103 asked implementers to do per file.
+OBSERVE, they do not CONTROL). architect (#5454 review, quoting
+production measurement — 83 real ``router_loop_terminated_by_exception``
+events in reyn-self's own event log, 79 ``RateLimitError`` / 4
+``InternalServerError``): the receiving mechanism for this failure shape
+is **#5382** (``LLMReplay``'s ``kind: "exception"`` fixtures), not a new
+"controllable-failure stub" design question — both observed causes are
+provider exceptions, exactly what #5382's closed vocabulary reproduces.
+This private replacement is provisional until #5382's vocabulary covers
+these causes (comment policy §8: the PR that extends #5382's vocabulary
+to `rate_limit`/`internal_server_error` owes this comment a rewrite).
+Reported to lead-coder/architect as the "does chain_id/turn_started work
+here" check #5103 asked implementers to do per file.
 
 No waiting, no sleeping, no threshold crossing: the point under test is
 WIRING (does the env var reaching a turn cause arm-then-disarm to be
@@ -160,8 +166,10 @@ async def test_stall_trace_disarmed_even_when_the_turn_raises(
     Not migrated to @pytest.mark.llm_stub (see module docstring): this
     test needs run_turn to genuinely RAISE, which LLMStub cannot do (it
     always completes normally) and the audit-event seam cannot inject
-    either (an observation seam, not a control seam) — a controllable-
-    failure stub is #5450's own open design question, not this file's."""
+    either (an observation seam, not a control seam). #5382 (LLMReplay
+    exception fixtures) is where this replaces itself once its vocabulary
+    covers rate_limit/internal_server_error (architect, #5454 review —
+    83 real production occurrences of exactly this failure shape)."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("REYN_STALL_TRACE", "5")
     session = _make_session(tmp_path)


### PR DESCRIPTION
**[tui-coder]** — part of #5382 (vocabulary correction; #5452/#5456 already merged).

## What

Adds `internal_server_error` to `LLMReplay`'s closed cause vocabulary,
based on real production measurement (architect's #5454 review).
`context_overflow`/`byte_limit` — initially removed in this PR's first
version, per that same review's reading of the measurement — were
**restored** after lead-coder's BLOCKING review caught a flaw in the
measurement's population (see below). Final vocabulary: 4 members —
`rate_limit` / `internal_server_error` / `context_overflow` /
`byte_limit`.

## History — two rounds of review, both verified independently

**Round 1 (architect, #5454)**: measured reyn-self's own event log —

```
$ grep -rl 'router_loop_terminated_by_exception' .reyn/events/ | wc -l
11
$ grep -rho '"cause": *"[A-Za-z]*"' .reyn/events/ | sort | uniq -c | sort -rn
  79 "cause": "RateLimitError"
   4 "cause": "InternalServerError"
```

Read as "the only causes ever observed in production" — proposed
narrowing the vocabulary to just those two, removing `context_overflow`/
`byte_limit` as never-observed illustrative examples.

**Round 2 (lead-coder, BLOCKING on this PR's first commit)** — caught the
flaw before merge: `router_loop_terminated_by_exception`
(`session.py:8073`) fires ONLY for an exception no inner handler
recovered from — a population that structurally excludes any cause reyn
successfully recovers from:

- `byte_limit` (HTTP 413) is classified by `engine.py:869` and drives a
  whole recovery machinery (`force_compact_now` /
  `_run_with_shrink_and_byte_reduction` / `_attempt_reactive_spill` / the
  #4944② learned ceiling) that runs BEFORE the loop would ever reach the
  terminal-exception handler. A successful recovery means that handler
  never fires — invisible to the measurement by construction, not
  because it doesn't happen.
- `context_overflow` **was** independently, actually observed in a real
  environment regardless — #4381's own title: *"実環境で router failed:
  Router context overflow after bounded shrink"*, directly contradicting
  "never actually been observed".
- #5382's own originating test
  (`test_5296_pr2_byte_reduction_same_turn_retry.py`) is itself a
  byte-reduction retry test — removing `byte_limit` would have left the
  very test that motivated this issue unable to use this mechanism.

I verified both claims independently before applying the fix (read
`session.py:8073`'s own "no inner handler took" framing myself; confirmed
`#4381`'s title via `gh issue view`) rather than taking either side's word.

lead-coder's corrected membership test: **"does one of reyn's own
production code paths classify/read this cause"**
(`is_context_overflow_error`, `saw_byte_limit` — both real, both read by
real call sites), not "does it appear in one specific terminal-failure
event's population". All four members pass that test.

## Changes (final state)

- `src/reyn/dev/testing/replay.py`: `_make_internal_server_error` added
  (`litellm.InternalServerError`, `status_code=500` by default).
  `_make_context_overflow_error`/`_make_byte_limit_error` restored
  unchanged from #5452. `_REPLAY_EXCEPTION_CAUSES` has all 4 members, with
  a docstring comment recording this correction history so a future
  reader doesn't re-litigate it from scratch.
- `tests/dev/test_5382_llm_replay_exception_causes.py`: witnesses 1–3, 5,
  6 restored to their pre-#5454 shape (`context_overflow`/`byte_limit`
  back in witnesses 2/3, including the 413 `status_code` check). Added a
  new witness for `internal_server_error` (the one uncontested addition).
- `tests/runtime/test_4405_stall_trace_wiring.py`: comment policy §8 fix
  (unchanged from this PR's first version) — the disarm-on-exception
  test's comment now correctly names #5382 as the receiving mechanism
  instead of a stale "#5450 controllable-failure-stub" reference.
  (lead-coder's cross-PR ruling: this file's hunk stays in #5458, not
  #5459, which independently touched the same comment — avoids a
  same-obligation-two-executors conflict architect flagged.)

## Verification

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/dev/test_5382_llm_replay_exception_causes.py` — 6/6 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py src/reyn/dev/testing/replay.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_collect_events_settle.py` — OK
- [x] `pytest tests/dev/ tests/runtime/test_4405_stall_trace_wiring.py` — 296 passed
- [x] **Strip-falsify (round 1, `internal_server_error`/removal)**: temporarily re-added `context_overflow`/`byte_limit` to the vocabulary (routed to a stand-in factory) — the then-corresponding regression witness correctly went red. Restored.
- [x] **Strip-falsify (round 2, the fix)**: temporarily removed `context_overflow`/`byte_limit` from the vocabulary again — witnesses 2/3 correctly went red (`UnknownReplayCause` instead of the expected `ContextWindowExceededError`/`BadRequestError`). Restored; all 9 tests (this file + `test_4405_stall_trace_wiring.py`) green again; no residual diff.

## Test plan

- [x] Automated (see above)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
