### PR TITLE
fix(#5103 ③④): migrate 2 more files to the stall_trace/turn_started seam, correct #5454's comment

### DIFF
--- a/tests/core/test_session_lifecycle_events_1800.py
+++ b/tests/core/test_session_lifecycle_events_1800.py
@@ -18,15 +18,17 @@ Four tests verifying the new P6 events fire at the right points:
 Policy compliance (docs/deep-dives/contributing/testing.md):
 - No MagicMock / AsyncMock / patch for Session collaborators.
 - Real Session, real EventLog, real StateLog.
-- Test 3 (turn_started) drives the REAL `RouterLoopDriver.run_turn` /
+- Both tests 3 and 4 drive the REAL `RouterLoopDriver.run_turn` /
   RouterLoop chain via `@pytest.mark.llm_stub` (#5103, architect design
-  "C2") — only `litellm.acompletion` itself is stubbed. Test 4
-  (turn_completed) still replaces `_loop_driver.run_turn` directly with a
-  plain async callable: its own subject is the turn_completed emit's
-  ORDERING relative to `run_turn`'s own return, so replacing `run_turn`
-  itself is what the test needs, not what it is working around (#5103
-  triage: this is the "timing observation" class, not the "LLM
-  avoidance" class the llm_stub migration targets).
+  "C2") — only `litellm.acompletion` itself is stubbed, never `run_turn`.
+  Test 4 (turn_completed) used to replace `_loop_driver.run_turn`
+  directly with a plain async callable purely to get a "how many events
+  existed when run_turn was called" observation point (#5103 triage's
+  own "timing observation" class). It now reads the SAME before/after
+  bracket off the public `stall_trace_armed`/`stall_trace_disarmed`
+  audit-events (#5103 ④, this issue's own new seam) — REYN_STALL_TRACE
+  is set purely to arm this observation pair; the N-second stall
+  detection itself is untested by design (see stall_trace.py).
 - Events observed via add_subscriber (public EventLog API), not via
   private state assertions.
 """
@@ -215,6 +217,7 @@ async def test_turn_started_emits_with_kind(tmp_path: Path, monkeypatch) -> None
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub
 async def test_turn_completed_emits_after_router_turn(tmp_path: Path, monkeypatch) -> None:
     """Tier 2: turn_completed is emitted in _run_router_loop() immediately after
     RouterLoopDriver.run_turn() returns — the terminal stop_reason point.
@@ -222,20 +225,26 @@ async def test_turn_completed_emits_after_router_turn(tmp_path: Path, monkeypatc
     One turn_completed is emitted per turn. It carries the chain_id that
     matches the user message's chain_id (cross-agent tracing, P6).
 
-    Same LLM-boundary fake approach as test_turn_started_emits_with_kind.
+    #5103 ④ migration: previously replaced `_loop_driver.run_turn` with a
+    private closure that recorded how many events had been collected at
+    the moment run_turn was CALLED, then asserted turn_completed's index
+    was >= that count — a private mid-dispatch observation point. Now a
+    REAL turn dispatches (`@pytest.mark.llm_stub`, only
+    `litellm.acompletion` is stubbed) and the SAME "before/after run_turn"
+    bracket is read off the public `stall_trace_armed`/
+    `stall_trace_disarmed` audit-events (#5103 ④, this issue) — armed is
+    the first statement inside `_run_turn_body`'s task, before run_turn is
+    dispatched; disarmed is in the outermost-of-innermost `finally`, after
+    run_turn has returned AND every subsequent boundary operation
+    (turn_end hooks, hot-reload, journal cut) has too. REYN_STALL_TRACE is
+    set purely to arm this observation pair — the N-second stall
+    detection itself is not this test's subject (stall_trace.py's own
+    docstring: no test exercises the actual firing, by design).
     """
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("REYN_STALL_TRACE", "5")
     session = _make_session(tmp_path)
     collected = _collect_events(session)
-
-    # Track order: record chain_id when run_turn is called, then verify
-    # turn_completed fires after (via event list ordering).
-    run_turn_called_at: list[int] = []
-
-    async def _noop_run_turn(user_text: str, chain_id: str) -> None:
-        run_turn_called_at.append(len(collected))
-
-    session._loop_driver.run_turn = _noop_run_turn  # type: ignore[method-assign]
 
     _chain_id = "test-chain-002"
     await session._put_inbox("user", {"text": "world", "chain_id": _chain_id})
@@ -251,21 +260,20 @@ async def test_turn_completed_emits_after_router_turn(tmp_path: Path, monkeypatc
         f"turn_completed.chain_id should be {_chain_id!r}, got: {completed_ev!r}"
     )
 
-    # turn_completed must appear after run_turn was called (= after the
-    # terminal stop_reason, not before).
     all_types = [e["type"] for e in collected]
+    idx_armed = all_types.index("stall_trace_armed")
     idx_completed = next(
         i for i, e in enumerate(collected) if e["type"] == "turn_completed"
     )
-    assert run_turn_called_at, "run_turn was never called"
-    run_turn_event_count = run_turn_called_at[0]
-    # turn_completed is at position idx_completed (0-based) in the event
-    # list. run_turn_event_count events were logged before run_turn
-    # returned. turn_completed must be at position >= run_turn_event_count
-    # (= it fires at or after the point where run_turn returned, never
-    # before).
-    assert idx_completed >= run_turn_event_count, (
-        f"turn_completed (at event idx {idx_completed}) must NOT appear before "
-        f"run_turn returns (run_turn saw {run_turn_event_count} events). "
+    idx_disarmed = all_types.index("stall_trace_disarmed")
+    # turn_completed must be strictly BETWEEN armed (before run_turn is
+    # dispatched) and disarmed (after run_turn returns AND the whole
+    # unwind chain completes) — proving it fires only after the terminal
+    # stop_reason, never before.
+    assert idx_armed < idx_completed < idx_disarmed, (
+        f"turn_completed (idx {idx_completed}) must fall strictly between "
+        f"stall_trace_armed (idx {idx_armed}) and stall_trace_disarmed "
+        f"(idx {idx_disarmed}) — it must not appear before run_turn "
+        f"dispatches or after the whole turn boundary has unwound. "
         f"Event sequence: {all_types}"
     )

--- a/tests/runtime/test_3595_s2_pipeline_nudge_origin.py
+++ b/tests/runtime/test_3595_s2_pipeline_nudge_origin.py
@@ -176,6 +176,7 @@ async def test_a_pipeline_nudge_still_runs_one_turn(
     await session._run_turn_body(
         TurnOrigin.PIPELINE_NUDGE, {"text": "", "chain_id": chain_id},
     )
+    await session._audit_events.drain()
     armed = [e for e in collected if e.type == "stall_trace_armed"]
     assert armed and armed[0].data["chain_id"] == chain_id, (
         "the pipeline-nudge kind ran no turn (stall_trace_armed never fired "
@@ -233,6 +234,7 @@ async def test_a_kind_restored_from_a_snapshot_as_a_plain_string_still_dispatche
 
     chain_id = "c-restored"
     await session._run_turn_body(restored_kind, {"text": "hi", "chain_id": chain_id})
+    await session._audit_events.drain()
     armed = [e for e in collected if e.type == "stall_trace_armed"]
     assert armed and armed[0].data["chain_id"] == chain_id, (
         "the restored plain-string kind ran no turn (stall_trace_armed never "

--- a/tests/runtime/test_3595_s2_pipeline_nudge_origin.py
+++ b/tests/runtime/test_3595_s2_pipeline_nudge_origin.py
@@ -147,38 +147,48 @@ async def test_a_pipeline_nudge_turn_cannot_execute_a_slash_command(
 
 
 @pytest.mark.asyncio
-async def test_a_pipeline_nudge_still_runs_one_turn(tmp_path: Path) -> None:
+@pytest.mark.llm_stub
+async def test_a_pipeline_nudge_still_runs_one_turn(
+    tmp_path: Path, monkeypatch,
+) -> None:
     """Tier 2: the nudge still drives a turn — the behaviour the rename must NOT
     change, since pumping the driver-session's executor is its entire purpose.
 
-    ``_run_turn_body`` is driven directly with a real ``RouterLoopDriver.run_turn``
-    replaced by a real async function on the real instance (the established
-    no-mock seam for observing that a turn body ran without a live LLM call), so
-    a member that fell through the dispatch table to nothing at all — which is
-    what a new member with no branch does, silently — is RED here.
-    """
+    ``_run_turn_body`` is driven directly (it is called this way in
+    production too — by ``run_one_iteration`` — no seam is invented for
+    this test) with a REAL ``RouterLoopDriver.run_turn`` dispatch
+    (``@pytest.mark.llm_stub``, only ``litellm.acompletion`` is stubbed,
+    #5103 ③). ``_run_turn_body`` is called directly here rather than
+    through the inbox/``run_one_iteration`` path, so ``turn_started``
+    (emitted one level up, in ``run_one_iteration``) never fires — the
+    public read available AT this level is ``stall_trace_armed``, the
+    first statement inside ``_run_turn_body`` itself, unconditionally
+    reached before dispatch regardless of ``kind``. A member that fell
+    through the dispatch table to nothing at all — what a new member
+    with no branch does, silently — never reaches that statement, so
+    this is RED for exactly the same failure this test always caught."""
+    monkeypatch.setenv("REYN_STALL_TRACE", "5")
     session = _session(tmp_path)
-    ran: list[str] = []
+    collected: list = []
+    session.subscribe_audit_events(collected.append)
 
-    async def _record_turn(*args, **kwargs):
-        ran.append(kwargs.get("user_text", args[0] if args else ""))
-        return None
-
-    session._loop_driver.run_turn = _record_turn
-
+    chain_id = "c-nudge-turn"
     await session._run_turn_body(
-        TurnOrigin.PIPELINE_NUDGE, {"text": "", "chain_id": "c-nudge-turn"},
+        TurnOrigin.PIPELINE_NUDGE, {"text": "", "chain_id": chain_id},
     )
-    assert ran, (
-        "the pipeline-nudge kind ran no turn. A member with no branch in "
-        "_run_turn_body is dropped silently — the attached pipeline run it was "
-        "supposed to start would hang until its timeout"
+    armed = [e for e in collected if e.type == "stall_trace_armed"]
+    assert armed and armed[0].data["chain_id"] == chain_id, (
+        "the pipeline-nudge kind ran no turn (stall_trace_armed never fired "
+        "for chain_id={!r}). A member with no branch in _run_turn_body is "
+        "dropped silently — the attached pipeline run it was supposed to "
+        "start would hang until its timeout: {!r}".format(chain_id, collected)
     )
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub
 async def test_a_kind_restored_from_a_snapshot_as_a_plain_string_still_dispatches(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch,
 ) -> None:
     """Tier 2: a kind that comes back off disk as a bare ``str`` is still the same
     value as the member — recovery needs no conversion step.
@@ -193,6 +203,13 @@ async def test_a_kind_restored_from_a_snapshot_as_a_plain_string_still_dispatche
     payload is round-tripped through ``json`` rather than asserted on in memory,
     because in-memory equality is exactly the thing that would still hold under
     the broken version.
+
+    #5103 ③ migration: dispatch is now observed via ``stall_trace_armed``
+    (public, real dispatch — ``@pytest.mark.llm_stub``) instead of a
+    private ``run_turn`` replacement — see
+    ``test_a_pipeline_nudge_still_runs_one_turn`` above for the full
+    rationale (same seam, same reason ``turn_started`` is unavailable at
+    this call depth).
     """
     session = _session(tmp_path)
     await session.submit_user_text("queued before the crash")
@@ -210,15 +227,15 @@ async def test_a_kind_restored_from_a_snapshot_as_a_plain_string_still_dispatche
         "reach no branch in _run_turn_body, and nothing would say so"
     )
 
-    ran: list[str] = []
+    monkeypatch.setenv("REYN_STALL_TRACE", "5")
+    collected: list = []
+    session.subscribe_audit_events(collected.append)
 
-    async def _record_turn(*args, **kwargs):
-        ran.append(kwargs.get("user_text", args[0] if args else ""))
-        return None
-
-    session._loop_driver.run_turn = _record_turn
-    await session._run_turn_body(restored_kind, {"text": "hi", "chain_id": "c-restored"})
-    assert ran, (
-        "the restored plain-string kind ran no turn — a recovered session would "
-        "drop every message it had queued"
+    chain_id = "c-restored"
+    await session._run_turn_body(restored_kind, {"text": "hi", "chain_id": chain_id})
+    armed = [e for e in collected if e.type == "stall_trace_armed"]
+    assert armed and armed[0].data["chain_id"] == chain_id, (
+        "the restored plain-string kind ran no turn (stall_trace_armed never "
+        f"fired for chain_id={chain_id!r}) — a recovered session would drop "
+        f"every message it had queued: {collected!r}"
     )

--- a/tests/runtime/test_4405_stall_trace_wiring.py
+++ b/tests/runtime/test_4405_stall_trace_wiring.py
@@ -20,18 +20,12 @@ The THIRD test (disarm-on-exception) keeps the private ``run_turn``
 replacement — it forces a genuine exception mid-turn, which
 ``LLMStub`` cannot do (it always returns a fixed non-erroring
 completion) and the new audit-events cannot inject either (they only
-OBSERVE, they do not CONTROL). This is NOT #5103's ② (turn-cancel
-control) boundary, corrected by architect on this PR's own review:
-production genuinely raises out of ``run_turn`` — a real reyn-self
-measurement found ``router_loop_terminated_by_exception`` firing across
-11 files, ``cause`` values ``RateLimitError``/``InternalServerError`` —
-so this is not an unreachable branch being pinned. The real receiving
-mechanism is #5382 (``LLMReplay`` replaying exception fixtures, a
-closed cause vocabulary seeded from those same two measured causes) —
-merged after this file's own last revision. Migrating THIS test onto
-that fixture-driven replay is left for whoever picks up #5382's own
-consumer sweep; comment policy §8 obligates that PR to update this
-paragraph.
+OBSERVE, they do not CONTROL). This is #5103's own boundary: the new
+seam closes ③ (content) and ④ (ordering) observation, never ②
+(controlling what a turn does) — a controllable-failure stub is that
+class's own open design question (#5450), not this PR's scope. Reported
+to lead-coder/architect as the "does chain_id/turn_started work here"
+check #5103 asked implementers to do per file.
 
 No waiting, no sleeping, no threshold crossing: the point under test is
 WIRING (does the env var reaching a turn cause arm-then-disarm to be
@@ -166,12 +160,8 @@ async def test_stall_trace_disarmed_even_when_the_turn_raises(
     Not migrated to @pytest.mark.llm_stub (see module docstring): this
     test needs run_turn to genuinely RAISE, which LLMStub cannot do (it
     always completes normally) and the audit-event seam cannot inject
-    either (an observation seam, not a control seam). Production
-    genuinely raises here (measured: router_loop_terminated_by_exception,
-    11 files, RateLimitError/InternalServerError) — #5382's LLMReplay
-    exception-fixture replay is the real receiving mechanism for
-    migrating this test off the private replacement; see the module
-    docstring."""
+    either (an observation seam, not a control seam) — a controllable-
+    failure stub is #5450's own open design question, not this file's."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("REYN_STALL_TRACE", "5")
     session = _make_session(tmp_path)

--- a/tests/runtime/test_4405_stall_trace_wiring.py
+++ b/tests/runtime/test_4405_stall_trace_wiring.py
@@ -20,12 +20,18 @@ The THIRD test (disarm-on-exception) keeps the private ``run_turn``
 replacement — it forces a genuine exception mid-turn, which
 ``LLMStub`` cannot do (it always returns a fixed non-erroring
 completion) and the new audit-events cannot inject either (they only
-OBSERVE, they do not CONTROL). This is #5103's own boundary: the new
-seam closes ③ (content) and ④ (ordering) observation, never ②
-(controlling what a turn does) — a controllable-failure stub is that
-class's own open design question (#5450), not this PR's scope. Reported
-to lead-coder/architect as the "does chain_id/turn_started work here"
-check #5103 asked implementers to do per file.
+OBSERVE, they do not CONTROL). This is NOT #5103's ② (turn-cancel
+control) boundary, corrected by architect on this PR's own review:
+production genuinely raises out of ``run_turn`` — a real reyn-self
+measurement found ``router_loop_terminated_by_exception`` firing across
+11 files, ``cause`` values ``RateLimitError``/``InternalServerError`` —
+so this is not an unreachable branch being pinned. The real receiving
+mechanism is #5382 (``LLMReplay`` replaying exception fixtures, a
+closed cause vocabulary seeded from those same two measured causes) —
+merged after this file's own last revision. Migrating THIS test onto
+that fixture-driven replay is left for whoever picks up #5382's own
+consumer sweep; comment policy §8 obligates that PR to update this
+paragraph.
 
 No waiting, no sleeping, no threshold crossing: the point under test is
 WIRING (does the env var reaching a turn cause arm-then-disarm to be
@@ -160,8 +166,12 @@ async def test_stall_trace_disarmed_even_when_the_turn_raises(
     Not migrated to @pytest.mark.llm_stub (see module docstring): this
     test needs run_turn to genuinely RAISE, which LLMStub cannot do (it
     always completes normally) and the audit-event seam cannot inject
-    either (an observation seam, not a control seam) — a controllable-
-    failure stub is #5450's own open design question, not this file's."""
+    either (an observation seam, not a control seam). Production
+    genuinely raises here (measured: router_loop_terminated_by_exception,
+    11 files, RateLimitError/InternalServerError) — #5382's LLMReplay
+    exception-fixture replay is the real receiving mechanism for
+    migrating this test off the private replacement; see the module
+    docstring."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("REYN_STALL_TRACE", "5")
     session = _make_session(tmp_path)


### PR DESCRIPTION
**[e2e-coder]** — part of #5103, continues #5454.

## This PR

Migrates 2 more of the remaining 6 ③④ files off the private `run_turn` replacement onto the public `turn_started`/`stall_trace_armed`/`stall_trace_disarmed` seam #5454 added:

- `tests/core/test_session_lifecycle_events_1800.py` — test 4 (`turn_completed`) now asserts `turn_completed` falls strictly between `stall_trace_armed` and `stall_trace_disarmed`, instead of a private closure counting "how many events existed when I was called".
- `tests/runtime/test_3595_s2_pipeline_nudge_origin.py` — both tests call `Session._run_turn_body` directly (bypassing `run_one_iteration`, so `turn_started` never fires at that call depth) — now assert `stall_trace_armed` fired with the chosen `chain_id`.

## Correction to #5454 (post-merge, architect finding)

`test_4405_stall_trace_wiring.py`'s disarm-on-exception test comment wrongly called its remaining private replacement "#5103's ② (control) boundary". architect measured production reyn-self events and found it genuinely raises out of `run_turn` (`router_loop_terminated_by_exception`, 11 files, `RateLimitError`/`InternalServerError`) — not an unreachable branch. The real receiving mechanism is **#5382** (`LLMReplay` exception-fixture replay, merged after #5454's last revision), not a ②-class control stub. Comment updated to name #5382 (comment policy §8).

## Remaining 4 files — NOT migrated, each with a checked, concrete reason

| File | Why the new seam doesn't cover it |
|---|---|
| `test_emit_hook_event_0059_phase5_part2.py` | Its `run_turn` replacement must itself **call** `emit_hook_event` mid-turn (simulating an LLM tool call) — `LLMStub` always returns a fixed non-tool-calling completion. Control requirement, not observation. |
| `test_hook_composer_reachability_phase5.py` | Self-stimulating loop-valve test runs up to **hundreds of real turns** (363 observed uncapped in its own strip-falsifier) to trip the cap. Migrating multiplies wall-clock cost by that factor for no new witness — LLM-avoidance is its own correct, established justification (same precedent `test_hook_loop_valve_1800_7.py` cited before ITS migration). |
| `test_3475_mcp_probe_priming_all_turn_kinds.py` | Subject is **STATE at a precise moment** (`router_host.mcp_tools_cache_snapshot`, a public property) captured exactly when `run_turn` is invoked — not dispatch order/identity. The new vocabulary deliberately carries no arbitrary state (only `chain_id`/`kind`/`seconds`), so it can't answer "what did the cache contain right now". |
| `test_3377_run_loop_survives_turn_cancel.py` | Explicitly documented as using "the same controllable-hang seam `test_2242_hard_cancel.py` uses" — needs `run_turn` to hang until externally released, then be `Task.cancel()`ed. #5450's own domain (architect has since posted a design there). |

## Test plan

- [x] `ruff check .` — green
- [x] `python scripts/test_tier_audit.py --strict` on all 3 changed test files — 11/11 OK
- [x] `python scripts/mypy_ratchet.py` — OK (baselined)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] Scoped `pytest` on all 3 changed files — 11 passed
- [x] (skipped — Visual, no TUI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
