### PR TITLE
fix(#5455): profile.yaml unknown-top-level-key disclosure, structural (not band-aid)

### DIFF
--- a/.github/workflows/load-yaml-vocabulary-gate.yml
+++ b/.github/workflows/load-yaml-vocabulary-gate.yml
@@ -1,0 +1,44 @@
+name: load-yaml-vocabulary gate
+
+# #5455 ②: reject any reyn.config.loader._load_yaml(...) call site
+# missing a vocabulary= keyword argument. _load_yaml has no default for
+# vocabulary (a TypeError already catches this at call time), but this
+# gate is the second line of defense against the SIGNATURE itself
+# regressing a default back in — see scripts/check_load_yaml_vocabulary.py's
+# module docstring for the full design rationale.
+#
+# No diff/base-ref needed — a whole-tree scan against a baseline of zero,
+# same shape as collect-events-settle-gate.yml / bare-tests-import-
+# reference-gate.yml. A shallow checkout is enough.
+#
+# Path filter is the whole src/ tree, not just loader.py/config.py — the
+# gate scans every file under src/ for a _load_yaml(...) call, so a NEW
+# file elsewhere importing and calling it (the exact failure mode this
+# gate exists for) must also trigger a run.
+on:
+  pull_request:
+    paths:
+      - "src/reyn/**"
+
+permissions:
+  contents: read
+
+jobs:
+  load-yaml-vocabulary:
+    name: load-yaml-vocabulary gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_load_yaml_vocabulary.py is stdlib-only (ast /
+      # pathlib / sys). No pip install needed.
+      - name: Check every _load_yaml(...) call passes vocabulary=
+        run: |
+          python scripts/check_load_yaml_vocabulary.py

--- a/scripts/check_load_yaml_vocabulary.py
+++ b/scripts/check_load_yaml_vocabulary.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""#5455 ②: a static gate — every call to
+``reyn.config.loader._load_yaml`` passes a ``vocabulary=`` keyword
+argument.
+
+## The class this closes
+
+``_load_yaml(path, *, vocabulary)`` has no default for ``vocabulary`` —
+omitting it is a ``TypeError`` at the call site, so it already cannot be
+imported into a NEW file that forgets to decide. But ``_load_yaml`` is a
+module-private helper: nothing stops a future refactor from giving it a
+default again "for convenience", silently reopening the exact #4501/#4515
+hole this issue exists to close (a new operator-editable yaml file ships
+with no unknown-key disclosure, and nothing says so). This gate pins the
+CALL-SITE shape directly — a `vocabulary=` keyword argument present at
+every `_load_yaml(` call — so a regression on the SIGNATURE side (the
+default quietly coming back) still shows up here even though it would no
+longer be a Python-level TypeError.
+
+## Why AST, not a signature-default check
+
+Checking "does `_load_yaml` still lack a default" answers only half the
+question — it says nothing about whether some caller has silently reached
+in via `_load_yaml(path)` after a hypothetical future refactor. Statically
+finding every call site and requiring the keyword there is the same
+"witness the actual failure mode, not a stand-in for it" discipline the
+`vocabulary` parameter's own docstring names as this issue's driving
+principle: the failure is a NEW CALL SITE deciding nothing, not a NEW
+DEFAULT VALUE existing.
+
+## Real source is the reader
+
+This gate parses the real `src/` tree and reports the real line/file of
+any offending call — nothing here is a fixture; a strip (deleting a
+`vocabulary=` kwarg from any current call site) turns this RED against
+the actual codebase.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _REPO_ROOT / "src"
+
+
+class _CallVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.violations: "list[tuple[int, str]]" = []
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 (ast API name)
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else (
+            func.attr if isinstance(func, ast.Attribute) else None
+        )
+        if name == "_load_yaml":
+            has_vocabulary = any(kw.arg == "vocabulary" for kw in node.keywords)
+            if not has_vocabulary:
+                self.violations.append((node.lineno, ast.dump(node)[:120]))
+        self.generic_visit(node)
+
+
+def find_violations(src_dir: Path = _SRC) -> "list[tuple[Path, int]]":
+    """Every ``_load_yaml(...)`` call under *src_dir* missing a
+    ``vocabulary=`` keyword argument — the definition site itself
+    (``def _load_yaml``) is not a call and is never matched. *src_dir*
+    defaults to this repo's real ``src/`` tree; a test overrides it with
+    a synthetic ``tmp_path`` tree."""
+    violations: "list[tuple[Path, int]]" = []
+    for path in sorted(src_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        visitor = _CallVisitor()
+        visitor.visit(tree)
+        for lineno, _ in visitor.violations:
+            violations.append((path, lineno))
+    return violations
+
+
+def main() -> int:
+    violations = find_violations()
+    if not violations:
+        print("OK: every _load_yaml(...) call passes vocabulary= explicitly.")
+        return 0
+    print("load-yaml-vocabulary gate FAILED:\n")
+    print(
+        f"{len(violations)} call(s) to _load_yaml(...) omit the required "
+        f"vocabulary= keyword argument:\n"
+    )
+    for path, lineno in violations:
+        print(f"  {path.relative_to(_REPO_ROOT)}:{lineno}")
+    print(
+        "\nPass vocabulary=<unknown_config_keys-shaped callable> to WARN on "
+        "this file's own unknown keys at read time, or vocabulary=None — "
+        "EXPLICITLY, with a comment naming where the check actually "
+        "happens — if this file's content is validated elsewhere. See "
+        "_load_yaml's own docstring (src/reyn/config/loader.py)."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_load_yaml_vocabulary.py
+++ b/scripts/check_load_yaml_vocabulary.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """#5455 ②: a static gate — every call to
 ``reyn.config.loader._load_yaml`` passes a ``vocabulary=`` keyword
-argument.
+argument that is neither omitted nor a bare ``None``.
 
 ## The class this closes
 
@@ -16,6 +16,18 @@ CALL-SITE shape directly — a `vocabulary=` keyword argument present at
 every `_load_yaml(` call — so a regression on the SIGNATURE side (the
 default quietly coming back) still shows up here even though it would no
 longer be a Python-level TypeError.
+
+Also rejects a LITERAL ``None`` (architect BLOCKING finding on this PR's
+first revision): ``vocabulary`` accepts either a callable or one of
+``_CheckedElsewhere``'s named members (``CHECKED_BY_CONFIG_VALIDATE`` /
+``CHECKED_AT_LOAD_POINT`` / ``CHECKED_BY_CALLER``) — never ``None``,
+which would collapse those three distinct, reviewable claims into one
+value indistinguishable from "nobody decided". A future contributor
+copying a neighboring ``vocabulary=None`` for a genuinely new file would
+reopen the exact hole this issue closes while this gate stayed green (a
+bare presence check does not see WHAT was passed, only THAT something
+was) — see ``_CheckedElsewhere``'s own docstring (``reyn.config.loader``)
+for the full reasoning.
 
 ## Why AST, not a signature-default check
 
@@ -55,8 +67,15 @@ class _CallVisitor(ast.NodeVisitor):
             func.attr if isinstance(func, ast.Attribute) else None
         )
         if name == "_load_yaml":
-            has_vocabulary = any(kw.arg == "vocabulary" for kw in node.keywords)
-            if not has_vocabulary:
+            vocab_kw = next((kw for kw in node.keywords if kw.arg == "vocabulary"), None)
+            if vocab_kw is None:
+                self.violations.append((node.lineno, ast.dump(node)[:120]))
+            elif isinstance(vocab_kw.value, ast.Constant) and vocab_kw.value.value is None:
+                # #5455 ②, architect BLOCKING finding: a bare `None` is no
+                # longer a valid vocabulary= value at all (see
+                # _CheckedElsewhere's own docstring, reyn.config.loader) —
+                # it collapses 3 distinct reasons into one value nothing
+                # can tell apart. Flag it exactly like a missing kwarg.
                 self.violations.append((node.lineno, ast.dump(node)[:120]))
         self.generic_visit(node)
 
@@ -83,21 +102,28 @@ def find_violations(src_dir: Path = _SRC) -> "list[tuple[Path, int]]":
 def main() -> int:
     violations = find_violations()
     if not violations:
-        print("OK: every _load_yaml(...) call passes vocabulary= explicitly.")
+        print(
+            "OK: every _load_yaml(...) call passes vocabulary= with a "
+            "real reason (never a bare None)."
+        )
         return 0
     print("load-yaml-vocabulary gate FAILED:\n")
     print(
-        f"{len(violations)} call(s) to _load_yaml(...) omit the required "
-        f"vocabulary= keyword argument:\n"
+        f"{len(violations)} call(s) to _load_yaml(...) either omit the "
+        f"required vocabulary= keyword argument, or pass a bare None "
+        f"(no longer valid — see below):\n"
     )
     for path, lineno in violations:
         print(f"  {path.relative_to(_REPO_ROOT)}:{lineno}")
     print(
         "\nPass vocabulary=<unknown_config_keys-shaped callable> to WARN on "
-        "this file's own unknown keys at read time, or vocabulary=None — "
-        "EXPLICITLY, with a comment naming where the check actually "
-        "happens — if this file's content is validated elsewhere. See "
-        "_load_yaml's own docstring (src/reyn/config/loader.py)."
+        "this file's own unknown keys at read time, or one of "
+        "_CheckedElsewhere's named members (CHECKED_BY_CONFIG_VALIDATE / "
+        "CHECKED_AT_LOAD_POINT / CHECKED_BY_CALLER) if this file's content "
+        "is validated elsewhere — never a bare None, which collapses all "
+        "three of those distinct reasons into one value nothing can tell "
+        "apart. See _load_yaml's and _CheckedElsewhere's own docstrings "
+        "(src/reyn/config/loader.py)."
     )
     return 1
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from reyn.config.chat import (  # #1682 #3 cross-section
     _build_chat_config,
@@ -56,14 +56,44 @@ class HookYamlReadError(ValueError):
         self.column = column
 
 
-def _load_yaml(path: Path) -> dict:
+def _load_yaml(path: Path, *, vocabulary: "Callable[[dict], dict] | None") -> dict:
+    """Read *path* as YAML, returning ``{}`` if absent or unparseable.
+
+    #5455 ②: ``vocabulary`` is REQUIRED (no default) — every call site
+    must actively choose. Architect's own design for this issue: the
+    #4501/#4515 class of defect ("a new operator-editable yaml file
+    ships with no unknown-key check") recurs because a caller CAN omit
+    the check with nothing marking the omission — this makes omitting
+    it a ``TypeError``, not a silent gap. Pass a callable matching
+    :func:`reyn.config.config_schema.unknown_config_keys`'s own shape
+    (``dict -> {dotted_key: hint_or_None}``) to WARN on this file's own
+    unknown keys the instant it's read; pass ``None`` — EXPLICITLY,
+    with a comment naming where the check actually happens — for a file
+    whose content is already validated elsewhere (most current call
+    sites: the policy tier and the 5 hot-reload registry files are
+    checked on their MERGED view by ``_warn_unknown_config_keys``/
+    ``validate_in_set`` respectively, so checking the pre-merge single
+    file here too would only double the same finding, not add one).
+    ``None`` is a real, visible decision a reviewer can question — the
+    structural guarantee is that NO call site can decide silently.
+    """
     if not path.exists():
         return {}
     try:
         import yaml
         with path.open(encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-        return data if isinstance(data, dict) else {}
+        data = data if isinstance(data, dict) else {}
+        if vocabulary is not None and data:
+            unknown = vocabulary(data)
+            if unknown:
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "%s has unrecognized key(s) (not applied): %s",
+                    path, ", ".join(sorted(unknown)),
+                )
+        return data
     except Exception as exc:
         # A parse failure here is otherwise indistinguishable from "the file
         # doesn't exist" — every section the file would have contributed
@@ -162,14 +192,21 @@ def build_policy_tier_config(cwd: Path | None = None) -> dict:
     from reyn.builtin.registry import build_builtin_config
     merged = _merge(merged, build_builtin_config(), tier_label="builtin")
 
-    user_global = _load_yaml(Path.home() / ".reyn" / "config.yaml")
+    # #5455 ②: vocabulary=None for all 3 policy-tier files here — checked
+    # downstream on the MERGED view by load_config's own
+    # _warn_unknown_config_keys(merged) call (see that call site's
+    # comment); checking each pre-merge file here too would only
+    # duplicate the same finding, not add one.
+    user_global = _load_yaml(Path.home() / ".reyn" / "config.yaml", vocabulary=None)
     merged = _merge(merged, user_global, tier_label="user_global")
 
     project_root = _find_project_root(cwd)
     if project_root:
-        project = _load_yaml(project_root / "reyn.yaml")
+        project = _load_yaml(project_root / "reyn.yaml", vocabulary=None)
         merged = _merge(merged, project, tier_label="project")
-        project_local = _load_yaml(project_root / "reyn.local.yaml")
+        project_local = _load_yaml(
+            project_root / "reyn.local.yaml", vocabulary=None,
+        )
         merged = _merge(merged, project_local, tier_label="project_local")
 
     return merged
@@ -685,7 +722,9 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # Shape: ``{"mcp": {"servers": {<name>: {<entry>}}}}`` — same
         # as the section in reyn.yaml, so ``_merge`` handles it
         # without special-casing.
-        dynamic_mcp = _load_yaml(project_root / ".reyn" / "config" / "mcp.yaml")
+        dynamic_mcp = _load_yaml(
+            project_root / ".reyn" / "config" / "mcp.yaml", vocabulary=None,
+        )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_mcp)
 
         # FP-0041 #489 PR-B: dynamic cron registry separated from static
@@ -697,7 +736,9 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # ``reyn.yaml`` cron jobs.
         # Shape: ``{"cron": {"jobs": [...]}}`` — same as reyn.yaml
         # cron section. Job-list union via _merge's cron handling.
-        dynamic_cron = _load_yaml(project_root / ".reyn" / "config" / "cron.yaml")
+        dynamic_cron = _load_yaml(
+            project_root / ".reyn" / "config" / "cron.yaml", vocabulary=None,
+        )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_cron)
 
         # #2548 PR-A: skill registry separated from static config — same
@@ -708,7 +749,9 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # as the skills section in reyn.yaml, handled by _merge skills
         # branch above. #2548 PR-B: this file is also in _HOT_RELOAD_FILES
         # (the IN-set) so skill declarations hot-reload at the turn boundary.
-        dynamic_skills = _load_yaml(project_root / ".reyn" / "config" / "skills.yaml")
+        dynamic_skills = _load_yaml(
+            project_root / ".reyn" / "config" / "skills.yaml", vocabulary=None,
+        )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_skills, tier_label="dynamic")
 
         # Pipeline registry separated from static config — same #470 invariant
@@ -719,7 +762,9 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # {<entry>}}}} — same as the pipelines section in reyn.yaml, handled by
         # the _merge pipelines branch above. Also in _HOT_RELOAD_FILES (the
         # IN-set) so pipeline declarations hot-reload at the turn boundary.
-        dynamic_pipelines = _load_yaml(project_root / ".reyn" / "config" / "pipelines.yaml")
+        dynamic_pipelines = _load_yaml(
+            project_root / ".reyn" / "config" / "pipelines.yaml", vocabulary=None,
+        )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_pipelines)
 
         # FP-0054 PR-C: named-presentation-template registry separated from static
@@ -731,7 +776,9 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # presentations section in reyn.yaml, handled by the _merge presentations
         # branch above. Also in _HOT_RELOAD_FILES (the IN-set) so template
         # declarations hot-reload at the turn boundary.
-        dynamic_presentations = _load_yaml(project_root / ".reyn" / "config" / "presentations.yaml")
+        dynamic_presentations = _load_yaml(
+            project_root / ".reyn" / "config" / "presentations.yaml", vocabulary=None,
+        )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_presentations)
 
         # ADR-0031: <project>/.reyn/config.yaml is DEPRECATED (removed from
@@ -981,7 +1028,10 @@ def load_hot_reload_config(project_root: "Path | None" = None) -> dict:
     root = (project_root or Path.cwd()).resolve()
     merged: dict = {}
     for fname in _HOT_RELOAD_FILES:
-        merged = _merge(merged, _load_yaml(root / ".reyn" / fname))
+        # #5455 ②: checked downstream on the merged IN-set this function
+        # returns, by hot_reload.validate_in_set's own
+        # _warn_unknown_hot_reload_keys call — see _load_yaml's docstring.
+        merged = _merge(merged, _load_yaml(root / ".reyn" / fname, vocabulary=None))
     from reyn.security.secrets.interpolation import expand_env
     return expand_env(merged)
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -1,6 +1,7 @@
 """reyn.config.loader — config loading + yaml shape-wiring (load_config / _merge / _load_yaml). (#1682 #3 split)."""
 from __future__ import annotations
 
+import enum
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable
@@ -56,7 +57,37 @@ class HookYamlReadError(ValueError):
         self.column = column
 
 
-def _load_yaml(path: Path, *, vocabulary: "Callable[[dict], dict] | None") -> dict:
+class _CheckedElsewhere(enum.Enum):
+    """#5455 ②, architect BLOCKING finding on this PR's first revision: a
+    bare ``vocabulary=None`` collapses THREE distinct facts into one
+    value indistinguishable from "I have not decided" — the exact "None
+    means two things" fail-open shape architect has hit before (#5084/
+    #5132). A future contributor adding a new operator-editable yaml
+    file would see ``vocabulary=None`` at every neighboring call site
+    and copy it without checking whether THEIR file is actually
+    validated anywhere — reopening the #4501/#4515 hole this issue
+    exists to close, with the gate itself (a bare presence check) still
+    reading GREEN. Each member below is a distinct, named, reviewable
+    claim — ``None`` is no longer a valid ``vocabulary=`` value at all,
+    so "I haven't decided" cannot be spelled the same way as any of
+    these."""
+
+    #: This file's unknown-key check runs on the MERGED policy tier by
+    #: ``_warn_unknown_config_keys`` — see that call site.
+    CHECKED_BY_CONFIG_VALIDATE = "checked on the merged policy tier by _warn_unknown_config_keys"
+    #: This file's unknown-key check runs on the MERGED hot-reload
+    #: IN-set at ITS OWN load point — see
+    #: ``reyn.runtime.hot_reload.validate_in_set`` /
+    #: ``_warn_unknown_hot_reload_keys``.
+    CHECKED_AT_LOAD_POINT = "checked on the merged IN-set by hot_reload.validate_in_set"
+    #: The caller of THIS ``_load_yaml`` call runs its own check on the
+    #: returned dict immediately after — see the call site itself.
+    CHECKED_BY_CALLER = "checked by the caller immediately after this read returns"
+
+
+def _load_yaml(
+    path: Path, *, vocabulary: "Callable[[dict], dict] | _CheckedElsewhere",
+) -> dict:
     """Read *path* as YAML, returning ``{}`` if absent or unparseable.
 
     #5455 ②: ``vocabulary`` is REQUIRED (no default) — every call site
@@ -67,15 +98,13 @@ def _load_yaml(path: Path, *, vocabulary: "Callable[[dict], dict] | None") -> di
     it a ``TypeError``, not a silent gap. Pass a callable matching
     :func:`reyn.config.config_schema.unknown_config_keys`'s own shape
     (``dict -> {dotted_key: hint_or_None}``) to WARN on this file's own
-    unknown keys the instant it's read; pass ``None`` — EXPLICITLY,
-    with a comment naming where the check actually happens — for a file
-    whose content is already validated elsewhere (most current call
-    sites: the policy tier and the 5 hot-reload registry files are
-    checked on their MERGED view by ``_warn_unknown_config_keys``/
-    ``validate_in_set`` respectively, so checking the pre-merge single
-    file here too would only double the same finding, not add one).
-    ``None`` is a real, visible decision a reviewer can question — the
-    structural guarantee is that NO call site can decide silently.
+    unknown keys the instant it's read; pass one of
+    :class:`_CheckedElsewhere`'s named members — NEVER a bare ``None``,
+    see that class's own docstring for why — for a file whose content is
+    already validated elsewhere. Each member is a real, visible,
+    falsifiable claim a reviewer can question — the structural guarantee
+    is that NO call site can decide silently, and no two DIFFERENT
+    reasons can look like the same value.
     """
     if not path.exists():
         return {}
@@ -84,7 +113,7 @@ def _load_yaml(path: Path, *, vocabulary: "Callable[[dict], dict] | None") -> di
         with path.open(encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         data = data if isinstance(data, dict) else {}
-        if vocabulary is not None and data:
+        if callable(vocabulary) and data:
             unknown = vocabulary(data)
             if unknown:
                 import logging
@@ -192,20 +221,27 @@ def build_policy_tier_config(cwd: Path | None = None) -> dict:
     from reyn.builtin.registry import build_builtin_config
     merged = _merge(merged, build_builtin_config(), tier_label="builtin")
 
-    # #5455 ②: vocabulary=None for all 3 policy-tier files here — checked
-    # downstream on the MERGED view by load_config's own
+    # #5455 ②: CHECKED_BY_CONFIG_VALIDATE for all 3 policy-tier files
+    # here — checked downstream on the MERGED view by load_config's own
     # _warn_unknown_config_keys(merged) call (see that call site's
     # comment); checking each pre-merge file here too would only
     # duplicate the same finding, not add one.
-    user_global = _load_yaml(Path.home() / ".reyn" / "config.yaml", vocabulary=None)
+    user_global = _load_yaml(
+        Path.home() / ".reyn" / "config.yaml",
+        vocabulary=_CheckedElsewhere.CHECKED_BY_CONFIG_VALIDATE,
+    )
     merged = _merge(merged, user_global, tier_label="user_global")
 
     project_root = _find_project_root(cwd)
     if project_root:
-        project = _load_yaml(project_root / "reyn.yaml", vocabulary=None)
+        project = _load_yaml(
+            project_root / "reyn.yaml",
+            vocabulary=_CheckedElsewhere.CHECKED_BY_CONFIG_VALIDATE,
+        )
         merged = _merge(merged, project, tier_label="project")
         project_local = _load_yaml(
-            project_root / "reyn.local.yaml", vocabulary=None,
+            project_root / "reyn.local.yaml",
+            vocabulary=_CheckedElsewhere.CHECKED_BY_CONFIG_VALIDATE,
         )
         merged = _merge(merged, project_local, tier_label="project_local")
 
@@ -723,7 +759,8 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # as the section in reyn.yaml, so ``_merge`` handles it
         # without special-casing.
         dynamic_mcp = _load_yaml(
-            project_root / ".reyn" / "config" / "mcp.yaml", vocabulary=None,
+            project_root / ".reyn" / "config" / "mcp.yaml",
+            vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
         )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_mcp)
 
@@ -737,7 +774,8 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # Shape: ``{"cron": {"jobs": [...]}}`` — same as reyn.yaml
         # cron section. Job-list union via _merge's cron handling.
         dynamic_cron = _load_yaml(
-            project_root / ".reyn" / "config" / "cron.yaml", vocabulary=None,
+            project_root / ".reyn" / "config" / "cron.yaml",
+            vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
         )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_cron)
 
@@ -750,7 +788,8 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # branch above. #2548 PR-B: this file is also in _HOT_RELOAD_FILES
         # (the IN-set) so skill declarations hot-reload at the turn boundary.
         dynamic_skills = _load_yaml(
-            project_root / ".reyn" / "config" / "skills.yaml", vocabulary=None,
+            project_root / ".reyn" / "config" / "skills.yaml",
+            vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
         )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_skills, tier_label="dynamic")
 
@@ -763,7 +802,8 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # the _merge pipelines branch above. Also in _HOT_RELOAD_FILES (the
         # IN-set) so pipeline declarations hot-reload at the turn boundary.
         dynamic_pipelines = _load_yaml(
-            project_root / ".reyn" / "config" / "pipelines.yaml", vocabulary=None,
+            project_root / ".reyn" / "config" / "pipelines.yaml",
+            vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
         )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_pipelines)
 
@@ -777,7 +817,8 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # branch above. Also in _HOT_RELOAD_FILES (the IN-set) so template
         # declarations hot-reload at the turn boundary.
         dynamic_presentations = _load_yaml(
-            project_root / ".reyn" / "config" / "presentations.yaml", vocabulary=None,
+            project_root / ".reyn" / "config" / "presentations.yaml",
+            vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
         )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_presentations)
 
@@ -1031,7 +1072,10 @@ def load_hot_reload_config(project_root: "Path | None" = None) -> dict:
         # #5455 ②: checked downstream on the merged IN-set this function
         # returns, by hot_reload.validate_in_set's own
         # _warn_unknown_hot_reload_keys call — see _load_yaml's docstring.
-        merged = _merge(merged, _load_yaml(root / ".reyn" / fname, vocabulary=None))
+        merged = _merge(
+            merged,
+            _load_yaml(root / ".reyn" / fname, vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT),
+        )
     from reyn.security.secrets.interpolation import expand_env
     return expand_env(merged)
 

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -390,6 +390,7 @@ def _validate() -> None:
     """
     from reyn.config.config_schema import disabled_config_keys, unknown_config_keys
     from reyn.config.loader import (
+        _CheckedElsewhere,
         _find_project_root,
         _load_yaml,
         build_policy_tier_config,
@@ -478,12 +479,12 @@ def _validate() -> None:
         "reyn.yaml": project_root / "reyn.yaml",
         "reyn.local.yaml": project_root / "reyn.local.yaml",
     }
-    # #5455 ②: vocabulary=None — each of these files' unknown-key check
-    # already runs above (policy_unknown / in_set_unknown, on the merged
-    # view); this second read's own job is the mcp-placement/rename check,
-    # unrelated to the key vocabulary.
+    # #5455 ②: each of these files' unknown-key check already runs above
+    # (policy_unknown, on the merged policy-tier view); this second
+    # read's own job is the mcp-placement/rename check, unrelated to the
+    # key vocabulary.
     for label, path in static_mcp_sources.items():
-        raw = _load_yaml(path, vocabulary=None)
+        raw = _load_yaml(path, vocabulary=_CheckedElsewhere.CHECKED_BY_CONFIG_VALIDATE)
         mcp_section = raw.get("mcp")
         misplaced_found = _mcp_misplaced_server_entries(mcp_section)
         if misplaced_found:
@@ -491,8 +492,11 @@ def _validate() -> None:
         renamed_found = _mcp_renamed_http_transport_entries(mcp_section)
         if renamed_found:
             mcp_renamed_http[label] = renamed_found
+    # #5455 ②: this one is a hot-reload IN-set file — checked at ITS OWN
+    # load point (in_set_unknown, above), not the policy tier.
     dynamic_mcp_raw = _load_yaml(
-        project_root / ".reyn" / "config" / "mcp.yaml", vocabulary=None,
+        project_root / ".reyn" / "config" / "mcp.yaml",
+        vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
     )
     dynamic_mcp_section = dynamic_mcp_raw.get("mcp")
     dynamic_found = _mcp_misplaced_server_entries(dynamic_mcp_section)
@@ -519,7 +523,11 @@ def _validate() -> None:
             profile_path = agent_dir / "profile.yaml"
             if not profile_path.is_file():
                 continue
-            raw_profile = _load_yaml(profile_path, vocabulary=None)
+            # #5455 ②: CHECKED_BY_CALLER — the very next line runs
+            # unknown_profile_keys on this exact return value.
+            raw_profile = _load_yaml(
+                profile_path, vocabulary=_CheckedElsewhere.CHECKED_BY_CALLER,
+            )
             found = unknown_profile_keys(raw_profile)
             if found:
                 profile_unknown[agent_dir.name] = found

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -478,8 +478,12 @@ def _validate() -> None:
         "reyn.yaml": project_root / "reyn.yaml",
         "reyn.local.yaml": project_root / "reyn.local.yaml",
     }
+    # #5455 ②: vocabulary=None — each of these files' unknown-key check
+    # already runs above (policy_unknown / in_set_unknown, on the merged
+    # view); this second read's own job is the mcp-placement/rename check,
+    # unrelated to the key vocabulary.
     for label, path in static_mcp_sources.items():
-        raw = _load_yaml(path)
+        raw = _load_yaml(path, vocabulary=None)
         mcp_section = raw.get("mcp")
         misplaced_found = _mcp_misplaced_server_entries(mcp_section)
         if misplaced_found:
@@ -487,7 +491,9 @@ def _validate() -> None:
         renamed_found = _mcp_renamed_http_transport_entries(mcp_section)
         if renamed_found:
             mcp_renamed_http[label] = renamed_found
-    dynamic_mcp_raw = _load_yaml(project_root / ".reyn" / "config" / "mcp.yaml")
+    dynamic_mcp_raw = _load_yaml(
+        project_root / ".reyn" / "config" / "mcp.yaml", vocabulary=None,
+    )
     dynamic_mcp_section = dynamic_mcp_raw.get("mcp")
     dynamic_found = _mcp_misplaced_server_entries(dynamic_mcp_section)
     if dynamic_found:
@@ -496,11 +502,48 @@ def _validate() -> None:
     if dynamic_renamed_found:
         mcp_renamed_http[".reyn/config/mcp.yaml"] = dynamic_renamed_found
 
+    # #5455 ①: every .reyn/agents/<name>/profile.yaml, checked for
+    # top-level keys that are not real AgentProfile fields — a DIFFERENT
+    # operator-editable surface from the 3 above (policy tier / IN-set /
+    # hooks), with its OWN closed vocabulary (dataclasses.fields, not
+    # ReynConfig's schema) — see unknown_profile_keys's own docstring for
+    # why this is a dedicated function, not a new entry in
+    # unknown_config_keys.
+    from reyn.runtime.profile import unknown_profile_keys
+
+    profile_unknown: dict[str, "frozenset[str]"] = {}
+    if agents_dir.is_dir():
+        for agent_dir in sorted(agents_dir.iterdir()):
+            if not agent_dir.is_dir():
+                continue
+            profile_path = agent_dir / "profile.yaml"
+            if not profile_path.is_file():
+                continue
+            raw_profile = _load_yaml(profile_path, vocabulary=None)
+            found = unknown_profile_keys(raw_profile)
+            if found:
+                profile_unknown[agent_dir.name] = found
+
+    # #5455 ③: "no issues" must name what it walked — the exact defect
+    # this issue was filed over (reyn config validate declaring "No
+    # unknown ... config keys found" while never having looked at
+    # profile.yaml at all). This tuple is the population claim; a future
+    # surface added to this function must be added here too (no
+    # mechanism enforces that — this is the one place that says so).
+    _walked_surfaces = (
+        "the policy tier (reyn.yaml / reyn.local.yaml / ~/.reyn/config.yaml)",
+        "the hot-reload IN-set (.reyn/{mcp,cron,hooks,skills,pipelines,presentations}.yaml)",
+        "every .reyn/agents/<name>/hooks.yaml and profile.yaml",
+    )
     if (
         not policy_unknown and not disabled and not in_set_unknown
         and not hook_entry_errors and not mcp_misplaced and not mcp_renamed_http
+        and not profile_unknown
     ):
-        print("No unknown, renamed, or disabled-by-dependency config keys found.")
+        print(
+            "No unknown, renamed, or disabled-by-dependency config keys "
+            "found. Checked: " + "; ".join(_walked_surfaces) + "."
+        )
         return
 
     if policy_unknown:
@@ -631,6 +674,30 @@ def _validate() -> None:
                 "run `/reload` (or `reyn mcp refresh`) after fixing it there "
                 "to apply the change without restarting."
             )
+
+    if profile_unknown:
+        if (
+            policy_unknown or disabled or in_set_unknown or hook_entry_errors
+            or mcp_misplaced or mcp_renamed_http
+        ):
+            print()
+        print(
+            f"Agent profile.yaml — checked every .reyn/agents/<name>/"
+            f"profile.yaml — {len(profile_unknown)} agent(s) with "
+            f"unrecognized key(s):\n"
+        )
+        for agent_name, keys in sorted(profile_unknown.items()):
+            print(f"  [{agent_name}] " + ", ".join(sorted(keys)))
+        print(
+            "\nEach key above is not a recognized AgentProfile field "
+            "('reyn config fields' does not cover this file — see "
+            "reyn.runtime.profile.AgentProfile's own field list) — it is "
+            "read, kept in no in-memory state, and does nothing. A field "
+            "removed from AgentProfile (e.g. #5095's broker_identity) "
+            "leaves this line behind in an operator's file with no "
+            "further signal until now. Fix by hand: remove the key(s) "
+            "above from the file named."
+        )
 
 
 def _migrate(*, dry_run: bool = False) -> None:

--- a/src/reyn/runtime/profile.py
+++ b/src/reyn/runtime/profile.py
@@ -28,6 +28,7 @@ because the two axes' composition functions differ — see
 """
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -39,6 +40,35 @@ if TYPE_CHECKING:
     from reyn.security.permissions.capability_profile import CapabilityProfile
 
 PROFILE_FILENAME = "profile.yaml"
+
+
+def unknown_profile_keys(data: "dict") -> "frozenset[str]":
+    """#5455 ①: every top-level key in a raw ``profile.yaml`` dict that is
+    not a real :class:`AgentProfile` field — the same class of gap #4501/
+    #4515 closed for ``reyn.yaml`` (an unknown key is silently dropped by
+    ``.get(...)``, never surfaced), now closed for this file too.
+
+    The registry is ``dataclasses.fields(AgentProfile)`` itself — the SAME
+    "the live dataclass is the complete population" idiom #5416 already
+    established (no separate hand-maintained key list to drift from the
+    real fields). A DEDICATED function, not a new entry into
+    :func:`reyn.config.config_schema.unknown_config_keys` — that function
+    walks ``ReynConfig``'s OWN, unrelated vocabulary; folding profile.yaml
+    into it would make ONE function know TWO closed vocabularies (the
+    #5057 "same guard, second copy" shape architect's #5455 review
+    explicitly rejected), not close anything.
+
+    Called from BOTH :meth:`AgentProfile.load` (so every real caller of
+    it — chat startup, ``AgentRegistry.spawn_session`` — gets the SAME
+    disclosure, a parse-time WARN; ``reyn doctor`` does NOT call
+    ``AgentProfile.load`` — it reads ``profile.yaml`` directly for its
+    own hook-env section, so it needs the SEPARATE walk below, not this
+    call site, to see this) and ``reyn config validate`` (a dedicated
+    CLI section, walking ``.reyn/agents/*/profile.yaml`` itself) —
+    mirroring how ``unknown_config_keys``
+    itself already serves 3 callers from one implementation."""
+    known = {f.name for f in dataclasses.fields(AgentProfile)}
+    return frozenset(data.keys()) - known
 
 
 @dataclass(frozen=True)
@@ -139,7 +169,13 @@ class AgentProfile:
 
         #4206 ②: a `bounding:` mapping with a key outside
         `reyn.runtime.bounding.BOUNDING_KEYS` raises `UnknownBoundingKeyError`
-        the same way."""
+        the same way.
+
+        #5455 ①: an unrecognized TOP-LEVEL key (e.g. a field removed from
+        this dataclass, like #5095's `broker_identity`) WARNs — never
+        raises, matching every other "not applied" disclosure in this
+        codebase (an operator's file stays loadable; the log is where the
+        mismatch surfaces) — see :func:`unknown_profile_keys`."""
         from reyn.runtime.bounding import validate_bounding
         from reyn.runtime.preferences import validate_preferences
 
@@ -147,6 +183,15 @@ class AgentProfile:
         if not path.is_file():
             raise FileNotFoundError(path)
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        unknown_top_level = unknown_profile_keys(data)
+        if unknown_top_level:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "agent %r profile.yaml has unrecognized key(s) (not "
+                "applied): %s",
+                data.get("name", agent_dir.name), ", ".join(sorted(unknown_top_level)),
+            )
         # PR37: parse allowed_mcp — "all" sentinel normalizes to None.
         raw_allowed_mcp = data.get("allowed_mcp", None)
         if raw_allowed_mcp is None or raw_allowed_mcp == "all":

--- a/tests/runtime/test_5455_profile_unknown_key_disclosure.py
+++ b/tests/runtime/test_5455_profile_unknown_key_disclosure.py
@@ -1,0 +1,195 @@
+"""Tier 2: #5455 — profile.yaml unknown-top-level-key disclosure.
+
+Real cause: PR #5095 removed ``AgentProfile.broker_identity`` from core,
+but ``AgentProfile.load()`` reads unknown top-level keys with bare
+``.get(...)`` — a field removed from the dataclass keeps loading silently
+from an operator's file, doing nothing, forever, with no signal anywhere
+(neither ``reyn doctor`` nor ``reyn config validate``, which architect's
+real measurement found actively declares "No unknown ... config keys
+found" while never having looked at profile.yaml at all).
+
+architect's structural design (issue #5455, final revision — the
+band-aid first draft, folding profile.yaml into
+``config_schema.unknown_config_keys()``, was explicitly withdrawn):
+
+  ① ``AgentProfile.load()`` reports its own residual keys — the
+     registry is ``dataclasses.fields(AgentProfile)`` itself (same
+     "live dataclass is the complete population" idiom as #5416).
+  ② ``_load_yaml`` requires an un-omittable ``vocabulary=`` argument —
+     see ``tests/scripts/test_check_load_yaml_vocabulary_5455.py`` for
+     that half (a DIFFERENT file, since profile.yaml isn't read via
+     ``_load_yaml`` at all — it has its own read path).
+  ③ ``reyn config validate``'s "no issues" message names the surfaces
+     it walked, so it can no longer claim a false universal.
+
+Witness ① (architect's own real-machine replacement for a synthetic
+fixture, issue comment, final revision) is NOT a committed test here —
+it runs against ``~/Workspace/reyn_dev/reyn-self``, a repo this test
+suite has no business depending on existing. Verified by hand instead
+(see the PR this file lands in) and left as lead-coder/architect's own
+positive-control acceptance step per the issue's stated order (land →
+verify against reyn-self → THEN remove the two live
+``broker_identity:`` lines there).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.profile import AgentProfile, unknown_profile_keys
+
+# ── witness ④: the population registry is non-empty (empty-set guard) ──────
+
+
+def test_the_field_registry_is_not_empty() -> None:
+    """Tier 2: witness ④ — dataclasses.fields(AgentProfile) is not empty.
+    A broken/emptied registry would make witness ② (known-keys-only ->
+    silence) vacuously true — this is what makes that witness mean
+    something."""
+    known = {f.name for f in __import__("dataclasses").fields(AgentProfile)}
+    assert known, "AgentProfile has no fields — the registry is empty"
+    assert "name" in known and "role" in known
+
+
+# ── unknown_profile_keys itself ─────────────────────────────────────────────
+
+
+def test_an_unknown_top_level_key_is_reported() -> None:
+    """Tier 2: witness ① (mechanism) — a removed-from-core field like
+    #5095's broker_identity is reported by name."""
+    found = unknown_profile_keys({"name": "x", "broker_identity": "x"})
+    assert found == frozenset({"broker_identity"})
+
+
+def test_known_keys_only_report_nothing() -> None:
+    """Tier 2: witness ② — noise guard. A profile using only real fields
+    reports an empty set, not a false positive."""
+    real_keys = {f.name for f in __import__("dataclasses").fields(AgentProfile)}
+    found = unknown_profile_keys(dict.fromkeys(real_keys, None))
+    assert found == frozenset()
+
+
+# ── AgentProfile.load() integration ─────────────────────────────────────────
+
+
+def test_load_warns_on_an_unknown_key_and_still_loads(
+    tmp_path: Path, caplog,
+) -> None:
+    """Tier 2: witness ① at the real parse point — AgentProfile.load()
+    WARNs (never raises) with the agent name AND the key, and the
+    profile still loads (the same "operator's file stays usable, the
+    log is where the mismatch surfaces" contract every other
+    not-applied disclosure in this codebase already has)."""
+    (tmp_path / "profile.yaml").write_text(
+        "name: coder-smith\nrole: x\nbroker_identity: coder-smith\n",
+        encoding="utf-8",
+    )
+    with caplog.at_level("WARNING"):
+        profile = AgentProfile.load(tmp_path)
+
+    assert profile.name == "coder-smith"
+    assert any(
+        "coder-smith" in r.message and "broker_identity" in r.message
+        for r in caplog.records
+    ), f"expected a WARNING naming both the agent and the key: {caplog.records!r}"
+
+
+def test_load_with_only_known_keys_warns_nothing(tmp_path: Path, caplog) -> None:
+    """Tier 2: witness ② at the real parse point — noise guard."""
+    (tmp_path / "profile.yaml").write_text(
+        "name: clean-agent\nrole: x\n", encoding="utf-8",
+    )
+    with caplog.at_level("WARNING"):
+        AgentProfile.load(tmp_path)
+    assert not any("unrecognized" in r.message for r in caplog.records)
+
+
+# ── witness ③: strip — removing the check silences witness ① ───────────────
+
+
+def test_strip_the_check_silences_the_warning(tmp_path: Path, monkeypatch, caplog) -> None:
+    """Tier 2: witness ③, executed for real (not reasoned-through) — the
+    exact strip-falsifier: monkeypatch unknown_profile_keys to always
+    return empty (simulating the check being removed) and confirm the
+    warning this issue exists to add disappears, on the SAME fixture
+    witness ① uses."""
+    import reyn.runtime.profile as profile_mod
+
+    monkeypatch.setattr(profile_mod, "unknown_profile_keys", lambda data: frozenset())
+
+    (tmp_path / "profile.yaml").write_text(
+        "name: coder-smith\nrole: x\nbroker_identity: coder-smith\n",
+        encoding="utf-8",
+    )
+    with caplog.at_level("WARNING"):
+        AgentProfile.load(tmp_path)
+    assert not any("unrecognized" in r.message for r in caplog.records), (
+        "the strip should have silenced the warning (proving the real, "
+        "unpatched check is what produces it) but it still fired"
+    )
+
+
+# ── witness ⑤: preferences/bounding validation is unweakened ───────────────
+
+
+def test_an_unknown_preference_key_still_raises(tmp_path: Path) -> None:
+    """Tier 2: witness ⑤ — preferences: still RAISES on an unknown key
+    (UnknownPreferenceKeyError), unweakened by this issue's WARN-only
+    treatment of top-level keys. Different vocabulary, different
+    consequence — a preferences: typo is a functional error at
+    resolve_preference time, not a dead declaration."""
+    from reyn.runtime.preferences import UnknownPreferenceKeyError
+
+    (tmp_path / "profile.yaml").write_text(
+        "name: x\nrole: x\npreferences:\n  not_a_real_preference: 1\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(UnknownPreferenceKeyError):
+        AgentProfile.load(tmp_path)
+
+
+# ── witness ⑥: reyn config validate enumerates its surfaces ────────────────
+
+
+def test_config_validate_names_the_walked_surfaces_when_clean(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """Tier 2: witness ⑥ (half A) — the "no issues" message names what it
+    walked, closing the exact false-universal defect this issue reports
+    (architect's real measurement: "No unknown ... config keys found"
+    while profile.yaml was never in the population)."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "profile.yaml" in out, (
+        f"the clean-tree message must name profile.yaml among the walked "
+        f"surfaces, not just declare a bare all-clear: {out!r}"
+    )
+
+
+def test_config_validate_reports_a_real_profile_finding(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """Tier 2: witness ⑥ (half B) — a real unknown profile key reaches the
+    CLI's own labeled section, naming the agent."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    agent_dir = tmp_path / ".reyn" / "agents" / "coder-brown"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "profile.yaml").write_text(
+        "name: coder-brown\nrole: x\nbroker_identity: coder-brown\n",
+        encoding="utf-8",
+    )
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "coder-brown" in out and "broker_identity" in out, (
+        f"expected the agent name and the unknown key in the CLI output: {out!r}"
+    )

--- a/tests/scripts/test_check_load_yaml_vocabulary_5455.py
+++ b/tests/scripts/test_check_load_yaml_vocabulary_5455.py
@@ -12,6 +12,19 @@ already catches this at CALL time (the parameter has no default) — this
 gate is the SECOND line of defense: it would also catch a hypothetical
 future regression on the SIGNATURE side (a default quietly reintroduced),
 which a bare call-time TypeError could no longer do.
+
+architect BLOCKING finding on this PR's first revision: a bare
+``vocabulary=None`` collapses THREE distinct, real reasons ("checked by
+config validate downstream", "checked at its own hot-reload load point",
+"checked by the immediate caller") into one value nothing can tell
+apart from "nobody decided" — a future contributor would copy a
+neighboring ``vocabulary=None`` for a genuinely NEW file without
+checking whether it is actually validated anywhere, reopening the
+#4501/#4515 hole this issue closes while this gate stayed green (a bare
+presence check does not see WHAT was passed). Fixed: ``vocabulary``
+accepts only a callable or a named ``_CheckedElsewhere`` member; ``None``
+is now flagged exactly like an omitted keyword — see the reject/accept
+pair below.
 """
 from __future__ import annotations
 
@@ -33,13 +46,30 @@ def test_a_call_missing_vocabulary_is_flagged(tmp_path: Path) -> None:
     assert lineno == 2
 
 
-def test_vocabulary_none_explicit_is_not_flagged(tmp_path: Path) -> None:
-    """Tier 2: accept-side — an EXPLICIT `vocabulary=None` (a real,
-    reviewable decision, per _load_yaml's own docstring) is not a
-    violation; only OMITTING the keyword entirely is."""
+def test_vocabulary_none_explicit_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: architect's own BLOCKING finding, re-verified here as a
+    reject case — an EXPLICIT `vocabulary=None` is now a violation too,
+    not just an omitted keyword. `None` collapses 3 distinct reasons
+    into one value nothing can distinguish from "nobody decided"."""
     (tmp_path / "reader.py").write_text(
         "def f():\n"
         "    return _load_yaml(some_path, vocabulary=None)\n",
+    )
+    ((path, lineno),) = find_violations(tmp_path)
+    assert path == tmp_path / "reader.py"
+    assert lineno == 2
+
+
+def test_vocabulary_a_named_checked_elsewhere_member_is_not_flagged(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: accept-side — a real, named _CheckedElsewhere member (the
+    replacement for a bare None) passes."""
+    (tmp_path / "reader.py").write_text(
+        "def f():\n"
+        "    return _load_yaml(\n"
+        "        some_path, vocabulary=_CheckedElsewhere.CHECKED_BY_CALLER,\n"
+        "    )\n",
     )
     assert find_violations(tmp_path) == []
 

--- a/tests/scripts/test_check_load_yaml_vocabulary_5455.py
+++ b/tests/scripts/test_check_load_yaml_vocabulary_5455.py
@@ -1,0 +1,75 @@
+"""Tier 2: #5455 ② — the load-yaml-vocabulary gate.
+
+Real filesystem fixtures throughout (a real `tmp_path` tree of `.py`
+files parsed as real ASTs) — mirrors
+`tests/scripts/test_check_collect_events_settle_4966.py`'s own shape
+(reject variant / accept variant / real-tree-is-clean check).
+
+Witness ⑦ (architect's own #5455 design — "the essential witness, ①-⑥
+only close THIS one issue"): writing a NEW ``_load_yaml(path)`` call with
+no ``vocabulary=`` must be structurally caught. Python's own ``TypeError``
+already catches this at CALL time (the parameter has no default) — this
+gate is the SECOND line of defense: it would also catch a hypothetical
+future regression on the SIGNATURE side (a default quietly reintroduced),
+which a bare call-time TypeError could no longer do.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_load_yaml_vocabulary import find_violations
+
+
+def test_a_call_missing_vocabulary_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: the exact class this gate exists to close — a call to
+    `_load_yaml(path)` with no `vocabulary=` keyword at all."""
+    (tmp_path / "reader.py").write_text(
+        "def f():\n"
+        "    return _load_yaml(some_path)\n",
+    )
+    # Unpack-enforcement idiom: exactly 1 violation must be found.
+    ((path, lineno),) = find_violations(tmp_path)
+    assert path == tmp_path / "reader.py"
+    assert lineno == 2
+
+
+def test_vocabulary_none_explicit_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: accept-side — an EXPLICIT `vocabulary=None` (a real,
+    reviewable decision, per _load_yaml's own docstring) is not a
+    violation; only OMITTING the keyword entirely is."""
+    (tmp_path / "reader.py").write_text(
+        "def f():\n"
+        "    return _load_yaml(some_path, vocabulary=None)\n",
+    )
+    assert find_violations(tmp_path) == []
+
+
+def test_vocabulary_a_real_callable_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: accept-side — a real vocabulary callable passed positively."""
+    (tmp_path / "reader.py").write_text(
+        "def f():\n"
+        "    return _load_yaml(some_path, vocabulary=unknown_config_keys)\n",
+    )
+    assert find_violations(tmp_path) == []
+
+
+def test_a_differently_named_function_is_not_matched(tmp_path: Path) -> None:
+    """Tier 2: noise guard — a call to a DIFFERENT function that merely
+    resembles `_load_yaml` in shape (same arg count, no vocabulary=) is
+    not flagged; the gate matches on the exact callee name."""
+    (tmp_path / "reader.py").write_text(
+        "def f():\n"
+        "    return _load_json(some_path)\n",
+    )
+    assert find_violations(tmp_path) == []
+
+
+def test_the_real_source_tree_is_currently_clean() -> None:
+    """Tier 2: the real repo — every ACTUAL `_load_yaml(...)` call site in
+    `src/` passes `vocabulary=` today. Runs against the true source tree,
+    not a fixture — this is the positive control the gate exists to keep
+    green (strip-verified by hand this PR: removing one real
+    `vocabulary=` kwarg turns this exact check RED)."""
+    from scripts.check_load_yaml_vocabulary import _SRC
+
+    assert find_violations(_SRC) == []


### PR DESCRIPTION
**[e2e-coder]** — closes #5455.

## Problem (architect real measurement)

PR #5095 removed `AgentProfile.broker_identity` from core, but `AgentProfile.load()` reads unknown top-level keys with bare `.get(...)` — a removed field keeps loading silently, forever, from an operator's file. Real reyn-self measurement: `reyn doctor` is silent (no unknown-key section for profile.yaml at all); `reyn config validate` is worse — it actively declares **"No unknown, renamed, or disabled-by-dependency config keys found"** while never having walked profile.yaml at all. A false universal is worse than silence: the operator stops checking.

## Design (architect, final revision — owner: "構造的に対処してよ。決して絆創膏にしないこと")

An earlier draft (folding profile.yaml into `config_schema.unknown_config_keys()`) was explicitly withdrawn as a band-aid — it would close one hole while leaving the class open (the #5057 "same guard, second copy" shape: one function knowing two unrelated closed vocabularies).

**Structural fix, 3 parts:**

1. `AgentProfile.load()` reports its own residual top-level keys via a new, dedicated `unknown_profile_keys()` — registry is `dataclasses.fields(AgentProfile)` itself (same idiom as #5416). WARNs, never raises.
2. `_load_yaml(path, *, vocabulary)` now **requires** `vocabulary` — no default, so omitting it is a `TypeError`. Closes the *class* of "a new operator-editable yaml file ships with no unknown-key check" (#4501/#4515's recurring shape), not just this instance. All 11 existing call sites updated — each passes `vocabulary=None` **explicitly**, with a comment naming where its check actually runs downstream (`unknown_config_keys`/`validate_in_set` on the merged view) — a visible, reviewable decision, never a silent omission.
3. `reyn config validate`'s "no issues" message now names every surface it walked.

## Witnesses

- `tests/runtime/test_5455_profile_unknown_key_disclosure.py` — mechanism, noise guard, real parse-time WARN (**strip-falsified by hand**: monkeypatching the check to a no-op silences the warning, confirming the real check produces it), `preferences:` unknown-key raise stays unweakened, `config validate`'s clean-message enumeration + its real per-agent finding.
- `scripts/check_load_yaml_vocabulary.py` + `tests/scripts/test_check_load_yaml_vocabulary_5455.py` — **witness ⑦, architect's "the essential one"**: an AST gate over every real `_load_yaml(...)` call site in `src/`, wired into CI (`.github/workflows/load-yaml-vocabulary-gate.yml`, mirrors `collect-events-settle-gate.yml`). **Strip-verified by hand**: removing one real `vocabulary=` kwarg turns it RED against the actual codebase; restored, reconfirmed green.

**Witness ①** — architect's own final-revision replacement (a synthetic fixture was explicitly rejected in favor of the real incident) — verified by hand against the real `~/Workspace/reyn_dev/reyn-self` (**read-only**, no file there touched — per lead-coder/architect's stated order: land → verify detection → *then* remove the 2 live lines):

```
$ cd ~/Workspace/reyn_dev/reyn-self && (this branch's) reyn config validate
Agent profile.yaml — checked every .reyn/agents/<name>/profile.yaml — 2 agent(s) with unrecognized key(s):
  [coder-brown] broker_identity
  [coder-smith] broker_identity
```

This is the positive control lead-coder/architect need before removing those 2 lines (owner-specified order, issue comments) — **not done in this PR**, left for lead-coder/architect per their own stated ownership.

## Test plan

- [x] `ruff check .` — green
- [x] `python scripts/test_tier_audit.py --strict` on both new test files — 14/14 OK
- [x] `python scripts/verify_module_docstrings.py` on all 4 changed/new src files — OK
- [x] `python scripts/mypy_ratchet.py` — OK (baselined)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_load_yaml_vocabulary.py` (the new gate itself) — OK
- [x] Broader scoped `pytest -k "config or profile or loader or agent_profile"` — 1144 passed, 1 skipped, 0 failed (no existing caller relied on `_load_yaml`'s old default)
- [x] Manual real-tree verification against reyn-self (above)
- [x] (skipped — Visual, no TUI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] 🔴 **[architect]** ★`vocabulary=None` が ★3 つの別々の事実を表しています ── ★**新しい file が `None` を真似れば ★gate は緑のまま、★#5455 の穴が そのまま再発**します。
