### PR TITLE
feat(#5450): LLMStub control="gated" mode, real litellm/httpx cancel-swallow finding

### DIFF
--- a/src/reyn/dev/testing/llm_stub.py
+++ b/src/reyn/dev/testing/llm_stub.py
@@ -40,10 +40,60 @@ Design (architect ruling, #5103):
 Only ``litellm.acompletion`` is patched (not ``aembedding``) — the turns
 this stub exists for reach the completion boundary, never the embedding
 one; a test that needs both should use ``@replay`` instead.
+
+#5450 ``control=``: a SECOND, orthogonal axis (architect design, #5450)
+for tests whose subject is CONTROLLING the LLM call, not merely avoiding
+it — "呼ばれたら止まり、外から明示的に進められる" (called-then-hung,
+externally released; e.g. #2242's hard-cancel-mid-generation tests).
+Before this, those tests replaced ``Session._loop_driver.run_turn``
+itself with a private controllable-hang closure — the SAME "手が届かな
+かった" gap #5103 closed for the observation-only files: the test's OWN
+docstring (``test_2242_hard_cancel.py``) already said the real
+suspension point is "inside its ``litellm.acompletion`` await", so the
+private replacement was standing in for a boundary this stub already
+patches. ``control="gated"`` moves the hang/release to the REAL
+boundary, so the real ``RouterLoopDriver``/``RouterLoop``/driver runs
+for real (#5103's whole point), while still giving the test the same
+external-release handle (``call_started``/``release``, the SAME 2
+``asyncio.Event``s the original private helper returned).
+
+Architect's design also specified a SECOND mode, ``"gated_swallow_
+cancel"`` — a hang whose ``CancelledError`` is caught and swallowed,
+simulating a third party (litellm/httpx) absorbing a cancellation
+instead of propagating it, to test whether reyn's own ``finally``
+still resets state under that hypothetical. NOT implemented: architect's
+own explicit precondition for keeping it ("実装の1手目に、litellm/httpx
+が実際に握り潰し得るかを実行で確かめてください — 起こし得ないなら B は
+保存でなく削除") was checked for real, and came back negative — see
+#5450's PR for the executed evidence. A mode with a real implementation
+but zero reachable production scenario, and (once its one committed test
+is deleted for the same reason) zero test consumer either, is exactly
+the #4866/#5442 "public surface nobody calls" shape this codebase has
+repeatedly closed rather than ratified — so it was never added, not
+added-then-removed.
+
+Unlimited await on ``call_started`` (no ``sleep``/``timeout``/``range(N)``,
+testing-policy time discipline) is how a test proves the real loop
+actually reached the LLM boundary — joined with #5454's ``turn_started``
+audit-event for "did the REAL driver run" (a stub being called is not,
+by itself, proof of that — see #5450's own witness ②).
 """
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+from typing import Any, Literal
+
+#: #5450: the closed vocabulary for `control=` — mirrors #5382's own
+#: closed `cause` vocabulary. A value outside this set raises at
+#: LLMStub construction time (fail fast, never a silently-ignored typo).
+#: Currently one member — see the module docstring for why
+#: "gated_swallow_cancel" was designed but never added.
+LLMStubControl = Literal["gated"]
+_CONTROL_MODES: "frozenset[str]" = frozenset({"gated"})
+
+
+class UnknownLLMStubControlError(ValueError):
+    """Raised when ``control=`` is not one of :data:`_CONTROL_MODES`."""
 
 
 class LLMStub:
@@ -57,10 +107,26 @@ class LLMStub:
             ...
         finally:
             stub.restore()
+
+    #5450: pass ``control="gated"`` (see module docstring) to hang the
+    call at the real LLM boundary until the test sets ``stub.release``;
+    ``stub.call_started`` fires the instant the call begins.
+    ``control=None`` (default) keeps #5103's original immediate-return
+    behavior unchanged.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, control: "LLMStubControl | None" = None) -> None:
         self._original_acompletion: Any = None
+        if control is not None and control not in _CONTROL_MODES:
+            raise UnknownLLMStubControlError(
+                f"control={control!r} is not one of {sorted(_CONTROL_MODES)!r}",
+            )
+        self.control = control
+        # #5450: created unconditionally (cheap) so a test can read
+        # `.call_started`/`.release` even before `install()` runs — mirrors
+        # the original private helper's own return-both-events shape.
+        self.call_started: "asyncio.Event" = asyncio.Event()
+        self.release: "asyncio.Event" = asyncio.Event()
 
     def install(self) -> None:
         import litellm
@@ -81,6 +147,15 @@ class LLMStub:
         # docstring). Kept as named params (not *args, **_) because litellm's
         # real callers invoke acompletion with keyword arguments.
         del messages, kwargs
+        if self.control == "gated":
+            # #5450: fire call_started the instant the call begins, then
+            # suspend on release — simulating the real await
+            # litellm.acompletion would be suspended inside. A
+            # CancelledError delivered here propagates normally (reyn's
+            # own code never swallows one here — see module docstring on
+            # why "gated_swallow_cancel" was never added).
+            self.call_started.set()
+            await self.release.wait()
         import litellm
 
         # #5103 TESTS-READ: finish_reason/tool_calls are set EXPLICITLY here

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -580,7 +580,11 @@ def pytest_configure(config: pytest.Config) -> None:
         "file, so it is invisible to #3662's MissingFixture safety net and to "
         "#5283's unconsumed-entry check. A test using this marker MUST NOT "
         "declare Tier 3 (Tier 3 = the model's output IS the subject under "
-        "test — see test_tier_audit.py's enforcement of this pairing).",
+        "test — see test_tier_audit.py's enforcement of this pairing). "
+        "#5450: optional control='gated' kwarg (reyn.dev.testing.llm_stub."
+        "LLMStubControl's closed vocabulary) hangs the call at the real LLM "
+        "boundary until the test sets the fixture's .release event — see "
+        "LLMStub's own module docstring.",
     )
     config.addinivalue_line(
         "markers",
@@ -742,7 +746,12 @@ def _llm_stub(request: pytest.FixtureRequest):
 
     from reyn.dev.testing.llm_stub import LLMStub
 
-    stub = LLMStub()
+    # #5450: control= is an optional marker kwarg — @pytest.mark.llm_stub
+    # (no args) keeps #5103's original immediate-return behavior;
+    # @pytest.mark.llm_stub(control="gated") hangs at the real LLM
+    # boundary — see LLMStub's own module docstring.
+    control = marker.kwargs.get("control")
+    stub = LLMStub(control=control)
     stub.install()
     try:
         yield stub

--- a/tests/dev/test_llm_stub_control_5450.py
+++ b/tests/dev/test_llm_stub_control_5450.py
@@ -1,0 +1,90 @@
+"""Tier 1/2: #5450 — ``LLMStub``'s ``control="gated"`` mode, the mechanism
+witnesses (architect's own #5450 design, witnesses ①③④⑦).
+
+Real ``litellm.acompletion`` boundary throughout — ``LLMStub.install()``
+patches it for real; no mock. Witness ② (does the REAL driver run, not
+just the stub) belongs to a per-file migration (e.g. ``test_2242_hard_
+cancel.py``) that also drives a real ``Session``, not this file, which
+tests ``LLMStub`` in isolation.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.dev.testing.llm_stub import (
+    LLMStub,
+    UnknownLLMStubControlError,
+)
+
+
+@pytest.mark.asyncio
+async def test_gated_call_hangs_until_release_is_set() -> None:
+    """Tier 1: witness ① — a control="gated" call fires call_started
+    immediately, then does NOT complete until the test sets release."""
+    stub = LLMStub(control="gated")
+    stub.install()
+    try:
+        call_task = asyncio.ensure_future(
+            stub._handle("m", [{"role": "user", "content": "hi"}]),
+        )
+        await stub.call_started.wait()
+
+        # not yet released — the call must still be pending.
+        await asyncio.sleep(0)
+        assert not call_task.done(), "the gated call completed before release was set"
+
+        stub.release.set()
+        response = await call_task
+        assert response.choices[0].finish_reason == "stop"
+    finally:
+        stub.restore()
+
+
+@pytest.mark.asyncio
+async def test_a_cancellation_while_gated_propagates_normally() -> None:
+    """Tier 1: witness (mechanism half of the deleted "gated_swallow_
+    cancel" question) — reyn's own stub does NOT swallow a
+    CancelledError delivered while suspended; it propagates exactly like
+    any other await. See LLMStub's own module docstring for the real,
+    executed litellm/httpx finding this decision rests on."""
+    stub = LLMStub(control="gated")
+    stub.install()
+    try:
+        call_task = asyncio.ensure_future(
+            stub._handle("m", [{"role": "user", "content": "hi"}]),
+        )
+        await stub.call_started.wait()
+
+        call_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await call_task
+    finally:
+        stub.restore()
+
+
+def test_an_unknown_control_value_raises_at_construction() -> None:
+    """Tier 1: witness — control= is a CLOSED vocabulary (mirrors #5382's
+    closed cause vocabulary); a typo fails LOUD, at construction, not
+    silently at call time."""
+    with pytest.raises(UnknownLLMStubControlError):
+        LLMStub(control="not_a_real_mode")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_control_none_is_unchanged_from_before_5450() -> None:
+    """Tier 1: accept-side / noise guard — the default (no control=) keeps
+    #5103's original immediate-return behavior, unaffected by #5450's
+    addition. The 8 files already migrated under #5103/#5459 depend on
+    this staying true."""
+    stub = LLMStub()
+    stub.install()
+    try:
+        response = await stub._handle("m", [{"role": "user", "content": "hi"}])
+        assert response.choices[0].finish_reason == "stop"
+        assert not stub.call_started.is_set(), (
+            "control=None must not touch call_started/release at all"
+        )
+    finally:
+        stub.restore()


### PR DESCRIPTION
**[e2e-coder]** — part of #5103, implements architect's #5450 design.

## Design

For the ②-classified tests whose subject is CONTROLLING the LLM call (called-then-hung, externally released) rather than merely avoiding it, `LLMStub` gets one control kwarg instead of a new stub type — `test_2242_hard_cancel.py`'s own docstring already named the real suspension point as "inside its `litellm.acompletion` await", so those tests' private `_loop_driver.run_turn` replacement was standing in for a boundary `LLMStub` already patches.

`control="gated"`: `call_started` fires the instant the call begins, then hangs until the test sets `release` — the same 2 `asyncio.Event`s the original private helper returned. Wired through `@pytest.mark.llm_stub(control="gated")` (a closed vocabulary, `LLMStubControl`, mirrors #5382's own closed `cause` vocabulary — an unknown value raises at construction, not silently at call time).

## The real finding — why "gated_swallow_cancel" was never added

Architect's design also specified a second mode simulating a third party (litellm/httpx) swallowing a `CancelledError`, explicitly conditioned on checking for real whether that's reachable: *"実装の1手目に、litellm/httpxが実際に握り潰し得るかを実行で確かめてください — 起こし得ないならBは保存でなく削除が正しい"*.

Checked against the installed litellm/httpx:

- `litellm/main.py`'s exception handling is uniformly `except Exception as e:` — `asyncio.CancelledError` has been a `BaseException` subclass (not `Exception`) since Python 3.8 *specifically* to prevent this exact accidental-swallow class, so none of these sites match it at all.
- `httpx/_client.py` has 5 real `except BaseException as exc:` sites (the ones that *would* match) — every one immediately `raise exc`s after resource cleanup; none swallow.
- The 2 real `except asyncio.CancelledError:` hits elsewhere in litellm (`logging_worker.py`, `realtime_streaming.py`) aren't on reyn's direct `acompletion()` call path (background logging queue / realtime-streaming API — reyn's default config is non-streaming, non-Router).

**Conclusion**: the swallow scenario isn't reachable through reyn's actual dependency chain. Per architect's own decision rule (lead-coder pre-accepted this outcome on the issue), `"gated_swallow_cancel"` was never added — not added-then-removed. A mode with a real implementation but zero reachable production scenario is exactly the #4866/#5442 "public surface nobody calls" shape this codebase keeps closing rather than ratifying.

## Tests

`tests/dev/test_llm_stub_control_5450.py`: gated hang/release round-trip, a `CancelledError` delivered while gated propagates normally (mechanism half of the deleted question), closed-vocabulary raise, and `control=None` stays byte-identical to pre-#5450 behavior. **Strip-verified by hand**: no-op-ing the `control="gated"` branch turned the mechanism test into a genuine hang, caught by `pytest-timeout` as a real failure; restored, reconfirmed green.

Full existing `@llm_stub` consumer sweep — all 21 files using the marker, 130 tests — re-run unaffected.

## Scope

This PR ships the verified mechanism. Migrating the 6 files that actually need `control="gated"` (`test_2242_hard_cancel.py` + the 5 others named in #5450's issue thread) is follow-up work — splitting keeps those WAL-invariant-heavy migrations independently reviewable, mirroring #5103's own successful "prove the mechanism first, migrate incrementally" pattern (#5454 → #5459).

## Test plan

- [x] `ruff check .` — green
- [x] `python scripts/test_tier_audit.py --strict` on the new test file — 4/4 OK
- [x] `python scripts/verify_module_docstrings.py` on the changed src file — OK
- [x] `python scripts/mypy_ratchet.py` — OK (baselined)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] Scoped `pytest` on the new file — 4 passed
- [x] Full `@llm_stub` consumer sweep (21 files) — 130 passed
- [x] Strip-falsify — genuinely executed (see above)
- [x] (skipped — Visual, no TUI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
