### PR TITLE
fix(#5450): migrate remaining 5 cancel/queue-state files to LLMStub control="gated"

### DIFF
--- a/tests/core/test_3377_run_loop_survives_turn_cancel.py
+++ b/tests/core/test_3377_run_loop_survives_turn_cancel.py
@@ -23,9 +23,16 @@ The cancel is delivered through the real mechanism (``Task.cancel()``, the same
 call ``cancel_inflight`` makes), not by raising ``CancelledError`` inside the
 test, which would prove nothing about a path that never catches it.
 
-Real ``Session`` / ``StateLog`` (no mocks). The only replaced collaborator is
-``RouterLoopDriver.run_turn``, method-assigned as a real async function — the
-same controllable-hang seam ``tests/core/test_2242_hard_cancel.py`` uses.
+Real ``Session`` / ``StateLog`` (no mocks). #5450 migration: the LLM
+boundary is ``@pytest.mark.llm_stub(control="gated")`` — the real
+``RouterLoopDriver``/``RouterLoop`` dispatch for real, hung at the real
+``litellm.acompletion`` boundary. The stub's ``release`` ``asyncio.Event``
+stays set once set() (no auto-reset), which is exactly "first turn hangs,
+every later turn returns at once" — no per-turn re-arming needed. "Every
+chain_id the run-loop actually dispatched" (the consumed-side witness) is
+now the public ``turn_started`` audit-event stream (#5450 witness ②),
+replacing the old private closure's own ``seen`` list — the SAME public
+seam this file's own dispatch proof now doubles as "the real driver ran".
 """
 from __future__ import annotations
 
@@ -38,7 +45,7 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
-from tests._support.events import collect_events, settle
+from tests._support.events import settle
 
 AGENT = "cancel-survival-agent"
 
@@ -53,28 +60,16 @@ def _make_session(tmp_path: Path) -> tuple[Session, StateLog]:
     return session, state_log
 
 
-def _install_hanging_first_turn(
-    session: Session,
-) -> tuple[asyncio.Event, asyncio.Event, list[str]]:
-    """First turn hangs at a real await point; later turns return at once.
+def _collect(session: Session) -> list:
+    """Subscribe through the public seam (Session.subscribe_audit_events,
+    #5260) — for witness ②: turn_started proves the REAL driver ran (#5450)."""
+    collected: list = []
+    session.subscribe_audit_events(collected.append)
+    return collected
 
-    ``started`` fires as the first turn suspends (where a real turn would be
-    inside its ``litellm.acompletion`` await); ``release`` is the test's gate.
-    ``seen`` records every chain_id the run-loop actually dispatched — the
-    consumed-side witness.
-    """
-    started = asyncio.Event()
-    release = asyncio.Event()
-    seen: list[str] = []
 
-    async def _run_turn(user_text: str, chain_id: str) -> None:
-        seen.append(chain_id)
-        if len(seen) == 1:
-            started.set()
-            await release.wait()
-
-    session._loop_driver.run_turn = _run_turn  # type: ignore[method-assign]
-    return started, release, seen
+def _seen_chain_ids(events: list) -> "set[str]":
+    return {e.data.get("chain_id") for e in events if e.type == "turn_started"}
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
@@ -106,7 +101,8 @@ async def _stop(session: Session, run_task: asyncio.Task) -> None:
 
 
 @pytest.mark.asyncio
-async def test_turn_scoped_cancel_leaves_the_run_loop_consuming(tmp_path):
+@pytest.mark.llm_stub(control="gated")
+async def test_turn_scoped_cancel_leaves_the_run_loop_consuming(tmp_path, _llm_stub):
     """Tier 2: #3377 — a cancel delivered to the per-turn sub-task by
     something other than ``cancel_inflight()`` abandons that turn but must
     NOT end the run-loop.
@@ -118,11 +114,11 @@ async def test_turn_scoped_cancel_leaves_the_run_loop_consuming(tmp_path):
     consuming from one parked forever on a dead path.
     """
     session, state_log = _make_session(tmp_path)
-    started, release, seen = _install_hanging_first_turn(session)
+    events = _collect(session)
     run_task = asyncio.create_task(session.run())
     try:
         await session._put_inbox("user", {"text": "one", "chain_id": "c-first"})
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await _llm_stub.call_started.wait()
 
         # The real delivery mechanism, NOT via cancel_inflight(): this is the
         # shape a Ctrl-C / timeout / stop-world operation produces.
@@ -130,32 +126,32 @@ async def test_turn_scoped_cancel_leaves_the_run_loop_consuming(tmp_path):
 
         # THE WITNESS: put, and require that it is consumed.
         await session._put_inbox("user", {"text": "two", "chain_id": "c-second"})
-        await _wait_for(lambda: "c-second" in seen)
-        assert "c-second" in seen, (
+        await _wait_for(lambda: "c-second" in _seen_chain_ids(events))
+        assert "c-second" in _seen_chain_ids(events), (
             "the second message was PUT but never CONSUMED — the run-loop died "
             "on a cancel aimed at a single turn"
         )
         assert session.inbox.empty(), "the inbox was not drained"
         assert not run_task.done(), "run() ended on a turn-scoped cancel"
     finally:
-        release.set()
+        _llm_stub.release.set()
         await _stop(session, run_task)
         await state_log.aclose()
 
 
 @pytest.mark.asyncio
-async def test_turn_scoped_cancel_of_unknown_origin_is_recorded(tmp_path, caplog):
+@pytest.mark.llm_stub(control="gated")
+async def test_turn_scoped_cancel_of_unknown_origin_is_recorded(tmp_path, caplog, _llm_stub):
     """Tier 2: #3377 — surviving is not enough; a turn killed by a cancel we
     did not initiate must leave a record naming the turn, so this can never
     again present as an unexplained stall with nothing in the log.
     """
     caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
     session, state_log = _make_session(tmp_path)
-    started, release, _seen = _install_hanging_first_turn(session)
     run_task = asyncio.create_task(session.run())
     try:
         await session._put_inbox("user", {"text": "one", "chain_id": "c-orphan"})
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await _llm_stub.call_started.wait()
         session._turn_owner_task.cancel()
         await _wait_for(lambda: any("c-orphan" in m for m in _warnings(caplog)))
 
@@ -163,13 +159,14 @@ async def test_turn_scoped_cancel_of_unknown_origin_is_recorded(tmp_path, caplog
         assert "cancel_inflight" in warning, warning
         assert "run-loop survives" in warning, warning
     finally:
-        release.set()
+        _llm_stub.release.set()
         await _stop(session, run_task)
         await state_log.aclose()
 
 
 @pytest.mark.asyncio
-async def test_self_initiated_cancel_stays_quiet(tmp_path, caplog):
+@pytest.mark.llm_stub(control="gated")
+async def test_self_initiated_cancel_stays_quiet(tmp_path, caplog, _llm_stub):
     """Tier 2: #3377 non-vacuity — ``cancel_inflight()`` is the EXPECTED way
     to abandon a turn (the user pressed cancel), so it must keep surviving
     silently. A warning that fires on every cancel would say nothing about
@@ -177,29 +174,30 @@ async def test_self_initiated_cancel_stays_quiet(tmp_path, caplog):
     """
     caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
     session, state_log = _make_session(tmp_path)
-    started, release, seen = _install_hanging_first_turn(session)
+    events = _collect(session)
     run_task = asyncio.create_task(session.run())
     try:
         await session._put_inbox("user", {"text": "one", "chain_id": "c-user-cancel"})
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await _llm_stub.call_started.wait()
 
         await session.cancel_inflight()
 
         await session._put_inbox("user", {"text": "two", "chain_id": "c-after"})
-        await _wait_for(lambda: "c-after" in seen)
-        assert "c-after" in seen, "the loop must survive its own cancel too"
+        await _wait_for(lambda: "c-after" in _seen_chain_ids(events))
+        assert "c-after" in _seen_chain_ids(events), "the loop must survive its own cancel too"
         assert [m for m in _warnings(caplog) if "c-user-cancel" in m] == [], (
             "a user-initiated turn cancel must not be reported as unexplained"
         )
     finally:
-        release.set()
+        _llm_stub.release.set()
         await _stop(session, run_task)
         await state_log.aclose()
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub(control="gated")
 async def test_cancelling_the_session_still_stops_the_loop_and_records_it(
-    tmp_path, caplog
+    tmp_path, caplog, _llm_stub,
 ):
     """Tier 2: #3377 — the other half of the design constraint. A cancel
     genuinely directed at the session (a real shutdown) must still end the
@@ -213,17 +211,19 @@ async def test_cancelling_the_session_still_stops_the_loop_and_records_it(
     """
     caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
     session, state_log = _make_session(tmp_path)
-    collected = collect_events(session._audit_events)
-    _started, release, seen = _install_hanging_first_turn(session)
+    events = _collect(session)
     run_task = asyncio.create_task(session.run())
     try:
         # Drive one full turn first, so the cancel below is delivered to a
         # loop that is demonstrably INSIDE its while — cancelling during
-        # run()'s start-up would exercise a different path.
-        release.set()
+        # run()'s start-up would exercise a different path. release() is set
+        # BEFORE any push, so this warmup turn never hangs at all — the
+        # stub's own gate passes straight through, same as an un-hung
+        # control="gated" call always would.
+        _llm_stub.release.set()
         await session._put_inbox("user", {"text": "one", "chain_id": "c-warmup"})
-        await _wait_for(lambda: "c-warmup" in seen and session.inbox.empty())
-        assert "c-warmup" in seen, "the loop never reached its idle inbox wait"
+        await _wait_for(lambda: "c-warmup" in _seen_chain_ids(events) and session.inbox.empty())
+        assert "c-warmup" in _seen_chain_ids(events), "the loop never reached its idle inbox wait"
         assert session.halted_reason is None
 
         run_task.cancel()
@@ -234,7 +234,7 @@ async def test_cancelling_the_session_still_stops_the_loop_and_records_it(
         assert session.halted_reason == "cancelled", (
             f"the loop ended without a halt record; got {session.halted_reason!r}"
         )
-        halted = [e for e in collected if e.type == "session_halted"]
+        halted = [e for e in events if e.type == "session_halted"]
         (halt_event,) = halted
         assert halt_event.data.get("reason") == "cancelled"
         assert any("cancelled" in m for m in _warnings(caplog))

--- a/tests/interfaces/test_3300_p2a_queue_state_publish.py
+++ b/tests/interfaces/test_3300_p2a_queue_state_publish.py
@@ -30,11 +30,12 @@ Covers (see the architect's #3300 design-pass comments on the issue):
      ``RemoteQueueView``, produce an accurate queue model end-to-end.
 
 Real ``Session``/``AgentRegistry``/``StateLog`` throughout — no
-``unittest.mock``. The only "fake" collaborator is the same controllable
-plain-async-function hang ``tests/core/test_2242_hard_cancel.py`` uses for
-``RouterLoopDriver.run_turn`` (a real method-assignment, not a mock), which is
-the established no-mock seam for putting a turn genuinely "mid-flight"
-without a real LLM call.
+``unittest.mock``. #5450 migration: the turn-mid-flight hang is now
+``@pytest.mark.llm_stub(control="gated")`` — the real
+``RouterLoopDriver``/``RouterLoop`` dispatch for real, hung at the real
+``litellm.acompletion`` boundary, replacing the private
+``_loop_driver.run_turn`` replacement ``tests/core/test_2242_hard_cancel.py``
+used before its own #5450 migration (#5468).
 """
 from __future__ import annotations
 
@@ -102,19 +103,12 @@ async def _stop_auto_driver(registry: AgentRegistry, name: str) -> None:
             pass
 
 
-def _install_hanging_run_turn(session: Session) -> tuple[asyncio.Event, asyncio.Event]:
-    """Same no-mock seam as ``tests/core/test_2242_hard_cancel.py``: a real, plain
-    async function method-assigned onto the instance, standing in for a
-    genuinely in-flight LLM call so a turn can be observed mid-flight."""
-    call_started = asyncio.Event()
-    release = asyncio.Event()
-
-    async def _hanging_run_turn(user_text: str, chain_id: str) -> None:
-        call_started.set()
-        await release.wait()
-
-    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
-    return call_started, release
+def _collect(session: Session) -> list:
+    """Subscribe through the public seam (Session.subscribe_audit_events,
+    #5260) — for witness ②: turn_started proves the REAL driver ran (#5450)."""
+    collected: list = []
+    session.subscribe_audit_events(collected.append)
+    return collected
 
 
 async def _sse_lines(text):
@@ -147,24 +141,31 @@ async def _connect_snapshot_only(status_provider) -> "dict":
 
 
 @pytest.mark.asyncio
-async def test_turn_active_accessor_reflects_busy_then_idle(tmp_path):
+@pytest.mark.llm_stub(control="gated")
+async def test_turn_active_accessor_reflects_busy_then_idle(tmp_path, _llm_stub):
     """Tier 2: ``Session.turn_active`` is False when idle, True once a turn is
     dispatched (mid-flight), and False again once it settles — an additive
-    read of the existing ``_turn_idle`` event, not a new authority."""
+    read of the existing ``_turn_idle`` event, not a new authority.
+
+    Witness ② (#5450): turn_started fires — proof the REAL driver
+    dispatched, not merely that the stub was called."""
     session = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    events = _collect(session)
     assert session.turn_active is False
 
-    call_started, release = _install_hanging_run_turn(session)
     await session._put_inbox("user", {"text": "hi", "chain_id": "c1"})
     turn_task = asyncio.create_task(session.run_one_iteration())
 
-    await asyncio.wait_for(call_started.wait(), timeout=5)
+    await _llm_stub.call_started.wait()
     assert session.turn_active is True
 
-    release.set()
-    completed = await asyncio.wait_for(turn_task, timeout=5)
+    _llm_stub.release.set()
+    completed = await turn_task
     assert completed is True
     assert session.turn_active is False
+
+    await session._audit_events.drain()
+    assert any(e.type == "turn_started" and e.data.get("chain_id") == "c1" for e in events)
 
 
 # ── 2. queued_user_messages() ────────────────────────────────────────────────
@@ -222,7 +223,8 @@ async def test_remote_parity_state_snapshot_matches_local_accessors(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_late_joiner_mid_turn_connect_reconstructs_correct_state(tmp_path):
+@pytest.mark.llm_stub(control="gated")
+async def test_late_joiner_mid_turn_connect_reconstructs_correct_state(tmp_path, _llm_stub):
     """Tier 2: #3300 P2a core correctness property. A client "connecting"
     DURING a turn — having missed the ``turn_started`` audit-event that
     dispatched the in-flight item — still reconstructs the CORRECT
@@ -240,12 +242,11 @@ async def test_late_joiner_mid_turn_connect_reconstructs_correct_state(tmp_path)
     _seed(tmp_path, AGENT)
     session = await registry.attach(AGENT)
     await _stop_auto_driver(registry, AGENT)
-
-    call_started, release = _install_hanging_run_turn(session)
+    events = _collect(session)
 
     await session.submit_user_text("dispatched-first")
     turn_task = asyncio.create_task(session.run_one_iteration())
-    await asyncio.wait_for(call_started.wait(), timeout=5)
+    await _llm_stub.call_started.wait()
 
     # A second submission arrives WHILE the first turn is still in flight —
     # it stays undispatched (server-authoritative queue, #3300 design-pass
@@ -266,13 +267,19 @@ async def test_late_joiner_mid_turn_connect_reconstructs_correct_state(tmp_path)
         "the dispatched one and not an empty queue"
     )
 
-    release.set()
-    await asyncio.wait_for(turn_task, timeout=5)
+    _llm_stub.release.set()
+    await turn_task
 
     # After the turn settles, a fresh connect reflects idle + still-queued.
     values_after = await _connect_snapshot_only(lambda: _snapshot(registry))
     assert values_after.get("turn_active") is False
     assert [item["text"] for item in values_after.get("queue", [])] == ["queued-second"]
+
+    # witness ②: the real driver dispatched "dispatched-first" — exactly one
+    # turn_started (the second submission stays queued, undispatched).
+    await session._audit_events.drain()
+    (started_ev,) = [e for e in events if e.type == "turn_started"]
+    assert started_ev.data.get("kind") == "user"
 
 
 # ── 5. order-race gate (design-pass pin D) ───────────────────────────────────
@@ -358,14 +365,19 @@ def test_remote_queue_view_snapshot_mid_stream_stays_consistent_with_redelivery(
 
 
 @pytest.mark.asyncio
-async def test_real_session_deltas_keep_remote_queue_view_accurate(tmp_path):
+@pytest.mark.llm_stub(control="gated")
+async def test_real_session_deltas_keep_remote_queue_view_accurate(tmp_path, _llm_stub):
     """Tier 2: a real ``Session``'s ``user_submitted`` (enqueue) and
     ``turn_started`` (dispatch) audit-events — the SAME events P1 (C) already
     emits and the renderer/AG-UI transport already forward — drive a
     ``RemoteQueueView`` to an accurate final state end-to-end (subscribe via
-    the public ``subscribe_audit_events`` seam, no private-state peeking)."""
+    the public ``subscribe_audit_events`` seam, no private-state peeking).
+
+    Witness ② (#5450) is implicit here: ``next(e for e in captured if
+    e.type == "turn_started")`` below raises ``StopIteration`` if the real
+    driver never actually dispatched — the test's own core mechanism
+    already depends on it, unlike a stub-only check."""
     session = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
-    call_started, release = _install_hanging_run_turn(session)
 
     view = RemoteQueueView()
     view.apply_snapshot(queue=[], turn_active=False, queue_seq=0)
@@ -384,20 +396,21 @@ async def test_real_session_deltas_keep_remote_queue_view_accurate(tmp_path):
     assert [i["text"] for i in view.queue()] == ["alpha"]
 
     turn_task = asyncio.create_task(session.run_one_iteration())
-    await asyncio.wait_for(call_started.wait(), timeout=5)
+    await _llm_stub.call_started.wait()
 
     await settle(session._audit_events)
     ts = next(e for e in captured if e.type == "turn_started")
     view.apply_turn_started(chain_id=ts.data["chain_id"], seq=ts.data["seq"])
     assert view.queue() == [], "the dispatched item must leave the queue model"
 
-    release.set()
-    await asyncio.wait_for(turn_task, timeout=5)
+    _llm_stub.release.set()
+    await turn_task
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub(control="gated")
 async def test_a_submission_while_the_reply_is_still_streaming_reaches_the_queue_model(
-    tmp_path,
+    tmp_path, _llm_stub,
 ):
     """Tier 2: #3688 — a message submitted WHILE an earlier turn is still
     in-flight (dispatched, not yet finished) must still be accepted by
@@ -423,7 +436,6 @@ async def test_a_submission_while_the_reply_is_still_streaming_reaches_the_queue
     this test does not cover.
     """
     session = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
-    call_started, release = _install_hanging_run_turn(session)
 
     view = RemoteQueueView()
     view.apply_snapshot(queue=[], turn_active=False, queue_seq=0)
@@ -440,7 +452,7 @@ async def test_a_submission_while_the_reply_is_still_streaming_reaches_the_queue
     )
 
     turn_task = asyncio.create_task(session.run_one_iteration())
-    await asyncio.wait_for(call_started.wait(), timeout=5)
+    await _llm_stub.call_started.wait()
 
     await settle(session._audit_events)
     ts = next(e for e in captured if e.type == "turn_started")
@@ -463,5 +475,5 @@ async def test_a_submission_while_the_reply_is_still_streaming_reaches_the_queue
     )
     assert [i["text"] for i in view.queue()] == ["beta"]
 
-    release.set()
-    await asyncio.wait_for(turn_task, timeout=5)
+    _llm_stub.release.set()
+    await turn_task

--- a/tests/interfaces/test_3300_p3_cancel_by_id.py
+++ b/tests/interfaces/test_3300_p3_cancel_by_id.py
@@ -32,10 +32,12 @@ Covers (see the architect's #3300 design-pass comments on the issue):
      per-surface wiring needed — the completeness gates bind this).
 
 Real ``Session``/``StateLog``/``AgentSnapshot`` throughout — no
-``unittest.mock``. The only "fake" collaborator is the same controllable
-plain-async-function hang ``tests/core/test_2242_hard_cancel.py`` /
-``tests/interfaces/test_3300_p2a_queue_state_publish.py`` use for
-``RouterLoopDriver.run_turn`` (a real method-assignment, not a mock).
+``unittest.mock``. #5450 migration: the turn-mid-flight hang is now
+``@pytest.mark.llm_stub(control="gated")`` — the real
+``RouterLoopDriver``/``RouterLoop`` dispatch for real, hung at the real
+``litellm.acompletion`` boundary, replacing the private
+``_loop_driver.run_turn`` replacement ``tests/core/test_2242_hard_cancel.py``
+used before its own #5450 migration (#5468).
 """
 from __future__ import annotations
 
@@ -60,19 +62,12 @@ def _make_session(wal: Path, snapshot_path: Path) -> tuple[Session, StateLog]:
     return session, state_log
 
 
-def _install_hanging_run_turn(session: Session) -> tuple[asyncio.Event, asyncio.Event]:
-    """Same no-mock seam as ``tests/core/test_2242_hard_cancel.py`` / P2a: a real,
-    plain async function method-assigned onto the instance, standing in for a
-    genuinely in-flight LLM call."""
-    call_started = asyncio.Event()
-    release = asyncio.Event()
-
-    async def _hanging_run_turn(user_text: str, chain_id: str) -> None:
-        call_started.set()
-        await release.wait()
-
-    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
-    return call_started, release
+def _collect(session: Session) -> list:
+    """Subscribe through the public seam (Session.subscribe_audit_events,
+    #5260) — for witness ②: turn_started proves the REAL driver ran (#5450)."""
+    collected: list = []
+    session.subscribe_audit_events(collected.append)
+    return collected
 
 
 def _reconstruct(agent_name: str, snapshot_path: Path, state_log: StateLog) -> AgentSnapshot:
@@ -106,17 +101,18 @@ async def test_cancel_queued_removes_undispatched_item(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_cancel_of_already_dispatched_message_is_a_noop(tmp_path):
+@pytest.mark.llm_stub(control="gated")
+async def test_cancel_of_already_dispatched_message_is_a_noop(tmp_path, _llm_stub):
     """Tier 2: cancelling a msg_id that has ALREADY been dispatched (consumed
     off the inbox to start its turn) is a no-op — it must NOT escalate to
     ``cancel_inflight`` (a distinct intent for the running turn)."""
     session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
-    call_started, release = _install_hanging_run_turn(session)
+    events = _collect(session)
     await session.submit_user_text("dispatch-me")
     msg_id = session.queued_user_messages()[0]["msg_id"]
 
     turn_task = asyncio.create_task(session.run_one_iteration())
-    await asyncio.wait_for(call_started.wait(), timeout=5)
+    await _llm_stub.call_started.wait()
     assert session.queued_user_messages() == [], "sanity: the item is now dispatched"
 
     cancelled = await session.cancel_queued(msg_id)
@@ -124,8 +120,12 @@ async def test_cancel_of_already_dispatched_message_is_a_noop(tmp_path):
     assert cancelled is False, "cancelling an already-dispatched item must be a no-op"
     assert session.turn_active is True, "the running turn must be UNAFFECTED by cancel_queued"
 
-    release.set()
-    await asyncio.wait_for(turn_task, timeout=5)
+    _llm_stub.release.set()
+    await turn_task
+
+    # witness ②: the real driver dispatched.
+    await session._audit_events.drain()
+    assert any(e.type == "turn_started" for e in events)
 
 
 @pytest.mark.asyncio
@@ -265,7 +265,8 @@ async def test_snapshot_journal_cancel_inbox_round_trip(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_cancel_scheduled_before_dispatch_wins_exclusively(tmp_path):
+@pytest.mark.llm_stub(control="gated")
+async def test_cancel_scheduled_before_dispatch_wins_exclusively(tmp_path, _llm_stub):
     """Tier 2: ★race gate (design-pass pin F, #79). ``cancel_queued`` and the
     dispatcher's own dequeue-then-promote (``run_one_iteration``) are launched
     as CONCURRENT asyncio tasks contending for the SAME queued item, cancel
@@ -274,9 +275,13 @@ async def test_cancel_scheduled_before_dispatch_wins_exclusively(tmp_path):
     cancel_queued`` docstrings), whichever task the loop runs first commits
     its exit atomically before the other can observe stale state: cancel wins
     here, EXCLUSIVELY — the item is discarded (skip-at-consume) when later
-    dequeued, never promoted (``turn_started`` never fires for it)."""
+    dequeued, never promoted (``turn_started`` never fires for it).
+
+    control="gated" is installed only as a safety net (no assertion needs
+    ``call_started``/``release`` here) — if dispatch ever DID win this race
+    (it must not), the LLM boundary must still be patched rather than
+    attempting a real network call."""
     session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
-    _install_hanging_run_turn(session)
 
     await session.submit_user_text("race-me")
     msg_id = session.queued_user_messages()[0]["msg_id"]
@@ -309,15 +314,18 @@ async def test_cancel_scheduled_before_dispatch_wins_exclusively(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_scheduled_before_cancel_wins_exclusively(tmp_path):
+@pytest.mark.llm_stub(control="gated")
+async def test_dispatch_scheduled_before_cancel_wins_exclusively(tmp_path, _llm_stub):
     """Tier 2: the REVERSE ordering of the race above — dispatch scheduled
     first. By the time cancel's task runs, the item is already consumed
     (its snapshot.inbox entry pruned + ``turn_started`` already emitted, both
     inside the dispatcher's own no-await synchronous prefix) — cancel
     observes "already dispatched" and correctly no-ops. EXACTLY ONE of the
-    two exits fires, never both, regardless of which ordering wins."""
+    two exits fires, never both, regardless of which ordering wins.
+
+    Witness ② (#5450) is implicit: ``assert "turn_started" in kinds`` below
+    already depends on the real driver having dispatched."""
     session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
-    call_started, release = _install_hanging_run_turn(session)
 
     await session.submit_user_text("race-me-2")
     msg_id = session.queued_user_messages()[0]["msg_id"]
@@ -328,8 +336,8 @@ async def test_dispatch_scheduled_before_cancel_wins_exclusively(tmp_path):
     iter_task = asyncio.create_task(session.run_one_iteration())
     cancel_task = asyncio.create_task(session.cancel_queued(msg_id))
 
-    await asyncio.wait_for(call_started.wait(), timeout=5)
-    cancelled = await asyncio.wait_for(cancel_task, timeout=5)
+    await _llm_stub.call_started.wait()
+    cancelled = await cancel_task
 
     assert cancelled is False, "dispatch won the race — cancel of an already-dispatched item is a no-op"
     await settle(session._audit_events)
@@ -339,8 +347,8 @@ async def test_dispatch_scheduled_before_cancel_wins_exclusively(tmp_path):
         "dispatch won the race — the item must NEVER ALSO be cancelled (exclusivity)"
     )
 
-    release.set()
-    finished = await asyncio.wait_for(iter_task, timeout=5)
+    _llm_stub.release.set()
+    finished = await iter_task
     assert finished is True
 
 
@@ -348,13 +356,18 @@ async def test_dispatch_scheduled_before_cancel_wins_exclusively(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_skip_at_consume_discards_cancelled_item_without_dispatch(tmp_path):
+@pytest.mark.llm_stub(control="gated")
+async def test_skip_at_consume_discards_cancelled_item_without_dispatch(tmp_path, _llm_stub):
     """Tier 2: a cancelled item still physically sitting in the plain
     ``asyncio.Queue`` (no removal API) is discarded — never dispatched, never
     staged as a ride-along — when it is eventually dequeued. A LATER queued
-    item is unaffected and dispatches normally."""
+    item is unaffected and dispatches normally.
+
+    Witness ② (#5450): turn_started fires for the SECOND (uncancelled)
+    item's chain_id — proof the real driver dispatched THAT item, not just
+    that the stub returned."""
     session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
-    call_started, release = _install_hanging_run_turn(session)
+    events = _collect(session)
 
     await session.submit_user_text("cancel-me")
     cancel_id = session.queued_user_messages()[0]["msg_id"]
@@ -365,11 +378,14 @@ async def test_skip_at_consume_discards_cancelled_item_without_dispatch(tmp_path
     # run_one_iteration must skip the cancelled item and dispatch the SECOND
     # (uncancelled) one instead — never a turn for the cancelled text.
     turn_task = asyncio.create_task(session.run_one_iteration())
-    await asyncio.wait_for(call_started.wait(), timeout=5)
-    release.set()
-    finished = await asyncio.wait_for(turn_task, timeout=5)
+    await _llm_stub.call_started.wait()
+    _llm_stub.release.set()
+    finished = await turn_task
     assert finished is True
     assert session.queued_user_messages() == []
+
+    await session._audit_events.drain()
+    assert any(e.type == "turn_started" for e in events)
 
 
 # ── 5. inbox_cancel delta / RemoteQueueView ──────────────────────────────────

--- a/tests/interfaces/test_3310_n2_reset_hydrate.py
+++ b/tests/interfaces/test_3310_n2_reset_hydrate.py
@@ -732,21 +732,12 @@ async def test_reset_call_parents_stale_call_id_does_not_nest_into_ghost_parent(
         await reg.shutdown()
 
 
-def _install_hanging_run_turn(session: Session):
-    """Same no-mock seam ``tests/interfaces/test_3300_p2a_queue_state_publish.py`` uses
-    (itself mirroring ``tests/core/test_2242_hard_cancel.py``): a real, plain
-    async function method-assigned onto the instance standing in for a
-    genuinely in-flight LLM call, so a turn can be held BUSY (never touching
-    a real LLM) while a SECOND submission queues behind it."""
-    call_started = asyncio.Event()
-    release = asyncio.Event()
-
-    async def _hanging_run_turn(user_text: str, chain_id: str) -> None:
-        call_started.set()
-        await release.wait()
-
-    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
-    return call_started, release
+def _collect(session: Session) -> list:
+    """Subscribe through the public seam (Session.subscribe_audit_events,
+    #5260) — for witness ②: turn_started proves the REAL driver ran (#5450)."""
+    collected: list = []
+    session.subscribe_audit_events(collected.append)
+    return collected
 
 
 async def _stop_auto_driver(reg: AgentRegistry, name: str) -> None:
@@ -773,8 +764,9 @@ async def _stop_auto_driver(reg: AgentRegistry, name: str) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub(control="gated")
 async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
-    tmp_path, monkeypatch,
+    tmp_path, monkeypatch, _llm_stub,
 ) -> None:
     """Tier 2: ``_queue_view`` / ``_queue_seeded`` witness, INDEPENDENT of the
     sent-queue WIDGET clear above (a strip check during review showed the
@@ -809,11 +801,11 @@ async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
         await reg.attach("alpha")
         beta = await reg.attach("beta")
         await _stop_auto_driver(reg, "beta")
+        events = _collect(beta)
 
-        call_started, release = _install_hanging_run_turn(beta)
         await beta.submit_user_text("beta busy trigger")
         turn_task = asyncio.create_task(beta.run_one_iteration())
-        await asyncio.wait_for(call_started.wait(), timeout=5)
+        await _llm_stub.call_started.wait()
 
         # A second submission arrives while the first is still in flight —
         # it stays undispatched (server-authoritative queue, #3300 §6b).
@@ -867,8 +859,12 @@ async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
                 "beta queued item" in t for t in sent_queue.rendered_texts()
             ), sent_queue.rendered_texts()
 
-        release.set()
-        await asyncio.wait_for(turn_task, timeout=5)
+        _llm_stub.release.set()
+        await turn_task
+
+        # witness ②: the real driver dispatched beta's own turn.
+        await beta._audit_events.drain()
+        assert any(e.type == "turn_started" for e in events)
     finally:
         await reg.shutdown()
 

--- a/tests/runtime/test_3694_persist_cancelled_turn_outcome.py
+++ b/tests/runtime/test_3694_persist_cancelled_turn_outcome.py
@@ -66,6 +66,15 @@ from tests._support.router_loop import FakeRouterHost, text_result
 from tests._support.router_loop import ScriptedLLM as _ScriptedLLM
 from tests._support.session import make_session as _make_session
 
+
+def _collect(session) -> list:
+    """Subscribe through the public seam (Session.subscribe_audit_events,
+    #5260) — for witness ②: turn_started proves the REAL driver ran (#5450)."""
+    collected: list = []
+    session.subscribe_audit_events(collected.append)
+    return collected
+
+
 # ── (a) shape ────────────────────────────────────────────────────────────
 
 
@@ -223,8 +232,9 @@ async def test_cooperative_cancel_persists_the_marker_via_real_router_loop() -> 
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub(control="gated")
 async def test_a_non_self_initiated_cancel_does_not_fabricate_a_user_cancel_marker(
-    tmp_path, monkeypatch,
+    tmp_path, monkeypatch, _llm_stub,
 ):
     """Tier 2: arm (f) — Session.run_one_iteration's hard-cancel catch only
     calls notify_turn_cancelled when the cancellation was
@@ -236,10 +246,10 @@ async def test_a_non_self_initiated_cancel_does_not_fabricate_a_user_cancel_mark
     Delivered through the REAL mechanism ``test_3377_run_loop_survives_turn_
     cancel.py`` itself uses: ``session._turn_owner_task.cancel()`` directly
     — bypassing ``cancel_inflight()`` entirely, so
-    ``_turn_cancel_self_initiated`` stays False. Real ``Session`` (no
-    mocks); only ``RouterLoopDriver.run_turn`` is replaced with a
-    controllable hang, the same seam ``test_2242_hard_cancel.py`` and
-    ``test_3377_...`` both use.
+    ``_turn_cancel_self_initiated`` stays False. Real ``Session``/real
+    ``RouterLoopDriver``/``RouterLoop`` (#5450: the LLM boundary is hung via
+    ``@pytest.mark.llm_stub(control="gated")``, not a private ``run_turn``
+    replacement).
 
     Falsification (performed for real): removing the ``else:`` gate
     (calling ``notify_turn_cancelled`` unconditionally) makes this test go
@@ -247,28 +257,25 @@ async def test_a_non_self_initiated_cancel_does_not_fabricate_a_user_cancel_mark
     cancel ever happened.
     """
     session = _make_session(tmp_path, monkeypatch=monkeypatch)
-    started = asyncio.Event()
-    release = asyncio.Event()
-
-    async def _hanging_run_turn(user_text, chain_id):
-        started.set()
-        await release.wait()
-
-    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
+    events = _collect(session)
 
     await session._put_inbox("user", {"text": "hello", "chain_id": "c-unknown-origin"})
     turn_task = asyncio.create_task(session.run_one_iteration())
     try:
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await _llm_stub.call_started.wait()
 
         # The REAL "not self-initiated" delivery mechanism — NOT cancel_inflight().
         session._turn_owner_task.cancel()
 
-        release.set()
-        completed = await asyncio.wait_for(turn_task, timeout=5)
+        _llm_stub.release.set()
+        completed = await turn_task
         assert completed is True  # the driver survives (per #3377)
     finally:
-        release.set()
+        _llm_stub.release.set()
+
+    # witness ②: the real driver dispatched before the cancel hit it.
+    await session._audit_events.drain()
+    assert any(e.type == "turn_started" for e in events)
 
     cancelled_markers = [
         m for m in session.history
@@ -284,7 +291,10 @@ async def test_a_non_self_initiated_cancel_does_not_fabricate_a_user_cancel_mark
 
 
 @pytest.mark.asyncio
-async def test_hard_cancel_via_cancel_inflight_persists_the_marker(tmp_path) -> None:
+@pytest.mark.llm_stub(control="gated")
+async def test_hard_cancel_via_cancel_inflight_persists_the_marker(
+    tmp_path, _llm_stub,
+) -> None:
     """Tier 2: arm (g) — the ② receiver, witnessed IN THIS FILE (not only
     cross-referenced) so a reader/reviewer of this file alone sees the
     positive path for the "more common" case the module docstring itself
@@ -303,19 +313,12 @@ async def test_hard_cancel_via_cancel_inflight_persists_the_marker(tmp_path) -> 
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snapshot.json",
     )
-    started = asyncio.Event()
-    release = asyncio.Event()
-
-    async def _hanging_run_turn(user_text: str, chain_id: str) -> None:
-        started.set()
-        await release.wait()
-
-    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
+    events = _collect(session)
 
     await session._put_inbox("user", {"text": "hello", "chain_id": "c-hard-cancel-g"})
     turn_task = asyncio.create_task(session.run_one_iteration())
     try:
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await _llm_stub.call_started.wait()
 
         # The REAL delivery mechanism: cancel_inflight() (NOT a raw
         # Task.cancel()) — sets _turn_cancel_self_initiated=True FIRST,
@@ -323,11 +326,15 @@ async def test_hard_cancel_via_cancel_inflight_persists_the_marker(tmp_path) -> 
         result = await session.cancel_inflight()
         assert "cancel" in result.lower()
 
-        release.set()
-        completed = await asyncio.wait_for(turn_task, timeout=5)
+        _llm_stub.release.set()
+        completed = await turn_task
         assert completed is True
     finally:
-        release.set()
+        _llm_stub.release.set()
+
+    # witness ②: the real driver dispatched before the cancel hit it.
+    await session._audit_events.drain()
+    assert any(e.type == "turn_started" for e in events)
 
     (marker,) = [
         m for m in session.history


### PR DESCRIPTION
**[e2e-coder]** — closes #5450 (except `test_5248_turn_finally.py`'s `wait_for_cancel` test, deferred to its own PR per lead-coder's ruling — see below).

## What

The remaining 5 of #5450's declared 11-file population (see the [structural-needle table on the issue](https://github.com/tya5/reyn/issues/5450#issuecomment-5460205154)):

- `tests/interfaces/test_3300_p2a_queue_state_publish.py` (4 usages)
- `tests/interfaces/test_3300_p3_cancel_by_id.py` (4 usages — including 2 race-condition tests; one keeps `control="gated"` installed purely as a safety net, since its own subject is "dispatch never wins this race", not the hang itself)
- `tests/interfaces/test_3310_n2_reset_hydrate.py` (1 usage)
- `tests/runtime/test_3694_persist_cancelled_turn_outcome.py` (2 usages)
- `tests/core/test_3377_run_loop_survives_turn_cancel.py` (1 usage, more complex shape — see below)

## `test_3377`'s shape

The private closure it replaced hung only on its FIRST call and recorded every dispatched `chain_id` in a local list. `LLMStub`'s `release` `asyncio.Event` never auto-resets, so once `.set()`, every LATER call passes straight through — exactly "first turn hangs, later turns return at once" with zero extra logic needed. "Every chain_id dispatched" is now read off the public `turn_started` audit-event stream instead of a private list — doubling as witness ②.

## Witness ②

Every migrated test asserts (or, where the test's own core mechanism already structurally depends on it — `test_3300_p3`'s two race tests, `test_3300_p2a`'s real-session-delta tests — implicitly relies on) `turn_started` firing: proof the real driver dispatched, not merely that the stub was called.

**Strip-verified by hand, across the whole batch at once**: removing `session.py`'s `turn_started` emit turned **13 assertions RED** — 2 of them as genuine **hangs** (`test_3377`'s own `_wait_for` polling loops never terminate without a `chain_id` ever appearing, caught by `pytest-timeout`), not just failed asserts — proving witness ② is a real functional dependency in several tests, not a bolted-on check. Restored, reconfirmed 44/44 green.

## Deferred

`test_5248_turn_finally.py`'s `wait_for_cancel` test is **not** included — per lead-coder's ruling it needs a two-sentence docstring (architect's own exact wording) explaining why witness ② is satisfied differently there (calling production's `_run_router_loop` directly means there's no substituted driver to hide behind — the call itself is the witness), landing alongside `fail_run_turn`'s own #5382/#5461 disposition in a separate PR.

## Test plan

- [x] `ruff check .` — green
- [x] `python scripts/test_tier_audit.py --strict` on all 5 files — 44/44 OK
- [x] `python scripts/mypy_ratchet.py` — OK (baselined)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] Scoped `pytest` on all 5 files — 44 passed
- [x] Strip-falsify witness ② across the whole batch — genuinely executed (see above)
- [x] (skipped — Visual, no TUI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
