### PR TITLE
fix(#5453): CI gate -- a BLOCKING PR requires one re-read note, report-only

### DIFF
--- a/.github/workflows/check-blocking-has-reread-note.yml
+++ b/.github/workflows/check-blocking-has-reread-note.yml
@@ -1,0 +1,115 @@
+name: BLOCKING PR has a re-read note
+
+# #5453: house rule 8's TESTS-READ note gate (`check-tests-read-names-its-tree.yml`)
+# only fires when a PR touches `tests/` — a `src`-only PR that raises and
+# clears a BLOCKING point (house rule 7's `BLOCKING`/`BLOCKING-CLEARED`
+# pair, enforced by `check-open-blocking-checkboxes.yml`) has no
+# mechanical trigger for a SEPARATE re-read record at all: the author can
+# post `BLOCKING-CLEARED` about their own fix, quoting the point back
+# verbatim, and merge — with nobody's comment ever naming the CURRENT
+# tree. architect's ruling (quoted on #5453): a PR with at least one
+# `BLOCKING` comment needs one TESTS-READ-shaped note naming its current
+# head, regardless of whether it touches `tests/`.
+#
+# This workflow mirrors `check-tests-read-names-its-tree.yml`'s own
+# 3-trigger / commit-status shape exactly (see that workflow's own
+# comments for the full history of why each piece is there:
+# `issue_comment` for a note arriving as a new comment; a commit STATUS,
+# never a check run, because a check run attaches to the triggering
+# event's own sha and `issue_comment` carries the DEFAULT BRANCH's sha,
+# not the PR's; `pending` posted before the script runs and
+# `success`/`failure` after, un-skippable via `if: always()`, so a job
+# that dies mid-run leaves `pending` rather than going silent).
+#
+# #5453 (lead-coder's own scoping): report-only. NOT added to branch
+# protection's required checks in this PR — lead-coder decides that
+# separately, after watching it run against real BLOCKING PRs, the same
+# caution `check_tests_read_names_its_tree.py`'s own module docstring
+# names for #5265's `startup_failure` exposure risk on required checks.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+env:
+  STATUS_CONTEXT: blocking-has-reread-note
+
+jobs:
+  blocking-has-reread-note:
+    name: BLOCKING PR carries a re-read note naming its tree
+    if: github.event_name == 'pull_request' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # No checkout of the PR — the comment/commit list is read from the
+      # API as DATA (mirrors check-tests-read-names-its-tree.yml's own
+      # reasoning: a contributor's tree is never executed here).
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Resolve this PR's number and head sha
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          SHA="$(gh pr view "$NUMBER" --json headRefOid -q .headRefOid)"
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Post pending status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.sha }}" \
+            -f state=pending \
+            -f context="$STATUS_CONTEXT" \
+            -f description="Checking whether a BLOCKING PR carries a re-read note..."
+
+      # scripts/check_blocking_has_reread_note.py is stdlib-only. No pip
+      # install needed. No `continue-on-error` — #5328's own fix
+      # (check-tests-read-names-its-tree.yml's sibling comment): that
+      # setting forces this step's (and so the job's own check-run's)
+      # conclusion to `success` regardless of the script's real exit
+      # code, disagreeing with the commit status posted below at the
+      # SAME push-time evaluation.
+      - name: Check the PR carries a re-read note if it has a BLOCKING comment
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_blocking_has_reread_note.py --pr "${{ steps.pr.outputs.number }}"
+
+      # `if: always()` — this step must run whether the check step above
+      # passed, failed, or (runner died first) never ran, so a dead job
+      # leaves the status `pending` (blocking merge) rather than silent.
+      - name: Post final status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ steps.check.outcome }}" = "success" ]; then
+            STATE=success
+            DESC="No BLOCKING comment, or a re-read note names this tree."
+          else
+            STATE=failure
+            DESC="BLOCKING comment with no re-read note naming this tree -- see the job log."
+          fi
+          gh api "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.sha }}" \
+            -f state="$STATE" \
+            -f context="$STATUS_CONTEXT" \
+            -f description="$DESC"

--- a/scripts/check_blocking_has_reread_note.py
+++ b/scripts/check_blocking_has_reread_note.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Fail a PR that carries a BLOCKING comment but no TESTS-READ-shaped note
+naming its CURRENT head — house rule 7's `BLOCKING-CLEARED` requires only
+a comment quoting the raised point back (already enforced by
+`check_open_blocking_checkboxes.py`), which any session can post about
+its own fix; nothing until now required a SEPARATE record of someone
+having engaged with the tree as it exists NOW (#5453).
+
+## The gap (#5453, lead-coder)
+
+House rule 8's `check_tests_read_names_its_tree.py` already gives this
+repo exactly the record shape wanted — a comment's first line naming the
+PR's CURRENT head, proven to be a real commit of the PR (never a stale
+SHA, never an issue-comment id mistaken for one) — but its TRIGGER is
+"does this PR touch `tests/``". A `src`-only PR that raised and cleared a
+BLOCKING point has no mechanical trigger for a re-read record at all:
+the author can post `BLOCKING-CLEARED` themselves, quoting the point back
+verbatim (satisfying `check_open_blocking_checkboxes.py`'s own
+condition A), and merge — with nobody's comment ever having named the
+CURRENT tree.
+
+architect's ruling (quoted by lead-coder on #5453): a PR with AT LEAST
+ONE `BLOCKING` comment requires ONE re-read record, regardless of
+whether it touches `tests/`. What the record must show: **that it
+exists** — the SAME thing house rule 8 already asks for, never
+AUTHORSHIP (every session in this repo authenticates as the same `gh`
+user; CLAUDE.md's own preamble — an authorship check is always
+vacuously true and was rejected for exactly that reason when
+`check_open_blocking_checkboxes.py` was designed). Boundary: "did a
+BLOCKING comment land", not every PR — the review round-trip this asks
+for is a finite resource lead-coder does not want spent where no
+blocking point was ever raised.
+
+## Reused, not reinvented
+
+This deliberately does NOT invent a new marker or a new comment shape.
+A `TESTS-READ (head <sha>)`-marked comment naming the PR's current head
+already IS "a record that someone engaged with this exact tree" —
+requiring the SAME marker here (rather than a second, parallel concept)
+means a PR that satisfies house rule 8 for an unrelated reason (it also
+touches `tests/`) automatically satisfies this rule too, with the same
+comment. `check_tests_read_names_its_tree.py` and
+`check_open_blocking_checkboxes.py` are loaded via
+``importlib.util.spec_from_file_location`` (mirroring
+`tests/scripts/test_check_tests_read_names_its_tree_5039.py`'s own
+established technique for reaching a `scripts/`-local module — this
+directory has no `__init__.py`, so a package import is not available)
+and their existing functions/regexes are called directly — the marker
+shape, the SHA-membership filter (`find_note_shas`'s own false-friend
+guard), and the "names the CURRENT head, not any past one" existential
+all come from there unchanged, so a future fix to either stays in sync
+with both gates automatically instead of drifting.
+
+## Report-only (lead-coder's own scoping, #5453)
+
+NOT added to required status checks in this PR — lead-coder decides
+that separately, after watching this run for real BLOCKING PRs without
+first making every one of them un-mergeable on a script's first outing
+(the same caution `check_tests_read_names_its_tree.py`'s own module
+comment names for #5265's `startup_failure` exposure risk). The CI
+workflow posts a commit status exactly like its sibling gate, just
+under its own status context, so branch protection can be told to
+require it later without touching this script.
+
+stdlib-only (argparse / json / subprocess — the marker regexes and SHA
+logic are IMPORTED, not reimplemented), mirroring
+`check_pr_closing_intent.py`/`check_tests_read_names_its_tree.py` so CI
+runs it dep-free.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+
+
+def _load(module_name: str, filename: str):
+    """Load a sibling ``scripts/`` module by file path (no ``__init__.py``
+    here, so a package import is not available — mirrors
+    ``tests/scripts/test_check_tests_read_names_its_tree_5039.py``'s own
+    established technique for reaching a script-local module)."""
+    spec = importlib.util.spec_from_file_location(module_name, _SCRIPTS_DIR / filename)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_tests_read = _load("_check_blocking_reread_tests_read", "check_tests_read_names_its_tree.py")
+_blocking = _load("_check_blocking_reread_blocking", "check_open_blocking_checkboxes.py")
+
+
+def _has_blocking_comment(comment_bodies: "list[str]") -> bool:
+    """True iff ANY comment's first line matches the `BLOCKING (head <sha>)`
+    shape (reused from `check_open_blocking_checkboxes.py` — the same form
+    check that excludes prose merely discussing the word, #5318's own
+    false-positive fix)."""
+    return any(
+        _blocking._BLOCKING_MARKER.search(_blocking._first_line(body))
+        for body in comment_bodies
+    )
+
+
+def evaluate(pr: dict) -> "tuple[int, list[str]]":
+    """``(exit_code, lines)`` for one PR payload.
+
+    *pr* carries ``comments`` (list of ``{'body':}``), ``commits`` (each
+    ``{'oid':}``) and ``headRefOid`` — the SAME shape
+    `check_tests_read_names_its_tree.evaluate` takes, minus ``files``
+    (this gate's trigger is "has a BLOCKING comment", never "touches
+    tests/"). Pure — the live and fixture paths both build this shape
+    first, so the decision is testable without GitHub."""
+    comment_bodies = [
+        c.get("body", "") for c in pr.get("comments", []) if isinstance(c.get("body"), str)
+    ]
+    if not _has_blocking_comment(comment_bodies):
+        return 0, ["OK — this PR carries no BLOCKING comment; #5453 does not apply."]
+
+    notes = [
+        _tests_read._first_line(body)
+        for body in comment_bodies
+        if _tests_read._NOTE_MARKER.search(_tests_read._first_line(body))
+    ]
+    if not notes:
+        return 1, [
+            "RED — this PR carries a BLOCKING comment but no TESTS-READ-shaped "
+            "note at all.",
+            "  #5453: a PR with a raised BLOCKING point needs one comment naming",
+            "  the tree that was re-read before merge — the marker and the head",
+            "  SHA must both be on a comment's FIRST line (same shape house rule",
+            "  8 already uses, e.g. `TESTS-READ (head abc1234)`).",
+        ]
+
+    commits = pr.get("commits", [])
+    if not commits:
+        return 1, [
+            "RED — this PR carries a BLOCKING comment but its commit list is "
+            "empty.",
+            "  Nothing here can be shown to have been read; refusing to pass a",
+            "  note that names a tree this check cannot locate.",
+        ]
+    oids = [c.get("oid", "") for c in commits]
+    head = pr.get("headRefOid", "")
+    if not head:
+        return 1, [
+            "RED — this PR's headRefOid is empty; cannot verify a note names",
+            "  the current tree.",
+        ]
+
+    resolved_count = 0
+    stale: "list[tuple[str, list[str]]]" = []
+    for note in notes:
+        shas = _tests_read.find_note_shas(note, oids)
+        if not shas:
+            continue
+        resolved_count += 1
+        if _tests_read._note_names_head(note, head, oids):
+            return 0, [f"OK — a TESTS-READ note names the current head {head}."]
+        stale.append((note, shas))
+
+    if not resolved_count:
+        return 1, [
+            "RED — a TESTS-READ-shaped note landed, but none of them names a",
+            "  commit of this PR. Add the head you read (e.g. `TESTS-READ (head",
+            "  abc1234)`), on the SAME first line as the marker.",
+        ]
+
+    lines = [
+        "RED — this PR has a BLOCKING comment, but no TESTS-READ note names",
+        f"  the current head {head}.",
+        "  (∃ over the CURRENT head — an older note naming an earlier commit",
+        "  does not count against a PR that has since moved. Post a FRESH note",
+        "  naming this head; earlier notes stay exactly as posted.)",
+    ]
+    for note_text, shas in stale:
+        lines.append(f"  note (first line): {note_text!r} — names {shas!r}, not the current head")
+    return 1, lines
+
+
+def fetch_pr(number: int) -> dict:
+    """Build the ``evaluate`` payload for a live PR via ``gh`` — no checkout."""
+    raw = subprocess.run(
+        ["gh", "pr", "view", str(number), "--json", "comments,commits,headRefOid"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    data = json.loads(raw)
+    commits = [{"oid": c.get("oid", "")} for c in data.get("commits", [])]
+    return {
+        "comments": data.get("comments", []),
+        "commits": commits,
+        "headRefOid": data.get("headRefOid", ""),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail a PR with a BLOCKING comment but no TESTS-READ-shaped note "
+            "naming the tree it read (#5453)."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pr", type=int, metavar="N", help="Live PR number, via gh.")
+    group.add_argument(
+        "--fixture", type=Path, metavar="PATH",
+        help=(
+            "JSON file with keys 'comments' ([{'body':}]), 'commits' "
+            "([{'oid':}]) and 'headRefOid'. Lets this run offline."
+        ),
+    )
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = build_parser().parse_args(argv)
+    pr = (
+        json.loads(args.fixture.read_text(encoding="utf-8"))
+        if args.fixture else fetch_pr(args.pr)
+    )
+    code, lines = evaluate(pr)
+    print("\n".join(lines))
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_blocking_has_reread_note.py
+++ b/scripts/check_blocking_has_reread_note.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-"""Fail a PR that carries a BLOCKING comment but no TESTS-READ-shaped note
-naming its CURRENT head — house rule 7's `BLOCKING-CLEARED` requires only
+"""Fail a PR that carries a BLOCKING comment but no TESTS-READ- or RE-READ-
+shaped note naming its CURRENT head — house rule 7's `BLOCKING-CLEARED`
+requires only
 a comment quoting the raised point back (already enforced by
 `check_open_blocking_checkboxes.py`), which any session can post about
 its own fix; nothing until now required a SEPARATE record of someone
@@ -31,17 +32,28 @@ BLOCKING comment land", not every PR — the review round-trip this asks
 for is a finite resource lead-coder does not want spent where no
 blocking point was ever raised.
 
-## Reused, not reinvented
+## Reused, not reinvented — plus one honest addition (architect, #5453)
 
-This deliberately does NOT invent a new marker or a new comment shape.
-A `TESTS-READ (head <sha>)`-marked comment naming the PR's current head
-already IS "a record that someone engaged with this exact tree" —
-requiring the SAME marker here (rather than a second, parallel concept)
-means a PR that satisfies house rule 8 for an unrelated reason (it also
-touches `tests/`) automatically satisfies this rule too, with the same
-comment. `check_tests_read_names_its_tree.py` and
-`check_open_blocking_checkboxes.py` are loaded via
-``importlib.util.spec_from_file_location`` (mirroring
+This deliberately does NOT invent a new marker or a new comment shape for
+the common case. A `TESTS-READ (head <sha>)`-marked comment naming the
+PR's current head already IS "a record that someone engaged with this
+exact tree" — accepting the SAME marker here (rather than a second,
+parallel concept) means a PR that satisfies house rule 8 for an
+unrelated reason (it also touches `tests/`) automatically satisfies this
+rule too, with the same comment.
+
+Architect's own non-blocking review of the first revision (quoted
+verbatim): reusing `TESTS-READ` UNCONDITIONALLY would make a `src`-only
+PR's re-read comment falsely claim "read a test that isn't in this diff
+at all" — 「`tests/` を触らない PR で `TESTS-READ` を出すと『diff に無い
+test を読んだ』と主張することになります」. `RE-READ (head <sha>)` is the
+honest form for exactly that case; `_is_reread_note` accepts EITHER
+marker, so a `tests/`-touching PR still clears both gates with ONE
+`TESTS-READ` comment, while a `src`-only PR can post the accurate
+`RE-READ` one instead of a claim it cannot back up.
+
+`check_tests_read_names_its_tree.py` and `check_open_blocking_checkboxes.py`
+are loaded via ``importlib.util.spec_from_file_location`` (mirroring
 `tests/scripts/test_check_tests_read_names_its_tree_5039.py`'s own
 established technique for reaching a `scripts/`-local module — this
 directory has no `__init__.py`, so a package import is not available)
@@ -72,6 +84,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -93,6 +106,28 @@ def _load(module_name: str, filename: str):
 
 _tests_read = _load("_check_blocking_reread_tests_read", "check_tests_read_names_its_tree.py")
 _blocking = _load("_check_blocking_reread_blocking", "check_open_blocking_checkboxes.py")
+
+#: architect's non-blocking recommendation on #5453 (quoted verbatim below,
+#: `evaluate`'s docstring) — reusing ONLY `_tests_read._NOTE_MARKER`
+#: (`TESTS-READ`/`TESTS-READY`) would make a `src`-only PR's re-read
+#: comment claim "read a test that isn't in this diff at all". `RE-READ
+#: (head <sha>)` is the honest form for that case; either marker satisfies
+#: THIS gate, so a PR that also touches `tests/` (and so already needs
+#: `TESTS-READ` for house rule 8) still clears both gates with ONE
+#: comment, while a `src`-only PR can post the accurate one.
+_RE_READ_MARKER = re.compile(r"RE-READ\s*\(\s*head\s", re.IGNORECASE)
+
+
+def _is_reread_note(first_line: str) -> bool:
+    """True iff *first_line* matches EITHER accepted note marker — house
+    rule 8's own `TESTS-READ`/`TESTS-READY` (reused unchanged, so a
+    `tests/`-touching PR's existing note keeps satisfying this gate too),
+    or this gate's own `RE-READ (head <sha>)` (architect's #5453
+    recommendation, for a PR where "TESTS-READ" would misstate what was
+    actually read)."""
+    return bool(
+        _tests_read._NOTE_MARKER.search(first_line) or _RE_READ_MARKER.search(first_line)
+    )
 
 
 def _has_blocking_comment(comment_bodies: "list[str]") -> bool:
@@ -124,16 +159,19 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     notes = [
         _tests_read._first_line(body)
         for body in comment_bodies
-        if _tests_read._NOTE_MARKER.search(_tests_read._first_line(body))
+        if _is_reread_note(_tests_read._first_line(body))
     ]
     if not notes:
         return 1, [
-            "RED — this PR carries a BLOCKING comment but no TESTS-READ-shaped "
-            "note at all.",
+            "RED — this PR carries a BLOCKING comment but no TESTS-READ- or "
+            "RE-READ-shaped note at all.",
             "  #5453: a PR with a raised BLOCKING point needs one comment naming",
             "  the tree that was re-read before merge — the marker and the head",
-            "  SHA must both be on a comment's FIRST line (same shape house rule",
-            "  8 already uses, e.g. `TESTS-READ (head abc1234)`).",
+            "  SHA must both be on a comment's FIRST line: `TESTS-READ (head",
+            "  abc1234)` (same shape house rule 8 already uses — one comment then",
+            "  satisfies both gates on a PR that also touches tests/) or, for a",
+            "  PR that does not touch tests/ at all, `RE-READ (head abc1234)`",
+            "  (architect, #5453 — TESTS-READ would misstate what was read).",
         ]
 
     commits = pr.get("commits", [])
@@ -160,18 +198,19 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
             continue
         resolved_count += 1
         if _tests_read._note_names_head(note, head, oids):
-            return 0, [f"OK — a TESTS-READ note names the current head {head}."]
+            return 0, [f"OK — a re-read note names the current head {head}."]
         stale.append((note, shas))
 
     if not resolved_count:
         return 1, [
-            "RED — a TESTS-READ-shaped note landed, but none of them names a",
-            "  commit of this PR. Add the head you read (e.g. `TESTS-READ (head",
-            "  abc1234)`), on the SAME first line as the marker.",
+            "RED — a TESTS-READ- or RE-READ-shaped note landed, but none of "
+            "them names a commit of this PR.",
+            "  Add the head you read (e.g. `TESTS-READ (head abc1234)` or",
+            "  `RE-READ (head abc1234)`), on the SAME first line as the marker.",
         ]
 
     lines = [
-        "RED — this PR has a BLOCKING comment, but no TESTS-READ note names",
+        "RED — this PR has a BLOCKING comment, but no re-read note names",
         f"  the current head {head}.",
         "  (∃ over the CURRENT head — an older note naming an earlier commit",
         "  does not count against a PR that has since moved. Post a FRESH note",
@@ -200,8 +239,8 @@ def fetch_pr(number: int) -> dict:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Fail a PR with a BLOCKING comment but no TESTS-READ-shaped note "
-            "naming the tree it read (#5453)."
+            "Fail a PR with a BLOCKING comment but no TESTS-READ- or RE-READ-"
+            "shaped note naming the tree it read (#5453)."
         ),
     )
     group = parser.add_mutually_exclusive_group(required=True)

--- a/tests/scripts/test_check_blocking_has_reread_note_5453.py
+++ b/tests/scripts/test_check_blocking_has_reread_note_5453.py
@@ -1,0 +1,137 @@
+"""Tier 1: `scripts/check_blocking_has_reread_note.py`'s own contract — a PR
+carrying a BLOCKING comment but no TESTS-READ-shaped note naming its
+CURRENT head is rejected (#5453).
+
+Contract, not OS invariant: the subject is a repo gate's decision function,
+protecting the same class house rule 8's own gate protects (a note
+EXISTING is not the same as a note naming THIS tree), but on a DIFFERENT
+trigger — "does this PR carry a BLOCKING comment" instead of "does it
+touch tests/".
+
+This module deliberately does NOT re-derive the marker/SHA logic — it
+reuses `check_tests_read_names_its_tree.py`'s own functions (loaded the
+same way the module under test loads them, via
+``importlib.util.spec_from_file_location``), so a behavior change there
+is exercised through the SAME code path this gate actually runs, not a
+second, independently-written copy that could silently drift.
+
+Payloads are built inline rather than fetched: `evaluate` is pure by
+design so the decision is testable without GitHub.
+"""
+from __future__ import annotations
+
+import importlib.util
+
+from tests._support.paths import REPO_ROOT
+
+_SPEC = importlib.util.spec_from_file_location(
+    "_check_blocking_has_reread_note",
+    REPO_ROOT / "scripts" / "check_blocking_has_reread_note.py",
+)
+_MOD = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MOD)
+
+
+def _pr(*, comments=(), commits=(), head="ffffffff"):
+    return {"comments": list(comments), "commits": list(commits), "headRefOid": head}
+
+
+def _commit(oid):
+    return {"oid": oid}
+
+
+def _blocking(head_sha: str) -> dict:
+    return {"body": f"**[lead-coder]** — BLOCKING (head {head_sha})\n\nsome point."}
+
+
+# ── accept side — rule does not apply ───────────────────────────────────────
+
+def test_no_blocking_comment_at_all_passes_without_needing_any_note():
+    """Tier 1: the boundary itself — a PR with zero BLOCKING comments is
+    entirely outside #5453's scope, regardless of whether a TESTS-READ
+    note exists (lead-coder: "全PRには広げないでください")."""
+    code, lines = _MOD.evaluate(_pr(comments=[{"body": "LGTM, nice work"}]))
+    assert code == 0
+    assert "does not apply" in "\n".join(lines)
+
+
+def test_a_fresh_tests_read_note_naming_the_current_head_passes():
+    """Tier 1: the accept path — a BLOCKING comment landed, and a
+    TESTS-READ-shaped note names the PR's current head."""
+    code, _ = _MOD.evaluate(_pr(
+        comments=[
+            _blocking("aaaaaaa"),
+            {"body": "BLOCKING-CLEARED (head bbbbbbb)\n\nfixed."},
+            {"body": "TESTS-READ (head bbbbbbb)"},
+        ],
+        commits=[_commit("aaaaaaa"), _commit("bbbbbbb")],
+        head="bbbbbbb",
+    ))
+    assert code == 0
+
+
+# ── reject side ─────────────────────────────────────────────────────────────
+
+def test_a_blocking_comment_with_no_tests_read_note_at_all_is_rejected():
+    """Tier 1: the #5453 gap itself — a BLOCKING comment was raised and
+    (per `check_open_blocking_checkboxes.py`'s own separate gate) may even
+    be correctly BLOCKING-CLEARED by the author, but NOTHING ever named
+    the current tree as re-read."""
+    code, lines = _MOD.evaluate(_pr(
+        comments=[
+            _blocking("aaaaaaa"),
+            {"body": "BLOCKING-CLEARED (head bbbbbbb)\n\nsome point."},
+        ],
+        commits=[_commit("aaaaaaa"), _commit("bbbbbbb")],
+        head="bbbbbbb",
+    ))
+    assert code == 1
+    assert "no TESTS-READ-shaped" in "\n".join(lines)
+
+
+def test_a_tests_read_note_naming_a_stale_head_is_rejected():
+    """Tier 1: #5204's own ∃-over-current-head rule, reused here — a note
+    naming an EARLIER commit does not satisfy a PR that has since moved,
+    the same shape `check_tests_read_names_its_tree.py`'s own gate
+    enforces for house rule 8."""
+    code, lines = _MOD.evaluate(_pr(
+        comments=[
+            _blocking("aaaaaaa"),
+            {"body": "TESTS-READ (head aaaaaaa)"},
+            {"body": "BLOCKING-CLEARED (head ccccccc)\n\nsome point."},
+        ],
+        commits=[_commit("aaaaaaa"), _commit("bbbbbbb"), _commit("ccccccc")],
+        head="ccccccc",
+    ))
+    assert code == 1
+    joined = "\n".join(lines)
+    assert "aaaaaaa" in joined
+    assert "ccccccc" in joined
+
+
+def test_a_prose_mention_of_the_word_blocking_does_not_trigger_the_rule():
+    """Tier 1: reused from `check_open_blocking_checkboxes.py`'s own
+    #5318 false-positive fix — a review comment discussing whether
+    something IS a blocking point (no `(head <sha>)` co-located) must not
+    be misread as a formal raise."""
+    code, lines = _MOD.evaluate(_pr(
+        comments=[{"body": "not sure this is blocking, thoughts?"}],
+    ))
+    assert code == 0
+    assert "does not apply" in "\n".join(lines)
+
+
+def test_a_tests_read_note_with_no_resolvable_sha_is_rejected():
+    """Tier 1: the #5096 shape, reused — a claim line landed but names
+    nothing resolvable as a real commit of this PR."""
+    code, lines = _MOD.evaluate(_pr(
+        comments=[
+            _blocking("aaaaaaa"),
+            {"body": "TESTS-READ. Passing."},
+        ],
+        commits=[_commit("aaaaaaa"), _commit("bbbbbbb")],
+        head="bbbbbbb",
+    ))
+    assert code == 1
+    assert "none of them names a" in "\n".join(lines)

--- a/tests/scripts/test_check_blocking_has_reread_note_5453.py
+++ b/tests/scripts/test_check_blocking_has_reread_note_5453.py
@@ -71,6 +71,63 @@ def test_a_fresh_tests_read_note_naming_the_current_head_passes():
     assert code == 0
 
 
+def test_a_reread_note_naming_the_current_head_also_passes():
+    """Tier 1: architect's #5453 non-blocking recommendation — a `src`-only
+    PR's comment claiming `TESTS-READ` would misstate what was actually
+    read (nothing under `tests/` is even in the diff); `RE-READ (head
+    <sha>)` is the honest form for that case, and this gate accepts it as
+    an equal alternative to `TESTS-READ`, never a lesser one."""
+    code, _ = _MOD.evaluate(_pr(
+        comments=[
+            _blocking("aaaaaaa"),
+            {"body": "BLOCKING-CLEARED (head bbbbbbb)\n\nfixed."},
+            {"body": "RE-READ (head bbbbbbb)"},
+        ],
+        commits=[_commit("aaaaaaa"), _commit("bbbbbbb")],
+        head="bbbbbbb",
+    ))
+    assert code == 0
+
+
+def test_one_tests_read_note_satisfies_both_this_gate_and_house_rule_8():
+    """Tier 1: architect's own stated benefit of reusing the SAME marker —
+    a PR that touches `tests/` (and so needs a `TESTS-READ` note for house
+    rule 8 regardless) does not need a SECOND, differently-marked comment
+    to also satisfy THIS gate. One `TESTS-READ` note, read through BOTH
+    gates' own `evaluate`, passes both — proven by actually invoking
+    `check_tests_read_names_its_tree.py`'s `evaluate` too (loaded the same
+    way the module under test loads it), not merely asserted in prose."""
+    import importlib.util as _ilu
+
+    tests_read_spec = _ilu.spec_from_file_location(
+        "_check_tests_read_names_its_tree_5453_dual",
+        REPO_ROOT / "scripts" / "check_tests_read_names_its_tree.py",
+    )
+    tests_read_mod = _ilu.module_from_spec(tests_read_spec)
+    assert tests_read_spec.loader is not None
+    tests_read_spec.loader.exec_module(tests_read_mod)
+
+    pr = _pr(
+        comments=[
+            _blocking("aaaaaaa"),
+            {"body": "BLOCKING-CLEARED (head bbbbbbb)\n\nfixed."},
+            {"body": "TESTS-READ (head bbbbbbb)"},
+        ],
+        commits=[_commit("aaaaaaa"), _commit("bbbbbbb")],
+        head="bbbbbbb",
+    )
+    blocking_code, _ = _MOD.evaluate(pr)
+    # check_tests_read_names_its_tree.evaluate additionally needs `files`
+    # (its own tests/-touching trigger) — absent here on purpose since
+    # this test's whole point is that the SAME comment clears both gates
+    # regardless of what triggered house rule 8's own check.
+    tests_read_code, _ = tests_read_mod.evaluate(
+        {**pr, "files": ["tests/scripts/test_check_doc_drift_5003.py"]}
+    )
+    assert blocking_code == 0
+    assert tests_read_code == 0
+
+
 # ── reject side ─────────────────────────────────────────────────────────────
 
 def test_a_blocking_comment_with_no_tests_read_note_at_all_is_rejected():
@@ -87,7 +144,7 @@ def test_a_blocking_comment_with_no_tests_read_note_at_all_is_rejected():
         head="bbbbbbb",
     ))
     assert code == 1
-    assert "no TESTS-READ-shaped" in "\n".join(lines)
+    assert "no TESTS-READ- or RE-READ-shaped" in "\n".join(lines)
 
 
 def test_a_tests_read_note_naming_a_stale_head_is_rejected():


### PR DESCRIPTION
**[tui-coder]** — closes #5453.

## What

A new report-only CI gate: a PR carrying at least one `BLOCKING` comment must also carry a `TESTS-READ`-shaped note naming its current head, regardless of whether the PR touches `tests/`.

## The gap (architect ruling, quoted by lead-coder on #5453)

House rule 8's existing gate (`check_tests_read_names_its_tree.py`) only triggers on "does this PR touch `tests/`". A `src`-only PR that raises and clears a BLOCKING point has no mechanical trigger for a re-read record at all — the author can post `BLOCKING-CLEARED` about their own fix, quoting the point back verbatim (satisfying `check_open_blocking_checkboxes.py`'s own condition A), and merge, with nobody's comment ever having named the CURRENT tree.

New trigger: a PR with at least one `BLOCKING` comment requires one re-read record, regardless of whether it touches `tests/`. What the record must show: **that it exists** — the same thing house rule 8 already asks for, never authorship (every session in this repo authenticates as the same `gh` user — an authorship check would be vacuously true, rejected for the same reason when `check_open_blocking_checkboxes.py` was designed).

Boundary (lead-coder's own scoping): "did a BLOCKING comment land", not every PR — the review round-trip this asks for is a finite resource.

## Reused, not reinvented — plus one honest addition (architect's non-blocking review)

Does NOT invent a new marker or comment shape for the common case. A `TESTS-READ (head <sha>)`-marked comment naming the PR's current head already IS "a record that someone engaged with this exact tree" — accepting the SAME marker here means a PR that also touches `tests/` (and so already satisfies house rule 8) automatically satisfies this rule too, with the same comment.

**Update**: architect's non-blocking review of the first revision — reusing `TESTS-READ` unconditionally makes a `src`-only PR's re-read comment falsely claim "read a test that isn't in this diff at all" (verbatim: 「`tests/` を触らない PR で `TESTS-READ` を出すと『diff に無い test を読んだ』と主張することになります」). `RE-READ (head <sha>)` is now also accepted, as an equal alternative — a `tests/`-touching PR still clears both gates with ONE `TESTS-READ` comment, while a `src`-only PR can post the accurate `RE-READ` one instead.

`scripts/check_tests_read_names_its_tree.py` and `scripts/check_open_blocking_checkboxes.py` are loaded via `importlib.util.spec_from_file_location` (mirroring `tests/scripts/test_check_tests_read_names_its_tree_5039.py`'s own established technique — `scripts/` has no `__init__.py`, so a package import is unavailable) and their existing functions/regexes are called directly. The marker shape, the SHA-membership filter, and the "names the CURRENT head, not any past one" existential all come from there unchanged — a future fix to either stays in sync with both gates instead of drifting.

## Report-only (lead-coder's own scoping)

NOT added to required status checks in this PR — lead-coder decides that separately, after watching this run against real BLOCKING PRs (the same caution `check_tests_read_names_its_tree.py`'s own module comment names for #5265's `startup_failure` exposure risk). The CI workflow posts a commit status under its own context (`blocking-has-reread-note`), mirroring its sibling's 3-step pending/check/final-status shape and `issue_comment` trigger, so branch protection can require it later without touching the script.

## Changes

- `scripts/check_blocking_has_reread_note.py`: new, stdlib-only. `_is_reread_note` accepts either `TESTS-READ`/`TESTS-READY` (house rule 8's own marker, reused via `_tests_read._NOTE_MARKER`) or the new `RE-READ (head <sha>)`.
- `tests/scripts/test_check_blocking_has_reread_note_5453.py`: 8 tests — accept (no BLOCKING comment at all; a fresh `TESTS-READ` note naming current head; a fresh `RE-READ` note naming current head; one `TESTS-READ` note satisfying BOTH this gate and house rule 8's own — proven by invoking both `evaluate()`s on the same payload), reject (BLOCKING with no note at all; a note naming a stale head; a prose mention of "blocking" that must not false-positive; a note with no resolvable SHA).
- `.github/workflows/check-blocking-has-reread-note.yml`: new, mirrors `check-tests-read-names-its-tree.yml`'s shape.

## Verification

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_blocking_has_reread_note_5453.py` — 8/8 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py scripts/check_blocking_has_reread_note.py tests/scripts/test_check_blocking_has_reread_note_5453.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/scripts/` — 1039 passed (full regression sweep, pre-rebase; re-ran the changed file post-rebase, 8/8 green)
- [x] Live smoke-test against 2 real PRs, re-run after the RE-READ addition: `--pr 5461` → OK ("a re-read note names the current head"); `--pr 5474` → OK ("a re-read note names the current head") — both still correct.
- [x] **Strip-falsify (trigger)**: temporarily forced `_has_blocking_comment` to always report "no BLOCKING comment" — all 3 reject-side witnesses correctly went from red to green (confirming the discriminator is load-bearing). Restored; all tests green again, no residual diff.
- [x] **Strip-falsify (RE-READ marker)**: temporarily disabled the `RE-READ` branch of `_is_reread_note` — the new RE-READ accept-path test correctly went red with `assert 1 == 0`. Restored; 8/8 green again, no residual diff.

## Test plan

- [x] Automated (see above)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

