### PR TITLE
fix(#5478): deleted-files gate (report-only) + check_doc_drift.py names its own scope

### DIFF
--- a/.github/workflows/check-doc-drift.yml
+++ b/.github/workflows/check-doc-drift.yml
@@ -1,9 +1,21 @@
-name: Doc-drift check
+name: Removed-identifier-in-docs check
 
 # #5003: flag a PR that removes an identifier from src/ without touching
 # any docs/ file that still names it. See
 # scripts/check_doc_drift.py's module docstring for the discriminator
 # (asks the PR, not the doc) and the structural exclusions.
+#
+# Renamed from "Doc-drift check" (#5478 ⑥, lead-coder): "doc drift"
+# reads as covering any way a doc goes stale, but this gate's needle is
+# narrowly REMOVED IDENTIFIERS — a name this script's grep can see.
+# lead-coder missed #5463 the same night (a doc's own COUNT claim,
+# "six things", going stale) precisely because a count is not an
+# identifier this gate's discriminator can ever catch; naming this
+# check "doc-drift" invited reading its green as broader coverage than
+# it provides — the same overclaim shape #5466 closed for
+# `events.ja.md`'s "every kind is listed" line. The rename is
+# cosmetic-only: the discriminator, exclusions, and warn-only posture
+# below are all unchanged.
 #
 # WARN-ONLY (architect ruling 2026-08-21, REVERTING the same day's
 # earlier promotion — #5010). Full account in
@@ -48,7 +60,7 @@ permissions:
 
 jobs:
   doc-drift:
-    name: doc-drift check (warn-only)
+    name: removed-identifier-in-docs check (warn-only)
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/detect-5478-deleted-files.yml
+++ b/.github/workflows/detect-5478-deleted-files.yml
@@ -1,0 +1,61 @@
+name: deleted-files report
+
+# #5478 ⑤: report (never block) which files a PR's own merge would
+# DELETE. See scripts/detect_5478_deleted_files.py's module docstring
+# for the discriminant (three-dot `--diff-filter=D`), why this is the
+# gap #5478 closes (before this, exactly one person — lead-coder — ran
+# this check by hand on every PR), and why it stays report-only (a
+# deletion is not itself a defect; visibility is the point).
+#
+# WARN-ONLY, same shape as detect-5419-behind-files.yml and
+# check-doc-drift.yml — this workflow only ever annotates; it never
+# fails the job, and carries no `pull-requests: write` permission.
+#
+# Trigger includes `synchronize` (not just `opened`) so a later push
+# that adds a deletion still gets reported, same reasoning as its two
+# sibling workflows.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  deleted-files-report:
+    name: deleted-files report (warn-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # fetch-depth: 0 (full history) — the three-dot diff needs the
+      # PR's base and head commits, and their shared merge-base, present
+      # locally; a shallow checkout would fail with "unknown revision".
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      # scripts/detect_5478_deleted_files.py is stdlib-only (argparse /
+      # json / subprocess, `git`/`gh` as external tools). No pip install
+      # needed.
+      - name: Report deleted files (never blocks)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          python scripts/detect_5478_deleted_files.py --pr "${{ github.event.pull_request.number }}" > deleted_files_output.txt 2>&1
+          exit_code=$?
+          cat deleted_files_output.txt
+          if [ "$exit_code" -eq 1 ]; then
+            while IFS= read -r line; do
+              echo "::warning::${line}"
+            done < <(grep '^  - `' deleted_files_output.txt)
+          fi
+          exit 0

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -779,12 +779,22 @@ def _print_findings_and_exit_code(findings: "list[Finding]", source: str) -> int
     reads — is directly testable without needing real PR/repo access
     (see tests/scripts/test_check_doc_drift_5003.py's `test_main_*`
     cases). 0 clean, 1 on any finding — see module docstring,
-    "Blocking" (promoted #5010)."""
+    "Blocking" (promoted #5010).
+
+    #5478 ⑥ (lead-coder): the printed text names its own needle —
+    "removed identifier" — rather than the unqualified "doc drift" this
+    script used to print. lead-coder missed #5463 (a doc's own COUNT
+    claim, "six things", going stale) precisely because a count is not
+    an identifier this script's grep can ever see; an "OK — no doc-drift
+    findings" line on that same PR would have read as a broader
+    all-clear than what this script actually checked. Never claim
+    coverage this script cannot back — the same overclaim shape #5466
+    closed for `events.ja.md`'s "every kind is listed" line."""
     if not findings:
-        print(f"OK — no doc-drift findings ({source}).")
+        print(f"OK — no removed-identifier-in-docs findings ({source}).")
         return 0
 
-    print(f"FAIL — doc-drift findings ({source}):\n")
+    print(f"FAIL — removed-identifier-in-docs findings ({source}):\n")
     for f in findings:
         print(f"  {f.identifier!r} removed from src/, still named in {f.doc_path} (untouched by this PR)")
     print(

--- a/scripts/detect_5478_deleted_files.py
+++ b/scripts/detect_5478_deleted_files.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""#5478 ⑤ — report (never block) the files a PR's own merge would DELETE.
+
+## The gap this closes
+
+Before this script, "does this merge delete any file" was checked by
+exactly one person, by hand, on every PR (lead-coder, #5478's own
+filing): `#5474` was squash-merged on the strength of an all-green CI
+run, and lead-coder's own deletion/identifier checks ran only
+AFTERWARD, out of band — this time both came back clean, but nothing
+would have stopped either from landing unseen on a night lead-coder
+missed it (lead-coder, verbatim: **無事だったのは運です**). Charter
+band question 1 — "who stops this if it repeats" — had exactly one
+answer: lead-coder personally, every single time.
+
+## What this measures
+
+    git diff <base>...<head> --diff-filter=D --name-only
+
+Three-dot (base vs. merge-base(base, head)) — the same discriminant
+`detect_5419_behind_files.py` uses for its own two-dot/three-dot split,
+and for the identical reason: a real merge (or squash) only ever
+applies what the BRANCH itself changed since it diverged from base, so
+three-dot is the set of paths this PR's own diff actually touches.
+`--diff-filter=D` narrows that to deletions. This is exactly the
+one-command form lead-coder specified in #5478's own body.
+
+## Report-only, deliberately (lead-coder, #5478 body, verbatim)
+
+> 削除が在ること自体は悪ではありません。見えることが要点
+
+A deletion is not itself a defect — refactors, dead-code removal, and
+retired scaffolding all delete files on purpose, routinely, in this
+repo. Blocking on "any deletion" would fail the ordinary case far more
+often than the rare unintended one. This script never fails the job —
+it prints the list (never just a count — the same #5419 §① rationale
+`detect_5419_behind_files.format_report` already established: a bare
+count moved nobody to act) so a reviewer sees it without having to run
+lead-coder's own manual command first.
+
+## Scope (says only what it checked, not what it guarantees)
+
+This reports FILE-level deletions from the PR's own three-dot diff. It
+says nothing about whether a deleted file's identifiers still linger in
+`docs/` — that is a SEPARATE, narrower question `check_doc_drift.py`
+already asks (see that script's own module docstring for its own scope
+disclaimer, tightened alongside this file in the same PR, #5478 ⑥).
+Two different needles, two different scripts, on purpose — folding them
+together would blur which one actually fired.
+
+Usage:
+    python scripts/detect_5478_deleted_files.py --pr 123
+    python scripts/detect_5478_deleted_files.py --base origin/main --head HEAD
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+def deleted_files(three_dot_diff_filter_d: "list[str]") -> "list[str]":
+    """Sorted, deduped — pure pass-through of an already-`--diff-filter=D`
+    file list. Kept as its own function (rather than inlined in `main`)
+    so the shape mirrors `detect_5419_behind_files.behind_files` — a
+    thin, offline-testable seam between "what git reported" and "what
+    this script does with it"."""
+    return sorted(set(f for f in three_dot_diff_filter_d if f))
+
+
+def format_report(branch_label: str, deleted: "list[str]") -> str:
+    """Report text — always names every file, never just a count (same
+    #5419 §① rationale `detect_5419_behind_files.format_report` already
+    established). Deliberately neutral wording: a deletion here is a
+    fact to see, not an accusation — see module docstring, "Report-only"."""
+    if not deleted:
+        return f"OK — {branch_label} deletes no file (this PR's own three-dot diff)."
+    lines = "\n".join(f"  - `{f}`" for f in deleted)
+    return (
+        f"REPORT (non-blocking) — {branch_label} deletes the following "
+        f"file(s):\n{lines}\n\n"
+        "A deletion is not itself a problem — this is visibility, not a "
+        "verdict (#5478). It says nothing about whether an identifier "
+        "any of these files defined still lingers in docs/ — see "
+        "check_doc_drift.py for that separate, narrower question."
+    )
+
+
+# ---------------------------------------------------------------------------
+# git/gh wrapper (thin — kept separate from the pure logic above)
+# ---------------------------------------------------------------------------
+
+
+def _git_diff_filter_d_name_only(base: str, head: str) -> "list[str]":
+    result = subprocess.run(
+        ["git", "diff", f"{base}...{head}", "--diff-filter=D", "--name-only"],
+        capture_output=True, text=True, check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _resolve_pr_refs(pr: str) -> "tuple[str, str]":
+    """(base, head) SHAs for an open PR — mirrors
+    `detect_5419_behind_files._resolve_pr_refs`/`check_doc_drift.py`'s
+    own `gh pr view --json baseRefOid,headRefOid` resolution, so all
+    three scripts read the same fields the same way."""
+    import json
+
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr), "--json", "baseRefOid,headRefOid"],
+        capture_output=True, text=True, check=True,
+    )
+    data = json.loads(result.stdout)
+    return data["baseRefOid"], data["headRefOid"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Report (never block) files a PR's own merge would DELETE (#5478 ⑤).",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pr", metavar="N", help="PR number — base/head resolved via `gh pr view`.")
+    group.add_argument(
+        "--base", metavar="REF",
+        help="Explicit base ref (with --head) — offline/direct invocation, no `gh` needed.",
+    )
+    parser.add_argument("--head", metavar="REF", help="Explicit head ref — required together with --base.")
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.base and not args.head:
+        parser.error("--base requires --head")
+
+    try:
+        if args.pr:
+            base, head = _resolve_pr_refs(args.pr)
+            branch_label = f"PR #{args.pr}"
+        else:
+            base, head = args.base, args.head
+            branch_label = args.head
+        deleted_raw = _git_diff_filter_d_name_only(base, head)
+    except subprocess.CalledProcessError as exc:
+        print(f"git/gh command failed: {exc.stderr}", file=sys.stderr)
+        return 2
+
+    deleted = deleted_files(deleted_raw)
+    report = format_report(branch_label, deleted)
+    print(report)
+
+    # Signal-only exit code (1 = deletions found) — the CI wrapper never
+    # treats this as job failure (#5478: report, not block).
+    return 1 if deleted else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_doc_drift_5003.py
+++ b/tests/scripts/test_check_doc_drift_5003.py
@@ -311,6 +311,25 @@ def test_exit_code_is_0_when_clean():
     assert exit_code == 0
 
 
+def test_printed_text_names_removed_identifier_not_bare_doc_drift(capsys):
+    """Tier 1: #5478 ⑥ (lead-coder) — the printed OK/FAIL lines must say
+    "removed-identifier", not the unqualified "doc-drift", so a reader
+    of a green run does not read broader coverage than this script
+    actually provides (lead-coder missed #5463's own COUNT-claim drift
+    — not an identifier — the same night, for exactly this reason)."""
+    m._print_findings_and_exit_code([], "test-source")
+    ok_out = capsys.readouterr().out
+    assert "removed-identifier" in ok_out
+    assert "doc-drift findings" not in ok_out
+
+    m._print_findings_and_exit_code(
+        [m.Finding(identifier="foo_bar_baz", doc_path="docs/x.md")], "test-source",
+    )
+    fail_out = capsys.readouterr().out
+    assert "removed-identifier" in fail_out
+    assert "doc-drift findings" not in fail_out
+
+
 def test_pure_only_flags_the_untouched_doc_among_several():
     """Tier 1: an identifier named in two docs, one touched one not — only
     the untouched one is flagged."""

--- a/tests/scripts/test_detect_5478_deleted_files.py
+++ b/tests/scripts/test_detect_5478_deleted_files.py
@@ -1,0 +1,133 @@
+"""Tier 1: #5478 ⑤ — the deleted-files discriminant (three-dot
+`--diff-filter=D`) and its report formatting.
+
+Mirrors `tests/scripts/test_detect_5419_behind_files.py`'s own shape
+(same report contract, same non-vacuity discipline) — see
+`scripts/detect_5478_deleted_files.py`'s module docstring for why
+three-dot is the right comparison and why this is deliberately
+report-only, never a block.
+"""
+from __future__ import annotations
+
+import subprocess
+
+from scripts.detect_5478_deleted_files import deleted_files, format_report
+
+
+def test_a_deleted_file_is_reported():
+    """Tier 1: the core pass-through — a file `--diff-filter=D` named is
+    in the report."""
+    assert deleted_files(["gone.py"]) == ["gone.py"]
+
+
+def test_no_deletions_yields_nothing():
+    """Tier 1: an empty diff-filter=D list reports nothing."""
+    assert deleted_files([]) == []
+
+
+def test_result_is_sorted_and_deduped():
+    """Tier 1: output order/dupes must not depend on git's own listing
+    order (never pin algorithm-level behaviour of an external tool)."""
+    assert deleted_files(["z.py", "a.py", "a.py"]) == ["a.py", "z.py"]
+
+
+def test_report_names_every_file_not_just_a_count():
+    """Tier 1: same #5419 §① rationale this gate reuses — the report
+    text must contain each filename, not a summary count."""
+    report = format_report("PR #123", ["docs/x.md", "src/y.py"])
+    assert "docs/x.md" in report
+    assert "src/y.py" in report
+
+
+def test_report_is_ok_when_nothing_deleted():
+    """Tier 1: the clean case reads as "OK", not a suppressed/empty
+    report — a silent-0 read must not look identical to "did not run"."""
+    report = format_report("PR #123", [])
+    assert "OK" in report
+    assert "REPORT" not in report
+
+
+def test_report_never_block_language():
+    """Tier 1: #5478 — lead-coder's own "見えることが要点" ruling. The
+    report text must read as informational, explicitly disclaiming a
+    merge block."""
+    report = format_report("PR #123", ["x.py"])
+    assert "non-blocking" in report
+
+
+def test_report_does_not_moralize_the_deletion():
+    """Tier 1: #5478 — "削除が在ること自体は悪ではありません" (lead-coder,
+    verbatim). The report must not read as an accusation — pins the
+    absence of judgment-laden language a future edit could introduce."""
+    report = format_report("PR #123", ["x.py"])
+    assert "not a problem" in report or "not itself a problem" in report
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity positive control — CONSTRUCTED, not read from a fixed
+# historical SHA pair (same #5419/#5420 discipline this gate reuses: a
+# fixture built fresh in a disposable tmp_path repo never skips in CI
+# and never rots when a real branch is deleted).
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def _has_branch(repo_dir: str, name: str) -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", name], cwd=repo_dir, capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _build_deletion_fixture(repo_dir: str) -> "tuple[str, str]":
+    """Returns (base_ref, head_ref): base has `keep.py` + `gone.py`; the
+    branch deletes `gone.py` (its own genuine change) and base advances
+    `keep.py` afterward (a base-side edit the branch never touches, so
+    `keep.py` must NOT show up as deleted from the branch's three-dot
+    diff — only `gone.py` should)."""
+    _git("init", "-q", cwd=repo_dir)
+    _git("config", "user.email", "test@example.com", cwd=repo_dir)
+    _git("config", "user.name", "Test", cwd=repo_dir)
+
+    with open(f"{repo_dir}/keep.py", "w") as f:
+        f.write("KEEP = 1\n")
+    with open(f"{repo_dir}/gone.py", "w") as f:
+        f.write("GONE = 1\n")
+    _git("add", "keep.py", "gone.py", cwd=repo_dir)
+    _git("commit", "-q", "-m", "base: add keep.py and gone.py", cwd=repo_dir)
+
+    _git("checkout", "-q", "-b", "feature", cwd=repo_dir)
+    _git("rm", "-q", "gone.py", cwd=repo_dir)
+    _git("commit", "-q", "-m", "feature: delete gone.py", cwd=repo_dir)
+    head_ref = _git("rev-parse", "HEAD", cwd=repo_dir)
+
+    _git("checkout", "-q", "main" if _has_branch(repo_dir, "main") else "master", cwd=repo_dir)
+    with open(f"{repo_dir}/keep.py", "w") as f:
+        f.write("KEEP = 2\n")
+    _git("commit", "-q", "-am", "base: advance keep.py after the fork", cwd=repo_dir)
+    base_ref = _git("rev-parse", "HEAD", cwd=repo_dir)
+
+    return base_ref, head_ref
+
+
+def test_positive_control_constructed_fresh_every_run(tmp_path):
+    """Tier 1: non-vacuity, built fresh in a disposable repo on every
+    test run. A gate wired to compare a ref to itself, or that reads
+    the wrong diff spec, would read an empty, permanently-green 0 here
+    instead of the real deletion the fixture constructs."""
+    repo_dir = str(tmp_path)
+    base_ref, head_ref = _build_deletion_fixture(repo_dir)
+
+    three_dot_d = subprocess.run(
+        ["git", "diff", f"{base_ref}...{head_ref}", "--diff-filter=D", "--name-only"],
+        cwd=repo_dir, capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+
+    deleted = deleted_files(three_dot_d)
+    assert deleted == ["gone.py"]


### PR DESCRIPTION
**[tui-coder]** — closes #5478.

## What

Two independent fixes, both from lead-coder's own #5478 filing:

1. **⑤ new**: `scripts/detect_5478_deleted_files.py` — a report-only CI gate listing the files a PR's own merge would delete.
2. **⑥ scope-honesty**: `check_doc_drift.py` renamed from "doc-drift" to "removed-identifier-in-docs" everywhere it names itself (workflow, job, printed OK/FAIL lines) — no logic change.

## Why (lead-coder, verbatim on #5478)

> #5474 が gate 全緑を根拠に merge されました（私は「pytest が抜けたら私が merge します」と書いていた）。私は事後に回して、どちらも 0 でした ── 今回は無事。★無事だったのは運です ── CI が全部緑でも、この 2 つは誰も見ていません。

Charter band question 1 ("who stops this if it repeats") had exactly one answer — lead-coder personally, every single time. lead-coder also self-disclosed a related mistake the same night (5 false revert-blocks from misreading a two-point diff as a merge's result) as evidence that a single human running a check by hand is not a substitute for a gate, however careful.

## ⑤ — deleted-files report

`git diff <base>...<head> --diff-filter=D --name-only` — the exact one-command form lead-coder specified. Mirrors `detect_5419_behind_files.py`'s own shape: pure `deleted_files()`/`format_report()` (offline-testable, no I/O), a thin git/gh wrapper, and a CI workflow that only ever annotates, never fails the job.

**Report-only, deliberately** (lead-coder, verbatim): 「削除が在ること自体は悪ではありません。見えることが要点」— a deletion is not itself a defect (refactors, dead-code removal, retired scaffolding all delete files on purpose, routinely); this is visibility, never a block.

8 tests, mirroring `test_detect_5419_behind_files.py`'s own structure including its non-vacuity positive control — a disposable git repo built fresh in `tmp_path` on every run, never a fixed historical SHA pair (which #5420's own review found rots and gets shallow-clone-skipped in CI).

## ⑥ — check_doc_drift.py names its own scope

lead-coder missed **#5463** the same night — a doc's own COUNT claim ("six things") going stale — precisely because a count is not an identifier this gate's grep can ever catch. Calling the gate "doc-drift" invited reading its green as broader coverage than it actually provides — the same overclaim shape **#5466** closed for `events.ja.md`'s "every kind is listed" line.

Renamed (cosmetic only — discriminator, exclusions, and warn-only posture all unchanged):
- Workflow: "Doc-drift check" → "Removed-identifier-in-docs check"
- Job: `doc-drift check (warn-only)` → `removed-identifier-in-docs check (warn-only)`
- Printed lines: `"OK — no doc-drift findings"` / `"FAIL — doc-drift findings"` → `"OK/FAIL — ... removed-identifier-in-docs findings"`

1 new test (`test_printed_text_names_removed_identifier_not_bare_doc_drift`) pins the printed text.

## Verification

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_detect_5478_deleted_files.py tests/scripts/test_check_doc_drift_5003.py` — 49/49 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` on all 4 changed Python files — OK
- [x] `python scripts/mypy_ratchet.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/scripts/` — 1056 passed (full regression sweep)
- [x] Live smoke-test: `detect_5478_deleted_files.py --pr 5474`/`--pr 5461` → 0 deletions, correct; `--base 5c7a1ae54^ --head 5c7a1ae54` (a real historical commit that DID delete `tests/hooks/test_5428_public_hook_env_snapshot.py`) → correctly reported. `check_doc_drift.py --pr 5474`/`--pr 5461` still OK post-rename.
- [x] **Strip-falsify (⑤)**: `deleted_files()` forced to always return `[]` — 3 witnesses (a deleted file reported, dedup/sort, the constructed non-vacuity control) correctly went red. Restored; all green, no residual diff.
- [x] **Strip-falsify (⑥)**: the OK-message reverted to the old unscoped text — the new pinning test correctly went red. Restored; all green, no residual diff.
- [x] YAML syntax-verified both new/changed workflow files via `python -c "import yaml; yaml.safe_load(...)"`.

## Test plan

- [x] Automated (see above)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
