### PR TITLE
fix(#5479): main-hourly-gate-sweep also runs on push:branches:[main]

### DIFF
--- a/.github/workflows/main-hourly-gate-sweep.yml
+++ b/.github/workflows/main-hourly-gate-sweep.yml
@@ -41,12 +41,43 @@ name: main hourly gate sweep
 # protection) — this runs on a schedule independent of any one PR, so
 # folding its result into a PR's merge gate would block merges on an
 # unrelated periodic run.
+#
+# #5479 (architect, self-correcting #5435/#5466's own acceptance basis):
+# `schedule` alone measured 2.7-12.8h between runs (GitHub's scheduler
+# under load), not the ~1h a reader of "hourly" would assume — the
+# composition-gap witness this workflow exists to provide could lag a
+# real break by up to ~13h. `push: branches: [main]` is ADDED below
+# (schedule stays, as the backstop for a run GitHub's scheduler drops
+# entirely) so the same 6-script sweep also runs once per merge, with no
+# delay. Cost: 1 extra workflow run per merge to main, a SINGLE job
+# running 6 scripts in sequence (never a matrix) — a different order of
+# magnitude from #4239's saturation concern, and #4257's owner ruling
+# ("don't touch the 5 existing per-PR workflows, keep this in one new
+# file") is untouched — only this one file's own trigger changes.
+# `pytest` itself (test.yml, `on: push: branches: [main]`) already runs
+# with no delay; only these 6 path-scoped, whole-tree gates were ever
+# subject to the ~13h lag — never read this fix as "main could go a
+# half-day without any signal at all".
+#
+# Deliberately NOT renamed in this PR (architect, verbatim): "hourly" is
+# already inaccurate now, but the rename lands together with #5480's own
+# step migration, in ONE PR — splitting them would leave a half-accurate
+# name standing for the gap between, and #5480 already touches repo
+# config inspection, so settling "what does this sweep actually mean"
+# once, at that point, costs one PR instead of two.
 on:
   schedule:
     # GitHub's own scheduler is best-effort under load — "roughly hourly",
     # not "always at :00". See the module comment above for why that's fine
-    # here (this is a composition-gap witness, not a merge gate).
+    # here (this is a composition-gap witness, not a merge gate) — kept as
+    # the backstop for a run GitHub's scheduler drops entirely, alongside
+    # `push` below (#5479).
     - cron: "0 * * * *"
+  # #5479: runs the same 6-script sweep once per merge to main, with no
+  # delay — `schedule` alone could lag a real composition break by up to
+  # ~13h (measured). See the module comment above for the full account.
+  push:
+    branches: [main]
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
**[tui-coder]** — closes #5479 (unblocks #5480).

## What

`main-hourly-gate-sweep.yml` (the 6-script composition-gap witness for `strict=false`, #4239/#4257) gains `push: branches: [main]` alongside its existing `schedule`.

## Why (architect, self-correcting #5435/#5466's own acceptance basis)

> `gh run list --workflow=main-hourly-gate-sweep.yml`: gaps of 2.7h–12.8h between real runs — GitHub's scheduler is "roughly hourly" under load, not "always at :00", and nobody reading "hourly" would read that as a max ~13h lag.

architect had cited "the compensating mechanism already exists (hourly sweep)" as part of the acceptance basis for both #5435 (`strict=false`) and #5466 — and now corrects the STRENGTH of that compensation: existing ≠ adequately fast. The correction is scoped, not overstated: `pytest` itself (`test.yml`, its own `push: branches: [main]`) already runs with no delay on every merge — only these 6 path-scoped, whole-tree gates were ever subject to the lag. This is never "main could go a half-day without any signal at all".

## Fix

```yaml
on:
  schedule:
    - cron: "0 * * * *"   # kept — backstop for a scheduler-dropped run
  push:
    branches: [main]       # added
  workflow_dispatch: {}
```

Cost: 1 extra workflow run per merge to main — a single job running the same 6 scripts in sequence, never a matrix, a different order of magnitude from #4239's saturation concern. #4257's owner ruling ("keep this in ONE new file, don't touch the 5 existing per-PR workflows") is untouched — only this one file's own trigger changes.

## Deliberately NOT renamed here (lead-coder, verbatim)

> "hourly" は既に偽ですが、rename は #5480 の PR で step の移設とまとめます。2 PR に分けると中途半端な名前の期間ができ、#5480 では repo 設定の検査が混ざるので、そのとき「何の sweep か」を確定させる方が1回で済みます。

## Witnesses (architect's own 4 — #2 explicitly NOT an accept condition)

| # | Expectation | How verified |
|---|---|---|
| 1 | A sweep run fires right after this PR's own merge | Observed live post-merge (workflow-trigger-only change — nothing to unit-test locally) |
| 2 | *(skipped — architect: needs reproducing a real composition break; an unreproducible-danger-shaped accept is a green nobody would ever push on)* | — |
| 3 | `schedule` still fires as before | Observed live (the block is kept, unchanged) |
| 4 | Strip: without the added `push:` block, GitHub Actions has structurally no trigger to fire this workflow on a push event | Verified by inspection — follows directly from the YAML itself |

## Deferred (lead-coder, explicitly, after this lands)

CLAUDE.md rule 9's own doc line ("pytest is immediate, the 6 gates lag up to ~13h") — writing it now would be false the moment this push lands; lead-coder adds it once this PR is merged.

## Verification

- [x] YAML syntax-verified: `python -c "import yaml; yaml.safe_load(open('.github/workflows/main-hourly-gate-sweep.yml'))"` — parses, `on:` resolves to `{schedule, push, workflow_dispatch}` as expected
- [x] `ruff check .` — clean (no Python files changed)
- [x] `grep -rl "main-hourly-gate-sweep" tests/ scripts/` — 0 hits, nothing else references this workflow to update

## Test plan

- [x] Automated (YAML syntax check; no Python code changed)
- [x] (skipped — Visual, standing waiver 2026-08-08)
- [ ] (live, post-merge) witness #1/#3 observed by lead-coder/architect per the table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
