### PR TITLE
fix(#5467): collect_events/settle also accept a Session (phase 1 of 2)

### DIFF
--- a/tests/_support/events.py
+++ b/tests/_support/events.py
@@ -45,28 +45,43 @@ delivery already happened" assumption explicit in the code by awaiting
 holding only a ``Session`` (never the internal ``EventLog``) had no way
 to call either helper — ``Session``'s own public surface
 (``subscribe_audit_events``) takes a callback, not a log to poll/drain,
-so such a test was left to either build a raw
-``subscribe_audit_events(list.append)`` (outside the
-``collect-events-settle`` gate's needle — that gate only recognizes a
-``collect_events()``-derived list) or reach into ``session._audit_events``
-directly (the same private-reach pattern #5382/#5455 closed elsewhere
-that same night — #5461's own settle call was exactly this). architect's
-bar: production gets NO new public API for this (a ``Session.drain()``
-with no real production meaning is not a seam worth adding) — instead
-BOTH helpers below now accept either an ``EventLog``-shaped object
-(anything with ``add_subscriber``/``drain``) OR a ``Session``, resolving
-via :func:`_resolve_log`. The private reach (``session._audit_events``)
+so ``collect_events(session)`` had no target to subscribe onto, and
+there was no public way to SETTLE at all: a caller was left to reach
+into ``session._audit_events`` directly to drain it (the same
+private-reach pattern #5382/#5455 closed elsewhere that same night —
+#5461's own settle call was exactly this). architect's bar: production
+gets NO new public API for this (a ``Session.drain()`` with no real
+production meaning is not a seam worth adding) — instead BOTH helpers
+below now accept either an ``EventLog``-shaped object (anything with
+``add_subscriber``/``drain``) OR a ``Session``, resolving via
+:func:`_resolve_log`. The private reach (``session._audit_events``)
 narrows to this ONE function, in this ONE file — never a second copy
 elsewhere.
 
-Phase 2 (separate PR, NOT this one): migrate the ~82 existing test call
-sites that currently reach ``session._audit_events``/build a raw
+A LATER, separate PR migrates the ~82 existing test call sites that
+currently reach ``session._audit_events``/build a raw
 ``subscribe_audit_events`` subscriber onto this new seam. Until that
 migration lands, ``git grep '_audit_events' -- tests/`` and
-``git grep 'subscribe_audit_events(' -- tests/`` are NOT yet zero —
-the ``collect-events-settle`` gate's scope stays exactly as narrow as
-it was before this PR for every one of those un-migrated sites; this
-PR only stops the count from growing further, it does not shrink it.
+``git grep 'subscribe_audit_events(' -- tests/`` are NOT yet zero.
+
+lead-coder BLOCKING correction (architect-corrected wording, same
+conclusion): this seam removes the REASON to write a raw subscriber
+(a ``Session`` can now reach ``collect_events``/``settle`` directly)
+— it does NOT mechanically prevent one. ``scripts/check_collect_
+events_settle.py`` already tracks the two STATICALLY-RESOLVABLE
+subscriber shapes (``<x>.add_subscriber(<name>.append)`` /
+``<x>.subscribe_audit_events(lambda e: <name>.append(e))`` — see that
+script's own module docstring), so a plain
+``subscribe_audit_events(list.append)`` written after this PR is
+already caught, same as before this PR. The genuine, DISCLOSED gap
+that gate names is a hand-rolled Sink CLASS instance
+(``class XSink: def __call__(self, e): ...``), which cannot be
+statically resolved to a single tracked name. This is exactly why the
+gap issue (#5465) exists — not because this seam made anything less
+visible, but because it never made the Sink-class shape more visible
+either. Only once phase 2 migrates every existing site does the count
+of un-migrated private-reach sites reach zero; the gate's own disclosed
+gap is a separate, narrower concern this PR neither closes nor widens.
 """
 from __future__ import annotations
 
@@ -83,7 +98,13 @@ def _resolve_log(obj: Any) -> Any:
     itself already takes on *log*'s shape. Anything else (a real
     ``EventLog``, or any other object with its own ``add_subscriber``/
     ``drain``) passes through unchanged. This is the ONE place in
-    ``tests/`` allowed to read ``_audit_events`` — see module docstring,
+    ``tests/`` allowed to read ``_audit_events`` FOR THE PURPOSE OF
+    SUBSCRIBING/DRAINING IT — a test may still reach ``session.
+    _audit_events.emit(...)`` directly to DRIVE its own scenario (the
+    same "arrange, not assert" distinction every test in this file
+    already relies on for a plain ``EventLog``'s own ``.emit()`` calls),
+    which is why this claim is scoped to subscribe/drain, not to every
+    read of the attribute anywhere in ``tests/``. See module docstring,
     "#5467 (architect ruling)"."""
     audit_events = getattr(obj, "_audit_events", None)
     return obj if audit_events is None else audit_events

--- a/tests/_support/events.py
+++ b/tests/_support/events.py
@@ -40,10 +40,53 @@ consumer may not have run yet, so ``collected`` can still be missing
 the event. If a test reads ``collected`` this way, make the "I assumed
 delivery already happened" assumption explicit in the code by awaiting
 :func:`settle` on the same log immediately before the read.
+
+#5467 (architect ruling) — ``Session`` acceptance, phase 1 of 2: a test
+holding only a ``Session`` (never the internal ``EventLog``) had no way
+to call either helper — ``Session``'s own public surface
+(``subscribe_audit_events``) takes a callback, not a log to poll/drain,
+so such a test was left to either build a raw
+``subscribe_audit_events(list.append)`` (outside the
+``collect-events-settle`` gate's needle — that gate only recognizes a
+``collect_events()``-derived list) or reach into ``session._audit_events``
+directly (the same private-reach pattern #5382/#5455 closed elsewhere
+that same night — #5461's own settle call was exactly this). architect's
+bar: production gets NO new public API for this (a ``Session.drain()``
+with no real production meaning is not a seam worth adding) — instead
+BOTH helpers below now accept either an ``EventLog``-shaped object
+(anything with ``add_subscriber``/``drain``) OR a ``Session``, resolving
+via :func:`_resolve_log`. The private reach (``session._audit_events``)
+narrows to this ONE function, in this ONE file — never a second copy
+elsewhere.
+
+Phase 2 (separate PR, NOT this one): migrate the ~82 existing test call
+sites that currently reach ``session._audit_events``/build a raw
+``subscribe_audit_events`` subscriber onto this new seam. Until that
+migration lands, ``git grep '_audit_events' -- tests/`` and
+``git grep 'subscribe_audit_events(' -- tests/`` are NOT yet zero —
+the ``collect-events-settle`` gate's scope stays exactly as narrow as
+it was before this PR for every one of those un-migrated sites; this
+PR only stops the count from growing further, it does not shrink it.
 """
 from __future__ import annotations
 
 from typing import Any
+
+
+def _resolve_log(obj: Any) -> Any:
+    """Resolve *obj* to the ``EventLog``-shaped thing :func:`collect_events`/
+    :func:`settle` should actually operate on.
+
+    A ``Session`` is recognized structurally (does it carry an
+    ``_audit_events`` attribute?), never by ``isinstance`` against the
+    production class — the same duck-typed posture ``add_subscriber``
+    itself already takes on *log*'s shape. Anything else (a real
+    ``EventLog``, or any other object with its own ``add_subscriber``/
+    ``drain``) passes through unchanged. This is the ONE place in
+    ``tests/`` allowed to read ``_audit_events`` — see module docstring,
+    "#5467 (architect ruling)"."""
+    audit_events = getattr(obj, "_audit_events", None)
+    return obj if audit_events is None else audit_events
 
 
 def collect_events(log: Any) -> list[Any]:
@@ -52,7 +95,11 @@ def collect_events(log: Any) -> list[Any]:
     production's ``EventStore`` uses, not a read-back of history.
 
     Call this immediately after constructing *log* (or as soon as a test
-    holds a reference to it), before any ``emit()`` the test cares about."""
+    holds a reference to it), before any ``emit()`` the test cares about.
+
+    #5467: *log* may also be a ``Session`` — resolved via
+    :func:`_resolve_log` to its underlying ``EventLog`` before subscribing."""
+    log = _resolve_log(log)
     collected: list[Any] = []
     log.add_subscriber(collected.append)
     return collected
@@ -71,5 +118,9 @@ async def settle(log: Any) -> None:
     polling read (``lambda: any(e.type == "x" for e in collected)``, or
     anything driven through a ``_wait_for``-style retry) does not need this
     — polling yields between attempts and gives the consumer a chance to
-    run regardless."""
+    run regardless.
+
+    #5467: *log* may also be a ``Session`` — resolved via
+    :func:`_resolve_log` to its underlying ``EventLog`` before draining."""
+    log = _resolve_log(log)
     await log.drain()

--- a/tests/core/test_3868_collect_events_helper.py
+++ b/tests/core/test_3868_collect_events_helper.py
@@ -2,13 +2,19 @@
 
 Real ``EventLog`` throughout (no mocks) — the helper is a thin wrapper over
 ``EventLog.add_subscriber``, so faking it would test nothing real.
+
+#5467 phase 1 (architect ruling): a real ``Session`` also throughout for the
+new ``Session``-acceptance tests below — the design's own bar is that this
+seam works with the exact object a caller who only has a ``Session`` (never
+its internal ``EventLog``) actually holds.
 """
 from __future__ import annotations
 
 import pytest
 
 from reyn.core.events.events import EventLog
-from tests._support.events import collect_events
+from tests._support.events import _resolve_log, collect_events, settle
+from tests._support.session import make_session
 
 
 @pytest.mark.asyncio
@@ -81,3 +87,68 @@ def test_collect_events_uses_the_real_subscriber_mechanism_not_a_readback() -> N
     log = EventLog()
     collected = collect_events(log)
     assert log.subscribers == [collected.append]
+
+
+# ---------------------------------------------------------------------------
+# #5467 phase 1 — Session acceptance (architect ruling)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_events_accepts_a_session_witness_1(tmp_path, monkeypatch) -> None:
+    """Tier 2: #5467 witness ① — a caller holding only a ``Session`` (never
+    its internal ``EventLog``) can call ``collect_events(session)`` directly
+    and genuinely capture a real emit — asserted on the PUBLIC-shaped
+    behavior (what was collected), never by introspecting ``_audit_events``'
+    own subscriber list (this repo's private-state rule: the private reach
+    inside ``_resolve_log`` drives the scenario here, exactly like every
+    other test in this file already drives its own EventLog by calling
+    ``.emit()`` directly; nothing here ASSERTS on private state)."""
+    session = make_session(tmp_path, monkeypatch=monkeypatch)
+    collected = collect_events(session)
+    session._audit_events.emit("tool_executed", op="read_file", path="/tmp/x")
+    await session._audit_events.drain()
+    assert [e.type for e in collected] == ["tool_executed"]
+
+
+@pytest.mark.asyncio
+async def test_settle_accepts_a_session_witness_2(tmp_path, monkeypatch) -> None:
+    """Tier 2: #5467 witness ② — ``await settle(session)`` drains the
+    SESSION'S OWN real ``_audit_events`` queue (never a private reach at the
+    call site — the private reach happens only inside ``_resolve_log``, the
+    one place #5467's design permits it). A real emit through the session's
+    own log, collected via the same seam, proves the drain reaches the
+    right queue."""
+    session = make_session(tmp_path, monkeypatch=monkeypatch)
+    collected = collect_events(session)
+    session._audit_events.emit("tool_executed", op="read_file", path="/tmp/x")
+    await settle(session)
+    assert [e.type for e in collected] == ["tool_executed"]
+
+
+def test_resolve_log_passes_a_plain_eventlog_through_unchanged() -> None:
+    """Tier 2: an object with no ``_audit_events`` attribute (a real
+    ``EventLog``, or any other log-shaped test double) passes through
+    ``_resolve_log`` unchanged — the ``Session`` branch is additive, never a
+    behavior change for every existing non-``Session`` caller."""
+    log = EventLog()
+    assert _resolve_log(log) is log
+
+
+def test_session_itself_has_neither_add_subscriber_nor_drain(tmp_path, monkeypatch) -> None:
+    """Tier 2: the deterministic, non-timing witness that ``_resolve_log``'s
+    ``Session``-detection branch is load-bearing, not incidental — a real
+    ``Session`` genuinely cannot satisfy ``collect_events``/``settle`` on
+    its own (no ``add_subscriber``, no ``drain`` method exists on the class
+    at all), so the two tests above passing is real evidence the resolution
+    ran, never a coincidence of ``Session`` already happening to duck-type
+    as a log. (Strip-falsify of ``_resolve_log`` itself — temporarily
+    forcing it to return *obj* unchanged — was run by hand: both
+    Session-acceptance tests above then fail with exactly this
+    ``AttributeError``, confirmed and reverted; not pinned here as its own
+    test because this repo's testing policy bans an assertion whose failure
+    mode is timing-shaped, and re-deriving the exact same two tests' own
+    behavior a second time would be the implementation, transcribed.)"""
+    session = make_session(tmp_path, monkeypatch=monkeypatch)
+    assert not hasattr(session, "add_subscriber")
+    assert not hasattr(session, "drain")

--- a/tests/core/test_3868_collect_events_helper.py
+++ b/tests/core/test_3868_collect_events_helper.py
@@ -136,19 +136,24 @@ def test_resolve_log_passes_a_plain_eventlog_through_unchanged() -> None:
 
 
 def test_session_itself_has_neither_add_subscriber_nor_drain(tmp_path, monkeypatch) -> None:
-    """Tier 2: the deterministic, non-timing witness that ``_resolve_log``'s
-    ``Session``-detection branch is load-bearing, not incidental — a real
-    ``Session`` genuinely cannot satisfy ``collect_events``/``settle`` on
-    its own (no ``add_subscriber``, no ``drain`` method exists on the class
-    at all), so the two tests above passing is real evidence the resolution
-    ran, never a coincidence of ``Session`` already happening to duck-type
-    as a log. (Strip-falsify of ``_resolve_log`` itself — temporarily
-    forcing it to return *obj* unchanged — was run by hand: both
-    Session-acceptance tests above then fail with exactly this
+    """Tier 2: the witness that ``_resolve_log``'s ``Session``-detection
+    branch is load-bearing, not incidental — a real ``Session`` genuinely
+    cannot satisfy ``collect_events``/``settle`` on its own (no
+    ``add_subscriber``, no ``drain`` method exists on the class at all), so
+    the two tests above passing is real evidence the resolution ran, never
+    a coincidence of ``Session`` already happening to duck-type as a log.
+    The ``hasattr(session, "_audit_events")`` line is the deny-side
+    assert's own accept-side sibling — without it, a ``make_session`` that
+    broke and returned something with neither attribute (or nothing at
+    all) would make this test pass just as vacuously as a real ``Session``
+    does (architect review, #5484). (Strip-falsify of ``_resolve_log``
+    itself — temporarily forcing it to return *obj* unchanged — was run by
+    hand: both Session-acceptance tests above then fail with exactly this
     ``AttributeError``, confirmed and reverted; not pinned here as its own
-    test because this repo's testing policy bans an assertion whose failure
-    mode is timing-shaped, and re-deriving the exact same two tests' own
-    behavior a second time would be the implementation, transcribed.)"""
+    test — the assertion itself is deterministic, not timing-shaped, but
+    re-deriving the exact same two tests' own behavior a second time would
+    be the implementation, transcribed, this repo's six-questions rule 2.)"""
     session = make_session(tmp_path, monkeypatch=monkeypatch)
+    assert hasattr(session, "_audit_events")
     assert not hasattr(session, "add_subscriber")
     assert not hasattr(session, "drain")


### PR DESCRIPTION
**[tui-coder]** — phase 1 of 2 for #5467. `#5467 stays open` — the migration of ~82 existing private-reach call sites is a separate, later PR.

## What

`tests/_support/events.py`'s `collect_events()`/`settle()` now also accept a `Session` (not only an `EventLog`-shaped object), via a new `_resolve_log()` — the ONE place in `tests/` allowed to read `_audit_events` for the purpose of subscribing/draining it (a test may still reach `_audit_events.emit(...)` directly to DRIVE its own scenario — see architect review below).

## Why (architect ruling)

> tests/_support/events.py:49 def collect_events(log): … log.add_subscriber(collected.append) / :61 async def settle(log): … ← どちらも log を要求
> session.py:1657 def subscribe_audit_events(...) ← 公開されているのはこれだけ / self._audit_events ← log 自体は private

A test holding only a `Session` (`Session.subscribe_audit_events()` takes a callback, not a log to poll/drain) had exactly two options before this PR: build a raw `subscribe_audit_events(list.append)` subscriber — outside the `collect-events-settle` gate's own needle, since that gate only recognizes a `collect_events()`-derived list — or reach into `session._audit_events` directly, the exact private-reach pattern #5382/#5455 closed elsewhere the same night. #5461's own `settle(session._audit_events)` call was exactly this, found as a side-effect of that PR's own fix.

architect's bar, quoted: 新しい公開 API を production に足しません — a `Session.drain()` with no real production meaning is not a seam worth adding. Both helpers below now duck-type: an object with `_audit_events` is treated as a `Session` and resolved to its underlying log; anything else (a real `EventLog`) passes through unchanged.

## Phase 1 of 2 (lead-coder, explicit scoping)

> 必ず段階に分けてください。1本目は tests/_support/events.py に「collect_events/settle が Session も受け取れる」口を足すところまで。既存 82 件の寄せは別 PR で、寄せ切るまで gate の射程は開いたままと本文に明示してください。82 file を一度に書き換える PR にはしないこと。

This PR is exactly that first step. Until the migration PR lands:
- `git grep '_audit_events' -- tests/` and `git grep 'subscribe_audit_events(' -- tests/` are **NOT yet zero** — 82 files still reach the private attribute directly (64 of them via `settle(session._audit_events)`).
- The `collect-events-settle` gate's scope is **unchanged** for every one of those sites, AND **lead-coder BLOCKING correction**: this PR removes the *reason* to write a raw subscriber (`subscribe_audit_events(list.append)` / `settle(session._audit_events)`) — it does **not** mechanically prevent one. The gate only ever tracks a `collect_events()`-derived list, so a brand-new test written after this PR is just as invisible to it as one written before. That gap is exactly why #5465 exists.

## Tests

4 new tests in `tests/core/test_3868_collect_events_helper.py`, a real `Session` throughout (`tests/_support/session.py`'s `make_session` — never a mock, per this repo's "don't fake a cheaply-constructible collaborator" rule):

1. `collect_events(session)` captures a real emit (witness ①).
2. `settle(session)` drains the session's own real queue (witness ②).
3. A plain `EventLog` passes through `_resolve_log` unchanged — additive, no behavior change for the ~125 existing `EventLog`-based callers.
4. `Session` genuinely has neither `add_subscriber` nor `drain` on its own — the deterministic, non-timing witness that the resolution branch is load-bearing (this repo's testing policy bans a duration-dependent assertion, so the strip-falsify of `_resolve_log` itself is documented as run-by-hand, not pinned as its own flaky-shaped test).

## A Tier-4 catch during development (disclosed, not just fixed silently)

The first revision of witness ① asserted directly on `session._audit_events.subscribers` — `test_tier_audit.py --strict` correctly flagged it as a private-state assertion. Rewritten to assert only on public-shaped behavior (what `collect_events(session)` actually collected via a real emit+drain), matching every other test in this file.

## lead-coder BLOCKING (2, both fixed — head `7ba6cc763`)

1. **Docstring overclaim**: the claim that this PR "stops the count from growing further" is not backed by any mechanism. This PR removes the *reason* to write a raw subscriber; it does not mechanically prevent one — that gap is exactly why **#5465** exists. Rewritten in `tests/_support/events.py`'s module docstring to say so explicitly (see also the architect round-2 correction below, on the mechanism claim this fix's first version made).
2. **Closing-intent hazard, more severe, fixed first**: this PR body's own first line placed a negated closing keyword next to `#5467` — GitHub's parser does not read the negation, only the keyword+number substring, so this **would have auto-closed #5467 on squash merge**, exactly as #4834 and #4986 both did (the live `closing-intent contradiction check` gate on this PR caught the identical shape). Fixed to `` `#5467 stays open` `` (house rule 4: no verb adjacent to the number, not "don't say it stays open" — and the literal phrase, when quoted here to explain the hazard, is itself backtick-wrapped, per lead-coder's follow-up catch that explaining the hazard by re-typing it bare reproduces the exact substring GitHub matches on).

## architect review, round 1 (0 blocks, 2 recommendations, both applied — head `57b97dd4b`)

1. `_resolve_log`'s own docstring claimed "the ONE place in `tests/` allowed to read `_audit_events`" — falsified within the SAME diff (the new tests read it 3 more times, directly, to DRIVE their own scenario). Narrowed to "for the purpose of subscribing/draining it".
2. `test_session_itself_has_neither_add_subscriber_nor_drain` only asserted the deny side — added the accept-side sibling, `assert hasattr(session, "_audit_events")`, so a broken `make_session` can't pass this test vacuously.

## architect review, round 2 — 1 BLOCKING on my own fix for lead-coder's point 1 above (fixed — head `7ba6cc763`)

The rewritten docstring claimed `check_collect_events_settle.py` "only recognizes a `collect_events()`-derived list" — **false**. That gate already tracks the two statically-resolvable raw-subscriber shapes (`<x>.add_subscriber(<name>.append)` / `<x>.subscribe_audit_events(lambda e: <name>.append(e))` — added after a prior 40-file census found the same class this PR describes) via `_tracked_name_from_subscriber_arg`. The paragraph described the gate's PRE-extension state in the present tense. **Conclusion unchanged** (the seam removes the reason, does not mechanically prevent) — the *reason* is corrected: the genuine, disclosed gap that gate names is a hand-rolled Sink **class** instance, not statically resolvable to one tracked name, never a bare raw-subscriber call (already caught before this PR, same as after).

## Verification

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/core/test_3868_collect_events_helper.py` — 9/9 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py tests/_support/events.py tests/core/test_3868_collect_events_helper.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK
- [x] `python scripts/check_collect_events_settle.py` — still green (the new tests drive their scenario via a direct `.emit()`/`.drain()` call — the same shape every other test in this file already uses — never through the gate's own tracked "collect_events() read without settle" needle)
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/core/ tests/runtime/` — 4949 passed, 8 skipped, 1 failed (`test_install_command_warns_on_tmp_args_on_darwin` — unrelated, no reference to `collect_events`/`_support.events`/`_audit_events`; a pre-existing platform-specific flake)
- [x] **Strip-falsify** (structural, not timing — this repo's testing policy bans a duration-dependent assertion): `_resolve_log` temporarily forced to return its argument unchanged — both Session-acceptance witnesses correctly failed with `AttributeError: 'Session' object has no attribute 'add_subscriber'`, the exact error the 4th test's own docstring names. Restored; 9/9 green again, no residual diff.

## Test plan

- [x] Automated (see above)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


