### PR TITLE
fix(#5490): closing-intent gate — check1/3's shared "declared" variable used the wrong vocabulary for check 3

### DIFF
--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -567,6 +567,46 @@ def find_closing_declarations(body: str) -> set[int]:
     return {int(m.group(1)) for m in _CLOSING_RE.finditer(text)}
 
 
+def find_declared_closing_intent(body: str) -> set[int]:
+    """Return issue numbers the body DECLARES closing intent for (#5490) —
+    the canonical vocabulary (:data:`_CANONICAL_CLOSING_RE`: Closes/Fixes/
+    Resolves), read with fences DEFUSED (:func:`_body_as_author_declared`)
+    so a backtick-fenced ``Closes #N`` still counts as the author's
+    declaration — the #2990/#3006 shape check 1 exists to catch, the same
+    fence-handling :func:`find_closing_declarations` already uses.
+
+    This is the THIRD combination this module needs, distinct from both
+    existing helpers:
+
+    ============================== ================= ==================
+    function                        vocabulary         fence reading
+    ============================== ================= ==================
+    ``find_closing_declarations``   broad (GitHub's)   author (defused)
+    ``find_canonical_closing_...``  narrow (declares)  GitHub (stripped)
+    ``find_declared_closing_intent``narrow (declares)  author (defused)
+    ============================== ================= ==================
+
+    Checks 1 and 3 (real incident #5490, 2026-08-29 — PR #5484 auto-closed
+    #5467 despite an open phase 2) both ask "did the author DECLARE
+    anything about #N", which is a narrow-vocabulary, author-perspective
+    question — the SAME "declares" checks 1/3 always meant, just computed
+    from the wrong vocabulary before this fix. ``find_closing_declarations``
+    (broad) let bare, GitHub-honored-but-never-declaring prose like
+    "auto-closed #N" register as a "declaration": check 3's own docstring
+    already named this exact shape as the case it must catch (`` `e.g.
+    "auto-close #N" in a sentence` ``) but could not, because it read
+    "declared" through the broad vocabulary that prose matches. Swapping to
+    the canonical vocabulary here — while KEEPING the author-defused fence
+    reading (NOT :func:`find_canonical_closing_declarations`'s GitHub-
+    stripped reading, which would blind check 1 to the fenced-Closes
+    incidents #2990/#3006 exist to catch — architect correction, #5490)
+    — closes exactly this gap without touching check 2's own, deliberately
+    different, use-vs-mention reading.
+    """
+    text = _body_as_author_declared(body)
+    return {int(m.group(1)) for m in _CANONICAL_CLOSING_RE.finditer(text)}
+
+
 def find_nonclosing_declarations(body: str) -> set[int]:
     """Return the set of issue numbers the body declares non-closing-intent for."""
     text = _body_as_author_declared(body)
@@ -680,11 +720,40 @@ def check_contradictions(
     the scan cannot be gated on commit count at all — see this module's
     own docstring (check 4's "Title source" note) for the full reasoning.
     """
+    # closing_declared stays BROAD (find_closing_declarations, unchanged) —
+    # this is check 1's OWN affirmative question ("did the body use ANY
+    # GitHub-honored keyword form, even bare/past-tense, that got fenced
+    # away") and deliberately does not narrow: test_boundary_1_check1_
+    # still_fires_when_only_the_number_is_fenced pins that a bare "fix"
+    # (no -es) fenced only around the number must still fire check 1;
+    # narrowing this set to the canonical vocabulary was tried and
+    # regressed that boundary (#5490 review) — check 1 needs the SAME
+    # breadth GitHub's own parser has, so it can catch what a fence hid
+    # FROM that breadth.
     closing_declared = find_closing_declarations(body)
     nonclosing_declared = find_nonclosing_declarations(body)
     discussing_declared = find_discussing_declarations(body)
     closing_refs_set = set(closing_refs)
     findings: list[Finding] = []
+
+    # #5490: check 3 (and check 4's exemption below) ask a DIFFERENT,
+    # narrower question than check 1 — "did the body engage with #N at
+    # all", for the purpose of NOT reporting "no declaration whatsoever"
+    # when something more specific already covers it. Two components:
+    #   - the CANONICAL vocabulary (find_declared_closing_intent) — the
+    #     real #5490 incident: "auto-closed #5467" (bare past-tense prose,
+    #     no genuine declaring intent) must NOT count as a declaration, or
+    #     check 3 stays silent exactly like it did when #5467 auto-closed
+    #     despite an open phase 2. Using the BROAD closing_declared here
+    #     instead (check 1's set) reintroduces that exact hole.
+    #   - the NEGATED set (find_negated_closing_declarations) — a body
+    #     like "it does not claim to close #4834" DOES engage with #4834
+    #     (a broken attempt at a non-closing declaration), and check 5
+    #     already reports that shape more precisely; omitting this half
+    #     made check 3 double-report every check-5 finding (regressed
+    #     6 existing tests — caught by the scoped pytest run, not assumed
+    #     from architect's own #5484-only measurement).
+    narrowly_declared = find_declared_closing_intent(body) | find_negated_closing_declarations(body)
 
     # Check 1 (false negative): declared closing but parser did not close.
     #
@@ -777,7 +846,7 @@ def check_contradictions(
     # not reported twice — the marker-vs-parser contradiction is already
     # reported by check 2 above, with a more precise message. No N in
     # closing_refs can escape: it is covered by check 2 or check 3.
-    declared_any = closing_declared | nonclosing_declared | discussing_declared
+    declared_any = narrowly_declared | nonclosing_declared | discussing_declared
     for n in sorted(closing_refs_set - declared_any):
         findings.append(
             Finding(
@@ -807,11 +876,21 @@ def check_contradictions(
     # the PR body's discussing markers — see module docstring "Check 4's
     # escape hatch" section for why a body-wide exemption would silently
     # defeat this check on the #3187 shape it exists to catch.
+    # #5490 scope note (disclosed, not silently different): this side still
+    # reads a commit message's OWN declaration through the BROAD vocabulary
+    # (find_closing_declarations), not the narrow swap above — a commit
+    # message containing bare "auto-closed #N" prose would still register
+    # here as a "declaration" needing the body's cover. Architect's
+    # prescription scoped the #5490 fix to the body-side `closing_declared`
+    # variable (the exemption's subtrahend, read by checks 1/3/4); this
+    # side computes what a commit independently asserts, a different
+    # question the #5490 incident did not exercise. Left as-is rather than
+    # widened without a design ruling on it.
     commit_closing_declared: set[int] = set()
     for msg in commit_messages or []:
         commit_closing_declared |= find_closing_declarations(msg) - find_discussing_declarations(msg)
 
-    for n in sorted(commit_closing_declared - closing_declared):
+    for n in sorted(commit_closing_declared - narrowly_declared):
         findings.append(
             Finding(
                 check=4,
@@ -860,7 +939,7 @@ def check_contradictions(
         title_closing_declared = (
             find_closing_declarations(title) - find_discussing_declarations(title)
         )
-        for n in sorted(title_closing_declared - closing_declared):
+        for n in sorted(title_closing_declared - narrowly_declared):
             findings.append(
                 Finding(
                     check=4,

--- a/tests/scripts/test_check_pr_closing_intent.py
+++ b/tests/scripts/test_check_pr_closing_intent.py
@@ -903,3 +903,92 @@ def test_title_scan_does_not_duplicate_a_commit_message_finding():
         title="fix #5299 regression in the cron runner",
     )
     assert _checks(findings) == [(4, 5299), (4, 5299)]
+
+
+# ---------------------------------------------------------------------------
+# Check 3: bare past-tense prose is not a declaration (real PR #5484 shape,
+# #5490 — check 3 stayed silent while #5467 auto-closed with an open phase 2).
+#
+# Real data, verbatim excerpt from `gh pr view 5484 --json body,
+# closingIssuesReferences` (#5484 was open when this fix was written; #5467
+# was already in closingIssuesReferences the whole time — check_contradictions
+# on the real body/refs pair returned 0 findings before this fix, architect's
+# own measurement). The excerpt below is the body's own description of the
+# hazard it had just fixed elsewhere in the SAME PR — the sentence that
+# would itself have auto-closed #5467 had it not already been superseded by
+# a real `#5467 stays open` fix earlier in the body; kept here exactly as the
+# live body reads (unfenced "auto-closed #5467"), since that unfenced prose
+# is the actual defect this fix closes.
+# ---------------------------------------------------------------------------
+
+_PR5484_BODY_EXCERPT = (
+    "**Closing-intent hazard, more severe, fixed first**: this PR body's "
+    "own first line placed a negated closing keyword next to `#5467` — "
+    "GitHub's parser does not read the negation, only the keyword+number "
+    "substring, so this **would have auto-closed #5467 on squash merge**, "
+    "exactly as #4834 and #4986 both did (the live `closing-intent "
+    "contradiction check` gate on this PR caught the identical shape)."
+)
+
+
+def test_check3_fires_on_the_real_5484_auto_closed_prose_shape():
+    """Tier 1: real reproduction, #5490 — PR #5484's own body. Bare
+    past-tense prose ("auto-closed #5467") is not a canonical declaration
+    (Closes/Fixes/Resolves), so it must not count as "the body said
+    something about #5467" for check 3's purpose — GitHub's parser
+    resolved #5467 via closingIssuesReferences regardless, and the body's
+    ONLY engagement with #5467 in this excerpt is descriptive prose about a
+    hazard, not a declaration. Real incident: #5467 auto-closed on #5484's
+    actual merge despite an open phase 2 (~82 remaining call sites) and had
+    to be reopened by hand — this gate was green throughout.
+
+    Before this fix: 0 findings (architect's own measurement against the
+    live PR). After: exactly this one."""
+    findings = m.check_contradictions(_PR5484_BODY_EXCERPT, closing_refs=[5467])
+    assert _checks(findings) == [(3, 5467)]
+
+
+def test_check3_positive_control_silent_with_the_broad_reader(monkeypatch):
+    """Tier 1: positive control (architect's own acceptance criterion) —
+    reverting ``find_declared_closing_intent`` to the OLD broad reader
+    (``find_closing_declarations``, the pre-#5490 behavior) makes the SAME
+    #5484 fixture go silent again. Without this, "red" on the test above
+    could be an artifact of the fixture or the test method rather than of
+    the vocabulary-narrowing fix itself; this isolates the ONE factor."""
+    monkeypatch.setattr(m, "find_declared_closing_intent", m.find_closing_declarations)
+    findings = m.check_contradictions(_PR5484_BODY_EXCERPT, closing_refs=[5467])
+    assert findings == []
+
+
+def test_check1_real_harm_unaffected_by_the_5490_narrowing():
+    """Tier 1: #5490 acceptance criterion — check 1's own real harm
+    (#2990/#3006's backtick-fenced `Closes #N`, already pinned by
+    ``test_check1_fires_on_backtick_fenced_closing_keyword_not_resolved``
+    above) must stay red. check 1 was deliberately NOT narrowed to the
+    canonical vocabulary — only check 3/4's "was anything declared at
+    all" question was (see ``find_declared_closing_intent``'s own
+    docstring for why narrowing check 1 too regressed a real boundary
+    test, ``test_boundary_1_check1_still_fires_when_only_the_number_is_
+    fenced``, during this fix's own development). Restated explicitly
+    here under this name so #5490's own acceptance criterion is pinned by
+    a test that names it, not only inferred from an existing test with an
+    unrelated name."""
+    findings = m.check_contradictions("`Closes #2620`", closing_refs=[])
+    assert _checks(findings) == [(1, 2620)]
+
+
+def test_find_declared_closing_intent_rejects_bare_past_tense():
+    """Tier 1: unit-level pin for the new finder — "auto-closed #N" (bare,
+    past tense) is not canonical; "Closes #N" is."""
+    assert m.find_declared_closing_intent("auto-closed #5467") == set()
+    assert m.find_declared_closing_intent("Closes #5467") == {5467}
+
+
+def test_find_declared_closing_intent_still_defuses_a_fence():
+    """Tier 1: unlike ``find_canonical_closing_declarations`` (GitHub-view,
+    fences stripped), ``find_declared_closing_intent`` uses the
+    AUTHOR-view fence reading (defused, not stripped) — a fenced
+    ``Closes #N`` still counts, the same behavior
+    ``find_closing_declarations`` already has and check 1 depends on."""
+    assert m.find_declared_closing_intent("`Closes #2620`") == {2620}
+    assert m.find_canonical_closing_declarations("`Closes #2620`") == set()

--- a/tests/scripts/test_check_pr_closing_intent.py
+++ b/tests/scripts/test_check_pr_closing_intent.py
@@ -992,3 +992,61 @@ def test_find_declared_closing_intent_still_defuses_a_fence():
     ``find_closing_declarations`` already has and check 1 depends on."""
     assert m.find_declared_closing_intent("`Closes #2620`") == {2620}
     assert m.find_canonical_closing_declarations("`Closes #2620`") == set()
+
+
+# ---------------------------------------------------------------------------
+# Check 4, the #5490 shape (architect review, non-blocking, PR #5493): the
+# fixture above only pins check 3's own real occurrence in PR #5484's BODY.
+# Live verification against the real PR during that review surfaced a SECOND
+# real instance of the identical bare-past-tense phrase — independently
+# present in a commit message — which check 4 now also catches (same
+# `narrowly_declared` exemption swap covers both). Neither architect's own
+# design nor this fix's first version anticipated this second instance; a
+# dedicated test closes the gap architect flagged: "the discovery itself
+# gets left behind" without one.
+#
+# Real data, verbatim excerpt from `gh pr view 5484 --json commits` — the
+# real second commit's own messageBody (headline: "fix(#5467): correct an
+# overclaim, a closing-intent hazard, and 3 architect points").
+# ---------------------------------------------------------------------------
+
+_PR5484_COMMIT_WITH_LEAK = (
+    "fix(#5467): correct an overclaim, a closing-intent hazard, and 3 arch…\n"
+    "\n"
+    "BLOCKING 2 (lead-coder, most severe, fixed first per instruction): the\n"
+    "PR body's own first line placed a negated closing keyword next to\n"
+    "#5467 -- GitHub's own parser does not read the negation, only the\n"
+    "keyword+number substring, so it would have auto-closed #5467 on squash\n"
+    "merge exactly as #4834 and #4986 both did, reason=COMPLETED, no human\n"
+    "involved. Corrected to \"#5467 stays open\" (no verb adjacent to the\n"
+    "number, backtick-wrapped per the gate's own prescribed escape)."
+)
+
+
+def test_check4_fires_on_the_real_5484_commit_shape():
+    """Tier 1: real reproduction — PR #5484's actual commit message, #5490.
+    The SAME bare-past-tense "auto-closed #5467" shape that fooled check 3
+    in the PR body (see ``test_check3_fires_on_the_real_5484_auto_closed_
+    prose_shape`` above) is ALSO present in a commit message, independently
+    — check 4's exemption (``commit_closing_declared - narrowly_declared``)
+    must not let the body's own equally-non-canonical mention exempt it.
+    With a body that declares nothing about #5467 at all, check 4 fires."""
+    findings = m.check_contradictions(
+        "unrelated body text",
+        closing_refs=[],
+        commit_messages=[_PR5484_COMMIT_WITH_LEAK],
+    )
+    assert _checks(findings) == [(4, 5467)]
+
+
+def test_check4_stays_silent_when_the_body_canonically_covers_the_commit_leak():
+    """Tier 1: accept side, same fixture — a body that DOES canonically
+    declare closing #5467 (``Closes #5467``) exempts the identical commit
+    leak, same as the pre-existing #3187 accept-side test does for its own
+    fixture."""
+    findings = m.check_contradictions(
+        "Closes #5467",
+        closing_refs=[5467],
+        commit_messages=[_PR5484_COMMIT_WITH_LEAK],
+    )
+    assert findings == []


### PR DESCRIPTION
**[e2e-coder]** — Closes #5490.

## Real incident (2026-08-29)

`#5467` (still needing an open phase 2, ~82 remaining call sites) was
`auto-closed` when PR #5484 merged — lead-coder reopened it by hand. The
closing-intent gate was green throughout.

lead-coder's own issue-body diagnosis (blaming check 5, the negation
check) was itself wrong — architect's measurement: `closingIssuesReferences`
already held `[5467]` while #5484 was open, and `check_contradictions`
returned 0 findings for the real body/refs pair. Check 5 was never
involved; the issue body's own "## 原因" section should not be trusted
(lead-coder's own words, on the issue).

## Root cause (architect)

Check 3's own docstring already names this exact case (bare-prose
auto-close mention in a sentence) as what it must catch, but check 3
reads "was anything declared about #N" via `find_closing_declarations` —
the BROAD vocabulary GitHub itself honors (`close`/`closed`/`fix`/
`fixed`/...). PR #5484's own body explained the hazard it had fixed
elsewhere using exactly that bare past-tense form next to the number —
which matches the broad vocabulary, so check 3 read the mention as a
genuine declaration and stayed silent. The mention forged the appearance
of a declaration.

The broad needle plays two roles that don't belong on one variable: a
mirror of what GitHub's own parser honors (must over-match — check 1's
question), and a narrower "did the author actually declare this" question
(must under-match — check 3/4's question).

## Fix (one variable, per architect's own prescription)

New `find_declared_closing_intent` gives check 3/4 the canonical
vocabulary already in this file (`_CANONICAL_CLOSING_RE`: Closes/Fixes/
Resolves) with the SAME author-view fence reading `find_closing_
declarations` uses (deliberately NOT `find_canonical_closing_declarations`'s
GitHub-view reading, which strips fenced spans entirely and would blind
check 1 to its own fenced-declaration incidents — architect's own explicit
warning, and confirmed by a real regression during development, below).

`check_contradictions` computes `closing_declared` (broad, feeds check 1
only, unchanged) and a new `narrowly_declared` (canonical + negated,
feeds check 3's "declared_any" and check 4's body/title exemptions).

## A real regression I caught before shipping (disclosed, not silently fixed)

Architect's own acceptance criteria verified the fix against PR #5484's
real data only. Running the full existing suite (`tests/scripts/
test_check_pr_closing_intent.py`) surfaced 6 real regressions my first
version introduced by naively swapping check 1's own `closing_declared`
variable to the narrow vocabulary too (matching architect's own code
sketch literally) — this broke:

- check 1's own real-harm boundary (a bare, non-canonical keyword form
  fenced only around the number) — check 1 legitimately needs the BROAD
  vocabulary, since its whole job is "did the body use ANY GitHub-honored
  keyword form that got fenced away", not only the canonical subset.
- check 5's own negated-keyword tests started double-firing check 3
  alongside check 5 for the same defect (a negated keyword IS an attempt
  to engage with #N, even if broken — check 5 already reports it more
  precisely).

Fixed by keeping check 1 on the broad reading (unchanged) and adding the
negated-keyword set to check 3/4's narrow "declared_any" concept, so a
negated mention still counts as "the body said something", deferring to
check 5's more precise report rather than duplicating it.

## Verification

- **Real reproduction**: PR #5484's actual body excerpt + `closing_refs=
  [5467]` → `[(3, 5467)]`.
- **Positive control (architect's own acceptance criterion, genuinely
  executed against LIVE data, not simulated)**: reverting
  `find_declared_closing_intent` to the old broad reader on the SAME live
  `gh pr view 5484` fetch → 0 findings, matching architect's own pre-fix
  measurement exactly. Narrow reading on the same live fetch → 2 findings
  (check 3, plus check 4 firing independently on the SAME sentence
  present in a commit message — a second, real instance of the identical
  defect this PR's #5484 data itself carries, not anticipated by my own
  hand-built fixture).
- **Check 1's real harm stays red**: `test_check1_fires_on_backtick_
  fenced_closing_keyword_not_resolved` (pre-existing) + a new test naming
  #5490's own acceptance criterion explicitly, `test_check1_real_harm_
  unaffected_by_the_5490_narrowing`.
- Full existing suite: 51/51 pre-existing tests pass unchanged after the
  correction above; 56/56 total with the new tests.

## Scope note (disclosed, not silently different)

`commit_closing_declared`'s OWN reading (what a commit message itself
declares) still uses the broad vocabulary — the same #5490-shaped defect
could in principle also apply there (a commit's own bare mention wrongly
counting as its own declaration), but architect's prescription scoped
this fix to the body-side `closing_declared`/`narrowly_declared` variable
specifically, and the real incident didn't exercise this side. Left
unwidened rather than expanded without a design ruling.

## Test plan

- [x] `ruff check .` — green
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_pr_closing_intent.py` — 56/56 OK
- [x] `python scripts/mypy_ratchet.py` — OK (baselined)
- [x] `python scripts/flat_tests_ratchet.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- [x] Scoped `pytest tests/scripts/test_check_pr_closing_intent.py` — 56 passed
- [x] Live positive control against `gh pr view 5484` — documented above, genuinely executed
- [x] (skipped — Visual, no TUI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
