### PR TITLE
fix(#5475): move compaction_started to CompactionEngine.compact()'s own entry

### DIFF
--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -405,14 +405,18 @@ class CompactionController:
         )
 
         new_turn_count = len(candidates)
-        self._events.emit(
-            "compaction_started",
-            new_turn_count=new_turn_count,
-            covers_through_seq=candidates[-1].seq,
-            had_previous=previous_summary is not None,
+        # #5475 (architect ruling): compaction_started now emits at
+        # CompactionEngine.compact()'s own entry — the one real entry both
+        # of its callers (this method, and retry_loop's own internal
+        # compaction attempts) share — not here. Moved, not duplicated
+        # (the old emit here is deleted, not left alongside the new one;
+        # see #5382/#5455 for why two emit sites for the same kind is
+        # rejected). This caller's own real `seq` (`candidates[-1].seq` —
+        # unlike retry_loop's wire-dict turns, `_turn_to_compactor_input`
+        # keeps `seq` per turn) is passed through explicitly.
+        chat_summary = await self._engine.compact(
+            input_chunk, covers_through=candidates[-1].seq,
         )
-
-        chat_summary = await self._engine.compact(input_chunk)
         structured = chat_summary.to_dict()
         covers = chat_summary.covers_through_seq or candidates[-1].seq
         # #1820 Part1: frame the rendered summary with a static reference-only

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -49,13 +49,14 @@ Drop priority when over budget:
 from __future__ import annotations
 
 import asyncio
+import enum
 import hashlib
 import json
 import logging
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
 from reyn.llm.json_parse import loads_lenient
 from reyn.llm.litellm_bootstrap import (
@@ -405,6 +406,40 @@ def estimate_tokens_for_any_turn(
 # ---------------------------------------------------------------------------
 # Dataclasses (replace the YAML artifact schemas)
 # ---------------------------------------------------------------------------
+
+
+class SeqUnavailable(enum.Enum):
+    """#5475 (architect ruling): named reasons a caller of :meth:`CompactionEngine.
+    compact` cannot supply a real ``covers_through_seq`` for its
+    ``compaction_started`` audit event.
+
+    A bare ``None`` was explicitly rejected — a consumer of the event cannot
+    tell "seq is absent" apart from "seq is unknown for a structural reason",
+    the same ambiguity architect named twice the same day (#5084/#5132) with
+    the same prescription: make the absence itself carry WHY, not just THAT.
+    """
+
+    #: `retry_loop`'s own internal compaction (`engine.py`'s own later
+    #: `engine.compact(input_chunk)` call, inside the halving/spill ladder)
+    #: builds `new_turns` from `RouterHistoryBuffer.decompose_history_for_
+    #: retry()`'s `raw_middle` — litellm WIRE dicts (`_serialise_turn`'s own
+    #: output), which structurally carry no `seq` field at all (that method's
+    #: own `seq_by_id` side-channel, keyed by `id(wire_dict)`, exists
+    #: specifically because the wire shape has no room for one). Threading
+    #: `seq_by_id` through to this call site was considered and rejected
+    #: (architect): an `id()`-keyed lookup silently breaks across any
+    #: copy/re-serialise, extending a fragile mechanism's lifetime rather
+    #: than fixing it.
+    WIRE_DICTS_CARRY_NO_SEQ = "wire_dicts_carry_no_seq"
+
+
+#: The `compaction_started` payload's `covers_through_seq` field: either a
+#: real seq (the controller's own caller, whose `new_turns` DO carry one —
+#: see `_turn_to_compactor_input`), or a named reason it cannot be supplied.
+#: No default anywhere `compact()` is called — an omitted value is a
+#: caller writing a payload it cannot actually back, caught by mypy at the
+#: call site, never a silently-accepted null.
+CoversThrough = Union[int, SeqUnavailable]
 
 
 @dataclass
@@ -1505,7 +1540,9 @@ class CompactionEngine:
             self._events.emit("summary_resummarize_failed", error=str(exc))
             return topic_arc
 
-    async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
+    async def compact(
+        self, input_chunk: HistoryChunkToCompact, *, covers_through: CoversThrough,
+    ) -> ChatSummary:
         """Run one compaction LLM call and return a ChatSummary.
 
         Axis 9: applies hard_truncate_summary to the returned topic_arc
@@ -1513,7 +1550,35 @@ class CompactionEngine:
 
         Raises on LLM error; callers wrap in try/except and emit
         ``compaction_failed`` if needed.
+
+        #5475 (architect ruling): emits ``compaction_started`` HERE, at the
+        one real entry both of this engine's callers share
+        (``CompactionController.force_compact_now`` and ``retry_loop``'s own
+        internal compaction attempts) — moved from ``CompactionController``,
+        not duplicated (the controller's own former emit is deleted in the
+        same change; see #5382/#5455 for why two emit sites for the same
+        kind is the shape this repo rejects). ``new_turn_count``/
+        ``had_previous`` are derived from *input_chunk* alone — both are
+        genuinely available to every caller. ``covers_through`` is NOT: the
+        controller's own caller can supply a real seq (its ``new_turns``
+        carry one), but ``retry_loop``'s cannot (its ``new_turns`` are wire
+        dicts with none) — a REQUIRED keyword-only argument, no default,
+        so the type checker catches an omission at the call site rather
+        than this method silently accepting a null it cannot justify.
         """
+        new_turn_count = len(input_chunk.new_turns)
+        covers_through_seq = covers_through if isinstance(covers_through, int) else None
+        covers_through_unavailable_reason = (
+            None if isinstance(covers_through, int) else covers_through.value
+        )
+        self._events.emit(
+            "compaction_started",
+            new_turn_count=new_turn_count,
+            covers_through_seq=covers_through_seq,
+            covers_through_unavailable_reason=covers_through_unavailable_reason,
+            had_previous=input_chunk.previous_summary is not None,
+        )
+
         # No `_token_cache.clear()` here (removed, #2937): text is immutable and
         # the tokenizer/fallback choice is a fixed per-session config, so a
         # cached (model, text) count is valid for the process's entire
@@ -2194,7 +2259,12 @@ async def retry_loop(
                     section_token_caps=section_caps,
                 )
                 try:
-                    chat_summary = await engine.compact(input_chunk)
+                    # #5475: raw_middle's turns are wire dicts (no `seq` —
+                    # see `SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ`'s own
+                    # docstring) — a real seq is not available to this caller.
+                    chat_summary = await engine.compact(
+                        input_chunk, covers_through=SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ,
+                    )
                     summary = chat_summary.to_dict()
                     # Only the ATTEMPTED slice is compacted — a smaller
                     # remainder (if any) stays in raw_middle for a later

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1565,6 +1565,15 @@ class CompactionEngine:
         dicts with none) — a REQUIRED keyword-only argument, no default,
         so the type checker catches an omission at the call site rather
         than this method silently accepting a null it cannot justify.
+
+        #5475 (architect, non-blocking): the emitted ``compaction_started``
+        payload's ``covers_through_seq``/``covers_through_unavailable_
+        reason`` fields are a PAIR, meant to be read together — JSON has
+        no union type, so the ``int | SeqUnavailable`` distinction this
+        method's own type signature carries has to split across two
+        fields on the wire. A consumer reading only ``covers_through_seq``
+        still sees a bare, unexplained ``null`` on the retry_loop path;
+        always check ``covers_through_unavailable_reason`` alongside it.
         """
         new_turn_count = len(input_chunk.new_turns)
         covers_through_seq = covers_through if isinstance(covers_through, int) else None

--- a/tests/core/test_3783_stage3_invert_default_to_recover.py
+++ b/tests/core/test_3783_stage3_invert_default_to_recover.py
@@ -90,7 +90,9 @@ class _StubEngineCompactRaises:
         self._compact_fn = compact_fn
         self._events = EventLog()
 
-    async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
+    async def compact(
+        self, input_chunk: HistoryChunkToCompact, *, covers_through=None,
+    ) -> ChatSummary:
         return await self._compact_fn(input_chunk)
 
 

--- a/tests/core/test_4883_compaction_schema_validation.py
+++ b/tests/core/test_4883_compaction_schema_validation.py
@@ -93,7 +93,7 @@ def test_valid_first_response_no_reprompt(monkeypatch) -> None:
         return _resp(_valid_json())
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
-    summary = asyncio.run(engine.compact(_chunk()))
+    summary = asyncio.run(engine.compact(_chunk(), covers_through=1))
 
     assert calls["n"] == 1
     assert summary.topic_arc == "did a thing"
@@ -119,7 +119,7 @@ def test_invalid_then_valid_recovers_via_reprompt(monkeypatch) -> None:
         return _resp(_valid_json())
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
-    summary = asyncio.run(engine.compact(_chunk()))
+    summary = asyncio.run(engine.compact(_chunk(), covers_through=1))
 
     assert calls["n"] == 2, "must re-prompt exactly once before succeeding"
     assert summary.topic_arc == "did a thing"
@@ -148,7 +148,7 @@ def test_persistently_invalid_exhausts_budget_and_raises(monkeypatch) -> None:
     monkeypatch.setattr("litellm.acompletion", _scripted)
 
     with pytest.raises(ValueError, match="missing required fields"):
-        asyncio.run(engine.compact(_chunk()))
+        asyncio.run(engine.compact(_chunk(), covers_through=1))
 
     assert calls["n"] == 2, "1 initial + 1 re-prompt attempt, per max_schema_reprompt_attempts=1"
     invalid_events = [e for e in collected if e.type == "compaction_schema_invalid"]
@@ -296,7 +296,7 @@ def test_structured_output_used_when_model_supports_it(monkeypatch) -> None:
         "reyn.services.compaction.engine._supports_structured_output",
         lambda model: _async_true(),
     )
-    asyncio.run(engine.compact(_chunk()))
+    asyncio.run(engine.compact(_chunk(), covers_through=1))
 
     rf = captured.get("response_format")
     assert rf is not None and rf.get("type") == "json_schema"
@@ -331,7 +331,7 @@ def test_json_object_used_when_model_does_not_support_structured_output(monkeypa
         "reyn.services.compaction.engine._supports_structured_output",
         lambda model: _async_false(),
     )
-    summary = asyncio.run(engine.compact(_chunk()))  # must NOT raise
+    summary = asyncio.run(engine.compact(_chunk(), covers_through=1))  # must NOT raise
 
     assert captured.get("response_format") == {"type": "json_object"}
     assert summary.topic_arc == "did a thing"
@@ -371,7 +371,7 @@ def test_provider_rejection_of_json_schema_is_not_caught_and_retried(monkeypatch
     )
 
     with pytest.raises(ValueError, match="provider rejected response_format"):
-        asyncio.run(engine.compact(_chunk()))
+        asyncio.run(engine.compact(_chunk(), covers_through=1))
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +443,7 @@ def test_partial_slices_eventually_cover_every_turn_with_no_gap(monkeypatch) -> 
     covered: list[int] = []
     for chunk in slices:
         seen_inputs.append(chunk)
-        summary = asyncio.run(engine.compact(chunk))
+        summary = asyncio.run(engine.compact(chunk, covers_through=chunk.new_turns[-1]["seq"]))
         covered.append(summary.covers_through_seq)
 
     assert covered == [1, 2, 3], (

--- a/tests/core/test_4951_local_covers_derivation.py
+++ b/tests/core/test_4951_local_covers_derivation.py
@@ -77,7 +77,7 @@ def test_covers_ignores_a_wrong_nonempty_echo(monkeypatch) -> None:
         return _resp(_json(new_turn_seqs=[1]))
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
-    summary = asyncio.run(engine.compact(chunk))
+    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.new_turns)))
     assert summary.covers_through_seq == 3, (
         f"expected covers_through_seq derived from the real input max "
         f"(3), not the wrong echo (1); got {summary.covers_through_seq}"
@@ -97,7 +97,7 @@ def test_covers_ignores_a_wrong_higher_echo(monkeypatch) -> None:
         return _resp(_json(new_turn_seqs=[999]))
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
-    summary = asyncio.run(engine.compact(chunk))
+    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.new_turns)))
     assert summary.covers_through_seq == 6, (
         f"expected covers_through_seq derived from the real input max (6), "
         f"not the inflated echo (999); got {summary.covers_through_seq}"
@@ -122,7 +122,7 @@ def test_empty_new_turn_seqs_no_longer_reprompts(monkeypatch) -> None:
         return _resp(_json(new_turn_seqs=[]))
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
-    summary = asyncio.run(engine.compact(chunk))
+    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.new_turns)))
 
     assert calls["n"] == 1, "an empty new_turn_seqs must not trigger a re-prompt"
     assert summary.covers_through_seq == 7
@@ -145,7 +145,7 @@ def test_empty_topic_arc_still_reprompts_regardless_of_new_turn_seqs(monkeypatch
         return _resp(_json(new_turn_seqs=[1]))
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
-    summary = asyncio.run(engine.compact(chunk))
+    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.new_turns)))
 
     assert calls["n"] == 2, "an empty topic_arc must still trigger exactly one re-prompt"
     assert summary.topic_arc == "did a thing"

--- a/tests/core/test_cost_chokepoint_1190.py
+++ b/tests/core/test_cost_chokepoint_1190.py
@@ -133,7 +133,7 @@ def test_compaction_engine_records_compaction_purpose(monkeypatch) -> None:
         previous_summary=None,
         new_turns=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
-    )))
+    ), covers_through=1))
     assert [c["purpose"] for c in rec.calls] == ["compaction"]
 
 
@@ -193,7 +193,7 @@ def test_compaction_engine_threads_agent(monkeypatch) -> None:
         previous_summary=None,
         new_turns=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
-    )))
+    ), covers_through=1))
     assert [c["agent"] for c in rec.calls] == ["researcher"]
 
 

--- a/tests/core/test_resummarize_3tier_271.py
+++ b/tests/core/test_resummarize_3tier_271.py
@@ -69,7 +69,7 @@ def _run(monkeypatch, engine, collected, *, compaction_arc: str, resummarize_arc
         new_turns=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
     )
-    summary = asyncio.run(engine.compact(chunk))
+    summary = asyncio.run(engine.compact(chunk, covers_through=1))
     return summary, calls, [e.type for e in collected]
 
 

--- a/tests/llm/test_chat_compaction_engine_11axis.py
+++ b/tests/llm/test_chat_compaction_engine_11axis.py
@@ -793,7 +793,9 @@ class _CountingEngine(CompactionEngine):
         )
         self.compact_call_count = 0
 
-    async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
+    async def compact(
+        self, input_chunk: HistoryChunkToCompact, *, covers_through=None,
+    ) -> ChatSummary:
         """Tier 2 stub: increment call count and return a stub summary."""
         self.compact_call_count += 1
         return ChatSummary(topic_arc="stub", covers_through_seq=0)

--- a/tests/llm/test_compaction_resolver_aware_1172.py
+++ b/tests/llm/test_compaction_resolver_aware_1172.py
@@ -79,7 +79,7 @@ def _run_capture(monkeypatch, engine: CompactionEngine) -> str:
         new_turns=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
     )
-    asyncio.run(engine.compact(chunk))
+    asyncio.run(engine.compact(chunk, covers_through=1))
     return seen["model"]
 
 

--- a/tests/runtime/test_compaction_controller_invariants.py
+++ b/tests/runtime/test_compaction_controller_invariants.py
@@ -19,6 +19,7 @@ expose synthetic ``budgets``.
 from __future__ import annotations
 
 import asyncio
+from typing import Callable
 
 import pytest  # noqa: F401 — used implicitly by pytest discovery
 
@@ -30,6 +31,7 @@ from reyn.services.compaction.engine import (
     ChatSummary,
     CompactionEngine,
     ComputedBudgets,
+    CoversThrough,
     HistoryChunkToCompact,
 )
 from tests._support.events import collect_events, settle
@@ -49,27 +51,57 @@ _STUB_BUDGETS = ComputedBudgets(
 )
 
 
-class _AbortingEngine(CompactionEngine):
-    """Engine stub that always raises so compaction aborts early (no LLM call)."""
+def _emit_compaction_started(
+    events: EventLog, input_chunk: HistoryChunkToCompact, covers_through: CoversThrough,
+) -> None:
+    """#5475: mirrors ``CompactionEngine.compact()``'s own real entry-point
+    emit — the stub engines below call this instead of a real ``compact()``
+    body, so this test file's own ``compaction_started`` witnesses stay
+    meaningful (the SAME shape production now emits, not a shape this file
+    invented independently that could silently drift from it)."""
+    events.emit(
+        "compaction_started",
+        new_turn_count=len(input_chunk.new_turns),
+        covers_through_seq=covers_through if isinstance(covers_through, int) else None,
+        covers_through_unavailable_reason=(
+            None if isinstance(covers_through, int) else covers_through.value
+        ),
+        had_previous=input_chunk.previous_summary is not None,
+    )
 
-    def __init__(self) -> None:
+
+class _AbortingEngine(CompactionEngine):
+    """Engine stub that always raises so compaction aborts early (no LLM call).
+
+    #5475: takes the SAME ``EventLog`` the controller/test observe (not a
+    private, disconnected one) — ``compaction_started`` now emits inside
+    ``compact()``, not the controller, so a stub whose own event log nobody
+    watches would silently stop producing that event for every test here."""
+
+    def __init__(self, events: EventLog) -> None:
         self._model = ""
-        self._events = EventLog()
+        self._events = events
         self._budgets = _STUB_BUDGETS
 
-    async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
+    async def compact(
+        self, input_chunk: HistoryChunkToCompact, *, covers_through: CoversThrough,
+    ) -> ChatSummary:
+        _emit_compaction_started(self._events, input_chunk, covers_through)
         raise RuntimeError("aborting engine stub: test-time abort")
 
 
 class _SucceedingEngine(CompactionEngine):
     """Engine stub that returns a minimal ChatSummary without an LLM call."""
 
-    def __init__(self) -> None:
+    def __init__(self, events: EventLog) -> None:
         self._model = ""
-        self._events = EventLog()
+        self._events = events
         self._budgets = _STUB_BUDGETS
 
-    async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
+    async def compact(
+        self, input_chunk: HistoryChunkToCompact, *, covers_through: CoversThrough,
+    ) -> ChatSummary:
+        _emit_compaction_started(self._events, input_chunk, covers_through)
         seqs = [int(t.get("seq", 0)) for t in input_chunk.new_turns if isinstance(t, dict)]
         return ChatSummary(topic_arc="stub", covers_through_seq=max(seqs) if seqs else 0)
 
@@ -77,11 +109,18 @@ class _SucceedingEngine(CompactionEngine):
 def _make_controller(
     *,
     history: list[ChatMessage],
-    engine: CompactionEngine,
+    engine_factory: "Callable[[EventLog], CompactionEngine]",
 ) -> tuple[CompactionController, list, list[ChatMessage], EventLog]:
-    """Return a (controller, collected, history, events) tuple ready for testing."""
+    """Return a (controller, collected, history, events) tuple ready for testing.
+
+    #5475: takes an ``engine_factory(events)`` rather than a pre-built
+    ``engine`` — the stub engines need the SAME ``events`` this function
+    builds below (their own ``compaction_started`` now lives inside
+    ``compact()``, see ``_emit_compaction_started`` above), which does not
+    exist yet at the caller's own call site."""
     events = EventLog()
     collected = collect_events(events)
+    engine = engine_factory(events)
 
     def _latest_summary():
         for m in reversed(history):
@@ -140,7 +179,7 @@ def test_force_compact_no_candidates_emits_forced_sync_no_started():
     to compact), force_compact_now emits compaction_check(outcome='forced_sync')
     with candidate_count=0 and does NOT emit compaction_started.
     """
-    ctrl, collected, _, events = _make_controller(history=_history(2), engine=_AbortingEngine())
+    ctrl, collected, _, events = _make_controller(history=_history(2), engine_factory=_AbortingEngine)
 
     asyncio.run(_run_and_settle(ctrl.force_compact_now(), events))
 
@@ -162,7 +201,7 @@ def test_force_compact_with_candidates_appends_summary():
     """Tier 2: with a compactable middle, force_compact_now runs the engine
     (compaction_started + compaction_completed) and appends a summary entry.
     """
-    ctrl, collected, hist, events = _make_controller(history=_history(7), engine=_SucceedingEngine())
+    ctrl, collected, hist, events = _make_controller(history=_history(7), engine_factory=_SucceedingEngine)
 
     asyncio.run(_run_and_settle(ctrl.force_compact_now(), events))
 
@@ -182,7 +221,7 @@ def test_force_compact_engine_failure_emits_failed():
     """Tier 2: when the engine raises mid-compaction, force_compact_now emits
     compaction_failed and returns (the try/except swallows the engine error
     rather than propagating it to the caller)."""
-    ctrl, collected, _, events = _make_controller(history=_history(7), engine=_AbortingEngine())
+    ctrl, collected, _, events = _make_controller(history=_history(7), engine_factory=_AbortingEngine)
 
     asyncio.run(_run_and_settle(ctrl.force_compact_now(), events))  # must not raise
 

--- a/tests/runtime/test_compaction_summary_preamble_1820.py
+++ b/tests/runtime/test_compaction_summary_preamble_1820.py
@@ -37,7 +37,9 @@ class _SucceedingEngine(CompactionEngine):
         self._events = EventLog()
         self._budgets = _STUB_BUDGETS
 
-    async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
+    async def compact(
+        self, input_chunk: HistoryChunkToCompact, *, covers_through=None,
+    ) -> ChatSummary:
         return ChatSummary(topic_arc="STUB_ARC", covers_through_seq=0)
 
 

--- a/tests/services/test_4703_compaction_spend_visible.py
+++ b/tests/services/test_4703_compaction_spend_visible.py
@@ -74,7 +74,7 @@ def test_chat_summary_carries_the_calls_own_real_usage(monkeypatch) -> None:
         model=_PRICED_MODEL, events=EventLog(),
         cfg=CompactionConfig(use_chars4_estimate=True),
     )
-    summary = asyncio.run(engine.compact(_chunk()))
+    summary = asyncio.run(engine.compact(_chunk(), covers_through=1))
     assert summary.prompt_tokens == 8200
     assert summary.completion_tokens == 340
     assert summary.cost_usd is not None and summary.cost_usd > 0.0
@@ -109,7 +109,7 @@ def test_usage_is_none_not_zero_when_the_response_carries_none(monkeypatch) -> N
         model=_PRICED_MODEL, events=EventLog(),
         cfg=CompactionConfig(use_chars4_estimate=True),
     )
-    summary = asyncio.run(engine.compact(_chunk()))
+    summary = asyncio.run(engine.compact(_chunk(), covers_through=1))
     assert summary.prompt_tokens is None
     assert summary.completion_tokens is None
     assert summary.cost_usd is None
@@ -131,13 +131,22 @@ def test_compaction_completed_event_carries_the_usage_end_to_end(monkeypatch) ->
         return _resp(prompt=500, completion=50, content=_SUMMARY_CONTENT)
     monkeypatch.setattr(litellm, "acompletion", _fake)
 
-    engine = CompactionEngine(
-        model=_PRICED_MODEL, events=EventLog(),
-        cfg=CompactionConfig(use_chars4_estimate=True),
-    )
-    engine._budgets = _STUB_BUDGETS  # noqa: SLF001 — test-setup shaping, not an assertion
+    def _build_engine(events: EventLog) -> CompactionEngine:
+        # #5475: built with the SAME EventLog `_make_controller` gives its
+        # controller — `compact()` now emits `compaction_started` through
+        # `self._events` itself, so an engine built against a separate,
+        # private EventLog (as this test did before #5475) would silently
+        # emit into a log nobody observes, exactly the disconnect
+        # `test_compaction_controller_invariants.py`'s own stub engines
+        # were fixed to avoid.
+        engine = CompactionEngine(
+            model=_PRICED_MODEL, events=events,
+            cfg=CompactionConfig(use_chars4_estimate=True),
+        )
+        engine._budgets = _STUB_BUDGETS  # noqa: SLF001 — test-setup shaping, not an assertion
+        return engine
 
-    ctrl, collected, _, events = _make_controller(history=_history(7), engine=engine)
+    ctrl, collected, _, events = _make_controller(history=_history(7), engine_factory=_build_engine)
 
     async def _run() -> None:
         await ctrl.force_compact_now()

--- a/tests/services/test_5329_compact_quota_not_wastefully_shrunk.py
+++ b/tests/services/test_5329_compact_quota_not_wastefully_shrunk.py
@@ -117,7 +117,7 @@ def test_quota_exhausted_compact_terminates_on_first_occurrence_bare() -> None:
     engine = _MinimalCompactionEngine()
     compact_calls = 0
 
-    async def _compact(input_chunk):
+    async def _compact(input_chunk, *, covers_through=None):
         nonlocal compact_calls
         compact_calls += 1
         raise _QuotaExhaustedError()
@@ -167,7 +167,7 @@ def test_transient_rate_limit_still_enters_the_shrink_ladder_unaffected() -> Non
     engine = _MinimalCompactionEngine()
     compact_calls = 0
 
-    async def _compact(input_chunk):
+    async def _compact(input_chunk, *, covers_through=None):
         nonlocal compact_calls
         compact_calls += 1
         raise _TransientRateLimitError()

--- a/tests/services/test_5380_same_cause_cap_spill_witness.py
+++ b/tests/services/test_5380_same_cause_cap_spill_witness.py
@@ -93,7 +93,7 @@ class _SameCauseOnCompactSpillableEngine(_OverflowingEngine):
         # the turns compact() was given.
         self.compact_calls_with_marker_gone = 0
 
-    async def compact(self, input_chunk):
+    async def compact(self, input_chunk, *, covers_through=None):
         self.compact_calls += 1
         turns = input_chunk.new_turns
         if any(t.get("content") == _SPILLABLE_MARKER for t in turns if isinstance(t, dict)):

--- a/tests/services/test_5475_compaction_started_moved_to_engine.py
+++ b/tests/services/test_5475_compaction_started_moved_to_engine.py
@@ -1,0 +1,140 @@
+"""Tier 2: #5475 — ``compaction_started`` moves to ``CompactionEngine.compact()``'s
+own entry (once, covering both real callers), not duplicated.
+
+architect ruling (#5382 review, refined on #5475 after an investigation
+disproved "payload derivable from ``input_chunk`` alone" for one field):
+event は行為に属し、呼び手には属しません — ``compact()`` is the one real
+entry both ``CompactionController.force_compact_now`` and ``retry_loop``'s
+own internal compaction attempts share, so the emit lives there, moved
+from the controller (not added alongside it — #5382/#5455's own ruling on
+two emit sites for the same kind).
+
+``new_turn_count``/``had_previous`` are genuinely derivable from
+``input_chunk`` alone for EITHER caller. ``covers_through_seq`` is not:
+the controller's own ``new_turns`` carry a real ``seq`` per turn
+(``_turn_to_compactor_input``); ``retry_loop``'s own ``new_turns`` are
+litellm wire dicts (``_serialise_turn``'s output) with no ``seq`` field at
+all. ``compact()`` therefore takes ``covers_through`` as a REQUIRED
+keyword-only argument (no default — an omission is a mypy error at the
+call site, never a silently-accepted null) typed
+``CoversThrough = int | SeqUnavailable``, so a consumer of the emitted
+event can tell "seq is a real value" apart from "seq is unknown, and
+here is WHY" rather than conflating both into a bare ``None``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.dev.testing.llm_stub import LLMStub
+from reyn.services.compaction.engine import (
+    CompactionEngine,
+    HistoryChunkToCompact,
+    SeqUnavailable,
+)
+from tests._support.events import collect_events, settle
+from tests._support.session import make_session
+
+# "compaction_started" has exactly ONE emit site in the whole tree (inside
+# CompactionEngine.compact() — compaction_controller.py's own former emit
+# is genuinely gone, not left alongside the new one) — checked BY HAND
+# (`git grep -n 'compaction_started' src/`), not as its own test: a
+# `len(x) == 1` population-count assertion is this repo's own testing
+# policy's "format pinning" (Tier 4) — see
+# `test_tier_audit.py`'s own rejection of exactly this shape. Not pinned
+# as a runtime test for the same reason `test_3868_collect_events_helper
+# .py`'s own strip-falsify witness is documented as run-by-hand rather
+# than encoded as an assertion whose failure mode this policy already
+# disallows. The two tests below are the BEHAVIORAL proof instead: if
+# compaction_controller.py still emitted its own compaction_started
+# alongside the engine's, the strip-falsify pass below (temporarily
+# removing the engine's own emit) would leave `test_controller_path_
+# carries_a_real_seq`'s event still present (from the surviving
+# controller-side emit) — it did not; both behavioral tests below went
+# red together when the engine's own emit was stripped, confirmed by
+# hand, restored.
+
+
+@pytest.mark.asyncio
+async def test_controller_path_carries_a_real_seq(tmp_path, monkeypatch):
+    """Tier 2: the CONTROLLER's own caller (whose new_turns carry a real
+    `seq` per turn) makes `compaction_started`'s `covers_through_seq` a
+    real int, with no `covers_through_unavailable_reason` — driven through
+    a real Session/CompactionController/CompactionEngine, no stand-in."""
+    session = make_session(tmp_path, monkeypatch=monkeypatch, t_max=2_500)
+    collected = collect_events(session)
+
+    stub = LLMStub()
+    stub.install()
+    try:
+        for i in range(8):
+            session._append_history(
+                _msg(f"filler turn {i} " * 40, seq=i + 1),
+            )
+        await session._compaction_controller.force_compact_now()
+        await settle(session)
+    finally:
+        stub.restore()
+
+    started = [e for e in collected if e.type == "compaction_started"]
+    assert started, "expected a real compaction_started event via the controller"
+    payload = started[0].data
+    assert isinstance(payload.get("covers_through_seq"), int), (
+        f"controller path must carry a real int seq, got "
+        f"{payload.get('covers_through_seq')!r}"
+    )
+    assert payload.get("covers_through_unavailable_reason") is None, (
+        "a real seq must not ALSO carry an unavailable-reason — the two "
+        "fields are mutually exclusive"
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_loop_shaped_path_carries_a_named_absence():
+    """Tier 2: the shape retry_loop's own caller actually has — wire-dict
+    `new_turns` with no `seq` — makes `covers_through_seq` None and names
+    WHY via `covers_through_unavailable_reason`, never a bare, unexplained
+    null. Drives the real `CompactionEngine.compact()` directly with the
+    SAME `SeqUnavailable` sentinel `engine.py`'s own retry_loop call site
+    passes, proving the sentinel's `.value` is what actually reaches the
+    event (not merely that the enum exists)."""
+    events = EventLog()
+    collected = collect_events(events)
+    engine = CompactionEngine(
+        "openai/test-standard-model", events, CompactionConfig(use_chars4_estimate=True),
+    )
+
+    stub = LLMStub()
+    stub.install()
+    try:
+        # A litellm-wire-dict-shaped turn (role/content only) — no "seq"
+        # key at all, matching what `decompose_history_for_retry`'s
+        # `raw_middle` actually contains (see module docstring).
+        chunk = HistoryChunkToCompact(
+            previous_summary=None,
+            new_turns=[{"role": "user", "content": "wire-shaped, no seq"}],
+            section_token_caps={},
+        )
+        await engine.compact(chunk, covers_through=SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ)
+        await settle(events)
+    finally:
+        stub.restore()
+
+    started = [e for e in collected if e.type == "compaction_started"]
+    assert started, "expected a real compaction_started event"
+    payload = started[0].data
+    assert payload.get("covers_through_seq") is None, (
+        "no real seq is available on this path — must not fabricate one"
+    )
+    assert payload.get("covers_through_unavailable_reason") == "wire_dicts_carry_no_seq", (
+        f"expected the named reason, got "
+        f"{payload.get('covers_through_unavailable_reason')!r} — a bare "
+        "None here would be indistinguishable from a bug that silently "
+        "dropped a real seq"
+    )
+
+
+def _msg(text: str, *, seq: int):
+    from reyn.runtime.chat_message import ChatMessage
+    return ChatMessage(role="user", content=text, seq=seq)

--- a/tests/services/test_compaction_token_cache_incremental.py
+++ b/tests/services/test_compaction_token_cache_incremental.py
@@ -131,7 +131,7 @@ def test_compact_does_not_clear_the_token_cache(monkeypatch) -> None:
         new_turns=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
     )
-    asyncio.run(engine.compact(chunk))
+    asyncio.run(engine.compact(chunk, covers_through=1))
 
     # Re-estimating the SAME text after compact() must be a cache HIT: same
     # value, and the tokenizer is NOT invoked again (still exactly 1 call).
@@ -170,8 +170,8 @@ def test_repeated_estimate_of_unchanged_text_is_a_cache_hit_across_compactions(m
         previous_summary=None, new_turns=[{"role": "user", "text": "t1", "seq": 1}],
         section_token_caps={},
     )
-    asyncio.run(engine.compact(chunk))
-    asyncio.run(engine.compact(chunk))  # a SECOND compaction cycle
+    asyncio.run(engine.compact(chunk, covers_through=1))
+    asyncio.run(engine.compact(chunk, covers_through=1))  # a SECOND compaction cycle
 
     second = estimate_tokens(text, model, use_chars4=False)
     assert second == first

--- a/tests/services/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/services/test_pr_n6_compaction_overflow_retry.py
@@ -404,7 +404,7 @@ class _OverflowingEngine:
         # (engine.py's Axis 2, "measured once at init time").
         self._T_comp_SP = 100
 
-    async def compact(self, input_chunk: HistoryChunkToCompact):
+    async def compact(self, input_chunk: HistoryChunkToCompact, *, covers_through=None):
         if self._fail_compact:
             raise CompactionOverflowError("test: compaction overflow")
         from reyn.services.compaction.engine import ChatSummary
@@ -465,7 +465,7 @@ def test_retry_loop_shrinks_tail_on_overflow(tmp_path) -> None:
             )
             self._events = EventLog()
 
-        async def compact(self, input_chunk):
+        async def compact(self, input_chunk, *, covers_through=None):
             from reyn.services.compaction.engine import ChatSummary
             return ChatSummary(topic_arc="stub", covers_through_seq=0)
 
@@ -735,7 +735,7 @@ def test_retry_loop_same_cause_cap_raises_before_shrink_paths_exhausted(tmp_path
     )
 
     class _SameCauseOnCompactEngine(_OverflowingEngine):
-        async def compact(self, input_chunk):
+        async def compact(self, input_chunk, *, covers_through=None):
             raise ContextOverflowError("compact also overflows, same cause")
 
     engine = _SameCauseOnCompactEngine(fail_compact=False)
@@ -792,7 +792,7 @@ class _CompactFailsOnceEngine(_OverflowingEngine):
         super().__init__(fail_compact=False)
         self._compact_calls = 0
 
-    async def compact(self, input_chunk):
+    async def compact(self, input_chunk, *, covers_through=None):
         self._compact_calls += 1
         if self._compact_calls == 1:
             raise CompactionOverflowError("first compact overflows")
@@ -1310,7 +1310,7 @@ class _Always413CompactEngine(_OverflowingEngine):
         self._T_comp_SP = 100
         self.compact_calls = 0
 
-    async def compact(self, input_chunk):
+    async def compact(self, input_chunk, *, covers_through=None):
         self.compact_calls += 1
         raise _FakeStatusError("compact 413", status_code=413)
 
@@ -1438,7 +1438,7 @@ def test_5367_3_spill_before_raise_resolves_byte_limit_mid_split_floor(tmp_path)
             super().__init__()
             self.compact_calls = 0
 
-        async def compact(self, input_chunk):
+        async def compact(self, input_chunk, *, covers_through=None):
             self.compact_calls += 1
             turn = input_chunk.new_turns[0]
             if turn.get("content") == "OVERSIZED_TOOL_RESULT":
@@ -1553,7 +1553,7 @@ def test_4947_stage1_success_resets_same_cause_streak(tmp_path) -> None:
             self._script = script
             self._idx = 0
 
-        async def compact(self, input_chunk):
+        async def compact(self, input_chunk, *, covers_through=None):
             should_fail = self._script[self._idx] if self._idx < len(self._script) else False
             self._idx += 1
             if should_fail:
@@ -1676,7 +1676,7 @@ def test_4947_stage1_floor_defers_instead_of_raising_when_not_byte_limit(tmp_pat
             super().__init__(fail_compact=False)
             self._called = False
 
-        async def compact(self, input_chunk):
+        async def compact(self, input_chunk, *, covers_through=None):
             if not self._called:
                 self._called = True
                 raise ValueError("not a byte-limit failure")
@@ -1721,7 +1721,7 @@ def test_4947_stage1_floor_names_413_when_it_is_a_byte_limit(tmp_path) -> None:
     cfg = _make_cfg()
 
     class _AlwaysByteLimitEngine(_OverflowingEngine):
-        async def compact(self, input_chunk):
+        async def compact(self, input_chunk, *, covers_through=None):
             raise _FakeStatusError("compact 413", status_code=413)
 
     engine = _AlwaysByteLimitEngine(fail_compact=False)


### PR DESCRIPTION
**[tui-coder]** — closes #5475.

## What

`compaction_started` moves from `CompactionController.force_compact_now` into `CompactionEngine.compact()`'s own entry — the one real entry both of the engine's callers share (the controller, and `retry_loop`'s own internal compaction attempts). Moved, not duplicated — the controller's old emit is deleted in the same change.

## Why (architect ruling, #5382 review)

> event は行為に属し、呼び手には属しません

Before this fix, `retry_loop`'s own internal `compact()` calls (the halving/spill ladder inside `engine.py`) were invisible to any audit-event observer, even though they're real, repeated, cost-attributed (#1190) production activity — only the controller's own caller ever emitted `compaction_started`.

## Investigated before implementing (posted to the issue thread before writing code)

architect's own open question — "can the payload be derived from `input_chunk` alone?" — is only partially true. `new_turn_count`/`had_previous` ARE derivable for both callers. `covers_through_seq` is NOT: the controller's own `new_turns` carry a real `seq` per turn (`_turn_to_compactor_input`), but `retry_loop`'s own `new_turns` are litellm wire dicts (`_serialise_turn`'s output, via `decompose_history_for_retry`'s `raw_middle`) with no `seq` field at all — that method's own `seq_by_id` side-channel, keyed by `id(wire_dict)`, exists specifically because the wire shape has no room for one.

## Design (architect ruling, option (c) of 3 presented)

`compact()` takes `covers_through` as a **required keyword-only argument, no default** — an omission is a mypy error at the call site, never a silently-accepted null. Typed `CoversThrough = int | SeqUnavailable`, where `SeqUnavailable` is a named enum (not a bare `None`) carrying WHY a real seq isn't available — a consumer of the emitted event can tell "seq is absent" apart from "seq is unknown for a structural reason", the same ambiguity architect rejected twice the same day (#5084/#5132) with the same prescription.

Options considered and rejected:
- **(a)** Thread `seq_by_id` through to `retry_loop`'s own `input_chunk` construction — rejected: an `id()`-keyed lookup silently breaks across any copy/re-serialise, extending a fragile mechanism's lifetime rather than fixing it.
- **(b)** Bare `covers_through_seq=None` — rejected: a consumer cannot distinguish "no seq" from "don't know".

## Changes

- `engine.py`: new `SeqUnavailable` enum (`WIRE_DICTS_CARRY_NO_SEQ`) and `CoversThrough = int | SeqUnavailable`. `compact()` gains the required `covers_through` kwarg and emits `compaction_started` at its own entry. `retry_loop`'s own call site passes `SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ`.
- `compaction_controller.py`: the old `compaction_started` emit is **deleted**. The controller's own call passes `covers_through=candidates[-1].seq` (a real int).
- New `tests/services/test_5475_compaction_started_moved_to_engine.py`: 2 tests — the controller path carries a real int (no unavailable-reason); the retry_loop-shaped path (a real `compact()` call with wire-dict-shaped `new_turns`, the SAME sentinel `engine.py`'s own retry_loop call site passes) carries the named absence, not a bare null.
- 15 existing test files updated: every direct `engine.compact(...)` call site now passes `covers_through` explicitly. One genuine end-to-end test (`test_4703_compaction_spend_visible.py`) constructs the engine with the SAME `EventLog` the controller/test observe — the emit now lives inside `compact()` itself, so an engine built against a private, disconnected `EventLog` (as it did before) would silently emit into a log nobody watches. `test_compaction_controller_invariants.py`'s own `_make_controller` now takes `engine_factory(events)` rather than a pre-built engine, for the same reason. Every hand-rolled `compact()` override across these files (stand-ins for `retry_loop`'s own engine collaborator) gained a permissive `covers_through=None` keyword param — these test `retry_loop`'s own control flow, not `covers_through` semantics.

## Verification

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — OK, 0 new debt (the missing-argument errors these test-file fixes address were all caught live by mypy/pyright during development)
- [x] `python scripts/test_tier_audit.py --strict` on all touched test files — 129/129 tests, 0 Tier-4 (one structural `len()==1` grep-count assertion was written, correctly flagged as this repo's own "format pinning" Tier-4 shape, and replaced with a module comment documenting the by-hand grep + the strip-falsify pass's own behavioral proof instead)
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/check_collect_events_settle.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_tests_path_literal_reference.py` / `flat_tests_ratchet.py` — all green
- [x] Full `tests/core/ tests/services/ tests/runtime/ tests/llm/` regression sweep: 5845 passed, 8 skipped (missing optional-dependency extras), 1 pre-existing unrelated platform flake (`test_install_command_warns_on_tmp_args_on_darwin` — no reference to `compact()`/`CompactionEngine`/`CompactionController` anywhere in it)
- [x] **Strip-falsify**: temporarily removed the engine's own `compaction_started` emit — both new tests correctly went red (no event at all). Restored; 2/2 green again, no residual diff.
- [x] A real bug found by the full regression sweep (not caught by the narrower per-directory sweeps run first): `test_3783_stage3_invert_default_to_recover.py`'s own `_StubEngineCompactRaises.compact()` silently swallowed the missing-argument `TypeError` into a generic retry-loop error path (`call_count[0] == 0` instead of the expected `3`) — fixed the same way as every other stand-in.

## Test plan

- [x] Automated (see above)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
