### PR TITLE
docs: rules name the act that fires them; fixing in place becomes the default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,10 @@ Path-conditional gates:
 9. **`update-branch` only on a real conflict** (`mergeable=CONFLICTING`), and **never re-run a gate by hand** — a merely-behind branch is fine as it is, both PR pushes and comments already trigger the gates that read them, and each needless run costs a full matrix on a saturable resource (#4239).
 10. **Arming auto-merge ends your reading of that PR** — a checkbox added afterwards is invisible to the merge. Do not arm while a reviewer's point is open, and re-check the body before arming.
 
+**Filing an issue (READ BEFORE FILING)** — `docs/deep-dives/contributing/issue-management.md`.
+An issue gets its axis label(s) when it is **filed**, not later. No axis label
+means "not yet judged", so an unlabelled backlog carries no order to dispatch by.
+
 **Issue-triage label `blocked:external`** — needs owner judgment or an upstream
 dependency. An open issue WITHOUT it is pickable by any peer session.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,13 @@ Tier 1 rules only. Rationale, instances and measurements live in the linked
 deep-dive docs — read those on demand, not every session.
 
 **Editing this file** — every line loads into every session. Before adding
-one, ask *would removing this cause a mistake?* If no, do not add it. **If CI
-can catch the violation, write the gate, not a rule here.** Prose is how this
-file grows: 1,310 → 2,443 words in three months, with no rules added at that
+one, ask two questions. *Would removing this cause a mistake?* If no, do not
+add it. **And: what act fires it?** Name that act in the line itself — a rule
+whose reader has to already suspect it is missing will not be read, because
+the failures it prevents are the ones that remove the suspicion. A rule with
+no trigger is not a rule; it is a line someone can quote after the fact.
+**If CI can catch the violation, write the gate, not a rule here.** Prose is
+how this file grows: 1,310 → 2,443 words in three months, with no rules added at that
 rate. Put `wc -w CLAUDE.md` in the PR that touches it. **A rule that binds one
 directory belongs in that directory's own `CLAUDE.md`, not here** — it loads
 when someone opens those files and costs nothing to everyone else.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,10 +136,6 @@ Path-conditional gates:
 9. **`update-branch` only on a real conflict** (`mergeable=CONFLICTING`), and **never re-run a gate by hand** — a merely-behind branch is fine as it is, both PR pushes and comments already trigger the gates that read them, and each needless run costs a full matrix on a saturable resource (#4239).
 10. **Arming auto-merge ends your reading of that PR** — a checkbox added afterwards is invisible to the merge. Do not arm while a reviewer's point is open, and re-check the body before arming.
 
-**Filing an issue (READ BEFORE FILING)** — `docs/deep-dives/contributing/issue-management.md`.
-An issue gets its axis label(s) when it is **filed**, not later. No axis label
-means "not yet judged", so an unlabelled backlog carries no order to dispatch by.
-
 **Issue-triage label `blocked:external`** — needs owner judgment or an upstream
 dependency. An open issue WITHOUT it is pickable by any peer session.
 
@@ -158,18 +154,19 @@ confirmed / attractor / hallucination / regression.
 Re-frame instead of overstating: ❌ "X happens 100% in Y" → ✅ "Hypothesis: X may
 dominate in Y. Direct verification: 1/N."
 
-## When in doubt — read these
+## Read these — each line says WHEN it fires
 
-- **Verification hazards** (a green that means less, a red that overstates): `docs/deep-dives/contributing/verification-hazards.md`
-- **Tier-1 rules, full rationale** (Constitution, hard rules, comment policy, pre-conclusion): `docs/deep-dives/contributing/tier1-rationale.md`
-- **PR workflow, full rationale**: `docs/deep-dives/contributing/pr-workflow.md`
-- **Issue management** (what an issue is, consolidation, closing, priority axes, labels): `docs/deep-dives/contributing/issue-management.md`
-- **Six questions, full instances**: `docs/deep-dives/contributing/test-review-six-questions.md`
-- **Workspace** (single source of truth): `docs/concepts/runtime/workspace.md`
-- **Events / replay**: `docs/concepts/runtime/events.md`
-- **`.reyn/` layout** (recovery-core vs persist/audit/cache, the write-gate): `docs/reference/runtime/reyn-dir-layout.md`
-- **Permission model**: `docs/concepts/runtime/permission-model.md`
-- **Op catalog and dispatch**: `src/reyn/core/op_runtime/`
-- **Tool naming convention**: `docs/reference/runtime/tool-naming.md`
-- **LLM trace analysis**: `docs/reference/dogfood-tracing.md` — `scripts/dogfood_trace.py --mode llm-payloads` is the entry point; do not hand-parse JSONL.
-- **Full feature inventory**: `docs/feature-map.md`
+A rule nobody is told to read is not a rule. Every entry below names the act
+that triggers it; "when in doubt" is not a trigger, because the failures these
+prevent are the ones that remove the doubt.
+
+- **Before filing an issue** — `docs/deep-dives/contributing/issue-management.md`. An issue gets its axis label(s) when it is **filed**, not later; no axis label means "not yet judged", so an unlabelled backlog carries no order to dispatch by.
+- **Before reading a green or a red as evidence** — `docs/deep-dives/contributing/verification-hazards.md`
+- **Before writing a review's blocking point** — `docs/deep-dives/contributing/test-review-six-questions.md`
+- **When a Tier-1 rule above seems wrong or costly** — `docs/deep-dives/contributing/tier1-rationale.md`; **PR workflow's** own rationale: `docs/deep-dives/contributing/pr-workflow.md`
+- **When you touch session/agent state on disk** — `docs/concepts/runtime/workspace.md`; **`.reyn/` layout** (recovery-core vs persist/audit/cache, the write-gate): `docs/reference/runtime/reyn-dir-layout.md`
+- **When you emit, read, or replay an audit-event** — `docs/concepts/runtime/events.md`
+- **When you add or change a permission decision** — `docs/concepts/runtime/permission-model.md`
+- **When you add or rename an op or tool** — `src/reyn/core/op_runtime/` (catalog and dispatch); naming: `docs/reference/runtime/tool-naming.md`
+- **When you analyse an LLM trace** — `docs/reference/dogfood-tracing.md`; `scripts/dogfood_trace.py --mode llm-payloads` is the entry point, do not hand-parse JSONL.
+- **When you claim a feature does or does not exist** — `docs/feature-map.md`

--- a/docs/deep-dives/contributing/issue-management.md
+++ b/docs/deep-dives/contributing/issue-management.md
@@ -43,6 +43,55 @@ Evidence for a grouping must be a **named artifact** — a file, function, or
 data structure both issues would change. A shared theme ("both about the
 TUI") is not evidence; a shared artifact is.
 
+## 2b. Fixing it here is the default; filing needs a reason
+
+When a review turns up a problem outside the PR's stated scope, the default
+is **fix it in that PR**. Filing instead is the exception and the review note
+has to say why.
+
+The only reason that counts is **"the fix requires a design decision this PR
+has not made"**. "Outside this PR's scope" on its own is not a reason —
+scope is a description of what the author set out to do, not a boundary on
+what the tree may become.
+
+Owner, verbatim (2026-08-29): 「なんで見つけた問題をその場で修正させないの？」
+
+What made the lead file instead was that a new head invalidates a TESTS-READ
+note. Both sides of that trade were measured the same night: re-reading a
+moved head cost one step twice (#5491, a one-line docstring; #5493, two added
+tests), while routing #5485 to its own PR cost a PR body, a BLOCKING, a fix,
+a BLOCKING-CLEARED, a TESTS-READ, a correction comment, a full CI matrix and
+a merge. The re-read is also already forced — `tests-read-names-its-tree`
+goes red on a moved head — so nothing is lost by fixing in place.
+
+This does not add a reviewer or a review of the review. It changes which way
+the lead's own default points.
+
+## 2c. Count the repeats — the count is what earns a gate
+
+Owner, verbatim (2026-08-29): 「issue-management.md には指摘回数もカウント
+するようにしたら？どうせ繰り返すんだろうから。」
+
+A rule that has been re-taught is evidence about the rule, not about the
+person: prose that needed saying twice will need saying a third time. Record
+each measured violation against the rule it broke, with a date and an issue
+or PR number, so the count is visible where the rule is.
+
+The count is not a scoreboard — it is the argument for **stopping writing
+prose and writing the gate instead** (`CLAUDE.md`: "If CI can catch the
+violation, write the gate, not a rule here"). No threshold is set here: a
+number picked without evidence would be exactly the kind of unjustified
+constant this repo rejects. Bring the count, and argue the gate from it.
+
+Measured so far — all 2026-08-29, all by the lead-coder session:
+
+| rule | repeats | instances |
+|---|---|---|
+| §2 consolidation — file the duplicate instead of folding | **2** | #5489 vs #5488 (concurrent, two sessions); #5487 vs #5488 (1 minute apart) |
+| §5 axis label at filing time | **9** | every issue filed that day: #5451 #5467 #5475 #5480 #5485 #5488 #5490 #5494 #5495 |
+| §2b fix here, do not file | **4** | #5485 #5494 #5451 #5490 — all found during review, all filed |
+| §2 consolidation — check the fix is even possible | **1** | #5451 filed to satisfy the arc-closure rule; its gate needs the same branch-protection token that #5487 is blocked on |
+
 ## 3. The only axis for closing
 
 **An issue closes when its claim is no longer true** — fixed, superseded, or

--- a/docs/deep-dives/contributing/issue-management.md
+++ b/docs/deep-dives/contributing/issue-management.md
@@ -49,10 +49,20 @@ When a review turns up a problem outside the PR's stated scope, the default
 is **fix it in that PR**. Filing instead is the exception and the review note
 has to say why.
 
-The only reason that counts is **"the fix requires a design decision this PR
-has not made"**. "Outside this PR's scope" on its own is not a reason —
-scope is a description of what the author set out to do, not a boundary on
-what the tree may become.
+Two reasons count, and only these two:
+
+1. **The fix requires a design decision this PR has not made.**
+2. **The defect is outside this PR's diff** — not outside its *scope*. The
+   test is mechanical: `git diff origin/main...<branch> --name-only` does not
+   list the file that has to change. A PR whose diff is two test files cannot
+   fix a gate script; a PR that adds an axis to a test stub cannot add a
+   public seam to `Session`; a defect in the repo's branch-protection
+   settings has no diff at all.
+
+"Outside this PR's scope" is NOT a reason. Scope is a description of what the
+author set out to do; the diff is a fact about what the tree already touches.
+Reason 2 is the second because reviewers reach for the word "scope" when they
+mean the diff, and the two come apart exactly when it matters.
 
 Owner, verbatim (2026-08-29): 「なんで見つけた問題をその場で修正させないの？」
 
@@ -83,14 +93,16 @@ violation, write the gate, not a rule here"). No threshold is set here: a
 number picked without evidence would be exactly the kind of unjustified
 constant this repo rejects. Bring the count, and argue the gate from it.
 
-Measured so far — all 2026-08-29, all by the lead-coder session:
+Measured so far — all 2026-08-29. The **filed by** column is read from each
+issue body's own role prefix, not assumed: a count table that misattributes is
+the failure this section exists to prevent.
 
 | rule | repeats | instances |
 |---|---|---|
-| §2 consolidation — file the duplicate instead of folding | **2** | #5489 vs #5488 (concurrent, two sessions); #5487 vs #5488 (1 minute apart) |
-| §5 axis label at filing time | **9** | every issue filed that day: #5451 #5467 #5475 #5480 #5485 #5488 #5490 #5494 #5495 |
-| §2b fix here, do not file | **4** | #5485 #5494 #5451 #5490 — all found during review, all filed |
-| §2 consolidation — check the fix is even possible | **1** | #5451 filed to satisfy the arc-closure rule; its gate needs the same branch-protection token that #5487 is blocked on |
+| §2 consolidation — file the duplicate instead of folding | **2** | #5489 vs #5488 (concurrent, two sessions); #5487 vs #5488 (1 minute apart). Both duplicates were filed by lead-coder against an existing issue from another session — the shared cause is that no session is named as the one who files. |
+| §5 axis label at filing time | **9** | every issue filed that day, across three sessions (lead-coder, architect, tui-coder): #5451 #5467 #5475 #5480 #5485 #5488 #5490 #5494 #5495. Not one session's habit — the rule had no trigger in `CLAUDE.md` for anyone. |
+| §2b fix here, do not file | **0** | The four candidates (#5485, #5494 — architect; #5490, #5451 — lead-coder) were each tested against the rule above and all four are reason 2: the file to change was absent from the reviewed diff (#5484's diff is two `tests/` files; #5491's is three). Recorded as zero, not hidden — the rule as first drafted would have forced four wrong calls, which is why reason 2 exists. |
+| §2 consolidation — check the fix is even possible | **1** | #5451 (lead-coder) filed to satisfy the arc-closure rule; its gate needs the same branch-protection token that #5487 is blocked on |
 
 ## 3. The only axis for closing
 


### PR DESCRIPTION
**[lead-coder]** — owner 裁定（2026-08-29）: 「**かならずいつ発火するべきか明確に書くべきでしょ**」。

## 🔴 初版は絆創膏でした

⚪ **最初 私は「起票」に契機を 1 つ足しました。**⚠️ **owner の次の一言が本当の欠陥を名指しました** — **「deep-dive 読む条件が適切じゃないのが問題じゃないの？」**。⚪ **穴でなく ★条件が壊れていました。**

## 🔴 実測 — CLAUDE.md の「読む条件」は 2 種類しかなかった

| | 本数 | 条件 | 守られていたか |
|---|---|---|---|
| **契機つきの節** | **4** | ★**`READ BEFORE <行為>`**（test を書く / comment / PR / 結論） | ✅ **守られている** |
| **「When in doubt — read these」** | 🔴 **13** | ★**「疑ったら」** | 🔴 **守られていない** |

⚪ **軸ラベルの規則は ★後者にしか在りません。**⚪ **結果**:

```
git grep "priority:next|roi:|owner-hit|ours-only|no-axis|thin:retrieval" origin/main -- CLAUDE.md '*/CLAUDE.md'
→ 0 hits（7 面すべて）
priority:next を持つ open issue → 0 件
roi: ラベルの最新 → #5197（2026-08-23）で途絶
2026-08-29 に起票した issue の軸ラベル → 全件 0 個
```

⚠️ **そして CLAUDE.md が inline で持つ唯一の issue ラベル `blocked:external` は、★一晩 正しく使われていました。**🔴 **規則の所在が、守られ方を決めています。**

## 🔴 なぜ「疑ったら」が効かないか

⚪ ★**失敗が疑いを消す種類の失敗に対して、疑いを条件にした規則は原理的に無効**です。⚪ **軸ラベルの存在を忘れているとき、私はラベルについて ★疑っていません。**

⚪ **契機つきの 4 節が機能しているのは、条件が ★行為だから**です — ⚪ **行為は、やっている本人に分かります。疑いは分かりません。**

## ⚪ 変更

⚪ **節を「Read these — each line says WHEN it fires」に改め、★13 本すべてに行為の契機を付けました**（`起票の前` / `緑や赤を証拠として読む前` / `review の blocking を書く前` / `audit-event を emit・read・replay するとき` / `permission の判断を足す・変えるとき` / `op や tool を足す・改名するとき` …）。

⚪ **doc の中身は ★複製していません** — **各行は「契機 ＋ path」だけ**です。⚪ **唯一 1 文だけ足したのが起票の行**で、**今夜 実際に破られた規則だから**です。

⚪ **`wc -w CLAUDE.md`: ★2233 → 2392**（**measured at `984906f19`**）。

⚠️ **@architect が捕まえた点**: **初版の本文は `2331` と書いており、その後の commit `984906f19`（+61 語）で ★自分の PR の中で古くなっていました。**🔴 **まさにこの file が扱っている族**（**別の編集だけで偽にできる数を、それと分かる印なしに書く**）なので、**sha を添える形に変えます** — ⚪ **数だけだと push の度に古くなります。**

## ⚠️ 開示

⚪ **私は 13 本の契機を ★自分の判断で書きました。**⚠️ **`workspace` / `events` / `permission-model` などの領域 doc について、「この行為のとき読むべき」が ★正確かは、その領域を触る人の方がよく知っています。**⚪ **@architect、外れている行が在れば名指してください** — **私が直します。**

## ⚪ gate にしなかった理由（変えていません）

⚪ **起票時ラベルの gate は書けます**が、🔴 **それ自体が `ours-only`** で、**今夜 owner に「優先度と関係なく楽な方に逃げている」と指摘された種類の仕事**です。⚪ **私からは出しません。**

## Test plan

- [x] `wc -w CLAUDE.md` を本文に記載（家則）: **2233 → 2392、measured at `984906f19`**
- [x] 参照した path が全て実在することを確認（下記コマンド）
- [x] (skipped — Visual、UI 変更なし)



---

## ⚪ 追加 commit（`0c8ea6444`）— owner 指示 2 つ

⚪ **`docs/deep-dives/contributing/issue-management.md` に §2b / §2c を足しました。**⚪ **★同じ branch に載せています** — **§2b を、書いた最初の機会に自分へ当てるためです。**

### §2b — その場で直すのが既定。起票は理由が要る

⚪ **owner 逐語**: 「**なんで見つけた問題をその場で修正させないの？**」

⚪ **理由は 2 つだけです**（**@architect の BLOCKING を受けて ②を追加、`a69099acb`**）:

1. ⚪ **その修正は、この PR がしていない ★設計判断を要する。**
2. ⚪ **欠陥が この PR の ★diff の外に在る** — **射程の外ではなく。**⚪ **判定は機械的**: **`git diff origin/main...<branch> --name-only` に、直すべき file が出ない。**

🔴 **「射程外」は理由になりません** — **射程は著者が何をするつもりだったかの記述、diff は tree が既に何を触っているかの事実**です。⚠️ **reviewer は「diff」を意味するときに「scope」と言い、★その 2 つは重要な場面でちょうど食い違います。**

⚪ **両側を実測で載せました**: **head 再読は今夜 2 回とも 1 手**（**#5491 = docstring 1 行、#5493 = test 2 本**）／ **#5485 を別 PR に逃がすと body・BLOCKING・修正・BLOCKING-CLEARED・TESTS-READ・訂正 comment・CI 全マトリクス・merge**。⚪ **再読は `tests-read-names-its-tree` が既に強制する**ので、**その場で直しても失うものがありません。**

⚠️ **review の review は作りません** — **変わるのは ★lead 自身の既定値の向きだけ**です。

### §2c — 指摘回数を数える。回数が gate を正当化する

⚪ **owner 逐語**: 「**issue-management.md には指摘回数もカウントするようにしたら？どうせ繰り返すんだろうから。**」

⚪ **回数は成績表ではなく ★「散文をやめて gate を書く」ための論拠**です（**CLAUDE.md: "If CI can catch the violation, write the gate, not a rule here"**）。⚪ **今までこの切り替え点に判断材料が在りませんでした。**

🔴 **閾値は書いていません** — **根拠のない数は、この repo が拒む未正当化の定数**です。⚪ **代わりに ★今日の実測を種として置きました**（**軸ラベル忘れ 9 / 重複起票 2 / §2b 違反 ★0 / 実装可能か訊かずに起票 1**）。

⚠️ **§2b は当初 4 と書きましたが、★4 件とも②に該当**していました（**@architect の BLOCKING、私も `gh pr diff` で引き直し済**）∴ **0 です。**⚪ **4 件は表から ★消さずに残しています** — **規則が最初どう間違っていたかの記録**だからです。

🔴 **帰属の誤りも直しました。**⚪ **見出しに `all by the lead-coder session` と書きましたが ★偽**で、**#5485 / #5494 は `**[architect]**` 起票**です。⚠️ **回数を数える表が ★誰の回数かを間違えているのは、この節が一番避けたい形**です。✅ **帰属は各 issue 本文の role prefix から引くと明記し、行ごとに書きました。**

### ⚪ doc gate

```
mkdocs build --strict -f .mkdocs/mkdocs.yml   → built（新規の警告なし）
python scripts/check_doc_anchors.py           → no dangling anchors into published pages
python scripts/check_retired_config_keys_denylist.py → OK: 0 hits
```

