### PR TITLE
fix(#5494): hook-event observation seam + run-one-turn helper

### DIFF
--- a/tests/_support/hooks.py
+++ b/tests/_support/hooks.py
@@ -1,0 +1,89 @@
+"""``collect_hook_events`` / ``run_one_turn`` — the hook-event-bus mirror of
+``tests/_support/events.py``'s ``collect_events``/``settle``, for #5494.
+
+architect finding (2026-08-29, while reviewing #5491): a test holding only a
+``Session`` had a public seam for audit events (``subscribe_audit_events``,
+and #5467's own ``collect_events(session)``/``settle(session)``) but NONE
+for hook events, and none for driving exactly one turn from a piece of user
+text — ``run()`` is an unbounded inbox while-loop, ``run_one_iteration()``
+processes exactly one inbox item of a SINGLE kind. Before this, such a test
+had no way to do either except reach ``session._hook_bus.subscribe()`` /
+``session._run_router_loop(...)`` directly — #5470's own production witness
+(``tests/dev/test_llm_stub_tool_call_5470.py``) did exactly that, and is
+this fix's own first migrated consumer.
+
+architect's ruling (#5467's own shape, applied HERE — same conclusion,
+narrower acceptance): production gets NO new public API for either — a
+``Session.subscribe_hook_events()``/``Session.run_one_turn()`` with no real
+production consumer would be a seam manufactured purely for tests, the
+exact shape #5442/#5447/#5443 removed the same night this issue was filed.
+The private reach narrows to the functions in THIS ONE file instead, same
+as ``collect_events``/``settle``'s own ``_resolve_log``.
+
+**Deliberately narrower than ``collect_events``**: :func:`collect_hook_events`
+accepts a ``Session`` ONLY, not also a raw ``HookBus`` (unlike
+``collect_events``'s dual ``EventLog``-or-``Session`` acceptance) —
+architect's explicit correction: accepting more types only grows the
+"which one do I pass" decision a caller has to make, and every current/
+foreseeable caller already holds a ``Session``, never a bare ``HookBus``.
+
+**Population split, not bundled** (architect's own measurement,
+``origin/main``, 2026-08-29): ``_hook_bus`` — 6 files — is small enough to
+seam-and-migrate in ONE PR (this one); ``_run_router_loop`` — 29 files, 85
+sites — is not, so :func:`run_one_turn` is added here (closing the "no
+public 1-turn seam" half of this issue) but its OWN migration is deferred
+to a later PR, the same phase-1/phase-2 split #5467 used (bundling both
+would risk the "#5467 phase 2, two unfinished migrations in parallel"
+shape architect explicitly weighed against).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.hooks.bus import HookBusSubscription
+    from reyn.runtime.session import Session
+
+
+def collect_hook_events(session: "Session") -> "HookBusSubscription":
+    """Subscribe to *session*'s hook-event bus (the ONE place in ``tests/``
+    allowed to read ``session._hook_bus`` for the purpose of subscribing to
+    it — a test may still reach ``session._hook_bus.publish(...)`` directly
+    to DRIVE its own scenario, the same "arrange, not assert" distinction
+    ``tests/_support/events.py``'s own ``_resolve_log`` already relies on).
+
+    Returns ``HookBus``'s own native subscription object (an async context
+    manager with ``get``/``get_nowait`` — see ``reyn.hooks.bus``'s own
+    module docstring) — the SAME shape ``reyn.hooks.composer``/
+    ``composed_consumer`` already use internally as real production
+    subscribers, not an adapted callback list the way ``collect_events``
+    wraps ``EventLog.add_subscriber``. ``HookBus`` has no callback-style
+    registration to wrap; forcing one here would add an internal draining
+    task this module does not otherwise need, purely to look like
+    ``collect_events``.
+
+    *session* only — deliberately narrower than ``collect_events``'s
+    dual ``EventLog``-or-``Session`` acceptance (see module docstring).
+    """
+    return session._hook_bus.subscribe()
+
+
+async def run_one_turn(session: "Session", user_text: str, chain_id: str) -> None:
+    """Run exactly one turn for *user_text* under *chain_id* on *session*
+    (the ONE place in ``tests/`` allowed to read ``session._run_router_loop``
+    for the purpose of driving one turn — same scoping discipline as
+    :func:`collect_hook_events` above).
+
+    Neither ``session.run()`` (an unbounded while-loop draining the
+    session's inbox) nor ``session.run_one_iteration()`` (processes exactly
+    one inbox item of a SINGLE kind) is the shape a test holding only a
+    ``Session`` — no inbox access — needs to drive one turn directly and
+    synchronously to completion. ``_run_router_loop`` is Session's own
+    internal turn-execution seam (already used internally by ``run()``,
+    ``run_one_iteration()``, and ``reyn.runtime.services.inter_agent_
+    messaging``'s several injection points); this wrapper changes none of
+    that seam's behavior, it gives a test a single named place to reach it
+    from, instead of each test file reaching ``session._run_router_loop``
+    on its own.
+    """
+    await session._run_router_loop(user_text, chain_id)

--- a/tests/core/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/core/test_2761_pr2_hotreload_immediate_apply.py
@@ -48,6 +48,7 @@ from reyn.runtime.session_params import CapabilityScope
 from reyn.security.permissions.permissions import PermissionDecl
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events, settle
+from tests._support.hooks import collect_hook_events
 from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ---------------------------------------------------------------------------
@@ -365,9 +366,12 @@ def test_get_active_hot_reloader_is_this_sessions_reloader(
 # H5) is a thin pass-through to that same dispatch call. So the PUBLISH
 # side of this invariant is reachable without session._hook_bus at all;
 # only the SUBSCRIBE side (attaching a raw, deliberately-never-drained
-# subscriber to force the overflow) still needs it — Session publishes no
-# accessor for the bus itself, matching family6b's ①/②'s same "no public
-# route, own construction target" acceptance (docs on that file).
+# subscriber to force the overflow) needed it directly — Session itself
+# still publishes no production accessor for the bus (#5494's own ruling:
+# a production seam manufactured purely for tests was explicitly rejected,
+# the same posture family6b's ①/② already took). #5494 gave tests/_support
+# a narrow test-side seam instead (collect_hook_events(session)), which
+# this test now uses below rather than reaching session._hook_bus itself.
 
 
 @pytest.mark.asyncio
@@ -388,7 +392,7 @@ async def test_hook_bus_emit_event_reaches_session_audit_events(
 
     # HookBus's default subscriber queue is bounded (128), so >128
     # undrained publishes guarantees at least one drop.
-    sub = session._hook_bus.subscribe()
+    sub = collect_hook_events(session)
     try:
         for i in range(200):
             await session.dispatch_external_event("turn_end", {"i": i})

--- a/tests/core/test_5494_hooks_helper.py
+++ b/tests/core/test_5494_hooks_helper.py
@@ -6,6 +6,19 @@ Session-acceptance tests — architect's own bar here is the same: this seam
 works with the exact object a caller who only holds a ``Session`` (no inbox
 access, no internal ``HookBus``/``RouterLoopDriver`` reference) actually
 has. Real ``Session``/``HookBus``/``RouterLoop`` throughout, no mocks.
+
+Load-bearing-ness (lead-coder BLOCKING, PR #5500): NOT pinned via a
+name-absence assert on ``Session`` (``not hasattr(session, "...")``) — that
+shape is inverted (turns red the day a legitimate public seam is added for
+a real consumer) and incomplete (blind to a differently-named seam). Both
+helpers' private reach is instead shown load-bearing by STRIP-FALSIFY,
+performed BY HAND: neutralizing ``collect_hook_events``'s body (raise
+instead of subscribing) turns 3 tests below RED; neutralizing
+``run_one_turn``'s delegate call turns ``test_run_one_turn_drives_the_
+real_router_loop`` RED. Both restored, confirmed GREEN again. See each
+removed test's own comment, at its former location below, for the
+detailed reasoning (same family #5449 already closed the opposite
+direction of — see ``test_5447_doctor_hook_env_single_source.py:24-30``).
 """
 from __future__ import annotations
 
@@ -83,17 +96,26 @@ def test_collect_hook_events_returns_the_hook_bus_own_subscription_type() -> Non
     assert isinstance(sub, HookBusSubscription)
 
 
-def test_session_itself_has_no_public_hook_bus_seam() -> None:
-    """Tier 2: the witness that ``collect_hook_events``'s private-reach
-    branch is load-bearing, not incidental — ``Session`` genuinely has no
-    public method for subscribing to hook events (architect's own ruling:
-    a production seam manufactured purely for tests was explicitly
-    rejected), so the tests above passing is real evidence the helper's
-    OWN private reach ran, never a coincidence of some public alternative
-    already existing."""
-    session = make_session(agent_name="hooks-helper-witness-noise")
-    assert hasattr(session, "_hook_bus")
-    assert not hasattr(session, "subscribe_hook_events")
+# load-bearing-ness witness (lead-coder BLOCKING, PR #5500): a prior version
+# of this file pinned NON-EXISTENCE of a specific method name
+# (`assert not hasattr(session, "subscribe_hook_events")`) as the load-
+# bearing witness for `collect_hook_events`'s private reach. Wrong on two
+# counts (same family #5449 already closed — see test_5447_doctor_hook_
+# env_single_source.py:24-30 — for the opposite direction of the same
+# "what absence means" mistake): (1) inverted — the day a public seam is
+# legitimately added for a real production consumer (architect's own
+# rejection condition was "no consumer TODAY", not "never"), this test
+# turns red and punishes the fixer, not the regression; (2) incomplete —
+# a public seam added under any OTHER name (`hook_events()`,
+# `observe_hooks()`, ...) leaves this assert green while the claim it
+# encodes goes false. Deleted; load-bearing-ness is shown by
+# STRIP-FALSIFY instead (performed by hand, #5500): replacing
+# `collect_hook_events`'s body with `raise RuntimeError(...)` turns the
+# three tests above RED (confirmed); restoring makes them green again.
+# `test_collect_hook_events_returns_the_hook_bus_own_subscription_type`
+# above already covers the "what exists" half safely (asserts the
+# returned object's type, which cannot go stale the way a name-absence
+# check does).
 
 
 # ---------------------------------------------------------------------------
@@ -126,12 +148,11 @@ async def test_run_one_turn_drives_the_real_router_loop() -> None:
     assert any(e.type == "turn_completed" for e in events)
 
 
-def test_session_itself_has_no_public_run_one_turn_seam() -> None:
-    """Tier 2: same discipline as the hook-bus noise guard above —
-    ``Session`` genuinely has no public "run one turn" method; the
-    private reach lives only inside ``run_one_turn`` (this file), never a
-    second copy elsewhere."""
-    from reyn.runtime.session import Session
-
-    assert hasattr(Session, "_run_router_loop")
-    assert not hasattr(Session, "run_one_turn")
+# load-bearing-ness witness: same correction as collect_hook_events's own
+# above (lead-coder BLOCKING, PR #5500) — a name-absence assert on Session
+# would be inverted (turns red the day a legitimate public seam is added)
+# and incomplete (blind to a differently-named one). Load-bearing-ness of
+# `run_one_turn`'s private reach is already shown by strip-falsify, BY
+# HAND, earlier in this arc (documented in the module docstring above):
+# neutralizing the delegate call inside `run_one_turn` turned
+# `test_run_one_turn_drives_the_real_router_loop` RED; restored, GREEN.

--- a/tests/core/test_5494_hooks_helper.py
+++ b/tests/core/test_5494_hooks_helper.py
@@ -1,0 +1,137 @@
+"""Tier 2: #5494 — ``tests/_support/hooks.py``'s ``collect_hook_events``/
+``run_one_turn`` test helpers.
+
+Same skeleton as ``test_3868_collect_events_helper.py``'s own #5467-phase-1
+Session-acceptance tests — architect's own bar here is the same: this seam
+works with the exact object a caller who only holds a ``Session`` (no inbox
+access, no internal ``HookBus``/``RouterLoopDriver`` reference) actually
+has. Real ``Session``/``HookBus``/``RouterLoop`` throughout, no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.emit_hook_event import handle as emit_handle
+from reyn.schemas.models import EmitHookEventIROp
+from reyn.security.permissions.permissions import PermissionDecl
+from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
+from tests._support.hooks import collect_hook_events, run_one_turn
+
+# ---------------------------------------------------------------------------
+# collect_hook_events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_hook_events_observes_a_real_publish() -> None:
+    """Tier 2: witness ① — a subscription obtained via the helper observes
+    a REAL event published onto this session's own hook bus. Effect
+    through the seam (a real op dispatch), never a private peek at
+    ``_hook_bus`` at the assertion site — the private reach lives only
+    inside ``collect_hook_events`` itself."""
+    session = make_session(agent_name="hooks-helper-witness")
+    sub = collect_hook_events(session)
+
+    ctx = OpContext(
+        workspace=None, events=session._audit_events, permission_decl=PermissionDecl(),
+        session_id=session.session_id, hook_bus=session._hook_bus,
+    )
+    op = EmitHookEventIROp(kind="emit_hook_event", event_name="ping")
+    result = await emit_handle(op, ctx)
+    assert result["status"] == "ok"
+
+    event = sub.get_nowait()
+    assert event.kind == f"llm:{session.session_id}:ping"
+
+
+@pytest.mark.asyncio
+async def test_collect_hook_events_strip_falsify_wrong_session_sees_nothing() -> None:
+    """Tier 2: witness ② — strip-falsify by construction (not by editing
+    source) — a subscription obtained for a DIFFERENT session's bus does
+    not see this session's publish, proving the assertion above is
+    load-bearing on the subscription actually being wired to the SAME bus
+    the publish landed on, not merely "some queue got something"."""
+    session_a = make_session(agent_name="hooks-helper-witness-a")
+    session_b = make_session(agent_name="hooks-helper-witness-b")
+    sub_b = collect_hook_events(session_b)
+
+    ctx = OpContext(
+        workspace=None, events=session_a._audit_events, permission_decl=PermissionDecl(),
+        session_id=session_a.session_id, hook_bus=session_a._hook_bus,
+    )
+    op = EmitHookEventIROp(kind="emit_hook_event", event_name="ping")
+    await emit_handle(op, ctx)
+
+    with pytest.raises(asyncio.QueueEmpty):
+        sub_b.get_nowait()
+
+
+def test_collect_hook_events_returns_the_hook_bus_own_subscription_type() -> None:
+    """Tier 1: the returned object is ``HookBus``'s own native subscription
+    shape (the same one ``reyn.hooks.composer``/``composed_consumer``
+    already use internally as real production subscribers) — not adapted
+    into a callback-list shape ``collect_events`` happens to use for a
+    DIFFERENT underlying mechanism (``EventLog.add_subscriber``)."""
+    from reyn.hooks.bus import HookBusSubscription
+
+    session = make_session(agent_name="hooks-helper-witness-type")
+    sub = collect_hook_events(session)
+    assert isinstance(sub, HookBusSubscription)
+
+
+def test_session_itself_has_no_public_hook_bus_seam() -> None:
+    """Tier 2: the witness that ``collect_hook_events``'s private-reach
+    branch is load-bearing, not incidental — ``Session`` genuinely has no
+    public method for subscribing to hook events (architect's own ruling:
+    a production seam manufactured purely for tests was explicitly
+    rejected), so the tests above passing is real evidence the helper's
+    OWN private reach ran, never a coincidence of some public alternative
+    already existing."""
+    session = make_session(agent_name="hooks-helper-witness-noise")
+    assert hasattr(session, "_hook_bus")
+    assert not hasattr(session, "subscribe_hook_events")
+
+
+# ---------------------------------------------------------------------------
+# run_one_turn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_drives_the_real_router_loop() -> None:
+    """Tier 2: ``run_one_turn`` reaches the REAL router loop for real — not
+    merely "the stub was called". A private `run_turn` replacement records
+    what it was invoked with (the same substitution class this repo's
+    testing policy already sanctions — replacing ONLY the LLM-adjacent
+    boundary, not the turn machinery around it), proving `run_one_turn`
+    genuinely drove the call rather than being a no-op wrapper."""
+    session = make_session(agent_name="run-one-turn-helper-witness")
+    events = collect_events(session._audit_events)
+
+    calls: list[str] = []
+
+    async def _record_run_turn(text: str, chain_id: str) -> None:
+        calls.append(text)
+
+    session._loop_driver.run_turn = _record_run_turn  # type: ignore[method-assign]
+
+    await run_one_turn(session, "hello", "run-one-turn-chain")
+    await settle(session._audit_events)
+
+    assert calls == ["hello"]
+    assert any(e.type == "turn_completed" for e in events)
+
+
+def test_session_itself_has_no_public_run_one_turn_seam() -> None:
+    """Tier 2: same discipline as the hook-bus noise guard above —
+    ``Session`` genuinely has no public "run one turn" method; the
+    private reach lives only inside ``run_one_turn`` (this file), never a
+    second copy elsewhere."""
+    from reyn.runtime.session import Session
+
+    assert hasattr(Session, "_run_router_loop")
+    assert not hasattr(Session, "run_one_turn")

--- a/tests/dev/test_llm_stub_tool_call_5470.py
+++ b/tests/dev/test_llm_stub_tool_call_5470.py
@@ -18,6 +18,7 @@ import pytest
 
 from reyn.dev.testing.llm_stub import LLMStub
 from tests._support.agent_session import make_session
+from tests._support.hooks import collect_hook_events, run_one_turn
 
 
 def _no_tool_result_yet(messages: "list[dict]") -> bool:
@@ -182,9 +183,15 @@ async def test_a_real_turn_dispatches_the_tool_call_and_terminates() -> None:
     "the model said nothing", the turn completes with zero tool calls, and
     `sub.get_nowait()` raises `asyncio.QueueEmpty` (RED), proving this
     assertion is load-bearing on the branch actually running, not a
-    tautology."""
+    tautology.
+
+    #5494: this test's own private reach into `session._hook_bus.
+    subscribe()` and `session._run_router_loop(...)` — the exact hole
+    architect found while reviewing this file — is now closed via
+    `tests/_support/hooks.py`'s `collect_hook_events`/`run_one_turn`;
+    migrated here as that fix's own first real consumer."""
     session = make_session(agent_name="tool-call-stub-witness")
-    sub = session._hook_bus.subscribe()
+    sub = collect_hook_events(session)
 
     stub = LLMStub(
         tool_call_for=_no_tool_result_yet,
@@ -193,7 +200,7 @@ async def test_a_real_turn_dispatches_the_tool_call_and_terminates() -> None:
     )
     stub.install()
     try:
-        await session._run_router_loop("hello", "tool-call-chain")
+        await run_one_turn(session, "hello", "tool-call-chain")
     finally:
         stub.restore()
 

--- a/tests/hooks/test_hook_event_bus_0059_phase4a.py
+++ b/tests/hooks/test_hook_event_bus_0059_phase4a.py
@@ -56,6 +56,7 @@ from reyn.hooks.schema import HookDef, PushBlock
 from reyn.runtime.session import Session
 from reyn.runtime.session_params import ReactivityConfig
 from tests._support.agent_session import make_session
+from tests._support.hooks import collect_hook_events
 
 # ---------------------------------------------------------------------------
 # Recording seam (mirrors test_hook_dispatcher_1800_5b.py's _Recorder)
@@ -332,8 +333,8 @@ async def test_per_session_bus_isolation(tmp_path):
     session_a = _make_session(tmp_path, name="a")
     session_b = _make_session(tmp_path, name="b")
 
-    sub_a = session_a._hook_bus.subscribe()
-    sub_b = session_b._hook_bus.subscribe()
+    sub_a = collect_hook_events(session_a)
+    sub_b = collect_hook_events(session_b)
 
     await session_a._hook_dispatcher.dispatch("turn_end", {"chain_id": "from-a"})
 

--- a/tests/runtime/test_4215_hook_bus_bridge.py
+++ b/tests/runtime/test_4215_hook_bus_bridge.py
@@ -34,6 +34,7 @@ from reyn.runtime.session_api import _spawn_pipeline_driver_session
 from reyn.runtime.session_params import PresentationWiring
 from tests._async_wait import wait_until
 from tests._support.agent_session import make_session
+from tests._support.hooks import collect_hook_events
 
 
 def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
@@ -105,13 +106,14 @@ async def test_attached_spawn_bridges_child_hook_events_to_the_parent(tmp_path: 
     # actually register (the public `subscriber_count` surface, reached
     # via `driver._hook_bus` — the established convention roughly 20
     # other tests in this repo already use, since there is no public
-    # `hook_bus` property). This wait doubles as the "a bridge task
-    # started" proof itself — no dedicated public surface needed for
-    # that fact alone.
+    # `hook_bus` property or `subscriber_count` seam — #5494 only closed
+    # the SUBSCRIBE side, via `collect_hook_events` below). This wait
+    # doubles as the "a bridge task started" proof itself — no dedicated
+    # public surface needed for that fact alone.
     try:
         await wait_until(lambda: driver._hook_bus.subscriber_count >= 1)
 
-        async with parent._hook_bus.subscribe() as parent_sub:
+        async with collect_hook_events(parent) as parent_sub:
             probe = HookEvent(
                 kind="builtin:external:test_probe",
                 payload={"marker": "reyn-4215-probe"},


### PR DESCRIPTION
**[e2e-coder]** — Closes #5494.

## What / Why

architect finding while reviewing #5491: a test holding only a `Session` had no public way to (a) observe hook events or (b) drive exactly one turn from a piece of user text — `run()` is an unbounded inbox while-loop, `run_one_iteration()` processes exactly one inbox item of a SINGLE kind. My own #5470 production witness reached `session._hook_bus.subscribe()` and `session._run_router_loop(...)` directly — the exact hole this closes.

## Design (architect's ruling — same shape as #5467, applied here)

NO new production API on `Session` — a seam manufactured purely for tests is exactly what #5442/#5447/#5443 removed the same night this issue was filed. New `tests/_support/hooks.py` gives `collect_hook_events(session)`/`run_one_turn(session, text, chain_id)`, private reach confined to those two functions only — mirrors `_resolve_log`'s own scoping discipline.

Deliberately narrower than `collect_events`: `collect_hook_events` accepts a `Session` ONLY, not also a raw `HookBus` (architect's explicit correction — accepting more types only grows the "which do I pass" decision a caller faces).

I built the opposite design first (genuine `Session` public methods), verified it working end to end, then reverted it cleanly the moment architect's ruling landed — disclosed via broker, no code cost carried into this PR.

## Scope (architect's own measurement, `origin/main`, confirmed by me fresh)

`_hook_bus` — 6 files. `_run_router_loop` — 29 files/85 sites. Per architect's split (small population: bundle seam+migration in one PR; large population: defer), this PR:

- adds both helpers
- migrates all 6 files' 5 real `.subscribe()` call sites (the OBSERVE side) to `collect_hook_events` — the several `.subscriber_count` reads and one `.publish()` call in those same files are a DIFFERENT concern (count polling, scenario-driving), left untouched and disclosed, not silently dropped
- migrates #5470's own file (the one that actually hit both holes) to `run_one_turn`, as this fix's first real consumer
- does NOT migrate the other 28 files/84 remaining `_run_router_loop` sites — deferred to a separate PR, the same phase-1/phase-2 split #5467 used, to avoid the "two unfinished migrations in parallel" risk architect explicitly weighed against

## Verification

Dedicated witnesses (`tests/core/test_5494_hooks_helper.py`, mirrors `test_3868_collect_events_helper.py`'s own skeleton): a real op dispatch observed through the seam; a wrong-session subscription **strip-falsified by construction** (a second real session's bus proves the wiring, not just "some queue got something"); returned-type check (`HookBus`'s own native subscription shape, not a callback-list adapter); accept-side noise guards (`Session` genuinely has neither new method, so the private reach is load-bearing, not incidental).

`run_one_turn` **strip-falsified BY HAND**: neutralized the delegate call inside `tests/_support/hooks.py` → the recorder-replaced `run_turn` never fired → RED, naming exactly why → restored → GREEN.

## Test plan

- [x] `ruff check .` — green
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 51/51 OK
- [x] `python scripts/mypy_ratchet.py` — OK (baselined)
- [x] `python scripts/flat_tests_ratchet.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` / `check_tests_path_literal_reference.py` — all OK
- [x] **Strip-falsify, executed**: `run_one_turn` neutralized → RED → restored → GREEN
- [x] Scoped `pytest` (new helper's own tests + 5 migrated files) — 51 passed
- [x] (skipped — Visual, no TUI surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
