### PR TITLE
fix(#5498): document why retry_loop's own covers_through_seq=0 is harmless

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1797,6 +1797,32 @@ class CompactionEngine:
         # partial-slice remainder it was never offered) — with the echo
         # never read at all, there is nothing left to clamp; #4956/#4951-A
         # closes the exposure at its root instead of bounding its output.
+        #
+        # #5498 (architect ruling, on this exact call site): for
+        # retry_loop's own caller, ``input_chunk.new_turns`` are litellm
+        # wire dicts with no ``seq`` key at all (see ``SeqUnavailable.
+        # WIRE_DICTS_CARRY_NO_SEQ``'s own docstring) — every ``t.get("seq",
+        # 0)`` above falls to its default, so ``covers`` is structurally
+        # 0 on that path. Confirmed harmless by TWO independent facts, not
+        # one:
+        #   (1) retry_loop never persists this ChatSummary to
+        #       ``history.jsonl`` at all (it stays a pure TRANSPORT
+        #       operation — see its own module comment) — a bogus 0 that
+        #       is never written can never be read back wrong.
+        #   (2) for the OTHER caller (CompactionController), a real 0
+        #       here would ALSO be masked — ``compaction_controller.py``'s
+        #       own ``covers = chat_summary.covers_through_seq or
+        #       candidates[-1].seq`` falls back to a real seq whenever
+        #       this value is falsy. That ``or`` was written for a
+        #       DIFFERENT reason (a wrong/empty LLM echo, #4951-A) — it
+        #       was never intended as a defense against THIS 0, but it
+        #       happens to also BE one; do not remove it.
+        # Both facts are load-bearing SEPARATELY — either one alone would
+        # still make this 0 harmless today, so a future change that
+        # removes only one of them (e.g. starts persisting retry_loop's
+        # own summary) needs to re-derive whether the other still holds
+        # before assuming this is still safe. See
+        # tests/services/test_5498_retry_loop_covers_zero_never_persisted.py.
         covers = compute_covers_through_seq(
             [t.get("seq", 0) for t in input_chunk.new_turns if isinstance(t, dict)]
         )

--- a/tests/services/test_5498_retry_loop_covers_zero_never_persisted.py
+++ b/tests/services/test_5498_retry_loop_covers_zero_never_persisted.py
@@ -1,0 +1,130 @@
+"""Tier 2: #5498 — the ``covers_through_seq=0`` `CompactionEngine.compact()`
+structurally produces for `retry_loop`'s own caller (its ``new_turns`` are
+litellm wire dicts with no ``seq`` key — see
+``SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ``'s own docstring, #5475) never
+reaches ``history.jsonl``.
+
+architect ruling (#5498): safety here rests on TWO independent facts —
+(1) `retry_loop` never persists its own `ChatSummary` to history at all
+(a pure TRANSPORT operation), (2) `CompactionController`'s own
+``covers_through_seq or candidates[-1].seq`` masks a real 0 too, for a
+DIFFERENT original reason (#4951-A). A test asserting only "retry_loop's
+compaction produced no summary in history" is green even if
+`history_appender` itself were dead (never called at all) — this file
+puts BOTH paths in the SAME test: the controller path proves a summary
+DOES land in history (the appender is genuinely alive), the retry_loop
+path proves one does NOT, from a real, driven overflow-recovery cycle
+(not a hand-built dict scenario with no real Session to persist into).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.dev.testing.llm_stub import LLMStub
+from tests._support.events import settle
+from tests.runtime.test_5296_pr2_byte_reduction_same_turn_retry import (
+    _ContentDrivenLoop,
+    _make_spill_session,
+    _push,
+)
+
+
+@pytest.mark.asyncio
+async def test_controller_summary_lands_in_history_but_retry_loop_summary_does_not(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: two real, driven paths in one test — the accept-side witness
+    (controller path: a summary DOES land) proves the appender this test
+    depends on for its OWN negative claim is genuinely alive, not merely
+    unreached."""
+    # ── Path 1: CompactionController — a real summary lands in history ──
+    ctrl_session = _make_spill_session(tmp_path, monkeypatch, t_max=7_000)
+    for i in range(30):
+        _push(ctrl_session, "user", f"filler turn {i} " * 40)
+
+    stub = LLMStub()
+    stub.install()
+    try:
+        await ctrl_session._compaction_controller.force_compact_now()
+        await settle(ctrl_session)
+    finally:
+        stub.restore()
+
+    ctrl_summaries = [m for m in ctrl_session.history if m.role == "summary"]
+    assert ctrl_summaries, (
+        "sanity: the controller path must produce a real summary entry — "
+        "if this fails, history_appender itself is dead, and the retry_loop "
+        "side below would pass VACUOUSLY (both prove nothing)"
+    )
+    assert ctrl_summaries[0].meta.get("structured", {}).get("covers_through_seq"), (
+        "the controller path's own summary must carry a real, nonzero "
+        "covers_through_seq — the `or candidates[-1].seq` fallback "
+        "(compaction_controller.py) is what guarantees this"
+    )
+
+    # ── Path 2: retry_loop's own internal compaction — no summary lands ──
+    retry_tmp = tmp_path / "retry"
+    retry_tmp.mkdir()
+    retry_session = _make_spill_session(
+        retry_tmp, monkeypatch, t_max=2_500,
+        max_shrink_iterations=25, recovery_policy="never",
+    )
+    budgets = retry_session._compaction_controller._engine.budgets
+    marker_text = "OVERSIZED_MARKER_5498"
+    marker_tokens = max(1, len(marker_text) // 4)
+    _FILLER_COUNT = 4
+    assert _FILLER_COUNT <= marker_tokens
+    head_tokens = budgets.effective_trigger + budgets.tail_budget + 1_000
+    head_text = "H" * (head_tokens * 4)
+    per_filler_tokens = max(1, budgets.tail_budget // _FILLER_COUNT)
+    filler_text = "F" * (per_filler_tokens * 4)
+
+    calls_seen: "list[bool]" = []
+
+    def _raise_on_marker_content(messages: list) -> bool:
+        has_marker = marker_text in messages[-1].get("content", "")
+        calls_seen.append(has_marker)
+        return has_marker
+
+    stub2 = LLMStub(raise_for=_raise_on_marker_content, cause="byte_limit")
+    stub2.install()
+    try:
+        _push(retry_session, "user", head_text)
+        _push(retry_session, "tool", marker_text, tool_call_id="tc-marker", name="big_tool")
+        for _i in range(_FILLER_COUNT):
+            _push(retry_session, "user", filler_text)
+
+        _seen_first = {"done": False}
+
+        def _fail_only_first(history: list, user_text: str) -> bool:
+            if _seen_first["done"]:
+                return False
+            _seen_first["done"] = True
+            return True
+
+        loop = _ContentDrivenLoop(_fail_only_first)
+        await retry_session._loop_driver._run_with_shrink(
+            loop, "continue please", chain_id="c1",
+        )
+        await settle(retry_session)
+    finally:
+        stub2.restore()
+
+    # Positive engagement witness — retry_loop's own compact() genuinely
+    # ran on real content (not zero calls, which would make the negative
+    # assertion below vacuous the same way an unreached appender would).
+    assert True in calls_seen, (
+        "sanity: retry_loop's own compact() must have actually run against "
+        "the marker content — otherwise the absence check below proves "
+        "nothing"
+    )
+
+    retry_summaries = [m for m in retry_session.history if m.role == "summary"]
+    assert not retry_summaries, (
+        f"retry_loop's own internal compaction must NOT persist a summary "
+        f"to history — it is a pure TRANSPORT operation (see "
+        f"CompactionEngine.compact()'s own #5498 comment); found "
+        f"{len(retry_summaries)} unexpected summary entries"
+    )


### PR DESCRIPTION
**[tui-coder]** — closes #5498.

## What

Documents why `covers_through_seq=0` — which `retry_loop`'s own internal `compact()` calls structurally produce (their `new_turns` are litellm wire dicts with no `seq` key — #5475's own finding) — is harmless, and adds one real, driven witness test.

## Investigated before implementing (posted to the issue thread before writing code)

Consumer trace: **zero observable consumers** of this value in production.

- `retry_loop`'s only production caller (`router_loop_driver.py`'s `_run_with_shrink`) captures only its final response, never the summary.
- `retry_loop` has no `history_appender`/`_append_history` call anywhere in its own body — a real code comment inside it already draws the line: it stays a pure TRANSPORT operation; compaction (the controller's own `_do_compaction`) is the SEMANTIC operation that retires history entries.
- The mutated `summary` is only threaded into `_router_main_call`'s own rendering (`render_summary_for_storage`, which never reads `covers_through_seq` at all).
- `retry_loop`'s own next iteration never reads it back either (`compute_covers_through_seq` only reads `new_turns`, never `previous_summary`).

architect's own independent census (all mentions, not just my needle) confirmed the same conclusion — every real read of `covers_through_seq` is `(latest.meta or {}).get('covers_through_seq', 0)`, from history's own `meta`, never from the `ChatSummary` object directly.

## architect ruling on top of the trace

Safety here rests on **two independent facts**, not one:

1. `retry_loop` never persists this `ChatSummary` at all.
2. For the OTHER caller (`CompactionController`), `compaction_controller.py`'s own `chat_summary.covers_through_seq or candidates[-1].seq` ALSO masks a real 0 — though that `or` was written for a different original reason (#4951-A, a wrong/empty LLM echo). It happens to also be a defense against this, and must not be removed.

## Changes

- `engine.py`: a comment at the exact call site (`compute_covers_through_seq(...)` inside `compact()`) documents both independent safety facts, and points at the witness test below so a future change that starts persisting `retry_loop`'s own summary re-derives whether the OTHER fact still holds before assuming safety.
- New `tests/services/test_5498_retry_loop_covers_zero_never_persisted.py`: **ONE test, two real driven paths** (architect's own prescription — a test asserting only absence is green even if `history_appender` is dead). Path 1 (`CompactionController`, real `force_compact_now`) proves a summary DOES land in history with a real nonzero `covers_through_seq` — the accept-side sanity that makes the negative claim below meaningful. Path 2 (`retry_loop`, driven via the real `RouterLoopDriver._run_with_shrink` through a genuine overflow-then-recover cycle, same construction `test_5296_pr2_byte_reduction_same_turn_retry.py`'s own witness uses) proves no summary lands, with its own positive engagement witness (the marker content actually reached `compact()` at least once) so the absence check cannot pass vacuously either.

## Verification

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — OK
- [x] `python scripts/test_tier_audit.py --strict` — 1/1, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_tests_path_literal_reference.py` / `flat_tests_ratchet.py` / `check_collect_events_settle.py` — all green
- [x] `pytest tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py tests/services/test_5498_retry_loop_covers_zero_never_persisted.py tests/services/test_5475_compaction_started_moved_to_engine.py tests/runtime/test_compaction_controller_invariants.py` — 18/18 green together
- [x] **Strip-falsify, both directions**: (1) temporarily appended a fake `"summary"`-role `ChatMessage` to the retry_loop session's history right before the negative assertion — correctly failed with the exact "unexpected summary entries" message. (2) temporarily disabled the overflow trigger so `retry_loop`'s `compact()` never ran — the positive engagement witness correctly failed first, proving the negative check was never reached vacuously. Both restored; 1/1 green again, no residual diff.

## Test plan

- [x] Automated (see above)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
