### PR TITLE
fix(#5522): review gate marker parse failures are no longer silent, and 2 gates now agree on backtick decoration

### DIFF
--- a/scripts/check_blocking_has_reread_note.py
+++ b/scripts/check_blocking_has_reread_note.py
@@ -131,12 +131,24 @@ def _is_reread_note(first_line: str) -> bool:
 
 
 def _has_blocking_comment(comment_bodies: "list[str]") -> bool:
-    """True iff ANY comment's first line matches the `BLOCKING (head <sha>)`
-    shape (reused from `check_open_blocking_checkboxes.py` — the same form
-    check that excludes prose merely discussing the word, #5318's own
-    false-positive fix)."""
+    """True iff ANY comment's first non-empty line matches the `BLOCKING
+    (head <sha>)` shape (reused from `check_open_blocking_checkboxes.py`
+    — the same form check that excludes prose merely discussing the
+    word, #5318's own false-positive fix).
+
+    #5522: reads `_blocking._first_nonempty_line`/`_undecorated`, not
+    the old `_first_line` (renamed) with no decoration-stripping — this
+    gate shares the EXACT same real incident #5522 fixed one level up:
+    a BLOCKING comment whose SHA was backtick-wrapped would make
+    `_BLOCKING_MARKER` not match here EITHER, so THIS gate would
+    silently conclude "no BLOCKING comment on this PR" and skip its own
+    TESTS-READ/RE-READ requirement entirely — the #5453 protection
+    quietly opting itself out on the exact same decoration that broke
+    the gate it is layered on top of."""
     return any(
-        _blocking._BLOCKING_MARKER.search(_blocking._first_line(body))
+        _blocking._BLOCKING_MARKER.search(
+            _blocking._undecorated(_blocking._first_nonempty_line(body)),
+        )
         for body in comment_bodies
     )
 

--- a/scripts/check_open_blocking_checkboxes.py
+++ b/scripts/check_open_blocking_checkboxes.py
@@ -34,7 +34,7 @@ points on every PR that follows the existing convention and pass
 vacuously — closing the deletion bypass by opening a much bigger one
 (silence via omission, on 100% of PRs, not the rare deliberate edit).
 
-## The two conditions, both required (A ∨ B)
+## The three conditions (A ∨ B ∨ C)
 
 **Condition A (comment)**: a comment whose first line matches the
 `BLOCKING (head <sha>)` shape is unresolved unless some LATER comment's
@@ -59,6 +59,28 @@ rewrite that removes the line entirely satisfies neither B-1 (not open)
 nor B-2 (not checked, there is nothing left to check). A alone lets
 omission through (see above). Only A ∨ B closes what #5311 measured
 without opening a new hole in the direction just closed.
+
+**Condition C (near-miss, #5522)**: a comment whose FIRST NON-EMPTY LINE
+names `BLOCKING`/`BLOCKING-CLEARED` but does not parse as either marker
+regex is RED — a THIRD failure mode neither A nor B could see. Real
+incident (lead-coder, 2026-08-29): a BLOCKING comment's first line read
+``**BLOCKING (head `9862413f0`)**`` — the backtick around the SHA broke
+`_BLOCKING_MARKER`'s match, and the gate said nothing at all for 12
+minutes; the PR only stayed red by the accident of an unrelated
+BLOCKING from a different reviewer. Before #5522, "no marker on this
+comment" and "a marker written wrong" were the same silence — condition
+C makes the second one loud. Scoped to the SAME first-non-empty-line
+surface condition A's own regexes read (never the whole body — a
+mid-body mention, including this docstring's OWN repeated use of the
+word, must never trip it).
+
+Same PR (#5522) also strips backtick/`*` decoration from a line before
+either marker regex runs (`_undecorated`) — the root cause of the
+specific incident above, not just its silence. Aligns this gate with
+`check_tests_read_names_its_tree.py`'s own already-permissive `_SHA`
+regex (architect ruling: "許容側が自然" — people decorate SHAs and
+keywords by hand, a machine stripping it once is cheaper than asking
+every writer never to).
 
 ## What this does NOT buy (disclosed, not hidden)
 
@@ -145,6 +167,40 @@ _CHECKED_BLOCK = re.compile(r"^[ \t]*[-*+][ \t]*\[[xX]\][ \t]*(?:\*\*[ \t]*)*�
 _BLOCKING_MARKER = re.compile(r"\bBLOCKING(?!-CLEARED)\s*\(\s*head\s+([0-9a-fA-F]{7,40})\s*\)")
 _CLEARED_MARKER = re.compile(r"\bBLOCKING-CLEARED\s*\(\s*head\s+([0-9a-fA-F]{7,40})\s*\)")
 
+#: #5522 — a bare word check, deliberately NOT anchored to the marker's own
+#: "(head <sha>)" shape: this is what NEAR-MISS DETECTION runs against, so
+#: it must catch exactly the cases the marker regexes above miss. Matches
+#: inside "BLOCKING-CLEARED" too (the `-` after "BLOCKING" is a non-word
+#: char, satisfying `\b` on both sides of the bare word) — deliberate, not
+#: an oversight: a decorated BLOCKING-CLEARED that fails _CLEARED_MARKER
+#: must ALSO be caught, and this one check does both without a second
+#: pattern. Case-sensitive, matching the marker regexes' own
+#: IGNORECASE-dropped posture (module docstring: prose is more likely to
+#: write "blocking" lowercase than a deliberate marker is).
+_BARE_WORD = re.compile(r"\bBLOCKING\b")
+
+#: #5522 (architect ruling on the issue thread): markdown decoration —
+#: backtick code-spans and `**`/`*` emphasis — is stripped from a line
+#: BEFORE either marker regex runs against it, aligning this gate's
+#: previously-strict posture with `check_tests_read_names_its_tree.py`'s
+#: own already-permissive one (that gate's `_SHA` regex tolerates a
+#: backtick between "head" and the hex run structurally; this one's
+#: `\s*` did not). "Align to the permissive side" (architect, quoting
+#: the reasoning): people decorate SHAs and keywords when they write by
+#: hand (lead-coder's own #5517 BLOCKING, architect's own separate
+#: instance, both real, both this same night) — a machine stripping
+#: decoration once is cheaper than asking every human writer never to.
+#: Precedent: `check_claude_md_doc_overlap.py` (#4928) already strips
+#: markdown decoration before tokenizing for the same reason. Neither
+#: a SHA nor the BLOCKING/BLOCKING-CLEARED keywords themselves ever
+#: contain a backtick or asterisk, so stripping cannot turn a
+#: non-marker line into a false-positive match.
+_DECORATION = re.compile(r"[`*]")
+
+
+def _undecorated(line: str) -> str:
+    return _DECORATION.sub("", line)
+
 
 def _normalize(text: str) -> str:
     """Whitespace-collapsed, stripped — the same "normalization is space-
@@ -153,8 +209,21 @@ def _normalize(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
-def _first_line(text: str) -> str:
-    return text.split("\n", 1)[0]
+def _first_nonempty_line(text: str) -> str:
+    """The comment's first non-empty line — the SAME scope both the
+    marker regexes and #5522's near-miss check read (architect ruling:
+    "marker規則が既に読んでいる面と同じ面に限る" — near-miss detection
+    must never widen the surface a formal marker match already uses,
+    or it would fire on prose anywhere the marker regex is not also
+    looking). A literal ``text.split("\\n", 1)[0]`` (this function's
+    pre-#5522 shape) would silently miss a comment that opens with a
+    blank line before its marker — a real gap this rename also closes,
+    not just the near-miss feature's own scoping."""
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
 
 
 def _identifying_line(comment_body: str) -> str:
@@ -226,13 +295,13 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     # an unresolved point with no deliberate action at all, worse than
     # the deletion bypass #5311 measured.
     for i, blocking_body in enumerate(comment_bodies):
-        blocking_match = _BLOCKING_MARKER.search(_first_line(blocking_body))
+        blocking_match = _BLOCKING_MARKER.search(_undecorated(_first_nonempty_line(blocking_body)))
         if not blocking_match:
             continue
         identifying = _identifying_line(blocking_body)
         resolved = False
         for later_body in comment_bodies[i + 1:]:
-            cleared_match = _CLEARED_MARKER.search(_first_line(later_body))
+            cleared_match = _CLEARED_MARKER.search(_undecorated(_first_nonempty_line(later_body)))
             if not cleared_match:
                 continue
             cleared_sha = cleared_match.group(1)
@@ -250,6 +319,42 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
                 f"'BLOCKING-CLEARED (head {head[:9] or '<sha>'})' whose body "
                 "contains that line."
             )
+
+    # Condition C (#5522) — near-miss detection. lead-coder's own real
+    # incident: a BLOCKING comment's first line read
+    # "**BLOCKING (head `9862413f0`)**" — the backtick around the SHA
+    # made `_BLOCKING_MARKER` NOT match, and the gate said nothing at
+    # all for 12 minutes; the PR only stayed red because of an
+    # UNRELATED BLOCKING from another reviewer. "Marker not found" and
+    # "marker written wrong" were indistinguishable failure modes.
+    #
+    # Scope is deliberately the SAME first-non-empty-line surface
+    # condition A's own marker regexes read — never the whole comment
+    # body (architect ruling: "契機を『本文にBLOCKINGの語が在る』にしな
+    # いでください — 形式を論じる散文が全部鳴ります", concretely this
+    # issue's OWN body and #5517's review comments, both of which
+    # discuss the word "BLOCKING" without ever intending it as a
+    # marker). A near-miss is real only when the word appears on the
+    # SAME line a marker would have to be on to be read at all.
+    for comment_body in comment_bodies:
+        first_line = _first_nonempty_line(comment_body)
+        if not first_line:
+            continue
+        undecorated_first_line = _undecorated(first_line)
+        if not _BARE_WORD.search(undecorated_first_line):
+            continue  # no BLOCKING/BLOCKING-CLEARED word on this line at all
+        if _BLOCKING_MARKER.search(undecorated_first_line) or _CLEARED_MARKER.search(
+            undecorated_first_line,
+        ):
+            continue  # a real marker, already handled by condition A above
+        findings.append(
+            "RED (near-miss) — a comment's first line names BLOCKING/"
+            "BLOCKING-CLEARED but does not parse as the marker shape "
+            f"'BLOCKING(-CLEARED) (head <sha>)': {first_line!r}. This "
+            "comment was NOT read as a blocking point or a clear — if "
+            "you meant it as one, fix the shape; if you meant prose "
+            "discussing the word, keep it off the comment's first line."
+        )
 
     if findings:
         return 1, findings

--- a/tests/scripts/test_check_open_blocking_checkboxes.py
+++ b/tests/scripts/test_check_open_blocking_checkboxes.py
@@ -183,6 +183,177 @@ def test_cleared_with_different_wording_does_not_resolve() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Condition C — near-miss detection + decoration-stripping (#5522)
+# ---------------------------------------------------------------------------
+
+
+def test_backtick_decorated_sha_now_matches_and_resolves() -> None:
+    """Tier 1: LOAD-BEARING — the real incident (lead-coder, #5517,
+    2026-08-29): a BLOCKING comment's first line read
+    ``**BLOCKING (head `9862413f0`)**`` — the backtick around the SHA
+    broke the pre-#5522 regex, so the gate saw no BLOCKING comment at
+    all and stayed silent for 12 minutes. Decoration is now stripped
+    before matching, so this now parses as a real marker AND (with a
+    matching CLEARED comment) resolves — the single-factor flip #5522's
+    own acceptance criterion names."""
+    code, _ = evaluate(_pr(
+        "",
+        comments=[
+            f"**[lead-coder]** — **BLOCKING (head `{_HEAD}`)**\nThe cache invalidation is missing.",
+            f"**[architect]** — BLOCKING-CLEARED (head {_HEAD})\nThe cache invalidation is missing.",
+        ],
+    ))
+    assert code == 0, "a decorated marker with a matching CLEARED comment must now resolve"
+
+
+def test_undecorated_form_of_the_same_comment_also_resolves() -> None:
+    """Tier 1: negative control for the test above — the SAME comment,
+    written without decoration, already worked pre-#5522 and must keep
+    working (this PR only ADDS tolerance, never narrows the accepted
+    shape)."""
+    code, _ = evaluate(_pr(
+        "",
+        comments=[
+            f"**[lead-coder]** — BLOCKING (head {_HEAD})\nThe cache invalidation is missing.",
+            f"**[architect]** — BLOCKING-CLEARED (head {_HEAD})\nThe cache invalidation is missing.",
+        ],
+    ))
+    assert code == 0
+
+
+def test_decorated_blocking_with_no_cleared_comment_fails_via_condition_a() -> None:
+    """Tier 1: a decorated BLOCKING comment with no CLEARED counterpart
+    at all now parses as a real marker (condition A fires, not just
+    condition C's near-miss) — matching the un-decorated case's own
+    behavior exactly."""
+    code, _ = evaluate(_pr(
+        "",
+        comments=[f"**BLOCKING (head `{_HEAD}`)**\nThe cache invalidation is missing."],
+    ))
+    assert code != 0
+
+
+def test_near_miss_single_factor_flip_malformed_is_red_fixed_is_green() -> None:
+    """Tier 1: LOAD-BEARING — #5522's own acceptance criterion ①, the
+    single-factor flip. A missing paren (a real typo shape, not
+    decoration `_undecorated` would strip — backtick/`*` decoration now
+    parses as a real marker after #5522's other fix, see the two tests
+    above, so it can no longer demonstrate near-miss in isolation) makes
+    the marker unrecognized: RED (near-miss). Adding ONLY the missing
+    paren, nothing else, makes the SAME comment GREEN once resolved by
+    a matching CLEARED comment."""
+    malformed_code, malformed_lines = evaluate(_pr(
+        "",
+        comments=[
+            f"**[x]** — BLOCKING (head {_HEAD}\nSome point.",  # missing closing paren
+            f"**[x]** — BLOCKING-CLEARED (head {_HEAD})\nSome point.",
+        ],
+    ))
+    assert malformed_code != 0
+    assert any("near-miss" in line for line in malformed_lines), (
+        f"expected a near-miss finding -- got {malformed_lines!r}"
+    )
+
+    fixed_code, _ = evaluate(_pr(
+        "",
+        comments=[
+            f"**[x]** — BLOCKING (head {_HEAD})\nSome point.",  # paren added -- the ONE flipped factor
+            f"**[x]** — BLOCKING-CLEARED (head {_HEAD})\nSome point.",
+        ],
+    ))
+    assert fixed_code == 0, "the SAME comment, only the missing paren added, must resolve"
+
+
+def test_near_miss_fires_specifically_not_just_condition_a_reusing_the_message() -> None:
+    """Tier 1: LOAD-BEARING falsification — the near-miss finding must
+    be distinguishably present (not just "some RED reason or other").
+    A decorated marker with NO sha-shaped hex run near "head" at all
+    (so it could never have parsed as a real marker even undecorated)
+    still gets flagged, proving condition C's own word-not-marker check
+    fires independently of condition A's marker-vs-no-marker logic."""
+    code, lines = evaluate(_pr(
+        "", comments=["**[x]** — **BLOCKING** (head `not-hex-at-all`)\nSome point."],
+    ))
+    assert code != 0
+    assert any("near-miss" in line for line in lines), (
+        f"expected a near-miss finding in the output -- got {lines!r}"
+    )
+
+
+def test_bare_word_on_first_line_with_no_sha_at_all_is_a_near_miss() -> None:
+    """Tier 1: a first line that says "BLOCKING" (uppercase, matching
+    the marker's own case-sensitivity) with nothing resembling `(head
+    <sha>)` at all — not a decoration problem, just no marker shape —
+    is still a near-miss, not silence: the word signals INTENT even
+    without a well-formed marker."""
+    code, lines = evaluate(_pr(
+        "", comments=["**[x]** — BLOCKING, needs a fix here."],
+    ))
+    assert code != 0
+    assert any("near-miss" in line for line in lines)
+
+
+def test_lowercase_blocking_in_prose_is_not_a_near_miss() -> None:
+    """Tier 1: deny-side sibling for the WORD check itself — lowercase
+    "blocking" (ordinary prose, case-sensitivity matches the marker
+    regexes' own IGNORECASE-dropped posture) does not trigger condition
+    C. Mirrors test_prose_mentioning_blocking_with_no_sha_is_not_a_raise
+    for condition A."""
+    code, lines = evaluate(_pr(
+        "", comments=["**[x]** — my blocking is closed, thanks."],
+    ))
+    assert code == 0
+    assert not any("near-miss" in line for line in lines)
+
+
+def test_blocking_word_only_in_the_middle_of_the_body_is_not_a_near_miss() -> None:
+    """Tier 1: LOAD-BEARING — #5522's own deny-side sibling requirement,
+    verbatim: "本文の途中にBLOCKINGを含むだけのcommentはnear-missにし
+    ない". A comment whose FIRST line is unrelated prose, with the word
+    BLOCKING appearing only later in the body, must not be flagged —
+    condition C is scoped to the same first-non-empty-line surface
+    condition A's own regexes read, never the whole body. This issue's
+    OWN body (architect named it explicitly) is the real-world instance
+    of this shape."""
+    code, lines = evaluate(_pr(
+        "",
+        comments=[
+            "**[x]** — Thanks for the fix, LGTM overall.\n\n"
+            "One note: the old BLOCKING gate implementation had a similar issue.",
+        ],
+    ))
+    assert code == 0
+    assert not any("near-miss" in line for line in lines)
+
+
+def test_blocking_cleared_word_alone_with_no_sha_is_also_a_near_miss() -> None:
+    """Tier 1: the bare-word check also catches a decorated/malformed
+    BLOCKING-CLEARED attempt, not just BLOCKING — `_BARE_WORD` matches
+    inside "BLOCKING-CLEARED" too (the hyphen is a word boundary)."""
+    code, lines = evaluate(_pr(
+        "", comments=["**[x]** — BLOCKING-CLEARED, see above."],
+    ))
+    assert code != 0
+    assert any("near-miss" in line for line in lines)
+
+
+def test_a_real_marker_never_also_reports_as_a_near_miss() -> None:
+    """Tier 1: a comment that DOES parse as a real marker (condition A)
+    must never ALSO be reported as a near-miss — the two are mutually
+    exclusive by construction (near-miss only fires when the marker
+    regex does NOT match)."""
+    code, lines = evaluate(_pr(
+        "",
+        comments=[
+            f"**[x]** — BLOCKING (head {_HEAD})\nSome point.",
+            f"**[x]** — BLOCKING-CLEARED (head {_HEAD})\nSome point.",
+        ],
+    ))
+    assert code == 0
+    assert not any("near-miss" in line for line in lines)
+
+
+# ---------------------------------------------------------------------------
 # Fail-closed / CLI plumbing (unchanged shape from #5135)
 # ---------------------------------------------------------------------------
 
@@ -214,3 +385,48 @@ def test_fixture_cli_supports_both_states(tmp_path) -> None:
     assert main(["--fixture", str(fixture)]) == 0
     fixture.write_text(json.dumps(_pr("- [ ] 🔴 todo")), encoding="utf-8")
     assert main(["--fixture", str(fixture)]) != 0
+
+
+# ---------------------------------------------------------------------------
+# #5522 acceptance point ② — TESTS-READ and BLOCKING treated the same
+# ---------------------------------------------------------------------------
+
+
+def test_tests_read_and_blocking_markers_both_survive_the_same_decoration() -> None:
+    """Tier 1: LOAD-BEARING — #5522's own acceptance criterion, verbatim:
+    "TESTS-READ と BLOCKING を同じ扱いにする test (どちらも掴む)". Before
+    #5522, `check_tests_read_names_its_tree.py`'s SHA extraction already
+    tolerated a backtick between the marker word and the hex run
+    (structurally — its hex-boundary pattern never required strict
+    adjacency to any literal character); `check_open_blocking_checkboxes.
+    py`'s marker did not (the real incident this issue fixes). Both must
+    now recognise the SAME backtick-decorated shape — driven entirely
+    through each module's own PUBLIC surface (`evaluate`/
+    `find_note_shas`), never a private regex object."""
+    import scripts.check_tests_read_names_its_tree as _tests_read
+
+    sha = "9862413f0abc123"
+
+    # BLOCKING side, via the real public evaluate() — a decorated marker
+    # WITH a matching CLEARED comment must resolve (green), the same
+    # single-factor-flip claim test_backtick_decorated_sha_now_matches_
+    # and_resolves already isolates in more detail; this test's own job
+    # is only the cross-gate comparison below.
+    blocking_code, _ = evaluate(_pr(
+        "",
+        comments=[
+            f"**[x]** — **BLOCKING (head `{sha}`)**\nSome point.",
+            f"**[x]** — BLOCKING-CLEARED (head {sha})\nSome point.",
+        ],
+        head=sha,
+    ))
+    assert blocking_code == 0, "decorated BLOCKING must resolve via the public evaluate() surface"
+
+    # TESTS-READ side, via the real public find_note_shas().
+    decorated_tests_read_line = f"**[x]** — TESTS-READ (head `{sha}`)"
+    found_shas = _tests_read.find_note_shas(decorated_tests_read_line, known_oids=[sha])
+    assert sha in found_shas, (
+        f"TESTS-READ's own public SHA extraction must recognise the SAME "
+        f"decorated SHA the BLOCKING gate's public evaluate() now does -- "
+        f"got {found_shas!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #5522. #5522 stays open per lead-coder's
merge-authority protocol.

## What

`check_open_blocking_checkboxes.py` now (①) flags a "near-miss" —
a comment whose first line names BLOCKING/BLOCKING-CLEARED but does
not parse as the marker shape — RED instead of silence, and (②) strips
backtick/`*` decoration before matching, aligning it with
`check_tests_read_names_its_tree.py`'s own already-permissive
behavior. Design fully specified by architect (issuecomment-5462415636),
no design judgment left to make.

## The real incident this closes

lead-coder's own BLOCKING on #5517 read `**BLOCKING (head
\`9862413f0\`)**` on its first line — the backtick around the SHA broke
the marker regex, and the gate concluded "no BLOCKING comment" and
stayed silent for 12 minutes. The PR only stayed red by the accident of
an unrelated BLOCKING from a different reviewer.

## A third, connected consumer found while implementing

`check_blocking_has_reread_note.py` (#5453) reaches into
`check_open_blocking_checkboxes.py`'s private `_BLOCKING_MARKER`/
`_first_line` directly to detect "does this PR carry a BLOCKING
comment at all". The SAME decoration bug would ALSO make #5453's own
gate silently conclude "no BLOCKING comment" and skip its TESTS-READ/
RE-READ requirement entirely — the #5453 protection quietly opting
itself out on the exact same input that broke the gate it sits on top
of. Updated to the renamed/decoration-aware helpers.

## Changes

- `scripts/check_open_blocking_checkboxes.py`: `_first_line` →
  `_first_nonempty_line` (also closes a real, separate gap: a literal
  line-0 read silently missed a comment opening with a blank line);
  new `_undecorated` (strips `` ` ``/`*` before matching); new
  condition C (near-miss), scoped to the SAME first-non-empty-line
  surface the marker regexes themselves read — never the whole body
  (this issue's own body, and #5517's review comments discussing the
  word "BLOCKING", are the real-world instances a body-wide trigger
  would have falsely flagged).
- `scripts/check_blocking_has_reread_note.py`: `_has_blocking_comment`
  updated to the renamed/decoration-aware helpers.
- `tests/scripts/test_check_open_blocking_checkboxes.py`: 11 new
  tests — both #5522 acceptance directions, the near-miss
  single-factor flip (isolated from the decoration fix using a
  malformed-paren shape backtick-stripping alone cannot rescue — a
  backtick-decorated example now correctly parses as a REAL marker
  after fix ②, so it can no longer demonstrate near-miss in
  isolation), the deny-side sibling (mid-body-only mention is never a
  near-miss), and a cross-gate symmetry test proving both gates now
  agree on the same decorated SHA — driven entirely through public
  functions (`evaluate`/`find_note_shas`), never a private regex
  object (caught + fixed a Tier-4 private-state flag on my own first
  draft of this test).

## Verification

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — OK
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_open_blocking_checkboxes.py tests/scripts/test_check_blocking_has_reread_note_5453.py` — 32/32, 0 Tier-4
- [x] `verify_module_docstrings` / `check_bare_tests_import_reference` / `check_file_depth_reference` / `check_subprocess_reyn_pin` / `check_tests_path_literal_reference` / `flat_tests_ratchet` — all green
- [x] `pytest tests/scripts/` full sweep — 1089/1089
- [x] Strip-falsify, both fixes independently: reverted condition C entirely — exactly the 4 near-miss-specific tests failed, all else green. Reverted `_undecorated` to a no-op — exactly the 1 decoration-resolves test failed, all near-miss tests (designed decoration-independent) stayed green. Both restored; full suite green again.

## Test plan

- [x] Automated (see above)
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
