### PR TITLE
fix(#5531): compaction messages preserve chronological order on head-side growth

### DIFF
--- a/src/reyn/prompt/compaction.py
+++ b/src/reyn/prompt/compaction.py
@@ -13,24 +13,45 @@ from __future__ import annotations
 #       overflow-retry loop) — the primary rolling-summary system prompt.
 # WHERE: reyn.services.compaction.engine — measured once at engine init
 #        (T_comp_SP) and sent as the sole system message of the compaction call.
-# WHY: PR-N6 — strengthened with an immutable-base + verbatim-preservation
-#      contract so the LLM appends to (never rewrites) previous_summary, and
-#      preserves file paths / line numbers / commit hashes / decision ids
-#      verbatim rather than paraphrasing them away.
+# WHY: #5531 (owner design dialogue) — the invariant is that a summary
+#      represents ONE continuous span, placed exactly where that span
+#      sat in time; the OLD "previous_summary is an immutable base you
+#      append new_turns onto" framing hard-coded ONE direction (new
+#      content always chronologically AFTER previous_summary) which is
+#      false whenever content is added from the OLDER side (retry_loop's
+#      own head-shrink path, #5531 condition C) — the input is now a
+#      single ORDERED `messages` array (an already-compacted summary is
+#      just one element, marked `role: "summary"`, condition④) so
+#      whichever direction content was added from, the array's own
+#      position already encodes the correct order — no separate framing
+#      to keep in sync with it. Preserves file paths / line numbers /
+#      commit hashes / decision ids verbatim rather than paraphrasing
+#      them away (unchanged from before #5531).
 # 日本語訳: 通常のロールング要約呼び出しで使う主システムプロンプト。
-#      previous_summary を不変の土台として扱い追記のみ許可し、パス・行番号・
-#      コミットハッシュ・決定識別子等は要約せず逐語的に保持させる。
+#      #5531: previous_summary は「不変の土台」ではなく、順序付き
+#      messages 配列の中の1要素(role="summary")として渡される — 配列の
+#      並び自体が正しい時系列を表すので、追記方向を決め打ちしない。
+#      パス・行番号・コミットハッシュ・決定識別子等は要約せず逐語的に
+#      保持させる(#5531以前と不変)。
 COMPACTION_SYSTEM_PROMPT = """\
 You are summarising a chunk of chat history into a structured rolling summary.
 
-CRITICAL — previous_summary handling:
-Treat `previous_summary` as an IMMUTABLE BASE. You MUST NOT re-summarise,
-rephrase, or modify any content already present in `previous_summary`.
-Your only task is to APPEND new information from `new_turns` to it.
-If `previous_summary` is null, start fresh from `new_turns`.
+INPUT SHAPE:
+`messages` is a single ORDERED array, oldest-first, of the exact chat span
+to summarise. Most elements are ordinary turns. AT MOST ONE element may
+instead be an ALREADY-COMPACTED summary, identified by `"role": "summary"`
+— its position in the array is where it chronologically belongs (it may be
+first, last, or anywhere among the turns; do not assume a fixed position).
 
-Fold the new_turns into the previous_summary (or start fresh if null).
-Produce a JSON object with these keys:
+CRITICAL — already-compacted content handling:
+Any element with `"role": "summary"` is an IMMUTABLE, ALREADY-CONDENSED
+representative of its own span. You MUST NOT re-summarise, rephrase, or
+drop content already present in it — incorporate it into your output AS
+IS, in its own place in the sequence. Every OTHER element (an ordinary
+turn) is new content you ARE summarising for the first time.
+
+Produce ONE summary spanning the entire ordered `messages` sequence.
+Output a JSON object with these keys:
   topic_arc         — 1-3 sentences on the current topic. Update when topic shifts.
   decisions         — array of bullet strings for choices made. Drop oldest minor ones if over cap.
   pending           — array of open items (questions, tasks, follow-ups). Remove resolved items.

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -29,6 +29,7 @@ from reyn.services.compaction.engine import (
     HistoryChunkToCompact,
     trim_head,
     trim_tail,
+    wrap_summary_as_message,
 )
 
 # #1820 Part1: static reference-only preamble prepended to every rendered
@@ -392,9 +393,18 @@ class CompactionController:
         if _ts is not None and getattr(_ts, "enabled", True):  # #4523: shadow default matches ThreatScanConfig.enabled's own declared True
             from reyn.security.secret_redaction import redact_secrets
             _redact = redact_secrets
+        # #5531 condition③: this caller is always tail-side — `candidates`
+        # comes from `_select_candidates(turns, prev_cover)`, which only
+        # ever returns turns chronologically AFTER `prev_cover` (the prior
+        # summary's own covers_through_seq) — so the order is always
+        # summary-then-new-turns, never the reverse (that only happens in
+        # retry_loop's own head-shrink path, engine.py).
+        _summary_messages = (
+            [wrap_summary_as_message(prev_structured)] if prev_structured else []
+        )
         input_chunk = HistoryChunkToCompact(
-            previous_summary=prev_structured,
-            new_turns=[_turn_to_compactor_input(t, redact=_redact) for t in candidates],
+            messages=_summary_messages
+            + [_turn_to_compactor_input(t, redact=_redact) for t in candidates],
             section_token_caps={
                 "topic_arc": cfg.section_token_caps.topic_arc,
                 "decisions": cfg.section_token_caps.decisions,

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -442,9 +442,43 @@ class SeqUnavailable(enum.Enum):
 CoversThrough = Union[int, SeqUnavailable]
 
 
+#: The ``role`` value marking an element of :attr:`HistoryChunkToCompact.
+#: messages` as an already-compacted summary rather than an ordinary turn
+#: — condition⑤'s own discriminator (#5531), matching the SAME convention
+#: the persisted-history layer already uses (a ``ChatMessage.role ==
+#: "summary"`` entry in ``history.jsonl``). One vocabulary, not two.
+SUMMARY_MESSAGE_ROLE = "summary"
+
+
+def wrap_summary_as_message(summary: dict) -> dict:
+    """#5531 condition④ — a previously-compacted summary is JUST a message
+    in :attr:`HistoryChunkToCompact.messages`, distinguished only by
+    :data:`SUMMARY_MESSAGE_ROLE`. This is the ONE place that wrapping
+    happens, so every caller (the controller's tail-side path, retry_loop's
+    tail- and head-side paths) produces byte-identical shape — see
+    ``CompactionEngine.compact``'s own docstring for why the field carries
+    no separate identity beyond this ``role`` marker."""
+    return {"role": SUMMARY_MESSAGE_ROLE, **summary}
+
+
 @dataclass
 class HistoryChunkToCompact:
     """Input to the compaction engine.
+
+    #5531 (owner design dialogue, invariant: a summary represents ONE
+    continuous span, placed exactly where that span sat in time):
+    ``messages`` is a SINGLE ordered list, oldest-first — the true
+    chronological sequence to compact. An already-compacted summary is
+    just one element of it (condition④), marked with
+    :data:`SUMMARY_MESSAGE_ROLE`, never assumed to sit at either end —
+    replaces the OLD ``previous_summary``/``new_turns`` two-field shape,
+    which could only express "previous_summary, then new_turns" (always
+    append) and had no way to represent content added from the OLDER
+    side (retry_loop's own head-shrink path, #5531 condition C's real
+    consequence — see that issue's own investigation comment for the
+    trace). Build via :func:`wrap_summary_as_message` for the summary
+    element, never a hand-rolled dict, so every caller uses the same
+    marker.
 
     #4389: ``section_token_caps`` is a HINT to the LLM only — it is
     serialised straight into the compaction prompt's user content (see
@@ -460,9 +494,8 @@ class HistoryChunkToCompact:
     call. Confirmed live (real LLM): setting ``topic_arc`` here to ~40 tokens
     had zero effect on the actual trim.
     """
-    new_turns: list[dict]                          # [{role, text, seq, ...}]
-    section_token_caps: dict                       # {topic_arc, decisions, ...} — LLM hint only, see docstring above
-    previous_summary: dict | None = None           # prior ChatSummary or None
+    messages: list[dict]                            # ordered, oldest-first: turns + at most one role=="summary" element
+    section_token_caps: dict                        # {topic_arc, decisions, ...} — LLM hint only, see docstring above
 
 
 @dataclass
@@ -1575,7 +1608,14 @@ class CompactionEngine:
         still sees a bare, unexplained ``null`` on the retry_loop path;
         always check ``covers_through_unavailable_reason`` alongside it.
         """
-        new_turn_count = len(input_chunk.new_turns)
+        # #5531: new_turn_count/had_previous are now derived from the
+        # single ordered `messages` list — a "summary" element (at most
+        # one, per HistoryChunkToCompact's own contract) is not a "new
+        # turn" being summarised for the first time.
+        summary_messages = [
+            m for m in input_chunk.messages if m.get("role") == SUMMARY_MESSAGE_ROLE
+        ]
+        new_turn_count = len(input_chunk.messages) - len(summary_messages)
         covers_through_seq = covers_through if isinstance(covers_through, int) else None
         covers_through_unavailable_reason = (
             None if isinstance(covers_through, int) else covers_through.value
@@ -1585,7 +1625,7 @@ class CompactionEngine:
             new_turn_count=new_turn_count,
             covers_through_seq=covers_through_seq,
             covers_through_unavailable_reason=covers_through_unavailable_reason,
-            had_previous=input_chunk.previous_summary is not None,
+            had_previous=bool(summary_messages),
         )
 
         # No `_token_cache.clear()` here (removed, #2937): text is immutable and
@@ -1602,13 +1642,18 @@ class CompactionEngine:
         # without growing unboundedly (the memory-leak risk a naive removal
         # of the clear would have traded it for).
 
+        # #5531: `messages` (the single ordered list, condition④) is the
+        # whole wire payload — no separate previous_summary/new_turns
+        # keys to keep in sync with each other (that split is exactly
+        # what made B's append-only prompt framing unfixable per-call:
+        # 2 fields cannot express "which side did the new content come
+        # from").
         user_content = json.dumps({
-            "previous_summary": input_chunk.previous_summary,
-            "new_turns": input_chunk.new_turns,
+            "messages": input_chunk.messages,
             "section_token_caps": input_chunk.section_token_caps,
         }, ensure_ascii=False)
 
-        messages = [
+        llm_messages = [
             {"role": "system", "content": _COMPACTION_SYSTEM_PROMPT},
             {"role": "user", "content": user_content},
         ]
@@ -1692,7 +1737,7 @@ class CompactionEngine:
         parsed: dict = {}
         raw = ""
         response = None
-        reprompt_messages = list(messages)
+        reprompt_messages = list(llm_messages)
         validation_errors: list[str] = []
         for attempt in range(max_attempts):
             response = await self._acompletion(
@@ -1799,7 +1844,8 @@ class CompactionEngine:
         # closes the exposure at its root instead of bounding its output.
         #
         # #5498 (architect ruling, on this exact call site): for
-        # retry_loop's own caller, ``input_chunk.new_turns`` are litellm
+        # retry_loop's own caller, ``input_chunk.messages``' turn elements
+        # (#5531 renamed the field from ``new_turns``) are litellm
         # wire dicts with no ``seq`` key at all (see ``SeqUnavailable.
         # WIRE_DICTS_CARRY_NO_SEQ``'s own docstring) — every ``t.get("seq",
         # 0)`` above falls to its default, so ``covers`` is structurally
@@ -1823,8 +1869,15 @@ class CompactionEngine:
         # own summary) needs to re-derive whether the other still holds
         # before assuming this is still safe. See
         # tests/services/test_5498_retry_loop_covers_zero_never_persisted.py.
+        # #5531: derive from `messages` MINUS the (at most one) summary
+        # element — its own covers_through_seq is not a "new turn" seq,
+        # and it may sit anywhere in the ordered list now (condition④),
+        # not just at index 0.
         covers = compute_covers_through_seq(
-            [t.get("seq", 0) for t in input_chunk.new_turns if isinstance(t, dict)]
+            [
+                t.get("seq", 0) for t in input_chunk.messages
+                if isinstance(t, dict) and t.get("role") != SUMMARY_MESSAGE_ROLE
+            ]
         )
 
         # #271 — 3-tier topic_arc bounding (replaces the lone Axis-9 blind cut):
@@ -2237,6 +2290,22 @@ async def retry_loop(
     # comment below for why re-slicing the SAME ``raw_middle`` on every
     # iteration without persisting this would just recreate the old cycle.
     _compact_attempt_len: int | None = None
+    # #5531 condition C: whether raw_middle has EVER been grown from the
+    # HEAD side (Phase 2, below) during this call — flipped True the
+    # first time that happens, never reset. Load-bearing for which order
+    # `summary` and `raw_middle`'s offered slice go into in
+    # `HistoryChunkToCompact.messages` below: Phase 1 (tail-shrink) and
+    # Phase 2 (head-shrink) are an `elif` chain, re-evaluated fresh each
+    # iteration, and NOTHING in this loop ever regrows `tail` once
+    # Phase 1 has shrunk it toward its floor — so Phase 1 firing and
+    # Phase 2 firing are never interleaved within one call: it is a
+    # ONE-WAY transition (tail-side growth, exhausted, THEN head-side
+    # growth, never back). While False, any content `raw_middle` holds
+    # is chronologically AFTER `summary` (condition③'s tail-side row);
+    # once True, the FRONT of `raw_middle` (which `_attempt_len` always
+    # offers first) is the most-recently-head-prepended, chronologically
+    # OLDEST content — BEFORE `summary` (condition③'s head-side row).
+    _raw_middle_grew_from_head = False
     # SP/new_msg never shrink (see the floor comment above) and never
     # change across iterations (both are fixed parameters) — computed once,
     # not on every floor check.
@@ -2288,9 +2357,22 @@ async def retry_loop(
                     _compact_attempt_len if _compact_attempt_len is not None
                     else len(raw_middle)
                 )
+                # #5531 conditions③④: order the single `messages` list by
+                # WHICH SIDE this offered slice came from, per the
+                # no-interleaving finding on `_raw_middle_grew_from_head`
+                # above — never a hand-decided "always append" (that was
+                # condition B's own bug).
+                _offered = raw_middle[:_attempt_len]
+                if summary is None:
+                    _summary_messages: list[dict] = []
+                else:
+                    _summary_messages = [wrap_summary_as_message(summary)]
+                if _raw_middle_grew_from_head:
+                    _messages = _offered + _summary_messages
+                else:
+                    _messages = _summary_messages + _offered
                 input_chunk = HistoryChunkToCompact(
-                    previous_summary=summary,
-                    new_turns=raw_middle[:_attempt_len],
+                    messages=_messages,
                     section_token_caps=section_caps,
                 )
                 try:
@@ -2673,6 +2755,7 @@ async def retry_loop(
             chunk = max(len(head) // 2, 1)
             raw_middle = head[-chunk:] + raw_middle
             head = head[:-chunk]
+            _raw_middle_grew_from_head = True  # #5531 condition③: flips the messages order below, permanently
         elif _last_recover_is_byte_limit:
             # #4885: token-only shrinking is exhausted (head/tail already at
             # or below their token minimums) but the triggering cause was an
@@ -2735,6 +2818,7 @@ async def retry_loop(
                 chunk = max(len(head) // 2, 1)
                 raw_middle = head[-chunk:] + raw_middle
                 head = head[:-chunk]
+                _raw_middle_grew_from_head = True  # #5531 condition③: same flag, byte-limit-override branch
             # If neither exceeds the new minimums either (head/tail were
             # ALREADY below even the halved ceiling), there is nothing left
             # to trim yet — still falls through without raising; the NEXT

--- a/tests/core/test_3783_stage3_invert_default_to_recover.py
+++ b/tests/core/test_3783_stage3_invert_default_to_recover.py
@@ -151,12 +151,12 @@ async def test_unrecognised_exception_recovers_when_shrinking_fixes_it(tmp_path)
     # keyword predicate) when the input is "too large" (mimics an output cut
     # off by an output-token cap); succeeds once the input has shrunk below it.
     async def _compact_fn(input_chunk: HistoryChunkToCompact):
-        if sum(1 for _ in input_chunk.new_turns) > 2:
+        if sum(1 for _ in input_chunk.messages) > 2:
             json.loads("{'unterminated")  # raises json.JSONDecodeError
         return ChatSummary(
             topic_arc="stub summary",
             covers_through_seq=max(
-                (t.get("seq", 0) for t in input_chunk.new_turns if isinstance(t, dict)),
+                (t.get("seq", 0) for t in input_chunk.messages if isinstance(t, dict)),
                 default=0,
             ),
         )

--- a/tests/core/test_4883_compaction_schema_validation.py
+++ b/tests/core/test_4883_compaction_schema_validation.py
@@ -71,8 +71,7 @@ def _engine(**cfg_kwargs) -> "tuple[CompactionEngine, list]":
 
 def _chunk() -> HistoryChunkToCompact:
     return HistoryChunkToCompact(
-        previous_summary=None,
-        new_turns=[{"role": "user", "text": "real content", "seq": 1}],
+        messages=[{"role": "user", "text": "real content", "seq": 1}],
         section_token_caps={},
     )
 
@@ -422,7 +421,7 @@ def test_partial_slices_eventually_cover_every_turn_with_no_gap(monkeypatch) -> 
         # driver below queues each chunk right before calling compact(),
         # so the next queued chunk IS the one this call was given.
         chunk = seen_inputs.pop(0)
-        seqs = [t["seq"] for t in chunk.new_turns]
+        seqs = [t["seq"] for t in chunk.messages]
         return _resp(json.dumps({
             "new_turn_seqs": seqs,
             "topic_arc": f"covers {seqs}",
@@ -434,8 +433,7 @@ def test_partial_slices_eventually_cover_every_turn_with_no_gap(monkeypatch) -> 
 
     slices = [
         HistoryChunkToCompact(
-            previous_summary=None,
-            new_turns=[{"role": "user", "text": "t", "seq": s}],
+            messages=[{"role": "user", "text": "t", "seq": s}],
             section_token_caps={},
         )
         for s in (1, 2, 3)
@@ -443,7 +441,7 @@ def test_partial_slices_eventually_cover_every_turn_with_no_gap(monkeypatch) -> 
     covered: list[int] = []
     for chunk in slices:
         seen_inputs.append(chunk)
-        summary = asyncio.run(engine.compact(chunk, covers_through=chunk.new_turns[-1]["seq"]))
+        summary = asyncio.run(engine.compact(chunk, covers_through=chunk.messages[-1]["seq"]))
         covered.append(summary.covers_through_seq)
 
     assert covered == [1, 2, 3], (

--- a/tests/core/test_4951_local_covers_derivation.py
+++ b/tests/core/test_4951_local_covers_derivation.py
@@ -1,6 +1,8 @@
 """Tier 2: OS invariant — #4951-A: ``covers_through_seq`` is derived
-UNCONDITIONALLY from ``compact()``'s own input (the ``new_turns`` reyn
-itself built and sent), never read from the LLM's ``new_turn_seqs`` echo.
+UNCONDITIONALLY from ``compact()``'s own input (the ``messages`` reyn
+itself built and sent — #5531 renamed this field from ``new_turns``, see
+``HistoryChunkToCompact``'s own docstring), never read from the LLM's
+``new_turn_seqs`` echo.
 
 Before this fix, a non-empty-but-WRONG echo passed straight through
 (``_validate_chat_summary_fields``'s emptiness check could not catch it,
@@ -56,8 +58,7 @@ def _engine(**cfg_kwargs) -> "tuple[CompactionEngine, list]":
 
 def _chunk(seqs: "list[int]") -> HistoryChunkToCompact:
     return HistoryChunkToCompact(
-        previous_summary=None,
-        new_turns=[
+        messages=[
             {"role": "user", "text": f"turn {s}", "seq": s} for s in seqs
         ],
         section_token_caps={},
@@ -77,7 +78,7 @@ def test_covers_ignores_a_wrong_nonempty_echo(monkeypatch) -> None:
         return _resp(_json(new_turn_seqs=[1]))
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
-    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.new_turns)))
+    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.messages)))
     assert summary.covers_through_seq == 3, (
         f"expected covers_through_seq derived from the real input max "
         f"(3), not the wrong echo (1); got {summary.covers_through_seq}"
@@ -97,7 +98,7 @@ def test_covers_ignores_a_wrong_higher_echo(monkeypatch) -> None:
         return _resp(_json(new_turn_seqs=[999]))
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
-    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.new_turns)))
+    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.messages)))
     assert summary.covers_through_seq == 6, (
         f"expected covers_through_seq derived from the real input max (6), "
         f"not the inflated echo (999); got {summary.covers_through_seq}"
@@ -122,7 +123,7 @@ def test_empty_new_turn_seqs_no_longer_reprompts(monkeypatch) -> None:
         return _resp(_json(new_turn_seqs=[]))
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
-    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.new_turns)))
+    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.messages)))
 
     assert calls["n"] == 1, "an empty new_turn_seqs must not trigger a re-prompt"
     assert summary.covers_through_seq == 7
@@ -145,7 +146,7 @@ def test_empty_topic_arc_still_reprompts_regardless_of_new_turn_seqs(monkeypatch
         return _resp(_json(new_turn_seqs=[1]))
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
-    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.new_turns)))
+    summary = asyncio.run(engine.compact(chunk, covers_through=max(t["seq"] for t in chunk.messages)))
 
     assert calls["n"] == 2, "an empty topic_arc must still trigger exactly one re-prompt"
     assert summary.topic_arc == "did a thing"

--- a/tests/core/test_cost_chokepoint_1190.py
+++ b/tests/core/test_cost_chokepoint_1190.py
@@ -130,8 +130,7 @@ def test_compaction_engine_records_compaction_purpose(monkeypatch) -> None:
         cfg=CompactionConfig(use_chars4_estimate=True), recorder=rec,
     )
     asyncio.run(engine.compact(HistoryChunkToCompact(
-        previous_summary=None,
-        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        messages=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
     ), covers_through=1))
     assert [c["purpose"] for c in rec.calls] == ["compaction"]
@@ -190,8 +189,7 @@ def test_compaction_engine_threads_agent(monkeypatch) -> None:
         recorder=rec, recorder_agent="researcher",
     )
     asyncio.run(engine.compact(HistoryChunkToCompact(
-        previous_summary=None,
-        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        messages=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
     ), covers_through=1))
     assert [c["agent"] for c in rec.calls] == ["researcher"]

--- a/tests/core/test_resummarize_3tier_271.py
+++ b/tests/core/test_resummarize_3tier_271.py
@@ -65,8 +65,7 @@ def _run(monkeypatch, engine, collected, *, compaction_arc: str, resummarize_arc
 
     monkeypatch.setattr("litellm.acompletion", _scripted)
     chunk = HistoryChunkToCompact(
-        previous_summary=None,
-        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        messages=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
     )
     summary = asyncio.run(engine.compact(chunk, covers_through=1))

--- a/tests/llm/test_compaction_resolver_aware_1172.py
+++ b/tests/llm/test_compaction_resolver_aware_1172.py
@@ -75,8 +75,7 @@ def _run_capture(monkeypatch, engine: CompactionEngine) -> str:
 
     monkeypatch.setattr("litellm.acompletion", _capture)
     chunk = HistoryChunkToCompact(
-        previous_summary=None,
-        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        messages=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
     )
     asyncio.run(engine.compact(chunk, covers_through=1))

--- a/tests/runtime/test_compaction_controller_invariants.py
+++ b/tests/runtime/test_compaction_controller_invariants.py
@@ -28,6 +28,7 @@ from reyn.core.events.events import EventLog
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.services.compaction_controller import CompactionController
 from reyn.services.compaction.engine import (
+    SUMMARY_MESSAGE_ROLE,
     ChatSummary,
     CompactionEngine,
     ComputedBudgets,
@@ -59,14 +60,20 @@ def _emit_compaction_started(
     body, so this test file's own ``compaction_started`` witnesses stay
     meaningful (the SAME shape production now emits, not a shape this file
     invented independently that could silently drift from it)."""
+    # #5531: new_turn_count/had_previous mirror CompactionEngine.compact()'s
+    # own derivation — a "summary" element (at most one) is not a "new
+    # turn" being summarised for the first time.
+    _summary_messages = [
+        m for m in input_chunk.messages if m.get("role") == SUMMARY_MESSAGE_ROLE
+    ]
     events.emit(
         "compaction_started",
-        new_turn_count=len(input_chunk.new_turns),
+        new_turn_count=len(input_chunk.messages) - len(_summary_messages),
         covers_through_seq=covers_through if isinstance(covers_through, int) else None,
         covers_through_unavailable_reason=(
             None if isinstance(covers_through, int) else covers_through.value
         ),
-        had_previous=input_chunk.previous_summary is not None,
+        had_previous=bool(_summary_messages),
     )
 
 
@@ -102,7 +109,7 @@ class _SucceedingEngine(CompactionEngine):
         self, input_chunk: HistoryChunkToCompact, *, covers_through: CoversThrough,
     ) -> ChatSummary:
         _emit_compaction_started(self._events, input_chunk, covers_through)
-        seqs = [int(t.get("seq", 0)) for t in input_chunk.new_turns if isinstance(t, dict)]
+        seqs = [int(t.get("seq", 0)) for t in input_chunk.messages if isinstance(t, dict)]
         return ChatSummary(topic_arc="stub", covers_through_seq=max(seqs) if seqs else 0)
 
 

--- a/tests/services/test_4703_compaction_spend_visible.py
+++ b/tests/services/test_4703_compaction_spend_visible.py
@@ -55,8 +55,7 @@ _SUMMARY_CONTENT = {
 
 def _chunk() -> HistoryChunkToCompact:
     return HistoryChunkToCompact(
-        previous_summary=None,
-        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        messages=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
     )
 

--- a/tests/services/test_5380_same_cause_cap_spill_witness.py
+++ b/tests/services/test_5380_same_cause_cap_spill_witness.py
@@ -95,7 +95,7 @@ class _SameCauseOnCompactSpillableEngine(_OverflowingEngine):
 
     async def compact(self, input_chunk, *, covers_through=None):
         self.compact_calls += 1
-        turns = input_chunk.new_turns
+        turns = input_chunk.messages
         if any(t.get("content") == _SPILLABLE_MARKER for t in turns if isinstance(t, dict)):
             raise ContextOverflowError("compact also overflows, same cause")
         self.compact_calls_with_marker_gone += 1

--- a/tests/services/test_5475_compaction_started_moved_to_engine.py
+++ b/tests/services/test_5475_compaction_started_moved_to_engine.py
@@ -11,10 +11,13 @@ two emit sites for the same kind).
 
 ``new_turn_count``/``had_previous`` are genuinely derivable from
 ``input_chunk`` alone for EITHER caller. ``covers_through_seq`` is not:
-the controller's own ``new_turns`` carry a real ``seq`` per turn
-(``_turn_to_compactor_input``); ``retry_loop``'s own ``new_turns`` are
-litellm wire dicts (``_serialise_turn``'s output) with no ``seq`` field at
-all. ``compact()`` therefore takes ``covers_through`` as a REQUIRED
+the controller's own turn elements (in ``input_chunk.messages``) carry a
+real ``seq`` per turn (``_turn_to_compactor_input``); ``retry_loop``'s own
+turn elements are litellm wire dicts (``_serialise_turn``'s output) with
+no ``seq`` field at all (#5531 renamed the field from ``new_turns`` to a
+single ordered ``messages`` list — see ``HistoryChunkToCompact``'s own
+docstring — but this seq-shape difference between the two callers is
+unchanged). ``compact()`` therefore takes ``covers_through`` as a REQUIRED
 keyword-only argument (no default — an omission is a mypy error at the
 call site, never a silently-accepted null) typed
 ``CoversThrough = int | SeqUnavailable``, so a consumer of the emitted
@@ -58,7 +61,7 @@ from tests._support.session import make_session
 
 @pytest.mark.asyncio
 async def test_controller_path_carries_a_real_seq(tmp_path, monkeypatch):
-    """Tier 2: the CONTROLLER's own caller (whose new_turns carry a real
+    """Tier 2: the CONTROLLER's own caller (whose turn elements carry a real
     `seq` per turn) makes `compaction_started`'s `covers_through_seq` a
     real int, with no `covers_through_unavailable_reason` — driven through
     a real Session/CompactionController/CompactionEngine, no stand-in."""
@@ -93,7 +96,7 @@ async def test_controller_path_carries_a_real_seq(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_retry_loop_shaped_path_carries_a_named_absence():
     """Tier 2: the shape retry_loop's own caller actually has — wire-dict
-    `new_turns` with no `seq` — makes `covers_through_seq` None and names
+    turn elements with no `seq` — makes `covers_through_seq` None and names
     WHY via `covers_through_unavailable_reason`, never a bare, unexplained
     null. Drives the real `CompactionEngine.compact()` directly with the
     SAME `SeqUnavailable` sentinel `engine.py`'s own retry_loop call site
@@ -112,8 +115,7 @@ async def test_retry_loop_shaped_path_carries_a_named_absence():
         # key at all, matching what `decompose_history_for_retry`'s
         # `raw_middle` actually contains (see module docstring).
         chunk = HistoryChunkToCompact(
-            previous_summary=None,
-            new_turns=[{"role": "user", "content": "wire-shaped, no seq"}],
+            messages=[{"role": "user", "content": "wire-shaped, no seq"}],
             section_token_caps={},
         )
         await engine.compact(chunk, covers_through=SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ)

--- a/tests/services/test_compaction_token_cache_incremental.py
+++ b/tests/services/test_compaction_token_cache_incremental.py
@@ -127,8 +127,7 @@ def test_compact_does_not_clear_the_token_cache(monkeypatch) -> None:
         cfg=CompactionConfig(use_chars4_estimate=False),
     )
     chunk = HistoryChunkToCompact(
-        previous_summary=None,
-        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        messages=[{"role": "user", "text": "hi", "seq": 1}],
         section_token_caps={},
     )
     asyncio.run(engine.compact(chunk, covers_through=1))
@@ -167,7 +166,7 @@ def test_repeated_estimate_of_unchanged_text_is_a_cache_hit_across_compactions(m
         cfg=CompactionConfig(use_chars4_estimate=False),
     )
     chunk = HistoryChunkToCompact(
-        previous_summary=None, new_turns=[{"role": "user", "text": "t1", "seq": 1}],
+        messages=[{"role": "user", "text": "t1", "seq": 1}],
         section_token_caps={},
     )
     asyncio.run(engine.compact(chunk, covers_through=1))

--- a/tests/services/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/services/test_pr_n6_compaction_overflow_retry.py
@@ -411,7 +411,7 @@ class _OverflowingEngine:
         return ChatSummary(
             topic_arc="stub summary",
             covers_through_seq=max(
-                (t.get("seq", 0) for t in input_chunk.new_turns if isinstance(t, dict)),
+                (t.get("seq", 0) for t in input_chunk.messages if isinstance(t, dict)),
                 default=0,
             ),
         )
@@ -1440,7 +1440,7 @@ def test_5367_3_spill_before_raise_resolves_byte_limit_mid_split_floor(tmp_path)
 
         async def compact(self, input_chunk, *, covers_through=None):
             self.compact_calls += 1
-            turn = input_chunk.new_turns[0]
+            turn = input_chunk.messages[0]
             if turn.get("content") == "OVERSIZED_TOOL_RESULT":
                 raise _FakeStatusError("compact 413", status_code=413)
             from reyn.services.compaction.engine import ChatSummary
@@ -1562,7 +1562,7 @@ def test_4947_stage1_success_resets_same_cause_streak(tmp_path) -> None:
             return ChatSummary(
                 topic_arc="stub",
                 covers_through_seq=max(
-                    (t.get("seq", 0) for t in input_chunk.new_turns if isinstance(t, dict)),
+                    (t.get("seq", 0) for t in input_chunk.messages if isinstance(t, dict)),
                     default=0,
                 ),
             )
@@ -1748,3 +1748,87 @@ def test_4947_stage1_floor_names_413_when_it_is_a_byte_limit(tmp_path) -> None:
     message = str(excinfo.value)
     assert "413" in message
     assert "single raw_middle turn alone" in message
+
+
+def test_5531_head_side_growth_orders_offered_slice_before_summary(tmp_path) -> None:
+    """Tier 2: #5531 condition③ — once raw_middle has grown from the HEAD
+    side (Phase 2: head is over its token minimum, tail is not), the
+    offered slice is chronologically OLDER than the running summary, so
+    ``HistoryChunkToCompact.messages`` must place the offered slice BEFORE
+    the summary element — the reverse of the tail-side (Phase 1) order a
+    prior summary always used before this fix. Drives a REAL retry_loop
+    with head far over a tiny budget and tail already under a generous
+    one, so Phase 2 fires on the very first overflow with no Phase 1
+    activity to confound the order this test is isolating."""
+    from reyn.services.compaction.engine import ChatSummary, ComputedBudgets
+
+    captured_orders: list[list[str]] = []
+
+    class _HeadShrinkEngine:
+        def __init__(self) -> None:
+            self.budgets = ComputedBudgets(
+                main_pool=100_000, head_budget=10, body_budget=500,
+                tail_budget=1_000, new_msg_budget=1_000,
+                B_M=90_000, main_M_room=99_000, effective_trigger=90_000,
+                section_caps={"topic_arc": 50, "decisions": 200, "pending": 150,
+                              "session_user_facts": 50, "artifacts_referenced": 175},
+            )
+            self._events = EventLog()
+            self._T_comp_SP = 100
+
+        async def compact(self, input_chunk, *, covers_through=None):
+            # Record the ROLE sequence of this call's messages — "summary"
+            # for the wrapped prior summary, "turn" for an ordinary
+            # offered-slice element — witnessing order via the same public
+            # discriminator production code reads, never a private field.
+            captured_orders.append([
+                "summary" if m.get("role") == "summary" else "turn"
+                for m in input_chunk.messages
+            ])
+            return ChatSummary(topic_arc="stub", covers_through_seq=0)
+
+    cfg = _make_cfg()
+    engine = _HeadShrinkEngine()
+    learner = TokenMultiplierLearner(storage_path=tmp_path / "m.json")
+
+    # head is FAR over head_budget=10 tokens (4 turns * ~100 tokens each,
+    # chars//4); tail is a single tiny turn, well under tail_budget=1_000
+    # — Phase 1 (tail shrink) never fires, isolating Phase 2 (head shrink).
+    head = _turns(["h" * 400] * 4)
+    tail = _turns(["t"])
+    raw_middle: list[dict] = []
+    new_msg = {"role": "user", "content": "hi", "seq": 99}
+    prior_summary = {"topic_arc": "already-compacted earlier span", "covers_through_seq": 1}
+
+    call_counts: list[int] = []
+    call_states: list[tuple] = []
+    # Overflow once (forces the Phase-2 head shrink below), then succeed —
+    # the compact() call this test is inspecting happens on the NEXT
+    # iteration, once raw_middle (freshly grown from head) is non-empty.
+    main_call = _make_shrink_call_count_main_call(1, call_counts, call_states)
+
+    asyncio.run(retry_loop(
+        SP="system",
+        head=head,
+        summary=prior_summary,
+        raw_middle=raw_middle,
+        tail=tail,
+        new_msg=new_msg,
+        cfg=cfg,
+        model="test-model",
+        engine=engine,  # type: ignore[arg-type]
+        learner=learner,
+        main_call=main_call,
+        max_iterations=8,
+    ))
+
+    assert captured_orders, "expected at least one compact() call after Phase 2 fired"
+    first_order = captured_orders[0]
+    assert "summary" in first_order and "turn" in first_order, (
+        f"expected both a summary element and offered turns in the first "
+        f"post-Phase-2 compact() call, got {first_order!r}"
+    )
+    assert first_order.index("turn") < first_order.index("summary"), (
+        f"condition③ (head-side growth): offered content must precede the "
+        f"summary element in messages — got order {first_order!r}"
+    )

--- a/tests/services/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/services/test_pr_n6_compaction_overflow_retry.py
@@ -1832,3 +1832,86 @@ def test_5531_head_side_growth_orders_offered_slice_before_summary(tmp_path) -> 
         f"condition③ (head-side growth): offered content must precede the "
         f"summary element in messages — got order {first_order!r}"
     )
+
+
+def test_5531_tail_side_growth_orders_summary_before_offered_slice(tmp_path) -> None:
+    """Tier 2: #5531 condition③ — the OTHER half of the order rule (the
+    head-side test above only witnesses one direction — architect BLOCKING
+    on PR #5533, head efa242321: a rule that only pins "head order" does
+    not distinguish "the rule is order-aware" from "the rule is hard-coded
+    to always head-order"). When raw_middle grows from the TAIL side only
+    (Phase 1; `_raw_middle_grew_from_head` stays False all call), the
+    offered slice is chronologically NEWER than the running summary, so
+    ``HistoryChunkToCompact.messages`` must place the summary element
+    FIRST — the reverse of the head-side order the test above pins. Drives
+    a REAL retry_loop with tail far over a tiny budget and head already
+    under a generous one, so Phase 1 fires on the very first overflow with
+    no Phase 2 activity to confound the order this test is isolating."""
+    from reyn.services.compaction.engine import ChatSummary, ComputedBudgets
+
+    captured_orders: list[list[str]] = []
+
+    class _TailShrinkEngine:
+        def __init__(self) -> None:
+            self.budgets = ComputedBudgets(
+                main_pool=100_000, head_budget=1_000, body_budget=500,
+                tail_budget=10, new_msg_budget=1_000,
+                B_M=90_000, main_M_room=99_000, effective_trigger=90_000,
+                section_caps={"topic_arc": 50, "decisions": 200, "pending": 150,
+                              "session_user_facts": 50, "artifacts_referenced": 175},
+            )
+            self._events = EventLog()
+            self._T_comp_SP = 100
+
+        async def compact(self, input_chunk, *, covers_through=None):
+            captured_orders.append([
+                "summary" if m.get("role") == "summary" else "turn"
+                for m in input_chunk.messages
+            ])
+            return ChatSummary(topic_arc="stub", covers_through_seq=0)
+
+    cfg = _make_cfg()
+    engine = _TailShrinkEngine()
+    learner = TokenMultiplierLearner(storage_path=tmp_path / "m.json")
+
+    # tail is FAR over tail_budget=10 tokens (4 turns * ~100 tokens each,
+    # chars//4); head is a single tiny turn, well under head_budget=1_000
+    # — Phase 2 (head shrink) never fires, isolating Phase 1 (tail shrink).
+    tail = _turns(["t" * 400] * 4)
+    head = _turns(["h"])
+    raw_middle: list[dict] = []
+    new_msg = {"role": "user", "content": "hi", "seq": 99}
+    prior_summary = {"topic_arc": "already-compacted earlier span", "covers_through_seq": 1}
+
+    call_counts: list[int] = []
+    call_states: list[tuple] = []
+    # Overflow once (forces the Phase-1 tail shrink below), then succeed —
+    # the compact() call this test is inspecting happens on the NEXT
+    # iteration, once raw_middle (freshly grown from tail) is non-empty.
+    main_call = _make_shrink_call_count_main_call(1, call_counts, call_states)
+
+    asyncio.run(retry_loop(
+        SP="system",
+        head=head,
+        summary=prior_summary,
+        raw_middle=raw_middle,
+        tail=tail,
+        new_msg=new_msg,
+        cfg=cfg,
+        model="test-model",
+        engine=engine,  # type: ignore[arg-type]
+        learner=learner,
+        main_call=main_call,
+        max_iterations=8,
+    ))
+
+    assert captured_orders, "expected at least one compact() call after Phase 1 fired"
+    first_order = captured_orders[0]
+    assert "summary" in first_order and "turn" in first_order, (
+        f"expected both a summary element and offered turns in the first "
+        f"post-Phase-1 compact() call, got {first_order!r}"
+    )
+    assert first_order.index("summary") < first_order.index("turn"), (
+        f"condition③ (tail-side growth): the summary element must precede "
+        f"offered content in messages — got order {first_order!r}"
+    )

--- a/tests/services/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/services/test_pr_n6_compaction_overflow_retry.py
@@ -1915,3 +1915,174 @@ def test_5531_tail_side_growth_orders_summary_before_offered_slice(tmp_path) -> 
         f"condition③ (tail-side growth): the summary element must precede "
         f"offered content in messages — got order {first_order!r}"
     )
+
+
+def test_5531_no_interleaving_tail_condition_stays_false_once_exhausted(tmp_path) -> None:
+    """Tier 2: #5531 investigation finding (architect BLOCKING #2, PR #5533,
+    head a78156291) — WITHIN one retry_loop call, once Phase 1's own
+    condition (tail token count > tail_min) goes False, it never becomes
+    True again. This is the finding that makes the 2-case order rule in
+    the two tests above sufficient — no interleaving means
+    `_raw_middle_grew_from_head` never needs to flip back to False once
+    True, so a 3-way "older-unsummarized / summary / newer-unsummarized"
+    sandwich order is never actually reachable.
+
+    Observable witness (no private-state read): tail's own token count, as
+    `main_call` receives it, is monotonically NON-INCREASING across every
+    call this retry_loop invocation makes — the only way Phase 1's
+    condition could go True again after going False is for something to
+    have grown tail back up, which this asserts never happens. Drives a
+    REAL retry_loop through BOTH Phase 1 (tail exhausts first) and Phase 2
+    (head shrinks next), so the assertion spans the exact transition
+    condition③ depends on, not just one phase in isolation."""
+    from reyn.services.compaction.engine import ChatSummary, ComputedBudgets
+
+    class _BothPhasesEngine:
+        def __init__(self) -> None:
+            self.budgets = ComputedBudgets(
+                main_pool=100_000, head_budget=10, body_budget=500,
+                tail_budget=10, new_msg_budget=1_000,
+                B_M=90_000, main_M_room=99_000, effective_trigger=90_000,
+                section_caps={"topic_arc": 50, "decisions": 200, "pending": 150,
+                              "session_user_facts": 50, "artifacts_referenced": 175},
+            )
+            self._events = EventLog()
+            self._T_comp_SP = 100
+
+        async def compact(self, input_chunk, *, covers_through=None):
+            return ChatSummary(topic_arc="stub", covers_through_seq=0)
+
+    cfg = _make_cfg()
+    engine = _BothPhasesEngine()
+    learner = TokenMultiplierLearner(storage_path=tmp_path / "m.json")
+
+    # Both tail and head start FAR over their tiny (10-token) budgets, so
+    # Phase 1 fires repeatedly until tail is exhausted, THEN Phase 2 fires
+    # for head — the exact transition this test observes.
+    tail = _turns(["t" * 400] * 6)
+    head = _turns(["h" * 400] * 6)
+    raw_middle: list[dict] = []
+    new_msg = {"role": "user", "content": "hi", "seq": 99}
+
+    tail_token_history: list[int] = []
+
+    async def _main_call(**kwargs):
+        t = kwargs["tail"]
+        h = kwargs["head"]
+        tail_tokens = _estimate_tokens_list(t, "test-model", use_chars4=True)
+        head_tokens = _estimate_tokens_list(h, "test-model", use_chars4=True)
+        tail_token_history.append(tail_tokens)
+        if head_tokens > 10 or tail_tokens > 10:
+            raise ContextOverflowError("simulated overflow")
+        from types import SimpleNamespace
+        return SimpleNamespace(usage=SimpleNamespace(prompt_tokens=1000), choices=[])
+
+    asyncio.run(retry_loop(
+        SP="system",
+        head=head,
+        summary=None,
+        raw_middle=raw_middle,
+        tail=tail,
+        new_msg=new_msg,
+        cfg=cfg,
+        model="test-model",
+        engine=engine,  # type: ignore[arg-type]
+        learner=learner,
+        main_call=_main_call,
+        max_iterations=30,
+    ))
+
+    assert any(
+        later < earlier for earlier, later in zip(tail_token_history, tail_token_history[1:])
+    ), (
+        "expected tail to actually shrink at least once (Phase 1 firing) "
+        f"during this call — got {tail_token_history!r}"
+    )
+    for earlier, later in zip(tail_token_history, tail_token_history[1:]):
+        assert later <= earlier, (
+            "condition③'s no-interleaving finding: tail's token count "
+            "must never increase within one retry_loop call (Phase 1's "
+            "own condition must stay False once it first goes False) — "
+            f"got history {tail_token_history!r}"
+        )
+
+
+def test_5531_at_most_one_summary_element_in_messages(tmp_path) -> None:
+    """Tier 2: #5531 condition④ (architect BLOCKING #3, PR #5533, head
+    a78156291) — HistoryChunkToCompact's own docstring contract is "AT
+    MOST ONE" element carries `role == SUMMARY_MESSAGE_ROLE`; with two,
+    which one is the actual prior summary becomes ambiguous. Drives a REAL
+    retry_loop through several overflow-recovery iterations (so `messages`
+    is rebuilt from scratch, with a real running `summary`, on every
+    compact() call) and asserts every single one of those calls' messages
+    carries at most one summary-role element — not merely that ONE
+    observed call happens to (the earlier order tests above only inspect
+    `captured_orders[0]`; this one inspects every call)."""
+    from reyn.services.compaction.engine import (
+        SUMMARY_MESSAGE_ROLE,
+        ChatSummary,
+        ComputedBudgets,
+    )
+
+    summary_role_counts: list[int] = []
+
+    class _CountingEngine:
+        def __init__(self) -> None:
+            self.budgets = ComputedBudgets(
+                main_pool=100_000, head_budget=10, body_budget=500,
+                tail_budget=10, new_msg_budget=1_000,
+                B_M=90_000, main_M_room=99_000, effective_trigger=90_000,
+                section_caps={"topic_arc": 50, "decisions": 200, "pending": 150,
+                              "session_user_facts": 50, "artifacts_referenced": 175},
+            )
+            self._events = EventLog()
+            self._T_comp_SP = 100
+
+        async def compact(self, input_chunk, *, covers_through=None):
+            summary_role_counts.append(sum(
+                1 for m in input_chunk.messages if m.get("role") == SUMMARY_MESSAGE_ROLE
+            ))
+            return ChatSummary(topic_arc="stub", covers_through_seq=0)
+
+    cfg = _make_cfg()
+    engine = _CountingEngine()
+    learner = TokenMultiplierLearner(storage_path=tmp_path / "m.json")
+
+    tail = _turns(["t" * 400] * 6)
+    head = _turns(["h" * 400] * 6)
+    raw_middle: list[dict] = []
+    new_msg = {"role": "user", "content": "hi", "seq": 99}
+    prior_summary = {"topic_arc": "already-compacted earlier span", "covers_through_seq": 1}
+
+    async def _main_call(**kwargs):
+        t = kwargs["tail"]
+        h = kwargs["head"]
+        tail_tokens = _estimate_tokens_list(t, "test-model", use_chars4=True)
+        head_tokens = _estimate_tokens_list(h, "test-model", use_chars4=True)
+        if head_tokens > 10 or tail_tokens > 10:
+            raise ContextOverflowError("simulated overflow")
+        from types import SimpleNamespace
+        return SimpleNamespace(usage=SimpleNamespace(prompt_tokens=1000), choices=[])
+
+    asyncio.run(retry_loop(
+        SP="system",
+        head=head,
+        summary=prior_summary,
+        raw_middle=raw_middle,
+        tail=tail,
+        new_msg=new_msg,
+        cfg=cfg,
+        model="test-model",
+        engine=engine,  # type: ignore[arg-type]
+        learner=learner,
+        main_call=_main_call,
+        max_iterations=30,
+    ))
+
+    assert summary_role_counts, "expected at least one compact() call"
+    for count in summary_role_counts:
+        assert count <= 1, (
+            f"HistoryChunkToCompact.messages must carry AT MOST ONE "
+            f"{SUMMARY_MESSAGE_ROLE!r}-role element — got {count} in one "
+            f"call; full history {summary_role_counts!r}"
+        )

--- a/tests/services/test_tool_result_cap_1128.py
+++ b/tests/services/test_tool_result_cap_1128.py
@@ -185,13 +185,16 @@ class _BMGatedEngine:
             ChatSummary,
             CompactionOverflowError,
         )
-        prev = json.dumps(input_chunk.previous_summary or {}, ensure_ascii=False)
-        turns = json.dumps(input_chunk.new_turns, ensure_ascii=False, default=str)
-        total = estimate_tokens(prev + turns, _MODEL, use_chars4=True)
+        # #5531: previous_summary/new_turns folded into one ordered
+        # `messages` list — everything in it (including any wrapped prior
+        # summary) counts toward the same token estimate the old
+        # prev+turns concatenation did.
+        turns = json.dumps(input_chunk.messages, ensure_ascii=False, default=str)
+        total = estimate_tokens(turns, _MODEL, use_chars4=True)
         if total > self.budgets.B_M:
             raise CompactionOverflowError(f"chunk {total} tok > B_M {self.budgets.B_M}")
         seq = max(
-            (t.get("seq", 0) for t in input_chunk.new_turns if isinstance(t, dict)),
+            (t.get("seq", 0) for t in input_chunk.messages if isinstance(t, dict)),
             default=0,
         )
         return ChatSummary(topic_arc="folded", covers_through_seq=seq)


### PR DESCRIPTION
**[tui-coder]** — part of #5531

## Scope

My own scope on #5531 is section "1. 期待動作" (the fold invariant) and section
"2. A/B/C" (the root-cause candidates) only — section "0" (the broader
overflow→continuation logic) was framing/context, not something I implemented.

## What changed

`HistoryChunkToCompact` carried `previous_summary`/`new_turns` as two separate
fields, hard-coding "new content is always chronologically AFTER the prior
summary" — false whenever `retry_loop`'s own head-shrink path (Phase 2) grows
`raw_middle` from the OLDER side. Folded into a single ordered `messages` list
per the owner's design dialogue (invariant: a summary represents ONE
continuous span, placed exactly where that span sat in time). A
previously-compacted summary is just one element of it
(`role: "summary"` / `SUMMARY_MESSAGE_ROLE` / `wrap_summary_as_message`) — the
array's own position encodes chronology, no separate append-only framing to
keep in sync with it.

`retry_loop` tracks `_raw_middle_grew_from_head`, flipped True the first time
Phase 2 fires. Investigation finding (not in the original issue): within one
`retry_loop` call, Phase 1 (tail-shrink) → Phase 2 (head-shrink) is a strictly
one-way, monotonic, never-interleaved transition — nothing in the loop ever
regrows `tail` once Phase 1 has shrunk it — so a 2-case order rule (matching
condition③'s table exactly) suffices; no 3-way sandwich structure is needed.

`compaction_controller.py`'s own caller is confirmed always tail-side
(`_select_candidates` only returns turns after `prev_cover`).

Updated the compaction system prompt (order-agnostic input shape, not the old
"previous_summary is an immutable base" framing) and all
`HistoryChunkToCompact` construction/consumption sites: 8 test files'
constructors, plus 5 test-double `compact()` stubs that read the old field
names directly (found via a full-tree grep, not just constructor call sites —
these were silent hangs/AttributeErrors the constructor-only sweep missed).

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 200 findings, all baselined
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 143 tests inspected, 0 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK (tests/ touched)
- [x] `python scripts/check_file_depth_reference.py` — OK (tests/ touched)
- [x] `python scripts/check_subprocess_reyn_pin.py` — OK (tests/ touched)
- [x] Scoped pytest: all 8 directly-touched test files green (41 passed)
- [x] Broader regression sweep (`tests/runtime|services|core|llm` + `-k compact`): 221 passed, 1 pre-existing unrelated skip (missing optional extra)
- [x] New test `test_5531_head_side_growth_orders_offered_slice_before_summary` — drives a REAL `retry_loop` through an actual Phase-2 head shrink, asserts the resulting `HistoryChunkToCompact.messages` order
- [x] Strip-falsify: forced the order branch to always-tail-order — confirmed exactly (and only) the new test fails, restored, confirmed green again
- [ ] (skipped — Visual) no UI surface touched

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
