### PR TITLE
fix(#5527): pin hook_trigger test double signatures against the real target

### DIFF
--- a/tests/_support/hooks.py
+++ b/tests/_support/hooks.py
@@ -38,6 +38,7 @@ shape architect explicitly weighed against).
 """
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -87,3 +88,58 @@ async def run_one_turn(session: "Session", user_text: str, chain_id: str) -> Non
     on its own.
     """
     await session._run_router_loop(user_text, chain_id)
+
+
+def _param_shape(sig: "inspect.Signature") -> "list[tuple[str, inspect._ParameterKind, bool]]":
+    """(name, kind, has-a-default) per parameter — deliberately NOT full
+    :class:`inspect.Parameter` equality: annotations differ harmlessly
+    between production's real string-quoted type hints and a test double's
+    own (often bare or absent) ones, and comparing exact default VALUES
+    would reject a double using an equivalent-but-not-``==``-identical
+    default. ``kind`` is load-bearing, not incidental: it is what
+    distinguishes a keyword-only parameter (``*, x=0``) from a
+    positional-or-keyword one with the same name and default (``x=0``) —
+    exactly the drift #5527 found in ``skipped_session_wide``, silent under
+    a name-and-default-only comparison."""
+    return [(p.name, p.kind, p.default is not inspect.Parameter.empty) for p in sig.parameters.values()]
+
+
+def assert_hook_trigger_signature(double: object) -> None:
+    """#5527 — pin a ``hook_trigger``-shaped test double's call signature
+    against the ONE real thing it stands in for
+    (``HookDispatcher.dispatch_external_batch``), inside the helper that
+    constructs the double — never per-test (architect's own prescription,
+    verbatim: "``inspect.signature(実物) == inspect.signature(double)`` を
+    ★double を作る helper の中で 1 度（test ごとに書かせない）").
+
+    Real incident this closes (#5516 arc, #5527): 3 hand-written
+    ``hook_trigger`` doubles kept the PRE-#5516 single-event signature
+    after production moved to the batch shape — each raised ``TypeError``
+    on the missing ``skipped_session_wide`` kwarg, silently swallowed by
+    ``HookDispatcher``'s own per-hook isolation ``try/except``, leaving an
+    unbounded ``_wait_for`` poll spinning forever (a hang, not a red test —
+    see this issue's own root-cause writeup). Call this once, right after
+    constructing the double, so a FUTURE signature change on
+    ``dispatch_external_batch`` breaks the double loudly (red) instead of
+    silently (a hang nobody can attribute to this).
+
+    Deliberately does not compare annotations or exact default identity —
+    see :func:`_param_shape`'s own docstring for why."""
+    from reyn.hooks.dispatcher import HookDispatcher
+
+    real_sig = inspect.signature(HookDispatcher.dispatch_external_batch)
+    # Drop ``self`` — the real target is an unbound function (accessed via
+    # the class, never instantiated here: constructing a HookDispatcher
+    # needs a HookRegistry + other DI this helper has no business knowing
+    # about), while *double* is called without a leading ``self`` (either
+    # a bare async function, or an instance whose own ``__call__`` already
+    # has ``self`` stripped by ``inspect.signature``'s bound-method rule).
+    real_shape = _param_shape(real_sig)[1:]
+    double_shape = _param_shape(inspect.signature(double))
+    assert real_shape == double_shape, (
+        f"hook_trigger double signature has drifted from the real "
+        f"HookDispatcher.dispatch_external_batch — real (self dropped): "
+        f"{real_shape!r}, double: {double_shape!r}. #5516/#5527: a "
+        f"drifted double's TypeError is swallowed by per-hook isolation "
+        f"and hangs the caller instead of failing loudly."
+    )

--- a/tests/_support/hooks.py
+++ b/tests/_support/hooks.py
@@ -104,13 +104,35 @@ def _param_shape(sig: "inspect.Signature") -> "list[tuple[str, inspect._Paramete
     return [(p.name, p.kind, p.default is not inspect.Parameter.empty) for p in sig.parameters.values()]
 
 
-def assert_hook_trigger_signature(double: object) -> None:
+def assert_hook_trigger_signature(double: object, real: object) -> None:
     """#5527 — pin a ``hook_trigger``-shaped test double's call signature
-    against the ONE real thing it stands in for
-    (``HookDispatcher.dispatch_external_batch``), inside the helper that
-    constructs the double — never per-test (architect's own prescription,
-    verbatim: "``inspect.signature(実物) == inspect.signature(double)`` を
-    ★double を作る helper の中で 1 度（test ごとに書かせない）").
+    against *real*, the SPECIFIC production callable it stands in for,
+    inside the helper that constructs the double — never per-test
+    (architect's own prescription, verbatim: "``inspect.signature(実物) ==
+    inspect.signature(double)`` を ★double を作る helper の中で 1 度（test
+    ごとに書かせない）").
+
+    *real* is REQUIRED, never defaulted — lead-coder's own BLOCKING finding
+    on this function's first version (PR #5534, head ce127578e): the
+    ``hook_trigger`` slot has TWO real occupants with genuinely different
+    signatures, not one —
+    ``HookDispatcher.dispatch_external_batch(point, payloads, *,
+    skipped_session_wide=0)`` (``skipped_session_wide`` KEYWORD-ONLY,
+    wired to ``Session.dispatch_external_event_batch`` for the H5 cron/
+    webhook out-of-process path) and ``Session._bridge_hook_trigger(point,
+    payloads, skipped_session_wide=0)`` (POSITIONAL-OR-KEYWORD, wired to
+    BOTH ``FsWatcher`` and ``MCPConnectionService`` via
+    ``hook_trigger=self._bridge_hook_trigger`` in ``session.py``). A
+    version of this function that hard-coded ONE of the two would pin some
+    doubles against the WRONG real target — catching no real drift for
+    them (a mismatched *kind* wrongly read as a pass, or a double made
+    STRICTER than the real thing it substitutes for, itself a #5527-shaped
+    hazard: a caller that legitimately passes ``skipped_session_wide``
+    positionally to the real occupant would 500 for real, red on the
+    double, exactly backwards). Production is not touched to unify the
+    two — out of #5527's own settled scope (architect: "production を
+    触らないでください") — so a caller must always say explicitly which
+    real occupant its double stands in for.
 
     Real incident this closes (#5516 arc, #5527): 3 hand-written
     ``hook_trigger`` doubles kept the PRE-#5516 single-event signature
@@ -119,27 +141,25 @@ def assert_hook_trigger_signature(double: object) -> None:
     ``HookDispatcher``'s own per-hook isolation ``try/except``, leaving an
     unbounded ``_wait_for`` poll spinning forever (a hang, not a red test —
     see this issue's own root-cause writeup). Call this once, right after
-    constructing the double, so a FUTURE signature change on
-    ``dispatch_external_batch`` breaks the double loudly (red) instead of
-    silently (a hang nobody can attribute to this).
+    constructing the double, so a FUTURE signature change on the real
+    target breaks the double loudly (red) instead of silently (a hang
+    nobody can attribute to this).
 
     Deliberately does not compare annotations or exact default identity —
     see :func:`_param_shape`'s own docstring for why."""
-    from reyn.hooks.dispatcher import HookDispatcher
-
-    real_sig = inspect.signature(HookDispatcher.dispatch_external_batch)
-    # Drop ``self`` — the real target is an unbound function (accessed via
-    # the class, never instantiated here: constructing a HookDispatcher
-    # needs a HookRegistry + other DI this helper has no business knowing
-    # about), while *double* is called without a leading ``self`` (either
-    # a bare async function, or an instance whose own ``__call__`` already
-    # has ``self`` stripped by ``inspect.signature``'s bound-method rule).
-    real_shape = _param_shape(real_sig)[1:]
+    real_shape = _param_shape(inspect.signature(real))
+    # Drop ``self`` ONLY when *real* is an unbound method accessed via its
+    # class (its first parameter is then literally named ``self``) — a
+    # bound method (``instance.method``) or a bare function already has no
+    # such leading parameter, so dropping unconditionally would wrongly
+    # eat *real*'s first real argument for those callers.
+    if real_shape and real_shape[0][0] == "self":
+        real_shape = real_shape[1:]
     double_shape = _param_shape(inspect.signature(double))
     assert real_shape == double_shape, (
-        f"hook_trigger double signature has drifted from the real "
-        f"HookDispatcher.dispatch_external_batch — real (self dropped): "
-        f"{real_shape!r}, double: {double_shape!r}. #5516/#5527: a "
-        f"drifted double's TypeError is swallowed by per-hook isolation "
-        f"and hangs the caller instead of failing loudly."
+        f"hook_trigger double signature has drifted from its real target "
+        f"{real!r} — real (self dropped if present): {real_shape!r}, "
+        f"double: {double_shape!r}. #5516/#5527: a drifted double's "
+        f"TypeError is swallowed by per-hook isolation and hangs the "
+        f"caller instead of failing loudly."
     )

--- a/tests/hooks/test_5527_hook_trigger_double_signature_pin.py
+++ b/tests/hooks/test_5527_hook_trigger_double_signature_pin.py
@@ -3,15 +3,21 @@
 
 Real incident (#5516 arc, root-caused #5527): 3 hand-written
 ``hook_trigger``-shaped test doubles kept the PRE-#5516 single-event
-signature after production moved to the batch shape
-(``HookDispatcher.dispatch_external_batch(point, payloads, *,
-skipped_session_wide=0)``). Each raised ``TypeError`` on the missing
-kwarg, silently swallowed by ``HookDispatcher``'s own per-hook isolation
-``try/except`` — the caller never saw a red test, only an unbounded
-``_wait_for`` poll that never terminated (a hang, not a failure). Architect's
-prescription (settled, #5527's own issue thread): pin a double's signature
-against the real target ONCE, inside the helper that constructs the double
-— this file proves that pin actually does the job it is for.
+signature after production moved to the batch shape. Each raised
+``TypeError`` on the missing kwarg, silently swallowed by ``HookDispatcher``'s
+own per-hook isolation ``try/except`` — the caller never saw a red test,
+only an unbounded ``_wait_for`` poll that never terminated (a hang, not a
+failure).
+
+lead-coder's own BLOCKING finding on this function's first version (PR
+#5534, head ce127578e): the ``hook_trigger`` slot has TWO real occupants
+with genuinely different signatures —
+``HookDispatcher.dispatch_external_batch`` (``skipped_session_wide``
+KEYWORD-ONLY) and ``Session._bridge_hook_trigger`` (POSITIONAL-OR-KEYWORD)
+— so the helper takes *real* explicitly, never defaults it. This file
+exercises BOTH real targets, not just one, so a future change that
+silently re-hardcodes a single default cannot pass this file's own tests
+while actually being wrong for the other target.
 
 Policy compliance:
 - No unittest.mock / MagicMock / AsyncMock / patch.
@@ -23,53 +29,104 @@ from __future__ import annotations
 
 import pytest
 
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.runtime.session import Session
 from tests._support.hooks import assert_hook_trigger_signature
 
+# The two real occupants of the hook_trigger slot (see module docstring) —
+# parametrized so every test below runs against BOTH, proving neither one
+# is silently favored by the helper's own implementation.
+_REAL_TARGETS = [
+    pytest.param(HookDispatcher.dispatch_external_batch, id="dispatch_external_batch"),
+    pytest.param(Session._bridge_hook_trigger, id="_bridge_hook_trigger"),
+]
 
-def test_a_drifted_double_signature_fails_loudly() -> None:
+
+@pytest.mark.parametrize("real", _REAL_TARGETS)
+def test_a_pre_5516_shaped_double_fails_loudly(real) -> None:
     """Tier 2: #5527 accept ① — a double whose signature has drifted from
-    the real ``dispatch_external_batch`` (here: the exact #5516-arc drift —
-    ``skipped_session_wide`` missing entirely) makes
-    ``assert_hook_trigger_signature`` raise, immediately and loudly (an
-    ``AssertionError``, not a hang, not a swallowed ``TypeError`` three
-    layers downstream inside ``HookDispatcher``'s own per-hook isolation)."""
+    *real* (here: the exact #5516-arc drift — ``skipped_session_wide``
+    missing entirely) makes ``assert_hook_trigger_signature`` raise,
+    immediately and loudly (an ``AssertionError``, not a hang, not a
+    swallowed ``TypeError`` three layers downstream inside
+    ``HookDispatcher``'s own per-hook isolation) — for EITHER real target."""
 
     async def _pre_5516_shaped_trigger(point: str, template_vars: dict) -> None:
         pass
 
     with pytest.raises(AssertionError, match="drifted"):
-        assert_hook_trigger_signature(_pre_5516_shaped_trigger)
+        assert_hook_trigger_signature(_pre_5516_shaped_trigger, real=real)
 
 
-def test_a_kind_only_drift_also_fails() -> None:
-    """Tier 2: #5527 accept ① — the SPECIFIC drift #5527's own investigation
-    found in the 2 real doubles this issue fixed: ``skipped_session_wide``
-    present, correctly named and defaulted, but declared POSITIONAL-OR-
-    KEYWORD instead of the real target's KEYWORD-ONLY kind (no leading
-    ``*``). Name-and-default-only comparison would miss this; ``kind`` must
-    be part of the compared shape."""
+def test_a_kind_only_drift_against_dispatch_external_batch_fails() -> None:
+    """Tier 2: #5527 accept ① — a double whose ``skipped_session_wide`` is
+    POSITIONAL-OR-KEYWORD (the real shape of the OTHER occupant,
+    ``Session._bridge_hook_trigger``) is a genuine drift against
+    ``dispatch_external_batch``, whose real ``skipped_session_wide`` is
+    KEYWORD-ONLY. Name-and-default-only comparison would miss this;
+    ``kind`` must be part of the compared shape."""
 
-    async def _wrong_kind_trigger(
+    async def _bridge_shaped_trigger(
         point: str, payloads: list, skipped_session_wide: int = 0,
     ) -> None:
         pass
 
     with pytest.raises(AssertionError, match="drifted"):
-        assert_hook_trigger_signature(_wrong_kind_trigger)
+        assert_hook_trigger_signature(
+            _bridge_shaped_trigger, real=HookDispatcher.dispatch_external_batch,
+        )
 
 
-def test_a_matching_double_does_not_fail() -> None:
+def test_a_kind_only_drift_against_bridge_hook_trigger_fails() -> None:
+    """Tier 2: #5527 accept ① — the MIRROR of the test above: a double
+    whose ``skipped_session_wide`` is KEYWORD-ONLY (the real shape of
+    ``dispatch_external_batch``) is a genuine drift against
+    ``Session._bridge_hook_trigger``, whose real ``skipped_session_wide``
+    is POSITIONAL-OR-KEYWORD — the SAME regression PR #5534's first
+    version actually introduced into ``_RecordingTrigger``/``_Recorder``
+    (a double made STRICTER than the real thing it substitutes for)."""
+
+    async def _dispatch_shaped_trigger(
+        point: str, payloads: list, *, skipped_session_wide: int = 0,
+    ) -> None:
+        pass
+
+    with pytest.raises(AssertionError, match="drifted"):
+        assert_hook_trigger_signature(
+            _dispatch_shaped_trigger, real=Session._bridge_hook_trigger,
+        )
+
+
+def test_a_double_matching_dispatch_external_batch_does_not_fail() -> None:
     """Tier 2: #5527 accept ② (the deny-side sibling) — a double whose
-    signature genuinely matches the real target does NOT raise. Without
-    this, an "always raise" implementation of ``assert_hook_trigger_
-    signature`` would pass accept ① for the wrong reason."""
+    signature genuinely matches ``dispatch_external_batch`` does NOT raise.
+    Without this, an "always raise" implementation would pass accept ①
+    for the wrong reason."""
 
     async def _correctly_shaped_trigger(
         point: str, payloads: list, *, skipped_session_wide: int = 0,
     ) -> None:
         pass
 
-    assert_hook_trigger_signature(_correctly_shaped_trigger)  # must not raise
+    assert_hook_trigger_signature(
+        _correctly_shaped_trigger, real=HookDispatcher.dispatch_external_batch,
+    )  # must not raise
+
+
+def test_a_double_matching_bridge_hook_trigger_does_not_fail() -> None:
+    """Tier 2: #5527 accept ② — the MIRROR deny-side proof for the OTHER
+    real target: a double whose signature genuinely matches
+    ``Session._bridge_hook_trigger`` (POSITIONAL-OR-KEYWORD) does NOT
+    raise."""
+
+    async def _correctly_shaped_trigger(
+        point: str, payloads: list, skipped_session_wide: int = 0,
+    ) -> None:
+        pass
+
+    assert_hook_trigger_signature(
+        _correctly_shaped_trigger, real=Session._bridge_hook_trigger,
+    )  # must not raise
 
 
 def test_a_matching_instance_double_does_not_fail() -> None:
@@ -82,11 +139,13 @@ def test_a_matching_instance_double_does_not_fail() -> None:
 
     class _CorrectlyShapedRecorder:
         async def __call__(
-            self, point: str, payloads: list, *, skipped_session_wide: int = 0,
+            self, point: str, payloads: list, skipped_session_wide: int = 0,
         ) -> None:
             pass
 
-    assert_hook_trigger_signature(_CorrectlyShapedRecorder())  # must not raise
+    assert_hook_trigger_signature(
+        _CorrectlyShapedRecorder(), real=Session._bridge_hook_trigger,
+    )  # must not raise
 
 
 def test_annotation_differences_alone_do_not_fail() -> None:
@@ -96,7 +155,9 @@ def test_annotation_differences_alone_do_not_fail() -> None:
     repeat production's own string-quoted type hints) must still pass when
     its name/kind/has-default shape genuinely matches."""
 
-    async def _unannotated_trigger(point, payloads, *, skipped_session_wide=0):
+    async def _unannotated_trigger(point, payloads, skipped_session_wide=0):
         pass
 
-    assert_hook_trigger_signature(_unannotated_trigger)  # must not raise
+    assert_hook_trigger_signature(
+        _unannotated_trigger, real=Session._bridge_hook_trigger,
+    )  # must not raise

--- a/tests/hooks/test_5527_hook_trigger_double_signature_pin.py
+++ b/tests/hooks/test_5527_hook_trigger_double_signature_pin.py
@@ -1,0 +1,102 @@
+"""Tier 2: OS invariant tests for #5527 —
+``tests._support.hooks.assert_hook_trigger_signature``.
+
+Real incident (#5516 arc, root-caused #5527): 3 hand-written
+``hook_trigger``-shaped test doubles kept the PRE-#5516 single-event
+signature after production moved to the batch shape
+(``HookDispatcher.dispatch_external_batch(point, payloads, *,
+skipped_session_wide=0)``). Each raised ``TypeError`` on the missing
+kwarg, silently swallowed by ``HookDispatcher``'s own per-hook isolation
+``try/except`` — the caller never saw a red test, only an unbounded
+``_wait_for`` poll that never terminated (a hang, not a failure). Architect's
+prescription (settled, #5527's own issue thread): pin a double's signature
+against the real target ONCE, inside the helper that constructs the double
+— this file proves that pin actually does the job it is for.
+
+Policy compliance:
+- No unittest.mock / MagicMock / AsyncMock / patch.
+- No private-state assertions — drives ``assert_hook_trigger_signature``
+  through its own public contract only.
+- Each docstring opens with ``Tier 2: ...``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests._support.hooks import assert_hook_trigger_signature
+
+
+def test_a_drifted_double_signature_fails_loudly() -> None:
+    """Tier 2: #5527 accept ① — a double whose signature has drifted from
+    the real ``dispatch_external_batch`` (here: the exact #5516-arc drift —
+    ``skipped_session_wide`` missing entirely) makes
+    ``assert_hook_trigger_signature`` raise, immediately and loudly (an
+    ``AssertionError``, not a hang, not a swallowed ``TypeError`` three
+    layers downstream inside ``HookDispatcher``'s own per-hook isolation)."""
+
+    async def _pre_5516_shaped_trigger(point: str, template_vars: dict) -> None:
+        pass
+
+    with pytest.raises(AssertionError, match="drifted"):
+        assert_hook_trigger_signature(_pre_5516_shaped_trigger)
+
+
+def test_a_kind_only_drift_also_fails() -> None:
+    """Tier 2: #5527 accept ① — the SPECIFIC drift #5527's own investigation
+    found in the 2 real doubles this issue fixed: ``skipped_session_wide``
+    present, correctly named and defaulted, but declared POSITIONAL-OR-
+    KEYWORD instead of the real target's KEYWORD-ONLY kind (no leading
+    ``*``). Name-and-default-only comparison would miss this; ``kind`` must
+    be part of the compared shape."""
+
+    async def _wrong_kind_trigger(
+        point: str, payloads: list, skipped_session_wide: int = 0,
+    ) -> None:
+        pass
+
+    with pytest.raises(AssertionError, match="drifted"):
+        assert_hook_trigger_signature(_wrong_kind_trigger)
+
+
+def test_a_matching_double_does_not_fail() -> None:
+    """Tier 2: #5527 accept ② (the deny-side sibling) — a double whose
+    signature genuinely matches the real target does NOT raise. Without
+    this, an "always raise" implementation of ``assert_hook_trigger_
+    signature`` would pass accept ① for the wrong reason."""
+
+    async def _correctly_shaped_trigger(
+        point: str, payloads: list, *, skipped_session_wide: int = 0,
+    ) -> None:
+        pass
+
+    assert_hook_trigger_signature(_correctly_shaped_trigger)  # must not raise
+
+
+def test_a_matching_instance_double_does_not_fail() -> None:
+    """Tier 2: #5527 accept ② — the SAME deny-side proof, but for an
+    instance whose ``__call__`` is correctly shaped (the actual double
+    shape both #5527-fixed doubles use, not a bare function) — proving the
+    helper's ``self``-stripping (via ``inspect.signature``'s own bound-
+    method behavior on ``__call__``) works for this shape too, not just a
+    bare async function."""
+
+    class _CorrectlyShapedRecorder:
+        async def __call__(
+            self, point: str, payloads: list, *, skipped_session_wide: int = 0,
+        ) -> None:
+            pass
+
+    assert_hook_trigger_signature(_CorrectlyShapedRecorder())  # must not raise
+
+
+def test_annotation_differences_alone_do_not_fail() -> None:
+    """Tier 2: #5527 — the helper deliberately does NOT compare type
+    annotations (see ``_param_shape``'s own docstring): a double with no
+    annotations at all (the common case — hand-written test doubles rarely
+    repeat production's own string-quoted type hints) must still pass when
+    its name/kind/has-default shape genuinely matches."""
+
+    async def _unannotated_trigger(point, payloads, *, skipped_session_wide=0):
+        pass
+
+    assert_hook_trigger_signature(_unannotated_trigger)  # must not raise

--- a/tests/mcp/test_2597_p1_reconnect_resync_read.py
+++ b/tests/mcp/test_2597_p1_reconnect_resync_read.py
@@ -29,6 +29,7 @@ from reyn.core.events.events import EventLog
 from reyn.mcp.client import MCPError
 from reyn.mcp.connection_service import MCPConnectionService
 from tests._support.events import collect_events
+from tests._support.hooks import assert_hook_trigger_signature
 from tests._support.paths import REPO_ROOT
 
 _SUPPORT_DIR = REPO_ROOT / "tests" / "_support"
@@ -137,17 +138,20 @@ async def test_reconnect_resync_also_fires_hook_trigger_identically_to_real_push
     session.py/hooks/ involvement needed to prove this bridge fires."""
 
     class _RecordingTrigger:
-        """#5516: batch-shaped -- (point, payloads, skipped_session_wide)."""
+        """#5516: batch-shaped -- (point, payloads, *, skipped_session_wide)."""
 
         def __init__(self) -> None:
             self.calls: list[tuple[str, list, int]] = []
 
         async def __call__(
-            self, point: str, payloads: list, skipped_session_wide: int = 0,
+            self, point: str, payloads: list, *, skipped_session_wide: int = 0,
         ) -> None:
             self.calls.append((point, payloads, skipped_session_wide))
 
     trigger = _RecordingTrigger()
+    # #5527: pin this double's shape against the real hook_trigger target
+    # ONCE, here at construction — not per test.
+    assert_hook_trigger_signature(trigger)
     events = EventLog(subscribers=[])
     collected = collect_events(events)
     service = MCPConnectionService(

--- a/tests/mcp/test_2597_p1_reconnect_resync_read.py
+++ b/tests/mcp/test_2597_p1_reconnect_resync_read.py
@@ -28,6 +28,7 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.mcp.client import MCPError
 from reyn.mcp.connection_service import MCPConnectionService
+from reyn.runtime.session import Session
 from tests._support.events import collect_events
 from tests._support.hooks import assert_hook_trigger_signature
 from tests._support.paths import REPO_ROOT
@@ -138,20 +139,28 @@ async def test_reconnect_resync_also_fires_hook_trigger_identically_to_real_push
     session.py/hooks/ involvement needed to prove this bridge fires."""
 
     class _RecordingTrigger:
-        """#5516: batch-shaped -- (point, payloads, *, skipped_session_wide)."""
+        """#5516: batch-shaped -- (point, payloads, skipped_session_wide).
+        #5527: matches ``Session._bridge_hook_trigger`` — the REAL callable
+        wired into ``MCPConnectionService(hook_trigger=...)`` in production
+        (``session.py``'s ``hook_trigger=self._bridge_hook_trigger``), not
+        ``HookDispatcher.dispatch_external_batch`` directly — the two have
+        different ``skipped_session_wide`` param kinds (see
+        ``assert_hook_trigger_signature``'s own docstring)."""
 
         def __init__(self) -> None:
             self.calls: list[tuple[str, list, int]] = []
 
         async def __call__(
-            self, point: str, payloads: list, *, skipped_session_wide: int = 0,
+            self, point: str, payloads: list, skipped_session_wide: int = 0,
         ) -> None:
             self.calls.append((point, payloads, skipped_session_wide))
 
     trigger = _RecordingTrigger()
-    # #5527: pin this double's shape against the real hook_trigger target
-    # ONCE, here at construction — not per test.
-    assert_hook_trigger_signature(trigger)
+    # #5527: pin this double's shape against the REAL callable it
+    # substitutes for in production (Session._bridge_hook_trigger, not
+    # HookDispatcher.dispatch_external_batch — see the double's own
+    # docstring above), ONCE, here at construction — not per test.
+    assert_hook_trigger_signature(trigger, real=Session._bridge_hook_trigger)
     events = EventLog(subscribers=[])
     collected = collect_events(events)
     service = MCPConnectionService(

--- a/tests/runtime/test_2608_h4_fs_watcher.py
+++ b/tests/runtime/test_2608_h4_fs_watcher.py
@@ -42,6 +42,7 @@ from reyn.hooks.schema import ALLOWED_HOOK_POINTS
 from reyn.runtime.fs_watcher import FsWatcher
 from reyn.runtime.session_params import ReactivityConfig
 from tests._support.agent_session import make_session
+from tests._support.hooks import assert_hook_trigger_signature
 
 watchdog = pytest.importorskip("watchdog", reason="fs-watch extra ('pip install reyn[fs-watch]') not installed")
 
@@ -55,19 +56,25 @@ class _Recorder:
     """A real recording async callable — the ``hook_trigger`` DI shape,
     no mock.
 
-    #5516: ``hook_trigger`` is now batch-shaped (``(point, payloads,
+    #5516: ``hook_trigger`` is now batch-shaped (``(point, payloads, *,
     skipped_session_wide=0)``). This recorder flattens each batch back to
     one ``(point, payload)`` tuple per event, preserving every existing
     call site's ``(point, template_vars) = trigger.calls[N]`` shape below
     unchanged — every test in this file only ever produces one file-write
     event per assertion, so batches stay length-1 in practice, but the
-    flatten is correct for N>1 too (never silently drops an event)."""
+    flatten is correct for N>1 too (never silently drops an event).
+
+    #5527: pins its own shape against the real hook_trigger target inside
+    ``__init__`` — once per instantiation, not per test — so a future
+    change to ``HookDispatcher.dispatch_external_batch`` breaks every one
+    of this file's 6 construction sites loudly (red) instead of hanging."""
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict]] = []
+        assert_hook_trigger_signature(self)
 
     async def __call__(
-        self, point: str, payloads: list, skipped_session_wide: int = 0,
+        self, point: str, payloads: list, *, skipped_session_wide: int = 0,
     ) -> None:
         self.calls.extend((point, dict(payload)) for payload in payloads)
 

--- a/tests/runtime/test_2608_h4_fs_watcher.py
+++ b/tests/runtime/test_2608_h4_fs_watcher.py
@@ -40,6 +40,7 @@ import pytest
 from reyn.hooks.matcher import matches
 from reyn.hooks.schema import ALLOWED_HOOK_POINTS
 from reyn.runtime.fs_watcher import FsWatcher
+from reyn.runtime.session import Session
 from reyn.runtime.session_params import ReactivityConfig
 from tests._support.agent_session import make_session
 from tests._support.hooks import assert_hook_trigger_signature
@@ -56,7 +57,7 @@ class _Recorder:
     """A real recording async callable — the ``hook_trigger`` DI shape,
     no mock.
 
-    #5516: ``hook_trigger`` is now batch-shaped (``(point, payloads, *,
+    #5516: ``hook_trigger`` is now batch-shaped (``(point, payloads,
     skipped_session_wide=0)``). This recorder flattens each batch back to
     one ``(point, payload)`` tuple per event, preserving every existing
     call site's ``(point, template_vars) = trigger.calls[N]`` shape below
@@ -64,17 +65,23 @@ class _Recorder:
     event per assertion, so batches stay length-1 in practice, but the
     flatten is correct for N>1 too (never silently drops an event).
 
-    #5527: pins its own shape against the real hook_trigger target inside
-    ``__init__`` — once per instantiation, not per test — so a future
-    change to ``HookDispatcher.dispatch_external_batch`` breaks every one
-    of this file's 6 construction sites loudly (red) instead of hanging."""
+    #5527: matches ``Session._bridge_hook_trigger`` — the REAL callable
+    wired into ``FsWatcher(hook_trigger=...)`` in production (``session.
+    py``'s ``hook_trigger=self._bridge_hook_trigger``), not
+    ``HookDispatcher.dispatch_external_batch`` directly — the two have
+    different ``skipped_session_wide`` param kinds (see
+    ``assert_hook_trigger_signature``'s own docstring). Pins its own shape
+    against that real target inside ``__init__`` — once per instantiation,
+    not per test — so a future change to ``_bridge_hook_trigger`` breaks
+    every one of this file's 6 construction sites loudly (red) instead of
+    hanging."""
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict]] = []
-        assert_hook_trigger_signature(self)
+        assert_hook_trigger_signature(self, real=Session._bridge_hook_trigger)
 
     async def __call__(
-        self, point: str, payloads: list, *, skipped_session_wide: int = 0,
+        self, point: str, payloads: list, skipped_session_wide: int = 0,
     ) -> None:
         self.calls.extend((point, dict(payload)) for payload in payloads)
 


### PR DESCRIPTION
**[tui-coder]** — closes #5527

Architect's prescription (settled on the issue, no design judgment remaining): pin a `hook_trigger`-shaped test double's call signature against the real target once, inside the helper that constructs the double — never per-test.

## 🔴 lead-coder's BLOCKING finding (head ce127578e) — addressed

**The `hook_trigger` slot has TWO real occupants with genuinely different signatures, not one:**

```
src/reyn/hooks/dispatcher.py:249  HookDispatcher.dispatch_external_batch
  async def dispatch_external_batch(
      self, point, payloads, *, skipped_session_wide: int = 0,
  ) -> None:                       ← KEYWORD-ONLY
  wired to Session.dispatch_external_event_batch (H5 cron/webhook path)

src/reyn/runtime/session.py:3622  Session._bridge_hook_trigger
  async def _bridge_hook_trigger(
      self, point, payloads, skipped_session_wide: int = 0,
  ) -> None:                       ← POSITIONAL-OR-KEYWORD
  wired to BOTH FsWatcher (session.py:5321) and MCPConnectionService
  (session.py:6328) via hook_trigger=self._bridge_hook_trigger
```

The first version of this PR hard-coded `dispatch_external_batch` as *the* real target. Both `_RecordingTrigger` (`test_2597`, substitutes for `MCPConnectionService`'s `hook_trigger`) and `_Recorder` (`test_2608_h4_fs_watcher.py`, substitutes for `FsWatcher`'s) actually stand in for `_bridge_hook_trigger`, not `dispatch_external_batch` — pinning them against the wrong real target meant the helper caught no real drift for them, and additionally made both doubles STRICTER than the real thing they substitute for (a caller legitimately passing `skipped_session_wide` positionally to the real `_bridge_hook_trigger` would succeed for real, fail on the double — backwards).

## Chosen option (of the 2 lead-coder offered)

**Option 1 — the helper takes the real target explicitly** (`assert_hook_trigger_signature(double, real)`, `real` always required, never defaulted). This is the only one compatible with #5527's own already-settled scope constraint (architect: "production を触らないでください") — unifying `_bridge_hook_trigger`'s param kind with `dispatch_external_batch`'s (option 2) would be a production change and a separate design call this PR does not make; lead-coder themselves noted they don't know whether `_bridge_hook_trigger`'s own POSITIONAL-OR-KEYWORD shape has an intentional reason.

## What changed

Reverted the incorrect `*,` I'd added to both doubles' own `skipped_session_wide` (restoring POSITIONAL-OR-KEYWORD, the real shape of `_bridge_hook_trigger`, the target they actually stand in for), wired each construction site's `assert_hook_trigger_signature` call to the correct real callable.

`test_hook_event_schema_registry_sync_0059.py`'s `_capture_dispatch` delegates via kwargs pass-through to the real method — structurally immune already, not a target. `test_2608_h2_hook_matcher.py`'s `_Recorder` doubles a different real target (`put_inbox`, fully generic) — out of scope.

`test_5527_hook_trigger_double_signature_pin.py` now exercises BOTH real targets explicitly (parametrized where the assertion is target-agnostic, mirrored where it's target-specific — the kind-only-drift case that only reproduces against ONE target at a time), including the exact regression this PR's first version introduced (a double shaped for one real target, asserted against the other).

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 200 findings, all baselined
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 25 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py tests/_support/hooks.py` — OK
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all OK (tests/ touched)
- [x] New tests prove both accept criteria against BOTH real targets, plus the wrong-target regression PR's first version introduced
- [x] Strip-falsify (post-redesign): forced the helper to never-raise → exactly the 4 drift tests failed; forced always-raise → exactly the 4 deny-side tests failed; reverted, confirmed green both times
- [x] Regression sweep: `tests/hooks/` + the 2 touched files — 427 passed
- [ ] (skipped — Visual) no UI surface touched

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
