### PR TITLE
fix(#5521): observe drain_folded task death via add_done_callback

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -90,6 +90,7 @@ file_changed
 file_read_media_denied
 force_close_triggered
 hook_changed
+hook_drain_task_died
 hook_event_emitted
 hook_push_fired
 hook_shell_executed

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -357,6 +357,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "file_read_media_denied",
     "force_close_triggered",
     "hook_changed",
+    "hook_drain_task_died",
     "hook_event_emitted",
     "hook_push_fired",
     "hook_shell_executed",

--- a/src/reyn/hooks/composed_consumer.py
+++ b/src/reyn/hooks/composed_consumer.py
@@ -36,7 +36,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import logging
+from typing import Any, Callable
 
 from reyn.hooks.bus import HookBus
 from reyn.hooks.composer import COMPOSED_KIND_PREFIX
@@ -55,9 +57,17 @@ class ComposedEventConsumer:
     :meth:`stop` at session teardown for a clean cancellation, mirroring
     ``reyn.hooks.composer.ComposerRegistry``'s start/stop shape."""
 
-    def __init__(self, *, bus: HookBus, dispatcher: HookDispatcher) -> None:
+    def __init__(
+        self, *, bus: HookBus, dispatcher: HookDispatcher,
+        emit_event: "Callable[..., Any] | None" = None,
+    ) -> None:
         self._bus = bus
         self._dispatcher = dispatcher
+        # #5521: audit-emit sink for this consumer's own drain-task-death
+        # observation (see :meth:`start`) — same None-tolerant,
+        # deferred-lambda-over-session pattern this class's own caller
+        # already uses for every sibling construction in session.py.
+        self._emit_event = emit_event
         self._task: "asyncio.Task | None" = None
 
     def start(self) -> None:
@@ -66,6 +76,16 @@ class ComposedEventConsumer:
         if self._task is not None:
             return
         self._task = asyncio.ensure_future(self._run())
+        # #5521 (architect ruling): observe — never swallow — this task's
+        # own eventual death. See ingress.py's own identical wiring /
+        # observe_drain_task_death's own docstring for the full contract.
+        from reyn.hooks.fold import observe_drain_task_death
+        self._task.add_done_callback(
+            functools.partial(
+                observe_drain_task_death,
+                emit_event=self._emit_event, label="ComposedEventConsumer",
+            )
+        )
 
     async def stop(self) -> None:
         """Cancel the background task and await its clean exit. Idempotent —

--- a/src/reyn/hooks/external_fire.py
+++ b/src/reyn/hooks/external_fire.py
@@ -38,6 +38,7 @@ isolation).
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 import weakref
 from typing import Any
@@ -133,6 +134,23 @@ class _SessionFireBridge:
                     "AgentRegistry.shutdown()'s drain (see tracked_tasks.py)."
                 )
                 self._drain_task = asyncio.create_task(self._drain())
+            # #5521 (architect ruling): observe — never swallow — this
+            # drain task's own eventual death, for EITHER branch above.
+            # ``self._session`` is typed Any (a test double may not carry
+            # ``_audit_events``) — same getattr-guarded posture as
+            # ``_background_tasks`` a few lines above, not a new idiom.
+            # See ingress.py's identical wiring / observe_drain_task_death's
+            # own docstring for the full contract.
+            from reyn.hooks.fold import observe_drain_task_death
+            audit_events = getattr(self._session, "_audit_events", None)
+            assert self._drain_task is not None  # just assigned by either branch above
+            self._drain_task.add_done_callback(
+                functools.partial(
+                    observe_drain_task_death,
+                    emit_event=(audit_events.emit if audit_events is not None else None),
+                    label="_SessionFireBridge",
+                )
+            )
         try:
             self._queue.put_nowait((point, template_vars))
         except asyncio.QueueFull:

--- a/src/reyn/hooks/fold.py
+++ b/src/reyn/hooks/fold.py
@@ -74,6 +74,7 @@ proof above.
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Awaitable, Callable, Protocol, TypeVar
 
 T = TypeVar("T")
@@ -136,6 +137,69 @@ async def drain_folded(
         for _ in range(n_more):
             batch.append(queue.get_nowait())
         await dispatch_batch(batch)
+
+
+def observe_drain_task_death(
+    task: "asyncio.Task[None]", *, emit_event: "Callable[..., Any] | None", label: str,
+) -> None:
+    """#5521 (architect ruling, on this issue's own thread) — wire via
+    ``task.add_done_callback(functools.partial(observe_drain_task_death,
+    emit_event=..., label=...))`` right where a caller creates the task
+    that runs :func:`drain_folded` forever (``asyncio.create_task``/
+    ``asyncio.ensure_future``).
+
+    This does NOT swallow anything and does NOT add a try/except anywhere
+    — :func:`drain_folded`'s own contract above ("this loop has NO
+    try/except of its own … a dispatch_batch that raises WOULD propagate
+    out and kill this while True loop with a single raise") is completely
+    unchanged. A ``done_callback`` fires strictly AFTER the task has
+    already ended, one way or another — it OBSERVES a death that already
+    happened, it cannot prevent or convert one. ``task.exception()`` on an
+    already-done, non-cancelled task returns the exception (never raises
+    it) — that is what makes this an observation, not a second isolation
+    layer of the #5516-arc-#5527 kind (this module deliberately does not
+    grow its own ``except Exception`` here).
+
+    ``task.cancelled()`` is checked FIRST and returns early — a cancelled
+    task is the NORMAL shutdown shape every one of this repo's 3 real
+    callers uses (``stop()``/``aclose()``: ``task.cancel()`` then await
+    with ``CancelledError`` suppressed), not a death. Calling
+    ``task.exception()`` on a cancelled task raises ``CancelledError``
+    itself, so this order is load-bearing, not incidental.
+
+    Real incident this closes (#5516 arc, #5521): the 3 current callers
+    each wrap their own ``dispatch_batch`` callback body in its own
+    ``try``/``except`` (see :func:`drain_folded`'s own docstring) — but
+    that convention is enforced NOWHERE. A future 4th caller that drops
+    that inner try/except would have its own callback's raise propagate
+    all the way up through this loop and kill the drain task PERMANENTLY
+    (the hook point it served never fires again) with — before this —
+    zero record anywhere an operator or ``doctor`` could read. #5356's
+    own ruling on the SAME "silent, persistent" shape
+    (``hooks_layer_rejected``) applies here directly: a log line alone is
+    invisible with the shipped config, and this failure is exactly the
+    kind #5356 was written for — permanent, not one-shot (contrast the
+    #5527 test-double-signature drift this issue was originally bundled
+    with: THAT failure is caught immediately, on the very next dispatch
+    attempt, by the callback's own surviving try/except, and is already
+    a WARNING-level log line at the shipped default — see architect's own
+    finding on this issue's thread for why the two get the OPPOSITE
+    visibility treatment).
+
+    ``emit_event`` is ``None``-tolerant (a caller/test double that hasn't
+    wired an audit-emit sink degrades to a silent no-op here, same
+    posture ``FsWatcher``'s own ``self._emit_event`` already has) —
+    OBSERVATION is best-effort by design; it must never itself become a
+    reason the drain task's real death is masked or delayed."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is None or emit_event is None:
+        return
+    emit_event(
+        "hook_drain_task_died", label=label,
+        reason=f"{type(exc).__name__}: {exc}",
+    )
 
 
 __all__ = ["drain_folded"]

--- a/src/reyn/hooks/ingress.py
+++ b/src/reyn/hooks/ingress.py
@@ -51,6 +51,7 @@ shape Phase 1 eliminated). What IS unified is the two-step shape
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
 
@@ -131,10 +132,18 @@ class _BoundedEventBridge:
         hook_trigger: "HookTrigger | None",
         maxsize: int,
         adapter_name: str,
+        emit_event: "Callable[..., Any] | None" = None,
     ) -> None:
         self._hook_trigger = hook_trigger
         self._maxsize = maxsize
         self._adapter_name = adapter_name
+        # #5521: audit-emit sink for observing a drain task's own death (see
+        # _ensure_drain_task's own comment) — deliberately the SAME
+        # None-tolerant, deferred-lambda-over-session pattern
+        # FsWatcher/MCPConnectionService already use for their own
+        # emit_event/emit_sink (this bridge's caller threads its own
+        # existing sink through here, not a new one).
+        self._emit_event = emit_event
         self._queue: "asyncio.Queue[HookEvent] | None" = None
         self._drain_task: "asyncio.Task | None" = None
         self._dropped_since_last_batch = 0
@@ -164,6 +173,20 @@ class _BoundedEventBridge:
             self._queue = asyncio.Queue(maxsize=self._maxsize)
         if self._drain_task is None or self._drain_task.done():
             self._drain_task = asyncio.create_task(self._drain())
+            # #5521 (architect ruling): observe — never swallow — this
+            # drain task's own eventual death. drain_folded's own
+            # try/except-free contract is unchanged; this only fires
+            # AFTER the task has already ended, and only records a
+            # genuine raise (a normal cancel — this class's own
+            # shutdown path — is excluded, see observe_drain_task_death's
+            # own docstring).
+            from reyn.hooks.fold import observe_drain_task_death
+            self._drain_task.add_done_callback(
+                functools.partial(
+                    observe_drain_task_death,
+                    emit_event=self._emit_event, label=self._adapter_name,
+                )
+            )
 
     async def _drain(self) -> None:
         from reyn.hooks.fold import drain_folded
@@ -236,9 +259,16 @@ class McpIngressAdapter:
     (:class:`~reyn.mcp.subscription_port.ListenSubscriptionAdapter`). This
     adapter itself never branches on which of those produced the signal."""
 
-    def __init__(self, *, hook_trigger: "HookTrigger | None", maxsize: int = 32) -> None:
+    def __init__(
+        self,
+        *,
+        hook_trigger: "HookTrigger | None",
+        maxsize: int = 32,
+        emit_event: "Callable[..., Any] | None" = None,
+    ) -> None:
         self._bridge = _BoundedEventBridge(
             hook_trigger=hook_trigger, maxsize=maxsize, adapter_name="McpIngressAdapter",
+            emit_event=emit_event,
         )
 
     def to_event(
@@ -265,9 +295,16 @@ class FsIngressAdapter:
     watched-paths OUT-set is entirely owned by ``FsWatcher``/
     ``FsWatchConfig`` (restart-only, no op/tool call reaches it)."""
 
-    def __init__(self, *, hook_trigger: "HookTrigger | None", maxsize: int = 32) -> None:
+    def __init__(
+        self,
+        *,
+        hook_trigger: "HookTrigger | None",
+        maxsize: int = 32,
+        emit_event: "Callable[..., Any] | None" = None,
+    ) -> None:
         self._bridge = _BoundedEventBridge(
             hook_trigger=hook_trigger, maxsize=maxsize, adapter_name="FsIngressAdapter",
+            emit_event=emit_event,
         )
 
     def to_event(self, path: str, event_type: str) -> HookEvent:

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -248,6 +248,10 @@ class MCPConnectionService:
         # duplicated.
         self._mcp_ingress_adapter = McpIngressAdapter(
             hook_trigger=hook_trigger, maxsize=_HOOK_EVENT_QUEUE_MAXSIZE,
+            # #5521: reuse this service's OWN emit_sink (above) for the
+            # ingress bridge's drain-task-death observation — the same
+            # None-tolerant sink, not a second one.
+            emit_event=emit_sink,
         )
         self._clients: dict[str, MCPClient] = {}
         # #2597 slice ②b: runtime-only, in-memory, NO WAL (Q4 — see module docstring).

--- a/src/reyn/runtime/fs_watcher.py
+++ b/src/reyn/runtime/fs_watcher.py
@@ -169,6 +169,10 @@ class FsWatcher:
         # Byte-identical behaviour (same maxsize, same drop+log on overflow).
         self._fs_ingress_adapter = FsIngressAdapter(
             hook_trigger=hook_trigger, maxsize=_QUEUE_MAXSIZE,
+            # #5521: reuse this watcher's OWN emit_event sink (above) for
+            # the ingress bridge's drain-task-death observation — the
+            # same None-tolerant sink, not a second one.
+            emit_event=emit_event,
         )
         self._started = False
         # #2623: resolved-symlink-path -> operator-configured-path rewrites,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5337,6 +5337,9 @@ class Session:
         )
         composed_consumer = ComposedEventConsumer(
             bus=hook_bus, dispatcher=hook_dispatcher,
+            # #5521: same deferred-lambda-over-self._audit_events pattern
+            # every sibling construction right above uses.
+            emit_event=lambda et, **kw: self._audit_events.emit(et, **kw),
         )
 # #2073 S1: the config hot-reloader reads ONLY the IN-set (.reyn/*.yaml); the
 # OUT-set (reyn.yaml) is restart-only and never picked up here. Applies at the

--- a/tests/hooks/test_5521_drain_task_death_observation.py
+++ b/tests/hooks/test_5521_drain_task_death_observation.py
@@ -1,0 +1,115 @@
+"""Tier 2: OS invariant tests for #5521 —
+``reyn.hooks.fold.observe_drain_task_death``.
+
+Architect's settled prescription (this issue's own thread): observe a
+``drain_folded``-running task's death via ``task.add_done_callback`` —
+never swallow (``drain_folded`` keeps its own no-try/except contract,
+unchanged). Investigation ① (this PR's own body) confirmed the 3 real
+callers (``ingress.py`` / ``composed_consumer.py`` / ``external_fire.py``)
+are unchanged in count; a 4th caller that drops the inner try/except its
+own callback needs would otherwise kill its drain task PERMANENTLY with
+zero record anywhere — this file proves the observation now closes that
+gap without adding a new isolation layer.
+
+Policy compliance:
+- No unittest.mock / MagicMock / AsyncMock / patch. Drives a REAL
+  ``asyncio.Task`` + a REAL ``EventLog`` — no stand-ins.
+- No private-state assertions — drives ``observe_drain_task_death``
+  through its own public contract only, and reads the resulting event
+  via ``EventLog``'s own public subscriber surface.
+- Each docstring opens with ``Tier 2: ...``.
+"""
+from __future__ import annotations
+
+import asyncio
+import functools
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.hooks.fold import drain_folded, observe_drain_task_death
+from tests._support.events import collect_events, settle
+
+
+async def _raising_dispatch_batch(batch: list) -> None:
+    raise ValueError("simulated: callback forgot its own try/except")
+
+
+async def _quiet_dispatch_batch(batch: list) -> None:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_a_callback_that_raises_records_the_drain_task_death() -> None:
+    """Tier 2: #5521 accept — a callback that raises (the #5527-shaped
+    hazard: a 4th caller of ``drain_folded`` that dropped its own inner
+    try/except) makes the wrapping task die, and that death is recorded
+    as a REAL ``hook_drain_task_died`` audit-event — driven through a
+    REAL ``asyncio.create_task(drain_folded(...))`` + a REAL ``EventLog``,
+    no stand-in for either."""
+    events = EventLog()
+    collected = collect_events(events)
+    queue: "asyncio.Queue[int]" = asyncio.Queue()
+
+    task = asyncio.create_task(drain_folded(queue, _raising_dispatch_batch))
+    task.add_done_callback(
+        functools.partial(observe_drain_task_death, emit_event=events.emit, label="test-caller")
+    )
+    await queue.put(1)  # wakes drain_folded's blocking get() -> dispatch_batch raises
+    await settle(events)
+
+    died = [e for e in collected if e.type == "hook_drain_task_died"]
+    assert died, f"expected a hook_drain_task_died event, got {[e.type for e in collected]!r}"
+    assert died[0].data.get("label") == "test-caller"
+    assert "ValueError" in died[0].data.get("reason", "")
+
+    assert task.done() and not task.cancelled()
+    with pytest.raises(ValueError, match="simulated"):
+        task.result()  # #5521: the raise still propagated for real — observation, not swallowing
+
+
+@pytest.mark.asyncio
+async def test_a_normal_cancel_does_not_record_a_death() -> None:
+    """Tier 2: #5521 accept, deny side — a task ended via ``task.cancel()``
+    (the REAL shutdown shape all 3 production callers use: ``stop()``/
+    ``aclose()``) must NOT be recorded as a death. Without this, an
+    "always record" implementation would pass the raise-side test above
+    for the wrong reason, and every ordinary session teardown would emit
+    a false alarm."""
+    events = EventLog()
+    collected = collect_events(events)
+    queue: "asyncio.Queue[int]" = asyncio.Queue()
+
+    task = asyncio.create_task(drain_folded(queue, _quiet_dispatch_batch))
+    task.add_done_callback(
+        functools.partial(observe_drain_task_death, emit_event=events.emit, label="test-caller")
+    )
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await settle(events)
+
+    died = [e for e in collected if e.type == "hook_drain_task_died"]
+    assert not died, f"a cancelled (normal shutdown) task must not be recorded, got {died!r}"
+
+
+@pytest.mark.asyncio
+async def test_emit_event_none_degrades_silently_without_raising() -> None:
+    """Tier 2: #5521 — ``emit_event=None`` (a caller/test double with no
+    audit-emit sink wired, same posture ``FsWatcher``'s own
+    ``self._emit_event`` already has) must not itself raise or otherwise
+    interfere with the task's own real death — observation is
+    best-effort, never a NEW point of failure."""
+    queue: "asyncio.Queue[int]" = asyncio.Queue()
+
+    task = asyncio.create_task(drain_folded(queue, _raising_dispatch_batch))
+    task.add_done_callback(
+        functools.partial(observe_drain_task_death, emit_event=None, label="test-caller")
+    )
+    await queue.put(1)
+    await asyncio.sleep(0)  # let the task run and die; add_done_callback fires synchronously after
+    await asyncio.sleep(0)
+
+    assert task.done()
+    with pytest.raises(ValueError, match="simulated"):
+        task.result()

--- a/tests/hooks/test_5521_drain_task_death_observation.py
+++ b/tests/hooks/test_5521_drain_task_death_observation.py
@@ -99,17 +99,45 @@ async def test_emit_event_none_degrades_silently_without_raising() -> None:
     audit-emit sink wired, same posture ``FsWatcher``'s own
     ``self._emit_event`` already has) must not itself raise or otherwise
     interfere with the task's own real death — observation is
-    best-effort, never a NEW point of failure."""
-    queue: "asyncio.Queue[int]" = asyncio.Queue()
+    best-effort, never a NEW point of failure.
 
-    task = asyncio.create_task(drain_folded(queue, _raising_dispatch_batch))
-    task.add_done_callback(
-        functools.partial(observe_drain_task_death, emit_event=None, label="test-caller")
+    A ``done_callback`` that itself raises does NOT propagate into this
+    test's own coroutine — asyncio routes it to the event LOOP's own
+    exception handler instead (never awaited, never surfaced as a red
+    test on its own) — so this installs a real handler to CAPTURE that,
+    the only way this test can actually witness the claim in its own
+    docstring. Waits on a REAL ``asyncio.Event`` set by a SECOND
+    ``done_callback`` (added right after the one under test — asyncio
+    runs a task's done-callbacks in the order they were added, so this
+    second one is guaranteed to run only once the first has already run)
+    — no ``sleep(N)``, unbounded."""
+    loop = asyncio.get_running_loop()
+    captured_loop_exceptions: list[BaseException] = []
+    original_handler = loop.get_exception_handler()
+
+    def _capture(loop: "asyncio.AbstractEventLoop", context: dict) -> None:
+        exc = context.get("exception")
+        if exc is not None:
+            captured_loop_exceptions.append(exc)
+
+    loop.set_exception_handler(_capture)
+    observed_done = asyncio.Event()
+    try:
+        queue: "asyncio.Queue[int]" = asyncio.Queue()
+        task = asyncio.create_task(drain_folded(queue, _raising_dispatch_batch))
+        task.add_done_callback(
+            functools.partial(observe_drain_task_death, emit_event=None, label="test-caller")
+        )
+        task.add_done_callback(lambda _t: observed_done.set())
+        await queue.put(1)
+        await observed_done.wait()
+    finally:
+        loop.set_exception_handler(original_handler)
+
+    assert not captured_loop_exceptions, (
+        f"observe_drain_task_death must not itself raise when emit_event=None "
+        f"— the event loop's own exception handler caught: {captured_loop_exceptions!r}"
     )
-    await queue.put(1)
-    await asyncio.sleep(0)  # let the task run and die; add_done_callback fires synchronously after
-    await asyncio.sleep(0)
-
     assert task.done()
     with pytest.raises(ValueError, match="simulated"):
-        task.result()
+        task.result()  # the drain task's OWN real death — unrelated to observe_drain_task_death's return


### PR DESCRIPTION
**[tui-coder]** — closes #5521 (2件目; 1件目/test double signature drift は #5527 → PR #5534 で先に closed)

Architect's settled prescription (issue thread): observe `drain_folded`'s eventual task death via `task.add_done_callback` — never swallow, `drain_folded`'s own contract stays unchanged.

## 調査① (実装着手前、lead-coder指示分) — 呼び口の数え直し

`grep -rn "drain_folded(" src/` — 現在も3つ、増えていません:
- `ingress.py:191`
- `composed_consumer.py:119`
- `external_fire.py:195`

この issue が備える「4人目」は今もまだ仮定です（既に居るわけではありません）。全文は issue コメントに投稿済み: https://github.com/tya5/reyn/issues/5521#issuecomment-5463021070

## What changed

`fold.py`'s `drain_folded` documents its own contract verbatim: "this loop has NO try/except of its own … a `dispatch_batch` that raises WOULD propagate out and kill this `while True` loop with a single raise" — safety currently comes ENTIRELY from convention: each of the 3 real callers wraps its own `dispatch_batch` callback body in its own try/except. That convention was enforced nowhere.

Added `observe_drain_task_death` (`fold.py`, adjacent to `drain_folded`) — checks `task.cancelled()` first (the real shutdown shape all 3 callers use, never a death) and returns early; otherwise reads `task.exception()` and emits `hook_drain_task_died` (new closed-vocabulary audit-event kind) only when non-`None`, degrading silently when no emit sink is wired.

Wired at all 3 real task-creation sites — `ingress.py`'s `_BoundedEventBridge` (shared by `McpIngressAdapter`/`FsIngressAdapter`, threaded from `FsWatcher`'s existing `self._emit_event` / `MCPConnectionService`'s existing `self._emit_sink`), `composed_consumer.py`'s `ComposedEventConsumer` (new `emit_event` param, threaded from its own `session.py` construction site with the same lambda pattern its sibling constructions already use), `external_fire.py`'s `_SessionFireBridge` (reuses `getattr(self._session, "_audit_events", None)`, mirroring this file's own existing defensive idiom for `_background_tasks`).

New audit-event kind `hook_drain_task_died` registered in `event_schema.py`'s `AUDIT_EVENT_KINDS` (closed vocabulary, #3410) and `docs/reference/runtime/events.md`'s enumeration — no `EVENT_AUDIT_REQUIREMENTS` entry, matching `hooks_layer_rejected`'s own precedent (#5356, same silent+persistent reasoning).

調査② (nested swallow layers 3–4 deep inside per-hook isolation) confirmed out of scope by architect — they never create a new path to `drain_folded`. Filed separately as #5536 per lead-coder's suggestion.

**band note**: the new `hook_drain_task_died` event does NOT answer band Q1 ("who stops this if it repeats") — it only records the fact of a death; nothing consumes it to auto-restart the drain task or otherwise bound a recurrence. It closes band Q2 (visible with the shipped config, once `doctor`/`reyn events` reads it) for what is otherwise a permanent, silent failure.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/mypy_ratchet.py` — 200 findings, all baselined
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 3 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all OK (tests/ touched)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` / `check_doc_anchors.py` / `check_retired_config_keys_denylist.py` — all OK (docs/ touched)
- [x] `check_fastmcp_import_boundary.py` — OK (mcp/ touched)
- [x] `test_audit_event_kind_vocabulary_3410.py` — 10 passed (new kind census-clean both directions)
- [x] New `test_5521_drain_task_death_observation.py`: a real `asyncio.create_task(drain_folded(...))` + real `EventLog` — raising callback records the event AND the raise still propagates for real (observation, not swallowing); normal `task.cancel()` records nothing; `emit_event=None` degrades silently — witnessed via a real `loop.set_exception_handler` capture (a `done_callback`'s own raise never propagates into the awaiting coroutine, so this is the only way to actually catch it), synchronized with a chained `done_callback` + `asyncio.Event` (no `sleep(N)`)
- [x] Strip-falsify all 3 directions on the shared helper: forced never-emit → only the raise-side test failed; forced always-record → only the cancel-deny-side test failed; dropped the `emit_event is None` guard → only the emit_event=None test failed (caught via the loop exception handler); reverted, confirmed green each time
- [x] Regression sweep: `tests/hooks` + `tests/mcp` + `tests/runtime` — 2699 passed, 7 pre-existing unrelated optional-extra skips
- [ ] (skipped — Visual) no UI surface touched

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
