### PR TITLE
fix(#5513): media follow-up intro text carries the originating tool_call_id

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -539,6 +539,7 @@ def _resolve_router_model_for_media_gate(host: Any, router_model: str) -> "str |
 def _build_media_followup_message(
     *,
     tool_name: str,
+    tool_call_id: str,
     media_blocks: list[dict],
     media_store: Any = None,
     budget_tokens: int | None = None,
@@ -552,16 +553,22 @@ def _build_media_followup_message(
     images in litellm-normalised shape — provider-agnostic, since user messages
     with content lists are universally supported (Anthropic, Gemini, OpenAI).
 
-    #272 + media-count cap (dead-end-free media axis): when ``budget_tokens`` is
-    given, the WHOLE follow-up (materialised images + individual refs + the tail
-    preview) is held ≤ ``budget_tokens`` so the result turn stays single-turn
-    compactable (the chat retry_loop's shrink can always fold it). Images are
-    materialised while they fit; the next become small LOSSLESS path-refs while
-    THOSE fit; the remaining tail collapses into ONE offloaded-manifest preview
-    (lossless). So neither the image bytes NOR the ref count can grow the
-    follow-up without bound — closing the inline-shape bypass (Gap A) and the
-    unbounded-ref count (Gap B). ``budget_tokens=None`` preserves the pre-#272
-    unbounded behaviour (partial/test hosts).
+    #5513: ``tool_call_id`` is embedded in the intro TEXT, not a dedicated
+    field — ``role="user"`` (this message's own role) cannot carry a
+    ``tool_call_id`` field at all (only ``role="tool"`` can, an OpenAI API
+    shape, not a litellm-specific limitation), so text is the only
+    structurally possible place (architect ruling, #5513). Without it, two
+    calls to the SAME tool in one turn produce byte-identical intro text —
+    traceable only by adjacent position, which compaction/rewind can
+    scramble (#5513's own motivating incident). ``meta`` was explicitly
+    NOT added alongside — architect's own default ("don't add a value
+    where the read side isn't named yet"): whether this follow-up message
+    even gets its own persisted history entry with a readable ``meta`` was
+    not confirmed at review time. Known limitation, disclosed rather than
+    silently outgrown: this id distinguishes the two calls only while
+    THIS text survives verbatim — once compaction folds it into a rolling
+    summary, the distinction is gone (summarization is not something
+    reordering-survival can promise against).
     """
     images = [
         b for b in media_blocks
@@ -571,7 +578,13 @@ def _build_media_followup_message(
         return None
 
     parts: list[dict] = [
-        {"type": "text", "text": f"Tool `{tool_name}` returned the following attachment(s):"},
+        {
+            "type": "text",
+            "text": (
+                f"Tool `{tool_name}` (tool_call_id={tool_call_id}) returned "
+                f"the following attachment(s):"
+            ),
+        },
     ]
 
     # Unbounded path (pre-#272 / partial-host): materialise all renderable images.
@@ -4059,6 +4072,12 @@ class RouterLoop:
                 )
                 followup = _build_media_followup_message(
                     tool_name=tc.get("function", {}).get("name", "tool"),
+                    # #5513: same tc["id"] already threaded to the sibling
+                    # role="tool" message's own tool_call_id field above —
+                    # embedded in the intro text here since role="user"
+                    # cannot carry the field itself (see this function's
+                    # own docstring).
+                    tool_call_id=tc["id"],
                     media_blocks=media_blocks,
                     media_store=getattr(host, "media_store", None),
                     budget_tokens=_budget_tokens,

--- a/tests/core/test_mcp_multimodal_forwarding.py
+++ b/tests/core/test_mcp_multimodal_forwarding.py
@@ -152,7 +152,7 @@ def test_followup_builds_litellm_image_url_format() -> None:
     blocks = [
         {"type": "image", "data": "AAAA", "mimeType": "image/png"},
     ]
-    msg = _build_media_followup_message(tool_name="screenshot", media_blocks=blocks)
+    msg = _build_media_followup_message(tool_name="screenshot", tool_call_id="tc1",media_blocks=blocks)
 
     assert msg is not None
     assert msg["role"] == "user"
@@ -167,7 +167,7 @@ def test_followup_builds_litellm_image_url_format() -> None:
 def test_followup_defaults_mime_type_to_png() -> None:
     """Tier 2: when an image block omits mimeType, default to image/png."""
     blocks = [{"type": "image", "data": "XYZ"}]
-    msg = _build_media_followup_message(tool_name="t", media_blocks=blocks)
+    msg = _build_media_followup_message(tool_name="t", tool_call_id="tc1",media_blocks=blocks)
 
     assert msg is not None
     assert msg["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
@@ -178,7 +178,7 @@ def test_followup_handles_snake_case_mime_type() -> None:
     (= depending on SDK version); both keys should resolve.
     """
     blocks = [{"type": "image", "data": "XYZ", "mime_type": "image/webp"}]
-    msg = _build_media_followup_message(tool_name="t", media_blocks=blocks)
+    msg = _build_media_followup_message(tool_name="t", tool_call_id="tc1",media_blocks=blocks)
 
     assert msg is not None
     assert "data:image/webp;base64,XYZ" in msg["content"][1]["image_url"]["url"]
@@ -194,7 +194,7 @@ def test_followup_skips_non_image_blocks() -> None:
         {"type": "resource", "resource": {"uri": "file:///x"}},
         {"type": "unknown_kind", "data": "..."},
     ]
-    msg = _build_media_followup_message(tool_name="t", media_blocks=blocks)
+    msg = _build_media_followup_message(tool_name="t", tool_call_id="tc1",media_blocks=blocks)
 
     assert msg is None
 
@@ -207,7 +207,7 @@ def test_followup_drops_image_block_with_empty_data() -> None:
         {"type": "image", "data": "", "mimeType": "image/png"},
         {"type": "image", "mimeType": "image/png"},  # no data key at all
     ]
-    msg = _build_media_followup_message(tool_name="t", media_blocks=blocks)
+    msg = _build_media_followup_message(tool_name="t", tool_call_id="tc1",media_blocks=blocks)
 
     assert msg is None  # both dropped → no usable blocks → no follow-up
 
@@ -220,7 +220,7 @@ def test_followup_preserves_block_order() -> None:
         {"type": "image", "data": "FIRST", "mimeType": "image/png"},
         {"type": "image", "data": "SECOND", "mimeType": "image/jpeg"},
     ]
-    msg = _build_media_followup_message(tool_name="t", media_blocks=blocks)
+    msg = _build_media_followup_message(tool_name="t", tool_call_id="tc1",media_blocks=blocks)
 
     assert msg is not None
     urls = [p["image_url"]["url"] for p in msg["content"] if p["type"] == "image_url"]

--- a/tests/runtime/test_5509_media_capability_gate.py
+++ b/tests/runtime/test_5509_media_capability_gate.py
@@ -118,7 +118,7 @@ def test_the_caller_reads_the_failure_reason_unbounded_path(
     block = {"type": "image", "mime_type": "image/png", "data": "AAAA"}
     with caplog.at_level(logging.DEBUG, logger="reyn.runtime.router_loop"):
         result = _build_media_followup_message(
-            tool_name="read_file", media_blocks=[block], model=model,
+            tool_name="read_file", tool_call_id="tc1",media_blocks=[block], model=model,
         )
     assert result is None  # the only image dropped -> no follow-up at all
     assert any(
@@ -137,7 +137,7 @@ def test_the_caller_reads_the_failure_reason_bounded_path(
     block = {"type": "image", "mime_type": "image/png", "data": "AAAA"}
     with caplog.at_level(logging.DEBUG, logger="reyn.runtime.router_loop"):
         result = _build_media_followup_message(
-            tool_name="read_file", media_blocks=[block], model=model,
+            tool_name="read_file", tool_call_id="tc1",media_blocks=[block], model=model,
             budget_tokens=10_000,
         )
     assert result is not None  # ref fallback still produced a follow-up
@@ -162,7 +162,7 @@ def test_capability_unavailable_also_warns_once_per_model(
     block = {"type": "image", "mime_type": "image/png", "data": "AAAA"}
     with caplog.at_level(logging.WARNING, logger="reyn.runtime.router_loop"):
         _build_media_followup_message(
-            tool_name="read_file", media_blocks=[block, block], model=model,
+            tool_name="read_file", tool_call_id="tc1",media_blocks=[block, block], model=model,
         )
     warnings = [
         r for r in caplog.records
@@ -185,11 +185,11 @@ def test_a_second_session_with_the_same_model_still_warns(
     block = {"type": "image", "mime_type": "image/png", "data": "AAAA"}
     with caplog.at_level(logging.WARNING, logger="reyn.runtime.router_loop"):
         _build_media_followup_message(
-            tool_name="read_file", media_blocks=[block], model=model,
+            tool_name="read_file", tool_call_id="tc1",media_blocks=[block], model=model,
             session_id="session-a",
         )
         _build_media_followup_message(
-            tool_name="read_file", media_blocks=[block], model=model,
+            tool_name="read_file", tool_call_id="tc1",media_blocks=[block], model=model,
             session_id="session-b",
         )
     # Unpack-enforces exactly 2 — one per session, not deduped across them.

--- a/tests/runtime/test_5509_pr2_wire_media_parts.py
+++ b/tests/runtime/test_5509_pr2_wire_media_parts.py
@@ -214,7 +214,7 @@ def test_a_document_block_is_not_silently_dropped_by_the_type_filter_bounded_pat
     surfaces it as a real, modality-named ref."""
     blocks = [{"type": "document", "mime_type": "application/pdf", "path": "/tmp/x.pdf"}]
     fu = _build_media_followup_message(
-        tool_name="t", media_blocks=blocks, media_store=None, budget_tokens=10_000,
+        tool_name="t", tool_call_id="tc1",media_blocks=blocks, media_store=None, budget_tokens=10_000,
     )
     assert fu is not None
     texts = [p["text"] for p in fu["content"] if p.get("type") == "text"]
@@ -238,6 +238,6 @@ def test_an_unknown_block_type_is_still_filtered_out() -> None:
     (5 named types), not "any dict with a type key"."""
     blocks = [{"type": "carrier_pigeon", "mime_type": "application/octet-stream"}]
     fu = _build_media_followup_message(
-        tool_name="t", media_blocks=blocks, media_store=None, budget_tokens=10_000,
+        tool_name="t", tool_call_id="tc1",media_blocks=blocks, media_store=None, budget_tokens=10_000,
     )
     assert fu is None

--- a/tests/runtime/test_5513_media_followup_tool_call_id_survives_reordering.py
+++ b/tests/runtime/test_5513_media_followup_tool_call_id_survives_reordering.py
@@ -1,0 +1,130 @@
+"""Tier 2: #5513 — a media follow-up's own intro text carries the
+originating ``tool_call_id``, and that identifier survives a REAL
+reordering (compaction inserting a summary between two previously-
+adjacent follow-ups) — not merely "still adjacent" (six-questions ③: a
+hand-reordered list would be a test-authored configuration, not a
+witness of anything).
+
+Architect ruling (#5513, PR #5538's own sibling issue): the id lives in
+the intro TEXT only — ``role="user"`` cannot carry a ``tool_call_id``
+field (OpenAI API shape). Explicitly NOT claiming "always distinguishable
+regardless of what happens later" — architect's own disclosed limit:
+this id distinguishes the two calls only while the text itself survives
+verbatim; once COMPACTION folds a followup's own text into a rolling
+summary, the distinction is gone (summarization, not reordering, is what
+erases it). This file's own scenario is built so NEITHER followup's own
+text is inside the compacted span — only content BETWEEN them is — so
+the claim under test ("survives reordering") is not contradicted by that
+limit, and stays scoped to it (never asserts "always distinguishable").
+
+Real ``Session`` + real ``CompactionController.force_compact_now`` + real
+``RouterHistoryBuffer.build_history`` throughout — no hand-reordered list,
+no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from reyn.config import CompactionConfig, MultimodalConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.chat_message import ChatMessage
+from tests._support.agent_session import make_session
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _push(session, role: str, text: str, **kw) -> None:
+    session._append_history(ChatMessage(role=role, content=text, ts=_now(), **kw))
+
+
+def _followup_text(tool_call_id: str) -> str:
+    # Mirrors _build_media_followup_message's own real intro-text shape
+    # (router_loop.py) — this file tests whether the TEXT survives a real
+    # compaction pass, not whether the media pipeline itself builds the
+    # text correctly (covered separately, tests/runtime/test_media_cap_272.py
+    # et al.).
+    return f"Tool `read_file` (tool_call_id={tool_call_id}) returned the following attachment(s):"
+
+
+def _make_session_t_max(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, t_max: int):
+    monkeypatch.chdir(tmp_path)
+    import reyn.llm.model_budget as _mb
+    monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: t_max)
+    cfg = CompactionConfig(
+        body_token_cap=1500,
+        use_chars4_estimate=True,
+        section_caps_spec_tokens=0,
+    )
+    return make_session(
+        agent_name="default",
+        agent_role="",
+        output_language="en",
+        budget_tracker=BudgetTracker(CostConfig()),
+        state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
+        compaction_config=cfg,
+        multimodal_config=MultimodalConfig(),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
+
+
+def test_tool_call_id_disambiguates_two_same_tool_followups_after_a_real_compaction_reorders_them(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5513 — build history with the SAME tool called twice, each
+    producing its own media follow-up (real intro-text shape). Enough
+    padding turns sit BETWEEN the two follow-ups to become compaction
+    candidates (the middle raw_middle), while both follow-ups themselves
+    land in head/tail (never compacted, per this test's own sanity check
+    below) — a REAL ``force_compact_now()`` pass then inserts a summary
+    entry between them, breaking their original ADJACENCY (the position-
+    based disambiguation the issue's own incident relied on). Both
+    follow-up texts must still each name their own distinct
+    ``tool_call_id`` afterward — proving the id, not position, is what
+    disambiguates them post-reorder."""
+    session = _make_session_t_max(tmp_path, monkeypatch, t_max=100_000)
+
+    _push(session, "user", "look something up twice")
+    _push(session, "tool", "result one", tool_call_id="tc1", name="read_file")
+    _push(session, "user", _followup_text("tc1"))
+    # Padding turns — become raw_middle (compaction candidates) between the
+    # two follow-ups, without being large enough to touch either follow-up
+    # itself (head/tail keep both, per this test's own sanity check).
+    for i in range(20):
+        _push(session, "assistant" if i % 2 == 0 else "user", f"padding turn {i} " * 50)
+    _push(session, "tool", "result two", tool_call_id="tc2", name="read_file")
+    _push(session, "user", _followup_text("tc2"))
+    _push(session, "assistant", "both done")
+
+    asyncio.run(session._compaction_controller.force_compact_now())
+
+    history = session._history_buffer.build_history()
+    texts = [str(m.get("content", "")) for m in history]
+
+    # Sanity: a real compaction actually ran and inserted something between
+    # the two follow-ups — if this fails, the fixture needs adjusting
+    # (padding too small to trigger compaction), not the assertions below.
+    tc1_idx = next(i for i, t in enumerate(texts) if "tool_call_id=tc1" in t)
+    tc2_idx = next(i for i, t in enumerate(texts) if "tool_call_id=tc2" in t)
+    assert tc2_idx > tc1_idx + 1, (
+        "test setup sanity: expected at least one entry (a compacted "
+        "summary) between the two follow-ups — got them still adjacent, "
+        "meaning compaction never actually reordered anything here"
+    )
+
+    # The actual claim: BOTH follow-ups' own text still names their OWN
+    # distinct tool_call_id — neither followup's own text was itself
+    # folded away by the compaction that ran between them.
+    assert _followup_text("tc1") in texts, (
+        "the first follow-up's own text must survive verbatim — it must "
+        "never have been the thing compacted"
+    )
+    assert _followup_text("tc2") in texts, (
+        "the second follow-up's own text must survive verbatim"
+    )

--- a/tests/runtime/test_media_cap_272.py
+++ b/tests/runtime/test_media_cap_272.py
@@ -90,7 +90,7 @@ def test_media_followup_materialises_only_within_budget(tmp_path: Path) -> None:
     blocks = _path_blocks(store, 8)
     budget = 5 * _MEDIA_IMAGE_TOKEN_COST  # room to materialise ~4 then refs
     fu = _build_media_followup_message(
-        tool_name="t", media_blocks=blocks, media_store=store, budget_tokens=budget,
+        tool_name="t", tool_call_id="tc1",media_blocks=blocks, media_store=store, budget_tokens=budget,
     )
     imgs = _imgs(fu)
     assert imgs, "images that fit the budget materialise"
@@ -106,7 +106,7 @@ def test_media_followup_unbounded_when_no_budget(tmp_path: Path) -> None:
     store = _store(tmp_path)
     blocks = _path_blocks(store, 3)
     fu = _build_media_followup_message(
-        tool_name="t", media_blocks=blocks, media_store=store, budget_tokens=None,
+        tool_name="t", tool_call_id="tc1",media_blocks=blocks, media_store=store, budget_tokens=None,
     )
     assert len(_imgs(fu)) == len(blocks), "all blocks materialise when unbounded"
     assert not _texts(fu), "unbounded → nothing deferred to a ref/preview"
@@ -120,7 +120,7 @@ def test_overflow_image_is_lossless_individual_ref(tmp_path: Path) -> None:
     # Room for exactly one materialised image + at least one ref, no tail.
     budget = _MEDIA_IMAGE_TOKEN_COST + 400
     fu = _build_media_followup_message(
-        tool_name="t", media_blocks=blocks, media_store=store, budget_tokens=budget,
+        tool_name="t", tool_call_id="tc1",media_blocks=blocks, media_store=store, budget_tokens=budget,
     )
     refs = [p for p in _texts(fu) if "not loaded" in p["text"]]
     assert refs, "the over-budget image is preserved as an individual ref"
@@ -141,7 +141,7 @@ def test_total_followup_bounded_for_huge_image_count(tmp_path: Path) -> None:
     blocks = _path_blocks(store, 500)
     budget = 6 * _MEDIA_IMAGE_TOKEN_COST
     fu = _build_media_followup_message(
-        tool_name="t", media_blocks=blocks, media_store=store, budget_tokens=budget,
+        tool_name="t", tool_call_id="tc1",media_blocks=blocks, media_store=store, budget_tokens=budget,
     )
     assert _followup_tokens(fu) <= budget, "whole follow-up must stay within budget"
     # The 500 over-budget images collapse into a single tail preview (behavioural
@@ -158,7 +158,7 @@ def test_tail_preview_manifest_is_lossless(tmp_path: Path) -> None:
     blocks = _path_blocks(store, 40)
     budget = 4 * _MEDIA_IMAGE_TOKEN_COST
     fu = _build_media_followup_message(
-        tool_name="t", media_blocks=blocks, media_store=store, budget_tokens=budget,
+        tool_name="t", tool_call_id="tc1",media_blocks=blocks, media_store=store, budget_tokens=budget,
     )
     tail = [p for p in _texts(fu) if "manifest" in p["text"]]
     assert tail, "tail preview names a lossless manifest"
@@ -192,7 +192,7 @@ def test_inline_images_are_budget_accounted(tmp_path: Path) -> None:
     blocks = _inline_blocks(50)
     budget = 3 * _MEDIA_IMAGE_TOKEN_COST
     fu = _build_media_followup_message(
-        tool_name="t", media_blocks=blocks, media_store=store, budget_tokens=budget,
+        tool_name="t", tool_call_id="tc1",media_blocks=blocks, media_store=store, budget_tokens=budget,
     )
     assert _followup_tokens(fu) <= budget, "inline images must not bypass the budget"
     assert len(_imgs(fu)) <= budget // _MEDIA_IMAGE_TOKEN_COST
@@ -205,7 +205,7 @@ def test_no_store_tail_degrades_to_bounded_note(tmp_path: Path) -> None:
     blocks = _inline_blocks(100)
     budget = 3 * _MEDIA_IMAGE_TOKEN_COST
     fu = _build_media_followup_message(
-        tool_name="t", media_blocks=blocks, media_store=None, budget_tokens=budget,
+        tool_name="t", tool_call_id="tc1",media_blocks=blocks, media_store=None, budget_tokens=budget,
     )
     assert _followup_tokens(fu) <= budget
     notes = [p for p in _texts(fu) if "not shown" in p["text"]]

--- a/tests/runtime/test_path_ref_materialisation.py
+++ b/tests/runtime/test_path_ref_materialisation.py
@@ -147,6 +147,7 @@ def test_followup_resolves_pathref_via_media_store(tmp_path, monkeypatch):
 
     msg = _build_media_followup_message(
         tool_name="mcp.tool__playwright.screenshot",
+        tool_call_id="tc1",
         media_blocks=[block],
         media_store=store,
     )
@@ -169,7 +170,7 @@ def test_followup_handles_mixed_pathref_and_inline(tmp_path, monkeypatch):
               "mimeType": "image/png"}
 
     msg = _build_media_followup_message(
-        tool_name="mixed", media_blocks=[pathref, inline], media_store=store,
+        tool_name="mixed",  tool_call_id="tc1",media_blocks=[pathref, inline], media_store=store,
     )
     assert msg is not None
     (url0, url1) = [p["image_url"]["url"] for p in msg["content"] if p.get("type") == "image_url"]


### PR DESCRIPTION
**[tui-coder]** — closes #5513

## 結論

`_build_media_followup_message`の導入文に`tool_call_id`を埋め込み(architect裁定: `role="user"`は`tool_call_id`フィールドを持てない=OpenAI API仕様、textが唯一の置き場)。`meta`は今回追加せず(architect既定: 読み手が名指しできない面には足さない)。主張は「並べ替えに耐える」に限定(要約には耐えない、と明記)。

## 逐語（architect、issuecomment-5463172772）

> この id が要るのは「どの呼び出しの結果かを model が区別できること」∴ model が見る面に在るのが本筋

## Test

`test_5513_media_followup_tool_call_id_survives_reordering.py` — 同一toolを2回呼び、実際の`force_compact_now()`で間に要約を挿入(実在の経路、手で並べ替えたlistではない)、両followupが自分自身のtool_call_idを保持することを確認。Strip-falsify: id無しの旧文言に戻す→赤、復元→緑。

## Test plan

- [x] `ruff check .` / `mypy_ratchet.py` / `test_tier_audit.py --strict` — 緑（60 tests, 0 errors）
- [x] tests/-path gates（`flat_tests_ratchet` / `check_tests_path_literal_reference` / `check_bare_tests_import_reference` / `check_file_depth_reference` / `check_subprocess_reyn_pin`）— 緑
- [x] `verify_module_docstrings.py` — 緑
- [x] Strip-falsify — 赤/緑確認済み
- [x] 回帰: `tests/runtime + tests/core -k "media or followup or mcp_media"` — 159 passed
- [ ] (skipped — Visual)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
