### PR TITLE
fix(#5512): memoize path-ref base64 encoding by content_hash

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -603,6 +603,11 @@ class MediaStore:
     message so the read_tool_result handler can surface a stub error.
     """
 
+    #: #5512: disclosed-as-arbitrary, not measured — see
+    #: ``self._base64_cache``'s own comment (in ``__init__``) for why a
+    #: real bound wasn't derived from data for a priority-not-high issue.
+    _BASE64_CACHE_MAX_ENTRIES = 64
+
     def __init__(
         self,
         config: MediaStoreConfig | None = None,
@@ -725,6 +730,64 @@ class MediaStore:
         # reaches :meth:`save_tool_result`; never read for a path whose
         # entry is absent — see :meth:`is_open_turn_file`.
         self._chain_by_path: "dict[Path, str]" = {}
+        # #5512 (owner: "base64 の memo/cache 化は issue 化しておいて —
+        # 優先度は高くしなくて良い"): a path-ref's file is re-read and
+        # re-base64'd on EVERY wire-materialisation call while it's still
+        # in the LLM-visible window (measured call sites:
+        # router_loop.py's ``_materialise_media_part`` +
+        # router_history_buffer.py's ``_materialise_path_ref_content``,
+        # both unconditional per-call — confirmed against origin/main,
+        # #5512 issue's own step①). This only saves I/O + CPU
+        # (re-encoding), never wire bytes — the data URL's own content is
+        # identical either way (#5512's own explicit non-goal: this is
+        # NOT a cost/budget fix). Process-internal only (lead-coder
+        # ruling — no persistence, so no "who deletes it" band Q1 to
+        # answer). Keyed by the path-ref's own ``content_hash`` (#383's
+        # canonical shape, ``chat_message.py``'s own module docstring —
+        # already present, not a new field this adds) so a changed file
+        # is a different key, never a stale hit (#5364's own
+        # `_offload_content_hash` precedent uses the identical
+        # content-hash-as-key idiom for the same reason). Bounded (band:
+        # cost/budget) — NOT measured against a real workload (this
+        # issue's own priority is explicitly "not high"; a future
+        # session with real numbers should replace this if it turns out
+        # to matter): a modest, disclosed-as-arbitrary entry cap, evicted
+        # FIFO (oldest-inserted first) on overflow — simple over exact
+        # LRU since this is a best-effort memo, not a correctness-
+        # bearing cache.
+        self._base64_cache: "dict[str, str]" = {}
+
+    def read_media_base64(
+        self, path_str: str, *, content_hash: "str | None" = None,
+    ) -> "tuple[str | None, bool]":
+        """Read + base64-encode media at *path_str*, memoized by
+        *content_hash* when given (#5512). Returns ``(b64_or_None,
+        found)`` — ``found=False`` mirrors :meth:`read_media`'s own
+        contract (missing file, never raises for that case).
+
+        A cache HIT skips the file read AND the base64 encode entirely —
+        the two real costs #5512 measured (never the wire byte count,
+        which this does not change at all). ``content_hash=None``
+        (a caller with no hash to key on) always misses — this method
+        degrades to plain ``read_media`` + encode in that case, never
+        raises for lacking one.
+        """
+        if content_hash is not None:
+            cached = self._base64_cache.get(content_hash)
+            if cached is not None:
+                return cached, True
+        data_bytes, found = self.read_media(path_str)
+        if not found:
+            return None, False
+        import base64
+        b64 = base64.b64encode(data_bytes).decode("ascii")
+        if content_hash is not None:
+            if len(self._base64_cache) >= self._BASE64_CACHE_MAX_ENTRIES:
+                # FIFO eviction: dict preserves insertion order (Python
+                # 3.7+) — the oldest-inserted key is the first one.
+                self._base64_cache.pop(next(iter(self._base64_cache)))
+            self._base64_cache[content_hash] = b64
+        return b64, True
 
     def _spill_manifest_path(self) -> Path:
         # #4584: PERSIST tier — `.reyn/memory/`, not `.reyn/cache/` (see

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -368,13 +368,19 @@ def _materialise_media_part(
         if media_store is None:
             return MediaMaterialiseFailure.NO_STORE
         try:
-            data_bytes, found = media_store.read_media(path)
+            # #5512: memoized by content_hash (the canonical path-ref
+            # field, #383) when the block carries one — a cache hit
+            # skips both the file read and the base64 re-encode this
+            # method used to unconditionally repeat on every call while
+            # the block stays in the LLM-visible window.
+            data_b64, found = media_store.read_media_base64(
+                path, content_hash=block.get("content_hash"),
+            )
         except PermissionError:
             return MediaMaterialiseFailure.PERMISSION_DENIED
         if not found:
             return MediaMaterialiseFailure.NOT_FOUND
-        import base64
-        data_b64 = base64.b64encode(data_bytes).decode("ascii")
+        assert data_b64 is not None  # found=True always pairs with a real value
         return build_wire_media_part(block.get("type") or "image", mime, data_b64)
     data = block.get("data")
     if isinstance(data, str) and data:

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -113,11 +113,32 @@ def _materialise_path_ref_content(
             continue
         path = part["path"]
         mime = part.get("mime_type") or part.get("mimeType") or "image/png"
-        data_bytes = _read_pathref_image(path, media_store)
-        if data_bytes is None:
-            continue
-        import base64
-        data_b64 = base64.b64encode(data_bytes).decode("ascii")
+        content_hash = part.get("content_hash")
+        data_b64: "str | None" = None
+        # #5512: memoized by content_hash via MediaStore's own cache when
+        # both a store AND a hash are available (the common case — a
+        # Reyn-owned tool-result media block, #383's canonical shape).
+        # ``PermissionError``/not-found here is NOT treated as a final
+        # answer — a path outside media_dir (a user-attached file, still
+        # carrying a hash) falls through to the SAME direct-disk-read
+        # fallback ``_read_pathref_image`` always had, preserving that
+        # pre-#5512 behavior exactly (only the found-in-store case is
+        # newly cached).
+        if media_store is not None and content_hash is not None:
+            try:
+                data_b64, found = media_store.read_media_base64(
+                    path, content_hash=content_hash,
+                )
+            except PermissionError:
+                data_b64, found = None, False
+            if not found:
+                data_b64 = None
+        if data_b64 is None:
+            data_bytes = _read_pathref_image(path, media_store)
+            if data_bytes is None:
+                continue
+            import base64
+            data_b64 = base64.b64encode(data_bytes).decode("ascii")
         materialised.append({
             "type": "image_url",
             "image_url": {"url": f"data:{mime};base64,{data_b64}"},

--- a/tests/data/test_5512_media_store_base64_cache.py
+++ b/tests/data/test_5512_media_store_base64_cache.py
@@ -1,0 +1,135 @@
+"""Tier 2: #5512 — ``MediaStore.read_media_base64`` memoizes the file
+read + base64 encode by ``content_hash`` (the canonical path-ref field,
+#383) — a second wire-materialisation call for the SAME content skips
+both the read and the encode; a call for DIFFERENT content (a new
+``content_hash``) does not skip either.
+
+owner: "base64 の memo/cache 化は issue 化しておいて — 優先度は高くしなくて
+良い". Explicit non-goal (issue body): wire byte count is unaffected —
+this is an I/O/CPU saving, never a cost/budget change.
+
+Accept criteria (lead-coder's own dispatch): witnessed by CALL COUNT on
+the real underlying read, never duration (repo testing policy — no
+sleep/timing-based assertions). Real ``MediaStore`` + real file on disk
+throughout; the "spy" below is a real wrapper around the production
+method (the #2937 counting-spy idiom already used elsewhere in this
+repo — a real callable recording invocations, not a mock/MagicMock),
+not a stand-in for MediaStore itself.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+
+
+def _new_store(tmp_path: Path) -> MediaStore:
+    return MediaStore(MediaStoreConfig(), project_root=tmp_path, session_id="test-session")
+
+
+def _counting_read_media(store: MediaStore) -> list:
+    """Wrap ``store.read_media`` with a REAL counting spy — records each
+    call's path, then delegates to the original implementation
+    unchanged. Returns the shared ``calls`` list the caller inspects."""
+    calls: list[str] = []
+    original = store.read_media
+
+    def _spy(path_str: str):
+        calls.append(path_str)
+        return original(path_str)
+
+    store.read_media = _spy  # type: ignore[method-assign]
+    return calls
+
+
+def test_a_second_read_for_the_same_content_hash_skips_the_underlying_read(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5512 accept ① — two ``read_media_base64`` calls for the
+    SAME ``content_hash`` invoke the real underlying ``read_media`` only
+    ONCE. Strip-falsify performed by hand while writing this test: with
+    the cache-store/cache-check lines in ``read_media_base64`` commented
+    out, this assertion correctly reads 2 (confirmed red); restored,
+    green — this is what makes the call-count assertion below an actual
+    witness of the docstring's own claim (#5521/#5513's own "does this
+    test witness what the docstring says" question, applied here), not
+    a number that would pass regardless of whether caching happened."""
+    store = _new_store(tmp_path)
+    raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 80
+    block = store.save_media(raw, mime_type="image/png", tool="test", seq=1)
+    path = block["path"]
+    content_hash = block["content_hash"]
+
+    calls = _counting_read_media(store)
+
+    b64_first, found_first = store.read_media_base64(path, content_hash=content_hash)
+    b64_second, found_second = store.read_media_base64(path, content_hash=content_hash)
+
+    assert found_first and found_second
+    assert b64_first == b64_second
+    # The second call must not have added a second recorded read — a
+    # bare count would pin an arbitrary number; this instead asserts the
+    # SECOND call left no trace at all (the spy's own call log is
+    # unchanged from what the first call alone produced).
+    assert calls == [path], (
+        f"expected the underlying read_media to fire only for the FIRST "
+        f"call (the second should hit the content_hash cache and leave "
+        f"no new entry), got {calls!r}"
+    )
+
+
+def test_a_different_content_hash_does_not_hit_the_stale_cache_entry(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5512 accept ②, deny side — a DIFFERENT ``content_hash``
+    (simulating changed content, the real invalidation mechanism the
+    issue itself named — a changed file is a different key by
+    construction) must NOT reuse the first call's cached value. Without
+    this, an "always return the first cached value regardless of key"
+    implementation would pass accept ① for the wrong reason."""
+    store = _new_store(tmp_path)
+    raw_a = b"\x89PNG\r\n\x1a\n" + b"\x00" * 80
+    raw_b = b"\x89PNG\r\n\x1a\n" + b"\x01" * 80
+    block_a = store.save_media(raw_a, mime_type="image/png", tool="test", seq=1)
+    block_b = store.save_media(raw_b, mime_type="image/png", tool="test", seq=2)
+    assert block_a["content_hash"] != block_b["content_hash"], (
+        "test setup sanity: two different file contents must produce two "
+        "different content_hash keys, or this test proves nothing"
+    )
+
+    calls = _counting_read_media(store)
+
+    b64_a, _ = store.read_media_base64(block_a["path"], content_hash=block_a["content_hash"])
+    b64_b, _ = store.read_media_base64(block_b["path"], content_hash=block_b["content_hash"])
+
+    assert b64_a != b64_b, "two different files must not resolve to the same base64 payload"
+    # Each distinct content_hash must produce its OWN recorded read — a
+    # cache hit on the wrong key would either drop one entry or merge
+    # the two paths; asserting the exact ordered pair rules out both.
+    assert calls == [block_a["path"], block_b["path"]], (
+        f"expected the underlying read_media to fire once PER distinct "
+        f"content_hash (no stale hit across different keys), got {calls!r}"
+    )
+
+
+def test_no_content_hash_never_caches(tmp_path: Path) -> None:
+    """Tier 2: #5512 — ``content_hash=None`` (a caller with no hash to key
+    on, e.g. a legacy path-ref block) always misses the cache — every
+    call re-reads. Documents the degrade explicitly rather than leaving
+    it as an untested assumption."""
+    store = _new_store(tmp_path)
+    raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 80
+    block = store.save_media(raw, mime_type="image/png", tool="test", seq=1)
+    path = block["path"]
+
+    calls = _counting_read_media(store)
+
+    store.read_media_base64(path, content_hash=None)
+    store.read_media_base64(path, content_hash=None)
+
+    # Both calls must have left their own trace — content_hash=None means
+    # neither could have been served from the cache.
+    assert calls == [path, path], (
+        f"content_hash=None must never be cached — expected a real read "
+        f"recorded for BOTH calls, got {calls!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — closes #5512

## 結論

path-ref をwireに載せる際、毎回file読み込み＋base64化していた(cache無し、実測で現在も確認)。`MediaStore.read_media_base64(path, content_hash=...)`を追加、`content_hash`(#383の既存フィールド)でmemo化。置き場はprocess内(band Q1回避、lead-coder推奨どおり)。boundは根拠なき定数64件FIFO(明示的に未測定と記載、優先度は高くないため)。

## 逐語（issue本文、実測で今も真）

```
src/reyn/runtime/router_loop.py:403 / router_history_buffer.py:123 の data:{mime};base64,{...}
```
※行番号は#5509/#5513でずれていたが、該当箇所は今も存在(確認済み)。

## Test

`test_5512_media_store_base64_cache.py` — 呼び出し回数(durationではなく)で観測。accept①(同一content_hash→2回目は読まない)/②deny側(別content_hash→読み直す)/content_hash=None→常にmiss。assertは`len(calls)==N`ではなくcall log自体の内容(test_tier_audit.py --strictがformat pinningとして検出→修正済み)。Strip-falsify: cache check分岐を無効化→①のみ赤、復元→緑。

## Test plan

- [x] `ruff check .` / `mypy_ratchet.py` / `test_tier_audit.py --strict` — 緑（3 tests, 0 errors）
- [x] tests/-path gates — 緑
- [x] Strip-falsify済み
- [x] 回帰: `tests/data + tests/runtime + tests/core -k "media or pathref or path_ref"` — 240 passed
- [ ] (skipped — Visual)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
