### PR TITLE
fix(#5350): process identity is a recorded fact, never derived from cwd

### DIFF
--- a/src/reyn/runtime/process_registry.py
+++ b/src/reyn/runtime/process_registry.py
@@ -30,6 +30,11 @@ WHAT GETS RECORDED, AND WHY NOT MORE
     arguments and workspace-internal paths belong to the invocation,
     not to a liveness marker.
 
+    Plus (#5350) ``{agent_name, broker_session_id}`` — both absent
+    (``None``) until a later call to :func:`record_process_identity`
+    sets one or both; never guessed, never derived from ``cwd`` (see
+    the "IDENTITY vs LIVENESS" section below for why).
+
 WHERE THE MARKER LIVES
     ``~/.reyn/processes/<pid>.json`` — a PID-keyed filename, never a
     shared subtree multiple processes both write into. This matters:
@@ -57,6 +62,32 @@ LIVENESS: REUSE, DON'T REINVENT (#5296's own lesson)
     this issue's own scope; a consolidation would need to weigh
     ``api/safe/``'s own sandbox-boundary reasoning, which this module
     has no business deciding).
+
+IDENTITY vs LIVENESS (#5350, owner-observed incident 2026-08-30)
+    A real incident: an operator-side script joined "which OS process is
+    this reyn/broker identity" on ``cwd`` — and sent ``SIGTERM`` to
+    unrelated ``zsh``/``nvim`` processes that merely happened to share a
+    directory with a registered agent. ``cwd`` never carries identity
+    (this module's own markers already recorded it as diagnostic
+    metadata only, never a join key — see :func:`live_processes`'s own
+    ``cwd``-based reap-event lookup, which resolves a PROJECT root from
+    it, never an IDENTITY). Architect ruling (#5350): identity must be
+    answered from a RECORDED fact (a marker this process wrote about
+    itself), never derived from ``cwd``/``comm`` (rewritten by
+    :mod:`reyn.runtime.proctitle`) or from ``list_sessions().active``
+    (registration, not liveness). :func:`record_process_identity` +
+    :func:`process_for_agent` close this — a process states its own
+    ``agent_name``/``broker_session_id`` (it already knows both; no
+    guessing), and a reader filters :func:`live_processes` by that
+    RECORDED field, never by position (``cwd``). Liveness stays a
+    SEPARATE question this module does not answer for a reyn agent
+    (that is ``.reyn/agents/<name>/state/``'s own mtime, per #5350's own
+    table) — this module only ever answers "is the OS process alive"
+    (:func:`~reyn.data.index.build_lock.pid_alive`), a narrower claim.
+
+    Explicitly OUT OF SCOPE (same posture as the rest of this module,
+    #5350 architect ruling): no kill/TTL decision lives here — this
+    closes "identity is readable", never "an identity gets acted on".
 
 WHAT THIS MODULE DOES NOT DO
     No cleanup of another process's live marker, ever (D-2 posture,
@@ -134,6 +165,13 @@ def register_process(subcommand: "str | None") -> None:
         "cwd": os.getcwd(),
         "subcommand": subcommand,
         "started_at": time.time(),
+        # #5350: absent (never guessed) until a later, more-informed call
+        # to :func:`record_process_identity` sets one or both — this
+        # process's own agent_name/broker_session_id are usually not yet
+        # resolved at THIS call site (register_process runs at CLI
+        # startup, before Session construction).
+        "agent_name": None,
+        "broker_session_id": None,
     }
     try:
         PROCESSES_DIR.mkdir(parents=True, exist_ok=True)
@@ -191,6 +229,71 @@ def unregister_process(pid: "int | None" = None) -> None:
         pid = os.getpid()
     _cleanup(pid)
     atexit.unregister(_cleanup)
+
+
+def record_process_identity(
+    *,
+    agent_name: "str | None" = None,
+    broker_session_id: "str | None" = None,
+    pid: "int | None" = None,
+) -> None:
+    """#5350 — a process records its OWN identity onto its already-written
+    marker, once it actually knows it (``register_process`` runs at CLI
+    startup, before that is usually resolved). Never a guess: the caller
+    is always the process itself (or code acting on its behalf) stating
+    a fact it already has — never a lookup, never derived from ``cwd``.
+
+    Only fields the caller actually passes are updated (``None`` here
+    means "nothing new to say", not "clear the existing value" — a
+    second caller that only knows ``broker_session_id`` must not erase
+    an ``agent_name`` a first caller already recorded). Best-effort,
+    matching this module's own posture throughout: no marker (the
+    process never called :func:`register_process`, or its write failed)
+    degrades to a silent no-op, never an exception that could interrupt
+    the caller's own real work over a diagnostic aid.
+    """
+    if pid is None:
+        pid = os.getpid()
+    marker_path = _marker_path(pid)
+    try:
+        data = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    if agent_name is not None:
+        data["agent_name"] = agent_name
+    if broker_session_id is not None:
+        data["broker_session_id"] = broker_session_id
+    try:
+        tmp_path = _tmp_marker_path(pid)
+        tmp_path.write_text(json.dumps(data), encoding="utf-8")
+        tmp_path.replace(marker_path)
+    except OSError:
+        logger.warning(
+            "process_registry: failed to record identity for pid %d "
+            "(diagnostic-only, does not block the caller)", pid, exc_info=True,
+        )
+
+
+def process_for_agent(agent_name: str) -> "list[dict]":
+    """#5350 — every currently-alive process whose OWN recorded
+    ``agent_name`` matches *agent_name* (via :func:`live_processes`,
+    which already reaps dead-PID markers as it reads). NEVER matched by
+    ``cwd`` — the architect-named incident this exists to prevent: an
+    unrelated process (a shell, an editor) sharing a directory with a
+    reyn agent is not that agent, and must never be returned here.
+    Ordinarily a list of 0 or 1 — more than one means two processes
+    both recorded the SAME ``agent_name`` (a caller error upstream, not
+    something this function corrects or hides)."""
+    return [m for m in live_processes() if m.get("agent_name") == agent_name]
+
+
+def process_for_broker_session(broker_session_id: str) -> "list[dict]":
+    """#5350 — the ``broker_session_id``-keyed sibling of
+    :func:`process_for_agent`, identical contract (never matched by
+    ``cwd``)."""
+    return [
+        m for m in live_processes() if m.get("broker_session_id") == broker_session_id
+    ]
 
 
 def live_processes() -> "list[dict]":

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -966,6 +966,13 @@ class Session:
         # Identity cluster owned by Agent — single source of truth, no fallback
         # construction (#3133 Priority-0 step-2, see docs/reference/runtime/session-construction.md#identity-the-agent-value-object-fp-0043-stage-2).
         self._agent = agent
+        # #5350: this Session's own agent_name is now definitively known —
+        # record it onto the CURRENT process's own process_registry marker
+        # (register_process() already ran at CLI startup, before this name
+        # was resolvable). Best-effort, matching that module's own
+        # posture throughout — never blocks Session construction.
+        from reyn.runtime.process_registry import record_process_identity
+        record_process_identity(agent_name=self._agent.agent_name)
         self._resolver = resolver or ModelResolver({})
         # Per-session runtime model override set by /model <class>; None -> Agent identity default, in-memory only
         self._model_override: str | None = None

--- a/tests/runtime/test_5226_process_registry.py
+++ b/tests/runtime/test_5226_process_registry.py
@@ -177,17 +177,28 @@ def test_marker_content_never_carries_argv_or_a_path_beyond_cwd(
 ) -> None:
     """Tier 2: acceptance ③ — a CONTENT inspection (not a behavioral
     strip-falsify): the marker this process writes about itself carries
-    EXACTLY {pid, ppid, cwd, subcommand, started_at} and nothing else —
-    no full argv, no path beyond cwd. Mirrors ``proctitle.py``'s own
-    explicit stance against leaking more than the minimum."""
+    EXACTLY {pid, ppid, cwd, subcommand, started_at, agent_name,
+    broker_session_id} and nothing else — no full argv, no path beyond
+    cwd. Mirrors ``proctitle.py``'s own explicit stance against leaking
+    more than the minimum. #5350 added the last two fields (both absent
+    — ``None`` — until a later :func:`record_process_identity` call sets
+    one or both); this test's own closed-set assertion is what makes a
+    future THIRD field a deliberate change, not a silent drift."""
     process_registry.register_process("chat")
     try:
         marker_path = _isolated_processes_dir / f"{os.getpid()}.json"
         raw = json.loads(marker_path.read_text(encoding="utf-8"))
 
-        assert set(raw.keys()) == {"pid", "ppid", "cwd", "subcommand", "started_at"}, (
+        assert set(raw.keys()) == {
+            "pid", "ppid", "cwd", "subcommand", "started_at",
+            "agent_name", "broker_session_id",
+        }, (
             f"#5226 REGRESSION: the marker carries an unexpected field — "
             f"got keys {sorted(raw.keys())!r}"
+        )
+        assert raw["agent_name"] is None and raw["broker_session_id"] is None, (
+            "#5350: register_process() must never guess an identity — "
+            "both fields start absent until record_process_identity sets one"
         )
         # `subcommand` must be the bare word passed in — never the full
         # argv this process was actually launched with (pytest's own,

--- a/tests/runtime/test_5350_process_identity_never_by_cwd.py
+++ b/tests/runtime/test_5350_process_identity_never_by_cwd.py
@@ -15,10 +15,14 @@ Real, separate OS subprocesses throughout (never a synthetic marker
 faked in-process for a PID that isn't actually running that code) —
 mirrors ``test_5226_process_registry.py``'s own convention, including
 its no-sleep/no-duration release-by-closing-stdin idiom (CLAUDE.md's own
-Ceiling/Floor rule).
+Ceiling/Floor rule) and its own ``out_of_process_reyn`` (#5028) pin —
+each subprocess imports ``reyn``, so its ``PYTHONPATH`` is pinned to the
+SAME checkout this test itself imports, never left to the ambient
+venv/worktree to resolve on its own.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
@@ -39,13 +43,20 @@ def _isolated_processes_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     return processes_dir
 
 
-def _spawn_identified_subprocess(*, cwd: Path, agent_name: "str | None") -> subprocess.Popen:
+def _spawn_identified_subprocess(
+    *, cwd: Path, agent_name: "str | None", pythonpath: str,
+) -> subprocess.Popen:
     """A REAL, separate OS subprocess that registers its own real PID,
     then (if *agent_name* is given) records its own identity — mirrors
     ``test_5226_process_registry.py``'s own ``_spawn_registering_
     subprocess``, extended to also exercise :func:`record_process_
     identity`. Blocks on a real stdin read (never a sleep) until the
-    test releases it by closing stdin."""
+    test releases it by closing stdin.
+
+    *pythonpath* is the ``out_of_process_reyn`` fixture's own value
+    (#5028) — pinned as this subprocess's ``PYTHONPATH`` so it imports
+    the SAME ``reyn`` this test itself imported, rather than trusting
+    the ambient venv/worktree to agree."""
     record_line = (
         f"process_registry.record_process_identity(agent_name={agent_name!r})\n"
         if agent_name is not None else ""
@@ -58,10 +69,11 @@ def _spawn_identified_subprocess(*, cwd: Path, agent_name: "str | None") -> subp
         f"{record_line}"
         "sys.stdin.readline()\n"  # blocks for real — released by closing stdin
     )
+    env = {**os.environ, "PYTHONPATH": pythonpath}
     return subprocess.Popen(
         [sys.executable, "-c", script, str(process_registry.PROCESSES_DIR)],
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        text=True, cwd=str(cwd),
+        text=True, cwd=str(cwd), env=env,
     )
 
 
@@ -73,7 +85,7 @@ def _wait_until(condition) -> None:
 
 
 def test_process_for_agent_ignores_a_same_cwd_process_recorded_under_a_different_name(
-    tmp_path: Path,
+    tmp_path: Path, out_of_process_reyn: str,
 ) -> None:
     """Tier 2: #5350 accept — two REAL processes share the exact same
     ``cwd`` (the incident's own shape: multiple processes in one
@@ -90,8 +102,12 @@ def test_process_for_agent_ignores_a_same_cwd_process_recorded_under_a_different
     not to leave this deny-only) are in this one test."""
     shared_cwd = tmp_path / "shared-workdir"
     shared_cwd.mkdir()
-    target = _spawn_identified_subprocess(cwd=shared_cwd, agent_name="target-agent")
-    other = _spawn_identified_subprocess(cwd=shared_cwd, agent_name="other-agent")
+    target = _spawn_identified_subprocess(
+        cwd=shared_cwd, agent_name="target-agent", pythonpath=out_of_process_reyn,
+    )
+    other = _spawn_identified_subprocess(
+        cwd=shared_cwd, agent_name="other-agent", pythonpath=out_of_process_reyn,
+    )
     try:
         _wait_until(lambda: len(process_registry.live_processes()) == 2)
         markers = process_registry.live_processes()
@@ -127,13 +143,15 @@ def test_process_for_agent_ignores_a_same_cwd_process_recorded_under_a_different
 
 
 def test_a_process_that_never_recorded_an_identity_is_never_matched(
-    tmp_path: Path,
+    tmp_path: Path, out_of_process_reyn: str,
 ) -> None:
     """Tier 2: #5350 — a registered reyn process that never called
     ``record_process_identity`` (``agent_name`` stays the ``None``
     ``register_process`` itself writes) is never returned by ANY
     ``process_for_agent`` query — ``None`` is not a wildcard."""
-    proc = _spawn_identified_subprocess(cwd=tmp_path, agent_name=None)
+    proc = _spawn_identified_subprocess(
+        cwd=tmp_path, agent_name=None, pythonpath=out_of_process_reyn,
+    )
     try:
         _wait_until(lambda: len(process_registry.live_processes()) == 1)
         assert process_registry.process_for_agent("target-agent") == [], (

--- a/tests/runtime/test_5350_process_identity_never_by_cwd.py
+++ b/tests/runtime/test_5350_process_identity_never_by_cwd.py
@@ -1,0 +1,146 @@
+"""Tier 2: #5350 — process identity is answered from a RECORDED fact
+(``process_registry``'s own ``agent_name``/``broker_session_id`` fields),
+never derived from ``cwd``.
+
+Real incident (owner-observed, 2026-08-30, relayed by lead-coder): an
+operator-side script treated "same ``cwd`` as a registered agent" as
+"is this agent" and sent ``SIGTERM`` to unrelated ``zsh``/``nvim``
+processes that merely happened to share a directory with a reyn agent.
+Architect ruling (#5350): ``cwd`` never carries identity — a process
+must record its OWN name (it already knows it; no guessing), and a
+reader (:func:`process_registry.process_for_agent`) must filter by that
+recorded field, never by position.
+
+Real, separate OS subprocesses throughout (never a synthetic marker
+faked in-process for a PID that isn't actually running that code) —
+mirrors ``test_5226_process_registry.py``'s own convention, including
+its no-sleep/no-duration release-by-closing-stdin idiom (CLAUDE.md's own
+Ceiling/Floor rule).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime import process_registry
+
+
+@pytest.fixture(autouse=True)
+def _isolated_processes_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Mirrors test_5226_process_registry.py's own fixture — the real
+    ``~/.reyn/processes/`` is shared, user-global state and must never
+    be touched by a test."""
+    processes_dir = tmp_path / "processes"
+    monkeypatch.setattr(process_registry, "PROCESSES_DIR", processes_dir)
+    return processes_dir
+
+
+def _spawn_identified_subprocess(*, cwd: Path, agent_name: "str | None") -> subprocess.Popen:
+    """A REAL, separate OS subprocess that registers its own real PID,
+    then (if *agent_name* is given) records its own identity — mirrors
+    ``test_5226_process_registry.py``'s own ``_spawn_registering_
+    subprocess``, extended to also exercise :func:`record_process_
+    identity`. Blocks on a real stdin read (never a sleep) until the
+    test releases it by closing stdin."""
+    record_line = (
+        f"process_registry.record_process_identity(agent_name={agent_name!r})\n"
+        if agent_name is not None else ""
+    )
+    script = (
+        "import sys\n"
+        "from reyn.runtime import process_registry\n"
+        "process_registry.PROCESSES_DIR = __import__('pathlib').Path(sys.argv[1])\n"
+        "process_registry.register_process('chat')\n"
+        f"{record_line}"
+        "sys.stdin.readline()\n"  # blocks for real — released by closing stdin
+    )
+    return subprocess.Popen(
+        [sys.executable, "-c", script, str(process_registry.PROCESSES_DIR)],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, cwd=str(cwd),
+    )
+
+
+def _wait_until(condition) -> None:
+    """CLAUDE.md's own Ceiling rule: poll unboundedly, no sleep-based
+    fixed wait — pytest's/CI's own --timeout is the kill switch."""
+    while not condition():
+        time.sleep(0)  # yield the GIL, not a duration this assertion depends on
+
+
+def test_process_for_agent_ignores_a_same_cwd_process_recorded_under_a_different_name(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5350 accept — two REAL processes share the exact same
+    ``cwd`` (the incident's own shape: multiple processes in one
+    directory). Only ONE recorded itself as ``"target-agent"``; the
+    other recorded a DIFFERENT name (standing in for an unrelated
+    process that happens to share the directory — zsh/nvim in the real
+    incident never call ``record_process_identity`` at all, but a
+    same-cwd SIBLING reyn process with a different name is the sharper
+    proof: it IS a real marker, IS in ``live_processes()``, and would
+    still be wrongly matched by any cwd-based join).
+
+    Both the deny side (the wrong-named process is NEVER returned) and
+    the accept side (the right one IS, per architect's own instruction
+    not to leave this deny-only) are in this one test."""
+    shared_cwd = tmp_path / "shared-workdir"
+    shared_cwd.mkdir()
+    target = _spawn_identified_subprocess(cwd=shared_cwd, agent_name="target-agent")
+    other = _spawn_identified_subprocess(cwd=shared_cwd, agent_name="other-agent")
+    try:
+        _wait_until(lambda: len(process_registry.live_processes()) == 2)
+        markers = process_registry.live_processes()
+        assert {m["cwd"] for m in markers} == {str(shared_cwd)}, (
+            "test setup sanity: both processes must share the exact same "
+            "cwd, or this test proves nothing about cwd-based mis-join"
+        )
+
+        matched = process_registry.process_for_agent("target-agent")
+
+        # Accept side: the right process IS found.
+        matched_pids = {m["pid"] for m in matched}
+        assert matched_pids == {target.pid}, (
+            f"expected process_for_agent('target-agent') to return exactly "
+            f"the process that recorded that name (pid {target.pid}), got "
+            f"{matched_pids!r}"
+        )
+        # Deny side: the SAME-cwd, differently-named process is never
+        # included — this is what would go red if the lookup joined on
+        # cwd instead of the recorded agent_name field.
+        assert other.pid not in matched_pids, (
+            f"#5350 REGRESSION: a same-cwd process recorded under a "
+            f"DIFFERENT agent_name (pid {other.pid}) was returned by "
+            f"process_for_agent('target-agent') — this is the exact "
+            f"cwd-mis-join shape the real incident produced"
+        )
+    finally:
+        for proc in (target, other):
+            if proc.stdin is not None:
+                proc.stdin.close()
+        for proc in (target, other):
+            proc.wait()
+
+
+def test_a_process_that_never_recorded_an_identity_is_never_matched(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5350 — a registered reyn process that never called
+    ``record_process_identity`` (``agent_name`` stays the ``None``
+    ``register_process`` itself writes) is never returned by ANY
+    ``process_for_agent`` query — ``None`` is not a wildcard."""
+    proc = _spawn_identified_subprocess(cwd=tmp_path, agent_name=None)
+    try:
+        _wait_until(lambda: len(process_registry.live_processes()) == 1)
+        assert process_registry.process_for_agent("target-agent") == [], (
+            "an unidentified process (agent_name still None) must never "
+            "match any real agent_name query"
+        )
+    finally:
+        if proc.stdin is not None:
+            proc.stdin.close()
+        proc.wait()


### PR DESCRIPTION
**[tui-coder]** — part of #5350

Architect ruling implemented in full (see issue comment thread): process identity is now a RECORDED fact (`process_registry.py`'s marker gains `agent_name`/`broker_session_id`, set via new `record_process_identity()`), never derived from `cwd`. New `process_for_agent`/`process_for_broker_session` filter `live_processes()` by the recorded field only.

One real reyn-core consumer wired: `Session.__init__` calls `record_process_identity(agent_name=...)` right after `self._agent` is set — the one place `agent_name` is universally, definitively known regardless of subcommand.

`broker_session_id` stays unwired within reyn-core (reyn's own runtime has no way to know it — that's a broker/launcher concept, outside this repo). The field + recording function are exposed for that external caller. #5350 stays open for that remainder, same convention as #5457.

Scope boundary honored per architect's explicit addition: **no kill/TTL logic** — this closes "identity is readable", never "an identity gets acted on" (process_registry's own docstring, owner-level decision).

Accept criteria (architect's own, both sides in one test per their explicit instruction): `test_5350_process_identity_never_by_cwd.py` — two real OS subprocesses share the exact same `cwd`; only the lookup on the recorded `agent_name` returns the right one, and the same-cwd differently-named sibling is never included.

Strip-falsify: rewrote `process_for_agent` to also join by `cwd` (simulating the real incident) — confirmed the deny-side assertion goes red, reverted, confirmed green.

## Test plan
- [x] `pytest tests/runtime/test_5350_process_identity_never_by_cwd.py tests/runtime/test_5226_process_registry.py` — 15/15 green
- [x] Regression sweep `tests/runtime -k "session_construction or session_invariants or process_registry or agent_snapshot"` — 28 passed, 1 pre-existing unrelated skip
- [x] `ruff check .` / `mypy_ratchet.py` / `test_tier_audit.py --strict` (changed test files) / `verify_module_docstrings.py` (changed src files) / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all clean
- [x] (skipped — no UI/TUI surface touched) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
