### PR TITLE
fix(#5467): migrate first phase-2 consumer off private _audit_events reach

### DIFF
--- a/tests/core/test_3377_run_loop_survives_turn_cancel.py
+++ b/tests/core/test_3377_run_loop_survives_turn_cancel.py
@@ -45,7 +45,7 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
-from tests._support.events import settle
+from tests._support.events import collect_events, settle
 
 AGENT = "cancel-survival-agent"
 
@@ -61,11 +61,10 @@ def _make_session(tmp_path: Path) -> tuple[Session, StateLog]:
 
 
 def _collect(session: Session) -> list:
-    """Subscribe through the public seam (Session.subscribe_audit_events,
-    #5260) — for witness ②: turn_started proves the REAL driver ran (#5450)."""
-    collected: list = []
-    session.subscribe_audit_events(collected.append)
-    return collected
+    """#5467 phase 2: through the shared test-support seam (was a raw
+    ``session.subscribe_audit_events(collected.append)`` subscriber) — for
+    witness ②: turn_started proves the REAL driver ran (#5450)."""
+    return collect_events(session)
 
 
 def _seen_chain_ids(events: list) -> "set[str]":
@@ -228,7 +227,7 @@ async def test_cancelling_the_session_still_stops_the_loop_and_records_it(
 
         run_task.cancel()
         await asyncio.gather(run_task, return_exceptions=True)
-        await settle(session._audit_events)
+        await settle(session)
 
         assert run_task.done(), "a cancel aimed at the session must stop the loop"
         assert session.halted_reason == "cancelled", (


### PR DESCRIPTION
**[tui-coder]** — part of #5467 (phase 2, batch 1 of N)

## 実測(このbranch、origin/main基準) — 母集団は再計測すると drift 済み

Issue内の数値(82/18/64)は投稿時点のもの。着手時点の再計測:

```
git grep -l '\._audit_events'        -- tests/  → 72 file (real attribute-access)
git grep -l 'subscribe_audit_events(' -- tests/  → 22 file
```
(生の `_audit_events` 部分文字列一致=90 fileのうち18 fileは `_build_audit_events_config`/`AuditEventsConfig` という別概念への誤爆 — 除外済み)

サブエージェントで全72 fileを個別分類(mechanical enumeration、判断は私で確認):

| bucket | 件数 | 内容 |
|---|---|---|
| **A — session-reach(移行対象)** | 59 file / 220 行 | 実 `Session` を private 経由で subscribe/settle/drain している |
| B — own-fake-double(対象外) | 6 file | testが自前で持つ fake double 自身の `_audit_events`(実Sessionへの private reach ではない) |
| C — other/unclear(対象外・理由明記) | 4 file | helper自身のdocstring / AST検査 / 意図的に public seamのみ使用 / 文字列リテラル内 のみ |

RAW `subscribe_audit_events(` 呼び出し(collect_events経由でない) = 20 file / 41行(Bucket Aと重複あり)。

⚠️ 分類の信頼度: batch分割してsubagentに投げた結果の一部(2 file)で誤り(行番号ずれ・reach point見落とし)を見つけ手で修正済み。特に reach point が多いfile(13行/15行)は再検証推奨(PR本文に開示)。

## ①「他に同じ形があるか」(lead-coder指示)

```
grep -n "^def \|^async def " tests/_support/*.py
```
→ `tests/_support/hooks.py:collect_hook_events(session)` は既に `Session` を直接受け取る公開helper(#5494で解決済み)。他に private 到達を要求する helper は見当たらず。

## このPRでやったこと(batch 1 = 1 file、accept criteria)

- `tests/core/test_3377_run_loop_survives_turn_cancel.py`: `session._audit_events.emit/drain` → `collect_events(session)`/`settle(session)` に移行。raw `subscribe_audit_events(collected.append)` も `collect_events(session)` に統一。
- テスト green(4/4)、ruff clean、tier_audit --strict clean、verify_module_docstrings OK。

## ③ 移行計画(全数を引いた上での分割理由)

★「後で」ではなく計画: 残り **58 file(Bucket A)+ 20 file(raw subscribe、重複除く)** は、#3868 PR-2(68 file 機械変換)・#5028(84 subprocess test)の前例に倣い、複数PRに分割して寄せる。1 PRあたり目安 10-15 file、同じ機械的パターン(`session._audit_events.X` → `X(session)` 経由)。各PRで残数を開示する(このPR時点の残数を上記に明記済み)。gate 拡張(#5467 issueの「1.5本目」)は未着手 — 別途確認が必要(architectの「1本目と同じPRに」の指示は既に merge 済みの#5484側の話で、本PRはphase 2の一部であり別途相談)。

## Test plan
- [x] `pytest tests/core/test_3377_run_loop_survives_turn_cancel.py tests/core/test_3868_collect_events_helper.py` — 13/13 green
- [x] `ruff check .` — clean
- [x] `test_tier_audit.py --strict` (changed file) — clean
- [x] `verify_module_docstrings.py` (changed file) — clean
- [x] (skipped — no UI/TUI surface touched) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
