### PR TITLE
fix(#5467): migrate 8 more test files off private _audit_events reach (batch 2)

### DIFF
--- a/tests/core/test_3783_stage3_invert_default_to_recover.py
+++ b/tests/core/test_3783_stage3_invert_default_to_recover.py
@@ -67,7 +67,7 @@ from reyn.services.compaction.engine import (
     UnrecoveredError,
     retry_loop,
 )
-from tests._support.events import settle
+from tests._support.events import collect_events, settle
 from tests._support.session import make_session as _make_session
 from tests._support.session import push as _push
 
@@ -317,8 +317,7 @@ async def test_compaction_side_unrecovered_error_emits_router_context_overflow_u
         raise RuntimeError("boom: compaction LLM always fails, any input size")
     monkeypatch.setattr(engine, "_acompletion", _always_fail)
 
-    seen: list = []
-    session._audit_events.add_subscriber(lambda e: seen.append(e.type))
+    events = collect_events(session)
 
     # #4885: UnrecoveredError, not ContextOverflowError — see the module
     # docstring's arm (c) note. This arm's RuntimeError is not a real
@@ -327,6 +326,7 @@ async def test_compaction_side_unrecovered_error_emits_router_context_overflow_u
     # below) via `run_turn`'s own widened except, not a type-merging rewrap.
     with pytest.raises(UnrecoveredError):
         await session._run_router_loop("trigger a turn", "chain-3783-stage3-c")
-    await settle(session._audit_events)
+    await settle(session)
 
+    seen = [e.type for e in events]
     assert "router_context_overflow_unrecovered" in seen

--- a/tests/core/test_3792_pr2_session_injection.py
+++ b/tests/core/test_3792_pr2_session_injection.py
@@ -34,7 +34,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.session import Session
 from reyn.runtime.turn_origin import TurnOrigin
 from tests._support.agent_session import make_session
-from tests._support.events import settle
+from tests._support.events import collect_events, settle
 
 AGENT = "pr2-injection-agent"
 
@@ -215,8 +215,7 @@ async def test_commit_appends_history_prunes_snapshot_emits_turn_started(tmp_pat
     one of the others.
     """
     session, state_log = _make_session(tmp_path / "s.wal", tmp_path / "s.json")
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
 
     msg_id = await session.submit_user_text("inject me", attribution=None)
     peeked = await session._inbox_arbiter.peek_mid_turn_injection()
@@ -227,7 +226,7 @@ async def test_commit_appends_history_prunes_snapshot_emits_turn_started(tmp_pat
     assert any(m["id"] == msg_id for m in session.journal.snapshot.inbox)
 
     await session._commit_mid_turn_injection(msg_id)
-    await settle(session._audit_events)
+    await settle(session)
 
     # (1) history
     assert len(session.history) == before_history_len + 1

--- a/tests/core/test_4496_pr2_event_backend.py
+++ b/tests/core/test_4496_pr2_event_backend.py
@@ -34,6 +34,7 @@ from reyn.core.events.backend import DiscardEventBackend, LocalEventBackend
 from reyn.core.events.events import EventLog
 from reyn.schemas.models import Event
 from tests._support.agent_session import make_session
+from tests._support.events import settle
 
 
 class _RaisingBackend:
@@ -277,7 +278,7 @@ async def test_session_with_discard_backend_still_delivers_to_real_subscribers(
     received = []
     session.subscribe_audit_events(received.append)
     emitted = session._audit_events.emit("test_event", foo="bar")
-    await session._audit_events.drain()  # #4961 C: see the file's first test
+    await settle(session)  # #4961 C: see the file's first test
 
     assert received == [emitted]
     assert emitted.data.get("foo") == "bar"

--- a/tests/runtime/test_5248_turn_finally.py
+++ b/tests/runtime/test_5248_turn_finally.py
@@ -50,7 +50,7 @@ async def test_router_failure_reaches_boundary_operations() -> None:
     would make the private replacement here permanent rather than
     provisional."""
     session = make_session(agent_name="turn-finally-failure")
-    events = collect_events(session._audit_events)
+    events = collect_events(session)
     calls: list[str] = []
 
     async def fail_run_turn(text: str, chain_id: str) -> None:
@@ -72,7 +72,7 @@ async def test_router_failure_reaches_boundary_operations() -> None:
 
     with pytest.raises(RuntimeError, match="router failure"):
         await session._run_router_loop("hello", "failure-chain")
-    await settle(session._audit_events)
+    await settle(session)
 
     assert calls == ["hook", "reload", "cut"]
     assert not [event for event in events if event.type == "turn_completed"]

--- a/tests/runtime/test_5256_quota_not_context_overflow.py
+++ b/tests/runtime/test_5256_quota_not_context_overflow.py
@@ -68,7 +68,7 @@ def test_quota_exhaustion_never_enters_shrink_and_never_ends_the_session(
        the issue names) and never propagates out of ``_handle_inbox_
        text`` at all (the session survives to handle a next turn)."""
     session = make_session(agent_name="quota_test")
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
 
     call_count = 0
 
@@ -84,7 +84,7 @@ def test_quota_exhaustion_never_enters_shrink_and_never_ends_the_session(
     async def _drive() -> None:
         # Must not raise — the generic catch-all keeps the session alive.
         await session._handle_inbox_text("hi", chain_id="chain-quota-1")
-        await settle(session._audit_events)
+        await settle(session)
 
     # architect review (#5292): a separate asyncio.run() per await runs each
     # on its OWN event loop — today's dispatch consumers happen to drain

--- a/tests/runtime/test_multisession_history_isolation_2348.py
+++ b/tests/runtime/test_multisession_history_isolation_2348.py
@@ -78,7 +78,7 @@ async def test_spawned_events_isolated_and_forwarder_survives_rewire(tmp_path, m
     assert a.events_dir != main.events_dir, "spawned session must have an isolated events dir"
 
     a._audit_events.emit("budget_warn", dimension="daily_tokens")
-    await settle(a._audit_events)
+    await settle(a)
 
     # subscriber completeness: the forwarder survived the swap → the outbox got the marker.
     msg = a.outbox.get_nowait()

--- a/tests/runtime/test_router_loop_swallow_instrument_187.py
+++ b/tests/runtime/test_router_loop_swallow_instrument_187.py
@@ -46,7 +46,7 @@ async def test_swallowed_router_loop_exception_emits_p6_event():
     event log even when the outbox only carries a classified summary.
     """
     s = make_session(agent_name="t")
-    collected = collect_events(s._audit_events)
+    collected = collect_events(s)
 
     async def _raise_mid_work(text: str, chain_id: str) -> None:
         # Stand-in for the real mid-work crash (final call_llm raising after
@@ -57,7 +57,7 @@ async def test_swallowed_router_loop_exception_emits_p6_event():
 
     # Must not propagate — the handler swallows-but-surfaces.
     await s._handle_inbox_text("hello", chain_id="c-test")
-    await settle(s._audit_events)
+    await settle(s)
 
     terminated = [
         e for e in collected

--- a/tests/runtime/test_session_notify_state_change.py
+++ b/tests/runtime/test_session_notify_state_change.py
@@ -31,7 +31,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
-from tests._support.events import settle
+from tests._support.events import collect_events, settle
 
 
 def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
@@ -198,12 +198,11 @@ async def test_notify_state_change_emits_observability_event(tmp_path):
     the call so the consumer actually runs before asserting delivery.
     """
     session = _make_session(tmp_path)
-    captured: list = []
-    await settle(session._audit_events)
-    session._audit_events.add_subscriber(captured.append)
+    await settle(session)
+    captured = collect_events(session)
 
     session.notify_state_change("perm granted", source="permission_manager")
-    await session._audit_events.drain()
+    await settle(session)
 
     state_events = [ev for ev in captured if ev.type == "state_change_notified"]
     assert state_events, "expected at least one state_change_notified event"


### PR DESCRIPTION
**[tui-coder]** — part of #5467 (phase 2, batch 2 of N)

Follow-on to #5549 (batch 1, TESTS-READY/auto-merge armed, not yet merged — this PR branches off `origin/main` directly per PR-workflow rule 10, since arming auto-merge ends further reading of that PR).

## 実測(このbranch、origin/main基準)

```
git grep -l '\._audit_events'        -- tests/  → 66 file (batch1の72から drift、#5549未マージ分は含まない)
git grep -l 'subscribe_audit_events(' -- tests/  → 22 file(このbatchは変化なし)
```

## ⚠️ 前batchの分類への訂正(手で個別確認して判明)

subagentのBucket A分類(session-reach)に含まれていた候補のうち、実際に着手して分かったこと: **grepが `._audit_events` に一致した箇所は「subscribe/settle/drain」だけでなく2つの別形を含んでいた** — `tests/_support/events.py`自身のdocstring([`_resolve_log`](https://github.com/tya5/reyn/blob/main/tests/_support/events.py)のscoping note)が最初から明記していた区別を、私の census では file 単位でしか見ていなかった:

1. **`.emit()`でシナリオを駆動している行** — private reach だが `_resolve_log` の docstring が明示的に許可("a test may still reach `session._audit_events.emit(...)` directly to DRIVE its own scenario")。**移行対象外**。今回 `test_4496_pr2_event_backend.py` / `test_multisession_history_isolation_2348.py` に各1行残存(意図的)。
2. **本物のEventLogオブジェクトをproduction constructorへ`events=`として渡している行**(`test_list_mcp_servers_canonical_shape.py`, `test_embed_cost_wiring_live_path.py`) — subscribe/settleと無関係、production側が本物のログを要求している。**#5467の射程外**、今回は触っていない。
3. **`.emit`をmonkeypatchで丸ごと差し替えている行**(`test_router_cap.py`, `test_limit_deny_force_close_router_cap_1496.py`) — subscribe/settle形ではない別の private reach。**#5467の射程外**、今回は触っていない。

∴ 前回報告した Bucket A=59 file は「settle/subscribe(list.append 相当)」のみを対象に絞ると実際にはもっと少ない。次batch着手前に file 単位でなく **行単位** で再分類してから進める。

## このPRでやったこと(8 file)

`session._audit_events.add_subscriber/settle/drain` → `collect_events(session)`/`settle(session)` に統一。

- `tests/core/test_3792_pr2_session_injection.py`
- `tests/core/test_3783_stage3_invert_default_to_recover.py`
- `tests/runtime/test_multisession_history_isolation_2348.py`(settle行のみ、emit行は意図的に残存)
- `tests/runtime/test_router_loop_swallow_instrument_187.py`(既に`collect_events(session._audit_events)`形だったのを`collect_events(session)`に簡素化)
- `tests/runtime/test_5248_turn_finally.py`(同上)
- `tests/runtime/test_5256_quota_not_context_overflow.py`(同上)
- `tests/core/test_4496_pr2_event_backend.py`(settle/drain行のみ、emit行は意図的に残存)
- `tests/runtime/test_session_notify_state_change.py`

全て real Session、real EventLog。挙動を変えない機械的置換(collect_events/settleの戻り値・ awaitタイミングは既存と同一)。

## 検証

- `pytest`(該当8ファイル) — 48/48 green
- `ruff check .` — clean
- `test_tier_audit.py --strict`(変更ファイル) — clean
- `verify_module_docstrings.py`(変更ファイル) — clean

## 残数(このPR後)

66 file(A+B+C混在の生カウント)。次batchは行単位で settle/subscribe(list.append相当)のみを対象に選び直す。

## Test plan
- [x] `pytest`(変更8ファイル) — 48/48 green
- [x] `ruff check .` / `test_tier_audit.py --strict` / `verify_module_docstrings.py` — all clean
- [x] (skipped — no UI/TUI surface touched) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
