### PR TITLE
fix(#5467): migrate 15 more test files off private _audit_events reach (batch 3)

### DIFF
--- a/tests/core/test_2242_hard_cancel.py
+++ b/tests/core/test_2242_hard_cancel.py
@@ -61,6 +61,7 @@ from reyn.runtime.router_loop import _EMPTY_RESPONSE_MSG
 from reyn.runtime.session import Session
 from reyn.user_intervention import InterventionAnswer
 from tests._support.agent_session import make_session
+from tests._support.events import settle
 
 AGENT = "hard-cancel-agent"
 # #5450: the real stub's canned reply for an empty/no-tool-call completion
@@ -197,7 +198,7 @@ async def test_hard_cancel_mid_generation_no_result_append_and_agent_survives(
     # is emitted in run_one_iteration BEFORE the turn's own task starts, so
     # its presence for c-hard-cancel is unaffected by that turn's later
     # cancellation.
-    await session._audit_events.drain()
+    await settle(session)
     started_chain_ids = {
         e.data.get("chain_id") for e in events if e.type == "turn_started"
     }
@@ -241,7 +242,7 @@ async def test_hard_cancel_prior_append_survives_wal_truncation(tmp_path, _llm_s
     await turn_task
     await session.journal.flush()
     # witness ②: the real driver dispatched for this turn.
-    await session._audit_events.drain()
+    await settle(session)
     assert any(e.type == "turn_started" for e in events)
 
     # sanity: the consumed marker's source event is durable pre-truncation.
@@ -328,7 +329,7 @@ async def test_external_cancel_of_driver_task_propagates(tmp_path, _llm_stub):
     # sanity: the hung reply never landed (the turn was torn down, not completed).
     assert not any(m.content == _STUB_REPLY for m in session.history)
     # witness ②: the real driver dispatched before the external cancel hit it.
-    await session._audit_events.drain()
+    await settle(session)
     assert any(e.type == "turn_started" for e in events)
     await state_log.aclose()
 
@@ -391,7 +392,7 @@ async def test_self_initiated_flag_does_not_leak_to_next_turn(tmp_path, _llm_stu
     # witness ②: both turns really dispatched (turn2's is emitted before its
     # own external cancel, in run_one_iteration, same ordering as witness ①
     # test above).
-    await session._audit_events.drain()
+    await settle(session)
     started_chain_ids = {
         e.data.get("chain_id") for e in events if e.type == "turn_started"
     }
@@ -443,7 +444,7 @@ async def test_await_quiescent_join_is_load_bearing_on_cancel(tmp_path, _llm_stu
         assert completed is True
 
         # witness ②: the real driver dispatched.
-        await session._audit_events.drain()
+        await settle(session)
         assert any(e.type == "turn_started" for e in events)
 
         # The join happened: the tracked straggler is settled (cancelled+joined)

--- a/tests/core/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/core/test_2761_pr2_hotreload_immediate_apply.py
@@ -301,7 +301,7 @@ async def test_session_hot_reloader_reload_reaches_session_audit_subscribers(
     session.subscribe_audit_events(lambda e: received.append(e.type))
 
     await session.hot_reloader.apply_all(exclude=frozenset())
-    await settle(session._audit_events)
+    await settle(session)
 
     assert "config_reloaded" in received, (
         f"a reload through session.hot_reloader must reach a subscriber "
@@ -326,7 +326,7 @@ async def test_strip_falsify_hot_reloader_audit_wiring_is_live(
 
     poisoned = HotReloader(project_root=tmp_path, events=EventLog())
     await poisoned.apply_all(exclude=frozenset())
-    await settle(session._audit_events)
+    await settle(session)
 
     assert "config_reloaded" not in received, (
         "a reload on an INDEPENDENT HotReloader must not reach this "
@@ -398,7 +398,7 @@ async def test_hook_bus_emit_event_reaches_session_audit_events(
             await session.dispatch_external_event("turn_end", {"i": i})
     finally:
         sub.close()
-    await settle(session._audit_events)
+    await settle(session)
 
     assert "bus_subscriber_dropped" in received, (
         f"a hook_bus subscriber-queue overflow must reach a subscriber "
@@ -422,7 +422,7 @@ async def test_strip_falsify_hook_bus_overflow_needs_a_live_subscriber(
 
     for i in range(200):
         await session.dispatch_external_event("turn_end", {"i": i})
-    await settle(session._audit_events)
+    await settle(session)
 
     assert "bus_subscriber_dropped" not in received, (
         "no subscriber was ever attached to hook_bus, so nothing should "

--- a/tests/core/test_4666_2_completed_response_opt_in.py
+++ b/tests/core/test_4666_2_completed_response_opt_in.py
@@ -205,12 +205,12 @@ async def test_put_outbox_emits_agent_response_committed_for_kind_agent(tmp_path
     ``agent_response_committed`` for a ``kind="agent"`` message, carrying
     the message's own text and chain_id."""
     session = _make_session(tmp_path)
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
 
     await session._put_outbox(OutboxMessage(
         kind="agent", text="the final reply", meta={"chain_id": "c1"},
     ))
-    await settle(session._audit_events)
+    await settle(session)
 
     committed = [e for e in collected if e.type == "agent_response_committed"]
     assert committed
@@ -225,9 +225,9 @@ async def test_put_outbox_does_not_emit_for_non_agent_kinds(tmp_path):
     ``agent_response_committed`` — this event is scoped to what the
     model actually said to the user, not every outbox traffic kind."""
     session = _make_session(tmp_path)
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
 
     await session._put_outbox(OutboxMessage(kind="status", text="thinking..."))
-    await settle(session._audit_events)
+    await settle(session)
 
     assert not any(e.type == "agent_response_committed" for e in collected)

--- a/tests/hooks/test_2608_h1_mcp_resource_updated_hook.py
+++ b/tests/hooks/test_2608_h1_mcp_resource_updated_hook.py
@@ -119,7 +119,7 @@ async def test_real_mcp_push_fires_configured_hook_into_session_inbox(tmp_path):
         },
     ]
     session = _make_session(tmp_path, hooks_config=hooks_config)
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     try:
         client = await session._mcp_connection_service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
         await client.subscribe_resource(_URI)
@@ -152,7 +152,7 @@ async def test_no_configured_hook_leaves_hook_side_a_pure_noop(tmp_path):
     is the byte-identical-to-today behavior the H1 design requires when no such
     hook is configured for the session."""
     session = _make_session(tmp_path, hooks_config=None)
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     try:
         client = await session._mcp_connection_service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
         await client.subscribe_resource(_URI)

--- a/tests/interfaces/test_3310_n2_reset_hydrate.py
+++ b/tests/interfaces/test_3310_n2_reset_hydrate.py
@@ -73,6 +73,7 @@ from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.events import settle
 
 # ── real seam: a queue-backed ClientTransport a test drives frame-by-frame ──
 
@@ -863,7 +864,7 @@ async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
         await turn_task
 
         # witness ②: the real driver dispatched beta's own turn.
-        await beta._audit_events.drain()
+        await settle(beta)
         assert any(e.type == "turn_started" for e in events)
     finally:
         await reg.shutdown()

--- a/tests/interfaces/test_cui_permission_answer_resumes_2690.py
+++ b/tests/interfaces/test_cui_permission_answer_resumes_2690.py
@@ -170,7 +170,7 @@ async def test_cui_write_approval_answer_resumes_blocked_turn(tmp_path, monkeypa
     session = _make_session(
         proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
     )
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     run_task = asyncio.create_task(session.run())
     try:
         await session.submit_user_text("write the file")
@@ -227,7 +227,7 @@ async def test_cui_read_approval_answer_resumes_identically(tmp_path, monkeypatc
     session = _make_session(
         proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
     )
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     run_task = asyncio.create_task(session.run())
     try:
         await session.submit_user_text("read the outside file")

--- a/tests/interfaces/test_user_submitted_render_3300.py
+++ b/tests/interfaces/test_user_submitted_render_3300.py
@@ -356,7 +356,7 @@ async def test_multi_client_each_subscriber_gets_its_own_echo_no_double_render(
     session.subscribe_audit_events(sink_b)
 
     await session.submit_user_text("one submit, two clients")
-    await settle(session._audit_events)
+    await settle(session)
 
     for sink in (sink_a, sink_b):
         matches = [e for e in sink.events if e.type == "user_submitted"]

--- a/tests/llm/test_1909_intra_turn_opt_in_narrowing.py
+++ b/tests/llm/test_1909_intra_turn_opt_in_narrowing.py
@@ -142,7 +142,7 @@ async def test_on_engages_mid_turn_and_emits_audit_event(tmp_path, monkeypatch):
         ]),
     )
     await session._handle_inbox_text("look something up then remember it", chain_id="c1")
-    await settle(session._audit_events)
+    await settle(session)
 
     (denied_msg,) = [m for m in session.history if m.tool_call_id == "tc_denied"]
     assert "tool_excluded" in str(denied_msg.content)

--- a/tests/llm/test_2608_run_loop_pickup.py
+++ b/tests/llm/test_2608_run_loop_pickup.py
@@ -114,7 +114,7 @@ async def test_dispatch_external_event_wakes_idle_run_loop_and_runs_hook_turn(
         },
     ]
     session = _make_session(tmp_path, hooks_config=hooks_config)
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
 
     run_task = asyncio.create_task(session.run())
     try:

--- a/tests/repo/test_3794_p3_audit_event_identifier_rename.py
+++ b/tests/repo/test_3794_p3_audit_event_identifier_rename.py
@@ -89,7 +89,7 @@ def test_public_emit_seam_and_private_field_write_the_same_event_log(tmp_path) -
         agent_name="p3-witness",
         snapshot_path=tmp_path / "snapshot.json",
     )
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     before = len(collected)
     session.emit_audit_event("p3_witness_kind", marker="p3-rename-witness")
     after = collected

--- a/tests/runtime/test_3595_s2_pipeline_nudge_origin.py
+++ b/tests/runtime/test_3595_s2_pipeline_nudge_origin.py
@@ -46,6 +46,7 @@ from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.turn_origin import TurnOrigin
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
 from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.slash import local_transport
 
@@ -169,14 +170,13 @@ async def test_a_pipeline_nudge_still_runs_one_turn(
     this is RED for exactly the same failure this test always caught."""
     monkeypatch.setenv("REYN_STALL_TRACE", "5")
     session = _session(tmp_path)
-    collected: list = []
-    session.subscribe_audit_events(collected.append)
+    collected = collect_events(session)
 
     chain_id = "c-nudge-turn"
     await session._run_turn_body(
         TurnOrigin.PIPELINE_NUDGE, {"text": "", "chain_id": chain_id},
     )
-    await session._audit_events.drain()
+    await settle(session)
     armed = [e for e in collected if e.type == "stall_trace_armed"]
     assert armed and armed[0].data["chain_id"] == chain_id, (
         "the pipeline-nudge kind ran no turn (stall_trace_armed never fired "
@@ -229,12 +229,11 @@ async def test_a_kind_restored_from_a_snapshot_as_a_plain_string_still_dispatche
     )
 
     monkeypatch.setenv("REYN_STALL_TRACE", "5")
-    collected: list = []
-    session.subscribe_audit_events(collected.append)
+    collected = collect_events(session)
 
     chain_id = "c-restored"
     await session._run_turn_body(restored_kind, {"text": "hi", "chain_id": chain_id})
-    await session._audit_events.drain()
+    await settle(session)
     armed = [e for e in collected if e.type == "stall_trace_armed"]
     assert armed and armed[0].data["chain_id"] == chain_id, (
         "the restored plain-string kind ran no turn (stall_trace_armed never "

--- a/tests/runtime/test_3787_project_context_watch.py
+++ b/tests/runtime/test_3787_project_context_watch.py
@@ -140,7 +140,7 @@ def test_session_constructs_a_second_watcher_for_the_agent_own_file(tmp_path) ->
         project_context="",
         workspace_state_dir=workspace_state_dir,
     )
-    collected = collect_events(s._audit_events)
+    collected = collect_events(s)
 
     agent_watcher = s._agent_context_watcher
     watcher_path = agent_watcher._path

--- a/tests/runtime/test_5356_hooks_layer_rejection_audit_event.py
+++ b/tests/runtime/test_5356_hooks_layer_rejection_audit_event.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 _AGENT = "wp-agent"
 
@@ -51,8 +52,7 @@ def test_write_paths_self_grant_drops_the_layer_and_emits_one_event(
     )
     session = _make_session(tmp_path)
 
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
     registry = session._build_hook_registry({})
 
     assert registry.hooks_for("turn_end") == [], (
@@ -78,8 +78,7 @@ def test_a_valid_per_agent_layer_emits_no_rejection_event(
     )
     session = _make_session(tmp_path)
 
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
     registry = session._build_hook_registry({})
 
     assert len(registry.hooks_for("turn_end")) == 1, "the valid hook must load"

--- a/tests/runtime/test_5367_reactive_ladder_absorbs_elide_sized_overflow.py
+++ b/tests/runtime/test_5367_reactive_ladder_absorbs_elide_sized_overflow.py
@@ -74,6 +74,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.chat_message import ChatMessage
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 
 class _FakeStatusError(Exception):
@@ -163,8 +164,7 @@ def test_reactive_ladder_recovers_an_elide_sized_overflow_via_spill(
         "oversized, or this test proves nothing about overflow recovery"
     )
 
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
 
     loop = _ContentDrivenLoop(
         lambda history, user_text: _has_content(history, huge)
@@ -258,8 +258,7 @@ def test_reactive_ladder_recovers_many_small_turns_via_compaction(
         "the assertions below"
     )
 
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
 
     loop = _ContentDrivenLoop(
         lambda history, user_text: _wire_estimate(history) > 2800

--- a/tests/runtime/test_5531_summary_reaches_first_main_call.py
+++ b/tests/runtime/test_5531_summary_reaches_first_main_call.py
@@ -45,6 +45,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.chat_message import ChatMessage
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 
 class _FakeStatusError(Exception):
@@ -146,8 +147,7 @@ def test_summary_reaches_main_call_after_compaction_empties_raw_middle(
     loop = _ContentDrivenLoop(
         lambda history, user_text: _wire_estimate(history) > 2800
     )
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
 
     result = asyncio.run(
         session._loop_driver._run_with_shrink_and_byte_reduction(


### PR DESCRIPTION
**[tui-coder]** — part of #5467 (phase 2, batch 3 of N)

Follow-on to #5549 (batch 1, merged) and #5550 (batch 2, TESTS-READY/auto-merge armed). Branched off `origin/main` per PR-workflow rule 10.

## 行単位で再分類してから着手(lead-coder指摘への対応)

前batchのfile単位census(66 file)を、49 file・189行について**行単位**で7形に再分類(subagent委譲+確認):

| shape | 件数 | migratable? |
|---|---|---|
| 1: plain-append subscribe(`add_subscriber(list.append)`等) | 45 | ✅ `collect_events(session)` |
| 3: settle/drain | 85 | ✅ `settle(session)` |
| 2: custom callback subscribe(型変換あり) | 5 | ❌ 射程外(bareなcollect_eventsで置換不可) |
| 4: `.emit()`駆動 | 27 | ❌ 射程外(docstringで明示許可) |
| 5: production constructorへ`events=`で渡す | 11 | ❌ 射程外(本物のlog必須) |
| 6: `.emit`をmonkeypatchで丸ごと差し替え | 5 | ❌ 射程外(別のprivate reach形) |
| 7: prose/docstring内の言及のみ | 11 | (コードではない) |

∴ 49 fileは READY=31 / PARTIAL=9(一部行のみ移行可) / SKIP=9(移行対象行なし)。

## このPRでやったこと(READY 31のうち先頭15file)

`session._audit_events.add_subscriber/settle/drain` → `collect_events(session)`/`settle(session)`。

- tests/interfaces/test_3310_n2_reset_hydrate.py
- tests/runtime/test_3787_project_context_watch.py
- tests/llm/test_2608_run_loop_pickup.py
- tests/repo/test_3794_p3_audit_event_identifier_rename.py
- tests/llm/test_1909_intra_turn_opt_in_narrowing.py
- tests/interfaces/test_user_submitted_render_3300.py
- tests/runtime/test_5531_summary_reaches_first_main_call.py
- tests/hooks/test_2608_h1_mcp_resource_updated_hook.py
- tests/interfaces/test_cui_permission_answer_resumes_2690.py
- tests/runtime/test_5356_hooks_layer_rejection_audit_event.py
- tests/runtime/test_5367_reactive_ladder_absorbs_elide_sized_overflow.py
- tests/runtime/test_3595_s2_pipeline_nudge_origin.py
- tests/core/test_4666_2_completed_response_opt_in.py
- tests/core/test_2761_pr2_hotreload_immediate_apply.py
- tests/core/test_2242_hard_cancel.py

全ファイルで `._audit_events` への到達が完全に0(`git grep`で確認済み、既存のシンプルなcollect_events(session._audit_events)/settle(session._audit_events)呼び出しをsession直渡しに簡素化したケース含む)。

## 検証

- pytest(該当15ファイル) — 91/91 green
- ruff clean / tier_audit --strict clean / verify_module_docstrings OK

## 残り(次batch向け、READY 31のうち16 file)

tests/interfaces/test_2280_durability_halt_observability.py / test_3300_p2a_queue_state_publish.py / test_3300_p3_cancel_by_id.py / tests/runtime/test_5282_ephemeral_narrowing_audit_event.py / test_pending_intervention_268.py / test_session_invariants.py / test_skill_invoke_3100.py / test_user_echo_broadcast.py / test_2608_h4_fs_watcher.py / test_2608_h5_cron_webhook_hooks.py / tests/dev/test_5382_llm_stub_compaction_selectivity.py / tests/core/test_hook_loop_valve_1800_7.py / tests/runtime/test_5276_toggle_audit_events.py / tests/core/test_pipeline_is2_driver_session.py(変数名`worker`、duck-typing要確認) / tests/runtime/test_4472_compaction_reads_durable_store.py・test_intervention_agent_routing.py(local `_run_and_settle(coro, log)` helperのlog引数をsessionに変更する形、構造注記あり)。

PARTIAL(9 file、一部行のみ)とSKIP(9 file、対象行なし)は今回のPRの範囲外(theme comment内に前回コメントで詳細記録済み)。

## Test plan
- [x] pytest(変更15ファイル) — 91/91 green
- [x] ruff / tier_audit --strict / verify_module_docstrings — all clean
- [x] (skipped — no UI/TUI surface touched) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
