### PR TITLE
fix(#5467): migrate final 16 READY files off private _audit_events reach (batch 4)

### DIFF
--- a/tests/core/test_hook_loop_valve_1800_7.py
+++ b/tests/core/test_hook_loop_valve_1800_7.py
@@ -30,6 +30,7 @@ from reyn.config.chat import LoopConfig, OnLimitConfig, SafetyConfig
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.events import settle
 
 
 def _make_session(tmp_path: Path, *, cap: int) -> Session:
@@ -128,7 +129,7 @@ async def test_no_hooks_valve_never_engages(tmp_path):
     await session.run_one_iteration()
     await _push_user(session, "u2")
     await session.run_one_iteration()
-    await session._audit_events.drain()
+    await settle(session)
 
     assert _ran_chain_ids(events) == ["u1", "u2"]  # both user turns ran
     assert _checkpoint_kinds(events) == []         # valve never tripped
@@ -147,7 +148,7 @@ async def test_hook_loop_exceeding_cap_is_suppressed(tmp_path):
     for chain_id in ("h1", "h2", "h3"):
         await _push_hook(session, chain_id)
         await session.run_one_iteration()
-    await session._audit_events.drain()
+    await settle(session)
 
     # h1, h2 ran (count 1, 2 ≤ cap); h3 (count 3 > cap) suppressed.
     assert _ran_chain_ids(events) == ["h1", "h2"]
@@ -170,7 +171,7 @@ async def test_counter_resets_on_user_turn(tmp_path):
     await session.run_one_iteration()
     await _push_hook(session, "h2")     # count 1 again (NOT 2) → runs
     await session.run_one_iteration()
-    await session._audit_events.drain()
+    await settle(session)
 
     # without the reset, h2 would be count 2 > 1 → suppressed. Its presence proves
     # the user turn re-armed the budget.
@@ -196,7 +197,7 @@ async def test_c_ride_alongs_do_not_increment(tmp_path):
     await session.run_one_iteration()
     await _push_hook(session, "h2", wake=True)    # count 2 > 1 → suppressed
     await session.run_one_iteration()
-    await session._audit_events.drain()
+    await settle(session)
 
     # h1 ran ⇒ the wake=false C did NOT increment (else count would be 2 → h1
     # suppressed). h2 suppressed by the cap.

--- a/tests/core/test_pipeline_is2_driver_session.py
+++ b/tests/core/test_pipeline_is2_driver_session.py
@@ -69,6 +69,7 @@ from reyn.tools.pipeline_verbs import (
 )
 from reyn.tools.types import RouterCallerState, ToolContext
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
 
 
 class _ScriptedAgentReply:
@@ -664,14 +665,13 @@ async def test_deliver_emits_task_settle_undelivered_when_reply_agent_gone(
     worker = reg.get_or_load("worker")
     driver.bind_session(worker, worker._router_host)
 
-    captured_events: list = []
-    worker._audit_events.add_subscriber(lambda ev: captured_events.append(ev))
+    captured_events = collect_events(worker)
 
     await driver._finish(status="ok", output={"x": 1})
     # #4961 C: emit()'s dispatch is now async (queue + consumer task), not
     # inline — the same drain() requirement as the other 9 sites this PR
     # already converted (see events.py's EventLog.drain() docstring).
-    await worker._audit_events.drain()
+    await settle(worker)
 
     matching = [ev for ev in captured_events if ev.type == "task_settle_undelivered"]
     assert matching, f"expected a task_settle_undelivered event; got: {captured_events}"
@@ -706,12 +706,11 @@ async def test_deliver_does_not_emit_task_settle_undelivered_on_successful_deliv
     worker = reg.get_or_load("worker")
     driver.bind_session(worker, worker._router_host)
 
-    captured_events: list = []
-    worker._audit_events.add_subscriber(lambda ev: captured_events.append(ev))
+    captured_events = collect_events(worker)
 
     await driver._finish(status="ok", output={"x": 1})
 
-    await worker._audit_events.drain()
+    await settle(worker)
 
     run_dir = pipeline_run_dir(tmp_path / ".reyn", "delivered-audit-run")
     terminal = _result_json(run_dir)

--- a/tests/dev/test_5382_llm_stub_compaction_selectivity.py
+++ b/tests/dev/test_5382_llm_stub_compaction_selectivity.py
@@ -14,7 +14,7 @@ through a REAL turn — the main router call is NOT recognized as a
 compaction call and must still complete normally.
 
 Isolated in its OWN file, and reads the collected event list only after
-``await settle(session._audit_events)`` — both deliberately.
+``await settle(session)`` — both deliberately.
 
 The settle() requirement is #4961 C (architect ruling, see
 ``tests/_support/events.py``'s own module docstring), not a new finding
@@ -83,7 +83,7 @@ def test_raise_for_compaction_leaves_the_main_router_call_untouched_end_to_end(
         # #4961 C: dispatch to `events` runs on a background consumer
         # task — settle() before the synchronous read below, right at
         # the spot that depends on delivery having already happened.
-        await settle(session._audit_events)
+        await settle(session)
         kinds = [e.type for e in events]
         assert "compaction_failed" in kinds, (
             f"test setup sanity: expected force_compact_now to have "

--- a/tests/interfaces/test_2280_durability_halt_observability.py
+++ b/tests/interfaces/test_2280_durability_halt_observability.py
@@ -91,7 +91,7 @@ async def test_process_edge_halt_emits_session_halted_once(tmp_path) -> None:
     log = StateLog(tmp_path / "wal.jsonl", worker=worker)
     session = make_session(agent_name="alpha", state_log=log)
     events: list[Event] = []
-    await settle(session._audit_events)
+    await settle(session)
     session.subscribe_audit_events(events.append)
     try:
         assert session.halted_reason is None
@@ -99,7 +99,7 @@ async def test_process_edge_halt_emits_session_halted_once(tmp_path) -> None:
 
         # Negative control: nothing halted-related emitted before the process
         # edge actually observes the failed health-signal.
-        await settle(session._audit_events)
+        await settle(session)
         assert not any(e.type == "session_halted" for e in events)
 
         cont = await session.run_one_iteration()
@@ -108,7 +108,7 @@ async def test_process_edge_halt_emits_session_halted_once(tmp_path) -> None:
 
         # Unpacking a 1-tuple is itself the "exactly one" behavioral assertion
         # (raises ValueError on zero or more than one) — never a len(...) pin.
-        await settle(session._audit_events)
+        await settle(session)
         (halted_event,) = [e for e in events if e.type == "session_halted"]
         assert halted_event.data.get("reason") == "durability_failure"
 
@@ -116,7 +116,7 @@ async def test_process_edge_halt_emits_session_halted_once(tmp_path) -> None:
         # the SAME event object, not a fresh one appended.
         cont2 = await session.run_one_iteration()
         assert cont2 is False
-        await settle(session._audit_events)
+        await settle(session)
         (still_only_event,) = [e for e in events if e.type == "session_halted"]
         assert still_only_event is halted_event, "re-check re-emitted session_halted"
     finally:
@@ -140,14 +140,14 @@ async def test_accept_edge_halt_also_emits_session_halted_once(tmp_path) -> None
     log = StateLog(tmp_path / "wal.jsonl", worker=worker)
     session = make_session(agent_name="alpha", state_log=log)
     events: list[Event] = []
-    await settle(session._audit_events)
+    await settle(session)
     session.subscribe_audit_events(events.append)
     try:
         await _inject_persistent_durability_failure(log)
 
         with pytest.raises(DurabilityHaltError):
             await session._put_inbox("user", {"text": "after disk death"})
-        await settle(session._audit_events)
+        await settle(session)
         (halted_event,) = [e for e in events if e.type == "session_halted"]
         assert halted_event.data.get("reason") == "durability_failure"
 
@@ -155,7 +155,7 @@ async def test_accept_edge_halt_also_emits_session_halted_once(tmp_path) -> None
         # retry) must NOT re-emit: the SAME event object, not a fresh one.
         with pytest.raises(DurabilityHaltError):
             await session._put_inbox("user", {"text": "still after disk death"})
-        await settle(session._audit_events)
+        await settle(session)
         (still_only_event,) = [e for e in events if e.type == "session_halted"]
         assert still_only_event is halted_event, "second submit re-emitted session_halted"
     finally:

--- a/tests/interfaces/test_3300_p2a_queue_state_publish.py
+++ b/tests/interfaces/test_3300_p2a_queue_state_publish.py
@@ -164,7 +164,7 @@ async def test_turn_active_accessor_reflects_busy_then_idle(tmp_path, _llm_stub)
     assert completed is True
     assert session.turn_active is False
 
-    await session._audit_events.drain()
+    await settle(session)
     assert any(e.type == "turn_started" and e.data.get("chain_id") == "c1" for e in events)
 
 
@@ -277,7 +277,7 @@ async def test_late_joiner_mid_turn_connect_reconstructs_correct_state(tmp_path,
 
     # witness ②: the real driver dispatched "dispatched-first" — exactly one
     # turn_started (the second submission stays queued, undispatched).
-    await session._audit_events.drain()
+    await settle(session)
     (started_ev,) = [e for e in events if e.type == "turn_started"]
     assert started_ev.data.get("kind") == "user"
 
@@ -387,7 +387,7 @@ async def test_real_session_deltas_keep_remote_queue_view_accurate(tmp_path, _ll
 
     await session.submit_user_text("alpha")
     # Apply the just-emitted user_submitted delta.
-    await settle(session._audit_events)
+    await settle(session)
     ev = next(e for e in captured if e.type == "user_submitted")
     view.apply_user_submitted(
         msg_id=ev.data["msg_id"], chain_id=ev.data["chain_id"],
@@ -398,7 +398,7 @@ async def test_real_session_deltas_keep_remote_queue_view_accurate(tmp_path, _ll
     turn_task = asyncio.create_task(session.run_one_iteration())
     await _llm_stub.call_started.wait()
 
-    await settle(session._audit_events)
+    await settle(session)
     ts = next(e for e in captured if e.type == "turn_started")
     view.apply_turn_started(chain_id=ts.data["chain_id"], seq=ts.data["seq"])
     assert view.queue() == [], "the dispatched item must leave the queue model"
@@ -444,7 +444,7 @@ async def test_a_submission_while_the_reply_is_still_streaming_reaches_the_queue
     session.subscribe_audit_events(lambda ev: captured.append(ev))
 
     await session.submit_user_text("alpha")
-    await settle(session._audit_events)
+    await settle(session)
     ev = next(e for e in captured if e.type == "user_submitted")
     view.apply_user_submitted(
         msg_id=ev.data["msg_id"], chain_id=ev.data["chain_id"],
@@ -454,7 +454,7 @@ async def test_a_submission_while_the_reply_is_still_streaming_reaches_the_queue
     turn_task = asyncio.create_task(session.run_one_iteration())
     await _llm_stub.call_started.wait()
 
-    await settle(session._audit_events)
+    await settle(session)
     ts = next(e for e in captured if e.type == "turn_started")
     view.apply_turn_started(chain_id=ts.data["chain_id"], seq=ts.data["seq"])
     assert view.queue() == []  # alpha dispatched; turn now "streaming" (hung)
@@ -462,7 +462,7 @@ async def test_a_submission_while_the_reply_is_still_streaming_reaches_the_queue
     # The reply is in flight (streaming) — submit a SECOND message now.
     captured.clear()
     await session.submit_user_text("beta")
-    await settle(session._audit_events)
+    await settle(session)
     ev2 = next(e for e in captured if e.type == "user_submitted")
     applied = view.apply_user_submitted(
         msg_id=ev2.data["msg_id"], chain_id=ev2.data["chain_id"],

--- a/tests/interfaces/test_3300_p3_cancel_by_id.py
+++ b/tests/interfaces/test_3300_p3_cancel_by_id.py
@@ -124,7 +124,7 @@ async def test_cancel_of_already_dispatched_message_is_a_noop(tmp_path, _llm_stu
     await turn_task
 
     # witness ②: the real driver dispatched.
-    await session._audit_events.drain()
+    await settle(session)
     assert any(e.type == "turn_started" for e in events)
 
 
@@ -303,7 +303,7 @@ async def test_cancel_scheduled_before_dispatch_wins_exclusively(tmp_path, _llm_
     finished = await asyncio.wait_for(iter_task, timeout=5)
     assert finished is False, "shutdown sentinel drains run_one_iteration"
 
-    await settle(session._audit_events)
+    await settle(session)
     kinds = [ev.type for ev in captured]
     assert "inbox_cancel" in kinds
     assert "turn_started" not in kinds, (
@@ -340,7 +340,7 @@ async def test_dispatch_scheduled_before_cancel_wins_exclusively(tmp_path, _llm_
     cancelled = await cancel_task
 
     assert cancelled is False, "dispatch won the race — cancel of an already-dispatched item is a no-op"
-    await settle(session._audit_events)
+    await settle(session)
     kinds = [ev.type for ev in captured]
     assert "turn_started" in kinds
     assert "inbox_cancel" not in kinds, (
@@ -384,7 +384,7 @@ async def test_skip_at_consume_discards_cancelled_item_without_dispatch(tmp_path
     assert finished is True
     assert session.queued_user_messages() == []
 
-    await session._audit_events.drain()
+    await settle(session)
     assert any(e.type == "turn_started" for e in events)
 
 
@@ -426,7 +426,7 @@ async def test_real_session_inbox_cancel_delta_drives_remote_queue_view(tmp_path
     session.subscribe_audit_events(lambda ev: captured.append(ev))
 
     await session.submit_user_text("alpha")
-    await settle(session._audit_events)
+    await settle(session)
     submitted = next(e for e in captured if e.type == "user_submitted")
     view.apply_user_submitted(
         msg_id=submitted.data["msg_id"], chain_id=submitted.data["chain_id"],
@@ -435,7 +435,7 @@ async def test_real_session_inbox_cancel_delta_drives_remote_queue_view(tmp_path
     assert [i["text"] for i in view.queue()] == ["alpha"]
 
     await session.cancel_queued(submitted.data["msg_id"])
-    await settle(session._audit_events)
+    await settle(session)
     cancel_ev = next(e for e in captured if e.type == "inbox_cancel")
     view.apply_inbox_cancel(msg_id=cancel_ev.data["msg_id"], seq=cancel_ev.data["seq"])
 

--- a/tests/runtime/test_2608_h4_fs_watcher.py
+++ b/tests/runtime/test_2608_h4_fs_watcher.py
@@ -418,7 +418,7 @@ async def test_session_owned_watcher_emits_file_changed_audit_event_with_no_hook
         snapshot_path=tmp_path / "snap.json",
         reactivity=ReactivityConfig(hooks_config=None, fs_watch_config=FsWatchConfig(paths=[str(watched_dir)], debounce_seconds=0.05)),
     )
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     try:
         await session._fs_watcher.start()
         assert session.fs_watcher_is_started()

--- a/tests/runtime/test_2608_h5_cron_webhook_hooks.py
+++ b/tests/runtime/test_2608_h5_cron_webhook_hooks.py
@@ -255,7 +255,7 @@ async def test_cron_fire_emits_cron_fired_audit_event_with_no_hook_configured(tm
     # (before the fire) to subscribe collect_events, then letting the
     # runner's own resolve inside _inbox_pusher return the SAME session.
     session = resolve_cron_session(reg, "news_agent", "morning_news")
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     job = CronJob(name="morning_news", schedule="0 9 * * *", to="news_agent", message="hi")
     await runner(job)
 
@@ -406,7 +406,7 @@ async def test_webhook_receipt_emits_webhook_received_audit_event_with_no_hook_c
     # (before the request) to subscribe collect_events, then letting
     # push_to_agent's own resolve return the SAME session.
     session = WebhookIngressAdapter().resolve_session(reg, "support_agent", "slack:U456")
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
 
     await push_to_agent(
         target_agent="support_agent",

--- a/tests/runtime/test_4472_compaction_reads_durable_store.py
+++ b/tests/runtime/test_4472_compaction_reads_durable_store.py
@@ -47,9 +47,9 @@ from tests._support.agent_session import make_session
 from tests._support.events import settle
 
 
-async def _run_and_settle(coro, log):
+async def _run_and_settle(coro, source):
     result = await coro
-    await settle(log)
+    await settle(source)
     return result
 
 
@@ -223,7 +223,7 @@ def test_a_capped_batch_makes_honest_incremental_progress_across_passes(
 
     from tests._support.events import collect_events
 
-    events = collect_events(s._audit_events)
+    events = collect_events(s)
 
     # A real, sizeable backlog -- each turn ~4KB, 30 turns -> ~120KB raw,
     # comfortably larger than a small forced batch cap below.
@@ -245,7 +245,7 @@ def test_a_capped_batch_makes_honest_incremental_progress_across_passes(
 
     monkeypatch.setattr(htr, "read_history_after", _tiny_batch_reader)
 
-    result1 = asyncio.run(_run_and_settle(s._compact_now_for_op(), s._audit_events))
+    result1 = asyncio.run(_run_and_settle(s._compact_now_for_op(), s))
     assert result1["summarized_turns"] > 0, "sanity: the first pass must make real progress"
 
     first_summary = s._latest_summary()

--- a/tests/runtime/test_5276_toggle_audit_events.py
+++ b/tests/runtime/test_5276_toggle_audit_events.py
@@ -73,10 +73,10 @@ async def test_visibility_toggle_emits_visibility_changed(tmp_path, monkeypatch)
     exactly once."""
     monkeypatch.chdir(tmp_path)
     s = _make_session(tmp_path)
-    collected = collect_events(s._audit_events)
+    collected = collect_events(s)
 
     s.set_capability_visible("tool", "grep", False)
-    await settle(s._audit_events)
+    await settle(s)
 
     seen = [e for e in collected if e.type == "visibility_changed"]
     assert seen, "expected a visibility_changed event, got none"
@@ -97,11 +97,11 @@ async def test_hook_toggle_emits_hook_changed_on_both_outcomes(tmp_path, monkeyp
     on record, not silence."""
     monkeypatch.chdir(tmp_path)
     s = _make_session(tmp_path, hooks_config=_STARTUP_HOOKS)
-    collected = collect_events(s._audit_events)
+    collected = collect_events(s)
 
     # Refused: startup-origin hook — no state change, but the ATTEMPT is recorded.
     refused = s.set_hook_enabled(_STARTUP_HOOK_NAME, False)
-    await settle(s._audit_events)
+    await settle(s)
     seen_refused = [e for e in collected if e.type == "hook_changed"]
     assert refused.applied is False
     assert seen_refused, "a refused hook-disable attempt must still emit hook_changed"
@@ -115,7 +115,7 @@ async def test_hook_toggle_emits_hook_changed_on_both_outcomes(tmp_path, monkeyp
 
     # Applied: an unknown/per-session name is freely disableable → applied=True.
     applied = s.set_hook_enabled("some-per-session-hook", False)
-    await settle(s._audit_events)
+    await settle(s)
     seen_applied = [e for e in collected if e.type == "hook_changed" and e is not seen_refused[0]]
     assert applied.applied is True
     assert seen_applied, "expected a hook_changed event for the applied toggle"

--- a/tests/runtime/test_5282_ephemeral_narrowing_audit_event.py
+++ b/tests/runtime/test_5282_ephemeral_narrowing_audit_event.py
@@ -109,12 +109,12 @@ async def test_engage_fires_once_on_the_transition_not_on_repeated_reads(
     ``untrusted_narrowing_engaged`` event must result, however many of those
     reads happen."""
     s = _session(tmp_path)
-    events = collect_events(s._audit_events)
+    events = collect_events(s)
 
     # Reads before the taint: no engage yet, must emit nothing.
     for _ in range(3):
         assert _UNTRUSTED_DENIED_TOOL not in _denied_by_turn_context(s)
-    await settle(s._audit_events)
+    await settle(s)
     assert _kinds(events, "untrusted_narrowing_engaged") == []
 
     _mark_untrusted(s)
@@ -125,7 +125,7 @@ async def test_engage_fires_once_on_the_transition_not_on_repeated_reads(
     # read count.
     for _ in range(5):
         assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(s)
-    await settle(s._audit_events)
+    await settle(s)
 
     assert _kinds(events, "untrusted_narrowing_engaged") == ["untrusted_narrowing_engaged"], (
         "5 identical-state reads must still produce exactly 1 engage event — "
@@ -145,11 +145,11 @@ async def test_lift_fires_once_when_the_taint_leaves_the_context(tmp_path: Path)
     taint_leaves_the_context``'s own removal shape), read several times
     while lifted. Exactly one lift event, not one per post-lift read."""
     s = _session(tmp_path)
-    events = collect_events(s._audit_events)
+    events = collect_events(s)
 
     _mark_untrusted(s)
     assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(s)
-    await settle(s._audit_events)
+    await settle(s)
     assert _kinds(events, "untrusted_narrowing_engaged") == ["untrusted_narrowing_engaged"], (
         "control arm: engage must have fired before lift is meaningful to test"
     )
@@ -159,7 +159,7 @@ async def test_lift_fires_once_when_the_taint_leaves_the_context(tmp_path: Path)
 
     for _ in range(5):
         assert _UNTRUSTED_DENIED_TOOL not in _denied_by_turn_context(s)
-    await settle(s._audit_events)
+    await settle(s)
 
     assert _kinds(events, "untrusted_narrowing_lifted") == ["untrusted_narrowing_lifted"], (
         "5 identical-state reads must still produce exactly 1 lift event — "
@@ -185,14 +185,14 @@ async def test_engage_then_lift_then_engage_again_is_one_of_each_per_flip(
     manually and not committed here per this repo's no-duration test
     policy)."""
     s = _session(tmp_path)
-    events = collect_events(s._audit_events)
+    events = collect_events(s)
 
     for _ in range(2):
         _mark_untrusted(s)
         assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(s)
         s.history = [m for m in s.history if not (m.meta or {}).get("external_source")]
         assert _UNTRUSTED_DENIED_TOOL not in _denied_by_turn_context(s)
-    await settle(s._audit_events)
+    await settle(s)
 
     assert _kinds(events, "untrusted_narrowing_engaged") == [
         "untrusted_narrowing_engaged", "untrusted_narrowing_engaged",

--- a/tests/runtime/test_intervention_agent_routing.py
+++ b/tests/runtime/test_intervention_agent_routing.py
@@ -36,9 +36,9 @@ from tests._support.agent_session import make_session
 from tests._support.events import collect_events, settle
 
 
-async def _run_and_settle(coro, log):
+async def _run_and_settle(coro, source):
     result = await coro
-    await settle(log)
+    await settle(source)
     return result
 
 
@@ -124,10 +124,10 @@ def test_default_routing_emits_user_channel_event(tmp_path: Path) -> None:
     traces, future routing-policy analysis) can see the decision.
     """
     session = make_session(agent_name="t")
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     iv = UserIntervention(kind="ask_user", prompt="Q?")
 
-    asyncio.run(_run_and_settle(session.handle_intervention(iv), session._audit_events))
+    asyncio.run(_run_and_settle(session.handle_intervention(iv), session))
 
     # session._audit_events is the EventLog used for chat-side events.
     events = [
@@ -172,10 +172,10 @@ def test_self_answer_branch_emits_self_answer_event() -> None:
     ``route="self_answer"``.
     """
     session = _SelfAnsweringSession(agent=Agent(agent_name="t"), **_recovery_kwargs("t"))
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     iv = UserIntervention(kind="permission.shell", prompt="Run ls?")
 
-    asyncio.run(_run_and_settle(session.handle_intervention(iv), session._audit_events))
+    asyncio.run(_run_and_settle(session.handle_intervention(iv), session))
 
     events = [
         e for e in [e.model_dump(mode="json") for e in collected]
@@ -231,17 +231,17 @@ def test_parent_delegate_branch_emits_parent_delegate_event() -> None:
     event on the parent's audit_events log.
     """
     parent = _SelfAnsweringSession(agent=Agent(agent_name="parent"), **_recovery_kwargs("parent"))
-    parent_collected = collect_events(parent._audit_events)
+    parent_collected = collect_events(parent)
     child = _DelegatingSession(agent=Agent(agent_name="child"), **_recovery_kwargs("child"))
-    child_collected = collect_events(child._audit_events)
+    child_collected = collect_events(child)
     child.set_parent(parent)
 
     iv = UserIntervention(kind="ask_user", prompt="Q?")
 
     async def _drive():
         await child.handle_intervention(iv)
-        await settle(child._audit_events)
-        await settle(parent._audit_events)
+        await settle(child)
+        await settle(parent)
 
     asyncio.run(_drive())
 
@@ -281,12 +281,12 @@ def test_self_answer_takes_precedence_over_parent_delegate() -> None:
     design (issue #254 design discussion log).
     """
     parent = _SelfAnsweringSession(agent=Agent(agent_name="parent"), **_recovery_kwargs("parent"))
-    parent_collected = collect_events(parent._audit_events)
+    parent_collected = collect_events(parent)
     child = _SelfAndParentSession(agent=Agent(agent_name="child"), **_recovery_kwargs("child"))
     child.set_parent(parent)
 
     iv = UserIntervention(kind="ask_user", prompt="Q?")
-    answer = asyncio.run(_run_and_settle(child.handle_intervention(iv), parent._audit_events))
+    answer = asyncio.run(_run_and_settle(child.handle_intervention(iv), parent))
 
     # Child self-answered, parent was never consulted.
     assert answer.text == "child-self"

--- a/tests/runtime/test_pending_intervention_268.py
+++ b/tests/runtime/test_pending_intervention_268.py
@@ -294,7 +294,7 @@ def test_handle_intervention_emits_user_channel_stalled_route_event() -> None:
     distinct from the regular ``"user_channel"`` route event.
     """
     session = make_session(agent_name="test")
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     session.register_intervention_listener("tui:current")
 
     async def _drive() -> None:
@@ -308,7 +308,7 @@ def test_handle_intervention_emits_user_channel_stalled_route_event() -> None:
         await asyncio.sleep(0)
         await session.discard_pending_intervention(iv.id)
         await task
-        await settle(session._audit_events)
+        await settle(session)
 
     asyncio.run(_drive())
 
@@ -364,7 +364,7 @@ def test_discard_pending_intervention_emits_audit_event_on_success() -> None:
     trail when the iv was actually discarded.
     """
     session = make_session(agent_name="test")
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
     session.register_intervention_listener("tui:current")
 
     async def _drive() -> None:
@@ -381,7 +381,7 @@ def test_discard_pending_intervention_emits_audit_event_on_success() -> None:
         )
         assert ok is True
         await task
-        await settle(session._audit_events)
+        await settle(session)
 
     asyncio.run(_drive())
 

--- a/tests/runtime/test_session_invariants.py
+++ b/tests/runtime/test_session_invariants.py
@@ -1159,7 +1159,7 @@ async def test_peer_no_reply_marker_surfaced_to_user_not_absorbed(
 
     session = _make_session(tmp_path, agent_name="default_agent")
     sub = _subscribe_outbox(session)  # BEFORE dispatch — see its own docstring
-    audit_collected = collect_events(session._audit_events)
+    audit_collected = collect_events(session)
 
     # Inject a no-reply marker as if a specialist peer sent it.
     marker = _no_reply_marker("specialist", "router completed without producing a text reply")
@@ -1201,7 +1201,7 @@ async def test_peer_no_reply_marker_surfaced_to_user_not_absorbed(
     )
 
     # Audit event log must contain peer_reply_failed_surfaced event (P6 audit).
-    await settle(session._audit_events)
+    await settle(session)
     audit_event_types = [e.type for e in audit_collected]
     assert "peer_reply_failed_surfaced" in audit_event_types, (
         f"B2-H2: expected 'peer_reply_failed_surfaced' audit event; got: {audit_event_types!r}"
@@ -1242,7 +1242,7 @@ async def test_peer_no_reply_marker_forwarded_upstream_in_pending_chain(
     session = _make_session(
         tmp_path, agent_name="relay_agent", registry=registry
     )
-    audit_collected = collect_events(session._audit_events)
+    audit_collected = collect_events(session)
 
     # Manually register a pending chain: relay_agent is waiting on "specialist"
     # for a request that came from "origin_agent".
@@ -1303,7 +1303,7 @@ async def test_peer_no_reply_marker_forwarded_upstream_in_pending_chain(
     )
 
     # Audit event log must contain peer_reply_failed_surfaced event (P6 audit).
-    await settle(session._audit_events)
+    await settle(session)
     audit_event_types = [e.type for e in audit_collected]
     assert "peer_reply_failed_surfaced" in audit_event_types, (
         f"B2-H2 relay: expected 'peer_reply_failed_surfaced' audit event; got: {audit_event_types!r}"

--- a/tests/runtime/test_skill_invoke_3100.py
+++ b/tests/runtime/test_skill_invoke_3100.py
@@ -395,7 +395,7 @@ async def test_session_skill_invoke_collision_is_loud(tmp_path):
     session = _session_with_skills(
         tmp_path, [entry], collisions={"shared": ["project", "dynamic"]},
     )
-    collected = collect_events(session._audit_events)
+    collected = collect_events(session)
 
     consumed, text = await session._maybe_handle_skill_invoke(":shared go")
     assert consumed is False
@@ -409,7 +409,7 @@ async def test_session_skill_invoke_collision_is_loud(tmp_path):
 
     # (2) a real audit-event was emitted (P6 band member) — read through the
     # session's real EventLog, not a private queue.
-    await settle(session._audit_events)
+    await settle(session)
     collision_events = [e for e in collected if e.type == "skill_invoke_collision"]
     assert collision_events, "expected a skill_invoke_collision audit-event to fire"
     assert all(e.data.get("name") == "shared" for e in collision_events)

--- a/tests/runtime/test_user_echo_broadcast.py
+++ b/tests/runtime/test_user_echo_broadcast.py
@@ -98,7 +98,7 @@ async def _user_submitted(session: Session, sink: _EventSink):
     # #4961 C / #4966: emit() dispatches to subscribers off the synchronous
     # caller — settle() before the read makes that wait explicit instead of
     # racing the background consumer.
-    await settle(session._audit_events)
+    await settle(session)
     matches = [e for e in sink.events if e.type == "user_submitted"]
     assert matches, "no user_submitted event observed"
     return matches[0]


### PR DESCRIPTION
**[tui-coder]** — part of #5467 (phase 2, batch 4 of N)

Follow-on to #5549 (batch 1, merged), #5550 (batch 2, armed), #5552 (batch 3, armed). Branched off `origin/main` per PR-workflow rule 10.

## このPRでやったこと(READY 31 の残り16 file全部)

`session._audit_events.add_subscriber/settle/drain` → `collect_events(session)`/`settle(session)`。全て前batchと同じ機械的パターン(SHAPE1/SHAPE3のみ)。

- tests/runtime/test_2608_h4_fs_watcher.py
- tests/runtime/test_2608_h5_cron_webhook_hooks.py
- tests/dev/test_5382_llm_stub_compaction_selectivity.py
- tests/core/test_hook_loop_valve_1800_7.py
- tests/runtime/test_5276_toggle_audit_events.py
- tests/runtime/test_pending_intervention_268.py
- tests/runtime/test_session_invariants.py
- tests/runtime/test_skill_invoke_3100.py
- tests/runtime/test_user_echo_broadcast.py
- tests/interfaces/test_2280_durability_halt_observability.py
- tests/interfaces/test_3300_p2a_queue_state_publish.py
- tests/interfaces/test_3300_p3_cancel_by_id.py
- tests/runtime/test_5282_ephemeral_narrowing_audit_event.py
- tests/core/test_pipeline_is2_driver_session.py(変数名`worker`だが実Session、duck-typing正常動作を確認)
- tests/runtime/test_4472_compaction_reads_durable_store.py(ローカル`_run_and_settle(coro, log)`helperの`log`引数を`s._audit_events`→`s`に変更、helper自体は無変更)
- tests/runtime/test_intervention_agent_routing.py(同じhelper indirection、11行/3箇所)

`git grep '\._audit_events'`で全16fileを再確認 — 残るのは全てprose/comment(SHAPE7)のみ、コード上の到達は0。

## 検証

- pytest(該当16ファイル) — 178/178 green
- ruff clean / tier_audit --strict clean(178 tests) / verify_module_docstrings OK

## ∴ READY 31 file 完了

batch1(1)+batch2(8、うちsettle以外の重複整理含む)+batch3(15)+batch4(16) = READY 31 file 全て移行完了。

## 残り(PARTIAL 9 file / SKIP 9 file)

lead-coder指示どおり、READY完了時点でPARTIAL/SKIPの扱い(移すか・射程外として閉じるか)を判断する番。PARTIAL 9件の移行可能な行(前batchのコメントに記録済み)とSKIP 9件(対象行なし)は本PRの範囲外。

## Test plan
- [x] pytest(変更16ファイル) — 178/178 green
- [x] ruff / tier_audit --strict / verify_module_docstrings — all clean
- [x] (skipped — no UI/TUI surface touched) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
