### PR TITLE
fix(#5514): wake=true mouth now reads the hook's own declared spillability

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -7764,14 +7764,30 @@ class Session:
             content=attributed,
             ts=_now_iso(),
             meta={"chain_id": chain_id},
-            # #5514 §4/§8 (owner correction, 2026-08-30): a hook push is
-            # MATERIAL (the whole reason #5514 was opened — a hook push
-            # had no cap and no offload, #5514 §5's own outset). Default
-            # hardcoded here, not read from ``hooks.yaml`` — a per-hook
-            # ``spillability:`` knob is a separate, later PR (scope
-            # narrowed by lead-coder to avoid landing config schema/
-            # loader/validation changes in this already-large PR).
-            spillability=Spillability.FIRST_CHOICE,
+            # #5514 §8 (lead-coder BLOCKING finding, 2026-08-30): reads
+            # the SAME per-hook ``spillability`` its own wake=false
+            # sibling (the ``next_turn_context`` ride-along, below) reads
+            # — both from the ONE payload dict
+            # ``HookDispatcher._push_resolved`` builds (dispatcher.py).
+            # An earlier version of this site hardcoded
+            # ``Spillability.FIRST_CHOICE`` instead of reading the
+            # payload — the exact "declaration reaches one mouth and
+            # silently misses the other" hazard #5514 §8 itself named,
+            # just manifesting at THIS mouth instead of the one §8's own
+            # text anticipated. Undeclared (no ``spillability`` key, a
+            # payload not built through ``_push_resolved`` at all) still
+            # falls back to ``FIRST_CHOICE`` — ``HookDef.spillability``'s
+            # own docstring is the reason: `None` (undeclared) resolves
+            # to FIRST_CHOICE, not ``Spillability.default()``'s general
+            # LAST_RESORT, because #5514's own opening motivation was
+            # "template_push has no cap and no offload" — defaulting its
+            # own knob to the least eager-to-spill tier would protect
+            # the exact path the issue exists to fix last.
+            spillability=(
+                Spillability(payload["spillability"])
+                if "spillability" in payload
+                else Spillability.FIRST_CHOICE
+            ),
         ))
         await self._put_outbox(OutboxMessage(
             kind="system",
@@ -8039,18 +8055,15 @@ class Session:
                     # exact gap #5514 names. ``kind`` (persisted here)
                     # lets a future reader recover what this was.
                     #
-                    # #5514 §8 (owner correction, 2026-08-30): the
-                    # classifier is ``entry_kind`` (already OS-trusted, see
-                    # the comment above) — a HOOK ride-along reads the
-                    # SAME per-hook ``spillability`` its own wake=true
-                    # sibling (``_handle_hook_message``) reads, both from
-                    # the ONE payload dict ``HookDispatcher._push_resolved``
-                    # builds (dispatcher.py) — the two mouths #5514 §8
-                    # requires a hook's declaration reach cannot drift
-                    # since they read the same field of the same payload.
-                    # Every other staged producer (send_to_session/agent/
-                    # cron/pipeline/peer) has no per-kind ruling yet and
-                    # defaults ``LAST_RESORT``.
+                    # #5514 §8: the classifier is ``entry_kind`` (already
+                    # OS-trusted, see the comment above) — a HOOK
+                    # ride-along reads the SAME per-hook ``spillability``
+                    # its own wake=true sibling (``_handle_hook_message``)
+                    # reads, both from the ONE payload dict
+                    # ``HookDispatcher._push_resolved`` builds
+                    # (dispatcher.py). Every other staged producer
+                    # (send_to_session/agent/cron/pipeline/peer) has no
+                    # per-kind ruling yet and defaults ``LAST_RESORT``.
                     meta={"kind": entry_kind},
                     spillability=(
                         Spillability(payload_data["spillability"])

--- a/tests/hooks/test_5514_hook_spillability_dispatch.py
+++ b/tests/hooks/test_5514_hook_spillability_dispatch.py
@@ -31,13 +31,17 @@ stage_next_turn_context) are recording real async callables, mirroring
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
 from reyn.hooks.dispatcher import HookDispatcher
 from reyn.hooks.registry import HookRegistry
 from reyn.hooks.schema import HookDef, PushBlock
 from reyn.runtime.chat_message import Spillability
+from tests._support.agent_session import make_session
 from tests._support.events import collect_events, settle
 
 
@@ -81,6 +85,59 @@ async def test_declared_spillability_reaches_the_wake_true_payload():
     args, _kwargs = call
     payload = args[1]  # _put_inbox(TurnOrigin.HOOK, {**payload, "wake": True})
     assert payload["spillability"] == "last_resort"
+
+
+@pytest.mark.asyncio
+async def test_declared_spillability_reaches_construction_on_wake_true(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5514 §8 — lead-coder BLOCKING finding, 2026-08-30. The
+    payload-only assertion above (``test_declared_spillability_reaches_
+    the_wake_true_payload``) proved the declaration is TRANSPORTED —
+    it did not prove ``Session._handle_hook_message`` (the wake=true
+    consumer) actually READS it: an earlier version of that method
+    hardcoded ``Spillability.FIRST_CHOICE`` regardless of what the
+    payload carried, and this exact test shape (payload-only) stayed
+    green through that regression, because "sent" and "sent to the
+    right place and used there" are different claims. This test drives
+    the REAL ``Session._handle_hook_message`` (not a re-implementation)
+    with a ``spillability: never``-shaped payload and reads the
+    CONSTRUCTED ``ChatMessage`` back off ``session.history`` — the
+    actual site #5514 §8 requires the declaration reach.
+
+    ``_run_router_loop`` is method-assigned to a real no-op async
+    function (not a mock) so this test isolates ``_handle_hook_message``'s
+    own history-append behaviour from a full router turn — mirrors
+    ``test_hook_message_is_fanned_out_to_live_outbox``
+    (test_hook_loop_valve_1800_7.py)'s own established pattern for the
+    SAME method.
+
+    Strip-falsify (performed during review): reverting
+    ``_handle_hook_message`` to hardcode ``spillability=Spillability.
+    FIRST_CHOICE`` makes the assertion below fail (``FIRST_CHOICE`` !=
+    ``NEVER``), confirming this test — unlike the payload-only one — DOES
+    catch the regression lead-coder found.
+    """
+    session = make_session(
+        agent_name="spillability-construction-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    session._run_router_loop = _noop  # type: ignore[method-assign]
+
+    await session._handle_hook_message({
+        "name": "policy-hook",
+        "text": "a standing policy, never to be spilled",
+        "wake": True,
+        "spillability": Spillability.NEVER.value,
+    })
+
+    (only,) = [m for m in session.history if m.role == "system"]
+    assert only.spillability is Spillability.NEVER
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — part of #5514, its own last remaining item per lead-coder's own accounting ("§1〜§5/§8の1〜3はmainに在ることを確認済…これ1件だけが残りです").

## What was wrong (lead-coder's own BLOCKING finding, verbatim evidence)

`HookDispatcher._push_resolved` (dispatcher.py) threads a hook's declared `spillability` into ONE payload dict both consumer mouths are meant to read from. The wake=false ride-along (`Session._handle_inbox_text`'s `next_turn_context` staging, `session.py`) already read it correctly. The wake=true trigger (`Session._handle_hook_message`, `session.py:7774`) **hardcoded `Spillability.FIRST_CHOICE`** instead — a hook declaring `spillability: last_resort` or `never` had that declaration silently discarded the moment it woke the session. This is #5514 §8's own named hazard ("宣言した人からは区別がつかない"), just manifesting at the mouth its own prior text did not anticipate (§8 was written assuming ② — the ride-along — was the risk; ① — the direct wake=true push — was the one that actually failed).

Three written claims were false as a result (all quoted and corrected in the diff/commit):
1. A comment claiming the two mouths "read the SAME... spillability... cannot drift" — false; only one mouth read it.
2. `dispatcher.py`'s own construction-site comment claiming the shared payload alone prevents one mouth from missing the declaration — true of construction, not of consumption; left as-is since the fix below makes it true again.
3. A comment attributing the hooks.yaml `spillability:` knob to "a separate, later PR" — false (it landed in #5531 PR-3 itself) and falsely attributed to lead-coder's own scoping ruling, which said the opposite. Removed.

## Why the existing test stayed green

`test_declared_spillability_reaches_the_wake_true_payload` (`tests/hooks/test_5514_hook_spillability_dispatch.py`) asserts on the **payload** `HookDispatcher` builds — it proves the declaration is *transported*, never that `_handle_hook_message` *reads* it. "Sent" and "sent to the right place and used there" are different claims; the accept criterion needed to move from transport to construction.

## What changed

- `src/reyn/runtime/session.py`: `_handle_hook_message` now reads `payload["spillability"]` (same shape the wake=false ride-along already used); undeclared/missing key still falls back to `FIRST_CHOICE` (`HookDef.spillability`'s own documented default). Both stale comments (①③ above) corrected/removed.
- `tests/hooks/test_5514_hook_spillability_dispatch.py`: **new** `test_declared_spillability_reaches_construction_on_wake_true` — drives the real `Session._handle_hook_message` (not a re-implementation) with a `spillability: never`-shaped payload, reads the constructed `ChatMessage` back off `session.history`. `_run_router_loop` is method-assigned to a real no-op async function (not a mock) to isolate this from a full router turn — mirrors `test_hook_loop_valve_1800_7.py::test_hook_message_is_fanned_out_to_live_outbox`'s own established pattern for the same method. The existing payload-only test is kept (a genuinely different, still-true claim).

## Strip-falsify (performed, verbatim per lead-coder's own accept criterion ④)

Reverting `_handle_hook_message`'s `spillability=` argument back to the hardcoded `Spillability.FIRST_CHOICE`:
```
FAILED tests/hooks/test_5514_hook_spillability_dispatch.py::test_declared_spillability_reaches_construction_on_wake_true
AssertionError: assert <Spillability.FIRST_CHOICE: 'first_choice'> is <Spillability.NEVER: 'never'>
```
The existing payload-only test (`test_declared_spillability_reaches_the_wake_true_payload`) stays green throughout the revert — confirming it alone would never have caught this, exactly lead-coder's own diagnosis of why the bug shipped.

## Verification

- **Local gates, all green**: `ruff check .`, `test_tier_audit.py --strict tests/hooks/test_5514_hook_spillability_dispatch.py` (7 tests, 0 Tier-4 violations), `verify_module_docstrings.py`, `mypy_ratchet.py`.
- **Scoped pytest**: `tests/hooks/` + `tests/core/test_hook_loop_valve_1800_7.py` (the other real consumer of `_handle_hook_message`) — 435 passed.

## Test plan

- [x] Unit test as listed above — passes locally.
- [x] Strip-falsification performed (quoted above) — confirms the new test catches the regression the payload-only test missed.
- [x] Scoped sweep across every real consumer of `_handle_hook_message` — all green.
- [x] (skipped — Visual, standing waiver 2026-08-08) No UI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
