### PR TITLE
fix(#5515): _BoundedEventBridge's queue-full drop is fail-visible

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -101,6 +101,7 @@ inbox_cancel
 index_dropped
 index_update_cost_warning
 index_updated
+ingress_bridge_dropped
 intervention_answer_submitted
 intervention_denied
 intervention_routed
@@ -464,6 +465,20 @@ from `.reyn/events` even when nothing was listening.
 All three are best-effort: a sink fault logs and is swallowed, never blocking
 the job's inbox delivery / the webhook's HTTP response / the watcher's drain
 loop.
+
+`mcp_resource_updated` and `file_changed` share one in-process delivery
+mechanism, `reyn.hooks.ingress._BoundedEventBridge` — a bounded queue that
+drops the newest event on overflow rather than blocking the producer or
+growing unboundedly. Before #5515 that drop was `logger.warning`-only,
+unlike the structurally identical `HookBus` subscriber-queue drop
+(`bus_subscriber_dropped`, #2886). `ingress_bridge_dropped` closes that gap
+for this bridge, on the same first-drop/every-100th cadence: metadata-only
+(`source` — the bridge's adapter name, `McpIngressAdapter` or
+`FsIngressAdapter`; `point` — the bare hook point; `drop_count` — cumulative,
+never reset), never the dropped event's own payload. `cron_fired` and
+`webhook_received` share a separate bridge (`_SessionFireBridge`,
+`reyn.hooks.external_fire`) with the same overflow shape; it is tracked
+separately (#5515 remainder, not yet closed).
 
 ## Credentials and OAuth
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -413,6 +413,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "index_dropped",
     "index_update_cost_warning",
     "index_updated",
+    "ingress_bridge_dropped",
     "intervention_answer_submitted",
     "intervention_denied",
     "intervention_routed",

--- a/src/reyn/hooks/ingress.py
+++ b/src/reyn/hooks/ingress.py
@@ -60,6 +60,15 @@ from reyn.hooks.schema_registry import bare_point, build_hook_payload, canonical
 
 logger = logging.getLogger(__name__)
 
+# #5515: fail-visible cadence for a queue-full drop in _BoundedEventBridge.
+# deliver() (below) — matched to src/reyn/hooks/bus.py:83's own
+# ``_AUDIT_EVERY_N_DROPS`` (HookBus._audit_drop's identical first-drop/
+# every-Nth discipline for a subscriber-queue overflow, #2886) rather than
+# picked fresh, so the two independent "bounded queue, drop, audit" call
+# sites in this codebase share one reasoned cadence instead of two
+# unrelated constants that happen to agree today.
+_AUDIT_EVERY_N_DROPS = 100
+
 # #5516: batch-shaped — called as ``hook_trigger(point, payloads,
 # skipped_session_wide=N)``: the folded batch (never empty, never a bare
 # single dict — clean break) plus the session-wide drop count since the
@@ -147,6 +156,11 @@ class _BoundedEventBridge:
         self._queue: "asyncio.Queue[HookEvent] | None" = None
         self._drain_task: "asyncio.Task | None" = None
         self._dropped_since_last_batch = 0
+        # #5515: cumulative, never reset (distinct from
+        # ``_dropped_since_last_batch`` above, which read-and-resets per
+        # dispatched batch) — mirrors ``_SessionFireBridge._drop_count``'s
+        # own identical split of the same two concerns one module over.
+        self._drop_count = 0
 
     def deliver(self, event: HookEvent) -> None:
         """SYNCHRONOUS, non-blocking. Never awaits, never raises."""
@@ -163,10 +177,45 @@ class _BoundedEventBridge:
             # so the next batch's event_context names this loss instead of
             # only a log line (band gate 2: visible with the shipped config).
             self._dropped_since_last_batch += 1
+            self._drop_count += 1
             logger.warning(
                 "%s: hook-event queue full (maxsize=%d) — dropping %r event",
                 self._adapter_name, self._maxsize, event.kind,
             )
+            self._audit_drop(event)
+
+    def dropped_count(self) -> int:
+        """Public, snapshot-style read of the cumulative number of events
+        dropped by this bridge because the queue was full at :meth:`deliver`
+        time (#5515) — mirrors ``_SessionFireBridge.dropped_count()``."""
+        return self._drop_count
+
+    def _audit_drop(self, event: HookEvent) -> None:
+        """Fire a metadata-only ``ingress_bridge_dropped`` P6 audit-event on
+        the FIRST drop and every Nth drop thereafter (#5515 — #2886's own
+        fail-visible discipline, applied so far only to ``HookBus``'s own
+        subscriber-queue drops, ``bus.py``'s ``_audit_drop``, and never to
+        THIS bridge's own equally-silent drop-newest overflow — ``bus.py``'s
+        own module docstring already describes the two bridges as sharing
+        the same non-blocking, drop-newest-and-log shape; only the
+        audit-visibility half was missing here). Never raises (best-effort
+        telemetry, same posture as ``HookBus._audit_drop``) and never
+        includes the dropped event's payload — ``source`` (this bridge's
+        own ``adapter_name``, distinguishing the MCP bridge from the Fs
+        bridge) plus the bare hook point and the cumulative count only."""
+        if self._emit_event is None:
+            return
+        if self._drop_count != 1 and self._drop_count % _AUDIT_EVERY_N_DROPS != 0:
+            return
+        try:
+            self._emit_event(
+                "ingress_bridge_dropped",
+                source=self._adapter_name,
+                point=bare_point(event.kind),
+                drop_count=self._drop_count,
+            )
+        except Exception as exc:  # noqa: BLE001 — telemetry is best-effort
+            logger.debug("%s: emit_event(ingress_bridge_dropped) failed: %s", self._adapter_name, exc)
 
     def _ensure_drain_task(self) -> None:
         if self._queue is None:

--- a/tests/hooks/test_5515_ingress_bridge_drop_fail_visible.py
+++ b/tests/hooks/test_5515_ingress_bridge_drop_fail_visible.py
@@ -1,0 +1,172 @@
+"""Tier 1: #5515 — ``_BoundedEventBridge.deliver``'s own queue-full drop is
+now fail-visible, mirroring ``HookBus._audit_drop``'s already-landed #2886
+discipline (``tests/hooks/test_hook_event_bus_0059_phase4a.py``) one layer
+over: the SAME first-drop/every-Nth cadence, a metadata-only
+``ingress_bridge_dropped`` P6 audit-event via the injected ``emit_event``
+sink, never the dropped event's own payload.
+
+Before this fix the drop was ``logger.warning``-only — invisible to
+``reyn events``/``session.subscribe_audit_events`` (#2886 closed the
+identical gap for ``HookBus``'s own subscriber-queue overflow; this bridge
+was the sibling the module docstrings already describe as sharing that
+overflow shape, and it never got the audit half).
+
+This file drives ``_BoundedEventBridge`` directly (a module-private class,
+but its OWN public constructor/``deliver``/``dropped_count`` surface — not
+another object's private state) with a real, tiny-``maxsize`` queue and a
+``hook_trigger`` that never drains, so overflow is forced deterministically
+within one coroutine (no ``await`` between ``deliver()`` calls, so the
+lazily-started drain task never gets a chance to run and empty the queue —
+same non-interleaving argument the existing bus.py suite relies on).
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.hooks.event import HookEvent
+from reyn.hooks.ingress import _AUDIT_EVERY_N_DROPS, _BoundedEventBridge
+
+
+def _recorder():
+    """A real recording callable (no MagicMock/patch) — same shape
+    test_hook_event_bus_0059_phase4a.py's own ``_recorder`` uses."""
+    calls: "list[tuple]" = []
+
+    def record(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    return record, calls
+
+
+async def _never_drains(*_args, **_kwargs) -> None:
+    """A ``hook_trigger`` that is never actually awaited by this test (the
+    queue overflows before the lazily-started drain task gets a chance to
+    run — see this module's own docstring) but must still be a real async
+    callable, matching ``HookTrigger``'s own signature."""
+    raise AssertionError("drain must never run within this test's own coroutine")
+
+
+@pytest.mark.asyncio
+async def test_queue_full_drop_is_fail_visible():
+    """Tier 1: overflowing the bridge's bounded queue increments
+    ``dropped_count()`` and fires a metadata-only ``ingress_bridge_dropped``
+    P6 audit-event on the FIRST drop — ``source``/``point``/``drop_count``
+    only, never the dropped event's own kind/payload.
+
+    Strip-falsify: remove the ``self._audit_drop(event)`` call in
+    ``_BoundedEventBridge.deliver`` (or the ``self._drop_count += 1`` line)
+    and this test goes RED — no ``ingress_bridge_dropped`` call / 0 calls
+    recorded (performed during review: reverting the call site makes
+    ``dropped_calls`` empty and the ``(only,)`` unpack below raises
+    ``ValueError``, not silently pass over an empty collection)."""
+    emit_event, calls = _recorder()
+    bridge = _BoundedEventBridge(
+        hook_trigger=_never_drains, maxsize=1, adapter_name="McpIngressAdapter",
+        emit_event=emit_event,
+    )
+
+    bridge.deliver(HookEvent(kind="builtin:external:mcp_resource_updated", payload={"n": 0}))
+    # Queue now holds 1 (its maxsize) undrained event; the NEXT deliver
+    # overflows it (drop-newest — the new event itself is dropped).
+    bridge.deliver(HookEvent(kind="builtin:external:mcp_resource_updated", payload={"n": 1}))
+
+    assert bridge.dropped_count() == 1
+
+    dropped_calls = [c for c in calls if c[0] and c[0][0] == "ingress_bridge_dropped"]
+    (only,) = dropped_calls  # exactly one audit-event fired — unpack-must-flip
+    (_args, kwargs) = only
+    assert kwargs["source"] == "McpIngressAdapter"
+    assert kwargs["point"] == "mcp_resource_updated"
+    assert kwargs["drop_count"] == 1
+    # never the dropped event's content
+    assert "kind" not in kwargs and "payload" not in kwargs
+
+    await bridge.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sustained_overflow_audits_first_then_every_nth_not_every_drop():
+    """Tier 1: under sustained overflow the audit-event fires on the first
+    drop and then only every Nth drop — not once per drop (``deliver`` is a
+    sync/never-raises hot path; auditing every drop would flood the audit
+    log under a burst faster than hooks can be dispatched). ``dropped_count()``
+    still counts every single drop regardless of audit cadence."""
+    emit_event, calls = _recorder()
+    bridge = _BoundedEventBridge(
+        hook_trigger=_never_drains, maxsize=1, adapter_name="FsIngressAdapter",
+        emit_event=emit_event,
+    )
+
+    total_delivers = _AUDIT_EVERY_N_DROPS + 2  # 1 fills the queue, the rest all drop
+    for i in range(total_delivers):
+        bridge.deliver(HookEvent(kind="builtin:external:file_changed", payload={"n": i}))
+
+    expected_drops = total_delivers - 1
+    assert bridge.dropped_count() == expected_drops
+
+    dropped_calls = [c for c in calls if c[0] and c[0][0] == "ingress_bridge_dropped"]
+    # first drop (drop_count == 1) + the Nth drop (drop_count == _AUDIT_EVERY_N_DROPS) —
+    # exactly two audit-events fired, unpack-must-flip if the cadence regresses.
+    (first_call, nth_call) = dropped_calls
+    assert first_call[1]["drop_count"] == 1
+    assert nth_call[1]["drop_count"] == _AUDIT_EVERY_N_DROPS
+
+    await bridge.aclose()
+
+
+@pytest.mark.asyncio
+async def test_source_distinguishes_which_adapters_bridge_dropped():
+    """Tier 1: lead-coder review requirement (#5515) — since
+    ``ingress_bridge_dropped`` is a SHARED kind (deliberately not split
+    per-adapter, matching ``composer_dropped``'s own shared-kind precedent),
+    the ``source`` field alone must let a reader tell which bridge dropped.
+    Both real adapter names (``McpIngressAdapter``/``FsIngressAdapter`` —
+    the literal strings ``ingress.py``'s two adapter classes pass as their
+    own ``adapter_name``) are proven NOT to collide here, independent of
+    ``test_queue_full_drop_is_fail_visible``'s own single-bridge check
+    above."""
+    mcp_emit, mcp_calls = _recorder()
+    fs_emit, fs_calls = _recorder()
+    mcp_bridge = _BoundedEventBridge(
+        hook_trigger=_never_drains, maxsize=1, adapter_name="McpIngressAdapter",
+        emit_event=mcp_emit,
+    )
+    fs_bridge = _BoundedEventBridge(
+        hook_trigger=_never_drains, maxsize=1, adapter_name="FsIngressAdapter",
+        emit_event=fs_emit,
+    )
+
+    for bridge in (mcp_bridge, fs_bridge):
+        bridge.deliver(HookEvent(kind="builtin:external:mcp_resource_updated", payload={}))
+        bridge.deliver(HookEvent(kind="builtin:external:mcp_resource_updated", payload={}))
+
+    (mcp_call,) = [c for c in mcp_calls if c[0] and c[0][0] == "ingress_bridge_dropped"]
+    (fs_call,) = [c for c in fs_calls if c[0] and c[0][0] == "ingress_bridge_dropped"]
+    assert mcp_call[1]["source"] == "McpIngressAdapter"
+    assert fs_call[1]["source"] == "FsIngressAdapter"
+    assert mcp_call[1]["source"] != fs_call[1]["source"]
+
+    await mcp_bridge.aclose()
+    await fs_bridge.aclose()
+
+
+@pytest.mark.asyncio
+async def test_no_emit_event_sink_is_still_silent_but_never_raises():
+    """Tier 1: ``emit_event=None`` (a session/test double with no audit sink
+    wired — the pre-#5515 default) must still be a byte-identical no-op for
+    the audit half: ``deliver`` never raises, and ``dropped_count()`` still
+    counts the drop even though nothing was there to receive an
+    audit-event."""
+    bridge = _BoundedEventBridge(
+        hook_trigger=_never_drains, maxsize=1, adapter_name="McpIngressAdapter",
+    )
+
+    bridge.deliver(HookEvent(kind="builtin:external:mcp_resource_updated", payload={"n": 0}))
+    bridge.deliver(HookEvent(kind="builtin:external:mcp_resource_updated", payload={"n": 1}))  # must not raise
+
+    assert bridge.dropped_count() == 1
+
+    await bridge.aclose()

--- a/tests/hooks/test_5515_ingress_bridge_drop_fail_visible.py
+++ b/tests/hooks/test_5515_ingress_bridge_drop_fail_visible.py
@@ -11,13 +11,18 @@ identical gap for ``HookBus``'s own subscriber-queue overflow; this bridge
 was the sibling the module docstrings already describe as sharing that
 overflow shape, and it never got the audit half).
 
-This file drives ``_BoundedEventBridge`` directly (a module-private class,
-but its OWN public constructor/``deliver``/``dropped_count`` surface — not
-another object's private state) with a real, tiny-``maxsize`` queue and a
-``hook_trigger`` that never drains, so overflow is forced deterministically
-within one coroutine (no ``await`` between ``deliver()`` calls, so the
-lazily-started drain task never gets a chance to run and empty the queue —
-same non-interleaving argument the existing bus.py suite relies on).
+Most of this file drives ``_BoundedEventBridge`` directly (a module-private
+class, but its OWN public constructor/``deliver``/``dropped_count`` surface
+— not another object's private state) with a real, tiny-``maxsize`` queue
+and a ``hook_trigger`` that never drains, so overflow is forced
+deterministically within one coroutine (no ``await`` between ``deliver()``
+calls, so the lazily-started drain task never gets a chance to run and
+empty the queue — same non-interleaving argument the existing bus.py suite
+relies on). ``test_source_distinguishes_which_adapters_bridge_dropped``
+instead drives the two real PUBLIC adapters (``McpIngressAdapter``/
+``FsIngressAdapter``) — see its own docstring for why a directly-constructed
+``_BoundedEventBridge`` with two self-chosen names cannot prove the claim
+that test makes.
 
 Policy (docs/deep-dives/contributing/testing.md): real instances only — no
 ``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
@@ -27,7 +32,12 @@ from __future__ import annotations
 import pytest
 
 from reyn.hooks.event import HookEvent
-from reyn.hooks.ingress import _AUDIT_EVERY_N_DROPS, _BoundedEventBridge
+from reyn.hooks.ingress import (
+    _AUDIT_EVERY_N_DROPS,
+    FsIngressAdapter,
+    McpIngressAdapter,
+    _BoundedEventBridge,
+)
 
 
 def _recorder():
@@ -123,34 +133,48 @@ async def test_source_distinguishes_which_adapters_bridge_dropped():
     ``ingress_bridge_dropped`` is a SHARED kind (deliberately not split
     per-adapter, matching ``composer_dropped``'s own shared-kind precedent),
     the ``source`` field alone must let a reader tell which bridge dropped.
-    Both real adapter names (``McpIngressAdapter``/``FsIngressAdapter`` —
-    the literal strings ``ingress.py``'s two adapter classes pass as their
-    own ``adapter_name``) are proven NOT to collide here, independent of
-    ``test_queue_full_drop_is_fail_visible``'s own single-bridge check
-    above."""
+
+    Drives the REAL ``McpIngressAdapter``/``FsIngressAdapter`` (not
+    ``_BoundedEventBridge`` constructed with a self-chosen literal
+    ``adapter_name``, which would only prove two hardcoded distinct strings
+    are distinct — a tautology that stays green even if both real classes
+    were renamed to pass the SAME ``adapter_name`` into their own bridge,
+    exactly the collision decision ② was meant to close). Only a NON-
+    COLLISION assertion (``!=``), never a literal-name assertion — the thing
+    protected is that they cannot collide, not what either name currently
+    is; a future rename of either adapter must not flip this red.
+
+    Strip-falsify (performed during review, lead-coder BLOCKING finding
+    2026-08-30): with ``FsIngressAdapter``'s own ``_BoundedEventBridge``
+    construction temporarily changed to pass ``adapter_name=
+    "McpIngressAdapter"`` (the same value ``McpIngressAdapter`` passes),
+    this test goes RED — ``AssertionError: ... both reported
+    'McpIngressAdapter'``. The FIRST version of this test (constructing
+    ``_BoundedEventBridge`` directly with two self-chosen literal names)
+    stayed GREEN through the identical strip, because it never drove
+    either real adapter class at all."""
     mcp_emit, mcp_calls = _recorder()
     fs_emit, fs_calls = _recorder()
-    mcp_bridge = _BoundedEventBridge(
-        hook_trigger=_never_drains, maxsize=1, adapter_name="McpIngressAdapter",
-        emit_event=mcp_emit,
-    )
-    fs_bridge = _BoundedEventBridge(
-        hook_trigger=_never_drains, maxsize=1, adapter_name="FsIngressAdapter",
-        emit_event=fs_emit,
-    )
+    mcp_adapter = McpIngressAdapter(hook_trigger=_never_drains, maxsize=1, emit_event=mcp_emit)
+    fs_adapter = FsIngressAdapter(hook_trigger=_never_drains, maxsize=1, emit_event=fs_emit)
 
-    for bridge in (mcp_bridge, fs_bridge):
-        bridge.deliver(HookEvent(kind="builtin:external:mcp_resource_updated", payload={}))
-        bridge.deliver(HookEvent(kind="builtin:external:mcp_resource_updated", payload={}))
+    for adapter, event in (
+        (mcp_adapter, HookEvent(kind="builtin:external:mcp_resource_updated", payload={})),
+        (fs_adapter, HookEvent(kind="builtin:external:file_changed", payload={})),
+    ):
+        adapter.deliver(event)
+        adapter.deliver(event)  # 2nd overflows the maxsize=1 queue
 
     (mcp_call,) = [c for c in mcp_calls if c[0] and c[0][0] == "ingress_bridge_dropped"]
     (fs_call,) = [c for c in fs_calls if c[0] and c[0][0] == "ingress_bridge_dropped"]
-    assert mcp_call[1]["source"] == "McpIngressAdapter"
-    assert fs_call[1]["source"] == "FsIngressAdapter"
-    assert mcp_call[1]["source"] != fs_call[1]["source"]
+    assert mcp_call[1]["source"] != fs_call[1]["source"], (
+        f"McpIngressAdapter and FsIngressAdapter must report distinguishable "
+        f"sources on the shared ingress_bridge_dropped kind -- both reported "
+        f"{mcp_call[1]['source']!r}"
+    )
 
-    await mcp_bridge.aclose()
-    await fs_bridge.aclose()
+    await mcp_adapter.aclose()
+    await fs_adapter.aclose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — part of #5515 (2-PR split, lead-coder review ruling: the issue names both bridges as "same defect, 2 sites," not "fix both in one PR"). This PR: `_BoundedEventBridge` (backs `mcp_resource_updated`/`file_changed`). `_SessionFireBridge` (backs `cron_fired`/`webhook_received`) is a deliberate follow-up applying this same shape, not bundled here.

## Read-mouth check (lead-coder's own gating question, answered before starting)

`bus_subscriber_dropped`'s only reader is the generic `session.subscribe_audit_events`/`reyn events` replay surface — proven by `test_2761_pr2_hotreload_immediate_apply.py::test_hook_bus_emit_event_reaches_session_audit_events`. No dedicated UI consumer exists for it either (`repl/renderer.py`'s own `subscribe_audit_events` use is a generic working-indicator, not kind-specific). `ingress_bridge_dropped` lands on the identical generic surface — not a 3rd write-mouth with no reader.

## What was wrong

`_BoundedEventBridge.deliver`'s queue-full branch (drop-newest overflow, `mcp_resource_updated`/`file_changed`'s shared in-process delivery bridge) was `logger.warning`-only — invisible to `reyn events`/`subscribe_audit_events`. `HookBus`'s structurally identical subscriber-queue overflow got the fail-visible fix in #2886 (`bus.py`'s own `_audit_drop`); this sibling bridge — which `bus.py`'s own module docstring already describes as sharing that overflow shape — never got the audit half.

## What changed

- `_BoundedEventBridge` gains a cumulative `self._drop_count` (distinct from `self._dropped_since_last_batch`, which read-and-resets per dispatched batch for `skipped_session_wide`) + public `dropped_count()`, mirroring `_SessionFireBridge`'s own existing split of the same two concerns.
- New `_audit_drop(event)`: fires a metadata-only `ingress_bridge_dropped` P6 audit-event on the first drop and every 100th thereafter — cadence matched to `bus.py:83`'s own `_AUDIT_EVERY_N_DROPS` (cited, not picked fresh — lead-coder review requirement). Payload: `source` (`McpIngressAdapter`/`FsIngressAdapter` — distinguishes which bridge), `point` (bare hook point), `drop_count` (cumulative). Never the dropped event's own payload.
- `ingress_bridge_dropped` registered in `AUDIT_EVENT_KINDS` + documented in `events.md`'s External events section.

## Design decisions (raised to lead-coder before implementing, all confirmed)

1. Cadence: bus.py's shape, N=100 cited from `bus.py:83`.
2. Kind: shared (`ingress_bridge_dropped`), not split per-adapter — `source` distinguishes producers (test below proves no collision), matching `composer_dropped`'s own shared-kind precedent. Kept separate from `bus_subscriber_dropped` — different actor (bridge vs. Bus subscriber).
3. Scope: this PR only; `_SessionFireBridge` is issue #5515's disclosed remainder.

## Tests (`tests/hooks/test_5515_ingress_bridge_drop_fail_visible.py`, 4 new)

- First-drop fires, payload shape (`source`/`point`/`drop_count`, never `kind`/`payload`).
- Sustained overflow: first + every-Nth cadence, not every drop.
- `source` distinguishes `McpIngressAdapter` from `FsIngressAdapter` (lead-coder's shared-kind requirement).
- `emit_event=None` stays a byte-identical no-op.

## Strip-falsify (performed, documented in the test file's own docstrings)

Reverting the `self._audit_drop(event)` call site to a no-op flips 3 of the 4 tests red (`ValueError: not enough values to unpack` on the `(only,) = dropped_calls` / `(mcp_call,) = [...]` / `(fs_call,) = [...]` unpacks — zero calls recorded). Restoring the call site returns all 4 to green.

## Verification

- **Local gates, all green**: `ruff check .`, `test_tier_audit.py --strict` (4/4, 0 Tier-4), `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`.
- **docs/ gate** (touched `events.md`): `mkdocs build --strict` (exit 0), `check_doc_anchors.py` (no new dangling anchors), `check_retired_config_keys_denylist.py` (0 hits).
- **Scoped pytest**: `tests/hooks/` + `tests/core/test_audit_event_kind_vocabulary_3410.py` — 444 passed (confirms the new literal kind is correctly censused as a producer of its own declaration, both directions).

## Test plan

- [x] 4 new unit tests, all pass locally.
- [x] Strip-falsification performed (documented above and in the test file) — confirms the tests catch the fix's absence.
- [x] Full kind-vocabulary census green (both directions: declared↔produced).
- [x] (skipped — Visual, standing waiver 2026-08-08) No UI surface touched.

part of #5515

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
