### PR TITLE
fix(#5515): _SessionFireBridge's queue-full drop is fail-visible

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -473,12 +473,17 @@ growing unboundedly. Before #5515 that drop was `logger.warning`-only,
 unlike the structurally identical `HookBus` subscriber-queue drop
 (`bus_subscriber_dropped`, #2886). `ingress_bridge_dropped` closes that gap
 for this bridge, on the same first-drop/every-100th cadence: metadata-only
-(`source` — the bridge's adapter name, `McpIngressAdapter` or
-`FsIngressAdapter`; `point` — the bare hook point; `drop_count` — cumulative,
-never reset), never the dropped event's own payload. `cron_fired` and
-`webhook_received` share a separate bridge (`_SessionFireBridge`,
-`reyn.hooks.external_fire`) with the same overflow shape; it is tracked
-separately (#5515 remainder, not yet closed).
+(`source` — the bridge's adapter name; `point` — the bare hook point;
+`drop_count` — cumulative, never reset), never the dropped event's own
+payload. `cron_fired` and `webhook_received` share a separate bridge
+(`_SessionFireBridge`, `reyn.hooks.external_fire`) with the same overflow
+shape and now fires the SAME kind on its own drop, keyed apart by `source`:
+
+| `source` | Bridge |
+|----------|--------|
+| `McpIngressAdapter` | `reyn.hooks.ingress._BoundedEventBridge` instance backing `mcp_resource_updated` |
+| `FsIngressAdapter` | `reyn.hooks.ingress._BoundedEventBridge` instance backing `file_changed` |
+| `_SessionFireBridge` | `reyn.hooks.external_fire._SessionFireBridge` — shared by `cron_fired`/`webhook_received` |
 
 ## Credentials and OAuth
 

--- a/src/reyn/hooks/external_fire.py
+++ b/src/reyn/hooks/external_fire.py
@@ -59,6 +59,16 @@ _DEFAULT_MAXSIZE = 32
 # established the cadence value, this one reuses it rather than re-deriving.
 _AUDIT_EVERY_N_DROPS = 100
 
+# #5515 review (lead-coder BLOCKING, 2026-08-30): the string this class
+# identifies itself by at TWO independent call sites -- observe_drain_task_
+# death's own ``label=`` (submit(), below) and ingress_bridge_dropped's own
+# ``source=`` (_audit_drop, below). Before this constant the two were
+# separately-typed literals that happened to read the same; nothing forced
+# them to stay in sync (a rename of one, missed at the other, would desync
+# silently -- neither call site would error, only an operator correlating
+# the two by eye would notice). One constant, both sites read it.
+_SOURCE_LABEL = "_SessionFireBridge"
+
 
 class _SessionFireBridge:
     """Per-Session bounded dispatch bridge (#2620) — the ``_BoundedEventBridge``
@@ -157,7 +167,7 @@ class _SessionFireBridge:
                 functools.partial(
                     observe_drain_task_death,
                     emit_event=(audit_events.emit if audit_events is not None else None),
-                    label="_SessionFireBridge",
+                    label=_SOURCE_LABEL,
                 )
             )
         try:
@@ -183,10 +193,11 @@ class _SessionFireBridge:
         posture :meth:`submit` already uses for its own drain-task-death
         observer a few lines up, not a new idiom. Never raises (best-effort
         telemetry) and never includes the dropped ``template_vars`` —
-        ``source`` (a fixed literal, ``"_SessionFireBridge"`` — matches the
-        label :meth:`submit` already passes ``observe_drain_task_death``,
-        distinguishing this bridge's drops from ``_BoundedEventBridge``'s on
-        the shared kind), ``point``, and the cumulative ``drop_count`` only."""
+        ``source`` (``_SOURCE_LABEL``, module-level — the SAME constant
+        :meth:`submit` already passes ``observe_drain_task_death`` as its
+        own ``label``, distinguishing this bridge's drops from
+        ``_BoundedEventBridge``'s on the shared kind), ``point``, and the
+        cumulative ``drop_count`` only."""
         audit_events = getattr(self._session, "_audit_events", None)
         if audit_events is None:
             return
@@ -195,7 +206,7 @@ class _SessionFireBridge:
         try:
             audit_events.emit(
                 "ingress_bridge_dropped",
-                source="_SessionFireBridge",
+                source=_SOURCE_LABEL,
                 point=point,
                 drop_count=self._drop_count,
             )

--- a/src/reyn/hooks/external_fire.py
+++ b/src/reyn/hooks/external_fire.py
@@ -50,6 +50,15 @@ logger = logging.getLogger(__name__)
 # the bound its in-process siblings already use for the same class of risk.
 _DEFAULT_MAXSIZE = 32
 
+# #5515: fail-visible cadence for a queue-full drop in _SessionFireBridge.
+# submit() (below) — same constant, same reasoning, as
+# reyn.hooks.ingress._AUDIT_EVERY_N_DROPS (matched to src/reyn/hooks/bus.py:83's
+# own ``_AUDIT_EVERY_N_DROPS``, #2886's first-drop/every-Nth discipline) —
+# this bridge is the SECOND of the two sites #5515 closes the audit gap
+# for; the PR that landed the first (``_BoundedEventBridge``) already
+# established the cadence value, this one reuses it rather than re-deriving.
+_AUDIT_EVERY_N_DROPS = 100
+
 
 class _SessionFireBridge:
     """Per-Session bounded dispatch bridge (#2620) — the ``_BoundedEventBridge``
@@ -162,6 +171,36 @@ class _SessionFireBridge:
                 "for this session)",
                 self._maxsize, point,
             )
+            self._audit_drop(point)
+
+    def _audit_drop(self, point: str) -> None:
+        """Fire a metadata-only ``ingress_bridge_dropped`` P6 audit-event on
+        the FIRST drop and every Nth drop thereafter (#5515 — the second of
+        the two sites this closes the gap for; see
+        ``reyn.hooks.ingress._BoundedEventBridge._audit_drop``'s own
+        docstring for the first). ``self._session`` is typed ``Any`` (a test
+        double may not carry ``_audit_events``) — same getattr-guarded
+        posture :meth:`submit` already uses for its own drain-task-death
+        observer a few lines up, not a new idiom. Never raises (best-effort
+        telemetry) and never includes the dropped ``template_vars`` —
+        ``source`` (a fixed literal, ``"_SessionFireBridge"`` — matches the
+        label :meth:`submit` already passes ``observe_drain_task_death``,
+        distinguishing this bridge's drops from ``_BoundedEventBridge``'s on
+        the shared kind), ``point``, and the cumulative ``drop_count`` only."""
+        audit_events = getattr(self._session, "_audit_events", None)
+        if audit_events is None:
+            return
+        if self._drop_count != 1 and self._drop_count % _AUDIT_EVERY_N_DROPS != 0:
+            return
+        try:
+            audit_events.emit(
+                "ingress_bridge_dropped",
+                source="_SessionFireBridge",
+                point=point,
+                drop_count=self._drop_count,
+            )
+        except Exception as exc:  # noqa: BLE001 — telemetry is best-effort
+            logger.debug("_SessionFireBridge: emit_event(ingress_bridge_dropped) failed: %s", exc)
 
     def pending_count(self) -> int:
         """Public, snapshot-style read of the number of ``(point,

--- a/tests/hooks/test_5515_session_fire_bridge_drop_fail_visible.py
+++ b/tests/hooks/test_5515_session_fire_bridge_drop_fail_visible.py
@@ -20,6 +20,27 @@ below reads ``received`` only after ``await settle(session)`` —
 ``tests/_support/events.settle``, the same wrapper
 ``test_2761_pr2_hotreload_immediate_apply.py`` uses.
 
+**Two different ``source`` assertions live in this file, protecting two
+different things (lead-coder review, 2026-08-30 — read this before adding
+a third)**:
+
+- ``test_queue_full_drop_is_fail_visible`` asserts ``source ==
+  "_SessionFireBridge"`` — LITERAL equality, deliberately. It protects
+  ``docs/reference/runtime/events.md``'s 3-row ``source`` table, which
+  names this literal explicitly; nothing else would flip red if this
+  bridge's ``_SOURCE_LABEL`` were renamed out from under that table, so
+  this assertion is the thing that forces the doc update.
+- ``test_source_distinguishes_this_bridge_from_the_ingress_bridge`` (PR1's
+  own review requirement, carried over) asserts non-collision only
+  (``!=``) — deliberately NEVER equality to a literal, because the
+  property it protects (this bridge and ``_BoundedEventBridge`` cannot
+  report the same ``source`` on the shared kind) does not depend on what
+  either name currently is, and a rename of EITHER one must not flip it
+  red on its own.
+
+Do not "fix" either into matching the other's style — they are answering
+different questions.
+
 Policy (docs/deep-dives/contributing/testing.md): real instances only — no
 ``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
 """
@@ -49,7 +70,12 @@ async def test_queue_full_drop_is_fail_visible(tmp_path: Path):
     metadata-only ``ingress_bridge_dropped`` P6 audit-event on the FIRST
     drop, reaching a subscriber registered via
     ``session.subscribe_audit_events`` — ``source``/``point``/``drop_count``
-    only, never the fired point's own ``template_vars``.
+    only, never the fired point's own ``template_vars``. ``source`` is
+    asserted by LITERAL equality here, deliberately — see this module's
+    own docstring ("Two different source assertions...") for why: it
+    guards ``events.md``'s 3-row table, not collision-freedom (that is
+    ``test_source_distinguishes_this_bridge_from_the_ingress_bridge``'s
+    own, separate job, below).
 
     No ``await`` between :func:`fire_and_forget` calls, so the lazily-
     started drain task never gets a chance to run before the queue
@@ -124,7 +150,10 @@ async def test_source_distinguishes_this_bridge_from_the_ingress_bridge(tmp_path
     non-collision assertion (``!=``, never equality to a literal) PR1's own
     ``test_source_distinguishes_which_adapters_bridge_dropped`` uses, for
     the same reason: a future rename of either source must not flip this
-    red.
+    red. This is the ONLY non-collision-style assertion in this file — its
+    sibling above (``test_queue_full_drop_is_fail_visible``) intentionally
+    uses the opposite policy (literal equality) for a different, disclosed
+    reason; see this module's own docstring.
 
     Strip-falsify (performed during review): with ``_SessionFireBridge.
     submit``'s own ``self._audit_drop(point)`` call removed, this test (and

--- a/tests/hooks/test_5515_session_fire_bridge_drop_fail_visible.py
+++ b/tests/hooks/test_5515_session_fire_bridge_drop_fail_visible.py
@@ -1,0 +1,167 @@
+"""Tier 2: #5515 (2nd of 2 sites) — ``_SessionFireBridge.submit``'s own
+queue-full drop is now fail-visible, applying the SAME shape
+``tests/hooks/test_5515_ingress_bridge_drop_fail_visible.py`` already
+proved for ``_BoundedEventBridge`` (#5515 PR1, landed) to this sibling
+out-of-process bridge (``cron_fired``/``webhook_received``). Both fire the
+SAME shared ``ingress_bridge_dropped`` P6 audit-event, keyed apart by
+``source`` — see ``docs/reference/runtime/events.md``'s "External events"
+section for the full 3-row table.
+
+Unlike PR1's file (which drove ``_BoundedEventBridge``/its adapters
+directly), this file drives the REAL PUBLIC production entry point,
+``reyn.hooks.external_fire.fire_and_forget``, against a real ``Session``
+(``tests/_support/agent_session.make_session`` — no mocks), and observes
+the audit-event via ``session.subscribe_audit_events`` — the same real
+consumer seam ``test_2761_pr2_hotreload_immediate_apply.py`` uses for
+``bus_subscriber_dropped``, and the one this whole issue's own read-mouth
+check (#5515 PR1's own PR body) rests on. ``EventLog.emit`` defers to an
+async dispatch queue whenever a loop is running (#4966), so every test
+below reads ``received`` only after ``await settle(session)`` —
+``tests/_support/events.settle``, the same wrapper
+``test_2761_pr2_hotreload_immediate_apply.py`` uses.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.hooks import external_fire
+from reyn.hooks.external_fire import _AUDIT_EVERY_N_DROPS
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+from tests._support.events import settle
+
+
+def _make_session(tmp_path: Path) -> Session:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return make_session(agent_name="fire-bridge-drop-agent", state_log=state_log)
+
+
+@pytest.mark.asyncio
+async def test_queue_full_drop_is_fail_visible(tmp_path: Path):
+    """Tier 2: overflowing the bridge's bounded queue increments
+    ``external_fire.dropped_dispatch_count(session)`` and fires a
+    metadata-only ``ingress_bridge_dropped`` P6 audit-event on the FIRST
+    drop, reaching a subscriber registered via
+    ``session.subscribe_audit_events`` — ``source``/``point``/``drop_count``
+    only, never the fired point's own ``template_vars``.
+
+    No ``await`` between :func:`fire_and_forget` calls, so the lazily-
+    started drain task never gets a chance to run before the queue
+    overflows (same non-interleaving argument PR1's / #2620's own suite
+    relies on).
+
+    Strip-falsify: remove the ``self._audit_drop(point)`` call in
+    ``_SessionFireBridge.submit`` (or the ``self._drop_count += 1`` line)
+    and this test goes RED — no ``ingress_bridge_dropped`` reaches
+    ``received`` (performed during review: the ``(only,)`` unpack below
+    raises ``ValueError`` over the empty result, not silently pass)."""
+    session = _make_session(tmp_path)
+    received: list[tuple[str, dict]] = []
+    session.subscribe_audit_events(lambda e: received.append((e.type, dict(e.data))))
+
+    maxsize = 1
+    external_fire.fire_and_forget(session, "webhook_received", {"sender": "a"}, maxsize=maxsize)
+    # Queue now holds 1 (its maxsize) undrained fire; the NEXT overflows it
+    # (drop-newest — the new fire itself is dropped).
+    external_fire.fire_and_forget(session, "webhook_received", {"sender": "b"}, maxsize=maxsize)
+
+    assert external_fire.dropped_dispatch_count(session) == 1
+
+    await settle(session)
+    dropped = [d for (kind, d) in received if kind == "ingress_bridge_dropped"]
+    (only,) = dropped  # exactly one audit-event fired — unpack-must-flip
+    assert only["source"] == "_SessionFireBridge"
+    assert only["point"] == "webhook_received"
+    assert only["drop_count"] == 1
+    # never the dropped fire's own template_vars
+    assert "sender" not in only and "template_vars" not in only
+
+
+@pytest.mark.asyncio
+async def test_sustained_overflow_audits_first_then_every_nth_not_every_drop(tmp_path: Path):
+    """Tier 2: under sustained overflow the audit-event fires on the first
+    drop and then only every Nth drop — not once per drop.
+    ``dropped_dispatch_count`` still counts every single drop regardless of
+    audit cadence (mirrors PR1's own identical proof for
+    ``_BoundedEventBridge``)."""
+    session = _make_session(tmp_path)
+    received: list[tuple[str, dict]] = []
+    session.subscribe_audit_events(lambda e: received.append((e.type, dict(e.data))))
+
+    maxsize = 1
+    total_fires = _AUDIT_EVERY_N_DROPS + 2  # 1 fills the queue, the rest all drop
+    for i in range(total_fires):
+        external_fire.fire_and_forget(
+            session, "cron_fired", {"i": i}, maxsize=maxsize,
+        )
+
+    expected_drops = total_fires - 1
+    assert external_fire.dropped_dispatch_count(session) == expected_drops
+
+    await settle(session)
+    dropped = [d for (kind, d) in received if kind == "ingress_bridge_dropped"]
+    # first drop (drop_count == 1) + the Nth drop (drop_count == _AUDIT_EVERY_N_DROPS) —
+    # exactly two audit-events fired, unpack-must-flip if the cadence regresses.
+    (first, nth) = dropped
+    assert first["drop_count"] == 1
+    assert nth["drop_count"] == _AUDIT_EVERY_N_DROPS
+
+
+@pytest.mark.asyncio
+async def test_source_distinguishes_this_bridge_from_the_ingress_bridge(tmp_path: Path):
+    """Tier 2: lead-coder review requirement carried over from PR1 (#5515)
+    — since ``ingress_bridge_dropped`` is a SHARED kind, ``source`` must
+    distinguish THIS bridge's drops from ``_BoundedEventBridge``'s. Drives
+    the real ``_SessionFireBridge`` (via ``fire_and_forget``) AND a real
+    ``McpIngressAdapter`` (via ``reyn.hooks.ingress``) against the SAME
+    session's audit stream, proving the two never collide — the identical
+    non-collision assertion (``!=``, never equality to a literal) PR1's own
+    ``test_source_distinguishes_which_adapters_bridge_dropped`` uses, for
+    the same reason: a future rename of either source must not flip this
+    red.
+
+    Strip-falsify (performed during review): with ``_SessionFireBridge.
+    submit``'s own ``self._audit_drop(point)`` call removed, this test (and
+    the two above) go RED — the ``(fire_call,)`` unpack raises
+    ``ValueError`` over an empty result (only the ingress-side drop still
+    fires; ``_SessionFireBridge``'s own drop is silent again, reproducing
+    exactly the pre-#5515 gap this PR closes)."""
+    from reyn.hooks.event import HookEvent
+    from reyn.hooks.ingress import McpIngressAdapter
+
+    session = _make_session(tmp_path)
+    received: list[tuple[str, dict]] = []
+    session.subscribe_audit_events(lambda e: received.append((e.type, dict(e.data))))
+
+    external_fire.fire_and_forget(session, "webhook_received", {}, maxsize=1)
+    external_fire.fire_and_forget(session, "webhook_received", {}, maxsize=1)
+    await settle(session)
+    (fire_call,) = [d for (kind, d) in received if kind == "ingress_bridge_dropped"]
+    received.clear()
+
+    async def _never_drains(*_args, **_kwargs) -> None:
+        raise AssertionError("drain must never run within this test's own coroutine")
+
+    mcp_adapter = McpIngressAdapter(
+        hook_trigger=_never_drains, maxsize=1,
+        # session.emit_audit_event -- the public (event_type, **data) seam,
+        # not session._audit_events.emit directly (no private-state reach).
+        emit_event=lambda et, **kw: session.emit_audit_event(et, **kw),
+    )
+    mcp_adapter.deliver(HookEvent(kind="builtin:external:mcp_resource_updated", payload={}))
+    mcp_adapter.deliver(HookEvent(kind="builtin:external:mcp_resource_updated", payload={}))
+    await mcp_adapter.aclose()
+    await settle(session)
+    (mcp_call,) = [d for (kind, d) in received if kind == "ingress_bridge_dropped"]
+
+    assert fire_call["source"] != mcp_call["source"], (
+        f"_SessionFireBridge and McpIngressAdapter must report distinguishable "
+        f"sources on the shared ingress_bridge_dropped kind -- both reported "
+        f"{fire_call['source']!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5515, 2nd of 2 sites (1st: `_BoundedEventBridge`, #5560, merged). Same shape, applied per lead-coder's own instruction after PR1's review settled it ("1本目でレビューが形を変えたら、2本目はそのままの適用で構いません").

## What was wrong

`_SessionFireBridge.submit`'s queue-full branch (drop-newest overflow, `cron_fired`/`webhook_received`'s shared out-of-process dispatch bridge) was `logger.warning`-only — the sibling gap #5560 closed for `_BoundedEventBridge`.

## What changed

- New `_audit_drop(point)`: fires the SAME shared `ingress_bridge_dropped` kind PR1 registered, same first-drop/every-100th cadence. `source="_SessionFireBridge"` (a fixed literal — matches the label `submit()` already passes `observe_drain_task_death`), `point`, `drop_count`. `self._session` is typed `Any` — reuses `submit()`'s own existing getattr-guarded posture for `_audit_events`, not a new idiom.
- `events.md`'s `#5515` remainder note replaced with the 3-row `source` table now that both sites are closed.

## Tests (`tests/hooks/test_5515_session_fire_bridge_drop_fail_visible.py`, 3 new)

Unlike PR1's file (drove `_BoundedEventBridge`/its adapters directly), this drives the REAL PUBLIC entry point (`external_fire.fire_and_forget`) against a real `Session`, observing via `session.subscribe_audit_events` — same real seam `test_2761_pr2_hotreload_immediate_apply.py` uses for `bus_subscriber_dropped`. `EventLog.emit` defers to an async dispatch queue under a running loop (#4966) — every read is preceded by `await settle(session)`.

- First-drop fires + payload shape.
- First+every-Nth cadence under sustained overflow.
- `source` distinguishes `_SessionFireBridge` from a real `McpIngressAdapter` on the SAME session's audit stream (PR1's own review requirement carried over — non-collision assertion only, never equality to a literal; a future rename of either source must not flip this red).

## Strip-falsify (performed, documented in the test file's own docstrings)

Removing the `self._audit_drop(point)` call flips all 3 tests red — the distinctness test specifically drops to a single source (`McpIngressAdapter`'s only), reproducing exactly the pre-#5515 gap.

## Verification

- **Local gates, all green**: `ruff check .`, `test_tier_audit.py --strict` (3/3, 0 Tier-4), `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`.
- **docs/ gate** (touched `events.md`): `mkdocs build --strict` (exit 0), `check_doc_anchors.py`, `check_retired_config_keys_denylist.py`.
- **Scoped pytest**: `tests/hooks/` + `tests/core/test_audit_event_kind_vocabulary_3410.py` — 447 passed.

## Test plan

- [x] 3 new unit tests, all pass locally.
- [x] Strip-falsification performed (documented above and in the test file).
- [x] Full kind-vocabulary census still green (no new kind — reuses PR1's `ingress_bridge_dropped`).
- [x] (skipped — Visual, standing waiver 2026-08-08) No UI surface touched.

part of #5515

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
