### PR TITLE
fix(#5536): hook consent-gate failure is fail-visible (group B)

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -176,12 +176,32 @@ class HookDispatcher:
         return self._registry
 
     def _consent_bus_now(self) -> Any:
-        """The consent bus iff a live intervention listener is attached, else None."""
+        """The consent bus iff a live intervention listener is attached, else None.
+
+        #5536 (architect ruling — group B, "挙動が変わり、かつ silent"):
+        ``self._consent_gate()`` raising is not a hypothetical — it is a
+        caller-supplied callable, live-evaluated per-dispatch (see this
+        class's own ``__init__`` docstring for why it is never frozen).
+        Before this fix, a raise here returned ``None`` with NO log —
+        the shell-hook consent path then falls back to its own
+        stdin/fail-closed branch (never fail-OPEN; that path itself is
+        safe), but in an unattended/non-TTY session "ask the operator"
+        silently becomes "refuse", and nothing records WHY. ``_log.
+        warning`` (never an audit-event — auditing a gate-evaluation
+        failure through the SAME consent machinery it is about to bypass
+        would be its own quieter failure mode) so the fallback and its
+        cause are at least visible in the process log, even though the
+        fallback itself was already the safe direction."""
         if self._consent_bus is None or self._consent_gate is None:
             return None
         try:
             return self._consent_bus if self._consent_gate() else None
-        except Exception:  # noqa: BLE001 — a gate error must not break dispatch
+        except Exception as exc:  # noqa: BLE001 — a gate error must not break dispatch
+            _log.warning(
+                "Hook consent gate raised — falling back to the fail-closed "
+                "stdin/non-TTY consent path (never fail-open) for this "
+                "dispatch: %s: %s", type(exc).__name__, exc,
+            )
             return None
 
     def replace_registry(self, registry: HookRegistry) -> None:

--- a/tests/hooks/test_5536_consent_gate_failure_visible.py
+++ b/tests/hooks/test_5536_consent_gate_failure_visible.py
@@ -1,0 +1,121 @@
+"""Tier 2: #5536 group B — ``HookDispatcher._consent_bus_now``'s own gate
+failure is now fail-visible.
+
+architect ruling (#5536, "挙動が変わり、かつ silent" — the real defect this
+issue names): ``consent_gate()`` is a caller-supplied, live-evaluated
+callable (never frozen at construction — see the dispatcher's own
+``__init__`` docstring). Before this fix, a raise there returned ``None``
+with NO log. ``None`` routes the shell-hook consent decision to its own
+stdin/fail-closed branch (never fail-OPEN — that branch itself was already
+safe; architect's own review confirmed this directly, not assumed). But in
+an unattended/non-TTY session "ask the operator" silently becomes "refuse
+this hook", and nothing recorded WHY.
+
+Accept-side pair (per architect's own instruction — deny side, not "the
+log fires"):
+- a raising gate reaches a WARNING log naming the fallback direction
+  ("fail-closed", never "fail-open") and the exception.
+- the sibling positive control: a gate that does NOT raise emits no such
+  warning — proving the assertion above isn't vacuously true (a warning
+  that always fires regardless would pass the first test for the wrong
+  reason).
+
+Note (#5536, architect's own correction): dispatcher.py:537 (the OTHER
+group-B site the issue originally named, pipeline_launch's render-failure
+catch) already logs a WARNING as of cc8efa267 (2026-08-29 19:55, landed
+before architect's own 05:03 review comment the next day) — verified via
+``git blame`` before starting this file, not assumed from the issue body.
+Only dispatcher.py:184 (this file's own subject) was still silent.
+
+No cadence (#5515's own first-drop/every-Nth discipline does NOT apply
+here, architect's own explicit instruction) — this is a FAILURE (an
+unexpected raise), not a DROP (an expected, bounded discard); every
+occurrence logs.
+
+Real HookDispatcher with a recording run_shell seam, mirroring
+test_hook_shell_push_2069.py's own established pattern — no mocks.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookDef
+
+
+class _Recorder:
+    """A recording async callable (records (args, kwargs); returns None) —
+    same shape test_hook_shell_push_2069.py's own ``_Recorder`` uses."""
+
+    def __init__(self) -> None:
+        self.calls: "list[tuple[tuple, dict]]" = []
+
+    async def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+def _dispatcher(hook: HookDef, *, consent_gate) -> "tuple[HookDispatcher, _Recorder]":
+    run_shell = _Recorder()
+    disp = HookDispatcher(
+        HookRegistry([hook]),
+        put_inbox=_Recorder(),
+        stage_next_turn_context=_Recorder(),
+        run_shell=run_shell,
+        consent_bus="a-real-live-bus-object",  # any non-None sentinel
+        consent_gate=consent_gate,
+    )
+    return disp, run_shell
+
+
+@pytest.mark.asyncio
+async def test_consent_gate_raise_logs_the_fail_closed_fallback(caplog):
+    """Tier 2: ① — a raising consent_gate reaches a WARNING naming the
+    fallback direction, through the real dispatch() → exec path, not by
+    calling the private _consent_bus_now() directly.
+
+    Strip-falsify: remove the ``_log.warning(...)`` call in
+    ``_consent_bus_now``'s own except branch and this test goes RED — no
+    WARNING record at all (performed during review)."""
+    def _raising_gate() -> bool:
+        raise RuntimeError("listener registry corrupted")
+
+    hook = HookDef(on="turn_end", exec=("true",))
+    disp, run_shell = _dispatcher(hook, consent_gate=_raising_gate)
+
+    with caplog.at_level(logging.WARNING):
+        await disp.dispatch("turn_end", {})
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    (only,) = warnings  # exactly one warning — unpack-must-flip
+    assert "fail-closed" in only.message
+    assert "fail-open" not in only.message.lower() or "never fail-open" in only.message
+    assert "RuntimeError" in only.message
+
+    # the dispatch itself was never blocked by the gate's own raise — the
+    # exec hook still ran, consent_bus falling back to None (the SAME
+    # value a caller with no consent machinery at all would see).
+    (call,) = run_shell.calls
+    _args, kwargs = call
+    assert kwargs["consent_bus"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_non_raising_gate_logs_nothing(caplog):
+    """Tier 2: ② — deny-side positive control. A consent_gate that
+    returns normally (whichever way) must not emit the group-B warning —
+    without this, ①'s assertion could pass under a broken implementation
+    that warns on EVERY dispatch regardless of whether the gate actually
+    raised."""
+    hook = HookDef(on="turn_end", exec=("true",))
+    disp, run_shell = _dispatcher(hook, consent_gate=lambda: True)
+
+    with caplog.at_level(logging.WARNING):
+        await disp.dispatch("turn_end", {})
+
+    assert caplog.records == []
+    (call,) = run_shell.calls
+    _args, kwargs = call
+    assert kwargs["consent_bus"] == "a-real-live-bus-object"


### PR DESCRIPTION
**[e2e-coder]** — part of #5536, group B only (architect's own 3-group split: A=telemetry, B=behavior-changing-and-silent — the real defect, C=catch scope). B/A/C split into separate PRs per lead-coder's own explicit instruction (this session had 2 PRs grow unwieldy tonight).

## Scope correction (verified before starting, disclosed)

The issue's own group B originally named 2 sites: `dispatcher.py:184` (consent gate) and `:537` (pipeline_launch render-failure). `git blame` shows `:537` already gained a `_log.warning()` in `cc8efa267` (2026-08-29 19:55) — landed **before** architect's own review comment (05:03 the next day), so architect's classification table was already stale when written. Confirmed with lead-coder and architect before proceeding (broker). This PR's scope: `dispatcher.py:184` alone.

## What was wrong

`_consent_bus_now`'s gate-error catch returned `None` with no log. `None` routes the shell-hook consent decision to its own stdin/fail-closed branch — never fail-open, that branch was already safe (verified against its own docstring). But in an unattended/non-TTY session, "ask the operator" silently becomes "refuse this hook," with nothing recording why.

## What changed

`_consent_bus_now`'s except branch now `_log.warning()`s, explicitly naming the fallback direction ("fail-closed", "never fail-open") and the exception. No cadence — architect's own explicit instruction: #5515's drop-cadence discipline doesn't apply to a FAILURE (unexpected by definition); every occurrence logs.

## Tests (`tests/hooks/test_5536_consent_gate_failure_visible.py`, 2 new)

Real `HookDispatcher.dispatch()` → exec path (not the private method directly), recording `run_shell` seam mirroring `test_hook_shell_push_2069.py`'s own pattern:

1. A raising `consent_gate` reaches exactly one WARNING naming the fallback + exception; the exec hook itself still runs (`consent_bus` falls back to `None`).
2. Deny-side positive control: a non-raising gate emits no such warning.

## Strip-falsify (performed, documented in the test's own docstring)

Removing the `_log.warning()` call flips (1) red — zero warning records, `(only,) = warnings` raises `ValueError`.

## Verification

- **Local gates, all green**: `ruff check .`, `test_tier_audit.py --strict` (2/2, 0 Tier-4), `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`.
- **Scoped pytest**: `tests/hooks/` — 439 passed.

## Test plan

- [x] 2 new unit tests, pass locally.
- [x] Strip-falsification performed (documented above and in the test file).
- [x] (skipped — Visual, standing waiver 2026-08-08) No UI surface touched.

part of #5536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
