### PR TITLE
fix(#5569): CI red -- wait on process_for_agent, not marker count

### DIFF
--- a/tests/runtime/test_5350_process_identity_never_by_cwd.py
+++ b/tests/runtime/test_5350_process_identity_never_by_cwd.py
@@ -109,7 +109,22 @@ def test_process_for_agent_ignores_a_same_cwd_process_recorded_under_a_different
         cwd=shared_cwd, agent_name="other-agent", pythonpath=out_of_process_reyn,
     )
     try:
-        _wait_until(lambda: len(process_registry.live_processes()) == 2)
+        # #5569 (lead-coder BLOCKING, 2026-08-30 CI red): the marker is
+        # written in TWO stages — process_registry.py:170-173's own
+        # comment ("agent_name/broker_session_id are usually not yet
+        # known" / "agent_name": None) registers the marker FIRST, then
+        # record_process_identity fills agent_name in later. Waiting on
+        # "2 markers exist" (the len()==2 form this line used to have)
+        # waits on stage 1 only — the assertions below depend on stage 2
+        # (agent_name populated), a LATER point in time. Landing between
+        # the two stages made process_for_agent('target-agent') return
+        # set() (CI's own observed failure). The wait condition must be
+        # the exact condition the assertions below depend on, not a
+        # weaker proxy for it ("count reached" is not "content arrived").
+        _wait_until(
+            lambda: process_registry.process_for_agent("target-agent")
+            and process_registry.process_for_agent("other-agent")
+        )
         markers = process_registry.live_processes()
         assert {m["cwd"] for m in markers} == {str(shared_cwd)}, (
             "test setup sanity: both processes must share the exact same "


### PR DESCRIPTION
**[e2e-coder]** — closes #5569, main-red fix (top priority, blocking #5565 and every other PR).

## What was wrong

`test_process_for_agent_ignores_a_same_cwd_process_recorded_under_a_different_name` waited on `_wait_until(lambda: len(live_processes()) == 2)` — "2 markers exist" — but its own assertions depend on a LATER point in time: `process_registry.py`'s marker is written in two stages (`register_process` writes `agent_name=None` first; `record_process_identity` fills it in later — `process_registry.py:170-173`'s own comment: "usually not yet resolved"). Landing between the two stages made `process_for_agent('target-agent')` return `set()` — CI's own observed failure (run `33295191710`, Python 3.11).

## What changed

Wait on the exact condition the assertions depend on:
```python
_wait_until(lambda: process_for_agent("target-agent") and process_for_agent("other-agent"))
```
`process_for_agent` filters on the recorded `agent_name` field (`process_registry.py:287`) — `None` (falsy) until stage 2 completes, so this condition genuinely IS "content arrived," not a weaker proxy. Verified directly against `process_registry.py`'s own source, not assumed from the issue body.

**The判別子, per lead-coder's own instruction**: the wait condition must be the exact condition the assertions depend on — "count reached" is not "content arrived."

`_wait_until` itself is unchanged (still unbounded-poll, `time.sleep(0)` only — CLAUDE.md's own Ceiling rule) — no sleep added, no duration increased.

## Sweep (boundary, not ceiling — per lead-coder's own instruction: report, don't necessarily fix)

Spot-checked the sibling file (`test_5226_process_registry.py`, 10 `_wait_until(lambda: len(live_processes()) == N)` sites): all assert only `pid`/`cwd` (stage-1 fields, written unconditionally at `register_process` time), never `agent_name` — **not affected** by this bug class.

A full repo sweep of every `_wait_until` call site (10 files total use the helper) was **not done** given this issue's own priority (main red). Disclosed, not silently skipped.

## Verification

- **Local gates, all green**: `ruff check .`, `test_tier_audit.py --strict` (2/2, 0 Tier-4).
- **Scoped pytest**: `test_5350_process_identity_never_by_cwd.py` + `test_5226_process_registry.py` — 13 passed. The fixed file alone run 5 consecutive times locally, all green.

## Test plan

- [x] Existing test now waits on the correct condition, passes locally (5x).
- [x] Sibling file spot-checked for the same shape — not affected, documented above.
- [x] (skipped — Visual, standing waiver 2026-08-08) No UI surface touched.

Closes #5569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
