### PR TITLE
fix(#5536): run_shell_hook's outer catch no longer swallows reyn's own bugs (group C)

### DIFF
--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -894,5 +894,25 @@ async def run_shell_hook(
         return result.stdout.decode("utf-8", errors="replace")
 
     except Exception as exc:
+        # #5536 group C (architect ruling): this is a SCOPE question, not
+        # a silence question — this catch already logs at ERROR. The
+        # defect is that ``except Exception`` also swallows a bug in
+        # REYN'S OWN code here (an AttributeError/TypeError/KeyError from
+        # this function's own logic) into the exact same "the hook run
+        # failed" outcome an external command failure gets — hiding a
+        # real reyn defect behind an indistinguishable-looking hook
+        # failure. Excluded via the SAME closed allowlist ``classify_
+        # llm_failure``'s own FATAL branch already uses (#3783 §2's own
+        # reasoning, reused here rather than re-derived: "An AttributeError
+        # in our own code must not become [silently absorbed]") — never a
+        # new concept, the existing one applied at a second call site.
+        # Re-raising here reaches dispatcher.py's own per-hook isolation
+        # boundary one level up (a WARNING there, still bounded to this
+        # one hook — see that except clause's own docstring for why that
+        # boundary's scope is already correct and untouched by #5536).
+        from reyn.services.compaction.engine import FATAL_EXC_TYPES
+
+        if isinstance(exc, FATAL_EXC_TYPES):
+            raise
         _log.error("shell-hook %r: unexpected error: %s", command, exc)
         return None

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1036,7 +1036,14 @@ class LLMFailureClass(enum.Enum):
 #: fall through to OVERFLOW's keyword fallback, not be treated as
 #: unshrinkable-and-fatal) — only the THREE types a bug in reyn's own
 #: code plausibly raises through this call path.
-_FATAL_EXC_TYPES: "tuple[type[BaseException], ...]" = (TypeError, AttributeError, KeyError)
+#:
+#: #5536 group C: made PUBLIC (was ``_FATAL_EXC_TYPES``) so
+#: ``reyn.hooks.shell_runner``'s own outer catch-all can reuse the SAME
+#: allowlist to exclude reyn's-own bugs from its best-effort "the hook
+#: run failed" catch, rather than inventing a second, divergent set (the
+#: exact "5 independent copies" failure class ``is_context_overflow_
+#: error``'s own docstring already names once for a sibling predicate).
+FATAL_EXC_TYPES: "tuple[type[BaseException], ...]" = (TypeError, AttributeError, KeyError)
 
 
 def _is_fatal_auth_error(exc: BaseException) -> bool:
@@ -1088,7 +1095,7 @@ def classify_llm_failure(exc: BaseException) -> LLMFailureClass:
     construction) — this function does not widen what reaches it, only
     names what was already implicitly assumed.
     """
-    if isinstance(exc, _FATAL_EXC_TYPES) or _is_fatal_auth_error(exc):
+    if isinstance(exc, FATAL_EXC_TYPES) or _is_fatal_auth_error(exc):
         return LLMFailureClass.FATAL
     if is_quota_exhausted_error(exc):
         return LLMFailureClass.RETRYABLE

--- a/tests/hooks/test_5536_run_shell_hook_fatal_scope.py
+++ b/tests/hooks/test_5536_run_shell_hook_fatal_scope.py
@@ -1,0 +1,135 @@
+"""Tier 2: #5536 group C — ``run_shell_hook``'s own outer catch-all
+(``shell_runner.py``'s last ``except Exception``) no longer swallows a bug
+in reyn's own code.
+
+architect ruling (#5536): this site is NOT a silence question — it already
+``_log.error``s. It is a SCOPE question: ``except Exception`` also catches
+an ``AttributeError``/``TypeError``/``KeyError`` raised by reyn's OWN
+logic inside this function, giving it the exact same "the hook run
+failed, return None" outcome an ordinary external command failure gets —
+hiding a genuine reyn defect behind an indistinguishable-looking hook
+failure. Processed by reusing the CLOSED allowlist ``classify_llm_
+failure``'s own FATAL branch already uses (``reyn.services.compaction.
+engine.FATAL_EXC_TYPES`` — made public for this reuse, #3783 §2's own
+"An AttributeError in our own code must not become [silently absorbed]"
+reasoning applied at a second call site, no new concept introduced).
+
+Accept-side pair:
+① a FATAL-classified exception (AttributeError) raised from inside the
+  try block now PROPAGATES OUT of run_shell_hook, instead of being
+  logged-and-swallowed into a ``None`` return.
+② deny/regression — an ORDINARY exception (OSError — the shape a real
+  external I/O failure raises) is still caught exactly as before:
+  logged at ERROR, ``None`` returned, never propagates. Without this,
+  ① alone could pass under an implementation that stopped catching
+  ANYTHING here, which would break every existing caller relying on
+  run_shell_hook's own documented "never raises, fail-safe" contract
+  for ordinary failures.
+
+Both drive the REAL ``run_shell_hook`` with a real (non-Mock)
+``SandboxBackend``-shaped object whose own ``run()`` raises the exception
+under test — the same "real callable that raises" pattern this session's
+own #5536 group A/B files already use (``_raising_emit``), applied to the
+sandbox seam instead.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from reyn.security.sandbox import SandboxPolicy
+
+
+class _RaisingBackend:
+    """A real (non-Mock) SandboxBackend whose own ``run()`` raises
+    *exc_factory()* — simulates a bug reached from inside run_shell_hook's
+    own try block, at the seam furthest from this function's own
+    top-level logic (proving the exception genuinely traverses the whole
+    function, not just a line near the top)."""
+
+    name = "raising"
+
+    def __init__(self, exc_factory) -> None:
+        self._exc_factory = exc_factory
+
+    def available(self) -> bool:
+        return True
+
+    async def run(self, argv, policy, *, stdin=None, cwd=None, cancel_event=None, hook_process_context=None):
+        raise self._exc_factory()
+
+
+@pytest.mark.asyncio
+async def test_a_fatal_bug_exception_propagates_instead_of_being_swallowed(
+    tmp_path: Path, caplog, monkeypatch: pytest.MonkeyPatch,
+):
+    """Tier 2: ① — AttributeError (one of the 3 FATAL_EXC_TYPES) raised
+    from inside run_shell_hook's own try block propagates out, rather
+    than being logged-and-absorbed into a ``None`` return.
+
+    Strip-falsify: remove the ``if isinstance(exc, FATAL_EXC_TYPES): raise``
+    branch in the outer except (revert to the pre-#5536 bare catch) and
+    this test goes RED — ``run_shell_hook`` returns ``None`` instead of
+    raising (performed during review)."""
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+    backend = _RaisingBackend(lambda: AttributeError("'NoneType' object has no attribute 'x'"))
+
+    with caplog.at_level(logging.ERROR), pytest.raises(AttributeError):
+        await run_shell_hook(
+            ["true"],
+            event_context={"events": [{"event": "turn_end"}], "skipped_session_wide": 0},
+            timeout_seconds=10,
+            sandbox_backend=backend,
+            sandbox_policy=SandboxPolicy(network=False, deny_subprocess=True, timeout_seconds=10),
+            allowlist_path=tmp_path / "allowlist.json",
+        )
+
+    # never absorbed into the ordinary "unexpected error" log line this
+    # site emits for a genuinely swallowed exception — the FATAL branch
+    # re-raises before that log call is reached.
+    assert not any("unexpected error" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_exception_is_still_caught_and_logged(
+    tmp_path: Path, caplog, monkeypatch: pytest.MonkeyPatch,
+):
+    """Tier 2: ② — deny/regression side. An OSError (NOT in
+    FATAL_EXC_TYPES — the shape a real external I/O failure raises, e.g.
+    the sandbox subprocess machinery itself failing) is caught exactly
+    as before: logged at ERROR, ``None`` returned, never propagates.
+    Without this, ① could pass under a broken implementation that
+    stopped catching anything at all here.
+
+    The property under test is "an ERROR-level log fires and the call
+    returns None" — NOT the exact log wording (lead-coder review note,
+    #5536 A/B: pin the property, not the phrasing).
+
+    Strip-falsify: widen the FATAL_EXC_TYPES check to re-raise
+    unconditionally (``if True: raise``) and this test goes RED — the
+    OSError propagates out of run_shell_hook instead of being caught,
+    an unhandled exception in this test's own await (performed during
+    review)."""
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+    backend = _RaisingBackend(lambda: OSError("subprocess machinery failed"))
+
+    with caplog.at_level(logging.ERROR):
+        result = await run_shell_hook(
+            ["true"],
+            event_context={"events": [{"event": "turn_end"}], "skipped_session_wide": 0},
+            timeout_seconds=10,
+            sandbox_backend=backend,
+            sandbox_policy=SandboxPolicy(network=False, deny_subprocess=True, timeout_seconds=10),
+            allowlist_path=tmp_path / "allowlist.json",
+        )
+
+    assert result is None
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    (only,) = error_records  # exactly one ERROR log — unpack-must-flip
+    assert "true" in only.getMessage() or "OSError" in only.getMessage()


### PR DESCRIPTION
**[e2e-coder]** — closes #5536 (all 3 groups landed: A telemetry #5571, B behavior-changing-and-silent #5566, C this PR — the catch-scope question).

## What was wrong

`shell_runner.py`'s outer `except Exception` (the last one in `run_shell_hook`) is not a silence question — it already `_log.error()`s. It's a SCOPE question: `except Exception` also catches an `AttributeError`/`TypeError`/`KeyError` raised by reyn's OWN logic inside this function, giving it the exact same "the hook run failed, return None" outcome an ordinary external command failure gets — hiding a genuine reyn defect behind an indistinguishable-looking hook failure.

## What changed

Reused the CLOSED allowlist `classify_llm_failure`'s own FATAL branch already uses (#3783 §2's own reasoning, applied at a second call site — no new concept, per architect's own instruction):

- `reyn.services.compaction.engine._FATAL_EXC_TYPES` made **public** (`FATAL_EXC_TYPES`) so `shell_runner.py` can reuse the SAME allowlist rather than duplicating a second, divergent one. Zero behaviour change — pure rename, one file, two references.
- `shell_runner.py`'s outer except: a `FATAL_EXC_TYPES`-matching exception now re-raises instead of being swallowed. Reaches `dispatcher.py`'s own per-hook isolation boundary one level up (a WARNING there, still bounded to that one hook) — that boundary's own scope is already correct and untouched.

## Tests (`tests/hooks/test_5536_run_shell_hook_fatal_scope.py`, 2 new)

Real `run_shell_hook`, real (non-Mock) `SandboxBackend`-shaped object whose own `run()` raises the exception under test:

1. `AttributeError` propagates out instead of being swallowed.
2. Deny/regression — an ordinary `OSError` (external I/O failure shape) is still caught exactly as before: logged at ERROR, `None` returned, never propagates. Property under test is "an ERROR log fires and `None` is returned," not the exact wording (lead-coder review note carried over from #5536 A/B).

## Strip-falsify (performed, both directions, documented inline)

- Removing the `FATAL_EXC_TYPES` check → ① goes red (returns `None` instead of raising).
- Widening it to re-raise unconditionally → ② goes red (the `OSError` propagates unhandled).

Both restored and reverified green.

## Verification

- **Local gates, all green**: `ruff check .`, `test_tier_audit.py --strict` (2/2, 0 Tier-4), `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_subprocess_reyn_pin.py`.
- **Scoped pytest**: `tests/hooks/` + `tests/services/` + `test_3783_stage3_invert_default_to_recover.py` (the FATAL-classification sibling test) — 609 passed.

## Test plan

- [x] 2 new unit tests, pass locally.
- [x] Strip-falsification performed both directions (documented inline).
- [x] (skipped — Visual, standing waiver 2026-08-08) No UI surface touched.

Closes #5536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
