### PR TITLE
feat(#5265): detect a PR head sha whose required checks will never report

### DIFF
--- a/scripts/detect_5265_startup_failure_blocked_prs.py
+++ b/scripts/detect_5265_startup_failure_blocked_prs.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""#5265 — detect a PR head sha whose required CI checks will NEVER be
+reported, so it stays ``mergeStateStatus=BLOCKED`` silently forever.
+
+## The failure this detects (measured, not guessed — #5265 issue thread)
+
+2026-08-26 15:24-15:44Z: 28 `gh run list` runs, all `conclusion ==
+"startup_failure"` (`jobs == 0` — GitHub itself never started the run),
+across PRs #5262/#5263/#5264. Every required branch-protection context
+(`pytest (Python 3.11)`, `pytest (Python 3.12)`, `ruff`, `test-tier
+audit`, `docs build (strict)`) was simply ABSENT from those PRs — not
+failing, not pending, never reported at all — so ``mergeStateStatus``
+stayed ``BLOCKED`` with no red anywhere on the PR to notice. A 7-day
+window before the incident (2026-08-15..08-22, 11,090 runs covered) had
+zero occurrences — this is not a frequent/periodic failure, so no
+timeout/polling cadence is appropriate here (see below).
+
+## Architect ruling (#5265, 2026-08-30) — the design this script implements
+
+Detection does not depend on frequency (a silent, unbounded-time failure
+is worth detecting even if rare); AUTOMATIC recovery does (the only
+recovery lever, PR close/reopen, drops auto-merge arming and has no
+"who re-arms it" answer) — so this script only DETECTS, never acts.
+
+The decision needs no waiting and no timeout: for a given PR head sha,
+required context can be classified from STRUCTURE alone, immediately —
+
+    - zero workflow runs recorded against this head sha  -> will NEVER
+      report (the workflow never started at all)
+    - every recorded run is `conclusion == "startup_failure"` with
+      `jobs == 0` -> will NEVER report (GitHub accepted the trigger but
+      produced nothing)
+    - at least one recorded run is anything else (queued, in_progress,
+      or a real conclusion) -> may still report; do NOT flag this head
+      (this is what a normal, still-running CI pass looks like too, and
+      the ONLY way to avoid a duration-dependent "wait N minutes" check
+      — CLAUDE.md's own Ceiling rule — is to read this off run STATE,
+      never off elapsed time)
+
+## Placement (architect ruling)
+
+NOT a GitHub Actions cron — the failure mode this detects is Actions
+itself failing to start a run, so a detector living inside Actions would
+go silent on exactly the days it is needed (self-referential silence).
+This script is the decision logic only (pure function below, deterministic,
+unit-testable, `gh`-free); it is meant to be invoked from OUTSIDE Actions
+(a peer session's own sweep, or `reyn-broker`'s `github_pr_watcher.py`
+plugin — a different repo, not touched here) rather than adding a new
+standing process of its own.
+
+Usage:
+    python scripts/detect_5265_startup_failure_blocked_prs.py --pr 5262
+    python scripts/detect_5265_startup_failure_blocked_prs.py --head-sha <sha>
+    python scripts/detect_5265_startup_failure_blocked_prs.py --fixture runs.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+_REPO = "tya5/reyn"
+
+
+def is_permanently_blocked(runs: "list[dict]") -> bool:
+    """True iff *runs* — every workflow run GitHub has recorded against
+    ONE head sha, each ``{"conclusion": str | None, "jobs_count": int |
+    None}`` — proves the required checks for this head sha will NEVER be
+    reported: no runs at all, or every recorded run is a dead
+    ``startup_failure``/``jobs==0`` run.
+
+    False means at least one run is neither absent nor dead — still
+    legitimately in flight (queued/in_progress) or already completed
+    normally (any other conclusion) — do not flag.
+
+    Pure, no I/O — the whole decision this script makes, isolated so it
+    is directly testable against fixture data without hitting GitHub.
+    accept-side note (architect, #5265): a detector that flags every
+    non-empty *runs* list too would pass the "0 runs"/"all dead" cases
+    for the wrong reason — this function's own deny case (a live,
+    in-progress run) is what proves it actually discriminates."""
+    if not runs:
+        return True
+    return all(_is_dead_run(r) for r in runs)
+
+
+def _is_dead_run(run: dict) -> bool:
+    return run.get("conclusion") == "startup_failure" and run.get("jobs_count") == 0
+
+
+def format_notification(pr_number: "str | int", head_sha: str, runs: "list[dict]") -> str:
+    """The notification text a detection must carry: which PR/head, and
+    the recovery lever + its own known cost (#5265's own body: close/
+    reopen drops auto-merge arming) — a reader must not have to re-derive
+    that from the issue thread before acting."""
+    if not runs:
+        reason = "no workflow run was ever recorded against this head sha"
+    else:
+        reason = (
+            f"all {len(runs)} recorded run(s) are dead "
+            "(conclusion=startup_failure, jobs=0)"
+        )
+    return (
+        f"RED #5265 — PR #{pr_number} (head {head_sha[:12]}) is "
+        f"permanently BLOCKED: {reason}. Required checks will never be "
+        "reported for this head. Recovery: close/reopen the PR "
+        "(re-fires the pull_request trigger without moving head — but "
+        "DROPS auto-merge arming, which must be re-armed after). If a "
+        "run exists, `gh run rerun <id>` may work instead and does not "
+        "affect auto-merge."
+    )
+
+
+# ---------------------------------------------------------------------------
+# gh wrapper (thin — kept separate from the pure logic above)
+# ---------------------------------------------------------------------------
+
+
+def _gh_json(args: "list[str]") -> object:
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    return json.loads(result.stdout)
+
+
+def _fetch_head_sha_for_pr(pr_number: str) -> str:
+    data = _gh_json([
+        "pr", "view", pr_number, "--repo", _REPO, "--json", "headRefOid",
+    ])
+    return data["headRefOid"]
+
+
+def _fetch_runs_for_head(head_sha: str) -> "list[dict]":
+    """Every workflow run GitHub has recorded for *head_sha*, normalized
+    to this script's own ``{"conclusion", "jobs_count"}`` shape. ``gh run
+    list`` has no ``--head-sha`` filter, so this fetches recent runs and
+    filters client-side (mirrors the issue thread's own recursive-bisect
+    workaround for the same ``gh run list`` pagination ceiling, at a much
+    smaller scale here — one head sha's worth of recent activity, not a
+    7-day sweep). ``jobs_count`` is only fetched (a second `gh` call, per
+    run) for a run whose conclusion is ``startup_failure`` — every other
+    conclusion already proves the run is not dead, per
+    :func:`is_permanently_blocked`'s own logic, so job count is
+    irrelevant to it."""
+    all_runs = _gh_json([
+        "run", "list", "--repo", _REPO, "--limit", "200",
+        "--json", "headSha,conclusion,status,databaseId",
+    ])
+    matching = [r for r in all_runs if r.get("headSha") == head_sha]
+    runs: "list[dict]" = []
+    for r in matching:
+        conclusion = r.get("conclusion") or None
+        jobs_count = None
+        if conclusion == "startup_failure":
+            jobs = _gh_json([
+                "run", "view", str(r["databaseId"]), "--repo", _REPO, "--json", "jobs",
+            ])
+            jobs_count = len(jobs.get("jobs", []))
+        runs.append({"conclusion": conclusion, "jobs_count": jobs_count})
+    return runs
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Detect a PR head sha whose required CI checks will never report (#5265).",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pr", metavar="N", help="PR number — head sha resolved via `gh pr view`.")
+    group.add_argument("--head-sha", metavar="SHA", help="A commit sha directly (no PR lookup).")
+    group.add_argument(
+        "--fixture", metavar="PATH",
+        help="Path to a JSON file shaped like _fetch_runs_for_head's own return "
+        "value (offline / already-fetched — never hits `gh`).",
+    )
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    pr_label: "str | int" = "?"
+    if args.fixture is not None:
+        from pathlib import Path
+        runs = json.loads(Path(args.fixture).read_text(encoding="utf-8"))
+        head_sha = args.fixture
+    else:
+        try:
+            if args.pr is not None:
+                pr_label = args.pr
+                head_sha = _fetch_head_sha_for_pr(args.pr)
+            else:
+                head_sha = args.head_sha
+            runs = _fetch_runs_for_head(head_sha)
+        except subprocess.CalledProcessError as exc:
+            print(f"gh call failed: {exc.stderr}", file=sys.stderr)
+            return 2
+
+    if is_permanently_blocked(runs):
+        print(format_notification(pr_label, head_sha, runs))
+        return 1
+
+    print(f"OK — head {head_sha[:12]} has at least one live/completed run, not permanently blocked.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_detect_5265_startup_failure_blocked_prs.py
+++ b/tests/scripts/test_detect_5265_startup_failure_blocked_prs.py
@@ -1,0 +1,110 @@
+"""Tier 1: #5265 — the startup_failure-blocked-PR detector's own decision
+contract (architect ruling, 2026-08-30).
+
+The 3-case accept set is the ruling's own literal wording:
+① no workflow runs at all for a head sha -> flagged (permanently blocked).
+② every recorded run is a dead startup_failure(jobs=0) run -> flagged.
+③ at least one run is still live/completed normally -> NOT flagged — the
+  deny side. Architect's own note: "①②だけの test は『全部名指す』実装でも
+  緑になる" (a test covering only ①② would still pass an implementation
+  that flags EVERY non-empty runs list, since ① and ② never exercise a
+  genuinely-alive run) — ③ is what proves the function discriminates at
+  all, not just returns True unconditionally for anything non-empty.
+
+Pure function, no `gh`, no network, no duration (CLAUDE.md's own Ceiling
+rule — the whole point of this detector's own design is answering from
+structure, never from elapsed time).
+
+Strip-falsify (performed during review): with ``is_permanently_blocked``
+reduced to ``return True`` unconditionally, the 4 deny-side tests below
+(a live run, a normally-completed run, a mixed dead+live population, and
+the jobs!=0 precision case) all go RED; the ①/② accept tests stay green
+either way (they never exercised the discrimination). Restored, all 8
+pass again.
+"""
+from __future__ import annotations
+
+from scripts.detect_5265_startup_failure_blocked_prs import (
+    format_notification,
+    is_permanently_blocked,
+)
+
+
+def test_zero_runs_is_flagged():
+    """Tier 1: ① — no workflow run was ever recorded for this head sha."""
+    assert is_permanently_blocked([]) is True
+
+
+def test_all_dead_startup_failure_runs_is_flagged():
+    """Tier 1: ② — every recorded run is startup_failure with jobs=0 —
+    the exact 28-run shape #5265's own measurement found (28/28,
+    run_attempt always 1, GitHub never retried)."""
+    runs = [
+        {"conclusion": "startup_failure", "jobs_count": 0},
+        {"conclusion": "startup_failure", "jobs_count": 0},
+    ]
+    assert is_permanently_blocked(runs) is True
+
+
+def test_a_live_in_progress_run_is_not_flagged():
+    """Tier 1: ③ — the deny side, and the real content of this test file.
+    A run that is still queued/in_progress (no conclusion yet) among the
+    recorded runs means required checks MAY still report — must not be
+    flagged. Without this test, an implementation that returns True for
+    ANY non-empty runs list would still pass ① and ②."""
+    runs = [{"conclusion": None, "jobs_count": None}]
+    assert is_permanently_blocked(runs) is False
+
+
+def test_a_normally_completed_run_is_not_flagged():
+    """Tier 1: ③'s own sibling — a run that already completed normally
+    (success/failure, NOT startup_failure) is not a dead run either;
+    required checks from it already reported (or will, on retry) through
+    the ordinary path."""
+    runs = [{"conclusion": "success", "jobs_count": 12}]
+    assert is_permanently_blocked(runs) is False
+
+
+def test_one_dead_run_alongside_one_live_run_is_not_flagged():
+    """Tier 1: mixed population — a startup_failure(jobs=0) run for one
+    required workflow alongside a still-running run for another must NOT
+    be flagged; at least one path to a reported required check remains."""
+    runs = [
+        {"conclusion": "startup_failure", "jobs_count": 0},
+        {"conclusion": None, "jobs_count": None},
+    ]
+    assert is_permanently_blocked(runs) is False
+
+
+def test_a_startup_failure_conclusion_with_nonzero_jobs_is_not_the_signature():
+    """Tier 1: deny-side precision — conclusion==startup_failure ALONE is
+    not the signature; #5265's own measured shape is jobs==0
+    specifically (GitHub accepted the trigger but started nothing). A
+    startup_failure with jobs recorded is a different, unmeasured shape
+    and must not be conflated with the one this detector targets."""
+    runs = [{"conclusion": "startup_failure", "jobs_count": 3}]
+    assert is_permanently_blocked(runs) is False
+
+
+def test_notification_names_the_pr_and_the_recovery_lever_and_its_cost():
+    """Tier 1: the notification must name the PR/head AND the recovery
+    lever (close/reopen) AND that lever's own known cost (drops
+    auto-merge arming) — #5265's own body found this cost the hard way;
+    a notification that omits it lets the next reader re-discover it."""
+    text = format_notification(5262, "abc123def456789", [])
+    assert "#5262" in text
+    assert "abc123def456" in text
+    assert "close/reopen" in text
+    assert "auto-merge" in text.lower()
+
+
+def test_notification_names_the_specific_reason_for_each_case():
+    """Tier 1: the ①/② distinction survives into the notification text —
+    a reader should not have to re-derive which of the two structural
+    shapes fired from the flag alone."""
+    zero_runs_text = format_notification(1, "sha1", [])
+    dead_runs_text = format_notification(
+        2, "sha2", [{"conclusion": "startup_failure", "jobs_count": 0}],
+    )
+    assert "no workflow run" in zero_runs_text.lower()
+    assert "startup_failure" in dead_runs_text.lower()


### PR DESCRIPTION
**[e2e-coder]** — implements #5265 per architect's own ruling (2026-08-30). Detection only, per that ruling — automatic recovery is deliberately NOT built here (see below).

## Background

2026-08-26 incident: 28 `gh`-recorded runs, all `conclusion=="startup_failure"`/`jobs==0`, across PRs #5262/#5263/#5264 in a 20-minute window — required branch-protection checks never reported, `mergeStateStatus` stayed `BLOCKED` with no red visible anywhere on the PR. A 7-day window before it (11,090 runs covered) had zero occurrences.

## The two decisions this ruling splits (architect)

| | Depends on frequency | Built here |
|---|---|---|
| **Detection** | No — a silent, unbounded-time failure is worth catching even if rare | ✅ Yes |
| **Automatic recovery** | Yes | ❌ No — the only lever (close/reopen) drops auto-merge arming with no "who re-arms it" answer |

## The decision logic (no waiting, no timeout)

For a PR head sha, structure alone answers immediately:
- zero workflow runs recorded → will never report (flag)
- every recorded run is `startup_failure`/`jobs==0` → will never report (flag)
- at least one run is anything else (queued/in_progress/any real conclusion) → may still report (do NOT flag)

Reading run STATE, never elapsed time, is the only way to avoid a duration-dependent "wait N minutes" check (CLAUDE.md's own Ceiling rule).

## What changed

`scripts/detect_5265_startup_failure_blocked_prs.py`: `is_permanently_blocked(runs)` is the pure decision (no `gh`, no network, no duration), isolated from a thin `gh`-wrapper CLI — same shape this repo's own `detect_4986_teardown_hang.py` already establishes.

**Placement**: NOT a GitHub Actions cron — the failure mode this detects is Actions itself failing to start a run, so a detector living inside Actions would go silent on exactly the days it's needed. Meant to be invoked from OUTSIDE Actions (a peer session's sweep, or `reyn-broker`'s `github_pr_watcher.py` plugin — a separate repo, not touched here), per architect's own "起動はActionsの外／既存の巡回に足す、新しい常駐を増やさない" instruction.

## Tests (`tests/scripts/test_detect_5265_startup_failure_blocked_prs.py`, 8 new)

2 accept cases (① zero runs ② all-dead runs) + 4 deny-side tests (a live run, a normally-completed run, a mixed dead+live population, and `startup_failure`-with-nonzero-jobs precision). Architect's own explicit warning: "①②だけの test は『全部名指す』実装でも緑になる" — ③ (a live run not flagged) is this file's real content.

## Strip-falsify (performed, documented in the test file's own module docstring)

Reducing `is_permanently_blocked` to `return True` unconditionally flips all 4 deny-side tests red while ①② stay green (they never exercised discrimination) — confirming the deny side's own necessity, not just asserted. Restored, all 8 pass again.

## Verification

- **Local gates, all green**: `ruff check .`, `test_tier_audit.py --strict` (8/8, 0 Tier-4), `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`.
- **Scoped pytest**: `tests/scripts/` — 1114 passed.

## Test plan

- [x] 8 new unit tests, pass locally.
- [x] Strip-falsification performed (documented above and in the test file).
- [x] (skipped — Visual, standing waiver 2026-08-08) No UI surface touched.

part of #5265 (detection only — automatic recovery deliberately deferred per architect's own ruling; broker-plugin wiring is a separate repo, tracked there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
