### PR TITLE
fix(#5580): ChatMessage normalizes spillability at construction — closes the #5514 persistence round trip

### DIFF
--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -55,6 +55,47 @@ class Spillability(StrEnum):
         failure instead."""
         return cls.LAST_RESORT
 
+
+def _normalize_spillability(value: object) -> Spillability:
+    """#5580: ``ChatMessage.__init__``'s ONE normalization point for
+    ``spillability`` — every construction path funnels through here,
+    including ``ChatMessage(**raw)`` from a read-back ``history.jsonl``
+    line (``Session._parse_history_line``).
+
+    #5514 closed the WRITE side (persisting ``.value``, a plain ``str``,
+    via ``asdict`` + ``json.dumps``) but not the READ side: a value that
+    survived a restart round-trip arrived here as that same plain ``str``,
+    which every consumer of ``msg.spillability`` (starting with
+    ``router_history_buffer.py``'s own ``.value`` access) assumed was
+    already a ``Spillability`` member — AttributeError the first time an
+    overflow ladder ran against a restarted session's history (#5580).
+
+    - ``None`` (omitted at a call site) → ``Spillability.default()``,
+      same as before this fix.
+    - Already a ``Spillability`` member → passed through unchanged (the
+      overwhelmingly common in-process construction path; StrEnum's own
+      ``isinstance`` check here is why the ORDER of the checks below
+      matters — a ``Spillability`` member is ALSO a ``str``).
+    - A plain ``str`` that names a real member (the read-back case) →
+      converted to that member.
+    - Anything else — an unrecognized string (a future value this
+      version's enum doesn't have yet, or a corrupted history line) —
+      degrades to ``Spillability.default()`` rather than raising. #5514
+      §1's own safe-side argument applies here identically: an unreadable
+      declaration must degrade availability, never fail the turn.
+    """
+    if value is None:
+        return Spillability.default()
+    if isinstance(value, Spillability):
+        return value
+    if isinstance(value, str):
+        try:
+            return Spillability(value)
+        except ValueError:
+            return Spillability.default()
+    return Spillability.default()
+
+
 # #73: typed (not form-sniffed) tool-outcome classification, stamped on a
 # ``role="tool"`` message's ``meta`` at PERSIST time by the ONE place that
 # already knows the classification (``router_loop.py``'s tool-result
@@ -254,7 +295,12 @@ class ChatMessage:
         tool_calls: "list[dict] | None" = None,
         tool_call_id: "str | None" = None,
         name: "str | None" = None,
-        spillability: "Spillability | None" = None,
+        # #5580: widened to accept a raw ``str`` too — ``ChatMessage(**raw)``
+        # from a read-back history.jsonl line passes exactly that shape
+        # (spillability was persisted as its ``.value``, #5514). See
+        # ``_normalize_spillability``'s own docstring for the full
+        # normalization this parameter goes through below.
+        spillability: "Spillability | str | None" = None,
     ) -> None:
         # Reject the pre-#383 ``"agent"`` spelling. Migration of on-disk
         # ``history.jsonl`` entries happens at load time via
@@ -275,9 +321,7 @@ class ChatMessage:
         self.tool_calls = tool_calls
         self.tool_call_id = tool_call_id
         self.name = name
-        self.spillability = (
-            spillability if spillability is not None else Spillability.default()
-        )
+        self.spillability = _normalize_spillability(spillability)
 
     @property
     def text(self) -> str:

--- a/tests/runtime/test_5580_chat_message_spillability_round_trip.py
+++ b/tests/runtime/test_5580_chat_message_spillability_round_trip.py
@@ -1,0 +1,163 @@
+"""Tier 2: #5580 — ``ChatMessage.spillability`` closes the persistence round
+trip #5514 left open.
+
+The crash (owner's real machine, verbatim traceback):
+``AttributeError: 'str' object has no attribute 'value'`` in
+``RouterHistoryBuffer.decompose_history_for_retry``
+(``router_history_buffer.py:952``, ``getattr(_turn, "spillability",
+Spillability.default()).value``).
+
+#5514 closed the WRITE side (persisting ``spillability`` as its ``.value``
+via ``asdict`` + ``json.dumps``) but not the READ side:
+``Session._parse_history_line`` reconstructs a ``ChatMessage`` via
+``ChatMessage(**raw)``, and pre-#5580 that passed the raw persisted
+``str`` straight into ``self.spillability`` with no coercion back to the
+``Spillability`` enum — invisible to any test that never restarted a
+session and read ``history.jsonl`` back, exactly why #5547/#5558's own
+TESTS-READ missed it (lead-coder's own disclosure, issue #5580).
+
+Fix: ``ChatMessage.__init__`` now normalizes via
+``chat_message._normalize_spillability`` — every construction path,
+including a read-back raw dict, ends up holding a real ``Spillability``
+member.
+
+Accept criteria (lead-coder, #5580's own ordering):
+① a value read back from a persisted (dict-shaped, plain-``str``
+  ``spillability``) line ends up as the enum, not a ``str``.
+② ``decompose_history_for_retry`` runs to completion against such a
+  read-back message (the actual crash site) rather than raising.
+③ an unrecognized string degrades to ``Spillability.default()`` without
+  raising.
+Plus the deny-side lead-coder explicitly warned ①-alone cannot rule out:
+a "collapse EVERYTHING to default()" implementation would also pass ①/③
+trivially — ``test_known_spillability_string_survives_round_trip_intact``
+proves a REAL, non-default value is preserved distinctly, not forced to
+default.
+
+Real ``ChatMessage`` / real ``RouterHistoryBuffer`` throughout — no mocks
+(CLAUDE.md mock ban), same construction pattern
+``tests/runtime/test_build_history_producer_calls_2939.py`` already uses.
+"""
+from __future__ import annotations
+
+from reyn.config.chat import CompactionConfig
+from reyn.runtime.chat_message import ChatMessage, Spillability
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+
+
+def _buffer(history: list, model: str = "gpt-5.6-luna") -> RouterHistoryBuffer:
+    """Real RouterHistoryBuffer over a fixed history list — same minimal
+    construction ``test_build_history_producer_calls_2939.py`` already
+    establishes as sufficient for exercising ``decompose_history_for_retry``."""
+    return RouterHistoryBuffer(
+        history_fn=lambda: history,
+        compaction=CompactionConfig(),
+        compaction_controller=None,
+        model_fn=lambda: model,
+        events=None,
+        media_store=None,
+        router_host=None,
+        universal_wrappers_enabled=False,
+        non_interactive=False,
+    )
+
+
+def _read_back(raw: dict) -> "ChatMessage | None":
+    """Mirrors ``Session._parse_history_line``'s own construction call —
+    the exact site #5580's fix lives at — without needing a real Session/
+    on-disk file: a JSON round trip through ``json.dumps``/``json.loads``
+    first, so *raw*'s ``spillability`` genuinely arrives as the plain
+    ``str`` a persisted line would hold, not a Python object already
+    carrying enum identity."""
+    import json
+    line = json.dumps(raw)
+    reloaded = json.loads(line)
+    return ChatMessage(**reloaded)
+
+
+# ---------------------------------------------------------------------------
+# ① read-back spillability is the enum, not a str
+# ---------------------------------------------------------------------------
+
+
+def test_read_back_spillability_is_an_enum_not_a_string():
+    """Tier 2: #5580 accept ① — a ``spillability`` value read back from a
+    persisted (plain-``str``) history line ends up as a real ``Spillability``
+    member, not the raw ``str``."""
+    msg = _read_back({
+        "role": "user", "content": "hi", "spillability": "first_choice",
+    })
+    assert isinstance(msg.spillability, Spillability)
+    assert msg.spillability == Spillability.FIRST_CHOICE
+    # the exact operation the crash site performs — must not raise here.
+    assert msg.spillability.value == "first_choice"
+
+
+def test_known_spillability_string_survives_round_trip_intact():
+    """Tier 2: #5580 accept ① deny-side (lead-coder's own warning: ①-alone
+    would also pass under an implementation that collapses EVERY read-back
+    value to default()) — proves a real, non-default value is preserved
+    distinctly, not forced to default()."""
+    msg = _read_back({
+        "role": "assistant", "content": "x", "spillability": "never",
+    })
+    assert msg.spillability is Spillability.NEVER
+    assert msg.spillability is not Spillability.default()
+
+
+# ---------------------------------------------------------------------------
+# ② decompose_history_for_retry runs against a read-back message
+# ---------------------------------------------------------------------------
+
+
+def test_decompose_history_for_retry_does_not_raise_on_read_back_history():
+    """Tier 2: #5580 accept ② — ``decompose_history_for_retry`` (the actual
+    crash site, ``router_history_buffer.py:952``) runs to completion
+    against read-back ``ChatMessage``s instead of raising ``AttributeError:
+    'str' object has no attribute 'value'``.
+
+    The exact reproduction: a session restarted, read history.jsonl back
+    (spillability arrives as plain str), then an overflow ladder ran."""
+    history = [
+        _read_back({
+            "role": "user", "content": "long question " * 50,
+            "spillability": "first_choice", "seq": 1,
+        }),
+        _read_back({
+            "role": "assistant", "content": "long answer " * 50,
+            "spillability": "last_resort", "seq": 2,
+        }),
+    ]
+    buf = _buffer(history)
+    # Pre-#5580 this line raised AttributeError: 'str' object has no
+    # attribute 'value' (router_history_buffer.py:952).
+    head, raw_middle, tail, summary, seq_by_id = buf.decompose_history_for_retry()
+    all_wire = head + raw_middle + tail
+    assert all_wire, "the fixture history must actually appear in the decomposition"
+    for wire in all_wire:
+        # #5514 §7-3: decompose annotates a plain-str .value onto the wire
+        # dict — this is the POST-annotation shape, correctly a str here.
+        assert isinstance(wire["spillability"], str)
+
+
+# ---------------------------------------------------------------------------
+# ③ an unrecognized string degrades to default(), never raises
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_spillability_string_degrades_to_default():
+    """Tier 2: #5580 accept ③ — an unrecognized ``spillability`` string
+    (a future enum value this version doesn't know, or a corrupted history
+    line) degrades to ``Spillability.default()`` rather than raising."""
+    msg = _read_back({
+        "role": "user", "content": "x", "spillability": "some_future_value",
+    })
+    assert msg.spillability is Spillability.default()
+
+
+def test_corrupted_non_string_spillability_degrades_to_default():
+    """Tier 2: #5580 accept ③ (non-string variant) — a history line could
+    carry any JSON-serializable garbage in this key (a corrupted write, a
+    hand-edited file); must degrade, not raise."""
+    msg = ChatMessage(role="user", content="x", spillability=None)
+    assert msg.spillability is Spillability.default()


### PR DESCRIPTION
**[e2e-coder]** — 🔴🔴 Fixes a production crash on `main`: `router failed: 'str' object has no attribute 'value'` (owner's real machine, tonight's #5514 regression).

## Root cause (lead-coder's own traced chain, [#5580](https://github.com/tya5/reyn/issues/5580))

1. `router_history_buffer.py:952` — `decompose_history_for_retry` does `getattr(_turn, "spillability", Spillability.default()).value`
2. `session.py`'s `_parse_history_line` does `ChatMessage(**raw)`, where `raw` is a `history.jsonl` dict whose `spillability` key is #5514's own persisted plain `str` (written via `asdict()`+`json.dumps` — `StrEnum`'s own `.value`)
3. `ChatMessage.__init__` only checked `is not None` and kept the `str` as-is

#5514 closed the WRITE side but never the READ side: an in-memory-constructed `ChatMessage` always got a real `Spillability` member, so the bug is invisible until a session restarts and reads `history.jsonl` back — exactly why #5547/#5558's own TESTS-READ missed it.

## Fix

`ChatMessage.__init__` now normalizes `spillability` via a new `_normalize_spillability` helper — every construction path, including a read-back raw dict, ends up holding a real `Spillability` member:

- `None` → `Spillability.default()`
- already a `Spillability` member → passed through
- a recognized `str` → converted
- anything else (unknown string, corrupted value) → `default()` (matching #5514 §1's own safe-side argument — an unreadable declaration degrades availability, never fails the turn)

Fixed at the entry point (lead-coder's own prescription), not at `router_history_buffer.py:952` — every other consumer of `msg.spillability` makes the same assumption.

## Accept criteria

- **①** a value read back from a persisted line ends up as the enum, not a str — plus the deny-side lead-coder explicitly required (①-alone would also pass under a "collapse everything to `default()`" implementation): a REAL, non-default value survives the round trip distinctly.
- **②** `decompose_history_for_retry` (the actual crash site) runs to completion against a read-back `ChatMessage` instead of raising.
- **③** an unrecognized string degrades to `default()` without raising.

5 tests added, `tests/runtime/test_5580_chat_message_spillability_round_trip.py`. **Strip-falsified genuinely**: reverted the `__init__` normalization, reran — 4/5 tests went RED, including the exact `AttributeError` this issue reports, reproduced verbatim inside the test suite; restored, all 5 green again.

## Persistence round-trip sweep (lead-coder's own request — "同じ形が他に無いか")

**None found.** Every `StrEnum`/`(str, Enum)` class in this repo (11 total) checked for the same shape (persisted via `.value`, reconstructed via a raw passthrough with no coercion back to the enum, later consumed via `.value`/an enum-only method):

- `UsageSource` (`llm/pricing.py`) → `TokenUsage.source`, read back via `parse_usage_source()` (`pricing.py:79-96`, wired at `pricing.py:211` and `llm.py:1522`) — already coerced, falls back to `UNKNOWN`.
- `RunStatus` (`runtime/task_types.py`) → `RunEntry.status` (`interfaces/web/run_registry.py:90`), read back via a `_parse_status()` helper (`run_registry.py:169-174`, wired at line 182) — already coerced, falls back to `RUNNING`.
- Every other enum (`Transport`, `ToolUseLayer`, `MediaCapability`, `MaxInputTokensFallbackReason`, `DeliveryOutcome`, `ComposerOp`, `QueuePolicy`, `TransportTier`) either has no persisted dataclass field at all, or its only serialization path is one-way (audit/observability events, or startup-time config parsing) with no corresponding reconstruction call site — not a candidate.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5580_chat_message_spillability_round_trip.py` — 5 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/chat_message.py` — clean
- [x] `python scripts/mypy_ratchet.py` — 200 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `python scripts/check_bare_tests_import_reference.py` — clean (tests/ touched)
- [x] `python scripts/check_file_depth_reference.py` — clean (tests/ touched)
- [x] Related test sweep: 123 tests across spillability/compaction/retry-ladder suites + 48 tests across history-loading/rewind/cold-start suites — all pass
- [x] (skipped — no visual surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
