### PR TITLE
fix(#5467): reconcile PARTIAL/SKIP against lead-coder's corrected needle

### DIFF
--- a/tests/cli/test_model_cost_block_1867.py
+++ b/tests/cli/test_model_cost_block_1867.py
@@ -70,6 +70,14 @@ class _FakeSession:
         # #4597 slice②: real EventLog, no fake — snapshot() is reconstructed
         # from a subscriber capture (mirrors testing.md's "snapshot-style
         # read", never asserting on the collaborator's own private state).
+        # #5467: this ``_audit_events`` is ``_FakeSession``'s OWN attribute
+        # (this class is a hand-built stand-in, never a real
+        # ``reyn.runtime.session.Session``) — #5467's migration is about a
+        # caller reaching into a real Session's private log from OUTSIDE it;
+        # here the object constructs and subscribes to its own log inside
+        # its own ``__init__``, which ``collect_events(self)``/``settle(self)``
+        # have no meaning for (there is no Session to resolve to). Out of
+        # #5467's scope, not a residual instance of the pattern it closes.
         self._audit_events = EventLog()
         self._audit_snapshot: list[tuple[str, dict]] = []
         self._audit_events.add_subscriber(

--- a/tests/cli/test_model_cost_warn.py
+++ b/tests/cli/test_model_cost_warn.py
@@ -205,6 +205,16 @@ class _FakeSession:
         # #4597 slice②: real EventLog, no fake — snapshot() is reconstructed
         # from a subscriber capture (mirrors testing.md's "snapshot-style
         # read", never asserting on the collaborator's own private state).
+        # #5467: this ``_audit_events`` is ``_FakeSession``'s OWN attribute
+        # (this class is a hand-built duck-type, never a real
+        # ``reyn.runtime.session.Session``) — #5467's migration is about a
+        # caller reaching into a real Session's private log from OUTSIDE it;
+        # here the object constructs and subscribes to its own log inside
+        # its own ``__init__`` (and every call site below that drains it is
+        # draining THIS fake's own attribute, not a Session's), which
+        # ``collect_events``/``settle`` have no meaning for — there is no
+        # Session to resolve to. Out of #5467's scope, not a residual
+        # instance of the pattern it closes.
         self._audit_events = EventLog()
         self._audit_snapshot: list[tuple[str, dict]] = []
         self._audit_events.add_subscriber(

--- a/tests/core/test_3868_collect_events_helper.py
+++ b/tests/core/test_3868_collect_events_helper.py
@@ -107,6 +107,14 @@ async def test_collect_events_accepts_a_session_witness_1(tmp_path, monkeypatch)
     session = make_session(tmp_path, monkeypatch=monkeypatch)
     collected = collect_events(session)
     session._audit_events.emit("tool_executed", op="read_file", path="/tmp/x")
+    # #5467: deliberately ``session._audit_events.drain()``, NOT
+    # ``settle(session)`` — this witness's own claim is "collect_events(session)
+    # alone genuinely resolves and subscribes", so draining through the OTHER
+    # helper here would let a broken settle() silently backstop a broken
+    # collect_events() (or vice versa) and this test would stay green either
+    # way. Witness② (test_settle_accepts_a_session_witness_2, below) is where
+    # settle(session) itself gets exercised — the two stay independent on
+    # purpose. This line is intentionally excluded from #5467's migration.
     await session._audit_events.drain()
     assert [e.type for e in collected] == ["tool_executed"]
 

--- a/tests/core/test_session_lifecycle_events_1800.py
+++ b/tests/core/test_session_lifecycle_events_1800.py
@@ -29,8 +29,9 @@ Policy compliance (docs/deep-dives/contributing/testing.md):
   audit-events (#5103 ④, this issue's own new seam) — REYN_STALL_TRACE
   is set purely to arm this observation pair; the N-second stall
   detection itself is untested by design (see stall_trace.py).
-- Events observed via add_subscriber (public EventLog API), not via
-  private state assertions.
+- Events observed via ``tests/_support/events.py``'s ``collect_events``/
+  ``settle`` (#5467) — the private reach onto ``session._audit_events``
+  narrows to that one file, never repeated here.
 """
 from __future__ import annotations
 
@@ -42,6 +43,7 @@ from reyn.core.events.event_schema import EVENT_AUDIT_REQUIREMENTS
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -57,28 +59,14 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
     )
 
 
-def _collect_events(session: Session) -> list[dict]:
-    """Subscribe a collector to the session's EventLog and return the list.
-
-    The returned list is mutated in-place as events arrive. #4961 C:
-    dispatch moved off of ``emit()``'s own synchronous caller onto a
-    queue-consumer task — a caller must ``await session._audit_events.drain()``
-    (or otherwise yield enough for the consumer to catch up) before this
-    list can be trusted to reflect everything emitted so far.
-    """
-    collected: list[dict] = []
-
-    def _subscriber(event) -> None:
-        collected.append({"type": event.type, **event.data})
-
-    # add_subscriber is the public API on EventLog; _audit_events is the
-    # session's internal EventLog that all session-level emits target.
-    session._audit_events.add_subscriber(_subscriber)
-    return collected
-
-
-def _events_of_type(collected: list[dict], kind: str) -> list[dict]:
-    return [e for e in collected if e["type"] == kind]
+def _events_of_type(collected: "list", kind: str) -> "list":
+    """#5467: ``collected`` is now the real :class:`Event` list
+    ``collect_events(session)`` returns (was a hand-rolled subscriber that
+    flattened each event to ``{"type": ..., **event.data}`` — a private-reach
+    workaround for the SAME reason #5467 closes elsewhere: there was no
+    public seam to observe the session's own log through). Filters on the
+    real ``.type`` attribute directly."""
+    return [e for e in collected if e.type == kind]
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +118,7 @@ async def test_session_started_and_completed_emit(tmp_path: Path, monkeypatch) -
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    collected = _collect_events(session)
+    collected = collect_events(session)
 
     # Pre-load shutdown sentinel; run_one_iteration()'s _drain_to_wake
     # will read it and return (None, None) → iteration returns False →
@@ -140,11 +128,11 @@ async def test_session_started_and_completed_emit(tmp_path: Path, monkeypatch) -
     # #4961 C: `session_completed` is emitted right at the tail of
     # run()'s own finally block, with no further internal await after
     # it — `await session.run()` returning does not by itself guarantee
-    # the consumer has drained it yet. `drain()` is deterministic
+    # the consumer has drained it yet. `settle()` is deterministic
     # (unlike a bare yield, which only helps if exactly one event is
     # pending); Session.run() itself now awaits this at its own real
     # shutdown path too — see its own comment there.
-    await session._audit_events.drain()
+    await settle(session)
 
     started = _events_of_type(collected, "session_started")
     completed = _events_of_type(collected, "session_completed")
@@ -152,17 +140,17 @@ async def test_session_started_and_completed_emit(tmp_path: Path, monkeypatch) -
     # Unpack-enforcement idiom: unpacking to exactly 1 element raises
     # ValueError if 0 or 2+ events fired — no len(...) == N needed.
     (started_ev,) = started
-    assert started_ev.get("agent_name") == "test-agent", (
+    assert started_ev.data.get("agent_name") == "test-agent", (
         f"session_started.agent_name mismatch: {started_ev!r}"
     )
 
     (completed_ev,) = completed
-    assert completed_ev.get("agent_name") == "test-agent", (
+    assert completed_ev.data.get("agent_name") == "test-agent", (
         f"session_completed.agent_name mismatch: {completed_ev!r}"
     )
 
     # session_started must appear before session_completed in the log
-    all_types = [e["type"] for e in collected]
+    all_types = [e.type for e in collected]
     idx_started = all_types.index("session_started")
     idx_completed = all_types.index("session_completed")
     assert idx_started < idx_completed, (
@@ -194,7 +182,7 @@ async def test_turn_started_emits_with_kind(tmp_path: Path, monkeypatch) -> None
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    collected = _collect_events(session)
+    collected = collect_events(session)
 
     _chain_id = "test-chain-001"
     await session._put_inbox("user", {"text": "hello", "chain_id": _chain_id})
@@ -202,11 +190,20 @@ async def test_turn_started_emits_with_kind(tmp_path: Path, monkeypatch) -> None
 
     assert result is True, "run_one_iteration should return True (not shutdown)"
 
+    # #4961 C: dispatch to `collected` is off-loop (a background consumer
+    # task) — this read must not race it. #5467's own migration exposed
+    # this gap: the ORIGINAL custom subscriber here was a hand-rolled
+    # callback (not a plain `.append`), invisible to
+    # scripts/check_collect_events_settle.py's tracked shapes, so the
+    # missing settle() before this read was never caught. Real,
+    # pre-existing bug — not introduced by this migration, only now
+    # visible (lead-coder, collect-events-settle gate).
+    await settle(session)
     started = _events_of_type(collected, "turn_started")
 
     # Unpack-enforcement idiom: exactly 1 turn_started must fire.
     (started_ev,) = started
-    assert started_ev.get("kind") == "user", (
+    assert started_ev.data.get("kind") == "user", (
         f"turn_started.kind should be 'user', got: {started_ev!r}"
     )
 
@@ -244,7 +241,7 @@ async def test_turn_completed_emits_after_router_turn(tmp_path: Path, monkeypatc
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("REYN_STALL_TRACE", "5")
     session = _make_session(tmp_path)
-    collected = _collect_events(session)
+    collected = collect_events(session)
 
     _chain_id = "test-chain-002"
     await session._put_inbox("user", {"text": "world", "chain_id": _chain_id})
@@ -252,18 +249,23 @@ async def test_turn_completed_emits_after_router_turn(tmp_path: Path, monkeypatc
 
     assert result is True
 
+    # #4961 C: same gap as test_turn_started_emits_with_kind above — the
+    # ORIGINAL custom subscriber here was invisible to the
+    # collect-events-settle gate, so this missing settle() before the
+    # read predates #5467's migration; now caught and fixed.
+    await settle(session)
     completed = _events_of_type(collected, "turn_completed")
 
     # Unpack-enforcement idiom: exactly 1 turn_completed must fire.
     (completed_ev,) = completed
-    assert completed_ev.get("chain_id") == _chain_id, (
+    assert completed_ev.data.get("chain_id") == _chain_id, (
         f"turn_completed.chain_id should be {_chain_id!r}, got: {completed_ev!r}"
     )
 
-    all_types = [e["type"] for e in collected]
+    all_types = [e.type for e in collected]
     idx_armed = all_types.index("stall_trace_armed")
     idx_completed = next(
-        i for i, e in enumerate(collected) if e["type"] == "turn_completed"
+        i for i, e in enumerate(collected) if e.type == "turn_completed"
     )
     idx_disarmed = all_types.index("stall_trace_disarmed")
     # turn_completed must be strictly BETWEEN armed (before run_turn is

--- a/tests/runtime/test_3694_persist_cancelled_turn_outcome.py
+++ b/tests/runtime/test_3694_persist_cancelled_turn_outcome.py
@@ -62,6 +62,7 @@ from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.router_loop import RouterLoop
 from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
 from tests._support.agent_session import make_session as _make_hard_cancel_session
+from tests._support.events import settle
 from tests._support.router_loop import FakeRouterHost, text_result
 from tests._support.router_loop import ScriptedLLM as _ScriptedLLM
 from tests._support.session import make_session as _make_session
@@ -107,6 +108,10 @@ def test_cancelled_marker_never_reaches_build_history(tmp_path, monkeypatch):
         compaction=session._compaction,
         compaction_controller=session._compaction_controller,
         model_fn=lambda: session._resolver.resolve(session.model).model,
+        # #5467: RouterHistoryBuffer's own ``events`` constructor param
+        # requires a real EventLog (production wiring, not a test-side
+        # observer) — collect_events()/settle() have no meaning here, there
+        # is nothing to subscribe to or drain. Out of #5467's scope.
         events=session._audit_events,
         media_store=session._media_store,
         router_host=session._router_host,
@@ -274,7 +279,7 @@ async def test_a_non_self_initiated_cancel_does_not_fabricate_a_user_cancel_mark
         _llm_stub.release.set()
 
     # witness ②: the real driver dispatched before the cancel hit it.
-    await session._audit_events.drain()
+    await settle(session)
     assert any(e.type == "turn_started" for e in events)
 
     cancelled_markers = [
@@ -333,7 +338,7 @@ async def test_hard_cancel_via_cancel_inflight_persists_the_marker(
         _llm_stub.release.set()
 
     # witness ②: the real driver dispatched before the cancel hit it.
-    await session._audit_events.drain()
+    await settle(session)
     assert any(e.type == "turn_started" for e in events)
 
     (marker,) = [

--- a/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
+++ b/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
@@ -46,6 +46,7 @@ from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.chat_message import ChatMessage, Spillability
 from reyn.services.compaction.engine import UnrecoveredError
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
 
 
 class _FakeStatusError(Exception):
@@ -165,8 +166,7 @@ def test_single_huge_tool_result_recovers_via_spill_not_compaction(
     _push(session, "tool", huge, tool_call_id="tc1", name="tool")
     _push(session, "assistant", "ok, done")
 
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
 
     loop = _ContentDrivenLoop(
         lambda history, user_text: _has_content(history, huge)
@@ -276,17 +276,19 @@ def test_history_dominant_overflow_recovers_via_pre_existing_compaction(
         # requires an explicit NEVER, not just the absence of a tool turn.
         _push(session, "user", turn_text, spillability=Spillability.NEVER)
 
-    events: list = []
-    compacted = {"done": False}
+    # #5467: was a custom ``_on_event``/``compacted`` dict subscriber (a
+    # side-effecting callback, not a plain append) reaching
+    # ``session._audit_events`` directly — collect_events(session) gives the
+    # same raw event list; the "has compaction_completed fired yet" check
+    # that used to live in the subscriber is now a plain derivation over
+    # that list, computed wherever it's needed instead of tracked as a
+    # side-effect.
+    events = collect_events(session)
 
-    def _on_event(e) -> None:
-        events.append(e)
-        if e.type == "compaction_completed":
-            compacted["done"] = True
+    def _compacted() -> bool:
+        return any(e.type == "compaction_completed" for e in events)
 
-    session._audit_events.add_subscriber(_on_event)
-
-    loop = _ContentDrivenLoop(lambda history, user_text: not compacted["done"])
+    loop = _ContentDrivenLoop(lambda history, user_text: not _compacted())
 
     result = asyncio.run(
         session._loop_driver._run_with_shrink_and_byte_reduction(
@@ -295,7 +297,7 @@ def test_history_dominant_overflow_recovers_via_pre_existing_compaction(
     )
     assert result is None  # the fake loop's own successful return
 
-    assert compacted["done"], "expected a real compaction_completed event"
+    assert _compacted(), "expected a real compaction_completed event"
     spill_events = [e for e in events if e.type == "tool_result_offloaded"]
     assert not spill_events, (
         "nothing was spillable (no tool-result turns) — spill must not "
@@ -325,8 +327,7 @@ def test_history_dominant_overflow_fails_fast_with_nothing_spillable(
     _push(session, "user", "hi", spillability=Spillability.NEVER)
     _push(session, "assistant", "ok", spillability=Spillability.NEVER)
 
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
 
     loop = _ContentDrivenLoop(lambda history, user_text: True)  # always 413
 
@@ -382,8 +383,7 @@ def test_recovery_policy_never_leaves_the_watermark_alone_and_terminates(
         # sanity now needs an explicit declaration, not just role != "tool".
         _push(session, "user", "X" * 320, spillability=Spillability.NEVER)
 
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
 
     loop = _ContentDrivenLoop(lambda history, user_text: True)  # always 413
 
@@ -610,13 +610,12 @@ async def test_spill_candidates_are_staged_head_then_mid_then_tail(
     public surface nor a snapshot-style read] exists, that absence is the
     finding" — here a public read DOES exist once driven through a real
     spill pass, so this is that seam, not a documented absence).
-    ``session._audit_events.drain()`` is required before reading the
+    ``settle(session)`` is required before reading the
     subscriber's list — events queue, they are not delivered
     synchronously inside ``emit()`` (measured directly: the subscriber
     list was empty without it, on every run)."""
     session = _make_spill_session(tmp_path, monkeypatch, t_max=2_500)
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
 
     # Head: one small tool turn. Mid: one turn whose content is FAR
     # larger than the head candidate — if global size-sort fired instead
@@ -662,11 +661,11 @@ async def test_spill_candidates_are_staged_head_then_mid_then_tail(
     )
 
     progressed_1 = await session._loop_driver._attempt_reactive_spill(chain_id="c1")
-    await session._audit_events.drain()
+    await settle(session)
     progressed_2 = await session._loop_driver._attempt_reactive_spill(chain_id="c1")
-    await session._audit_events.drain()
+    await settle(session)
     progressed_3 = await session._loop_driver._attempt_reactive_spill(chain_id="c1")
-    await session._audit_events.drain()
+    await settle(session)
     assert (progressed_1, progressed_2, progressed_3) == (True, True, True), (
         "each of the 3 calls must make genuine progress (one candidate "
         f"each) — got {(progressed_1, progressed_2, progressed_3)!r}"
@@ -914,8 +913,7 @@ async def test_spill_turn_content_offload_event_names_trigger_overflow(
     ``router_history_buffer.py`` turns this RED (the event would carry
     ``"cap"`` instead)."""
     session = _make_spill_session(tmp_path, monkeypatch, t_max=2_500)
-    events: list = []
-    session._audit_events.add_subscriber(lambda e: events.append(e))
+    events = collect_events(session)
 
     _push(session, "tool", "huge tool result " + "z" * 5_000, tool_call_id="tc-1", name="tool")
     for i in range(20):
@@ -923,7 +921,7 @@ async def test_spill_turn_content_offload_event_names_trigger_overflow(
         _push(session, "assistant", f"filler answer number {i} " * 8)
 
     await session._loop_driver._attempt_reactive_spill(chain_id="c1")
-    await session._audit_events.drain()
+    await settle(session)
 
     offloaded = [e for e in events if e.type == "tool_result_offloaded"]
     assert offloaded, "test setup sanity: at least one candidate must have been spilled"
@@ -1134,21 +1132,26 @@ def test_mid_only_spill_bounds_by_candidate_exhaustion_wire_bytes_never_move(
     for i in range(3):
         _push(session2, "user", f"tail filler {i} " * 8, spillability=Spillability.NEVER)
         _push(session2, "assistant", f"tail reply {i} " * 8, spillability=Spillability.NEVER)
-    spilled_so_far = {"n": 0}
-    session2._audit_events.add_subscriber(
-        lambda e: spilled_so_far.__setitem__("n", spilled_so_far["n"] + 1)
-        if e.type == "tool_result_offloaded" else None
-    )
-    loop2 = _ContentDrivenLoop(lambda history, user_text: spilled_so_far["n"] < 3)
+    # #5467: was a custom counting subscriber (a side-effecting callback,
+    # not a plain append) reaching ``session2._audit_events`` directly —
+    # collect_events(session2) gives the same raw event list; the running
+    # spill count that used to live in the subscriber is now a plain
+    # derivation over that list.
+    events2 = collect_events(session2)
+
+    def _spilled_so_far() -> int:
+        return sum(1 for e in events2 if e.type == "tool_result_offloaded")
+
+    loop2 = _ContentDrivenLoop(lambda history, user_text: _spilled_so_far() < 3)
     result = asyncio.run(
         session2._loop_driver._run_with_shrink_and_byte_reduction(
             loop2, "continue please", chain_id="c1",
         )
     )
     assert result is None, "the turn must ultimately succeed once all mid candidates spilled"
-    assert spilled_so_far["n"] == 3, (
+    assert _spilled_so_far() == 3, (
         "the turn must have spilled all 3 mid candidates before succeeding "
-        f"— got {spilled_so_far['n']!r}"
+        f"— got {_spilled_so_far()!r}"
     )
 
 
@@ -1227,8 +1230,7 @@ def test_spill_population_exhausted_reports_count_and_breakdown_when_all_never(
         )
         raw_middle_population = len(raw_middle)
 
-        events: list = []
-        session._audit_events.add_subscriber(lambda e: events.append(e))
+        events = collect_events(session)
 
         with pytest.raises(UnrecoveredError):
             asyncio.run(
@@ -1237,7 +1239,7 @@ def test_spill_population_exhausted_reports_count_and_breakdown_when_all_never(
                     "continue please", chain_id="c1",
                 )
             )
-        asyncio.run(session._audit_events.drain())
+        asyncio.run(settle(session))
     finally:
         stub.restore()
 

--- a/tests/runtime/test_list_mcp_servers_canonical_shape.py
+++ b/tests/runtime/test_list_mcp_servers_canonical_shape.py
@@ -65,12 +65,21 @@ def test_end_to_end_list_mcp_servers_matches_conversation_and_llm_text(tmp_path)
 
     outbox = session.outbox
     forwarder = ChatLifecycleForwarder(outbox)
+    # #5467: subscribing a REAL production ``ChatLifecycleForwarder`` — this
+    # test drives the actual production wiring mechanism itself, not a
+    # test-side event collector. ``collect_events()`` returns a plain list
+    # built from ITS OWN subscriber; it has no way to attach an existing,
+    # already-constructed subscriber object like ``forwarder`` in its place.
+    # Out of #5467's scope (the "hand-rolled Sink instance" gap #5465 named,
+    # here on the production side rather than a test double).
     session._audit_events.add_subscriber(forwarder)
 
     loop = RouterLoop(host=session.router_host, chain_id="c1", router_model="gpt-4o")
     catalog = {"list_mcp_servers": {"function": {"name": "list_mcp_servers", "parameters": {}}}}
     ctx = DispatchContext(
         caller_kind="router", caller_id="alice", chain_id="c1",
+        # #5467: DispatchContext's own ``events`` param requires a real
+        # EventLog (production wiring) — out of scope, same reason as above.
         tool_catalog=catalog, events=session._audit_events,
     )
 


### PR DESCRIPTION
**[tui-coder]** — part of #5467, reconciliation against lead-coder's corrected needle

Follow-on to batches 1–4 (#5549/#5550/#5552/#5554, all merged/armed). Branched off `origin/main` per PR-workflow rule 10.

## 実測(このbranch)

```
git grep -nE '\._audit_events\.(drain|add_subscriber)' -- tests/
```
着手前: 27 hit / 8 file(lead-coder実測)。本PR後: **9 hit / 4 file** — 全て理由をfile内に逐語で記録。

## 突き合わせ結果(15 fileの内訳)

| file | 対応 |
|---|---|
| `test_2242_hard_cancel.py` / `test_3595_s2_pipeline_nudge_origin.py` / `test_3310_n2_reset_hydrate.py` / `test_5531_summary_reaches_first_main_call.py` / `test_5356_hooks_layer_rejection_audit_event.py` / `test_5367_reactive_ladder_absorbs_elide_sized_overflow.py` | 既にbatch3で移行済み(needleの再計測drift、現在0) |
| `test_hook_composer_reachability_phase5.py` / `test_emit_hook_event_0059_phase5_part2.py` | 他PRで既に`_audit_events`参照ごと消滅(現在0、確認済み) |
| `test_session_lifecycle_events_1800.py`(3) | ★移行(理由「死んでいた」): custom subscriberがflat-dictへ変換していただけ — `collect_events(session)`の生Eventに切替、downstreamを`.type`/`.data.get()`へ書き換え |
| `test_3694_persist_cancelled_turn_outcome.py`(2 settle分) | ★移行。残る`events=session._audit_events`(constructor引数)はfile内に逐語で理由記録 |
| `test_5296_pr2_byte_reduction_same_turn_retry.py`(14) | ★全14移行。うち2箇所はcustom counting/side-effect subscriberだったため、生event listから都度導出する形に書き換え(behaviorは同一) |
| `test_list_mcp_servers_canonical_shape.py`(1) | file内に逐語で理由記録(本物のproduction `ChatLifecycleForwarder`をsubscribeしている、`collect_events`は既存subscriberオブジェクトの差し替え先を持たない) |
| `test_model_cost_block_1867.py`(1) / `test_model_cost_warn.py`(5) | file内に逐語で理由記録(`_FakeSession`という手作りduck-type自身の`_audit_events`属性 — 実Sessionではなく#5467の射程外) |
| `test_3868_collect_events_helper.py`(1) | file内に逐語で理由記録(#5467自身のwitness、collect_eventsとsettleを独立に検証するため意図的に`settle`を使わない) |

## ⚠️ 閉じる条件④への疑問(判断を仰ぎたい点)

本文逐語「上のneedleが**0 hit**、かつ残した例外がfile内に逐語で書かれていること」— この2つは字面上両立しません(例外として残す限りneedleは非0のまま)。今回は「例外は理由をfile内に書けば残してよい」と解釈し、9 hit(4 file、全て理由明記)まで削減しました。もし字面通り0 hitが必須なら、Bucket B 2file(`_FakeSession`という別クラスの自前属性)の属性名自体をrenameする必要があり、それは#5467の射程(実Sessionへのprivate reach)を超えます — その場合は別途ご指示ください。

## 検証

- pytest(該当7ファイル) — 49 passed / 7 skipped(pre-existing、litellm pricing DB無し環境)
- ruff clean / tier_audit --strict clean(56 tests) / verify_module_docstrings OK

## Test plan
- [x] pytest(変更7ファイル) — 49 passed/7 skipped(pre-existing)
- [x] ruff / tier_audit --strict / verify_module_docstrings — all clean
- [x] (skipped — no UI/TUI surface touched) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
