### PR TITLE
fix(#5579): /compact no longer claims "already fits" when the window is still full

### DIFF
--- a/src/reyn/interfaces/slash/compact.py
+++ b/src/reyn/interfaces/slash/compact.py
@@ -58,6 +58,29 @@ async def compact_cmd(ctx: "SlashContext", args: str) -> None:
     n = result.get("summarized_turns", 0)
     if n <= 0:
         free_after = result.get("free_window_after")
+        # #5579 (owner's real machine, 2026-08-30): ``summarized_turns == 0``
+        # has THREE possible causes — genuinely nothing to fold, an attempt
+        # that folded nothing, or a watermark that failed to advance — and
+        # this function has no way to tell them apart (``force_compact_now``
+        # returns nothing; see session.py's own ``_compact_now_for_op``).
+        # The PREVIOUS wording asserted "already fits the window"
+        # unconditionally on ``n <= 0`` — true only for the first cause. The
+        # owner's own machine showed the contradiction directly: "already
+        # fits the window. Free window: ~0 tokens." in the SAME line.
+        # ``free_window_after`` (``max(0, effective_trigger - after)``,
+        # already computed, no new threshold needed) is the one number that
+        # actually says whether the window fits: `> 0` means room remains,
+        # `== 0` means it does not — regardless of why ``n`` came back 0.
+        if free_after is not None and free_after <= 0:
+            await reply(
+                ctx,
+                "Nothing was compacted this pass, and the window is still "
+                "full (~0 tokens free) — /compact did not free any room. "
+                "This may mean there was nothing eligible to fold, or an "
+                "attempt folded nothing; either way, running /compact "
+                "again right now is unlikely to help further.",
+            )
+            return
         tail = f" Free window: ~{free_after} tokens." if free_after is not None else ""
         await reply(
             ctx,

--- a/tests/interfaces/test_slash_compact_cmd.py
+++ b/tests/interfaces/test_slash_compact_cmd.py
@@ -75,7 +75,11 @@ async def test_compact_nothing_to_compact_no_free_window() -> None:
 
 @pytest.mark.asyncio
 async def test_compact_nothing_to_compact_with_free_window_includes_token_count() -> None:
-    """Tier 2: summarized_turns=0 + free_window_after → token count surfaced in reply."""
+    """Tier 2: #5579 accept ②' (deny side) — summarized_turns=0 with a
+    GENUINELY free window (free_window_after > 0) keeps the 'already fits'
+    claim, unchanged, with the token count surfaced in reply. This is the
+    deny-side counterweight to accept ①: proves the fix does not become
+    "always warn regardless of free_window_after"."""
     async def _nothing():
         return {"summarized_turns": 0, "free_window_after": 45000}
 
@@ -83,6 +87,32 @@ async def test_compact_nothing_to_compact_with_free_window_includes_token_count(
     await compact_cmd(_ctx(session), "")
     text = session.reply_text()
     assert "45000" in text, f"expected free token count in reply; got: {text!r}"
+    assert "already fits" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_compact_nothing_summarized_but_window_still_full_does_not_claim_fits() -> None:
+    """Tier 2: #5579 accept ①' — the owner's own observed contradiction
+    (summarized_turns=0 AND free_window_after=0 in the SAME reply) must not
+    happen. summarized_turns == 0 has three possible causes (no candidates
+    / attempted-but-folded-nothing / watermark-didn't-advance) that
+    _compact_now_for_op cannot currently distinguish (see compact.py's own
+    comment) — the fix does not need to name which one happened; it only
+    must stop asserting 'already fits the window' when free_window_after
+    says otherwise (== 0, no threshold — max(0, effective_trigger - after)
+    is already an exact computed value, not an estimate needing a fudge
+    factor)."""
+    async def _stuck():
+        return {"summarized_turns": 0, "free_window_after": 0}
+
+    session = _FakeSession(compact_now=_stuck)
+    await compact_cmd(_ctx(session), "")
+    text = session.reply_text()
+    assert text, "expected a non-empty reply, not silence"
+    assert "already fits" not in text.lower(), (
+        f"reply must not claim the window already fits when free_window_after=0; got: {text!r}"
+    )
+    assert not session.error_text()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — `/compact` no longer claims "already fits the window" when the window is actually still full ([#5579](https://github.com/tya5/reyn/issues/5579)).

## Owner's real machine (verbatim)

```
/compact

✓ Nothing to compact right now — recent history already fits the window. Free window: ~0 tokens.
```

A contradiction in the same reply.

## Root cause (lead-coder's own trace)

`summarized_turns == 0` has THREE possible meanings — no candidates to fold (genuinely fits), compaction ran but folded nothing, or the watermark failed to advance — and the previous wording collapsed all three into "already fits the window" unconditionally on `n <= 0`, true only for the first.

## Precedent cited (#5531 §9.6, `spill_candidate_population_exhausted`)

> "Candidate 0" is ambiguous by itself

The same arc already solved this shape (a count breakdown distinguishing "exhausted" from "made none"). Per lead-coder's explicit permission, this fix does **not** attempt that breakdown here: `_compact_now_for_op` has no way to distinguish the three causes today (`force_compact_now` returns nothing), and lead-coder explicitly allowed "cannot distinguish" as an acceptable answer — as long as the wording stops asserting "fits" when it doesn't.

## Fix

Gate the "already fits the window" claim on `free_window_after > 0` (`max(0, effective_trigger - after)`, already computed — **no new threshold**, per owner's standing "no unjustified constants" instruction). `free_window_after == 0` gets an honest, cause-agnostic reply instead: nothing was freed, the window is still full, running `/compact` again right now is unlikely to help.

## Accept criteria

- **①'** `summarized_turns=0` AND `free_window_after=0` (the owner's own observed contradiction) — no longer claims "already fits".
- **②'** (deny side) `summarized_turns=0` with a genuinely free window (`free_window_after > 0`) — unchanged, still claims "already fits" with the token count. Rules out an "always warn" implementation.
- **③'** `summarized_turns > 0` (real compaction happened) — unchanged (existing tests, untouched code path).

1 test added (①'), 1 test annotated to make its deny-side role explicit (②' — the existing test already covered this case; its docstring now says so). **Strip-falsified genuinely**: reverted the `free_window_after` gate, reran — the new ①' test failed with the EXACT owner-observed contradictory text reproduced verbatim inside the test output; restored, all 8 green again.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_slash_compact_cmd.py` — 8 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/slash/compact.py` — clean
- [x] `python scripts/mypy_ratchet.py` — 200 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `python scripts/check_bare_tests_import_reference.py` — clean (tests/ touched)
- [x] `python scripts/check_file_depth_reference.py` — clean (tests/ touched)
- [x] (skipped — no visual surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
