### PR TITLE
fix(#5557): document (a)-driving reasoning for 16 emit sites (misc files)

### DIFF
--- a/tests/core/test_3868_collect_events_helper.py
+++ b/tests/core/test_3868_collect_events_helper.py
@@ -106,6 +106,13 @@ async def test_collect_events_accepts_a_session_witness_1(tmp_path, monkeypatch)
     ``.emit()`` directly; nothing here ASSERTS on private state)."""
     session = make_session(tmp_path, monkeypatch=monkeypatch)
     collected = collect_events(session)
+    # #5557: this ``.emit()`` DRIVES the scenario (produces a real event for
+    # collect_events(session) to genuinely capture) — the assert below reads
+    # `collected`, but the claim under test is "collect_events(session) is
+    # correctly wired", not "production emits `tool_executed` in some
+    # specific business flow". The event type/payload are arbitrary
+    # placeholders; any real event would serve identically. Not the
+    # #5557-named "test fakes what production is supposed to emit" pattern.
     session._audit_events.emit("tool_executed", op="read_file", path="/tmp/x")
     # #5467: deliberately ``session._audit_events.drain()``, NOT
     # ``settle(session)`` — this witness's own claim is "collect_events(session)
@@ -129,6 +136,10 @@ async def test_settle_accepts_a_session_witness_2(tmp_path, monkeypatch) -> None
     right queue."""
     session = make_session(tmp_path, monkeypatch=monkeypatch)
     collected = collect_events(session)
+    # #5557: same reasoning as witness ① above — this ``.emit()`` drives
+    # the scenario (produces a real event for settle(session) to genuinely
+    # drain), the claim is about the settle() plumbing, not a specific
+    # production behavior.
     session._audit_events.emit("tool_executed", op="read_file", path="/tmp/x")
     await settle(session)
     assert [e.type for e in collected] == ["tool_executed"]

--- a/tests/core/test_4496_pr2_event_backend.py
+++ b/tests/core/test_4496_pr2_event_backend.py
@@ -277,6 +277,10 @@ async def test_session_with_discard_backend_still_delivers_to_real_subscribers(
 
     received = []
     session.subscribe_audit_events(received.append)
+    # #5557: "test_event" is a synthetic, non-production event type — this
+    # emit exists only to drive the "does subscribe_audit_events deliver
+    # regardless of the configured backend" plumbing witness above; the
+    # claim is not that production ever emits an event named "test_event".
     emitted = session._audit_events.emit("test_event", foo="bar")
     await settle(session)  # #4961 C: see the file's first test
 

--- a/tests/core/test_5260_session_subscribe_audit_events_kinds.py
+++ b/tests/core/test_5260_session_subscribe_audit_events_kinds.py
@@ -35,6 +35,11 @@ async def test_a_kinds_declaration_through_the_public_seam_is_honoured() -> None
         lambda e: received.append(e.type), kinds={"session_halted"},
     )
 
+    # #5557: both emits below drive the "does the kinds= filter pass/block
+    # by type" mechanism witness — the specific event types are arbitrary
+    # (any two distinct real kinds would serve identically); the claim is
+    # about subscribe_audit_events's filter, not about when production
+    # actually emits session_halted/visibility_changed.
     session._audit_events.emit("session_halted", reason="test")
     session._audit_events.emit("visibility_changed", kind="tool", name="x", on=True, applied=True)
     await settle(session._audit_events)
@@ -56,6 +61,8 @@ async def test_omitting_kinds_still_admits_every_event() -> None:
     received: list[str] = []
     session.subscribe_audit_events(lambda e: received.append(e.type))
 
+    # #5557: same reasoning as the test above — drives the "no kinds= means
+    # every event admitted" mechanism witness, event types are arbitrary.
     session._audit_events.emit("session_halted", reason="test")
     session._audit_events.emit("visibility_changed", kind="tool", name="x", on=True, applied=True)
     await settle(session._audit_events)

--- a/tests/core/test_5329_shutdown_sentinel_halted_reason.py
+++ b/tests/core/test_5329_shutdown_sentinel_halted_reason.py
@@ -150,6 +150,20 @@ async def test_shutdown_sentinel_branch_respects_an_already_set_reason(tmp_path)
     # handler does, immediately, before its while-loop's next condition
     # check) THEN queue the shutdown sentinel — the shape a real cancel
     # racing a real shutdown produces.
+    #
+    # #5557 positive control (observed, not assumed): stripped this manual
+    # emit and drove session.run() through a REAL Task.cancel() instead —
+    # production's own except asyncio.CancelledError handler in
+    # Session.run() genuinely emits session_halted(reason="cancelled")
+    # through this exact code path with no test-side fabrication. Observed
+    # directly: `STRIP-TEST OBSERVED halted_reason: cancelled` /
+    # `STRIP-TEST OBSERVED events: [..., 'session_halted', ...]`. The SAME
+    # real-cancel path is independently pinned end-to-end by
+    # test_3377_run_loop_survives_turn_cancel.py::test_cancelling_the_
+    # session_still_stops_the_loop_and_records_it, so this test's own
+    # manual emit — standing in for that sibling path so THIS test can
+    # focus on its own claim (the shutdown-sentinel branch must not
+    # double-emit) — is legitimate driving, not a fake.
     session._halted_reason = "cancelled"
     session._audit_events.emit("session_halted", reason="cancelled")
     await settle(session._audit_events)

--- a/tests/interfaces/test_3310_n3_remote_switch_parity.py
+++ b/tests/interfaces/test_3310_n3_remote_switch_parity.py
@@ -489,6 +489,13 @@ async def test_switch_announce_precedes_any_new_session_audit_event(tmp_path) ->
         source.start()
 
         async def _adversary() -> None:
+            # #5557: this emit is a flood/racing SIGNAL for the ordering
+            # witness below (announce-before-subscribe) — the assertion
+            # reads the POSITION of these events relative to a barrier, not
+            # their content or whether production would emit turn_started
+            # here specifically. "turn_started" is chosen only because it's
+            # in the renderer-forwarded type set; any forwarded type would
+            # serve identically.
             for _ in range(200):
                 session_b._audit_events.emit("turn_started")
                 await asyncio.sleep(0)

--- a/tests/interfaces/test_5041_1_frame_agent_attribution.py
+++ b/tests/interfaces/test_5041_1_frame_agent_attribution.py
@@ -177,6 +177,12 @@ async def test_audit_event_frame_carries_the_currently_attached_agents_name(
         transport = InProcessTransport(reg, intervention_channel="test-5041")
         transport.start()
         try:
+            # #5557: this emit only DRIVES frame creation on the audit-event
+            # path — the assert below reads `frame.agent` (a PRODUCTION-
+            # computed attribution field, read fresh from
+            # `registry.attached_name` at frame-build time), never this
+            # emit's own type/chain_id. The event.type filter just finds
+            # the right frame; "turn_started" could be any forwarded kind.
             alpha._audit_events.emit("turn_started", chain_id="c-5041")
             frame = None
             while frame is None:

--- a/tests/runtime/test_5276_mcp_subscription_reactive_cache.py
+++ b/tests/runtime/test_5276_mcp_subscription_reactive_cache.py
@@ -112,6 +112,11 @@ async def test_a_relevant_event_marks_dirty_but_does_not_itself_recompute(
     s.mcp_subscription_state()  # lazy fill: 1 real call
     assert call_count["n"] == 1
 
+    # #5557: this emit only drives the dirty-marking scenario — every
+    # assert in this test reads `call_count` (an unrelated collaborator's
+    # own call tally via `_counting_wrapper`), never this emit's own
+    # type/data. The event kind matters only insofar as it's IN the
+    # subscribed set; the payload is arbitrary.
     s._audit_events.emit("mcp_resource_subscribed", server="srv", uri="resource://x")
     await settle(s._audit_events)
 
@@ -152,6 +157,8 @@ async def test_mcp_reconnect_failed_also_marks_dirty(tmp_path, monkeypatch) -> N
     s.mcp_subscription_state()  # lazy fill: 1 real call
     assert call_count["n"] == 1
 
+    # #5557: same reasoning as the previous test — drives dirty-marking,
+    # every assert reads `call_count`, not this emit's own event.
     s._audit_events.emit("mcp_reconnect_failed", server="srv")
     await settle(s._audit_events)
 
@@ -178,6 +185,8 @@ async def test_an_unrelated_event_does_not_trigger_a_recompute(tmp_path, monkeyp
     s.mcp_subscription_state()  # lazy fill: 1 real call
     assert call_count["n"] == 1
 
+    # #5557: same reasoning — this is the falsification contrast (an
+    # unrelated kind), asserts still only read `call_count`.
     s._audit_events.emit("user_submitted", text="hello", chain_id="c1", msg_id="m1", seq=1)
     await settle(s._audit_events)
 

--- a/tests/runtime/test_multisession_history_isolation_2348.py
+++ b/tests/runtime/test_multisession_history_isolation_2348.py
@@ -77,6 +77,10 @@ async def test_spawned_events_isolated_and_forwarder_survives_rewire(tmp_path, m
 
     assert a.events_dir != main.events_dir, "spawned session must have an isolated events dir"
 
+    # #5557: "budget_warn" is an arbitrary payload driving the #2348 event-
+    # dir isolation + forwarder-survival witnesses below (outbox delivery,
+    # per-session dir routing) — any real event type would serve
+    # identically. Not a claim that production emits budget_warn here.
     a._audit_events.emit("budget_warn", dimension="daily_tokens")
     await settle(a)
 

--- a/tests/runtime/test_teardown_completeness_2783.py
+++ b/tests/runtime/test_teardown_completeness_2783.py
@@ -69,6 +69,10 @@ async def test_shutdown_drains_event_store(tmp_path, monkeypatch):
     reg = _make_registry(tmp_path)
     session = reg.get_or_load("owner")
 
+    # #5557: "budget_warn" is an arbitrary payload — this test's claim is
+    # about registry.shutdown()'s DRAIN mechanism (a queued-but-unwritten
+    # event lands on disk before exit), any real event type would serve
+    # identically. Not a claim that production emits budget_warn here.
     session._audit_events.emit("budget_warn", dimension="daily_tokens")
     await reg.shutdown()
 
@@ -196,6 +200,9 @@ async def test_remove_session_closes_event_store_synchronously_before_cancel(tmp
     spawned = reg.get_session("owner", spawned_sid)
     spawned.register_intervention_listener("test")
 
+    # #5557: same reasoning as the sibling test above — this claim is
+    # about remove_session()'s own synchronous-close ordering, not about
+    # production emitting budget_warn.
     spawned._audit_events.emit("budget_warn", dimension="daily_tokens")
 
     await reg.remove_session("owner", spawned_sid, record=False)


### PR DESCRIPTION
**[tui-coder]** — part of #5557 (misc files, 9 file / 16 site)

Judgment table posted to the issue (https://github.com/tya5/reyn/issues/5557#issuecomment-5467750581): all 37 `._audit_events.emit(...)` sites classified. This PR carries the in-file evidence for the 16 `(a)` DRIVING sites in the 9 non-`test_mcp_install_state_change_emitter.py` files (that file, 15 sites, is a separate PR per the issue's own split instruction). No (b) sites exist in this repo at time of census — confirmed via a real positive-control strip-test (see issue comment: https://github.com/tya5/reyn/issues/5557#issuecomment-5467773495).

## 判別子(issue本文どおり)

「そのtestのassertが、そのemitが出したeventを読んでいるか」— 読んでいれば(b)疑い、読んでいなければ(a)駆動。

## このPRでやったこと

各サイトに `#5557` タグ付きの逐語コメントを追加(なぜ(a)か、根拠1文):

- `test_3868_collect_events_helper.py`(2件): #5467自身のwitness、合成イベントでplumbingを証明
- `test_4496_pr2_event_backend.py`(1件): "test_event"という合成type、backend配送のplumbing witness
- `test_5260_session_subscribe_audit_events_kinds.py`(4件): kindsフィルタ機構自体のwitness
- `test_5329_shutdown_sentinel_halted_reason.py`(1件): 正の対照で実証済み(production も同じ経路でsession_haltedを出す、strip-test観測済み)
- `test_3310_n3_remote_switch_parity.py`(1件): adversary flood、位置(順序)を読むだけ
- `test_5041_1_frame_agent_attribution.py`(1件): frame生成のトリガー、assertは別artifact(frame.agent)を読む
- `test_5276_mcp_subscription_reactive_cache.py`(3件): dirty-marking機構のwitness、assertはcall_countを読む
- `test_multisession_history_isolation_2348.py`(1件): #2348 isolation/forwarder witnessの任意payload
- `test_teardown_completeness_2783.py`(2件): #2783 drainメカニズムのwitness、任意payload

## 検証

- pytest(該当9ファイル) — 56/56 green
- ruff clean / tier_audit --strict clean(56 tests) / collect-events-settle gate green / verify_module_docstrings OK

## Test plan
- [x] pytest(変更9ファイル) — 56/56 green
- [x] ruff / tier_audit --strict / collect-events-settle gate / verify_module_docstrings — all clean
- [x] (skipped — no UI/TUI surface touched) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
