### PR TITLE
fix(#5578): durable compaction reservation is no longer byte-axis-only

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -2402,7 +2402,7 @@ chat:
     body_token_cap: 1500               # hard cap on summary body tokens (post-truncation)
     resummarize_passes: 1              # LLM re-compression passes before hard_truncate floor
     max_schema_reprompt_attempts: 1    # bounded re-prompt budget on invalid compaction JSON
-    recovery_policy: next_turn         # #5296: compaction only; spill follows the constraint
+    recovery_policy: next_turn         # #5296/#5578: compaction only, any overflow axis; spill follows the constraint
     max_shrink_iterations: 8           # orphaned since #5531 PR-3 -- parses/validates, nothing reads it
     # Section budget weights within body, normalised at runtime.
     section_weights:
@@ -2429,7 +2429,7 @@ chat:
 | `body_token_cap` | int | `1500` | Hard cap on summary body tokens after post-truncation. |
 | `resummarize_passes` | int | `1` | Max LLM re-compression passes when a produced `topic_arc` overshoots its body budget, before the deterministic `hard_truncate` floor. `0` = skip re-summary (straight to the floor). |
 | `max_schema_reprompt_attempts` | int | `1` | #4883: bounded re-prompt budget when the compaction LLM's JSON response has an empty/missing `topic_arc` (whose emptiness can't be told apart from a dead response). Exhausting the budget raises rather than silently accepting an empty summary. `0` = raise on the first invalid response, no re-prompt. `new_turn_seqs` plays no part in this: `covers_through_seq` is derived from `compact()`'s own input, never read from an LLM echo (#4951-A) — and #4951-B removed the `new_turn_seqs` key from the schema/prompt entirely, so there is nothing left to gate or not gate. |
-| `recovery_policy` | `never` \| `next_turn` | `next_turn` | #5296: controls only irreversible compaction after measured byte-limit exhaustion. `next_turn` preserves the current behavior: compaction is persisted for the following turn; `never` skips compaction and ends with the existing structured error. It does not control spill; spill is triggered by the constraint itself. |
+| `recovery_policy` | `never` \| `next_turn` | `next_turn` | #5296: controls only irreversible compaction after a measured shrink-ladder exhaustion (`UnrecoveredError`) — any overflow axis, byte-limit (HTTP 413) or token-context, since #5578 (pre-#5578 this only fired for a byte-limit cause; a token-cause exhaustion had no persisted recovery at all, so every subsequent turn re-ran the identical shrink from the same un-compacted history). `next_turn` preserves the current behavior: compaction is persisted for the following turn; `never` skips compaction and ends with the existing structured error. It does not control spill; spill is triggered by the constraint itself. |
 | `max_shrink_iterations` | int | `8` | 🔴 **Orphaned since #5531 PR-3** — `retry_loop` no longer takes an iteration cap at all (termination is a proven lexicographic measure, not a count; see `retry_loop`'s own "Bounded termination proof" docstring). This field still parses and validates (`>= 1`) but nothing reads it. Removing the field itself (schema/validation/this row/its own dedicated test file) is a disclosed, separate follow-up — kept here, marked, rather than silently left claiming a live effect it no longer has. |
 | `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out for large deployments). |
 

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -13,10 +13,11 @@ look like, so acting on it risked compacting a conversation that would
 have fit fine (#5296 decided this in principle, #5528 carried it out).
 Auto-compaction is now driven solely by the ``retry_loop`` overflow
 recovery path (:meth:`force_compact_now`, reached reactively on an actual
-measured overflow — see ``router_loop_driver.py``'s own byte-limit
-recovery call), plus on-demand (the ``compact`` op / ``/compact``). With
-no background task, compaction always runs synchronously inside the
-serial router handler.
+measured overflow — see ``router_loop_driver.py``'s own recovery call,
+#5578: axis-agnostic since then, byte- and token-cause exhaustion alike),
+plus on-demand (the ``compact`` op / ``/compact``). With no background
+task, compaction always runs synchronously inside the serial router
+handler.
 
 All event emissions go through the injected ``event_log``; no silent
 state changes (P6).  Business logic lives entirely here; Session

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -454,14 +454,21 @@ class RouterLoopDriver:
         raise on the FIRST mid-only spill instead of trying the next one.
 
         force_compact_now double-call check (asked for explicitly, #5364
-        §1.6): ``_run_with_shrink``'s OWN except block conditionally calls
-        ``force_compact_now()``, but ONLY when ``saw_byte_limit`` is True
-        (see that method's own docstring) — a token-cause retry re-enters
-        ``_run_with_shrink`` with ``saw_byte_limit=False`` on that
-        particular failure, so this wrapper making token-cause overflow
-        retryable does NOT make that side-effect fire twice; it simply
-        never gates on a token-cause failure at all, unchanged from
-        before this fix.
+        §1.6; corrected #5578): ``_run_with_shrink``'s OWN except block
+        conditionally calls ``force_compact_now()`` — pre-#5578, ONLY when
+        ``saw_byte_limit`` was True; #5578 dropped that axis gate, so it
+        now fires whenever ``recovery_policy == "next_turn"``, on EITHER
+        axis (see that except block's own comment for why the old
+        byte-only gate's reason — #4885's proactive pre-trigger already
+        handling the token axis — no longer holds; #5528 removed that
+        pre-trigger). A token-cause retry CAN now re-enter
+        ``_run_with_shrink`` and hit that side-effect again on this
+        wrapper's own next iteration — this is NOT a new double-call risk:
+        ``force_compact_now()`` itself already returns immediately once
+        the watermark has caught up to everything durably available (zero
+        candidates), the SAME bound the byte-axis case already relied on
+        before this fix. Each repeat is a cheap no-op, not a repeated
+        summarization LLM call.
         """
         from reyn.services.compaction.engine import UnrecoveredError as _UnrecoveredError
 
@@ -793,54 +800,72 @@ class RouterLoopDriver:
                     # fixtures that still pass it) is its own scoped
                     # follow-up, not folded into this already-large PR.
                 )
-            except _UnrecoveredError as _unrecovered:
-                # #4954 (b), architect-ruled: on a BYTE-limit exhaustion
-                # (an HTTP 413 that recurred all the way to retry_loop's
-                # own terminal condition), trigger a REAL compaction here
-                # — in the driver's except block, not inside retry_loop
-                # itself (retry_loop stays a pure TRANSPORT operation;
-                # compaction is the SEMANTIC operation that actually
-                # retires history entries, Session's own docstring:
-                # "the only operation meant to retire an entry"). Routed
-                # through `force_compact_now` — the SAME durable-watermark
-                # path `ContextBudgetAdvisor`'s pre-frame guard already
-                # uses (`_durable_active_history_after`-backed,
-                # continuous from the last real `covers_through_seq`) —
-                # deliberately NOT `retry_loop`'s own compaction result:
-                # its `covers` can cover only `raw_middle` while skipping
-                # `head` entirely, which is not continuous from the
-                # previous watermark and would silently mark the OLDEST
-                # unsummarized part of history "covered" without ever
-                # summarizing it (exactly owner's own real-machine shape).
+            except _UnrecoveredError:
+                # #4954 (b), architect-ruled, WIDENED #5578: on ANY
+                # UnrecoveredError exhaustion (byte-limit 413 OR a
+                # non-byte, token-axis terminal cause — no longer gated on
+                # `_unrecovered.saw_byte_limit`), trigger a REAL compaction
+                # here — in the driver's except block, not inside
+                # retry_loop itself (retry_loop stays a pure TRANSPORT
+                # operation; compaction is the SEMANTIC operation that
+                # actually retires history entries, Session's own
+                # docstring: "the only operation meant to retire an
+                # entry"). Routed through `force_compact_now` — the SAME
+                # durable-watermark path `ContextBudgetAdvisor`'s
+                # pre-frame guard already uses
+                # (`_durable_active_history_after`-backed, continuous from
+                # the last real `covers_through_seq`) — deliberately NOT
+                # `retry_loop`'s own compaction result: its `covers` can
+                # cover only `raw_middle` while skipping `head` entirely,
+                # which is not continuous from the previous watermark and
+                # would silently mark the OLDEST unsummarized part of
+                # history "covered" without ever summarizing it (exactly
+                # owner's own real-machine shape).
                 #
-                # This turn still fails — re-raised below unchanged. What
-                # this buys is the NEXT turn: a real compaction now
-                # advances the watermark, so a persistent 413 becomes "one
-                # turn fails, not every turn" once paired with #4958 (the
-                # projection that reads the advanced watermark back). No
-                # new infinite-loop guard needed — force_compact_now
-                # already returns immediately on `self._compacting` (a
-                # concurrent pass) or zero candidates (nothing left to
-                # compact = terminal), and this except fires at most once
-                # per turn.
+                # #5578: previously gated on `_unrecovered.saw_byte_limit`
+                # — a token-cause exhaustion never reached this line at
+                # all. That gate's OWN stated reason (this file's own,
+                # now-removed docstring, quoting #4885/architect ruling
+                # ④): "a token overflow reaching this point means #4885's
+                # own pre-trigger estimate was wrong; the adaptive learner
+                # fixes that, not a second compaction trigger here." That
+                # pre-trigger (`ContextBudgetAdvisor.maybe_force_compact`,
+                # estimate-based, proactive) no longer exists — #5528
+                # (owner ruling, same family as #5367's elide removal)
+                # removed it, verbatim: "a local token estimate cannot
+                # know what the actual provider payload will look like, so
+                # acting on it risked compacting a conversation that would
+                # have fit fine" (compaction_controller.py's own module
+                # docstring, which this PR also corrects — see its own
+                # #5578 note). With no pre-trigger left, a token-cause
+                # exhaustion has NO durable recovery path at all — every
+                # turn re-starts from the same un-compacted history and
+                # re-runs the identical (LLM-call-costing) shrink from
+                # scratch (owner's own real-machine report, #5578: reyn-
+                # self history.jsonl files grew to 4.6-5.9MB over 5 days
+                # with no persisted compaction). `recovery_policy`'s own
+                # docstring (config/chat.py) never named an axis — it is
+                # declared as a stop-line on the "irreversible compaction
+                # step" itself, not on byte-specifically — so this widening
+                # corrects the call site to match the config's own already
+                # axis-agnostic contract, not a new design decision.
                 #
-                # #5364 §1.6: this except block can now be reached MORE
-                # THAN ONCE per turn for a non-byte (token-axis) cause too
-                # — `_run_with_shrink_and_byte_reduction` retries on ANY
-                # `UnrecoveredError`, mode-independent, not only a
-                # byte-limited one (the OLD gate here read "a token
-                # overflow reaching this point means #4885's pre-trigger
-                # estimate was wrong" — that assumed a token-cause failure
-                # could only ever reach here ONCE, which is no longer
-                # true: it is the expected shape on retry iterations 2+
-                # after a spill made progress). The `saw_byte_limit` check
-                # immediately below is UNCHANGED by this — a token-cause
-                # retry still skips `force_compact_now()` here every time,
-                # exactly as before this fix.
-                if (
-                    _unrecovered.saw_byte_limit
-                    and self._compaction.recovery_policy == "next_turn"
-                ):
+                # Repeat-bounding (band's own first question — who stops
+                # this if it repeats): unchanged mechanism, now exercised
+                # on both axes. `force_compact_now` already returns
+                # immediately on `self._compacting` (a concurrent pass) or
+                # zero candidates (nothing left to compact = terminal) —
+                # #5364 §1.6's own note (right below, unchanged) already
+                # established this except block CAN be reached more than
+                # once per turn (`_run_with_shrink_and_byte_reduction`
+                # retries on ANY `UnrecoveredError`); each such repeat
+                # calls `force_compact_now()` again, but the SECOND call
+                # onward finds the watermark already caught up to
+                # everything durably available and returns immediately —
+                # no new call this PR adds, no new unbounded-repeat shape,
+                # only a gate this call already had to survive repeating
+                # under (the byte-axis case already exercised this).
+                if self._compaction.recovery_policy == "next_turn":
                     await self._compaction_controller.force_compact_now()
                 raise
             return _shim.usage

--- a/tests/runtime/test_retry_loop_chat_wiring_1125.py
+++ b/tests/runtime/test_retry_loop_chat_wiring_1125.py
@@ -402,15 +402,43 @@ def test_byte_limit_recovery_policy_controls_compaction(
     )
 
 
-def test_non_byte_limit_exhaustion_does_not_trigger_compaction(
-    tmp_path, monkeypatch,
+@pytest.mark.parametrize(
+    ("recovery_policy", "compaction_expected"),
+    [("next_turn", True), ("never", False)],
+)
+def test_token_axis_recovery_policy_controls_compaction(
+    tmp_path, monkeypatch, recovery_policy: str, compaction_expected: bool,
 ) -> None:
-    """Tier 1: falsification pair — a NON-byte-limit exhaustion
-    (`saw_byte_limit=False`) must NOT trigger `force_compact_now`.
-    #4885's own token-overflow pre-trigger already handles that axis; a
-    non-byte-limit failure reaching here means the pre-trigger's estimate
-    was wrong, which the adaptive learner fixes, not a second compaction
-    trigger here (architect ruling ④)."""
+    """Tier 1: #5578 — a token-axis (non-byte-limit) exhaustion now controls
+    real compaction identically to the byte axis, mirroring
+    ``test_byte_limit_recovery_policy_controls_compaction`` immediately above.
+
+    Pre-#5578 this test (then named
+    ``test_non_byte_limit_exhaustion_does_not_trigger_compaction``) asserted
+    the OPPOSITE — that a token-axis exhaustion must NEVER trigger
+    ``force_compact_now``, reasoning that "#4885's own token-overflow
+    pre-trigger already handles that axis; a non-byte-limit failure reaching
+    here means the pre-trigger's estimate was wrong" (architect ruling ④).
+    That premise is dead: #5528 (owner ruling, same family as #5367's elide
+    removal) removed the pre-trigger it named
+    (``ContextBudgetAdvisor.maybe_force_compact``) entirely — verbatim,
+    compaction_controller.py's own module docstring: "a local token estimate
+    cannot know what the actual provider payload will look like, so acting
+    on it risked compacting a conversation that would have fit fine." With
+    the pre-trigger gone, a token-axis exhaustion had NO durable recovery
+    path left at all — every turn re-started from the same un-compacted
+    history and re-ran the identical shrink from scratch (owner's own
+    real-machine report, #5578: reyn-self history.jsonl grew to 4.6-5.9MB
+    over 5 days with zero persisted compaction). This is not "fixed the
+    test to pass" — the mechanism the old assertion depended on no longer
+    exists; the correct assertion changed with it.
+
+    ``recovery_policy``'s own docstring (config/chat.py) never named an
+    axis — it is declared as a stop-line on the "irreversible compaction
+    step" itself, not byte-specifically — so widening the call site to
+    match is a correction to the config's own already-declared scope, not
+    a new design decision.
+    """
     from reyn.services.compaction.engine import UnrecoveredError
 
     cfg = CompactionConfig(
@@ -418,6 +446,7 @@ def test_non_byte_limit_exhaustion_does_not_trigger_compaction(
         use_chars4_estimate=True,
         section_caps_spec_tokens=0,
         max_shrink_iterations=3,
+        recovery_policy=recovery_policy,
     )
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
     bt = BudgetTracker(CostConfig())
@@ -449,7 +478,7 @@ def test_non_byte_limit_exhaustion_does_not_trigger_compaction(
 
     assert excinfo.value.saw_byte_limit is False
     checks = [e for e in events if e.type == "compaction_check"]
-    assert not checks, (
-        f"force_compact_now must not fire on a non-byte-limit exhaustion; "
-        f"observed: {[e.data for e in checks]!r}"
+    assert bool(checks) is compaction_expected, (
+        f"recovery_policy={recovery_policy!r} expected compaction="
+        f"{compaction_expected}, observed: {[e.data for e in checks]!r}"
     )


### PR DESCRIPTION
**[e2e-coder]** — Widens `recovery_policy`'s trigger from byte-axis-only to any overflow axis, closing the "why does every turn shrink" gap ([#5578](https://github.com/tya5/reyn/issues/5578)), per lead-coder's ruling on this session's own reading (issuecomment-5467793425).

See the commit message for the full trace: root cause, why this is a config-scope correction (not a new design decision — `recovery_policy`'s own docstring never named an axis), the 3 things falsified before writing any code, the doc-drift fixes landed in the same PR (`compaction_controller.py`'s module docstring, `_run_with_shrink_and_byte_reduction`'s own docstring, `reyn-yaml.md`), the band answer, and the strip-falsify evidence.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_retry_loop_chat_wiring_1125.py` — 9 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py <2 changed src files>` — clean
- [x] `python scripts/mypy_ratchet.py` — 200 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `python scripts/check_bare_tests_import_reference.py` — clean (tests/ touched)
- [x] `python scripts/check_file_depth_reference.py` — clean (tests/ touched)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — built clean (docs/ touched)
- [x] `python scripts/check_doc_anchors.py` — "no dangling anchors into published pages"
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Related test sweep: 82 tests across quota/classification/overflow-ladder/byte-reduction suites — all pass
- [x] (skipped — no visual surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)