### PR TITLE
fix(#5557): document (a)-driving reasoning for test_mcp_install's 15 emit sites

### DIFF
--- a/tests/core/test_mcp_install_state_change_emitter.py
+++ b/tests/core/test_mcp_install_state_change_emitter.py
@@ -26,6 +26,21 @@ Pins:
 Tier 2 because the contract is the foundation for the rest of the
 #398 v4 emitter family — config_watcher / sp_loader / etc. follow the
 same dispatch table pattern.
+
+#5557 classification (all 15 ``._audit_events.emit(...)`` sites in this
+file, applying the issue's own discriminator — "does the assert read
+the event THIS emit produced?"): (a) DRIVING, uniformly. Every emit here
+DRIVES the ``_on_audit_event_for_state_change`` subscriber under test;
+every assert in this file reads ``_state_changes(session)`` — a
+DERIVED history entry the subscriber mints — never the raw emitted
+event's own type/data. The event names/payloads (``mcp_server_
+installed``, ``mcp_server_removed``, ``index_dropped``, and the
+deliberately-non-mapped ``router_iteration_started``/``llm_called``/
+``act_executed`` used as negative controls) are the INPUT the dispatch
+table under test is keyed on, not a claim that this file witnesses
+whether production actually fires them in some specific business
+scenario — that's covered elsewhere (the real op_runtime handlers that
+emit these events on a genuine install/remove/index-drop).
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[tui-coder]** — part of #5557 (test_mcp_install_state_change_emitter.py, 15 site, own PR per issue's own split instruction)

Judgment table posted to the issue (https://github.com/tya5/reyn/issues/5557#issuecomment-5467750581): all 37 sites classified. All 15 `._audit_events.emit(...)` sites in this file are `(a)` DRIVING.

## 判別子(issue本文どおり)

「そのtestのassertが、そのemitが出したeventを読んでいるか」

## 根拠(1箇所にまとめて記録)

この file の全testが同じ構造 — `_on_audit_event_for_state_change` subscriberをdriveするために生eventをemitし、assertは全て`_state_changes(session)`(subscriberがmintするderived history entry)を読む、生eventの内容は読まない。`router_iteration_started`/`llm_called`/`act_executed`は「dispatch tableに無いeventは無視される」ことを示す否定側の対照。「productionがこの特定シナリオでこのeventを出すか」の主張はこのfileの範囲外(それは実際のop_runtimeハンドラの仕事で、別途カバーされている)。

15箇所を個別にコメントせず、moduleのdocstring 1箇所にまとめて記録(全箇所が同一の理由のため)。

## 検証

- pytest — 10/10 green
- ruff clean / tier_audit --strict clean(10 tests) / verify_module_docstrings OK

## Test plan
- [x] pytest — 10/10 green
- [x] ruff / tier_audit --strict / verify_module_docstrings — all clean
- [x] (skipped — no UI/TUI surface touched) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
