### PR TITLE
fix(#5577): both overflow-classification arms in router_loop_driver.py now use classify_llm_failure

### DIFF
--- a/docs/concepts/data-retrieval/chat-compaction.md
+++ b/docs/concepts/data-retrieval/chat-compaction.md
@@ -86,9 +86,13 @@ forever or silently drops content.
 ### Two failure sites, one way in
 
 Recovery is entered from exactly one place: `retry_loop` is called only after
-the *router's own* call raised something `_is_context_overflow_error` accepts. A
-`compact()` overflow is therefore never a way in — it is a failure **nested
-inside** a recovery already under way.
+the *router's own* call raised something `classify_llm_failure` classifies as
+`OVERFLOW` (#5577 — both this entry gate and the retry-arm inside
+`_router_main_call` classify through the same function, not
+`is_context_overflow_error`'s own keyword fallback alone, so a FATAL or
+RETRYABLE cause whose message text merely resembles an overflow no longer
+enters here). A `compact()` overflow is therefore never a way in — it is a
+failure **nested inside** a recovery already under way.
 
 The two sites still shrink **different payloads**, so they draw from different
 candidates. Conflating them touches a compartment that was not even sent.

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -537,11 +537,17 @@ class RouterLoopDriver:
         from reyn.services.compaction.engine import (
             ContextOverflowError as _ContextOverflowError,
         )
+
+        # #5577: both call sites in this method (below and in
+        # ``_router_main_call`` further down) now classify through the
+        # SAME ``classify_llm_failure`` — see each call site's own comment
+        # for what changed and why.
+        from reyn.services.compaction.engine import LLMFailureClass as _LLMFailureClass
         from reyn.services.compaction.engine import (
             UnrecoveredError as _UnrecoveredError,
         )
         from reyn.services.compaction.engine import (
-            is_context_overflow_error as _is_context_overflow_error,
+            classify_llm_failure as _classify_llm_failure,
         )
         # #4954 (b): `UnrecoveredError` IS caught here now, but only to
         # read `.saw_byte_limit` and trigger a real compaction as a side
@@ -576,46 +582,33 @@ class RouterLoopDriver:
         try:
             return await loop.run(user_text=user_text, history=history)
         except Exception as _exc:
-            # #5256: a provider usage-window/plan quota exhaustion is NEVER
-            # shrinkable — it is time-based, not input-size-based — and
-            # entering retry_loop below would spend more of the SAME
-            # exhausted quota on compaction's own LLM call (the real
-            # incident: 2 agents x 2 turns x 3 shrink attempts = 12 wasted
-            # calls, each itself hitting the same 429). Without this gate,
-            # a RateLimitError whose message happens to contain a context-
-            # overflow keyword (e.g. "usage LIMIT reached") matches is_
-            # context_overflow_error's own keyword fallback and gets
-            # misdiagnosed as "context too large" — the exact defect this
-            # issue reports (see this file's own witness in test_5256_
-            # quota_not_context_overflow.py, which pins that a quota
-            # exception DOES classify as overflow today, proving this
-            # gate is load-bearing, not decorative).
+            # #5577: unified onto classify_llm_failure — previously this
+            # site hand-excluded ONLY quota (is_quota_exhausted_error)
+            # before falling to is_context_overflow_error's own keyword
+            # fallback, so a FATAL exception (a plain AttributeError/
+            # TypeError/KeyError in reyn's own glue code) or a RETRYABLE
+            # one (5xx/timeout/connection failure) whose str() happened to
+            # contain "context"/"token"/"length"/"limit"/"too long"/"too
+            # large" was NOT excluded and got misdiagnosed as overflow —
+            # the exact #3783/#5543 defect class, just left open on THIS
+            # one arm (#5577's own falsification, not assumed: verified
+            # is_quota_exhausted_error is called identically inside
+            # classify_llm_failure's own RETRYABLE branch, so removing the
+            # manual pre-check here changes nothing for quota — it is now
+            # additionally excluded for FATAL/other-RETRYABLE too, closing
+            # the gap #5543 was created to close but never reached this
+            # site).
             #
-            # Checked BEFORE is_context_overflow_error, but not because
-            # ordering changes the OUTCOME (it doesn't — that predicate
-            # calling ensure_litellm_ready_or_defer() to check for
-            # litellm.ContextWindowExceededError first, then this check
-            # right after, would still end in the same re-raise). It's
-            # checked first so the quota path never pays for warming
-            # litellm at all — a plain attribute read on exc.body, no
-            # import, no warm-up cost, for a cause that was never going to
-            # be treated as an overflow either way.
-            #
-            # Re-raising here (never wrapped in ContextOverflowError/
-            # UnrecoveredError) means it propagates to run_turn's own
-            # except, which does NOT catch a bare RateLimitError, then to
-            # Session._handle_inbox_text's generic catch-all — which
-            # already does the right thing for an un-wrapped exception:
-            # surface it via the outbox (classify_router_error) and
-            # return normally, keeping the session alive (owner ruling,
-            # #5256: quota exhaustion must never end the session).
-            from reyn.runtime.error_format import (
-                is_quota_exhausted_error as _is_quota_exhausted_error,
-            )
-            if _is_quota_exhausted_error(_exc):
-                raise
-            # #3783 stage 1: single shared predicate (was an inline copy).
-            if not _is_context_overflow_error(_exc):
+            # Re-raising when NOT OVERFLOW (never wrapped in
+            # ContextOverflowError/UnrecoveredError) means it propagates to
+            # run_turn's own except, then to Session._handle_inbox_text's
+            # generic catch-all — which already does the right thing for
+            # an un-wrapped exception: surface it via the outbox
+            # (classify_router_error) and return normally, keeping the
+            # session alive (owner ruling, #5256: quota exhaustion must
+            # never end the session — unaffected by this change, see
+            # test_5256_quota_not_context_overflow.py).
+            if _classify_llm_failure(_exc) is not _LLMFailureClass.OVERFLOW:
                 raise
             self._events.emit(
                 "router_context_overflow_detected", error=repr(_exc)
@@ -748,9 +741,23 @@ class RouterLoopDriver:
                 try:
                     _usage = await loop.run(user_text=user_text, history=_msgs)
                 except Exception as _call_exc:
-                    # #3783 stage 1: single shared predicate (was an inline
-                    # copy) — closes over the outer method's own import.
-                    if _is_context_overflow_error(_call_exc):
+                    # #5577: unified onto classify_llm_failure (closes over
+                    # the outer method's own import) — was
+                    # is_context_overflow_error alone, with NO exclusion
+                    # for a FATAL exception (AttributeError/TypeError/
+                    # KeyError) or a RETRYABLE one (5xx/timeout/quota)
+                    # whose message text happened to contain an overflow
+                    # keyword; both used to get wrapped as
+                    # ContextOverflowError and enter the shrink ladder —
+                    # burning real LLM calls chasing a cause no amount of
+                    # shrinking can fix, then reporting the wrong
+                    # diagnosis (#3783's own owner ruling, unreached here
+                    # until now). A genuine overflow (litellm's typed
+                    # ContextWindowExceededError, a 413, or an unrecognized
+                    # exception shape — classify_llm_failure's own
+                    # exhaustive-by-elimination default) is unaffected —
+                    # still wrapped and still shrinks.
+                    if _classify_llm_failure(_call_exc) is _LLMFailureClass.OVERFLOW:
                         raise _ContextOverflowError(str(_call_exc)) from _call_exc
                     raise
                 return _RouterUsageShim(_usage)

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -25,6 +25,51 @@ if TYPE_CHECKING:
     from reyn.config.chat import SafetyConfig
 
 
+def _is_shrinkable_overflow(exc: BaseException) -> bool:
+    """#5577/#5593 — is *exc* a cause the shrink ladder should be entered
+    for?
+
+    ``classify_llm_failure``'s own fallthrough is unconditionally
+    ``OVERFLOW`` for anything that is neither FATAL nor RETRYABLE — a
+    default calibrated for ``retry_loop``'s OWN inner except clause,
+    which (per that function's own docstring) "only ever catches
+    CompactionOverflowError/ContextOverflowError today, both already
+    overflow-shaped by construction" — i.e. that default never actually
+    had to defend against a genuinely unrelated exception shape reaching
+    it, because nothing UNRELATED could reach it there.
+
+    Both call sites in THIS module are different: they catch ``Exception``
+    from ``loop.run()`` — ANY exception the router/provider stack can
+    raise, including one neither FATAL, RETRYABLE, nor an overflow at all
+    (#5593's real incident: ``StructuredOutputUnsupportedModelError`` —
+    not in ``FATAL_EXC_TYPES``, not a rate-limit/timeout/5xx/quota shape,
+    so ``classify_llm_failure``'s fallthrough classified it OVERFLOW,
+    wrapped it, and the shrink ladder burned real LLM calls on a cause no
+    amount of shrinking could ever fix, then reported the wrong
+    diagnosis — UnrecoveredError, out of context, for a config error).
+
+    Fix: still exclude FATAL/RETRYABLE via ``classify_llm_failure``
+    (#5577's own gain — a quota/5xx/timeout exception whose message text
+    merely resembles an overflow keyword must not enter here), but for
+    anything classify_llm_failure's OWN 3-way split does not itself
+    prove is FATAL or RETRYABLE, require the STRONGER, narrower
+    ``is_context_overflow_error`` signal too (litellm's typed
+    ``ContextWindowExceededError``, a 413, or an overflow keyword) —
+    restoring the pre-#5577 conservative default (unmatched shape =
+    False, do not enter) for this module's own two call sites, which
+    ``classify_llm_failure``'s bare fallthrough was never designed to
+    answer for."""
+    from reyn.services.compaction.engine import LLMFailureClass, classify_llm_failure
+    from reyn.services.compaction.engine import (
+        is_context_overflow_error as _is_context_overflow_error,
+    )
+
+    failure_class = classify_llm_failure(exc)
+    if failure_class in (LLMFailureClass.FATAL, LLMFailureClass.RETRYABLE):
+        return False
+    return _is_context_overflow_error(exc)
+
+
 def _narrowing_per_iteration(safety: "SafetyConfig") -> bool:
     """Whether ``safety.threat_scan.capability_narrowing`` is at the ``iteration``
     rung (#3501). Delegates to the config object's own predicate rather than
@@ -538,16 +583,12 @@ class RouterLoopDriver:
             ContextOverflowError as _ContextOverflowError,
         )
 
-        # #5577: both call sites in this method (below and in
-        # ``_router_main_call`` further down) now classify through the
-        # SAME ``classify_llm_failure`` — see each call site's own comment
-        # for what changed and why.
-        from reyn.services.compaction.engine import LLMFailureClass as _LLMFailureClass
+        # #5577/#5593: both call sites in this method (below and in
+        # ``_router_main_call`` further down) now classify through
+        # ``_is_shrinkable_overflow`` — see that helper's own docstring
+        # and each call site's own comment for what changed and why.
         from reyn.services.compaction.engine import (
             UnrecoveredError as _UnrecoveredError,
-        )
-        from reyn.services.compaction.engine import (
-            classify_llm_failure as _classify_llm_failure,
         )
         # #4954 (b): `UnrecoveredError` IS caught here now, but only to
         # read `.saw_byte_limit` and trigger a real compaction as a side
@@ -582,24 +623,16 @@ class RouterLoopDriver:
         try:
             return await loop.run(user_text=user_text, history=history)
         except Exception as _exc:
-            # #5577: unified onto classify_llm_failure — previously this
-            # site hand-excluded ONLY quota (is_quota_exhausted_error)
-            # before falling to is_context_overflow_error's own keyword
-            # fallback, so a FATAL exception (a plain AttributeError/
-            # TypeError/KeyError in reyn's own glue code) or a RETRYABLE
-            # one (5xx/timeout/connection failure) whose str() happened to
-            # contain "context"/"token"/"length"/"limit"/"too long"/"too
-            # large" was NOT excluded and got misdiagnosed as overflow —
-            # the exact #3783/#5543 defect class, just left open on THIS
-            # one arm (#5577's own falsification, not assumed: verified
-            # is_quota_exhausted_error is called identically inside
-            # classify_llm_failure's own RETRYABLE branch, so removing the
-            # manual pre-check here changes nothing for quota — it is now
-            # additionally excluded for FATAL/other-RETRYABLE too, closing
-            # the gap #5543 was created to close but never reached this
-            # site).
+            # #5577/#5593: unified onto ``_is_shrinkable_overflow`` (this
+            # module's own helper — see its docstring for the full
+            # history: #5577 first unified onto classify_llm_failure
+            # alone, which fixed quota/FATAL/RETRYABLE misdiagnosis but
+            # introduced a real regression #5593 caught — an unrelated
+            # exception, neither FATAL/RETRYABLE nor a real overflow,
+            # fell through classify_llm_failure's own unconditional
+            # OVERFLOW default and entered the shrink ladder anyway).
             #
-            # Re-raising when NOT OVERFLOW (never wrapped in
+            # Re-raising when NOT a shrinkable overflow (never wrapped in
             # ContextOverflowError/UnrecoveredError) means it propagates to
             # run_turn's own except, then to Session._handle_inbox_text's
             # generic catch-all — which already does the right thing for
@@ -608,7 +641,7 @@ class RouterLoopDriver:
             # session alive (owner ruling, #5256: quota exhaustion must
             # never end the session — unaffected by this change, see
             # test_5256_quota_not_context_overflow.py).
-            if _classify_llm_failure(_exc) is not _LLMFailureClass.OVERFLOW:
+            if not _is_shrinkable_overflow(_exc):
                 raise
             self._events.emit(
                 "router_context_overflow_detected", error=repr(_exc)
@@ -741,23 +774,24 @@ class RouterLoopDriver:
                 try:
                     _usage = await loop.run(user_text=user_text, history=_msgs)
                 except Exception as _call_exc:
-                    # #5577: unified onto classify_llm_failure (closes over
-                    # the outer method's own import) — was
-                    # is_context_overflow_error alone, with NO exclusion
-                    # for a FATAL exception (AttributeError/TypeError/
-                    # KeyError) or a RETRYABLE one (5xx/timeout/quota)
-                    # whose message text happened to contain an overflow
-                    # keyword; both used to get wrapped as
-                    # ContextOverflowError and enter the shrink ladder —
-                    # burning real LLM calls chasing a cause no amount of
-                    # shrinking can fix, then reporting the wrong
-                    # diagnosis (#3783's own owner ruling, unreached here
-                    # until now). A genuine overflow (litellm's typed
-                    # ContextWindowExceededError, a 413, or an unrecognized
-                    # exception shape — classify_llm_failure's own
-                    # exhaustive-by-elimination default) is unaffected —
-                    # still wrapped and still shrinks.
-                    if _classify_llm_failure(_call_exc) is _LLMFailureClass.OVERFLOW:
+                    # #5577/#5593: unified onto ``_is_shrinkable_overflow``
+                    # — was is_context_overflow_error alone (#5577's own
+                    # pre-fix), with NO exclusion for a FATAL exception
+                    # (AttributeError/TypeError/KeyError) or a RETRYABLE
+                    # one (5xx/timeout/quota) whose message text happened
+                    # to contain an overflow keyword; both used to get
+                    # wrapped as ContextOverflowError and enter the shrink
+                    # ladder — burning real LLM calls chasing a cause no
+                    # amount of shrinking can fix, then reporting the
+                    # wrong diagnosis (#3783's own owner ruling, unreached
+                    # here until #5577). A genuine overflow (litellm's
+                    # typed ContextWindowExceededError, a 413, or an
+                    # overflow-keyword match — see the helper's own
+                    # docstring for #5593's own correction: an UNRECOGNIZED
+                    # exception shape now correctly does NOT enter, unlike
+                    # classify_llm_failure's own bare fallthrough) is
+                    # unaffected — still wrapped and still shrinks.
+                    if _is_shrinkable_overflow(_call_exc):
                         raise _ContextOverflowError(str(_call_exc)) from _call_exc
                     raise
                 return _RouterUsageShim(_usage)

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -940,14 +940,13 @@ def is_context_overflow_error(exc: BaseException) -> bool:
     to classify as True here at EVERY call site that reaches this
     function without its own quota guard first (#5256's outer
     ``_run_with_shrink`` gate always checks quota before calling this —
-    unaffected either way — but ``_router_main_call``'s own except,
-    router_loop_driver.py, calls this DIRECTLY with no such guard: a
-    quota exhaustion striking THAT call site, after ``retry_loop``'s
-    compact() call already succeeded once, would re-enter the shrink
-    ladder there instead — the SAME wasteful class #5329's compact()-wrap
-    fix closes at a DIFFERENT call site). Checked here, at the single
-    shared predicate, rather than adding a guard at each of its call
-    sites individually — #5329's own reason to exist is exactly a
+    unaffected either way; #5577 moved ``_router_main_call``'s own except,
+    router_loop_driver.py, off calling this function directly onto
+    ``classify_llm_failure`` instead — quota still excluded either way,
+    since that function's own RETRYABLE branch calls THIS SAME
+    ``is_quota_exhausted_error`` check, just one level up). Checked here,
+    at the single shared predicate, rather than adding a guard at each of
+    its call sites individually — #5329's own reason to exist is exactly a
     call-site-by-call-site guard missing one spot; a fix at the ONE
     predicate every site funnels through cannot have a missed spot.
     """

--- a/tests/runtime/test_5577_unify_overflow_classification_arms.py
+++ b/tests/runtime/test_5577_unify_overflow_classification_arms.py
@@ -1,0 +1,165 @@
+"""Tier 2: #5577 — both `router_loop_driver.py` overflow-classification
+arms now classify through `classify_llm_failure`, not
+`is_context_overflow_error` alone.
+
+Lead-coder's own trace (#5577): two call sites both catch an exception and
+decide "is this overflow, enter the shrink ladder" — arm① at
+``_run_with_shrink``'s outer except (line ~584, decides whether to enter
+``retry_loop`` at all), arm② inside ``_router_main_call`` (line ~741,
+decides whether a RETRY within an already-entered ladder wraps as
+``ContextOverflowError``). Both previously called
+``is_context_overflow_error`` directly — arm① additionally hand-excluded
+ONLY quota (``is_quota_exhausted_error``) first; arm② excluded nothing at
+all. Neither excluded a FATAL exception (a plain ``AttributeError``/
+``TypeError``/``KeyError`` in reyn's own glue code) or a RETRYABLE one
+(5xx/timeout/connection failure) whose ``str()`` happened to contain an
+overflow keyword ("context"/"token"/"length"/"limit"/"too long"/"too
+large") — both classes got misdiagnosed as overflow and entered the
+shrink ladder, burning real LLM calls chasing a cause no amount of
+shrinking can fix (#3783's own owner ruling — the defect class #5543
+created ``classify_llm_failure`` to close, left open on these two arms).
+
+Falsified before writing (issue's own 3-point ask):
+① Is ``is_quota_exhausted_error``'s manual pre-check in arm① safe to
+   remove? Read both implementations directly:
+   ``classify_llm_failure``'s RETRYABLE branch (engine.py) calls
+   ``is_quota_exhausted_error(exc)`` — the SAME function, first thing
+   checked after FATAL — so a quota exception classifies RETRYABLE
+   (never OVERFLOW) identically either way. No counter-example exists.
+② What does unifying arm② change, and is it correct? Previously-
+   misclassified FATAL/RETRYABLE-but-keyword-matching exceptions no
+   longer enter the shrink ladder — the exact direction #3783's owner
+   ruling (quoted in the source) already established as correct.
+③ `git grep is_context_overflow_error -- src/` — exactly these 2 call
+   sites remain (`router_loop_driver.py:~537,~741`); the "3 inline
+   copies" `engine.py:879`'s own comment names are historical (#3783
+   stage 1 already unified them before this issue existed).
+
+Real ``Session``/``RouterLoop`` throughout (``call_llm_tools`` patched at
+``reyn.runtime.router_loop.call_llm_tools`` with a real async callable
+that raises — never a mock, per testing.md) — same idiom
+``tests/runtime/test_5256_quota_not_context_overflow.py`` already
+establishes for this exact call-site family.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
+
+
+def test_arm1_fatal_exception_does_not_enter_shrink_ladder(monkeypatch) -> None:
+    """Tier 2: #5577 accept — arm① (``_run_with_shrink``'s outer except).
+
+    A FATAL-shaped exception (``AttributeError`` whose message contains
+    "token" — the exact shape #5568's own incident produced) on the VERY
+    FIRST LLM call must not enter the shrink ladder: exactly one LLM call,
+    no ``router_context_overflow_detected`` event, the session survives.
+    """
+    session = make_session(agent_name="arm1_fatal_test")
+    collected = collect_events(session)
+
+    call_count = 0
+
+    async def _fake_call_llm_tools(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise AttributeError("'NoneType' object has no attribute 'token'")
+
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools", _fake_call_llm_tools,
+    )
+
+    async def _drive() -> None:
+        await session._handle_inbox_text("hi", chain_id="chain-arm1-fatal")
+        await settle(session)
+
+    asyncio.run(_drive())
+
+    assert call_count == 1, (
+        f"expected exactly 1 LLM call (no shrink retry entered), got {call_count}"
+    )
+    kinds = [e.type for e in collected]
+    assert "router_context_overflow_detected" not in kinds, (
+        "a FATAL exception (AttributeError) must never be classified as "
+        "context overflow, even though its message contains 'token'"
+    )
+    terminated = [e for e in collected if e.type == "router_loop_terminated_by_exception"]
+    assert terminated, "the exception must reach the generic catch-all's own P6 instrument"
+    assert terminated[0].data["error_type"] == "AttributeError"
+
+
+def test_arm1_genuine_overflow_still_shrinks(monkeypatch) -> None:
+    """Tier 2: #5577 deny — arm① still classifies a REAL overflow as
+    overflow and enters the shrink ladder (rules out an "always deny"
+    implementation that would trivially pass the FATAL test above by
+    never entering the ladder for anything)."""
+    session = make_session(agent_name="arm1_overflow_test")
+    collected = collect_events(session)
+
+    async def _fake_call_llm_tools(*args, **kwargs):
+        raise RuntimeError("maximum context length exceeded")
+
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools", _fake_call_llm_tools,
+    )
+
+    async def _drive() -> None:
+        await session._handle_inbox_text("hi", chain_id="chain-arm1-overflow")
+        await settle(session)
+
+    asyncio.run(_drive())
+
+    kinds = [e.type for e in collected]
+    assert "router_context_overflow_detected" in kinds, (
+        "a genuine context-overflow-shaped exception must still enter the "
+        "shrink ladder — arm① must not have become 'never classify as "
+        "overflow'"
+    )
+
+
+def test_arm2_fatal_exception_on_a_retry_stops_the_ladder(monkeypatch) -> None:
+    """Tier 2: #5577 accept — arm② (inside ``_router_main_call``, the
+    retry_loop-injected callable).
+
+    First LLM call raises a genuine overflow (arm① classifies OVERFLOW,
+    enters retry_loop). The SECOND call — made by retry_loop's own
+    ``main_call`` invocation, arm②'s own except block — raises a FATAL
+    exception (AttributeError). Must NOT be wrapped as
+    ``ContextOverflowError`` and must NOT trigger a third call (proving
+    the ladder stopped rather than continuing to shrink a cause no amount
+    of shrinking can fix)."""
+    session = make_session(agent_name="arm2_fatal_test")
+    collected = collect_events(session)
+
+    call_count = 0
+
+    async def _fake_call_llm_tools(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("maximum context length exceeded")
+        raise AttributeError("'NoneType' object has no attribute 'token'")
+
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools", _fake_call_llm_tools,
+    )
+
+    async def _drive() -> None:
+        await session._handle_inbox_text("hi", chain_id="chain-arm2-fatal")
+        await settle(session)
+
+    asyncio.run(_drive())
+
+    assert call_count == 2, (
+        f"expected exactly 2 LLM calls (1st overflow enters the ladder, "
+        f"2nd FATAL stops it — never a 3rd shrink attempt), got {call_count}"
+    )
+    terminated = [e for e in collected if e.type == "router_loop_terminated_by_exception"]
+    assert terminated, "the un-wrapped AttributeError must reach the generic catch-all"
+    assert terminated[0].data["error_type"] == "AttributeError", (
+        "arm② must propagate the FATAL exception UNWRAPPED — not as "
+        "ContextOverflowError/UnrecoveredError, which would misreport the "
+        "cause as an overflow that never happened"
+    )

--- a/tests/runtime/test_5577_unify_overflow_classification_arms.py
+++ b/tests/runtime/test_5577_unify_overflow_classification_arms.py
@@ -40,6 +40,25 @@ Real ``Session``/``RouterLoop`` throughout (``call_llm_tools`` patched at
 that raises — never a mock, per testing.md) — same idiom
 ``tests/runtime/test_5256_quota_not_context_overflow.py`` already
 establishes for this exact call-site family.
+
+#5593 (lead-coder's own catch, CI-red on this file's own PR): the first
+version of this fix classified through ``classify_llm_failure`` ALONE —
+its own fallthrough is unconditionally OVERFLOW for anything that is
+NEITHER FATAL nor RETRYABLE, a default calibrated for ``retry_loop``'s
+inner except clause (which only ever catches its own two overflow-shaped
+exception types, per that function's own docstring), not for this
+module's two arms, which catch ANY exception from ``loop.run()``. A
+genuinely unrelated exception — ``StructuredOutputUnsupportedModelError``
+(not in FATAL_EXC_TYPES, not a rate-limit/timeout/5xx/quota shape) — fell
+through to OVERFLOW, entered the shrink ladder, burned real LLM calls,
+and surfaced as a misleading ``UnrecoveredError``. Fixed via
+``_is_shrinkable_overflow`` (this module's own helper): still excludes
+FATAL/RETRYABLE through ``classify_llm_failure``, but additionally
+requires ``is_context_overflow_error``'s own narrower, positive signal
+for anything classify_llm_failure's 3-way split does not itself prove —
+restoring the pre-#5577 conservative default (unmatched shape = do not
+enter) for exactly the unrecognized case classify_llm_failure was never
+designed to answer.
 """
 from __future__ import annotations
 
@@ -163,3 +182,62 @@ def test_arm2_fatal_exception_on_a_retry_stops_the_ladder(monkeypatch) -> None:
         "ContextOverflowError/UnrecoveredError, which would misreport the "
         "cause as an overflow that never happened"
     )
+
+
+class _UnclassifiableModelConfigError(Exception):
+    """A stand-in for #5593's own real incident
+    (``StructuredOutputUnsupportedModelError``): neither in
+    ``FATAL_EXC_TYPES``, nor a rate-limit/timeout/5xx/quota shape, nor
+    carrying an overflow keyword in its message — genuinely unclassifiable
+    by ``classify_llm_failure``'s own 3-way split, which is exactly why
+    its bare fallthrough misdiagnosed the production incident as OVERFLOW.
+    A plain, locally-defined ``Exception`` subclass rather than the real
+    ``StructuredOutputUnsupportedModelError`` — that type is itself an
+    ``AgentStepError`` subclass with its OWN unrelated special-casing
+    further up ``Session``'s own call chain (structured-output pipeline
+    semantics this test's ephemeral, schema-free session never triggers);
+    using it here would test that unrelated interaction, not
+    ``_is_shrinkable_overflow``'s own classification."""
+
+
+def test_unclassifiable_exception_does_not_enter_the_ladder(monkeypatch) -> None:
+    """Tier 2: #5593's own real incident, pinned directly — an exception
+    that is neither FATAL, RETRYABLE, nor a real overflow must NOT enter
+    the shrink ladder — arm① must not wrap it as
+    ``ContextOverflowError``/``UnrecoveredError``, which would misreport
+    an unrelated error as a context overflow.
+
+    ``classify_llm_failure`` ALONE would misclassify this as OVERFLOW
+    (its own unconditional fallthrough) — this is exactly the gap
+    ``_is_shrinkable_overflow`` closes on top of it."""
+    session = make_session(agent_name="arm1_unclassifiable_test")
+    collected = collect_events(session)
+
+    call_count = 0
+
+    async def _fake_call_llm_tools(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise _UnclassifiableModelConfigError("model-x does not support this call shape")
+
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools", _fake_call_llm_tools,
+    )
+
+    async def _drive() -> None:
+        await session._handle_inbox_text("hi", chain_id="chain-arm1-unclassifiable")
+        await settle(session)
+
+    asyncio.run(_drive())
+
+    assert call_count == 1, (
+        f"expected exactly 1 LLM call (no shrink retry entered), got {call_count}"
+    )
+    kinds = [e.type for e in collected]
+    assert "router_context_overflow_detected" not in kinds, (
+        "an unclassifiable exception (neither FATAL, RETRYABLE, nor a "
+        "real overflow) must never be classified as context overflow"
+    )
+    terminated = [e for e in collected if e.type == "router_loop_terminated_by_exception"]
+    assert terminated, "the exception must reach the generic catch-all's own P6 instrument"
+    assert terminated[0].data["error_type"] == "_UnclassifiableModelConfigError"


### PR DESCRIPTION
**[e2e-coder]** — Unifies both `router_loop_driver.py` overflow-classification arms onto `classify_llm_failure`, per lead-coder's ruling on this session's own 3-point falsification (issue #5577).

See the commit message for the full trace: root cause per arm, the 3 falsification points checked before writing (quota-exclusion equivalence, arm② behavior-change correctness, the live-call-site census), the fix, and the same-PR doc-drift fixes (`engine.py`'s `is_context_overflow_error` docstring, `chat-compaction.md`'s "Two failure sites, one way in" section).

## Strip-falsify highlight

Reverted to origin/main, reran the new tests — the arm② test's `call_count` came back **7** (not the expected 2): the pre-fix code retried an `AttributeError` as if it were shrinkable overflow, reproducing the exact "burning real LLM calls chasing a cause no amount of shrinking can fix" failure #3783's own owner ruling warned against. Restored, all 3 green.

## CI-red incident (lead-coder's own catch, after this PR was TESTS-READ + auto-merge armed)

pytest failed 8 tests, identically on 3.11/3.12. Root cause: the two overflow
predicates disagree on their own **default**. `is_context_overflow_error`'s
default for "none of the known shapes" is `False` (do not enter the shrink
ladder). `classify_llm_failure`'s own fallthrough is unconditionally
`OVERFLOW` for "neither FATAL nor RETRYABLE" — a default calibrated for
`retry_loop`'s own inner except clause, which (per that function's own
docstring) only ever catches its own two overflow-shaped exception types.
This PR widened *where* `classify_llm_failure` gets called — from that narrow
inner except to this module's two arms, which catch `Exception` from
`loop.run()` (literally anything) — without the two predicates' opposite
defaults being noticed. A real production exception,
`StructuredOutputUnsupportedModelError` (not FATAL, not RETRYABLE, no
overflow keyword), fell through to OVERFLOW, entered the shrink ladder,
burned real LLM calls, and surfaced as a misleading `UnrecoveredError` for
what was actually a config error.

Lead-coder offered 3 repair options and left the choice to me. **Chose
option 1** — do not touch `classify_llm_failure`'s own ratified 3-way split
(that would need architect's separate ruling, option 2) — added
`_is_shrinkable_overflow(exc)`: still excludes FATAL/RETRYABLE via
`classify_llm_failure` (this PR's own real gain — a quota/5xx/timeout
exception whose message merely resembles an overflow keyword must not enter
here), but additionally requires `is_context_overflow_error`'s own narrower,
positive signal for anything not proven FATAL/RETRYABLE — restoring the
pre-#5577 conservative default for this module's own two call sites only.
`classify_llm_failure` itself is unchanged.

New required accept test (lead-coder's own condition to re-arm):
`test_unclassifiable_exception_does_not_enter_the_ladder`, pinning the exact
incident shape via a locally-defined dummy exception (not the real
`StructuredOutputUnsupportedModelError` — that type is itself an
`AgentStepError` subclass with unrelated `Session`-level special-casing that
would test the wrong interaction).

**Strip-falsified** (this follow-up commit): reverted to the bare
`classify_llm_failure()`-only version, reran — the new test fails (the
unclassifiable exception is misclassified as overflow and enters the
ladder). Restored the fix, reran — 4/4 pass.

Re-verified: this file's own 4 tests (4/4), the 8 originally CI-failing
tests plus their sibling suites (21/21), and the wider related suite —
`classify_llm_failure`, quota-vs-overflow, #3783 stage3, PR-n6 compaction
overflow retry, this file (60/60). All 8 local gates re-run and green.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5577_unify_overflow_classification_arms.py` — 4 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py <2 changed src files>` — clean
- [x] `python scripts/mypy_ratchet.py` — 200 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `python scripts/check_bare_tests_import_reference.py` — clean (tests/ touched)
- [x] `python scripts/check_file_depth_reference.py` — clean (tests/ touched)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — built clean (docs/ touched)
- [x] `python scripts/check_doc_anchors.py` — "no dangling anchors into published pages"
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Related test sweep: 20+54 tests across quota/classification/overflow-retry suites — all pass
- [x] (skipped — no visual surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
