### PR TITLE
fix(#5588): compaction progress display skeleton -- real signals + pure render layer

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -93,6 +93,11 @@ from .chrome import (
     status_line_text,
 )
 from .compact import compact_caps
+from .compaction_progress import (
+    CompactionProgressRow,
+    CompactionProgressSnapshot,
+    compaction_progress_lines,
+)
 from .completion import CompletionPopup, CompletionState, compute_completion
 from .gutter import (
     _RUNNING_FRAME_PERIOD,
@@ -1948,6 +1953,12 @@ class TextualChatApp(App):
             )
             if config_warning is not None:
                 yield ConfigWarningLine(config_warning, id="config-warning")
+            # #5588: always composed (matching ActivityRow's own "created
+            # hidden, shown/hidden live via a reactive attribute" shape) —
+            # never conditionally yielded like ConfigWarningLine above,
+            # since whether compaction is running can change many times
+            # within one session, unlike a config-key count fixed at boot.
+            yield CompactionProgressRow(id="compaction-progress")
             # Bottom chrome: a focusable menu row that also carries the slim
             # status-values segment (#3326: MenuBar owns placing StatusLine on
             # whichever row has room, collapsing the two previously-separate rows
@@ -6744,6 +6755,7 @@ class TextualChatApp(App):
         # snapshot per rendered row.
         self._turn_usage_fn = (snap or {}).get("turn_usage_fn")
         self._refresh_status(snap)
+        self._refresh_compaction_progress(snap)
         try:
             drawer = self.query_one("#drawer", ContentSwitcher)
         except Exception:
@@ -6761,6 +6773,34 @@ class TextualChatApp(App):
         except Exception:
             return  # not yet mounted
         menubar.update_status(self._status_text(snap))
+
+    def _refresh_compaction_progress(self, snap: "dict | None | object" = _UNSET) -> None:
+        """#5588: re-render the shrink-flow progress chrome row from a fresh
+        snapshot (or the already-read ``snap``) — the "down" trigger for
+        :class:`CompactionProgressRow`'s own ``reactive`` ``lines``
+        attribute, matching :meth:`_refresh_status`'s own shape exactly.
+        Absent snapshot key (a REMOTE connection, which does not report
+        this yet — see ``status.py``'s own #5588 comment) degrades to
+        ``is_compacting=False``, never a fabricated value."""
+        try:
+            row = self.query_one(CompactionProgressRow)
+        except Exception:
+            return  # not yet mounted
+        snapshot = self._snapshot() if snap is _UNSET else snap
+        raw = (snapshot or {}).get("compaction_progress_raw") or {}
+        row.lines = compaction_progress_lines(
+            CompactionProgressSnapshot(
+                is_compacting=raw.get("is_compacting", False),
+                spill_done=(
+                    raw["raw_middle_total"] - raw["raw_middle_remaining"]
+                    if raw.get("raw_middle_total") is not None
+                    and raw.get("raw_middle_remaining") is not None
+                    else None
+                ),
+                spill_total=raw.get("raw_middle_total"),
+                call_count=raw.get("upstream_recovery_call_count"),
+            )
+        )
 
     def watch__destination(self, old_value: "_Destination", new_value: "_Destination") -> None:
         """#5131: the App is now showing a DIFFERENT agent (init or a real

--- a/src/reyn/interfaces/inline/textual_chat/compaction_progress.py
+++ b/src/reyn/interfaces/inline/textual_chat/compaction_progress.py
@@ -39,6 +39,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from textual.reactive import reactive
+from textual.widgets import Static
+
 if TYPE_CHECKING:
     from reyn.services.compaction.engine import RetryLoopTerminal
 
@@ -178,3 +181,38 @@ def compaction_failure_text(terminal: "RetryLoopTerminal") -> str:
         _T.MID_FLOOR: "1つのやり取りが単独で大きすぎます",
         _T.ROOM_FLOOR: "最新のメッセージだけで窓に入りません",
     }[terminal]
+
+
+class CompactionProgressRow(Static):
+    """The chrome widget half of #5588 — a plain top-level sibling of
+    ``MenuBar`` in the app's compose order (same placement family as
+    :class:`~.chrome.ConfigWarningLine`), rendering whatever
+    :func:`compaction_progress_lines` returns.
+
+    #5131 "down" discipline: the App writes :attr:`lines` (a ``reactive``
+    attribute) from its own periodic snapshot read — this widget never
+    queries ``Session``/the registry itself (Gate A: this module does not,
+    and must not, import ``reyn.interfaces.transport``/``reyn.runtime.
+    registry``). :meth:`watch_lines` is the ONE place that reacts, matching
+    ``ActivityRow``'s own established shape for a conditionally-visible
+    chrome row: absent (``display = False``) whenever there is nothing to
+    show, never an empty visible row occupying the layout slot."""
+
+    DEFAULT_CSS = """
+    CompactionProgressRow {
+        height: auto;
+        padding: 0 1;
+    }
+    """
+
+    can_focus = False
+
+    lines: "reactive[list[str]]" = reactive(list, always_update=True)
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__("", **kwargs)
+        self.display = False
+
+    def watch_lines(self, new_lines: "list[str]") -> None:
+        self.display = bool(new_lines)
+        self.update("\n".join(new_lines))

--- a/src/reyn/interfaces/inline/textual_chat/compaction_progress.py
+++ b/src/reyn/interfaces/inline/textual_chat/compaction_progress.py
@@ -1,0 +1,180 @@
+"""Shrink-flow (compaction/overflow-recovery) progress display — pure render
+layer (#5588).
+
+Two readers, one display, three layered lines (architect design, #5588
+issue thread — quoted verbatim in this module's own docstrings below):
+
+- Line 1 answers the general user's ONLY real question: "should I wait, or
+  is this stuck?" — always sayable, since the ladder's own termination is a
+  PREDICATE (same input -> same result), never a probability.
+- Line 2 answers "is it actually doing something right now" — distinguishes
+  "waiting on a slow LLM response" from "genuinely stalled", so a slow
+  provider never gets misread as a hang and triggers an unnecessary restart
+  (the exact failure this display exists to prevent — architect: "健全な
+  回復を再起動させます").
+- Line 3 is the owner's analysis line: which rung of the ladder is active,
+  and how much headroom each rung has left. Never collapsed into a single
+  percentage — the rungs use different, individually-honest units (a
+  monotone fraction, a raw value that can legitimately grow, a binary
+  in/out, another monotone fraction) and folding them into one number would
+  either lie (a value that increases reads as "regressed") or hide the
+  figure that matters (architect: "段の単位が違い、②は増えもします").
+
+#5588 skeleton-first note (lead-coder ruling, issue thread): the real
+``rung``/``levers_left``/lap/call-count PRODUCER fields land in #5592
+(e2e-coder), not landed in this tree as of this module's creation — see
+that issue. Deriving them here from engine internals instead would create
+a SECOND counting site for the same fact (architect, #5350's own family:
+"2か所で数えるとズレます") — this module never does that. Every optional
+field below defaults to ``None`` and the render functions degrade
+gracefully (never fabricating a number), matching CLAUDE.md's own rule.
+
+Only ``is_compacting`` (via ``Session.is_compacting`` / #5588) and
+``terminal`` (via the ``router_context_overflow_unrecovered`` event's own
+new field, also #5588) are wired to something real as of this module's
+introduction — both landed in THIS PR, no producer dependency.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.services.compaction.engine import RetryLoopTerminal
+
+
+@dataclass(frozen=True)
+class CompactionProgressSnapshot:
+    """The full designed shape (#5588) — every field beyond ``is_compacting``
+    is optional and ``None`` until its producer lands (see module docstring).
+    A caller with only ``is_compacting=True`` still gets a correct, honest
+    line 1; lines 2/3 render only the pieces they actually have data for.
+    """
+
+    is_compacting: bool = False
+
+    #: Line 2 — which real LLM call this pass is currently awaiting a
+    #: response from ("summary" | "main_call"), or ``None`` when nothing is
+    #: currently in flight (a between-calls moment, not a stall — see
+    #: :func:`compaction_progress_lines`'s own "no fabricated conflation"
+    #: note). Elapsed seconds, DISPLAY ONLY (CLAUDE.md: never used for a
+    #: machine timeout decision) — omitted entirely when ``None``, the same
+    #: "never coerce an unknown clock to 0s" rule ``activity_row.py`` already
+    #: follows.
+    waiting_for: "str | None" = None
+    waiting_elapsed_s: "float | None" = None
+
+    #: Line 3 — rung① spill: consumed / total un-spilled candidates
+    #: (``levers_left``, #5592 — the population NEVER shrinks by
+    #: redefinition, per owner ruling; only consumption moves this).
+    spill_done: "int | None" = None
+    spill_total: "int | None" = None
+
+    #: rung② slice: the CURRENT mid-turn compact-attempt length (can legally
+    #: grow — binary search doubles on success — never rendered as a
+    #: fraction/percent).
+    slice_len: "int | None" = None
+
+    #: rung③ refill: which of head/tail still has non-summary content left
+    #: to move into the middle candidate pool (a 2-value in/out fact, not a
+    #: count).
+    head_available: "bool | None" = None
+    tail_available: "bool | None" = None
+
+    #: rung④ budget: halvings already taken / halvings until the room floor
+    #: (a real fraction — the floor IS fixed, so this ratio is honest).
+    budget_halvings_done: "int | None" = None
+    budget_halvings_max: "int | None" = None
+
+    #: Which rung is CURRENTLY active ("spill" | "slice" | "refill" |
+    #: "budget") — drives the ``← 今 ①`` marker. #5592.
+    active_rung: "str | None" = None
+
+    #: Monotonically-increasing episode counter (#5588, architect's final
+    #: addition) — the ONE figure that is never allowed to look like a
+    #: regression even when rung① is refilled to a taller-looking fraction
+    #: at the start of a new episode. #5592.
+    lap: "int | None" = None
+
+    #: Total LLM calls made across this recovery so far — MUST be shown
+    #: alongside spill_done/spill_total, never alone (architect, #5588
+    #: correction: "片方だけでは今回の事故がまた見えません" — candidates
+    #: alone hides a disproportionate call count; calls alone hides how much
+    #: further there is to go). #5592.
+    call_count: "int | None" = None
+
+
+_RUNG_LABELS = {"spill": "①", "slice": "②", "refill": "③", "budget": "④"}
+
+
+def compaction_progress_lines(snap: CompactionProgressSnapshot) -> "list[str]":
+    """Render the (up to) 3 chrome lines for *snap* — ``[]`` when nothing is
+    running (the accept/deny pair from the issue's own acceptance criteria:
+    this display is invisible whenever ``is_compacting`` is False, never a
+    persistent/toggled row).
+
+    Each line renders independently of whether the OTHER lines have data —
+    a caller with only ``is_compacting=True`` still gets a correct line 1.
+    """
+    if not snap.is_compacting:
+        return []
+
+    lines = ["⟳ 文脈を縮めています（自動で終わります）"]
+
+    if snap.waiting_for is not None:
+        # #5588: "応答待ち" (waiting) vs "進捗なし" (no progress) are
+        # DELIBERATELY different words — this function never says "no
+        # progress" for anything; the only state it knows how to name
+        # honestly, from a real signal, is "waiting for X" (an in-flight
+        # call). A genuinely-stalled state (no call in flight AND no
+        # forward motion) has no producer signal yet and is correctly
+        # rendered as line 2 simply absent, never guessed at.
+        target = {"summary": "要約", "main_call": "本文"}.get(snap.waiting_for, snap.waiting_for)
+        elapsed = ""
+        if snap.waiting_elapsed_s is not None:
+            elapsed = f" {int(snap.waiting_elapsed_s)}秒"
+        lines.append(f"  {target}の応答を待っています{elapsed}")
+
+    rung_parts = []
+    if snap.spill_done is not None and snap.spill_total is not None:
+        call_suffix = "" if snap.call_count is None else f"  呼び出し {snap.call_count}"
+        rung_parts.append(f"① 退避 {snap.spill_done}/{snap.spill_total}{call_suffix}")
+    if snap.slice_len is not None:
+        rung_parts.append(f"② 分割 {snap.slice_len}")
+    if snap.head_available is not None or snap.tail_available is not None:
+        avail = []
+        if snap.head_available:
+            avail.append("head")
+        if snap.tail_available:
+            avail.append("tail")
+        rung_parts.append(f"③ 補充 {'/'.join(avail) if avail else '—'}")
+    if snap.budget_halvings_done is not None and snap.budget_halvings_max is not None:
+        rung_parts.append(f"④ 予算 {snap.budget_halvings_done}/{snap.budget_halvings_max}")
+
+    if rung_parts:
+        line3 = "  " + "  ".join(rung_parts)
+        if snap.lap is not None:
+            line3 += f"  · 周回 {snap.lap}"
+        if snap.active_rung is not None and snap.active_rung in _RUNG_LABELS:
+            line3 += f"     ← 今 {_RUNG_LABELS[snap.active_rung]}"
+        lines.append(line3)
+
+    return lines
+
+
+#: architect's own exact wording (#5588 issue thread) — never derived from
+#: RetryLoopTerminal's own member NAME/value string (that would be the same
+#: "parse the reason text" pattern this design explicitly forbids elsewhere;
+#: instead this is a closed dict keyed on the ENUM MEMBER itself).
+def compaction_failure_text(terminal: "RetryLoopTerminal") -> str:
+    """The end-of-recovery FAILURE line, naming WHICH impossibility fired —
+    never a parse of ``UnrecoveredError``'s own ``reason``/``repr()`` text
+    (architect ruling, #5588: "reason 文字列を解析しないこと"). Keyed on the
+    ``RetryLoopTerminal`` enum member itself, imported lazily by the caller
+    (this module takes no hard dependency on ``reyn.services.compaction``)."""
+    from reyn.services.compaction.engine import RetryLoopTerminal as _T
+
+    return {
+        _T.MID_FLOOR: "1つのやり取りが単独で大きすぎます",
+        _T.ROOM_FLOOR: "最新のメッセージだけで窓に入りません",
+    }[terminal]

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -673,6 +673,14 @@ def _snapshot_for_session(registry, s, config=None):
         # method is real ``Session.context_window_status``) — gated by
         # ``ctx_compaction_reported`` above.
         "ctx_compaction_status_fn": ctx_compaction_status_fn,
+        # #5588: LOCAL genuinely measures this below (Session.
+        # compaction_progress_raw — a cheap dict build from already-cached
+        # values, safe every frame). NOT yet declared through the
+        # ChatReadModelCapabilities "reported" machinery (#5009's own
+        # pattern) — REMOTE/AG-UI simply lacks this key today, and the
+        # chrome consumer treats a missing key the same as "nothing to
+        # show" (is_compacting defaults False). A follow-up, not done here.
+        "compaction_progress_raw": s.compaction_progress_raw(),
         # LOCAL genuinely measures cron config below (via
         # ``_extract_cron_jobs``) whenever a ``config`` is given — gated
         # by ``cron_jobs_reported`` above, declared True unconditionally:

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -203,6 +203,16 @@ class CompactionController:
         self._compacting: bool = False
 
     @property
+    def is_compacting(self) -> bool:
+        """#5588: is a compaction pass currently in flight — the ONE real,
+        zero-fabrication signal this PR's TUI progress display is built on.
+        A thin public read of the existing ``_compacting`` guard (already
+        set/cleared around :meth:`force_compact_now`'s own
+        ``_run_compaction`` call, above) — no new state, just a public
+        accessor for state that already existed private-only until now."""
+        return self._compacting
+
+    @property
     def _engine(self) -> CompactionEngine:
         """The compaction engine, built via the factory on first reference
         and cached (single owner, computed at most once — #3671 follow-up).

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -1135,9 +1135,21 @@ class RouterLoopDriver:
         # the SAME schema — `repr(_overflow_exc)` now correctly names
         # whichever one actually happened instead of always the latter.
         except (_ContextOverflowError, _UnrecoveredError) as _overflow_exc:
+            # #5588: `terminal` is the RetryLoopTerminal member (MID_FLOOR/
+            # ROOM_FLOOR) when this is an UnrecoveredError -- omitted
+            # (never fabricated as a string) for a plain ContextOverflowError,
+            # which carries no ladder-terminal distinction. Lets a consumer
+            # (the shrink-flow progress display) name which impossibility
+            # fired WITHOUT parsing `error`'s repr() text (architect ruling,
+            # #5588: "reason 文字列を解析しないこと").
+            _terminal = getattr(_overflow_exc, "terminal", None)
             self._events.emit(
                 "router_context_overflow_unrecovered",
                 error=repr(_overflow_exc),
+                # .value (a plain str), not the raw Enum member -- this dict
+                # gets json.dumps'd verbatim by EventStore, and RetryLoopTerminal
+                # is a bare enum.Enum (not IntEnum/StrEnum), not JSON-safe as-is.
+                terminal=_terminal.value if _terminal is not None else None,
             )
             raise
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -10153,6 +10153,13 @@ class Session:
         ``context_window_status`` above."""
         return self._budget_advisor.raw_context_window()
 
+    @property
+    def is_compacting(self) -> bool:
+        """#5588: forwarding → CompactionController.is_compacting — the ONE
+        real, zero-fabrication signal the shrink-flow progress chrome row
+        gates on. Cheap (a bool read), safe every render frame."""
+        return self._compaction_controller.is_compacting
+
     async def _compact_now_for_op(self) -> dict:
         """#272/#1128/#191: voluntary-compaction callback (compact op + /compact).
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1439,6 +1439,20 @@ class Session:
         # Publish this session's EventLog as the ambient LLM-chokepoint sink (#1669, see docs/reference/runtime/session-construction.md#family-1-audit-event-spine-p6)
         from reyn.core.events.events import set_llm_request_event_log
         set_llm_request_event_log(self._audit_events)
+        # #5588: cache the #5592 observability fields (raw_middle_remaining/
+        # _total on compaction_shrink_recovered, upstream_recovery_call_count
+        # on llm_request/llm_request_error) as they arrive on THIS session's
+        # own audit log, for the shrink-flow progress chrome row to read
+        # cheaply once per frame via compaction_progress_raw() below. Never
+        # a second counting site (architect, #5350's own family: "2か所で
+        # 数えるとズレます") — this only CACHES what those events already
+        # computed and emitted, it derives nothing itself.
+        self._compaction_progress_state: "dict[str, int | None]" = {
+            "raw_middle_remaining": None,
+            "raw_middle_total": None,
+            "upstream_recovery_call_count": None,
+        }
+        self._audit_events.add_subscriber(self._on_compaction_progress_event)
         # Publish reyn.yaml llm.router.* as the ambient router config (#1829 S3b, see docs/reference/runtime/session-construction.md#misc-lifecycle-wiring)
         if router_config is not None:
             from reyn.llm.llm import set_router_config
@@ -10159,6 +10173,35 @@ class Session:
         real, zero-fabrication signal the shrink-flow progress chrome row
         gates on. Cheap (a bool read), safe every render frame."""
         return self._compaction_controller.is_compacting
+
+    def _on_compaction_progress_event(self, event) -> None:
+        """#5588: see :attr:`_compaction_progress_state`'s own comment at
+        construction — caches, never derives."""
+        if event.type == "compaction_shrink_recovered":
+            self._compaction_progress_state["raw_middle_remaining"] = (
+                event.data.get("raw_middle_remaining")
+            )
+            self._compaction_progress_state["raw_middle_total"] = (
+                event.data.get("raw_middle_total")
+            )
+        elif event.type in ("llm_request", "llm_request_error"):
+            # #5592: this field is None outside a recovery episode — only
+            # overwrite the cache with a REAL count, never clear a
+            # currently-displayed count back to unknown on an ordinary
+            # (non-recovery) call that happens to interleave.
+            count = event.data.get("upstream_recovery_call_count")
+            if count is not None:
+                self._compaction_progress_state["upstream_recovery_call_count"] = count
+
+    def compaction_progress_raw(self) -> dict:
+        """#5588: ``is_compacting`` plus the latest #5592 observability
+        fields cached from this session's own audit log (see
+        :meth:`_on_compaction_progress_event`) — cheap (a dict build from
+        already-cached values), safe every render frame. The TUI layer
+        builds its own ``CompactionProgressSnapshot`` from this plain dict
+        (this module stays free of any ``interfaces/`` import — Session is
+        reused by every surface, not only the Textual TUI)."""
+        return {"is_compacting": self.is_compacting, **self._compaction_progress_state}
 
     async def _compact_now_for_op(self) -> dict:
         """#272/#1128/#191: voluntary-compaction callback (compact op + /compact).

--- a/tests/core/test_3783_stage3_invert_default_to_recover.py
+++ b/tests/core/test_3783_stage3_invert_default_to_recover.py
@@ -64,6 +64,7 @@ from reyn.services.compaction.engine import (
     ComputedBudgets,
     ContextOverflowError,
     HistoryChunkToCompact,
+    RetryLoopTerminal,
     UnrecoveredError,
     retry_loop,
 )
@@ -330,3 +331,14 @@ async def test_compaction_side_unrecovered_error_emits_router_context_overflow_u
 
     seen = [e.type for e in events]
     assert "router_context_overflow_unrecovered" in seen
+
+    # #5588: the event's own `terminal` field must name WHICH ladder
+    # impossibility fired (MID_FLOOR here — this arm's own scenario is the
+    # mid-slice binary search bottoming out at attempt-length 1, never the
+    # budget-halving floor) — never left to a consumer's own parse of
+    # `error`'s repr() text.
+    (overflow_event,) = [e for e in events if e.type == "router_context_overflow_unrecovered"]
+    assert overflow_event.data.get("terminal") == RetryLoopTerminal.MID_FLOOR.value, (
+        f"expected terminal={RetryLoopTerminal.MID_FLOOR.value!r}, "
+        f"got {overflow_event.data.get('terminal')!r}"
+    )

--- a/tests/interfaces/test_5588_compaction_progress_chrome.py
+++ b/tests/interfaces/test_5588_compaction_progress_chrome.py
@@ -1,0 +1,185 @@
+"""Tier 2: #5588 — the shrink-flow progress row, mounted in a REAL
+``TextualChatApp`` and driven from a REAL ``Session``'s own snapshot (the
+production ``interfaces/repl/status.py::_snapshot_for_session()`` seam, not
+a hand-typed dict).
+
+Real ``Session``/``AgentRegistry``/``EventLog`` throughout. Driving via a
+direct ``session._audit_events.emit(...)`` call for
+``compaction_shrink_recovered``/``llm_request`` is the same legitimate
+"arrange, not assert" pattern established across #5557/#5588's own prior
+tests: this file's claim is "the chrome row renders what the snapshot
+carries", not "production fires these events in scenario X" (that belongs
+to tests/services/test_5592_observability_fields.py). Setting
+``session._compaction_controller._compacting`` directly (no public setter
+exists — see ``CompactionController.is_compacting``'s own read-only
+property) is the same class of legitimate scenario-arrangement, not an
+assertion on private state.
+
+``_MutableSnapshotReadModel``/``_EventOnlyTransport`` mirror
+``test_3338_tui_status_chrome_liveness.py``'s own classes of the same name
+byte-for-byte (each TUI test file keeps its own local copy, per that
+file's own established convention — no cross-test-file import)."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.compaction_progress import CompactionProgressRow
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
+from reyn.interfaces.repl.status import _snapshot_for_session
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.runtime.registry import AgentRegistry
+from reyn.schemas.models import Event
+from tests._support.agent_session import make_session
+
+
+class _MutableSnapshotReadModel(ChatReadModel):
+    @property
+    def capabilities(self):
+        return LOCAL_CHAT_READ_CAPABILITIES
+
+    def __init__(self, snap: dict) -> None:
+        self.snap = snap
+
+    def snapshot(self, config=None):
+        return self.snap
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    @property
+    def history_path(self) -> Path:
+        return Path("/tmp/reyn_5588_history")
+
+    def conversation_history(self, *, limit=None, agent=None, session_id=None):
+        return []
+
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
+
+class _EventOnlyTransport(ClientTransportStub):
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg) -> None:
+        pass
+
+    async def cancel_inflight(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+async def _make_app_with_real_session(tmp_path: Path):
+    state_log = StateLog(tmp_path / "state.wal")
+    holder: dict = {}
+
+    def _factory(profile):
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+            registry=holder.get("reg"),
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    reg.create("alpha")
+    session = reg.get_or_load("alpha")
+    snap = _snapshot_for_session(reg, session)
+    app = TextualChatApp(
+        transport=_EventOnlyTransport(), read_model=_MutableSnapshotReadModel(snap),
+    )
+    return app, session, reg
+
+
+@pytest.mark.asyncio
+async def test_row_absent_while_not_compacting(tmp_path: Path) -> None:
+    """Tier 2: accept/deny — the row is mounted but hidden (the issue's
+    own deny criterion: never a persistently-visible row)."""
+    app, _session, _reg = await _make_app_with_real_session(tmp_path)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        row = app.query_one(CompactionProgressRow)
+        assert row.display is False
+
+
+@pytest.mark.asyncio
+async def test_row_shows_real_events_driven_snapshot(tmp_path: Path) -> None:
+    """Tier 2: accept — with is_compacting=True and real
+    compaction_shrink_recovered/llm_request events on the session's own
+    audit log, the mounted row renders the exact text
+    compaction_progress_lines() produces from that real data — an
+    end-to-end proof from Session through the App's own refresh cycle to
+    the rendered widget, not just the pure render layer in isolation."""
+    app, session, reg = await _make_app_with_real_session(tmp_path)
+    session._compaction_controller._compacting = True  # arrange: no public setter
+    session._audit_events.emit(
+        "compaction_shrink_recovered",
+        cause="ContextOverflowError", iteration=0, consecutive=1,
+        t_max_override=None, raw_middle_remaining=2464, raw_middle_total=2469,
+    )
+    session._audit_events.emit(
+        "llm_request", model="x", input_chars=100,
+        max_input_tokens_applied=8000, upstream_recovery_call_count=43,
+    )
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # Re-read the snapshot NOW (post-emit) — _snapshot() runs fresh
+        # every render frame in production; this test's own snap dict must
+        # be refreshed the same way, not reused stale from before the emits.
+        fresh_snap = _snapshot_for_session(reg, session)
+        app._read_model.snap = fresh_snap
+        app._refresh_compaction_progress()
+        await pilot.pause()
+
+        row = app.query_one(CompactionProgressRow)
+        assert row.display is True
+        assert row.lines[0] == "⟳ 文脈を縮めています（自動で終わります）"
+        assert "① 退避 5/2469  呼び出し 43" in row.lines[-1]

--- a/tests/interfaces/test_5588_compaction_progress_render.py
+++ b/tests/interfaces/test_5588_compaction_progress_render.py
@@ -1,0 +1,155 @@
+"""Tier 1: #5588 — the shrink-flow progress display's pure render layer.
+
+``compaction_progress_lines``/``compaction_failure_text`` are pure functions
+over a plain dataclass — no Session, no Textual app, no event log. Real
+``RetryLoopTerminal`` members throughout (the actual production enum, never
+a stand-in), since the failure-message mapping's whole point is fidelity to
+those exact members.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.compaction_progress import (
+    CompactionProgressSnapshot,
+    compaction_failure_text,
+    compaction_progress_lines,
+)
+from reyn.services.compaction.engine import RetryLoopTerminal
+
+
+def test_not_compacting_renders_nothing():
+    """Tier 1: accept/deny pair, deny side — is_compacting=False (the
+    default) renders zero lines, regardless of what other fields are set.
+    This is the acceptance criterion's own deny half: the display must
+    never persist once a pass has ended."""
+    snap = CompactionProgressSnapshot(is_compacting=False, spill_done=5, spill_total=12)
+    assert compaction_progress_lines(snap) == []
+
+
+def test_compacting_with_only_the_flag_still_renders_line_1():
+    """Tier 1: accept side — is_compacting=True alone (no producer fields
+    yet) still renders a correct, honest line 1. This is the #5588
+    skeleton-first shape: nothing here is fabricated, but the one real
+    signal available renders something true."""
+    snap = CompactionProgressSnapshot(is_compacting=True)
+    lines = compaction_progress_lines(snap)
+    assert lines == ["⟳ 文脈を縮めています（自動で終わります）"]
+
+
+def test_line_2_names_summary_wait_with_elapsed():
+    """Tier 1: waiting_for='summary' renders the 要約 (summary) wait line,
+    with the elapsed seconds appended when known."""
+    snap = CompactionProgressSnapshot(
+        is_compacting=True, waiting_for="summary", waiting_elapsed_s=12.7,
+    )
+    lines = compaction_progress_lines(snap)
+    assert lines[1] == "  要約の応答を待っています 12秒"
+
+
+def test_line_2_names_main_call_wait_without_elapsed_when_unknown():
+    """Tier 1: waiting_for='main_call' renders the 本文 (main body) wait
+    line; waiting_elapsed_s=None omits the clock entirely rather than
+    coercing to 0秒 (mirrors activity_row.py's own "never fabricate an
+    unknown elapsed time" rule)."""
+    snap = CompactionProgressSnapshot(is_compacting=True, waiting_for="main_call")
+    lines = compaction_progress_lines(snap)
+    assert lines[1] == "  本文の応答を待っています"
+
+
+def test_line_2_absent_when_waiting_for_is_none():
+    """Tier 1: waiting_for=None (the default) — no line 2 at all, never a
+    fabricated "no progress" line (this render layer never claims to know
+    a stall occurred; see the module's own docstring)."""
+    snap = CompactionProgressSnapshot(is_compacting=True)
+    lines = compaction_progress_lines(snap)
+    assert lines == ["⟳ 文脈を縮めています（自動で終わります）"]
+
+
+def test_line_3_shows_spill_and_call_count_together():
+    """Tier 1: #5588 architect correction — spill_done/spill_total and
+    call_count must render TOGETHER on the same segment, never one without
+    the other (the exact incident this display exists to make visible:
+    candidates shrinking while calls grow disproportionately)."""
+    snap = CompactionProgressSnapshot(
+        is_compacting=True, spill_done=5, spill_total=2469, call_count=43,
+    )
+    lines = compaction_progress_lines(snap)
+    assert "① 退避 5/2469  呼び出し 43" in lines[-1]
+
+
+def test_line_3_spill_without_call_count_omits_the_call_segment():
+    """Tier 1: call_count=None (not yet known/wired) — the spill fraction
+    still renders alone, never a fabricated call count."""
+    snap = CompactionProgressSnapshot(is_compacting=True, spill_done=5, spill_total=2469)
+    lines = compaction_progress_lines(snap)
+    assert "① 退避 5/2469" in lines[-1]
+    assert "呼び出し" not in lines[-1]
+
+
+def test_line_3_all_four_rungs_plus_lap_plus_active_marker():
+    """Tier 1: the full architect-designed line 3 shape, all fields
+    present — matches the issue's own verbatim mockup byte-for-byte on the
+    rung segments (spacing choices are this module's own, per lead-coder's
+    delegation)."""
+    snap = CompactionProgressSnapshot(
+        is_compacting=True,
+        spill_done=5, spill_total=2469, call_count=43,
+        slice_len=4,
+        head_available=True, tail_available=True,
+        budget_halvings_done=1, budget_halvings_max=4,
+        lap=2, active_rung="spill",
+    )
+    lines = compaction_progress_lines(snap)
+    line3 = lines[-1]
+    assert "① 退避 5/2469  呼び出し 43" in line3
+    assert "② 分割 4" in line3
+    assert "③ 補充 head/tail" in line3
+    assert "④ 予算 1/4" in line3
+    assert "周回 2" in line3
+    assert "← 今 ①" in line3
+
+
+def test_line_3_refill_shows_only_the_still_available_side():
+    """Tier 1: head_available=True, tail_available=False renders only
+    'head' — never fabricates the unavailable side as present."""
+    snap = CompactionProgressSnapshot(
+        is_compacting=True, head_available=True, tail_available=False,
+    )
+    lines = compaction_progress_lines(snap)
+    assert "③ 補充 head" in lines[-1]
+    assert "tail" not in lines[-1]
+
+
+def test_line_3_absent_when_no_rung_field_is_known():
+    """Tier 1: every rung field None (skeleton-only state) — line 3 is
+    simply absent, not an empty/placeholder line."""
+    snap = CompactionProgressSnapshot(is_compacting=True, waiting_for="summary")
+    lines = compaction_progress_lines(snap)
+    assert lines == [
+        "⟳ 文脈を縮めています（自動で終わります）",
+        "  要約の応答を待っています",
+    ]
+
+
+def test_failure_text_mid_floor():
+    """Tier 1: MID_FLOOR maps to architect's own exact wording — never a
+    parse of UnrecoveredError's own reason/repr() text."""
+    assert compaction_failure_text(RetryLoopTerminal.MID_FLOOR) == (
+        "1つのやり取りが単独で大きすぎます"
+    )
+
+
+def test_failure_text_room_floor():
+    """Tier 1: ROOM_FLOOR maps to architect's own exact wording, distinct
+    from MID_FLOOR's — the issue's own deny criterion (the two members
+    must never collapse to the same text)."""
+    assert compaction_failure_text(RetryLoopTerminal.ROOM_FLOOR) == (
+        "最新のメッセージだけで窓に入りません"
+    )
+
+
+def test_failure_text_mid_floor_and_room_floor_are_distinct():
+    """Tier 1: #5588 deny criterion, explicit — the 2 RetryLoopTerminal
+    members must render as 2 different strings, not collapsed to one."""
+    assert compaction_failure_text(RetryLoopTerminal.MID_FLOOR) != (
+        compaction_failure_text(RetryLoopTerminal.ROOM_FLOOR)
+    )

--- a/tests/runtime/test_5588_compaction_progress_session_wiring.py
+++ b/tests/runtime/test_5588_compaction_progress_session_wiring.py
@@ -1,0 +1,97 @@
+"""Tier 2: #5588 — Session.compaction_progress_raw() caches the real #5592
+observability fields as they arrive on this session's own audit log.
+
+Real ``Session``, real ``EventLog`` throughout. Driving via a direct
+``session._audit_events.emit(...)`` call (not the full retry_loop machinery)
+is legitimate here — #5557's own established discriminator: this test's
+claim is "the subscriber correctly caches what a real
+compaction_shrink_recovered/llm_request(_error) event already carries", not
+"production fires this event in scenario X" (that claim belongs to
+tests/services/test_5592_observability_fields.py and
+tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py, which drive
+the real ladder end-to-end)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.core.events.state_log import StateLog
+from tests._support.agent_session import make_session
+
+
+def _make_session(tmp_path: Path):
+    return make_session(
+        agent_name="compaction-progress-wiring-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+
+
+def test_raw_starts_with_every_field_none(tmp_path):
+    """Tier 2: before any compaction_shrink_recovered/llm_request(_error)
+    has fired, every cached field reads None — never a fabricated 0."""
+    session = _make_session(tmp_path)
+    raw = session.compaction_progress_raw()
+    assert raw == {
+        "is_compacting": False,
+        "raw_middle_remaining": None,
+        "raw_middle_total": None,
+        "upstream_recovery_call_count": None,
+    }
+
+
+def test_compaction_shrink_recovered_populates_raw_middle_fields(tmp_path):
+    """Tier 2: a real compaction_shrink_recovered event's own
+    raw_middle_remaining/raw_middle_total land in compaction_progress_raw()
+    verbatim — the exact field names #5592 actually emits (verified against
+    engine.py:3081-3082's own emit call), not a renamed/derived copy."""
+    session = _make_session(tmp_path)
+    session._audit_events.emit(
+        "compaction_shrink_recovered",
+        cause="ContextOverflowError", iteration=0, consecutive=1,
+        t_max_override=None, raw_middle_remaining=5, raw_middle_total=2469,
+    )
+    raw = session.compaction_progress_raw()
+    assert raw["raw_middle_remaining"] == 5
+    assert raw["raw_middle_total"] == 2469
+
+
+def test_llm_request_populates_call_count_only_when_not_none(tmp_path):
+    """Tier 2: upstream_recovery_call_count is None outside a recovery
+    episode (#5592's own documented contract) — an ordinary llm_request
+    with count=None must NOT clear an already-cached real count back to
+    unknown (an interleaved ordinary call must not blank the display)."""
+    session = _make_session(tmp_path)
+    session._audit_events.emit(
+        "llm_request", model="x", input_chars=100,
+        max_input_tokens_applied=8000, upstream_recovery_call_count=3,
+    )
+    assert session.compaction_progress_raw()["upstream_recovery_call_count"] == 3
+
+    # An ordinary (non-recovery) call interleaves — count is None on THIS
+    # event, but the cache must keep the last REAL count.
+    session._audit_events.emit(
+        "llm_request", model="x", input_chars=50,
+        max_input_tokens_applied=8000, upstream_recovery_call_count=None,
+    )
+    assert session.compaction_progress_raw()["upstream_recovery_call_count"] == 3
+
+
+def test_llm_request_error_also_populates_call_count(tmp_path):
+    """Tier 2: llm_request_error (the failure-path sibling) carries the
+    same field and must also update the cache — a rejected request still
+    counts toward the call sequence (#5592's own motivating incident: a
+    rejected request is still billed and must not vanish from the count)."""
+    session = _make_session(tmp_path)
+    session._audit_events.emit(
+        "llm_request_error", model="x", error="boom",
+        upstream_recovery_call_count=7,
+    )
+    assert session.compaction_progress_raw()["upstream_recovery_call_count"] == 7
+
+
+def test_is_compacting_reads_live_not_cached(tmp_path):
+    """Tier 2: is_compacting is NEVER cached from an event (unlike the
+    other 3 fields) — it forwards live to CompactionController.is_compacting
+    on every read, matching #5588's earlier is_compacting property tests."""
+    session = _make_session(tmp_path)
+    assert session.compaction_progress_raw()["is_compacting"] is False

--- a/tests/runtime/test_compaction_controller_invariants.py
+++ b/tests/runtime/test_compaction_controller_invariants.py
@@ -235,3 +235,58 @@ def test_force_compact_engine_failure_emits_failed():
     assert [e for e in collected if e.type == "compaction_failed"], (
         "engine failure during force_compact_now must emit compaction_failed"
     )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4: is_compacting (#5588) — True only while a pass is in flight
+# ---------------------------------------------------------------------------
+
+
+class _ObservingEngine(CompactionEngine):
+    """#5588: like ``_SucceedingEngine``, but captures ``ctrl.is_compacting``
+    from INSIDE its own ``compact()`` call — the only way to observe the
+    flag's value DURING a pass from a test that otherwise only sees before/
+    after force_compact_now's single await chain."""
+
+    def __init__(self, events: EventLog, ctrl_holder: dict) -> None:
+        self._model = ""
+        self._events = events
+        self._budgets = _STUB_BUDGETS
+        self._ctrl_holder = ctrl_holder
+        self.observed_during_compact: "bool | None" = None
+
+    async def compact(
+        self, input_chunk: HistoryChunkToCompact, *, covers_through: CoversThrough,
+    ) -> ChatSummary:
+        _emit_compaction_started(self._events, input_chunk, covers_through)
+        self.observed_during_compact = self._ctrl_holder["ctrl"].is_compacting
+        seqs = [int(t.get("seq", 0)) for t in input_chunk.messages if isinstance(t, dict)]
+        return ChatSummary(topic_arc="stub", covers_through_seq=max(seqs) if seqs else 0)
+
+
+def test_is_compacting_true_only_during_a_pass():
+    """Tier 2: #5588 — CompactionController.is_compacting reads False before
+    force_compact_now runs, True from inside the engine's own compact() call
+    (observed via a real, not simulated, mid-call read), and False again
+    once force_compact_now has returned — the exact signal the shrink-flow
+    progress chrome row gates its own visibility on."""
+    ctrl_holder: dict = {}
+    engine_box: list = []
+
+    def _factory(events: EventLog) -> CompactionEngine:
+        engine = _ObservingEngine(events, ctrl_holder)
+        engine_box.append(engine)
+        return engine
+
+    ctrl, _collected, _hist, events = _make_controller(history=_history(7), engine_factory=_factory)
+    ctrl_holder["ctrl"] = ctrl
+
+    assert ctrl.is_compacting is False, "must read False before any pass starts"
+
+    asyncio.run(_run_and_settle(ctrl.force_compact_now(), events))
+
+    (engine,) = engine_box
+    assert engine.observed_during_compact is True, (
+        "is_compacting must read True from inside the engine's own compact() call"
+    )
+    assert ctrl.is_compacting is False, "must read False again once the pass has returned"


### PR DESCRIPTION
**[tui-coder]** — part of #5588. Continuation of the skeleton (chrome wiring + real screenshot), per lead-coder's explicit "#5595の続きに進んでください" after #5592 landed.

## #5592の実フィールド名(確認済み)

`raw_middle_remaining`/`raw_middle_total`(`compaction_shrink_recovered`)、`upstream_recovery_call_count`(`llm_request`/`llm_request_error`)。`rung`/`周回`は未着地 — lead-coderの確認どおり、今回の射程は「退避と呼び出し回数を両方出す」のみ。

## このPRでやったこと(skeleton PR #5595 + このcommitで追加)

**Session側**(real、never derive twice):
- `Session._on_compaction_progress_event`: construction時に1度subscribe、`raw_middle_remaining/_total`・`upstream_recovery_call_count`をcache(deriveしない、cacheのみ)
- `Session.compaction_progress_raw()`: 軽量dict、毎frame安全
- `status.py`の`_snapshot_for_session`に`compaction_progress_raw`key追加(LOCAL限定、REMOTE/AG-UIは今回未対応・開示済み)

**TUI側**(#5131 down=reactive+watch_のみ、Gate A/B green):
- `CompactionProgressRow(Static)`: `ConfigWarningLine`と同じ配置(MenuBarの兄弟)、`reactive lines`属性、`watch_lines`がdisplay切り替え+再描画。widget自身はSession/registryを一切import・queryしない。
- `app.py`: 常時compose(ActivityRowと同じ「作成時hidden、live show/hide」形)、既存の`_refresh_status`と同じ呼び出し箇所から`_refresh_compaction_progress`

## 実際に描画された画面(owner gate用)

https://claude.ai/code/artifact/3f76b5d9-317e-4a8d-9170-e238b06cfa76

`App.export_screenshot()`で実際のrun_test()harness内から取得(仕様の説明ではなく実際に見えたもの)。real Session→real events→real snapshot refresh→real widget、の全経路で確認。

## 検証

- pytest(このPR分) — 27/27 green、broader sweep(tests/interfaces -k "chrome or status or activity") 142 passed(1件事前存在の無関係なasyncio teardown警告、単独実行で本PRのtestからでないこと確認済み)
- ruff clean / mypy_ratchet clean / tier_audit --strict clean(20 tests) / verify_module_docstrings OK
- Gate A(`check_tui_widget_boundary.py`) OK / Gate B(`check_tui_reactive_ratchet.py`) OK(ceiling到達だが超過せず) / `test_tui_colour_tokens.py` OK

## 未対応(明示)

REMOTE/AG-UI側のcompaction_progress_raw報告、「応答待ち」elapsed timer計装(line 2)、rung②③④/周回(該当producer fieldが着地すれば)。

## Test plan
- [x] pytest(該当ファイル) — 27/27 green
- [x] ruff / mypy_ratchet / tier_audit --strict / verify_module_docstrings — all clean
- [x] Gate A/B(TUI固有) — all clean
- [x] (screenshot submitted above — owner review pending) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
