### PR TITLE
fix(#5598): map role="summary" to an accepted wire role before it reaches the provider

### DIFF
--- a/docs/concepts/data-retrieval/chat-compaction.md
+++ b/docs/concepts/data-retrieval/chat-compaction.md
@@ -274,6 +274,18 @@ token budgets (derived from `section_weights`):
 `covers_through_seq` is derived deterministically by the compaction postprocessor
 and the result is appended as a `role: "summary"` entry in `history.jsonl`.
 
+`"summary"` is reyn's own internal vocabulary — the discriminator watermark/
+trim/spill logic reads — never a value a provider recognises as a chat role.
+The normal turn path never leaks it to the wire (it attaches the summary via
+a separate, already-`"assistant"`-role synthetic turn instead); the overflow-
+recovery path (`retry_loop`, both the compact()-origin fold and a pre-
+existing persisted summary reached through `decompose_history_for_retry`)
+maps it to `"assistant"` at its own wire-egress point (`_router_main_call`)
+before it ever reaches `loop.run` (#5598 — a provider that validates role
+names rejects an un-mapped `"summary"` outright, with a 400 in ~2 seconds,
+before inference even starts, regardless of payload size: the turn right
+after a compaction succeeds always failed).
+
 Token budgets use `litellm.token_counter` by default for accuracy; a cheaper
 `len(text) // 4` heuristic is available for latency-sensitive deployments
 (`use_chars4_estimate: true`). A third path is automatic, not operator-set:

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from reyn.runtime.chat_message import Spillability
 from reyn.services.compaction.engine import SUMMARY_MESSAGE_ROLE
+from reyn.services.compaction.engine import wire_role as _wire_role
 
 if TYPE_CHECKING:
     from reyn.config.chat import SafetyConfig
@@ -846,8 +847,31 @@ class RouterLoopDriver:
                 # inside `_serialise_turn` (which stays the canonical,
                 # provider-identical quantity #2957 PR-B's own docstring
                 # requires).
+                #
+                # #5598 (owner's real machine): the SAME reasoning applies
+                # to `role` — `decompose_history_for_retry`'s own turns
+                # filter includes a `role == SUMMARY_MESSAGE_ROLE` element
+                # (#5531, unlike `build_history`'s own normal-turn path,
+                # which never reaches this bug — it attaches its summary
+                # via a SEPARATE, already-"assistant"-role synthetic
+                # bridge turn, never `wrap_summary_as_message`), and
+                # retry_loop's own fold-success branch (engine.py) appends
+                # a FRESH `wrap_summary_as_message` result straight into
+                # `head`, bypassing `_serialise_turn` entirely — this is
+                # THE one place both of those converge before becoming
+                # `loop.run`'s payload. `SUMMARY_MESSAGE_ROLE` ("summary")
+                # is reyn's own internal discriminator (watermark/trim/
+                # spill logic reads it), never a value a provider
+                # recognises as a chat role — left un-mapped, a provider
+                # that validates role names against a fixed enum 400s the
+                # request outright in ~2 seconds, before inference even
+                # starts, so no amount of shrinking can recover from it
+                # (see `wire_role`'s own docstring for the full incident).
                 _msgs = [
-                    {k: v for k, v in t.items() if k != "spillability"}
+                    {
+                        **{k: v for k, v in t.items() if k != "spillability"},
+                        "role": _wire_role(t.get("role", "")),
+                    }
                     for t in list(head) + list(tail)
                 ]
                 try:

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -448,7 +448,61 @@ CoversThrough = Union[int, SeqUnavailable]
 #: — condition⑤'s own discriminator (#5531), matching the SAME convention
 #: the persisted-history layer already uses (a ``ChatMessage.role ==
 #: "summary"`` entry in ``history.jsonl``). One vocabulary, not two.
+#:
+#: #5598: this is reyn's OWN internal vocabulary — a discriminator
+#: `watermark`/`trim`/`spill` logic reads (``router_history_buffer.py``,
+#: ``router_loop_driver.py``, this module's own ``compact()``), never a
+#: value a provider recognises as a chat role. Every genuine wire-egress
+#: point must run it through :func:`wire_role` before it reaches
+#: ``loop.run``/litellm — see that function's own docstring for the
+#: incident this closes.
 SUMMARY_MESSAGE_ROLE = "summary"
+
+
+def wire_role(role: str) -> str:
+    """#5598 (owner's real machine, 2026-08-30) — maps reyn's own internal
+    role vocabulary to the value a provider actually accepts on the wire.
+    Two internal roles have no provider equivalent:
+
+    - ``"agent"`` — a legacy pre-migration straggler
+      (``router_history_buffer.py``'s own pre-existing normalize-on-read).
+    - :data:`SUMMARY_MESSAGE_ROLE` (``"summary"``) — reyn's own
+      discriminator for an already-compacted summary turn, read by
+      watermark/trim/spill logic, never a provider role. Left un-mapped
+      at the wire boundary, a provider that validates role names against
+      a fixed enum (the incident: `gpt-5.6-luna`, "Invalid value:
+      'summary'. Supported values are: 'assistant', 'system', 'developer',
+      and 'user'.") rejects the request outright, with a 400 that fires
+      in ~2 seconds regardless of payload size — the request never
+      reaches inference at all, so no amount of shrinking (compaction,
+      spill, any rung of the overflow ladder) can ever recover from it.
+      This is the SAME turn that just successfully summarised: the very
+      next request that includes that summary is the one that 400s.
+
+    Both collapse to ``"assistant"`` — a summary's own content already
+    self-identifies via its ``"[summary of earlier conversation]\\n"``
+    prefix (:func:`wrap_summary_as_message`'s own decoration), so the
+    role does not need to carry that information a second time.
+
+    Deliberately NOT applied inside :func:`wrap_summary_as_message`
+    itself, nor anywhere :data:`SUMMARY_MESSAGE_ROLE` is used to build
+    :class:`HistoryChunkToCompact` (``compaction_controller.py``'s own
+    call site, ``retry_loop``'s own ``raw_middle`` inclusion) or read
+    back by ``compact()``'s own "does a previous summary already exist"
+    check (this module, ``m.get("role") == SUMMARY_MESSAGE_ROLE``) —
+    those are reyn's OWN internal representation, never wire-serialised
+    as individual role-tagged messages (``compact()``'s own LLM call
+    embeds the whole ``messages`` list as JSON TEXT inside one
+    ``"user"``-role wire message, never as separate wire roles) —
+    normalizing there would break the very discriminator this function's
+    own docstring says stays internal. Apply this ONLY at a genuine
+    wire-egress point, immediately before a dict becomes part of what
+    ``loop.run``/litellm actually receives — see
+    ``RouterHistoryBuffer._serialise_turn`` and
+    ``RouterLoopDriver._router_main_call`` for the two such points."""
+    if role in ("agent", SUMMARY_MESSAGE_ROLE):
+        return "assistant"
+    return role
 
 
 def wrap_summary_as_message(summary: dict) -> dict:

--- a/tests/runtime/test_5598_summary_role_normalized_on_wire.py
+++ b/tests/runtime/test_5598_summary_role_normalized_on_wire.py
@@ -1,0 +1,212 @@
+"""Tier 2: #5598 — a summary turn reaches the wire with a `role` the
+provider actually accepts, never reyn's own internal `SUMMARY_MESSAGE_
+ROLE` ("summary") discriminator.
+
+Owner's real machine (relayed by lead-coder, 2026-08-30): the turn right
+after a compaction SUCCEEDS always 400s. Verbatim upstream error:
+"Invalid value: 'summary'. Supported values are: 'assistant', 'system',
+'developer', and 'user'." — `param: input[391]`, rejected in ~2 seconds
+regardless of payload size (63万字 ≈ 160k tokens against a 1.05M window —
+not a size problem; the request is rejected before inference even starts,
+so no amount of shrinking can ever recover from it).
+
+## Root cause (traced directly, not assumed)
+
+`retry_loop`'s own fold-success branch (`engine.py`) appends a FRESH
+`wrap_summary_as_message(...)` result straight into `head` —
+`{"role": SUMMARY_MESSAGE_ROLE, ...}` — bypassing `_serialise_turn`
+entirely (that dict is built directly, never routed through the
+normal-turn wire-serialisation path). `RouterLoopDriver._router_main_call`
+(`router_loop_driver.py`) then sends `head` (plus `tail`) to `loop.run()`
+as-is, after only stripping the internal `spillability` key — `role`
+itself was never remapped.
+
+`build_history()` (the NORMAL, non-overflow turn path) does NOT have
+this bug: its own summary handling attaches a SEPARATE, already-
+`"assistant"`-role synthetic bridge turn (`router_history_buffer.py`,
+"the bridge") and never touches `wrap_summary_as_message` at all — this
+issue's own shape is confined to the overflow-recovery path
+(`decompose_history_for_retry` → `retry_loop` → `_router_main_call`),
+which is exactly why the owner's incident showed up specifically as
+"the turn right after a compaction succeeds" (compaction only ever runs
+as part of overflow recovery here) rather than on every ordinary turn.
+
+## Falsified before writing (lead-coder's own 2-point ask)
+
+1. Does `wrap_summary_as_message`'s output ALSO feed `HistoryChunkToCompact`
+   (`compaction_controller.py`'s own call site, and `retry_loop`'s own
+   `raw_middle` inclusion)? Yes — confirmed by reading both call sites
+   directly. The fix therefore does NOT touch `wrap_summary_as_message`
+   itself, nor `_serialise_turn`'s summary branch (whose OWN output can
+   also flow into `HistoryChunkToCompact.messages` via `raw_middle`) —
+   only `_router_main_call`'s own existing wire-shaping step, the ONE
+   place `head`/`tail` (never `raw_middle`) actually become `loop.run`'s
+   payload (matching the file's own pre-existing precedent: it already
+   strips `spillability` HERE rather than inside `_serialise_turn`, for
+   exactly the same "canonical quantity vs. wire shape" reason).
+2. Does `engine.py`'s own `m.get("role") == SUMMARY_MESSAGE_ROLE` check
+   (`compact()`'s own "does a previous summary already exist" read) ever
+   see a wire-normalized dict? No — confirmed by reading `compact()`
+   directly: `input_chunk.messages` is embedded as JSON TEXT inside one
+   `"user"`-role wire message to compact()'s OWN LLM call, never
+   serialised as individual wire roles — `SUMMARY_MESSAGE_ROLE` never
+   reaches a real wire role field on THAT path either way, so this fix
+   (scoped to `_router_main_call` alone) cannot touch it.
+
+Real `Session`/`RouterLoopDriver`/`CompactionEngine` throughout (a fake
+``litellm.acompletion`` for the compaction call, same idiom
+``test_5582_compaction_forced_non_streaming.py`` already establishes; a
+content-driven fake `loop.run` for the main call, same idiom
+``test_5296_pr2_byte_reduction_same_turn_retry.py`` already establishes
+for this exact scenario shape).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import litellm
+import pytest
+
+from reyn.config import CompactionConfig, MultimodalConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.chat_message import ChatMessage, Spillability
+from tests._support.agent_session import make_session
+from tests._support.events import settle
+
+_SUMMARY_CONTENT = {
+    "topic_arc": "the conversation so far", "new_turn_seqs": [],
+    "decisions": [], "pending": [], "session_user_facts": [], "artifacts_referenced": [],
+}
+
+
+def _now() -> str:
+    from datetime import UTC, datetime
+    return datetime.now(UTC).isoformat()
+
+
+def _push(session, role: str, text: str, **kw) -> None:
+    session._append_history(ChatMessage(role=role, content=text, ts=_now(), **kw))
+
+
+class _FakeStatusError(Exception):
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class _RecordingLoop:
+    """A fake ``RouterLoop`` that raises a genuine overflow-shaped error
+    exactly while the FIRST call's own content (``raw_middle``'s
+    candidates, still un-folded) is present — mirroring
+    ``_ContentDrivenLoop``'s own "content-driven, not a hardcoded call
+    count" idiom — and succeeds from then on, once ``retry_loop``'s own
+    fold has replaced that content with a summary. Records the exact
+    ``history`` payload of EVERY call, so the test inspects the real wire
+    shape ``_router_main_call`` produced rather than inferring it."""
+
+    def __init__(self, *, fail_marker: str) -> None:
+        self._fail_marker = fail_marker
+        self.calls: "list[list[dict]]" = []
+
+    async def run(self, *, user_text: str, history: "list[dict]") -> "object | None":
+        self.calls.append(history)
+        if any(self._fail_marker in str(t.get("content", "")) for t in history):
+            raise _FakeStatusError("request too large", status_code=413)
+        return None
+
+
+def test_summary_reaches_wire_with_an_accepted_role_not_summary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5598 accept — after retry_loop's own compact() succeeds
+    on real, non-empty ``raw_middle`` content and folds it into a fresh
+    summary appended to ``head``, the VERY NEXT ``main_call`` (still
+    inside the SAME recovery episode — the owner's own incident shape)
+    must never include a wire dict whose ``role`` is
+    ``SUMMARY_MESSAGE_ROLE`` ("summary")."""
+    from reyn.services.compaction.engine import SUMMARY_MESSAGE_ROLE
+
+    monkeypatch.chdir(tmp_path)
+    import reyn.llm.model_budget as _mb
+    monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: 2_500)
+
+    async def _fake_acompletion(model, messages, **kw):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=json.dumps(_SUMMARY_CONTENT)),
+            )],
+            usage=SimpleNamespace(prompt_tokens=100, completion_tokens=10),
+        )
+    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+
+    cfg = CompactionConfig(
+        body_token_cap=1500, use_chars4_estimate=True, section_caps_spec_tokens=0,
+        max_shrink_iterations=1,
+    )
+    state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    bt = BudgetTracker(CostConfig())
+    session = make_session(
+        agent_name="default", agent_role="", output_language="en",
+        budget_tracker=bt, state_log=state_log, compaction_config=cfg,
+        multimodal_config=MultimodalConfig(),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
+
+    # Real filler (plain user/assistant, spill-ineligible) surrounding a
+    # single, large tool-result turn — enough that
+    # decompose_history_for_retry puts genuine content into raw_middle
+    # (not just head/tail), so retry_loop's own rung① compact() call
+    # actually fires. Filler AFTER the tool turn keeps `tail` itself free
+    # of any "tool"-role content, isolating `_run_with_shrink`'s own
+    # FIRST attempt (via `build_history()`, which sends everything raw)
+    # as the one call whose content genuinely triggers the fake 413 —
+    # not a later, already-folded call whose tail happens to share the
+    # same marker text.
+    for i in range(20):
+        _push(session, "user", f"filler question {i} " * 8, spillability=Spillability.NEVER)
+        _push(session, "assistant", f"filler answer {i} " * 8, spillability=Spillability.NEVER)
+    _push(session, "tool", "mid result payload " * 100, tool_call_id="tc-mid0", name="tool")
+    for i in range(3):
+        _push(session, "user", f"tail filler {i} " * 8, spillability=Spillability.NEVER)
+        _push(session, "assistant", f"tail reply {i} " * 8, spillability=Spillability.NEVER)
+
+    head, raw_middle, tail, _summary, _ = (
+        session._loop_driver._history_buffer.decompose_history_for_retry()
+    )
+    mid_ids = {t.get("tool_call_id") for t in raw_middle if t.get("role") == "tool"}
+    assert mid_ids == {"tc-mid0"}, (
+        f"test setup sanity: raw_middle must hold the real candidate for "
+        f"retry_loop's own compact() to fire — got {mid_ids!r}"
+    )
+    assert not [t for t in tail if t.get("role") == "tool"], (
+        "test setup sanity: tail must hold no tool candidate, or the "
+        "fake 413's own content marker cannot isolate the FIRST "
+        "(un-folded) attempt from a later, already-folded one"
+    )
+
+    loop = _RecordingLoop(fail_marker="mid result payload")
+    asyncio.run(session._loop_driver._run_with_shrink(loop, "continue please", chain_id="c1"))
+    asyncio.run(settle(session))
+
+    assert loop.calls, "loop.run must have been called at least once"
+    for i, history in enumerate(loop.calls):
+        offending = [t for t in history if t.get("role") == SUMMARY_MESSAGE_ROLE]
+        assert not offending, (
+            f"call {i}: history sent to loop.run() carries a wire dict "
+            f"with role=={SUMMARY_MESSAGE_ROLE!r} — the exact shape a "
+            f"provider that validates role names rejects with a 400 in "
+            f"~2 seconds, before inference even starts: {offending!r}"
+        )
+    summary_present = any(
+        "[summary of earlier conversation]" in str(t.get("content", ""))
+        for history in loop.calls for t in history
+    )
+    assert summary_present, (
+        "test setup sanity: the fresh summary must actually be present "
+        "in what was sent (as an accepted role) — otherwise this test "
+        "isn't exercising the bug's own trigger at all"
+    )


### PR DESCRIPTION
**[e2e-coder]** — Fixes #5598: the turn right after a compaction succeeds always 400s. Verbatim upstream: "Invalid value: 'summary'. Supported values are: 'assistant', 'system', 'developer', and 'user'." Rejected in ~2 seconds regardless of payload size — not a size problem, the request never reaches inference at all, so no amount of shrinking recovers from it.

See the commit message for the full trace: root cause, the 2 falsification points lead-coder asked for (checked by reading the actual code, not assumed), the fix, and the strip-falsify.

## Root cause

`retry_loop`'s own fold-success branch appends a fresh `wrap_summary_as_message(...)` result — `{"role": "summary", ...}` — straight into `head`, bypassing `_serialise_turn` entirely. `RouterLoopDriver._router_main_call` then sends `head`+`tail` to `loop.run()` as-is, after only stripping the internal `spillability` key — `role` itself was never remapped. `build_history()` (the normal, non-overflow turn path) doesn't have this bug — it attaches its summary via a separate, already-`"assistant"`-role synthetic bridge turn — so the bug is confined to the overflow-recovery path, exactly matching the incident's own shape ("the turn right after a compaction succeeds").

## Fix

New `wire_role(role)` helper (`engine.py`, next to `SUMMARY_MESSAGE_ROLE`'s own definition): maps `"agent"` and `SUMMARY_MESSAGE_ROLE` to `"assistant"`. Applied at `_router_main_call`'s own existing wire-shaping step (`router_loop_driver.py`) — the ONE place `head`/`tail` actually become `loop.run`'s payload, matching the file's own pre-existing precedent (it already strips `spillability` there for the same reason). `wrap_summary_as_message`/`_serialise_turn`'s summary branch/`HistoryChunkToCompact` are all untouched — reyn's own internal vocabulary stays internal.

## Falsify before writing (lead-coder's own 2-point ask)

1. Does `wrap_summary_as_message`'s output also feed `HistoryChunkToCompact`? Yes (confirmed by reading both call sites) — the fix therefore does NOT touch `wrap_summary_as_message` itself.
2. Does `compact()`'s own "does a previous summary already exist" check (`m.get("role") == SUMMARY_MESSAGE_ROLE`) ever see a wire-normalized dict? No — `compact()`'s own LLM call embeds `input_chunk.messages` as JSON text inside one `"user"`-role wire message, never as individual wire roles. Confirmed further by the pre-existing `had_previous` tests staying green unmodified.

## Strip-falsify

Reverted `_router_main_call`'s own role-mapping line, reran the new test — `role=="summary"` reaches the recorded wire payload exactly as the real incident showed. Restored, reran — green.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5598_summary_role_normalized_on_wire.py` — 1 test, 0 errors
- [x] `python scripts/verify_module_docstrings.py <2 changed src files>` — clean
- [x] `python scripts/mypy_ratchet.py` — 200 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `python scripts/check_bare_tests_import_reference.py` — clean (tests/ touched)
- [x] `python scripts/check_file_depth_reference.py` — clean (tests/ touched)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — built clean (docs/ touched)
- [x] `python scripts/check_doc_anchors.py` — "no dangling anchors into published pages"
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] New test + related suite (112 tests across compaction/retry_loop/quota/classify/observability files) — all green
- [x] `tests/runtime/` (2112, 5 pre-existing unrelated skips), `tests/services/` (176, 1 pre-existing unrelated env flake confirmed against origin/main) — all green
- [x] (skipped — no visual surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
