### PR TITLE
fix(#5599 follow-up): wire-message key allow-list, not deny-list

### DIFF
--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -26,6 +26,22 @@ if TYPE_CHECKING:
     from reyn.config.chat import SafetyConfig
 
 
+#: #5599 follow-up — the exhaustive set of keys a real chat-completions
+#: wire message may carry, enumerated directly from `_serialise_turn`'s
+#: own construction (router_history_buffer.py — `role`/`content` always,
+#: `tool_calls`/`tool_call_id`/`name` when the ChatMessage carries them)
+#: plus the 3 reasoning-continuity fields `_REASONING_BUNDLE_FIELDS`
+#: (reasoning_continuity.py) attaches. An ALLOW-list, not a deny-list —
+#: see `_router_main_call`'s own comment for why (a deny-list already
+#: missed one real internal key, `wrap_summary_as_message`'s own
+#: `**summary` spread, alongside the `spillability` key it did know
+#: about).
+_WIRE_MESSAGE_KEYS = (
+    "role", "content", "tool_calls", "tool_call_id", "name",
+    "reasoning_content", "thinking_blocks", "provider_specific_fields",
+)
+
+
 def _is_shrinkable_overflow(exc: BaseException) -> bool:
     """#5577/#5593 — is *exc* a cause the shrink ladder should be entered
     for?
@@ -867,9 +883,29 @@ class RouterLoopDriver:
                 # request outright in ~2 seconds, before inference even
                 # starts, so no amount of shrinking can recover from it
                 # (see `wire_role`'s own docstring for the full incident).
+                #
+                # #5599 follow-up (lead-coder's own catch, same PR's own
+                # site re-read after #5598 landed): a DENY-list here
+                # (originally just `!= "spillability"`) misses every OTHER
+                # internal key, and one already existed —
+                # `wrap_summary_as_message` (engine.py) spreads `**summary`
+                # into the dict it returns, so retry_loop's fresh fold-
+                # success `head` entry carries `topic_arc`/`decisions`/
+                # `pending`/`session_user_facts`/`artifacts_referenced`/
+                # `covers_through_seq` — none of them a real chat-
+                # completions message field — straight onto the wire
+                # alongside the role fix. `_WIRE_MESSAGE_KEYS` (module
+                # level, this file) is the structural fix (CLAUDE.md:
+                # close the CLASS of hole, not the one instance) — an
+                # ALLOW-list cannot miss a FUTURE internal key the same
+                # way `spillability` alone already missed this one; a new
+                # internal annotation now has to be added there
+                # deliberately to reach the wire, not omitted from a
+                # strip-list to leak by default. See that constant's own
+                # docstring for where each key comes from.
                 _msgs = [
                     {
-                        **{k: v for k, v in t.items() if k != "spillability"},
+                        **{k: v for k, v in t.items() if k in _WIRE_MESSAGE_KEYS},
                         "role": _wire_role(t.get("role", "")),
                     }
                     for t in list(head) + list(tail)

--- a/tests/runtime/test_5598_summary_role_normalized_on_wire.py
+++ b/tests/runtime/test_5598_summary_role_normalized_on_wire.py
@@ -119,17 +119,14 @@ class _RecordingLoop:
         return None
 
 
-def test_summary_reaches_wire_with_an_accepted_role_not_summary(
+def _drive_overflow_recovery_through_a_real_fold(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Tier 2: #5598 accept — after retry_loop's own compact() succeeds
-    on real, non-empty ``raw_middle`` content and folds it into a fresh
-    summary appended to ``head``, the VERY NEXT ``main_call`` (still
-    inside the SAME recovery episode — the owner's own incident shape)
-    must never include a wire dict whose ``role`` is
-    ``SUMMARY_MESSAGE_ROLE`` ("summary")."""
-    from reyn.services.compaction.engine import SUMMARY_MESSAGE_ROLE
-
+) -> "list[list[dict]]":
+    """Shared setup for both #5598 (role) and #5599-follow-up (key
+    allow-list) — a real overflow on ``raw_middle`` content, a real
+    ``compact()`` success (fake litellm response, real fold), then the
+    retried ``main_call`` — returns every ``loop.run()`` call's own
+    ``history`` payload for the caller to inspect."""
     monkeypatch.chdir(tmp_path)
     import reyn.llm.model_budget as _mb
     monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: 2_500)
@@ -191,9 +188,24 @@ def test_summary_reaches_wire_with_an_accepted_role_not_summary(
     loop = _RecordingLoop(fail_marker="mid result payload")
     asyncio.run(session._loop_driver._run_with_shrink(loop, "continue please", chain_id="c1"))
     asyncio.run(settle(session))
+    return loop.calls
 
-    assert loop.calls, "loop.run must have been called at least once"
-    for i, history in enumerate(loop.calls):
+
+def test_summary_reaches_wire_with_an_accepted_role_not_summary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5598 accept — after retry_loop's own compact() succeeds
+    on real, non-empty ``raw_middle`` content and folds it into a fresh
+    summary appended to ``head``, the VERY NEXT ``main_call`` (still
+    inside the SAME recovery episode — the owner's own incident shape)
+    must never include a wire dict whose ``role`` is
+    ``SUMMARY_MESSAGE_ROLE`` ("summary")."""
+    from reyn.services.compaction.engine import SUMMARY_MESSAGE_ROLE
+
+    calls = _drive_overflow_recovery_through_a_real_fold(tmp_path, monkeypatch)
+
+    assert calls, "loop.run must have been called at least once"
+    for i, history in enumerate(calls):
         offending = [t for t in history if t.get("role") == SUMMARY_MESSAGE_ROLE]
         assert not offending, (
             f"call {i}: history sent to loop.run() carries a wire dict "
@@ -203,10 +215,64 @@ def test_summary_reaches_wire_with_an_accepted_role_not_summary(
         )
     summary_present = any(
         "[summary of earlier conversation]" in str(t.get("content", ""))
-        for history in loop.calls for t in history
+        for history in calls for t in history
     )
     assert summary_present, (
         "test setup sanity: the fresh summary must actually be present "
         "in what was sent (as an accepted role) — otherwise this test "
         "isn't exercising the bug's own trigger at all"
     )
+
+
+def test_wire_message_carries_no_internal_summary_structure_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5599 follow-up — lead-coder's own catch, same wire-egress
+    site re-read after #5598 landed. ``wrap_summary_as_message`` spreads
+    ``**summary`` into the dict it returns (engine.py), so retry_loop's
+    fresh fold-success ``head`` entry carries ``topic_arc``/``decisions``/
+    ``pending``/``session_user_facts``/``artifacts_referenced``/
+    ``covers_through_seq`` — none of them a real chat-completions message
+    field. The ORIGINAL #5598 fix only stripped ``spillability`` (a
+    deny-list) and left these six untouched.
+
+    Accept: none of the 6 internal ``ChatSummary`` keys ever appear on a
+    wire dict sent to ``loop.run()``.
+    Deny: ``tool_calls``/``tool_call_id``/``name`` (the fields a REAL
+    tool-result turn carries) survive the same allow-list — proves the
+    fix is a genuine allow-list, not an accidental "strip everything"
+    that would also break tool-result turns (a real regression the
+    allow-list's own falsify point ② already caught once: dropping
+    ``name`` broke a real tool message, "A function call output without
+    a call_id requires a name")."""
+    _INTERNAL_SUMMARY_STRUCTURE_KEYS = (
+        "topic_arc", "decisions", "pending",
+        "session_user_facts", "artifacts_referenced", "covers_through_seq",
+    )
+    calls = _drive_overflow_recovery_through_a_real_fold(tmp_path, monkeypatch)
+
+    assert calls, "loop.run must have been called at least once"
+    for i, history in enumerate(calls):
+        for t in history:
+            leaked = [k for k in _INTERNAL_SUMMARY_STRUCTURE_KEYS if k in t]
+            assert not leaked, (
+                f"call {i}: a wire dict carries internal ChatSummary "
+                f"structure key(s) {leaked!r} — no real chat-completions "
+                f"message field has these: {t!r}"
+            )
+
+    tool_turns = [
+        t for history in calls for t in history if t.get("role") == "tool"
+    ]
+    assert tool_turns, (
+        "test setup sanity: the real tool-result turn must survive "
+        "somewhere in what was sent — otherwise the deny side below "
+        "isn't exercised at all"
+    )
+    for t in tool_turns:
+        assert t.get("tool_call_id") and t.get("name"), (
+            f"a real tool-result turn must keep its tool_call_id/name — "
+            f"an allow-list that drops them breaks the turn (real "
+            f"incident: \"A function call output without a call_id "
+            f"requires a name\"): {t!r}"
+        )


### PR DESCRIPTION
**[e2e-coder]** — Follow-up to #5599 (lead-coder's own catch, same wire-egress site re-read after #5598 landed). Owner is waiting live on this.

## Bug

`_router_main_call`'s wire-shaping step (`router_loop_driver.py`, touched by #5599) stripped only `spillability` — a **deny-list** that missed a real internal key already present. `wrap_summary_as_message` (`engine.py`) spreads `**summary` into the dict it returns, so `retry_loop`'s own fresh fold-success `head` entry carries `topic_arc`/`decisions`/`pending`/`session_user_facts`/`artifacts_referenced`/`covers_through_seq` — none of them a real chat-completions message field — straight onto the wire alongside #5598's own role fix.

## Fix

Replace the deny-list with an **allow-list** (`_WIRE_MESSAGE_KEYS`, module-level constant) — the structural fix. An allow-list cannot miss a *future* internal key the same way `spillability` alone already missed this one; a new internal annotation now has to be added there deliberately to reach the wire, not omitted from a strip-list to leak by default.

## Falsify (lead-coder's own 2-point ask)

1. `head`/`tail` dicts differ in shape between `_serialise_turn`'s own construction and `wrap_summary_as_message`'s direct injection — read both directly. Wire keys enumerated from `_serialise_turn`'s own body: `role`/`content` always, `tool_calls`/`tool_call_id`/`name` when the `ChatMessage` carries them, plus the 3 reasoning-continuity fields `_REASONING_BUNDLE_FIELDS` attaches.
2. Dropping `name` breaks a real tool message ("A function call output without a call_id requires a name") — confirmed by keeping it in the allow-list and asserting tool turns survive with `tool_call_id`/`name` intact (the new test's own deny side).

## Strip-falsify

Reverted to the deny-list, reran the new test — all 6 internal `ChatSummary` keys reach the recorded wire payload exactly as predicted. Restored, reran — green.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5598_summary_role_normalized_on_wire.py` — 2 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/services/router_loop_driver.py` — clean
- [x] `python scripts/mypy_ratchet.py` — 200 findings, all baselined
- [x] `python scripts/flat_tests_ratchet.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `python scripts/check_bare_tests_import_reference.py` — clean (tests/ touched)
- [x] `python scripts/check_file_depth_reference.py` — clean (tests/ touched)
- [x] Related suite (102 tests across compaction/retry_loop/quota/classify/observability/wire-role files) — all green
- [x] (skipped — no visual surface touched; no docs/ touched, doc gates not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
