### PR TITLE
feat(#5603): litellm compat patches as a repo module, not a site-packages .pth file

### DIFF
--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -305,6 +305,33 @@ into anything read back after the fact.
 process should ever be reaped automatically is an owner-level judgment call
 explicitly out of this slice's scope until the count is visible at all.
 
+### litellm compat patches ([#5603](https://github.com/tya5/reyn/issues/5603))
+
+```
+litellm compat patches (#5603) — measured class-attribute state,
+not a restated declaration that the patch module exists:
+  ✓ applied: stream_chunk_recovery (A)
+  ✓ applied: overflow_diagnosis (B)
+```
+
+Reads the ACTUAL applied-state flag reyn's own `src/reyn/llm/
+_litellm_compat_patches.py` sets on the real litellm class objects after
+triggering the real `ensure_litellm_ready()` chokepoint — never a
+restatement that the patch module merely imports successfully. This
+distinction is the whole point (#5603's own motivating incident, #5568): a
+previous hand-placed `site-packages` patch could fail silently on a litellm
+version bump (`ModuleNotFoundError` inside a `.pth` file — the process still
+starts, the patch is simply not applied, nothing says so anywhere). D-1: a
+`✗ NOT applied` line here is a real, measured gap, not a declaration that
+should be true.
+
+`stream_chunk_recovery` (A) is correctness-critical — see
+`_litellm_compat_patches.py`'s own module docstring for why its own failure
+to apply makes `ensure_litellm_ready()` itself return unusable rather than
+silently degrading. `overflow_diagnosis` (B) is diagnostic-only; its own
+failure to apply only means a genuinely-failed call surfaces a worse
+diagnosis, never a wrong DATA result.
+
 ## Not applicable, measured (not a later slice)
 
 C-6's "listen port declared-vs-effective" example does NOT apply to reyn's

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -106,6 +106,7 @@ intervention_answer_submitted
 intervention_denied
 intervention_routed
 limit_denied
+litellm_compat_patch_applied
 llm_call_retry
 llm_call_retry_exhausted
 llm_called

--- a/scripts/mypy_ratchet_baseline.json
+++ b/scripts/mypy_ratchet_baseline.json
@@ -496,6 +496,18 @@
     "code": "attr-defined"
   },
   {
+    "file": "src/reyn/llm/_litellm_compat_patches.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/llm/_litellm_compat_patches.py",
+    "code": "method-assign"
+  },
+  {
+    "file": "src/reyn/llm/_litellm_compat_patches.py",
+    "code": "union-attr"
+  },
+  {
     "file": "src/reyn/llm/llm.py",
     "code": "arg-type"
   },

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -418,6 +418,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "intervention_denied",
     "intervention_routed",
     "limit_denied",
+    "litellm_compat_patch_applied",
     "llm_call_retry",
     "llm_call_retry_exhausted",
     "llm_called",

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -380,7 +380,18 @@ def _print_litellm_patch_status() -> None:
     litellm`` every real call pays) so the measurement reflects what THIS
     process's own real usage would actually get — a doctor run that
     skipped the import could only ever report "not yet imported", which
-    answers nothing about whether the patch itself still applies."""
+    answers nothing about whether the patch itself still applies.
+
+    #4421 seam-gate review (lead-coder): this function itself never
+    imports ``litellm`` — the applied-state READ lives in
+    ``_litellm_compat_patches.report_applied_state()`` (the seam's own
+    module, already exempted from the gate with its own documented
+    reason), so this file's own litellm touch is exactly the ONE call to
+    ``ensure_litellm_ready()`` every other doctor check already routes
+    through. Folding the read into this file too would have meant a
+    SECOND file the gate has to trust "already warmed" without a
+    structural guarantee — the exact drift #4421 exists to prevent."""
+    from reyn.llm._litellm_compat_patches import report_applied_state
     from reyn.llm.litellm_bootstrap import ensure_litellm_ready
 
     mod = ensure_litellm_ready()
@@ -389,29 +400,21 @@ def _print_litellm_patch_status() -> None:
         print("    warning above, if any); nothing to measure")
         return
 
-    try:
-        from litellm.completion_extras.litellm_responses_transformation import (
-            handler as _H,
-        )
-        applied_a = bool(
-            getattr(_H.ResponsesToCompletionBridgeHandler, "_reyn_5603_patched", False),
-        )
-    except Exception as exc:  # noqa: BLE001 — report, never raise (D-2)
-        print(f"  ✗ stream_chunk_recovery (A): could not measure ({type(exc).__name__}: {exc})")
-        applied_a = None
-    if applied_a is not None:
-        state = "✓ applied" if applied_a else "✗ NOT applied — correctness-critical, see #5603"
-        print(f"  {state}: stream_chunk_recovery (A)")
+    state = report_applied_state()
 
-    try:
-        from litellm.llms.chatgpt.responses import transformation as _T
-        applied_b = bool(getattr(_T.ChatGPTResponsesAPIConfig, "_reyn_5603b_patched", False))
-    except Exception as exc:  # noqa: BLE001 — report, never raise (D-2)
-        print(f"  ✗ overflow_diagnosis (B): could not measure ({type(exc).__name__}: {exc})")
-        applied_b = None
-    if applied_b is not None:
-        state = "✓ applied" if applied_b else "⚠ NOT applied — diagnostic-only, see #5603"
-        print(f"  {state}: overflow_diagnosis (B)")
+    applied_a = state["stream_chunk_recovery"]
+    if isinstance(applied_a, bool):
+        label = "✓ applied" if applied_a else "✗ NOT applied — correctness-critical, see #5603"
+        print(f"  {label}: stream_chunk_recovery (A)")
+    else:
+        print(f"  ✗ stream_chunk_recovery (A): {applied_a}")
+
+    applied_b = state["overflow_diagnosis"]
+    if isinstance(applied_b, bool):
+        label = "✓ applied" if applied_b else "⚠ NOT applied — diagnostic-only, see #5603"
+        print(f"  {label}: overflow_diagnosis (B)")
+    else:
+        print(f"  ✗ overflow_diagnosis (B): {applied_b}")
 
 
 def _print_hook_env_snapshot(resolved_root: Path) -> None:

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -363,6 +363,56 @@ def run(args: argparse.Namespace) -> None:
     print("override resolve_base_dir_candidate uses, not a restated declaration):")
     _print_hook_env_snapshot(resolved_root)
 
+    # ── #5603: litellm compat-patch applied state ───────────────────────────
+    print()
+    print("litellm compat patches (#5603) — measured class-attribute state,")
+    print("not a restated declaration that the patch module exists:")
+    _print_litellm_patch_status()
+
+
+def _print_litellm_patch_status() -> None:
+    """#5603 (architect fail-safe ②, D-1): reads the ACTUAL applied-state
+    flag reyn's own patch functions set on the real litellm class objects
+    — never a restatement of "the patch module is present" (which would
+    be true even if the patch silently failed to apply, the exact #5568
+    incident this whole issue exists to prevent recurring). Triggers the
+    real ``ensure_litellm_ready()`` chokepoint (the same one-time ``import
+    litellm`` every real call pays) so the measurement reflects what THIS
+    process's own real usage would actually get — a doctor run that
+    skipped the import could only ever report "not yet imported", which
+    answers nothing about whether the patch itself still applies."""
+    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+    mod = ensure_litellm_ready()
+    if mod is None:
+        print("  ? not checked — litellm itself failed to import (see the")
+        print("    warning above, if any); nothing to measure")
+        return
+
+    try:
+        from litellm.completion_extras.litellm_responses_transformation import (
+            handler as _H,
+        )
+        applied_a = bool(
+            getattr(_H.ResponsesToCompletionBridgeHandler, "_reyn_5603_patched", False),
+        )
+    except Exception as exc:  # noqa: BLE001 — report, never raise (D-2)
+        print(f"  ✗ stream_chunk_recovery (A): could not measure ({type(exc).__name__}: {exc})")
+        applied_a = None
+    if applied_a is not None:
+        state = "✓ applied" if applied_a else "✗ NOT applied — correctness-critical, see #5603"
+        print(f"  {state}: stream_chunk_recovery (A)")
+
+    try:
+        from litellm.llms.chatgpt.responses import transformation as _T
+        applied_b = bool(getattr(_T.ChatGPTResponsesAPIConfig, "_reyn_5603b_patched", False))
+    except Exception as exc:  # noqa: BLE001 — report, never raise (D-2)
+        print(f"  ✗ overflow_diagnosis (B): could not measure ({type(exc).__name__}: {exc})")
+        applied_b = None
+    if applied_b is not None:
+        state = "✓ applied" if applied_b else "⚠ NOT applied — diagnostic-only, see #5603"
+        print(f"  {state}: overflow_diagnosis (B)")
+
 
 def _print_hook_env_snapshot(resolved_root: Path) -> None:
     """#5428: the operator-facing consumer this issue required — ``reyn

--- a/src/reyn/llm/_litellm_compat_patches.py
+++ b/src/reyn/llm/_litellm_compat_patches.py
@@ -1,0 +1,359 @@
+"""#5603 — reyn's own local patches to litellm's Responses-API bridge,
+made reproducible AS A DEPENDENCY (repo module + startup import, not a
+`site-packages`-direct `.pth` file — see this module's own docstring
+sections below for the incident this replaces).
+
+## Why this exists at all (owner's own 2 questions, #5603)
+
+> "依存ライブラリ側の場合は、依存としてパッチ当てる方法ないとダメだよ？"
+> "reyn の import は litellm ver up で壊れることないの？フェールセーフ
+>  対応まで考えてるの？"
+
+The PREVIOUS form (#5568) lived as `litellm_patch.py` + `zz_litellm_patch.pth`
+dropped straight into `site-packages/` by hand. Two real defects, both
+disclosed by the owner's own questions:
+
+1. **Not reproducible as a dependency** — a fresh `.venv`, a CI runner, or
+   any OTHER machine never gets it. `pip install -U litellm` does not
+   remove it (so it LOOKS durable), but that is not the same claim as "it
+   is declared anywhere reyn's own dependency graph can reproduce."
+2. **Fails silently on a version bump** — a broken `.pth` line degrades to
+   `Error processing line 1 of …/zz_litellm_patch.pth: ModuleNotFoundError
+   … Remainder of file ignored`. The PROCESS STILL STARTS. The patch is
+   simply not applied. Nothing in reyn's own event log or console says so.
+   The original bug this patch exists to fix comes back with zero signal.
+
+## The fix (architect's own design, #5603)
+
+- **Lives in this repo, imported from reyn's own startup chokepoint**
+  (:func:`reyn.llm.litellm_bootstrap.ensure_litellm_ready`) — the ONE
+  place `import litellm` itself is allowed, so a patch-application
+  failure surfaces at the SAME seam an `import litellm` failure already
+  does, not silently past it.
+- **No version-ceiling constant.** Owner's own standing instruction: never
+  embed an unjustified number without a rationale or a config knob. A
+  declared "verified up to litellm X.Y.Z" ceiling would BE such a number
+  (who re-verifies it on the next litellm release?). Architect's own
+  ruling: the CI-side scaffold test (`tests/scaffold/test_5603_*.py`)
+  answers "does the defect still exist" directly, against whatever
+  litellm version is actually installed — no proxy measure (a version
+  number, a symbol's mere presence) stands in for the real question. Red
+  there means "upstream may have fixed it — remove the workaround and
+  this test," never "reyn broke."
+- **Each patch function is a no-op when the defect it targets is not
+  present**, BY CONSTRUCTION, not by a runtime self-check — see each
+  function's own docstring for exactly which line makes this true. A
+  stale patch left applied after litellm genuinely fixes the underlying
+  defect (the window between the scaffold test going red and someone
+  actually removing this module) therefore changes nothing observable.
+- **Correctness-critical vs. diagnostic-only get different failure
+  modes** (architect's own ruling — the two patches are NOT the same
+  risk class):
+  - :func:`apply_stream_chunk_recovery` (A) fixes a defect that DISCARDS
+    a real, successful response (`ValueError("Unknown items in responses
+    API response: []")` → `APIConnectionError` for a conversation the
+    model actually answered). Silently running WITHOUT this patch means
+    reyn returns a wrong/failed result for otherwise-correct upstream
+    behavior — "正しさに必要". If this patch cannot be applied (the
+    private symbols it depends on moved), :func:`apply_all` re-raises,
+    which the SAME `except Exception: result = None` branch
+    `ensure_litellm_ready` already has treats identically to any other
+    `import litellm` failure — every no-fallback caller (a real
+    completion/embedding call) correctly sees "litellm unusable" rather
+    than silently running with a known-broken bridge.
+  - :func:`apply_overflow_diagnosis` (B) only IMPROVES which exception
+    TYPE a genuinely-failed call surfaces as (misdiagnosis, not data
+    loss — the call was going to fail either way; #5568's own record:
+    "診断を直すだけで、呼びが通るようになるわけではない"). If this one
+    cannot be applied, the call still fails with a worse diagnosis, not a
+    wrong answer — logged as a WARNING and an audit-event, not fatal.
+
+## Observability (architect's fail-safe #2 — lens 7)
+
+Both application attempts emit ONE `litellm_compat_patch_applied` audit-
+event each (success or failure, never silent) via the caller-supplied
+`EventLog`, and `reyn doctor` prints the same measured state (never a
+restated declaration — this module's own flags ARE the measurement).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from reyn.core.events.events import EventLog
+
+
+def apply_stream_chunk_recovery(events: "EventLog | None" = None) -> bool:
+    """#5568(A) — litellm's ``ResponsesToCompletionBridgeHandler.
+    _collect_response_from_stream_async`` (the ``stream:false`` branch of
+    the Responses→chat-completions bridge) discards every streamed chunk
+    unconditionally (``async for _ in stream_iter: pass``) and returns
+    ONLY whatever ``completed_response.response`` already carries. When
+    the provider's own terminal ``response.completed`` event reports an
+    EMPTY ``output`` (litellm's own known gap — the terminal event does
+    not always carry the full content the stream already delivered piece
+    by piece), the real, already-delivered content is discarded and the
+    caller sees ``ValueError("Unknown items in responses API response:
+    [])`` → ``APIConnectionError`` for a conversation the model actually
+    answered.
+
+    Reproduced directly (no provider, no network — #5603's own falsify):
+    a synthetic async iterator yielding a real ``OUTPUT_ITEM_DONE`` chunk,
+    paired with a ``completed_response.response`` reporting ``output=[]``
+    — the UNPATCHED method returns ``output=[]`` regardless (see
+    ``tests/scaffold/test_5603_litellm_stream_recovery_defects.py`` for
+    the same repro CI runs against the live installed version).
+
+    Fix: record ``OUTPUT_ITEM_DONE``/``OUTPUT_TEXT_DONE`` chunks as they
+    stream past (litellm's OWN ``record_output_item_chunk``/
+    ``record_output_text_chunk`` — no new parsing written here), and only
+    when the completed response's own ``output`` is empty, substitute the
+    recovered items. **No-op when the defect is absent**: the line
+    ``if isinstance(out, list) and len(out) == 0`` is the ENTIRE
+    substitution condition — a completed response that already carries a
+    non-empty ``output`` (the ordinary, non-defective case) is returned
+    completely unchanged; this patched method never inspects, let alone
+    overwrites, a non-empty result.
+
+    Correctness-critical (see this module's own docstring): raises if the
+    private symbols this depends on have moved — the caller
+    (:func:`apply_all`) does not catch this, by design.
+
+    Returns ``True`` on this call (idempotent — a second call after the
+    first is a no-op via the ``_reyn_5603_patched`` guard, still returns
+    ``True``)."""
+    from litellm.completion_extras.litellm_responses_transformation import handler as H
+    from litellm.responses.sse_output_recovery import (
+        record_output_item_chunk,
+        record_output_text_chunk,
+    )
+    from litellm.types.llms.openai import ResponsesAPIStreamEvents
+
+    cls = H.ResponsesToCompletionBridgeHandler
+    if getattr(cls, "_reyn_5603_patched", False):
+        return True
+
+    def _as_dict(chunk: Any) -> "dict | None":
+        if isinstance(chunk, dict):
+            return chunk
+        for attr in ("model_dump", "dict"):
+            fn = getattr(chunk, attr, None)
+            if callable(fn):
+                try:
+                    return fn()
+                except Exception:  # noqa: BLE001 — a malformed chunk is skipped, not fatal
+                    pass
+        return None
+
+    async def _collect_response_from_stream_async(self: Any, stream_iter: Any) -> Any:
+        items: dict = {}
+        text_only: dict = {}
+        async for chunk in stream_iter:
+            t = getattr(chunk, "type", None)
+            if t not in (
+                ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+                ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
+            ):
+                continue
+            d = _as_dict(chunk)
+            if not d:
+                continue
+            if t == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
+                record_output_item_chunk(parsed_chunk=d, output_items=items)
+            else:
+                record_output_text_chunk(
+                    parsed_chunk=d, output_items=items, text_only_items=text_only,
+                )
+
+        completed = getattr(stream_iter, "completed_response", None)
+        response_obj = getattr(completed, "response", None) if completed else None
+        if response_obj is None:
+            raise ValueError("Stream ended without a completed response")
+
+        hidden_params = getattr(stream_iter, "_hidden_params", None)
+        response = self._coerce_response_object(response_obj, hidden_params)
+
+        out = getattr(response, "output", None)
+        if isinstance(out, list) and len(out) == 0:
+            merged = {**text_only}
+            merged.update(items)
+            if merged:
+                response.output = [v for _, v in sorted(merged.items())]
+
+        return response
+
+    cls._collect_response_from_stream_async = _collect_response_from_stream_async
+    cls._reyn_5603_patched = True
+    return True
+
+
+def apply_overflow_diagnosis(events: "EventLog | None" = None) -> bool:
+    """#5568(B) — a provider (observed: a real gpt-5.6-luna deployment)
+    can end a Responses-API SSE stream after only ``response.created``/
+    ``response.in_progress`` on a genuine context-length overflow, with
+    NO terminal event and no body — the OpenAI public streaming-events
+    spec's own documented shape for "started, then cut off", also
+    reported independently by other client implementations against the
+    SAME upstream behavior (maximhq/bifrost#4413). litellm's own
+    ``_extract_completed_response_from_sse`` (a pure function — no
+    network, no ``logging_obj``) returns ``(None, None)`` for this input:
+    no completed response AND no error message, because nothing in the
+    truncated stream told it WHY. The caller then raises
+    ``OpenAIError(message=error_message or raw_response.text, ...)`` —
+    since ``error_message`` is ``None``, the WHOLE raw SSE body (real
+    incident: 163,835 bytes) becomes the exception's message, and reyn's
+    own ``is_context_overflow_error``/``classify_llm_failure`` (neither
+    a real ``ContextWindowExceededError`` nor a recognisable keyword
+    anywhere in that raw SSE blob) both fail to recognise it as an
+    overflow.
+
+    Reproduced directly (no provider — #5603's own falsify): a synthetic
+    SSE string containing only ``response.created``/``response.
+    in_progress`` lines fed to the unpatched, pure
+    ``_extract_completed_response_from_sse`` returns ``(None, None)`` —
+    see ``tests/scaffold/test_5603_litellm_stream_recovery_defects.py``.
+
+    Fix: on the SAME "no completed response" failure, re-scan the raw SSE
+    for ANY terminal event or ANY real output content; if genuinely
+    neither is present (the truncated-overflow shape, not some other
+    provider error this patch has no business reinterpreting), re-raise
+    as ``litellm.ContextWindowExceededError`` instead — reyn's own
+    ``classify_llm_failure``/``is_context_overflow_error`` then correctly
+    classify it as OVERFLOW. This corrects the DIAGNOSIS only — it does
+    not make the call succeed (#5568's own record: "診断を直すだけで、
+    呼びが通るようになるわけではない").
+
+    **No-op when the defect is absent**: this patch wraps the ORIGINAL
+    method in a try/except and re-raises the SAME exception UNCHANGED
+    whenever a genuine terminal event or real output content is present
+    in the raw SSE (``if has_terminal or has_body: raise``) — an ordinary
+    successful call, or a call that fails for any OTHER reason, is never
+    touched; the wrapped call only ever converts the ONE specific silent-
+    truncation shape.
+
+    Diagnostic-only (see this module's own docstring): a failure to apply
+    this patch is logged, never fatal — the caller (:func:`apply_all`)
+    catches any exception here.
+
+    Returns ``True`` on this call (idempotent — a second call after the
+    first is a no-op via the ``_reyn_5603b_patched`` guard, still returns
+    ``True``)."""
+    from litellm.llms.chatgpt.responses import transformation as T
+    from litellm.responses.sse_output_recovery import parse_sse_json_chunk
+    from litellm.types.llms.openai import ResponsesAPIStreamEvents
+
+    cls = getattr(T, "ChatGPTResponsesAPIConfig", None)
+    if cls is None:
+        for name in dir(T):
+            o = getattr(T, name)
+            if isinstance(o, type) and hasattr(o, "_extract_completed_response_from_sse"):
+                cls = o
+                break
+    if cls is None:
+        raise AttributeError(
+            "reyn #5603(B): could not locate the Responses-API config class "
+            "in litellm.llms.chatgpt.responses.transformation — upstream "
+            "may have restructured this module"
+        )
+    if getattr(cls, "_reyn_5603b_patched", False):
+        return True
+
+    orig = cls.transform_response_api_response
+
+    def transform_response_api_response(
+        self: Any, model: Any, raw_response: Any, logging_obj: Any,
+    ) -> Any:
+        try:
+            return orig(self, model=model, raw_response=raw_response, logging_obj=logging_obj)
+        except Exception as exc:
+            body = getattr(raw_response, "text", "") or ""
+            if not body.lstrip().startswith(("data:", "event:")):
+                raise
+            seen = set()
+            for line in body.splitlines():
+                d = parse_sse_json_chunk(line)
+                if d:
+                    seen.add(d.get("type"))
+            terminal = {
+                ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+                getattr(ResponsesAPIStreamEvents, "RESPONSE_INCOMPLETE", None),
+                getattr(ResponsesAPIStreamEvents, "RESPONSE_FAILED", None),
+            }
+            has_terminal = bool(seen & terminal)
+            has_body = any(
+                t and ("output_text" in str(t) or "output_item" in str(t)) for t in seen
+            )
+            if has_terminal or has_body:
+                raise
+            import litellm
+            raise litellm.ContextWindowExceededError(
+                message=(
+                    "reyn #5603(B): the upstream stream ended after "
+                    f"{sorted(str(t) for t in seen if t)} with no terminal "
+                    "event and no output — the shape the Responses API "
+                    "produces on a context-length overflow whose error "
+                    "event carries an empty message"
+                ),
+                model=model,
+                llm_provider="openai",
+            ) from exc
+
+    cls.transform_response_api_response = transform_response_api_response
+    cls._reyn_5603b_patched = True
+    return True
+
+
+def apply_all(events: "EventLog | None" = None) -> None:
+    """#5603 — the ONE call site :func:`reyn.llm.litellm_bootstrap.
+    ensure_litellm_ready` makes. Applies both patches with their own,
+    DIFFERENT failure semantics (see each function's own docstring for
+    why they differ):
+
+    - :func:`apply_stream_chunk_recovery` (A, correctness-critical) —
+      exceptions propagate UNCAUGHT. ``ensure_litellm_ready``'s own
+      surrounding ``try/except Exception: result = None`` then treats a
+      failure here identically to any other ``import litellm`` failure.
+    - :func:`apply_overflow_diagnosis` (B, diagnostic-only) — caught
+      here, logged as a WARNING, and reported via the audit-event below;
+      never blocks litellm from becoming usable.
+
+    Both successes/failures emit ``litellm_compat_patch_applied`` (one
+    event per patch, `events` may be ``None`` — same posture as this
+    module's own sibling hooks in ``litellm_bootstrap.py``, which already
+    treat a missing ``EventLog`` as "skip the audit-event, still do the
+    work")."""
+    import logging
+
+    log = logging.getLogger(__name__)
+
+    ok_a = False
+    try:
+        apply_stream_chunk_recovery(events)
+        ok_a = True
+    finally:
+        if events is not None:
+            events.emit(
+                "litellm_compat_patch_applied",
+                patch="stream_chunk_recovery", issue="#5603", applied=ok_a,
+            )
+    # #5603: A is correctness-critical — a failure above already
+    # propagated past the `finally` (which only records the event, never
+    # swallows) before reaching here, so this line only runs on success.
+
+    try:
+        apply_overflow_diagnosis(events)
+        ok_b = True
+    except Exception as exc:  # noqa: BLE001 — diagnostic-only, never fatal
+        ok_b = False
+        log.warning(
+            "reyn #5603(B): could not patch litellm's Responses-API "
+            "context-overflow diagnosis (upstream may have restructured "
+            "the private symbols this depends on) — calls that hit the "
+            "underlying defect will surface a generic error instead of a "
+            "recognised context-overflow: %r", exc,
+        )
+    if events is not None:
+        events.emit(
+            "litellm_compat_patch_applied",
+            patch="overflow_diagnosis", issue="#5603", applied=ok_b,
+        )

--- a/src/reyn/llm/_litellm_compat_patches.py
+++ b/src/reyn/llm/_litellm_compat_patches.py
@@ -303,6 +303,57 @@ def apply_overflow_diagnosis(events: "EventLog | None" = None) -> bool:
     return True
 
 
+def report_applied_state() -> "dict[str, bool | str]":
+    """#5603 (lead-coder's own #4421 seam-gate review) — the ONE place
+    that reads the real applied-state class-attribute flags back off the
+    actual litellm classes, so ``reyn doctor`` (or any other future
+    caller) never needs its own ``import litellm``. The gate
+    (``tests/security/test_4421_litellm_import_seam.py``) enforces this
+    module as the sole place ``src/reyn`` code may touch litellm outside
+    ``litellm_bootstrap.py`` itself — a caller reaching for litellm
+    directly to answer "is the patch applied" would defeat that, exactly
+    the class of drift the gate exists to catch.
+
+    Caller's own responsibility: call ``ensure_litellm_ready()`` FIRST
+    (this function does not — it only reads state, never triggers
+    import/apply itself, matching this module's own "no side effect
+    beyond what ``apply_all`` already did" contract). If litellm was
+    never successfully imported in this process, both patch classes are
+    unreachable and this function reports that explicitly rather than
+    raising.
+
+    Returns a dict with 2 keys, ``stream_chunk_recovery`` and
+    ``overflow_diagnosis``, each mapped to ``True`` (applied), ``False``
+    (not applied — a genuine gap, see ``apply_all``'s own docstring for
+    which of the two is correctness-critical), or a short string
+    describing why the state could not be measured at all (e.g. the
+    litellm submodule that class normally lives in was itself
+    restructured — the SAME shape the scaffold test's own "GOOD NEWS, not
+    a regression" framing already treats as "upstream changed, go check
+    the workaround," not a reyn-side bug)."""
+    state: "dict[str, bool | str]" = {}
+
+    try:
+        from litellm.completion_extras.litellm_responses_transformation import (
+            handler as _H,
+        )
+        state["stream_chunk_recovery"] = bool(
+            getattr(_H.ResponsesToCompletionBridgeHandler, "_reyn_5603_patched", False),
+        )
+    except Exception as exc:  # noqa: BLE001 — report, never raise
+        state["stream_chunk_recovery"] = f"could not measure ({type(exc).__name__}: {exc})"
+
+    try:
+        from litellm.llms.chatgpt.responses import transformation as _T
+        state["overflow_diagnosis"] = bool(
+            getattr(_T.ChatGPTResponsesAPIConfig, "_reyn_5603b_patched", False),
+        )
+    except Exception as exc:  # noqa: BLE001 — report, never raise
+        state["overflow_diagnosis"] = f"could not measure ({type(exc).__name__}: {exc})"
+
+    return state
+
+
 def apply_all(events: "EventLog | None" = None) -> None:
     """#5603 — the ONE call site :func:`reyn.llm.litellm_bootstrap.
     ensure_litellm_ready` makes. Applies both patches with their own,

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -558,6 +558,21 @@ def ensure_litellm_ready(
                     # attribute access afterward instead of needing its
                     # own submodule import statement outside the seam.
                     import litellm.litellm_core_utils.logging_worker  # noqa: F401
+
+                    # #5603: reyn's own local litellm patches, applied ONCE
+                    # inside this same seam (never a `site-packages`-direct
+                    # `.pth` file — see `_litellm_compat_patches`'s own
+                    # module docstring for the incident that replaces). The
+                    # correctness-critical patch (A) is UNCAUGHT here — its
+                    # own failure falls into the SAME `except Exception:
+                    # result = None` this `import litellm` failure already
+                    # uses, so a no-fallback caller sees "litellm unusable"
+                    # rather than silently running with a known-broken
+                    # bridge; the diagnostic-only patch (B) catches its own
+                    # failures internally and only warns (see
+                    # `_litellm_compat_patches.apply_all`'s own docstring).
+                    from reyn.llm._litellm_compat_patches import apply_all as _apply_litellm_patches
+                    _apply_litellm_patches(events)
                     result = litellm
                 except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
                     result = None

--- a/tests/interfaces/test_5603_doctor_litellm_patch_status.py
+++ b/tests/interfaces/test_5603_doctor_litellm_patch_status.py
@@ -1,0 +1,48 @@
+"""Tier 2: #5603 — ``reyn doctor``'s litellm compat-patch status line.
+
+D-1 (doctor's own rule, module docstring): measure, don't assert — this
+check must read the REAL applied-state flag reyn's own patch functions
+set on the real litellm class objects, never restate that the patch
+module merely exists (which would still be true even if the patch itself
+silently failed to apply — the exact #5568 incident this whole issue
+exists to prevent recurring).
+
+Real ``ensure_litellm_ready()``/real litellm import throughout (this
+check's own whole point is to trigger the SAME chokepoint a real call
+uses) — no mock, no stand-in class.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.cli.commands.doctor import _print_litellm_patch_status
+
+
+def test_both_patches_report_applied_after_a_real_import(capsys) -> None:
+    """Tier 2: #5603 accept — a real ``ensure_litellm_ready()`` call
+    (triggered by this function itself) applies both patches; the doctor
+    line reads their own real class-attribute flags back and reports
+    both applied."""
+    _print_litellm_patch_status()
+    out = capsys.readouterr().out
+
+    assert "✓ applied: stream_chunk_recovery (A)" in out, out
+    assert "✓ applied: overflow_diagnosis (B)" in out, out
+
+
+def test_measures_the_real_class_attribute_not_a_restated_declaration(capsys) -> None:
+    """Tier 2: #5603 accept — the reported state is read directly off the
+    real litellm class objects, not derived from "the patch module
+    imports successfully" (D-1's own distinction, and the #5568
+    incident's own root cause: a broken import can leave the patch
+    module unusable while the REST of the process still starts fine —
+    only reading the actual flag distinguishes the two)."""
+    from litellm.completion_extras.litellm_responses_transformation import handler as H
+    from litellm.llms.chatgpt.responses import transformation as T
+
+    _print_litellm_patch_status()
+
+    assert getattr(H.ResponsesToCompletionBridgeHandler, "_reyn_5603_patched", False) is True
+    assert getattr(T.ChatGPTResponsesAPIConfig, "_reyn_5603b_patched", False) is True
+
+    out = capsys.readouterr().out
+    assert "✓ applied: stream_chunk_recovery (A)" in out
+    assert "✓ applied: overflow_diagnosis (B)" in out

--- a/tests/llm/test_5603_litellm_bootstrap_patch_integration.py
+++ b/tests/llm/test_5603_litellm_bootstrap_patch_integration.py
@@ -1,0 +1,106 @@
+"""Tier 2: #5603 — ``ensure_litellm_ready``'s own integration with reyn's
+litellm compat patches: the two DIFFERENT failure semantics architect
+ruled for (correctness-critical A propagates uncaught; diagnostic-only B
+is caught and warned).
+
+Real ``ensure_litellm_ready``/real litellm import throughout — only the
+patch APPLICATION function itself is monkeypatched to simulate "the
+private symbol this depends on moved" (a real, environment-shaped
+failure this test cannot otherwise force without actually breaking the
+installed litellm package), following
+``test_litellm_lazy_load.py``'s own established reset pattern for this
+module's process-global one-shot state.
+"""
+from __future__ import annotations
+
+import reyn.llm.litellm_bootstrap as litellm_bootstrap
+
+
+def _reset_litellm_ready_state():
+    """Same reset ``test_litellm_lazy_load.py`` already established for
+    this module's process-global one-shot guards, PLUS the #4395 axis②
+    cooldown pair (``_litellm_import_cooldown_until``/``_litellm_import_
+    failure_warned``) — a forced failure in one test would otherwise arm
+    the cooldown and make every subsequent test's own genuine attempt
+    silently short-circuit to ``None`` without even importing, exactly
+    the bug this reset must not reproduce. Returns a restore callable."""
+    saved_ready = litellm_bootstrap._litellm_ready
+    saved_registry = dict(litellm_bootstrap._ready_registry)
+    saved_cooldown = litellm_bootstrap._litellm_import_cooldown_until
+    saved_warned = litellm_bootstrap._litellm_import_failure_warned
+    litellm_bootstrap._litellm_ready = False
+    litellm_bootstrap._ready_registry.clear()
+    litellm_bootstrap._litellm_import_cooldown_until = 0.0
+    litellm_bootstrap._litellm_import_failure_warned = False
+
+    def _restore() -> None:
+        litellm_bootstrap._litellm_ready = saved_ready
+        litellm_bootstrap._ready_registry.clear()
+        litellm_bootstrap._ready_registry.update(saved_registry)
+        litellm_bootstrap._litellm_import_cooldown_until = saved_cooldown
+        litellm_bootstrap._litellm_import_failure_warned = saved_warned
+
+    return _restore
+
+
+def test_correctness_critical_patch_failure_makes_litellm_unusable(monkeypatch) -> None:
+    """Tier 2: #5603 accept — when the correctness-critical patch (A)
+    cannot be applied (its own private symbols moved), the SAME
+    `except Exception: result = None` branch a real `import litellm`
+    failure already uses catches it — `ensure_litellm_ready()` returns
+    `None`, exactly the "litellm unusable this call" signal every no-
+    fallback caller already knows how to handle. Never a silent "started
+    anyway with a known-broken bridge"."""
+    import reyn.llm._litellm_compat_patches as patches
+
+    def _broken_apply_a(events=None):
+        raise AttributeError("reyn #5603 test: simulated moved private symbol")
+
+    monkeypatch.setattr(patches, "apply_stream_chunk_recovery", _broken_apply_a)
+
+    restore = _reset_litellm_ready_state()
+    try:
+        result = litellm_bootstrap.ensure_litellm_ready()
+        assert result is None, (
+            "a correctness-critical patch-apply failure must make "
+            "ensure_litellm_ready() return None, same as any other "
+            "import-litellm failure — got a real module instead"
+        )
+    finally:
+        restore()
+
+
+def test_diagnostic_only_patch_failure_still_leaves_litellm_usable(monkeypatch) -> None:
+    """Tier 2: #5603 deny — when the diagnostic-only patch (B) cannot be
+    applied, litellm is STILL returned as usable (its own failure is
+    caught and warned inside ``apply_all``, never propagated) — a worse
+    diagnosis on a call that would have failed anyway is not the same
+    class of defect as a wrong DATA result on an otherwise-successful
+    call."""
+    import reyn.llm._litellm_compat_patches as patches
+
+    def _broken_apply_b(events=None):
+        raise AttributeError("reyn #5603 test: simulated moved private symbol")
+
+    monkeypatch.setattr(patches, "apply_overflow_diagnosis", _broken_apply_b)
+
+    restore = _reset_litellm_ready_state()
+    try:
+        result = litellm_bootstrap.ensure_litellm_ready()
+        assert result is not None, (
+            "a diagnostic-only patch-apply failure must NOT make "
+            "ensure_litellm_ready() return None — litellm itself is "
+            "still perfectly usable"
+        )
+    finally:
+        restore()
+
+
+def test_both_patches_applying_cleanly_leaves_litellm_usable() -> None:
+    """Tier 2: #5603 accept (sanity) — the ordinary, unbroken case."""
+    restore = _reset_litellm_ready_state()
+    try:
+        result = litellm_bootstrap.ensure_litellm_ready()
+        assert result is not None
+    finally:
+        restore()

--- a/tests/llm/test_5603_litellm_compat_patches.py
+++ b/tests/llm/test_5603_litellm_compat_patches.py
@@ -1,0 +1,238 @@
+"""Tier 2: #5603 — reyn's own local litellm patches
+(``src/reyn/llm/_litellm_compat_patches.py``), migrated from a hand-placed
+``site-packages`` file (#5568) into a repo module reyn's own startup
+chokepoint imports.
+
+Real litellm classes throughout (no mock, no stand-in) — each patch
+function is exercised against the SAME synthetic-object reproduction
+``tests/scaffold/test_5603_litellm_stream_recovery_defects.py`` uses for
+the unpatched defect, confirming the PATCHED side actually recovers it.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.llm._litellm_compat_patches import (
+    apply_all,
+    apply_overflow_diagnosis,
+    apply_stream_chunk_recovery,
+)
+
+
+def _fresh_bridge_handler_class():
+    from litellm.completion_extras.litellm_responses_transformation import handler as H
+    importlib.reload(H)
+    return H
+
+
+def _fresh_responses_config_class():
+    from litellm.llms.chatgpt.responses import transformation as T
+    importlib.reload(T)
+    return T
+
+
+def test_stream_chunk_recovery_recovers_the_real_defect() -> None:
+    """Tier 2: #5603(A) accept — after patching, the SAME synthetic
+    scenario the scaffold test pins as "still broken unpatched" now
+    returns the real, streamed content instead of an empty ``output``."""
+    from litellm.types.llms.openai import ResponsesAPIStreamEvents
+
+    H = _fresh_bridge_handler_class()
+    apply_stream_chunk_recovery()
+    cls = H.ResponsesToCompletionBridgeHandler
+
+    class _FakeCompleted:
+        def __init__(self, response: dict) -> None:
+            self.response = response
+
+    class _FakeChunk:
+        type = ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE
+
+        def model_dump(self) -> dict:
+            return {
+                "type": ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+                "output_index": 0,
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "recovered"}],
+                },
+            }
+
+    class _FakeStream:
+        def __init__(self) -> None:
+            self.completed_response = _FakeCompleted({"output": []})
+            self._hidden_params = None
+
+        def __aiter__(self):
+            return self._gen()
+
+        async def _gen(self):
+            yield _FakeChunk()
+
+    async def _drive():
+        return await cls()._collect_response_from_stream_async(_FakeStream())
+
+    result = asyncio.run(_drive())
+    assert result.output == [
+        {"type": "message", "content": [{"type": "output_text", "text": "recovered"}]},
+    ], result.output
+
+
+def test_stream_chunk_recovery_is_a_no_op_when_output_already_non_empty() -> None:
+    """Tier 2: #5603(A) deny — a completed response that already carries
+    real output (the ordinary, non-defective case) is returned
+    byte-identical, unpatched or patched — this method never inspects,
+    let alone overwrites, a non-empty result."""
+    H = _fresh_bridge_handler_class()
+    apply_stream_chunk_recovery()
+    cls = H.ResponsesToCompletionBridgeHandler
+
+    original_output = [{"type": "message", "content": [{"type": "output_text", "text": "already there"}]}]
+
+    class _FakeCompleted:
+        def __init__(self, response: dict) -> None:
+            self.response = response
+
+    class _FakeStream:
+        def __init__(self) -> None:
+            self.completed_response = _FakeCompleted({"output": list(original_output)})
+            self._hidden_params = None
+
+        def __aiter__(self):
+            return self._gen()
+
+        async def _gen(self):
+            return
+            yield  # pragma: no cover — makes this an async generator with zero items
+
+    async def _drive():
+        return await cls()._collect_response_from_stream_async(_FakeStream())
+
+    result = asyncio.run(_drive())
+    assert result.output == original_output, result.output
+
+
+def test_stream_chunk_recovery_is_idempotent() -> None:
+    """Tier 2: #5603(A) — calling apply twice, then driving the real
+    reproduction scenario, still returns exactly ONE recovered item —
+    never through the private ``_reyn_5603_patched`` guard's own
+    attribute directly (CLAUDE.md testing policy), through the public
+    behavior a double-wrap would actually corrupt (two stacked wrappers
+    would record the same chunk twice)."""
+    from litellm.types.llms.openai import ResponsesAPIStreamEvents
+
+    H = _fresh_bridge_handler_class()
+    apply_stream_chunk_recovery()
+    apply_stream_chunk_recovery()
+    cls = H.ResponsesToCompletionBridgeHandler
+
+    class _FakeCompleted:
+        def __init__(self, response: dict) -> None:
+            self.response = response
+
+    class _FakeChunk:
+        type = ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE
+
+        def model_dump(self) -> dict:
+            return {
+                "type": ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+                "output_index": 0,
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "recovered"}],
+                },
+            }
+
+    class _FakeStream:
+        def __init__(self) -> None:
+            self.completed_response = _FakeCompleted({"output": []})
+            self._hidden_params = None
+
+        def __aiter__(self):
+            return self._gen()
+
+        async def _gen(self):
+            yield _FakeChunk()
+
+    async def _drive():
+        return await cls()._collect_response_from_stream_async(_FakeStream())
+
+    result = asyncio.run(_drive())
+    assert result.output == [
+        {"type": "message", "content": [{"type": "output_text", "text": "recovered"}]},
+    ], (
+        f"a double-apply must recover the SAME single item once, not "
+        f"twice (a stacked double-wrap would) — got {result.output!r}"
+    )
+
+
+def test_overflow_diagnosis_converts_the_real_defect() -> None:
+    """Tier 2: #5603(B) accept — a raw SSE truncated after
+    response.created/response.in_progress (no terminal event, no output)
+    is converted to a real ``ContextWindowExceededError`` by the patched
+    ``transform_response_api_response`` — real litellm classification
+    (``classify_llm_failure``) then correctly reads it as OVERFLOW."""
+    import litellm
+
+    from reyn.services.compaction.engine import LLMFailureClass, classify_llm_failure
+
+    T = _fresh_responses_config_class()
+    apply_overflow_diagnosis()
+    cls = T.ChatGPTResponsesAPIConfig
+
+    class _FakeRawResponse:
+        status_code = 200
+        text = (
+            'data: {"type": "response.created", '
+            '"response": {"status": "in_progress", "output": []}}\n\n'
+            'data: {"type": "response.in_progress", '
+            '"response": {"status": "in_progress", "output": []}}\n\n'
+        )
+
+    class _FakeLoggingObj:
+        def post_call(self, **kwargs) -> None:
+            pass
+
+    with pytest.raises(litellm.ContextWindowExceededError):
+        cls().transform_response_api_response(
+            model="test-model", raw_response=_FakeRawResponse(), logging_obj=_FakeLoggingObj(),
+        )
+
+    try:
+        cls().transform_response_api_response(
+            model="test-model", raw_response=_FakeRawResponse(), logging_obj=_FakeLoggingObj(),
+        )
+    except litellm.ContextWindowExceededError as exc:
+        assert classify_llm_failure(exc) is LLMFailureClass.OVERFLOW
+
+
+def test_overflow_diagnosis_is_idempotent() -> None:
+    """Tier 2: #5603(B) — calling apply twice does not double-wrap the
+    method (the ``_reyn_5603b_patched`` guard)."""
+    T = _fresh_responses_config_class()
+    apply_overflow_diagnosis()
+    cls = T.ChatGPTResponsesAPIConfig
+    first = cls.transform_response_api_response
+    apply_overflow_diagnosis()
+    assert cls.transform_response_api_response is first
+
+
+def test_apply_all_emits_one_audit_event_per_patch() -> None:
+    """Tier 2: #5603 accept (architect's fail-safe ②) — both application
+    attempts are visible on a real ``EventLog``, success or failure,
+    never silent — the exact gap the original ``.pth``-based patch had
+    (stderr only, nothing in reyn's own event trail)."""
+    _fresh_bridge_handler_class()
+    _fresh_responses_config_class()
+    collected: "list" = []
+    events = EventLog(subscribers=[lambda e: collected.append(e)])
+
+    apply_all(events)
+
+    fired = [e for e in collected if e.type == "litellm_compat_patch_applied"]
+    patches = {e.data["patch"]: e.data["applied"] for e in fired}
+    assert patches == {"stream_chunk_recovery": True, "overflow_diagnosis": True}, patches

--- a/tests/llm/test_5603_litellm_compat_patches.py
+++ b/tests/llm/test_5603_litellm_compat_patches.py
@@ -23,6 +23,26 @@ from reyn.llm._litellm_compat_patches import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _reset_litellm_ready_after_reload():
+    """Same reset ``tests/scaffold/test_5603_litellm_stream_recovery_
+    defects.py`` establishes, for the same reason — every test in this
+    file calls ``importlib.reload`` on a litellm submodule (via
+    ``_fresh_bridge_handler_class``/``_fresh_responses_config_class``
+    below), which replaces the class object a PRIOR test's own
+    ``apply_*`` call already patched. Left unreset,
+    ``litellm_bootstrap._litellm_ready`` staying ``True`` would make a
+    LATER test/caller in the same process trust a stale "already
+    applied" belief against the now-unpatched, freshly-reloaded class
+    (six questions Q5 — a shared mutable object no test here bounds
+    without this). See the scaffold file's own twin fixture for the
+    full trace (lead-coder's own #4421-follow-up catch)."""
+    yield
+    import reyn.llm.litellm_bootstrap as litellm_bootstrap
+    litellm_bootstrap._litellm_ready = False
+    litellm_bootstrap._ready_registry.clear()
+
+
 def _fresh_bridge_handler_class():
     from litellm.completion_extras.litellm_responses_transformation import handler as H
     importlib.reload(H)

--- a/tests/scaffold/test_5603_litellm_stream_recovery_defects.py
+++ b/tests/scaffold/test_5603_litellm_stream_recovery_defects.py
@@ -46,6 +46,35 @@ from __future__ import annotations
 import asyncio
 import importlib
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_litellm_ready_after_reload():
+    """Lead-coder's own #4421-follow-up catch: every test in this file
+    calls ``importlib.reload`` on a litellm submodule to get an
+    unpatched class — ``reload`` re-runs the module's own ``class``
+    statement, so the OLD (possibly already-patched, by an earlier test
+    in this same process) class object is replaced by a genuinely fresh
+    one. ``litellm_bootstrap.py``'s own ``ensure_litellm_ready()`` has a
+    fast path (``if _litellm_ready: return ...`` — never re-applies) —
+    left untouched, a LATER test/caller in the SAME process that expects
+    the patch to still be applied would get the stale, now-unpatched
+    class, with the result depending on test EXECUTION ORDER (six
+    questions Q5 — a shared mutable object no test here bounds).
+
+    Invariant this restores after every test: **if
+    ``litellm_bootstrap._litellm_ready`` is ``True``, the patch is
+    applied** — resetting it to ``False`` here means the very next
+    ``ensure_litellm_ready()`` call (this file's own, or any other
+    file's, in the same process) genuinely rebuilds `sys.modules` state
+    and re-applies both patches fresh, rather than trusting a belief
+    that could already be stale."""
+    yield
+    import reyn.llm.litellm_bootstrap as litellm_bootstrap
+    litellm_bootstrap._litellm_ready = False
+    litellm_bootstrap._ready_registry.clear()
+
 
 def test_defect_a_stream_chunks_discarded_when_completed_output_empty() -> None:
     """Tier 2: #5603(A) — GREEN means STILL BROKEN (see this file's own module

--- a/tests/scaffold/test_5603_litellm_stream_recovery_defects.py
+++ b/tests/scaffold/test_5603_litellm_stream_recovery_defects.py
@@ -1,0 +1,178 @@
+# scaffold: triggered_by="#5603 — reyn's own litellm Responses-API workarounds (src/reyn/llm/_litellm_compat_patches.py)"
+# scaffold: removed_by="the litellm defects these tests reproduce are fixed upstream — see each test's own docstring"
+"""Tier scaffold: #5603 — "does the upstream litellm defect this repo
+works around still exist" tests, run against the RAW, UNPATCHED litellm
+classes (never reyn's own patched versions).
+
+## The red/green meaning is INVERTED here (read before touching)
+
+- **GREEN = the defect still reproduces** = reyn's own workaround
+  (`src/reyn/llm/_litellm_compat_patches.py`) is still needed. This is
+  the expected, ONGOING state.
+- **RED = the defect no longer reproduces** = litellm fixed it upstream.
+  **This is GOOD NEWS, not a regression.** Remove
+  `src/reyn/llm/_litellm_compat_patches.py`, its own call site in
+  `litellm_bootstrap.py`, and THIS FILE, in the same PR (this file's own
+  ``removed_by`` trigger).
+
+Each test's own failure message repeats this so a reader who has not seen
+this docstring is not misled by a red CI run.
+
+## Why this file exists at all (architect's own design, #5603)
+
+The mechanism that "notices litellm fixed something" and the mechanism
+that "notices reyn's own patch silently stopped applying (upstream
+RENAMED, not REMOVED, a symbol the patch depends on)" are architect's own
+prescribed SAME ONE test, not two: this file tests the DEFECT ITSELF
+(litellm's own observable behavior), never "did reyn's patch get
+applied" — a version bump, a private-symbol rename, or a genuine upstream
+fix are all, from this file's own point of view, indistinguishable
+inputs that all either reproduce the defect (green) or don't (red). No
+version-ceiling constant is declared anywhere (owner's own standing
+instruction against an unjustified number with no rationale/config
+knob) — this file itself IS the up-to-date-with-whatever's-installed
+check the ceiling would have tried to approximate.
+
+Both defects are reproduced directly against synthetic objects — no
+network, no provider, no ``logging_obj`` — confirmed exactly as #5603's
+own falsify point ① asked: ``importlib.reload`` on the owning module
+gives back a genuinely fresh, unpatched class even after reyn's own
+patch has already mutated the module-level class object earlier in this
+same process (this repo's own test suite may have already called
+``ensure_litellm_ready()`` — real, verified directly, not assumed).
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+
+def test_defect_a_stream_chunks_discarded_when_completed_output_empty() -> None:
+    """Tier 2: #5603(A) — GREEN means STILL BROKEN (see this file's own module
+    docstring for why red/green is inverted here).
+
+    litellm's unpatched ``ResponsesToCompletionBridgeHandler.
+    _collect_response_from_stream_async`` (the ``stream:false`` branch of
+    the Responses→chat-completions bridge) discards every streamed chunk
+    unconditionally (``async for _ in stream_iter: pass``) and returns
+    ONLY whatever the terminal ``completed_response.response`` itself
+    reports. When that terminal event's own ``output`` is empty — a real,
+    already-delivered ``OUTPUT_ITEM_DONE`` chunk notwithstanding — the
+    real content is silently discarded.
+
+    ``importlib.reload`` gets a genuinely fresh, unpatched class even if
+    reyn's own patch already mutated the module-level class object
+    earlier in this same process (falsified directly, #5603's own point
+    ①) — this test's own reproduction is therefore never accidentally
+    exercising reyn's patched version instead of litellm's real one."""
+    from litellm.completion_extras.litellm_responses_transformation import handler as H
+    from litellm.types.llms.openai import ResponsesAPIStreamEvents
+
+    importlib.reload(H)
+    cls = H.ResponsesToCompletionBridgeHandler
+
+    class _FakeCompleted:
+        def __init__(self, response: dict) -> None:
+            self.response = response
+
+    class _FakeChunk:
+        """A real ``OUTPUT_ITEM_DONE`` chunk carrying genuine content —
+        exactly the shape ``record_output_item_chunk`` (litellm's own
+        helper) can recover, if only the unpatched method looked at
+        chunks at all."""
+
+        type = ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE
+
+        def model_dump(self) -> dict:
+            return {
+                "type": ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+                "output_index": 0,
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "hello real content"}],
+                },
+            }
+
+    class _FakeStream:
+        def __init__(self) -> None:
+            # The terminal event itself reports an EMPTY output — the
+            # real incident's own shape (litellm's own known gap: the
+            # terminal `response.completed` event does not always carry
+            # everything the stream already delivered piece by piece).
+            self.completed_response = _FakeCompleted({"output": []})
+            self._hidden_params = None
+
+        def __aiter__(self):
+            return self._gen()
+
+        async def _gen(self):
+            yield _FakeChunk()
+
+    async def _drive() -> object:
+        instance = cls()
+        return await instance._collect_response_from_stream_async(_FakeStream())
+
+    result = asyncio.run(_drive())
+
+    assert result.output == [], (
+        "GOOD NEWS, not a regression: litellm's raw "
+        "_collect_response_from_stream_async no longer discards a real "
+        "streamed chunk when the terminal event's own output is empty "
+        "(got a non-empty output back from the UNPATCHED method — the "
+        "defect #5603(A) works around appears fixed upstream). Remove "
+        "src/reyn/llm/_litellm_compat_patches.py's "
+        "apply_stream_chunk_recovery, its call site in "
+        "litellm_bootstrap.py, and this test file, in the same PR."
+    )
+
+
+def test_defect_b_truncated_overflow_stream_yields_no_error_message() -> None:
+    """Tier 2: #5603(B) — GREEN means STILL BROKEN (see this file's own module
+    docstring for why red/green is inverted here).
+
+    A provider ending a Responses-API SSE stream after only
+    ``response.created``/``response.in_progress`` (a genuine context-
+    length overflow whose error event carries no message — OpenAI's own
+    public streaming-events spec documents ``response.created`` as
+    status ``"in_progress"`` with an empty ``output``; the SAME shape is
+    independently reported by other client implementations against this
+    upstream behavior, maximhq/bifrost#4413) makes litellm's own PURE
+    ``_extract_completed_response_from_sse`` (no network, no
+    ``logging_obj`` — a real function call, not a mock) return
+    ``(None, None)``: no completed response AND no error message. The
+    caller then raises a generic ``OpenAIError`` carrying the ENTIRE raw
+    SSE body as its message (real incident: 163,835 bytes) — reyn's own
+    ``is_context_overflow_error``/``classify_llm_failure`` both fail to
+    recognise this as a context overflow (no real
+    ``ContextWindowExceededError`` type, no keyword anywhere in the raw
+    SSE blob)."""
+    from litellm.llms.chatgpt.responses import transformation as T
+
+    importlib.reload(T)
+    cls = T.ChatGPTResponsesAPIConfig
+
+    # A genuine SSE stream that started and was cut off — no
+    # response.completed / response.incomplete / response.failed, no
+    # output_text / output_item event anywhere.
+    truncated_sse = (
+        'data: {"type": "response.created", '
+        '"response": {"status": "in_progress", "output": []}}\n\n'
+        'data: {"type": "response.in_progress", '
+        '"response": {"status": "in_progress", "output": []}}\n\n'
+    )
+
+    instance = cls()
+    completed, error_message = instance._extract_completed_response_from_sse(truncated_sse)
+
+    assert completed is None and error_message is None, (
+        "GOOD NEWS, not a regression: litellm's raw "
+        "_extract_completed_response_from_sse no longer returns "
+        "(None, None) for a stream truncated after response.created/"
+        "response.in_progress with no terminal event (got "
+        f"completed={completed!r}, error_message={error_message!r} from "
+        "the UNPATCHED method — the defect #5603(B) works around appears "
+        "fixed or changed upstream). Remove "
+        "src/reyn/llm/_litellm_compat_patches.py's "
+        "apply_overflow_diagnosis, its call site in "
+        "litellm_bootstrap.py, and this test file, in the same PR."
+    )

--- a/tests/security/test_4421_litellm_import_seam.py
+++ b/tests/security/test_4421_litellm_import_seam.py
@@ -45,6 +45,37 @@ handle a broken/still-warming environment.
   seam is not a production litellm-touching one, #4415's own "dev-only, 6
   sites" bucket). Scanning them would fail this gate on infrastructure
   built to intercept litellm, not to bypass it.
+- ``llm/_litellm_compat_patches.py`` (#5603, lead-coder's own seam-gate
+  review) — this exemption is FILE-scoped (this gate has no per-function
+  granularity), and covers 3 functions with 2 DIFFERENT reasons, both
+  disclosed here rather than assumed by proximity:
+  - ``apply_all()`` (and the ``apply_stream_chunk_recovery``/
+    ``apply_overflow_diagnosis`` it calls) is invoked from EXACTLY ONE
+    place: inside ``ensure_litellm_ready()``'s own success path, AFTER
+    ``import litellm`` has already completed inside that SAME chokepoint
+    — never called from anywhere else. So these functions' own litellm
+    imports execute only at a point where litellm is provably already
+    warm, the same relationship ``litellm_bootstrap.py``'s own internal
+    helpers already have to ``ensure_litellm_ready()`` — a second part
+    of the seam's own body, not a bypass of it.
+  - ``report_applied_state()`` carries NO such structural guarantee (its
+    own docstring says so explicitly — the caller must warm litellm
+    first, this function does not) because it is a general-purpose
+    READER any future caller may reach for. It is safe anyway for a
+    DIFFERENT reason: every litellm touch inside it is wrapped in its
+    own ``try/except Exception`` that degrades to a "could not measure"
+    string rather than raising — called cold (litellm never
+    successfully imported), it cannot crash the caller, it can only
+    under-report. This is the intentional design this function's own
+    docstring already states ("this function does not [call
+    ensure_litellm_ready] — matching this module's own 'no side effect'
+    contract"), not an oversight papered over by the exemption.
+  This is narrower than ``litellm_bootstrap.py``'s own exemption (that
+  whole file is presumed trusted, #4450's own disclosed limit above) —
+  it covers exactly these 3 functions' own reasoning, stated here so the
+  next person adding a 4th function to this file has to ask which of the
+  two shapes above (or neither) it fits, rather than inheriting the
+  exemption by simply landing in an already-excluded file.
 
 **Known limit** (mirrors #4410's own framing): this gate can only ever see
 reyn's OWN import statements — a third-party library that touches litellm
@@ -102,19 +133,26 @@ def _seam_scan_root_and_exclusions():
     src = root / "src" / "reyn"
     seam_file = (src / "llm" / "litellm_bootstrap.py").resolve()
     dev_testing_dir = (src / "dev" / "testing").resolve()
-    return root, src, seam_file, dev_testing_dir
+    # #5603 — see module docstring's own "Excluded within src/reyn" entry
+    # for the exact reasoning (2 different shapes, one per function, both
+    # disclosed there rather than inherited by merely landing in this file).
+    compat_patches_file = (src / "llm" / "_litellm_compat_patches.py").resolve()
+    return root, src, seam_file, dev_testing_dir, compat_patches_file
 
 
 def test_no_litellm_import_outside_the_seam() -> None:
-    """Tier 1: no file under src/reyn (outside litellm_bootstrap.py and
-    dev/testing/) imports litellm in any form. See module docstring for
-    the contract, scope decision, and this gate's own limit."""
-    root, src, seam_file, dev_testing_dir = _seam_scan_root_and_exclusions()
+    """Tier 1: no file under src/reyn (outside litellm_bootstrap.py,
+    dev/testing/, and _litellm_compat_patches.py) imports litellm in any
+    form. See module docstring for the contract, scope decision, and
+    this gate's own limit."""
+    root, src, seam_file, dev_testing_dir, compat_patches_file = _seam_scan_root_and_exclusions()
 
     offenders: list[str] = []
     for py in src.rglob("*.py"):
         resolved = py.resolve()
         if resolved == seam_file:
+            continue
+        if resolved == compat_patches_file:
             continue
         if resolved == dev_testing_dir or dev_testing_dir in resolved.parents:
             continue
@@ -178,7 +216,9 @@ def test_the_seam_file_itself_is_excluded_not_silently_unreachable() -> None:
     the scan's exclusion list is doing real work (skipping a file that
     would otherwise fail the gate), not merely pointing at a path that
     happens not to exist or not to import litellm at all."""
-    _root, _src, seam_file, _dev_testing_dir = _seam_scan_root_and_exclusions()
+    _root, _src, seam_file, _dev_testing_dir, _compat_patches_file = (
+        _seam_scan_root_and_exclusions()
+    )
     assert seam_file.is_file(), "the seam file path itself must exist"
     tree = ast.parse(seam_file.read_text(encoding="utf-8"))
     found_any = any(_imports_litellm(node) for node in ast.walk(tree))
@@ -186,4 +226,26 @@ def test_the_seam_file_itself_is_excluded_not_silently_unreachable() -> None:
         "litellm_bootstrap.py no longer contains any litellm import — the "
         "exclusion in the main gate test is not actually exercised; if "
         "this fires, either the seam moved or the detector itself broke"
+    )
+
+
+def test_the_compat_patches_file_is_excluded_not_silently_unreachable() -> None:
+    """Tier 1: #5603 accept-side for the ``_litellm_compat_patches.py``
+    exclusion — same shape as the seam-file's own twin above: this file
+    genuinely DOES import litellm (that's the whole point of
+    ``apply_stream_chunk_recovery``/``apply_overflow_diagnosis``/
+    ``report_applied_state``); this confirms the exclusion is doing real
+    work, not pointing at a path that happens not to exist or not to
+    import litellm at all."""
+    _root, _src, _seam_file, _dev_testing_dir, compat_patches_file = (
+        _seam_scan_root_and_exclusions()
+    )
+    assert compat_patches_file.is_file(), "the compat-patches file path itself must exist"
+    tree = ast.parse(compat_patches_file.read_text(encoding="utf-8"))
+    found_any = any(_imports_litellm(node) for node in ast.walk(tree))
+    assert found_any, (
+        "_litellm_compat_patches.py no longer contains any litellm import "
+        "— the exclusion in the main gate test is not actually exercised; "
+        "if this fires, either the file moved/changed or the detector "
+        "itself broke"
     )


### PR DESCRIPTION
**[e2e-coder]** — Fixes #5603: reyn's local litellm patches (#5568) become a repo module reyn's own startup imports, instead of a hand-placed `site-packages/*.pth` file. Owner's own 2 questions drove this: "依存ライブラリ側の場合は、依存としてパッチ当てる方法ないとダメだよ？" and "reyn の import は litellm ver up で壊れることないの？フェールセーフ対応まで考えてるの？"

## A/C decision (architect's own condition, resolved before implementing)

A (repo module + startup import), not C (fork + `litellm @ git+...`) — the decisive test: can the defect be reproduced offline, against synthetic objects, without a real provider? **Yes for both #5568 defects** — falsified directly (see the scaffold test). C would only be required if a live provider were needed to observe the defect.

## Design

- **Repo module** (`src/reyn/llm/_litellm_compat_patches.py`), applied from `ensure_litellm_ready()` — the one existing chokepoint every `import litellm` already passes through.
- **No version-ceiling constant** (owner's own standing instruction against an unjustified number). Instead: `tests/scaffold/test_5603_litellm_stream_recovery_defects.py` — **red/green is INVERTED**: green = the defect still reproduces = the workaround is still needed; red = upstream fixed it = remove `_litellm_compat_patches.py` + this test in the same PR. Runs in CI every time, against whatever litellm is actually installed.
- **Two different failure semantics** (architect's own ruling — the two patches are not the same risk class):
  - `apply_stream_chunk_recovery` (A) — correctness-critical (discards a real successful response). Failure to apply propagates **uncaught** into the same `except Exception: result = None` an `import litellm` failure already uses.
  - `apply_overflow_diagnosis` (B) — diagnostic-only (worse error classification, not data loss). Failure to apply is caught, logged as WARNING, reported via audit-event — never fatal.
- **No-op by construction**, not a runtime self-check — each patch's own substitution condition doubles as its no-op guard (see each function's own docstring).

## Observability (architect's fail-safe ②, lens 7)

`litellm_compat_patch_applied` audit-event (one per patch, success or failure) + a new `reyn doctor` section reading the real class-attribute flags — D-1 (measure, don't assert): never a restatement that the module merely imports, which was true in the #5568 incident even while the patch itself silently failed.

## Falsify (lead-coder's own 2-point ask)

1. Does `importlib.reload` give back a genuinely fresh, unpatched class even after reyn's own patch already mutated the module-level class object earlier in the same process? **Yes** — confirmed standalone, then again inside an actual pytest run with an earlier test already having called `ensure_litellm_ready()`.
2. No-op-ness: confirmed by construction (see each patch's own docstring for the exact line) — no runtime self-check needed.

Both #5568 defects reproduced directly, offline, no provider/network/mock:
- (A) the unpatched `_collect_response_from_stream_async` body is `async for _ in stream_iter: pass` — a synthetic chunk stream with real content still returns empty output.
- (B) the unpatched, pure `_extract_completed_response_from_sse` returns `(None, None)` for a synthetic SSE truncated after `response.created`/`response.in_progress`.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict <5 new test files>` — 13 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py <4 changed src files>` — clean
- [x] `python scripts/mypy_ratchet.py` — 203 findings, all baselined (3 new (file, code) pairs, disclosed: dynamic monkeypatching of third-party classes)
- [x] `python scripts/flat_tests_ratchet.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `python scripts/check_bare_tests_import_reference.py` — clean (tests/ touched)
- [x] `python scripts/check_file_depth_reference.py` — clean (tests/ touched)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — built clean (docs/ touched)
- [x] `python scripts/check_doc_anchors.py` — "no dangling anchors into published pages"
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] 5 new test files (scaffold reproduction, patch-function unit tests incl. no-op/idempotency, bootstrap integration proving the two failure semantics, doctor status line) + `test_audit_event_kind_vocabulary_3410.py` (new event kind) — all green
- [x] `tests/llm/` (767), `tests/scaffold/` (2), `tests/interfaces/ -k doctor` (57) — all green
- [x] (skipped — no visual surface touched)

⚪ The hand-placed `.pth` file in `reyn-self/.venv` and `junk/litellm/venv` stays until this PR lands, then gets removed (lead-coder's own note on #5603 — removal is tracked separately, not blocking merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
