### PR TITLE
fix(#5606): tests/scaffold/'s own Tier-docstring vocabulary, Rule 1

### DIFF
--- a/docs/deep-dives/contributing/testing.ja.md
+++ b/docs/deep-dives/contributing/testing.ja.md
@@ -337,6 +337,10 @@ def test_ledger_jsonl_format_during_migration():
 
 スキャフォールディングテストは `tests/scaffold/` に配置します。このディレクトリ配下のファイルは、PR レビュー時にトリガーが古くなっていないか（トリガーイベントがすでに発生済みでないか）スキャンされます。
 
+### docstring: 数値 Tier ではなく `Tier scaffold:`
+
+Rule 1（tier-docstring、`scripts/test_tier_audit.py`）は全テスト関数に Tier の宣言を強制しますが、「スキャフォールディングは Tier ではありません」（上記）ため、真にスキャフォールディングなテストは Tier 1/2/3 のどれも名乗れません。代わりに `"""Tier scaffold: ..."""` を宣言してください — 受理されるのは `tests/scaffold/` の中だけです。`tests/scaffold/` の外で同じ宣言をすると Tier-docstring の ERROR になります（#5606 — さもなくば「Tier scaffold:」がどのファイルからでも使える Tier 4 の逃げ道になってしまいます）。
+
 ### スナップショットテストの例外
 
 スナップショットテストは**レガシーリファクタのスキャフォールディング**（Coulman の「キャラクタリゼーションテスト」のユースケース）としてのみ許可されます。条件:
@@ -550,7 +554,7 @@ LLM 依存の OS パスを新たに追加する場合:
 
 検出ルール (6):
 
-- Missing Tier docstring (= Tier 宣言の欠如)
+- Missing Tier docstring (= Tier 宣言の欠如; `tests/scaffold/` の中だけ `Tier scaffold:` も受理、#5606)
 - Format pinning (= 行数 / 文字数等の Tier 4 違反)
 - Private state assertion (= プライベート状態への assertion)
 - MagicMock / AsyncMock / patch の使用

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -853,6 +853,16 @@ The PR that fires the trigger event **must also remove the scaffolding tests in 
 
 Scaffolding tests live in `tests/scaffold/`. Files under that directory are scanned during PR review for stale triggers (whose triggering event has already happened).
 
+### Docstring: `Tier scaffold:`, not a numeric Tier
+
+Rule 1 (tier-docstring, `scripts/test_tier_audit.py`) forces every test
+function to declare a Tier — but "Scaffolding is not a Tier" (above), so a
+genuine scaffold test has none of Tier 1/2/3 to name. Declare
+`"""Tier scaffold: ..."""` instead — accepted **only** inside
+`tests/scaffold/`; the same declaration outside `tests/scaffold/` is a
+Tier-docstring ERROR (#5606 — otherwise it would be a Tier 4 escape route
+usable from anywhere).
+
 ### Snapshot test exception
 
 A snapshot test is permitted **only** as scaffolding for legacy refactor (Coulman's "characterization test" use case). It must:
@@ -1382,7 +1392,7 @@ Use it as a pre-commit check when adding new tests, for a Tier 4 violation sweep
 
 Detection rules (6):
 
-- Missing or malformed Tier docstring (regex: `^Tier [123][abc]?:` — colon must follow directly)
+- Missing or malformed Tier docstring (regex: `^Tier [123][abc]?:` — colon must follow directly; inside `tests/scaffold/` only, `^Tier scaffold:` is also accepted, #5606)
 - Format pinning (line count / char count / exact length = Tier 4 violation)
 - Private state assertion
 - MagicMock / AsyncMock / patch usage

--- a/docs/reference/test-tier-audit.md
+++ b/docs/reference/test-tier-audit.md
@@ -59,6 +59,15 @@ docstring that does not match this pattern, trigger this error.
 **Why:** Without the Tier label, there is no way to know whether a test
 belongs at all (Tier 4 = do not write) or what contract it is asserting.
 
+**`tests/scaffold/`'s own vocabulary (#5606):** a scaffold test — an
+extraction-refactor characterization, or #5603's "does the upstream defect
+this repo works around still exist" shape — genuinely fits none of Tier
+1/2/3 (its subject is a third party's behavior or a past state, not a reyn
+contract). Inside `tests/scaffold/` only, `"""Tier scaffold: ..."""` is
+accepted in place of a numeric Tier. Declaring `"""Tier scaffold: ..."""`
+**outside** `tests/scaffold/` is an ERROR — that vocabulary is not a Tier 4
+escape route reachable from anywhere else.
+
 ### Rule 2 — Format pinning (Tier 4 ERROR)
 
 Expressions of the form `len(...) [<>=] N` pin the exact length of a string,

--- a/scripts/test_tier_audit.py
+++ b/scripts/test_tier_audit.py
@@ -36,6 +36,17 @@ from typing import Literal
 
 TIER_DOCSTRING_RE = re.compile(r"^Tier [123][abc]?:", re.IGNORECASE)
 
+# #5606 — tests/scaffold/'s own vocabulary. A scaffold test (extraction-
+# refactor characterization, or #5603's "does the upstream defect this repo
+# works around still exist" shape) genuinely fits none of Tier 1/2/3 — its
+# own subject is a third party's behavior or a past state, not a reyn
+# contract — so Rule 1 forced it to misdeclare (CLAUDE.md six questions ⑥:
+# "the declared Tier is not the one question 1 named"). Accepted ONLY inside
+# tests/scaffold/ (`in_scaffold` below) — accepting it everywhere would open
+# a Tier 4 escape route the deny-side branch below exists specifically to
+# close.
+SCAFFOLD_DOCSTRING_RE = re.compile(r"^Tier scaffold:", re.IGNORECASE)
+
 # #3670: the SAME line-terminator pattern ast._splitlines_no_ff uses
 # internally, inlined here (not imported — that name is private CPython
 # internals we don't want a hard dependency on) so `_cached_source_segment`
@@ -356,16 +367,40 @@ class TestAuditor:
                 )
             elif not TIER_DOCSTRING_RE.match(docstring.strip()):
                 first_line = docstring.strip().splitlines()[0]
-                result.findings.append(
-                    Finding(
-                        rule="tier-docstring",
-                        level="ERROR",
-                        line=node.lineno,
-                        message=f'docstring does not start with "Tier N:": {first_line!r}',
-                        suggestion='Change first docstring line to """Tier 1/2/3a/3b: ..."""',
-                        policy_ref="testing.ja.md: 各テストの docstring 一行目に Tier の明記",
+                is_scaffold_declaration = bool(SCAFFOLD_DOCSTRING_RE.match(docstring.strip()))
+                if is_scaffold_declaration and in_scaffold:
+                    pass  # #5606: tests/scaffold/'s own vocabulary — valid here
+                elif is_scaffold_declaration and not in_scaffold:
+                    # #5606 deny side: "Tier scaffold:" is tests/scaffold/'s
+                    # own vocabulary, not a Tier 4 escape route usable from
+                    # anywhere else — without this branch, accepting the
+                    # scaffold form above would open exactly that hole.
+                    result.findings.append(
+                        Finding(
+                            rule="tier-docstring",
+                            level="ERROR",
+                            line=node.lineno,
+                            message=f'"Tier scaffold:" declared outside tests/scaffold/: {first_line!r}',
+                            suggestion=(
+                                "tests/scaffold/'s own vocabulary is not valid "
+                                "outside tests/scaffold/ — declare a real "
+                                'Tier 1/2/3a/3b, or move this test into '
+                                "tests/scaffold/ with triggered_by/removed_by metadata"
+                            ),
+                            policy_ref="testing.ja.md: 各テストの docstring 一行目に Tier の明記 (#5606)",
+                        )
                     )
-                )
+                else:
+                    result.findings.append(
+                        Finding(
+                            rule="tier-docstring",
+                            level="ERROR",
+                            line=node.lineno,
+                            message=f'docstring does not start with "Tier N:": {first_line!r}',
+                            suggestion='Change first docstring line to """Tier 1/2/3a/3b: ..."""',
+                            policy_ref="testing.ja.md: 各テストの docstring 一行目に Tier の明記",
+                        )
+                    )
 
         # --- Rule 2: Format pinning ---
         if self._rule_active("format-pinning"):

--- a/tests/scaffold/test_5603_litellm_stream_recovery_defects.py
+++ b/tests/scaffold/test_5603_litellm_stream_recovery_defects.py
@@ -77,7 +77,7 @@ def _reset_litellm_ready_after_reload():
 
 
 def test_defect_a_stream_chunks_discarded_when_completed_output_empty() -> None:
-    """Tier 2: #5603(A) — GREEN means STILL BROKEN (see this file's own module
+    """Tier scaffold: #5603(A) — GREEN means STILL BROKEN (see this file's own module
     docstring for why red/green is inverted here).
 
     litellm's unpatched ``ResponsesToCompletionBridgeHandler.
@@ -156,7 +156,7 @@ def test_defect_a_stream_chunks_discarded_when_completed_output_empty() -> None:
 
 
 def test_defect_b_truncated_overflow_stream_yields_no_error_message() -> None:
-    """Tier 2: #5603(B) — GREEN means STILL BROKEN (see this file's own module
+    """Tier scaffold: #5603(B) — GREEN means STILL BROKEN (see this file's own module
     docstring for why red/green is inverted here).
 
     A provider ending a Responses-API SSE stream after only

--- a/tests/scripts/test_tier_audit_scaffold_vocabulary_5606.py
+++ b/tests/scripts/test_tier_audit_scaffold_vocabulary_5606.py
@@ -1,0 +1,151 @@
+"""Tier 1: Rule 1 (tier-docstring) accepts "Tier scaffold:" inside
+tests/scaffold/, and rejects it (deny side, ERROR) everywhere else.
+
+Lead-coder's own #5606 finding (surfaced during #5604 review): Rule 1's
+``TIER_DOCSTRING_RE`` (``^Tier [123][abc]?:``) does not vary on
+``in_scaffold`` — only Rules 5/6 do — so a genuine scaffold test (an
+extraction-refactor characterization, or #5603's "does the upstream defect
+this repo works around still exist" shape) has no Tier of its own to name:
+its subject is a third party's behavior or a past state, not a reyn
+contract. Forced to pick Tier 1/2/3 anyway, it necessarily misdeclares
+(CLAUDE.md six questions ⑥: "the declared Tier is not the one question 1
+named") — and there was no way to write it that avoided this, because the
+gate itself forced the choice.
+
+This test drives the auditor's own ``_audit_test`` directly (same idiom as
+the sibling self-test ``tests/scripts/test_tier_audit_format_pin.py``) so
+both branches — accept inside ``tests/scaffold/``, deny outside — are
+exercised against the SAME docstring text, varying only ``in_scaffold``.
+
+Deny side is the load-bearing half (lead-coder's own explicit requirement,
+issue #5606): without it, "Tier scaffold:" would be a Tier 4 escape route
+usable from any file, not tests/scaffold/'s own vocabulary.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests._support.paths import REPO_ROOT
+
+
+def _load_audit_module():
+    """Import ``scripts/test_tier_audit.py`` as a module without invoking it.
+
+    Same loader idiom as ``test_tier_audit_format_pin.py`` — the script's
+    filename starts with ``test_`` so pytest would otherwise try to collect
+    it as a test module.
+    """
+    repo_root = REPO_ROOT
+    script = repo_root / "scripts" / "test_tier_audit.py"
+    spec = importlib.util.spec_from_file_location("_audit_tier_audit_scaffold_5606", script)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def audit_mod():
+    return _load_audit_module()
+
+
+def _tier_docstring_findings(audit_mod, source: str, *, in_scaffold: bool) -> list:
+    """Return the ``tier-docstring`` findings for *source*, driving Rule 1
+    directly with the given ``in_scaffold`` flag — the exact parameter Rule
+    1 previously ignored (#5606's own finding)."""
+    auditor = audit_mod.TestAuditor(check_rules={"tier-docstring"})
+    tree = ast.parse(source)
+    func = next(
+        (n for n in tree.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))),
+        None,
+    )
+    assert func is not None, "test source must define exactly one test function"
+    result = auditor._audit_test(
+        Path("inline.py"), source, source.splitlines(),
+        audit_mod._split_source_lines(source), func, in_scaffold=in_scaffold,
+    )
+    return [f for f in result.findings if f.rule == "tier-docstring"]
+
+
+_SCAFFOLD_SRC = (
+    "def test_upstream_defect_still_reproduces():\n"
+    '    """Tier scaffold: does the upstream defect this repo works around\n'
+    '    still reproduce — GREEN means still broken, see module docstring."""\n'
+    "    assert True\n"
+)
+
+
+# ── Accept side: "Tier scaffold:" inside tests/scaffold/ ────────────────────
+
+
+def test_scaffold_declaration_accepted_inside_scaffold(audit_mod) -> None:
+    """Tier 1: #5606 accept — the SAME docstring that fails outside
+    (below) is accepted with no finding when ``in_scaffold=True``."""
+    findings = _tier_docstring_findings(audit_mod, _SCAFFOLD_SRC, in_scaffold=True)
+    assert findings == [], findings
+
+
+# ── Deny side: "Tier scaffold:" outside tests/scaffold/ is an ERROR ─────────
+
+
+def test_scaffold_declaration_rejected_outside_scaffold(audit_mod) -> None:
+    """Tier 1: #5606 deny (lead-coder's own explicit requirement) — the
+    IDENTICAL docstring, only ``in_scaffold=False`` this time, must be an
+    ERROR. Without this, "Tier scaffold:" would be a Tier 4 escape route
+    reachable from any test file, not tests/scaffold/'s own vocabulary."""
+    (only,) = _tier_docstring_findings(audit_mod, _SCAFFOLD_SRC, in_scaffold=False)
+    assert only.level == "ERROR", only
+    assert "Tier scaffold:" in only.message, only.message
+    assert "outside tests/scaffold/" in only.message, only.message
+
+
+# ── Regression: numeric Tier declarations are unaffected, either side ───────
+
+
+def test_numeric_tier_still_accepted_inside_scaffold(audit_mod) -> None:
+    """Tier 1: #5606 non-regression — a scaffold test may still declare a
+    real numeric Tier (e.g. Tier 2) instead of the scaffold vocabulary;
+    Rule 1's existing numeric-Tier path is untouched by this fix."""
+    src = (
+        "def test_something():\n"
+        '    """Tier 2: a scaffold test that happens to fit a real tier."""\n'
+        "    assert True\n"
+    )
+    assert _tier_docstring_findings(audit_mod, src, in_scaffold=True) == []
+
+
+def test_numeric_tier_still_accepted_outside_scaffold(audit_mod) -> None:
+    """Tier 1: #5606 non-regression — the ordinary, non-scaffold case is
+    unaffected: a real numeric Tier declaration outside tests/scaffold/
+    still passes exactly as before."""
+    src = (
+        "def test_something():\n"
+        '    """Tier 2: an ordinary, non-scaffold test."""\n'
+        "    assert True\n"
+    )
+    assert _tier_docstring_findings(audit_mod, src, in_scaffold=False) == []
+
+
+def test_malformed_docstring_still_rejected_either_side(audit_mod) -> None:
+    """Tier 1: #5606 non-regression — a docstring matching neither the
+    numeric Tier form nor "Tier scaffold:" is still rejected, in or out of
+    tests/scaffold/ — the fix only widens the accepted vocabulary inside
+    tests/scaffold/, it does not loosen the fallback ERROR."""
+    src = (
+        "def test_something():\n"
+        '    """not a tier declaration at all."""\n'
+        "    assert True\n"
+    )
+    for in_scaffold in (True, False):
+        (only,) = _tier_docstring_findings(audit_mod, src, in_scaffold=in_scaffold)
+        assert only.level == "ERROR", (in_scaffold, only)
+        assert "Tier scaffold:" not in only.message, (
+            "the generic-malformed-docstring error must not be confused "
+            f"with the scaffold-specific deny message: {only.message!r}"
+        )


### PR DESCRIPTION
**[e2e-coder]** — fixes #5606: `test_tier_audit.py` Rule 1 (tier-docstring) forced every `tests/scaffold/` test to misdeclare a Tier it doesn't have, because Rule 1 never varied on `in_scaffold` (only Rules 5/6 do).

## What changed

- New `SCAFFOLD_DOCSTRING_RE` (`^Tier scaffold:`), accepted by Rule 1 **only** inside `tests/scaffold/`.
- **Deny side** (lead-coder's own explicit requirement): the identical declaration **outside** `tests/scaffold/` is a Rule 1 ERROR — otherwise `Tier scaffold:` would be a Tier 4 escape route reachable from any file.
- **Migration choice, stated explicitly per instruction**: `tests/scaffold/test_5603_litellm_stream_recovery_defects.py`'s 2 test functions are migrated from the misdeclared `Tier 2:` to `Tier scaffold:` in this same PR — this is the exact motivating case the issue names (its module docstring already used the phrase "Tier scaffold" as prose).
- Docs updated in the same PR: `docs/deep-dives/contributing/testing.md`'s scaffolding Annex (new subsection) + its Rule-1 one-liner, and `docs/reference/test-tier-audit.md`'s Rule 1 section.
- New self-test: `tests/scripts/test_tier_audit_scaffold_vocabulary_5606.py` — drives `TestAuditor._audit_test` directly with `in_scaffold=True/False` on the *same* docstring text (accept inside, deny outside), plus non-regression coverage for numeric-Tier declarations and the generic malformed-docstring fallback.

## Strip-falsify

A throwaway probe file placed outside `tests/scaffold/`, declaring `"""Tier scaffold: ..."""`, run through `scripts/test_tier_audit.py --strict` directly (not just the unit test) genuinely ERRORs with the new deny-side message. Removed after confirming.

## Scope note (per issue)

Migrating other existing scaffold tests (if any misdeclare) is out of scope for this issue — only the vocabulary + the one named motivating case (#5603's file) are addressed here.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict <changed test files>`
- [x] `python scripts/verify_module_docstrings.py scripts/test_tier_audit.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py`
- [x] Scoped `pytest tests/scripts/ tests/scaffold/` — 1119/1119 passed
- [x] Strip-falsify: live probe file outside tests/scaffold/ genuinely ERRORs

Closes #5606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
