### PR TITLE
classify HTTP 200 + non-JSON body as RETRYABLE, before keyword scan (part of #5568)

### DIFF
--- a/docs/concepts/data-retrieval/chat-compaction.md
+++ b/docs/concepts/data-retrieval/chat-compaction.md
@@ -124,7 +124,7 @@ ladder, not inside it:
 | class | examples | what happens |
 |---|---|---|
 | **Overflow** | context-window error, HTTP 413, a response cut off by an output cap (`JSONDecodeError`) | enters the ladder |
-| **Retryable** | 5xx, timeout, rate limit, connection error, HTTP 200 with a body that fails to parse as JSON (#5568 — a transport/protocol failure, unconditionally, regardless of what keywords the broken body happens to contain) | retried with backoff; never shrinks |
+| **Retryable** | 5xx, timeout, rate limit, connection error, HTTP 200 on an exception (#5568 — litellm raises `status_code == 200` only when transport succeeded but response-object conversion failed; a transport/protocol failure, unconditionally, regardless of what keywords the broken body happens to contain) | retried with backoff; never shrinks |
 | **Fatal** | `TypeError` / `AttributeError` / `KeyError`, authentication, model-not-found | propagates unchanged; never shrinks |
 
 Both arms classify through the same `classify_llm_failure` (#5543/#5531 §10) —

--- a/docs/concepts/data-retrieval/chat-compaction.md
+++ b/docs/concepts/data-retrieval/chat-compaction.md
@@ -124,7 +124,7 @@ ladder, not inside it:
 | class | examples | what happens |
 |---|---|---|
 | **Overflow** | context-window error, HTTP 413, a response cut off by an output cap (`JSONDecodeError`) | enters the ladder |
-| **Retryable** | 5xx, timeout, rate limit, connection error | retried with backoff; never shrinks |
+| **Retryable** | 5xx, timeout, rate limit, connection error, HTTP 200 with a body that fails to parse as JSON (#5568 — a transport/protocol failure, unconditionally, regardless of what keywords the broken body happens to contain) | retried with backoff; never shrinks |
 | **Fatal** | `TypeError` / `AttributeError` / `KeyError`, authentication, model-not-found | propagates unchanged; never shrinks |
 
 Both arms classify through the same `classify_llm_failure` (#5543/#5531 §10) —

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1130,13 +1130,19 @@ def classify_llm_failure(exc: BaseException) -> LLMFailureClass:
     1. FATAL — an exact ``isinstance`` match on reyn's own closed bug-type
        allowlist, or an auth-error shape (class name / status code).
     2. RETRYABLE — ``is_quota_exhausted_error`` (a provider usage-window
-       exhaustion, #5256), or the SAME infra/rate-limit signal
+       exhaustion, #5256), the SAME infra/rate-limit signal
        ``llm.py``'s own ``_llm_call_with_retry`` already retries
        (5xx / timeout / connection failure / rate-limit-429), checked
        WITHOUT importing that module (this function must not create a
        ``compaction`` → ``llm`` import cycle — the two modules' retry
        machinery stays two callers of the SAME classification, not one
-       importing the other's private helper).
+       importing the other's private helper) — OR (#5568, below) an HTTP
+       200 whose body is not parseable as JSON, checked BEFORE
+       ``is_context_overflow_error``'s own keyword-string fallback ever
+       runs (that fallback lives one level up, in
+       ``router_loop_driver._is_shrinkable_overflow`` — it is only ever
+       reached for a cause this function itself classified OVERFLOW, so
+       returning RETRYABLE here is what keeps this cause out of it).
     3. OVERFLOW — ``is_context_overflow_error`` (this module's own,
        already-shared predicate — 413 / token-length signals, with a
        keyword-string fallback for a flattened provider exception).
@@ -1147,6 +1153,34 @@ def classify_llm_failure(exc: BaseException) -> LLMFailureClass:
     ``ContextOverflowError`` today, both already overflow-shaped by
     construction) — this function does not widen what reaches it, only
     names what was already implicitly assumed.
+
+    #5568 (owner's real-machine incident, reyn-self ``coder-brown``):
+    litellm's ``OpenAIResponsesAPIConfig.transform_response_api_response``
+    (the class reyn's own ``provider=openai`` config resolves to when
+    talking to a local proxy — NOT the ``ChatGPTResponsesAPIConfig``
+    #5603(B) patches, confirmed unreached in production via a reach-marker
+    with 0 matching lines) does ``raw_response.json()`` inside a bare
+    ``try/except Exception`` and, on failure, raises ``OpenAIError(message=
+    raw_response.text, status_code=raw_response.status_code)`` — an HTTP
+    200 (the request DID succeed at the transport layer) wrapping the
+    ENTIRE raw response body (in the observed incident, a raw SSE stream
+    the upstream proxy returned despite ``stream: false``) as the
+    exception's own message. Because that body can coincidentally contain
+    an overflow-shaped keyword (an ``error`` frame's own text), the
+    pre-#5568 fallthrough to OVERFLOW let this reach
+    ``is_context_overflow_error``'s keyword fallback and enter the shrink
+    ladder — repeatedly halving and re-sending a 9M-character history
+    against a cause no amount of shrinking can fix (a transport/protocol
+    failure, not an input-size one; ADR-0044 I2: "do not apply an
+    irreversible remedy to a reversible cause" — waiting/retrying is
+    reversible, shrinking permanently discards conversation content).
+    architect's own ruling (issue #5568): the root cause is the upstream
+    proxy's contract violation (owner's own hand, a separate fix, layered
+    ABOVE the provider per the owner's standing "reyn fights above the
+    provider layer" principle) — reyn's own correction is classification
+    only, never teaching litellm/reyn to accept the malformed response
+    (that would make the proxy's own defect permanently invisible, the
+    exact Q3 "does the repair destroy the evidence" band violation).
     """
     if isinstance(exc, FATAL_EXC_TYPES) or _is_fatal_auth_error(exc):
         return LLMFailureClass.FATAL
@@ -1166,6 +1200,19 @@ def classify_llm_failure(exc: BaseException) -> LLMFailureClass:
         or (isinstance(code, int) and 500 <= code < 600)
     ):
         return LLMFailureClass.RETRYABLE
+    # #5568: HTTP 200 (the request genuinely succeeded at the transport
+    # layer) whose body is not parseable as JSON is a protocol/transport
+    # failure, unconditionally — never an input-size question, so it must
+    # never reach the OVERFLOW keyword fallback below regardless of what
+    # words the broken body happens to contain. `str(exc)` is the SAME
+    # value `is_context_overflow_error`'s own keyword fallback reads
+    # (this module's own established convention for "the message text a
+    # flattened provider exception carries").
+    if code == 200:
+        try:
+            json.loads(str(exc))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return LLMFailureClass.RETRYABLE
     return LLMFailureClass.OVERFLOW
 
 

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1136,13 +1136,13 @@ def classify_llm_failure(exc: BaseException) -> LLMFailureClass:
        WITHOUT importing that module (this function must not create a
        ``compaction`` → ``llm`` import cycle — the two modules' retry
        machinery stays two callers of the SAME classification, not one
-       importing the other's private helper) — OR (#5568, below) an HTTP
-       200 whose body is not parseable as JSON, checked BEFORE
-       ``is_context_overflow_error``'s own keyword-string fallback ever
-       runs (that fallback lives one level up, in
-       ``router_loop_driver._is_shrinkable_overflow`` — it is only ever
-       reached for a cause this function itself classified OVERFLOW, so
-       returning RETRYABLE here is what keeps this cause out of it).
+       importing the other's private helper) — OR (#5568, below)
+       ``status_code == 200``, checked BEFORE ``is_context_overflow_
+       error``'s own keyword-string fallback ever runs (that fallback
+       lives one level up, in ``router_loop_driver._is_shrinkable_
+       overflow`` — it is only ever reached for a cause this function
+       itself classified OVERFLOW, so returning RETRYABLE here is what
+       keeps this cause out of it).
     3. OVERFLOW — ``is_context_overflow_error`` (this module's own,
        already-shared predicate — 413 / token-length signals, with a
        keyword-string fallback for a flattened provider exception).
@@ -1174,6 +1174,40 @@ def classify_llm_failure(exc: BaseException) -> LLMFailureClass:
     failure, not an input-size one; ADR-0044 I2: "do not apply an
     irreversible remedy to a reversible cause" — waiting/retrying is
     reversible, shrinking permanently discards conversation content).
+
+    The honest predicate is ``status_code == 200`` alone — NOT also
+    checking whether the message parses as JSON. litellm's own exception
+    ``__str__``/``.message`` always carries a class-name prefix (e.g.
+    ``"litellm.APIError: <body>"``, confirmed directly against a real
+    ``litellm.APIError`` instance), so a check like ``json.loads(str(exc))``
+    would ALWAYS fail regardless of whether the underlying body was JSON
+    or not — measuring nothing beyond what ``code == 200`` already
+    measures, while giving the false impression of a narrower, message-
+    content-aware check. ``code == 200`` alone is also sufficient by
+    construction: ``transform_response_api_response`` raises status 200
+    ONLY on this exact "transport succeeded, response-object conversion
+    failed" shape (architect's own trace) — no separate message-content
+    check is needed to confirm that, and checking the private prefix
+    string instead (architect's own rejected option (ii)) would repeat
+    #5603's own mistake of depending on a private, version-fragile
+    litellm implementation detail.
+
+    Disclosed tradeoff (architect's own ruling, kept here deliberately):
+    in a still-broken-proxy world, a REAL overflow signal (an SSE
+    ``error`` frame reading "exceeds the context window") can be buried
+    inside a 200-status exception's own body — this predicate classifies
+    that RETRYABLE too, not OVERFLOW. This is correct, not a gap:
+    shrinking is not a repair for "the proxy returned SSE for a
+    stream: false request" (the real incident kept producing the same
+    200+SSE shape even after shrinking a 9M-character history down to
+    18K), and once the proxy is fixed (#5568's own separate "A"), a
+    genuine overflow reaches this function as a real 4xx
+    ``ContextWindowExceededError`` and classifies OVERFLOW exactly as
+    before. The way back to that world is fixing the proxy, never
+    compensating for it in classification — compensating would make the
+    proxy's own contract violation permanently invisible (Q3: does the
+    repair destroy the evidence).
+
     architect's own ruling (issue #5568): the root cause is the upstream
     proxy's contract violation (owner's own hand, a separate fix, layered
     ABOVE the provider per the owner's standing "reyn fights above the
@@ -1200,19 +1234,26 @@ def classify_llm_failure(exc: BaseException) -> LLMFailureClass:
         or (isinstance(code, int) and 500 <= code < 600)
     ):
         return LLMFailureClass.RETRYABLE
-    # #5568: HTTP 200 (the request genuinely succeeded at the transport
-    # layer) whose body is not parseable as JSON is a protocol/transport
-    # failure, unconditionally — never an input-size question, so it must
-    # never reach the OVERFLOW keyword fallback below regardless of what
-    # words the broken body happens to contain. `str(exc)` is the SAME
-    # value `is_context_overflow_error`'s own keyword fallback reads
-    # (this module's own established convention for "the message text a
-    # flattened provider exception carries").
+    # #5568 (architect's own honest predicate, PR #5614 review): an HTTP
+    # 200 (the request genuinely succeeded at the transport layer) on an
+    # EXCEPTION is a protocol/transport failure, unconditionally — never
+    # an input-size question — so it must never reach the OVERFLOW
+    # keyword fallback below. `status_code == 200` alone, deliberately
+    # NOT also checking whether the message parses as JSON: litellm's own
+    # exception `__str__`/`.message` always carries a class-name prefix
+    # (e.g. `"litellm.APIError: <body>"`), so a `json.loads(str(exc))`
+    # check would ALWAYS fail regardless of the underlying body — an
+    # earlier version of this branch had exactly that check, which
+    # measured nothing beyond `code == 200` already does (lead-coder's
+    # own catch, PR #5614 review, confirmed directly against a real
+    # `litellm.APIError`). See this function's own docstring for the
+    # disclosed tradeoff (a genuine overflow signal buried in a 200
+    # exception's body also classifies RETRYABLE here — correct, not a
+    # gap) and why the private prefix string is deliberately NOT checked
+    # either (#5603's own "depended on a private, version-fragile litellm
+    # detail" mistake, not repeated here).
     if code == 200:
-        try:
-            json.loads(str(exc))
-        except (json.JSONDecodeError, TypeError, ValueError):
-            return LLMFailureClass.RETRYABLE
+        return LLMFailureClass.RETRYABLE
     return LLMFailureClass.OVERFLOW
 
 

--- a/tests/runtime/test_5568_classify_200_non_json_retryable.py
+++ b/tests/runtime/test_5568_classify_200_non_json_retryable.py
@@ -1,6 +1,7 @@
-"""Tier 2: #5568 — ``classify_llm_failure`` classifies an HTTP 200 whose
-body is not parseable as JSON as ``RETRYABLE``, structurally, BEFORE
-``is_context_overflow_error``'s own keyword-string fallback ever runs.
+"""Tier 2: #5568 — ``classify_llm_failure`` classifies a real litellm
+exception carrying ``status_code == 200`` as ``RETRYABLE``, structurally,
+BEFORE ``is_context_overflow_error``'s own keyword-string fallback ever
+runs.
 
 Owner's real-machine incident (reyn-self ``coder-brown``, 2026-08-30):
 litellm's ``OpenAIResponsesAPIConfig.transform_response_api_response``
@@ -23,11 +24,25 @@ would make the proxy's own contract violation permanently invisible, the
 Q3 "does the repair destroy the evidence" band violation). The upstream
 proxy fix (owner's own hand) is out of scope for this PR.
 
-Reachability witness (architect's own explicit requirement, closing the
-exact hole #5603 exposed — a patched function production never actually
-reaches still shows green): this file's own accept test does NOT call
-``classify_llm_failure`` directly. It drives a REAL ``Session`` +
-``RouterLoop`` turn end to end and fakes the TRANSPORT boundary
+The honest predicate (round 2, lead-coder's own catch + architect's own
+follow-up ruling, PR #5614 review): ``status_code == 200`` ALONE — an
+earlier version of this fix also checked whether the message parses as
+JSON, but litellm's own exception ``__str__``/``.message`` always carries
+a class-name prefix (``"litellm.APIError: <body>"``), so that check
+ALWAYS failed for a real litellm exception regardless of the underlying
+body — measuring nothing beyond what ``code == 200`` already measures.
+This file's own tests now construct a REAL ``litellm.APIError`` (not a
+hand-built stand-in whose ``str()`` has no such prefix) — the earlier
+version's own hand-built exception was the reason this gap went
+unnoticed: its message had no prefix, so the (redundant, now-removed)
+JSON check happened to still work for it, while silently doing nothing
+for any REAL litellm exception.
+
+Reachability witness (architect's own explicit requirement, addressing
+the exact hole #5603 exposed — a patched function production never
+actually reaches still shows green): this file's own accept test does
+NOT call ``classify_llm_failure`` directly. It drives a REAL ``Session``
++ ``RouterLoop`` turn end to end and fakes the TRANSPORT boundary
 (``litellm.acompletion``, monkeypatched — same idiom
 ``test_5582_compaction_forced_non_streaming.py`` already establishes for
 inspecting/controlling what litellm receives/returns) so
@@ -51,19 +66,6 @@ import pytest
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events, settle
 
-
-class _FakeOpenAI200NonJsonError(Exception):
-    """Real, scripted stand-in for the exact exception shape
-    ``OpenAIResponsesAPIConfig.transform_response_api_response`` raises
-    when a ``stream: false`` request receives an SSE body instead of
-    JSON — an HTTP 200 status carrying the ENTIRE raw stream text as its
-    own message (architect's own #5568 trace, quoted above)."""
-
-    def __init__(self, sse_body: str) -> None:
-        super().__init__(sse_body)
-        self.status_code = 200
-
-
 # A real-shaped SSE body carrying an ``error`` frame whose own text
 # happens to contain an overflow-suggestive keyword ("context window") —
 # deliberately NOT an overflow-keyword-free body: this is what makes the
@@ -74,7 +76,7 @@ class _FakeOpenAI200NonJsonError(Exception):
 # keyword-free SSE body would pass this test's own assertions even
 # WITHOUT the fix (confirmed directly: reverting the fix and rerunning
 # with a keyword-free body stayed green — the exact false-negative this
-# body avoids). Genuinely non-JSON (fails json.loads) either way.
+# body avoids).
 _SSE_BODY = (
     'data: {"type": "response.created", '
     '"response": {"status": "in_progress", "output": []}}\n\n'
@@ -112,7 +114,14 @@ def test_production_path_200_non_json_classifies_retryable_not_overflow(
     async def _fake_acompletion(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        raise _FakeOpenAI200NonJsonError(_SSE_BODY)
+        # A REAL litellm.APIError — not a hand-built stand-in (lead-
+        # coder's own catch: a hand-built exception's str() carries no
+        # class-name prefix, unlike a real one, so it can mask a fix that
+        # doesn't actually work against production's own exception shape).
+        raise litellm.APIError(
+            status_code=200, message=_SSE_BODY,
+            llm_provider="openai", model="gpt-5.6-luna",
+        )
 
     monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
 
@@ -146,7 +155,7 @@ def test_production_path_200_non_json_classifies_retryable_not_overflow(
     # instrument, typed correctly — not swallowed, not misreported.
     terminated = [e for e in collected if e.type == "router_loop_terminated_by_exception"]
     assert terminated, "the exception must reach the generic catch-all's own P6 instrument"
-    assert terminated[0].data["error_type"] == "_FakeOpenAI200NonJsonError"
+    assert terminated[0].data["error_type"] == "APIError"
 
     msgs = _drain_outbox(session)
     error_msgs = [m for m in msgs if m.kind == "error"]
@@ -183,35 +192,4 @@ def test_production_path_genuine_overflow_still_classifies_overflow(
         "a genuine context-overflow-shaped exception must still enter "
         "the shrink ladder — #5568's own fix must not have become "
         "'never classify as overflow'"
-    )
-
-
-# ── deny: a 200 whose body IS valid JSON is untouched (byte-identical) ──
-
-
-def test_classify_llm_failure_200_with_valid_json_message_stays_overflow(
-) -> None:
-    """Tier 2: #5568 deny — the new branch is scoped EXACTLY to "200 +
-    body fails json.loads"; a 200-status exception whose message DOES
-    parse as JSON must classify exactly as it did before this fix
-    (falls through to OVERFLOW, unchanged) — proving this is not a
-    blanket "any 200 is retryable" widening.
-
-    Unit-level on the classifier itself (not the reachability-witness
-    concern above): this deny case tests the FUNCTION's own scoping, not
-    whether production reaches it — a 200-status exception with a
-    well-formed JSON body is not itself a real incident this PR
-    addresses; #5568's own defect is specifically the non-JSON case."""
-    from reyn.services.compaction.engine import LLMFailureClass, classify_llm_failure
-
-    class _Fake200JsonError(Exception):
-        def __init__(self, msg: str) -> None:
-            super().__init__(msg)
-            self.status_code = 200
-
-    exc = _Fake200JsonError('{"error": {"message": "context length exceeded"}}')
-    assert classify_llm_failure(exc) is LLMFailureClass.OVERFLOW, (
-        "a 200-status exception whose message DOES parse as JSON must "
-        "stay on its pre-#5568 classification path — this fix's own "
-        "branch must never fire for it"
     )

--- a/tests/runtime/test_5568_classify_200_non_json_retryable.py
+++ b/tests/runtime/test_5568_classify_200_non_json_retryable.py
@@ -1,0 +1,217 @@
+"""Tier 2: #5568 — ``classify_llm_failure`` classifies an HTTP 200 whose
+body is not parseable as JSON as ``RETRYABLE``, structurally, BEFORE
+``is_context_overflow_error``'s own keyword-string fallback ever runs.
+
+Owner's real-machine incident (reyn-self ``coder-brown``, 2026-08-30):
+litellm's ``OpenAIResponsesAPIConfig.transform_response_api_response``
+does ``raw_response.json()`` inside a bare ``try/except Exception`` and,
+on failure, raises ``OpenAIError(message=raw_response.text,
+status_code=raw_response.status_code)`` — an HTTP 200 (the request
+genuinely succeeded at the transport layer) wrapping the ENTIRE raw
+response body (a raw SSE stream the upstream proxy returned despite
+``stream: false``) as the exception's own message. Because that body can
+coincidentally contain an overflow-shaped keyword, the pre-#5568
+fallthrough to OVERFLOW let this reach ``is_context_overflow_error``'s
+keyword fallback and enter the shrink ladder — repeatedly halving and
+re-sending a 9M-character history against a cause no amount of shrinking
+can fix (ADR-0044 I2: never apply an irreversible remedy to a reversible
+cause).
+
+architect's own ruling (issue #5568): reyn's correction is classification
+ONLY — never teaching litellm to accept the malformed response (that
+would make the proxy's own contract violation permanently invisible, the
+Q3 "does the repair destroy the evidence" band violation). The upstream
+proxy fix (owner's own hand) is out of scope for this PR.
+
+Reachability witness (architect's own explicit requirement, closing the
+exact hole #5603 exposed — a patched function production never actually
+reaches still shows green): this file's own accept test does NOT call
+``classify_llm_failure`` directly. It drives a REAL ``Session`` +
+``RouterLoop`` turn end to end and fakes the TRANSPORT boundary
+(``litellm.acompletion``, monkeypatched — same idiom
+``test_5582_compaction_forced_non_streaming.py`` already establishes for
+inspecting/controlling what litellm receives/returns) so
+``call_llm_tools`` → ``recorded_acompletion`` → ``litellm.acompletion``
+all run for real, exactly as architect's own acceptance text names the
+path (``call_llm_tools`` → ``recorded_acompletion``) — the classification
+result is read off the SAME observable behavior (0 compaction attempts,
+no ``router_context_overflow_detected``, a typed error surfaces) that
+``test_5577_unify_overflow_classification_arms.py`` and
+``test_5256_quota_not_context_overflow.py`` already use for this exact
+family of defect (misclassification at the production except-clause
+chain), never from calling the classifier in isolation.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import litellm
+import pytest
+
+from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
+
+
+class _FakeOpenAI200NonJsonError(Exception):
+    """Real, scripted stand-in for the exact exception shape
+    ``OpenAIResponsesAPIConfig.transform_response_api_response`` raises
+    when a ``stream: false`` request receives an SSE body instead of
+    JSON — an HTTP 200 status carrying the ENTIRE raw stream text as its
+    own message (architect's own #5568 trace, quoted above)."""
+
+    def __init__(self, sse_body: str) -> None:
+        super().__init__(sse_body)
+        self.status_code = 200
+
+
+# A real-shaped SSE body carrying an ``error`` frame whose own text
+# happens to contain an overflow-suggestive keyword ("context window") —
+# deliberately NOT an overflow-keyword-free body: this is what makes the
+# strip-falsify meaningful. Without this fix, `classify_llm_failure`
+# falls through to OVERFLOW, and `is_context_overflow_error`'s own
+# keyword fallback (`_CONTEXT_OVERFLOW_KEYWORDS` includes "context") then
+# matches THIS text, so the misclassification actually reproduces — a
+# keyword-free SSE body would pass this test's own assertions even
+# WITHOUT the fix (confirmed directly: reverting the fix and rerunning
+# with a keyword-free body stayed green — the exact false-negative this
+# body avoids). Genuinely non-JSON (fails json.loads) either way.
+_SSE_BODY = (
+    'data: {"type": "response.created", '
+    '"response": {"status": "in_progress", "output": []}}\n\n'
+    'data: {"type": "response.in_progress", '
+    '"response": {"status": "in_progress", "output": []}}\n\n'
+    'data: {"type": "error", '
+    '"error": {"message": "Your input exceeds the context window"}}\n\n'
+)
+
+
+def _drain_outbox(session) -> list:
+    msgs = []
+    while not session.outbox.empty():
+        msgs.append(session.outbox.get_nowait())
+    return msgs
+
+
+def test_production_path_200_non_json_classifies_retryable_not_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5568 accept + reachability witness.
+
+    A real Session/RouterLoop turn whose ONLY faked boundary is
+    ``litellm.acompletion`` (never ``classify_llm_failure`` itself, never
+    ``call_llm_tools``, never ``is_shrinkable_overflow`` — every real
+    function on the actual production path runs). Never enters the shrink
+    ladder (0 compaction attempts, no ``router_context_overflow_detected``)
+    and the session survives with a typed error surfaced — never silently
+    burning real calls shrinking a cause no shrink can fix."""
+    session = make_session(agent_name="classify_200_nonjson_test")
+    collected = collect_events(session)
+
+    call_count = 0
+
+    async def _fake_acompletion(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise _FakeOpenAI200NonJsonError(_SSE_BODY)
+
+    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+
+    async def _drive() -> None:
+        # Must not raise — the generic catch-all keeps the session alive.
+        await session._handle_inbox_text("hi", chain_id="chain-5568-1")
+        await settle(session)
+
+    asyncio.run(_drive())
+
+    # ① never shrinkable: exactly one real litellm.acompletion call — a
+    # shrink retry, or the compaction ladder's own fold call, would have
+    # made a second/third one.
+    assert call_count == 1, (
+        f"expected exactly 1 litellm.acompletion call (no shrink retry "
+        f"entered), got {call_count}"
+    )
+
+    kinds = [e.type for e in collected]
+    assert "router_context_overflow_detected" not in kinds, (
+        "an HTTP 200 + non-JSON body must never be classified as context "
+        "overflow — that is precisely #5568's own real-machine incident"
+    )
+    assert not [e for e in collected if e.type == "compaction_started"], (
+        "no compaction pass may have been attempted — this cause is "
+        "unshrinkable by construction (a transport/protocol failure, not "
+        "an input-size one)"
+    )
+
+    # The exception genuinely reached the generic catch-all's own P6
+    # instrument, typed correctly — not swallowed, not misreported.
+    terminated = [e for e in collected if e.type == "router_loop_terminated_by_exception"]
+    assert terminated, "the exception must reach the generic catch-all's own P6 instrument"
+    assert terminated[0].data["error_type"] == "_FakeOpenAI200NonJsonError"
+
+    msgs = _drain_outbox(session)
+    error_msgs = [m for m in msgs if m.kind == "error"]
+    assert error_msgs, "the operator must see something — not a silent end"
+
+
+def test_production_path_genuine_overflow_still_classifies_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5568 accept-2 (sibling, ruling-out over-narrowing) — a
+    REAL context-length overflow, through the SAME production path, must
+    still enter the shrink ladder exactly as before. Without this test,
+    the accept side above could pass trivially with an implementation
+    that stopped classifying ANYTHING as overflow."""
+    session = make_session(agent_name="classify_200_nonjson_overflow_sibling_test")
+    collected = collect_events(session)
+
+    async def _fake_acompletion(*args, **kwargs):
+        raise litellm.ContextWindowExceededError(
+            message="This model's maximum context length is 128000 tokens",
+            model="gpt-5.6-luna", llm_provider="openai",
+        )
+
+    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+
+    async def _drive() -> None:
+        await session._handle_inbox_text("hi", chain_id="chain-5568-2")
+        await settle(session)
+
+    asyncio.run(_drive())
+
+    kinds = [e.type for e in collected]
+    assert "router_context_overflow_detected" in kinds, (
+        "a genuine context-overflow-shaped exception must still enter "
+        "the shrink ladder — #5568's own fix must not have become "
+        "'never classify as overflow'"
+    )
+
+
+# ── deny: a 200 whose body IS valid JSON is untouched (byte-identical) ──
+
+
+def test_classify_llm_failure_200_with_valid_json_message_stays_overflow(
+) -> None:
+    """Tier 2: #5568 deny — the new branch is scoped EXACTLY to "200 +
+    body fails json.loads"; a 200-status exception whose message DOES
+    parse as JSON must classify exactly as it did before this fix
+    (falls through to OVERFLOW, unchanged) — proving this is not a
+    blanket "any 200 is retryable" widening.
+
+    Unit-level on the classifier itself (not the reachability-witness
+    concern above): this deny case tests the FUNCTION's own scoping, not
+    whether production reaches it — a 200-status exception with a
+    well-formed JSON body is not itself a real incident this PR
+    addresses; #5568's own defect is specifically the non-JSON case."""
+    from reyn.services.compaction.engine import LLMFailureClass, classify_llm_failure
+
+    class _Fake200JsonError(Exception):
+        def __init__(self, msg: str) -> None:
+            super().__init__(msg)
+            self.status_code = 200
+
+    exc = _Fake200JsonError('{"error": {"message": "context length exceeded"}}')
+    assert classify_llm_failure(exc) is LLMFailureClass.OVERFLOW, (
+        "a 200-status exception whose message DOES parse as JSON must "
+        "stay on its pre-#5568 classification path — this fix's own "
+        "branch must never fire for it"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5568 (not the full fix — the upstream proxy contract violation, "A", stays owner's own hand per architect's ruling).

## What changed

`classify_llm_failure` (`src/reyn/services/compaction/engine.py`) now classifies an HTTP `200` whose body fails `json.loads` as `RETRYABLE` — structurally, before any keyword scan ever runs. `litellm` is untouched.

## Why (owner's real-machine incident, reyn-self `coder-brown`, 2026-08-30)

`prompt_tokens=1,080,968`, `completion_tokens=0`, `finish_reason="stop"`, `cost_usd=0.43`, and compaction never ran once that session. Traced to litellm's `OpenAIResponsesAPIConfig.transform_response_api_response` (the class reyn's own `provider=openai` config resolves to against a local proxy — **not** `ChatGPTResponsesAPIConfig`, which #5603(B) patches; confirmed unreached in production via a reach-marker with 0 matching lines across two real pids). That class does `raw_response.json()` inside a bare `try/except Exception` and, on failure, raises `OpenAIError(message=raw_response.text, status_code=raw_response.status_code)` — an HTTP 200 (the request genuinely succeeded at the transport layer) wrapping the **entire raw SSE response body** as the exception's own message.

Because that body can coincidentally contain an overflow-shaped keyword (an SSE `error` frame's own text), the pre-fix unconditional `OVERFLOW` fallthrough let this reach `is_context_overflow_error`'s keyword fallback and enter the shrink ladder — repeatedly halving and re-sending a 9M-character history against a cause no amount of shrinking can fix (ADR-0044 I2: never apply an irreversible remedy to a reversible cause).

## architect's ruling (issue #5568) — two defects, two owners

- **Root cause (A)**: the upstream proxy returns SSE for a `stream: false` request — a genuine contract violation. Owner's own hand (`junk/litellm` config or patch), out of scope here — teaching litellm/reyn's own compat layer to accept the malformed response would make the proxy's own defect permanently invisible (Q3: does the repair destroy the evidence).
- **reyn's own defect**: the misclassification, fixed in this PR, reyn-side only.

## Reachability witness (architect's own explicit requirement — the exact hole #5603 exposed)

The accept test drives a real `Session` + `RouterLoop` turn end to end and fakes **only** the transport boundary (`litellm.acompletion`, monkeypatched) — `call_llm_tools` → `recorded_acompletion` → `litellm.acompletion` all run for real, exactly matching architect's own acceptance text. It never calls `classify_llm_failure` directly.

## 4 acceptance shapes (architect's own text)

- **accept**: production path, HTTP 200 + non-JSON SSE body carrying a coincidental "context window" keyword (matching the real incident — verified load-bearing: a keyword-free body stayed falsely green even without the fix) → `RETRYABLE` → 0 compaction attempts, no `router_context_overflow_detected`, session survives with a typed error surfaced (pre-fix this is a raw `UnrecoveredError` escaping `_handle_inbox_text`, confirmed during the strip-falsify).
- **accept-2 (sibling)**: same path, a REAL `ContextWindowExceededError` still classifies `OVERFLOW` and enters the ladder — proving no over-narrowing.
- **deny**: a 200-status exception whose message DOES parse as JSON stays on its pre-fix classification (`OVERFLOW`) — unit-level on the classifier's own scoping.
- **Strip-falsify (executed)**: reverting the new branch turns the accept test genuinely RED (`UnrecoveredError` raised); restoring returns it to green.

## #5603(B) — not deleted here

`src/reyn/llm/_litellm_compat_patches.py`'s `apply_overflow_diagnosis` (targeting `ChatGPTResponsesAPIConfig`) is confirmed production-inert (reyn's own `provider=openai` config never resolves to that class). Architect recommends deleting it once A (the proxy fix) lands — not in this PR. `reyn doctor`'s own B status line is unaffected and not misleading — the patch genuinely is applied to the class it targets, it just never gets reached in production.

## Docs

`docs/concepts/data-retrieval/chat-compaction.md`'s classification table updated in the same PR (CLAUDE.md hard rule) — its "Retryable" row's example list was implicitly exhaustive and is now false without this addition.

## Round-2 review fix (lead-coder + architect, PR review 2026-09-01)

Lead-coder's own catch: `json.loads(str(exc))` always fails for a REAL litellm exception (litellm's own `__str__`/`.message` always carries a class-name prefix, e.g. `"litellm.APIError: <body>"`, confirmed directly) — the original predicate's effective behavior was already just `status_code == 200`; the JSON-parse check measured nothing extra, and the old deny test only stayed green because it used a hand-built exception with no such prefix (not representative of production).

architect's own follow-up ruling: the honest predicate is `status_code == 200` alone — `OpenAIResponsesAPIConfig.transform_response_api_response` raises 200 ONLY on the exact "transport succeeded, response-object conversion failed" shape, so no separate message-content check is needed. Checking the private `"litellm.ClassName: "` prefix string instead (option ii) was rejected — the same #5603 mistake (a private, version-fragile litellm implementation detail), not repeated here.

Disclosed tradeoff (kept in the docstring per architect's own explicit requirement): in a still-broken-proxy world, a genuine overflow signal buried in a 200-status exception's body now also classifies RETRYABLE. This is correct, not a gap — shrinking never repairs a "proxy returned SSE for stream:false" cause; once the proxy is fixed (A), a genuine overflow reaches this function as a real 4xx `ContextWindowExceededError` and classifies OVERFLOW exactly as before.

Tests updated: both now construct a REAL `litellm.APIError`/`litellm.ContextWindowExceededError` (never a hand-built stand-in). The old "200 + valid JSON stays OVERFLOW" deny test is dropped — with the predicate now `status_code == 200` alone, that scenario is no longer a real deny case, and its only witness was the test's own hand-built construction (six questions Q3). The existing genuine-overflow sibling test covers the "real 4xx stays OVERFLOW" deny case, as instructed.

Re-verified: strip-falsify re-executed against the corrected predicate (red without it, green restored); 23/23 related tests pass; all gates green.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5568_classify_200_non_json_retryable.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/services/compaction/engine.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py`
- [x] Scoped `pytest` — 3/3 new + 72/72 related (test_5577/test_5256/test_3783/test_5329/PR-N6/retry_loop_chat_wiring/#5578/#5498/#5543/#5603 suites)
- [x] Strip-falsify executed (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51

