### PR TITLE
fix(#5618): the shrink-progress gate reads the driver's recovery episode, not just the controller's flag

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/compaction_progress.py
+++ b/src/reyn/interfaces/inline/textual_chat/compaction_progress.py
@@ -33,6 +33,18 @@ Only ``is_compacting`` (via ``Session.is_compacting`` / #5588) and
 ``terminal`` (via the ``router_context_overflow_unrecovered`` event's own
 new field, also #5588) are wired to something real as of this module's
 introduction — both landed in THIS PR, no producer dependency.
+
+#5618 corrected what ``is_compacting`` actually reports. It was the
+compaction CONTROLLER's flag alone, which rises only inside
+``force_compact_now`` — so a real overflow recovery, which runs the retry
+ladder against the engine directly and never touches that flag, left this
+whole display structurally invisible on the one path a user most needs it
+(owner, real machine, mid-recovery: "tui では進捗わからない"). It is now
+the OR of that flag and the loop driver's own recovery-episode state, each
+with its own try/finally. The numbers below are additionally joined
+against the episode they were measured in, so a finished episode's figures
+degrade to ``None`` (line 2's "waiting" state) rather than rendering as
+this episode's progress.
 """
 from __future__ import annotations
 

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -680,6 +680,11 @@ def _snapshot_for_session(registry, s, config=None):
         # pattern) — REMOTE/AG-UI simply lacks this key today, and the
         # chrome consumer treats a missing key the same as "nothing to
         # show" (is_compacting defaults False). A follow-up, not done here.
+        # #5618: is_compacting inside this dict is now the OR of the
+        # compaction controller's flag and the loop driver's recovery
+        # episode, so this REPL surface picks up recovery progress on the
+        # retry-ladder path too — it reads the same gate as the TUI, and
+        # the fix landed in Session, below both of them.
         "compaction_progress_raw": s.compaction_progress_raw(),
         # LOCAL genuinely measures cron config below (via
         # ``_extract_cron_jobs``) whenever a ``config`` is given — gated

--- a/src/reyn/runtime/services/execution_driver.py
+++ b/src/reyn/runtime/services/execution_driver.py
@@ -61,3 +61,16 @@ class ExecutionDriver(Protocol):
     def cancel_event(self) -> "asyncio.Event | None":
         """Per-turn asyncio.Event set by request_cancel(), or None (#2813)."""
         ...
+
+    @property
+    def recovery_episode(self) -> "int | None":
+        """#5618: current overflow-recovery episode number, or None when not
+        recovering. ``Session.is_compacting`` ORs this with the compaction
+        controller's own flag to gate the TUI's shrink-progress row.
+
+        A driver that runs no retry ladder returns None permanently — that is
+        a true answer, not a stub. ``Session`` reads this defensively, so an
+        implementation predating #5618 degrades to "never recovering" rather
+        than raising; keeping it declared HERE is what stops that degradation
+        from being silent for a driver that should have implemented it."""
+        ...

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -340,6 +340,15 @@ class PipelineExecutorDriver:
         Ctrl-C, same as every pre-#2813 caller with no cancel_event to pass."""
         return None
 
+    @property
+    def recovery_episode(self) -> None:
+        """#5618: always None — this driver executes a pipeline's steps and
+        never enters the router's bounded-shrink retry ladder, so there is no
+        recovery episode to be inside of. Declared rather than left to
+        ``Session``'s ``getattr`` default so the answer is this driver's own
+        stated one, not an absence that happens to read the same."""
+        return None
+
     # ── internals ──────────────────────────────────────────────────────────────
 
     def _pipeline_registry(self) -> Any:

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -16,6 +16,7 @@ RouterHostAdapter.turn_cancel_fn callback wired in Session.__init__.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import TYPE_CHECKING, Any, Callable
 
 from reyn.runtime.chat_message import Spillability
@@ -175,6 +176,24 @@ class RouterLoopDriver:
         # deep-cancel propagation into running subprocess ops (#1470).
         self._turn_cancel_requested: bool = False
         self._turn_cancel_event: asyncio.Event = asyncio.Event()
+        # #5618: the recovery-episode state the TUI's shrink-progress row
+        # gates on. NOT the controller's `_compacting` flag — that one rises
+        # only inside `force_compact_now`, and the retry ladder below calls
+        # the engine directly (`_run_with_shrink`), so a real overflow
+        # recovery never lifted it and the row structurally never appeared
+        # (owner, real machine, mid-recovery: "tui では進捗わからない").
+        # Depth, not a bool, because the ladder re-enters: the inner segment
+        # and the outer `except _UnrecoveredError` (reactive spill →
+        # force_compact_now → resend) BOTH scope an episode, and a bool
+        # would end the episode at the inner exit while recovery is still
+        # running — the row would blink off mid-way. The number is what
+        # `Session.compaction_progress_raw` joins the cached figures against
+        # for freshness, so it must advance only on a genuinely NEW recovery,
+        # never on another segment of the current one — see
+        # `_recovery_episode_scope`'s `continues_previous` for the case where
+        # the two segments do not nest and the rule needs saying out loud.
+        self._recovery_depth: int = 0
+        self._recovery_episode_number: int = 0
         # 0062: per-session structured-output override, set post-construction by
         # ``configure_structured_output`` (mirrors the existing ``_loop_observer``
         # Tier-2 test-seam pattern — a public post-construction configure call, NOT
@@ -189,6 +208,48 @@ class RouterLoopDriver:
         _set_fn = getattr(router_host, "_set_cancel_event", None)
         if callable(_set_fn):
             _set_fn(self._turn_cancel_event)
+
+    # ── Recovery episode (#5618) ─────────────────────────────────────────────
+
+    @property
+    def recovery_episode(self) -> "int | None":
+        """#5618: the current overflow-recovery episode number, or None when
+        this driver is not recovering. A STATE the consumer reads (the TUI
+        polls a snapshot on its own heartbeat), never an edge it has to be
+        present to catch — an event-arrival inference cannot answer "is it
+        still going?" at an arbitrary later read, which is the only question
+        the progress row actually asks.
+
+        Cheap (two int reads), safe every render frame.
+        """
+        return self._recovery_episode_number if self._recovery_depth > 0 else None
+
+    @contextlib.contextmanager
+    def _recovery_episode_scope(self, *, continues_previous: bool = False):
+        """#5618: enter/exit one recovery-episode segment, re-entrantly.
+
+        The `finally` is the load-bearing part: an exception, or a cancel,
+        must still leave the depth at 0 — this regulates RESIDUE, not
+        ordering, so no call site needs to know about any other.
+
+        ``continues_previous`` exists because the two scopes do NOT nest. The
+        outer one is opened from an `except` clause, i.e. AFTER the inner one
+        has already unwound, so a plain 0→1 transition there would allocate a
+        SECOND number for what the user experiences as one uninterrupted
+        recovery — and the figures stamped during the first half would then be
+        judged stale and blank out mid-recovery, which is the flicker this
+        design exists to avoid. Passing it says "this is the same recovery,
+        keep its number". The caller only passes it when the number it is
+        adopting was allocated during its OWN call, so a stale number from an
+        earlier recovery can never be resumed.
+        """
+        self._recovery_depth += 1
+        if self._recovery_depth == 1 and not continues_previous:
+            self._recovery_episode_number += 1
+        try:
+            yield
+        finally:
+            self._recovery_depth -= 1
 
     # ── Cancel lifecycle (#1468 / #1470) ─────────────────────────────────────
 
@@ -633,26 +694,56 @@ class RouterLoopDriver:
         from reyn.services.compaction.engine import UnrecoveredError as _UnrecoveredError
 
         attempt = 0
-        while True:
-            watermark_before = self._history_buffer.compaction_watermark()
-            try:
-                return await self._run_with_shrink(loop, user_text, chain_id=chain_id)
-            except _UnrecoveredError:
-                # Compact axis: measured FIRST — `_run_with_shrink`'s own
-                # except block (its PRE-EXISTING #4954(b) side-effect) may
-                # already have advanced the watermark during the call
-                # above, before this exception ever reached here.
-                compact_progressed = (
-                    self._history_buffer.compaction_watermark() > watermark_before
-                )
-                # Spill axis: always attempted too, even if compact already
-                # progressed — a genuinely spillable candidate should still
-                # be spilled (§1.6's own "1つずつ spill" contract), not
-                # skipped just because the OTHER axis happened to move.
-                spill_progressed = await self._attempt_reactive_spill(chain_id=chain_id)
-                if not compact_progressed and not spill_progressed:
-                    raise
-                attempt += 1
+        # #5618: the OUTER episode scope. It must outlive the `except` block
+        # that opens it — the recovery continues through the reactive spill,
+        # the force_compact, AND the resend on the next lap, and the user is
+        # waiting on all of it as one wait. A plain `with` inside the except
+        # would close at `continue` and blink the progress row off between
+        # laps, so the scope is parked on an ExitStack that unwinds when this
+        # wrapper leaves, however it leaves (return, re-raise, or cancel).
+        # Entered at most ONCE (the stack is only non-empty after the first
+        # failure): the resend's own inner scope then nests at depth 2 and
+        # does not bump the episode number, so one recovery keeps one number
+        # and the figures cached under it stay fresh across every lap.
+        episode_entered = False
+        # #5618: the number the ladder below allocated for THIS call, if it
+        # got that far. `_run_with_shrink` opens its own episode on the
+        # overflow path, so by the time an UnrecoveredError reaches us the
+        # number has usually already moved — and the outer scope should then
+        # adopt it rather than allocate a fresh one (see
+        # `_recovery_episode_scope`). Comparing against the value captured
+        # HERE is what keeps that adoption honest: if the ladder never opened
+        # an episode this call, the number is some earlier recovery's and must
+        # not be resumed.
+        episode_at_entry = self._recovery_episode_number
+        with contextlib.ExitStack() as episode_stack:
+            while True:
+                watermark_before = self._history_buffer.compaction_watermark()
+                try:
+                    return await self._run_with_shrink(loop, user_text, chain_id=chain_id)
+                except _UnrecoveredError:
+                    if not episode_entered:
+                        episode_stack.enter_context(self._recovery_episode_scope(
+                            continues_previous=(
+                                self._recovery_episode_number != episode_at_entry
+                            ),
+                        ))
+                        episode_entered = True
+                    # Compact axis: measured FIRST — `_run_with_shrink`'s own
+                    # except block (its PRE-EXISTING #4954(b) side-effect) may
+                    # already have advanced the watermark during the call
+                    # above, before this exception ever reached here.
+                    compact_progressed = (
+                        self._history_buffer.compaction_watermark() > watermark_before
+                    )
+                    # Spill axis: always attempted too, even if compact already
+                    # progressed — a genuinely spillable candidate should still
+                    # be spilled (§1.6's own "1つずつ spill" contract), not
+                    # skipped just because the OTHER axis happened to move.
+                    spill_progressed = await self._attempt_reactive_spill(chain_id=chain_id)
+                    if not compact_progressed and not spill_progressed:
+                        raise
+                    attempt += 1
                 # #5296 PR-2 ⑥: chain_id is the SAME value this call already
                 # closes over — no new chain_id, no re-emitted
                 # user_submitted/turn_started/WAL append (those all live
@@ -1013,104 +1104,113 @@ class RouterLoopDriver:
             from reyn.llm.llm import (
                 start_upstream_recovery_call_counter as _start_upstream_recovery_call_counter,
             )
-            _upstream_counter_token = _start_upstream_recovery_call_counter()
-            try:
+            # #5618: this segment IS the ladder (rungs ①〜④) — entering the
+            # episode here is what finally lifts the progress row's gate on
+            # the path that actually runs during a real overflow recovery.
+            # Deliberately the same region the #5592 upstream-call counter
+            # already scopes: the numbers the row displays come from that
+            # counter, so the episode the row is gated on and the episode
+            # those numbers belong to are the same span by construction,
+            # not by two independently-maintained boundaries agreeing.
+            with self._recovery_episode_scope():
+                _upstream_counter_token = _start_upstream_recovery_call_counter()
                 try:
-                    _shim = await _retry_loop(
-                        SP=self._history_buffer.build_system_prompt(),
-                        head=_head,
-                        raw_middle=_raw_middle,
-                        tail=_tail,
-                        new_msg=_new_msg,
-                        cfg=self._compaction,
-                        model=self._effective_router_model_class(),
-                        engine=engine,
-                        learner=self._token_learner,
-                        main_call=_router_main_call,
-                        spill_fn=_spill_fn,
-                        on_summary_used=_on_recovery_summary_used,
-                        # #5531 §10: no `max_iterations=` any more —
-                        # retry_loop abolished its iteration-count bound
-                        # (see its own "Bounded termination proof"
-                        # docstring). #4957's `chat.compaction.
-                        # max_shrink_iterations` config knob is therefore
-                        # ORPHANED by this change (nothing reads it any
-                        # more) — disclosed, not silently left: removing
-                        # the knob itself (schema/validation/docs/the ~10
-                        # test fixtures that still pass it) is its own
-                        # scoped follow-up, not folded into this already-
-                        # large PR.
-                    )
-                finally:
-                    _reset_upstream_recovery_call_counter(_upstream_counter_token)
-            except _UnrecoveredError:
-                # #4954 (b), architect-ruled, WIDENED #5578: on ANY
-                # UnrecoveredError exhaustion (byte-limit 413 OR a
-                # non-byte, token-axis terminal cause — no longer gated on
-                # `_unrecovered.saw_byte_limit`), trigger a REAL compaction
-                # here — in the driver's except block, not inside
-                # retry_loop itself (retry_loop stays a pure TRANSPORT
-                # operation; compaction is the SEMANTIC operation that
-                # actually retires history entries, Session's own
-                # docstring: "the only operation meant to retire an
-                # entry"). Routed through `force_compact_now` — the SAME
-                # durable-watermark path `ContextBudgetAdvisor`'s
-                # pre-frame guard already uses
-                # (`_durable_active_history_after`-backed, continuous from
-                # the last real `covers_through_seq`) — deliberately NOT
-                # `retry_loop`'s own compaction result: its `covers` can
-                # cover only `raw_middle` while skipping `head` entirely,
-                # which is not continuous from the previous watermark and
-                # would silently mark the OLDEST unsummarized part of
-                # history "covered" without ever summarizing it (exactly
-                # owner's own real-machine shape).
-                #
-                # #5578: previously gated on `_unrecovered.saw_byte_limit`
-                # — a token-cause exhaustion never reached this line at
-                # all. That gate's OWN stated reason (this file's own,
-                # now-removed docstring, quoting #4885/architect ruling
-                # ④): "a token overflow reaching this point means #4885's
-                # own pre-trigger estimate was wrong; the adaptive learner
-                # fixes that, not a second compaction trigger here." That
-                # pre-trigger (`ContextBudgetAdvisor.maybe_force_compact`,
-                # estimate-based, proactive) no longer exists — #5528
-                # (owner ruling, same family as #5367's elide removal)
-                # removed it, verbatim: "a local token estimate cannot
-                # know what the actual provider payload will look like, so
-                # acting on it risked compacting a conversation that would
-                # have fit fine" (compaction_controller.py's own module
-                # docstring, which this PR also corrects — see its own
-                # #5578 note). With no pre-trigger left, a token-cause
-                # exhaustion has NO durable recovery path at all — every
-                # turn re-starts from the same un-compacted history and
-                # re-runs the identical (LLM-call-costing) shrink from
-                # scratch (owner's own real-machine report, #5578: reyn-
-                # self history.jsonl files grew to 4.6-5.9MB over 5 days
-                # with no persisted compaction). `recovery_policy`'s own
-                # docstring (config/chat.py) never named an axis — it is
-                # declared as a stop-line on the "irreversible compaction
-                # step" itself, not on byte-specifically — so this widening
-                # corrects the call site to match the config's own already
-                # axis-agnostic contract, not a new design decision.
-                #
-                # Repeat-bounding (band's own first question — who stops
-                # this if it repeats): unchanged mechanism, now exercised
-                # on both axes. `force_compact_now` already returns
-                # immediately on `self._compacting` (a concurrent pass) or
-                # zero candidates (nothing left to compact = terminal) —
-                # #5364 §1.6's own note (right below, unchanged) already
-                # established this except block CAN be reached more than
-                # once per turn (`_run_with_shrink_and_byte_reduction`
-                # retries on ANY `UnrecoveredError`); each such repeat
-                # calls `force_compact_now()` again, but the SECOND call
-                # onward finds the watermark already caught up to
-                # everything durably available and returns immediately —
-                # no new call this PR adds, no new unbounded-repeat shape,
-                # only a gate this call already had to survive repeating
-                # under (the byte-axis case already exercised this).
-                if self._compaction.recovery_policy == "next_turn":
-                    await self._compaction_controller.force_compact_now()
-                raise
+                    try:
+                        _shim = await _retry_loop(
+                            SP=self._history_buffer.build_system_prompt(),
+                            head=_head,
+                            raw_middle=_raw_middle,
+                            tail=_tail,
+                            new_msg=_new_msg,
+                            cfg=self._compaction,
+                            model=self._effective_router_model_class(),
+                            engine=engine,
+                            learner=self._token_learner,
+                            main_call=_router_main_call,
+                            spill_fn=_spill_fn,
+                            on_summary_used=_on_recovery_summary_used,
+                            # #5531 §10: no `max_iterations=` any more —
+                            # retry_loop abolished its iteration-count bound
+                            # (see its own "Bounded termination proof"
+                            # docstring). #4957's `chat.compaction.
+                            # max_shrink_iterations` config knob is therefore
+                            # ORPHANED by this change (nothing reads it any
+                            # more) — disclosed, not silently left: removing
+                            # the knob itself (schema/validation/docs/the ~10
+                            # test fixtures that still pass it) is its own
+                            # scoped follow-up, not folded into this already-
+                            # large PR.
+                        )
+                    finally:
+                        _reset_upstream_recovery_call_counter(_upstream_counter_token)
+                except _UnrecoveredError:
+                    # #4954 (b), architect-ruled, WIDENED #5578: on ANY
+                    # UnrecoveredError exhaustion (byte-limit 413 OR a
+                    # non-byte, token-axis terminal cause — no longer gated on
+                    # `_unrecovered.saw_byte_limit`), trigger a REAL compaction
+                    # here — in the driver's except block, not inside
+                    # retry_loop itself (retry_loop stays a pure TRANSPORT
+                    # operation; compaction is the SEMANTIC operation that
+                    # actually retires history entries, Session's own
+                    # docstring: "the only operation meant to retire an
+                    # entry"). Routed through `force_compact_now` — the SAME
+                    # durable-watermark path `ContextBudgetAdvisor`'s
+                    # pre-frame guard already uses
+                    # (`_durable_active_history_after`-backed, continuous from
+                    # the last real `covers_through_seq`) — deliberately NOT
+                    # `retry_loop`'s own compaction result: its `covers` can
+                    # cover only `raw_middle` while skipping `head` entirely,
+                    # which is not continuous from the previous watermark and
+                    # would silently mark the OLDEST unsummarized part of
+                    # history "covered" without ever summarizing it (exactly
+                    # owner's own real-machine shape).
+                    #
+                    # #5578: previously gated on `_unrecovered.saw_byte_limit`
+                    # — a token-cause exhaustion never reached this line at
+                    # all. That gate's OWN stated reason (this file's own,
+                    # now-removed docstring, quoting #4885/architect ruling
+                    # ④): "a token overflow reaching this point means #4885's
+                    # own pre-trigger estimate was wrong; the adaptive learner
+                    # fixes that, not a second compaction trigger here." That
+                    # pre-trigger (`ContextBudgetAdvisor.maybe_force_compact`,
+                    # estimate-based, proactive) no longer exists — #5528
+                    # (owner ruling, same family as #5367's elide removal)
+                    # removed it, verbatim: "a local token estimate cannot
+                    # know what the actual provider payload will look like, so
+                    # acting on it risked compacting a conversation that would
+                    # have fit fine" (compaction_controller.py's own module
+                    # docstring, which this PR also corrects — see its own
+                    # #5578 note). With no pre-trigger left, a token-cause
+                    # exhaustion has NO durable recovery path at all — every
+                    # turn re-starts from the same un-compacted history and
+                    # re-runs the identical (LLM-call-costing) shrink from
+                    # scratch (owner's own real-machine report, #5578: reyn-
+                    # self history.jsonl files grew to 4.6-5.9MB over 5 days
+                    # with no persisted compaction). `recovery_policy`'s own
+                    # docstring (config/chat.py) never named an axis — it is
+                    # declared as a stop-line on the "irreversible compaction
+                    # step" itself, not on byte-specifically — so this widening
+                    # corrects the call site to match the config's own already
+                    # axis-agnostic contract, not a new design decision.
+                    #
+                    # Repeat-bounding (band's own first question — who stops
+                    # this if it repeats): unchanged mechanism, now exercised
+                    # on both axes. `force_compact_now` already returns
+                    # immediately on `self._compacting` (a concurrent pass) or
+                    # zero candidates (nothing left to compact = terminal) —
+                    # #5364 §1.6's own note (right below, unchanged) already
+                    # established this except block CAN be reached more than
+                    # once per turn (`_run_with_shrink_and_byte_reduction`
+                    # retries on ANY `UnrecoveredError`); each such repeat
+                    # calls `force_compact_now()` again, but the SECOND call
+                    # onward finds the watermark already caught up to
+                    # everything durably available and returns immediately —
+                    # no new call this PR adds, no new unbounded-repeat shape,
+                    # only a gate this call already had to survive repeating
+                    # under (the byte-axis case already exercised this).
+                    if self._compaction.recovery_policy == "next_turn":
+                        await self._compaction_controller.force_compact_now()
+                    raise
             return _shim.usage
 
     # ── Main turn entry point ─────────────────────────────────────────────────

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -839,6 +839,20 @@ class HookToggleResult:
     origin: "str | None"
 
 
+#: #5618: the ``_compaction_progress_state`` keys that describe progress
+#: WITHIN a recovery episode, and are therefore meaningless once that episode
+#: has ended — ``compaction_progress_raw()`` reports these as unknown unless
+#: the episode they were measured in is still the one running. The other keys
+#: in that dict are durable facts (#5578's ``persisted_covers_through_seq``:
+#: a fold that happened and stays true), so they are NOT joined; blanking
+#: those between episodes would hide a correct answer.
+_IN_FLIGHT_PROGRESS_KEYS = (
+    "raw_middle_remaining",
+    "raw_middle_total",
+    "upstream_recovery_call_count",
+)
+
+
 class Session:
     def __init__(
         self,
@@ -1466,6 +1480,13 @@ class Session:
             "upstream_recovery_call_count": None,
             "persisted_covers_through_seq": None,
         }
+        # #5618: which recovery episode the IN-FLIGHT figures above were
+        # measured in.
+        # None = nothing cached yet. compaction_progress_raw() joins this
+        # against the driver's CURRENT episode number and reports the figures
+        # as unknown when they disagree, so a finished episode's numbers never
+        # get shown as the next one's progress.
+        self._compaction_progress_episode: "int | None" = None
         self._audit_events.add_subscriber(self._on_compaction_progress_event)
         # Publish reyn.yaml llm.router.* as the ambient router config (#1829 S3b, see docs/reference/runtime/session-construction.md#misc-lifecycle-wiring)
         if router_config is not None:
@@ -10187,14 +10208,58 @@ class Session:
 
     @property
     def is_compacting(self) -> bool:
-        """#5588: forwarding → CompactionController.is_compacting — the ONE
-        real, zero-fabrication signal the shrink-flow progress chrome row
-        gates on. Cheap (a bool read), safe every render frame."""
-        return self._compaction_controller.is_compacting
+        """#5588/#5618: the OR of TWO states, each owning its own try/finally
+        — the shrink-flow progress chrome row's gate.
+
+        - ``CompactionController.is_compacting`` — a compaction driven THROUGH
+          the controller (the threshold pass, ``force_compact_now``).
+        - ``RouterLoopDriver.recovery_episode`` — an overflow recovery running
+          the retry ladder, which calls the engine DIRECTLY and so never
+          touches the controller's flag. #5588 forwarded only to the
+          controller, which is why the row structurally never appeared during
+          a real recovery (#5618, owner real machine) — the one path where a
+          user most needs it.
+
+        Neither is inferred from event arrival: both are states with an
+        explicit exit, so a consumer reading at an arbitrary later moment gets
+        a real answer rather than "an event went past a while ago".
+
+        Cheap (two attribute reads), safe every render frame.
+        """
+        return (
+            self._compaction_controller.is_compacting
+            or self._recovery_episode() is not None
+        )
+
+    def _recovery_episode(self) -> "int | None":
+        """#5618: this session's loop driver's current recovery-episode number,
+        or None when it is not recovering.
+
+        ``getattr`` because ``_loop_driver`` is an injectable seam
+        (``ExecutionDriver``) — ``PipelineExecutorDriver`` and the pipeline
+        test drivers run no retry ladder at all, so "no episode" is their true
+        answer, not a forgotten field. The two drivers that CAN recover both
+        declare it, and the seam test pins that they do."""
+        return getattr(self._loop_driver, "recovery_episode", None)
 
     def _on_compaction_progress_event(self, event) -> None:
         """#5588: see :attr:`_compaction_progress_state`'s own comment at
-        construction — caches, never derives."""
+        construction — caches, never derives.
+
+        #5618: every write also records WHICH recovery episode it belongs to,
+        so :meth:`compaction_progress_raw` can tell a figure from this episode
+        apart from one left over by the previous. Recorded on write rather
+        than cleared on episode end deliberately: a clear needs a place to run,
+        and any such place opens a window between "cleared" and "next value
+        written" where the row would show nothing for no real reason. Stamping
+        the number has no window — the figure and its episode are written
+        together or not at all.
+
+        The stamp is taken ONLY on a branch that actually writes a figure. An
+        unconditional stamp at the top would let an ordinary interleaved
+        ``llm_request`` (one carrying no count) re-date the PREVIOUS episode's
+        figures as belonging to the current one — resurrecting exactly the
+        stale numbers the join exists to hide."""
         if event.type == "compaction_shrink_recovered":
             self._compaction_progress_state["raw_middle_remaining"] = (
                 event.data.get("raw_middle_remaining")
@@ -10202,6 +10267,7 @@ class Session:
             self._compaction_progress_state["raw_middle_total"] = (
                 event.data.get("raw_middle_total")
             )
+            self._compaction_progress_episode = self._recovery_episode()
         elif event.type in ("llm_request", "llm_request_error"):
             # #5592: this field is None outside a recovery episode — only
             # overwrite the cache with a REAL count, never clear a
@@ -10210,6 +10276,7 @@ class Session:
             count = event.data.get("upstream_recovery_call_count")
             if count is not None:
                 self._compaction_progress_state["upstream_recovery_call_count"] = count
+                self._compaction_progress_episode = self._recovery_episode()
         elif event.type == "recovery_summary_persisted":
             # #5578/#5610: three outcomes, and only ONE of them moved the
             # watermark. ``already_covered`` (idempotent no-op) and
@@ -10222,6 +10289,12 @@ class Session:
                 self._compaction_progress_state["persisted_covers_through_seq"] = (
                     event.data.get("covers_through_seq")
                 )
+                # #5618, deliberately NOT stamped with an episode: this one is
+                # a DURABLE watermark, not in-flight progress. The fold it
+                # records stays true after the recovery that produced it has
+                # ended, which is exactly when the Ctx pane's "folded" row
+                # (#5619) shows it. Episode-joining it would blank a fact that
+                # is still correct — the opposite of what the join is for.
 
     def compaction_progress_raw(self) -> dict:
         """#5588: ``is_compacting`` plus the latest #5592 observability
@@ -10230,8 +10303,30 @@ class Session:
         already-cached values), safe every render frame. The TUI layer
         builds its own ``CompactionProgressSnapshot`` from this plain dict
         (this module stays free of any ``interfaces/`` import — Session is
-        reused by every surface, not only the Textual TUI)."""
-        return {"is_compacting": self.is_compacting, **self._compaction_progress_state}
+        reused by every surface, not only the Textual TUI).
+
+        #5618: the IN-FLIGHT figures (see ``_IN_FLIGHT_PROGRESS_KEYS``) are
+        returned only when the episode they were stamped with IS the episode
+        running now. Otherwise they read ``None`` —
+        unknown, which is what they honestly are: the previous episode's
+        remaining/total says nothing about this one's progress, and the row
+        renders its "waiting" state rather than a stale fraction that looks
+        like it is still moving. Nothing is ever cleared (see
+        :meth:`_on_compaction_progress_event`); staleness is decided at READ
+        time, so there is no instant at which a real figure has been erased and
+        its replacement has not yet arrived.
+
+        ``persisted_covers_through_seq`` is deliberately NOT joined: #5578's
+        watermark is a durable fact about a fold that happened, still true —
+        and still displayed by the Ctx pane's "folded" row (#5619) — long after
+        the episode that produced it ended. Blanking it between episodes would
+        hide a correct answer, which is the opposite of the join's purpose."""
+        figures = dict(self._compaction_progress_state)
+        episode = self._recovery_episode()
+        if episode is None or episode != self._compaction_progress_episode:
+            for key in _IN_FLIGHT_PROGRESS_KEYS:
+                figures[key] = None
+        return {"is_compacting": self.is_compacting, **figures}
 
     async def _compact_now_for_op(self) -> dict:
         """#272/#1128/#191: voluntary-compaction callback (compact op + /compact).

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -10235,12 +10235,15 @@ class Session:
         """#5618: this session's loop driver's current recovery-episode number,
         or None when it is not recovering.
 
-        ``getattr`` because ``_loop_driver`` is an injectable seam
-        (``ExecutionDriver``) — ``PipelineExecutorDriver`` and the pipeline
-        test drivers run no retry ladder at all, so "no episode" is their true
-        answer, not a forgotten field. The two drivers that CAN recover both
-        declare it, and the seam test pins that they do."""
-        return getattr(self._loop_driver, "recovery_episode", None)
+        Read DIRECTLY, never through a ``getattr`` default (architect, #5630):
+        a default would make ``None`` mean two different things — "this driver
+        is not recovering" and "this driver never implemented the field" — and
+        the second is a fail-open that silently restores the very #5618 bug
+        this method exists to fix, on any future driver that forgets. Absent
+        must be loud. ``recovery_episode`` is declared on the ``ExecutionDriver``
+        seam, so a driver that runs no retry ladder answers None on purpose
+        (``PipelineExecutorDriver`` does exactly that) rather than by omission."""
+        return self._loop_driver.recovery_episode
 
     def _on_compaction_progress_event(self, event) -> None:
         """#5588: see :attr:`_compaction_progress_state`'s own comment at

--- a/tests/interfaces/test_5588_compaction_progress_chrome.py
+++ b/tests/interfaces/test_5588_compaction_progress_chrome.py
@@ -151,12 +151,27 @@ async def test_row_absent_while_not_compacting(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_row_shows_real_events_driven_snapshot(tmp_path: Path) -> None:
-    """Tier 2: accept — with is_compacting=True and real
-    compaction_shrink_recovered/llm_request events on the session's own
-    audit log, the mounted row renders the exact text
-    compaction_progress_lines() produces from that real data — an
-    end-to-end proof from Session through the App's own refresh cycle to
-    the rendered widget, not just the pure render layer in isolation."""
+    """Tier 2: accept — a CONTROLLER-driven compaction (the threshold pass /
+    force_compact_now) mounts the row and renders line 1, end-to-end from
+    Session through the App's own refresh cycle to the rendered widget rather
+    than the pure render layer in isolation.
+
+    #5618 narrowed what this can claim. The rung figures
+    (raw_middle_remaining, upstream_recovery_call_count) are measured by the
+    retry LADDER and are now joined against the recovery episode they were
+    measured in — a controller compaction is a different operation and runs
+    in no episode, so those figures correctly read unknown here and line 3
+    does not render. The arrangement below (controller flag up, ladder events
+    on the log, no episode) is one production cannot produce at all: the
+    engine emits those events from inside retry_loop, which only runs inside
+    an episode.
+
+    So this asserts the controller path's real contract — the row appears and
+    says the honest thing — and, as the deny half, that it does NOT print rung
+    numbers it never measured. The ladder path's own figures are witnessed
+    where they actually occur, in
+    tests/runtime/test_5618_recovery_episode_gate.py, which drives the real
+    ladder end-to-end."""
     app, session, reg = await _make_app_with_real_session(tmp_path)
     session._compaction_controller._compacting = True  # arrange: no public setter
     session._audit_events.emit(
@@ -182,4 +197,10 @@ async def test_row_shows_real_events_driven_snapshot(tmp_path: Path) -> None:
         row = app.query_one(CompactionProgressRow)
         assert row.display is True
         assert row.lines[0] == "⟳ 文脈を縮めています（自動で終わります）"
-        assert "① 退避 5/2469  呼び出し 43" in row.lines[-1]
+        blob = "\n".join(row.lines)
+        assert "① 退避" not in blob, (
+            f"the row printed ladder rung figures during a controller-driven "
+            f"compaction, which measures none of them — those numbers would "
+            f"be another operation's, shown as this one's progress:\n{blob}"
+        )
+        assert "呼び出し" not in blob, blob

--- a/tests/interfaces/test_5588_compaction_progress_chrome.py
+++ b/tests/interfaces/test_5588_compaction_progress_chrome.py
@@ -168,10 +168,13 @@ async def test_row_shows_real_events_driven_snapshot(tmp_path: Path) -> None:
 
     So this asserts the controller path's real contract — the row appears and
     says the honest thing — and, as the deny half, that it does NOT print rung
-    numbers it never measured. The ladder path's own figures are witnessed
-    where they actually occur, in
-    tests/runtime/test_5618_recovery_episode_gate.py, which drives the real
-    ladder end-to-end."""
+    numbers it never measured.
+
+    Accept sibling (architect, #5630): the figures ARE rendered on the path
+    that measures them — ``test_the_measured_figures_are_reported_while_their_
+    episode_runs`` in tests/runtime/test_5618_recovery_episode_gate.py, which
+    drives the real ladder end-to-end. Without that sibling, this test's deny
+    half would be satisfied by a pane that never shows the figures at all."""
     app, session, reg = await _make_app_with_real_session(tmp_path)
     session._compaction_controller._compacting = True  # arrange: no public setter
     session._audit_events.emit(

--- a/tests/runtime/test_5588_compaction_progress_session_wiring.py
+++ b/tests/runtime/test_5588_compaction_progress_session_wiring.py
@@ -43,11 +43,25 @@ def test_raw_starts_with_every_field_none(tmp_path):
     }
 
 
-def test_compaction_shrink_recovered_populates_raw_middle_fields(tmp_path):
-    """Tier 2: a real compaction_shrink_recovered event's own
-    raw_middle_remaining/raw_middle_total land in compaction_progress_raw()
-    verbatim — the exact field names #5592 actually emits (verified against
-    engine.py:3081-3082's own emit call), not a renamed/derived copy."""
+def test_compaction_shrink_recovered_figures_read_unknown_outside_an_episode(tmp_path):
+    """Tier 2: #5618 rewrote what these 3 tests can claim. The subscriber
+    still caches a real compaction_shrink_recovered event's own
+    raw_middle_remaining/raw_middle_total verbatim (the exact field names
+    #5592 emits, verified against engine.py:3081-3082's own emit call) —
+    but ``compaction_progress_raw()`` now JOINS the cache against the
+    driver's current recovery-episode number before returning it, and this
+    session has no episode running, so the honest answer is unknown.
+
+    Emitting these events with no episode in flight is not a state
+    production can reach at all: the engine emits
+    compaction_shrink_recovered from inside retry_loop, which only runs
+    inside an episode. The accept side — the same fields cached and
+    RETURNED during a real recovery — is therefore witnessed where it
+    actually happens, by the ladder-driven tests in
+    test_5618_recovery_episode_gate.py, not by a hand-emitted event here.
+    What this test still pins is the deny direction of the join, which is
+    the whole point of #5618's freshness rule: a figure that belongs to no
+    current episode is never reported as if it belonged to this one."""
     session = _make_session(tmp_path)
     session._audit_events.emit(
         "compaction_shrink_recovered",
@@ -55,42 +69,37 @@ def test_compaction_shrink_recovered_populates_raw_middle_fields(tmp_path):
         t_max_override=None, raw_middle_remaining=5, raw_middle_total=2469,
     )
     raw = session.compaction_progress_raw()
-    assert raw["raw_middle_remaining"] == 5
-    assert raw["raw_middle_total"] == 2469
+    assert raw["raw_middle_remaining"] is None, raw
+    assert raw["raw_middle_total"] is None, raw
 
 
-def test_llm_request_populates_call_count_only_when_not_none(tmp_path):
-    """Tier 2: upstream_recovery_call_count is None outside a recovery
-    episode (#5592's own documented contract) — an ordinary llm_request
-    with count=None must NOT clear an already-cached real count back to
-    unknown (an interleaved ordinary call must not blank the display)."""
+def test_a_call_count_from_no_episode_is_never_reported_as_this_ones(tmp_path):
+    """Tier 2: the same #5618 join, on the OTHER producer — the
+    upstream_recovery_call_count carried by llm_request / llm_request_error
+    (#5592's failure-path sibling: a rejected request is still billed and
+    still counts). Both event types are exercised because they are two
+    separate branches into the same cache, and a join applied to only one
+    of them would leave the other reporting a stale count.
+
+    #5592's own "an interleaved ordinary call (count=None) must not blank a
+    real count" contract still holds in the subscriber, but it is no longer
+    observable from outside without an episode to join against — it is
+    witnessed on the production path instead, by the ladder-driven accept
+    test in test_5618_recovery_episode_gate.py, where the count is seen to
+    PROGRESS across a real recovery (a blanking write would show up there
+    as the count dropping back to unknown mid-episode)."""
     session = _make_session(tmp_path)
     session._audit_events.emit(
         "llm_request", model="x", input_chars=100,
         max_input_tokens_applied=8000, upstream_recovery_call_count=3,
     )
-    assert session.compaction_progress_raw()["upstream_recovery_call_count"] == 3
+    assert session.compaction_progress_raw()["upstream_recovery_call_count"] is None
 
-    # An ordinary (non-recovery) call interleaves — count is None on THIS
-    # event, but the cache must keep the last REAL count.
-    session._audit_events.emit(
-        "llm_request", model="x", input_chars=50,
-        max_input_tokens_applied=8000, upstream_recovery_call_count=None,
-    )
-    assert session.compaction_progress_raw()["upstream_recovery_call_count"] == 3
-
-
-def test_llm_request_error_also_populates_call_count(tmp_path):
-    """Tier 2: llm_request_error (the failure-path sibling) carries the
-    same field and must also update the cache — a rejected request still
-    counts toward the call sequence (#5592's own motivating incident: a
-    rejected request is still billed and must not vanish from the count)."""
-    session = _make_session(tmp_path)
     session._audit_events.emit(
         "llm_request_error", model="x", error="boom",
         upstream_recovery_call_count=7,
     )
-    assert session.compaction_progress_raw()["upstream_recovery_call_count"] == 7
+    assert session.compaction_progress_raw()["upstream_recovery_call_count"] is None
 
 
 def test_is_compacting_reads_live_not_cached(tmp_path):

--- a/tests/runtime/test_5618_recovery_episode_gate.py
+++ b/tests/runtime/test_5618_recovery_episode_gate.py
@@ -1,0 +1,424 @@
+"""Tier 2: #5618 — the shrink-progress gate rises during a REAL retry-ladder
+recovery, the path that never lifted it before.
+
+#5588 gated the TUI's progress row on ``Session.is_compacting``, which
+forwarded only to ``CompactionController.is_compacting``. That flag is set
+exclusively inside ``force_compact_now``; the overflow retry ladder calls the
+compaction engine directly, so during a genuine recovery the flag stayed False
+and the row was structurally invisible — the one moment a user most needs it
+(owner, real machine, mid-recovery: "tui では進捗わからない"). ``is_compacting``
+is now the OR of that flag and the loop driver's own recovery-episode state.
+
+Everything here drives the REAL ladder: a real ``Session``, a real
+``RouterLoopDriver``, a real ``MediaStore``, and
+``_run_with_shrink_and_byte_reduction`` — the same entry the production turn
+uses. The only fake is ``_ContentDrivenLoop``, a stand-in for ``RouterLoop``
+that raises a 413-shaped error while a given payload is still present; it is
+the established harness in
+``tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py``, reproduced
+here rather than imported so this file stays self-contained.
+
+**Why the assertions sample from inside the loop.** ``is_compacting`` is a
+state with an exit, and the claim is about its value WHILE recovery runs — by
+the time the drive returns, the episode is over by design. ``_ContentDrivenLoop
+.run`` is called by the ladder itself, so recording the gate there reads it at
+genuinely mid-flight moments on the real call path. This is a probe, not a
+second implementation: it stores what the public API returned, and asserts
+nothing on its own.
+
+Nothing here writes a duration. The ladder terminates on its own content
+predicate, and every assertion is over recorded values, never over how long
+anything took.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from reyn.config import CompactionConfig, MultimodalConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.chat_message import ChatMessage
+from reyn.services.compaction.engine import UnrecoveredError
+from tests._support.agent_session import make_session
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _push(session, role: str, text: str, **kw) -> None:
+    """The real, WAL-durable write path — a bare ``session.history.append``
+    leaves the durable store empty, and the compaction candidate read is from
+    the durable store (#4472)."""
+    session._append_history(ChatMessage(role=role, content=text, ts=_now(), **kw))
+
+
+def _has_content(history: "list[dict]", needle: str) -> bool:
+    return any(needle in str(m.get("content", "")) for m in history)
+
+
+class _FakeStatusError(Exception):
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class _ProbingLoop:
+    """A fake ``RouterLoop`` that raises a 413-shaped error while
+    ``should_fail(history, user_text)`` holds, and records the shrink-progress
+    gate on EVERY call.
+
+    The recording is the point: ``run`` is invoked once before the ladder is
+    entered and again from inside it, so ``samples`` ends up holding the gate's
+    value at real mid-recovery moments as well as outside one.
+    """
+
+    def __init__(self, session, should_fail) -> None:
+        self._session = session
+        self._should_fail = should_fail
+        self.calls: "list[list[dict]]" = []
+        self.samples: "list[dict]" = []
+
+    def _sample(self) -> None:
+        raw = self._session.compaction_progress_raw()
+        self.samples.append({
+            "is_compacting": raw["is_compacting"],
+            "call_count": raw["upstream_recovery_call_count"],
+            "raw_middle_remaining": raw["raw_middle_remaining"],
+            # The discriminator architect asked for: the controller's own flag,
+            # read at the SAME instant. It stays False on this path, so a True
+            # gate above can only have come from the new recovery-episode
+            # state. This is the one internal read here, and it is the whole
+            # point of the pairing — without it, a "fix" that made the
+            # controller flag rise on the ladder path would pass unnoticed.
+            "controller": self._session._compaction_controller.is_compacting,
+        })
+
+    async def run(self, *, user_text: str, history: "list[dict]") -> "object | None":
+        self.calls.append(history)
+        self._sample()
+        if self._should_fail(history, user_text):
+            raise _FakeStatusError("request too large", status_code=413)
+        return None
+
+
+def _make_spill_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A real Session with a real MediaStore — the default ``make_session``
+    passes ``media_store=None``, and the spill mechanism needs a real one to
+    have any effect at all."""
+    monkeypatch.chdir(tmp_path)
+    cfg = CompactionConfig(
+        body_token_cap=1500,
+        use_chars4_estimate=True,
+        section_caps_spec_tokens=0,
+        max_shrink_iterations=1,
+        recovery_policy="next_turn",
+        spill_granularity="turn",
+    )
+    return make_session(
+        agent_name="default",
+        agent_role="",
+        output_language="en",
+        budget_tracker=BudgetTracker(CostConfig()),
+        state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
+        compaction_config=cfg,
+        multimodal_config=MultimodalConfig(),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
+
+
+def _drive_a_recovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Set up a single oversized tool result and run the real ladder over it.
+
+    One huge tool result is the cheapest history that genuinely overflows and
+    genuinely recovers: the spill retires it and the retry succeeds, so the
+    drive returns normally instead of terminating unrecovered.
+    """
+    session = _make_spill_session(tmp_path, monkeypatch)
+    _push(session, "user", "look something up")
+    huge = "Y" * 50_000
+    _push(session, "tool", huge, tool_call_id="tc1", name="tool")
+    _push(session, "assistant", "ok, done")
+
+    loop = _ProbingLoop(session, lambda history, _user_text: _has_content(history, huge))
+    result = asyncio.run(
+        session._loop_driver._run_with_shrink_and_byte_reduction(
+            loop, "continue please", chain_id="c1",
+        )
+    )
+    return session, loop, result
+
+
+# ── accept ─────────────────────────────────────────────────────────────────
+
+
+def test_the_gate_rises_during_a_real_retry_ladder_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5618's acceptance criterion. During a recovery that runs the
+    ladder — never touching ``force_compact_now`` — the progress gate reads
+    True at least once. Before #5618 every sample here read False, which is
+    exactly why the row never appeared on a real overflow.
+
+    Paired with the controller's own flag sampled at the same instant: it is
+    False throughout, so this is a genuine new signal and not the old one
+    happening to fire. Without that pairing the test would still pass if
+    someone "fixed" this by making the controller flag rise on the ladder
+    path, which is the design architect ruled out (the ladder is not a
+    controller-driven compaction)."""
+    _session, loop, _result = _drive_a_recovery(tmp_path, monkeypatch)
+
+    assert loop.samples, "the fake loop was never called — the ladder never ran"
+    lifted = [s for s in loop.samples if s["is_compacting"]]
+    assert lifted, (
+        f"the shrink-progress gate never rose during a real ladder recovery — "
+        f"this is #5618 itself. samples={loop.samples!r}"
+    )
+    assert all(not s["controller"] for s in loop.samples), (
+        f"the compaction CONTROLLER's flag rose on the ladder path; the gate "
+        f"above would then prove nothing new: {loop.samples!r}"
+    )
+
+
+def test_the_measured_figures_are_reported_while_their_episode_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the accept side of #5618's episode join. The figures the row
+    displays are cached from #5592's own events and returned ONLY when the
+    episode they were stamped with is the one running — so this pins that a
+    real, in-flight episode does return them. Without it, a join that always
+    reported ``None`` would satisfy every deny test in this file while showing
+    the user a permanently empty row."""
+    _session, loop, _result = _drive_a_recovery(tmp_path, monkeypatch)
+
+    measured = [
+        s for s in loop.samples
+        if s["call_count"] is not None or s["raw_middle_remaining"] is not None
+    ]
+    assert measured, (
+        f"no sample carried a measured figure while its own episode was "
+        f"running — the join is hiding live values, not stale ones: "
+        f"{loop.samples!r}"
+    )
+    assert all(s["is_compacting"] for s in measured), (
+        f"a figure was reported for an episode the gate says is not running: "
+        f"{measured!r}"
+    )
+
+
+# ── deny ───────────────────────────────────────────────────────────────────
+
+
+def test_the_gate_falls_again_once_the_recovery_has_succeeded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: deny ①. The episode has an exit, and it runs: after a recovery
+    that SUCCEEDED, the gate reads False again. Strip the inner scope's
+    ``finally`` and this is the test that goes red — the depth never returns
+    to 0 and the row stays lit for the rest of the session."""
+    session, _loop, _result = _drive_a_recovery(tmp_path, monkeypatch)
+
+    assert session.is_compacting is False
+    assert session.compaction_progress_raw()["is_compacting"] is False
+
+
+def test_a_finished_episodes_figures_are_not_reported_afterwards(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the freshness rule, witnessed on the real path. Figures WERE
+    genuinely measured and cached during the drive (the accept test above
+    reads them mid-flight), yet once that episode has ended they read
+    ``None`` — unknown, which is what they honestly are about any later
+    moment.
+
+    This is the same mechanism that keeps the previous episode's numbers out
+    of the NEXT one: the join compares the stamp against the current episode
+    number, and a stamp from episode N matches neither "no episode" nor
+    episode N+1. Nothing is ever cleared, so there is no window in which a
+    real figure has been erased and its replacement has not yet arrived."""
+    session, loop, _result = _drive_a_recovery(tmp_path, monkeypatch)
+
+    measured = [
+        s for s in loop.samples
+        if s["call_count"] is not None or s["raw_middle_remaining"] is not None
+    ]
+    assert measured, (
+        "nothing was measured during the drive, so this test would pass "
+        "vacuously — it must witness real figures going stale, not absent "
+        "ones staying absent"
+    )
+
+    raw = session.compaction_progress_raw()
+    assert raw["upstream_recovery_call_count"] is None, raw
+    assert raw["raw_middle_remaining"] is None, raw
+    assert raw["raw_middle_total"] is None, raw
+
+
+def test_the_gate_falls_again_when_the_recovery_terminates_unrecovered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: deny ②. The failure exit, which is the one a bare
+    ``flag = False`` after the call would miss: the ladder raises
+    ``UnrecoveredError`` straight through both episode scopes, and the
+    ``finally`` in each is what still brings the depth back to 0.
+
+    The overflow here is the new message itself — nothing in history to spill
+    or fold, so both reduction axes are dry on the first attempt and the
+    wrapper re-raises rather than looping."""
+    session = _make_spill_session(tmp_path, monkeypatch)
+    _push(session, "user", "hello")
+
+    loop = _ProbingLoop(session, lambda _history, _user_text: True)
+    with pytest.raises(UnrecoveredError):
+        asyncio.run(
+            session._loop_driver._run_with_shrink_and_byte_reduction(
+                loop, "X" * 200_000, chain_id="c-fail",
+            )
+        )
+
+    assert session.is_compacting is False
+    assert session.compaction_progress_raw()["is_compacting"] is False
+
+
+def test_an_ordinary_turn_never_lifts_the_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: deny ③. A turn that never overflows never enters the ladder, so
+    the gate is False at every sample — the row must not appear on ordinary
+    traffic. This is the criterion that stops "fix #5618 by reporting True
+    more often" from passing."""
+    session = _make_spill_session(tmp_path, monkeypatch)
+    _push(session, "user", "hello")
+
+    loop = _ProbingLoop(session, lambda _history, _user_text: False)
+    asyncio.run(
+        session._loop_driver._run_with_shrink_and_byte_reduction(
+            loop, "just a normal question", chain_id="c-ok",
+        )
+    )
+
+    assert loop.samples, "the fake loop was never called"
+    assert all(not s["is_compacting"] for s in loop.samples), loop.samples
+    assert session.is_compacting is False
+
+
+# ── episode identity ───────────────────────────────────────────────────────
+
+
+def test_a_previous_recoverys_figures_are_never_shown_during_the_next(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the join's premise, stated as what the user would actually see.
+    Two separate recoveries on the same session must not share an identity, or
+    the first one's figures would render as the second one's progress — a row
+    that appears to be making progress it has not made.
+
+    Asserted through the public read rather than on the episode number itself:
+    the number is an implementation detail of the join, while "recovery 2 never
+    displays recovery 1's numbers" is the property that matters and the one
+    that stays true if the join is ever implemented differently.
+
+    The second recovery is driven by an oversized NEW MESSAGE rather than by
+    history. After the first recovery spilled the oversized tool result that
+    same history no longer overflows, so repeating the first scenario would
+    silently not recover at all and this test would assert over an empty list
+    — green having had nothing to bite on."""
+    session = _make_spill_session(tmp_path, monkeypatch)
+
+    _push(session, "user", "look something up")
+    huge = "Y" * 50_000
+    _push(session, "tool", huge, tool_call_id="tc1", name="tool")
+    _push(session, "assistant", "ok, done")
+    first_loop = _ProbingLoop(
+        session, lambda history, _user_text: _has_content(history, huge),
+    )
+    asyncio.run(
+        session._loop_driver._run_with_shrink_and_byte_reduction(
+            first_loop, "continue please", chain_id="c-a",
+        )
+    )
+
+    measured_first = [
+        (s["call_count"], s["raw_middle_remaining"])
+        for s in first_loop.samples
+        if s["call_count"] is not None or s["raw_middle_remaining"] is not None
+    ]
+    assert measured_first, (
+        "the first recovery measured nothing, so there are no stale figures "
+        "for the second one to wrongly display — this test would pass "
+        "vacuously"
+    )
+
+    second_loop = _ProbingLoop(session, lambda _history, _user_text: True)
+    with pytest.raises(UnrecoveredError):
+        asyncio.run(
+            session._loop_driver._run_with_shrink_and_byte_reduction(
+                second_loop, "X" * 200_000, chain_id="c-b",
+            )
+        )
+
+    assert second_loop.samples, "the second drive never called the loop"
+    leaked = [
+        s for s in second_loop.samples
+        if (s["call_count"], s["raw_middle_remaining"]) in measured_first
+        and (s["call_count"] is not None or s["raw_middle_remaining"] is not None)
+    ]
+    assert not leaked, (
+        f"the second recovery displayed the first one's figures "
+        f"({leaked!r} also seen in {measured_first!r}) — the join let a "
+        f"finished episode's numbers render as this one's progress"
+    )
+
+
+def test_the_figures_do_not_blank_out_between_the_ladders_own_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: once a figure has been reported during a recovery, no later
+    sample in that SAME recovery reports unknown while the gate is still up.
+
+    **What this does and does not witness.** Samples are taken where the ladder
+    calls the loop, which is a handful of points across the whole recovery. At
+    that resolution this pins the ordinary case (a figure, once shown, keeps
+    being shown) but it does NOT catch every way the join could blank a live
+    figure — in particular it did not catch the two-identity defect described
+    below, which was found by instrumenting the episode number directly during
+    development and is NOT covered by any test here. Disclosed rather than
+    implied: the production consumer polls on its own ~1s heartbeat and so
+    samples far more finely than this test can.
+
+    The defect, kept on the record because the fix it produced is load-bearing:
+    the ladder opens an episode scope, and the wrapper opens a SECOND one from
+    its `except` clause AFTER the first has already unwound, so a naive
+    "0->1 allocates a number" rule handed one uninterrupted recovery two
+    identities (measured during development: 1, 1, 2 across a single drive).
+    Because figures are joined against the episode they were stamped in,
+    everything measured before the second identity was allocated would be
+    judged stale at that instant, and the row would go empty in the middle of
+    the recovery the user is watching. ``_recovery_episode_scope``'s
+    ``continues_previous`` is what prevents it."""
+    _session, loop, _result = _drive_a_recovery(tmp_path, monkeypatch)
+
+    live = [s for s in loop.samples if s["is_compacting"]]
+    assert live, "the gate never rose, so this test would pass vacuously"
+
+    seen_a_figure = False
+    for sample in live:
+        has_figure = (
+            sample["call_count"] is not None
+            or sample["raw_middle_remaining"] is not None
+        )
+        if has_figure:
+            seen_a_figure = True
+            continue
+        assert not seen_a_figure, (
+            f"a figure was reported earlier in this recovery and then went "
+            f"back to unknown while the gate was still up: {live!r}"
+        )
+    assert seen_a_figure, (
+        "no figure was ever reported during the recovery, so the blanking "
+        "this test is about could not have been observed"
+    )

--- a/tests/runtime/test_5618_recovery_episode_gate.py
+++ b/tests/runtime/test_5618_recovery_episode_gate.py
@@ -96,6 +96,13 @@ class _ProbingLoop:
             # point of the pairing — without it, a "fix" that made the
             # controller flag rise on the ladder path would pass unnoticed.
             "controller": self._session._compaction_controller.is_compacting,
+            # #5630 (architect): the episode NUMBER, read from the driver's own
+            # public ``recovery_episode`` property. The figures alone cannot
+            # witness a mid-recovery identity change — they only blank in the
+            # gaps between these sample points — so the number is what makes
+            # the strip below actually fail. Ruled policy-OK on review: what is
+            # read here is a public property of a real driver.
+            "episode": self._session._loop_driver.recovery_episode,
         })
 
     async def run(self, *, user_text: str, history: "list[dict]") -> "object | None":
@@ -374,6 +381,41 @@ def test_a_previous_recoverys_figures_are_never_shown_during_the_next(
     )
 
 
+def test_one_recovery_keeps_one_episode_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: a single uninterrupted recovery carries ONE episode identity.
+
+    This is the witness for ``continues_previous``, and it exists because an
+    earlier version of this file could not produce one. The two episode scopes
+    do NOT nest — the wrapper opens the outer one from its `except` clause,
+    AFTER the ladder's own scope has already unwound — so a plain
+    "depth 0->1 allocates a number" rule hands one recovery two identities
+    (measured: 1, 1, 2 across a single drive).
+
+    That matters because the figures are joined against the episode they were
+    stamped in: the moment a second identity is allocated, everything measured
+    under the first is judged stale and the row goes empty in the middle of the
+    recovery the user is watching.
+
+    **Why this reads the number and not the figures.** The sibling below
+    watches the figures instead, and cannot see this: the blanking falls in the
+    gaps BETWEEN the points where the ladder calls the loop, so the figures
+    look continuous at that sampling resolution while the identity underneath
+    has already changed. Reviewer strip (architect, #5630): remove
+    ``continues_previous`` from ``_recovery_episode_scope`` and this test goes
+    red on two distinct identities — measured, not predicted."""
+    _session, loop, _result = _drive_a_recovery(tmp_path, monkeypatch)
+
+    episodes = [s["episode"] for s in loop.samples if s["episode"] is not None]
+    assert episodes, "the ladder never ran, so this test would pass vacuously"
+    assert set(episodes) == {episodes[0]}, (
+        f"one recovery carried more than one episode identity ({episodes!r}) — "
+        f"the figures measured under the earlier one are judged stale the "
+        f"instant the later one is allocated, and the row blanks mid-recovery"
+    )
+
+
 def test_the_figures_do_not_blank_out_between_the_ladders_own_calls(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -382,24 +424,16 @@ def test_the_figures_do_not_blank_out_between_the_ladders_own_calls(
 
     **What this does and does not witness.** Samples are taken where the ladder
     calls the loop, which is a handful of points across the whole recovery. At
-    that resolution this pins the ordinary case (a figure, once shown, keeps
-    being shown) but it does NOT catch every way the join could blank a live
-    figure — in particular it did not catch the two-identity defect described
-    below, which was found by instrumenting the episode number directly during
-    development and is NOT covered by any test here. Disclosed rather than
-    implied: the production consumer polls on its own ~1s heartbeat and so
-    samples far more finely than this test can.
-
-    The defect, kept on the record because the fix it produced is load-bearing:
-    the ladder opens an episode scope, and the wrapper opens a SECOND one from
-    its `except` clause AFTER the first has already unwound, so a naive
-    "0->1 allocates a number" rule handed one uninterrupted recovery two
-    identities (measured during development: 1, 1, 2 across a single drive).
-    Because figures are joined against the episode they were stamped in,
-    everything measured before the second identity was allocated would be
-    judged stale at that instant, and the row would go empty in the middle of
-    the recovery the user is watching. ``_recovery_episode_scope``'s
-    ``continues_previous`` is what prevents it."""
+    that resolution this pins the ordinary case — a figure, once shown, keeps
+    being shown — but it cannot see a blanking that falls entirely in the gaps
+    BETWEEN those points. The two-identity defect is exactly such a case, which
+    is why it has its own witness above
+    (``test_one_recovery_keeps_one_episode_identity``, reading the episode
+    number rather than the figures): this test stayed green through that defect
+    and through the reviewer strip that reintroduces it. Kept because the
+    figures are what the user actually reads, and because the production
+    consumer polls on its own ~1s heartbeat and so samples far more finely than
+    either test does."""
     _session, loop, _result = _drive_a_recovery(tmp_path, monkeypatch)
 
     live = [s for s in loop.samples if s["is_compacting"]]

--- a/tests/runtime/test_execution_driver_seam.py
+++ b/tests/runtime/test_execution_driver_seam.py
@@ -45,6 +45,17 @@ class FakeDriver:
         """#2813: no interactive-turn cancel_event concept for this fake."""
         return None
 
+    @property
+    def recovery_episode(self) -> None:
+        """#5618/#5630: this fake runs no retry ladder, so None is its real
+        answer. Present because ``Session.is_compacting`` reads the attribute
+        DIRECTLY rather than through a ``getattr`` default — a default would
+        let "never implemented" masquerade as "not recovering" and silently
+        reinstate the bug #5618 fixed. Keeping it here is this seam test's
+        stated job: the file's own docstring requires every ExecutionDriver
+        signature to stay in sync with RouterLoopDriver."""
+        return None
+
     def request_cancel(self) -> None:
         self._cancel_requested = True
 


### PR DESCRIPTION
**[tui-coder]** — fixes #5618

## 何が起きていたか

#5588 は進捗行の gate を `Session.is_compacting` に置きましたが、その中身は `CompactionController.is_compacting` への転送だけでした。あの flag が立つのは `force_compact_now` の内側だけ。**実際の overflow 回復（retry ladder）は controller を通らず engine を直接呼ぶ**ので、flag は最後まで False のまま — 行は構造的に一度も出ませんでした。owner 実機の「tui では進捗わからない」はこれです。

## 設計（architect 裁定どおり）

信号は **driver が持つ状態**であって、event 到着からの推定ではありません。到着は「今始まった」しか言えず、poll する消費者（TUI は約1秒ハートビートで snapshot を読む）が任意の後の時点で「まだ続いてる?」と聞いたときに答えを持ちません。

1. **`RouterLoopDriver.recovery_episode`** — 非回復時 None、回復中は episode 番号。**再入可能な深さ計数**にしてあるのは、梯子が2区間に分かれるためです: inner（rung ①〜④、#5592 の upstream-call counter と同じ区間に合わせてあるので、行が gate する episode と数字が属する episode が構造的に同一）と、outer の `except _UnrecoveredError`（reactive spill → force_compact_now → 再送）。それぞれ自分の `try/finally` で入退場するので、例外でも cancel でも深さは 0 に戻ります — 規定しているのは順序ではなく残留です。

   outer は素の `with` ではなく `ExitStack` に載せています。開いた except 節より長生きする必要がある（回復は次の lap の再送まで続き、user はその全部を1回の待ちとして待っている）ためです。

2. **`Session.is_compacting` = controller の flag OR driver の episode**。REPL の status も同じ gate を読むので同時に直ります。

3. **鮮度は reset ではなく join**。subscriber は数字を書くとき measured した episode を一緒に stamp し、`compaction_progress_raw()` は stamp が現在の episode と一致するときだけ数字を返します。**消す処理は置きません** — 消す場所を作ると「消した後・次を書く前」の窓ができ、理由もなく行が空になります。stamp は実際に値を書く分岐でのみ取るので、count を持たない ordinary な `llm_request` が割り込んでも前 episode の数字を今のものとして再日付けできません。

## 実装中に見つけた裁定の穴（と修正）

**2つの scope は入れ子になりません。** outer は inner が既に unwind した後の except 節で開くので、素直な「深さ 0→1 で採番」だと **1回の連続した回復に episode が2つ**割り当たります（実測: 単一 drive で 1, 1, 2）。数字は episode と join されるので、2つ目が採番された瞬間に前半の実測値が stale 判定になり、**user が見ている最中に行が空白化**します。`_recovery_episode_scope` に `continues_previous` を追加し、wrapper は**自分の call 中に採番された番号のときだけ**引き継ぐようにしました（それ以前の回復の古い番号は絶対に resume されない）。

## テスト

`tests/runtime/test_5618_recovery_episode_gate.py`（Tier 2、8本）は **実 ladder を drive** します — 実 Session / 実 driver / 実 MediaStore で `_run_with_shrink_and_byte_reduction`、production の turn と同じ入口。fake は `RouterLoop` の代役1つだけ。

gate は**梯子自身が呼ぶ loop の中から sample** します。主張が「回復中の値」だからで、drive が返る頃には設計上 episode は終わっています。accept 側の assertion はすべて**同じ瞬間の controller flag と対**にしてあります — 終始 False なので、True になった gate は新しい状態由来としかあり得ず、「controller flag を ladder でも立てる」という architect が却下した実装では通りません。

**カバレッジは主張せず開示します**: sample 点は梯子が loop を呼ぶ数箇所です。この解像度で通常の非空白化は pin できますが、**上記の episode 2重採番は捕まえられませんでした**（開発中に episode 番号を直接計器化して発見）。test の docstring 自身にそう書いてあります。production の消費者は約1秒でもっと細かく sample します。

### strip-falsify（各々、意図した test だけを赤にする / 他は緑のまま）
- (a) OR から driver 側を外す → accept 2本が赤、deny は全部緑
- (b) episode scope の退場を外す → 「成功後 False」系が赤
- (c) join の episode 比較を外す → 鮮度系が赤

全て復元後に緑を再確認済み。

### 既存 test 3本の書き換え
`test_5588_compaction_progress_session_wiring.py` の3本は、**production が到達し得ない状態**を記述していました（episode 無しでそれらの event を emit — engine は retry_loop の内側から emit する）。episode 無しで正直に witness できる **join の deny 方向**を述べる形に変え、accept 側は実経路で回る ladder-driven の新ファイルへ移しました。

## 面の義務（同じ PR）

`compaction_progress.py` の module docstring と `status.py` の #5588 注記が両方「controller の flag」と書いていたので、OR と join を述べる形に更新。`events.md` は非変更（**event の形は不変、config knob も追加なし**）。

## Test plan
- [x] `tests/runtime/test_5618_recovery_episode_gate.py` 8本 緑
- [x] strip-falsify 3本（上記 a/b/c）
- [x] `ruff check .` / `test_tier_audit.py --strict`（12/12 OK, Tier 4 違反 0）/ `verify_module_docstrings.py` / `mypy_ratchet` / `flat_tests_ratchet` / `check_tests_path_literal_reference` / `check_bare_tests_import_reference` / `check_file_depth_reference` / `check_tui_widget_boundary` / `check_tui_reactive_ratchet` — 全て OK
- [x] `tests/runtime/` `tests/interfaces/` `tests/services/` — 4451 passed / 5 skipped / 0 failed
- [x] full suite 1回完走: 13013 passed、失敗5件のうち4件は clean main の worktree で再現確認済の既存/環境依存（`test_3009_mcp_tool_call_write_denial_hint` ×2、`test_mcp_install_ux_fixes_318_319_320::...on_darwin`、`test_fastmcp_core_dep_import_chain`）。残り1件 `test_5588_compaction_progress_chrome` は本 PR 由来で、下記のとおり修正済
- [ ] Visual（standing waiver、実機で owner 判断）

## architect 裁定との相違（1点、要判断）

裁定の受入に「既存: controller 経由の表示は変わらない（既存 test 無変更で緑）」がありますが、`test_5588_compaction_progress_chrome.py::test_row_shows_real_events_driven_snapshot` は**変更が必要でした**。この test は controller flag を手で立て、同時に ladder の event を episode 無しで emit する — production が到達できない組み合わせです（engine は retry_loop の内側から emit する）。join を入れると、**controller 主導の compaction 中に ladder 実測の数字は出なくなります**。

これは同じ裁定の join 規則（「記録した番号 == 現在の番号 のときだけ返す」）の素直な帰結で、かつ安全側だと判断しました: あの数字は別 operation の実測値であり、それを今の operation の進捗として出すのは Ctx pane の #5009 パスが潰してきた fabrication そのものです。test は controller 経路の本当の契約（行は出る・line 1 は出る・**測っていない rung の数字は出さない**）を述べる形に更新しました。判断が違えば戻します。

## 残り（この PR 外、開示）
`compaction_started` は engine が emit しているのに TUI 側に `on_compaction_started` が無く（`on_compaction_completed` / `on_compaction_failed` はある）、**開始通知だけ非対称**です。owner 指摘。これは edge（通知）の話で本 PR の gate（state）とは別問題なので混ぜていません — 別 issue 化の要否は lead-coder 判断待ち。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
