### PR TITLE
fix(#5625): name the startup-only max_input_tokens fallback for what it is

### DIFF
--- a/src/reyn/llm/model_budget.py
+++ b/src/reyn/llm/model_budget.py
@@ -60,12 +60,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Conservative default when LiteLLM does not recognize the model.
-# 128K is a reasonable floor — all modern production models (Gemini, GPT-4o,
-# Claude 3.x) have context windows of ≥128K, so compaction using this default
-# will trigger earlier than necessary but never allow the prompt to exceed the
-# real budget.
-_FALLBACK_MAX_INPUT_TOKENS = 128_000
+# ★ Stand-in only, used before litellm resolves a real value (#5625) —
+# `reason="not_ready"` (still loading, self-corrects) or `"uncataloged"`
+# (permanent). NOT the model's real context window: read the resolved value
+# off `max_input_tokens_applied` on the `llm_request` audit-event instead.
+# Why 128_000 specifically: this module's own "Fallback policy" docstring.
+_STARTUP_FALLBACK_MAX_INPUT_TOKENS = 128_000
 
 
 class MaxInputTokensFallbackReason(str, Enum):
@@ -229,8 +229,8 @@ def _resolve_max_input(
         else "model not cataloged"
     )
     return (
-        _FALLBACK_MAX_INPUT_TOKENS,
-        f"reyn fallback default: {_FALLBACK_MAX_INPUT_TOKENS:,} tokens ({reason_text})",
+        _STARTUP_FALLBACK_MAX_INPUT_TOKENS,
+        f"reyn fallback default: {_STARTUP_FALLBACK_MAX_INPUT_TOKENS:,} tokens ({reason_text})",
         reason,
     )
 
@@ -245,7 +245,7 @@ def get_max_input_tokens(
     """Return the maximum input token budget for *model*.
 
     Queries LiteLLM's model catalog (`litellm.get_model_info`). If the model
-    is not recognized, returns the conservative default (_FALLBACK_MAX_INPUT_TOKENS)
+    is not recognized, returns the conservative default (_STARTUP_FALLBACK_MAX_INPUT_TOKENS)
     and emits a ``model_budget_fallback`` observability event.
 
     Parameters
@@ -280,7 +280,7 @@ def get_max_input_tokens(
                 f"model_budget: litellm has not finished loading in this "
                 f"process yet, so model={model!r}'s real context window is "
                 f"not known — using conservative fallback of "
-                f"{_FALLBACK_MAX_INPUT_TOKENS:,} tokens (temporary; will "
+                f"{_STARTUP_FALLBACK_MAX_INPUT_TOKENS:,} tokens (temporary; will "
                 f"self-correct once litellm is ready)"
             )
         else:
@@ -288,7 +288,7 @@ def get_max_input_tokens(
                 f"model_budget: max_input_tokens unknown for model={model!r} "
                 f"— litellm has no catalog entry for it (checked after "
                 f"litellm finished loading); using conservative fallback of "
-                f"{_FALLBACK_MAX_INPUT_TOKENS:,} tokens (permanent for this "
+                f"{_STARTUP_FALLBACK_MAX_INPUT_TOKENS:,} tokens (permanent for this "
                 f"process unless llm.models.<tier>.max_input_tokens is "
                 f"configured, or litellm's own catalog is updated)"
             )
@@ -297,7 +297,7 @@ def get_max_input_tokens(
             events.emit(
                 "model_budget_fallback",
                 model=model,
-                fallback_tokens=_FALLBACK_MAX_INPUT_TOKENS,
+                fallback_tokens=_STARTUP_FALLBACK_MAX_INPUT_TOKENS,
                 reason=reason.value,
                 phase=phase,
                 run_id=run_id,
@@ -331,7 +331,7 @@ def get_max_input_tokens(
             f"model_budget: max_input_tokens for model={model!r} is now "
             f"resolved via litellm catalog to {value:,} tokens (previously "
             f"used the temporary NOT_READY fallback of "
-            f"{_FALLBACK_MAX_INPUT_TOKENS:,})"
+            f"{_STARTUP_FALLBACK_MAX_INPUT_TOKENS:,})"
         )
     return value
 

--- a/tests/core/test_4680_2_notready_uncataloged.py
+++ b/tests/core/test_4680_2_notready_uncataloged.py
@@ -26,7 +26,7 @@ import pytest
 
 from reyn.core.events.events import EventLog
 from reyn.llm.model_budget import (
-    _FALLBACK_MAX_INPUT_TOKENS,
+    _STARTUP_FALLBACK_MAX_INPUT_TOKENS,
     MaxInputTokensFallbackReason,
     _resolve_max_input,
     _warned_models,
@@ -85,7 +85,7 @@ def test_resolve_max_input_reports_not_ready_reason(monkeypatch) -> None:
         "reyn.llm.litellm_bootstrap.ensure_litellm_ready_or_defer", _raise_not_ready,
     )
     value, source, reason = _resolve_max_input("some/model-4680-2-a")
-    assert value == _FALLBACK_MAX_INPUT_TOKENS
+    assert value == _STARTUP_FALLBACK_MAX_INPUT_TOKENS
     assert reason is MaxInputTokensFallbackReason.NOT_READY
     assert "not yet loaded" in source
 
@@ -95,7 +95,7 @@ def test_resolve_max_input_reports_uncataloged_reason() -> None:
     loaded/reachable — no NOT_READY monkeypatch here) reports
     ``UNCATALOGED``."""
     value, source, reason = _resolve_max_input("unknown/garbage-4680-2-b")
-    assert value == _FALLBACK_MAX_INPUT_TOKENS
+    assert value == _STARTUP_FALLBACK_MAX_INPUT_TOKENS
     assert reason is MaxInputTokensFallbackReason.UNCATALOGED
     assert "not cataloged" in source
 
@@ -225,7 +225,7 @@ def test_not_ready_then_resolved_emits_a_correction_log(monkeypatch, caplog) -> 
     )
     with caplog.at_level(logging.WARNING):
         first = get_max_input_tokens(model)
-    assert first == _FALLBACK_MAX_INPUT_TOKENS
+    assert first == _STARTUP_FALLBACK_MAX_INPUT_TOKENS
     assert any("not finished loading" in r.message for r in caplog.records)
     caplog.clear()
 
@@ -235,7 +235,7 @@ def test_not_ready_then_resolved_emits_a_correction_log(monkeypatch, caplog) -> 
 
     with caplog.at_level(logging.WARNING):
         second = get_max_input_tokens(model)
-    assert second != _FALLBACK_MAX_INPUT_TOKENS
+    assert second != _STARTUP_FALLBACK_MAX_INPUT_TOKENS
     assert any(
         "is now resolved via litellm catalog" in r.message for r in caplog.records
     ), (

--- a/tests/core/test_model_budget.py
+++ b/tests/core/test_model_budget.py
@@ -18,7 +18,7 @@ import pytest
 
 from reyn.core.events.events import EventLog
 from reyn.llm.model_budget import (
-    _FALLBACK_MAX_INPUT_TOKENS,
+    _STARTUP_FALLBACK_MAX_INPUT_TOKENS,
     get_max_input_tokens,
     get_max_input_tokens_source,
 )
@@ -36,7 +36,7 @@ def test_known_model_returns_positive_int() -> None:
 def test_unknown_model_returns_fallback() -> None:
     """Tier 2: a model string unknown to LiteLLM returns the conservative fallback."""
     result = get_max_input_tokens("unknown/garbage-model-xyz-test-only")
-    assert result == _FALLBACK_MAX_INPUT_TOKENS
+    assert result == _STARTUP_FALLBACK_MAX_INPUT_TOKENS
 
 
 def test_fallback_emits_observability_event() -> None:
@@ -52,13 +52,13 @@ def test_fallback_emits_observability_event() -> None:
     assert len(fallback_events) >= 1
     ev = fallback_events[0]
     assert ev.data["model"] == model
-    assert ev.data["fallback_tokens"] == _FALLBACK_MAX_INPUT_TOKENS
+    assert ev.data["fallback_tokens"] == _STARTUP_FALLBACK_MAX_INPUT_TOKENS
 
 
 def test_fallback_value_always_positive() -> None:
     """Tier 2: the fallback default is a positive integer (safe for compaction arithmetic)."""
-    assert isinstance(_FALLBACK_MAX_INPUT_TOKENS, int)
-    assert _FALLBACK_MAX_INPUT_TOKENS > 0
+    assert isinstance(_STARTUP_FALLBACK_MAX_INPUT_TOKENS, int)
+    assert _STARTUP_FALLBACK_MAX_INPUT_TOKENS > 0
 
 
 # ── #1162 provider-prefix-strip-retry ─────────────────────────────────────────
@@ -74,14 +74,14 @@ def test_proxy_prefixed_model_resolves_via_prefix_strip(wrong_prefix: str) -> No
     real 1M window wasted on premature compaction) before #1162.
     """
     bare_window = get_max_input_tokens(_BARE)
-    if bare_window == _FALLBACK_MAX_INPUT_TOKENS:
+    if bare_window == _STARTUP_FALLBACK_MAX_INPUT_TOKENS:
         pytest.skip(f"litellm catalog lacks {_BARE!r} in this env — strip target absent")
     prefixed_window = get_max_input_tokens(f"{wrong_prefix}/{_BARE}")
     assert prefixed_window == bare_window, (
         f"{wrong_prefix}/{_BARE} must resolve to the bare model's window "
         f"({bare_window}) via prefix-strip, got {prefixed_window}"
     )
-    assert prefixed_window > _FALLBACK_MAX_INPUT_TOKENS, (
+    assert prefixed_window > _STARTUP_FALLBACK_MAX_INPUT_TOKENS, (
         "prefix-strip must surface the real (>128K) window, not the fallback"
     )
 
@@ -89,7 +89,7 @@ def test_proxy_prefixed_model_resolves_via_prefix_strip(wrong_prefix: str) -> No
 def test_prefix_strip_resolution_emits_no_fallback_event() -> None:
     """Tier 2: a prefix-strip-resolvable model does NOT emit model_budget_fallback
     (it resolved — the event is reserved for genuinely-unknown models)."""
-    if get_max_input_tokens(_BARE) == _FALLBACK_MAX_INPUT_TOKENS:
+    if get_max_input_tokens(_BARE) == _STARTUP_FALLBACK_MAX_INPUT_TOKENS:
         pytest.skip(f"litellm catalog lacks {_BARE!r} in this env")
     events = EventLog()
     collected = collect_events(events)
@@ -105,7 +105,7 @@ def test_unknown_prefixed_model_still_falls_back() -> None:
     collected = collect_events(events)
     model = "openai/totally-made-up-proxy-model-1162-xyz"
     result = get_max_input_tokens(model, events=events)
-    assert result == _FALLBACK_MAX_INPUT_TOKENS
+    assert result == _STARTUP_FALLBACK_MAX_INPUT_TOKENS
     # the fallback event still fires for the genuinely-unknown model (unchanged).
     assert [e for e in collected if e.type == "model_budget_fallback"]
 
@@ -140,7 +140,7 @@ def test_source_for_unknown_model_names_reyn_fallback() -> None:
     so these two are the only two real sources)."""
     source = get_max_input_tokens_source("unknown/garbage-model-xyz-test-only")
     assert source.startswith("reyn fallback default")
-    assert str(_FALLBACK_MAX_INPUT_TOKENS) in source.replace(",", "")
+    assert str(_STARTUP_FALLBACK_MAX_INPUT_TOKENS) in source.replace(",", "")
 
 
 def test_source_for_prefix_strip_resolved_model_names_bare_litellm_hit() -> None:
@@ -154,7 +154,7 @@ def test_source_for_prefix_strip_resolved_model_names_bare_litellm_hit() -> None
     from reyn.llm.litellm_bootstrap import ensure_litellm_ready
     ensure_litellm_ready()
 
-    if get_max_input_tokens(_BARE) == _FALLBACK_MAX_INPUT_TOKENS:
+    if get_max_input_tokens(_BARE) == _STARTUP_FALLBACK_MAX_INPUT_TOKENS:
         pytest.skip(f"litellm catalog lacks {_BARE!r} in this env")
     source = get_max_input_tokens_source(f"openai/{_BARE}")
     assert source.startswith("litellm catalog:")

--- a/tests/llm/test_4689_max_input_tokens_priority.py
+++ b/tests/llm/test_4689_max_input_tokens_priority.py
@@ -183,5 +183,5 @@ def test_a_model_with_no_registered_override_still_uses_the_catalog():
     unrelated model never registered still resolves through the normal
     catalog/fallback path, unaffected."""
     result = get_max_input_tokens("unknown/garbage-model-4689-unregistered")
-    from reyn.llm.model_budget import _FALLBACK_MAX_INPUT_TOKENS
-    assert result == _FALLBACK_MAX_INPUT_TOKENS
+    from reyn.llm.model_budget import _STARTUP_FALLBACK_MAX_INPUT_TOKENS
+    assert result == _STARTUP_FALLBACK_MAX_INPUT_TOKENS


### PR DESCRIPTION
**[lead-coder/sonnet]** — 

Closes #5625

## What

`_FALLBACK_MAX_INPUT_TOKENS = 128_000` (`src/reyn/llm/model_budget.py`) is a
stand-in used only while a real value cannot yet be resolved — litellm still
loading (`reason="not_ready"`, self-corrects) or the model genuinely
uncataloged (permanent). Its value coincides with `max_output_tokens`
(128,000) and was misread as the model's context window (#5621 R2, gpt-5.6-luna's
real window is 1,050,000).

Renamed to `_STARTUP_FALLBACK_MAX_INPUT_TOKENS` and rewrote the residue at its
declaration (comments.md Class B — compressed, reason kept) to say:
- what it is (a stand-in only, not the real window)
- what NOT to read it as (the model's real context window)
- where the real number is observed (`max_input_tokens_applied` on the
  `llm_request` audit-event)
- a pointer to the module's own "Fallback policy" docstring for why 128_000
  specifically (that reasoning already lived there — not duplicated again)

**Value and behavior unchanged** — rename + comment only, per the issue's own
deny clause.

## Every reference migrated (grepped against origin/main)

```
$ git grep -n "_FALLBACK_MAX_INPUT_TOKENS" origin/main -- src tests docs
src/reyn/llm/model_budget.py:68:_FALLBACK_MAX_INPUT_TOKENS = 128_000
src/reyn/llm/model_budget.py:232,233,248,283,291,300,334  (7 more call sites)
tests/core/test_4680_2_notready_uncataloged.py:29,88,98,228,238
tests/core/test_model_budget.py:21,39,55,60,61,77,84,92,108,143
tests/llm/test_4689_max_input_tokens_priority.py:186,187
```

All migrated to `_STARTUP_FALLBACK_MAX_INPUT_TOKENS`; a post-rename grep for
the old bare identifier (outside the new name) across the whole repo returns
0 hits. No doc mentions the private constant by name (checked
`docs/reference/config/reyn-yaml.md` and `docs/reference/runtime/events.md`,
the two files that discuss this fallback — they name the `128,000` value and
the `fallback_tokens` event field, never the identifier itself), so no doc
changes were needed. No rename-guard test pattern exists in this repo for a
private constant, so none was added (issue's own deny: rename only).

## Gates

- `ruff check .` — pass
- `python scripts/verify_module_docstrings.py src/reyn/llm/model_budget.py` — OK
- `python scripts/mypy_ratchet.py` — OK (203/210 baselined, unchanged)
- `python scripts/flat_tests_ratchet.py` — OK
- `python scripts/test_tier_audit.py --strict <3 changed test files>` — 36/36 OK
- `python scripts/check_bare_tests_import_reference.py` — OK
- `python scripts/check_file_depth_reference.py` — OK
- `python scripts/check_subprocess_reyn_pin.py` — OK
- `python scripts/check_tests_path_literal_reference.py` — OK, re-run immediately before push
- `check_removed_identifier_in_docs.py` — does not exist in this repo, skipped
- docs unchanged → mkdocs/anchor gates not applicable

## Test plan

- [x] `ruff check .`
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/model_budget.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict` on the 3 changed test files
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] `python scripts/check_tests_path_literal_reference.py` (re-run before push)
- [x] `pytest` scoped to the 3 files referencing the constant — 38 passed
- [x] (skipped — docs/ not touched, mkdocs/anchor gates not applicable)
- [x] (skipped — Visual, standing waiver per owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LZ2nN392xjGJNJzpCc8T5
