### PR TITLE
fix(#5624): reject unknown wire roles

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -502,6 +502,8 @@ def wire_role(role: str) -> str:
     ``RouterLoopDriver._router_main_call`` for the two such points."""
     if role in ("agent", SUMMARY_MESSAGE_ROLE):
         return "assistant"
+    if role not in ("user", "assistant", "tool", "system"):
+        raise ValueError(f"unknown wire role: {role!r}")
     return role
 
 

--- a/tests/core/test_wire_role_5624.py
+++ b/tests/core/test_wire_role_5624.py
@@ -1,0 +1,21 @@
+"""Tier 1: #5624 enforces the wire-role allow-list."""
+from __future__ import annotations
+
+import pytest
+
+from reyn.services.compaction.engine import wire_role
+
+
+def test_wire_role_accepts_known_and_internal_assistant_roles() -> None:
+    """Tier 1: known wire roles and internal assistant aliases are accepted."""
+    assert [wire_role(role) for role in ("user", "assistant", "tool", "system")] == [
+        "user", "assistant", "tool", "system"
+    ]
+    assert wire_role("agent") == "assistant"
+    assert wire_role("summary") == "assistant"
+
+
+def test_wire_role_rejects_unknown_role_with_role_name() -> None:
+    """Tier 1: an unknown role is rejected with its role name in the error."""
+    with pytest.raises(ValueError, match="spill_record"):
+        wire_role("spill_record")


### PR DESCRIPTION
**[coder-smith]** — Enforce the wire-role allow-list at `wire_role`. part of #5624

- Preserve `agent` and `summary` normalization to `assistant`.
- Accept `user`, `assistant`, `tool`, and `system`.
- Raise `ValueError` containing the role name for unknown roles such as `spill_record`.
- Add Tier 1 accept and deny witnesses.

Verification:
- `.venv/bin/ruff check src/reyn/services/compaction/engine.py tests/core/test_wire_role_5624.py`
- `.venv/bin/python scripts/test_tier_audit.py --strict tests/core/test_wire_role_5624.py`
- `.venv/bin/python scripts/verify_module_docstrings.py src/reyn/services/compaction/engine.py`
- `.venv/bin/python -m pytest tests/core/test_wire_role_5624.py tests/core/test_chat_compaction_engine.py -q` (`12 passed`)

Closes #5624