### PR TITLE
fix(#5605): declare remote compaction progress unavailable

### DIFF
--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -123,6 +123,9 @@ _GROUPED_AXIS_KEYS = {
     # ctx_compaction_reported" per project_remote_snapshot's own inline
     # comment at this key -- the axis name differs from the dict key name.
     "ctx_compaction_status_fn": "ctx_compaction_reported",
+    # #5605: compaction progress is reported through the same capability axis
+    # as its remote placeholder; the explicit flag distinguishes no fold yet.
+    "compaction_progress_raw": "compaction_progress_reported",
     # #4996/#5050: this key predates the *_reported convention (named
     # "intervention_head" on the capabilities class, not
     # "pending_intervention_head_reported") — the METHOD-axis field, not a

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6787,7 +6787,11 @@ class TextualChatApp(App):
         except Exception:
             return  # not yet mounted
         snapshot = self._snapshot() if snap is _UNSET else snap
-        raw = (snapshot or {}).get("compaction_progress_raw") or {}
+        snapshot = snapshot or {}
+        if not snapshot.get("compaction_progress_reported", True):
+            row.lines = ["compaction progress not reported on this connection"]
+            return
+        raw = snapshot.get("compaction_progress_raw") or {}
         row.lines = compaction_progress_lines(
             CompactionProgressSnapshot(
                 is_compacting=raw.get("is_compacting", False),

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1584,7 +1584,11 @@ def ctx_pane_lines(snap: "dict | None") -> list[str]:
             if snap.get("ctx_compaction_reported", False)
             else "compaction   not reported on this connection"
         ),
-        _folded_line(snap.get("compaction_progress_raw")),
+        _folded_line(
+            snap.get("compaction_progress_raw")
+            if snap.get("compaction_progress_reported", True)
+            else None
+        ),
     ]
 
 

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -318,6 +318,7 @@ class ChatReadModelCapabilities:
     # shape `hooks_reported` above closes for the Hook pane, not the
     # `_CLEARED_NON_FABRICATING_KEYS` shape its two siblings are.
     hooks_config_warnings_reported: bool
+    compaction_progress_reported: bool
 
 
 def reported_snapshot_keys(
@@ -374,6 +375,7 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     visibility_items_reported=True,
     mcp_subscriptions_reported=True,
     hooks_config_warnings_reported=True,
+    compaction_progress_reported=True,
 )
 
 #: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these
@@ -413,6 +415,7 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     # the server session's real hooks_config_warnings for a remote
     # client to read) -- False, not True; see the field's own docstring.
     hooks_config_warnings_reported=False,
+    compaction_progress_reported=False,
 )
 
 
@@ -922,6 +925,7 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # never has a genuine zero-trigger state, so "0%" here reads as
         # false reassurance, not as an honest empty state).
         "ctx_compaction_status_fn": None,
+        "compaction_progress_raw": None,
         # #3283 ④: the keyed per-turn cost/token lookup is a SESSION-local read
         # (the tracker's per-turn buckets are process-local, in-memory, and not
         # projected onto the AG-UI wire) → None for remote, and the right

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -141,6 +141,7 @@ def test_capabilities_dataclass_rejects_a_missing_field():
         visibility_items_reported=True,
         mcp_subscriptions_reported=True,
         hooks_config_warnings_reported=True,
+        compaction_progress_reported=True,
     )
     with pytest.raises(TypeError):
         ChatReadModelCapabilities(  # type: ignore[call-arg]
@@ -201,6 +202,7 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
         "visibility_items_reported",
         "mcp_subscriptions_reported",
         "hooks_config_warnings_reported",
+        "compaction_progress_reported",
     }
 
 

--- a/tests/interfaces/test_5605_remote_compaction_progress.py
+++ b/tests/interfaces/test_5605_remote_compaction_progress.py
@@ -1,0 +1,42 @@
+"""Tier 1/2: #5605 declares remote compaction progress reporting."""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.chrome import ctx_pane_lines
+from reyn.interfaces.repl.read_model import (
+    LOCAL_CHAT_READ_CAPABILITIES,
+    REMOTE_CHAT_READ_CAPABILITIES,
+    project_remote_snapshot,
+    reported_snapshot_keys,
+)
+
+
+def test_compaction_progress_capability_distinguishes_local_and_remote() -> None:
+    """Tier 1: LOCAL reports progress while REMOTE does not."""
+    assert LOCAL_CHAT_READ_CAPABILITIES.compaction_progress_reported is True
+    assert REMOTE_CHAT_READ_CAPABILITIES.compaction_progress_reported is False
+    keys = reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)
+    assert keys["compaction_progress_reported"] is False
+
+
+def test_remote_progress_is_explicitly_unreported() -> None:
+    """Tier 2: remote Ctx chrome says unreported, not no fold yet."""
+    snap = project_remote_snapshot({})
+    assert snap["compaction_progress_reported"] is False
+    assert snap["compaction_progress_raw"] is None
+    lines = ctx_pane_lines(snap)
+    folded = next(line for line in lines if line.startswith("folded"))
+    assert "not reported on this connection" in folded
+
+
+def test_reported_local_progress_preserves_the_real_fold_state() -> None:
+    """Tier 2: a reported progress dict still renders measured state."""
+    snap = {
+        "ctx_window": 1000,
+        "ctx_used": 100,
+        "compaction_progress_reported": True,
+        "compaction_progress_raw": {"persisted_covers_through_seq": None},
+    }
+    lines = ctx_pane_lines(snap)
+    folded = next(line for line in lines if line.startswith("folded"))
+    assert "no recovery fold persisted yet" in folded
+    assert "not reported" not in folded


### PR DESCRIPTION
**[coder-smith]** — Distinguish unavailable remote compaction progress from a measured idle state. Closes #5605

- Add `compaction_progress_reported` to `ChatReadModelCapabilities` (LOCAL true, REMOTE false).
- Project the remote absence explicitly and render `not reported on this connection` in Ctx/CompactionProgress chrome.
- Preserve LOCAL progress rendering.
- Add Tier 1/2 accept and deny witnesses.

Verification:
- `.venv/bin/ruff check .`
- Tier audit (3 tests, 0 errors)
- `verify_module_docstrings.py`
- `mypy_ratchet.py`, `flat_tests_ratchet.py`, path/bare/depth gates
- Focused pytest: 43 passed

Closes #5605