### PR TITLE
fix(#4478): .reyn/media/ counts against the project-wide storage cap

### DIFF
--- a/docs/reference/runtime/reyn-dir-layout.md
+++ b/docs/reference/runtime/reyn-dir-layout.md
@@ -122,6 +122,17 @@ Everything else is excluded, by one of four reasons:
 │                           migrated into this once, on first touch, then inert history.
 ├── events/ traces/ logs/   AUDIT — append-only forensic record; never restored
 │   audit-trail/ tool-results/ media/
+│                           `media/` (#4478): flat `<file>` for a legacy
+│                           write with no agent identity, `<agent>/
+│                           <session_id>/<file>` for a real one (the
+│                           SAME nesting shape `history-content/` above
+│                           already uses, `MediaStore.media_content_dir_
+│                           for`) — counts toward the SAME project-wide
+│                           `storage.max_bytes`/`storage.pin` cap as
+│                           `history-content/`, not a separate one; a
+│                           flat (legacy) file is a pin-unprotected
+│                           eviction candidate, disclosed, never
+│                           migrated.
 ├── cache/                  DERIVED — rebuilt after restore. ⚠️ "rebuilt after
 │                           restore" describes what belongs in this tier, not a
 │                           blanket safety claim about deleting `cache/` itself:

--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -11,13 +11,20 @@ Two storage directories with parallel file naming convention:
                          per #385). PR-C lands the writer; PR-D wires
                          the consumer + preview generation.
 
-Filename convention (both dirs):
+Filename convention:
 
   <YYYYMMDDTHHMMSS>-<chain_short>-<tool>-<seq>.<ext>
 
-This sorts chronologically with ``ls -la``, groups by conversation chain
-when you grep for ``<chain_short>``, and is browseable as plain files —
-users can ``open``, ``ls``, or delete entries to manage disk usage.
+``.reyn/tool-results/`` (frozen, read-only, #5364) and a LEGACY (pre-
+#4478, ``agent_name``-less) ``.reyn/media/`` write both keep this flat,
+single level. A ``.reyn/media/`` write with a real ``agent_name`` (the
+common case) nests one level further, ``<agent>/<session_id>/…`` (#4478
+— the SAME shape history-content already used, see :func:`media_
+content_dir_for`) — the filename itself is unchanged either way. This
+sorts chronologically with ``ls -la`` (within a session's own
+directory), groups by conversation chain when you grep for
+``<chain_short>``, and is browseable as plain files — users can
+``open``, ``ls``, or delete entries to manage disk usage.
 
 ChatMessage carries **path-refs** (= ``{"type": "image", "path": ...,
 "mime_type": ..., "content_hash": ...}``) instead of inline base64. The
@@ -31,60 +38,61 @@ contract Phase 1 = "(a) Persistent until user delete"; #5364 §1.6 /
 #5366 have since landed a Phase-2 SLICE for history-content only — see
 the split below):
 
-  - **Media (``.reyn/media/``) — still no auto-GC.** Files written by
-    :meth:`save_media` remain on disk until a user / operator deletes
-    them out-of-band (= ``rm``, file explorer, cleanup script). No TTL,
-    max-N, or session-end cleanup exists for this directory today.
+  - **Media (``.reyn/media/``) — project-wide auto-GC (#4478, architect
+    ruling: "母集団を1つ広げるだけ").** No media-only cap, no TTL /
+    max-N / session-end policy (owner rejected all three — none of them
+    bound BYTES, the actual resource: a TTL still lets 3 large images
+    blow the cap before any age out; max-N treats 1000 tiny files the
+    same as 1000 huge ones). Instead, ``.reyn/media/`` counts against
+    the SAME ``storage.max_bytes`` / ``storage.pin`` project-wide cap
+    ``.reyn/memory/history-content/`` already used (#5366) — one
+    operator number for the whole project, not two that could
+    individually pass while their SUM doubles it. Per-session eviction
+    (below) still does not apply to media — only the project-wide layer
+    does.
   - **History-content (``.reyn/memory/history-content/``, #5364) — auto-GC
-    now EXISTS, in two layers, not yet enforced end-to-end.** Per-session:
-    every :meth:`save_tool_result` call runs
-    :meth:`_evict_history_content_over_cap`, deleting THIS session's own
-    oldest files (protecting only the write's own open turn) once its
-    directory exceeds ``history_content_max_bytes`` (#5364 §1.6 / #5388
-    — this layer is live in production). Project-wide: a
-    ``storage.max_bytes`` / ``storage.pin`` config
-    (#5366 1/N, ``ReynConfig.storage``) and a candidate-selection
-    function (:func:`cross_session_eviction_candidates`, #5366 2/N,
-    pin-only by design — no liveness filter; see that function's own
-    docstring for why) both exist, but nothing calls the candidate
-    function yet — the project-wide cap is configured and its eviction
-    ORDER is computed, with no delete pass wired to either. That wiring
-    is a later #5366 slice.
+    in two layers.** Per-session: every :meth:`save_tool_result` call
+    runs :meth:`_evict_history_content_over_cap`, deleting THIS
+    session's own oldest files (protecting only the write's own open
+    turn) once its directory exceeds ``history_content_max_bytes``
+    (#5364 §1.6 / #5388 — this layer is live in production).
+    Project-wide (#5366, wired end-to-end by #4478): every
+    :meth:`save_tool_result` call also runs :meth:`_evict_cross_
+    session_over_cap`, which measures BOTH trees' combined bytes
+    against ``storage.max_bytes`` and evicts the oldest non-pinned
+    candidate from EITHER tree (:func:`cross_session_eviction_
+    candidates`, one merged oldest-first order, :func:`_merge_oldest_
+    first`) until back under cap, or refuses the new write
+    (``MediaStoreWriteUnavailable``) if it cannot. Media's OWN writes
+    (:meth:`save_media`) do not themselves trigger this pre-check today
+    — a disclosed gap (#4478), see that method's own docstring.
   - **Cross-turn / cross-session re-access supported.** A path-ref
     minted in user turn 1 remains valid in user turn 2 / next chat
     session / a forwarded A2A peer's expand — the file is still there,
     for any file eviction above hasn't reached.
     (See Q1 of the frozen contract: ``agent_id = agent name`` durable
     identity, not per-turn ``chain_id``.)
-  - **Media disk usage still grows unboundedly.** Documented operational
-    caveat — operators are expected to ``ls -la .reyn/media/`` and clean
-    up periodically. The browsable filename convention makes manual
-    audit straightforward. :meth:`MediaStore.storage_stats` (#4478
-    Phase 1) gives a scripted read of this instead of a manual ``ls``:
-    file counts + byte totals per directory, policy-independent.
-  - **Phase 2 reservation (media only).** When measurement surfaces a
-    real disk pressure or stale-handle problem for ``.reyn/media/``
-    specifically, a config-driven policy (TTL / LRU / session-end /
-    mixed) would need its own reyn.yaml insertion point — the
-    ``multimodal:`` block is the natural one; no schema reservation
-    made today (= YAGNI). History-content already has its own separate
-    ``storage:`` block (#5366 1/N) instead of sharing this one.
+  - **Media disk usage grows unboundedly only when ``storage.max_bytes``
+    is unset** (``None``, the default — a fail-safe operators are
+    expected to rarely need, owner's own framing). Once set, the
+    project-wide layer above bounds media the same way it bounds
+    history-content. :meth:`MediaStore.storage_stats` (#4478 Phase 1)
+    gives a scripted read of the current footprint (file counts + byte
+    totals per directory, policy-independent) whether or not a cap is
+    configured — useful for deciding WHAT to set ``max_bytes`` to, not
+    just for confirming eviction fired.
+  - **Owner-scoped UX caveat (#4478):** a rewind/scrollback replay can
+    now show an image as missing (the SAME ``lost`` vocabulary #5364-B
+    already uses for a missing tool-result body) once eviction has
+    actually run — owner's own explicit acceptance: "過去を遡ったとき、
+    画像が消えていることを許容する".
 
 Out of scope (= future work):
-  - Wiring :func:`cross_session_eviction_candidates` (#5366 2/N) to an
-    actual delete pass honoring ``storage.max_bytes`` — the project-wide
-    GC's own acceptance criteria MUST cover the user-visible side, not
-    just "no consumer crashes": every read consumer already tolerates a
-    missing file (404 / ``None`` / a silently dropped content block —
-    #4478's own consumer sweep confirmed this), but a silently dropped
-    block is a scrollback image or tool-result the USER sees vanish
-    with no explanation, not a safe no-op. "Does this crash" is not
-    "is this a good experience" — that wiring needs to answer the
-    second question too, not just the first.
-  - Media (``.reyn/media/``) Phase 2 cleanup policy (= TTL / max-N /
-    session boundary) — trigger is measurement evidence, not
-    hypothesis; #4478 lands the measurement (``storage_stats``) without
-    the policy.
+  - Wiring the project-wide pre-check into :meth:`save_media` itself
+    (today it only runs from :meth:`save_tool_result` — see
+    :meth:`_evict_cross_session_over_cap`'s own docstring for why this
+    was left for a follow-up: 4 real call sites whose own
+    ``MediaStoreWriteUnavailable`` handling is unaudited).
   - Cross-host RPC dispatcher for ``resource_uri`` (= #385 β core
     impl sub-task 3, pending scheme arbitration).
 """
@@ -362,9 +370,16 @@ class MediaStorageStats:
 
 
 def _dir_stats(directory: Path) -> tuple[int, int]:
-    """(file_count, total_bytes) for the flat, single-level layout both
-    storage dirs use (see the module docstring's filename convention —
-    neither dir nests subdirectories). Missing directory → ``(0, 0)``,
+    """(file_count, total_bytes) for a FLAT, single-level directory —
+    the legacy ``.reyn/tool-results/`` tree (frozen, #5364), and a
+    pre-#4478 ``.reyn/media/`` write with no ``agent_name`` (the
+    legacy-construction fallback :meth:`MediaStore.save_media` still
+    uses — see that method's own docstring). NOT ``.reyn/media/`` as a
+    whole any more: a post-#4478 write nests under
+    ``<agent>/<session_id>/`` (:func:`media_content_dir_for`), so a
+    caller measuring the WHOLE media tree needs
+    :func:`_dir_stats_recursive` instead (:meth:`MediaStore.storage_
+    stats`'s own call site, #4478). Missing directory → ``(0, 0)``,
     same as "nothing written yet" rather than an error; a file that
     disappears mid-scan (a concurrent delete, raising
     ``FileNotFoundError``) is skipped rather than propagating, since this
@@ -441,6 +456,38 @@ def _eviction_order(directory: Path) -> list[Path]:
             continue
     entries.sort(key=lambda pair: pair[0])
     return [path for _, path in entries]
+
+
+def _merge_oldest_first(*candidate_lists: list[Path]) -> list[Path]:
+    """#4478: merge N already-mtime-sorted candidate lists (each the
+    output of :func:`_eviction_order`, possibly pin-filtered by
+    :func:`cross_session_eviction_candidates`) into ONE globally
+    oldest-first order — architect's own design (issue #4478, "母集団
+    を1つ広げるだけ"): the project-wide cap has always been ONE number
+    against ONE ``_eviction_order``, and adding a second tree
+    (``.reyn/media/``) must not silently become "evict this tree first,
+    then that one" — a directory-scoped bias `_eviction_order` itself
+    was never designed to have (see its own docstring: "which one goes
+    first" is oldest-mtime, period, not oldest-per-directory).
+
+    Re-stats every candidate (cheap — eviction is not a hot path, and
+    ``_eviction_order``'s own output already discards the mtime it
+    computed) rather than threading mtimes through every caller's own
+    return type. A candidate that vanishes between listing and this
+    re-stat (a concurrent delete) sorts to the END (``float("inf")``)
+    rather than raising — harmless: :meth:`MediaStore._evict_cross_
+    session_over_cap`'s own delete loop already tolerates a vanished
+    candidate (best-effort, logged, skipped), so a mis-ordered-last
+    ghost entry costs nothing."""
+    def _mtime(path: Path) -> float:
+        try:
+            return path.stat().st_mtime
+        except FileNotFoundError:
+            return float("inf")
+
+    merged = [p for candidates in candidate_lists for p in candidates]
+    merged.sort(key=_mtime)
+    return merged
 
 
 # #385 β core impl sub-task 1: cross-host capable resource URI scheme.
@@ -553,6 +600,34 @@ def history_content_dir_for(
     already does for the state dir)."""
     cfg = config or MediaStoreConfig()
     root = (project_root / cfg.history_content_dir).resolve()
+    return root / _safe_token(agent_name) / _safe_token(session_id)
+
+
+def media_content_dir_for(
+    project_root: Path, agent_name: str, session_id: str,
+    config: "MediaStoreConfig | None" = None,
+) -> Path:
+    """#4478 (architect ruling — "新しい概念0"): the SAME
+    ``<agent>/<session_id>/`` nesting shape :func:`history_content_dir_for`
+    already establishes for ``.reyn/memory/history-content/``, applied
+    to ``.reyn/media/`` — not a new concept, the same one reused so
+    :func:`cross_session_eviction_candidates`'s own pin match
+    (``path.relative_to(root).parts[0]`` against a pinned agent name)
+    has an agent segment to read for a NEW media write, closing the
+    asymmetry a flat ``.reyn/media/`` layout had against pin protection
+    (#4478's own real finding: a flat file's ``parts[0]`` is its own
+    filename, which can never match a pinned agent name — enumerated as
+    a candidate, never excluded).
+
+    Unlike :func:`history_content_dir_for` (which RAISES when
+    ``agent_name`` is empty — that caller, :meth:`MediaStore.save_tool_
+    result`, always has a real one), :meth:`MediaStore.save_media`'s own
+    call site keeps the pre-#4478 FLAT fallback when it has none (a
+    legacy/read-only construction, #4478's own scope: "既存の
+    agent_name省略の legacy 呼び口は flat") — this function itself never
+    decides that; its own caller branches before calling it."""
+    cfg = config or MediaStoreConfig()
+    root = (project_root / cfg.media_dir).resolve()
     return root / _safe_token(agent_name) / _safe_token(session_id)
 
 
@@ -940,13 +1015,38 @@ class MediaStore:
         SHA-256 of ``data`` (= verifies the path-ref hasn't drifted
         from the original content; used by the history builder when
         materialising back to a data URL).
+
+        #4478 (architect ruling): nested under ``<agent>/<session_id>/``
+        (:func:`media_content_dir_for`, the SAME shape #5364's own
+        ``history_content_dir_for`` already uses) when this store has a
+        real ``agent_name`` — the precondition
+        :func:`cross_session_eviction_candidates`'s own pin filter needs
+        to protect a pinned agent's media (#4478's own real finding: a
+        FLAT file's own filename sits where the filter reads an agent
+        name, so it can never match a pin — enumerated as a candidate,
+        never excluded). A legacy/read-only construction with no
+        ``agent_name`` (4 of the 5 production ``MediaStore`` call sites
+        per :meth:`_history_content_dir`'s own docstring) stays FLAT,
+        unchanged — the pre-#4478 contract. Existing flat files are
+        NEVER migrated (no migration script — #4478's own owner-scoped
+        ruling: reyn-self carries 0 such files today; elsewhere, a
+        pre-#4478 file simply remains a pin-unprotected eviction
+        candidate, disclosed in :func:`cross_session_eviction_
+        candidates`'s own call site, never silently claimed safe).
         """
-        self._media_dir.mkdir(parents=True, exist_ok=True)
+        media_dir = (
+            media_content_dir_for(
+                self._project_root, self._agent_name, self._session_id, self._config,
+            )
+            if self._agent_name
+            else self._media_dir
+        )
+        media_dir.mkdir(parents=True, exist_ok=True)
         chain_short = _safe_token(chain_id)[:6] if chain_id else ""
         tool_token = _safe_token(tool) or "tool"
         ext = _ext_for_mime(mime_type)
         filename = f"{_timestamp()}-{chain_short}-{tool_token}-{seq}{ext}"
-        path = self._media_dir / filename
+        path = media_dir / filename
         path.write_bytes(data)
         block: dict = {
             "type": "image",
@@ -1290,21 +1390,47 @@ class MediaStore:
     def _evict_cross_session_over_cap(self) -> None:
         """#5366 §3 (architect design, final ruling — issuecomment-
         5451564768 / lead-coder confirmation issuecomment-5451700-ish):
-        bound the PROJECT-wide (cross-session) history-content footprint
-        against ``StorageConfig.max_bytes`` — a DIFFERENT number than
+        bound the PROJECT-wide (cross-session) footprint against
+        ``StorageConfig.max_bytes`` — a DIFFERENT number than
         :attr:`MediaStoreConfig.history_content_max_bytes` (this store's
         own per-session backstop, see that field's docstring for why the
         two are deliberately never the same). No-op when ``max_bytes``
         is unset (``None`` — the field's own default means "off", not
         "check anyway").
 
-        Candidates come from :func:`cross_session_eviction_candidates`
-        against the project-wide root (:func:`history_content_root_for`)
-        minus pinned agents — deliberately no liveness filter (see that
-        function's own docstring for why: #5388's per-session cap
-        already evicts a LIVE session's own old files, so a liveness
-        filter here would protect cross-session GC MORE than per-session
-        GC protects itself, for the same resource).
+        #4478 (architect ruling — "母集団を1つ広げるだけ。新しい概念は
+        1つも要りません"): ``.reyn/media/`` counts against this SAME
+        cap, alongside ``.reyn/memory/history-content/`` — one operator
+        number, not two (owner ruling, #5366's own design pass: an
+        operator declares ONE "how many bytes this project may use";
+        two separate caps could both individually pass while their SUM
+        doubles it). Total is the SUM of both trees'
+        :func:`_dir_stats_recursive`; candidates from BOTH are merged
+        into ONE globally oldest-first order (:func:`_merge_oldest_first`
+        — never "drain tree A, then tree B", which `_eviction_order`
+        was never designed to mean either way).
+
+        ⚠️ Pin protects a media file only when it was written AFTER
+        #4478 (:meth:`save_media`'s own ``<agent>/<session_id>/``
+        nesting, :func:`media_content_dir_for` — architect ruling, same
+        shape history-content already uses, so the SAME
+        :func:`cross_session_eviction_candidates` pin match just works).
+        A pre-#4478 FLAT file's own filename sits where the filter reads
+        an agent name, so it never matches a pin — enumerated as a
+        candidate, never excluded (disclosed, never migrated — #4478's
+        own owner-scoped ruling: reyn-self carries 0 such files today).
+
+        ⚠️ Also disclosed: this pre-check runs from :meth:`save_tool_
+        result` only (unchanged from #5366) — a media-only-heavy
+        project does not self-trigger eviction from :meth:`save_media`
+        itself; the population widened here still only gets CONSULTED
+        on a tool-result write. Wiring the same pre-check into
+        :meth:`save_media` touches 4 real call sites
+        (``web.py``/``file.py``/``mcp.py``/``router_loop.py``) whose own
+        ``MediaStoreWriteUnavailable`` handling is unaudited — out of
+        this PR's own authorized scope (witnesses 1/3/4/5 only,
+        lead-coder), named here as a real follow-up, not silently
+        assumed solved.
 
         Runs BEFORE the write this call is guarding (a pre-check, same
         shape as the ``durability_failed`` check right above its own
@@ -1331,13 +1457,24 @@ class MediaStore:
         max_bytes = self._storage.max_bytes
         if max_bytes is None:
             return
-        root = history_content_root_for(self._project_root, self._config)
-        _, total = _dir_stats_recursive(root)
+        history_content_root = history_content_root_for(self._project_root, self._config)
+        _, history_content_total = _dir_stats_recursive(history_content_root)
+        _, media_total = _dir_stats_recursive(self._media_dir)
+        total = history_content_total + media_total
         if total <= max_bytes:
             return
-        candidates = cross_session_eviction_candidates(
-            root, pin=self._storage.pin,
+        history_content_candidates = cross_session_eviction_candidates(
+            history_content_root, pin=self._storage.pin,
         )
+        # #4478: a NEW (post-#4478) nested media write's own pin match
+        # works exactly like history-content's; a pre-#4478 flat file's
+        # own filename sits where the filter reads an agent name, so it
+        # never matches a pin — enumerated as a candidate, never
+        # excluded (disclosed, not silently claimed protected).
+        media_candidates = cross_session_eviction_candidates(
+            self._media_dir, pin=self._storage.pin,
+        )
+        candidates = _merge_oldest_first(history_content_candidates, media_candidates)
         for path in candidates:
             if total <= max_bytes:
                 return
@@ -1373,17 +1510,25 @@ class MediaStore:
         mirroring :func:`cross_session_eviction_candidates`'s own "no
         pin → return everything ``_eviction_order`` finds" shape: an
         empty result here always means "nothing to evict", never
-        "couldn't compute")."""
+        "couldn't compute"). #4478: the population and merge order are
+        the SAME widened ones :meth:`_evict_cross_session_over_cap`
+        computes — see that method's own docstring."""
         max_bytes = self._storage.max_bytes
         if max_bytes is None:
             return []
-        root = history_content_root_for(self._project_root, self._config)
-        _, total = _dir_stats_recursive(root)
+        history_content_root = history_content_root_for(self._project_root, self._config)
+        _, history_content_total = _dir_stats_recursive(history_content_root)
+        _, media_total = _dir_stats_recursive(self._media_dir)
+        total = history_content_total + media_total
         if total <= max_bytes:
             return []
-        candidates = cross_session_eviction_candidates(
-            root, pin=self._storage.pin,
+        history_content_candidates = cross_session_eviction_candidates(
+            history_content_root, pin=self._storage.pin,
         )
+        media_candidates = cross_session_eviction_candidates(
+            self._media_dir, pin=self._storage.pin,
+        )
+        candidates = _merge_oldest_first(history_content_candidates, media_candidates)
         preview: list[Path] = []
         for path in candidates:
             if total <= max_bytes:
@@ -1687,8 +1832,16 @@ class MediaStore:
         session-end policy ("trigger is measurement evidence, not
         hypothesis"). Mirrors the chat presenter's own public
         ``image_cache_size_bytes``-style snapshot-read pattern (#4376),
-        applied here to on-disk rather than in-memory storage."""
-        media_count, media_bytes = _dir_stats(self._media_dir)
+        applied here to on-disk rather than in-memory storage.
+
+        #4478: ``_dir_stats_recursive``, not ``_dir_stats`` — a
+        post-#4478 write nests under ``<agent>/<session_id>/``
+        (:func:`media_content_dir_for`), so the flat, one-level
+        ``_dir_stats`` this used to call would silently undercount every
+        such file (a real regression this file's own docstring update
+        closes, caught by the pre-existing CLI/API stats tests going
+        genuinely red under the nesting change)."""
+        media_count, media_bytes = _dir_stats_recursive(self._media_dir)
         # #5364: tool-result writes moved to history_content_root (nested
         # per session) — tool_result_file_count/bytes measure the CURRENT
         # write location, same field name/meaning as before the move

--- a/tests/data/test_4478_media_eviction.py
+++ b/tests/data/test_4478_media_eviction.py
@@ -146,28 +146,6 @@ def test_a_legacy_flat_media_file_is_a_pin_unprotected_candidate(tmp_path):
     )
 
 
-def test_reviewer_strip_removing_nesting_makes_the_pin_test_fail(tmp_path):
-    """Tier 2: reviewer strip (architect's own required witness) —
-    reverting save_media to the pre-#4478 flat write makes the pin-
-    protection accept test genuinely fail, proving that test actually
-    depends on the nesting rather than passing vacuously."""
-    store = MediaStore(
-        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
-    )
-    # Simulate the pre-#4478 flat write directly (bypassing save_media's
-    # own nesting) — the same construction save_media used to produce.
-    store.media_dir.mkdir(parents=True, exist_ok=True)
-    flat_path = store.media_dir / "20260101T000000-abc-tool-1.png"
-    flat_path.write_bytes(b"\x89PNG\r\n")
-
-    candidates = cross_session_eviction_candidates(store.media_dir, pin=["alice"])
-    assert flat_path in candidates, (
-        "sanity: a flat write (the pre-#4478 shape) must NOT be excluded "
-        "by pin — proving the pin-protection accept test above is "
-        "genuinely exercising the nesting, not passing vacuously"
-    )
-
-
 # ── the project-wide cap's own widened population ────────────────────────────
 
 

--- a/tests/data/test_4478_media_eviction.py
+++ b/tests/data/test_4478_media_eviction.py
@@ -1,0 +1,298 @@
+"""Tier 2: #4478 — ``.reyn/media/`` (images) counts against the SAME
+project-wide ``StorageConfig.max_bytes`` cap ``.reyn/memory/history-
+content/`` already does — architect ruling: "母集団を1つ広げるだけ。新
+しい概念は1つも要りません。". No TTL / max-N / a media-only cap — one
+operator number, the existing eviction order (oldest-first) and pin
+mechanism, reused.
+
+A real, pre-existing structural gap made pin unenforceable for media:
+``.reyn/media/`` was a FLAT directory (``save_media`` wrote directly
+under ``media_dir``, no per-agent nesting), so
+``cross_session_eviction_candidates``'s own pin match
+(``path.relative_to(root).parts[0]`` against a pinned agent name) read
+a media file's own FILENAME where it expected an agent name — never a
+match, so pin silently gave media no protection at all. Architect's
+own follow-up ruling (same issue): ``save_media`` now nests under
+``<agent>/<session_id>/`` — the SAME shape ``history_content_dir_for``
+already established for tool-results, "0 new concepts" — when a real
+``agent_name`` is available; a legacy/read-only construction (no
+``agent_name``) keeps the pre-#4478 flat write. Existing flat files are
+never migrated (disclosed as pin-unprotected candidates, never
+silently claimed safe) — owner-scoped: reyn-self carries 0 such files.
+
+Same idiom as ``tests/data/test_5366_cross_session_eviction_driver.py``
+(this file's own established sibling for the tool-results side): real
+on-disk writes via real ``MediaStore`` instances, no fakes.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from reyn.config.infra import StorageConfig
+from reyn.data.workspace.media_store import (
+    MediaStore,
+    MediaStoreConfig,
+    MediaStoreWriteUnavailable,
+    cross_session_eviction_candidates,
+    media_content_dir_for,
+)
+
+
+def _bump_mtime_forward(directory) -> None:
+    """Same determinism helper #5366's own driver test uses — forces
+    every existing file further into the past so write-order ties never
+    race real filesystem mtime-tick granularity."""
+    for path in directory.rglob("*"):
+        if path.is_file():
+            st = path.stat()
+            os.utime(path, (st.st_atime, st.st_mtime - 1))
+
+
+# ── save_media's own nesting (the pin precondition) ──────────────────────────
+
+
+def test_save_media_nests_under_agent_and_session_when_agent_name_is_set(tmp_path):
+    """Tier 2: accept — a store constructed with a real ``agent_name``
+    writes new media under ``<media_dir>/<agent>/<session_id>/…`` (the
+    SAME shape history-content's own ``history_content_dir_for`` already
+    uses), not flat directly under ``media_dir``."""
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+    )
+    block = store.save_media(b"\x89PNG\r\n", mime_type="image/png")
+
+    written = (tmp_path / block["path"]).resolve()
+    expected_dir = media_content_dir_for(tmp_path, "alice", "main")
+    assert written.parent == expected_dir, (
+        f"expected the file under {expected_dir}, got {written.parent}"
+    )
+    assert written.exists()
+
+
+def test_save_media_with_no_agent_name_stays_flat_legacy_contract(tmp_path):
+    """Tier 2: legacy contract — a store with NO ``agent_name`` (4 of 5
+    production construction sites are read-only and legitimately have
+    none, per ``_history_content_dir``'s own docstring) keeps writing
+    directly under ``media_dir``, unchanged from before #4478 — never
+    raises, never nests."""
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path, session_id="main")
+    block = store.save_media(b"\x89PNG\r\n", mime_type="image/png")
+
+    written = (tmp_path / block["path"]).resolve()
+    media_dir = (tmp_path / MediaStoreConfig().media_dir).resolve()
+    assert written.parent == media_dir, (
+        f"a store with no agent_name must stay flat under {media_dir}, "
+        f"got {written.parent}"
+    )
+
+
+# ── pin now protects (only) a post-#4478 nested media file ──────────────────
+
+
+def test_pinned_agents_nested_media_is_excluded_from_eviction_candidates(tmp_path):
+    """Tier 2: accept — the real point of the nesting. A NEW (post-#4478)
+    media file written by a PINNED agent is excluded from
+    cross_session_eviction_candidates — witness 2 becomes real."""
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+    )
+    block = store.save_media(b"\x89PNG\r\n", mime_type="image/png")
+    written = (tmp_path / block["path"]).resolve()
+
+    media_dir = (tmp_path / MediaStoreConfig().media_dir).resolve()
+    candidates = cross_session_eviction_candidates(media_dir, pin=["alice"])
+    assert written not in candidates, (
+        "a pinned agent's own nested media file must be excluded from "
+        "the eviction candidate list"
+    )
+
+
+def test_an_unpinned_agents_nested_media_is_a_candidate(tmp_path):
+    """Tier 2: deny sibling — a NEW nested media file from an agent NOT
+    in the pin list is a real candidate, same as history-content."""
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+    )
+    block = store.save_media(b"\x89PNG\r\n", mime_type="image/png")
+    written = (tmp_path / block["path"]).resolve()
+
+    media_dir = (tmp_path / MediaStoreConfig().media_dir).resolve()
+    candidates = cross_session_eviction_candidates(media_dir, pin=["alice"])
+    assert written in candidates, (
+        "an agent not in the pin list must remain a real candidate"
+    )
+
+
+def test_a_legacy_flat_media_file_is_a_pin_unprotected_candidate(tmp_path):
+    """Tier 2: deny — a pre-#4478-shaped flat file (no agent_name at
+    write time) is a candidate REGARDLESS of pin — this file names the
+    disclosed gap directly: "pin protects media" is NOT claimed for a
+    flat file, only for a post-#4478 nested one."""
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path, session_id="main")
+    block = store.save_media(b"\x89PNG\r\n", mime_type="image/png")
+    written = (tmp_path / block["path"]).resolve()
+
+    media_dir = (tmp_path / MediaStoreConfig().media_dir).resolve()
+    # Even pinning a name that happens to equal this flat file's own
+    # first path segment (its filename) cannot protect it — parts[0]
+    # for a flat file IS the filename, never an agent name; pinning an
+    # unrelated real agent leaves the flat file unaffected either way.
+    candidates = cross_session_eviction_candidates(media_dir, pin=["alice"])
+    assert written in candidates, (
+        "a legacy flat media file must remain a candidate — pin has no "
+        "attribution to match it against"
+    )
+
+
+def test_reviewer_strip_removing_nesting_makes_the_pin_test_fail(tmp_path):
+    """Tier 2: reviewer strip (architect's own required witness) —
+    reverting save_media to the pre-#4478 flat write makes the pin-
+    protection accept test genuinely fail, proving that test actually
+    depends on the nesting rather than passing vacuously."""
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+    )
+    # Simulate the pre-#4478 flat write directly (bypassing save_media's
+    # own nesting) — the same construction save_media used to produce.
+    store.media_dir.mkdir(parents=True, exist_ok=True)
+    flat_path = store.media_dir / "20260101T000000-abc-tool-1.png"
+    flat_path.write_bytes(b"\x89PNG\r\n")
+
+    candidates = cross_session_eviction_candidates(store.media_dir, pin=["alice"])
+    assert flat_path in candidates, (
+        "sanity: a flat write (the pre-#4478 shape) must NOT be excluded "
+        "by pin — proving the pin-protection accept test above is "
+        "genuinely exercising the nesting, not passing vacuously"
+    )
+
+
+# ── the project-wide cap's own widened population ────────────────────────────
+
+
+def test_media_bytes_count_toward_the_same_project_wide_cap(tmp_path):
+    """Tier 2: accept — witness 1/5. A tool-result write's own pre-check
+    now measures history-content BYTES PLUS media BYTES together against
+    ONE ``max_bytes`` — an over-cap state driven by media ALONE still
+    triggers eviction on the next tool-result write, and media's own
+    older files are real candidates (not a second, separately-tracked
+    number)."""
+    storage = StorageConfig(max_bytes=600)
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=storage,
+    )
+    alice_media_block = alice.save_media(b"a" * 500, mime_type="image/png")
+    _bump_mtime_forward(tmp_path)
+
+    bob = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=storage,
+    )
+    # bob's own tool-result write's pre-check must see alice's MEDIA
+    # bytes (500) already over cap once bob adds a text write on top —
+    # this only proves the point if the cap counts media at all.
+    bob.save_tool_result("b" * 200, mime_type="text/plain", seq=1)
+    _bump_mtime_forward(tmp_path)
+
+    # This second write's own pre-check now sees the combined total
+    # over cap and must evict alice's older MEDIA file to make room.
+    bob.save_tool_result("c" * 10, mime_type="text/plain", seq=2)
+
+    alice_media_path = (tmp_path / alice_media_block["path"]).resolve()
+    assert not alice_media_path.exists(), (
+        "alice's older media file must have been evicted once the "
+        "COMBINED (history-content + media) total went over cap"
+    )
+
+
+def test_pinned_agents_media_survives_a_combined_cap_eviction(tmp_path):
+    """Tier 2: accept sibling — witness 2, driven through the real
+    combined-cap eviction path (not just the candidate-listing unit
+    check above)."""
+    storage = StorageConfig(max_bytes=600, pin=["alice"])
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=storage,
+    )
+    alice_media_block = alice.save_media(b"a" * 500, mime_type="image/png")
+    _bump_mtime_forward(tmp_path)
+
+    bob = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=storage,
+    )
+    bob.save_tool_result("b" * 500, mime_type="text/plain", seq=1)
+
+    alice_media_path = (tmp_path / alice_media_block["path"]).resolve()
+    assert alice_media_path.exists(), (
+        "a pinned agent's media must survive combined-cap eviction"
+    )
+
+
+def test_max_bytes_none_never_evicts_media_either(tmp_path):
+    """Tier 2: witness 3 — the None-default failsafe covers media too,
+    not just history-content."""
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=StorageConfig(max_bytes=None),
+    )
+    block = alice.save_media(b"a" * 10_000, mime_type="image/png")
+    _bump_mtime_forward(tmp_path)
+
+    bob = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=StorageConfig(max_bytes=None),
+    )
+    bob.save_tool_result("b" * 10_000, mime_type="text/plain", seq=1)
+
+    assert (tmp_path / block["path"]).resolve().exists(), (
+        "max_bytes=None must never evict anything, media included"
+    )
+
+
+def test_raises_write_unavailable_when_media_and_history_content_both_pinned_over_cap(
+    tmp_path,
+):
+    """Tier 2: witness 4/core — every candidate (both trees) pinned, so
+    the combined population cannot shrink below cap; the next write must
+    refuse rather than mint a ref that pushes the project further over."""
+    storage = StorageConfig(max_bytes=100, pin=["alice"])
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=storage,
+    )
+    alice.save_media(b"a" * 500, mime_type="image/png")
+    _bump_mtime_forward(tmp_path)
+
+    bob = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=storage,
+    )
+    with pytest.raises(MediaStoreWriteUnavailable):
+        bob.save_tool_result("b" * 500, mime_type="text/plain", seq=1)
+
+
+def test_preview_lists_a_media_file_that_would_be_evicted(tmp_path):
+    """Tier 2: cross_session_eviction_preview() reports media candidates
+    too, without deleting anything — the SAME "what would go" surface
+    #5366 item ④ already gives text results."""
+    storage = StorageConfig(max_bytes=600)
+    alice = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
+        storage=storage,
+    )
+    alice_media_block = alice.save_media(b"a" * 500, mime_type="image/png")
+    _bump_mtime_forward(tmp_path)
+
+    bob = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=storage,
+    )
+    bob.save_tool_result("b" * 500, mime_type="text/plain", seq=1)
+
+    preview = bob.cross_session_eviction_preview()
+    alice_media_path = (tmp_path / alice_media_block["path"]).resolve()
+    assert alice_media_path in preview
+    assert alice_media_path.exists(), "a preview must never actually delete anything"

--- a/tests/data/test_4478_media_eviction.py
+++ b/tests/data/test_4478_media_eviction.py
@@ -188,7 +188,20 @@ def test_media_bytes_count_toward_the_same_project_wide_cap(tmp_path):
 def test_pinned_agents_media_survives_a_combined_cap_eviction(tmp_path):
     """Tier 2: accept sibling — witness 2, driven through the real
     combined-cap eviction path (not just the candidate-listing unit
-    check above)."""
+    check above).
+
+    #4478 review (lead-coder's own real strip finding): a SINGLE
+    tool-result write's own pre-check sees the disk state BEFORE that
+    write lands (:meth:`MediaStore._evict_cross_session_over_cap`'s own
+    docstring) — one write alone never actually triggers eviction, so
+    a prior version of this test asserting only "the pinned file
+    survives" passed vacuously (nothing was ever at risk of being
+    evicted). This version drives a SECOND write (matching #5366's own
+    established `test_a_later_write_evicts_an_older_other_agents_file_
+    once_over_cap` pattern) so eviction genuinely fires, and asserts
+    BOTH directions: the pinned agent's media survives AND the
+    unpinned agent's media is actually gone — either alone cannot tell
+    "protected" apart from "nothing happened"."""
     storage = StorageConfig(max_bytes=600, pin=["alice"])
     alice = MediaStore(
         MediaStoreConfig(), project_root=tmp_path, agent_name="alice", session_id="main",
@@ -197,15 +210,38 @@ def test_pinned_agents_media_survives_a_combined_cap_eviction(tmp_path):
     alice_media_block = alice.save_media(b"a" * 500, mime_type="image/png")
     _bump_mtime_forward(tmp_path)
 
+    carol = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="carol", session_id="main",
+        storage=storage,
+    )
+    carol_media_block = carol.save_media(b"c" * 500, mime_type="image/png")
+    _bump_mtime_forward(tmp_path)
+
+    # Pre-check sees alice(500) + carol(500) = 1000, still under cap
+    # relative to itself (this write's own pre-check runs BEFORE it
+    # lands) -> allowed through. The project is now genuinely over cap
+    # (1000 > 600) on disk, but nothing re-checks until the NEXT write.
     bob = MediaStore(
         MediaStoreConfig(), project_root=tmp_path, agent_name="bob", session_id="main",
         storage=storage,
     )
-    bob.save_tool_result("b" * 500, mime_type="text/plain", seq=1)
+    bob.save_tool_result("b" * 10, mime_type="text/plain", seq=1)
+    _bump_mtime_forward(tmp_path)
+
+    # This SECOND write's own pre-check now sees the project over cap
+    # and evicts the oldest non-pinned candidate — carol's media —
+    # while alice's pinned media must survive.
+    bob.save_tool_result("b" * 10, mime_type="text/plain", seq=2)
 
     alice_media_path = (tmp_path / alice_media_block["path"]).resolve()
+    carol_media_path = (tmp_path / carol_media_block["path"]).resolve()
     assert alice_media_path.exists(), (
         "a pinned agent's media must survive combined-cap eviction"
+    )
+    assert not carol_media_path.exists(), (
+        "sanity: an unpinned agent's older media must have actually "
+        "been evicted — otherwise 'alice survives' could mean nothing "
+        "happened at all"
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — Owner decision (2026-09-02, chat, verbatim: "4478 はい") — accepting that a rewind/scrollback replay may show an image as missing once eviction has actually run, same as tool-results already does. Policy per architect ruling (2026-08-29): no TTL / max-N / a media-only cap — none of those bound BYTES, the actual resource (a TTL still lets 3 large images blow the cap before any age out; max-N treats 1000 tiny files the same as 1000 huge ones; two separate caps could both pass individually while their sum doubles the real footprint). Instead, `.reyn/media/` joins the SAME `storage.max_bytes`/`storage.pin` cap `.reyn/memory/history-content/` already used (#5366) — one operator number, the existing eviction order (oldest-first) and pin mechanism, reused, zero new concepts.

## Population widening (witnesses 1/3/4/5)

`_evict_cross_session_over_cap` / `cross_session_eviction_preview` now measure BOTH trees' combined bytes against ONE `max_bytes`, and merge BOTH trees' own eviction candidates into ONE globally oldest-first order (new `_merge_oldest_first` helper) — never "drain tree A, then tree B". `storage_stats()` switched from the flat, one-level `_dir_stats` to `_dir_stats_recursive` for media — a real regression caught by the pre-existing CLI/API stats tests going genuinely red once media could nest.

## The pin design fork (escalated, not guessed)

`.reyn/media/` was a FLAT directory — `cross_session_eviction_candidates`'s own pin match (`path.relative_to(root).parts[0]` against a pinned agent name) had no agent segment to read for a media file, so pin silently gave media zero protection. Escalated via broker rather than picking an option myself; architect ruled: reuse the SAME `<agent>/<session_id>/` nesting shape `history_content_dir_for` already established (new `media_content_dir_for`, "0 new concepts") — `save_media` nests under it when a real `agent_name` is available; a legacy/read-only construction (no `agent_name`, 4 of 5 production sites) keeps the pre-#4478 flat write. Existing flat files are never migrated (owner-scoped: reyn-self carries 0 such files today) — disclosed as pin-unprotected eviction candidates, never silently claimed safe.

## Disclosed, not silently assumed solved

The project-wide pre-check still runs from `save_tool_result` only (unchanged from #5366) — `save_media` itself does not self-trigger eviction. Wiring it in touches 4 real call sites (`web.py`/`file.py`/`mcp.py`/`router_loop.py`) whose own `MediaStoreWriteUnavailable` handling is unaudited — named as a real follow-up in this PR's own docstrings, out of the authorized scope (population-widening + pin nesting only), and filed separately as #5653.

## Tests

10 new tests (`tests/data/test_4478_media_eviction.py`): `save_media`'s own nesting (accept + legacy-flat-contract), pin protection (accept + 2 deny siblings: unpinned agent, legacy flat file), and the combined-cap witnesses (media counts toward the cap, pin survives combined eviction, `max_bytes=None` never evicts media either, refuses when every candidate in both trees is pinned, preview lists a media candidate without deleting it).

**Strip-falsified directly by me, twice (a reviewer action, not a committed test — lead-coder's own review caught an earlier revision that wrongly tried to commit this as a test, duplicating the legacy-deny assertion; removed):** (1) reverting `save_media` to the pre-#4478 flat write turned 3 tests genuinely red (the nesting test itself, pin protection, and the write-refuse witness); (2) dropping media from the population-widening sum turned 2 tests genuinely red (combined-cap eviction, write-refuse). Both restored, 10/10 green. Full regression sweep (138 tests across #4478/#5366/#5364/#5512/media-store/storage-CLI suites) green. All local gates green, `mkdocs build --strict` clean.

## Docs

`reyn-dir-layout.md` gains a `media/` entry (the new nesting shape + shared cap); `media_store.py`'s own module docstring, `save_media`'s, `_evict_cross_session_over_cap`'s, and `_dir_stats`'/`storage_stats`'s own docstrings rewritten to match — the module docstring's own "still no auto-GC" / "grows unboundedly" / "flat, both dirs" claims were all stale the moment this PR's own mechanism changed.

Closes #4478

## Test plan
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/data/test_4478_media_eviction.py` — 10 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/data/workspace/media_store.py` — clean
- [x] `python scripts/mypy_ratchet.py` — clean
- [x] `python scripts/flat_tests_ratchet.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `python scripts/check_bare_tests_import_reference.py` — clean
- [x] `python scripts/check_file_depth_reference.py` — clean
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py` — clean
- [x] scoped pytest — new tests (10/10) + regression sweep (138/138)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
