### PR TITLE
feat(#4364): reyn doctor -- project-wide storage cap row (storage.max_bytes/pin) + #5653 known-gap disclosure

### DIFF
--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -220,6 +220,64 @@ def _events_dir_stats(root: Path) -> "tuple[int, int, date | None]":
     return count, total_bytes, oldest
 
 
+def _print_storage_cap_status(config: Any, media_stats: Any) -> None:
+    """part of #4364 (2026-09-02): ``storage.max_bytes``/``storage.pin``
+    (:class:`~reyn.config.infra.StorageConfig`, #5366) is the ONE
+    project-wide, cross-session disk cap covering ``.reyn/media/`` +
+    ``.reyn/memory/history-content/`` TOGETHER (#4478 — one operator
+    number, not two, so two individually-under-cap trees can't silently
+    sum over it). ``media_stats`` is the SAME
+    :class:`~reyn.data.workspace.media_store.MediaStorageStats` snapshot
+    ``run()`` already computed via ``store.storage_stats()`` (#5652's own
+    recursive ``_dir_stats_recursive`` — correctly counts a nested
+    ``<agent>/<session_id>/`` write) — this function is not a second
+    producer of that count (D-1/CLAUDE.md: one producer, or the two
+    silently drift); ``.tool_result_bytes`` measures
+    ``.reyn/memory/history-content/`` despite its own legacy field name
+    (see ``storage_stats``'s own docstring — tool-result writes moved
+    there under #5364).
+
+    D-3: ``max_bytes=None`` (the field's own documented "off" state,
+    never a second boolean) prints "unconfigured" — never a fabricated
+    number, and never silently omits the line the way a bare "cap: none"
+    might read as "0 bytes allowed" instead of "no cap at all".
+
+    Known gap (#5653, disclosed here per lead-coder's own #4364
+    assignment): the eviction PRE-CHECK
+    (:meth:`~reyn.data.workspace.media_store.MediaStore.
+    _evict_cross_session_over_cap`) runs only from ``save_tool_result`` —
+    ``save_media`` does not call it, so a media-only-heavy project's own
+    writes never self-trigger eviction; the cap is still only ever
+    CONSULTED when a tool-result write happens to occur. This line is
+    read-only visibility (D-2) — doctor never evicts anything itself."""
+    from reyn.config.infra import StorageConfig
+
+    storage_cfg = getattr(config, "storage", None) or StorageConfig()
+    used_bytes = media_stats.media_bytes + media_stats.tool_result_bytes
+
+    if storage_cfg.max_bytes is None:
+        print(
+            f"  storage.max_bytes: unconfigured (no project-wide cap — "
+            f"{used_bytes:,} bytes currently used, unbounded)",
+        )
+    else:
+        over = used_bytes > storage_cfg.max_bytes
+        mark = "⚠" if over else "✓"
+        suffix = " — OVER CAP" if over else ""
+        print(
+            f"  {mark} storage.max_bytes={storage_cfg.max_bytes:,}: "
+            f"{used_bytes:,} bytes currently used{suffix}",
+        )
+
+    pin_desc = ", ".join(storage_cfg.pin) if storage_cfg.pin else "none"
+    print(f"  storage.pin: {pin_desc}")
+    print(
+        "  ⚠ known gap (#5653): the cap pre-check runs only from a "
+        "tool-result write — a media-only-heavy project's own save_media "
+        "writes never self-trigger eviction on their own",
+    )
+
+
 def run(args: argparse.Namespace) -> None:
     from reyn.config.config_schema import walk_config_schema
     from reyn.config.loader import _find_project_root, load_config
@@ -281,10 +339,13 @@ def run(args: argparse.Namespace) -> None:
         else:
             print("  ✓ no file currently exceeds the declared policy")
 
-    # ── C-7: media/ / tool-results/ / history.jsonl — no declared retention
-    # policy exists for any of these yet (#4478/#4476 Phase 2 unimplemented)
-    # — the visibility itself IS the finding (#4480: "no one owns this
-    # resource" made visible, not asserted).
+    # ── C-7: media/ / tool-results/ / history.jsonl — no PER-RESOURCE
+    # declared retention policy for any of these (#4480: "no one owns this
+    # resource" made visible, not asserted). #4478 landed a project-wide
+    # CAP covering media/+tool-results/ jointly (storage.max_bytes/pin) —
+    # a separate, coarser knob than a per-resource policy; see the
+    # "Project-wide storage cap" block below this section for it. history.jsonl
+    # has no policy of any kind yet.
     print()
     print("Disk usage — no declared retention policy (visibility only):")
     # #5364: read-only here (storage_stats never writes) — session_id is
@@ -318,6 +379,12 @@ def run(args: argparse.Namespace) -> None:
     print(f"  total (media+tool-results+history): {total_bytes_all:,} bytes")
     if free_bytes is not None:
         print(f"  (filesystem free space: {free_bytes:,} bytes)")
+
+    # ── C-7 addendum: project-wide storage cap (part of #4364, 2026-09-02)──
+    print()
+    print("Project-wide storage cap (storage.max_bytes/pin, #5366/#4478 —")
+    print("bounds media/ + tool-results/ TOGETHER, one operator number):")
+    _print_storage_cap_status(config, media_stats)
 
     # ── C-1: hook argv[0] launch probe (#4364 PR-2, architect ruling) ──────
     print()

--- a/tests/interfaces/test_4364_storage_cap_doctor_row.py
+++ b/tests/interfaces/test_4364_storage_cap_doctor_row.py
@@ -1,0 +1,97 @@
+"""Tier 2: #4364 (lead-coder assignment, part of #4364) — ``reyn doctor``
+gains a project-wide storage cap row (``storage.max_bytes``/``storage.pin``,
+#5366/#4478) plus the #5653 known-gap disclosure.
+
+No mocks — drives the real ``run`` against a real :class:`MediaStore` write
+under ``tmp_path``, matching this command family's own established shape
+(``test_4364_pr3a_doctor_cli.py``).
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+from reyn.interfaces.cli.commands.doctor import run
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_real_media(project_root: Path, *, agent_name: str) -> int:
+    """Writes one real media file via the real ``MediaStore.save_media``
+    (post-#4478 ``<agent>/<session_id>/`` nesting) and returns its byte
+    count, so the doctor row's own number is checked against genuine
+    on-disk content, not a hand-computed guess."""
+    store = MediaStore(
+        MediaStoreConfig(),
+        project_root=project_root,
+        agent_name=agent_name,
+        session_id="s1",
+    )
+    data = b"x" * 777
+    store.save_media(data, mime_type="image/png")
+    return len(data)
+
+
+def test_storage_cap_row_reflects_declared_max_bytes_and_differs_when_unset(
+    tmp_path: Path, capsys,
+):
+    """Tier 2: accept-side — the SAME real on-disk media write produces a
+    DIFFERENT storage-cap row depending on whether ``storage.max_bytes``
+    is declared. Configured: names the real cap and the real measured
+    usage. Unconfigured (no ``storage:`` block, the field's own
+    documented default): says "unconfigured", never invents a number."""
+    written_bytes = _write_real_media(tmp_path, agent_name="alice")
+
+    # -- configured --
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        MINIMAL_REYN_YAML + "storage:\n  max_bytes: 100000\n  pin: [\"alice\"]\n",
+    )
+    run(Namespace(project_root=str(tmp_path)))
+    configured_out = capsys.readouterr().out
+    configured_line = next(
+        line for line in configured_out.splitlines() if "currently used" in line
+    )
+    assert "100,000" in configured_line
+    assert f"{written_bytes:,} bytes currently used" in configured_line
+    pin_line = next(line for line in configured_out.splitlines() if line.strip().startswith("storage.pin:"))
+    assert "alice" in pin_line
+
+    # -- unconfigured (same on-disk content, different config) --
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+    run(Namespace(project_root=str(tmp_path)))
+    unconfigured_out = capsys.readouterr().out
+    unconfigured_line = next(
+        line for line in unconfigured_out.splitlines() if "currently used" in line
+    )
+
+    assert configured_line != unconfigured_line
+    assert "unconfigured" in unconfigured_line
+
+    # #5653 known-gap disclosure — present in both runs, unconditionally.
+    assert "known gap (#5653)" in configured_out
+    assert "known gap (#5653)" in unconfigured_out
+
+
+def test_storage_cap_row_when_unconfigured_never_fabricates_a_number(
+    tmp_path: Path, capsys,
+):
+    """Tier 2: deny-side — with no ``storage:`` block at all (``max_bytes``
+    stays ``None``, the field's own default), the row must say
+    "unconfigured" and must NOT print the ``storage.max_bytes=<N>``
+    form at all — that literal substring only ever appears on the
+    configured branch, so its absence here is the falsifiable check that
+    no number was invented for the unset case."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    cap_line = next(line for line in out.splitlines() if "currently used" in line)
+    assert "unconfigured" in cap_line
+    assert "storage.max_bytes=" not in out


### PR DESCRIPTION
**[e2e-coder]** — part of #4364 (append-one-check-at-a-time arc; issue stays open).

## What

`reyn doctor` gains one new inspection: a **project-wide storage cap row** — `storage.max_bytes`/`storage.pin` (`StorageConfig`, #5366) next to the real measured usage, plus the #5653 known-gap disclosure. Per lead-coder's assignment on #4364: this is the "next check" now pickable because #4478's own residual audit closed (media/ + history-content share one project-wide cap since #4478; the remaining gap is filed as #5653, disclosed by this new row, not fixed here).

Sample output:

```
Project-wide storage cap (storage.max_bytes/pin, #5366/#4478 —
bounds media/ + tool-results/ TOGETHER, one operator number):
  ✓ storage.max_bytes=100,000: 777 bytes currently used
  storage.pin: alice
  ⚠ known gap (#5653): the cap pre-check runs only from a tool-result write — a media-only-heavy project's own save_media writes never self-trigger eviction on their own
```

Unconfigured (`storage.max_bytes` unset, the field's own default):

```
  storage.max_bytes: unconfigured (no project-wide cap — 777 bytes currently used, unbounded)
  storage.pin: none
  ⚠ known gap (#5653): ...
```

## Design notes

- **Single producer, no new measurement.** `_print_storage_cap_status` reuses the SAME `MediaStorageStats` `run()` already computed via `store.storage_stats()` (#5652's own recursive `_dir_stats_recursive`) — `media_bytes + tool_result_bytes` is exactly the population `MediaStore._evict_cross_session_over_cap` sums against `storage.max_bytes` (`tool_result_bytes` measures `.reyn/memory/history-content/` despite its legacy field name, per that method's own docstring). No second directory walk.
- **D-3 (never fabricate a number)**: `max_bytes=None` prints "unconfigured", never a "0 bytes" or any other invented cap value.
- **D-2 (report-only)**: this is visibility only — doctor never evicts, never calls `_evict_cross_session_over_cap`.
- **Comment-only staleness fix**: the section's own leading comment claimed "no declared retention policy exists for any of these yet (#4478/#4476 Phase 2 unimplemented)" — no longer true for media/ specifically since #4478. Corrected the comment (not the printed section header text, which `test_no_declared_policy_section_lists_all_three_unowned_resources` pins — still true for tool-results/history.jsonl, unchanged). Scope stayed to this one inspection; no other doctor check touched.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4364_storage_cap_doctor_row.py` — 2/2 OK, 0 Tier 4
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/doctor.py`
- [x] `python scripts/mypy_ratchet.py` — 200/207 baselined, 0 new pairs
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] All 8 `reyn doctor`-family test files — 56/56 green (nothing else regressed)
- [x] `tests/scripts/test_3126_doc_anchor_gate.py` — 356/356 green (no dangling anchors)
- [ ] (skipped — no interactive TUI surface; CLI-only output, exercised by the tests above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
