### PR TITLE
test(#4986): diagnostic-rich assertion for the flaky WAL-reconstruction test

### DIFF
--- a/tests/runtime/test_run_prompt_async_3978_p4e.py
+++ b/tests/runtime/test_run_prompt_async_3978_p4e.py
@@ -253,8 +253,88 @@ async def test_legacy_kind_none_chain_still_uses_the_relay_continuation_path(
     )
 
 
+def _wal_diagnostic_dump(
+    *, task_id: str, all_events: "list[dict]", caller, request: "pytest.FixtureRequest",
+) -> str:
+    """part of #4986: assertion-failure diagnostics ONLY — never changes
+    control flow, never sleeps, never retries (CLAUDE.md: a duration must
+    never be reached for by a test, in either direction). Assembled lazily
+    (an ``assert cond, msg`` message expression is only evaluated once
+    ``cond`` is already falsy — zero cost on the green path).
+
+    Surfaces exactly what lead-coder's own #4986 next-step named, so the
+    NEXT real CI red (7/7 today, 0/45 locally reproduced per this
+    session's own finding on that issue) answers its own reproduction
+    question directly, without a throwaway diagnostic branch/PR:
+
+    1. The WAL's own real ``(kind, chain_id)`` population at the moment
+       of failure — what IS there, not just that the expected entry
+       wasn't found.
+    2. Whether ``task_id`` exists under a DIFFERENT ``kind`` (a shape
+       mismatch) or not at all (genuinely absent) — these are different
+       failure classes and the plain assertion message could not tell
+       them apart.
+    3. ``DurabilityWorker``'s own drain state right after ``flush()``
+       returned — ``queue.qsize()`` / whether the drainer task itself
+       reports ``done()`` — the SAME internals :meth:`SnapshotJournal.
+       flush`'s own barrier depends on (see that method's docstring).
+    4. The xdist worker id and (to the extent ``request.node.session.
+       items`` exposes it — the list IS ordered per-worker, so the
+       immediately-PRECEDING entry is a real read, not a guess) the test
+       that ran immediately before this one in the SAME worker process —
+       the #4986 issue's own real-CI reports name a shared worker (gw2)
+       across unrelated failures as one live hypothesis."""
+    import os
+
+    kind_chain_pairs = [(e.get("kind"), e.get("chain_id")) for e in all_events]
+    same_chain_id_events = [e for e in all_events if e.get("chain_id") == task_id]
+    if same_chain_id_events:
+        shape_note = (
+            f"{len(same_chain_id_events)} WAL event(s) DO carry "
+            f"chain_id={task_id!r}, under kind(s)="
+            f"{sorted({str(e.get('kind')) for e in same_chain_id_events})!r} "
+            f"— not simply missing, a SHAPE mismatch"
+        )
+    else:
+        shape_note = (
+            f"NO WAL event anywhere carries chain_id={task_id!r} — "
+            f"genuinely absent, not a shape mismatch"
+        )
+
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "(not under xdist)")
+    prev_test = "(unknown — request.node not found in session.items)"
+    try:
+        items = request.node.session.items
+        idx = items.index(request.node)
+        prev_test = (
+            items[idx - 1].nodeid if idx > 0
+            else "(first test collected for this worker's own run)"
+        )
+    except Exception:  # noqa: BLE001 — diagnostic-only, must never mask the real assertion
+        pass
+
+    drain_state = "(no DurabilityWorker reached — StateLog has no worker)"
+    try:
+        dworker = caller._state_log._worker  # noqa: SLF001
+        qsize = dworker._queue.qsize() if dworker._queue is not None else "(queue never created)"  # noqa: SLF001
+        drainer_done = dworker._drainer.done() if dworker._drainer is not None else "(drainer never created)"  # noqa: SLF001
+        drain_state = f"queue.qsize()={qsize}, drainer.done()={drainer_done}"
+    except Exception:  # noqa: BLE001 — diagnostic-only, must never mask the real assertion
+        pass
+
+    return (
+        "\n  -- #4986 diagnostics (assertion-failure only; no retry, no sleep) --\n"
+        f"  WAL (kind, chain_id) pairs, replay order: {kind_chain_pairs}\n"
+        f"  {shape_note}\n"
+        f"  drain state right after flush(): {drain_state}\n"
+        f"  xdist worker: {worker!r}, previous test in this worker: {prev_test!r}\n"
+    )
+
+
 @pytest.mark.asyncio
-async def test_registered_chain_wal_event_reconstructs_with_the_right_shape(tmp_path):
+async def test_registered_chain_wal_event_reconstructs_with_the_right_shape(
+    tmp_path, request,
+):
     """Tier 2c: NOT a truncate-falsify test — this replays every WAL event
     from applied_seq=0 (nothing is truncated below any floor). The actual
     truncation-survives-WAL-truncation coverage for kind/waiting_on/
@@ -267,7 +347,14 @@ async def test_registered_chain_wal_event_reconstructs_with_the_right_shape(tmp_
     kind="prompt", the correct waiting_on, the correct requester — i.e.
     did this producer's call to register() pass what it claims to, proven
     by reading it back via pure WAL replay rather than trusting the
-    in-memory chain object alone."""
+    in-memory chain object alone.
+
+    part of #4986: both assertions below carry a diagnostic dump on
+    failure only (see :func:`_wal_diagnostic_dump`) — this test's own
+    flakiness on CI (Python 3.12 only, 7/7 today, 0/45 reproduced
+    locally per this session's own finding on that issue) has no known
+    reproduction recipe yet; the next real red now answers its own
+    question instead of needing a second investigation pass."""
     reg = _make_registry(tmp_path)
     _seed(tmp_path, "alpha")
     _seed(tmp_path, "beta")
@@ -289,13 +376,21 @@ async def test_registered_chain_wal_event_reconstructs_with_the_right_shape(tmp_
         e for e in all_events
         if e.get("kind") == "chain_register" and e.get("chain_id") == task_id
     ]
-    assert chain_events, f"no chain_register WAL event found for {task_id!r}"
+    assert chain_events, (
+        f"no chain_register WAL event found for {task_id!r}"
+        + _wal_diagnostic_dump(
+            task_id=task_id, all_events=all_events, caller=caller, request=request,
+        )
+    )
 
     replayed = AgentSnapshot.empty("alpha")
     replayed.apply_events(all_events)
     reconstructed = replayed.pending_chains.get(task_id)
     assert reconstructed is not None, (
         f"chain {task_id!r} must reconstruct from pure WAL replay"
+        + _wal_diagnostic_dump(
+            task_id=task_id, all_events=all_events, caller=caller, request=request,
+        )
     )
     assert reconstructed["task_kind"] == "prompt"
     assert reconstructed["waiting_on"] == ["beta"]


### PR DESCRIPTION
**[e2e-coder]** — part of #4986.

## What

Enriches `test_registered_chain_wal_event_reconstructs_with_the_right_shape`'s own two assertions with real diagnostics, so the **next** real CI red (7/7 today, 0/45 reproduced locally per this session's own finding on the issue) answers its own reproduction question directly — no throwaway diagnostic branch/PR (lead-coder's own ruling on this: a diagnostic-only branch consumes a whole CI queue slot and is discarded; this form is a permanent improvement).

## What's in the diagnostic dump (assertion-failure only)

1. **The WAL's own real `(kind, chain_id)` population** at the moment of failure — what IS there, not just that the expected entry wasn't found.
2. **Shape vs. absence**: whether `task_id` exists under a DIFFERENT `kind` (a shape mismatch) or not at all (genuinely absent) — the plain assertion message couldn't distinguish these, and they point at different mechanisms.
3. **`DurabilityWorker`'s own drain state** right after `flush()` returns: `queue.qsize()` / `drainer.done()` — the same internals `SnapshotJournal.flush`'s own barrier depends on.
4. **xdist worker id + the immediately-preceding test in that worker** — via `request.node.session.items` (already ordered per-worker by xdist; no new global hook, no `conftest.py` change). The issue's own real-CI reports name a shared worker (`gw2`) across unrelated failures as one live hypothesis.

## Design notes

- **Diagnostics only — zero behavior change.** No `sleep`, no retry (CLAUDE.md: a duration must never be reached for by a test, and "wait it into passing" hides the symptom rather than surfacing it). The dump is built lazily — `assert cond, msg`'s own `msg` expression is only evaluated once `cond` is already falsy, so this costs nothing on the green path.
- **Defensively safe**: every internals-reaching lookup (the `DurabilityWorker` chain, `request.node.session.items`) is wrapped in a broad `except Exception` — a diagnostic that itself crashes would replace the real, informative `AssertionError` with a confusing secondary one, which would be strictly worse than the plain message this PR is improving on.
- **Verified via genuine strip-falsify**: deliberately broke the assertion (`.get("deliberately-wrong-id")` instead of the real `task_id`), confirmed the exact diagnostic block renders — both single-process and under real `-n auto` (`-n 2`, 2 test files) — then restored. Output samples in the commit message.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_run_prompt_async_3978_p4e.py` — 5/5 OK, 0 Tier 4
- [x] `python scripts/mypy_ratchet.py` — 200/207 baselined, 0 new pairs
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] `tests/scripts/test_3126_doc_anchor_gate.py` — 356/356 green
- [x] All 5 tests in the touched file green, both standalone and under `-n auto` xdist
- [x] Genuine strip-falsify of both diagnostic call sites (see Design notes)
- [ ] (skipped — no user-visible surface; test-diagnostics only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
