### PR TITLE
fix(#5633): forward compaction_started to the TUI as a marker

### DIFF
--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -180,13 +180,41 @@ class ChatLifecycleForwarder:
 
     # ── Compaction (issue #162) ──────────────────────────────────────────
 
+    def on_compaction_started(self, data: dict) -> None:
+        """Surface a ``[⟳ compacting N turns]`` marker when a real compaction
+        pass begins (#5633 — owner: "縮小フロー開始開始通知みたいなものは tui
+        で受けてないのかしら？").
+
+        Before this handler, ``completed``/``failed`` both had a marker but
+        ``started`` had none — asymmetric, and the gap this issue's own
+        finding names: the event was emitted (``engine.py``'s
+        ``compact()``), nothing in ``src/reyn/interfaces/`` ever consumed it.
+
+        Deliberately independent of #5618/#5630's `is_compacting`/
+        `recovery_episode` progress-row gate — that is STATE a polling
+        consumer reads each frame; this is an EDGE, a one-line transcript
+        marker for the moment compaction begins, the same shape
+        ``on_compaction_completed``/``on_compaction_failed`` already use for
+        their own edges. Neither replaces the other: the progress row answers
+        "is it running right now", this marker answers "something just
+        started" for a reader who was not watching the row at that instant.
+
+        ``new_turn_count`` mirrors ``on_compaction_completed``'s own field
+        name for the same count (this pass's target, not its result) —
+        absent degrades to a generic marker, never a fabricated count."""
+        count = data.get("new_turn_count")
+        if isinstance(count, int) and count > 0:
+            self._enqueue(f"[⟳ compacting {count} turn{'s' if count != 1 else ''}]")
+        else:
+            self._enqueue("[⟳ compacting history]")
+
     def on_compaction_failed(self, data: dict) -> None:
         """Surface a ``[✗ compaction failed: <reason>]`` error marker.
 
         ``compaction_controller.py`` emits ``compaction_failed`` when the
         summarisation LLM call raises. Without this handler the user sees the
-        ``compaction_started`` side-effect (spinner clears) but gets no signal
-        that compaction silently failed — early turns are still unsummarised and
+        ``compaction_started`` marker (#5633) but gets no signal that
+        compaction silently failed — early turns are still unsummarised and
         context pressure continues unrelieved.
         """
         reason = str(data.get("error") or "unknown error")

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -380,18 +380,18 @@ class CompactionController:
         self._compacting = True
         try:
             await self._run_compaction(candidates, latest)
-        except Exception as exc:
-            # #5633: CompactionEngine.compact() now emits its OWN
-            # `compaction_failed` (the same "one real entry" argument
-            # #5475 already made for `compaction_started` — see
-            # compact()'s own docstring) and marks the exception it raises
-            # with `_reyn_compaction_failed_emitted` so this catch-all
-            # (which also covers failures in THIS method's own post-
-            # compact() work — `_append_history`/`_render_summary`, not
-            # reached by compact()'s own try) doesn't emit a second
-            # `compaction_failed` for the identical failure.
-            if not getattr(exc, "_reyn_compaction_failed_emitted", False):
-                self._events.emit("compaction_failed", error=str(exc))
+        except Exception:
+            # #5633 (lead-coder review): NOT re-emitted here. Whatever
+            # `_run_compaction` raises has already had its own
+            # `compaction_failed` emitted at its own origin —
+            # `CompactionEngine.compact()`'s own except for a compact()
+            # failure, or `_run_compaction`'s own post-processing
+            # `try`/`except` for anything after `compact()` returns (see
+            # `_run_compaction`'s own comment for why those two `try`
+            # blocks never overlap). This bare catch exists only so a
+            # compaction failure never propagates past `force_compact_now`
+            # to ITS OWN caller.
+            pass
         finally:
             self._compacting = False
 
@@ -522,39 +522,58 @@ class CompactionController:
         # rejected). This caller's own real `seq` (`candidates[-1].seq` —
         # unlike retry_loop's wire-dict turns, `_turn_to_compactor_input`
         # keeps `seq` per turn) is passed through explicitly.
+        # #5633 (lead-coder review): deliberately OUTSIDE any try/except in
+        # THIS method — a compact() failure is already fully handled at its
+        # own origin (CompactionEngine.compact()'s own except emits
+        # `compaction_failed` and re-raises; see its own docstring). Nothing
+        # here may also catch it: which side emits for a given failure is
+        # decided STRUCTURALLY, by which try/except block the failure
+        # physically raises inside, never by a caller re-inspecting the
+        # exception for a marker.
         chat_summary = await self._engine.compact(
             input_chunk, covers_through=candidates[-1].seq,
         )
-        structured = chat_summary.to_dict()
-        covers = chat_summary.covers_through_seq or candidates[-1].seq
-        # #1820 Part1: frame the rendered summary with a static reference-only
-        # preamble (Hermes SUMMARY_PREFIX analog) so the model treats the summary as
-        # history — NOT a fresh instruction — and does not re-execute `pending` work
-        # after a reverse-signal (stop / undo / change of direction). Prepended here
-        # (controller-owned, render-fn-independent) so every rendered summary carries
-        # it. Static string → no LLM dependency.
-        rendered = _SUMMARY_PREAMBLE + self._render_summary(structured)
+        try:
+            structured = chat_summary.to_dict()
+            covers = chat_summary.covers_through_seq or candidates[-1].seq
+            # #1820 Part1: frame the rendered summary with a static reference-only
+            # preamble (Hermes SUMMARY_PREFIX analog) so the model treats the summary as
+            # history — NOT a fresh instruction — and does not re-execute `pending` work
+            # after a reverse-signal (stop / undo / change of direction). Prepended here
+            # (controller-owned, render-fn-independent) so every rendered summary carries
+            # it. Static string → no LLM dependency.
+            rendered = _SUMMARY_PREAMBLE + self._render_summary(structured)
 
-        summary_msg = self._make_summary_message(rendered, structured, covers)
-        self._append_history(summary_msg)
-        self._events.emit(
-            "compaction_completed",
-            new_turn_count=new_turn_count,
-            covers_through_seq=covers,
-            section_lengths={
-                k: len(v) if isinstance(v, list) else len(str(v))
-                for k, v in structured.items()
-                if k != "covers_through_seq"
-            },
-            # #4703 axis①: the compact() LLM call's own real usage — see
-            # ChatSummary's own docstring for why it lives there and not in
-            # ``structured``/``to_dict()`` (never persisted to history.jsonl).
-            # None only when usage genuinely could not be read off the
-            # response — never coerced to 0.
-            prompt_tokens=chat_summary.prompt_tokens,
-            completion_tokens=chat_summary.completion_tokens,
-            cost_usd=chat_summary.cost_usd,
-        )
+            summary_msg = self._make_summary_message(rendered, structured, covers)
+            self._append_history(summary_msg)
+            self._events.emit(
+                "compaction_completed",
+                new_turn_count=new_turn_count,
+                covers_through_seq=covers,
+                section_lengths={
+                    k: len(v) if isinstance(v, list) else len(str(v))
+                    for k, v in structured.items()
+                    if k != "covers_through_seq"
+                },
+                # #4703 axis①: the compact() LLM call's own real usage — see
+                # ChatSummary's own docstring for why it lives there and not in
+                # ``structured``/``to_dict()`` (never persisted to history.jsonl).
+                # None only when usage genuinely could not be read off the
+                # response — never coerced to 0.
+                prompt_tokens=chat_summary.prompt_tokens,
+                completion_tokens=chat_summary.completion_tokens,
+                cost_usd=chat_summary.cost_usd,
+            )
+        except Exception as exc:
+            # #5633: this method's OWN failure surface — everything AFTER
+            # compact() returns a real ChatSummary (rendering, persisting,
+            # emitting compaction_completed). compact() itself is outside
+            # this try (see the comment above it) so its own failures can
+            # never reach here — this except only ever fires for a
+            # genuinely NEW failure, never the same one compact() already
+            # emitted `compaction_failed` for.
+            self._events.emit("compaction_failed", error=str(exc))
+            raise
 
 
 __all__ = ["CompactionController"]

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -381,7 +381,17 @@ class CompactionController:
         try:
             await self._run_compaction(candidates, latest)
         except Exception as exc:
-            self._events.emit("compaction_failed", error=str(exc))
+            # #5633: CompactionEngine.compact() now emits its OWN
+            # `compaction_failed` (the same "one real entry" argument
+            # #5475 already made for `compaction_started` — see
+            # compact()'s own docstring) and marks the exception it raises
+            # with `_reyn_compaction_failed_emitted` so this catch-all
+            # (which also covers failures in THIS method's own post-
+            # compact() work — `_append_history`/`_render_summary`, not
+            # reached by compact()'s own try) doesn't emit a second
+            # `compaction_failed` for the identical failure.
+            if not getattr(exc, "_reyn_compaction_failed_emitted", False):
+                self._events.emit("compaction_failed", error=str(exc))
         finally:
             self._compacting = False
 

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -470,47 +470,66 @@ class CompactionController:
     ) -> None:
         """Call the compaction engine and persist the resulting summary entry."""
         cfg = self._config
-        prev_structured: dict | None = None
-        if previous_summary is not None:
-            meta = previous_summary.meta or {}
-            structured = meta.get("structured")
-            if isinstance(structured, dict):
-                prev_structured = structured
-                # carry forward the prior covers_through_seq for continuity
-                if "covers_through_seq" not in prev_structured:
-                    prev_structured = {
-                        **prev_structured,
-                        "covers_through_seq": meta.get("covers_through_seq", 0),
-                    }
+        # #5633 (lead-coder review, the gap the first restructure left
+        # silent): this setup segment — building prev_structured, redact,
+        # the input_chunk's own list comprehension over `candidates` — runs
+        # BEFORE compact() is ever called, so compaction_started has not
+        # fired yet on THIS attempt; before this PR, force_compact_now's
+        # own catch-all still emitted `compaction_failed` for a failure
+        # here (an observability regression this PR would otherwise have
+        # introduced, not merely a dangling-marker gap). Its own try/except
+        # keeps compact() itself the only call outside any local try (see
+        # the comment just above that call).
+        try:
+            prev_structured: dict | None = None
+            if previous_summary is not None:
+                meta = previous_summary.meta or {}
+                structured = meta.get("structured")
+                if isinstance(structured, dict):
+                    prev_structured = structured
+                    # carry forward the prior covers_through_seq for continuity
+                    if "covers_through_seq" not in prev_structured:
+                        prev_structured = {
+                            **prev_structured,
+                            "covers_through_seq": meta.get("covers_through_seq", 0),
+                        }
 
-        # FP-0050/#1822 S3 (#1820): strip credential/token values from turn text
-        # before it enters the summarizer input (so secrets aren't baked into the
-        # persisted summary). Gated by threat_scan.enabled; None/disabled → no-op.
-        _ts = self._threat_scan
-        _redact = None
-        if _ts is not None and getattr(_ts, "enabled", True):  # #4523: shadow default matches ThreatScanConfig.enabled's own declared True
-            from reyn.security.secret_redaction import redact_secrets
-            _redact = redact_secrets
-        # #5531 condition③: this caller is always tail-side — `candidates`
-        # comes from `_select_candidates(turns, prev_cover)`, which only
-        # ever returns turns chronologically AFTER `prev_cover` (the prior
-        # summary's own covers_through_seq) — so the order is always
-        # summary-then-new-turns, never the reverse (that only happens in
-        # retry_loop's own head-shrink path, engine.py).
-        _summary_messages = (
-            [wrap_summary_as_message(prev_structured)] if prev_structured else []
-        )
-        input_chunk = HistoryChunkToCompact(
-            messages=_summary_messages
-            + [_turn_to_compactor_input(t, redact=_redact) for t in candidates],
-            section_token_caps={
-                "topic_arc": cfg.section_token_caps.topic_arc,
-                "decisions": cfg.section_token_caps.decisions,
-                "pending": cfg.section_token_caps.pending,
-                "session_user_facts": cfg.section_token_caps.session_user_facts,
-                "artifacts_referenced": cfg.section_token_caps.artifacts_referenced,
-            },
-        )
+            # FP-0050/#1822 S3 (#1820): strip credential/token values from turn text
+            # before it enters the summarizer input (so secrets aren't baked into the
+            # persisted summary). Gated by threat_scan.enabled; None/disabled → no-op.
+            _ts = self._threat_scan
+            _redact = None
+            if _ts is not None and getattr(_ts, "enabled", True):  # #4523: shadow default matches ThreatScanConfig.enabled's own declared True
+                from reyn.security.secret_redaction import redact_secrets
+                _redact = redact_secrets
+            # #5531 condition③: this caller is always tail-side — `candidates`
+            # comes from `_select_candidates(turns, prev_cover)`, which only
+            # ever returns turns chronologically AFTER `prev_cover` (the prior
+            # summary's own covers_through_seq) — so the order is always
+            # summary-then-new-turns, never the reverse (that only happens in
+            # retry_loop's own head-shrink path, engine.py).
+            _summary_messages = (
+                [wrap_summary_as_message(prev_structured)] if prev_structured else []
+            )
+            input_chunk = HistoryChunkToCompact(
+                messages=_summary_messages
+                + [_turn_to_compactor_input(t, redact=_redact) for t in candidates],
+                section_token_caps={
+                    "topic_arc": cfg.section_token_caps.topic_arc,
+                    "decisions": cfg.section_token_caps.decisions,
+                    "pending": cfg.section_token_caps.pending,
+                    "session_user_facts": cfg.section_token_caps.session_user_facts,
+                    "artifacts_referenced": cfg.section_token_caps.artifacts_referenced,
+                },
+            )
+        except Exception as exc:
+            # #5633: this segment's OWN failure surface — see the comment
+            # above the try for why it needs one (compaction_started has
+            # not fired yet here, but the pre-#5633 catch-all DID emit for
+            # this segment, so omitting this try/except would be a
+            # regression, not merely a non-issue).
+            self._events.emit("compaction_failed", error=str(exc))
+            raise
 
         new_turn_count = len(candidates)
         # #5475 (architect ruling): compaction_started now emits at

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1991,12 +1991,15 @@ class CompactionEngine:
         to ensure the body ≤ body_budget tokens deterministically.
 
         Re-raises on LLM/validation error, after emitting ``compaction_failed``
-        itself (see below) — a caller MAY additionally emit its own
-        ``compaction_failed`` for a failure in its own post-``compact()``
-        work (``CompactionController._run_compaction``'s own post-processing:
-        ``_append_history``/``_render_summary`` etc.), but must first check
-        the raised exception for ``_reyn_compaction_failed_emitted`` (set
-        below) to avoid a duplicate emission for the SAME failure.
+        itself (see below) — bare, with no marker attribute written on the
+        exception. A caller's own code that runs AFTER this call returns
+        (``CompactionController._run_compaction``'s own post-processing:
+        ``_append_history``/``_render_summary`` etc.) needs its OWN
+        ``try``/``except`` around just that work to close the marker for
+        ITS OWN failures — never around this call too, or the same
+        failure would emit twice. See that method's own comment for the
+        structural (not marker-based) way it keeps the two `try` blocks
+        from overlapping.
 
         #5475 (architect ruling): emits ``compaction_started`` HERE, at the
         one real entry both of this engine's callers share
@@ -2381,12 +2384,15 @@ class CompactionEngine:
             )
         except Exception as exc:
             self._events.emit("compaction_failed", error=str(exc))
-            # #5633: mark so CompactionController's own except (the
-            # controller-path's OTHER failure surface -- post-processing
-            # after this call returns, e.g. _append_history/_render_summary
-            # raising) doesn't emit a SECOND compaction_failed for the
-            # SAME failure -- see compaction_controller.py's own check.
-            exc._reyn_compaction_failed_emitted = True  # type: ignore[attr-defined]
+            # #5633 (lead-coder review, structural not agreement-based):
+            # no marker is written on *exc* here. Which side emits
+            # `compaction_failed` for a given failure is decided by WHICH
+            # try/except catches it, not by a third party inspecting an
+            # attribute a foreign exception happens to carry --
+            # CompactionController._run_compaction's own except around
+            # THIS call (if any exists at a caller) must not ALSO emit;
+            # see that method's own comment on why its try/except split
+            # keeps this call outside the block that emits.
             raise
 
 

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1990,8 +1990,13 @@ class CompactionEngine:
         Axis 9: applies hard_truncate_summary to the returned topic_arc
         to ensure the body ≤ body_budget tokens deterministically.
 
-        Raises on LLM error; callers wrap in try/except and emit
-        ``compaction_failed`` if needed.
+        Re-raises on LLM/validation error, after emitting ``compaction_failed``
+        itself (see below) — a caller MAY additionally emit its own
+        ``compaction_failed`` for a failure in its own post-``compact()``
+        work (``CompactionController._run_compaction``'s own post-processing:
+        ``_append_history``/``_render_summary`` etc.), but must first check
+        the raised exception for ``_reyn_compaction_failed_emitted`` (set
+        below) to avoid a duplicate emission for the SAME failure.
 
         #5475 (architect ruling): emits ``compaction_started`` HERE, at the
         one real entry both of this engine's callers share
@@ -1999,7 +2004,19 @@ class CompactionEngine:
         internal compaction attempts) — moved from ``CompactionController``,
         not duplicated (the controller's own former emit is deleted in the
         same change; see #5382/#5455 for why two emit sites for the same
-        kind is the shape this repo rejects). ``new_turn_count``/
+        kind is the shape this repo rejects).
+
+        #5633 (lead-coder finding on PR #5661): ``compaction_failed`` emits
+        HERE too, for the same reason — ``retry_loop``'s own internal
+        compaction attempts (``RecoveryLadder._stage_fold``) had NO
+        ``compaction_failed`` emit anywhere on failure (only
+        ``CompactionController.force_compact_now`` did, #384 in
+        ``compaction_controller.py``), so a ``compaction_started`` marker
+        the TUI shows for a failed ladder-path fold never closed. Emitting
+        here closes it for BOTH callers, the same "one real entry" argument
+        #5475 already made for ``compaction_started``.
+
+        ``new_turn_count``/
         ``had_previous`` are derived from *input_chunk* alone — both are
         genuinely available to every caller. ``covers_through`` is NOT: the
         controller's own caller can supply a real seq (its ``new_turns``
@@ -2054,313 +2071,323 @@ class CompactionEngine:
             input_chars=input_chars,
         )
 
-        # No `_token_cache.clear()` here (removed, #2937): text is immutable and
-        # the tokenizer/fallback choice is a fixed per-session config, so a
-        # cached (model, text) count is valid for the process's entire
-        # lifetime — clearing it had no staleness justification. It forced a
-        # COLD, synchronous, full-history re-tokenization on every turn right
-        # after a compaction (build_history() re-estimates the whole raw
-        # history every turn to check the elide trigger) — on a long
-        # conversation this froze the event loop for real, user-visible
-        # seconds, repeating every time compaction fired again as the chat
-        # kept growing. The cache is now LRU-bounded (`_token_cache_put`)
-        # instead of periodically nuked, so it stays warm (the perf fix)
-        # without growing unboundedly (the memory-leak risk a naive removal
-        # of the clear would have traded it for).
+        try:
+            # No `_token_cache.clear()` here (removed, #2937): text is immutable and
+            # the tokenizer/fallback choice is a fixed per-session config, so a
+            # cached (model, text) count is valid for the process's entire
+            # lifetime — clearing it had no staleness justification. It forced a
+            # COLD, synchronous, full-history re-tokenization on every turn right
+            # after a compaction (build_history() re-estimates the whole raw
+            # history every turn to check the elide trigger) — on a long
+            # conversation this froze the event loop for real, user-visible
+            # seconds, repeating every time compaction fired again as the chat
+            # kept growing. The cache is now LRU-bounded (`_token_cache_put`)
+            # instead of periodically nuked, so it stays warm (the perf fix)
+            # without growing unboundedly (the memory-leak risk a naive removal
+            # of the clear would have traded it for).
 
-        # #5531: `messages` (the single ordered list, condition④) is the
-        # whole wire payload — no separate previous_summary/new_turns
-        # keys to keep in sync with each other (that split is exactly
-        # what made B's append-only prompt framing unfixable per-call:
-        # 2 fields cannot express "which side did the new content come
-        # from").
-        user_content = json.dumps({
-            "messages": input_chunk.messages,
-            "section_token_caps": input_chunk.section_token_caps,
-        }, ensure_ascii=False)
+            # #5531: `messages` (the single ordered list, condition④) is the
+            # whole wire payload — no separate previous_summary/new_turns
+            # keys to keep in sync with each other (that split is exactly
+            # what made B's append-only prompt framing unfixable per-call:
+            # 2 fields cannot express "which side did the new content come
+            # from").
+            user_content = json.dumps({
+                "messages": input_chunk.messages,
+                "section_token_caps": input_chunk.section_token_caps,
+            }, ensure_ascii=False)
 
-        llm_messages = [
-            {"role": "system", "content": _COMPACTION_SYSTEM_PROMPT},
-            {"role": "user", "content": user_content},
-        ]
+            llm_messages = [
+                {"role": "system", "content": _COMPACTION_SYSTEM_PROMPT},
+                {"role": "user", "content": user_content},
+            ]
 
-        # #4883: the compaction JSON has no required fields (response_format
-        # is {"type": "json_object"} — "must be JSON", not "must have these
-        # keys"). A syntactically-valid-but-structurally-empty response
-        # (e.g. "{}") previously passed through untouched: topic_arc
-        # missing -> "" -> an empty summary silently overwrote the real
-        # turns in history, with no error and no re-prompt. topic_arc IS
-        # the summary, so its absence/emptiness is now a validation
-        # failure, not a silently-accepted default — bounded re-prompt
-        # (same shape 0062's schema_validate_fn uses in router_loop.py),
-        # then raise if still invalid, joining the existing "raise on
-        # empty response" safety net below (compaction_controller.py's
-        # caller already wraps this in try/except and emits
-        # compaction_failed + never calls _append_history on any raise here
-        # — the ONLY change in observable behavior on failure is WHICH cases
-        # raise, not what raising does).
-        #
-        # #4951-B: this used to also name new_turn_seqs as a second
-        # load-bearing field validated here ("covers_through_seq decides
-        # what's now unrecoverable via this call's own fallback"). No
-        # longer true — new_turn_seqs is not in the schema at all now
-        # (removed, see _CHAT_SUMMARY_JSON_SCHEMA's own comment), so there
-        # is nothing to validate: covers_through_seq is derived
-        # unconditionally from compact()'s own input below, never from
-        # this response.
-        max_attempts = 1 + max(0, int(getattr(self._cfg, "max_schema_reprompt_attempts", 1)))
-        # #4883: schema-constrained generation when the model supports it
-        # (json_schema, strict) — the GENERATION-time leg; json_object is
-        # the fallback for models the capability precheck says do not (or
-        # cannot be determined to) support it. Post-parse validation below
-        # is the floor in BOTH cases (see _CHAT_SUMMARY_JSON_SCHEMA's own
-        # docstring for why schema constraints alone can't replace it).
-        #
-        # DELIBERATELY the opposite of 0062's own unsupported-model
-        # behavior — do not unify these two just because they share the
-        # same capability check (architect/lead-coder, #4883): 0062 §2.1
-        # raises StructuredOutputUnsupportedModelError with NO silent
-        # fallback because an AgentStep's caller explicitly asked for
-        # structured output — an unsupported model is THAT step's own
-        # failure, contained to one step. Compaction never had a
-        # schema-constrained contract to violate; it is an opportunistic
-        # upgrade to an existing best-effort call, and its failure mode is
-        # different in kind: raising here means the context window never
-        # opens back up, i.e. the conversation itself cannot continue —
-        # turning "summary quality isn't guaranteed" into "the session is
-        # stuck" would be strictly worse than today. So compaction degrades
-        # instead of raising on an unsupported model — the post-parse
-        # validation floor is what still catches an empty/malformed
-        # json_object response either way.
-        #
-        # The degrade decision is made HERE, before the call — not by
-        # catching a provider rejection and retrying without
-        # response_format (fallback_without_response_format stays False
-        # below, on BOTH legs). 0062's own text is explicit about why (its
-        # capability precheck exists precisely so the call never has to
-        # find out the hard way): "Do NOT catch-classify a provider
-        # rejection for this — a raw 400 can't be reliably told apart from
-        # transient/other errors." A provider rejection despite a True
-        # precheck (the capability table lagging reality) is therefore a
-        # genuine call failure, not a signal to silently retry a
-        # differently-shaped request — it propagates like any other
-        # `_acompletion` failure, caught by CompactionController's
-        # existing try/except (-> compaction_failed), which is the
-        # pre-existing safety net this fix already leans on for the
-        # exhausted-reprompt-budget case above.
-        if await _supports_structured_output(self._model):
-            _response_format = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "compaction_chat_summary",
-                    "schema": _CHAT_SUMMARY_JSON_SCHEMA,
-                    "strict": True,
-                },
-            }
-        else:
-            _response_format = {"type": "json_object"}
-        _fallback_without_rf = False
-        parsed: dict = {}
-        raw = ""
-        response = None
-        reprompt_messages = list(llm_messages)
-        validation_errors: list[str] = []
-        for attempt in range(max_attempts):
-            response = await self._acompletion(
-                reprompt_messages,
-                response_format=_response_format,
-                fallback_without_response_format=_fallback_without_rf,
-            )
-            raw = (response.choices[0].message.content or "").strip()
-            if not raw:
+            # #4883: the compaction JSON has no required fields (response_format
+            # is {"type": "json_object"} — "must be JSON", not "must have these
+            # keys"). A syntactically-valid-but-structurally-empty response
+            # (e.g. "{}") previously passed through untouched: topic_arc
+            # missing -> "" -> an empty summary silently overwrote the real
+            # turns in history, with no error and no re-prompt. topic_arc IS
+            # the summary, so its absence/emptiness is now a validation
+            # failure, not a silently-accepted default — bounded re-prompt
+            # (same shape 0062's schema_validate_fn uses in router_loop.py),
+            # then raise if still invalid, joining the existing "raise on
+            # empty response" safety net below (compaction_controller.py's
+            # caller already wraps this in try/except and emits
+            # compaction_failed + never calls _append_history on any raise here
+            # — the ONLY change in observable behavior on failure is WHICH cases
+            # raise, not what raising does).
+            #
+            # #4951-B: this used to also name new_turn_seqs as a second
+            # load-bearing field validated here ("covers_through_seq decides
+            # what's now unrecoverable via this call's own fallback"). No
+            # longer true — new_turn_seqs is not in the schema at all now
+            # (removed, see _CHAT_SUMMARY_JSON_SCHEMA's own comment), so there
+            # is nothing to validate: covers_through_seq is derived
+            # unconditionally from compact()'s own input below, never from
+            # this response.
+            max_attempts = 1 + max(0, int(getattr(self._cfg, "max_schema_reprompt_attempts", 1)))
+            # #4883: schema-constrained generation when the model supports it
+            # (json_schema, strict) — the GENERATION-time leg; json_object is
+            # the fallback for models the capability precheck says do not (or
+            # cannot be determined to) support it. Post-parse validation below
+            # is the floor in BOTH cases (see _CHAT_SUMMARY_JSON_SCHEMA's own
+            # docstring for why schema constraints alone can't replace it).
+            #
+            # DELIBERATELY the opposite of 0062's own unsupported-model
+            # behavior — do not unify these two just because they share the
+            # same capability check (architect/lead-coder, #4883): 0062 §2.1
+            # raises StructuredOutputUnsupportedModelError with NO silent
+            # fallback because an AgentStep's caller explicitly asked for
+            # structured output — an unsupported model is THAT step's own
+            # failure, contained to one step. Compaction never had a
+            # schema-constrained contract to violate; it is an opportunistic
+            # upgrade to an existing best-effort call, and its failure mode is
+            # different in kind: raising here means the context window never
+            # opens back up, i.e. the conversation itself cannot continue —
+            # turning "summary quality isn't guaranteed" into "the session is
+            # stuck" would be strictly worse than today. So compaction degrades
+            # instead of raising on an unsupported model — the post-parse
+            # validation floor is what still catches an empty/malformed
+            # json_object response either way.
+            #
+            # The degrade decision is made HERE, before the call — not by
+            # catching a provider rejection and retrying without
+            # response_format (fallback_without_response_format stays False
+            # below, on BOTH legs). 0062's own text is explicit about why (its
+            # capability precheck exists precisely so the call never has to
+            # find out the hard way): "Do NOT catch-classify a provider
+            # rejection for this — a raw 400 can't be reliably told apart from
+            # transient/other errors." A provider rejection despite a True
+            # precheck (the capability table lagging reality) is therefore a
+            # genuine call failure, not a signal to silently retry a
+            # differently-shaped request — it propagates like any other
+            # `_acompletion` failure, caught by CompactionController's
+            # existing try/except (-> compaction_failed), which is the
+            # pre-existing safety net this fix already leans on for the
+            # exhausted-reprompt-budget case above.
+            if await _supports_structured_output(self._model):
+                _response_format = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "compaction_chat_summary",
+                        "schema": _CHAT_SUMMARY_JSON_SCHEMA,
+                        "strict": True,
+                    },
+                }
+            else:
+                _response_format = {"type": "json_object"}
+            _fallback_without_rf = False
+            parsed: dict = {}
+            raw = ""
+            response = None
+            reprompt_messages = list(llm_messages)
+            validation_errors: list[str] = []
+            for attempt in range(max_attempts):
+                response = await self._acompletion(
+                    reprompt_messages,
+                    response_format=_response_format,
+                    fallback_without_response_format=_fallback_without_rf,
+                )
+                raw = (response.choices[0].message.content or "").strip()
+                if not raw:
+                    if attempt + 1 < max_attempts:
+                        validation_errors = ["response was empty"]
+                        self._events.emit(
+                            "compaction_schema_invalid",
+                            attempt=attempt,
+                            max_attempts=max_attempts,
+                            errors=validation_errors,
+                        )
+                        reprompt_messages = _append_schema_reprompt(
+                            reprompt_messages, raw, validation_errors,
+                        )
+                        continue
+                    raise ValueError("compaction LLM returned empty response")
+
+                parsed = loads_lenient(
+                    raw,
+                    on_raw_decode=lambda discarded_len, head: logger.warning(
+                        "compaction_json_raw_decode_recovered: discarded %d bytes of "
+                        "trailing garbage after valid JSON object. head=%r",
+                        discarded_len,
+                        head,
+                    ),
+                )
+                validation_errors = _validate_chat_summary_fields(parsed)
+                if not validation_errors:
+                    break
+                self._events.emit(
+                    "compaction_schema_invalid",
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    errors=validation_errors,
+                )
                 if attempt + 1 < max_attempts:
-                    validation_errors = ["response was empty"]
-                    self._events.emit(
-                        "compaction_schema_invalid",
-                        attempt=attempt,
-                        max_attempts=max_attempts,
-                        errors=validation_errors,
-                    )
                     reprompt_messages = _append_schema_reprompt(
                         reprompt_messages, raw, validation_errors,
                     )
                     continue
-                raise ValueError("compaction LLM returned empty response")
-
-            parsed = loads_lenient(
-                raw,
-                on_raw_decode=lambda discarded_len, head: logger.warning(
-                    "compaction_json_raw_decode_recovered: discarded %d bytes of "
-                    "trailing garbage after valid JSON object. head=%r",
-                    discarded_len,
-                    head,
-                ),
-            )
-            validation_errors = _validate_chat_summary_fields(parsed)
-            if not validation_errors:
-                break
-            self._events.emit(
-                "compaction_schema_invalid",
-                attempt=attempt,
-                max_attempts=max_attempts,
-                errors=validation_errors,
-            )
-            if attempt + 1 < max_attempts:
-                reprompt_messages = _append_schema_reprompt(
-                    reprompt_messages, raw, validation_errors,
+                raise ValueError(
+                    f"compaction LLM response missing required fields after "
+                    f"{max_attempts} attempt(s): {validation_errors}"
                 )
-                continue
-            raise ValueError(
-                f"compaction LLM response missing required fields after "
-                f"{max_attempts} attempt(s): {validation_errors}"
+
+            # #4703 axis①: this call's own usage, for the compaction_completed
+            # marker CompactionController emits below (never a resummarize-pass
+            # call's usage — those are a rare, bounded-to-1-by-default backstop;
+            # the primary compact() call is the dominant cost, and capturing
+            # every resummarize pass too would need threading usage out of
+            # _resummarize_topic_arc as well, a disclosed follow-up, not silent
+            # scope creep). None if usage genuinely could not be read off the
+            # response — never coerced to 0. Reflects the FINAL (successful)
+            # attempt only — a re-prompt's own usage is not summed in, the same
+            # "primary call dominates, re-prompt passes are a disclosed gap"
+            # shape the resummarize-pass comment above already establishes.
+            _usage = getattr(response, "usage", None)
+            _prompt_tokens = getattr(_usage, "prompt_tokens", None)
+            _completion_tokens = getattr(_usage, "completion_tokens", None)
+            _cost_usd: "float | None" = None
+            if isinstance(_prompt_tokens, int) and isinstance(_completion_tokens, int):
+                from reyn.llm.pricing import TokenUsage, estimate_cost
+                _cost_usd, _ = estimate_cost(
+                    self._model,
+                    TokenUsage(prompt_tokens=_prompt_tokens, completion_tokens=_completion_tokens),
+                )
+
+            # #4951-A: derive unconditionally from the INPUT reyn itself built
+            # and passed to compact() — never from the LLM's output. This is
+            # the fallback that used to fire only when the (now-removed) echo
+            # was empty, promoted to the sole path (owner: "compaction は圧縮
+            # 対象メッセージしか送らないはずなのでいらないと思うんだけど？" —
+            # confirmed correct, #4951). The LLM's echo could only ever match
+            # this value or be wrong (the prompt forbade sorting/filtering/
+            # computing the max, so a model that ignored some turns still
+            # echoed every seq) — there was no case where trusting the echo
+            # over reyn's own input was more correct, only cases where it
+            # silently wasn't (a non-empty-but-wrong echo used to pass through
+            # unchecked; the old fallback only caught an EMPTY echo).
+            #
+            # #4951-B: the ``new_turn_seqs`` KEY itself is now REMOVED from
+            # both the schema (``_CHAT_SUMMARY_JSON_SCHEMA``) and the system
+            # prompt (``reyn.prompt.compaction``) — reyn no longer asks the LLM
+            # to echo it at all (A had already stopped reading the echo; this
+            # closes the other half). Owner ruling: the LLM path's information
+            # gain is zero by construction (established by reading the
+            # prompt's own constraint above, not by measurement — "測定は反例
+            # にしかならん", a measurement can only ever supply a
+            # counterexample). ``ChatSummaryRaw.new_turn_seqs`` is likewise
+            # removed (0 consumers — this dataclass is never constructed
+            # anywhere in the tree; ``ChatSummary.to_dict()`` never included
+            # the field even before this removal).
+            #
+            # #4947 ③ note: this also supersedes ③'s own earlier clamp-based
+            # fix for the same exposure (an over-claiming echo covering a
+            # partial-slice remainder it was never offered) — with the echo
+            # never read at all, there is nothing left to clamp; #4956/#4951-A
+            # closes the exposure at its root instead of bounding its output.
+            #
+            # #5498 (architect ruling, on this exact call site): for
+            # retry_loop's own caller, ``input_chunk.messages``' turn elements
+            # (#5531 renamed the field from ``new_turns``) are litellm
+            # wire dicts with no ``seq`` key at all (see ``SeqUnavailable.
+            # WIRE_DICTS_CARRY_NO_SEQ``'s own docstring) — every ``t.get("seq",
+            # 0)`` above falls to its default, so ``covers`` is structurally
+            # 0 on that path. Confirmed harmless by TWO independent facts, not
+            # one:
+            #   (1) #5612 (architect co-vet, PR #5617): retry_loop's own
+            #       summary IS persisted now, per successful fold
+            #       (``on_summary_used`` -> ``CompactionController.
+            #       persist_recovery_summary``, router_loop_driver.py) — the
+            #       "never persists" claim this comment used to make here is
+            #       no longer true. The 0 computed at THIS call site is still
+            #       harmless, but for a DIFFERENT, still-live reason: the
+            #       persist-time caller never reads this value at all — it
+            #       re-derives its own real ``covers_through_seq`` from
+            #       ``decompose_history_for_retry``'s own ``seq_by_id`` map
+            #       (the actual folded turns' real seqs,
+            #       ``max(..., default=0)`` — router_loop_driver.py's own
+            #       ``_on_recovery_summary_used``) — and even a bogus 0 that
+            #       DID somehow reach ``persist_recovery_summary`` is rejected
+            #       outright there (``if covers_through_seq <= 0: ... return``,
+            #       never appended — ``compaction_controller.py``).
+            #   (2) for the OTHER caller (CompactionController), a real 0
+            #       here would ALSO be masked — ``compaction_controller.py``'s
+            #       own ``covers = chat_summary.covers_through_seq or
+            #       candidates[-1].seq`` falls back to a real seq whenever
+            #       this value is falsy. That ``or`` was written for a
+            #       DIFFERENT reason (a wrong/empty LLM echo, #4951-A) — it
+            #       was never intended as a defense against THIS 0, but it
+            #       happens to also BE one; do not remove it.
+            # Both facts are load-bearing SEPARATELY — either one alone would
+            # still make this 0 harmless today, so a future change that
+            # removes only one of them (e.g. starts persisting retry_loop's
+            # own summary) needs to re-derive whether the other still holds
+            # before assuming this is still safe. See
+            # tests/services/test_5498_retry_loop_covers_zero_never_persisted.py.
+            # #5531: derive from `messages` MINUS every summary element (there
+            # can be more than one — see HistoryChunkToCompact's own
+            # docstring) — none of their own covers_through_seq values are a
+            # "new turn" seq, and each may sit anywhere in the ordered list
+            # now (condition④), not just at index 0. The filter below already
+            # excludes all of them, not just the first.
+            covers = compute_covers_through_seq(
+                [
+                    t.get("seq", 0) for t in input_chunk.messages
+                    if isinstance(t, dict) and t.get("role") != SUMMARY_MESSAGE_ROLE
+                ]
             )
 
-        # #4703 axis①: this call's own usage, for the compaction_completed
-        # marker CompactionController emits below (never a resummarize-pass
-        # call's usage — those are a rare, bounded-to-1-by-default backstop;
-        # the primary compact() call is the dominant cost, and capturing
-        # every resummarize pass too would need threading usage out of
-        # _resummarize_topic_arc as well, a disclosed follow-up, not silent
-        # scope creep). None if usage genuinely could not be read off the
-        # response — never coerced to 0. Reflects the FINAL (successful)
-        # attempt only — a re-prompt's own usage is not summed in, the same
-        # "primary call dominates, re-prompt passes are a disclosed gap"
-        # shape the resummarize-pass comment above already establishes.
-        _usage = getattr(response, "usage", None)
-        _prompt_tokens = getattr(_usage, "prompt_tokens", None)
-        _completion_tokens = getattr(_usage, "completion_tokens", None)
-        _cost_usd: "float | None" = None
-        if isinstance(_prompt_tokens, int) and isinstance(_completion_tokens, int):
-            from reyn.llm.pricing import TokenUsage, estimate_cost
-            _cost_usd, _ = estimate_cost(
+            # #271 — 3-tier topic_arc bounding (replaces the lone Axis-9 blind cut):
+            #   T1 fit         — within budget → no LLM, unchanged (common case).
+            #   T2 re-summarize — overshoot → LLM re-compression (judgment loss, the
+            #                     user's "intentional summary compression is fine"),
+            #                     bounded to ``resummarize_passes`` (default 1).
+            #   T3 hard_truncate — deterministic floor, always applied last so
+            #                     topic_arc ≤ body_budget is NEVER violated (the
+            #                     dead-end-free bound; rare backstop after T2).
+            body_budget = self._budgets.body_budget
+            topic_arc = str(parsed.get("topic_arc") or "")
+            passes = max(0, int(getattr(self._cfg, "resummarize_passes", 1)))
+            for _ in range(passes):
+                before_tokens = estimate_tokens(topic_arc, self._model, use_chars4=self._use_chars4)
+                if before_tokens <= body_budget:
+                    break  # T1: fits
+                topic_arc = await self._resummarize_topic_arc(topic_arc, body_budget)
+                self._events.emit(
+                    "summary_resummarized",
+                    original_tokens=before_tokens,
+                    target_budget=body_budget,
+                    result_tokens=estimate_tokens(topic_arc, self._model, use_chars4=self._use_chars4),
+                )
+            topic_arc = hard_truncate_summary(  # T3: deterministic floor
+                topic_arc,
+                body_budget,
                 self._model,
-                TokenUsage(prompt_tokens=_prompt_tokens, completion_tokens=_completion_tokens),
+                self._events,
+                use_chars4=self._use_chars4,
             )
 
-        # #4951-A: derive unconditionally from the INPUT reyn itself built
-        # and passed to compact() — never from the LLM's output. This is
-        # the fallback that used to fire only when the (now-removed) echo
-        # was empty, promoted to the sole path (owner: "compaction は圧縮
-        # 対象メッセージしか送らないはずなのでいらないと思うんだけど？" —
-        # confirmed correct, #4951). The LLM's echo could only ever match
-        # this value or be wrong (the prompt forbade sorting/filtering/
-        # computing the max, so a model that ignored some turns still
-        # echoed every seq) — there was no case where trusting the echo
-        # over reyn's own input was more correct, only cases where it
-        # silently wasn't (a non-empty-but-wrong echo used to pass through
-        # unchecked; the old fallback only caught an EMPTY echo).
-        #
-        # #4951-B: the ``new_turn_seqs`` KEY itself is now REMOVED from
-        # both the schema (``_CHAT_SUMMARY_JSON_SCHEMA``) and the system
-        # prompt (``reyn.prompt.compaction``) — reyn no longer asks the LLM
-        # to echo it at all (A had already stopped reading the echo; this
-        # closes the other half). Owner ruling: the LLM path's information
-        # gain is zero by construction (established by reading the
-        # prompt's own constraint above, not by measurement — "測定は反例
-        # にしかならん", a measurement can only ever supply a
-        # counterexample). ``ChatSummaryRaw.new_turn_seqs`` is likewise
-        # removed (0 consumers — this dataclass is never constructed
-        # anywhere in the tree; ``ChatSummary.to_dict()`` never included
-        # the field even before this removal).
-        #
-        # #4947 ③ note: this also supersedes ③'s own earlier clamp-based
-        # fix for the same exposure (an over-claiming echo covering a
-        # partial-slice remainder it was never offered) — with the echo
-        # never read at all, there is nothing left to clamp; #4956/#4951-A
-        # closes the exposure at its root instead of bounding its output.
-        #
-        # #5498 (architect ruling, on this exact call site): for
-        # retry_loop's own caller, ``input_chunk.messages``' turn elements
-        # (#5531 renamed the field from ``new_turns``) are litellm
-        # wire dicts with no ``seq`` key at all (see ``SeqUnavailable.
-        # WIRE_DICTS_CARRY_NO_SEQ``'s own docstring) — every ``t.get("seq",
-        # 0)`` above falls to its default, so ``covers`` is structurally
-        # 0 on that path. Confirmed harmless by TWO independent facts, not
-        # one:
-        #   (1) #5612 (architect co-vet, PR #5617): retry_loop's own
-        #       summary IS persisted now, per successful fold
-        #       (``on_summary_used`` -> ``CompactionController.
-        #       persist_recovery_summary``, router_loop_driver.py) — the
-        #       "never persists" claim this comment used to make here is
-        #       no longer true. The 0 computed at THIS call site is still
-        #       harmless, but for a DIFFERENT, still-live reason: the
-        #       persist-time caller never reads this value at all — it
-        #       re-derives its own real ``covers_through_seq`` from
-        #       ``decompose_history_for_retry``'s own ``seq_by_id`` map
-        #       (the actual folded turns' real seqs,
-        #       ``max(..., default=0)`` — router_loop_driver.py's own
-        #       ``_on_recovery_summary_used``) — and even a bogus 0 that
-        #       DID somehow reach ``persist_recovery_summary`` is rejected
-        #       outright there (``if covers_through_seq <= 0: ... return``,
-        #       never appended — ``compaction_controller.py``).
-        #   (2) for the OTHER caller (CompactionController), a real 0
-        #       here would ALSO be masked — ``compaction_controller.py``'s
-        #       own ``covers = chat_summary.covers_through_seq or
-        #       candidates[-1].seq`` falls back to a real seq whenever
-        #       this value is falsy. That ``or`` was written for a
-        #       DIFFERENT reason (a wrong/empty LLM echo, #4951-A) — it
-        #       was never intended as a defense against THIS 0, but it
-        #       happens to also BE one; do not remove it.
-        # Both facts are load-bearing SEPARATELY — either one alone would
-        # still make this 0 harmless today, so a future change that
-        # removes only one of them (e.g. starts persisting retry_loop's
-        # own summary) needs to re-derive whether the other still holds
-        # before assuming this is still safe. See
-        # tests/services/test_5498_retry_loop_covers_zero_never_persisted.py.
-        # #5531: derive from `messages` MINUS every summary element (there
-        # can be more than one — see HistoryChunkToCompact's own
-        # docstring) — none of their own covers_through_seq values are a
-        # "new turn" seq, and each may sit anywhere in the ordered list
-        # now (condition④), not just at index 0. The filter below already
-        # excludes all of them, not just the first.
-        covers = compute_covers_through_seq(
-            [
-                t.get("seq", 0) for t in input_chunk.messages
-                if isinstance(t, dict) and t.get("role") != SUMMARY_MESSAGE_ROLE
-            ]
-        )
-
-        # #271 — 3-tier topic_arc bounding (replaces the lone Axis-9 blind cut):
-        #   T1 fit         — within budget → no LLM, unchanged (common case).
-        #   T2 re-summarize — overshoot → LLM re-compression (judgment loss, the
-        #                     user's "intentional summary compression is fine"),
-        #                     bounded to ``resummarize_passes`` (default 1).
-        #   T3 hard_truncate — deterministic floor, always applied last so
-        #                     topic_arc ≤ body_budget is NEVER violated (the
-        #                     dead-end-free bound; rare backstop after T2).
-        body_budget = self._budgets.body_budget
-        topic_arc = str(parsed.get("topic_arc") or "")
-        passes = max(0, int(getattr(self._cfg, "resummarize_passes", 1)))
-        for _ in range(passes):
-            before_tokens = estimate_tokens(topic_arc, self._model, use_chars4=self._use_chars4)
-            if before_tokens <= body_budget:
-                break  # T1: fits
-            topic_arc = await self._resummarize_topic_arc(topic_arc, body_budget)
-            self._events.emit(
-                "summary_resummarized",
-                original_tokens=before_tokens,
-                target_budget=body_budget,
-                result_tokens=estimate_tokens(topic_arc, self._model, use_chars4=self._use_chars4),
+            return ChatSummary(
+                topic_arc=topic_arc,
+                covers_through_seq=covers,
+                decisions=list(parsed.get("decisions") or []),
+                pending=list(parsed.get("pending") or []),
+                session_user_facts=list(parsed.get("session_user_facts") or []),
+                artifacts_referenced=list(parsed.get("artifacts_referenced") or []),
+                prompt_tokens=_prompt_tokens,
+                completion_tokens=_completion_tokens,
+                cost_usd=_cost_usd,
             )
-        topic_arc = hard_truncate_summary(  # T3: deterministic floor
-            topic_arc,
-            body_budget,
-            self._model,
-            self._events,
-            use_chars4=self._use_chars4,
-        )
-
-        return ChatSummary(
-            topic_arc=topic_arc,
-            covers_through_seq=covers,
-            decisions=list(parsed.get("decisions") or []),
-            pending=list(parsed.get("pending") or []),
-            session_user_facts=list(parsed.get("session_user_facts") or []),
-            artifacts_referenced=list(parsed.get("artifacts_referenced") or []),
-            prompt_tokens=_prompt_tokens,
-            completion_tokens=_completion_tokens,
-            cost_usd=_cost_usd,
-        )
+        except Exception as exc:
+            self._events.emit("compaction_failed", error=str(exc))
+            # #5633: mark so CompactionController's own except (the
+            # controller-path's OTHER failure surface -- post-processing
+            # after this call returns, e.g. _append_history/_render_summary
+            # raising) doesn't emit a SECOND compaction_failed for the
+            # SAME failure -- see compaction_controller.py's own check.
+            exc._reyn_compaction_failed_emitted = True  # type: ignore[attr-defined]
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime/test_5633_ladder_compact_failure_closes_marker.py
+++ b/tests/runtime/test_5633_ladder_compact_failure_closes_marker.py
@@ -1,0 +1,131 @@
+"""Tier 2: #5633 (lead-coder BLOCKING on PR #5661) — a failed ``compact()``
+call reached through ``RecoveryLadder``/``retry_loop``'s own internal fold
+(``_stage_fold``, ``engine.py``) now emits ``compaction_failed``, closing
+the ``compaction_started`` marker the TUI shows.
+
+Real incident this closes: before this PR, ``compaction_failed`` was
+emitted from exactly ONE site, ``CompactionController.force_compact_now``
+(``compaction_controller.py``) — the CONTROLLER path. The LADDER path
+(this file's own scenario) called the SAME ``CompactionEngine.compact()``
+but on failure only classified/re-raised the exception
+(``_classify_and_wrap_compact_failure``) — never emitted
+``compaction_failed`` anywhere. Since #5475, ``compaction_started`` emits
+from ``compact()`` itself and fires for BOTH callers — so the ladder path
+COULD show "[⟳ compacting N turns]" (this PR's own #5633 marker) with no
+event ever closing it. lead-coder's own finding: deleting
+``test_compaction_started_is_not_surfaced`` (this PR's earlier revision)
+was only half-justified without this witness.
+
+Driven through a REAL Session/RouterLoopDriver/RecoveryLadder, exactly
+like ``test_5531_summary_reaches_first_main_call.py``'s own harness (same
+``_make_session_t_max``-shaped fixture, same many-small-turns overflow
+shape that forces retry_loop to actually reach ``_stage_fold``) — but
+with ``LLMStub``'s ``raise_for="compaction"`` mode (#5382) so every
+compact() call raises for real, instead of stubbing a success.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from reyn.config import CompactionConfig, MultimodalConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.chat_message import ChatMessage
+from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
+
+
+class _AlwaysOverflowingLoop:
+    """Every attempt reports the wire as still oversized — with every
+    ``compact()`` call ALSO raising (via the ``llm_stub`` marker below),
+    neither reduction axis in ``_run_with_shrink_and_byte_reduction`` can
+    ever progress, so the ladder exhausts and re-raises for real."""
+
+    async def run(self, *, user_text: str, history: "list[dict]") -> "object | None":
+        raise _FakeStatusError("request too large", status_code=413)
+
+
+class _FakeStatusError(Exception):
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _push(session, role: str, text: str, **kw) -> None:
+    session._append_history(ChatMessage(role=role, content=text, ts=_now(), **kw))
+
+
+def _make_session_t_max(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, t_max: int):
+    """Mirrors test_5531_summary_reaches_first_main_call.py's own builder:
+    default fold_persist_policy/max_shrink_iterations — compaction must
+    actually be reachable (attempted), not merely skipped for lack of
+    candidates."""
+    monkeypatch.chdir(tmp_path)
+    import reyn.llm.model_budget as _mb
+    monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: t_max)
+    cfg = CompactionConfig(
+        body_token_cap=1500,
+        use_chars4_estimate=True,
+        section_caps_spec_tokens=0,
+    )
+    return make_session(
+        agent_name="default",
+        agent_role="",
+        output_language="en",
+        budget_tracker=BudgetTracker(CostConfig()),
+        state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
+        compaction_config=cfg,
+        multimodal_config=MultimodalConfig(),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
+
+
+@pytest.mark.llm_stub(raise_for="compaction", cause="rate_limit")
+def test_a_failed_ladder_path_compact_call_emits_compaction_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: see module docstring. compaction_started fires (retry_loop
+    genuinely reached _stage_fold and called compact()), compact() raises
+    for real (LLMStub's raise_for="compaction" mode), and — the fix under
+    test — compaction_failed now fires too, closing the marker."""
+    session = _make_session_t_max(tmp_path, monkeypatch, t_max=2800)
+
+    for i in range(1, 6):
+        _push(session, "user" if i % 2 else "assistant", f"turn-{i}", seq=i)
+    # Many small turns whose SUM overflows (mirrors #5531/#5367's own
+    # fixture) — nothing to spill onto individually, so retry_loop must
+    # actually reach the fold stage to make any progress at all.
+    texts = [f"turn-{i}:" + ("X" * 320) for i in range(6, 36)]
+    for i, text in enumerate(texts, start=6):
+        _push(session, "user" if i % 2 else "assistant", text, seq=i)
+
+    events = collect_events(session)
+    loop = _AlwaysOverflowingLoop()
+
+    with pytest.raises(Exception):
+        asyncio.run(
+            session._loop_driver._run_with_shrink_and_byte_reduction(
+                loop, "continue please", chain_id="c1",
+            )
+        )
+    asyncio.run(settle(session))
+
+    kinds = [e.type for e in events]
+    assert "compaction_started" in kinds, (
+        "test setup sanity: expected retry_loop to have genuinely "
+        f"reached _stage_fold/compact() — got event kinds: {kinds!r}"
+    )
+    assert "compaction_failed" in kinds, (
+        "expected the failed compact() call to close the "
+        "compaction_started marker with compaction_failed — before "
+        "#5633's fix, the ladder path (retry_loop's own internal fold) "
+        f"never emitted compaction_failed anywhere; got: {kinds!r}"
+    )

--- a/tests/runtime/test_chat_lifecycle_forwarder.py
+++ b/tests/runtime/test_chat_lifecycle_forwarder.py
@@ -14,6 +14,18 @@ Pins:
   3. Missing ``new_turn_count`` falls back to a generic marker (=
      forward-compat with event-shape variation).
   4. Unrelated event types are dropped (= no spurious outbox writes).
+  5. #5633: ``compaction_started`` gets the same treatment (marker,
+     pluralisation, fallback) — before this, ``completed``/``failed`` both
+     had a marker and ``started`` had none. This supersedes a prior pin
+     here (``test_compaction_started_is_not_surfaced``, deleted in the
+     same change) that argued a started-but-never-closed marker would
+     mislead a reader after a mid-run abort. That risk does not hold:
+     every abort after ``compaction_started`` fires is already followed
+     by ``compaction_failed`` (``compaction_controller.py``'s caller
+     wraps the engine's ``compact()`` in try/except and always emits
+     ``compaction_failed`` on raise — see ``engine.py``'s own comment on
+     ``compact()``'s raise path) — the started marker is never left
+     dangling.
 """
 from __future__ import annotations
 
@@ -29,6 +41,54 @@ def _drain(q: asyncio.Queue) -> list[Any]:
     while not q.empty():
         items.append(q.get_nowait())
     return items
+
+
+def test_compaction_started_emits_system_marker() -> None:
+    """Tier 2: #5633 — compaction_started with new_turn_count writes
+    [⟳ compacting N turns]. Before this handler, the event existed
+    (engine.py's own compact() emits it, verified) but nothing in
+    src/reyn/interfaces/ ever consumed it — completed/failed both had a
+    marker, started had none."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="compaction_started",
+        data={"new_turn_count": 8, "covers_through_seq": 42, "had_previous": False},
+    ))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.kind == "system"
+    assert only.text == "[⟳ compacting 8 turns]"
+
+
+def test_compaction_started_singular_turn_uses_singular_label() -> None:
+    """Tier 2: pluralisation — 1 turn is singular, mirrors completed's own."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="compaction_started", data={"new_turn_count": 1}))
+    msgs = _drain(q)
+    assert msgs[0].text == "[⟳ compacting 1 turn]"
+
+
+def test_compaction_started_missing_count_uses_generic_marker() -> None:
+    """Tier 2: forward-compat fallback when new_turn_count is absent —
+    mirrors compaction_completed's own established shape."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="compaction_started", data={}))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.text == "[⟳ compacting history]"
+
+
+def test_compaction_started_zero_count_uses_generic_marker() -> None:
+    """Tier 2: a 0-count event is treated as missing — never a spurious
+    "[⟳ compacting 0 turns]"."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="compaction_started", data={"new_turn_count": 0}))
+    msgs = _drain(q)
+    assert msgs[0].text == "[⟳ compacting history]"
 
 
 def test_compaction_completed_emits_system_marker() -> None:
@@ -156,19 +216,6 @@ def test_unrelated_event_is_dropped() -> None:
     fwd(Event(type="phase_started", data={"phase": "resolve"}))
     fwd(Event(type="llm_called", data={"model": "gemini-2.5-flash-lite"}))
     fwd(Event(type="user_message_received", data={"text": "hi"}))
-    assert _drain(q) == []
-
-
-def test_compaction_started_is_not_surfaced() -> None:
-    """Tier 2: compaction_started doesn't emit a marker (= only completed does).
-
-    A compaction may abort mid-run; surfacing the marker on completion
-    only guarantees the user signal corresponds to a real summary
-    landing in history.
-    """
-    q: asyncio.Queue = asyncio.Queue()
-    fwd = ChatLifecycleForwarder(q)
-    fwd(Event(type="compaction_started", data={"new_turn_count": 8}))
     assert _drain(q) == []
 
 

--- a/tests/runtime/test_compaction_controller_invariants.py
+++ b/tests/runtime/test_compaction_controller_invariants.py
@@ -245,6 +245,52 @@ def test_force_compact_engine_failure_emits_failed():
 
 
 # ---------------------------------------------------------------------------
+# Invariant 3b (#5633, lead-coder BLOCKING on PR #5661): a failure BEFORE
+# compact() is ever called must still emit compaction_failed
+# ---------------------------------------------------------------------------
+
+
+def test_force_compact_pre_compact_setup_failure_emits_failed():
+    """Tier 2: #5633 — a failure in _run_compaction's OWN setup segment
+    (building prev_structured/the input_chunk, before compact() is ever
+    called) must still emit compaction_failed. Before #5633's first
+    revision, force_compact_now's own catch-all emitted for ANY failure in
+    _run_compaction, including this segment; the first #5633 restructure
+    (compact() outside any try, post-processing in its own try) left this
+    EARLIER segment in neither try — a real observability regression
+    caught by lead-coder's own review, not a hypothetical.
+
+    Triggers a REAL exception in real production code (render_summary_
+    for_storage's own ``.strip()`` on a non-string ``topic_arc`` — no
+    mock/stand-in): a genuinely malformed persisted summary (the kind a
+    corrupted history.jsonl could contain) is exactly the kind of input
+    this segment must not silently swallow. compact() must never be
+    reached (compaction_started absent) — proves this is THIS segment's
+    own except firing, not the compact()-internal or post-processing
+    one."""
+    history = [
+        ChatMessage(
+            role="summary", content="stale", seq=0,
+            meta={"structured": {"topic_arc": 12345}},  # not a str -> .strip() raises
+        ),
+        *_history(7),
+    ]
+    ctrl, collected, _, events = _make_controller(history=history, engine_factory=_SucceedingEngine)
+
+    asyncio.run(_run_and_settle(ctrl.force_compact_now(), events))  # must not raise
+
+    kinds = [e.type for e in collected]
+    assert "compaction_started" not in kinds, (
+        f"test setup sanity: compact() must never be reached for this "
+        f"segment's own except to be the one under test — got: {kinds!r}"
+    )
+    assert "compaction_failed" in kinds, (
+        "a failure in _run_compaction's own pre-compact() setup segment "
+        f"must still emit compaction_failed — got: {kinds!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Invariant 4: is_compacting (#5588) — True only while a pass is in flight
 # ---------------------------------------------------------------------------
 

--- a/tests/runtime/test_compaction_controller_invariants.py
+++ b/tests/runtime/test_compaction_controller_invariants.py
@@ -94,7 +94,14 @@ class _AbortingEngine(CompactionEngine):
         self, input_chunk: HistoryChunkToCompact, *, covers_through: CoversThrough,
     ) -> ChatSummary:
         _emit_compaction_started(self._events, input_chunk, covers_through)
-        raise RuntimeError("aborting engine stub: test-time abort")
+        # #5633: mirrors CompactionEngine.compact()'s own real except —
+        # compaction_failed now emits from compact() itself (the same
+        # "one real entry both callers share" argument #5475 already made
+        # for compaction_started), so a stub whose own event log nobody
+        # watches would otherwise silently stop producing that event too.
+        error = RuntimeError("aborting engine stub: test-time abort")
+        self._events.emit("compaction_failed", error=str(error))
+        raise error
 
 
 class _SucceedingEngine(CompactionEngine):


### PR DESCRIPTION
**[tui-coder]** — Closes #5633.

## Gap measured

`compaction_started` is genuinely emitted (`CompactionEngine.compact()`'s own entry, #5475), but nothing in `src/reyn/interfaces/` ever consumed it — `compaction_completed`/`compaction_failed` both surfaced a system marker in the conv pane, `started` had none. Confirmed this still holds after #5630/#5645 (that work gates the progress-row `is_compacting` state, a different edge from this one-shot marker).

## Change

- `ChatLifecycleForwarder.on_compaction_started` — same marker/pluralisation/fallback shape as `on_compaction_completed`: `[⟳ compacting N turns]`, singular for N=1, generic `[⟳ compacting history]` when `new_turn_count` is absent or 0.
- Deleted `test_compaction_started_is_not_surfaced`, a prior pin arguing a "started" marker risked being left dangling after a mid-run abort.
- **BLOCKING fix (lead-coder)**: that deletion was only half-justified — `compaction_failed` was emitted from exactly ONE site (`compaction_controller.py:384`, the CONTROLLER path only). The LADDER path (`RecoveryLadder._stage_fold`/retry_loop's own internal fold, `engine.py`) called the same `compact()` but on failure only classified/re-raised (`_classify_and_wrap_compact_failure`) — never emitted `compaction_failed`. Since `compaction_started` fires from `compact()` itself for BOTH callers (#5475), the ladder path could show the marker with nothing ever closing it. **Fix**: moved the `compaction_failed` emit into `compact()` itself — the same "one real entry both callers share" argument #5475 already made for `compaction_started`.
- **Follow-up BLOCKING (lead-coder)**: the first fix's de-dup (a marker attribute on the raised exception, read via `getattr`) was an agreement, not a structure. **Restructured** `CompactionController._run_compaction` instead: `compact()` is called OUTSIDE any local try/except (its own failures are already fully handled at `compact()`'s own origin), and everything AFTER it returns (render/persist/`compaction_completed`) sits in its OWN try/except that emits `compaction_failed` only for failures in THAT segment. Which side emits is now decided by which `try`/`except` block the failure physically raises inside, never by inspecting an attribute. `force_compact_now`'s outer `except` no longer emits at all. `test_compaction_controller_invariants.py`'s `_AbortingEngine` stub updated to mirror this (it already mirrored `compaction_started`'s #5475 move; now mirrors `compaction_failed`'s move too).
- **3rd-round BLOCKING (lead-coder)**: that restructure left a silent gap — `_run_compaction`'s PRE-`compact()` setup segment (`prev_structured`/redact/`input_chunk` construction) was in NEITHER try. Before this PR, `force_compact_now`'s own catch-all emitted for a failure ANYWHERE in `_run_compaction`, including this segment — an observability regression, not a hypothetical. **Fix**: wrapped that setup segment in its OWN try/except that emits `compaction_failed` for failures in THAT segment — `compact()` remains the only call outside any local try.

## Accept/deny witness

Real-emit-site correctness (`compaction_started`'s field shapes via a real `Session`/`CompactionController`/`CompactionEngine`) is already covered by `tests/services/test_5475_compaction_started_moved_to_engine.py`. This PR adds the forwarder-side accept/deny (4 new tests in `tests/runtime/test_chat_lifecycle_forwarder.py`), driven the same way every sibling test in that file is (a real `Event`/`asyncio.Queue`, `ChatLifecycleForwarder` as the unit under test) — matching this file's own established, already-reviewed convention for `compaction_completed`/`compaction_failed`.

Strip-falsified: reverting `on_compaction_started` turns exactly the 4 new tests red, nothing else (33 → 29 passed, same 4 failures every time).

**New witness for the "opened marker always closes" invariant**: `tests/runtime/test_5633_ladder_compact_failure_closes_marker.py` — a real `Session`/`RouterLoopDriver`/`RecoveryLadder` scenario (same overflow-forcing shape as `test_5531_summary_reaches_first_main_call.py`) where every `compact()` call raises for real (`LLMStub`'s `raise_for="compaction"` mode, #5382), confirming `compaction_started` AND `compaction_failed` both fire. Strip-falsified: reverting `engine.py`/`compaction_controller.py` turns exactly this one test red, nothing else. Re-verified against the TRUE pre-#5633 baseline (`engine.py`/`compaction_controller.py` checked out from `7a56c2f1f`, the branch's own base) after the restructure — same red, same reason.

**3rd-round witness**: a REAL (unmocked) exception from `render_summary_for_storage`'s own `.strip()` on a non-string `topic_arc` — a genuinely malformed persisted summary — confirms `compaction_failed` fires and `compaction_started` does NOT (proving `compact()` was never reached, so this is the setup segment's own except, not `compact()`-internal or post-processing). Strip-falsified: reverting the setup segment's try/except turns exactly this one test red.

## Test plan

- [x] `ruff check` on changed files
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_chat_lifecycle_forwarder.py` — 33/33 OK
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/lifecycle_forwarder.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] `python scripts/check_tui_widget_boundary.py`
- [x] `pytest tests/runtime/test_chat_lifecycle_forwarder.py tests/runtime/test_5633_ladder_compact_failure_closes_marker.py tests/runtime/test_compaction_controller_invariants.py tests/core/test_4883_compaction_schema_validation.py tests/core/test_compact_op_272.py tests/dev/test_5382_llm_stub_compaction_selectivity.py tests/services/test_5475_compaction_started_moved_to_engine.py` — 58 passed
- [x] `pytest tests/services/` (scoped sweep, `engine.py`/`compaction_controller.py` both live there) — 177 tests, 1 pre-existing unrelated failure (`test_2961_token_counter_fallback_false_positive.py::test_empty_string_estimate_does_not_warn`, confirmed failing identically with this PR's changes stashed out — a token_counter-cooldown state leak, not caused by this change)
- [x] `pytest tests/runtime/` (full scoped sweep) — 2173 passed, 1 pre-existing unrelated flake (`test_run_prompt_async_3978_p4e.py::test_registered_chain_wal_event_reconstructs_with_the_right_shape`, same one confirmed unrelated earlier this session)
- [x] `pytest tests/runtime/` (scoped sweep) — 2171 passed, 1 pre-existing unrelated flake (`test_run_prompt_async_3978_p4e.py::test_registered_chain_wal_event_reconstructs_with_the_right_shape`, confirmed failing on clean main too, not caused by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7



