### PR TITLE
fix(#5654): prompt-kind task_settled reports its real status, drop a comment stale count

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1224,9 +1224,11 @@ class TextualChatApp(App):
        between a tab and the pane it opens, most visible on the Cost tab's
        column-aligned table (reyn-reviewer, #4544's own investigation).
        Fixes ALL 5 Static panes (cost/ctx/pipe/cron/help) from this ONE
-       rule — `_MENU_TABS` (chrome.py) has 14 entries, `_LIST_PANES` has 9;
-       the other 9 are OptionList, explicitly excluded (architect's own
-       measurement, #4554): OptionList already has `padding: 0` above by
+       rule — every OTHER `_MENU_TABS` (chrome.py) entry is an OptionList,
+       explicitly excluded (architect's own measurement, #4554). Naming
+       exact `_MENU_TABS`/`_LIST_PANES` entry counts here was tried once
+       and #5654's own Task tab addition already falsified it (#5657) —
+       deliberately not re-added: OptionList already has `padding: 0` above by
        design (full-width row highlight on selection — adding padding here
        would shrink that highlight), so this rule intentionally targets
        Static only, never OptionList. */

--- a/src/reyn/runtime/services/inter_agent_messaging.py
+++ b/src/reyn/runtime/services/inter_agent_messaging.py
@@ -640,6 +640,20 @@ class InterAgentMessaging:
             # on_settle="drop" (a future caller could pass it) genuinely
             # means nothing is surfaced, not "surfaced anyway, plus
             # settle() also ran a no-op disposition."
+            # #5654 fix-forward (architect §1.6, lead-coder review on
+            # #5661): captured BEFORE settle() below — ``settle()`` deletes
+            # the chain record immediately (ADR-0040 D4, no terminal-status
+            # retention), so ``pending`` itself is gone by the time
+            # task_settled is dispatched. ``cancel_requested_at`` is
+            # ChainManager's own durable, request-time-independent record
+            # of "an operator asked to cancel this" (#5654's own
+            # ``mark_cancel_requested`` — set the moment the request lands,
+            # not when/whether the target's turn actually stops by then) —
+            # the correct ground truth here, unlike a live cancel-flag
+            # check, which would read the CALLER's own turn-cancel state
+            # (irrelevant: it's the TARGET's turn that was asked to stop).
+            _was_cancelled = pending.cancel_requested_at is not None
+
             async def _deliver() -> None:
                 self._append_history(
                     "user", injected_text, _now_iso(), history_meta,
@@ -661,11 +675,21 @@ class InterAgentMessaging:
             if self._dispatch_task_settled is not None:
                 from reyn.hooks.schema_registry import build_hook_payload
 
+                # #5654 fix-forward: before this fix, status was hard-coded
+                # "ok" regardless of ``_was_cancelled`` — the same silent
+                # lie ``task_verbs.py``'s own ``_CANCEL_TASK_DESCRIPTION``
+                # disclaims for the OPPOSITE direction ("cancelled while
+                # the task keeps running"): an operator-cancelled prompt
+                # task settling as "ok" is cancellation reported as
+                # success. The pipeline path (``PipelineExecutorDriver.
+                # _finish``) already passes its own real status
+                # ("ok"/"failed"/"cancelled") the same way — this closes
+                # the asymmetry.
                 await self._dispatch_task_settled(
                     "task_settled",
                     build_hook_payload(
                         "task_settled", task_id=chain_id, kind="prompt",
-                        status="ok",
+                        status="cancelled" if _was_cancelled else "ok",
                         session=self._session_id_fn() if self._session_id_fn else "main",
                         result=response,
                     ),

--- a/tests/runtime/test_task_types_3978_p1_prime.py
+++ b/tests/runtime/test_task_types_3978_p1_prime.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 
@@ -107,11 +107,16 @@ def _build_handler(
     *,
     agent_name: str = "specialist",
     router_actions: "list | None" = None,
-) -> "tuple[InterAgentMessaging, dict[str, Any]]":
+    dispatch_task_settled: "Callable[[str, dict], Any] | None" = None,
+) -> "tuple[InterAgentMessaging, dict[str, Any], ChainManager]":
     """Real InterAgentMessaging wired with plain stub callbacks — same
     pattern test_a2a_handler_invariants.py's own `_build_handler` uses.
     `state["current_task"]` mirrors Session.current_task via the same
-    get/set-callable injection Session itself uses in production."""
+    get/set-callable injection Session itself uses in production. Also
+    returns the real `ChainManager` (#5654 fix-forward's own tests need
+    it to `.register()`/`.mark_cancel_requested()` a real task-shaped
+    chain before driving `handle_agent_response`) — existing callers
+    ignore the third element."""
     state_log = StateLog(tmp_path / "state.wal")
     event_store = EventStore(tmp_path / "events")
     event_log = EventLog(subscribers=[event_store])
@@ -177,8 +182,9 @@ def _build_handler(
         set_router_loop_agent_replies=lambda v: None,
         get_current_task=lambda: state["current_task"],
         set_current_task=lambda v: state.update({"current_task": v}),
+        dispatch_task_settled=dispatch_task_settled,
     )
-    return handler, state
+    return handler, state, chain_manager
 
 
 @pytest.mark.asyncio
@@ -190,7 +196,7 @@ async def test_normal_completion_clears_current_task(tmp_path: Path) -> None:
     async def _final_answer(text, chain_id, state):
         state["outbox"].append(OutboxMessage(kind="agent", text="the real answer", meta={}))
 
-    handler, state = _build_handler(tmp_path, router_actions=[_final_answer])
+    handler, state, _chains = _build_handler(tmp_path, router_actions=[_final_answer])
     state["current_task"] = CurrentTask()  # simulates router_loop.py's prior SET
 
     await handler.handle_agent_response({
@@ -214,7 +220,7 @@ async def test_redelegation_during_settle_is_not_wiped(tmp_path: Path) -> None:
     async def _redelegates(text, chain_id, state):
         state["current_task"] = fresh_task  # mirrors host.mark_task_pending()
 
-    handler, state = _build_handler(tmp_path, router_actions=[_redelegates])
+    handler, state, _chains = _build_handler(tmp_path, router_actions=[_redelegates])
     state["current_task"] = CurrentTask()  # the task being settled
 
     await handler.handle_agent_response({
@@ -236,7 +242,7 @@ async def test_exception_during_settle_clears_current_task(tmp_path: Path) -> No
     async def _boom(text, chain_id, state):
         raise ValueError("simulated router failure")
 
-    handler, state = _build_handler(tmp_path, router_actions=[_boom])
+    handler, state, _chains = _build_handler(tmp_path, router_actions=[_boom])
     state["current_task"] = CurrentTask()
 
     await handler.handle_agent_response({
@@ -255,7 +261,7 @@ async def test_no_reply_marker_path_also_clears_current_task(tmp_path: Path) -> 
     current_task, not just the try/except's own two branches."""
     from reyn.runtime.services.inter_agent_messaging import _no_reply_marker
 
-    handler, state = _build_handler(tmp_path)
+    handler, state, _chains = _build_handler(tmp_path)
     state["current_task"] = CurrentTask()
 
     await handler.handle_agent_response({
@@ -321,3 +327,79 @@ async def test_rewind_clears_current_task_on_the_same_live_session(tmp_path: Pat
     session.restore_state(AgentSnapshot.empty("alpha"))
 
     assert session.current_task is None
+
+
+# ---------------------------------------------------------------------------
+# #5654 fix-forward (architect §1.6, lead-coder review on #5661): a
+# prompt-kind task_settled must report the REAL outcome, not a fixed "ok"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_settled_reports_cancelled_when_the_operator_cancelled_it(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: an operator-cancelled prompt task's task_settled must NOT
+    say "ok" — before this fix it always did, regardless of
+    `cancel_requested_at`, the same silent lie
+    task_verbs.py's own `_CANCEL_TASK_DESCRIPTION` disclaims for the
+    OPPOSITE direction ("cancelled while the task keeps running").
+    `mark_cancel_requested` is the REAL production method `/tasks
+    cancel`'s own `cancel_task` op calls (task_verbs.py) — no stand-in."""
+    settled: "list[dict]" = []
+
+    async def _dispatch_task_settled(kind: str, payload: dict) -> None:
+        settled.append(payload)
+
+    handler, state, chains = _build_handler(
+        tmp_path, dispatch_task_settled=_dispatch_task_settled,
+    )
+    from reyn.runtime.task_types import Requester
+    await chains.register(
+        chain_id="task-1", depth=1, original_text="please help",
+        sender="specialist", waiting_on={"peer"},
+        requester=Requester(agent_name="specialist", session_id="main"),
+        origin_depth=1, kind="prompt", cancel=lambda: None,
+    )
+    await chains.mark_cancel_requested("task-1")
+
+    await handler.handle_agent_response({
+        "from_agent": "peer", "response": "peer's reply", "depth": 1,
+        "chain_id": "task-1",
+    })
+
+    (payload,) = settled
+    assert payload["status"] == "cancelled", (
+        f"an operator-cancelled task must settle as cancelled, not "
+        f"{payload['status']!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_settled_reports_ok_when_never_cancelled(tmp_path: Path) -> None:
+    """Tier 2: the accept-side sibling — an ordinary, never-cancelled
+    prompt task's task_settled still reports "ok" (this fix must not flip
+    the default)."""
+    settled: "list[dict]" = []
+
+    async def _dispatch_task_settled(kind: str, payload: dict) -> None:
+        settled.append(payload)
+
+    handler, state, chains = _build_handler(
+        tmp_path, dispatch_task_settled=_dispatch_task_settled,
+    )
+    from reyn.runtime.task_types import Requester
+    await chains.register(
+        chain_id="task-2", depth=1, original_text="please help",
+        sender="specialist", waiting_on={"peer"},
+        requester=Requester(agent_name="specialist", session_id="main"),
+        origin_depth=1, kind="prompt", cancel=lambda: None,
+    )
+
+    await handler.handle_agent_response({
+        "from_agent": "peer", "response": "peer's reply", "depth": 1,
+        "chain_id": "task-2",
+    })
+
+    (payload,) = settled
+    assert payload["status"] == "ok"


### PR DESCRIPTION
**[tui-coder]** — part of #5654 (fix-forward, per lead-coder: architect's post-hoc A-種 co-vet on #5657 found 2 small gaps, both closed here in 1 PR rather than 2 new issues).

## ① `inter_agent_messaging.py:668` — prompt-kind `task_settled` hard-coded `status="ok"`

Architect's §1.6 originally specified fixing this in the same arc; it fell through in implementation. `PipelineExecutorDriver._finish` already passes its own real status (`ok`/`failed`/`cancelled`) — the prompt path was asymmetric, and #5654's own `/tasks cancel` command made the asymmetry directly visible to an operator (cancel a task from the list, watch it settle as `"ok"`).

**Fix**: read `ChainManager`'s own durable `cancel_requested_at` (#5654's `mark_cancel_requested`) on the `pending` chain, captured *before* `settle()` deletes the record (ADR-0040 D4: no terminal-status retention). This is the correct ground truth — durable, recorded the moment the request lands, independent of whether/when the target's turn actually stops — not a live per-driver cancel flag (which would read the CALLER's own turn-cancel state, not the TARGET's; I tried that approach first and self-corrected after tracing the actual cross-session cancel mechanism, `_cancel_hook` → `target.cancel_inflight()`).

## ② `app.py:1227` — a stale, falsified comment

"`_MENU_TABS` (chrome.py) has **14** entries" — #5654's own Task tab addition made this **15**. CLAUDE.md hard rule: a describing comment is stale the moment the code it describes changes, fixed in the same PR. Rewritten to not assert an exact count at all (matching lead-coder's own standing rule against baking a number into a comment/name that a different, unrelated edit can silently falsify).

## Tests

`tests/runtime/test_task_types_3978_p1_prime.py` (extends its own established real-`InterAgentMessaging`-instance harness, `_build_handler` — no mocks):
- `test_task_settled_reports_cancelled_when_the_operator_cancelled_it` — registers a real `"prompt"`-kind chain, calls the real `ChainManager.mark_cancel_requested` (the same method `/tasks cancel`'s own `cancel_task` op calls), drives `handle_agent_response` directly, asserts the dispatched `task_settled` payload's `status == "cancelled"`.
- `test_task_settled_reports_ok_when_never_cancelled` — accept-side sibling, confirms the fix doesn't flip the default.

Strip-falsified: reverting `inter_agent_messaging.py`'s fix turns exactly the first new test red (`'ok' != 'cancelled'`), nothing else.

## Test plan

- [x] `ruff check` on changed files
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_task_types_3978_p1_prime.py` — 9/9 OK
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/services/inter_agent_messaging.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] `python scripts/check_tui_widget_boundary.py`
- [x] `python scripts/check_tui_reactive_ratchet.py`
- [x] `pytest tests/runtime/test_task_types_3978_p1_prime.py tests/runtime/test_5654_tasks_wiring.py tests/interfaces/test_5654_task_pane.py tests/interfaces/test_3338_tui_status_chrome_liveness.py` — 66 passed
- [x] `pytest tests/runtime/` (full scoped sweep) — 2175 passed, 1 pre-existing unrelated flake (`test_run_prompt_async_3978_p4e.py::test_registered_chain_wal_event_reconstructs_with_the_right_shape`, the same one already tracked/enriched by #5660)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
