### PR TITLE
docs(#5663): name WHO arms/merges a PR (CLAUDE.md rule 10 + pr-workflow.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Path-conditional gates:
    - Verbatim has two different targets: `BLOCKING-CLEARED` quotes the `BLOCKING` comment's **identifying line** (its first non-empty line after the marker), never a summary; a checked `- [x] 🔴` needs a comment quoting **that line itself**, not restated in the body. One comment can cover several checked lines.
 8. **A PR touching `tests/` does not self-merge until a reviewer's TESTS-READ claim lands as a comment's FIRST line** (marker + head SHA together; grounds go from line 2 on).
 9. **`update-branch` only on a real conflict** (`mergeable=CONFLICTING`), and **never re-run a gate by hand** — a merely-behind branch is fine as it is, both PR pushes and comments already trigger the gates that read them, and each needless run costs a full matrix on a saturable resource (#4239).
-10. **Arming auto-merge ends your reading of that PR** — a checkbox added afterwards is invisible to the merge. Do not arm while a reviewer's point is open, and re-check the body before arming.
+10. **Arming auto-merge and merging are the reviewer's act (lead-coder in this repo), never the implementer's** — the implementer's turn ends at push + report. **Arming auto-merge ends your reading of that PR** — a checkbox added afterwards is invisible to the merge. Do not arm while a reviewer's point is open, and re-check the body before arming.
 
 **Issue-triage label `blocked:external`** — needs owner judgment or an upstream
 dependency. An open issue WITHOUT it is pickable by any peer session.

--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -419,6 +419,14 @@ These rules then keep multi-session work coherent:
    same as it always was; a green here means "some note names the exact
    tree about to merge," never "the tree was reviewed by the right people."
 
+9. **Arming auto-merge and merging are the reviewer's act (lead-coder in
+   this repo), never the implementer's — the implementer's turn ends at
+   push + report.** Real incident (#5662, 2026-09-02): an implementer saw
+   CI green and a TESTS-READ note already posted and armed/merged the PR
+   themselves, before the reviewer (who still raises new points
+   mid-review — three times the same night on #5661) had said the PR was
+   done; harmless only because nothing further was in fact raised.
+
 ## Bundling and the owner's veto unit
 
 A doc PR that exists to give the owner a veto opportunity should ship alone.


### PR DESCRIPTION
**[tui-coder]** — Closes #5663.

## Gap (docs-maintainer confirmed: rule absence, not an unread rule)

`CLAUDE.md` rule 10 stated WHEN to arm auto-merge but never WHO may. `pr-workflow.md` had 0 role-split hits across `auto-merge`/`arms`/`arming`/`who merges`/`lead-coder.*merge`/`coder.*merge`/`implementer.*merge`. Real incident (#5662, 2026-09-02): I saw CI green + a TESTS-READ note already posted and armed/merged the PR myself — harmless (nothing further was raised), but the reviewer (who raised new points mid-review three times the same night on #5661) had not said the PR was done. Reading "CI is green" as "conditions met" was the natural reading of an actually-missing rule.

## Why a rule, not a gate

`gh` authenticates every session as the same user, so `mergedBy` can't distinguish an implementer's own merge from a reviewer's (`pr-workflow.md`'s own opening paragraph already says this) — the exact exception CLAUDE.md's own editing rule carves out ("If CI can catch the violation, write the gate, not a rule here" — this one can't be caught).

## Change

- `CLAUDE.md` rule 10: one sentence added to the front, no new bullet — **"Arming auto-merge and merging are the reviewer's act (lead-coder in this repo), never the implementer's — the implementer's turn ends at push + report."**
- `docs/deep-dives/contributing/pr-workflow.md`: the same sentence as a new numbered rationale item (9) — no existing rule-10-shaped section to extend, so this is genuinely new — with today's incident as a 1-line example.

`wc -w CLAUDE.md`: **2529** (was 2505).

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml`
- [x] `python scripts/check_doc_anchors.py` — no dangling anchors into published pages
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] `ruff check` — n/a (no `.py` files touched)
- [x] `python scripts/mypy_ratchet.py` — n/a, run anyway for the ratchet baseline, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
