### PR TITLE
feat(#5505): trusted per-agent hooks layer (.reyn/config/agents/<name>/hooks.yaml)

### DIFF
--- a/docs/concepts/runtime/config-hot-reload.md
+++ b/docs/concepts/runtime/config-hot-reload.md
@@ -80,31 +80,60 @@ run on every reload:
 | `mcp` | Re-probes MCP servers via the existing turn-boundary refresh chain. Reports whether the in-memory tool cache changed. |
 | `per_agent_capability` | Re-reads `.reyn/agents/<name>/profile.yaml` and updates `allowed_mcp` on the three holders the Session owns (session / skill_runner / router_host). |
 | `new_agent` | Confirming no-op: agent discovery is filesystem-live (the `AgentRegistry` walks `.reyn/agents/` per call), so a newly added agent is already visible without a reload step. Kept as an explicit seam for accounting. |
-| `hooks` | Re-reads global `.reyn/config/hooks.yaml` + per-agent `.reyn/agents/<name>/hooks.yaml`, re-combines with the fixed startup layer, and swaps the hook dispatcher's registry. |
+| `hooks` | Re-reads global `.reyn/config/hooks.yaml` + per-agent `.reyn/agents/<name>/hooks.yaml`, re-combines with the fixed startup and trusted-per-agent layers, and swaps the hook dispatcher's registry. |
 
-## Hooks three-layer COMBINE
+## Hooks 5-layer COMBINE
 
-The hook registry is built additively from three layers, in order:
+The hook registry is built additively from five layers, in
+[`HOOK_ORIGIN_ORDER`](../../reference/config/reyn-yaml.md#hooks-block)'s
+own order:
 
 | Layer | File | Set | On reload |
 |-------|------|-----|-----------|
 | **startup** | `reyn.yaml` | OUT-set | Captured once at boot; never re-read |
 | **runtime** | `.reyn/config/hooks.yaml` | IN-set | Re-read on every reload |
+| **trusted-per-agent** (#5505) | `.reyn/config/agents/<name>/hooks.yaml` | neither — boot-only, not in the IN-set | Captured once at boot; never re-read |
 | **per-agent** | `.reyn/agents/<name>/hooks.yaml` | IN-set | Re-read on every reload |
+| **per-session** (#2285) | `<session_state_dir>/hooks.yaml` | session-local, session-lifetime | Re-read on every reload |
 
-The COMBINE is additive: `startup ∪ runtime ∪ per-agent`. A removed hook is
-absent from the rebuilt registry — removal is handled by reconstruction (no
-explicit remove step).
+The COMBINE is additive: `startup ∪ runtime ∪ trusted-per-agent ∪ per-agent ∪
+per-session`. A removed hook is absent from the rebuilt registry — removal is
+handled by reconstruction (no explicit remove step) — except
+**trusted-per-agent**, which is deliberately NOT reconstructed from the file on
+a reload (see below); removing that file only takes effect on restart.
 
-**Per-layer boot resilience.** The trusted startup layer (`reyn.yaml`, operator-
-controlled) must load — a failure is fail-loud. Each untrusted layer (runtime,
-per-agent) is try-added independently:
+**trusted-per-agent** (`.reyn/config/agents/<name>/hooks.yaml`) carries
+**only** the permission-bearing per-hook keys (`write_paths`/`subprocess`/
+`network`) — the grant mechanism #5356 (below) otherwise leaves with no
+per-agent path at all. See [Concepts: Hooks §
+Sandbox](hooks.md#which-layer-may-grant-the-three-sandbox-axes) for the full
+rationale, including the two separate senses of "trusted" this layer
+carries.
 
-- A bad runtime layer keeps `startup ∪ per-agent`; the bad layer is dropped + warned.
-- A bad per-agent layer keeps `startup ∪ runtime`; the bad layer is dropped + warned.
+**Per-layer boot resilience.** The trusted startup layer (`reyn.yaml`,
+operator-controlled) must load — a failure is fail-loud. The
+**trusted-per-agent** layer gets the SAME fail-loud posture, at boot only
+(architect ruling: a permission-bearing layer silently dropping mid-session
+is worse than a refused boot) — unlike every OTHER post-startup layer below,
+which is try-added independently:
+
+- A bad runtime layer keeps every other good layer; the bad layer is dropped + warned.
+- A bad per-agent layer keeps every other good layer; the bad layer is dropped + warned.
+- A bad per-session layer keeps every other good layer; the bad layer is dropped + warned.
 
 On the reload path, validate-before-apply also rejects a bad runtime layer up
-front (defense-in-depth).
+front (defense-in-depth). **trusted-per-agent** is never part of validate-
+before-apply — it is outside the IN-set entirely.
+
+## The per-agent self-grant restriction (#5356)
+
+`write_paths`/`subprocess`/`network` are REJECTED outright — a load-time
+`HookConfigError`, not a silent drop — when declared at **per-agent** or
+**per-session**: an agent can already write either file via the ordinary
+file-write op, so a grant declared there is a confused-deputy self-grant,
+not an operator's expressed will. The same three keys are honored at
+**startup**, **runtime**, and **trusted-per-agent** — none of those three is
+agent-writable.
 
 ## Triggers
 

--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -688,6 +688,52 @@ value, including the floor — is your decision on that axis, and a decision is
 never reported. The invariant: an operator's expressed will is applied or
 refused, never silently dropped.
 
+### Which layer may grant the three sandbox axes
+
+`subprocess`/`network`/`write_paths` are per-hook GRANTS, not mere config —
+declaring one is expressing trust in that hook's own argv. Not every hooks.yaml
+layer may do that:
+
+- **Rejected outright** at `.reyn/agents/<name>/hooks.yaml` (per-agent) and
+  the per-session `hooks.yaml` (#5356) — an agent can already write either
+  file via the ordinary file-write op, so a grant declared there is a
+  confused-deputy self-grant (the same agent writes the rule AND is bound
+  by it), not an operator's expressed will. A hook entry declaring any of
+  the three at either layer fails to load with a `HookConfigError` naming
+  where to move it instead.
+- **Honored** at `reyn.yaml` (startup), `.reyn/config/hooks.yaml` (runtime),
+  and `.reyn/config/agents/<name>/hooks.yaml` (**trusted per-agent**, below)
+  — none of these three is agent-writable.
+
+**The trusted per-agent layer** (`.reyn/config/agents/<name>/hooks.yaml`,
+introduced by #5505) exists so an operator can still grant `write_paths`/
+`subprocess`/`network` to ONE specific agent's hooks without handing every
+agent the SAME grant at the shared `.reyn/config/hooks.yaml` runtime layer
+— the gap #5356 otherwise left with zero mechanism. It sits in the COMBINE
+between `runtime` and `per-agent` (see [Concepts: Config
+hot-reload](config-hot-reload.md) for the full layer order) and carries
+**only** the three permission-bearing keys above; a positional hook value
+(e.g. where `hooks_add` writes `.turn_done`-style state) still belongs at
+the ordinary per-agent layer, which needs no trust.
+
+Two senses of "trusted" are both in play for this layer, and they answer
+different questions — naming both here so neither reads as the other:
+
+- **Write-zone boundary** (which this section is about): the file lives
+  under `.reyn/config/`, the SAME write-gate prefix `.reyn/config/hooks.yaml`
+  already sits under — an agent's ordinary file-write op cannot reach it, so
+  no new trust mechanism was built for this layer; it is protected for free
+  by an existing boundary.
+- **Re-read cadence** (a SEPARATE axis — architect's own correction,
+  #5505/#5351): this layer is **boot-only**, not hot-reloadable. A bad file
+  here refuses Session construction outright (fail-loud), the same posture
+  `reyn.yaml` itself has — deliberately NOT the drop-and-warn posture every
+  OTHER post-startup layer (`runtime`/`per-agent`/`per-session`) gets on a
+  malformed file. The reasoning: this layer carries permission-bearing
+  values, and a permission silently disappearing mid-session (the
+  drop-and-warn shape) is worse than a boot that refuses to start. A config
+  change here takes effect on the next restart only.
+
 ### Consent and allowlist
 
 `exec`/`exec_capture` argv require operator consent before they run. The consent flow depends on whether a live intervention listener is attached:
@@ -854,9 +900,13 @@ composers:
     emit: { kind: composed:deploy_approved }
 ```
 
-A Session reads `composers:` from the SAME 4-layer additive combine as
-`hooks:` (`reyn.yaml` startup ∪ `.reyn/config/hooks.yaml` runtime ∪
-per-agent ∪ per-session) and starts every configured Composer automatically
+A Session reads `composers:` from its own 4-layer additive combine
+(`reyn.yaml` startup ∪ `.reyn/config/hooks.yaml` runtime ∪ per-agent ∪
+per-session) — the SAME 4 layers `hooks:` had before #5505 added a 5th,
+`hooks:`-only layer (the [trusted per-agent
+layer](#which-layer-may-grant-the-three-sandbox-axes) above); `composers:`
+was out of that issue's scope and still combines across exactly these 4 —
+and starts every configured Composer automatically
 (`start_composers`, called from `run()` alongside the filesystem watcher's
 own start) — no manual wiring required. Composers are **startup-only**: a
 config change takes effect on the next session start, not via the hooks

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -77,10 +77,14 @@ table's `Declared in` cells against them in CI, mirroring
 [`events.md`'s own doc↔code gate](../runtime/events.md). A key gaining
 agent/session write capability without this table catching up → red.
 
-⚠️ **One exception to the exception**: `composers` is read from the same 4-layer
-combine as `hooks` (`reyn.yaml` ∪ `.reyn/config/hooks.yaml` ∪ per-agent ∪
+⚠️ **One exception to the exception**: `composers` is read from its own
+4-layer combine (`reyn.yaml` ∪ `.reyn/config/hooks.yaml` ∪ per-agent ∪
 per-session) but is **not** hot-reloaded — added or removed entries take effect
-at the next session start.
+at the next session start. `hooks` itself gained a 5th layer, `.reyn/config/
+agents/<name>/hooks.yaml` (trusted per-agent, #5505 — see [hooks §
+sandbox](../../concepts/runtime/hooks.md#which-layer-may-grant-the-three-sandbox-axes)),
+which `composers` does NOT share — that layer carries only the permission-
+bearing per-hook keys, out of `composers`'s own scope.
 
 Note that this table's axis is only the two **project-level** surfaces
 (`reyn.yaml` and `.reyn/config/`). `hooks`, `composers`, and the permission keys
@@ -1346,6 +1350,16 @@ hooks:
 | `pipeline_launch` | map | _none_ | Launch a registered pipeline (one of the four schemes). `name` (required — the pipeline's registered name; unregistered → warns and skips the launch, the hook point still completes), `input_template` (optional — a `dict`'s string leaves are each Jinja2-rendered against the event's template vars; a plain string is rendered once and its output parsed as a JSON object; omitted → `input=None`). Async/detached: the result arrives later on this session's own inbox as a `pipeline_result` message. |
 | `fold` | bool | `true` (the floor) | #5516 — **`exec` / `exec_capture` / `template_push` only** (not `pipeline_launch`, which can never fold — see below). When several queued events are already waiting at launch time, this hook's default is to receive them all in ONE launch (`exec`/`exec_capture`: one array on stdin; `template_push`: N renders concatenated into one push) rather than one launch per event. Set `false` to opt OUT — each event still arrives array-wrapped (`[payload]`, single-item — the array shape itself is unconditional), but as its own separate launch. The one real reason to opt out: wanting more wake opportunities — a hook that should "think" once per event, not once per batch. **If you opt out, know the cost**: an opted-out hook spends ONE inbox turn PER EVENT instead of once per batch — a burst that would cost a folded hook 1 turn costs an opted-out one N. Declaring `fold:` on a `pipeline_launch` hook is a `HookConfigError` (its receiver takes one `input: dict` per launch and can never fold; the key would silently do nothing there otherwise). |
 
+> ⚠️ `subprocess`/`network`/`write_paths` are REJECTED at the untrusted
+> per-agent (`.reyn/agents/<name>/hooks.yaml`) and per-session layers
+> (#5356 — an agent can already write either file, so a grant there is a
+> confused-deputy self-grant). To grant one of these to ONE specific
+> agent, declare it at the **trusted per-agent** layer instead —
+> `.reyn/config/agents/<name>/hooks.yaml` (#5505) — which is honored the
+> same as `reyn.yaml`/`.reyn/config/hooks.yaml`. See [Concepts: hooks §
+> Which layer may grant the three sandbox
+> axes](../../concepts/runtime/hooks.md#which-layer-may-grant-the-three-sandbox-axes).
+
 **Interpolating a project path — `${REYN_PROJECT_DIR}`, not an absolute
 path.** `reyn.yaml`'s `hooks:` block (this layer only — `exec`/`exec_capture`
 argv, `write_paths`) expands reyn's own `${REYN_PROJECT_DIR}` token to this
@@ -1471,11 +1485,12 @@ for the current bounding mechanisms, and
 [Concepts: hooks § Async Bus and Composer](../../concepts/runtime/hooks.md#async-bus-and-composer-event-correlation)
 for the composed→wake wiring itself.
 
-Composers are read from the SAME 4-layer additive combine as `hooks:`
-(`reyn.yaml` startup ∪ `.reyn/config/hooks.yaml` runtime ∪ per-agent ∪
-per-session) but are **startup-only** — added/removed composer entries take
-effect on the next session start, not via the hooks hot-reload seam (a live
-Composer's in-flight `PendingStore` correlation state has no analogous
+Composers are read from their own 4-layer additive combine (`reyn.yaml`
+startup ∪ `.reyn/config/hooks.yaml` runtime ∪ per-agent ∪ per-session — the
+SAME 4 layers `hooks:` had before #5505's trusted-per-agent layer, which is
+`hooks:`-only) but are **startup-only** — added/removed composer entries
+take effect on the next session start, not via the hooks hot-reload seam (a
+live Composer's in-flight `PendingStore` correlation state has no analogous
 reload-time reconciliation yet).
 
 ## `fs_watch` block

--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -272,18 +272,23 @@ lambdas.
 
 The config-derivation this builder takes as inputs is resolved inline, BEFORE the builder
 call:
-- Hooks are LAYERED (#2073 S2b): the `reyn.yaml` startup layer (OUT-set, captured once as
-  `_startup_hooks_raw`, never re-read on reload) ∪ the `.reyn/config/hooks.yaml` runtime layer
-  (IN-set, hot-reloadable; the LLM-op writes it in S3). `_build_hook_registry` combines
-  them; the boot registry includes the runtime layer too (active from session start,
-  mirroring `.reyn/mcp.yaml`), and the hooks-reapply seam re-reads only the runtime layer +
-  re-combines.
-- Composers mirror the same layering (Hook-Event Redesign Phase 4b/5, #2880/#2881):
-  `_startup_composers_raw` captures the `composers:` startup (OUT-set) layer once;
-  `_build_composer_defs` combines it with the runtime/per-agent/per-session layers (same
-  4-layer additive shape as `_build_hook_registry`). Composers are v1-startup-only — no
-  hot-reload/reapply seam, unlike hooks (restarting a live Composer's `PendingStore`
-  mid-session is a separate, not-yet-designed concern).
+- Hooks are LAYERED (#2073 S2b, #5505): the `reyn.yaml` startup layer (OUT-set, captured
+  once as `_startup_hooks_raw`, never re-read on reload) ∪ the `.reyn/config/hooks.yaml`
+  runtime layer (IN-set, hot-reloadable; the LLM-op writes it in S3) ∪ the trusted
+  per-agent layer (#5505: `.reyn/config/agents/<name>/hooks.yaml`, captured once as
+  `_trusted_per_agent_hooks_raw` — boot-only like startup, fail-loud like startup, NOT in
+  the IN-set) ∪ per-agent ∪ per-session. `_build_hook_registry` combines all five, in
+  `HOOK_ORIGIN_ORDER`'s own order; the boot registry includes the runtime layer too (active
+  from session start, mirroring `.reyn/mcp.yaml`), and the hooks-reapply seam re-reads only
+  the runtime/per-agent/per-session layers + re-combines (trusted-per-agent, like startup,
+  never re-reads).
+- Composers mirror the PRE-#5505 hooks layering (Hook-Event Redesign Phase 4b/5,
+  #2880/#2881) — `hooks:`-only, #5505's trusted-per-agent layer was out of that issue's
+  scope: `_startup_composers_raw` captures the `composers:` startup (OUT-set) layer once;
+  `_build_composer_defs` combines it with the runtime/per-agent/per-session layers (its own
+  4-layer additive shape — `_build_hook_registry` gained a 5th layer, composers did not).
+  Composers are v1-startup-only — no hot-reload/reapply seam, unlike hooks (restarting a
+  live Composer's `PendingStore` mid-session is a separate, not-yet-designed concern).
 - `_build_composer_pending_store` (#3180) runs inside the Family 3 builder and returns the
   `DurablePendingStore` shared by every `durable` composer (`op: deadline` by default), or
   `None` when no definition asks for durability — so a durability-free session writes no

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -1229,6 +1229,42 @@ def load_per_agent_hooks(
     return hooks if isinstance(hooks, list) else []
 
 
+def load_trusted_per_agent_hooks(
+    project_root: "Path | None", agent_name: str
+) -> list:
+    """#5505: load the TRUSTED per-agent hooks layer — ONLY
+    ``.reyn/config/agents/<name>/hooks.yaml`` (NOT
+    ``.reyn/agents/<name>/hooks.yaml``, :func:`load_per_agent_hooks`'s own
+    path — same directory NAME, different parent, a real trust boundary:
+    ``.reyn/config/`` is under ``_RECOVERY_CORE_WRITE_PREFIXES``, so an
+    agent cannot write here via the ordinary file-write op, unlike the
+    untrusted per-agent layer).
+
+    Carries ONLY the permission-bearing keys (``write_paths``/
+    ``subprocess``/``network`` — :data:`~reyn.hooks.sandbox_scope.
+    HOOK_SANDBOX_SCOPE`'s own right column) that #5356 made impossible to
+    grant per-agent at all; positional hook values still belong at the
+    existing (untrusted) per-agent layer.
+
+    Same read shape as :func:`load_per_agent_hooks` (this function's own
+    sibling): ``[]`` when the file or key is absent — a no-op layer, never
+    a special case a caller has to handle. Callers that need this layer's
+    OWN boot-only/fail-loud contract (a genuine parse failure must refuse
+    to proceed, not silently degrade to ``[]`` — architect ruling,
+    #5505/#5351: this layer is permission-bearing, so a bad file silently
+    dropping mid-session is worse than refusing to boot) get that from
+    :func:`read_and_expand_hooks_yaml` itself, which this function does
+    NOT swallow: a genuine YAML syntax error still raises
+    ``HookYamlReadError`` here, uncaught — the same shape
+    :func:`load_per_agent_hooks` already has for its own layer, kept
+    consistent rather than special-cased per caller."""
+    root = (project_root or Path.cwd()).resolve()
+    path = root / ".reyn" / "config" / "agents" / agent_name / "hooks.yaml"
+    data = read_and_expand_hooks_yaml(path, agent_name=agent_name, project_root=root)
+    hooks = (data or {}).get("hooks")
+    return hooks if isinstance(hooks, list) else []
+
+
 def _build_external_transports_config(raw: object):
     """Parse the ``external_transports:`` section (FP-0041 #489 PR-D2).
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -1229,6 +1229,27 @@ def load_per_agent_hooks(
     return hooks if isinstance(hooks, list) else []
 
 
+def trusted_per_agent_hooks_path(project_root: Path, agent_name: str) -> Path:
+    """#5505: the ONE fact — ``.reyn/config/agents/<name>/hooks.yaml`` —
+    both real readers of this layer must agree on: this module's own
+    :func:`load_trusted_per_agent_hooks` (drop-and-report contract:
+    ``reyn config validate``/``reyn doctor``) and
+    :meth:`~reyn.runtime.session.Session._trusted_per_agent_hooks_path`
+    (fail-loud contract: the live boot path). Two DIFFERENT readers for
+    two genuinely different contracts is the right design (lead-coder
+    review, #5669) — what must NOT differ is the path itself, since a
+    drift here is invisible: either reader landing on the wrong location
+    degrades to ``[]`` (a normal, silent no-op layer), never a red. Kept
+    as its own tiny function rather than inlined at either call site —
+    the same reasoning this module's own :data:`HOOK_SANDBOX_SCOPE`-
+    derived key list and :data:`~reyn.hooks.schema.HOOK_ORIGIN_ORDER`
+    already apply one level down: a fact with two real consumers gets
+    ONE declaration, not a second hand-typed copy (this PR's own
+    ``schema.py`` comment, verbatim: "a second hand-typed copy would be
+    the exact 'same fact in 2 places' risk")."""
+    return project_root / ".reyn" / "config" / "agents" / agent_name / "hooks.yaml"
+
+
 def load_trusted_per_agent_hooks(
     project_root: "Path | None", agent_name: str
 ) -> list:
@@ -1238,7 +1259,9 @@ def load_trusted_per_agent_hooks(
     path — same directory NAME, different parent, a real trust boundary:
     ``.reyn/config/`` is under ``_RECOVERY_CORE_WRITE_PREFIXES``, so an
     agent cannot write here via the ordinary file-write op, unlike the
-    untrusted per-agent layer).
+    untrusted per-agent layer). Path itself comes from
+    :func:`trusted_per_agent_hooks_path` — see that function's own
+    docstring for why it is not inlined here.
 
     Carries ONLY the permission-bearing keys (``write_paths``/
     ``subprocess``/``network`` — :data:`~reyn.hooks.sandbox_scope.
@@ -1259,7 +1282,7 @@ def load_trusted_per_agent_hooks(
     :func:`load_per_agent_hooks` already has for its own layer, kept
     consistent rather than special-cased per caller."""
     root = (project_root or Path.cwd()).resolve()
-    path = root / ".reyn" / "config" / "agents" / agent_name / "hooks.yaml"
+    path = trusted_per_agent_hooks_path(root, agent_name)
     data = read_and_expand_hooks_yaml(path, agent_name=agent_name, project_root=root)
     hooks = (data or {}).get("hooks")
     return hooks if isinstance(hooks, list) else []

--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -529,9 +529,16 @@ def _parse_entry(
                 f"its own {origin} hooks.yaml, so a "
                 f"{_agent_writable_key} grant declared there is a "
                 f"self-grant, not an operator's expressed will (#5356). "
+                # #5505: this used to point at startup/runtime only — both
+                # agent-LESS layers, no per-agent grant mechanism existed
+                # at all until this trusted layer landed (architect's own
+                # point reviewing #5505: the old guidance goes stale the
+                # moment this layer exists, so it must move in the SAME
+                # PR, not a follow-up).
                 f"Declare {_agent_writable_key} at the startup "
-                f"(reyn.yaml) or runtime (.reyn/config/hooks.yaml) layer "
-                f"instead — neither is agent-writable."
+                f"(reyn.yaml), runtime (.reyn/config/hooks.yaml), or "
+                f"trusted-per-agent (.reyn/config/agents/<name>/hooks.yaml) "
+                f"layer instead — none of the three is agent-writable."
             )
 
     subprocess_raw = _sandbox_bool("subprocess")

--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -318,8 +318,9 @@ class HookDef:
         three axes are expressible at every per-site sandbox surface.
     origin:
         #5213: which config LAYER declared this hook — one of
-        ``HOOK_ORIGIN_ORDER`` (``"startup"``/``"runtime"``/``"per-agent"``/
-        ``"per-session"``), threaded through by
+        ``HOOK_ORIGIN_ORDER`` (``"startup"``/``"runtime"``/
+        ``"trusted-per-agent"``/``"per-agent"``/``"per-session"``),
+        threaded through by
         :func:`~reyn.hooks.loader.load_hooks`'s ``origin=`` parameter, or
         ``"unknown"`` (the default) for a ``HookDef`` constructed directly
         without threading one through (test fixtures, most existing
@@ -432,21 +433,26 @@ class HookDef:
     spillability_max_chars: "int | None" = field(default=None)
 
 
-#: #5213: the 4 config layers ``hooks:`` composes across, in ORDER FROM LEAST
+#: #5213: the config layers ``hooks:`` composes across, in ORDER FROM LEAST
 #: TO MOST specific (trust runs the same direction, most-to-least) —
 #: ``Session._build_hook_registry``'s own combine loop's real layer order:
 #: ``startup`` (reyn.yaml, the operator's, trusted) → ``runtime``
-#: (``.reyn/config/hooks.yaml``) → ``per-agent`` (``.reyn/agents/<name>/hooks.yaml``)
-#: → ``per-session`` (session-defined, read from the SAME per-session state
-#: file ``disabled:`` itself is persisted to). Deliberately NOT re-derived
-#: from that loop's own string literals (a second hand-typed copy would be
-#: the exact "same fact in 2 places" risk this session's own #5202/#5206
-#: work flagged repeatedly) — this IS the one declared vocabulary; the
-#: combine loop's own labels must match these 4 strings exactly, or a hook
-#: silently gets treated as more-specific-than-it-is by
-#: :func:`hook_origin_is_at_least_as_specific_as` (fail-open, per that
-#: function's own "unrecognized origin" branch).
-HOOK_ORIGIN_ORDER = ("startup", "runtime", "per-agent", "per-session")
+#: (``.reyn/config/hooks.yaml``) → ``trusted-per-agent`` (#5505:
+#: ``.reyn/config/agents/<name>/hooks.yaml`` — protected for free by the
+#: SAME ``.reyn/config/`` write-gate prefix ``runtime`` sits under; carries
+#: ONLY the permission-bearing keys ``HOOK_SANDBOX_SCOPE`` names, boot-only
+#: and fail-loud, see :meth:`~reyn.runtime.session.Session._build_hook_
+#: registry`'s own docstring) → ``per-agent``
+#: (``.reyn/agents/<name>/hooks.yaml``) → ``per-session`` (session-defined,
+#: read from the SAME per-session state file ``disabled:`` itself is
+#: persisted to). Deliberately NOT re-derived from that loop's own string
+#: literals (a second hand-typed copy would be the exact "same fact in 2
+#: places" risk this session's own #5202/#5206 work flagged repeatedly) —
+#: this IS the one declared vocabulary; the combine loop's own labels must
+#: match these strings exactly, or a hook silently gets treated as
+#: more-specific-than-it-is by :func:`hook_origin_is_at_least_as_specific_as`
+#: (fail-open, per that function's own "unrecognized origin" branch).
+HOOK_ORIGIN_ORDER = ("startup", "runtime", "trusted-per-agent", "per-agent", "per-session")
 
 
 def hook_origin_is_at_least_as_specific_as(origin: str, layer: str) -> bool:
@@ -471,8 +477,13 @@ def hook_origin_is_at_least_as_specific_as(origin: str, layer: str) -> bool:
     (reyn.yaml/reyn.local.yaml, read once at boot, never re-read from a
     writable path) is restart-only. Both genuinely differ from per-agent/
     per-session, so ``"per-agent"`` is the correct threshold — everything
-    less specific than per-agent (``startup``, ``runtime``) stays
-    protected. An earlier version of this threshold used ``"runtime"``,
+    less specific than per-agent (``startup``, ``runtime``,
+    ``trusted-per-agent``) stays protected. #5505's own ``trusted-per-agent``
+    layer (``.reyn/config/agents/<name>/hooks.yaml``) is protected for the
+    SAME ``_RECOVERY_CORE_WRITE_PREFIXES`` reason as ``runtime`` — both sit
+    under ``.reyn/config/`` — so this threshold needed no change when that
+    layer was added; it falls out of the existing rule for free (architect
+    ruling, #5505). An earlier version of this threshold used ``"runtime"``,
     treating ``.reyn/config/hooks.yaml`` as agent-writable on the strength
     of a stale pre-#2073-file-split filename (``.reyn/hooks.yaml``) — caught
     in #5218 review before merge; #5220 swept the remaining bare mentions

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -358,19 +358,23 @@ def _validate() -> None:
     ``allow_write_paths`` (the agent-level sandbox.policy field name,
     written at the wrong per-hook site) pass ``validate`` silently while
     doing nothing — architect's own real incident. #4501 closed it for
-    ONE of hooks' three real input paths: the ``.reyn/config/hooks.yaml``
-    runtime IN-set. #4364 PR-1 found the other two the same night —
-    ``_build_hook_registry``'s own 3-layer COMBINE (startup / runtime /
-    per-agent) names them: reyn.yaml's own top-level ``hooks:`` (the
+    ONE of hooks' real input paths: the ``.reyn/config/hooks.yaml``
+    runtime IN-set. #4364 PR-1 found two more the same night —
+    ``_build_hook_registry``'s own (then-3-layer, now #5505's 5-layer)
+    COMBINE names them: reyn.yaml's own top-level ``hooks:`` (the
     layer ``docs/concepts/runtime/hooks.md`` actually tells operators to
     write in, and architect's own real incident lived there, not in the
-    IN-set #4501 fixed) and every ``.reyn/agents/<name>/hooks.yaml``. All
-    three now feed through ``load_hooks`` (the SAME parser hook-loading
-    itself uses, per this function's own "check exactly what startup
-    checks" discipline) and any ``HookConfigError`` per source is
-    reported as a fourth labeled section — never raised: this command
-    REPORTS, per the docstring above, so a malformed hook entry is caught
-    here rather than only at the next actual hook-load.
+    IN-set #4501 fixed) and every ``.reyn/agents/<name>/hooks.yaml``. #5505
+    added a 4th: every ``.reyn/config/agents/<name>/hooks.yaml`` (the
+    trusted per-agent layer) — the same reasoning applies unchanged (a
+    malformed entry there would otherwise only surface at the NEXT boot,
+    refusing it per that layer's own fail-loud contract, with no earlier
+    warning). All four now feed through ``load_hooks`` (the SAME parser
+    hook-loading itself uses, per this function's own "check exactly what
+    startup checks" discipline) and any ``HookConfigError`` per source is
+    reported as a labeled section — never raised: this command REPORTS,
+    per the docstring above, so a malformed hook entry is caught here
+    rather than only at the next actual hook-load.
 
     Uses ``build_policy_tier_config`` — the SAME construction
     ``load_config``'s own startup warning uses (architect's explicit
@@ -396,6 +400,7 @@ def _validate() -> None:
         build_policy_tier_config,
         load_hot_reload_config,
         load_per_agent_hooks,
+        load_trusted_per_agent_hooks,
     )
     from reyn.hooks.loader import load_hooks
     from reyn.hooks.schema import HookConfigError
@@ -416,8 +421,10 @@ def _validate() -> None:
     # #4501/#4364 PR-1: hooks[] entries are a free-form list the top-level
     # schema walk above never opens — feed EVERY real input path through the
     # real parser to catch a malformed/wrong-scope key inside one, same as an
-    # actual hook-load would. Three sources, mirroring
-    # Session._build_hook_registry's own startup/runtime/per-agent layers:
+    # actual hook-load would. Four sources, mirroring
+    # Session._build_hook_registry's own startup/runtime/trusted-per-agent/
+    # per-agent layers (this command has no per-SESSION source — there is
+    # no live session to read one from):
     hook_entry_errors: dict[str, str] = {}
 
     # (1) reyn.yaml top-level `hooks:` (the startup layer — the one
@@ -456,6 +463,28 @@ def _validate() -> None:
                 load_hooks(agent_hooks_raw)
             except HookConfigError as exc:
                 hook_entry_errors[f".reyn/agents/{agent_dir.name}/hooks.yaml"] = str(exc)
+
+    # (4) every .reyn/config/agents/<name>/hooks.yaml (#5505: the trusted
+    # per-agent layer — a 4th real input path this command's own docstring
+    # names, added the moment the layer exists per CLAUDE.md's "a mechanism
+    # describing doc/check is stale the moment the mechanism changes"; a
+    # malformed file here would otherwise only surface at the NEXT actual
+    # boot, refusing it (fail-loud, #5505) with no earlier warning this
+    # report-only command could have given). Same `.reyn/config/` root as
+    # (2) above, per-agent-scoped like (3) — load_trusted_per_agent_hooks
+    # mirrors Session._read_trusted_per_agent_hooks_raw exactly.
+    trusted_agents_dir = project_root / ".reyn" / "config" / "agents"
+    if trusted_agents_dir.is_dir():
+        for agent_dir in sorted(trusted_agents_dir.iterdir()):
+            if not agent_dir.is_dir():
+                continue
+            trusted_hooks_raw = load_trusted_per_agent_hooks(project_root, agent_dir.name)
+            if not trusted_hooks_raw:
+                continue
+            try:
+                load_hooks(trusted_hooks_raw)
+            except HookConfigError as exc:
+                hook_entry_errors[f".reyn/config/agents/{agent_dir.name}/hooks.yaml"] = str(exc)
 
     # #4631: mcp.<name> written where mcp.servers.<name> belongs loads
     # without error AND without a warning (unknown_config_keys never opens

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -569,10 +569,11 @@ def _print_hook_env_snapshot(resolved_root: Path) -> None:
 
 def _configured_exec_hooks(config: object, project_root: Path) -> "list[HookDef]":
     """Every configured ``exec``/``exec_capture`` ``HookDef``, across ALL
-    layers (startup/runtime/per-agent — #5351 (B-2), was startup-only
-    before: this used to build its own single-layer ``load_hooks(config.
-    hooks)`` registry, silently never probing a runtime or per-agent
-    hook's argv at all) — the caller reads ``.name``/``.on``/``.exec``/
+    layers (startup/runtime/trusted-per-agent (#5505)/per-agent — #5351
+    (B-2), was startup-only before: this used to build its own
+    single-layer ``load_hooks(config.hooks)`` registry, silently never
+    probing a runtime or per-agent hook's argv at all) — the caller reads
+    ``.name``/``.on``/``.exec``/
     ``.exec_capture``/``.subprocess``/``.network``/``.write_paths``/
     ``.origin`` directly off it, so the per-hook sandbox knobs AND the
     layer that declared it travel with the argv rather than being
@@ -789,13 +790,31 @@ def _mcp_initialized_evidence(events_dir: Path) -> "tuple[dict[str, dict], int]"
 
 
 def _merged_hook_registry(config: object, project_root: Path) -> object:
-    """The 3-layer ADDITIVE combine (#4555's own registry read as the
+    """The 4-layer ADDITIVE combine (#4555's own registry read as the
     reference — ``Session._build_hook_registry``'s SAME shape, minus the
-    4th, session-scoped per-session layer doctor's standalone-process
+    5th, session-scoped per-session layer doctor's standalone-process
     read has no way to reach): reyn.yaml's top-level ``hooks:`` (startup,
     trusted — must load, fail loud) -> ``.reyn/config/hooks.yaml`` (runtime
-    IN-set) -> every ``.reyn/agents/<name>/hooks.yaml`` (per-agent). Each
-    untrusted layer is try-added independently — a malformed one is
+    IN-set) -> every ``.reyn/config/agents/<name>/hooks.yaml`` (#5505:
+    trusted per-agent) -> every ``.reyn/agents/<name>/hooks.yaml``
+    (per-agent).
+
+    #5505 deliberate divergence from the live Session: a live Session
+    treats a malformed trusted-per-agent file as FAIL-LOUD (refuses to
+    boot — that layer is permission-bearing). This standalone doctor
+    process never crashes on ANY finding (D-2: report-only, never mutate
+    — "Exits 0 regardless of findings", this module's own standing rule)
+    — so here it is try-added like every other untrusted layer below,
+    same as the trusted STARTUP layer already isn't (see that one's own
+    unguarded ``load_hooks`` call, unchanged). A bad trusted-per-agent
+    file surfaces here as a dropped layer (same visible shape as any
+    other malformed layer), not as a doctor crash — the caller reading
+    ``hooks_layer_rejected``-shaped output (or a future doctor line, not
+    added by this PR) is who would need to know a LIVE boot with this
+    same file would actually refuse to start; that stronger contract is
+    Session's own, not reproduced here.
+
+    Each untrusted layer is try-added independently — a malformed one is
     dropped, its siblings kept (same per-layer resilience as the real
     Session combine), so one bad file cannot hide a real zero-responder
     gap in the layers that DID load.
@@ -827,7 +846,11 @@ def _merged_hook_registry(config: object, project_root: Path) -> object:
     silently reads the WRONG project when the process cwd differs from
     *project_root*, e.g. ``reyn doctor --project-root <other-dir>`` or
     any test driving ``run()`` directly with a ``tmp_path``)."""
-    from reyn.config.loader import load_hot_reload_config, load_per_agent_hooks
+    from reyn.config.loader import (
+        load_hot_reload_config,
+        load_per_agent_hooks,
+        load_trusted_per_agent_hooks,
+    )
     from reyn.hooks.loader import HookConfigError, load_hooks
     from reyn.hooks.registry import HookRegistry
 
@@ -839,6 +862,18 @@ def _merged_hook_registry(config: object, project_root: Path) -> object:
     in_set_merged = load_hot_reload_config(project_root)
     in_set_hooks = in_set_merged.get("hooks") or []
     layers = [("runtime", in_set_hooks if isinstance(in_set_hooks, list) else [])]
+
+    # #5505: trusted per-agent layer — see this function's own docstring
+    # for why it is try-added HERE (unlike the live Session's fail-loud
+    # contract for the same file).
+    trusted_agents_dir = project_root / ".reyn" / "config" / "agents"
+    if trusted_agents_dir.is_dir():
+        for agent_dir in sorted(trusted_agents_dir.iterdir()):
+            if not agent_dir.is_dir():
+                continue
+            trusted_hooks = load_trusted_per_agent_hooks(project_root, agent_dir.name)
+            if trusted_hooks:
+                layers.append(("trusted-per-agent", trusted_hooks))
 
     agents_dir = project_root / ".reyn" / "agents"
     if agents_dir.is_dir():

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1323,6 +1323,18 @@ class Session:
 
         # HookBus/HookDispatcher/fs_watcher/composers/hot_reloader built together below; the config-derivation feeding them stays inline as builder inputs (#1800 slice 5b / #3082 Family 3, see session-construction.md#family-3-hook-event-reactivity)
         self._startup_hooks_raw: list = hooks_config if isinstance(hooks_config, list) else []
+        # #5505: trusted-per-agent hooks layer (.reyn/config/agents/<name>/hooks.yaml)
+        # — BOOT-ONLY, captured ONCE here (mirrors self._startup_hooks_raw immediately
+        # above; _build_hook_registry never re-reads this file, even on hot-reload) and
+        # FAIL-LOUD: a genuine YAML syntax error propagates uncaught from this read,
+        # refusing Session construction — architect ruling (#5505/#5351): this layer
+        # carries PERMISSION-bearing values, so a bad file silently dropping mid-session
+        # (the untrusted-layer shape every other post-startup layer has) is worse than
+        # refusing to boot. See _build_hook_registry's own docstring for the combine
+        # position (between runtime and per-agent) and _read_trusted_per_agent_hooks_raw's
+        # own docstring for why this is NOT routed through _read_hooks_yaml_layer_key
+        # (that helper drop-and-warns on a read failure — the opposite contract).
+        self._trusted_per_agent_hooks_raw: list = self._read_trusted_per_agent_hooks_raw()
         # composers: startup (OUT-set) layer, combined with the other 3 layers by _build_composer_defs; v1 startup-only, no hot-reload (Hook-Event Redesign Phase 4b/5, #2880/#2881, see session-construction.md#family-3-hook-event-reactivity)
         self._startup_composers_raw: list = (
             composers_config if isinstance(composers_config, list) else []
@@ -6424,17 +6436,38 @@ class Session:
         hr.register_seam("visibility_override", self._reapply_visibility_override_seam)
 
     def _build_hook_registry(self, in_set: "dict | None" = None) -> "object":
-        """Build the LAYERED hook registry — the three-layer COMBINE (#2073 S2b + the
-        per-agent-hooks add-on), ADDITIVE in order startup → runtime → per-agent:
+        """Build the LAYERED hook registry — the #2073 S2b + per-agent-hooks
+        + #5505 trusted-per-agent COMBINE, ADDITIVE in
+        :data:`~reyn.hooks.schema.HOOK_ORIGIN_ORDER`'s own order (startup →
+        runtime → trusted-per-agent → per-agent → per-session):
 
         - **startup** — the reyn.yaml hooks (``self._startup_hooks_raw``, captured once
           at boot, the restart-only OUT-set, never re-read on a reload);
         - **runtime** — the global ``.reyn/config/hooks.yaml`` (from the IN-set);
+        - **trusted-per-agent** (#5505) — ``.reyn/config/agents/<name>/hooks.yaml``
+          (``self._trusted_per_agent_hooks_raw``, captured ONCE at boot like
+          ``startup`` — NOT re-read here even though this method itself is
+          called on every hot-reload, and NOT try/except-wrapped like every
+          layer below: a malformed file there fails the SAME way a bad
+          startup layer does, at the FIRST call this method ever makes
+          (boot), never later — architect ruling: this layer carries
+          PERMISSION-bearing values (the ONLY keys allowed here — the
+          #5356 rejection this layer exists to give operators back — see
+          ``reyn.hooks.loader``'s own ``_AGENT_WRITABLE_ORIGINS``/
+          ``_AGENT_WRITABLE_SANDBOX_KEYS``), so a silently-dropped mid-session
+          permission is worse than a refused boot);
         - **per-agent** — ``.reyn/agents/<name>/hooks.yaml`` (read directly here, same
-          IN-set grain but scoped per agent).
+          IN-set grain but scoped per agent);
+        - **per-session** — the 4th, most-specific layer (#2285).
 
-        Rebuilding from scratch each call means a removed hook (runtime or per-agent)
-        simply isn't in the new registry — removal handled by construction.
+        Rebuilding from scratch each call means a removed hook (runtime,
+        per-agent, or per-session) simply isn't in the new registry —
+        removal handled by construction. ``trusted-per-agent`` is the one
+        exception: it is NOT in the hot-reload IN-set at all (architect
+        ruling, #5505/#5351 open item ①) — a change to that FILE has no
+        effect until restart, by design; only the cached
+        ``self._trusted_per_agent_hooks_raw`` (read once, see ``__init__``)
+        is ever consulted here.
 
         Threads ``self._composed_schemas`` (#2889 — computed once in
         ``__init__`` from ``self._composer_defs``, BEFORE this is first
@@ -6448,10 +6481,11 @@ class Session:
         this — a malformed persisted ``.reyn/config/hooks.yaml`` or per-agent file must NOT
         crash boot, NOR may one bad UNTRUSTED layer drop a good sibling. So the trusted
         startup layer (reyn.yaml — the operator's) must load (a failure propagates =
-        fail loud), then each untrusted layer is try-added INDEPENDENTLY: a bad runtime
-        keeps startup ∪ per-agent; a bad per-agent keeps startup ∪ runtime; each bad
-        layer is dropped + warned. (On the reload path validate-before-apply also rejects
-        a bad runtime layer up front; this is the boot + defence-in-depth guard.)
+        fail loud), the trusted-per-agent layer likewise (see above), then each REMAINING
+        untrusted layer is try-added INDEPENDENTLY: a bad runtime keeps every OTHER good
+        layer; a bad per-agent likewise; each bad layer is dropped + warned. (On the
+        reload path validate-before-apply also rejects a bad runtime layer up front; this
+        is the boot + defence-in-depth guard.)
 
         #5213: each layer is now parsed by its OWN ``load_hooks`` call
         (``origin=<label>``), and the resulting registries' ``HookDef``
@@ -6475,8 +6509,30 @@ class Session:
         defs = load_hooks(
             list(self._startup_hooks_raw), composed_schemas, origin="startup",
         ).all_defs()
+
+        # runtime — untrusted, try-added (see the loop below for per-agent/per-session).
+        if runtime_list:
+            try:
+                defs = defs + load_hooks(runtime_list, composed_schemas, origin="runtime").all_defs()
+            except HookConfigError as exc:
+                logger.warning(
+                    "config hot-reload: malformed runtime hooks layer — skipped, keeping "
+                    "the valid hook layers: %s", exc,
+                )
+                self._audit_events.emit(
+                    "hooks_layer_rejected", layer="runtime", reason=str(exc),
+                )
+
+        # #5505: trusted-per-agent — UNGUARDED, matching the trusted startup
+        # layer above (not the try/except every layer below it gets). The
+        # combine position (between runtime and per-agent) is
+        # HOOK_ORIGIN_ORDER's own — see this method's own docstring for the
+        # boot-only/fail-loud rationale.
+        defs = defs + load_hooks(
+            list(self._trusted_per_agent_hooks_raw), composed_schemas, origin="trusted-per-agent",
+        ).all_defs()
+
         for label, layer in (
-            ("runtime", runtime_list),
             ("per-agent", per_agent_list),
             ("per-session", per_session_list),  # #2285: session-defined hooks (try-add like untrusted)
         ):
@@ -6570,10 +6626,48 @@ class Session:
         SAME primitive :meth:`_read_per_agent_hooks` uses."""
         return self._read_hooks_yaml_layer_key(self._hooks_yaml_layers()[1][1], "hooks")
 
+    def _trusted_per_agent_hooks_path(self) -> Path:
+        """#5505: ``.reyn/config/agents/<name>/hooks.yaml`` — the trusted
+        per-agent hooks layer's own path. Deliberately NOT added to
+        :meth:`_hooks_yaml_layers` (that registry is shared by BOTH the
+        ``hooks:`` and ``composers:`` readers — this layer carries ONLY
+        ``hooks:``, composers were never part of this issue's scope), so
+        it gets its own dedicated accessor rather than a 3rd tuple entry
+        that would silently also expose a ``composers:`` key nothing reads
+        from this path today."""
+        return (
+            self._hot_reload_project_root() / ".reyn" / "config" / "agents"
+            / self.agent_name / "hooks.yaml"
+        )
+
+    def _read_trusted_per_agent_hooks_raw(self) -> list:
+        """#5505: read the trusted per-agent hooks layer's ``hooks:`` key —
+        BOOT-ONLY (called exactly once, from ``__init__``, into
+        ``self._trusted_per_agent_hooks_raw``; :meth:`_build_hook_registry`
+        reads that cached list on every call, never this method again) and
+        FAIL-LOUD: unlike :meth:`_read_hooks_yaml_layer_key` (which every
+        OTHER hooks.yaml-shaped layer uses, and which drop-and-warns via
+        ``self._hooks_config_warnings`` on a ``HookYamlReadError``), this
+        calls :func:`~reyn.config.loader.read_and_expand_hooks_yaml`
+        DIRECTLY — a genuine YAML syntax error propagates uncaught,
+        refusing Session construction (architect ruling, #5505/#5351: a
+        permission-bearing layer failing silently mid-session is worse
+        than refusing to boot; see :meth:`_build_hook_registry`'s own
+        docstring). ``[]`` when the file or key is absent — a no-op layer,
+        same as every sibling reader."""
+        from reyn.config.loader import read_and_expand_hooks_yaml
+        data = read_and_expand_hooks_yaml(
+            self._trusted_per_agent_hooks_path(),
+            agent_name=self.agent_name,
+            project_root=self._hot_reload_project_root(),
+        )
+        hooks = (data or {}).get("hooks")
+        return hooks if isinstance(hooks, list) else []
+
     def _build_composer_defs(self, in_set: "dict | None" = None) -> list:
         """Build the LAYERED ``ComposerDef`` list (Hook-Event Redesign Phase 4b/5,
         proposal 0059 §5/§9, #2880/#2881) — the SAME 4-layer additive COMBINE
-        shape as :meth:`_build_hook_registry` (startup -> runtime -> per-agent
+        shape :meth:`_build_hook_registry` used to have (startup -> runtime -> per-agent
         -> per-session), applied to ``composers:`` instead of ``hooks:``.
 
         Unlike hooks, composers are v1 **startup-only** — this is called ONCE
@@ -6584,10 +6678,12 @@ class Session:
         concern from a hook-registry swap, which has no analogous in-flight
         state to lose).
 
-        Per-layer resilience mirrors ``_build_hook_registry`` exactly: the
-        trusted startup (reyn.yaml) layer must parse+cycle-check cleanly or
-        this fails loud (an operator config error); each of the 3 untrusted
-        layers (runtime/per-agent/per-session) is try-added independently — a
+        Per-layer resilience mirrors ``_build_hook_registry``'s pre-#5505
+        shape (composers never gained the #5505 trusted-per-agent layer —
+        out of that issue's scope, ``hooks:``-only): the trusted startup
+        (reyn.yaml) layer must parse+cycle-check cleanly or this fails loud
+        (an operator config error); each of the 3 untrusted layers
+        (runtime/per-agent/per-session) is try-added independently — a
         malformed layer is warned + dropped, keeping its valid siblings."""
         from reyn.hooks.composer import ComposerConfigError, load_composers
         runtime = (in_set or {}).get("composers") or []

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6628,17 +6628,24 @@ class Session:
 
     def _trusted_per_agent_hooks_path(self) -> Path:
         """#5505: ``.reyn/config/agents/<name>/hooks.yaml`` — the trusted
-        per-agent hooks layer's own path. Deliberately NOT added to
-        :meth:`_hooks_yaml_layers` (that registry is shared by BOTH the
-        ``hooks:`` and ``composers:`` readers — this layer carries ONLY
-        ``hooks:``, composers were never part of this issue's scope), so
-        it gets its own dedicated accessor rather than a 3rd tuple entry
-        that would silently also expose a ``composers:`` key nothing reads
-        from this path today."""
-        return (
-            self._hot_reload_project_root() / ".reyn" / "config" / "agents"
-            / self.agent_name / "hooks.yaml"
-        )
+        per-agent hooks layer's own path, delegated to
+        :func:`~reyn.config.loader.trusted_per_agent_hooks_path` (the
+        SAME single source :func:`~reyn.config.loader.
+        load_trusted_per_agent_hooks` — the OTHER real reader of this
+        layer, used by ``reyn config validate``/``reyn doctor`` — reads
+        the path from; lead-coder review, #5669: a 2nd hand-typed copy of
+        this specific fact drifts invisibly, since either reader landing
+        on the wrong location degrades to ``[]``, a normal-looking no-op
+        layer, never a red).
+
+        Deliberately NOT added to :meth:`_hooks_yaml_layers` (that
+        registry is shared by BOTH the ``hooks:`` and ``composers:``
+        readers — this layer carries ONLY ``hooks:``, composers were
+        never part of this issue's scope), so it gets its own dedicated
+        accessor rather than a 3rd tuple entry that would silently also
+        expose a ``composers:`` key nothing reads from this path today."""
+        from reyn.config.loader import trusted_per_agent_hooks_path
+        return trusted_per_agent_hooks_path(self._hot_reload_project_root(), self.agent_name)
 
     def _read_trusted_per_agent_hooks_raw(self) -> list:
         """#5505: read the trusted per-agent hooks layer's ``hooks:`` key —

--- a/tests/hooks/test_5356_write_paths_rejected_at_agent_writable_origin.py
+++ b/tests/hooks/test_5356_write_paths_rejected_at_agent_writable_origin.py
@@ -73,7 +73,10 @@ def test_agent_writable_key_rejected_at_agent_writable_origins_accepted_elsewher
 
     # Positive side — the SAME entry, at a non-agent-writable origin,
     # loads clean and the declaration survives onto the HookDef.
-    for safe_origin in ("startup", "runtime"):
+    # #5505: "trusted-per-agent" (.reyn/config/agents/<name>/hooks.yaml)
+    # joined this list — the new mechanism this issue exists to give
+    # operators back after #5356 closed the per-agent hole.
+    for safe_origin in ("startup", "runtime", "trusted-per-agent"):
         registry = load_hooks([entry], origin=safe_origin)
         (hook,) = registry.all_defs()
         expected = tuple(entry[key]) if key == "write_paths" else entry[key]
@@ -86,7 +89,7 @@ def test_entry_with_no_agent_writable_keys_is_unaffected_at_any_origin() -> None
     per-agent/per-session. The rejection is scoped to the KEYS' presence,
     not the origin generally."""
     entry = {"on": "turn_end", "exec": ["/usr/bin/true"]}
-    for origin in ("startup", "runtime", "per-agent", "per-session", "unknown"):
+    for origin in ("startup", "runtime", "trusted-per-agent", "per-agent", "per-session", "unknown"):
         registry = load_hooks([entry], origin=origin)
         (hook,) = registry.all_defs()
         assert hook.write_paths is None

--- a/tests/interfaces/test_4501_validate_hook_entries.py
+++ b/tests/interfaces/test_4501_validate_hook_entries.py
@@ -217,6 +217,94 @@ def test_a_well_formed_per_agent_hooks_file_produces_no_finding(project, capsys)
     assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
 
 
+# ── #5505: .reyn/config/agents/<name>/hooks.yaml (the trusted per-agent layer) ──
+
+
+def test_a_malformed_entry_in_a_trusted_per_agent_hooks_file_is_now_caught(project, capsys):
+    """Tier 2: #5505 — the 4th real input path, added the moment the
+    layer exists (CLAUDE.md: a mechanism-describing check is stale the
+    moment the mechanism changes). Otherwise a malformed file here would
+    only surface at the NEXT actual boot, refusing it (fail-loud, #5505)
+    with zero earlier warning this report-only command could have given."""
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "config" / "agents" / "planner" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    allow_write_paths: [\"/tmp\"]\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" in out
+    assert ".reyn/config/agents/planner/hooks.yaml" in out
+    assert "allow_write_paths" in out
+    assert "write_paths" in out
+
+
+def test_a_well_formed_trusted_per_agent_hooks_file_produces_no_finding(project, capsys):
+    """Tier 2: accept-side for the trusted-per-agent source."""
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "config" / "agents" / "planner" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    write_paths: [\"/tmp\"]\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" not in out
+    assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
+
+
+def test_a_trusted_per_agent_dir_with_no_hooks_file_is_silently_skipped(project, capsys):
+    """Tier 2: accept-side — an agent directory that exists under
+    .reyn/config/agents/ but has no hooks.yaml must not be treated as a
+    malformed source; load_trusted_per_agent_hooks's own [] default
+    covers this."""
+    (project / ".reyn" / "config" / "agents" / "planner").mkdir(parents=True)
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" not in out
+
+
+def test_the_untrusted_and_trusted_per_agent_source_labels_never_collide(project, capsys):
+    """Tier 2: falsification pair — a malformed entry at the OLD
+    (untrusted) per-agent path and a DIFFERENT malformed entry at the NEW
+    trusted path, for the SAME agent name, must each surface under their
+    own distinct, correctly-prefixed label — proving the two 4-source
+    scans do not conflate the two directories."""
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "agents" / "planner" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    nam: typo_untrusted\n",
+    )
+    _write_yaml(
+        project / ".reyn" / "config" / "agents" / "planner" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    nam: typo_trusted\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert ".reyn/agents/planner/hooks.yaml" in out
+    assert ".reyn/config/agents/planner/hooks.yaml" in out
+
+
 def test_an_agent_dir_with_no_hooks_file_is_silently_skipped(project, capsys):
     """Tier 2: accept-side — an agent directory that exists (e.g. it has
     state/ from a prior run) but no hooks.yaml at all must not be treated

--- a/tests/interfaces/test_5351_doctor_hook_probe_layer_origin.py
+++ b/tests/interfaces/test_5351_doctor_hook_probe_layer_origin.py
@@ -1,6 +1,7 @@
 """Tier 2: #5351 (B-2) — ``reyn doctor``'s hook launch probe (#4364 PR-2 /
-C-1) now covers ALL hook layers (startup/runtime/per-agent) and names
-which layer declared each hook, not just the startup one.
+C-1) now covers ALL hook layers (startup/runtime/trusted-per-agent (#5505)/
+per-agent) and names which layer declared each hook, not just the startup
+one.
 
 Before this fix, ``_configured_exec_hooks`` built its own single-layer
 ``load_hooks(config.hooks)`` registry — a ``per-agent``-only
@@ -64,6 +65,37 @@ def test_a_per_agent_only_hook_is_now_probed_and_labeled_per_agent(
     assert "per-agent-exec-hook (per-agent)" in out, (
         f"a per-agent-only exec hook must now be probed AND labeled with "
         f"its real origin -- full output:\n{out}"
+    )
+    assert "is runnable under this hook's sandbox" in out
+
+
+def test_a_trusted_per_agent_only_hook_is_now_probed_and_labeled(
+    tmp_path: Path, capsys,
+) -> None:
+    """Tier 2: #5505 — the doctor probe's own 4th layer. A hook declared
+    ONLY under ``.reyn/config/agents/<name>/hooks.yaml`` (trusted per-agent)
+    must appear in the probe section, labeled ``(trusted-per-agent)`` —
+    the same "declared, accepted, effect not visible" shape this file's
+    own module docstring names, one layer later."""
+    if not _this_hosts_default_backend_can_probe():
+        pytest.skip("this host's default sandbox backend cannot probe (see helper docstring)")
+    if not Path("/usr/bin/true").is_file():
+        pytest.skip("this host has no /usr/bin/true — the probe's own control binary is absent")
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        tmp_path / ".reyn" / "config" / "agents" / "myagent" / "hooks.yaml",
+        "hooks:\n"
+        '  - "on": session_start\n'
+        "    name: trusted-per-agent-exec-hook\n"
+        '    exec: ["/usr/bin/true"]\n',
+    )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    assert "trusted-per-agent-exec-hook (trusted-per-agent)" in out, (
+        f"a trusted-per-agent exec hook must now be probed AND labeled "
+        f"with its real origin -- full output:\n{out}"
     )
     assert "is runnable under this hook's sandbox" in out
 

--- a/tests/runtime/test_5505_trusted_per_agent_hooks.py
+++ b/tests/runtime/test_5505_trusted_per_agent_hooks.py
@@ -1,0 +1,272 @@
+"""Tier 2: #5505 — the trusted per-agent hooks layer
+(`.reyn/config/agents/<name>/hooks.yaml`), architect ruling on #5351
+(2026-08-29, corrected).
+
+#5356 (merged, `988ce6e52`) closed a real confused-deputy hole: an agent
+could self-grant `write_paths`/`subprocess`/`network` by declaring them at
+its own (agent-writable) per-agent/per-session hooks.yaml. After #5356,
+operators had ZERO mechanism to grant per-agent write_paths at all —
+architect's own words: "空セルは『あれば便利』ではなく『security fix が
+意図的に作った穴』". This is that missing mechanism.
+
+Settled design (not re-litigated here):
+- New layer inserted between `runtime` and `per-agent` in
+  `HOOK_ORIGIN_ORDER`; #5213's `disabled:` threshold (`layer="per-agent"`)
+  stays correct unchanged — the new layer is less specific.
+- Trusted for free by the existing `.reyn/config/` write-gate prefix — no
+  new trust mechanism.
+- Carries ONLY the 3 permission-bearing keys (derived from
+  `HOOK_SANDBOX_SCOPE`'s own right column, never a 2nd hand-list).
+- Boot-only / fail-loud (architect ruling): captured once at `__init__`,
+  never re-read on hot-reload; a malformed file refuses Session
+  construction, unlike every other post-startup layer (drop + warn).
+
+No mocks: a real Session, observed via the public inbox (E-hooks push
+there) and via `_state_log`/direct file writes, mirroring
+`test_2073_per_agent_hooks.py`'s own established pattern for this exact
+family of test.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config.loader import load_trusted_per_agent_hooks
+from reyn.core.events.state_log import StateLog
+from reyn.hooks.loader import HookConfigError, load_hooks
+from reyn.hooks.schema import HOOK_ORIGIN_ORDER, hook_origin_is_at_least_as_specific_as
+from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
+from tests._support.agent_session import make_session
+
+_AGENT = "trusted-agent"
+_HOOK = "hooks:\n  - on: turn_end\n    template_push:\n      message: {msg}\n      wake: true\n"
+_STARTUP = [{"on": "turn_end", "template_push": {"message": "startup", "wake": True}}]
+
+
+def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
+    return make_session(
+        agent_name=_AGENT,
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        reactivity=ReactivityConfig(hooks_config=hooks_config),
+    )
+
+
+def _write_runtime(tmp_path: Path, msg: str) -> None:
+    (tmp_path / ".reyn" / "config").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".reyn" / "config" / "hooks.yaml").write_text(_HOOK.format(msg=msg), encoding="utf-8")
+
+
+def _write_per_agent(tmp_path: Path, msg: str) -> Path:
+    agent_dir = tmp_path / ".reyn" / "agents" / _AGENT
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    path = agent_dir / "hooks.yaml"
+    path.write_text(_HOOK.format(msg=msg), encoding="utf-8")
+    return path
+
+
+def _write_trusted_per_agent(tmp_path: Path, msg: str) -> Path:
+    agent_dir = tmp_path / ".reyn" / "config" / "agents" / _AGENT
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    path = agent_dir / "hooks.yaml"
+    path.write_text(_HOOK.format(msg=msg), encoding="utf-8")
+    return path
+
+
+async def _drain_texts(session: Session) -> set:
+    texts = set()
+    while not session.inbox.empty():
+        _kind, payload = session.inbox.get_nowait()
+        texts.add(payload.get("text"))
+    return texts
+
+
+# ── the loader (read directly, not via the top-level IN-set) ────────────────
+
+
+def test_load_trusted_per_agent_hooks_reads_the_config_scoped_path(tmp_path: Path) -> None:
+    """Tier 2: reads `.reyn/config/agents/<name>/hooks.yaml`, NOT
+    `.reyn/agents/<name>/hooks.yaml` — the untrusted per-agent layer's own
+    path, a different directory entirely."""
+    _write_trusted_per_agent(tmp_path, "trusted")
+    hooks = load_trusted_per_agent_hooks(tmp_path, _AGENT)
+    assert [h.get("on", h.get(True)) for h in hooks] == ["turn_end"]
+
+
+def test_load_trusted_per_agent_hooks_does_not_read_the_untrusted_path(tmp_path: Path) -> None:
+    """Tier 2: falsification pair for the test above — a hook written at
+    the OLD (untrusted) per-agent path must not leak into this loader's
+    own read, proving the two paths are genuinely distinct, not aliases."""
+    _write_per_agent(tmp_path, "untrusted-only")
+    assert load_trusted_per_agent_hooks(tmp_path, _AGENT) == []
+
+
+def test_load_trusted_per_agent_hooks_absent_is_empty(tmp_path: Path) -> None:
+    """Tier 2: an absent trusted-per-agent file (or dir) yields [] — a
+    no-op layer, never an error."""
+    assert load_trusted_per_agent_hooks(tmp_path, _AGENT) == []
+
+
+# ── HOOK_ORIGIN_ORDER / #5213 threshold (unaffected by the new layer) ───────
+
+
+def test_trusted_per_agent_sits_between_runtime_and_per_agent() -> None:
+    """Tier 2: the settled insertion point — HOOK_ORIGIN_ORDER's own order,
+    architect ruling."""
+    assert HOOK_ORIGIN_ORDER == (
+        "startup", "runtime", "trusted-per-agent", "per-agent", "per-session",
+    )
+
+
+def test_5213_disabled_threshold_still_protects_trusted_per_agent() -> None:
+    """Tier 2: #5213's own `disabled:` layer-bypass threshold
+    (`layer="per-agent"`) needed NO change when this layer was added — it
+    falls out of the existing rule for free (architect ruling): a hook
+    declared at trusted-per-agent is NOT disableable via the per-agent/
+    per-session `disabled:` mechanism (same protected side as startup and
+    runtime), while a hook declared AT per-agent or per-session still is."""
+    assert hook_origin_is_at_least_as_specific_as("trusted-per-agent", "per-agent") is False
+    assert hook_origin_is_at_least_as_specific_as("per-agent", "per-agent") is True
+    assert hook_origin_is_at_least_as_specific_as("per-session", "per-agent") is True
+
+
+# ── the self-grant restriction stays closed at the OLD 2 origins, opens at the NEW one ──
+
+
+@pytest.mark.parametrize("key,value", [
+    ("write_paths", ["/tmp/somewhere"]),
+    ("subprocess", True),
+    ("network", True),
+])
+def test_trusted_per_agent_origin_accepts_the_keys_5356_rejects_elsewhere(
+    key: str, value,
+) -> None:
+    """Tier 2: #5505's own core acceptance criterion — the exact keys #5356
+    made impossible to grant per-agent load CLEAN at the new
+    trusted-per-agent origin, the same as they already do at startup/
+    runtime (falsification pair: the SAME entry still rejected at
+    per-agent/per-session, unaffected by this change)."""
+    entry = {"on": "turn_end", "exec": ["/usr/bin/true"], key: value}
+
+    registry = load_hooks([entry], origin="trusted-per-agent")
+    (hook,) = registry.all_defs()
+    assert getattr(hook, key) == (tuple(value) if key == "write_paths" else value)
+
+    for agent_writable_origin in ("per-agent", "per-session"):
+        with pytest.raises(HookConfigError, match=f"{key}.*not permitted"):
+            load_hooks([entry], origin=agent_writable_origin)
+
+
+def test_5356_rejection_message_now_names_the_trusted_per_agent_layer() -> None:
+    """Tier 2: architect's own #5505 review point — the #5356 rejection
+    message pointed at startup/runtime only, BOTH agent-less layers; the
+    moment a real per-agent grant mechanism exists, that guidance goes
+    stale. Must be updated in the SAME PR (CLAUDE.md: a doc/message
+    describing a mechanism is stale the moment the mechanism changes)."""
+    entry = {"on": "turn_end", "exec": ["/usr/bin/true"], "write_paths": ["/tmp/x"]}
+    with pytest.raises(HookConfigError) as exc_info:
+        load_hooks([entry], origin="per-agent")
+    message = str(exc_info.value)
+    assert "trusted-per-agent" in message
+    assert ".reyn/config/agents/<name>/hooks.yaml" in message
+
+
+# ── the 5-layer additive COMBINE (boot) ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_boot_combines_all_four_file_backed_layers_additively(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: at boot the dispatcher carries startup ∪ runtime ∪
+    trusted-per-agent ∪ per-agent (the 5th, per-session, is exercised in
+    #2073's own suite — unaffected by this change, not re-tested here).
+    Dispatching turn_end fires all four (additive; observed via the
+    inbox)."""
+    monkeypatch.chdir(tmp_path)
+    _write_runtime(tmp_path, "runtime")
+    _write_trusted_per_agent(tmp_path, "trusted")
+    _write_per_agent(tmp_path, "agent")
+    session = _make_session(tmp_path, hooks_config=_STARTUP)
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    assert await _drain_texts(session) == {"startup", "runtime", "trusted", "agent"}
+
+
+@pytest.mark.asyncio
+async def test_trusted_per_agent_hooks_carry_the_right_origin(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: a hook declared at the trusted-per-agent layer is tagged
+    with that ORIGIN specifically (not "unknown", not "per-agent") — the
+    #5213 provenance field this whole COMBINE depends on."""
+    monkeypatch.chdir(tmp_path)
+    _write_trusted_per_agent(tmp_path, "trusted")
+    session = _make_session(tmp_path)
+    registry = session._hook_dispatcher._registry  # noqa: SLF001
+    (hook,) = [h for h in registry.hooks_for("turn_end") if h.origin == "trusted-per-agent"]
+    assert hook.origin == "trusted-per-agent"
+
+
+# ── boot-only: the reapply seam does NOT re-read this layer ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_reapply_does_not_reread_trusted_per_agent_layer(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: #5505's own core boot-only witness — unlike runtime/
+    per-agent/per-session (see #2073's own reapply-rereads test for the
+    positive control on a sibling layer), REWRITING the trusted-per-agent
+    file after boot and running the hooks reapply seam does NOT pick up
+    the change. This is the architect-ruled trade (no live-reload for
+    this layer), not an oversight — falsified against
+    `test_reapply_rereads_per_agent_layer`'s own positive-control shape
+    for the untrusted per-agent sibling, proving the SAME test recipe
+    behaves oppositely for this layer specifically."""
+    from reyn.config.loader import load_hot_reload_config
+
+    monkeypatch.chdir(tmp_path)
+    _write_trusted_per_agent(tmp_path, "trusted_v1")
+    session = _make_session(tmp_path, hooks_config=_STARTUP)
+
+    _write_trusted_per_agent(tmp_path, "trusted_v2")  # rewrite AFTER boot
+    changed = await session._reapply_hooks(load_hot_reload_config(tmp_path))
+    assert changed is True  # the reapply itself still runs/returns True
+
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    texts = await _drain_texts(session)
+    assert "trusted_v1" in texts, "the BOOT-time content must still be the one that fires"
+    assert "trusted_v2" not in texts, "a post-boot rewrite must NOT be picked up (boot-only)"
+
+
+# ── fail-loud: a malformed trusted-per-agent file refuses construction ──────
+
+
+def test_malformed_trusted_per_agent_layer_refuses_session_construction(tmp_path: Path) -> None:
+    """Tier 2: #5505's own core fail-loud witness — a shape-malformed
+    trusted-per-agent hooks.yaml (the SAME "no scheme" malformed shape
+    #2073's own suite uses for its untrusted-layer drop-and-warn tests)
+    raises OUT of Session construction here instead — the deliberate
+    OPPOSITE of the untrusted per-agent/runtime/per-session siblings
+    (falsification pair: #2073's own
+    test_bad_per_agent_keeps_startup_and_runtime proves the untrusted
+    layer does NOT raise for the identical malformed shape)."""
+    agent_dir = tmp_path / ".reyn" / "config" / "agents" / _AGENT
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "hooks.yaml").write_text("hooks:\n  - on: turn_end\n", encoding="utf-8")
+
+    with pytest.raises(HookConfigError):
+        _make_session(tmp_path, hooks_config=_STARTUP)
+
+
+@pytest.mark.asyncio
+async def test_a_good_trusted_per_agent_layer_alongside_bad_runtime_still_boots(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: non-regression — a GOOD trusted-per-agent layer does not
+    itself prevent boot when a SIBLING untrusted layer (runtime) is
+    malformed; the untrusted layer's own independent try-add resilience
+    (#2073's add-on refinement) is unaffected by this new layer sitting
+    between it and per-agent in the combine order."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn" / "config").mkdir(parents=True)
+    (tmp_path / ".reyn" / "config" / "hooks.yaml").write_text("hooks:\n  - on: turn_end\n", encoding="utf-8")
+    _write_trusted_per_agent(tmp_path, "trusted")
+
+    session = _make_session(tmp_path, hooks_config=_STARTUP)  # must NOT raise
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    assert await _drain_texts(session) == {"startup", "trusted"}  # bad runtime dropped, good siblings kept

--- a/tests/runtime/test_5505_trusted_per_agent_hooks.py
+++ b/tests/runtime/test_5505_trusted_per_agent_hooks.py
@@ -32,7 +32,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.config.loader import load_trusted_per_agent_hooks
+from reyn.config.loader import load_trusted_per_agent_hooks, trusted_per_agent_hooks_path
 from reyn.core.events.state_log import StateLog
 from reyn.hooks.loader import HookConfigError, load_hooks
 from reyn.hooks.schema import HOOK_ORIGIN_ORDER, hook_origin_is_at_least_as_specific_as
@@ -81,6 +81,61 @@ async def _drain_texts(session: Session) -> set:
         _kind, payload = session.inbox.get_nowait()
         texts.add(payload.get("text"))
     return texts
+
+
+# ── the ONE path both real readers must agree on (lead-coder review, #5669) ──
+#
+# `config/loader.py`'s own load_trusted_per_agent_hooks (drop-and-report
+# contract: reyn config validate / reyn doctor) and Session's own
+# _trusted_per_agent_hooks_path (fail-loud contract: the live boot path)
+# used to each build ".reyn"/"config"/"agents"/<name>/"hooks.yaml" by hand
+# — a genuine "same fact in 2 places" risk this PR's own schema.py comment
+# names verbatim for a DIFFERENT fact (HOOK_ORIGIN_ORDER), but had not yet
+# been applied to this one. A drift here is invisible: either reader
+# landing on the wrong location degrades to [] (a normal-looking no-op
+# layer), never a red — so this must be checked structurally, not by
+# waiting for a symptom.
+
+
+def test_session_and_config_loader_agree_on_the_exact_same_path(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: #5669 review — both real readers now delegate to the SAME
+    `trusted_per_agent_hooks_path()` function; this directly compares
+    Session's own private path accessor against config.loader's public
+    one, for the same (project_root, agent_name), rather than trusting
+    that "both call the same function" holds by inspection alone."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    from_config_loader = trusted_per_agent_hooks_path(tmp_path, _AGENT)
+    from_session = session._trusted_per_agent_hooks_path()  # noqa: SLF001
+    assert from_session == from_config_loader
+
+
+@pytest.mark.asyncio
+async def test_a_file_written_via_the_shared_path_function_is_seen_by_both_readers(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: #5669 review — the behavioral form of the test above. A
+    hooks.yaml written at exactly the location
+    `trusted_per_agent_hooks_path()` computes (never the hardcoded
+    `_write_trusted_per_agent` helper this file's other tests use) is
+    picked up by BOTH `load_trusted_per_agent_hooks` (config.loader's own
+    reader) AND a real booted Session (the fail-loud reader) — proving
+    agreement behaviorally, not just as equal path strings."""
+    monkeypatch.chdir(tmp_path)
+    path = trusted_per_agent_hooks_path(tmp_path, _AGENT)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_HOOK.format(msg="via_shared_path_fn"), encoding="utf-8")
+
+    # Reader 1: config.loader's own function.
+    hooks = load_trusted_per_agent_hooks(tmp_path, _AGENT)
+    assert [h.get("on", h.get(True)) for h in hooks] == ["turn_end"]
+
+    # Reader 2: a real booted Session (the fail-loud contract's own path).
+    session = _make_session(tmp_path, hooks_config=_STARTUP)
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    assert await _drain_texts(session) == {"startup", "via_shared_path_fn"}
 
 
 # ── the loader (read directly, not via the top-level IN-set) ────────────────


### PR DESCRIPTION
**[e2e-coder]** — part of #5505 (open item ② below remains unresolved by design), part of #5351.

Architect ruling on #5351 (2026-08-30, corrected 08-29): #5356 (merged) closed a real confused-deputy hole — an agent could self-grant `write_paths`/`subprocess`/`network` by declaring them at its own agent-writable hooks.yaml — but left operators with **zero mechanism** to grant per-agent `write_paths` at all. This PR is that missing mechanism.

## What changed

**New layer**: `.reyn/config/agents/<name>/hooks.yaml` — trusted for free by the existing `.reyn/config/` write-gate prefix, no new trust mechanism.

- `HOOK_ORIGIN_ORDER` gains `"trusted-per-agent"` between `"runtime"` and `"per-agent"` (settled insertion point). #5213's `disabled:` threshold (`layer="per-agent"`) needed no change — it falls out of the existing rule for free.
- Carries **only** the 3 permission-bearing keys, derived from `HOOK_SANDBOX_SCOPE`'s own right column (never a 2nd hand-list — the same registry #5356's own `_AGENT_WRITABLE_SANDBOX_KEYS` derives from).
- **Boot-only / fail-loud** (architect ruling): captured once at `Session.__init__` (`self._trusted_per_agent_hooks_raw`), never re-read by `_build_hook_registry` even on hot-reload; a malformed file propagates uncaught, refusing Session construction — the OPPOSITE of every other post-startup layer (drop + warn). Both mechanisms strip-falsified (verified RED when disabled, restored byte-identical, green again).
- #5356's own rejection message updated (architect's own review point): the old "declare it at startup or runtime" guidance named two agent-LESS layers and goes stale the moment a real per-agent grant mechanism exists — now names the new layer too.
- `reyn doctor`'s hook probe and `reyn config validate` both extended to read + label the new layer (a 4th real input path; a malformed file here would otherwise only surface at the NEXT boot, refusing it with no earlier warning).
- Docs updated: `docs/concepts/runtime/hooks.md` gets a new section explicitly naming **both** senses of "trusted" this layer carries (write-zone boundary vs. re-read cadence — tui-coder's own retraction on #5351 found these conflated once already, so both are named here to close that off). `docs/concepts/runtime/config-hot-reload.md`, `docs/reference/config/reyn-yaml.md`, `docs/reference/runtime/session-construction.md` updated for the new layer, and for the now-stale "composers use the SAME N-layer combine as hooks" claims (composers stayed 4-layer, hooks is now 5 — out of #5505's own scope, `hooks:`-only).
- **`trusted_per_agent_hooks_path(project_root, agent_name)`** (lead-coder review): the path itself (`.reyn/config/agents/<name>/hooks.yaml`) was being built by hand in two places — `config/loader.py`'s `load_trusted_per_agent_hooks` (drop-and-report contract: `reyn config validate`/`reyn doctor`) and `Session._trusted_per_agent_hooks_path` (fail-loud contract: the live boot path). Two DIFFERENT readers for two genuinely different contracts is correct design; two hand-typed copies of the PATH is not (this PR's own `schema.py` comment names the "same fact in 2 places" risk verbatim for a different fact). A drift here is invisible — either reader landing on the wrong location degrades to `[]`, a normal-looking no-op layer, never a red. Both readers now delegate to this one function.

**Open item ② (exec's `cd`/`cwd` scope) is untouched** — no such key exists in the schema at all yet, so implementing this never forced a decision on it. Per lead-coder's explicit instruction I did not decide it myself. **Architect ruling has since landed (recorded verbatim on #5505): no `cd`/cwd knob — explicit drop.** Reopen condition: a real hook that genuinely cannot declare its own working directory via the layered `hooks:`/env surface actually shows up.

## Tests (19 new test functions + test_5356 extended, 552 in the full hooks-family sweep — all pass)

`tests/runtime/test_5505_trusted_per_agent_hooks.py` (new, 14 tests):
- Loader reads the right (config-scoped) path, not the untrusted one.
- `HOOK_ORIGIN_ORDER` position + #5213 threshold protection (unaffected).
- #5356 accept-at-new-layer / still-reject-at-old-layers, and the rejection message names the new layer.
- 4-layer additive boot combine, correct `origin` tagging.
- **Boot-only witness**: a post-boot rewrite of the file is NOT picked up by the reapply seam (strip-falsified).
- **Fail-loud witness**: a malformed file raises OUT of Session construction (strip-falsified; falsification pair against #2073's own untrusted-layer drop-and-warn shape).
- A good trusted-per-agent layer survives a malformed sibling (runtime) — the untrusted layer's own independent resilience is unaffected.
- **The 2 readers agree on the exact same path**: a direct equality check (Session's own accessor vs. `config.loader`'s function, same inputs) and a behavioral one (a file written at the shared function's own path is seen by both real readers) — strip-falsified by reintroducing the exact drift shape (a typo'd path segment) and confirming the equality test goes RED.

Extended: `tests/hooks/test_5356_write_paths_rejected_at_agent_writable_origin.py` (new layer joins the accepted-origin set), `tests/interfaces/test_4501_validate_hook_entries.py` (+4: malformed/well-formed/absent/label-collision for the new source), `tests/interfaces/test_5351_doctor_hook_probe_layer_origin.py` (+1: probed and labeled `(trusted-per-agent)`).

## Local gates (all green)
- `ruff check .`
- `python scripts/test_tier_audit.py --strict <all touched test files>` — 35 tests inspected, 0 errors
- `python scripts/verify_module_docstrings.py <all touched src files>`
- `python scripts/mypy_ratchet.py`
- `python scripts/flat_tests_ratchet.py`
- `python scripts/check_tests_path_literal_reference.py`
- `python scripts/check_bare_tests_import_reference.py`
- `python scripts/check_file_depth_reference.py`
- `python scripts/check_subprocess_reyn_pin.py`
- `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py` (docs/ touched, in that order)
- `pytest <full hooks-family sweep>` — 552 passed, foreground, single run

## Test plan
- [x] All 552 tests in the hooks-family sweep pass locally (foreground, single run)
- [x] `ruff check .` clean
- [x] All applicable local gates green (incl. the docs path-conditional gate, in order)
- [x] Strip-falsified: boot-only (no re-read) and fail-loud mechanisms both verified RED when disabled, restored byte-identical, green again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51

